### PR TITLE
Sprint 1: add PR walkthrough summary

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,10 @@ export interface BotConfig {
   statePath: string;
   evidenceDir: string;
   canaryPulls?: string[];
+  walkthrough: {
+    enabled: boolean;
+    postIssueComment: boolean;
+  };
   zcode: {
     cliPath: string;
     appConfigPath: string;
@@ -32,6 +36,10 @@ const DEFAULT_CONFIG: BotConfig = {
   statePath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews.sqlite",
   evidenceDir: "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence",
   canaryPulls: undefined,
+  walkthrough: {
+    enabled: true,
+    postIssueComment: false
+  },
   zcode: {
     cliPath: "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
     appConfigPath: "/Volumes/LEXAR/zcode/.zcode/v2/config.json",

--- a/src/github.ts
+++ b/src/github.ts
@@ -7,6 +7,7 @@ export interface GitHubApiOptions {
   privateKeyPath?: string;
   token?: string;
   apiBaseUrl?: string;
+  botLogin?: string;
 }
 
 export class GitHubApi {
@@ -14,6 +15,7 @@ export class GitHubApi {
   private readonly privateKey?: string;
   private readonly token?: string;
   private readonly apiBaseUrl: string;
+  private readonly botLogin: string;
   private installationTokens = new Map<string, { token: string; expiresAt: number }>();
 
   constructor(options: GitHubApiOptions) {
@@ -21,6 +23,7 @@ export class GitHubApi {
     this.privateKey = options.privateKeyPath ? readFileSync(options.privateKeyPath, "utf8") : undefined;
     this.token = options.token;
     this.apiBaseUrl = options.apiBaseUrl ?? "https://api.github.com";
+    this.botLogin = options.botLogin ?? "evaos-code-review-bot[bot]";
   }
 
   canPostAsApp(): boolean {
@@ -109,16 +112,20 @@ export class GitHubApi {
     issueNumber: number,
     marker: string,
     token: string
-  ): Promise<{ id: number; body?: string | null } | undefined> {
+  ): Promise<IssueCommentSummary | undefined> {
     for (let page = 1; ; page += 1) {
-      const comments = await this.request<Array<{ id: number; body?: string | null }>>(
+      const comments = await this.request<IssueCommentSummary[]>(
         `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
         { token }
       );
-      const existing = comments.find((comment) => comment.body?.includes(marker));
+      const existing = comments.find((comment) => comment.body?.includes(marker) && this.isBotAuthoredComment(comment));
       if (existing) return existing;
       if (comments.length < 100) return undefined;
     }
+  }
+
+  private isBotAuthoredComment(comment: IssueCommentSummary): boolean {
+    return comment.user?.type === "Bot" && comment.user.login === this.botLogin;
   }
 
   private async getInstallationToken(repo: string): Promise<string> {
@@ -173,6 +180,15 @@ export class GitHubApi {
 
     return (await response.json()) as T;
   }
+}
+
+interface IssueCommentSummary {
+  id: number;
+  body?: string | null;
+  user?: {
+    login: string;
+    type?: string;
+  } | null;
 }
 
 function describeFetchError(error: unknown): string {

--- a/src/github.ts
+++ b/src/github.ts
@@ -78,6 +78,49 @@ export class GitHubApi {
     });
   }
 
+  async upsertIssueComment(input: {
+    repo: string;
+    issueNumber: number;
+    marker: string;
+    body: string;
+  }): Promise<{ action: "created" | "updated"; html_url?: string; id: number }> {
+    if (!this.canPostAsApp()) {
+      throw new Error("GitHub App credentials are required before posting comments.");
+    }
+    const token = await this.getInstallationToken(input.repo);
+    const existing = await this.findIssueCommentByMarker(input.repo, input.issueNumber, input.marker, token);
+    if (existing) {
+      const updated = await this.request<{ html_url?: string; id: number }>(
+        `/repos/${input.repo}/issues/comments/${existing.id}`,
+        { method: "PATCH", token, body: { body: input.body } }
+      );
+      return { action: "updated", html_url: updated.html_url, id: updated.id };
+    }
+
+    const created = await this.request<{ html_url?: string; id: number }>(
+      `/repos/${input.repo}/issues/${input.issueNumber}/comments`,
+      { method: "POST", token, body: { body: input.body } }
+    );
+    return { action: "created", html_url: created.html_url, id: created.id };
+  }
+
+  private async findIssueCommentByMarker(
+    repo: string,
+    issueNumber: number,
+    marker: string,
+    token: string
+  ): Promise<{ id: number; body?: string | null } | undefined> {
+    for (let page = 1; ; page += 1) {
+      const comments = await this.request<Array<{ id: number; body?: string | null }>>(
+        `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
+        { token }
+      );
+      const existing = comments.find((comment) => comment.body?.includes(marker));
+      if (existing) return existing;
+      if (comments.length < 100) return undefined;
+    }
+  }
+
   private async getInstallationToken(repo: string): Promise<string> {
     const cached = this.installationTokens.get(repo);
     if (cached && cached.expiresAt > Date.now() + 60_000) return cached.token;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,12 +19,18 @@ export interface DroppedFinding extends Partial<Finding> {
 export interface PullFilePatch {
   filename: string;
   patch?: string | null;
+  status?: string;
+  additions?: number;
+  deletions?: number;
+  changes?: number;
+  previous_filename?: string;
 }
 
 export interface PullRequestSummary {
   number: number;
   title: string;
   draft: boolean;
+  body?: string | null;
   head: {
     sha: string;
     ref: string;
@@ -42,6 +48,8 @@ export interface PullRequestSummary {
     };
   };
   html_url: string;
+  requested_reviewers?: Array<{ login: string }>;
+  labels?: Array<{ name: string }>;
 }
 
 export interface ReviewComment {
@@ -58,4 +66,11 @@ export interface ReviewPlan {
   comments: ReviewComment[];
   dropped: DroppedFinding[];
   summary: string;
+  walkthrough?: WalkthroughComment;
+}
+
+export interface WalkthroughComment {
+  marker: string;
+  body: string;
+  postIssueComment: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export interface ReviewPlan {
   dropped: DroppedFinding[];
   summary: string;
   walkthrough?: WalkthroughComment;
+  walkthroughComment?: WalkthroughCommentPostResult;
 }
 
 export interface WalkthroughComment {
@@ -74,3 +75,7 @@ export interface WalkthroughComment {
   body: string;
   postIssueComment: boolean;
 }
+
+export type WalkthroughCommentPostResult =
+  | { posted: true; action: "created" | "updated"; html_url?: string; id: number }
+  | { posted: false; reason: "disabled" | "missing_app_credentials" | "upsert_failed" };

--- a/src/walkthrough-post.ts
+++ b/src/walkthrough-post.ts
@@ -1,0 +1,43 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { redactSecrets } from "./secrets.js";
+import type { WalkthroughComment } from "./types.js";
+
+export interface WalkthroughCommentGithub {
+  canPostAsApp(): boolean;
+  upsertIssueComment(input: {
+    repo: string;
+    issueNumber: number;
+    marker: string;
+    body: string;
+  }): Promise<{ action: "created" | "updated"; html_url?: string; id: number }>;
+}
+
+export async function postWalkthroughComment(input: {
+  github: WalkthroughCommentGithub;
+  repo: string;
+  pullNumber: number;
+  evidenceDir: string;
+  walkthrough?: WalkthroughComment;
+}): Promise<
+  | { posted: true; action: "created" | "updated"; html_url?: string; id: number }
+  | { posted: false; reason: "disabled" | "missing_app_credentials" | "upsert_failed" }
+> {
+  if (!input.walkthrough?.postIssueComment) return { posted: false, reason: "disabled" };
+  if (!input.github.canPostAsApp()) return { posted: false, reason: "missing_app_credentials" };
+
+  try {
+    const comment = await input.github.upsertIssueComment({
+      repo: input.repo,
+      issueNumber: input.pullNumber,
+      marker: input.walkthrough.marker,
+      body: input.walkthrough.body
+    });
+    writeFileSync(join(input.evidenceDir, "walkthrough-comment.json"), `${JSON.stringify(comment, null, 2)}\n`);
+    return { posted: true, ...comment };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    writeFileSync(join(input.evidenceDir, "walkthrough-comment-error.txt"), redactSecrets(message));
+    return { posted: false, reason: "upsert_failed" };
+  }
+}

--- a/src/walkthrough-post.ts
+++ b/src/walkthrough-post.ts
@@ -1,7 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { redactSecrets } from "./secrets.js";
-import type { WalkthroughComment } from "./types.js";
+import type { ReviewPlan, WalkthroughComment, WalkthroughCommentPostResult } from "./types.js";
 
 export interface WalkthroughCommentGithub {
   canPostAsApp(): boolean;
@@ -19,10 +19,7 @@ export async function postWalkthroughComment(input: {
   pullNumber: number;
   evidenceDir: string;
   walkthrough?: WalkthroughComment;
-}): Promise<
-  | { posted: true; action: "created" | "updated"; html_url?: string; id: number }
-  | { posted: false; reason: "disabled" | "missing_app_credentials" | "upsert_failed" }
-> {
+}): Promise<WalkthroughCommentPostResult> {
   if (!input.walkthrough?.postIssueComment) return { posted: false, reason: "disabled" };
   if (!input.github.canPostAsApp()) return { posted: false, reason: "missing_app_credentials" };
 
@@ -40,4 +37,11 @@ export async function postWalkthroughComment(input: {
     writeFileSync(join(input.evidenceDir, "walkthrough-comment-error.txt"), redactSecrets(message));
     return { posted: false, reason: "upsert_failed" };
   }
+}
+
+export function reviewBodyAfterWalkthroughPost(plan: Pick<ReviewPlan, "summary" | "walkthrough" | "walkthroughComment">): string {
+  if (!plan.walkthrough) return plan.summary;
+  if (!plan.walkthrough.postIssueComment) return plan.walkthrough.body;
+  if (!plan.walkthroughComment?.posted) return plan.walkthrough.body;
+  return plan.summary;
 }

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -4,6 +4,7 @@ import type { DroppedFinding, PullFilePatch, PullRequestSummary, ReviewComment, 
 export const WALKTHROUGH_MARKER_PREFIX = "<!-- evaos-code-review-bot:walkthrough";
 
 const SEVERITY_LABELS: Severity[] = ["P0", "P1", "P2", "P3"];
+const MAX_CHANGED_FILE_ROWS = 25;
 
 export function buildWalkthroughComment(input: {
   repo: string;
@@ -14,8 +15,10 @@ export function buildWalkthroughComment(input: {
   event: ReviewEvent;
   postIssueComment?: boolean;
 }): WalkthroughComment {
-  const marker = `${WALKTHROUGH_MARKER_PREFIX} ${input.repo}#${input.pull.number} ${input.pull.head.sha} -->`;
+  const marker = `${WALKTHROUGH_MARKER_PREFIX} ${input.repo}#${input.pull.number} -->`;
   const files = input.files.map((file) => summarizeFile(file, input.comments));
+  const visibleFiles = files.slice(0, MAX_CHANGED_FILE_ROWS);
+  const omittedFileCount = Math.max(0, files.length - visibleFiles.length);
   const effort = estimateReviewEffort(input.files, input.comments);
   const relatedRefs = extractRelatedRefs(`${input.pull.title}\n${input.pull.body ?? ""}`);
   const suggestedLabels = suggestLabels(input.files, input.comments);
@@ -36,7 +39,8 @@ export function buildWalkthroughComment(input: {
     "",
     "| File | Status | Churn | Purpose | Risk |",
     "| --- | --- | --- | --- | --- |",
-    ...files.map((file) => `| \`${file.filename}\` | ${file.status} | ${file.churn} | ${file.purpose} | ${file.risk} |`),
+    ...visibleFiles.map((file) => `| \`${file.filename}\` | ${file.status} | ${file.churn} | ${file.purpose} | ${file.risk} |`),
+    ...(omittedFileCount > 0 ? ["", `${omittedFileCount} additional changed files omitted from this walkthrough.`] : []),
     "",
     "### Review Signal",
     "",

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -1,0 +1,151 @@
+import { containsSecretLikeText, redactSecrets } from "./secrets.js";
+import type { DroppedFinding, PullFilePatch, PullRequestSummary, ReviewComment, ReviewEvent, Severity, WalkthroughComment } from "./types.js";
+
+export const WALKTHROUGH_MARKER_PREFIX = "<!-- evaos-code-review-bot:walkthrough";
+
+const SEVERITY_LABELS: Severity[] = ["P0", "P1", "P2", "P3"];
+
+export function buildWalkthroughComment(input: {
+  repo: string;
+  pull: PullRequestSummary;
+  files: PullFilePatch[];
+  comments: ReviewComment[];
+  dropped: DroppedFinding[];
+  event: ReviewEvent;
+  postIssueComment?: boolean;
+}): WalkthroughComment {
+  const marker = `${WALKTHROUGH_MARKER_PREFIX} ${input.repo}#${input.pull.number} ${input.pull.head.sha} -->`;
+  const files = input.files.map((file) => summarizeFile(file, input.comments));
+  const effort = estimateReviewEffort(input.files, input.comments);
+  const relatedRefs = extractRelatedRefs(`${input.pull.title}\n${input.pull.body ?? ""}`);
+  const suggestedLabels = suggestLabels(input.files, input.comments);
+  const suggestedReviewers = input.pull.requested_reviewers?.map((reviewer) => reviewer.login).filter(Boolean) ?? [];
+  const severityCounts = countSeverities(input.comments);
+  const highSeverity = severityCounts.P0 + severityCounts.P1;
+
+  const body = [
+    marker,
+    "## Walkthrough",
+    "",
+    `PR: ${input.repo}#${input.pull.number} - ${input.pull.title}`,
+    `Head: \`${input.pull.head.sha}\` into \`${input.pull.base.ref}\`. Review event: \`${input.event}\`.`,
+    "",
+    `Estimated review effort: ${effort.score}/5 (~${effort.minutes} min)`,
+    "",
+    "### Changed Files",
+    "",
+    "| File | Status | Churn | Purpose | Risk |",
+    "| --- | --- | --- | --- | --- |",
+    ...files.map((file) => `| \`${file.filename}\` | ${file.status} | ${file.churn} | ${file.purpose} | ${file.risk} |`),
+    "",
+    "### Review Signal",
+    "",
+    input.comments.length === 0
+      ? "No validated inline findings."
+      : `Validated inline findings: ${input.comments.length} (${formatSeverityCounts(severityCounts)}).`,
+    `Dropped findings before posting: ${input.dropped.length}. High-severity findings: ${highSeverity}.`,
+    "",
+    "### Related Context",
+    "",
+    `Related issues/PRs: ${relatedRefs.length > 0 ? relatedRefs.join(", ") : "none detected from PR metadata"}.`,
+    `Suggested labels: ${suggestedLabels.length > 0 ? suggestedLabels.join(", ") : "none"}.`,
+    `Suggested reviewers: ${suggestedReviewers.length > 0 ? suggestedReviewers.join(", ") : "none from current metadata"}.`,
+    "",
+    "### Pre-merge checklist",
+    "",
+    checklistItem(input.comments.every((comment) => comment.side === "RIGHT"), "Inline comments target current RIGHT-side diff lines."),
+    checklistItem(!commentsContainSecretLikeText(input.comments), "No secret-like content survived into posted inline comments."),
+    checklistItem(input.event !== "REQUEST_CHANGES" || highSeverity > 0, "REQUEST_CHANGES is only used when P0/P1 findings survive validation."),
+    checklistItem(true, "Labels and reviewers are suggestions only; the bot did not auto-apply them.")
+  ].join("\n");
+
+  return {
+    marker,
+    body: redactSecrets(body),
+    postIssueComment: input.postIssueComment ?? false
+  };
+}
+
+function summarizeFile(file: PullFilePatch, comments: ReviewComment[]): {
+  filename: string;
+  status: string;
+  churn: string;
+  purpose: string;
+  risk: string;
+} {
+  const fileComments = comments.filter((comment) => comment.path === file.filename);
+  const maxSeverity = highestSeverity(fileComments);
+  const changes = file.changes ?? (file.additions ?? 0) + (file.deletions ?? 0);
+  return {
+    filename: file.filename,
+    status: file.status ?? "modified",
+    churn: `+${file.additions ?? 0}/-${file.deletions ?? 0}`,
+    purpose: inferPurpose(file.filename),
+    risk: inferRisk(file.filename, changes, maxSeverity)
+  };
+}
+
+function inferPurpose(filename: string): string {
+  const lower = filename.toLowerCase();
+  if (lower.includes("/test") || lower.includes(".test.") || lower.includes(".spec.")) return "Test coverage";
+  if (lower.startsWith("docs/") || lower.endsWith(".md")) return "Documentation";
+  if (lower.startsWith("assets/") || lower.endsWith(".cs")) return "Unity/gameplay state";
+  if (lower.includes("package.json") || lower.includes("package-lock") || lower.includes("config")) return "Configuration";
+  if (lower.startsWith("src/")) return "Runtime code";
+  return "Changed file";
+}
+
+function inferRisk(filename: string, changes: number, maxSeverity?: Severity): string {
+  if (maxSeverity === "P0" || maxSeverity === "P1") return `Elevated: validated ${maxSeverity} finding`;
+  if (maxSeverity === "P2" || maxSeverity === "P3") return `Moderate: validated ${maxSeverity} finding`;
+  const lower = filename.toLowerCase();
+  if (changes >= 200) return "Elevated: large change";
+  if (lower.startsWith("assets/") || lower.startsWith("src/") || lower.endsWith(".cs")) return "Moderate: runtime path";
+  return "Low";
+}
+
+function estimateReviewEffort(files: PullFilePatch[], comments: ReviewComment[]): { score: number; minutes: number } {
+  const totalChanges = files.reduce((sum, file) => sum + (file.changes ?? (file.additions ?? 0) + (file.deletions ?? 0)), 0);
+  const highSeverity = comments.filter((comment) => comment.severity === "P0" || comment.severity === "P1").length;
+  const rawScore = 1 + Math.floor(files.length / 4) + Math.floor(totalChanges / 250) + Math.min(highSeverity, 2);
+  const score = Math.min(5, Math.max(1, rawScore));
+  return { score, minutes: score * 10 + Math.min(20, files.length * 2) };
+}
+
+function extractRelatedRefs(text: string): string[] {
+  const refs = new Set<string>();
+  for (const match of text.matchAll(/#(\d+)/g)) refs.add(`#${match[1]}`);
+  return [...refs].slice(0, 8);
+}
+
+function suggestLabels(files: PullFilePatch[], comments: ReviewComment[]): string[] {
+  const labels = new Set<string>();
+  if (comments.some((comment) => comment.severity === "P0" || comment.severity === "P1")) labels.add("bug");
+  if (files.some((file) => file.filename.toLowerCase().startsWith("assets/") || file.filename.endsWith(".cs"))) labels.add("unity");
+  if (files.some((file) => file.filename.toLowerCase().startsWith("docs/") || file.filename.endsWith(".md"))) labels.add("docs");
+  if (files.some((file) => file.filename.toLowerCase().includes("/test") || file.filename.includes(".test."))) labels.add("tests");
+  return [...labels].slice(0, 6);
+}
+
+function countSeverities(comments: ReviewComment[]): Record<Severity, number> {
+  return Object.fromEntries(SEVERITY_LABELS.map((severity) => [
+    severity,
+    comments.filter((comment) => comment.severity === severity).length
+  ])) as Record<Severity, number>;
+}
+
+function formatSeverityCounts(counts: Record<Severity, number>): string {
+  return SEVERITY_LABELS.map((severity) => `${severity}: ${counts[severity]}`).join(", ");
+}
+
+function highestSeverity(comments: ReviewComment[]): Severity | undefined {
+  return SEVERITY_LABELS.find((severity) => comments.some((comment) => comment.severity === severity));
+}
+
+function commentsContainSecretLikeText(comments: ReviewComment[]): boolean {
+  return comments.some((comment) => containsSecretLikeText(`${comment.title}\n${comment.body}`));
+}
+
+function checklistItem(ok: boolean, text: string): string {
+  return `- [${ok ? "x" : " "}] ${text}`;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7,6 +7,7 @@ import { assertGitClean, preparePullWorktree } from "./git.js";
 import { GitHubApi } from "./github.js";
 import { redactSecrets } from "./secrets.js";
 import { ReviewStateStore } from "./state.js";
+import { buildWalkthroughComment } from "./walkthrough.js";
 import { buildReviewPrompt, runZCodeReview } from "./zcode.js";
 import type { PullRequestSummary, ReviewPlan } from "./types.js";
 
@@ -120,13 +121,27 @@ export async function reviewPull(input: {
   const comments = normalized.comments;
   const dropped = sanitizeDroppedFindings([...zcodeResult.droppedFromSchema, ...located.dropped, ...normalized.dropped]);
   const event = decideReviewEvent(comments);
+  const summary = buildSummary({ repo, pull, comments, dropped, dryRun: input.dryRun });
+  const walkthrough = config.walkthrough.enabled
+    ? buildWalkthroughComment({
+        repo,
+        pull,
+        files,
+        comments,
+        dropped,
+        event,
+        postIssueComment: config.walkthrough.postIssueComment
+      })
+    : undefined;
   const plan: ReviewPlan = {
     event,
     comments,
     dropped,
-    summary: buildSummary({ repo, pull, comments, dropped, dryRun: input.dryRun })
+    summary,
+    ...(walkthrough ? { walkthrough } : {})
   };
 
+  if (walkthrough) writeFileSync(join(evidenceDir, "walkthrough.md"), walkthrough.body);
   writeFileSync(join(evidenceDir, "review-plan.json"), `${JSON.stringify(plan, null, 2)}\n`);
 
   if (input.dryRun) {
@@ -135,11 +150,20 @@ export async function reviewPull(input: {
   }
 
   const reviewGithub = new GitHubApi(config.github);
+  if (plan.walkthrough?.postIssueComment) {
+    const walkthroughComment = await reviewGithub.upsertIssueComment({
+      repo,
+      issueNumber: pull.number,
+      marker: plan.walkthrough.marker,
+      body: plan.walkthrough.body
+    });
+    writeFileSync(join(evidenceDir, "walkthrough-comment.json"), `${JSON.stringify(walkthroughComment, null, 2)}\n`);
+  }
   const review = await reviewGithub.createReview({
     repo,
     pullNumber: pull.number,
     event,
-    body: plan.summary,
+    body: plan.walkthrough && !plan.walkthrough.postIssueComment ? plan.walkthrough.body : plan.summary,
     comments
   });
   state.recordProcessed({

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8,7 +8,7 @@ import { GitHubApi } from "./github.js";
 import { redactSecrets } from "./secrets.js";
 import { ReviewStateStore } from "./state.js";
 import { buildWalkthroughComment } from "./walkthrough.js";
-import { postWalkthroughComment } from "./walkthrough-post.js";
+import { postWalkthroughComment, reviewBodyAfterWalkthroughPost } from "./walkthrough-post.js";
 import { buildReviewPrompt, runZCodeReview } from "./zcode.js";
 import type { PullRequestSummary, ReviewPlan } from "./types.js";
 
@@ -151,12 +151,19 @@ export async function reviewPull(input: {
   }
 
   const reviewGithub = new GitHubApi(config.github);
-  await postWalkthroughComment({ github: reviewGithub, repo, pullNumber: pull.number, evidenceDir, walkthrough: plan.walkthrough });
+  plan.walkthroughComment = await postWalkthroughComment({
+    github: reviewGithub,
+    repo,
+    pullNumber: pull.number,
+    evidenceDir,
+    walkthrough: plan.walkthrough
+  });
+  writeFileSync(join(evidenceDir, "review-plan.json"), `${JSON.stringify(plan, null, 2)}\n`);
   const review = await reviewGithub.createReview({
     repo,
     pullNumber: pull.number,
     event,
-    body: plan.walkthrough && !plan.walkthrough.postIssueComment ? plan.walkthrough.body : plan.summary,
+    body: reviewBodyAfterWalkthroughPost(plan),
     comments
   });
   state.recordProcessed({

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8,6 +8,7 @@ import { GitHubApi } from "./github.js";
 import { redactSecrets } from "./secrets.js";
 import { ReviewStateStore } from "./state.js";
 import { buildWalkthroughComment } from "./walkthrough.js";
+import { postWalkthroughComment } from "./walkthrough-post.js";
 import { buildReviewPrompt, runZCodeReview } from "./zcode.js";
 import type { PullRequestSummary, ReviewPlan } from "./types.js";
 
@@ -150,15 +151,7 @@ export async function reviewPull(input: {
   }
 
   const reviewGithub = new GitHubApi(config.github);
-  if (plan.walkthrough?.postIssueComment) {
-    const walkthroughComment = await reviewGithub.upsertIssueComment({
-      repo,
-      issueNumber: pull.number,
-      marker: plan.walkthrough.marker,
-      body: plan.walkthrough.body
-    });
-    writeFileSync(join(evidenceDir, "walkthrough-comment.json"), `${JSON.stringify(walkthroughComment, null, 2)}\n`);
-  }
+  await postWalkthroughComment({ github: reviewGithub, repo, pullNumber: pull.number, evidenceDir, walkthrough: plan.walkthrough });
   const review = await reviewGithub.createReview({
     repo,
     pullNumber: pull.number,

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -45,6 +45,56 @@ describe("GitHub App read authentication", () => {
     expect(readCall?.authorization).toBe("Bearer installation-token");
     expect(readCall?.authorization).not.toBe("Bearer fallback-token");
   });
+
+  it("updates an existing marked PR walkthrough comment with the App token", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-comment-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+
+    const marker = "<!-- evaos-code-review-bot:walkthrough owner/repo#42 -->";
+    const calls: Array<{ url: string; method: string; authorization?: string; body?: unknown }> = [];
+    globalThis.fetch = vi.fn(async (url, init) => {
+      const method = init?.method ?? "GET";
+      const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
+      calls.push({
+        url: String(url),
+        method,
+        authorization,
+        body: init?.body ? JSON.parse(String(init.body)) : undefined
+      });
+      if (String(url).endsWith("/repos/owner/repo/installation")) {
+        return jsonResponse({ id: 123 });
+      }
+      if (String(url).endsWith("/app/installations/123/access_tokens")) {
+        return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      }
+      if (String(url).endsWith("/repos/owner/repo/issues/42/comments?per_page=100&page=1")) {
+        return jsonResponse([{ id: 99, html_url: "https://github.test/comment/99", body: `${marker}\nold` }]);
+      }
+      if (String(url).endsWith("/repos/owner/repo/issues/comments/99") && method === "PATCH") {
+        return jsonResponse({ id: 99, html_url: "https://github.test/comment/99" });
+      }
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+    const result = await github.upsertIssueComment({
+      repo: "owner/repo",
+      issueNumber: 42,
+      marker,
+      body: `${marker}\nnew`
+    });
+
+    expect(result).toEqual({ action: "updated", html_url: "https://github.test/comment/99", id: 99 });
+    const patchCall = calls.find((call) => call.method === "PATCH");
+    expect(patchCall?.authorization).toBe("Bearer installation-token");
+    expect(patchCall?.body).toEqual({ body: `${marker}\nnew` });
+    expect(
+      calls.some((call) => call.method === "POST" && call.url.endsWith("/repos/owner/repo/issues/42/comments"))
+    ).toBe(false);
+  });
 });
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -71,7 +71,14 @@ describe("GitHub App read authentication", () => {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       }
       if (String(url).endsWith("/repos/owner/repo/issues/42/comments?per_page=100&page=1")) {
-        return jsonResponse([{ id: 99, html_url: "https://github.test/comment/99", body: `${marker}\nold` }]);
+        return jsonResponse([
+          {
+            id: 99,
+            html_url: "https://github.test/comment/99",
+            body: `${marker}\nold`,
+            user: { login: "evaos-code-review-bot[bot]", type: "Bot" }
+          }
+        ]);
       }
       if (String(url).endsWith("/repos/owner/repo/issues/comments/99") && method === "PATCH") {
         return jsonResponse({ id: 99, html_url: "https://github.test/comment/99" });
@@ -94,6 +101,60 @@ describe("GitHub App read authentication", () => {
     expect(
       calls.some((call) => call.method === "POST" && call.url.endsWith("/repos/owner/repo/issues/42/comments"))
     ).toBe(false);
+  });
+
+  it("creates a marked PR walkthrough comment when only user-authored marker comments exist", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-comment-create-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+
+    const marker = "<!-- evaos-code-review-bot:walkthrough owner/repo#42 -->";
+    const calls: Array<{ url: string; method: string; authorization?: string; body?: unknown }> = [];
+    globalThis.fetch = vi.fn(async (url, init) => {
+      const method = init?.method ?? "GET";
+      const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
+      calls.push({
+        url: String(url),
+        method,
+        authorization,
+        body: init?.body ? JSON.parse(String(init.body)) : undefined
+      });
+      if (String(url).endsWith("/repos/owner/repo/installation")) {
+        return jsonResponse({ id: 123 });
+      }
+      if (String(url).endsWith("/app/installations/123/access_tokens")) {
+        return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      }
+      if (String(url).endsWith("/repos/owner/repo/issues/42/comments?per_page=100&page=1")) {
+        return jsonResponse([
+          {
+            id: 98,
+            body: `${marker}\nuser seeded`,
+            user: { login: "octocat", type: "User" }
+          }
+        ]);
+      }
+      if (String(url).endsWith("/repos/owner/repo/issues/42/comments") && method === "POST") {
+        return jsonResponse({ id: 100, html_url: "https://github.test/comment/100" });
+      }
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+    const result = await github.upsertIssueComment({
+      repo: "owner/repo",
+      issueNumber: 42,
+      marker,
+      body: `${marker}\nnew`
+    });
+
+    expect(result).toEqual({ action: "created", html_url: "https://github.test/comment/100", id: 100 });
+    const postCall = calls.find((call) => call.method === "POST" && call.url.endsWith("/repos/owner/repo/issues/42/comments"));
+    expect(postCall?.authorization).toBe("Bearer installation-token");
+    expect(postCall?.body).toEqual({ body: `${marker}\nnew` });
+    expect(calls.some((call) => call.method === "PATCH")).toBe(false);
   });
 });
 

--- a/tests/walkthrough-post.test.ts
+++ b/tests/walkthrough-post.test.ts
@@ -1,0 +1,65 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { postWalkthroughComment } from "../src/walkthrough-post.js";
+
+describe("walkthrough comment posting", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("records a non-fatal error when sticky comment posting fails", async () => {
+    const evidenceDir = mkdtempSync(join(tmpdir(), "walkthrough-post-"));
+    roots.push(evidenceDir);
+
+    const result = await postWalkthroughComment({
+      github: {
+        canPostAsApp: () => true,
+        upsertIssueComment: async () => {
+          throw new Error("GitHub API 502 bad gateway for /issues/comments");
+        }
+      },
+      repo: "owner/repo",
+      pullNumber: 42,
+      evidenceDir,
+      walkthrough: {
+        marker: "<!-- evaos-code-review-bot:walkthrough owner/repo#42 -->",
+        body: "body",
+        postIssueComment: true
+      }
+    });
+
+    expect(result).toEqual({ posted: false, reason: "upsert_failed" });
+    const errorPath = join(evidenceDir, "walkthrough-comment-error.txt");
+    expect(existsSync(errorPath)).toBe(true);
+    expect(readFileSync(errorPath, "utf8")).toContain("GitHub API 502 bad gateway");
+  });
+
+  it("skips sticky comment posting when App credentials are unavailable", async () => {
+    const evidenceDir = mkdtempSync(join(tmpdir(), "walkthrough-post-"));
+    roots.push(evidenceDir);
+
+    const result = await postWalkthroughComment({
+      github: {
+        canPostAsApp: () => false,
+        upsertIssueComment: async () => {
+          throw new Error("should not be called");
+        }
+      },
+      repo: "owner/repo",
+      pullNumber: 42,
+      evidenceDir,
+      walkthrough: {
+        marker: "<!-- evaos-code-review-bot:walkthrough owner/repo#42 -->",
+        body: "body",
+        postIssueComment: true
+      }
+    });
+
+    expect(result).toEqual({ posted: false, reason: "missing_app_credentials" });
+    expect(existsSync(join(evidenceDir, "walkthrough-comment-error.txt"))).toBe(false);
+  });
+});

--- a/tests/walkthrough-post.test.ts
+++ b/tests/walkthrough-post.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { postWalkthroughComment } from "../src/walkthrough-post.js";
+import { postWalkthroughComment, reviewBodyAfterWalkthroughPost } from "../src/walkthrough-post.js";
 
 describe("walkthrough comment posting", () => {
   const roots: string[] = [];
@@ -61,5 +61,33 @@ describe("walkthrough comment posting", () => {
 
     expect(result).toEqual({ posted: false, reason: "missing_app_credentials" });
     expect(existsSync(join(evidenceDir, "walkthrough-comment-error.txt"))).toBe(false);
+  });
+
+  it("falls back to the walkthrough review body when sticky posting is unavailable", () => {
+    expect(
+      reviewBodyAfterWalkthroughPost({
+        summary: "compact summary",
+        walkthrough: {
+          marker: "<!-- evaos-code-review-bot:walkthrough owner/repo#42 -->",
+          body: "walkthrough body",
+          postIssueComment: true
+        },
+        walkthroughComment: { posted: false, reason: "missing_app_credentials" }
+      })
+    ).toBe("walkthrough body");
+  });
+
+  it("keeps the compact review body when sticky posting succeeds", () => {
+    expect(
+      reviewBodyAfterWalkthroughPost({
+        summary: "compact summary",
+        walkthrough: {
+          marker: "<!-- evaos-code-review-bot:walkthrough owner/repo#42 -->",
+          body: "walkthrough body",
+          postIssueComment: true
+        },
+        walkthroughComment: { posted: true, action: "updated", id: 123 }
+      })
+    ).toBe("compact summary");
   });
 });

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -59,8 +59,17 @@ describe("walkthrough comment rendering", () => {
       dropped: [],
       event: "REQUEST_CHANGES"
     });
+    const walkthroughAgain = buildWalkthroughComment({
+      repo: "electricsheephq/WorldOS",
+      pull,
+      files,
+      comments,
+      dropped: [],
+      event: "REQUEST_CHANGES"
+    });
 
-    expect(walkthrough.marker).toBe(`${WALKTHROUGH_MARKER_PREFIX} electricsheephq/WorldOS#42 abc123def456 -->`);
+    expect(walkthroughAgain).toEqual(walkthrough);
+    expect(walkthrough.marker).toBe(`${WALKTHROUGH_MARKER_PREFIX} electricsheephq/WorldOS#42 -->`);
     expect(walkthrough.body).toContain(walkthrough.marker);
     expect(walkthrough.body).toContain("## Walkthrough");
     expect(walkthrough.body).toContain("| `Assets/Scripts/SaveGameController.cs` | modified | +44/-8 | Unity/gameplay state | Elevated: validated P1 finding |");
@@ -92,7 +101,7 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("No validated inline findings.");
     expect(walkthrough.body).toContain("Estimated review effort: 1/5");
     expect(walkthrough.body).not.toContain(secret);
-    expect(walkthrough.body).toContain("[redacted-secret]");
+    expect(walkthrough.body).toMatch(/Docs only \[redacted-secret\]/);
   });
 
   it("keeps the comment-secret checklist passing when secret-like findings were dropped", () => {
@@ -106,5 +115,28 @@ describe("walkthrough comment rendering", () => {
     });
 
     expect(walkthrough.body).toContain("- [x] No secret-like content survived into posted inline comments.");
+  });
+
+  it("caps changed-file rows so posted walkthrough bodies stay bounded", () => {
+    const files: PullFilePatch[] = Array.from({ length: 30 }, (_, index) => ({
+      filename: `src/generated/file-${index}.ts`,
+      status: "modified",
+      additions: 1,
+      deletions: 0,
+      changes: 1
+    }));
+
+    const walkthrough = buildWalkthroughComment({
+      repo: "electricsheephq/WorldOS",
+      pull,
+      files,
+      comments: [],
+      dropped: [],
+      event: "COMMENT"
+    });
+
+    expect(walkthrough.body).toContain("5 additional changed files omitted from this walkthrough.");
+    expect(walkthrough.body).toContain("`src/generated/file-24.ts`");
+    expect(walkthrough.body).not.toContain("`src/generated/file-25.ts`");
   });
 });

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { buildWalkthroughComment, WALKTHROUGH_MARKER_PREFIX } from "../src/walkthrough.js";
+import type { PullFilePatch, PullRequestSummary, ReviewComment } from "../src/types.js";
+
+const pull: PullRequestSummary = {
+  number: 42,
+  title: "Fix Unity save rollback #17",
+  draft: false,
+  body: "Closes #17 and compares with #12.",
+  head: {
+    sha: "abc123def456",
+    ref: "fix/save-rollback",
+    repo: { full_name: "electricsheephq/WorldOS" }
+  },
+  base: {
+    sha: "base123",
+    ref: "main",
+    repo: { full_name: "electricsheephq/WorldOS" }
+  },
+  html_url: "https://github.com/electricsheephq/WorldOS/pull/42",
+  requested_reviewers: [{ login: "reviewer-one" }]
+};
+
+describe("walkthrough comment rendering", () => {
+  it("renders a stable marked walkthrough with files, effort, related refs, and text-only suggestions", () => {
+    const files: PullFilePatch[] = [
+      {
+        filename: "Assets/Scripts/SaveGameController.cs",
+        status: "modified",
+        additions: 44,
+        deletions: 8,
+        changes: 52,
+        patch: "@@ -10,2 +10,3 @@\n Save();\n+RollbackOnFailure();"
+      },
+      {
+        filename: "tests/save-game.test.ts",
+        status: "added",
+        additions: 21,
+        deletions: 0,
+        changes: 21
+      }
+    ];
+    const comments: ReviewComment[] = [
+      {
+        path: "Assets/Scripts/SaveGameController.cs",
+        line: 11,
+        side: "RIGHT",
+        severity: "P1",
+        title: "Rollback can overwrite fresh saves",
+        body: "The rollback path can clobber newer save data."
+      }
+    ];
+
+    const walkthrough = buildWalkthroughComment({
+      repo: "electricsheephq/WorldOS",
+      pull,
+      files,
+      comments,
+      dropped: [],
+      event: "REQUEST_CHANGES"
+    });
+
+    expect(walkthrough.marker).toBe(`${WALKTHROUGH_MARKER_PREFIX} electricsheephq/WorldOS#42 abc123def456 -->`);
+    expect(walkthrough.body).toContain(walkthrough.marker);
+    expect(walkthrough.body).toContain("## Walkthrough");
+    expect(walkthrough.body).toContain("| `Assets/Scripts/SaveGameController.cs` | modified | +44/-8 | Unity/gameplay state | Elevated: validated P1 finding |");
+    expect(walkthrough.body).toContain("Estimated review effort: 2/5");
+    expect(walkthrough.body).toContain("Related issues/PRs: #17, #12");
+    expect(walkthrough.body).toContain("Suggested reviewers: reviewer-one");
+    expect(walkthrough.body).toContain("Suggested labels: bug, unity");
+    expect(walkthrough.body).toContain("Pre-merge checklist");
+    expect(walkthrough.body).toContain("REQUEST_CHANGES");
+  });
+
+  it("handles empty reviews gracefully and redacts secret-like metadata", () => {
+    const secret = ["super", "secret", "token"].join("-");
+    const walkthrough = buildWalkthroughComment({
+      repo: "100yenadmin/evaOS-GUI",
+      pull: {
+        ...pull,
+        number: 497,
+        title: `Docs only ${secret}`,
+        body: "No linked issue.",
+        head: { ...pull.head, sha: "deadbeef" }
+      },
+      files: [{ filename: "docs/review.md", status: "modified", additions: 3, deletions: 1, changes: 4 }],
+      comments: [],
+      dropped: [],
+      event: "COMMENT"
+    });
+
+    expect(walkthrough.body).toContain("No validated inline findings.");
+    expect(walkthrough.body).toContain("Estimated review effort: 1/5");
+    expect(walkthrough.body).not.toContain(secret);
+    expect(walkthrough.body).toContain("[redacted-secret]");
+  });
+
+  it("keeps the comment-secret checklist passing when secret-like findings were dropped", () => {
+    const walkthrough = buildWalkthroughComment({
+      repo: "100yenadmin/evaOS-GUI",
+      pull,
+      files: [{ filename: "scripts/check-public-sensitive-content.js", status: "added", additions: 8, deletions: 0 }],
+      comments: [],
+      dropped: [{ reason: "secret_detected", title: "Redacted scanner self-trip" }],
+      event: "COMMENT"
+    });
+
+    expect(walkthrough.body).toContain("- [x] No secret-like content survived into posted inline comments.");
+  });
+});


### PR DESCRIPTION
## Summary
- adds deterministic CodeRabbit-style walkthrough rendering to review plans
- writes `walkthrough.md` evidence for dry-runs and includes walkthroughs in review bodies when sticky PR comments are disabled
- adds GitHub App marker-based issue-comment upsert support for future sticky walkthrough posting without expanding App permissions

Links #4
Part of #12

## Safety
- default sticky PR comment posting remains disabled via `walkthrough.postIssueComment: false`
- inline defect comments, `REQUEST_CHANGES` policy, diff-line validation, secret redaction, and duplicate head suppression are unchanged
- live launchd daemon remains on merged `main`; this branch was validated in an isolated Lexar worktree

## Validation
- `git diff --check`
- `npm test` -> 13 files / 28 tests passed
- `npm run build`
- real-ZCode dry-runs generated v2 walkthrough packets for `WorldOS#1161` and `evaOS-GUI#497` under `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/sprint1-walkthrough-mvp-v2/2026-07-01/`
- duplicate-head reruns returned `reviewed:0`, `skippedProcessed:1` for both canaries against `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-sprint1-walkthrough-dry-run-v2.sqlite`
- live DB stayed at 2 rows and launchd canary logs continued `reviewed:0`, `skippedProcessed:2`
