### PR TITLE
Sprint 2: validate repo policy config schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Pilot local worker for ZCode/GLM-5.2 pull request reviews.
 - Installs a temporary per-worktree ZCode policy that allows read-only file tools, disables Bash/mutation/subagents, then restores/removes it before the clean check.
 - Sets `ZCODE_MODEL_RETRY_MAX_RETRIES=0` by default so provider rate limits fail fast instead of multiplying requests.
 - Resolves repo profiles before review; once profiles are configured, unknown or disabled repos skip closed before GitHub PR fetches.
+- Schema-validates repo policy, allowlist, canary, pre-merge check, and finishing-touch config before runtime use.
 - Keeps maintainer PR-comment commands disabled by default; when enabled, only configured trusted authors can steer read-only reviews.
 
 ## Commands

--- a/config.example.json
+++ b/config.example.json
@@ -27,21 +27,74 @@
         "defaultBranch": "main",
         "reviewProfile": "assertive",
         "promptNote": "Prioritize Unity scene, save-state, gameplay, release-regression, and data-loss risks.",
+        "autoReview": {
+          "baseBranches": ["main"],
+          "labels": ["!wip", "!do-not-review"]
+        },
         "pathFilters": ["Assets/**", "Packages/**", "ProjectSettings/**", "src/**", "tests/**", "!Library/**"],
+        "pathInstructions": {
+          "Assets/**": ["Prioritize scene, prefab, save-state, and gameplay regressions."],
+          "ProjectSettings/**": ["Treat build/release behavior changes as high risk."]
+        },
         "riskyPaths": ["Assets/**", "ProjectSettings/**", "Packages/manifest.json"],
         "proofExpectations": ["Mention Unity editor/play-mode or focused smoke evidence when relevant."],
         "validationHints": ["Prefer correctness, persistence, CI, and release findings over style-only feedback."],
-        "readinessHints": ["Scene, save, build, or package changes need explicit rollback and smoke notes."]
+        "readinessHints": ["Scene, save, build, or package changes need explicit rollback and smoke notes."],
+        "preMergeChecks": {
+          "title": {
+            "mode": "warning",
+            "instructions": "Title should name the gameplay or release behavior changed."
+          },
+          "testEvidence": {
+            "mode": "warning",
+            "instructions": "Look for focused Unity/editor smoke, CI, or fixture evidence when code changes affect runtime behavior."
+          }
+        },
+        "finishingTouches": {
+          "unitTests": {
+            "enabled": false,
+            "instructions": "Design-only declaration until finishing-touch commands are explicitly enabled."
+          }
+        },
+        "suggestedLabels": ["unity", "gameplay", "regression-hardening"]
       },
       "100yenadmin/evaOS-GUI": {
         "displayName": "evaOS Workbench",
         "defaultBranch": "main",
         "reviewProfile": "assertive",
         "promptNote": "Prioritize Electron/Workbench runtime regressions, packaged-app resource shape, bridge control, and macOS permission identity risk.",
+        "autoReview": {
+          "baseBranches": ["main"],
+          "labels": ["!wip", "!do-not-review"]
+        },
         "pathFilters": ["src/**", "apps/**", "scripts/**", "package.json", "package-lock.json", "!dist/**"],
+        "pathInstructions": {
+          "apps/eva-desktop-mac/**": ["Check macOS identity, helper path, and packaged resource shape risk."],
+          "scripts/**": ["Treat release, packaging, and artifact-shape changes as high risk."]
+        },
         "riskyPaths": ["scripts/**", "apps/eva-desktop-mac/**", "package.json"],
         "proofExpectations": ["Mention focused app smoke, packaged resource checks, or CI artifact proof when relevant."],
-        "validationHints": ["Do not ask for broad local suites when remote CI or fast-smoke proof is the right gate."]
+        "validationHints": ["Do not ask for broad local suites when remote CI or fast-smoke proof is the right gate."],
+        "preMergeChecks": {
+          "description": {
+            "mode": "warning",
+            "instructions": "Description should name app/runtime behavior and validation evidence."
+          },
+          "testEvidence": {
+            "mode": "warning",
+            "instructions": "Look for focused app smoke, packaged resource checks, or CI proof."
+          }
+        },
+        "finishingTouches": {
+          "docstrings": {
+            "enabled": false,
+            "instructions": "Design-only declaration until finishing-touch commands are explicitly enabled."
+          },
+          "unitTests": {
+            "enabled": false
+          }
+        },
+        "suggestedLabels": ["workbench", "macos", "regression-hardening"]
       },
       "electricsheephq/evaos-code-review-bot": {
         "enabled": false,
@@ -52,7 +105,20 @@
         "pathFilters": ["src/**", "tests/**", "docs/**", "config.example.json", "package.json", "package-lock.json"],
         "riskyPaths": ["src/github.ts", "src/state.ts", "src/worker.ts", "src/zcode.ts"],
         "proofExpectations": ["Require focused tests, TypeScript build, duplicate-suppression proof, and release-status proof before live promotion."],
-        "readinessHints": ["Do not expand live monitoring from this example profile alone."]
+        "readinessHints": ["Do not expand live monitoring from this example profile alone."],
+        "preMergeChecks": {
+          "testEvidence": {
+            "mode": "error",
+            "instructions": "Require focused tests, TypeScript build, and beta release-status proof before live promotion."
+          }
+        },
+        "finishingTouches": {
+          "unitTests": {
+            "enabled": false,
+            "instructions": "Do not auto-generate tests from the bot during live review until opt-in command gates ship."
+          }
+        },
+        "suggestedLabels": ["bot", "regression-hardening"]
       }
     },
     "orgFallbacks": {

--- a/docs/repo-profiles.md
+++ b/docs/repo-profiles.md
@@ -20,11 +20,31 @@ Profiles live under `repoProfiles` in the bot config:
         "defaultBranch": "main",
         "reviewProfile": "assertive",
         "promptNote": "Prioritize Unity scene, save-state, gameplay, and release-regression risks.",
+        "autoReview": {
+          "baseBranches": ["main"],
+          "labels": ["!wip", "!do-not-review"]
+        },
         "pathFilters": ["Assets/**", "Packages/**", "!Library/**"],
+        "pathInstructions": {
+          "Assets/**": ["Prioritize scene, prefab, save-state, and gameplay regressions."]
+        },
         "riskyPaths": ["Assets/**", "ProjectSettings/**"],
         "proofExpectations": ["Mention Unity editor/play-mode smoke evidence when relevant."],
         "validationHints": ["Prefer correctness and release findings over style-only feedback."],
-        "readinessHints": ["Scene and save changes need rollback notes."]
+        "readinessHints": ["Scene and save changes need rollback notes."],
+        "preMergeChecks": {
+          "testEvidence": {
+            "mode": "warning",
+            "instructions": "Look for focused Unity/editor smoke, CI, or fixture evidence."
+          }
+        },
+        "finishingTouches": {
+          "unitTests": {
+            "enabled": false,
+            "instructions": "Declaration only until opt-in finishing-touch commands are enabled."
+          }
+        },
+        "suggestedLabels": ["unity", "gameplay"]
       }
     }
   }
@@ -47,12 +67,40 @@ evidence are recorded.
 - `promptNote`: repo-specific review instruction injected into the ZCode prompt.
 - `pathFilters`: include/exclude globs applied before prompt construction.
   Excludes start with `!`.
+- `pathInstructions`: path-specific review guidance injected into the prompt
+  for matching code areas.
 - `riskyPaths`: high-risk file areas called out in the prompt.
 - `proofExpectations`: evidence the reviewer should look for in PRs.
 - `validationHints`: repo-specific correctness and CI guidance.
 - `readinessHints`: release or rollout readiness notes.
+- `autoReview`: declarative branch and label filters. These are reviewer policy
+  metadata only in v0.2; they do not grant new GitHub permissions or bypass
+  `skipDrafts`, `canaryPulls`, duplicate suppression, or live config gates.
+- `preMergeChecks`: advisory checks the reviewer should consider when building
+  summaries. Each check has `mode: "off" | "warning" | "error"`,
+  optional `instructions`, and optional numeric `threshold` from 0 to 100.
+  These modes do not create GitHub Checks or force `REQUEST_CHANGES` by
+  themselves.
+- `finishingTouches`: declaration surface for future opt-in commands such as
+  docstrings or unit-test suggestions. Entries must remain `enabled: false`
+  until #11 ships explicit command handling and promotion gates.
 - `suggestedLabels` / `suggestedReviewers`: reserved for later enrichment; they
   do not auto-apply labels or reviewers.
+
+## Validation Rules
+
+Configuration loads fail closed before the daemon starts when:
+
+- `pilotRepos` or profile repo keys are not GitHub `owner/repo` names.
+- `canaryPulls` are not `owner/repo#number` strings.
+- booleans, positive integer timeouts/concurrency values, string arrays, or
+  policy modes have the wrong type.
+- pre-merge check thresholds are outside 0-100.
+- finishing-touch declarations omit a boolean `enabled` value.
+
+This is intentionally stricter than the TypeScript interfaces. The live config
+is JSON outside this repository, so runtime validation is the safety net that
+prevents a typo from changing monitoring behavior silently.
 
 ## Graduation To Live Review
 
@@ -70,3 +118,6 @@ Use this path for each new repo from #14 or future allowlists:
 
 Do not treat `config.example.json` as live config. The active launchd config is
 outside the repo under `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/`.
+Do not add repos whose GitHub App installation cannot be verified; public
+visibility or an admin user's `gh repo view` is not enough because reviews must
+be authored by `evaos-code-review-bot`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import { loadConfig } from "./config.js";
 import { formatDaemonLog } from "./daemon-log.js";
 import { GitHubApi } from "./github.js";
 import { collectReleaseStatus } from "./release-status.js";
-import { listReposToScan, resolveRepoProfile } from "./repo-policy.js";
+import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
 import { runOnce } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
 
@@ -22,17 +22,19 @@ async function main(): Promise<void> {
     const monitoredRepos = listReposToScan(config);
     for (const repo of monitoredRepos) {
       const repoPolicy = resolveRepoProfile(config, repo);
+      const policy = buildRepoPolicySnapshot(config, repo);
       if (!repoPolicy.allowed) {
-        readChecks.push({ repo, ok: true, skippedByPolicy: repoPolicy.reason });
+        readChecks.push({ repo, ok: true, policy, skippedByPolicy: repoPolicy.reason });
         continue;
       }
       try {
         await github.listOpenPulls(repo);
-        readChecks.push({ repo, ok: true });
+        readChecks.push({ repo, ok: true, policy });
       } catch (error) {
         readChecks.push({
           repo,
           ok: false,
+          policy,
           error: error instanceof Error ? error.message : String(error)
         });
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,12 +50,47 @@ export interface RepoProfileConfig {
   reviewProfile?: "chill" | "assertive";
   promptNote?: string;
   pathFilters?: string[];
+  pathInstructions?: Record<string, string[]>;
   riskyPaths?: string[];
   proofExpectations?: string[];
   validationHints?: string[];
   readinessHints?: string[];
+  autoReview?: RepoAutoReviewConfig;
+  preMergeChecks?: RepoPreMergeChecksConfig;
+  finishingTouches?: RepoFinishingTouchesConfig;
   suggestedLabels?: string[];
   suggestedReviewers?: string[];
+}
+
+export interface RepoAutoReviewConfig {
+  baseBranches?: string[];
+  labels?: string[];
+}
+
+export interface RepoPreMergeChecksConfig {
+  title?: RepoPreMergeCheckConfig;
+  description?: RepoPreMergeCheckConfig;
+  linkedIssue?: RepoPreMergeCheckConfig;
+  testEvidence?: RepoPreMergeCheckConfig;
+  docs?: RepoPreMergeCheckConfig;
+  docstrings?: RepoPreMergeCheckConfig;
+}
+
+export interface RepoPreMergeCheckConfig {
+  mode: "off" | "warning" | "error";
+  instructions?: string;
+  threshold?: number;
+}
+
+export interface RepoFinishingTouchesConfig {
+  docstrings?: RepoFinishingTouchConfig;
+  unitTests?: RepoFinishingTouchConfig;
+  stackedPr?: RepoFinishingTouchConfig;
+}
+
+export interface RepoFinishingTouchConfig {
+  enabled: boolean;
+  instructions?: string;
 }
 
 export interface CommandConfig {
@@ -127,11 +162,32 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function validateConfig(config: BotConfig): void {
-  if (!Array.isArray(config.pilotRepos)) throw new Error("config.pilotRepos must be an array");
-  if (!Array.isArray(config.commands.botMentions)) throw new Error("config.commands.botMentions must be an array");
-  if (!Array.isArray(config.commands.trustedAuthors)) throw new Error("config.commands.trustedAuthors must be an array");
+  validateStringArray(config.pilotRepos, "config.pilotRepos");
+  for (const repo of config.pilotRepos) validateRepoName(repo, "config.pilotRepos");
+  if (config.canaryPulls !== undefined) {
+    validateStringArray(config.canaryPulls, "config.canaryPulls");
+    for (const canary of config.canaryPulls) validateCanaryPull(canary, "config.canaryPulls");
+  }
+  validateBoolean(config.skipDrafts, "config.skipDrafts");
+  validatePositiveInteger(config.pollIntervalMs, "config.pollIntervalMs");
+  validateBoolean(config.activation.reviewExistingOpenPrsOnActivation, "config.activation.reviewExistingOpenPrsOnActivation");
+  validatePositiveInteger(config.reviewConcurrency.maxActiveRuns, "config.reviewConcurrency.maxActiveRuns");
+  validatePositiveInteger(config.reviewConcurrency.leaseTtlMs, "config.reviewConcurrency.leaseTtlMs");
+  validateBoolean(config.walkthrough.enabled, "config.walkthrough.enabled");
+  validateBoolean(config.walkthrough.postIssueComment, "config.walkthrough.postIssueComment");
+  validateBoolean(config.commands.enabled, "config.commands.enabled");
+  validateStringArray(config.commands.botMentions, "config.commands.botMentions");
+  validateStringArray(config.commands.trustedAuthors, "config.commands.trustedAuthors");
+  validateBoolean(config.commands.acknowledge, "config.commands.acknowledge");
+  validatePositiveInteger(config.zcode.timeoutMs, "config.zcode.timeoutMs");
+  validatePositiveInteger(config.zcode.maxPatchBytes, "config.zcode.maxPatchBytes");
+  validateNonNegativeInteger(config.zcode.retryMaxRetries, "config.zcode.retryMaxRetries");
+
   if (!config.repoProfiles) return;
 
+  if (config.repoProfiles.enableOrgFallbacks !== undefined) {
+    validateBoolean(config.repoProfiles.enableOrgFallbacks, "repoProfiles.enableOrgFallbacks");
+  }
   validateProfileRecord(config.repoProfiles.repos, "repoProfiles.repos");
   validateProfileRecord(config.repoProfiles.orgFallbacks, "repoProfiles.orgFallbacks");
 }
@@ -139,7 +195,13 @@ function validateConfig(config: BotConfig): void {
 function validateProfileRecord(record: Record<string, RepoProfileConfig> | undefined, label: string): void {
   if (!record) return;
   for (const [key, profile] of Object.entries(record)) {
+    if (label.endsWith(".repos")) validateRepoName(key, label);
+    if (label.endsWith(".orgFallbacks")) validateOwnerName(key, label);
     if (!isRecord(profile)) throw new Error(`${label}.${key} must be an object`);
+    if (profile.enabled !== undefined) validateBoolean(profile.enabled, `${label}.${key}.enabled`);
+    validateOptionalString(profile.displayName, `${label}.${key}.displayName`);
+    validateOptionalString(profile.defaultBranch, `${label}.${key}.defaultBranch`);
+    validateOptionalString(profile.promptNote, `${label}.${key}.promptNote`);
     if (profile.reviewProfile && profile.reviewProfile !== "chill" && profile.reviewProfile !== "assertive") {
       throw new Error(`${label}.${key}.reviewProfile must be "chill" or "assertive"`);
     }
@@ -152,10 +214,112 @@ function validateProfileRecord(record: Record<string, RepoProfileConfig> | undef
       "suggestedLabels",
       "suggestedReviewers"
     ] as const) {
-      const value = profile[field];
-      if (value !== undefined && (!Array.isArray(value) || value.some((entry) => typeof entry !== "string"))) {
-        throw new Error(`${label}.${key}.${field} must be an array of strings`);
-      }
+      validateOptionalStringArray(profile[field], `${label}.${key}.${field}`);
     }
+    validatePathInstructions(profile.pathInstructions, `${label}.${key}.pathInstructions`);
+    validateAutoReview(profile.autoReview, `${label}.${key}.autoReview`);
+    validatePreMergeChecks(profile.preMergeChecks, `${label}.${key}.preMergeChecks`);
+    validateFinishingTouches(profile.finishingTouches, `${label}.${key}.finishingTouches`);
   }
+}
+
+function validateAutoReview(value: unknown, label: string): void {
+  if (value === undefined) return;
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  validateOptionalStringArray(value.baseBranches, `${label}.baseBranches`);
+  validateOptionalStringArray(value.labels, `${label}.labels`);
+}
+
+function validatePreMergeChecks(value: unknown, label: string): void {
+  if (value === undefined) return;
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  for (const field of ["title", "description", "linkedIssue", "testEvidence", "docs", "docstrings"] as const) {
+    validatePreMergeCheck(value[field], `${label}.${field}`);
+  }
+}
+
+function validatePreMergeCheck(value: unknown, label: string): void {
+  if (value === undefined) return;
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  if (value.mode !== "off" && value.mode !== "warning" && value.mode !== "error") {
+    throw new Error(`${label}.mode must be "off", "warning", or "error"`);
+  }
+  validateOptionalString(value.instructions, `${label}.instructions`);
+  if (value.threshold !== undefined) validatePercentage(value.threshold, `${label}.threshold`);
+}
+
+function validateFinishingTouches(value: unknown, label: string): void {
+  if (value === undefined) return;
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  for (const field of ["docstrings", "unitTests", "stackedPr"] as const) {
+    validateFinishingTouch(value[field], `${label}.${field}`);
+  }
+}
+
+function validateFinishingTouch(value: unknown, label: string): void {
+  if (value === undefined) return;
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  validateBoolean(value.enabled, `${label}.enabled`);
+  validateOptionalString(value.instructions, `${label}.instructions`);
+}
+
+function validatePathInstructions(value: unknown, label: string): void {
+  if (value === undefined) return;
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  for (const [pathPattern, instructions] of Object.entries(value)) {
+    if (!pathPattern.trim()) throw new Error(`${label} keys must be non-empty path patterns`);
+    validateStringArray(instructions, `${label}.${pathPattern}`);
+  }
+}
+
+function validateOptionalString(value: unknown, label: string): void {
+  if (value !== undefined && typeof value !== "string") throw new Error(`${label} must be a string`);
+}
+
+function validateStringArray(value: unknown, label: string): void {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string" || entry.length === 0)) {
+    throw new Error(`${label} must be an array of non-empty strings`);
+  }
+}
+
+function validateOptionalStringArray(value: unknown, label: string): void {
+  if (value === undefined) return;
+  validateStringArray(value, label);
+}
+
+function validateBoolean(value: unknown, label: string): void {
+  if (typeof value !== "boolean") throw new Error(`${label} must be a boolean`);
+}
+
+function validatePositiveInteger(value: unknown, label: string): void {
+  if (!Number.isInteger(value) || Number(value) < 1) throw new Error(`${label} must be a positive integer`);
+}
+
+function validateNonNegativeInteger(value: unknown, label: string): void {
+  if (!Number.isInteger(value) || Number(value) < 0) throw new Error(`${label} must be a non-negative integer`);
+}
+
+function validatePercentage(value: unknown, label: string): void {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 100) {
+    throw new Error(`${label} must be a number from 0 to 100`);
+  }
+}
+
+function validateRepoName(value: string, label: string): void {
+  const [owner, repo, extra] = value.split("/");
+  if (extra !== undefined || !owner || !repo) throw new Error(`${label} entries must be GitHub owner/repo names`);
+  validateOwnerName(owner, `${label}.${value}.owner`);
+  validateOwnerName(repo, `${label}.${value}.repo`);
+}
+
+function validateOwnerName(value: string, label: string): void {
+  if (!/^[A-Za-z0-9_.-]+$/.test(value)) throw new Error(`${label} must contain only GitHub name characters`);
+}
+
+function validateCanaryPull(value: string, label: string): void {
+  const [repo, pullNumber, extra] = value.split("#");
+  if (extra !== undefined || !repo || !pullNumber || !/^[1-9][0-9]*$/.test(pullNumber)) {
+    throw new Error(`${label} entries must use owner/repo#number`);
+  }
+  validateRepoName(repo, label);
 }

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -6,6 +6,7 @@ export type RepoProfileSkipReason = "repo_profile_disabled" | "repo_profile_miss
 
 export interface ResolvedRepoProfile extends RepoProfileConfig {
   repo: string;
+  canonicalRepo: string;
   source: RepoProfileSource;
 }
 
@@ -13,14 +14,30 @@ export type RepoProfileResolution =
   | { allowed: true; profile: ResolvedRepoProfile }
   | { allowed: false; reason: RepoProfileSkipReason };
 
+export interface RepoPolicySnapshot {
+  repo: string;
+  canonicalRepo: string;
+  allowed: boolean;
+  source?: RepoProfileSource;
+  displayName?: string;
+  reviewProfile?: "chill" | "assertive";
+  pathFilters?: string[];
+  autoReview?: RepoProfileConfig["autoReview"];
+  preMergeChecks?: RepoProfileConfig["preMergeChecks"];
+  finishingTouches?: RepoProfileConfig["finishingTouches"];
+  suggestedLabels?: string[];
+  suggestedReviewers?: string[];
+  skippedByPolicy?: RepoProfileSkipReason;
+}
+
 export function listReposToScan(config: BotConfig): string[] {
-  const configured = unique(config.pilotRepos);
+  const configured = uniqueRepos(config.pilotRepos);
   if (configured.length > 0) return configured;
 
   const explicitRepos = Object.entries(config.repoProfiles?.repos ?? {})
     .filter(([, profile]) => profile.enabled !== false)
     .map(([repo]) => repo);
-  return unique(explicitRepos);
+  return uniqueRepos(explicitRepos);
 }
 
 export function resolveRepoProfile(config: BotConfig, repo: string): RepoProfileResolution {
@@ -32,26 +49,56 @@ export function resolveRepoProfile(config: BotConfig, repo: string): RepoProfile
     };
   }
 
-  const explicit = registry?.repos?.[repo];
+  const explicit = findProfileByRepo(registry?.repos, repo);
   if (explicit) {
-    if (explicit.enabled === false) return { allowed: false, reason: "repo_profile_disabled" };
+    const [, profile] = explicit;
+    const explicitRepo = explicit[0];
+    if (profile.enabled === false) return { allowed: false, reason: "repo_profile_disabled" };
     return {
       allowed: true,
-      profile: normalizeProfile(repo, "explicit", explicit)
+      profile: normalizeProfile(explicitRepo, "explicit", profile)
     };
   }
 
   const org = repo.split("/")[0];
-  const fallback = org ? registry?.orgFallbacks?.[org] : undefined;
-  if (fallback && fallback.enabled === false) return { allowed: false, reason: "repo_profile_disabled" };
+  const fallback = org ? findProfileByOwner(registry?.orgFallbacks, org) : undefined;
+  if (fallback && fallback[1].enabled === false) return { allowed: false, reason: "repo_profile_disabled" };
   if (registry?.enableOrgFallbacks && fallback) {
     return {
       allowed: true,
-      profile: normalizeProfile(repo, "org_fallback", fallback)
+      profile: normalizeProfile(repo, "org_fallback", fallback[1])
     };
   }
 
   return { allowed: false, reason: "repo_profile_missing" };
+}
+
+export function buildRepoPolicySnapshot(config: BotConfig, repo: string): RepoPolicySnapshot {
+  const resolution = resolveRepoProfile(config, repo);
+  if (!resolution.allowed) {
+    return {
+      repo,
+      canonicalRepo: canonicalRepoName(repo),
+      allowed: false,
+      skippedByPolicy: resolution.reason
+    };
+  }
+
+  const profile = resolution.profile;
+  return {
+    repo,
+    canonicalRepo: profile.canonicalRepo,
+    allowed: true,
+    source: profile.source,
+    displayName: profile.displayName,
+    reviewProfile: profile.reviewProfile,
+    pathFilters: profile.pathFilters,
+    autoReview: profile.autoReview,
+    preMergeChecks: profile.preMergeChecks,
+    finishingTouches: profile.finishingTouches,
+    suggestedLabels: profile.suggestedLabels,
+    suggestedReviewers: profile.suggestedReviewers
+  };
 }
 
 export function filterPullFilesForProfile(files: PullFilePatch[], profile: ResolvedRepoProfile): PullFilePatch[] {
@@ -79,11 +126,17 @@ export function buildRepoProfilePromptSection(profile: ResolvedRepoProfile): str
 
   if (profile.defaultBranch) lines.push(`- Default branch: ${profile.defaultBranch}`);
   if (profile.promptNote) lines.push(`- Repo-specific instruction: ${profile.promptNote}`);
+  pushAutoReview(lines, profile.autoReview);
   pushList(lines, "Path filters", profile.pathFilters);
+  pushPathInstructions(lines, profile.pathInstructions);
   pushList(lines, "High-risk paths", profile.riskyPaths);
   pushList(lines, "Proof expectations", profile.proofExpectations);
   pushList(lines, "Validation hints", profile.validationHints);
   pushList(lines, "Readiness hints", profile.readinessHints);
+  pushPreMergeChecks(lines, profile.preMergeChecks);
+  pushFinishingTouches(lines, profile.finishingTouches);
+  pushList(lines, "Allowed label suggestions", profile.suggestedLabels);
+  pushList(lines, "Allowed reviewer suggestions", profile.suggestedReviewers);
 
   return lines.join("\n");
 }
@@ -96,9 +149,28 @@ function normalizeProfile(
   return {
     ...profile,
     repo,
+    canonicalRepo: canonicalRepoName(repo),
     source,
     reviewProfile: profile.reviewProfile ?? "assertive"
   };
+}
+
+function findProfileByRepo(
+  profiles: Record<string, RepoProfileConfig> | undefined,
+  repo: string
+): [string, RepoProfileConfig] | undefined {
+  if (!profiles) return undefined;
+  const target = canonicalRepoName(repo);
+  return Object.entries(profiles).find(([candidate]) => canonicalRepoName(candidate) === target);
+}
+
+function findProfileByOwner(
+  profiles: Record<string, RepoProfileConfig> | undefined,
+  owner: string
+): [string, RepoProfileConfig] | undefined {
+  if (!profiles) return undefined;
+  const target = owner.toLowerCase();
+  return Object.entries(profiles).find(([candidate]) => candidate.toLowerCase() === target);
 }
 
 function hasProfileRegistry(registry: BotConfig["repoProfiles"]): boolean {
@@ -114,8 +186,62 @@ function pushList(lines: string[], label: string, values: string[] | undefined):
   lines.push(`- ${label}: ${values.join("; ")}`);
 }
 
-function unique(values: string[]): string[] {
-  return [...new Set(values.filter(Boolean))];
+function pushAutoReview(lines: string[], autoReview: ResolvedRepoProfile["autoReview"]): void {
+  if (!autoReview) return;
+  pushList(lines, "Auto-review base branches", autoReview.baseBranches);
+  pushList(lines, "Auto-review label filters", autoReview.labels);
+}
+
+function pushPathInstructions(lines: string[], pathInstructions: ResolvedRepoProfile["pathInstructions"]): void {
+  if (!pathInstructions || Object.keys(pathInstructions).length === 0) return;
+  lines.push("- Path-specific instructions:");
+  for (const [pattern, instructions] of Object.entries(pathInstructions)) {
+    lines.push(`  - ${pattern}: ${instructions.join("; ")}`);
+  }
+}
+
+function pushPreMergeChecks(lines: string[], checks: ResolvedRepoProfile["preMergeChecks"]): void {
+  if (!checks) return;
+  const entries = Object.entries(checks).filter(([, check]) => check !== undefined);
+  if (entries.length === 0) return;
+  lines.push("- Pre-merge checks (advisory; do not invent CI status):");
+  for (const [name, check] of entries) {
+    if (!check) continue;
+    const details = [`mode=${check.mode}`];
+    if (check.threshold !== undefined) details.push(`threshold=${check.threshold}`);
+    if (check.instructions) details.push(check.instructions);
+    lines.push(`  - ${name}: ${details.join("; ")}`);
+  }
+}
+
+function pushFinishingTouches(lines: string[], touches: ResolvedRepoProfile["finishingTouches"]): void {
+  if (!touches) return;
+  const entries = Object.entries(touches).filter(([, touch]) => touch !== undefined);
+  if (entries.length === 0) return;
+  lines.push("- Finishing-touch commands (declarations only; do not execute or offer as active unless enabled):");
+  for (const [name, touch] of entries) {
+    if (!touch) continue;
+    const details = [`enabled=${touch.enabled}`];
+    if (touch.instructions) details.push(touch.instructions);
+    lines.push(`  - ${name}: ${details.join("; ")}`);
+  }
+}
+
+function uniqueRepos(values: string[]): string[] {
+  const seen = new Set<string>();
+  const output: string[] = [];
+  for (const value of values.filter(Boolean)) {
+    const canonical = canonicalRepoName(value);
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
+    output.push(value);
+  }
+  return output;
+}
+
+function canonicalRepoName(repo: string): string {
+  const [owner, name] = repo.split("/");
+  return `${owner?.toLowerCase() ?? ""}/${name?.toLowerCase() ?? ""}`;
 }
 
 function matchesGlob(path: string, pattern: string): boolean {

--- a/tests/repo-policy.test.ts
+++ b/tests/repo-policy.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadConfig } from "../src/config.js";
-import { buildRepoProfilePromptSection, filterPullFilesForProfile, resolveRepoProfile } from "../src/repo-policy.js";
+import {
+  buildRepoPolicySnapshot,
+  buildRepoProfilePromptSection,
+  filterPullFilesForProfile,
+  listReposToScan,
+  resolveRepoProfile
+} from "../src/repo-policy.js";
 import { runOnce } from "../src/worker.js";
 import { buildReviewPrompt } from "../src/zcode.js";
 import type { PullFilePatch, PullRequestSummary } from "../src/types.js";
@@ -108,6 +114,33 @@ describe("repo profile registry", () => {
     });
   });
 
+  it("matches repo profiles case-insensitively while preserving configured repo names", () => {
+    const config = loadConfig(
+      writeConfig({
+        pilotRepos: ["electricsheephq/worldOS", "ElectricSheepHQ/WorldOS"],
+        repoProfiles: {
+          repos: {
+            "electricsheephq/WorldOS": {
+              displayName: "WorldOS Unity",
+              reviewProfile: "assertive"
+            }
+          }
+        }
+      })
+    );
+
+    expect(listReposToScan(config)).toEqual(["electricsheephq/worldOS"]);
+    expect(resolveRepoProfile(config, "electricsheephq/worldOS")).toMatchObject({
+      allowed: true,
+      profile: {
+        repo: "electricsheephq/WorldOS",
+        canonicalRepo: "electricsheephq/worldos",
+        source: "explicit",
+        displayName: "WorldOS Unity"
+      }
+    });
+  });
+
   it("applies include and exclude path filters before prompt construction", () => {
     const resolved = resolveRepoProfile(
       loadConfig(
@@ -136,6 +169,154 @@ describe("repo profile registry", () => {
       "src/worker.ts",
       "README.md"
     ]);
+  });
+
+  it("rejects invalid repo policy config before runtime use", () => {
+    expect(() =>
+      loadConfig(
+        writeConfig({
+          pilotRepos: ["not-a-repo"],
+          repoProfiles: {
+            repos: {
+              "not-a-repo": {
+                reviewProfile: "loud"
+              }
+            }
+          }
+        })
+      )
+    ).toThrow(/owner\/repo/);
+
+    expect(() =>
+      loadConfig(
+        writeConfig({
+          canaryPulls: ["electricsheephq/WorldOS#abc"]
+        })
+      )
+    ).toThrow(/owner\/repo#number/);
+
+    expect(() =>
+      loadConfig(
+        writeConfig({
+          repoProfiles: {
+            repos: {
+              "electricsheephq/WorldOS": {
+                preMergeChecks: {
+                  testEvidence: { mode: "block" }
+                }
+              }
+            }
+          }
+        })
+      )
+    ).toThrow(/preMergeChecks\.testEvidence\.mode/);
+
+    expect(() =>
+      loadConfig(
+        writeConfig({
+          repoProfiles: {
+            repos: {
+              "electricsheephq/WorldOS": {
+                finishingTouches: {
+                  unitTests: { enabled: "yes" }
+                }
+              }
+            }
+          }
+        })
+      )
+    ).toThrow(/finishingTouches\.unitTests\.enabled/);
+  });
+
+  it("renders repo policy checks and finishing-touch declarations as prompt-only guidance", () => {
+    const resolved = resolveRepoProfile(
+      loadConfig(
+        writeConfig({
+          pilotRepos: ["electricsheephq/evaos-code-review-bot"],
+          repoProfiles: {
+            repos: {
+              "electricsheephq/evaos-code-review-bot": {
+                autoReview: {
+                  baseBranches: ["main", "release/.*"],
+                  labels: ["!wip", "ready-for-review"]
+                },
+                pathInstructions: {
+                  "src/github.ts": ["Treat App-authored identity regressions as high risk."],
+                  "src/state.ts": ["Check duplicate-suppression invariants."]
+                },
+                preMergeChecks: {
+                  title: { mode: "warning", instructions: "Title should name the safety behavior." },
+                  testEvidence: { mode: "error", instructions: "Require focused tests and release-status proof." },
+                  docstrings: { mode: "off", threshold: 80 }
+                },
+                finishingTouches: {
+                  docstrings: { enabled: false, instructions: "Design only; do not execute during review." },
+                  unitTests: { enabled: false }
+                },
+                suggestedLabels: ["bot", "regression-hardening"],
+                suggestedReviewers: ["100yenadmin"]
+              }
+            }
+          }
+        })
+      ),
+      "electricsheephq/evaos-code-review-bot"
+    );
+    const profile = expectAllowed(resolved);
+    const prompt = buildRepoProfilePromptSection(profile);
+
+    expect(prompt).toContain("Auto-review base branches: main; release/.*");
+    expect(prompt).toContain("src/github.ts: Treat App-authored identity regressions as high risk.");
+    expect(prompt).toContain("Pre-merge checks (advisory; do not invent CI status)");
+    expect(prompt).toContain("testEvidence: mode=error; Require focused tests and release-status proof.");
+    expect(prompt).toContain("Finishing-touch commands (declarations only");
+    expect(prompt).toContain("unitTests: enabled=false");
+    expect(prompt).toContain("Allowed label suggestions: bot; regression-hardening");
+    expect(prompt).toContain("Allowed reviewer suggestions: 100yenadmin");
+  });
+
+  it("builds compact policy snapshots for doctor and release evidence", () => {
+    const config = loadConfig(
+      writeConfig({
+        pilotRepos: ["electricsheephq/evaos-code-review-bot", "electricsheephq/unknown"],
+        repoProfiles: {
+          repos: {
+            "electricsheephq/evaos-code-review-bot": {
+              displayName: "Review bot",
+              pathFilters: ["src/**"],
+              preMergeChecks: {
+                testEvidence: { mode: "error", instructions: "Require focused test proof." }
+              },
+              finishingTouches: {
+                unitTests: { enabled: false }
+              }
+            }
+          }
+        }
+      })
+    );
+
+    expect(buildRepoPolicySnapshot(config, "electricsheephq/evaos-code-review-bot")).toMatchObject({
+      repo: "electricsheephq/evaos-code-review-bot",
+      canonicalRepo: "electricsheephq/evaos-code-review-bot",
+      allowed: true,
+      source: "explicit",
+      displayName: "Review bot",
+      reviewProfile: "assertive",
+      pathFilters: ["src/**"],
+      preMergeChecks: {
+        testEvidence: { mode: "error", instructions: "Require focused test proof." }
+      },
+      finishingTouches: {
+        unitTests: { enabled: false }
+      }
+    });
+    expect(buildRepoPolicySnapshot(config, "electricsheephq/unknown")).toEqual({
+      repo: "electricsheephq/unknown",
+      canonicalRepo: "electricsheephq/unknown",
+      allowed: false,
+      skippedByPolicy: "repo_profile_missing"
+    });
   });
 
   it("injects repo profile guidance into the ZCode prompt", () => {


### PR DESCRIPTION
## Summary
- adds strict zero-dependency validation for repo policy, allowlist, canary, pre-merge check, and finishing-touch config
- adds case-insensitive canonical repo matching plus compact doctor policy snapshots
- documents prompt-only pre-merge/finishing-touch declarations and safe allowlist/App-install boundaries

Refs #5
Refs #14
Links #28

## Validation
- `npx vitest run tests/repo-policy.test.ts --pool=forks --poolOptions.forks.singleFork=true`
- `npm test -- --pool=forks --poolOptions.forks.singleFork=true`
- `npm run build`
- active live config doctor via App installation token: `ok=true`, 19 monitored repos, 0 failed reads, commands disabled, all current repos using default policy source

## Safety
- no live config mutation
- no App permission expansion
- finishing-touch config is declaration/prompt-only in this PR
- Martian/lossless-claw remains pending canonical App-install confirmation and is not promoted live
