### PR TITLE
Reliability: retire historical failed review heads

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -80,6 +80,25 @@ Rows recorded as `status=skipped` with a baseline activation reason are not
 release-blocking errors. They are the expected way to prevent retroactive review
 spam when a live beta starts monitoring existing open PR heads.
 
+Failed rows remain release-blocking until they are retried, superseded by a
+successful current-head review, or explicitly retired with evidence that the
+head is no longer eligible. Before retiring a failed row, run `coverage-audit`
+and confirm the target PR is closed, draft-skipped, stale, or otherwise absent
+from the eligible open-head set. Retire only the exact failed head:
+
+```bash
+npx tsx src/cli.ts retire-failed \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --repo owner/repo \
+  --pr 123 \
+  --head-sha <failed-head-sha> \
+  --reason closed_or_stale_after_coverage_audit
+```
+
+Do not retire an active failed current head. Use `retry-failed` or disable the
+repo through the tracked allowlist/policy lane when the provider is repeatedly
+rate-limited.
+
 ## Rollback
 
 Default rollback is to restart the existing launchd job after checking out the

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { runDaemonCycle } from "./daemon.js";
 import { GitHubApi } from "./github.js";
 import { collectReleaseStatus } from "./release-status.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
+import { ReviewStateStore } from "./state.js";
 import { isSuccessfulRetryStatus, retryFailedHead, runOnce } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
 
@@ -128,6 +129,27 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "retire-failed") {
+    if (!args.repo) throw new Error("--repo is required for retire-failed");
+    if (!args.pr) throw new Error("--pr is required for retire-failed");
+    if (!args["head-sha"]) throw new Error("--head-sha is required for retire-failed");
+    if (!args.reason) throw new Error("--reason is required for retire-failed");
+    const config = loadConfig(args.config);
+    const state = new ReviewStateStore(args["state-path"] ?? config.statePath);
+    try {
+      const retired = state.retireFailedReview({
+        repo: args.repo,
+        pullNumber: Number(args.pr),
+        headSha: args["head-sha"],
+        reason: args.reason
+      });
+      console.log(JSON.stringify({ ok: true, retired }, null, 2));
+    } finally {
+      state.close();
+    }
+    return;
+  }
+
   if (command === "daemon") {
     const config = loadConfig(args.config);
     const monitoredRepos = listReposToScan(config);
@@ -176,6 +198,7 @@ interface ParsedArgs {
   config?: string;
   repo?: string;
   pr?: string;
+  reason?: string;
   "expected-head"?: string;
   "launchd-label"?: string;
   "state-path"?: string;

--- a/src/state.ts
+++ b/src/state.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { dirname } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { redactSecrets } from "./secrets.js";
 import type { ReviewEvent } from "./types.js";
 
 export type ProcessedStatus = "dry_run" | "posted" | "skipped" | "failed";
@@ -20,6 +21,13 @@ export interface ProcessedReviewRecord {
 
 export interface StoredProcessedReviewRecord extends ProcessedReviewRecord {
   createdAt: string;
+}
+
+export interface RetireFailedReviewInput {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  reason: string;
 }
 
 export interface ReviewRunLease {
@@ -134,6 +142,29 @@ export class ReviewStateStore {
       );
   }
 
+  retireFailedReview(input: RetireFailedReviewInput): StoredProcessedReviewRecord {
+    const existing = this.getProcessedReview(input.repo, input.pullNumber, input.headSha);
+    if (!existing) {
+      throw new Error(`Refusing to retire missing review row for ${input.repo}#${input.pullNumber}@${input.headSha}`);
+    }
+    if (existing.status !== "failed") {
+      throw new Error(
+        `Refusing to retire ${input.repo}#${input.pullNumber}@${input.headSha}: status is ${existing.status}, not failed`
+      );
+    }
+
+    const reason = normalizeRetirementReason(input.reason);
+    const previousError = existing.error ? `; previous_error=${redactSecrets(existing.error)}` : "";
+    this.recordProcessed({
+      repo: input.repo,
+      pullNumber: input.pullNumber,
+      headSha: input.headSha,
+      status: "skipped",
+      error: `retired_failed_head:${reason}${previousError}`
+    });
+    return this.getProcessedReview(input.repo, input.pullNumber, input.headSha)!;
+  }
+
   hasRepoActivation(repo: string): boolean {
     const row = this.db.prepare("select 1 from repo_activation_watermarks where repo = ? limit 1").get(repo);
     return Boolean(row);
@@ -214,6 +245,16 @@ export class ReviewStateStore {
   close(): void {
     this.db.close();
   }
+}
+
+function normalizeRetirementReason(reason: string): string {
+  const normalized = reason
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9._-]+/g, "_")
+    .replaceAll(/^_+|_+$/g, "")
+    .slice(0, 80);
+  return normalized || "operator_acknowledged";
 }
 
 interface ProcessedReviewRow {

--- a/tests/review-budget.test.ts
+++ b/tests/review-budget.test.ts
@@ -47,11 +47,13 @@ describe("review run budget", () => {
   });
 
   it("prevents worker review work when the active run cap is reached", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-budget-config-"));
+    roots.push(root);
     const budget = new ReviewRunBudget(1);
     expect(budget.tryStart()).toBe(true);
 
     const status = await reviewPull({
-      config: minimalConfig(),
+      config: minimalConfig(root),
       github: {} as GitHubApi,
       state: {
         hasProcessed: () => false
@@ -69,13 +71,15 @@ describe("review run budget", () => {
 
   it("uses SQLite leases to cap overlapping worker entrypoints", async () => {
     const store = createStore(roots);
-    const lease = store.tryAcquireReviewRunLease(1, 60_000, new Date("2026-07-01T00:00:00.000Z"));
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-budget-config-"));
+    roots.push(root);
+    const lease = store.tryAcquireReviewRunLease(1, 60_000, new Date());
     expect(lease).toBeDefined();
 
     const budget = new ReviewRunBudget(5);
     const status = await reviewPull({
       config: {
-        ...minimalConfig(),
+        ...minimalConfig(root),
         reviewConcurrency: {
           maxActiveRuns: 1,
           leaseTtlMs: 60_000
@@ -102,14 +106,14 @@ function createStore(roots: string[]): ReviewStateStore {
   return new ReviewStateStore(join(root, "state.sqlite"));
 }
 
-function minimalConfig(): BotConfig {
+function minimalConfig(root: string): BotConfig {
   return {
     pilotRepos: ["electricsheephq/WorldOS"],
     pollIntervalMs: 60_000,
     skipDrafts: true,
-    workRoot: "/unused",
-    statePath: "/unused/state.sqlite",
-    evidenceDir: "/unused/evidence",
+    workRoot: join(root, "work"),
+    statePath: join(root, "state.sqlite"),
+    evidenceDir: join(root, "evidence"),
     activation: {
       reviewExistingOpenPrsOnActivation: false
     },

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -43,6 +43,63 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("retires an exact failed head into a nonblocking historical skip", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-state-retire-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    store.recordProcessed({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 212,
+      headSha: "failed-head",
+      status: "failed",
+      error: "ZCode failed before completion: spawnSync node ETIMEDOUT"
+    });
+
+    const retired = store.retireFailedReview({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 212,
+      headSha: "failed-head",
+      reason: "closed_or_stale_after_coverage_audit"
+    });
+
+    expect(retired).toMatchObject({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 212,
+      headSha: "failed-head",
+      status: "skipped",
+      error: "retired_failed_head:closed_or_stale_after_coverage_audit; previous_error=ZCode failed before completion: spawnSync node ETIMEDOUT"
+    });
+    expect(store.getProcessedReview("100yenadmin/Lossless-Codex-Orchestrator-LCO", 212, "failed-head")).toMatchObject({
+      status: "skipped",
+      error: expect.stringContaining("retired_failed_head:closed_or_stale_after_coverage_audit")
+    });
+    expect(store.hasProcessed("100yenadmin/Lossless-Codex-Orchestrator-LCO", 212, "failed-head")).toBe(true);
+    store.close();
+  });
+
+  it("refuses to retire a non-failed processed head", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-state-retire-posted-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    store.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1214,
+      headSha: "posted-head",
+      status: "posted",
+      event: "COMMENT"
+    });
+
+    expect(() => store.retireFailedReview({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1214,
+      headSha: "posted-head",
+      reason: "operator_request"
+    })).toThrow("status is posted, not failed");
+    store.close();
+  });
+
   it("caps active review leases and releases them", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-state-"));
     roots.push(root);


### PR DESCRIPTION
## Summary\n- add an explicit `retire-failed` CLI command for exact failed review heads\n- preserve duplicate suppression by converting retired failures to nonblocking skipped rows with a retirement marker\n- document the evidence gate in the beta release runbook\n- fix review-budget test isolation so the full suite passes in clean Lexar worktrees\n\nCloses #43.\n\n## Validation\n- `npm test -- tests/state.test.ts tests/release-status.test.ts`\n- `npm test`\n- `npm run build`\n\n## Runtime note\nThis is intended for the current live incident where release-status is red from 15 historical LCO failed heads while launchd is running and coverage audit reports zero unprocessed eligible heads. Active failed current heads should still be retried or left blocking; do not retire active failures.