### PR TITLE
Sprint 2: keep daemon alive across cycle failures

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "./config.js";
-import { formatDaemonLog } from "./daemon-log.js";
+import { runDaemonCycle } from "./daemon.js";
 import { GitHubApi } from "./github.js";
 import { collectReleaseStatus } from "./release-status.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
@@ -93,33 +93,15 @@ async function main(): Promise<void> {
     for (;;) {
       cycle += 1;
       const dryRun = args["dry-run"] !== "false";
-      console.log(formatDaemonLog({
-        event: "daemon_cycle_start",
+      await runDaemonCycle({
         cycle,
         dryRun,
         pilotRepos: config.pilotRepos,
         monitoredRepos,
         canaryPulls: config.canaryPulls ?? [],
-        commandsEnabled: config.commands.enabled
-      }));
-      try {
-        const result = await runOnce({ configPath: args.config, dryRun });
-        console.log(formatDaemonLog({
-          event: "daemon_cycle_complete",
-          cycle,
-          dryRun,
-          result
-        }));
-      } catch (error) {
-        console.error(formatDaemonLog({
-          event: "daemon_cycle_failed",
-          level: "error",
-          cycle,
-          dryRun,
-          error: error instanceof Error ? error.message : String(error)
-        }));
-        throw error;
-      }
+        commandsEnabled: config.commands.enabled,
+        configPath: args.config
+      });
       await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));
     }
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,0 +1,56 @@
+import { formatDaemonLog } from "./daemon-log.js";
+import { runOnce, type RunOnceResult } from "./worker.js";
+
+export type DaemonCycleResult =
+  | { ok: true; result: RunOnceResult }
+  | { ok: false; error: string };
+
+export interface RunDaemonCycleOptions {
+  cycle: number;
+  dryRun: boolean;
+  configPath?: string;
+  pilotRepos: string[];
+  monitoredRepos: string[];
+  canaryPulls: string[];
+  commandsEnabled: boolean;
+  runOnceImpl?: (options: { configPath?: string; dryRun: boolean }) => Promise<RunOnceResult>;
+  stdout?: (line: string) => void;
+  stderr?: (line: string) => void;
+}
+
+export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<DaemonCycleResult> {
+  const stdout = input.stdout ?? console.log;
+  const stderr = input.stderr ?? console.error;
+  const runOnceImpl = input.runOnceImpl ?? runOnce;
+
+  stdout(formatDaemonLog({
+    event: "daemon_cycle_start",
+    cycle: input.cycle,
+    dryRun: input.dryRun,
+    pilotRepos: input.pilotRepos,
+    monitoredRepos: input.monitoredRepos,
+    canaryPulls: input.canaryPulls,
+    commandsEnabled: input.commandsEnabled
+  }));
+
+  try {
+    const result = await runOnceImpl({ configPath: input.configPath, dryRun: input.dryRun });
+    stdout(formatDaemonLog({
+      event: "daemon_cycle_complete",
+      cycle: input.cycle,
+      dryRun: input.dryRun,
+      result
+    }));
+    return { ok: true, result };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    stderr(formatDaemonLog({
+      event: "daemon_cycle_failed",
+      level: "error",
+      cycle: input.cycle,
+      dryRun: input.dryRun,
+      error: message
+    }));
+    return { ok: false, error: message };
+  }
+}

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { runDaemonCycle } from "../src/daemon.js";
+
+describe("daemon cycle resilience", () => {
+  it("logs runtime cycle failures without throwing out of the daemon loop", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const result = await runDaemonCycle({
+      cycle: 8,
+      dryRun: false,
+      configPath: "/config.json",
+      pilotRepos: ["electricsheephq/WorldOS"],
+      monitoredRepos: ["electricsheephq/WorldOS"],
+      canaryPulls: [],
+      commandsEnabled: false,
+      runOnceImpl: async () => {
+        throw new Error("ZCode failed before completion: spawnSync node ETIMEDOUT with ghp_1234567890abcdefghijklmnopqrstuvwx");
+      },
+      stdout: (line) => stdout.push(line),
+      stderr: (line) => stderr.push(line)
+    });
+
+    expect(result.ok).toBe(false);
+    expect(stdout).toHaveLength(1);
+    expect(JSON.parse(stdout[0]!)).toMatchObject({
+      event: "daemon_cycle_start",
+      cycle: 8,
+      dryRun: false
+    });
+    expect(stderr).toHaveLength(1);
+    const failure = JSON.parse(stderr[0]!);
+    expect(failure).toMatchObject({
+      event: "daemon_cycle_failed",
+      level: "error",
+      cycle: 8,
+      dryRun: false
+    });
+    expect(failure.error).toContain("ETIMEDOUT");
+    expect(failure.error).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #40. Links #28, #41, #42, #43, and #44.

This PR moves one daemon polling cycle into a testable `runDaemonCycle` helper and changes the live daemon loop so runtime cycle failures are logged and the polling loop continues instead of throwing out to launchd.

The startup/config/auth path is still outside the loop and remains fatal. This only changes runtime cycle failures after the daemon has already loaded config and started polling.

## Why

The LCO#183 incident showed the old behavior: a ZCode `ETIMEDOUT` escaped the cycle, killed launchd, and left no current DB/evidence row for the missed head. PR #39 added per-PR failed-row evidence. This PR adds the loop boundary so any remaining cycle-level throw is logged and the daemon sleeps/continues.

## Validation

- RED first: `tests/daemon-loop.test.ts` initially failed because `src/daemon.ts` did not exist.
- Focused test passed: `npm test -- --pool=forks --poolOptions.forks.singleFork=true tests/daemon-loop.test.ts`.
- Build passed: `npm run build`.
- Full local suite passed: `npm test -- --pool=forks --poolOptions.forks.singleFork=true` (22 files, 77 tests).

## Safety

- No live config mutation.
- No GitHub App permission expansion.
- No posting behavior changes.
- Error logs still flow through `formatDaemonLog`, preserving redaction.
- Fatal startup/config failures remain handled by top-level `main().catch`.
