### PR TITLE
Sprint 2: add beta release cadence runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Pilot local worker for ZCode/GLM-5.2 pull request reviews.
 
 ```bash
 npm run doctor
+npm run release:status -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expected-head "$(git rev-parse HEAD)"
 npm run run-once -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-dry-run.json --dry-run true --repo electricsheephq/WorldOS --pr 1161
 npm run daemon -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-dry-run.json --dry-run true
 ```
@@ -34,3 +35,9 @@ npm run run-once -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/c
 ```
 
 The worker derives transient ZCode CLI model environment from the existing ZCode app config at `/Volumes/LEXAR/zcode/.zcode/v2/config.json`; it does not copy the Z.ai API key into this repository.
+
+## Live Beta Releases
+
+The live launchd worker is a local beta release surface, not just whatever
+`main` happens to contain. Before promoting a merged PR to the live worker,
+follow [docs/beta-release-runbook.md](docs/beta-release-runbook.md).

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -1,0 +1,121 @@
+# evaOS Code Review Bot Beta Release Runbook
+
+This repository runs a live local beta worker through launchd. Treat each live
+update as a named beta release, not as an informal pull from `main`.
+
+## Release Boundary
+
+The beta release unit is:
+
+- source checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- launchd job: `com.electricsheephq.evaos-code-review-bot`
+- launchd config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+- state DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
+- evidence root: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
+
+The beta release unit does not include expanding monitored repos, GitHub App
+permissions, ZCode tools, auto-merge, approvals, or repair behavior. Those need
+their own tracked issue, PR, dry-run evidence, and explicit promotion gate.
+
+## Cadence
+
+- Cut at most one normal beta promotion per focused sprint lane unless a safety
+  fix requires a patch beta.
+- Prefer small beta releases after each merged PR that changes live reviewer
+  behavior.
+- Keep the live daemon scoped to the current active config until the allowlist
+  issue and App-install gates pass.
+- Do not let launchd run an unrecorded or stale checkout after a merge.
+
+## Promotion Flow
+
+Run from a clean release checkout on `main`:
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git status --short
+git pull --ff-only
+npm test
+npm run build
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+sleep 5
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+If the first `release:status` fails only because launchd is still on the
+previous head before restart, record that as pre-promotion state. The
+post-restart `release:status` must pass before calling the beta promoted.
+
+## Required Gates
+
+- GitHub PR merged to `main` with checks green and no current-head actionable
+  review threads.
+- Release checkout is clean and exactly at the intended source SHA.
+- `npm test` and `npm run build` pass from the release checkout.
+- `release:status` records exact source SHA, branch, config path, launchd job,
+  launchd dry-run mode, state DB row count, and error count.
+- launchd emits a fresh heartbeat after restart.
+- live DB has no unexpected error rows.
+- GitHub tracker issue records source SHA, config path, launchd proof, DB proof,
+  rollback command, and next action.
+
+## Stale Main Guard
+
+Do not promote when any of these are true:
+
+- `release:status` reports `expected_head` failed.
+- `release:status` reports `clean_checkout` failed.
+- launchd is not running the expected config path.
+- state DB has error rows that are not already triaged in GitHub.
+- live config would widen monitored repos without the allowlist gate.
+
+Rows recorded as `status=skipped` with a baseline activation reason are not
+release-blocking errors. They are the expected way to prevent retroactive review
+spam when a live beta starts monitoring existing open PR heads.
+
+## Rollback
+
+Default rollback is to restart the existing launchd job after checking out the
+last known-good merge commit:
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin
+git checkout main
+git reset --hard <last-known-good-merge-sha>
+npm run build
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+```
+
+Use `git reset --hard` only as an explicit rollback operation with the target
+SHA recorded in GitHub. Do not use rollback to bypass code review or to erase
+unrelated dirty work.
+
+To stop the live beta worker entirely:
+
+```bash
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist
+```
+
+## Evidence Packet
+
+For each beta promotion, record:
+
+- GitHub PR and merge commit.
+- `release:status` JSON before and after restart.
+- `npm test` and `npm run build` result.
+- launchd stdout heartbeat lines after restart.
+- live DB row/error count.
+- rollback SHA and command.
+- next monitoring action or heartbeat.
+
+Keep raw evidence under `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
+or session notes. Do not paste secrets, private keys, tokens, cookies, raw
+customer data, or long logs into GitHub comments.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "doctor": "tsx src/cli.ts doctor",
+    "release:status": "tsx src/cli.ts release-status",
     "run-once": "tsx src/cli.ts run-once",
     "daemon": "tsx src/cli.ts daemon"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import { loadConfig } from "./config.js";
 import { formatDaemonLog } from "./daemon-log.js";
 import { GitHubApi } from "./github.js";
+import { collectReleaseStatus } from "./release-status.js";
 import { runOnce } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
 
@@ -44,6 +45,19 @@ async function main(): Promise<void> {
       }
     }, null, 2));
     if (readChecks.some((check) => !check.ok)) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "release-status") {
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      configPath: args.config,
+      expectedHead: args["expected-head"],
+      launchdLabel: args["launchd-label"],
+      statePath: args["state-path"]
+    });
+    console.log(JSON.stringify(status, null, 2));
+    if (!status.ok) process.exitCode = 1;
     return;
   }
 
@@ -121,6 +135,9 @@ interface ParsedArgs {
   config?: string;
   repo?: string;
   pr?: string;
+  "expected-head"?: string;
+  "launchd-label"?: string;
+  "state-path"?: string;
   "dry-run"?: string;
   zcode?: string;
   [key: string]: string | string[] | undefined;

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -1,0 +1,191 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { loadConfig } from "./config.js";
+
+export interface ReleaseRepoStatus {
+  branch: string;
+  head: string;
+  dirtyFiles: string[];
+}
+
+export interface ReleaseLaunchdStatus {
+  label: string;
+  state: "running" | "not_running" | "unknown";
+  pid?: number;
+  configPath?: string;
+  dryRun?: boolean;
+}
+
+export interface ReleaseDatabaseStatus {
+  rowCount: number;
+  errorCount: number;
+  skippedCount?: number;
+}
+
+export interface ReleaseStatusInput {
+  repo: ReleaseRepoStatus;
+  expectedHead?: string;
+  configPath: string;
+  launchd: ReleaseLaunchdStatus;
+  database: ReleaseDatabaseStatus;
+  now?: Date;
+}
+
+export interface ReleaseStatus {
+  ok: boolean;
+  checkedAt: string;
+  releaseUnit: {
+    channel: "local-beta";
+    sourceHead: string;
+    branch: string;
+    configPath: string;
+  };
+  repo: ReleaseRepoStatus;
+  launchd: ReleaseLaunchdStatus;
+  database: ReleaseDatabaseStatus;
+  gates: Array<{ name: string; ok: boolean; detail: string }>;
+  rollback: {
+    restartCommand: string;
+    unloadCommand: string;
+  };
+}
+
+export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
+  const expectedHeadOk = !input.expectedHead || input.repo.head === input.expectedHead;
+  const branchOk = input.repo.branch === "main";
+  const cleanOk = input.repo.dirtyFiles.length === 0;
+  const launchdRunningOk = input.launchd.state === "running";
+  const launchdConfigOk = input.launchd.configPath === input.configPath;
+  const dbOk = input.database.errorCount === 0;
+  const gates = [
+    {
+      name: "expected_head",
+      ok: expectedHeadOk,
+      detail: input.expectedHead ? `${input.repo.head} ${expectedHeadOk ? "==" : "!="} ${input.expectedHead}` : "not configured"
+    },
+    {
+      name: "clean_checkout",
+      ok: cleanOk,
+      detail: cleanOk ? "clean" : `${input.repo.dirtyFiles.length} dirty file(s)`
+    },
+    {
+      name: "release_branch",
+      ok: branchOk,
+      detail: input.repo.branch
+    },
+    {
+      name: "launchd_running",
+      ok: launchdRunningOk,
+      detail: input.launchd.state
+    },
+    {
+      name: "launchd_config",
+      ok: launchdConfigOk,
+      detail: input.launchd.configPath ?? "not detected"
+    },
+    {
+      name: "live_db_no_errors",
+      ok: dbOk,
+      detail: `${input.database.errorCount} blocking error row(s)`
+    }
+  ];
+
+  return {
+    ok: gates.every((gate) => gate.ok),
+    checkedAt: (input.now ?? new Date()).toISOString(),
+    releaseUnit: {
+      channel: "local-beta",
+      sourceHead: input.repo.head,
+      branch: input.repo.branch,
+      configPath: input.configPath
+    },
+    repo: input.repo,
+    launchd: input.launchd,
+    database: input.database,
+    gates,
+    rollback: {
+      restartCommand: `launchctl kickstart -k gui/$(id -u)/${input.launchd.label}`,
+      unloadCommand: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/${input.launchd.label}.plist`
+    }
+  };
+}
+
+export function collectReleaseStatus(input: {
+  cwd: string;
+  configPath?: string;
+  expectedHead?: string;
+  launchdLabel?: string;
+  statePath?: string;
+}): ReleaseStatus {
+  const config = loadConfig(input.configPath);
+  const configPath = input.configPath ?? "(default config)";
+  return buildReleaseStatus({
+    repo: readRepoStatus(input.cwd),
+    expectedHead: input.expectedHead,
+    configPath,
+    launchd: readLaunchdStatus(input.launchdLabel ?? "com.electricsheephq.evaos-code-review-bot"),
+    database: readDatabaseStatus(input.statePath ?? config.statePath)
+  });
+}
+
+function readRepoStatus(cwd: string): ReleaseRepoStatus {
+  return {
+    branch: git(cwd, ["branch", "--show-current"]) || "(detached)",
+    head: git(cwd, ["rev-parse", "HEAD"]),
+    dirtyFiles: git(cwd, ["status", "--short"])
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+  };
+}
+
+function readLaunchdStatus(label: string): ReleaseLaunchdStatus {
+  const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
+  const target = uid === undefined ? label : `gui/${uid}/${label}`;
+  const result = spawnSync("launchctl", ["print", target], { encoding: "utf8" });
+  if (result.status !== 0) return { label, state: "unknown" };
+  const stdout = result.stdout;
+  const state = stdout.match(/\bstate = (\w+)/)?.[1] === "running" ? "running" : "not_running";
+  const pidText = stdout.match(/\bpid = (\d+)/)?.[1];
+  const args = stdout.match(/arguments = \{([\s\S]*?)\n\t\}/)?.[1] ?? "";
+  const configMatch = args.match(/--config\s*\n\s*([^\n]+)/);
+  const dryRunMatch = args.match(/--dry-run\s*\n\s*([^\n]+)/);
+  return {
+    label,
+    state,
+    ...(pidText ? { pid: Number(pidText) } : {}),
+    ...(configMatch?.[1] ? { configPath: configMatch[1].trim() } : {}),
+    ...(dryRunMatch?.[1] ? { dryRun: dryRunMatch[1].trim() !== "false" } : {})
+  };
+}
+
+function readDatabaseStatus(statePath: string): ReleaseDatabaseStatus {
+  if (!existsSync(statePath)) return { rowCount: 0, errorCount: 0 };
+  const db = new DatabaseSync(statePath, { readOnly: true });
+  try {
+    const row = db
+      .prepare(
+        `select count(*) as rowCount,
+                sum(case when status = 'skipped' then 1 else 0 end) as skippedCount,
+                sum(case
+                  when status = 'failed' then 1
+                  when status != 'skipped' and error is not null and error != '' then 1
+                  else 0
+                end) as errorCount
+           from processed_reviews`
+      )
+      .get() as { rowCount?: number; skippedCount?: number | null; errorCount?: number | null };
+    return {
+      rowCount: row.rowCount ?? 0,
+      skippedCount: row.skippedCount ?? 0,
+      errorCount: row.errorCount ?? 0
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1,0 +1,141 @@
+import { mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildReleaseStatus } from "../src/release-status.js";
+
+describe("beta release status", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("fails closed when the live checkout is dirty or not at the expected head", () => {
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "actual-head",
+        dirtyFiles: ["src/config.ts"]
+      },
+      expectedHead: "expected-head",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        pid: 123,
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-live.json",
+        dryRun: false
+      },
+      database: { rowCount: 2, errorCount: 0 },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.gates).toContainEqual({ name: "expected_head", ok: false, detail: "actual-head != expected-head" });
+    expect(status.gates).toContainEqual({ name: "clean_checkout", ok: false, detail: "1 dirty file(s)" });
+    expect(status.rollback.restartCommand).toContain("launchctl kickstart -k");
+  });
+
+  it("reports a passing beta release surface without exposing secrets", () => {
+    const evidenceRoot = mkdtempSync(join(tmpdir(), "release-status-"));
+    roots.push(evidenceRoot);
+    mkdirSync(join(evidenceRoot, "nested"), { recursive: true });
+
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        pid: 456,
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-live.json",
+        dryRun: false
+      },
+      database: { rowCount: 2, errorCount: 0 },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(true);
+    expect(status.releaseUnit).toMatchObject({
+      channel: "local-beta",
+      sourceHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-live.json"
+    });
+    expect(JSON.stringify(status)).not.toMatch(/PRIVATE KEY|ghp_|BEGIN RSA|BEGIN OPENSSH/);
+  });
+
+  it("fails closed when launchd config path cannot be verified", () => {
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running"
+      },
+      database: { rowCount: 2, errorCount: 0 },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.gates).toContainEqual({ name: "launchd_config", ok: false, detail: "not detected" });
+  });
+
+  it("fails closed when promotion is attempted from a non-main branch", () => {
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "sprint/2-release-cadence",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false
+      },
+      database: { rowCount: 2, errorCount: 0 },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.gates).toContainEqual({ name: "release_branch", ok: false, detail: "sprint/2-release-cadence" });
+  });
+
+  it("treats baseline skipped rows as non-blocking database state", () => {
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false
+      },
+      database: { rowCount: 21, errorCount: 0, skippedCount: 16 },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(true);
+    expect(status.gates).toContainEqual({ name: "live_db_no_errors", ok: true, detail: "0 blocking error row(s)" });
+    expect(status.database.skippedCount).toBe(16);
+  });
+});


### PR DESCRIPTION
## Summary
Adds release discipline for the live local beta worker so future Sprint 2 changes are promoted through a named beta release flow instead of informal `main` sync.

## Changes
- Adds `docs/beta-release-runbook.md` with cadence, promotion gates, stale-main guard, rollback, and evidence packet requirements.
- Adds `npm run release:status` / `src/cli.ts release-status` to report exact source SHA, dirty state, launchd config/state, live DB counts, and rollback commands.
- Adds release-status tests covering stale/dirty checkout failure, missing launchd config failure, baseline skipped rows, and secret-safe output.
- Links README to the beta release runbook.

## Validation
- `git diff --check`
- `npm test` (15 files / 38 tests)
- `npm run build`
- Local release-status smoke from feature worktree against live launchd config showed expected failure only on dirty feature checkout while launchd/config/DB gates were healthy.

## Live Runtime Note
Current launchd is running `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`, not the older canary config path. Live DB currently has 5 posted rows and 16 baseline skipped rows; skipped baseline rows are intentionally non-blocking in this PR.

Closes #29.
Links #28.
