### PR TITLE
Sprint 2: guard reviews against stale PR heads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Pilot local worker for ZCode/GLM-5.2 pull request reviews.
 - Uses `REQUEST_CHANGES` only for validated P0/P1 findings.
 - Drops findings that cannot be placed on current RIGHT-side diff lines.
 - Drops secret-looking findings instead of redacting and posting them.
+- Re-fetches PR state before command-triggered review, before planning comments, and before live posting; stale-head output is recorded and skipped.
 - Redacts secret-looking material from local evidence logs before writing them.
 - Verifies the ZCode worktree is clean, including untracked files, after every review run.
 - Caps ZCode prompt patch bytes and kills long ZCode runs with `zcode.timeoutMs`.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -41,6 +41,7 @@ export interface RunOnceResult {
   commandReviewRequested: number;
   skippedProcessed: number;
   skippedCapacity: number;
+  skippedStaleHead: number;
   baselinedExisting: number;
   policySkips: { repo: string; reason: string }[];
 }
@@ -54,7 +55,8 @@ type ReviewPullResult =
   | "skipped_command_stop"
   | "skipped_command_explain"
   | "skipped_processed"
-  | "skipped_capacity";
+  | "skipped_capacity"
+  | "skipped_stale_head";
 
 export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
   const config = loadConfig(options.configPath);
@@ -73,6 +75,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
     commandReviewRequested: 0,
     skippedProcessed: 0,
     skippedCapacity: 0,
+    skippedStaleHead: 0,
     baselinedExisting: 0,
     policySkips: []
   };
@@ -118,6 +121,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
         if (status === "reviewed_command") result.commandReviewRequested += 1;
         if (status === "skipped_processed") result.skippedProcessed += 1;
         if (status === "skipped_capacity") result.skippedCapacity += 1;
+        if (status === "skipped_stale_head") result.skippedStaleHead += 1;
       }
     }
     return result;
@@ -153,6 +157,15 @@ export async function reviewPull(input: {
   }
 
   const commandReviewRequested = commandDecision.shouldReview;
+  if (commandReviewRequested) {
+    const livePull = await github.getPull(repo, pull.number);
+    const stale = detectStalePullHead({ expected: pull, live: livePull, phase: "before_review" });
+    if (stale) {
+      const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision);
+      recordStaleHeadSkip({ state, repo, pull, stale, evidenceDir });
+      return "skipped_stale_head";
+    }
+  }
   if (!commandReviewRequested && state.hasProcessed(repo, pull.number, pull.head.sha)) return "skipped_processed";
   const budget = input.budget ?? new ReviewRunBudget(config.reviewConcurrency.maxActiveRuns);
   if (!budget.tryStart()) return "skipped_capacity";
@@ -165,8 +178,7 @@ export async function reviewPull(input: {
       await recordAndAcknowledgeCommandDecision({ config, github, state, repo, pull, commandDecision });
     }
 
-    const evidenceBaseDir = join(config.evidenceDir, localDateFolder(), repo.replace("/", "__"), `pr-${pull.number}`, pull.head.sha);
-    const evidenceDir = commandReviewRequested ? join(evidenceBaseDir, `command-${commandDecision.commandId}`) : evidenceBaseDir;
+    const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision);
     mkdirSync(evidenceDir, { recursive: true });
 
     const files = await github.listPullFiles(repo, pull.number);
@@ -207,6 +219,13 @@ export async function reviewPull(input: {
 
     assertGitClean(worktree.path);
 
+    const liveBeforePlan = await github.getPull(repo, pull.number);
+    const staleBeforePlan = detectStalePullHead({ expected: pull, live: liveBeforePlan, phase: "before_plan" });
+    if (staleBeforePlan) {
+      recordStaleHeadSkip({ state, repo, pull, stale: staleBeforePlan, evidenceDir });
+      return "skipped_stale_head";
+    }
+
     const located = validateFindingLocations(zcodeResult.findings, reviewFiles);
     const normalized = normalizeFindingsForReview(located.valid, { maxInlineComments: 25 });
     const comments = normalized.comments;
@@ -245,6 +264,13 @@ export async function reviewPull(input: {
     if (input.dryRun) {
       state.recordProcessed({ repo, pullNumber: pull.number, headSha: pull.head.sha, status: "dry_run", event });
       return commandReviewRequested ? "reviewed_command" : "reviewed";
+    }
+
+    const liveBeforePost = await github.getPull(repo, pull.number);
+    const staleBeforePost = detectStalePullHead({ expected: pull, live: liveBeforePost, phase: "before_post" });
+    if (staleBeforePost) {
+      recordStaleHeadSkip({ state, repo, pull, stale: staleBeforePost, evidenceDir });
+      return "skipped_stale_head";
     }
 
     const reviewGithub = new GitHubApi(config.github);
@@ -317,6 +343,59 @@ export function activateRepoForNewOnlyReview(input: {
 export function isCanaryAllowed(config: Pick<BotConfig, "canaryPulls">, repo: string, pullNumber: number): boolean {
   if (!config.canaryPulls || config.canaryPulls.length === 0) return true;
   return new Set(config.canaryPulls).has(`${repo}#${pullNumber}`);
+}
+
+export type StaleHeadPhase = "before_review" | "before_plan" | "before_post";
+
+export interface StaleHeadEvidence {
+  reason: `stale_head_${StaleHeadPhase}`;
+  expectedHeadSha: string;
+  liveHeadSha: string;
+  expectedBaseSha: string;
+  liveBaseSha: string;
+}
+
+export function detectStalePullHead(input: {
+  expected: PullRequestSummary;
+  live: PullRequestSummary;
+  phase: StaleHeadPhase;
+}): StaleHeadEvidence | undefined {
+  if (input.expected.head.sha === input.live.head.sha && input.expected.base.sha === input.live.base.sha) return undefined;
+  return {
+    reason: `stale_head_${input.phase}`,
+    expectedHeadSha: input.expected.head.sha,
+    liveHeadSha: input.live.head.sha,
+    expectedBaseSha: input.expected.base.sha,
+    liveBaseSha: input.live.base.sha
+  };
+}
+
+function buildEvidenceDir(
+  config: BotConfig,
+  repo: string,
+  pull: PullRequestSummary,
+  commandDecision: CommandDecision
+): string {
+  const evidenceBaseDir = join(config.evidenceDir, localDateFolder(), repo.replace("/", "__"), `pr-${pull.number}`, pull.head.sha);
+  return commandDecision.shouldReview ? join(evidenceBaseDir, `command-${commandDecision.commandId}`) : evidenceBaseDir;
+}
+
+function recordStaleHeadSkip(input: {
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  stale: StaleHeadEvidence;
+  evidenceDir: string;
+}): void {
+  mkdirSync(input.evidenceDir, { recursive: true });
+  writeFileSync(join(input.evidenceDir, "stale-head.json"), `${JSON.stringify(input.stale, null, 2)}\n`);
+  input.state.recordProcessed({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    status: "skipped",
+    error: `${input.stale.reason}: live=${input.stale.liveHeadSha}`
+  });
 }
 
 async function resolvePullCommandDecision(input: {

--- a/tests/stale-head.test.ts
+++ b/tests/stale-head.test.ts
@@ -1,0 +1,131 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { BotConfig } from "../src/config.js";
+import type { GitHubApi } from "../src/github.js";
+import { ReviewRunBudget } from "../src/review-budget.js";
+import { ReviewStateStore } from "../src/state.js";
+import type { PullRequestSummary } from "../src/types.js";
+import { detectStalePullHead, reviewPull } from "../src/worker.js";
+
+describe("exact-head stale guards", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("detects a stale PR head with phase-specific evidence", () => {
+    expect(detectStalePullHead({
+      expected: pull(1213, "head-a", "base-a"),
+      live: pull(1213, "head-b", "base-a"),
+      phase: "before_review"
+    })).toEqual({
+      reason: "stale_head_before_review",
+      expectedHeadSha: "head-a",
+      liveHeadSha: "head-b",
+      expectedBaseSha: "base-a",
+      liveBaseSha: "base-a"
+    });
+
+    expect(detectStalePullHead({
+      expected: pull(1213, "head-a", "base-a"),
+      live: pull(1213, "head-a", "base-a"),
+      phase: "before_post"
+    })).toBeUndefined();
+  });
+
+  it("skips a command-triggered review when the live head moved before review work starts", async () => {
+    const root = mkdtempSync(join(tmpdir(), "stale-head-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = minimalConfig(root);
+    const github = {
+      listIssueComments: async () => [
+        {
+          id: 9001,
+          body: "@evaos-code-review-bot re-review",
+          user: { login: "100yenadmin", type: "User" }
+        }
+      ],
+      getPull: async () => pull(1213, "new-head", "base-a"),
+      listPullFiles: async () => {
+        throw new Error("stale command review should not fetch files");
+      },
+      canPostAsApp: () => false
+    } as unknown as GitHubApi;
+
+    await expect(reviewPull({
+      config,
+      github,
+      state: store,
+      repo: "electricsheephq/WorldOS",
+      pull: pull(1213, "old-head", "base-a"),
+      dryRun: true,
+      useZCode: false,
+      budget: new ReviewRunBudget(1)
+    })).resolves.toBe("skipped_stale_head");
+
+    expect(store.hasProcessed("electricsheephq/WorldOS", 1213, "old-head")).toBe(true);
+    store.close();
+  });
+});
+
+function minimalConfig(root: string): BotConfig {
+  mkdirSync(join(root, "work"), { recursive: true });
+  return {
+    pilotRepos: ["electricsheephq/WorldOS"],
+    pollIntervalMs: 60_000,
+    skipDrafts: true,
+    workRoot: join(root, "work"),
+    statePath: join(root, "state.sqlite"),
+    evidenceDir: join(root, "evidence"),
+    activation: {
+      reviewExistingOpenPrsOnActivation: false
+    },
+    reviewConcurrency: {
+      maxActiveRuns: 1,
+      leaseTtlMs: 60_000
+    },
+    walkthrough: {
+      enabled: false,
+      postIssueComment: false
+    },
+    commands: {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    },
+    zcode: {
+      cliPath: "/unused/zcode.cjs",
+      appConfigPath: "/unused/config.json",
+      model: "GLM-5.2",
+      timeoutMs: 1,
+      maxPatchBytes: 1,
+      retryMaxRetries: 0
+    },
+    github: {}
+  };
+}
+
+function pull(number: number, headSha: string, baseSha: string): PullRequestSummary {
+  return {
+    number,
+    title: `PR ${number}`,
+    draft: false,
+    head: {
+      sha: headSha,
+      ref: `pr-${number}`
+    },
+    base: {
+      sha: baseSha,
+      ref: "main",
+      repo: {
+        full_name: "electricsheephq/WorldOS"
+      }
+    },
+    html_url: `https://github.test/electricsheephq/WorldOS/pull/${number}`
+  };
+}


### PR DESCRIPTION
## Summary
- re-fetch live PR state before command-triggered review work, before planning comments, and before live posting
- skip and record stale-head output instead of posting comments from an old head
- add stale-head evidence JSON and daemon counter support
- add tests for stale-head detection and command-triggered stale skip behavior

Closes #16
Links #28

## Validation
- npm test (20 files / 68 tests)
- npm run build
- git diff --check

## Live beta boundary
No active config expansion. This only hardens the existing review loop and should be promoted through docs/beta-release-runbook.md after merge.