### PR TITLE
Sprint 2: add maintainer command control surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Pilot local worker for ZCode/GLM-5.2 pull request reviews.
 - Installs a temporary per-worktree ZCode policy that allows read-only file tools, disables Bash/mutation/subagents, then restores/removes it before the clean check.
 - Sets `ZCODE_MODEL_RETRY_MAX_RETRIES=0` by default so provider rate limits fail fast instead of multiplying requests.
 - Resolves repo profiles before review; once profiles are configured, unknown or disabled repos skip closed before GitHub PR fetches.
+- Keeps maintainer PR-comment commands disabled by default; when enabled, only configured trusted authors can steer read-only reviews.
 
 ## Commands
 
@@ -49,3 +50,11 @@ Use [docs/repo-profiles.md](docs/repo-profiles.md) to add repo-specific review
 guidance, risky paths, proof expectations, and path filters. Profiles are
 prompt/config metadata only; they do not expand GitHub permissions, live
 monitoring, ZCode tools, approvals, or repair behavior by themselves.
+
+## Maintainer Commands
+
+Use [docs/maintainer-commands.md](docs/maintainer-commands.md) for the dormant
+trusted command surface. Commands are PR comments such as
+`@evaos-code-review-bot review`, `re-review`, `explain`, and `stop`; they stay
+behind `commands.enabled` and cannot repair, merge, approve, push branches, or
+expand monitoring.

--- a/config.example.json
+++ b/config.example.json
@@ -13,6 +13,12 @@
   "workRoot": "/Volumes/LEXAR/repos/evaos-code-review-bot/runtime",
   "statePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews.sqlite",
   "evidenceDir": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence",
+  "commands": {
+    "enabled": false,
+    "botMentions": ["@evaos-code-review-bot"],
+    "trustedAuthors": ["100yenadmin"],
+    "acknowledge": false
+  },
   "repoProfiles": {
     "enableOrgFallbacks": false,
     "repos": {

--- a/docs/maintainer-commands.md
+++ b/docs/maintainer-commands.md
@@ -1,0 +1,70 @@
+# Maintainer Commands
+
+Maintainer commands are a narrow PR-comment control surface for trusted humans
+and agents. They do not grant repair, merge, approval, branch-push, test-run, or
+repo-mutation capabilities. Commands only steer the existing read-only review
+pipeline.
+
+Commands are disabled by default:
+
+```json
+{
+  "commands": {
+    "enabled": false,
+    "botMentions": ["@evaos-code-review-bot"],
+    "trustedAuthors": ["100yenadmin"],
+    "acknowledge": false
+  }
+}
+```
+
+Enable them only in a tracked beta promotion after GitHub App permissions and
+comment-volume behavior are verified.
+
+## Supported Commands
+
+Each command must appear as its own trimmed line in a PR comment:
+
+- `@evaos-code-review-bot review`
+- `@evaos-code-review-bot re-review`
+- `@evaos-code-review-bot explain`
+- `@evaos-code-review-bot stop`
+
+`review` and `re-review` route into the same ZCode review pipeline used by
+polling. They still use the current PR head SHA, current RIGHT-side diff-line
+validation, secret redaction, ZCode read-only policy, and Git clean checks.
+
+`explain` records the command and can post a marker-backed status comment when
+`commands.acknowledge` is enabled. It does not start a review.
+
+`stop` records the command and skips queued review work for that PR/head when
+the command is the latest unprocessed command.
+
+## Trust Boundary
+
+Only authors listed in `commands.trustedAuthors` are executable in this MVP.
+Unauthorized commands are detected and ignored. Collaborator/maintainer
+permission lookup can be added later, but it should be tested against the
+GitHub App's installed permissions before enabling in live config.
+
+## Dedupe Boundary
+
+Commands are deduped by:
+
+- repo
+- PR number
+- live head SHA
+- GitHub comment id
+
+Reprocessing the same command comment on the same head does nothing. A new push
+creates a new head SHA, so the same comment id is not treated as proof for the
+new head unless a trusted author comments again.
+
+## Evidence
+
+Command-triggered reviews write evidence under the normal PR/head evidence path
+with a `command-<comment-id>` subfolder. The evidence includes the command
+source JSON. Polling reviews keep the existing evidence path shape.
+
+The live daemon result includes command counters such as `skippedCommandStop`,
+`skippedCommandExplain`, `commandReviewRequested`, and `skippedPolicy`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,7 @@ async function main(): Promise<void> {
       repoProfilesEnabled: Boolean(config.repoProfiles),
       activation: config.activation,
       reviewConcurrency: config.reviewConcurrency,
+      commandsEnabled: config.commands.enabled,
       statePath: config.statePath,
       workRoot: config.workRoot,
       zcode: zcode.redacted,
@@ -96,7 +97,8 @@ async function main(): Promise<void> {
         dryRun,
         pilotRepos: config.pilotRepos,
         monitoredRepos,
-        canaryPulls: config.canaryPulls ?? []
+        canaryPulls: config.canaryPulls ?? [],
+        commandsEnabled: config.commands.enabled
       }));
       try {
         const result = await runOnce({ configPath: args.config, dryRun });

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,144 @@
+import type { CommandConfig } from "./config.js";
+
+export type ReviewCommandAction = "review" | "re-review" | "explain" | "stop";
+
+export interface IssueCommentCommandSource {
+  id: number;
+  body?: string | null;
+  html_url?: string;
+  user?: {
+    login: string;
+    type?: string;
+  } | null;
+}
+
+export interface ReviewCommand {
+  action: ReviewCommandAction;
+  commentId: number;
+  author: string;
+  body: string;
+  url?: string;
+}
+
+export interface UnauthorizedReviewCommand {
+  action: ReviewCommandAction;
+  commentId: number;
+  author: string;
+}
+
+export interface CollectedReviewCommands {
+  commands: ReviewCommand[];
+  unauthorized: UnauthorizedReviewCommand[];
+}
+
+export type CommandDecision =
+  | { action: "none"; shouldReview: false }
+  | {
+      action: ReviewCommandAction;
+      shouldReview: boolean;
+      commandId: number;
+      command: ReviewCommand;
+    };
+
+export function parseReviewCommand(comment: IssueCommentCommandSource, config: CommandConfig): ReviewCommand | undefined {
+  if (!config.enabled) return undefined;
+  const action = parseCommandAction(comment.body, config.botMentions);
+  if (!action) return undefined;
+  const author = comment.user?.login;
+  if (!author || !isTrustedAuthor(author, config)) return undefined;
+  return {
+    action,
+    commentId: comment.id,
+    author,
+    body: comment.body ?? "",
+    url: comment.html_url
+  };
+}
+
+export function collectTrustedReviewCommands(
+  comments: IssueCommentCommandSource[],
+  config: CommandConfig
+): CollectedReviewCommands {
+  if (!config.enabled) return { commands: [], unauthorized: [] };
+
+  const commands: ReviewCommand[] = [];
+  const unauthorized: UnauthorizedReviewCommand[] = [];
+  for (const comment of comments) {
+    const action = parseCommandAction(comment.body, config.botMentions);
+    if (!action) continue;
+    const author = comment.user?.login ?? "(unknown)";
+    if (!isTrustedAuthor(author, config)) {
+      unauthorized.push({ action, commentId: comment.id, author });
+      continue;
+    }
+    commands.push({
+      action,
+      commentId: comment.id,
+      author,
+      body: comment.body ?? "",
+      url: comment.html_url
+    });
+  }
+
+  return {
+    commands: commands.sort((left, right) => left.commentId - right.commentId),
+    unauthorized
+  };
+}
+
+export function decideCommandAction(input: {
+  commands: ReviewCommand[];
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  hasProcessedCommand: (repo: string, pullNumber: number, headSha: string, commentId: number) => boolean;
+}): CommandDecision {
+  const pending = input.commands.filter(
+    (command) => !input.hasProcessedCommand(input.repo, input.pullNumber, input.headSha, command.commentId)
+  );
+  const latest = pending.at(-1);
+  if (!latest) return { action: "none", shouldReview: false };
+
+  return {
+    action: latest.action,
+    commandId: latest.commentId,
+    command: latest,
+    shouldReview: latest.action === "review" || latest.action === "re-review"
+  };
+}
+
+export function buildCommandStatusMarker(repo: string, pullNumber: number, headSha: string): string {
+  return `<!-- evaos-command-status ${repo}#${pullNumber} ${headSha} -->`;
+}
+
+export function buildCommandStatusBody(input: {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  decision: Exclude<CommandDecision, { action: "none"; shouldReview: false }>;
+}): string {
+  const verb = input.decision.shouldReview ? "queued a current-head review" : "recorded command state";
+  return [
+    buildCommandStatusMarker(input.repo, input.pullNumber, input.headSha),
+    `evaOS Code Review Bot ${verb} for \`${input.repo}#${input.pullNumber}\` at \`${input.headSha}\`.`,
+    `Command: \`${input.decision.action}\` from \`${input.decision.command.author}\` comment \`${input.decision.commandId}\`.`,
+    "Safety boundary: command handling cannot approve, merge, repair, push branches, or expand repo permissions."
+  ].join("\n\n");
+}
+
+function parseCommandAction(body: string | null | undefined, mentions: string[]): ReviewCommandAction | undefined {
+  if (!body) return undefined;
+  const normalizedMentions = mentions.map((mention) => mention.toLowerCase());
+  for (const line of body.split(/\r?\n/)) {
+    const normalized = line.trim().replace(/\s+/g, " ").toLowerCase();
+    for (const mention of normalizedMentions) {
+      const suffix = normalized.startsWith(`${mention} `) ? normalized.slice(mention.length + 1) : undefined;
+      if (suffix === "review" || suffix === "re-review" || suffix === "explain" || suffix === "stop") return suffix;
+    }
+  }
+  return undefined;
+}
+
+function isTrustedAuthor(author: string, config: CommandConfig): boolean {
+  return config.trustedAuthors.includes(author) || config.trustedAuthors.includes("*");
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export interface BotConfig {
     postIssueComment: boolean;
   };
   repoProfiles?: RepoProfilesConfig;
+  commands: CommandConfig;
   zcode: {
     cliPath: string;
     appConfigPath: string;
@@ -57,6 +58,13 @@ export interface RepoProfileConfig {
   suggestedReviewers?: string[];
 }
 
+export interface CommandConfig {
+  enabled: boolean;
+  botMentions: string[];
+  trustedAuthors: string[];
+  acknowledge: boolean;
+}
+
 const DEFAULT_CONFIG: BotConfig = {
   pilotRepos: ["electricsheephq/WorldOS", "100yenadmin/evaOS-GUI"],
   pollIntervalMs: 90_000,
@@ -75,6 +83,12 @@ const DEFAULT_CONFIG: BotConfig = {
   walkthrough: {
     enabled: true,
     postIssueComment: false
+  },
+  commands: {
+    enabled: false,
+    botMentions: ["@evaos-code-review-bot"],
+    trustedAuthors: [],
+    acknowledge: false
   },
   zcode: {
     cliPath: "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
@@ -114,6 +128,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function validateConfig(config: BotConfig): void {
   if (!Array.isArray(config.pilotRepos)) throw new Error("config.pilotRepos must be an array");
+  if (!Array.isArray(config.commands.botMentions)) throw new Error("config.commands.botMentions must be an array");
+  if (!Array.isArray(config.commands.trustedAuthors)) throw new Error("config.commands.trustedAuthors must be an array");
   if (!config.repoProfiles) return;
 
   validateProfileRecord(config.repoProfiles.repos, "repoProfiles.repos");

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,6 @@
 import { createSign } from "node:crypto";
 import { readFileSync } from "node:fs";
+import type { IssueCommentCommandSource } from "./commands.js";
 import type { PullFilePatch, PullRequestSummary, ReviewComment, ReviewEvent } from "./types.js";
 
 export interface GitHubApiOptions {
@@ -56,6 +57,18 @@ export class GitHubApi {
       );
       files.push(...chunk);
       if (chunk.length < 100) return files;
+    }
+  }
+
+  async listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]> {
+    const comments: IssueCommentCommandSource[] = [];
+    for (let page = 1; ; page += 1) {
+      const chunk = await this.request<IssueCommentCommandSource[]>(
+        `/repos/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
+        { token: await this.getReadToken(repo) }
+      );
+      comments.push(...chunk);
+      if (chunk.length < 100) return comments;
     }
   }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -5,6 +5,8 @@ import { DatabaseSync } from "node:sqlite";
 import type { ReviewEvent } from "./types.js";
 
 export type ProcessedStatus = "dry_run" | "posted" | "skipped" | "failed";
+export type ProcessedCommandAction = "review" | "re-review" | "explain" | "stop";
+export type ProcessedCommandStatus = "triggered" | "explained" | "stopped" | "ignored";
 
 export interface ProcessedReviewRecord {
   repo: string;
@@ -19,6 +21,17 @@ export interface ProcessedReviewRecord {
 export interface ReviewRunLease {
   leaseId: string;
   expiresAt: string;
+}
+
+export interface ProcessedCommandRecord {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  commentId: number;
+  action: ProcessedCommandAction;
+  status: ProcessedCommandStatus;
+  author?: string;
+  url?: string;
 }
 
 export class ReviewStateStore {
@@ -50,6 +63,20 @@ export class ReviewStateStore {
         lease_id text primary key,
         started_at text not null,
         expires_at text not null
+      );
+    `);
+    this.db.exec(`
+      create table if not exists processed_commands (
+        repo text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        comment_id integer not null,
+        action text not null,
+        status text not null,
+        author text,
+        url text,
+        created_at text not null default (datetime('now')),
+        primary key (repo, pull_number, head_sha, comment_id)
       );
     `);
   }
@@ -124,6 +151,36 @@ export class ReviewStateStore {
 
   releaseReviewRunLease(leaseId: string): void {
     this.db.prepare("delete from review_run_leases where lease_id = ?").run(leaseId);
+  }
+
+  hasProcessedCommand(repo: string, pullNumber: number, headSha: string, commentId: number): boolean {
+    const row = this.db
+      .prepare(
+        `select 1 from processed_commands
+         where repo = ? and pull_number = ? and head_sha = ? and comment_id = ?
+         limit 1`
+      )
+      .get(repo, pullNumber, headSha, commentId);
+    return Boolean(row);
+  }
+
+  recordProcessedCommand(record: ProcessedCommandRecord): void {
+    this.db
+      .prepare(
+        `insert or replace into processed_commands
+          (repo, pull_number, head_sha, comment_id, action, status, author, url, created_at)
+         values (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`
+      )
+      .run(
+        record.repo,
+        record.pullNumber,
+        record.headSha,
+        record.commentId,
+        record.action,
+        record.status,
+        record.author ?? null,
+        record.url ?? null
+      );
   }
 
   close(): void {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,5 +1,12 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  buildCommandStatusBody,
+  buildCommandStatusMarker,
+  collectTrustedReviewCommands,
+  decideCommandAction,
+  type CommandDecision
+} from "./commands.js";
 import { loadConfig, type BotConfig } from "./config.js";
 import { validateFindingLocations } from "./diff.js";
 import { decideReviewEvent, normalizeFindingsForReview } from "./findings.js";
@@ -29,6 +36,9 @@ export interface RunOnceResult {
   skippedDraft: number;
   skippedCanary: number;
   skippedPolicy: number;
+  skippedCommandStop: number;
+  skippedCommandExplain: number;
+  commandReviewRequested: number;
   skippedProcessed: number;
   skippedCapacity: number;
   baselinedExisting: number;
@@ -37,9 +47,12 @@ export interface RunOnceResult {
 
 type ReviewPullResult =
   | "reviewed"
+  | "reviewed_command"
   | "skipped_draft"
   | "skipped_canary"
   | "skipped_policy"
+  | "skipped_command_stop"
+  | "skipped_command_explain"
   | "skipped_processed"
   | "skipped_capacity";
 
@@ -55,6 +68,9 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
     skippedDraft: 0,
     skippedCanary: 0,
     skippedPolicy: 0,
+    skippedCommandStop: 0,
+    skippedCommandExplain: 0,
+    commandReviewRequested: 0,
     skippedProcessed: 0,
     skippedCapacity: 0,
     baselinedExisting: 0,
@@ -93,10 +109,13 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
           useZCode: options.useZCode ?? true,
           budget
         });
-        if (status === "reviewed") result.reviewed += 1;
+        if (status === "reviewed" || status === "reviewed_command") result.reviewed += 1;
         if (status === "skipped_draft") result.skippedDraft += 1;
         if (status === "skipped_canary") result.skippedCanary += 1;
         if (status === "skipped_policy") result.skippedPolicy += 1;
+        if (status === "skipped_command_stop") result.skippedCommandStop += 1;
+        if (status === "skipped_command_explain") result.skippedCommandExplain += 1;
+        if (status === "reviewed_command") result.commandReviewRequested += 1;
         if (status === "skipped_processed") result.skippedProcessed += 1;
         if (status === "skipped_capacity") result.skippedCapacity += 1;
       }
@@ -122,7 +141,19 @@ export async function reviewPull(input: {
   if (!repoPolicy.allowed) return "skipped_policy";
   if (config.skipDrafts && pull.draft) return "skipped_draft";
   if (!isCanaryAllowed(config, repo, pull.number)) return "skipped_canary";
-  if (state.hasProcessed(repo, pull.number, pull.head.sha)) return "skipped_processed";
+
+  const commandDecision = await resolvePullCommandDecision({ config, github, state, repo, pull });
+  if (commandDecision.action === "stop") {
+    await recordAndAcknowledgeCommandDecision({ config, github, state, repo, pull, commandDecision });
+    return "skipped_command_stop";
+  }
+  if (commandDecision.action === "explain") {
+    await recordAndAcknowledgeCommandDecision({ config, github, state, repo, pull, commandDecision });
+    return "skipped_command_explain";
+  }
+
+  const commandReviewRequested = commandDecision.shouldReview;
+  if (!commandReviewRequested && state.hasProcessed(repo, pull.number, pull.head.sha)) return "skipped_processed";
   const budget = input.budget ?? new ReviewRunBudget(config.reviewConcurrency.maxActiveRuns);
   if (!budget.tryStart()) return "skipped_capacity";
   let lease: ReviewRunLease | undefined;
@@ -130,8 +161,12 @@ export async function reviewPull(input: {
   try {
     lease = state.tryAcquireReviewRunLease(config.reviewConcurrency.maxActiveRuns, config.reviewConcurrency.leaseTtlMs);
     if (!lease) return "skipped_capacity";
+    if (commandReviewRequested) {
+      await recordAndAcknowledgeCommandDecision({ config, github, state, repo, pull, commandDecision });
+    }
 
-    const evidenceDir = join(config.evidenceDir, localDateFolder(), repo.replace("/", "__"), `pr-${pull.number}`, pull.head.sha);
+    const evidenceBaseDir = join(config.evidenceDir, localDateFolder(), repo.replace("/", "__"), `pr-${pull.number}`, pull.head.sha);
+    const evidenceDir = commandReviewRequested ? join(evidenceBaseDir, `command-${commandDecision.commandId}`) : evidenceBaseDir;
     mkdirSync(evidenceDir, { recursive: true });
 
     const files = await github.listPullFiles(repo, pull.number);
@@ -151,6 +186,9 @@ export async function reviewPull(input: {
       maxPatchBytes: config.zcode.maxPatchBytes
     });
     writeFileSync(join(evidenceDir, "repo-profile.json"), `${JSON.stringify(repoPolicy.profile, null, 2)}\n`);
+    if (commandDecision.action !== "none") {
+      writeFileSync(join(evidenceDir, "command.json"), `${JSON.stringify(commandDecision.command, null, 2)}\n`);
+    }
     writeFileSync(join(evidenceDir, "review-prompt.txt"), redactSecrets(prompt));
 
     const zcodeResult = input.useZCode
@@ -174,7 +212,14 @@ export async function reviewPull(input: {
     const comments = normalized.comments;
     const dropped = sanitizeDroppedFindings([...zcodeResult.droppedFromSchema, ...located.dropped, ...normalized.dropped]);
     const event = decideReviewEvent(comments);
-    const summary = buildSummary({ repo, pull, comments, dropped, dryRun: input.dryRun });
+    const summary = buildSummary({
+      repo,
+      pull,
+      comments,
+      dropped,
+      dryRun: input.dryRun,
+      commandDecision
+    });
     const walkthrough = config.walkthrough.enabled
       ? buildWalkthroughComment({
           repo,
@@ -199,7 +244,7 @@ export async function reviewPull(input: {
 
     if (input.dryRun) {
       state.recordProcessed({ repo, pullNumber: pull.number, headSha: pull.head.sha, status: "dry_run", event });
-      return "reviewed";
+      return commandReviewRequested ? "reviewed_command" : "reviewed";
     }
 
     const reviewGithub = new GitHubApi(config.github);
@@ -226,7 +271,7 @@ export async function reviewPull(input: {
       event,
       reviewUrl: review.html_url
     });
-    return "reviewed";
+    return commandReviewRequested ? "reviewed_command" : "reviewed";
   } finally {
     if (lease) state.releaseReviewRunLease(lease.leaseId);
     budget.finish();
@@ -274,6 +319,66 @@ export function isCanaryAllowed(config: Pick<BotConfig, "canaryPulls">, repo: st
   return new Set(config.canaryPulls).has(`${repo}#${pullNumber}`);
 }
 
+async function resolvePullCommandDecision(input: {
+  config: BotConfig;
+  github: GitHubApi;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+}): Promise<CommandDecision> {
+  if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
+
+  const comments = await input.github.listIssueComments(input.repo, input.pull.number);
+  const collected = collectTrustedReviewCommands(comments, input.config.commands);
+  return decideCommandAction({
+    commands: collected.commands,
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    hasProcessedCommand: (repo, pullNumber, headSha, commentId) =>
+      input.state.hasProcessedCommand(repo, pullNumber, headSha, commentId)
+  });
+}
+
+async function recordAndAcknowledgeCommandDecision(input: {
+  config: BotConfig;
+  github: GitHubApi;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  commandDecision: Exclude<CommandDecision, { action: "none"; shouldReview: false }>;
+}): Promise<void> {
+  input.state.recordProcessedCommand({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    commentId: input.commandDecision.commandId,
+    action: input.commandDecision.action,
+    status:
+      input.commandDecision.action === "stop"
+        ? "stopped"
+        : input.commandDecision.action === "explain"
+          ? "explained"
+          : "triggered",
+    author: input.commandDecision.command.author,
+    url: input.commandDecision.command.url
+  });
+
+  if (input.config.commands.acknowledge && input.github.canPostAsApp()) {
+    await input.github.upsertIssueComment({
+      repo: input.repo,
+      issueNumber: input.pull.number,
+      marker: buildCommandStatusMarker(input.repo, input.pull.number, input.pull.head.sha),
+      body: buildCommandStatusBody({
+        repo: input.repo,
+        pullNumber: input.pull.number,
+        headSha: input.pull.head.sha,
+        decision: input.commandDecision
+      })
+    });
+  }
+}
+
 export function localDateFolder(now = new Date()): string {
   const year = String(now.getFullYear()).padStart(4, "0");
   const month = String(now.getMonth() + 1).padStart(2, "0");
@@ -298,11 +403,18 @@ function buildSummary(input: {
   comments: { severity: string }[];
   dropped: { reason: string }[];
   dryRun: boolean;
+  commandDecision?: CommandDecision;
 }): string {
   const p0p1 = input.comments.filter((comment) => comment.severity === "P0" || comment.severity === "P1").length;
-  return [
+  const lines = [
     `evaOS ZCode review ${input.dryRun ? "dry run" : "result"} for ${input.repo}#${input.pull.number} at ${input.pull.head.sha}.`,
     `Inline comments: ${input.comments.length}. High-severity comments: ${p0p1}. Dropped findings: ${input.dropped.length}.`,
     "Pilot policy: this bot never approves PRs; it requests changes only for validated P0/P1 findings."
-  ].join("\n\n");
+  ];
+  if (input.commandDecision && input.commandDecision.action !== "none") {
+    lines.push(
+      `Command source: ${input.commandDecision.action} comment ${input.commandDecision.commandId} by ${input.commandDecision.command.author}.`
+    );
+  }
+  return lines.join("\n\n");
 }

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { collectTrustedReviewCommands, decideCommandAction, parseReviewCommand } from "../src/commands.js";
+
+describe("maintainer command parsing", () => {
+  const config = {
+    enabled: true,
+    botMentions: ["@evaos-code-review-bot"],
+    trustedAuthors: ["100yenadmin", "coderabbitai"],
+    acknowledge: false
+  };
+
+  it("parses exact review, re-review, explain, and stop commands", () => {
+    expect(parseReviewCommand(comment(101, "100yenadmin", "@evaos-code-review-bot review"), config)).toMatchObject({
+      action: "review",
+      commentId: 101,
+      author: "100yenadmin"
+    });
+    expect(parseReviewCommand(comment(102, "100yenadmin", "@evaos-code-review-bot re-review"), config)).toMatchObject({
+      action: "re-review"
+    });
+    expect(parseReviewCommand(comment(103, "100yenadmin", "@evaos-code-review-bot explain"), config)).toMatchObject({
+      action: "explain"
+    });
+    expect(parseReviewCommand(comment(104, "100yenadmin", "@evaos-code-review-bot stop"), config)).toMatchObject({
+      action: "stop"
+    });
+  });
+
+  it("ignores disabled, malformed, and untrusted commands", () => {
+    expect(parseReviewCommand(comment(101, "100yenadmin", "@evaos-code-review-bot review"), { ...config, enabled: false })).toBeUndefined();
+    expect(parseReviewCommand(comment(102, "100yenadmin", "@evaos-code-review-bot repair"), config)).toBeUndefined();
+    expect(parseReviewCommand(comment(103, "drive-by", "@evaos-code-review-bot review"), config)).toBeUndefined();
+  });
+
+  it("collects trusted commands and reports unauthorized attempts without executing them", () => {
+    const collected = collectTrustedReviewCommands(
+      [
+        comment(101, "drive-by", "@evaos-code-review-bot review"),
+        comment(102, "100yenadmin", "@evaos-code-review-bot explain"),
+        comment(103, "coderabbitai", "@evaos-code-review-bot re-review")
+      ],
+      config
+    );
+
+    expect(collected.commands.map((command) => command.commentId)).toEqual([102, 103]);
+    expect(collected.unauthorized.map((entry) => entry.commentId)).toEqual([101]);
+  });
+
+  it("uses the latest unprocessed command for the current head", () => {
+    const collected = collectTrustedReviewCommands(
+      [
+        comment(101, "100yenadmin", "@evaos-code-review-bot review"),
+        comment(102, "100yenadmin", "@evaos-code-review-bot stop")
+      ],
+      config
+    );
+
+    expect(decideCommandAction({
+      commands: collected.commands,
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1161,
+      headSha: "head-1",
+      hasProcessedCommand: () => false
+    })).toMatchObject({
+      action: "stop",
+      commandId: 102,
+      shouldReview: false
+    });
+  });
+
+  it("routes review commands into the safe review pipeline", () => {
+    const collected = collectTrustedReviewCommands(
+      [comment(101, "100yenadmin", "@evaos-code-review-bot review")],
+      config
+    );
+
+    expect(decideCommandAction({
+      commands: collected.commands,
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1161,
+      headSha: "head-1",
+      hasProcessedCommand: () => false
+    })).toMatchObject({
+      action: "review",
+      commandId: 101,
+      shouldReview: true
+    });
+  });
+
+  it("dedupes already processed command comments for the same head", () => {
+    const collected = collectTrustedReviewCommands(
+      [comment(101, "100yenadmin", "@evaos-code-review-bot review")],
+      config
+    );
+
+    expect(decideCommandAction({
+      commands: collected.commands,
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1161,
+      headSha: "head-1",
+      hasProcessedCommand: (_repo, _pull, _head, commentId) => commentId === 101
+    })).toEqual({ action: "none", shouldReview: false });
+  });
+});
+
+function comment(id: number, login: string, body: string) {
+  return {
+    id,
+    body,
+    html_url: `https://github.test/comment/${id}`,
+    user: {
+      login,
+      type: login.endsWith("ai") ? "Bot" : "User"
+    }
+  };
+}

--- a/tests/review-budget.test.ts
+++ b/tests/review-budget.test.ts
@@ -121,6 +121,12 @@ function minimalConfig(): BotConfig {
       enabled: false,
       postIssueComment: false
     },
+    commands: {
+      enabled: false,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: [],
+      acknowledge: false
+    },
     zcode: {
       cliPath: "/unused/zcode.cjs",
       appConfigPath: "/unused/config.json",

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -67,4 +67,25 @@ describe("review state store", () => {
     expect(store.tryAcquireReviewRunLease(1, 1_000, new Date("2026-07-01T00:00:02.000Z"))).toBeDefined();
     store.close();
   });
+
+  it("deduplicates processed command comments per repo, PR, head SHA, and comment id", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-command-state-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    expect(store.hasProcessedCommand("electricsheephq/WorldOS", 1161, "head-a", 123)).toBe(false);
+    store.recordProcessedCommand({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1161,
+      headSha: "head-a",
+      commentId: 123,
+      action: "review",
+      status: "triggered"
+    });
+
+    expect(store.hasProcessedCommand("electricsheephq/WorldOS", 1161, "head-a", 123)).toBe(true);
+    expect(store.hasProcessedCommand("electricsheephq/WorldOS", 1161, "head-b", 123)).toBe(false);
+    expect(store.hasProcessedCommand("electricsheephq/WorldOS", 1161, "head-a", 124)).toBe(false);
+    store.close();
+  });
 });


### PR DESCRIPTION
## Summary
- add dormant trusted PR-comment commands: review, re-review, explain, and stop
- dedupe commands by repo, PR, live head SHA, and GitHub comment id
- add command state storage, command parsing/authorization tests, and command counters in daemon output
- document the command trust boundary and keep commands disabled by default in config.example.json

Closes #15
Links #28
Links #16

## Validation
- npm test (19 files / 66 tests after rebase onto #33)
- npm run build
- git diff --check

## Live beta boundary
This PR does not enable command handling in the active launchd config. The live daemon remains on commandsEnabled:false after promotion unless a separate config promotion explicitly enables it.