### PR TITLE
Guard PR review rollout activation

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -3,6 +3,13 @@
   "pollIntervalMs": 90000,
   "skipDrafts": true,
   "canaryPulls": ["electricsheephq/WorldOS#1161", "100yenadmin/evaOS-GUI#497"],
+  "activation": {
+    "reviewExistingOpenPrsOnActivation": false
+  },
+  "reviewConcurrency": {
+    "maxActiveRuns": 5,
+    "leaseTtlMs": 900000
+  },
   "workRoot": "/Volumes/LEXAR/repos/evaos-code-review-bot/runtime",
   "statePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews.sqlite",
   "evidenceDir": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,8 @@ async function main(): Promise<void> {
       monitoredRepos,
       canaryPulls: config.canaryPulls ?? [],
       repoProfilesEnabled: Boolean(config.repoProfiles),
+      activation: config.activation,
+      reviewConcurrency: config.reviewConcurrency,
       statePath: config.statePath,
       workRoot: config.workRoot,
       zcode: zcode.redacted,

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,13 @@ export interface BotConfig {
   statePath: string;
   evidenceDir: string;
   canaryPulls?: string[];
+  activation: {
+    reviewExistingOpenPrsOnActivation: boolean;
+  };
+  reviewConcurrency: {
+    maxActiveRuns: number;
+    leaseTtlMs: number;
+  };
   walkthrough: {
     enabled: boolean;
     postIssueComment: boolean;
@@ -58,6 +65,13 @@ const DEFAULT_CONFIG: BotConfig = {
   statePath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews.sqlite",
   evidenceDir: "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence",
   canaryPulls: undefined,
+  activation: {
+    reviewExistingOpenPrsOnActivation: false
+  },
+  reviewConcurrency: {
+    maxActiveRuns: 5,
+    leaseTtlMs: 15 * 60_000
+  },
   walkthrough: {
     enabled: true,
     postIssueComment: false

--- a/src/github.ts
+++ b/src/github.ts
@@ -31,9 +31,14 @@ export class GitHubApi {
   }
 
   async listOpenPulls(repo: string): Promise<PullRequestSummary[]> {
-    return this.request<PullRequestSummary[]>(`/repos/${repo}/pulls?state=open&per_page=100`, {
-      token: await this.getReadToken(repo)
-    });
+    const pulls: PullRequestSummary[] = [];
+    for (let page = 1; ; page += 1) {
+      const chunk = await this.request<PullRequestSummary[]>(`/repos/${repo}/pulls?state=open&per_page=100&page=${page}`, {
+        token: await this.getReadToken(repo)
+      });
+      pulls.push(...chunk);
+      if (chunk.length < 100) return pulls;
+    }
   }
 
   async getPull(repo: string, pullNumber: number): Promise<PullRequestSummary> {

--- a/src/review-budget.ts
+++ b/src/review-budget.ts
@@ -1,0 +1,24 @@
+export class ReviewRunBudget {
+  private readonly maxRuns: number;
+  private currentRuns = 0;
+
+  constructor(maxActiveRuns: number) {
+    if (!Number.isInteger(maxActiveRuns)) throw new Error("maxActiveRuns must be an integer");
+    if (maxActiveRuns < 1) throw new Error("maxActiveRuns must be at least 1");
+    this.maxRuns = maxActiveRuns;
+  }
+
+  get activeRuns(): number {
+    return this.currentRuns;
+  }
+
+  tryStart(): boolean {
+    if (this.currentRuns >= this.maxRuns) return false;
+    this.currentRuns += 1;
+    return true;
+  }
+
+  finish(): void {
+    this.currentRuns = Math.max(0, this.currentRuns - 1);
+  }
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,4 +1,5 @@
 import { mkdirSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { dirname } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { ReviewEvent } from "./types.js";
@@ -13,6 +14,11 @@ export interface ProcessedReviewRecord {
   event?: ReviewEvent;
   reviewUrl?: string;
   error?: string;
+}
+
+export interface ReviewRunLease {
+  leaseId: string;
+  expiresAt: string;
 }
 
 export class ReviewStateStore {
@@ -32,6 +38,18 @@ export class ReviewStateStore {
         error text,
         created_at text not null default (datetime('now')),
         primary key (repo, pull_number, head_sha)
+      );
+
+      create table if not exists repo_activation_watermarks (
+        repo text primary key,
+        activated_at text not null,
+        created_at text not null default (datetime('now'))
+      );
+
+      create table if not exists review_run_leases (
+        lease_id text primary key,
+        started_at text not null,
+        expires_at text not null
       );
     `);
   }
@@ -59,6 +77,53 @@ export class ReviewStateStore {
         record.reviewUrl ?? null,
         record.error ?? null
       );
+  }
+
+  hasRepoActivation(repo: string): boolean {
+    const row = this.db.prepare("select 1 from repo_activation_watermarks where repo = ? limit 1").get(repo);
+    return Boolean(row);
+  }
+
+  recordRepoActivation(repo: string, activatedAt = new Date().toISOString()): void {
+    this.db
+      .prepare(
+        `insert or ignore into repo_activation_watermarks
+          (repo, activated_at, created_at)
+         values (?, ?, datetime('now'))`
+      )
+      .run(repo, activatedAt);
+  }
+
+  tryAcquireReviewRunLease(maxActiveRuns: number, leaseTtlMs: number, now = new Date()): ReviewRunLease | undefined {
+    if (!Number.isInteger(maxActiveRuns)) throw new Error("maxActiveRuns must be an integer");
+    if (maxActiveRuns < 1) throw new Error("maxActiveRuns must be at least 1");
+    if (!Number.isInteger(leaseTtlMs)) throw new Error("leaseTtlMs must be an integer");
+    if (leaseTtlMs < 1) throw new Error("leaseTtlMs must be at least 1");
+
+    const leaseId = randomUUID();
+    const startedAt = now.toISOString();
+    const expiresAt = new Date(now.getTime() + leaseTtlMs).toISOString();
+    this.db.exec("begin immediate");
+    try {
+      this.db.prepare("delete from review_run_leases where expires_at <= ?").run(startedAt);
+      const row = this.db.prepare("select count(*) as count from review_run_leases").get() as { count: number };
+      if (row.count >= maxActiveRuns) {
+        this.db.exec("commit");
+        return undefined;
+      }
+      this.db
+        .prepare("insert into review_run_leases (lease_id, started_at, expires_at) values (?, ?, ?)")
+        .run(leaseId, startedAt, expiresAt);
+      this.db.exec("commit");
+      return { leaseId, expiresAt };
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
+  releaseReviewRunLease(leaseId: string): void {
+    this.db.prepare("delete from review_run_leases where lease_id = ?").run(leaseId);
   }
 
   close(): void {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6,8 +6,9 @@ import { decideReviewEvent, normalizeFindingsForReview } from "./findings.js";
 import { assertGitClean, preparePullWorktree } from "./git.js";
 import { GitHubApi } from "./github.js";
 import { filterPullFilesForProfile, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
+import { ReviewRunBudget } from "./review-budget.js";
 import { redactSecrets } from "./secrets.js";
-import { ReviewStateStore } from "./state.js";
+import { ReviewStateStore, type ReviewRunLease } from "./state.js";
 import { buildWalkthroughComment } from "./walkthrough.js";
 import { postWalkthroughComment, reviewBodyAfterWalkthroughPost } from "./walkthrough-post.js";
 import { buildReviewPrompt, runZCodeReview } from "./zcode.js";
@@ -29,15 +30,24 @@ export interface RunOnceResult {
   skippedCanary: number;
   skippedPolicy: number;
   skippedProcessed: number;
+  skippedCapacity: number;
+  baselinedExisting: number;
   policySkips: { repo: string; reason: string }[];
 }
 
-type ReviewPullResult = "reviewed" | "skipped_draft" | "skipped_canary" | "skipped_policy" | "skipped_processed";
+type ReviewPullResult =
+  | "reviewed"
+  | "skipped_draft"
+  | "skipped_canary"
+  | "skipped_policy"
+  | "skipped_processed"
+  | "skipped_capacity";
 
 export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
   const config = loadConfig(options.configPath);
   const github = new GitHubApi(config.github);
   const state = new ReviewStateStore(config.statePath);
+  const budget = new ReviewRunBudget(config.reviewConcurrency.maxActiveRuns);
   const result: RunOnceResult = {
     reposScanned: 0,
     pullsSeen: 0,
@@ -46,6 +56,8 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
     skippedCanary: 0,
     skippedPolicy: 0,
     skippedProcessed: 0,
+    skippedCapacity: 0,
+    baselinedExisting: 0,
     policySkips: []
   };
   try {
@@ -62,6 +74,14 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
         ? [await github.getPull(repo, options.pullNumber)]
         : await github.listOpenPulls(repo);
       result.pullsSeen += pulls.length;
+      const activation = activateRepoForNewOnlyReview({
+        config,
+        state,
+        repo,
+        pulls,
+        scopedPullNumber: options.pullNumber
+      });
+      result.baselinedExisting += activation.baselined;
       for (const pull of pulls) {
         const status = await reviewPull({
           config,
@@ -70,13 +90,15 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
           repo,
           pull,
           dryRun: options.dryRun,
-          useZCode: options.useZCode ?? true
+          useZCode: options.useZCode ?? true,
+          budget
         });
         if (status === "reviewed") result.reviewed += 1;
         if (status === "skipped_draft") result.skippedDraft += 1;
         if (status === "skipped_canary") result.skippedCanary += 1;
         if (status === "skipped_policy") result.skippedPolicy += 1;
         if (status === "skipped_processed") result.skippedProcessed += 1;
+        if (status === "skipped_capacity") result.skippedCapacity += 1;
       }
     }
     return result;
@@ -93,6 +115,7 @@ export async function reviewPull(input: {
   pull: PullRequestSummary;
   dryRun: boolean;
   useZCode: boolean;
+  budget?: ReviewRunBudget;
 }): Promise<ReviewPullResult> {
   const { config, github, state, repo, pull } = input;
   const repoPolicy = resolveRepoProfile(config, repo);
@@ -100,103 +123,150 @@ export async function reviewPull(input: {
   if (config.skipDrafts && pull.draft) return "skipped_draft";
   if (!isCanaryAllowed(config, repo, pull.number)) return "skipped_canary";
   if (state.hasProcessed(repo, pull.number, pull.head.sha)) return "skipped_processed";
+  const budget = input.budget ?? new ReviewRunBudget(config.reviewConcurrency.maxActiveRuns);
+  if (!budget.tryStart()) return "skipped_capacity";
+  let lease: ReviewRunLease | undefined;
 
-  const evidenceDir = join(config.evidenceDir, localDateFolder(), repo.replace("/", "__"), `pr-${pull.number}`, pull.head.sha);
-  mkdirSync(evidenceDir, { recursive: true });
+  try {
+    lease = state.tryAcquireReviewRunLease(config.reviewConcurrency.maxActiveRuns, config.reviewConcurrency.leaseTtlMs);
+    if (!lease) return "skipped_capacity";
 
-  const files = await github.listPullFiles(repo, pull.number);
-  const reviewFiles = filterPullFilesForProfile(files, repoPolicy.profile);
-  const worktree = preparePullWorktree({
-    repo,
-    pullNumber: pull.number,
-    expectedHeadSha: pull.head.sha,
-    workRoot: config.workRoot
-  });
+    const evidenceDir = join(config.evidenceDir, localDateFolder(), repo.replace("/", "__"), `pr-${pull.number}`, pull.head.sha);
+    mkdirSync(evidenceDir, { recursive: true });
 
-  const prompt = buildReviewPrompt({
-    repo,
-    pull,
-    files: reviewFiles,
-    repoProfile: repoPolicy.profile,
-    maxPatchBytes: config.zcode.maxPatchBytes
-  });
-  writeFileSync(join(evidenceDir, "repo-profile.json"), `${JSON.stringify(repoPolicy.profile, null, 2)}\n`);
-  writeFileSync(join(evidenceDir, "review-prompt.txt"), redactSecrets(prompt));
+    const files = await github.listPullFiles(repo, pull.number);
+    const reviewFiles = filterPullFilesForProfile(files, repoPolicy.profile);
+    const worktree = preparePullWorktree({
+      repo,
+      pullNumber: pull.number,
+      expectedHeadSha: pull.head.sha,
+      workRoot: config.workRoot
+    });
 
-  const zcodeResult = input.useZCode
-    ? runZCodeReview({
-        cwd: worktree.path,
-        prompt,
-        cliPath: config.zcode.cliPath,
-        appConfigPath: config.zcode.appConfigPath,
-        model: config.zcode.model,
-        providerId: config.zcode.providerId,
-        evidenceDir,
-        timeoutMs: config.zcode.timeoutMs,
-        retryMaxRetries: config.zcode.retryMaxRetries
-      })
-    : { findings: [], droppedFromSchema: [], rawResponse: "{\"findings\":[]}" };
+    const prompt = buildReviewPrompt({
+      repo,
+      pull,
+      files: reviewFiles,
+      repoProfile: repoPolicy.profile,
+      maxPatchBytes: config.zcode.maxPatchBytes
+    });
+    writeFileSync(join(evidenceDir, "repo-profile.json"), `${JSON.stringify(repoPolicy.profile, null, 2)}\n`);
+    writeFileSync(join(evidenceDir, "review-prompt.txt"), redactSecrets(prompt));
 
-  assertGitClean(worktree.path);
+    const zcodeResult = input.useZCode
+      ? runZCodeReview({
+          cwd: worktree.path,
+          prompt,
+          cliPath: config.zcode.cliPath,
+          appConfigPath: config.zcode.appConfigPath,
+          model: config.zcode.model,
+          providerId: config.zcode.providerId,
+          evidenceDir,
+          timeoutMs: config.zcode.timeoutMs,
+          retryMaxRetries: config.zcode.retryMaxRetries
+        })
+      : { findings: [], droppedFromSchema: [], rawResponse: "{\"findings\":[]}" };
 
-  const located = validateFindingLocations(zcodeResult.findings, reviewFiles);
-  const normalized = normalizeFindingsForReview(located.valid, { maxInlineComments: 25 });
-  const comments = normalized.comments;
-  const dropped = sanitizeDroppedFindings([...zcodeResult.droppedFromSchema, ...located.dropped, ...normalized.dropped]);
-  const event = decideReviewEvent(comments);
-  const summary = buildSummary({ repo, pull, comments, dropped, dryRun: input.dryRun });
-  const walkthrough = config.walkthrough.enabled
-    ? buildWalkthroughComment({
-        repo,
-        pull,
-        files,
-        comments,
-        dropped,
-        event,
-        postIssueComment: config.walkthrough.postIssueComment
-      })
-    : undefined;
-  const plan: ReviewPlan = {
-    event,
-    comments,
-    dropped,
-    summary,
-    ...(walkthrough ? { walkthrough } : {})
-  };
+    assertGitClean(worktree.path);
 
-  if (walkthrough) writeFileSync(join(evidenceDir, "walkthrough.md"), walkthrough.body);
-  writeFileSync(join(evidenceDir, "review-plan.json"), `${JSON.stringify(plan, null, 2)}\n`);
+    const located = validateFindingLocations(zcodeResult.findings, reviewFiles);
+    const normalized = normalizeFindingsForReview(located.valid, { maxInlineComments: 25 });
+    const comments = normalized.comments;
+    const dropped = sanitizeDroppedFindings([...zcodeResult.droppedFromSchema, ...located.dropped, ...normalized.dropped]);
+    const event = decideReviewEvent(comments);
+    const summary = buildSummary({ repo, pull, comments, dropped, dryRun: input.dryRun });
+    const walkthrough = config.walkthrough.enabled
+      ? buildWalkthroughComment({
+          repo,
+          pull,
+          files: reviewFiles,
+          comments,
+          dropped,
+          event,
+          postIssueComment: config.walkthrough.postIssueComment
+        })
+      : undefined;
+    const plan: ReviewPlan = {
+      event,
+      comments,
+      dropped,
+      summary,
+      ...(walkthrough ? { walkthrough } : {})
+    };
 
-  if (input.dryRun) {
-    state.recordProcessed({ repo, pullNumber: pull.number, headSha: pull.head.sha, status: "dry_run", event });
+    if (walkthrough) writeFileSync(join(evidenceDir, "walkthrough.md"), walkthrough.body);
+    writeFileSync(join(evidenceDir, "review-plan.json"), `${JSON.stringify(plan, null, 2)}\n`);
+
+    if (input.dryRun) {
+      state.recordProcessed({ repo, pullNumber: pull.number, headSha: pull.head.sha, status: "dry_run", event });
+      return "reviewed";
+    }
+
+    const reviewGithub = new GitHubApi(config.github);
+    plan.walkthroughComment = await postWalkthroughComment({
+      github: reviewGithub,
+      repo,
+      pullNumber: pull.number,
+      evidenceDir,
+      walkthrough: plan.walkthrough
+    });
+    writeFileSync(join(evidenceDir, "review-plan.json"), `${JSON.stringify(plan, null, 2)}\n`);
+    const review = await reviewGithub.createReview({
+      repo,
+      pullNumber: pull.number,
+      event,
+      body: reviewBodyAfterWalkthroughPost(plan),
+      comments
+    });
+    state.recordProcessed({
+      repo,
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "posted",
+      event,
+      reviewUrl: review.html_url
+    });
     return "reviewed";
+  } finally {
+    if (lease) state.releaseReviewRunLease(lease.leaseId);
+    budget.finish();
+  }
+}
+
+export function activateRepoForNewOnlyReview(input: {
+  config: Pick<BotConfig, "activation" | "canaryPulls" | "skipDrafts">;
+  state: Pick<ReviewStateStore, "hasProcessed" | "hasRepoActivation" | "recordRepoActivation" | "recordProcessed">;
+  repo: string;
+  pulls: PullRequestSummary[];
+  scopedPullNumber?: number;
+  now?: Date;
+}): { activated: boolean; baselined: number } {
+  const { config, state, repo, pulls } = input;
+  if (input.scopedPullNumber !== undefined) return { activated: false, baselined: 0 };
+  const repoHasCanaryOverride = (config.canaryPulls ?? []).some((entry) => entry.startsWith(`${repo}#`));
+  if (repoHasCanaryOverride) return { activated: false, baselined: 0 };
+  if (state.hasRepoActivation(repo)) return { activated: false, baselined: 0 };
+
+  if (config.activation.reviewExistingOpenPrsOnActivation) {
+    state.recordRepoActivation(repo, (input.now ?? new Date()).toISOString());
+    return { activated: true, baselined: 0 };
   }
 
-  const reviewGithub = new GitHubApi(config.github);
-  plan.walkthroughComment = await postWalkthroughComment({
-    github: reviewGithub,
-    repo,
-    pullNumber: pull.number,
-    evidenceDir,
-    walkthrough: plan.walkthrough
-  });
-  writeFileSync(join(evidenceDir, "review-plan.json"), `${JSON.stringify(plan, null, 2)}\n`);
-  const review = await reviewGithub.createReview({
-    repo,
-    pullNumber: pull.number,
-    event,
-    body: reviewBodyAfterWalkthroughPost(plan),
-    comments
-  });
-  state.recordProcessed({
-    repo,
-    pullNumber: pull.number,
-    headSha: pull.head.sha,
-    status: "posted",
-    event,
-    reviewUrl: review.html_url
-  });
-  return "reviewed";
+  let baselined = 0;
+  for (const pull of pulls) {
+    if (config.skipDrafts && pull.draft) continue;
+    if (state.hasProcessed(repo, pull.number, pull.head.sha)) continue;
+    state.recordProcessed({
+      repo,
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+    baselined += 1;
+  }
+  state.recordRepoActivation(repo, (input.now ?? new Date()).toISOString());
+  return { activated: true, baselined };
 }
 
 export function isCanaryAllowed(config: Pick<BotConfig, "canaryPulls">, repo: string, pullNumber: number): boolean {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -32,7 +32,7 @@ describe("GitHub App read authentication", () => {
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
       }
-      if (String(url).endsWith("/repos/owner/repo/pulls?state=open&per_page=100")) {
+      if (String(url).endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=1")) {
         return jsonResponse([]);
       }
       return jsonResponse({ message: "unexpected" }, 404);
@@ -41,9 +41,42 @@ describe("GitHub App read authentication", () => {
     const github = new GitHubApi({ appId: "4184532", privateKeyPath, token: "fallback-token" });
     await github.listOpenPulls("owner/repo");
 
-    const readCall = calls.find((call) => call.url.endsWith("/repos/owner/repo/pulls?state=open&per_page=100"));
+    const readCall = calls.find((call) => call.url.endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=1"));
     expect(readCall?.authorization).toBe("Bearer installation-token");
     expect(readCall?.authorization).not.toBe("Bearer fallback-token");
+  });
+
+  it("paginates open PR reads so activation can baseline every listed open head", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-read-pages-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      calls.push(String(url));
+      if (String(url).endsWith("/repos/owner/repo/installation")) {
+        return jsonResponse({ id: 123 });
+      }
+      if (String(url).endsWith("/app/installations/123/access_tokens")) {
+        return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      }
+      if (String(url).endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=1")) {
+        return jsonResponse(Array.from({ length: 100 }, (_, index) => pull(index + 1)));
+      }
+      if (String(url).endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=2")) {
+        return jsonResponse([pull(101)]);
+      }
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+    const pulls = await github.listOpenPulls("owner/repo");
+
+    expect(pulls).toHaveLength(101);
+    expect(calls.some((url) => url.endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=1"))).toBe(true);
+    expect(calls.some((url) => url.endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=2"))).toBe(true);
   });
 
   it("updates an existing marked PR walkthrough comment with the App token", async () => {
@@ -163,4 +196,24 @@ function jsonResponse(body: unknown, status = 200): Response {
     status,
     headers: { "Content-Type": "application/json" }
   });
+}
+
+function pull(number: number) {
+  return {
+    number,
+    title: `PR ${number}`,
+    draft: false,
+    head: {
+      sha: `head-${number}`,
+      ref: `pr-${number}`
+    },
+    base: {
+      sha: "base",
+      ref: "main",
+      repo: {
+        full_name: "owner/repo"
+      }
+    },
+    html_url: `https://github.test/owner/repo/pull/${number}`
+  };
 }

--- a/tests/review-activation.test.ts
+++ b/tests/review-activation.test.ts
@@ -1,0 +1,167 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ReviewStateStore } from "../src/state.js";
+import type { PullRequestSummary } from "../src/types.js";
+import { activateRepoForNewOnlyReview } from "../src/worker.js";
+
+describe("new-only repo activation", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("baselines existing open PR heads only on first repo activation", () => {
+    const store = createStore(roots);
+    const repo = "electricsheephq/WorldOS";
+    const pulls = [pull(1161, "old-head"), pull(1185, "old-draft-head", true)];
+
+    const first = activateRepoForNewOnlyReview({
+      config: newOnlyConfig(),
+      state: store,
+      repo,
+      pulls,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    const second = activateRepoForNewOnlyReview({
+      config: newOnlyConfig(),
+      state: store,
+      repo,
+      pulls,
+      now: new Date("2026-07-01T00:01:00.000Z")
+    });
+
+    expect(first).toEqual({ activated: true, baselined: 1 });
+    expect(second).toEqual({ activated: false, baselined: 0 });
+    expect(store.hasRepoActivation(repo)).toBe(true);
+    expect(store.hasProcessed(repo, 1161, "old-head")).toBe(true);
+    expect(store.hasProcessed(repo, 1185, "old-draft-head")).toBe(false);
+    expect(store.hasProcessed(repo, 1190, "future-head")).toBe(false);
+    store.close();
+  });
+
+  it("does not baseline canary or explicit PR runs", () => {
+    const store = createStore(roots);
+    const repo = "100yenadmin/evaOS-GUI";
+    const pulls = [pull(497, "canary-head")];
+
+    const canary = activateRepoForNewOnlyReview({
+      config: newOnlyConfig({ canaryPulls: [`${repo}#497`] }),
+      state: store,
+      repo,
+      pulls
+    });
+    const explicit = activateRepoForNewOnlyReview({
+      config: newOnlyConfig(),
+      state: store,
+      repo,
+      pulls,
+      scopedPullNumber: 497
+    });
+
+    expect(canary).toEqual({ activated: false, baselined: 0 });
+    expect(explicit).toEqual({ activated: false, baselined: 0 });
+    expect(store.hasRepoActivation(repo)).toBe(false);
+    expect(store.hasProcessed(repo, 497, "canary-head")).toBe(false);
+    store.close();
+  });
+
+  it("scopes canary activation bypass to the current repository", () => {
+    const store = createStore(roots);
+    const repo = "100yenadmin/Lossless-Codex-Orchestrator-LCO";
+
+    const result = activateRepoForNewOnlyReview({
+      config: newOnlyConfig({ canaryPulls: ["electricsheephq/WorldOS#1161"] }),
+      state: store,
+      repo,
+      pulls: [pull(64, "existing-head")]
+    });
+
+    expect(result).toEqual({ activated: true, baselined: 1 });
+    expect(store.hasRepoActivation(repo)).toBe(true);
+    expect(store.hasProcessed(repo, 64, "existing-head")).toBe(true);
+    store.close();
+  });
+
+  it("does not overwrite existing processed review rows during activation", () => {
+    const records: unknown[] = [];
+    const result = activateRepoForNewOnlyReview({
+      config: newOnlyConfig(),
+      state: {
+        hasProcessed: (_repo: string, pullNumber: number) => pullNumber === 1161,
+        hasRepoActivation: () => false,
+        recordProcessed: (record: unknown) => records.push(record),
+        recordRepoActivation: () => undefined
+      },
+      repo: "electricsheephq/WorldOS",
+      pulls: [pull(1161, "already-reviewed"), pull(1190, "old-unreviewed")]
+    });
+
+    expect(result).toEqual({ activated: true, baselined: 1 });
+    expect(records).toEqual([
+      expect.objectContaining({
+        pullNumber: 1190,
+        headSha: "old-unreviewed",
+        status: "skipped"
+      })
+    ]);
+  });
+
+  it("can intentionally review existing open PR heads when configured", () => {
+    const store = createStore(roots);
+    const repo = "100yenadmin/Lossless-Codex-Orchestrator-LCO";
+
+    const result = activateRepoForNewOnlyReview({
+      config: newOnlyConfig({ reviewExistingOpenPrsOnActivation: true }),
+      state: store,
+      repo,
+      pulls: [pull(64, "existing-head")]
+    });
+
+    expect(result).toEqual({ activated: true, baselined: 0 });
+    expect(store.hasRepoActivation(repo)).toBe(true);
+    expect(store.hasProcessed(repo, 64, "existing-head")).toBe(false);
+    store.close();
+  });
+});
+
+function createStore(roots: string[]): ReviewStateStore {
+  const root = mkdtempSync(join(tmpdir(), "evaos-review-activation-"));
+  roots.push(root);
+  return new ReviewStateStore(join(root, "state.sqlite"));
+}
+
+function newOnlyConfig(overrides: {
+  canaryPulls?: string[];
+  reviewExistingOpenPrsOnActivation?: boolean;
+} = {}) {
+  return {
+    skipDrafts: true,
+    canaryPulls: overrides.canaryPulls,
+    activation: {
+      reviewExistingOpenPrsOnActivation: overrides.reviewExistingOpenPrsOnActivation ?? false
+    }
+  };
+}
+
+function pull(number: number, sha: string, draft = false): PullRequestSummary {
+  return {
+    number,
+    title: `PR ${number}`,
+    draft,
+    head: {
+      sha,
+      ref: `pr-${number}`
+    },
+    base: {
+      sha: "base",
+      ref: "main",
+      repo: {
+        full_name: "owner/repo"
+      }
+    },
+    html_url: `https://github.test/owner/repo/pull/${number}`
+  };
+}

--- a/tests/review-budget.test.ts
+++ b/tests/review-budget.test.ts
@@ -1,0 +1,154 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { BotConfig } from "../src/config.js";
+import type { GitHubApi } from "../src/github.js";
+import { ReviewRunBudget } from "../src/review-budget.js";
+import { ReviewStateStore } from "../src/state.js";
+import type { PullRequestSummary } from "../src/types.js";
+import { reviewPull } from "../src/worker.js";
+
+describe("review run budget", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("caps concurrent active review runs", () => {
+    const budget = new ReviewRunBudget(5);
+
+    expect(Array.from({ length: 5 }, () => budget.tryStart())).toEqual([true, true, true, true, true]);
+    expect(budget.tryStart()).toBe(false);
+    expect(budget.activeRuns).toBe(5);
+
+    budget.finish();
+
+    expect(budget.activeRuns).toBe(4);
+    expect(budget.tryStart()).toBe(true);
+    expect(budget.activeRuns).toBe(5);
+  });
+
+  it("rejects invalid max active run settings", () => {
+    expect(() => new ReviewRunBudget(0)).toThrow("maxActiveRuns must be at least 1");
+    expect(() => new ReviewRunBudget(5.5)).toThrow("maxActiveRuns must be an integer");
+  });
+
+  it("does not let activeRuns go negative on extra finish calls", () => {
+    const budget = new ReviewRunBudget(2);
+
+    budget.finish();
+
+    expect(budget.activeRuns).toBe(0);
+    expect(budget.tryStart()).toBe(true);
+    expect(budget.tryStart()).toBe(true);
+    expect(budget.tryStart()).toBe(false);
+  });
+
+  it("prevents worker review work when the active run cap is reached", async () => {
+    const budget = new ReviewRunBudget(1);
+    expect(budget.tryStart()).toBe(true);
+
+    const status = await reviewPull({
+      config: minimalConfig(),
+      github: {} as GitHubApi,
+      state: {
+        hasProcessed: () => false
+      } as unknown as ReviewStateStore,
+      repo: "electricsheephq/WorldOS",
+      pull: pull(1190, "new-head"),
+      dryRun: true,
+      useZCode: false,
+      budget
+    });
+
+    expect(status).toBe("skipped_capacity");
+    expect(budget.activeRuns).toBe(1);
+  });
+
+  it("uses SQLite leases to cap overlapping worker entrypoints", async () => {
+    const store = createStore(roots);
+    const lease = store.tryAcquireReviewRunLease(1, 60_000, new Date("2026-07-01T00:00:00.000Z"));
+    expect(lease).toBeDefined();
+
+    const budget = new ReviewRunBudget(5);
+    const status = await reviewPull({
+      config: {
+        ...minimalConfig(),
+        reviewConcurrency: {
+          maxActiveRuns: 1,
+          leaseTtlMs: 60_000
+        }
+      },
+      github: {} as GitHubApi,
+      state: store,
+      repo: "electricsheephq/WorldOS",
+      pull: pull(1190, "new-head"),
+      dryRun: true,
+      useZCode: false,
+      budget
+    });
+
+    expect(status).toBe("skipped_capacity");
+    expect(budget.activeRuns).toBe(0);
+    store.close();
+  });
+});
+
+function createStore(roots: string[]): ReviewStateStore {
+  const root = mkdtempSync(join(tmpdir(), "evaos-review-budget-"));
+  roots.push(root);
+  return new ReviewStateStore(join(root, "state.sqlite"));
+}
+
+function minimalConfig(): BotConfig {
+  return {
+    pilotRepos: ["electricsheephq/WorldOS"],
+    pollIntervalMs: 60_000,
+    skipDrafts: true,
+    workRoot: "/unused",
+    statePath: "/unused/state.sqlite",
+    evidenceDir: "/unused/evidence",
+    activation: {
+      reviewExistingOpenPrsOnActivation: false
+    },
+    reviewConcurrency: {
+      maxActiveRuns: 5,
+      leaseTtlMs: 60_000
+    },
+    walkthrough: {
+      enabled: false,
+      postIssueComment: false
+    },
+    zcode: {
+      cliPath: "/unused/zcode.cjs",
+      appConfigPath: "/unused/config.json",
+      model: "GLM-5.2",
+      timeoutMs: 1,
+      maxPatchBytes: 1,
+      retryMaxRetries: 0
+    },
+    github: {}
+  };
+}
+
+function pull(number: number, sha: string): PullRequestSummary {
+  return {
+    number,
+    title: `PR ${number}`,
+    draft: false,
+    head: {
+      sha,
+      ref: `pr-${number}`
+    },
+    base: {
+      sha: "base",
+      ref: "main",
+      repo: {
+        full_name: "owner/repo"
+      }
+    },
+    html_url: `https://github.test/owner/repo/pull/${number}`
+  };
+}

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -29,4 +29,42 @@ describe("review state store", () => {
     expect(store.hasProcessed("electricsheephq/WorldOS", 1205, "def456")).toBe(false);
     store.close();
   });
+
+  it("stores one activation watermark per repository", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-state-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    expect(store.hasRepoActivation("electricsheephq/WorldOS")).toBe(false);
+    store.recordRepoActivation("electricsheephq/WorldOS", "2026-07-01T00:00:00.000Z");
+
+    expect(store.hasRepoActivation("electricsheephq/WorldOS")).toBe(true);
+    expect(store.hasRepoActivation("100yenadmin/evaOS-GUI")).toBe(false);
+    store.close();
+  });
+
+  it("caps active review leases and releases them", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-state-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    const first = store.tryAcquireReviewRunLease(1, 60_000, new Date("2026-07-01T00:00:00.000Z"));
+    const blocked = store.tryAcquireReviewRunLease(1, 60_000, new Date("2026-07-01T00:00:01.000Z"));
+
+    expect(first).toBeDefined();
+    expect(blocked).toBeUndefined();
+    store.releaseReviewRunLease(first!.leaseId);
+    expect(store.tryAcquireReviewRunLease(1, 60_000, new Date("2026-07-01T00:00:02.000Z"))).toBeDefined();
+    store.close();
+  });
+
+  it("expires stale active review leases", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-state-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    expect(store.tryAcquireReviewRunLease(1, 1_000, new Date("2026-07-01T00:00:00.000Z"))).toBeDefined();
+    expect(store.tryAcquireReviewRunLease(1, 1_000, new Date("2026-07-01T00:00:02.000Z"))).toBeDefined();
+    store.close();
+  });
 });


### PR DESCRIPTION
## Summary
- add repo activation watermarks so first rollout baselines existing open non-draft PR heads as skipped instead of reviewing backlog
- default to new-only activation while preserving an explicit backfill escape hatch
- add a SQLite-backed 5-active-run review lease plus local budget guard, and expose activation/concurrency in doctor output
- paginate open PR reads so activation does not miss repositories with more than 100 open PRs

Closes #30.
Closes #31.

## Validation
- `npx vitest run tests/state.test.ts tests/review-activation.test.ts tests/review-budget.test.ts`
- `npx vitest run tests/github-app-read.test.ts tests/review-activation.test.ts tests/review-budget.test.ts tests/state.test.ts`
- `npm run build`
- `npm test` (18 files / 59 tests)

## Rollout notes
- Existing live DB rows stay valid; activation baselining skips already-processed rows and avoids rewriting posted/dry-run review history.
- Draft PR heads are not baselined when `skipDrafts` is enabled; when they become ready, they can be reviewed as a readiness event.
- Keep App installation limited to WorldOS/evaOS-GUI until GitHub App permissions are installed on LCO.