### PR TITLE
Sprint 2: add failed-head retry command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -124,7 +124,9 @@ async function main(): Promise<void> {
       useZCode: args.zcode !== "false"
     });
     console.log(JSON.stringify(result, null, 2));
-    if (result.status !== "reviewed" && result.status !== "reviewed_command") process.exitCode = 1;
+    if (result.status !== "reviewed" && result.status !== "reviewed_command" && result.status !== "dry_run") {
+      process.exitCode = 1;
+    }
     return;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { runDaemonCycle } from "./daemon.js";
 import { GitHubApi } from "./github.js";
 import { collectReleaseStatus } from "./release-status.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
-import { runOnce } from "./worker.js";
+import { retryFailedHead, runOnce } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
 
 async function main(): Promise<void> {
@@ -108,6 +108,26 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "retry-failed") {
+    if (!args.repo) throw new Error("--repo is required for retry-failed");
+    if (!args.pr) throw new Error("--pr is required for retry-failed");
+    if (!args["head-sha"]) throw new Error("--head-sha is required for retry-failed");
+    if (args["dry-run"] !== "true" && args["dry-run"] !== "false") {
+      throw new Error("retry-failed requires explicit --dry-run true or --dry-run false");
+    }
+    const result = await retryFailedHead({
+      configPath: args.config,
+      repo: args.repo,
+      pullNumber: Number(args.pr),
+      headSha: args["head-sha"],
+      dryRun: args["dry-run"] === "true",
+      useZCode: args.zcode !== "false"
+    });
+    console.log(JSON.stringify(result, null, 2));
+    if (result.status !== "reviewed" && result.status !== "reviewed_command") process.exitCode = 1;
+    return;
+  }
+
   if (command === "daemon") {
     const config = loadConfig(args.config);
     const monitoredRepos = listReposToScan(config);
@@ -160,6 +180,7 @@ interface ParsedArgs {
   "launchd-label"?: string;
   "state-path"?: string;
   "dry-run"?: string;
+  "head-sha"?: string;
   zcode?: string;
   [key: string]: string | string[] | undefined;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { runDaemonCycle } from "./daemon.js";
 import { GitHubApi } from "./github.js";
 import { collectReleaseStatus } from "./release-status.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
-import { retryFailedHead, runOnce } from "./worker.js";
+import { isSuccessfulRetryStatus, retryFailedHead, runOnce } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
 
 async function main(): Promise<void> {
@@ -124,9 +124,7 @@ async function main(): Promise<void> {
       useZCode: args.zcode !== "false"
     });
     console.log(JSON.stringify(result, null, 2));
-    if (result.status !== "reviewed" && result.status !== "reviewed_command" && result.status !== "dry_run") {
-      process.exitCode = 1;
-    }
+    if (!isSuccessfulRetryStatus(result.status)) process.exitCode = 1;
     return;
   }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -205,8 +205,15 @@ export async function retryFailedHeadWithDeps(input: {
     livePull: pull
   });
   try {
+    const retryReviewConfig: BotConfig = {
+      ...config,
+      reviewConcurrency: {
+        ...config.reviewConcurrency,
+        maxActiveRuns: 1
+      }
+    };
     const status = await input.reviewPullImpl({
-      config,
+      config: retryReviewConfig,
       github,
       state,
       repo: options.repo,
@@ -328,15 +335,6 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   }
 
   const commandReviewRequested = commandDecision.shouldReview;
-  if (commandReviewRequested) {
-    const livePull = await github.getPull(repo, pull.number);
-    const stale = detectStalePullHead({ expected: pull, live: livePull, phase: "before_review" });
-    if (stale) {
-      const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision);
-      recordStaleHeadSkip({ state, repo, pull, stale, evidenceDir });
-      return "skipped_stale_head";
-    }
-  }
   if (
     input.processedHeadPolicy !== "retry_failed_head" &&
     !commandReviewRequested &&
@@ -351,11 +349,17 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   try {
     lease = state.tryAcquireReviewRunLease(config.reviewConcurrency.maxActiveRuns, config.reviewConcurrency.leaseTtlMs);
     if (!lease) return "skipped_capacity";
+    const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision);
+    const liveBeforeReview = await github.getPull(repo, pull.number);
+    const staleBeforeReview = detectStalePullHead({ expected: pull, live: liveBeforeReview, phase: "before_review" });
+    if (staleBeforeReview) {
+      recordStaleHeadSkip({ state, repo, pull, stale: staleBeforeReview, evidenceDir });
+      return "skipped_stale_head";
+    }
     if (commandReviewRequested) {
       await recordAndAcknowledgeCommandDecision({ config, github, state, repo, pull, commandDecision });
     }
 
-    const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision);
     mkdirSync(evidenceDir, { recursive: true });
 
     const files = await github.listPullFiles(repo, pull.number);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -52,7 +52,21 @@ export interface RunOnceResult {
   policySkips: { repo: string; reason: string }[];
 }
 
-type ReviewPullResult =
+export interface RetryFailedHeadResult {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  status: ReviewPullResult | "failed" | "dry_run";
+}
+
+export interface FailedHeadRetryTarget {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  previousError?: string;
+}
+
+export type ReviewPullResult =
   | "reviewed"
   | "reviewed_command"
   | "skipped_draft"
@@ -144,6 +158,122 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
   }
 }
 
+export async function retryFailedHead(options: {
+  configPath?: string;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  dryRun: boolean;
+  useZCode?: boolean;
+}): Promise<RetryFailedHeadResult> {
+  const config = loadConfig(options.configPath);
+  const github = new GitHubApi(config.github);
+  const state = new ReviewStateStore(config.statePath);
+  const budget = new ReviewRunBudget(1);
+  try {
+    const repoPolicy = resolveRepoProfile(config, options.repo);
+    if (!repoPolicy.allowed) {
+      throw new Error(`Refusing retry for repo skipped by policy: ${options.repo} (${repoPolicy.reason})`);
+    }
+    const pull = await github.getPull(options.repo, options.pullNumber);
+    const retryTarget = prepareFailedHeadRetry({
+      state,
+      repo: options.repo,
+      pullNumber: options.pullNumber,
+      headSha: options.headSha,
+      livePull: pull
+    });
+    try {
+      const status = await reviewPull({
+        config,
+        github,
+        state,
+        repo: options.repo,
+        pull,
+        dryRun: options.dryRun,
+        useZCode: options.useZCode ?? true,
+        budget,
+        ignoreProcessedHead: true
+      });
+      const retryStatus = options.dryRun && (status === "reviewed" || status === "reviewed_command") ? "dry_run" : status;
+      restoreFailedRetryRowIfNeeded({
+        state,
+        retryTarget,
+        reason: retryStatus === "dry_run" ? "retry_dry_run" : `retry_did_not_review=${retryStatus}`
+      });
+      return {
+        repo: options.repo,
+        pullNumber: options.pullNumber,
+        headSha: options.headSha,
+        status: retryStatus
+      };
+    } catch (error) {
+      recordFailedReview({ config, state, repo: options.repo, pull, error });
+      return {
+        repo: options.repo,
+        pullNumber: options.pullNumber,
+        headSha: options.headSha,
+        status: "failed"
+      };
+    }
+  } finally {
+    state.close();
+  }
+}
+
+export function restoreFailedRetryRowIfNeeded(input: {
+  state: Pick<ReviewStateStore, "getProcessedReview" | "recordProcessed">;
+  retryTarget: FailedHeadRetryTarget;
+  reason: string;
+}): void {
+  const current = input.state.getProcessedReview(
+    input.retryTarget.repo,
+    input.retryTarget.pullNumber,
+    input.retryTarget.headSha
+  );
+  if (current?.status === "posted") return;
+  if (current?.status === "failed") return;
+
+  input.state.recordProcessed({
+    repo: input.retryTarget.repo,
+    pullNumber: input.retryTarget.pullNumber,
+    headSha: input.retryTarget.headSha,
+    status: "failed",
+    error: input.retryTarget.previousError
+      ? `${input.retryTarget.previousError}; ${input.reason}`
+      : input.reason
+  });
+}
+
+export function prepareFailedHeadRetry(input: {
+  state: Pick<ReviewStateStore, "getProcessedReview">;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  livePull: PullRequestSummary;
+}): FailedHeadRetryTarget {
+  if (input.livePull.head.sha !== input.headSha) {
+    throw new Error(`Refusing retry for stale head: requested=${input.headSha} live=${input.livePull.head.sha}`);
+  }
+
+  const processed = input.state.getProcessedReview(input.repo, input.pullNumber, input.headSha);
+  if (!processed) {
+    throw new Error(`No processed review row exists for ${input.repo}#${input.pullNumber}@${input.headSha}`);
+  }
+  if (processed.status !== "failed") {
+    throw new Error(
+      `Refusing retry for ${input.repo}#${input.pullNumber}@${input.headSha}: status is ${processed.status}, not failed`
+    );
+  }
+
+  return {
+    repo: input.repo,
+    pullNumber: input.pullNumber,
+    headSha: input.headSha,
+    ...(processed.error ? { previousError: processed.error } : {})
+  };
+}
+
 export async function reviewPull(input: {
   config: BotConfig;
   github: GitHubApi;
@@ -153,6 +283,7 @@ export async function reviewPull(input: {
   dryRun: boolean;
   useZCode: boolean;
   budget?: ReviewRunBudget;
+  ignoreProcessedHead?: boolean;
 }): Promise<ReviewPullResult> {
   const { config, github, state, repo, pull } = input;
   const repoPolicy = resolveRepoProfile(config, repo);
@@ -180,7 +311,9 @@ export async function reviewPull(input: {
       return "skipped_stale_head";
     }
   }
-  if (!commandReviewRequested && state.hasProcessed(repo, pull.number, pull.head.sha)) return "skipped_processed";
+  if (!input.ignoreProcessedHead && !commandReviewRequested && state.hasProcessed(repo, pull.number, pull.head.sha)) {
+    return "skipped_processed";
+  }
   const budget = input.budget ?? new ReviewRunBudget(config.reviewConcurrency.maxActiveRuns);
   if (!budget.tryStart()) return "skipped_capacity";
   let lease: ReviewRunLease | undefined;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -78,6 +78,27 @@ export type ReviewPullResult =
   | "skipped_capacity"
   | "skipped_stale_head";
 
+export function isSuccessfulRetryStatus(status: RetryFailedHeadResult["status"]): boolean {
+  switch (status) {
+    case "reviewed":
+    case "reviewed_command":
+    case "dry_run":
+    case "skipped_processed":
+      return true;
+    case "failed":
+    case "skipped_draft":
+    case "skipped_canary":
+    case "skipped_policy":
+    case "skipped_command_stop":
+    case "skipped_command_explain":
+    case "skipped_capacity":
+    case "skipped_stale_head":
+      return false;
+    default:
+      return assertNever(status);
+  }
+}
+
 export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
   const config = loadConfig(options.configPath);
   const github = new GitHubApi(config.github);
@@ -360,6 +381,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     if (!lease) return "skipped_capacity";
     const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision);
     if (input.processedHeadPolicy === "retry_failed_head") {
+      const current = state.getProcessedReview(repo, pull.number, pull.head.sha);
+      if (current?.status !== "failed") return "skipped_processed";
       const liveBeforeReview = await github.getPull(repo, pull.number);
       const staleBeforeReview = detectStalePullHead({ expected: pull, live: liveBeforeReview, phase: "before_review" });
       if (staleBeforeReview) {
@@ -621,6 +644,10 @@ export function recordFailedReview(input: {
 function retryFailureError(previousError: string | undefined, error: unknown): string {
   const retryError = error instanceof Error ? error.message : String(error);
   return previousError ? `${previousError}; retry_error=${retryError}` : retryError;
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled retry status: ${String(value)}`);
 }
 
 async function resolvePullCommandDecision(input: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -335,6 +335,15 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   }
 
   const commandReviewRequested = commandDecision.shouldReview;
+  if (commandReviewRequested) {
+    const livePull = await github.getPull(repo, pull.number);
+    const stale = detectStalePullHead({ expected: pull, live: livePull, phase: "before_review" });
+    if (stale) {
+      const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision);
+      recordStaleHeadSkip({ state, repo, pull, stale, evidenceDir });
+      return "skipped_stale_head";
+    }
+  }
   if (
     input.processedHeadPolicy !== "retry_failed_head" &&
     !commandReviewRequested &&
@@ -350,11 +359,13 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     lease = state.tryAcquireReviewRunLease(config.reviewConcurrency.maxActiveRuns, config.reviewConcurrency.leaseTtlMs);
     if (!lease) return "skipped_capacity";
     const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision);
-    const liveBeforeReview = await github.getPull(repo, pull.number);
-    const staleBeforeReview = detectStalePullHead({ expected: pull, live: liveBeforeReview, phase: "before_review" });
-    if (staleBeforeReview) {
-      recordStaleHeadSkip({ state, repo, pull, stale: staleBeforeReview, evidenceDir });
-      return "skipped_stale_head";
+    if (input.processedHeadPolicy === "retry_failed_head") {
+      const liveBeforeReview = await github.getPull(repo, pull.number);
+      const staleBeforeReview = detectStalePullHead({ expected: pull, live: liveBeforeReview, phase: "before_review" });
+      if (staleBeforeReview) {
+        recordStaleHeadSkip({ state, repo, pull, stale: staleBeforeReview, evidenceDir });
+        return "skipped_stale_head";
+      }
     }
     if (commandReviewRequested) {
       await recordAndAcknowledgeCommandDecision({ config, github, state, repo, pull, commandDecision });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -171,53 +171,77 @@ export async function retryFailedHead(options: {
   const state = new ReviewStateStore(config.statePath);
   const budget = new ReviewRunBudget(1);
   try {
-    const repoPolicy = resolveRepoProfile(config, options.repo);
-    if (!repoPolicy.allowed) {
-      throw new Error(`Refusing retry for repo skipped by policy: ${options.repo} (${repoPolicy.reason})`);
-    }
-    const pull = await github.getPull(options.repo, options.pullNumber);
-    const retryTarget = prepareFailedHeadRetry({
+    return await retryFailedHeadWithDeps({ config, github, state, budget, options, reviewPullImpl: reviewPull });
+  } finally {
+    state.close();
+  }
+}
+
+export async function retryFailedHeadWithDeps(input: {
+  config: BotConfig;
+  github: GitHubApi;
+  state: ReviewStateStore;
+  budget: ReviewRunBudget;
+  options: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    dryRun: boolean;
+    useZCode?: boolean;
+  };
+  reviewPullImpl: (input: ReviewPullInput) => Promise<ReviewPullResult>;
+}): Promise<RetryFailedHeadResult> {
+  const { config, github, state, budget, options } = input;
+  const repoPolicy = resolveRepoProfile(config, options.repo);
+  if (!repoPolicy.allowed) {
+    throw new Error(`Refusing retry for repo skipped by policy: ${options.repo} (${repoPolicy.reason})`);
+  }
+  const pull = await github.getPull(options.repo, options.pullNumber);
+  const retryTarget = prepareFailedHeadRetry({
+    state,
+    repo: options.repo,
+    pullNumber: options.pullNumber,
+    headSha: options.headSha,
+    livePull: pull
+  });
+  try {
+    const status = await input.reviewPullImpl({
+      config,
+      github,
       state,
+      repo: options.repo,
+      pull,
+      dryRun: options.dryRun,
+      useZCode: options.useZCode ?? true,
+      budget,
+      processedHeadPolicy: "retry_failed_head"
+    });
+    const retryStatus = options.dryRun && (status === "reviewed" || status === "reviewed_command") ? "dry_run" : status;
+    restoreFailedRetryRowIfNeeded({
+      state,
+      retryTarget,
+      reason: retryStatus === "dry_run" ? "retry_dry_run" : `retry_did_not_review=${retryStatus}`
+    });
+    return {
       repo: options.repo,
       pullNumber: options.pullNumber,
       headSha: options.headSha,
-      livePull: pull
+      status: retryStatus
+    };
+  } catch (error) {
+    recordFailedReview({
+      config,
+      state,
+      repo: options.repo,
+      pull,
+      error: retryFailureError(retryTarget.previousError, error)
     });
-    try {
-      const status = await reviewPull({
-        config,
-        github,
-        state,
-        repo: options.repo,
-        pull,
-        dryRun: options.dryRun,
-        useZCode: options.useZCode ?? true,
-        budget,
-        ignoreProcessedHead: true
-      });
-      const retryStatus = options.dryRun && (status === "reviewed" || status === "reviewed_command") ? "dry_run" : status;
-      restoreFailedRetryRowIfNeeded({
-        state,
-        retryTarget,
-        reason: retryStatus === "dry_run" ? "retry_dry_run" : `retry_did_not_review=${retryStatus}`
-      });
-      return {
-        repo: options.repo,
-        pullNumber: options.pullNumber,
-        headSha: options.headSha,
-        status: retryStatus
-      };
-    } catch (error) {
-      recordFailedReview({ config, state, repo: options.repo, pull, error });
-      return {
-        repo: options.repo,
-        pullNumber: options.pullNumber,
-        headSha: options.headSha,
-        status: "failed"
-      };
-    }
-  } finally {
-    state.close();
+    return {
+      repo: options.repo,
+      pullNumber: options.pullNumber,
+      headSha: options.headSha,
+      status: "failed"
+    };
   }
 }
 
@@ -274,7 +298,7 @@ export function prepareFailedHeadRetry(input: {
   };
 }
 
-export async function reviewPull(input: {
+export interface ReviewPullInput {
   config: BotConfig;
   github: GitHubApi;
   state: ReviewStateStore;
@@ -283,8 +307,10 @@ export async function reviewPull(input: {
   dryRun: boolean;
   useZCode: boolean;
   budget?: ReviewRunBudget;
-  ignoreProcessedHead?: boolean;
-}): Promise<ReviewPullResult> {
+  processedHeadPolicy?: "normal" | "retry_failed_head";
+}
+
+export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResult> {
   const { config, github, state, repo, pull } = input;
   const repoPolicy = resolveRepoProfile(config, repo);
   if (!repoPolicy.allowed) return "skipped_policy";
@@ -311,7 +337,11 @@ export async function reviewPull(input: {
       return "skipped_stale_head";
     }
   }
-  if (!input.ignoreProcessedHead && !commandReviewRequested && state.hasProcessed(repo, pull.number, pull.head.sha)) {
+  if (
+    input.processedHeadPolicy !== "retry_failed_head" &&
+    !commandReviewRequested &&
+    state.hasProcessed(repo, pull.number, pull.head.sha)
+  ) {
     return "skipped_processed";
   }
   const budget = input.budget ?? new ReviewRunBudget(config.reviewConcurrency.maxActiveRuns);
@@ -571,6 +601,11 @@ export function recordFailedReview(input: {
     status: "failed",
     error: errorMessage
   });
+}
+
+function retryFailureError(previousError: string | undefined, error: unknown): string {
+  const retryError = error instanceof Error ? error.message : String(error);
+  return previousError ? `${previousError}; retry_error=${retryError}` : retryError;
 }
 
 async function resolvePullCommandDecision(input: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -244,10 +244,11 @@ export async function retryFailedHeadWithDeps(input: {
       budget,
       processedHeadPolicy: "retry_failed_head"
     });
-    const retryStatus = options.dryRun && (status === "reviewed" || status === "reviewed_command") ? "dry_run" : status;
-    restoreFailedRetryRowIfNeeded({
-      state,
-      retryTarget,
+      const retryStatus = options.dryRun && (status === "reviewed" || status === "reviewed_command") ? "dry_run" : status;
+      // A retry dry-run is a successful inspection, but the failed row must remain retryable for the later live run.
+      restoreFailedRetryRowIfNeeded({
+        state,
+        retryTarget,
       reason: retryStatus === "dry_run" ? "retry_dry_run" : `retry_did_not_review=${retryStatus}`
     });
     return {

--- a/tests/stale-head.test.ts
+++ b/tests/stale-head.test.ts
@@ -70,6 +70,45 @@ describe("exact-head stale guards", () => {
     expect(store.hasProcessed("electricsheephq/WorldOS", 1213, "old-head")).toBe(true);
     store.close();
   });
+
+  it("skips a normal review when the live base moved before work starts", async () => {
+    const root = mkdtempSync(join(tmpdir(), "stale-base-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = {
+      ...minimalConfig(root),
+      commands: {
+        enabled: false,
+        botMentions: ["@evaos-code-review-bot"],
+        trustedAuthors: [],
+        acknowledge: false
+      }
+    };
+    const github = {
+      getPull: async () => pull(1214, "same-head", "base-b"),
+      listPullFiles: async () => {
+        throw new Error("stale base review should not fetch files");
+      },
+      canPostAsApp: () => false
+    } as unknown as GitHubApi;
+
+    await expect(reviewPull({
+      config,
+      github,
+      state: store,
+      repo: "electricsheephq/WorldOS",
+      pull: pull(1214, "same-head", "base-a"),
+      dryRun: true,
+      useZCode: false,
+      budget: new ReviewRunBudget(1)
+    })).resolves.toBe("skipped_stale_head");
+
+    expect(store.getProcessedReview("electricsheephq/WorldOS", 1214, "same-head")).toMatchObject({
+      status: "skipped",
+      error: expect.stringContaining("stale_head_before_review")
+    });
+    store.close();
+  });
 });
 
 function minimalConfig(root: string): BotConfig {

--- a/tests/stale-head.test.ts
+++ b/tests/stale-head.test.ts
@@ -70,45 +70,6 @@ describe("exact-head stale guards", () => {
     expect(store.hasProcessed("electricsheephq/WorldOS", 1213, "old-head")).toBe(true);
     store.close();
   });
-
-  it("skips a normal review when the live base moved before work starts", async () => {
-    const root = mkdtempSync(join(tmpdir(), "stale-base-"));
-    roots.push(root);
-    const store = new ReviewStateStore(join(root, "state.sqlite"));
-    const config = {
-      ...minimalConfig(root),
-      commands: {
-        enabled: false,
-        botMentions: ["@evaos-code-review-bot"],
-        trustedAuthors: [],
-        acknowledge: false
-      }
-    };
-    const github = {
-      getPull: async () => pull(1214, "same-head", "base-b"),
-      listPullFiles: async () => {
-        throw new Error("stale base review should not fetch files");
-      },
-      canPostAsApp: () => false
-    } as unknown as GitHubApi;
-
-    await expect(reviewPull({
-      config,
-      github,
-      state: store,
-      repo: "electricsheephq/WorldOS",
-      pull: pull(1214, "same-head", "base-a"),
-      dryRun: true,
-      useZCode: false,
-      budget: new ReviewRunBudget(1)
-    })).resolves.toBe("skipped_stale_head");
-
-    expect(store.getProcessedReview("electricsheephq/WorldOS", 1214, "same-head")).toMatchObject({
-      status: "skipped",
-      error: expect.stringContaining("stale_head_before_review")
-    });
-    store.close();
-  });
 });
 
 function minimalConfig(root: string): BotConfig {

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -3,9 +3,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { BotConfig } from "../src/config.js";
+import type { GitHubApi } from "../src/github.js";
+import { ReviewRunBudget } from "../src/review-budget.js";
 import { ReviewStateStore } from "../src/state.js";
 import type { PullRequestSummary } from "../src/types.js";
-import { localDateFolder, recordFailedReview } from "../src/worker.js";
+import {
+  localDateFolder,
+  prepareFailedHeadRetry,
+  recordFailedReview,
+  restoreFailedRetryRowIfNeeded,
+  reviewPull
+} from "../src/worker.js";
 
 describe("worker review failures", () => {
   const roots: string[] = [];
@@ -36,6 +44,185 @@ describe("worker review failures", () => {
     );
     expect(evidence).toContain("ETIMEDOUT");
     expect(evidence).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+    state.close();
+  });
+
+  it("prepares exactly one failed current head for retry without deleting the failure row", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1223,
+      headSha: "head-retry",
+      status: "failed",
+      error: "transient API timeout"
+    });
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1223,
+      headSha: "other-head",
+      status: "failed",
+      error: "separate failure"
+    });
+
+    const result = prepareFailedHeadRetry({
+      state,
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1223,
+      headSha: "head-retry",
+      livePull: pullSummary(1223, "head-retry")
+    });
+    expect(result).toMatchObject({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1223,
+      headSha: "head-retry"
+    });
+    expect(state.getProcessedReview("electricsheephq/WorldOS", 1223, "head-retry")).toMatchObject({
+      status: "failed"
+    });
+    expect(state.getProcessedReview("electricsheephq/WorldOS", 1223, "other-head")).toMatchObject({
+      status: "failed"
+    });
+    state.close();
+  });
+
+  it("refuses retry when the requested failed head is stale", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-stale-retry-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1224,
+      headSha: "old-head",
+      status: "failed",
+      error: "transient API timeout"
+    });
+    expect(() => prepareFailedHeadRetry({
+      state,
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1224,
+      headSha: "old-head",
+      livePull: pullSummary(1224, "new-head")
+    })).toThrow("Refusing retry for stale head");
+
+    expect(state.getProcessedReview("electricsheephq/WorldOS", 1224, "old-head")).toMatchObject({
+      status: "failed"
+    });
+    state.close();
+  });
+
+  it("refuses retry when the current head is not failed", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-nonfailed-retry-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1225,
+      headSha: "head-posted",
+      status: "posted",
+      event: "COMMENT"
+    });
+    expect(() => prepareFailedHeadRetry({
+      state,
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1225,
+      headSha: "head-posted",
+      livePull: pullSummary(1225, "head-posted")
+    })).toThrow("status is posted, not failed");
+    state.close();
+  });
+
+  it("preserves the failed row when retry review work is skipped for capacity", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-capacity-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1226, "head-capacity");
+    const budget = new ReviewRunBudget(1);
+    expect(budget.tryStart()).toBe(true);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1226,
+      headSha: "head-capacity",
+      status: "failed",
+      error: "transient API timeout"
+    });
+
+    await expect(reviewPull({
+      config,
+      github: {} as unknown as GitHubApi,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: false,
+      budget,
+      ignoreProcessedHead: true
+    })).resolves.toBe("skipped_capacity");
+    expect(state.getProcessedReview("electricsheephq/WorldOS", 1226, "head-capacity")).toMatchObject({
+      status: "failed"
+    });
+    budget.finish();
+    state.close();
+  });
+
+  it("restores a failed row after a retry dry-run records dry_run", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-dry-run-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const retryTarget = {
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1227,
+      headSha: "head-dry-run",
+      previousError: "transient API timeout"
+    };
+    state.recordProcessed({
+      repo: retryTarget.repo,
+      pullNumber: retryTarget.pullNumber,
+      headSha: retryTarget.headSha,
+      status: "dry_run",
+      event: "COMMENT"
+    });
+
+    restoreFailedRetryRowIfNeeded({ state, retryTarget, reason: "retry_dry_run" });
+
+    expect(state.getProcessedReview(retryTarget.repo, retryTarget.pullNumber, retryTarget.headSha)).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("retry_dry_run")
+    });
+    state.close();
+  });
+
+  it("does not rewrite an already failed retry row for intentional skip statuses", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-skip-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const retryTarget = {
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1228,
+      headSha: "head-skip",
+      previousError: "original failure"
+    };
+    state.recordProcessed({
+      repo: retryTarget.repo,
+      pullNumber: retryTarget.pullNumber,
+      headSha: retryTarget.headSha,
+      status: "failed",
+      error: retryTarget.previousError
+    });
+
+    restoreFailedRetryRowIfNeeded({ state, retryTarget, reason: "retry_did_not_review=skipped_command_stop" });
+
+    expect(state.getProcessedReview(retryTarget.repo, retryTarget.pullNumber, retryTarget.headSha)).toMatchObject({
+      status: "failed",
+      error: "original failure"
+    });
     state.close();
   });
 });

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -12,6 +12,7 @@ import {
   prepareFailedHeadRetry,
   recordFailedReview,
   restoreFailedRetryRowIfNeeded,
+  retryFailedHeadWithDeps,
   reviewPull
 } from "../src/worker.js";
 
@@ -161,7 +162,7 @@ describe("worker review failures", () => {
       dryRun: true,
       useZCode: false,
       budget,
-      ignoreProcessedHead: true
+      processedHeadPolicy: "retry_failed_head"
     })).resolves.toBe("skipped_capacity");
     expect(state.getProcessedReview("electricsheephq/WorldOS", 1226, "head-capacity")).toMatchObject({
       status: "failed"
@@ -225,6 +226,138 @@ describe("worker review failures", () => {
     });
     state.close();
   });
+
+  it("keeps a failed row after a retry dry-run reaches the reviewed path", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-orchestrator-dry-run-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1229, "head-retry-dry-run");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "failed",
+      error: "original timeout"
+    });
+
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: true,
+        useZCode: false
+      },
+      reviewPullImpl: async ({ state: retryState, repo, pull: retryPull }) => {
+        retryState.recordProcessed({
+          repo,
+          pullNumber: retryPull.number,
+          headSha: retryPull.head.sha,
+          status: "dry_run",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      }
+    });
+
+    expect(result.status).toBe("dry_run");
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("original timeout; retry_dry_run")
+    });
+    state.close();
+  });
+
+  it("keeps a posted row after a live retry successfully posts a review", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-orchestrator-posted-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1230, "head-retry-posted");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "failed",
+      error: "original timeout"
+    });
+
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async ({ state: retryState, repo, pull: retryPull }) => {
+        retryState.recordProcessed({
+          repo,
+          pullNumber: retryPull.number,
+          headSha: retryPull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/1230#pullrequestreview-1"
+        });
+        return "reviewed";
+      }
+    });
+
+    expect(result.status).toBe("reviewed");
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "posted",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/1230#pullrequestreview-1"
+    });
+    state.close();
+  });
+
+  it("preserves original failure context when retry review work throws", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-orchestrator-throw-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1231, "head-retry-throw");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "failed",
+      error: "original timeout"
+    });
+
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async () => {
+        throw new Error("second timeout");
+      }
+    });
+
+    expect(result.status).toBe("failed");
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "failed",
+      error: "original timeout; retry_error=second timeout"
+    });
+    state.close();
+  });
 });
 
 function minimalConfig(root: string): BotConfig {
@@ -281,4 +414,10 @@ function pullSummary(number: number, headSha: string): PullRequestSummary {
     },
     html_url: `https://github.com/electricsheephq/WorldOS/pull/${number}`
   };
+}
+
+function retryGithub(pull: PullRequestSummary): GitHubApi {
+  return {
+    getPull: async () => pull
+  } as unknown as GitHubApi;
 }

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -358,6 +358,55 @@ describe("worker review failures", () => {
     });
     state.close();
   });
+
+  it("restores a failed row after real reviewPull records a stale-head skip", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-real-stale-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1232, "head-retry-stale", "base-original");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "failed",
+      error: "original timeout"
+    });
+    let getPullCalls = 0;
+    const github = {
+      getPull: async () => {
+        getPullCalls += 1;
+        return getPullCalls === 1 ? pull : pullSummary(pull.number, pull.head.sha, "base-new");
+      },
+      listIssueComments: async () => [],
+      listPullFiles: async () => {
+        throw new Error("stale retry should not fetch files");
+      },
+      canPostAsApp: () => false
+    } as unknown as GitHubApi;
+
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github,
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: reviewPull
+    });
+
+    expect(result.status).toBe("skipped_stale_head");
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "failed",
+      error: "original timeout; retry_did_not_review=skipped_stale_head"
+    });
+    state.close();
+  });
 });
 
 function minimalConfig(root: string): BotConfig {
@@ -397,7 +446,7 @@ function minimalConfig(root: string): BotConfig {
   };
 }
 
-function pullSummary(number: number, headSha: string): PullRequestSummary {
+function pullSummary(number: number, headSha: string, baseSha = "base"): PullRequestSummary {
   return {
     number,
     title: `PR ${number}`,
@@ -408,7 +457,7 @@ function pullSummary(number: number, headSha: string): PullRequestSummary {
       repo: { full_name: "electricsheephq/WorldOS" }
     },
     base: {
-      sha: "base",
+      sha: baseSha,
       ref: "main",
       repo: { full_name: "electricsheephq/WorldOS" }
     },

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -8,6 +8,7 @@ import { ReviewRunBudget } from "../src/review-budget.js";
 import { ReviewStateStore } from "../src/state.js";
 import type { PullRequestSummary } from "../src/types.js";
 import {
+  isSuccessfulRetryStatus,
   localDateFolder,
   prepareFailedHeadRetry,
   recordFailedReview,
@@ -406,6 +407,72 @@ describe("worker review failures", () => {
       error: "original timeout; retry_did_not_review=skipped_stale_head"
     });
     state.close();
+  });
+
+  it("treats a retry row posted after prepare as an already-resolved no-op", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-race-posted-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1233, "head-retry-race");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "failed",
+      error: "original timeout"
+    });
+    const github = {
+      getPull: async () => pull,
+      listIssueComments: async () => [],
+      listPullFiles: async () => {
+        throw new Error("already-resolved retry should not fetch files");
+      },
+      canPostAsApp: () => false
+    } as unknown as GitHubApi;
+
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github,
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async (input) => {
+        state.recordProcessed({
+          repo: "electricsheephq/WorldOS",
+          pullNumber: pull.number,
+          headSha: pull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/1233#pullrequestreview-1"
+        });
+        return reviewPull(input);
+      }
+    });
+
+    expect(result.status).toBe("skipped_processed");
+    expect(isSuccessfulRetryStatus(result.status)).toBe(true);
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "posted",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/1233#pullrequestreview-1"
+    });
+    state.close();
+  });
+
+  it("keeps retry CLI success status mapping explicit", () => {
+    expect(isSuccessfulRetryStatus("reviewed")).toBe(true);
+    expect(isSuccessfulRetryStatus("reviewed_command")).toBe(true);
+    expect(isSuccessfulRetryStatus("dry_run")).toBe(true);
+    expect(isSuccessfulRetryStatus("skipped_processed")).toBe(true);
+    expect(isSuccessfulRetryStatus("failed")).toBe(false);
+    expect(isSuccessfulRetryStatus("skipped_capacity")).toBe(false);
+    expect(isSuccessfulRetryStatus("skipped_stale_head")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds an explicit `retry-failed --repo --pr --head-sha` operator command for one failed current PR head.
- Refuses stale heads and non-failed rows before clearing any DB state.
- Re-records `failed` if the retry run fails again, preserving release-status visibility.

Closes #41.
Links #28, #39, #42, #43, #44.

## Validation
- `npm test -- --pool=forks --poolOptions.forks.singleFork=true tests/worker-failure.test.ts`
- `npm run build`
- `npm test -- --pool=forks --poolOptions.forks.singleFork=true`

## Live Retry Evidence
Evidence dir: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/retry-failed-v0.1/`

Copy-DB dry-run proof:
```json
{
  "repo": "electricsheephq/evaos-code-review-bot",
  "pullNumber": 46,
  "headSha": "392494e43106625c843a7db9919c16976e8c3c10",
  "status": "reviewed"
}
```

Live retry proof:
```json
{
  "repo": "electricsheephq/evaos-code-review-bot",
  "pullNumber": 46,
  "headSha": "392494e43106625c843a7db9919c16976e8c3c10",
  "status": "reviewed"
}
```

Current-head review URL: https://github.com/electricsheephq/evaos-code-review-bot/pull/46#pullrequestreview-4604673204

Release status after retry: `ok=true`, `live_db_no_errors=0 blocking error row(s)`.

## Notes
- Original LCO#183 is now merged/closed, so this PR uses the new real failed-row incident on `evaos-code-review-bot#46` as the live backfill proof.
- Failed rows still block silent duplicate posting; this command is an explicit operator path for current-head recovery.
