### PR TITLE
Sprint 2: add repo profile policy registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Pilot local worker for ZCode/GLM-5.2 pull request reviews.
 - Caps ZCode prompt patch bytes and kills long ZCode runs with `zcode.timeoutMs`.
 - Installs a temporary per-worktree ZCode policy that allows read-only file tools, disables Bash/mutation/subagents, then restores/removes it before the clean check.
 - Sets `ZCODE_MODEL_RETRY_MAX_RETRIES=0` by default so provider rate limits fail fast instead of multiplying requests.
+- Resolves repo profiles before review; once profiles are configured, unknown or disabled repos skip closed before GitHub PR fetches.
 
 ## Commands
 
@@ -41,3 +42,10 @@ The worker derives transient ZCode CLI model environment from the existing ZCode
 The live launchd worker is a local beta release surface, not just whatever
 `main` happens to contain. Before promoting a merged PR to the live worker,
 follow [docs/beta-release-runbook.md](docs/beta-release-runbook.md).
+
+## Repo Profiles
+
+Use [docs/repo-profiles.md](docs/repo-profiles.md) to add repo-specific review
+guidance, risky paths, proof expectations, and path filters. Profiles are
+prompt/config metadata only; they do not expand GitHub permissions, live
+monitoring, ZCode tools, approvals, or repair behavior by themselves.

--- a/config.example.json
+++ b/config.example.json
@@ -6,6 +6,51 @@
   "workRoot": "/Volumes/LEXAR/repos/evaos-code-review-bot/runtime",
   "statePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews.sqlite",
   "evidenceDir": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence",
+  "repoProfiles": {
+    "enableOrgFallbacks": false,
+    "repos": {
+      "electricsheephq/WorldOS": {
+        "displayName": "WorldOS Unity",
+        "defaultBranch": "main",
+        "reviewProfile": "assertive",
+        "promptNote": "Prioritize Unity scene, save-state, gameplay, release-regression, and data-loss risks.",
+        "pathFilters": ["Assets/**", "Packages/**", "ProjectSettings/**", "src/**", "tests/**", "!Library/**"],
+        "riskyPaths": ["Assets/**", "ProjectSettings/**", "Packages/manifest.json"],
+        "proofExpectations": ["Mention Unity editor/play-mode or focused smoke evidence when relevant."],
+        "validationHints": ["Prefer correctness, persistence, CI, and release findings over style-only feedback."],
+        "readinessHints": ["Scene, save, build, or package changes need explicit rollback and smoke notes."]
+      },
+      "100yenadmin/evaOS-GUI": {
+        "displayName": "evaOS Workbench",
+        "defaultBranch": "main",
+        "reviewProfile": "assertive",
+        "promptNote": "Prioritize Electron/Workbench runtime regressions, packaged-app resource shape, bridge control, and macOS permission identity risk.",
+        "pathFilters": ["src/**", "apps/**", "scripts/**", "package.json", "package-lock.json", "!dist/**"],
+        "riskyPaths": ["scripts/**", "apps/eva-desktop-mac/**", "package.json"],
+        "proofExpectations": ["Mention focused app smoke, packaged resource checks, or CI artifact proof when relevant."],
+        "validationHints": ["Do not ask for broad local suites when remote CI or fast-smoke proof is the right gate."]
+      },
+      "electricsheephq/evaos-code-review-bot": {
+        "enabled": false,
+        "displayName": "evaOS Code Review Bot",
+        "defaultBranch": "main",
+        "reviewProfile": "assertive",
+        "promptNote": "Self-monitoring profile for dry-run/eval only until the App install and live allowlist gates are approved.",
+        "pathFilters": ["src/**", "tests/**", "docs/**", "config.example.json", "package.json", "package-lock.json"],
+        "riskyPaths": ["src/github.ts", "src/state.ts", "src/worker.ts", "src/zcode.ts"],
+        "proofExpectations": ["Require focused tests, TypeScript build, duplicate-suppression proof, and release-status proof before live promotion."],
+        "readinessHints": ["Do not expand live monitoring from this example profile alone."]
+      }
+    },
+    "orgFallbacks": {
+      "electricsheephq": {
+        "displayName": "Electric Sheep conservative fallback",
+        "reviewProfile": "assertive",
+        "promptNote": "Conservative fallback profile for explicitly enabled dry-run scans only.",
+        "validationHints": ["Fallback profiles must not expand runtime permissions or live monitoring by themselves."]
+      }
+    }
+  },
   "zcode": {
     "cliPath": "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
     "appConfigPath": "/Volumes/LEXAR/zcode/.zcode/v2/config.json",

--- a/docs/repo-profiles.md
+++ b/docs/repo-profiles.md
@@ -1,0 +1,72 @@
+# Repo Profiles
+
+Repo profiles make review behavior explicit per repository before the bot scales
+beyond the original pilot repos. They are advisory policy metadata only: a
+profile cannot grant new GitHub permissions, enable ZCode write tools, expand
+the live allowlist, approve PRs, run tests, or execute PR code.
+
+## Config Shape
+
+Profiles live under `repoProfiles` in the bot config:
+
+```json
+{
+  "pilotRepos": ["electricsheephq/WorldOS"],
+  "repoProfiles": {
+    "enableOrgFallbacks": false,
+    "repos": {
+      "electricsheephq/WorldOS": {
+        "displayName": "WorldOS Unity",
+        "defaultBranch": "main",
+        "reviewProfile": "assertive",
+        "promptNote": "Prioritize Unity scene, save-state, gameplay, and release-regression risks.",
+        "pathFilters": ["Assets/**", "Packages/**", "!Library/**"],
+        "riskyPaths": ["Assets/**", "ProjectSettings/**"],
+        "proofExpectations": ["Mention Unity editor/play-mode smoke evidence when relevant."],
+        "validationHints": ["Prefer correctness and release findings over style-only feedback."],
+        "readinessHints": ["Scene and save changes need rollback notes."]
+      }
+    }
+  }
+}
+```
+
+When `repoProfiles.repos` or `repoProfiles.orgFallbacks` is configured, a repo
+must resolve to an explicit profile or an intentionally enabled org fallback.
+Unknown repos are skipped before GitHub PR fetches. This is deliberate: expanded
+monitoring should fail closed until App install, policy, and beta promotion
+evidence are recorded.
+
+## Fields
+
+- `enabled`: set to `false` to keep a profile documented but not reviewable.
+- `displayName`: human-friendly repo name for prompts and evidence.
+- `defaultBranch`: expected base branch for reviewer context.
+- `reviewProfile`: `chill` or `assertive`; current Sprint 2 default is
+  `assertive`.
+- `promptNote`: repo-specific review instruction injected into the ZCode prompt.
+- `pathFilters`: include/exclude globs applied before prompt construction.
+  Excludes start with `!`.
+- `riskyPaths`: high-risk file areas called out in the prompt.
+- `proofExpectations`: evidence the reviewer should look for in PRs.
+- `validationHints`: repo-specific correctness and CI guidance.
+- `readinessHints`: release or rollout readiness notes.
+- `suggestedLabels` / `suggestedReviewers`: reserved for later enrichment; they
+  do not auto-apply labels or reviewers.
+
+## Graduation To Live Review
+
+Use this path for each new repo from #14 or future allowlists:
+
+1. Add or update a repo profile in config/docs with `enabled` left conservative.
+2. Verify the GitHub App is installed and can read/post on that repo.
+3. Run dry-run scans against one current PR and one negative-control/noise PR.
+4. Check evidence for valid inline coordinates, zero secrets, zero repo
+   mutation, and no duplicate review attempts.
+5. Update the tracker issue with the profile snapshot and dry-run evidence.
+6. Add the repo to the active live config only in a dedicated PR/promotion lane.
+7. Promote through `docs/beta-release-runbook.md` and verify
+   `npm run release:status` plus fresh launchd heartbeats.
+
+Do not treat `config.example.json` as live config. The active launchd config is
+outside the repo under `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import { loadConfig } from "./config.js";
 import { formatDaemonLog } from "./daemon-log.js";
 import { GitHubApi } from "./github.js";
 import { collectReleaseStatus } from "./release-status.js";
+import { listReposToScan, resolveRepoProfile } from "./repo-policy.js";
 import { runOnce } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
 
@@ -18,7 +19,13 @@ async function main(): Promise<void> {
     });
     const github = new GitHubApi(config.github);
     const readChecks = [];
-    for (const repo of config.pilotRepos) {
+    const monitoredRepos = listReposToScan(config);
+    for (const repo of monitoredRepos) {
+      const repoPolicy = resolveRepoProfile(config, repo);
+      if (!repoPolicy.allowed) {
+        readChecks.push({ repo, ok: true, skippedByPolicy: repoPolicy.reason });
+        continue;
+      }
       try {
         await github.listOpenPulls(repo);
         readChecks.push({ repo, ok: true });
@@ -33,7 +40,9 @@ async function main(): Promise<void> {
     console.log(JSON.stringify({
       ok: readChecks.every((check) => check.ok),
       pilotRepos: config.pilotRepos,
+      monitoredRepos,
       canaryPulls: config.canaryPulls ?? [],
+      repoProfilesEnabled: Boolean(config.repoProfiles),
       statePath: config.statePath,
       workRoot: config.workRoot,
       zcode: zcode.redacted,
@@ -74,6 +83,7 @@ async function main(): Promise<void> {
 
   if (command === "daemon") {
     const config = loadConfig(args.config);
+    const monitoredRepos = listReposToScan(config);
     let cycle = 0;
     for (;;) {
       cycle += 1;
@@ -83,6 +93,7 @@ async function main(): Promise<void> {
         cycle,
         dryRun,
         pilotRepos: config.pilotRepos,
+        monitoredRepos,
         canaryPulls: config.canaryPulls ?? []
       }));
       try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ export interface BotConfig {
     enabled: boolean;
     postIssueComment: boolean;
   };
+  repoProfiles?: RepoProfilesConfig;
   zcode: {
     cliPath: string;
     appConfigPath: string;
@@ -26,6 +27,27 @@ export interface BotConfig {
     privateKeyPath?: string;
     token?: string;
   };
+}
+
+export interface RepoProfilesConfig {
+  enableOrgFallbacks?: boolean;
+  repos?: Record<string, RepoProfileConfig>;
+  orgFallbacks?: Record<string, RepoProfileConfig>;
+}
+
+export interface RepoProfileConfig {
+  enabled?: boolean;
+  displayName?: string;
+  defaultBranch?: string;
+  reviewProfile?: "chill" | "assertive";
+  promptNote?: string;
+  pathFilters?: string[];
+  riskyPaths?: string[];
+  proofExpectations?: string[];
+  validationHints?: string[];
+  readinessHints?: string[];
+  suggestedLabels?: string[];
+  suggestedReviewers?: string[];
 }
 
 const DEFAULT_CONFIG: BotConfig = {
@@ -58,6 +80,7 @@ export function loadConfig(configPath?: string): BotConfig {
   merged.github.appId = process.env.EVAOS_REVIEW_BOT_APP_ID ?? merged.github.appId;
   merged.github.privateKeyPath = process.env.EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH ?? merged.github.privateKeyPath;
   merged.github.token = process.env.GITHUB_TOKEN ?? merged.github.token;
+  validateConfig(merged);
 
   return merged;
 }
@@ -73,4 +96,36 @@ function deepMerge(base: unknown, overlay: unknown): unknown {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateConfig(config: BotConfig): void {
+  if (!Array.isArray(config.pilotRepos)) throw new Error("config.pilotRepos must be an array");
+  if (!config.repoProfiles) return;
+
+  validateProfileRecord(config.repoProfiles.repos, "repoProfiles.repos");
+  validateProfileRecord(config.repoProfiles.orgFallbacks, "repoProfiles.orgFallbacks");
+}
+
+function validateProfileRecord(record: Record<string, RepoProfileConfig> | undefined, label: string): void {
+  if (!record) return;
+  for (const [key, profile] of Object.entries(record)) {
+    if (!isRecord(profile)) throw new Error(`${label}.${key} must be an object`);
+    if (profile.reviewProfile && profile.reviewProfile !== "chill" && profile.reviewProfile !== "assertive") {
+      throw new Error(`${label}.${key}.reviewProfile must be "chill" or "assertive"`);
+    }
+    for (const field of [
+      "pathFilters",
+      "riskyPaths",
+      "proofExpectations",
+      "validationHints",
+      "readinessHints",
+      "suggestedLabels",
+      "suggestedReviewers"
+    ] as const) {
+      const value = profile[field];
+      if (value !== undefined && (!Array.isArray(value) || value.some((entry) => typeof entry !== "string"))) {
+        throw new Error(`${label}.${key}.${field} must be an array of strings`);
+      }
+    }
+  }
 }

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -1,0 +1,135 @@
+import type { BotConfig, RepoProfileConfig } from "./config.js";
+import type { PullFilePatch } from "./types.js";
+
+export type RepoProfileSource = "default" | "explicit" | "org_fallback";
+export type RepoProfileSkipReason = "repo_profile_disabled" | "repo_profile_missing";
+
+export interface ResolvedRepoProfile extends RepoProfileConfig {
+  repo: string;
+  source: RepoProfileSource;
+}
+
+export type RepoProfileResolution =
+  | { allowed: true; profile: ResolvedRepoProfile }
+  | { allowed: false; reason: RepoProfileSkipReason };
+
+export function listReposToScan(config: BotConfig): string[] {
+  const configured = unique(config.pilotRepos);
+  if (configured.length > 0) return configured;
+
+  const explicitRepos = Object.entries(config.repoProfiles?.repos ?? {})
+    .filter(([, profile]) => profile.enabled !== false)
+    .map(([repo]) => repo);
+  return unique(explicitRepos);
+}
+
+export function resolveRepoProfile(config: BotConfig, repo: string): RepoProfileResolution {
+  const registry = config.repoProfiles;
+  if (!hasProfileRegistry(registry)) {
+    return {
+      allowed: true,
+      profile: normalizeProfile(repo, "default", {})
+    };
+  }
+
+  const explicit = registry?.repos?.[repo];
+  if (explicit) {
+    if (explicit.enabled === false) return { allowed: false, reason: "repo_profile_disabled" };
+    return {
+      allowed: true,
+      profile: normalizeProfile(repo, "explicit", explicit)
+    };
+  }
+
+  const org = repo.split("/")[0];
+  const fallback = org ? registry?.orgFallbacks?.[org] : undefined;
+  if (fallback && fallback.enabled === false) return { allowed: false, reason: "repo_profile_disabled" };
+  if (registry?.enableOrgFallbacks && fallback) {
+    return {
+      allowed: true,
+      profile: normalizeProfile(repo, "org_fallback", fallback)
+    };
+  }
+
+  return { allowed: false, reason: "repo_profile_missing" };
+}
+
+export function filterPullFilesForProfile(files: PullFilePatch[], profile: ResolvedRepoProfile): PullFilePatch[] {
+  const filters = profile.pathFilters?.filter(Boolean) ?? [];
+  if (filters.length === 0) return files;
+
+  const includeFilters = filters.filter((pattern) => !pattern.startsWith("!"));
+  const excludeFilters = filters.filter((pattern) => pattern.startsWith("!")).map((pattern) => pattern.slice(1));
+
+  return files.filter((file) => {
+    const included = includeFilters.length === 0 || includeFilters.some((pattern) => matchesGlob(file.filename, pattern));
+    const excluded = excludeFilters.some((pattern) => matchesGlob(file.filename, pattern));
+    return included && !excluded;
+  });
+}
+
+export function buildRepoProfilePromptSection(profile: ResolvedRepoProfile): string {
+  const lines = [
+    "Repository profile guidance:",
+    `- Repo: ${profile.repo}`,
+    `- Source: ${profile.source}`,
+    `- Display name: ${profile.displayName ?? profile.repo}`,
+    `- Review profile: ${profile.reviewProfile ?? "assertive"}`
+  ];
+
+  if (profile.defaultBranch) lines.push(`- Default branch: ${profile.defaultBranch}`);
+  if (profile.promptNote) lines.push(`- Repo-specific instruction: ${profile.promptNote}`);
+  pushList(lines, "Path filters", profile.pathFilters);
+  pushList(lines, "High-risk paths", profile.riskyPaths);
+  pushList(lines, "Proof expectations", profile.proofExpectations);
+  pushList(lines, "Validation hints", profile.validationHints);
+  pushList(lines, "Readiness hints", profile.readinessHints);
+
+  return lines.join("\n");
+}
+
+function normalizeProfile(
+  repo: string,
+  source: RepoProfileSource,
+  profile: RepoProfileConfig
+): ResolvedRepoProfile {
+  return {
+    ...profile,
+    repo,
+    source,
+    reviewProfile: profile.reviewProfile ?? "assertive"
+  };
+}
+
+function hasProfileRegistry(registry: BotConfig["repoProfiles"]): boolean {
+  return Boolean(
+    registry &&
+      ((registry.repos && Object.keys(registry.repos).length > 0) ||
+        (registry.orgFallbacks && Object.keys(registry.orgFallbacks).length > 0))
+  );
+}
+
+function pushList(lines: string[], label: string, values: string[] | undefined): void {
+  if (!values || values.length === 0) return;
+  lines.push(`- ${label}: ${values.join("; ")}`);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function matchesGlob(path: string, pattern: string): boolean {
+  const normalizedPath = path.replace(/^\/+/, "");
+  const normalizedPattern = pattern.replace(/^\/+/, "");
+  return globToRegExp(normalizedPattern).test(normalizedPath);
+}
+
+function globToRegExp(pattern: string): RegExp {
+  const placeholder = "\0DOUBLE_STAR\0";
+  const escaped = pattern
+    .replaceAll("**", placeholder)
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replaceAll("*", "[^/]*")
+    .replaceAll(placeholder, ".*");
+  return new RegExp(`^${escaped}$`);
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,6 +5,7 @@ import { validateFindingLocations } from "./diff.js";
 import { decideReviewEvent, normalizeFindingsForReview } from "./findings.js";
 import { assertGitClean, preparePullWorktree } from "./git.js";
 import { GitHubApi } from "./github.js";
+import { filterPullFilesForProfile, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
 import { redactSecrets } from "./secrets.js";
 import { ReviewStateStore } from "./state.js";
 import { buildWalkthroughComment } from "./walkthrough.js";
@@ -26,10 +27,12 @@ export interface RunOnceResult {
   reviewed: number;
   skippedDraft: number;
   skippedCanary: number;
+  skippedPolicy: number;
   skippedProcessed: number;
+  policySkips: { repo: string; reason: string }[];
 }
 
-type ReviewPullResult = "reviewed" | "skipped_draft" | "skipped_canary" | "skipped_processed";
+type ReviewPullResult = "reviewed" | "skipped_draft" | "skipped_canary" | "skipped_policy" | "skipped_processed";
 
 export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
   const config = loadConfig(options.configPath);
@@ -41,12 +44,20 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
     reviewed: 0,
     skippedDraft: 0,
     skippedCanary: 0,
-    skippedProcessed: 0
+    skippedPolicy: 0,
+    skippedProcessed: 0,
+    policySkips: []
   };
   try {
-    const repos = options.repo ? [options.repo] : config.pilotRepos;
+    const repos = options.repo ? [options.repo] : listReposToScan(config);
     for (const repo of repos) {
       result.reposScanned += 1;
+      const repoPolicy = resolveRepoProfile(config, repo);
+      if (!repoPolicy.allowed) {
+        result.skippedPolicy += 1;
+        result.policySkips.push({ repo, reason: repoPolicy.reason });
+        continue;
+      }
       const pulls = options.pullNumber
         ? [await github.getPull(repo, options.pullNumber)]
         : await github.listOpenPulls(repo);
@@ -64,6 +75,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
         if (status === "reviewed") result.reviewed += 1;
         if (status === "skipped_draft") result.skippedDraft += 1;
         if (status === "skipped_canary") result.skippedCanary += 1;
+        if (status === "skipped_policy") result.skippedPolicy += 1;
         if (status === "skipped_processed") result.skippedProcessed += 1;
       }
     }
@@ -83,6 +95,8 @@ export async function reviewPull(input: {
   useZCode: boolean;
 }): Promise<ReviewPullResult> {
   const { config, github, state, repo, pull } = input;
+  const repoPolicy = resolveRepoProfile(config, repo);
+  if (!repoPolicy.allowed) return "skipped_policy";
   if (config.skipDrafts && pull.draft) return "skipped_draft";
   if (!isCanaryAllowed(config, repo, pull.number)) return "skipped_canary";
   if (state.hasProcessed(repo, pull.number, pull.head.sha)) return "skipped_processed";
@@ -91,6 +105,7 @@ export async function reviewPull(input: {
   mkdirSync(evidenceDir, { recursive: true });
 
   const files = await github.listPullFiles(repo, pull.number);
+  const reviewFiles = filterPullFilesForProfile(files, repoPolicy.profile);
   const worktree = preparePullWorktree({
     repo,
     pullNumber: pull.number,
@@ -98,7 +113,14 @@ export async function reviewPull(input: {
     workRoot: config.workRoot
   });
 
-  const prompt = buildReviewPrompt({ repo, pull, files, maxPatchBytes: config.zcode.maxPatchBytes });
+  const prompt = buildReviewPrompt({
+    repo,
+    pull,
+    files: reviewFiles,
+    repoProfile: repoPolicy.profile,
+    maxPatchBytes: config.zcode.maxPatchBytes
+  });
+  writeFileSync(join(evidenceDir, "repo-profile.json"), `${JSON.stringify(repoPolicy.profile, null, 2)}\n`);
   writeFileSync(join(evidenceDir, "review-prompt.txt"), redactSecrets(prompt));
 
   const zcodeResult = input.useZCode
@@ -117,7 +139,7 @@ export async function reviewPull(input: {
 
   assertGitClean(worktree.path);
 
-  const located = validateFindingLocations(zcodeResult.findings, files);
+  const located = validateFindingLocations(zcodeResult.findings, reviewFiles);
   const normalized = normalizeFindingsForReview(located.valid, { maxInlineComments: 25 });
   const comments = normalized.comments;
   const dropped = sanitizeDroppedFindings([...zcodeResult.droppedFromSchema, ...located.dropped, ...normalized.dropped]);

--- a/src/zcode.ts
+++ b/src/zcode.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, rmdirSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseFindings } from "./findings.js";
+import { buildRepoProfilePromptSection, type ResolvedRepoProfile } from "./repo-policy.js";
 import { redactSecrets } from "./secrets.js";
 import { buildZCodeRuntimeEnv, resolveZCodeProviderEnv } from "./zcode-env.js";
 import type { Finding, PullFilePatch, PullRequestSummary } from "./types.js";
@@ -16,6 +17,7 @@ export function buildReviewPrompt(input: {
   repo: string;
   pull: PullRequestSummary;
   files: PullFilePatch[];
+  repoProfile?: ResolvedRepoProfile;
   maxPatchBytes?: number;
 }): string {
   const fileList = input.files.map((file) => `- ${file.filename}`).join("\n");
@@ -42,6 +44,7 @@ export function buildReviewPrompt(input: {
     `Pull request: #${input.pull.number} ${input.pull.title}`,
     `Head SHA: ${input.pull.head.sha}`,
     "",
+    ...(input.repoProfile ? [buildRepoProfilePromptSection(input.repoProfile), ""] : []),
     "Files:",
     fileList,
     "",

--- a/tests/repo-policy.test.ts
+++ b/tests/repo-policy.test.ts
@@ -1,0 +1,228 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadConfig } from "../src/config.js";
+import { buildRepoProfilePromptSection, filterPullFilesForProfile, resolveRepoProfile } from "../src/repo-policy.js";
+import { runOnce } from "../src/worker.js";
+import { buildReviewPrompt } from "../src/zcode.js";
+import type { PullFilePatch, PullRequestSummary } from "../src/types.js";
+import type { RepoProfileResolution, ResolvedRepoProfile } from "../src/repo-policy.js";
+
+describe("repo profile registry", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("loads explicit repo profile guidance from config", () => {
+    const config = loadConfig(
+      writeConfig({
+        pilotRepos: ["electricsheephq/WorldOS"],
+        repoProfiles: {
+          repos: {
+            "electricsheephq/WorldOS": {
+              displayName: "WorldOS Unity",
+              defaultBranch: "main",
+              reviewProfile: "assertive",
+              promptNote: "Prioritize Unity scene, save-state, and gameplay regressions.",
+              riskyPaths: ["Assets/**", "ProjectSettings/**"],
+              proofExpectations: ["Mention Unity play-mode or editor smoke evidence when relevant."],
+              validationHints: ["Prefer current-diff correctness findings over style feedback."],
+              readinessHints: ["Release-impacting scene changes require explicit rollback notes."]
+            }
+          }
+        }
+      })
+    );
+
+    const resolved = resolveRepoProfile(config, "electricsheephq/WorldOS");
+    const profile = expectAllowed(resolved);
+
+    expect(resolved.allowed).toBe(true);
+    expect(profile).toMatchObject({
+      repo: "electricsheephq/WorldOS",
+      displayName: "WorldOS Unity",
+      reviewProfile: "assertive",
+      source: "explicit"
+    });
+    expect(buildRepoProfilePromptSection(profile)).toContain("Unity scene, save-state");
+  });
+
+  it("skips explicitly disabled repos closed", () => {
+    const config = loadConfig(
+      writeConfig({
+        pilotRepos: ["100yenadmin/evaOS-GUI"],
+        repoProfiles: {
+          repos: {
+            "100yenadmin/evaOS-GUI": {
+              enabled: false,
+              displayName: "Workbench"
+            }
+          }
+        }
+      })
+    );
+
+    expect(resolveRepoProfile(config, "100yenadmin/evaOS-GUI")).toEqual({
+      allowed: false,
+      reason: "repo_profile_disabled"
+    });
+  });
+
+  it("requires explicit opt-in before org fallback profiles can review unknown repos", () => {
+    const baseProfileConfig = {
+      pilotRepos: ["electricsheephq/evaos-support-control"],
+      repoProfiles: {
+        orgFallbacks: {
+          electricsheephq: {
+            displayName: "Electric Sheep fallback",
+            promptNote: "Apply conservative TypeScript service review policy."
+          }
+        }
+      }
+    };
+    const fallbackDisabled = loadConfig(writeConfig(baseProfileConfig));
+    const fallbackEnabled = loadConfig(
+      writeConfig({
+        ...baseProfileConfig,
+        repoProfiles: {
+          ...baseProfileConfig.repoProfiles,
+          enableOrgFallbacks: true
+        }
+      })
+    );
+
+    expect(resolveRepoProfile(fallbackDisabled, "electricsheephq/evaos-support-control")).toEqual({
+      allowed: false,
+      reason: "repo_profile_missing"
+    });
+    expect(resolveRepoProfile(fallbackEnabled, "electricsheephq/evaos-support-control")).toMatchObject({
+      allowed: true,
+      profile: {
+        repo: "electricsheephq/evaos-support-control",
+        source: "org_fallback",
+        displayName: "Electric Sheep fallback"
+      }
+    });
+  });
+
+  it("applies include and exclude path filters before prompt construction", () => {
+    const resolved = resolveRepoProfile(
+      loadConfig(
+        writeConfig({
+          repoProfiles: {
+            repos: {
+              "electricsheephq/evaos-code-review-bot": {
+                displayName: "Review bot",
+                pathFilters: ["src/**", "README.md", "!src/generated/**"]
+              }
+            }
+          }
+        })
+      ),
+      "electricsheephq/evaos-code-review-bot"
+    );
+    const profile = expectAllowed(resolved);
+    const files: PullFilePatch[] = [
+      { filename: "src/worker.ts", status: "modified", additions: 4, deletions: 1, changes: 5, patch: "+worker" },
+      { filename: "src/generated/types.ts", status: "modified", additions: 9, deletions: 0, changes: 9, patch: "+generated" },
+      { filename: "README.md", status: "modified", additions: 2, deletions: 0, changes: 2, patch: "+docs" },
+      { filename: "docs/runbook.md", status: "modified", additions: 3, deletions: 0, changes: 3, patch: "+runbook" }
+    ];
+
+    expect(filterPullFilesForProfile(files, profile).map((file) => file.filename)).toEqual([
+      "src/worker.ts",
+      "README.md"
+    ]);
+  });
+
+  it("injects repo profile guidance into the ZCode prompt", () => {
+    const resolved = resolveRepoProfile(
+      loadConfig(
+        writeConfig({
+          repoProfiles: {
+            repos: {
+              "electricsheephq/evaos-code-review-bot": {
+                displayName: "evaOS review bot",
+                reviewProfile: "assertive",
+                promptNote: "Focus on duplicate suppression, secret redaction, and GitHub App identity.",
+                riskyPaths: ["src/github.ts", "src/state.ts"]
+              }
+            }
+          }
+        })
+      ),
+      "electricsheephq/evaos-code-review-bot"
+    );
+    const profile = expectAllowed(resolved);
+
+    const prompt = buildReviewPrompt({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pull,
+      files: [{ filename: "src/state.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "+dedupe" }],
+      repoProfile: profile
+    });
+
+    expect(prompt).toContain("Repository profile guidance");
+    expect(prompt).toContain("duplicate suppression, secret redaction");
+    expect(prompt).toContain("src/state.ts");
+  });
+
+  it("lets the worker skip unknown repos before GitHub fetches", async () => {
+    const root = mkdtempSync(join(tmpdir(), "repo-profile-state-"));
+    roots.push(root);
+    const configPath = writeConfig({
+      pilotRepos: ["electricsheephq/missing-repo"],
+      statePath: join(root, "reviews.sqlite"),
+      repoProfiles: {
+        repos: {
+          "electricsheephq/WorldOS": {
+            displayName: "WorldOS"
+          }
+        }
+      }
+    });
+
+    await expect(runOnce({ configPath, dryRun: true, useZCode: false })).resolves.toMatchObject({
+      reposScanned: 1,
+      pullsSeen: 0,
+      skippedPolicy: 1,
+      policySkips: [{ repo: "electricsheephq/missing-repo", reason: "repo_profile_missing" }]
+    });
+  });
+
+  function writeConfig(config: unknown): string {
+    const root = mkdtempSync(join(tmpdir(), "repo-profile-config-"));
+    roots.push(root);
+    const path = join(root, "config.json");
+    writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`);
+    return path;
+  }
+});
+
+function expectAllowed(resolution: RepoProfileResolution): ResolvedRepoProfile {
+  expect(resolution.allowed).toBe(true);
+  if (!resolution.allowed) throw new Error(`Expected repo profile to be allowed, got ${resolution.reason}`);
+  return resolution.profile;
+}
+
+const pull: PullRequestSummary = {
+  number: 32,
+  title: "Add repo policy registry",
+  draft: false,
+  body: "Closes #17",
+  head: {
+    sha: "profile-head",
+    ref: "sprint/2-repo-profiles",
+    repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+  },
+  base: {
+    sha: "profile-base",
+    ref: "main",
+    repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+  },
+  html_url: "https://github.com/electricsheephq/evaos-code-review-bot/pull/32",
+  requested_reviewers: []
+};


### PR DESCRIPTION
## Summary
- add a repo profile registry with explicit repo profiles, disabled-profile handling, and opt-in org fallback profiles
- inject profile guidance into ZCode review prompts and apply profile path filters before prompt/inline validation
- add worker/doctor visibility for monitored repos and policy skips without expanding live monitoring
- document repo-profile graduation and add safe example profiles, including self-monitoring as disabled example-only metadata

Closes #17
Links #28
Links #5
Links #14

## Validation
- npm test (16 files / 45 tests)
- npm run build
- git diff --check

## Live beta boundary
This PR does not change the active launchd config or expand the live repo allowlist. After merge, promote through docs/beta-release-runbook.md and verify npm run release:status against active-installed-live.json.