### PR TITLE
Sprint 2: add filter-impact evidence for repo profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Pilot local worker for ZCode/GLM-5.2 pull request reviews.
 - Installs a temporary per-worktree ZCode policy that allows read-only file tools, disables Bash/mutation/subagents, then restores/removes it before the clean check.
 - Sets `ZCODE_MODEL_RETRY_MAX_RETRIES=0` by default so provider rate limits fail fast instead of multiplying requests.
 - Resolves repo profiles before review; once profiles are configured, unknown or disabled repos skip closed before GitHub PR fetches.
+- Writes `filter-impact.json` evidence for profile path filters and always preserves common safety-critical root/workflow/config files unless explicitly excluded.
 - Schema-validates repo policy, allowlist, canary, pre-merge check, and finishing-touch config before runtime use.
 - Keeps maintainer PR-comment commands disabled by default; when enabled, only configured trusted authors can steer read-only reviews.
 

--- a/config.active-profiles.example.json
+++ b/config.active-profiles.example.json
@@ -42,7 +42,7 @@
           "baseBranches": ["main"],
           "labels": ["!wip", "!do-not-review"]
         },
-        "pathFilters": ["Assets/**", "Packages/**", "ProjectSettings/**", "src/**", "tests/**", "!Library/**", "!Temp/**"],
+        "pathFilters": ["Assets/**", "Packages/**", "ProjectSettings/**", "extensions/**", "qa/**", "src/**", "tests/**", "!Library/**", "!Temp/**"],
         "pathInstructions": {
           "Assets/**": ["Prioritize scene, prefab, save-state, asset-reference, and gameplay regressions."],
           "ProjectSettings/**": ["Treat build, platform, input, graphics, and release behavior changes as high risk."]
@@ -251,7 +251,7 @@
           "baseBranches": ["main"],
           "labels": ["!wip", "!do-not-review"]
         },
-        "pathFilters": ["src/**", "app/**", "pages/**", "components/**", "content/**", "public/**", "package.json", "package-lock.json"],
+        "pathFilters": ["src/**", "app/**", "pages/**", "components/**", "content/**", "public/**", "supabase/**", "package.json", "package-lock.json"],
         "riskyPaths": ["app/**", "pages/**", "content/**", "public/**"],
         "proofExpectations": ["Look for focused route, form, SEO, accessibility, or deploy smoke evidence."],
         "validationHints": ["Call out broken CTAs, forms, metadata, tracking, or public content regressions."],
@@ -277,7 +277,7 @@
           "baseBranches": ["main"],
           "labels": ["!wip", "!do-not-review"]
         },
-        "pathFilters": ["src/**", "server/**", "agents/**", "tools/**", "tests/**", "docs/**", "package.json", "package-lock.json"],
+        "pathFilters": ["src/**", "server/**", "agents/**", "tools/**", "tests/**", "docs/**", "supabase/**", "package.json", "package-lock.json"],
         "riskyPaths": ["agents/**", "tools/**", "server/**", "src/**"],
         "proofExpectations": ["Look for focused agent/tool/runtime proof and no-secret evidence."],
         "validationHints": ["Call out permission widening, unsafe tool execution, stale memory, and customer-data leakage."],
@@ -459,7 +459,7 @@
           "baseBranches": ["main"],
           "labels": ["!wip", "!do-not-review"]
         },
-        "pathFilters": ["src/**", "apps/**", "scripts/**", "tests/**", "package.json", "package-lock.json", "!dist/**", "!release/**"],
+        "pathFilters": ["src/**", "apps/**", "mobile/**", "scripts/**", "tests/**", "package.json", "package-lock.json", "!dist/**", "!release/**"],
         "pathInstructions": {
           "apps/eva-desktop-mac/**": ["Check macOS identity, helper path, TCC identity, and packaged resource shape risk."],
           "scripts/**": ["Treat release, packaging, and artifact-shape changes as high risk."]
@@ -524,7 +524,7 @@
           "baseBranches": ["main"],
           "labels": ["!wip", "!do-not-review"]
         },
-        "pathFilters": ["Assets/**", "Packages/**", "ProjectSettings/**", "src/**", "tests/**", "!Library/**", "!Temp/**"],
+        "pathFilters": ["Assets/**", "Packages/**", "ProjectSettings/**", "extensions/**", "qa/**", "src/**", "tests/**", "!Library/**", "!Temp/**"],
         "pathInstructions": {
           "Assets/**": ["Prioritize scene, prefab, asset-reference, and gameplay regressions."],
           "ProjectSettings/**": ["Treat build, input, graphics, and package settings as high risk."]

--- a/docs/repo-profiles.md
+++ b/docs/repo-profiles.md
@@ -66,7 +66,9 @@ evidence are recorded.
   `assertive`.
 - `promptNote`: repo-specific review instruction injected into the ZCode prompt.
 - `pathFilters`: include/exclude globs applied before prompt construction.
-  Excludes start with `!`.
+  Excludes start with `!`. Include filters are hard prompt filters, not just
+  ranking hints: files that do not match a profile include or a built-in safety
+  include are omitted from the model prompt.
 - `pathInstructions`: path-specific review guidance injected into the prompt
   for matching code areas.
 - `riskyPaths`: high-risk file areas called out in the prompt.
@@ -101,6 +103,25 @@ Configuration loads fail closed before the daemon starts when:
 This is intentionally stricter than the TypeScript interfaces. The live config
 is JSON outside this repository, so runtime validation is the safety net that
 prevents a typo from changing monitoring behavior silently.
+
+## Filter Impact Evidence
+
+The worker writes `filter-impact.json` in every review evidence directory before
+prompt construction. It records:
+
+- original changed-file count
+- included and excluded file counts
+- profile include/exclude filters
+- built-in safety include patterns
+- per-file include/exclude reason and matched pattern
+
+Profile include filters are augmented by a built-in safety include baseline for
+common root, workflow, dependency, runtime, release, and security files such as
+`.github/**`, `README.md`, `AGENTS.md`, `package-lock.json`, `pnpm-lock.yaml`,
+`tsconfig*.json`, `Dockerfile`, `Makefile`, `pyproject.toml`, `go.mod`,
+`Cargo.toml`, `*.plist`, and entitlements files. Explicit profile excludes
+still win, so do not add broad `!` filters without checking filter-impact
+evidence.
 
 ## Graduation To Live Review
 
@@ -147,4 +168,6 @@ npx tsx src/cli.ts doctor --config /path/to/candidate-live-config.json
 
 Then run dry-run review evidence for at least one current PR and one
 negative-control PR per newly profiled repo group before promoting through
-`docs/beta-release-runbook.md`.
+`docs/beta-release-runbook.md`. The promotion packet must include
+`filter-impact.json` summaries proving important changed files were not hidden
+by profile filters.

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -30,6 +30,77 @@ export interface RepoPolicySnapshot {
   skippedByPolicy?: RepoProfileSkipReason;
 }
 
+export type PullFileFilterReason =
+  | "no_profile_filters"
+  | "matched_profile_include"
+  | "matched_safety_include"
+  | "excluded_by_profile"
+  | "no_matching_include";
+
+export interface PullFileFilterDecision {
+  filename: string;
+  included: boolean;
+  reason: PullFileFilterReason;
+  pattern?: string;
+}
+
+export interface PullFileFilterImpact {
+  originalCount: number;
+  includedCount: number;
+  excludedCount: number;
+  profileIncludeFilters: string[];
+  profileExcludeFilters: string[];
+  safetyIncludePatterns: string[];
+  included: PullFileFilterDecision[];
+  excluded: PullFileFilterDecision[];
+}
+
+const SAFETY_INCLUDE_PATTERNS = [
+  ".github/**",
+  "README.md",
+  "AGENTS.md",
+  "CHANGELOG.md",
+  "SECURITY.md",
+  "CODEOWNERS",
+  "Dockerfile",
+  "Dockerfile.*",
+  "docker-compose*.yml",
+  "Makefile",
+  "justfile",
+  "package.json",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "bun.lock",
+  "tsconfig*.json",
+  "vite.config.*",
+  "vitest.config.*",
+  "playwright.config.*",
+  "next.config.*",
+  "tailwind.config.*",
+  "eslint.config.*",
+  ".npmrc",
+  ".nvmrc",
+  ".node-version",
+  ".env.example",
+  ".gitleaks.toml",
+  ".gitattributes",
+  ".gitignore",
+  "go.mod",
+  "go.sum",
+  "Cargo.toml",
+  "Cargo.lock",
+  "pyproject.toml",
+  "uv.lock",
+  "requirements*.txt",
+  "poetry.lock",
+  "Pipfile",
+  "Pipfile.lock",
+  "**/*.plist",
+  "**/*.entitlements",
+  "**/*.entitlements.plist"
+];
+
 export function listReposToScan(config: BotConfig): string[] {
   const configured = uniqueRepos(config.pilotRepos);
   if (configured.length > 0) return configured;
@@ -102,17 +173,31 @@ export function buildRepoPolicySnapshot(config: BotConfig, repo: string): RepoPo
 }
 
 export function filterPullFilesForProfile(files: PullFilePatch[], profile: ResolvedRepoProfile): PullFilePatch[] {
-  const filters = profile.pathFilters?.filter(Boolean) ?? [];
-  if (filters.length === 0) return files;
+  const impact = buildPullFileFilterImpact(files, profile);
+  const included = new Set(impact.included.map((decision) => decision.filename));
+  return files.filter((file) => included.has(file.filename));
+}
 
+export function buildPullFileFilterImpact(
+  files: PullFilePatch[],
+  profile: ResolvedRepoProfile
+): PullFileFilterImpact {
+  const filters = profile.pathFilters?.filter(Boolean) ?? [];
   const includeFilters = filters.filter((pattern) => !pattern.startsWith("!"));
   const excludeFilters = filters.filter((pattern) => pattern.startsWith("!")).map((pattern) => pattern.slice(1));
-
-  return files.filter((file) => {
-    const included = includeFilters.length === 0 || includeFilters.some((pattern) => matchesGlob(file.filename, pattern));
-    const excluded = excludeFilters.some((pattern) => matchesGlob(file.filename, pattern));
-    return included && !excluded;
-  });
+  const decisions = files.map((file) => decideFileFilter(file.filename, includeFilters, excludeFilters));
+  const included = decisions.filter((decision) => decision.included);
+  const excluded = decisions.filter((decision) => !decision.included);
+  return {
+    originalCount: files.length,
+    includedCount: included.length,
+    excludedCount: excluded.length,
+    profileIncludeFilters: includeFilters,
+    profileExcludeFilters: excludeFilters,
+    safetyIncludePatterns: SAFETY_INCLUDE_PATTERNS,
+    included,
+    excluded
+  };
 }
 
 export function buildRepoProfilePromptSection(profile: ResolvedRepoProfile): string {
@@ -237,6 +322,56 @@ function uniqueRepos(values: string[]): string[] {
     output.push(value);
   }
   return output;
+}
+
+function decideFileFilter(
+  filename: string,
+  includeFilters: string[],
+  excludeFilters: string[]
+): PullFileFilterDecision {
+  const excludePattern = excludeFilters.find((pattern) => matchesGlob(filename, pattern));
+  if (excludePattern) {
+    return {
+      filename,
+      included: false,
+      reason: "excluded_by_profile",
+      pattern: excludePattern
+    };
+  }
+
+  if (includeFilters.length === 0) {
+    return {
+      filename,
+      included: true,
+      reason: "no_profile_filters"
+    };
+  }
+
+  const includePattern = includeFilters.find((pattern) => matchesGlob(filename, pattern));
+  if (includePattern) {
+    return {
+      filename,
+      included: true,
+      reason: "matched_profile_include",
+      pattern: includePattern
+    };
+  }
+
+  const safetyPattern = SAFETY_INCLUDE_PATTERNS.find((pattern) => matchesGlob(filename, pattern));
+  if (safetyPattern) {
+    return {
+      filename,
+      included: true,
+      reason: "matched_safety_include",
+      pattern: safetyPattern
+    };
+  }
+
+  return {
+    filename,
+    included: false,
+    reason: "no_matching_include"
+  };
 }
 
 function canonicalRepoName(repo: string): string {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,7 +12,12 @@ import { validateFindingLocations } from "./diff.js";
 import { decideReviewEvent, normalizeFindingsForReview } from "./findings.js";
 import { assertGitClean, preparePullWorktree } from "./git.js";
 import { GitHubApi } from "./github.js";
-import { filterPullFilesForProfile, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
+import {
+  buildPullFileFilterImpact,
+  filterPullFilesForProfile,
+  listReposToScan,
+  resolveRepoProfile
+} from "./repo-policy.js";
 import { ReviewRunBudget } from "./review-budget.js";
 import { redactSecrets } from "./secrets.js";
 import { ReviewStateStore, type ReviewRunLease } from "./state.js";
@@ -33,6 +38,7 @@ export interface RunOnceResult {
   reposScanned: number;
   pullsSeen: number;
   reviewed: number;
+  failed: number;
   skippedDraft: number;
   skippedCanary: number;
   skippedPolicy: number;
@@ -67,6 +73,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
     reposScanned: 0,
     pullsSeen: 0,
     reviewed: 0,
+    failed: 0,
     skippedDraft: 0,
     skippedCanary: 0,
     skippedPolicy: 0,
@@ -102,16 +109,23 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
       });
       result.baselinedExisting += activation.baselined;
       for (const pull of pulls) {
-        const status = await reviewPull({
-          config,
-          github,
-          state,
-          repo,
-          pull,
-          dryRun: options.dryRun,
-          useZCode: options.useZCode ?? true,
-          budget
-        });
+        let status: ReviewPullResult;
+        try {
+          status = await reviewPull({
+            config,
+            github,
+            state,
+            repo,
+            pull,
+            dryRun: options.dryRun,
+            useZCode: options.useZCode ?? true,
+            budget
+          });
+        } catch (error) {
+          recordFailedReview({ config, state, repo, pull, error });
+          result.failed += 1;
+          continue;
+        }
         if (status === "reviewed" || status === "reviewed_command") result.reviewed += 1;
         if (status === "skipped_draft") result.skippedDraft += 1;
         if (status === "skipped_canary") result.skippedCanary += 1;
@@ -183,6 +197,7 @@ export async function reviewPull(input: {
 
     const files = await github.listPullFiles(repo, pull.number);
     const reviewFiles = filterPullFilesForProfile(files, repoPolicy.profile);
+    const filterImpact = buildPullFileFilterImpact(files, repoPolicy.profile);
     const worktree = preparePullWorktree({
       repo,
       pullNumber: pull.number,
@@ -198,6 +213,7 @@ export async function reviewPull(input: {
       maxPatchBytes: config.zcode.maxPatchBytes
     });
     writeFileSync(join(evidenceDir, "repo-profile.json"), `${JSON.stringify(repoPolicy.profile, null, 2)}\n`);
+    writeFileSync(join(evidenceDir, "filter-impact.json"), `${JSON.stringify(filterImpact, null, 2)}\n`);
     if (commandDecision.action !== "none") {
       writeFileSync(join(evidenceDir, "command.json"), `${JSON.stringify(commandDecision.command, null, 2)}\n`);
     }
@@ -395,6 +411,32 @@ function recordStaleHeadSkip(input: {
     headSha: input.pull.head.sha,
     status: "skipped",
     error: `${input.stale.reason}: live=${input.stale.liveHeadSha}`
+  });
+}
+
+export function recordFailedReview(input: {
+  config: BotConfig;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  error: unknown;
+}): void {
+  const evidenceDir = buildEvidenceDir(input.config, input.repo, input.pull, { action: "none", shouldReview: false });
+  const errorMessage = redactSecrets(input.error instanceof Error ? input.error.message : String(input.error));
+  mkdirSync(evidenceDir, { recursive: true });
+  writeFileSync(join(evidenceDir, "review-error.json"), `${JSON.stringify({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    error: errorMessage,
+    recordedAt: new Date().toISOString()
+  }, null, 2)}\n`);
+  input.state.recordProcessed({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    status: "failed",
+    error: errorMessage
   });
 }
 

--- a/tests/repo-policy.test.ts
+++ b/tests/repo-policy.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadConfig } from "../src/config.js";
 import {
+  buildPullFileFilterImpact,
   buildRepoPolicySnapshot,
   buildRepoProfilePromptSection,
   filterPullFilesForProfile,
@@ -169,6 +170,66 @@ describe("repo profile registry", () => {
       "src/worker.ts",
       "README.md"
     ]);
+  });
+
+  it("keeps safety-critical root and workflow files visible despite narrow path filters", () => {
+    const profile = expectAllowed(
+      resolveRepoProfile(
+        loadConfig(
+          writeConfig({
+            repoProfiles: {
+              repos: {
+                "electricsheephq/WorldOS": {
+                  displayName: "WorldOS",
+                  pathFilters: ["Assets/**", "ProjectSettings/**", "!ProjectSettings/generated/**"]
+                }
+              }
+            }
+          })
+        ),
+        "electricsheephq/WorldOS"
+      )
+    );
+    const files: PullFilePatch[] = [
+      { filename: "Assets/Scene.unity", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "+scene" },
+      { filename: ".github/workflows/build.yml", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "+ci" },
+      { filename: "package-lock.json", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "+lock" },
+      { filename: "tsconfig.json", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "+ts" },
+      { filename: "ProjectSettings/generated/cache.asset", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "+cache" },
+      { filename: "docs/notes.md", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "+notes" }
+    ];
+
+    const impact = buildPullFileFilterImpact(files, profile);
+
+    expect(filterPullFilesForProfile(files, profile).map((file) => file.filename)).toEqual([
+      "Assets/Scene.unity",
+      ".github/workflows/build.yml",
+      "package-lock.json",
+      "tsconfig.json"
+    ]);
+    expect(impact).toMatchObject({
+      originalCount: 6,
+      includedCount: 4,
+      excludedCount: 2
+    });
+    expect(impact.included).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ filename: "Assets/Scene.unity", reason: "matched_profile_include", pattern: "Assets/**" }),
+        expect.objectContaining({ filename: ".github/workflows/build.yml", reason: "matched_safety_include", pattern: ".github/**" }),
+        expect.objectContaining({ filename: "package-lock.json", reason: "matched_safety_include", pattern: "package-lock.json" }),
+        expect.objectContaining({ filename: "tsconfig.json", reason: "matched_safety_include", pattern: "tsconfig*.json" })
+      ])
+    );
+    expect(impact.excluded).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          filename: "ProjectSettings/generated/cache.asset",
+          reason: "excluded_by_profile",
+          pattern: "ProjectSettings/generated/**"
+        }),
+        expect.objectContaining({ filename: "docs/notes.md", reason: "no_matching_include" })
+      ])
+    );
   });
 
   it("rejects invalid repo policy config before runtime use", () => {
@@ -346,6 +407,49 @@ describe("repo profile registry", () => {
     }
   });
 
+  it("keeps representative active-profile changed surfaces visible", () => {
+    const template = JSON.parse(readFileSync(new URL("../config.active-profiles.example.json", import.meta.url), "utf8"));
+    const config = loadConfig(writeConfig(template));
+    const cases = [
+      {
+        repo: "electricsheephq/WorldOS",
+        files: ["extensions/renderers/shared/room_recipes.json", "qa/export_scene_grid.py", "qa/seed_gfx_crypt_2room.py"]
+      },
+      {
+        repo: "100yenadmin/evaOS-GUI",
+        files: [
+          ".github/workflows/pr-checks.yml",
+          ".github/workflows/public-security-scan.yml",
+          ".gitleaks.toml",
+          "mobile/eas.json",
+          "mobile/scripts/build.js"
+        ]
+      },
+      {
+        repo: "electricsheephq/electric-sheep-eva-marketing-site",
+        files: ["supabase/functions/create-stripe-checkout/index.ts"]
+      },
+      {
+        repo: "electricsheephq/evaos-cortex",
+        files: [
+          ".env.example",
+          "supabase/config.toml",
+          "supabase/functions/_shared/finance_metrics.ts",
+          "supabase/functions/finance-metrics-refresh/index.test.ts",
+          "supabase/functions/finance-metrics-refresh/index.ts"
+        ]
+      }
+    ];
+
+    for (const testCase of cases) {
+      const profile = expectAllowed(resolveRepoProfile(config, testCase.repo));
+      const files = testCase.files.map((filename) => patchFile(filename));
+      const impact = buildPullFileFilterImpact(files, profile);
+      expect(impact.excluded, `${testCase.repo} excluded ${impact.excluded.map((entry) => entry.filename).join(", ")}`).toEqual([]);
+      expect(filterPullFilesForProfile(files, profile).map((file) => file.filename)).toEqual(testCase.files);
+    }
+  });
+
   it("injects repo profile guidance into the ZCode prompt", () => {
     const resolved = resolveRepoProfile(
       loadConfig(
@@ -414,6 +518,17 @@ function expectAllowed(resolution: RepoProfileResolution): ResolvedRepoProfile {
   expect(resolution.allowed).toBe(true);
   if (!resolution.allowed) throw new Error(`Expected repo profile to be allowed, got ${resolution.reason}`);
   return resolution.profile;
+}
+
+function patchFile(filename: string): PullFilePatch {
+  return {
+    filename,
+    status: "modified",
+    additions: 1,
+    deletions: 0,
+    changes: 1,
+    patch: `+${filename}`
+  };
 }
 
 const pull: PullRequestSummary = {

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { BotConfig } from "../src/config.js";
+import { ReviewStateStore } from "../src/state.js";
+import type { PullRequestSummary } from "../src/types.js";
+import { localDateFolder, recordFailedReview } from "../src/worker.js";
+
+describe("worker review failures", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("records a failed head with redacted evidence so duplicate suppression can hold", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-failure-"));
+    roots.push(root);
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = minimalConfig(root);
+    const pull = pullSummary(1222, "head-failed");
+
+    recordFailedReview({
+      config,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      error: new Error("ZCode failed before completion: spawnSync node ETIMEDOUT with ghp_1234567890abcdefghijklmnopqrstuvwx")
+    });
+
+    expect(state.hasProcessed("electricsheephq/WorldOS", 1222, "head-failed")).toBe(true);
+    const evidence = readFileSync(
+      join(root, "evidence", localDateFolder(), "electricsheephq__WorldOS", "pr-1222", "head-failed", "review-error.json"),
+      "utf8"
+    );
+    expect(evidence).toContain("ETIMEDOUT");
+    expect(evidence).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+    state.close();
+  });
+});
+
+function minimalConfig(root: string): BotConfig {
+  return {
+    pilotRepos: ["electricsheephq/WorldOS"],
+    pollIntervalMs: 60_000,
+    skipDrafts: true,
+    workRoot: join(root, "work"),
+    statePath: join(root, "state.sqlite"),
+    evidenceDir: join(root, "evidence"),
+    activation: {
+      reviewExistingOpenPrsOnActivation: false
+    },
+    reviewConcurrency: {
+      maxActiveRuns: 1,
+      leaseTtlMs: 60_000
+    },
+    walkthrough: {
+      enabled: false,
+      postIssueComment: false
+    },
+    commands: {
+      enabled: false,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: [],
+      acknowledge: false
+    },
+    zcode: {
+      cliPath: "/unused/zcode.cjs",
+      appConfigPath: "/unused/config.json",
+      model: "GLM-5.2",
+      timeoutMs: 1,
+      maxPatchBytes: 1,
+      retryMaxRetries: 0
+    },
+    github: {}
+  };
+}
+
+function pullSummary(number: number, headSha: string): PullRequestSummary {
+  return {
+    number,
+    title: `PR ${number}`,
+    draft: false,
+    head: {
+      sha: headSha,
+      ref: `pr-${number}`,
+      repo: { full_name: "electricsheephq/WorldOS" }
+    },
+    base: {
+      sha: "base",
+      ref: "main",
+      repo: { full_name: "electricsheephq/WorldOS" }
+    },
+    html_url: `https://github.com/electricsheephq/WorldOS/pull/${number}`
+  };
+}


### PR DESCRIPTION
## Summary

Refs #5. Links #14 and #28.

This PR hardens the active repo-profile rollout path before any profile-backed live config promotion:

- Adds `filter-impact.json` evidence for every review run, including original/included/excluded file counts and per-file include/exclude reasons.
- Adds a built-in safety include baseline so common root/workflow/config/security/release files stay visible to ZCode unless a profile explicitly excludes them.
- Widens active-profile template filters where the v0.2 dry-run eval proved representative files would otherwise be hidden.
- Records per-PR review failures as redacted `failed` DB rows plus `review-error.json` evidence so a ZCode timeout does not kill the daemon without a trace.

## Safety

- No live config mutation in this PR.
- No GitHub App permission expansion.
- Commands remain disabled in the active-profile template/eval config.
- Explicit `!` profile excludes still win over safety includes.
- Failed review heads are deduped as processed and release-status treats `failed` rows as blocking.

## Evidence

Eval packet:
`/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/profile-template-eval-20260701T044833+0700/filter-impact-patched-v3/`

Key local gates:

- `npm run build` passed.
- `npm test -- --pool=forks --poolOptions.forks.singleFork=true` passed: 21 files, 76 tests.
- App-auth doctor passed: 19 monitored repos, 19 explicit profiles, App installation read mode, 0 failed reads.
- Full-scan dry-run/no-ZCode passed: 19 repos scanned, 63 PRs seen, 59 existing heads baselined, 0 failures.
- Six scoped representative dry-runs passed: all reviewed once, 0 failures, 0 stale heads.
- Duplicate-head rerun passed: all six reviewed 0 and skippedProcessed 1.
- Filter-impact summary passed: excludedTotal=0 across the six representative PRs.

Representative PRs:

- `electricsheephq/WorldOS#1222`
- `100yenadmin/evaOS-GUI#497`
- `electricsheephq/evaos-support-control#160`
- `electricsheephq/electric-sheep-eva-marketing-site#33`
- `electricsheephq/evaos-cortex#2080`
- `electricsheephq/evaos-cortex-plugin#50`

## Runtime Note

The current live launchd worker stopped before this PR because pre-patch daemon behavior let a ZCode `ETIMEDOUT` escape the cycle. After merge, sync `main`, restart launchd, and verify release-status/heartbeat before promoting profile-backed live config.
