### PR TITLE
Sprint 2: add monitored PR coverage audit

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 import { loadConfig } from "./config.js";
+import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
 import { runDaemonCycle } from "./daemon.js";
 import { GitHubApi } from "./github.js";
 import { collectReleaseStatus } from "./release-status.js";
@@ -72,6 +73,27 @@ async function main(): Promise<void> {
     });
     console.log(JSON.stringify(status, null, 2));
     if (!status.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "coverage-audit") {
+    const config = loadConfig(args.config);
+    const github = new GitHubApi(config.github);
+    const state = CoverageStateReader.open(args["state-path"] ?? config.statePath);
+    try {
+      const audit = await collectCoverageAudit({
+        config,
+        github,
+        state,
+        repo: args.repo,
+        pullNumber: args.pr ? Number(args.pr) : undefined,
+        verifyCurrentHeads: args["verify-current-heads"] !== "false"
+      });
+      console.log(JSON.stringify(audit, null, 2));
+      if (!audit.ok) process.exitCode = 1;
+    } finally {
+      state.close();
+    }
     return;
   }
 

--- a/src/coverage-audit.ts
+++ b/src/coverage-audit.ts
@@ -1,0 +1,331 @@
+import { existsSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import type { BotConfig } from "./config.js";
+import { listReposToScan, resolveRepoProfile, type RepoProfileSkipReason } from "./repo-policy.js";
+import type { StoredProcessedReviewRecord } from "./state.js";
+import { isCanaryAllowed } from "./worker.js";
+import type { PullRequestSummary } from "./types.js";
+
+export type CoverageSkipReason = RepoProfileSkipReason | "draft" | "closed" | "canary";
+
+export interface CoverageAuditSummary {
+  reposScanned: number;
+  pullsSeen: number;
+  processed: number;
+  unprocessed: number;
+  skipped: number;
+  staleHeads: number;
+  readFailures: number;
+}
+
+export interface CoverageAuditPullEntry {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  title: string;
+  url: string;
+  draft: boolean;
+  state?: string;
+}
+
+export interface CoverageProcessedEntry extends CoverageAuditPullEntry {
+  status: StoredProcessedReviewRecord["status"];
+  event?: StoredProcessedReviewRecord["event"];
+  reviewUrl?: string;
+  error?: string;
+  createdAt: string;
+}
+
+export interface CoverageUnprocessedEntry extends CoverageAuditPullEntry {
+  previousProcessedHeads: string[];
+}
+
+export interface CoverageSkippedEntry {
+  repo: string;
+  reason: CoverageSkipReason;
+  pullNumber?: number;
+  headSha?: string;
+  title?: string;
+  url?: string;
+}
+
+export interface CoverageReadFailure {
+  repo: string;
+  error: string;
+}
+
+export interface CoverageStaleHead {
+  repo: string;
+  pullNumber: number;
+  expectedHeadSha: string;
+  liveHeadSha: string;
+  expectedState?: string;
+  liveState?: string;
+  title: string;
+  url: string;
+}
+
+export interface CoverageAuditReport {
+  ok: boolean;
+  checkedAt: string;
+  scopedRepo?: string;
+  scopedPullNumber?: number;
+  summary: CoverageAuditSummary;
+  processed: CoverageProcessedEntry[];
+  unprocessed: CoverageUnprocessedEntry[];
+  skipped: CoverageSkippedEntry[];
+  staleHeads: CoverageStaleHead[];
+  readFailures: CoverageReadFailure[];
+}
+
+export interface CoverageGitHubApi {
+  listOpenPulls(repo: string): Promise<PullRequestSummary[]>;
+  getPull(repo: string, pullNumber: number): Promise<PullRequestSummary>;
+}
+
+export interface CoverageStateLookup {
+  getProcessedReview(repo: string, pullNumber: number, headSha: string): StoredProcessedReviewRecord | undefined;
+  listProcessedReviewsForPull(repo: string, pullNumber: number): StoredProcessedReviewRecord[];
+}
+
+export class CoverageStateReader implements CoverageStateLookup {
+  private constructor(private readonly db: DatabaseSync | undefined) {}
+
+  static open(statePath: string): CoverageStateReader {
+    if (!existsSync(statePath)) return new CoverageStateReader(undefined);
+    return new CoverageStateReader(new DatabaseSync(statePath, { readOnly: true }));
+  }
+
+  getProcessedReview(repo: string, pullNumber: number, headSha: string): StoredProcessedReviewRecord | undefined {
+    if (!this.db) return undefined;
+    const row = this.db
+      .prepare(
+        `select repo, pull_number, head_sha, status, event, review_url, error, created_at
+         from processed_reviews
+         where repo = ? and pull_number = ? and head_sha = ?
+         limit 1`
+      )
+      .get(repo, pullNumber, headSha) as ProcessedReviewRow | undefined;
+    return row ? mapProcessedReviewRow(row) : undefined;
+  }
+
+  listProcessedReviewsForPull(repo: string, pullNumber: number): StoredProcessedReviewRecord[] {
+    if (!this.db) return [];
+    const rows = this.db
+      .prepare(
+        `select repo, pull_number, head_sha, status, event, review_url, error, created_at
+         from processed_reviews
+         where repo = ? and pull_number = ?
+         order by datetime(created_at) desc`
+      )
+      .all(repo, pullNumber) as unknown as ProcessedReviewRow[];
+    return rows.map(mapProcessedReviewRow);
+  }
+
+  close(): void {
+    this.db?.close();
+  }
+}
+
+export async function collectCoverageAudit(input: {
+  config: BotConfig;
+  github: CoverageGitHubApi;
+  state: CoverageStateLookup;
+  repo?: string;
+  pullNumber?: number;
+  verifyCurrentHeads?: boolean;
+  now?: Date;
+}): Promise<CoverageAuditReport> {
+  const report: CoverageAuditReport = {
+    ok: true,
+    checkedAt: (input.now ?? new Date()).toISOString(),
+    ...(input.repo ? { scopedRepo: input.repo } : {}),
+    ...(input.pullNumber !== undefined ? { scopedPullNumber: input.pullNumber } : {}),
+    summary: {
+      reposScanned: 0,
+      pullsSeen: 0,
+      processed: 0,
+      unprocessed: 0,
+      skipped: 0,
+      staleHeads: 0,
+      readFailures: 0
+    },
+    processed: [],
+    unprocessed: [],
+    skipped: [],
+    staleHeads: [],
+    readFailures: []
+  };
+
+  const repos = input.repo ? [input.repo] : listReposToScan(input.config);
+  for (const repo of repos) {
+    report.summary.reposScanned += 1;
+    const repoPolicy = resolveRepoProfile(input.config, repo);
+    if (!repoPolicy.allowed) {
+      report.skipped.push({ repo, reason: repoPolicy.reason });
+      report.summary.skipped += 1;
+      if (input.repo) {
+        report.readFailures.push({
+          repo,
+          error: `Scoped repo is not eligible for coverage audit: ${repoPolicy.reason}`
+        });
+        report.summary.readFailures += 1;
+      }
+      continue;
+    }
+
+    let pulls: PullRequestSummary[];
+    try {
+      pulls = input.pullNumber !== undefined
+        ? [await input.github.getPull(repo, input.pullNumber)]
+        : await input.github.listOpenPulls(repo);
+    } catch (error) {
+      report.readFailures.push({ repo, error: error instanceof Error ? error.message : String(error) });
+      report.summary.readFailures += 1;
+      continue;
+    }
+
+    report.summary.pullsSeen += pulls.length;
+    for (const pull of pulls) {
+      const closed = pull.state !== undefined && pull.state !== "open";
+      if (closed) {
+        pushSkipped(report, repo, pull, "closed");
+        continue;
+      }
+      if (input.config.skipDrafts && pull.draft) {
+        pushSkipped(report, repo, pull, "draft");
+        continue;
+      }
+      if (!isCanaryAllowed(input.config, repo, pull.number)) {
+        pushSkipped(report, repo, pull, "canary");
+        continue;
+      }
+
+      if (input.verifyCurrentHeads && input.pullNumber === undefined) {
+        let livePull: PullRequestSummary;
+        try {
+          livePull = await input.github.getPull(repo, pull.number);
+        } catch (error) {
+          report.readFailures.push({ repo, error: error instanceof Error ? error.message : String(error) });
+          report.summary.readFailures += 1;
+          continue;
+        }
+        if (isStaleCandidate(pull, livePull)) {
+          report.staleHeads.push({
+            repo,
+            pullNumber: pull.number,
+            expectedHeadSha: pull.head.sha,
+            liveHeadSha: livePull.head.sha,
+            ...(pull.state ? { expectedState: pull.state } : {}),
+            ...(livePull.state ? { liveState: livePull.state } : {}),
+            title: pull.title,
+            url: pull.html_url
+          });
+          report.summary.staleHeads += 1;
+          if (livePull.state !== undefined && livePull.state !== "open") {
+            pushSkipped(report, repo, livePull, "closed");
+            continue;
+          }
+          if (input.config.skipDrafts && livePull.draft) {
+            pushSkipped(report, repo, livePull, "draft");
+            continue;
+          }
+          pushProcessedOrUnprocessed(report, input.state, repo, livePull);
+          continue;
+        }
+      }
+
+      pushProcessedOrUnprocessed(report, input.state, repo, pull);
+    }
+  }
+
+  report.ok = report.summary.unprocessed === 0 && report.summary.readFailures === 0;
+  return report;
+}
+
+function pushProcessedOrUnprocessed(
+  report: CoverageAuditReport,
+  state: CoverageStateLookup,
+  repo: string,
+  pull: PullRequestSummary
+): void {
+  const processed = state.getProcessedReview(repo, pull.number, pull.head.sha);
+  if (processed) {
+    report.processed.push({
+      ...pullEntry(repo, pull),
+      status: processed.status,
+      ...(processed.event ? { event: processed.event } : {}),
+      ...(processed.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
+      ...(processed.error ? { error: processed.error } : {}),
+      createdAt: processed.createdAt
+    });
+    report.summary.processed += 1;
+    return;
+  }
+
+  report.unprocessed.push({
+    ...pullEntry(repo, pull),
+    previousProcessedHeads: state
+      .listProcessedReviewsForPull(repo, pull.number)
+      .filter((record) => record.headSha !== pull.head.sha)
+      .map((record) => record.headSha)
+  });
+  report.summary.unprocessed += 1;
+}
+
+function pushSkipped(
+  report: CoverageAuditReport,
+  repo: string,
+  pull: PullRequestSummary,
+  reason: CoverageSkipReason
+): void {
+  report.skipped.push({
+    repo,
+    reason,
+    pullNumber: pull.number,
+    headSha: pull.head.sha,
+    title: pull.title,
+    url: pull.html_url
+  });
+  report.summary.skipped += 1;
+}
+
+function pullEntry(repo: string, pull: PullRequestSummary): CoverageAuditPullEntry {
+  return {
+    repo,
+    pullNumber: pull.number,
+    headSha: pull.head.sha,
+    title: pull.title,
+    url: pull.html_url,
+    draft: pull.draft,
+    ...(pull.state ? { state: pull.state } : {})
+  };
+}
+
+function isStaleCandidate(expected: PullRequestSummary, live: PullRequestSummary): boolean {
+  return expected.head.sha !== live.head.sha || expected.base.sha !== live.base.sha || expected.state !== live.state;
+}
+
+interface ProcessedReviewRow {
+  repo: string;
+  pull_number: number;
+  head_sha: string;
+  status: StoredProcessedReviewRecord["status"];
+  event: StoredProcessedReviewRecord["event"] | null;
+  review_url: string | null;
+  error: string | null;
+  created_at: string;
+}
+
+function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRecord {
+  return {
+    repo: row.repo,
+    pullNumber: row.pull_number,
+    headSha: row.head_sha,
+    status: row.status,
+    ...(row.event ? { event: row.event } : {}),
+    ...(row.review_url ? { reviewUrl: row.review_url } : {}),
+    ...(row.error ? { error: row.error } : {}),
+    createdAt: row.created_at
+  };
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -18,6 +18,10 @@ export interface ProcessedReviewRecord {
   error?: string;
 }
 
+export interface StoredProcessedReviewRecord extends ProcessedReviewRecord {
+  createdAt: string;
+}
+
 export interface ReviewRunLease {
   leaseId: string;
   expiresAt: string;
@@ -86,6 +90,30 @@ export class ReviewStateStore {
       .prepare("select 1 from processed_reviews where repo = ? and pull_number = ? and head_sha = ? limit 1")
       .get(repo, pullNumber, headSha);
     return Boolean(row);
+  }
+
+  getProcessedReview(repo: string, pullNumber: number, headSha: string): StoredProcessedReviewRecord | undefined {
+    const row = this.db
+      .prepare(
+        `select repo, pull_number, head_sha, status, event, review_url, error, created_at
+         from processed_reviews
+         where repo = ? and pull_number = ? and head_sha = ?
+         limit 1`
+      )
+      .get(repo, pullNumber, headSha) as ProcessedReviewRow | undefined;
+    return row ? mapProcessedReviewRow(row) : undefined;
+  }
+
+  listProcessedReviewsForPull(repo: string, pullNumber: number): StoredProcessedReviewRecord[] {
+    const rows = this.db
+      .prepare(
+        `select repo, pull_number, head_sha, status, event, review_url, error, created_at
+         from processed_reviews
+         where repo = ? and pull_number = ?
+         order by datetime(created_at) desc`
+      )
+      .all(repo, pullNumber) as unknown as ProcessedReviewRow[];
+    return rows.map(mapProcessedReviewRow);
   }
 
   recordProcessed(record: ProcessedReviewRecord): void {
@@ -186,4 +214,28 @@ export class ReviewStateStore {
   close(): void {
     this.db.close();
   }
+}
+
+interface ProcessedReviewRow {
+  repo: string;
+  pull_number: number;
+  head_sha: string;
+  status: ProcessedStatus;
+  event: ReviewEvent | null;
+  review_url: string | null;
+  error: string | null;
+  created_at: string;
+}
+
+function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRecord {
+  return {
+    repo: row.repo,
+    pullNumber: row.pull_number,
+    headSha: row.head_sha,
+    status: row.status,
+    ...(row.event ? { event: row.event } : {}),
+    ...(row.review_url ? { reviewUrl: row.review_url } : {}),
+    ...(row.error ? { error: row.error } : {}),
+    createdAt: row.created_at
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface PullRequestSummary {
   number: number;
   title: string;
   draft: boolean;
+  state?: string;
   body?: string | null;
   head: {
     sha: string;

--- a/tests/coverage-audit.test.ts
+++ b/tests/coverage-audit.test.ts
@@ -1,0 +1,367 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import type { BotConfig } from "../src/config.js";
+import { collectCoverageAudit, CoverageStateReader } from "../src/coverage-audit.js";
+import type { GitHubApi } from "../src/github.js";
+import { ReviewStateStore } from "../src/state.js";
+import type { PullRequestSummary } from "../src/types.js";
+
+const roots: string[] = [];
+
+describe("coverage audit", () => {
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("reports open eligible heads without DB rows while preserving skip/read-failure reasons", async () => {
+    const { root, state } = createState();
+    state.recordProcessed({
+      repo: "owner/allowed",
+      pullNumber: 1,
+      headSha: "head-1",
+      status: "posted",
+      event: "COMMENT"
+    });
+    state.recordProcessed({
+      repo: "owner/allowed",
+      pullNumber: 3,
+      headSha: "old-head-3",
+      status: "posted",
+      event: "COMMENT"
+    });
+    const rowsBefore = countProcessedRows(root);
+
+    const audit = await collectCoverageAudit({
+      config: {
+        ...minimalConfig(root),
+        pilotRepos: ["owner/allowed", "owner/disabled", "owner/missing", "owner/read-fail"],
+        repoProfiles: {
+          repos: {
+            "owner/allowed": { displayName: "Allowed" },
+            "owner/disabled": { enabled: false, displayName: "Disabled" },
+            "owner/read-fail": { displayName: "Read Fail" }
+          }
+        }
+      },
+      github: {
+        listOpenPulls: async (repo: string) => {
+          if (repo === "owner/read-fail") throw new Error("GitHub API 404 for /repos/owner/read-fail/pulls");
+          if (repo !== "owner/allowed") throw new Error(`unexpected GitHub fetch for ${repo}`);
+          return [
+            pull(1, "head-1"),
+            pull(2, "head-2", { draft: true }),
+            pull(3, "head-3"),
+            pull(4, "head-4")
+          ];
+        }
+      } as unknown as GitHubApi,
+      state
+    });
+
+    expect(audit.ok).toBe(false);
+    expect(audit.summary).toMatchObject({
+      reposScanned: 4,
+      pullsSeen: 4,
+      processed: 1,
+      unprocessed: 2,
+      skipped: 3,
+      readFailures: 1
+    });
+    expect(audit.unprocessed.map((entry) => `${entry.repo}#${entry.pullNumber}@${entry.headSha}`)).toEqual([
+      "owner/allowed#3@head-3",
+      "owner/allowed#4@head-4"
+    ]);
+    expect(audit.unprocessed[0]?.previousProcessedHeads).toEqual(["old-head-3"]);
+    expect(audit.skipped).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ repo: "owner/allowed", pullNumber: 2, reason: "draft" }),
+        expect.objectContaining({ repo: "owner/disabled", reason: "repo_profile_disabled" }),
+        expect.objectContaining({ repo: "owner/missing", reason: "repo_profile_missing" })
+      ])
+    );
+    expect(audit.readFailures).toEqual([
+      expect.objectContaining({ repo: "owner/read-fail", error: expect.stringContaining("GitHub API 404") })
+    ]);
+    expect(countProcessedRows(root)).toBe(rowsBefore);
+    state.close();
+  });
+
+  it("supports canary and single-PR scoping without marking closed PRs as misses", async () => {
+    const { root, state } = createState();
+    let getPullCount = 0;
+
+    const audit = await collectCoverageAudit({
+      config: {
+        ...minimalConfig(root),
+        canaryPulls: ["owner/allowed#7"],
+        repoProfiles: {
+          repos: {
+            "owner/allowed": { displayName: "Allowed" }
+          }
+        }
+      },
+      github: {
+        getPull: async () => {
+          getPullCount += 1;
+          return pull(8, "head-8", { state: "closed" });
+        }
+      } as unknown as GitHubApi,
+      state,
+      repo: "owner/allowed",
+      pullNumber: 8,
+      verifyCurrentHeads: true
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      reposScanned: 1,
+      pullsSeen: 1,
+      processed: 0,
+      unprocessed: 0,
+      skipped: 1,
+      readFailures: 0
+    });
+    expect(audit.skipped).toEqual([
+      expect.objectContaining({ repo: "owner/allowed", pullNumber: 8, reason: "closed" })
+    ]);
+    expect(getPullCount).toBe(1);
+    expect(countProcessedRows(root)).toBe(0);
+    state.close();
+  });
+
+  it("fails scoped audits when the requested repo is not eligible by policy", async () => {
+    const { root, state } = createState();
+
+    const audit = await collectCoverageAudit({
+      config: {
+        ...minimalConfig(root),
+        repoProfiles: {
+          repos: {
+            "owner/allowed": { displayName: "Allowed" }
+          }
+        }
+      },
+      github: {
+        getPull: async () => {
+          throw new Error("getPull should not be called for a policy-skipped scoped repo");
+        }
+      } as unknown as GitHubApi,
+      state,
+      repo: "owner/typo",
+      pullNumber: 1
+    });
+
+    expect(audit.ok).toBe(false);
+    expect(audit.summary).toMatchObject({
+      reposScanned: 1,
+      pullsSeen: 0,
+      unprocessed: 0,
+      skipped: 1,
+      readFailures: 1
+    });
+    expect(audit.skipped).toEqual([
+      expect.objectContaining({ repo: "owner/typo", reason: "repo_profile_missing" })
+    ]);
+    expect(audit.readFailures).toEqual([
+      expect.objectContaining({ repo: "owner/typo", error: expect.stringContaining("repo_profile_missing") })
+    ]);
+    state.close();
+  });
+
+  it("does not create a missing DB path while auditing", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-coverage-missing-db-"));
+    roots.push(root);
+    const statePath = join(root, "missing", "state.sqlite");
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(9, "head-9")]
+      } as unknown as GitHubApi,
+      state: CoverageStateReader.open(statePath)
+    });
+
+    expect(audit.summary.unprocessed).toBe(1);
+    expect(audit.unprocessed[0]?.previousProcessedHeads).toEqual([]);
+    expect(existsSync(statePath)).toBe(false);
+    expect(existsSync(join(root, "missing"))).toBe(false);
+  });
+
+  it("re-reads unprocessed open candidates and reports stale heads separately", async () => {
+    const { root, state } = createState();
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(10, "old-head")],
+        getPull: async () => pull(10, "new-head")
+      } as unknown as GitHubApi,
+      state,
+      verifyCurrentHeads: true
+    });
+
+    expect(audit.ok).toBe(false);
+    expect(audit.summary).toMatchObject({
+      staleHeads: 1,
+      unprocessed: 1
+    });
+    expect(audit.staleHeads).toEqual([
+      expect.objectContaining({
+        repo: "owner/allowed",
+        pullNumber: 10,
+        expectedHeadSha: "old-head",
+        liveHeadSha: "new-head"
+      })
+    ]);
+    expect(audit.unprocessed.map((entry) => entry.headSha)).toEqual(["new-head"]);
+    state.close();
+  });
+
+  it("does not fail the audit when a stale listed PR is closed on re-read", async () => {
+    const { root, state } = createState();
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(11, "head-11", { state: "open" })],
+        getPull: async () => pull(11, "head-11", { state: "closed" })
+      } as unknown as GitHubApi,
+      state,
+      verifyCurrentHeads: true
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      staleHeads: 1,
+      unprocessed: 0,
+      skipped: 1,
+      readFailures: 0
+    });
+    expect(audit.staleHeads).toEqual([
+      expect.objectContaining({
+        repo: "owner/allowed",
+        pullNumber: 11,
+        expectedState: "open",
+        liveState: "closed"
+      })
+    ]);
+    state.close();
+  });
+
+  it("counts a stale live head as processed when the live head already has a DB row", async () => {
+    const { root, state } = createState();
+    state.recordProcessed({
+      repo: "owner/allowed",
+      pullNumber: 12,
+      headSha: "new-head",
+      status: "posted",
+      event: "COMMENT"
+    });
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(12, "old-head")],
+        getPull: async () => pull(12, "new-head")
+      } as unknown as GitHubApi,
+      state,
+      verifyCurrentHeads: true
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      staleHeads: 1,
+      processed: 1,
+      unprocessed: 0,
+      readFailures: 0
+    });
+    expect(audit.processed).toEqual([
+      expect.objectContaining({
+        repo: "owner/allowed",
+        pullNumber: 12,
+        headSha: "new-head",
+        status: "posted"
+      })
+    ]);
+    state.close();
+  });
+});
+
+function createState(): { root: string; state: ReviewStateStore } {
+  const root = mkdtempSync(join(tmpdir(), "evaos-coverage-audit-"));
+  roots.push(root);
+  return { root, state: new ReviewStateStore(join(root, "state.sqlite")) };
+}
+
+function countProcessedRows(root: string): number {
+  const db = new DatabaseSync(join(root, "state.sqlite"));
+  try {
+    return (db.prepare("select count(*) as count from processed_reviews").get() as { count: number }).count;
+  } finally {
+    db.close();
+  }
+}
+
+function minimalConfig(root: string): BotConfig {
+  return {
+    pilotRepos: ["owner/allowed"],
+    pollIntervalMs: 60_000,
+    skipDrafts: true,
+    workRoot: join(root, "work"),
+    statePath: join(root, "state.sqlite"),
+    evidenceDir: join(root, "evidence"),
+    activation: {
+      reviewExistingOpenPrsOnActivation: false
+    },
+    reviewConcurrency: {
+      maxActiveRuns: 1,
+      leaseTtlMs: 60_000
+    },
+    walkthrough: {
+      enabled: false,
+      postIssueComment: false
+    },
+    commands: {
+      enabled: false,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: [],
+      acknowledge: false
+    },
+    zcode: {
+      cliPath: "/unused/zcode.cjs",
+      appConfigPath: "/unused/config.json",
+      model: "GLM-5.2",
+      timeoutMs: 1,
+      maxPatchBytes: 1,
+      retryMaxRetries: 0
+    },
+    github: {}
+  };
+}
+
+function pull(
+  number: number,
+  headSha: string,
+  options: { draft?: boolean; state?: string } = {}
+): PullRequestSummary {
+  return {
+    number,
+    title: `PR ${number}`,
+    draft: options.draft ?? false,
+    state: options.state ?? "open",
+    head: {
+      sha: headSha,
+      ref: `pr-${number}`,
+      repo: { full_name: "owner/allowed" }
+    },
+    base: {
+      sha: "base",
+      ref: "main",
+      repo: { full_name: "owner/allowed" }
+    },
+    html_url: `https://github.test/owner/allowed/pull/${number}`
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a read-only `coverage-audit` command that compares open non-draft PR heads in monitored repos against review DB rows.
- Reports processed, unprocessed, skipped, stale-head, and read-failure buckets without posting comments or mutating state.
- Uses a read-only SQLite reader so missing DB paths are not created during audits.

Closes #42.
Links #28, #41, #43, #44.

## Validation
- `npm test -- --pool=forks --poolOptions.forks.singleFork=true tests/coverage-audit.test.ts`
- `npm run build`
- `npm test -- --pool=forks --poolOptions.forks.singleFork=true`
- Live installed-config audit evidence: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/coverage-audit-v0.1/coverage-audit-final-2.json`

## Live Audit Result
```json
{
  "ok": true,
  "summary": {
    "reposScanned": 19,
    "pullsSeen": 66,
    "processed": 62,
    "unprocessed": 0,
    "skipped": 4,
    "staleHeads": 0,
    "readFailures": 0
  }
}
```

## Notes
- During validation, the audit correctly flagged newly created live PRs before the daemon's next cycle processed them. After cycle completion, the final audit passed with zero unprocessed eligible heads.
- Stale PR transitions remain visible in `staleHeads`, but closed-on-reread transitions no longer fail the miss detector when no eligible head is unprocessed.
