### PR TITLE
Reliability: gate release status on daemon heartbeat

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,4 +1,6 @@
 import { formatDaemonLog } from "./daemon-log.js";
+import { loadConfig } from "./config.js";
+import { ReviewStateStore, type DaemonHeartbeatEvent } from "./state.js";
 import { runOnce, type RunOnceResult } from "./worker.js";
 
 export type DaemonCycleResult =
@@ -14,6 +16,7 @@ export interface RunDaemonCycleOptions {
   canaryPulls: string[];
   commandsEnabled: boolean;
   runOnceImpl?: (options: { configPath?: string; dryRun: boolean }) => Promise<RunOnceResult>;
+  recordHeartbeatImpl?: (event: DaemonHeartbeatEvent, error?: string) => void;
   stdout?: (line: string) => void;
   stderr?: (line: string) => void;
 }
@@ -22,7 +25,18 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   const stdout = input.stdout ?? console.log;
   const stderr = input.stderr ?? console.error;
   const runOnceImpl = input.runOnceImpl ?? runOnce;
+  const recordHeartbeat = input.recordHeartbeatImpl ?? ((event: DaemonHeartbeatEvent, error?: string) => {
+    recordDaemonHeartbeatFromConfig({
+      configPath: input.configPath,
+      cycle: input.cycle,
+      dryRun: input.dryRun,
+      event,
+      error,
+      stderr
+    });
+  });
 
+  recordHeartbeat("daemon_cycle_start");
   stdout(formatDaemonLog({
     event: "daemon_cycle_start",
     cycle: input.cycle,
@@ -41,6 +55,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
       dryRun: input.dryRun,
       result
     }));
+    recordHeartbeat("daemon_cycle_complete");
     return { ok: true, result };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -51,6 +66,40 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
       dryRun: input.dryRun,
       error: message
     }));
+    recordHeartbeat("daemon_cycle_failed", message);
     return { ok: false, error: message };
+  }
+}
+
+function recordDaemonHeartbeatFromConfig(input: {
+  configPath?: string;
+  cycle: number;
+  dryRun: boolean;
+  event: DaemonHeartbeatEvent;
+  error?: string;
+  stderr: (line: string) => void;
+}): void {
+  try {
+    const config = loadConfig(input.configPath);
+    const state = new ReviewStateStore(config.statePath);
+    try {
+      state.recordDaemonHeartbeat({
+        cycle: input.cycle,
+        dryRun: input.dryRun,
+        event: input.event,
+        ...(input.error ? { error: input.error } : {})
+      });
+    } finally {
+      state.close();
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    input.stderr(formatDaemonLog({
+      event: "daemon_heartbeat_failed",
+      level: "error",
+      cycle: input.cycle,
+      dryRun: input.dryRun,
+      error: message
+    }));
   }
 }

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -23,12 +23,23 @@ export interface ReleaseDatabaseStatus {
   skippedCount?: number;
 }
 
+export interface ReleaseHeartbeatStatus {
+  status: "fresh" | "stale" | "missing";
+  maxAgeMs: number;
+  latestAt?: string;
+  ageMs?: number;
+  cycle?: number;
+  event?: string;
+  dryRun?: boolean;
+}
+
 export interface ReleaseStatusInput {
   repo: ReleaseRepoStatus;
   expectedHead?: string;
   configPath: string;
   launchd: ReleaseLaunchdStatus;
   database: ReleaseDatabaseStatus;
+  heartbeat: ReleaseHeartbeatStatus;
   now?: Date;
 }
 
@@ -44,6 +55,7 @@ export interface ReleaseStatus {
   repo: ReleaseRepoStatus;
   launchd: ReleaseLaunchdStatus;
   database: ReleaseDatabaseStatus;
+  heartbeat: ReleaseHeartbeatStatus;
   gates: Array<{ name: string; ok: boolean; detail: string }>;
   rollback: {
     restartCommand: string;
@@ -58,6 +70,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const launchdRunningOk = input.launchd.state === "running";
   const launchdConfigOk = input.launchd.configPath === input.configPath;
   const dbOk = input.database.errorCount === 0;
+  const heartbeatOk = input.heartbeat.status === "fresh";
   const gates = [
     {
       name: "expected_head",
@@ -88,6 +101,11 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       name: "live_db_no_errors",
       ok: dbOk,
       detail: `${input.database.errorCount} blocking error row(s)`
+    },
+    {
+      name: "daemon_heartbeat_recent",
+      ok: heartbeatOk,
+      detail: describeHeartbeat(input.heartbeat)
     }
   ];
 
@@ -103,6 +121,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     repo: input.repo,
     launchd: input.launchd,
     database: input.database,
+    heartbeat: input.heartbeat,
     gates,
     rollback: {
       restartCommand: `launchctl kickstart -k gui/$(id -u)/${input.launchd.label}`,
@@ -120,12 +139,15 @@ export function collectReleaseStatus(input: {
 }): ReleaseStatus {
   const config = loadConfig(input.configPath);
   const configPath = input.configPath ?? "(default config)";
+  const now = new Date();
   return buildReleaseStatus({
     repo: readRepoStatus(input.cwd),
     expectedHead: input.expectedHead,
     configPath,
     launchd: readLaunchdStatus(input.launchdLabel ?? "com.electricsheephq.evaos-code-review-bot"),
-    database: readDatabaseStatus(input.statePath ?? config.statePath)
+    database: readDatabaseStatus(input.statePath ?? config.statePath),
+    heartbeat: readHeartbeatStatus(input.statePath ?? config.statePath, config.pollIntervalMs * 2, now),
+    now
   });
 }
 
@@ -184,6 +206,57 @@ function readDatabaseStatus(statePath: string): ReleaseDatabaseStatus {
   } finally {
     db.close();
   }
+}
+
+function readHeartbeatStatus(statePath: string, maxAgeMs: number, now: Date): ReleaseHeartbeatStatus {
+  if (!existsSync(statePath)) return { status: "missing", maxAgeMs };
+  const db = new DatabaseSync(statePath, { readOnly: true });
+  try {
+    const table = db
+      .prepare("select 1 from sqlite_master where type = 'table' and name = 'daemon_heartbeat' limit 1")
+      .get();
+    if (!table) return { status: "missing", maxAgeMs };
+
+    const row = db
+      .prepare(
+        `select cycle, event, dry_run, recorded_at
+         from daemon_heartbeat
+         where id = 1 and recorded_at is not null
+         limit 1`
+      )
+      .get() as { cycle: number; event: string; dry_run: number; recorded_at: string } | undefined;
+    if (!row) return { status: "missing", maxAgeMs };
+
+    const latestTime = Date.parse(row.recorded_at);
+    if (!Number.isFinite(latestTime)) {
+      return {
+        status: "stale",
+        maxAgeMs,
+        latestAt: row.recorded_at,
+        cycle: row.cycle,
+        event: row.event,
+        dryRun: row.dry_run === 1
+      };
+    }
+    const ageMs = Math.max(0, now.getTime() - latestTime);
+    return {
+      status: ageMs <= maxAgeMs ? "fresh" : "stale",
+      maxAgeMs,
+      latestAt: row.recorded_at,
+      ageMs,
+      cycle: row.cycle,
+      event: row.event,
+      dryRun: row.dry_run === 1
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function describeHeartbeat(heartbeat: ReleaseHeartbeatStatus): string {
+  if (heartbeat.status === "missing") return `missing heartbeat row; max age ${heartbeat.maxAgeMs}ms`;
+  const age = heartbeat.ageMs === undefined ? "unknown" : `${heartbeat.ageMs}ms`;
+  return `${heartbeat.status}; age ${age}; max ${heartbeat.maxAgeMs}ms; event ${heartbeat.event ?? "unknown"}; cycle ${heartbeat.cycle ?? "unknown"}`;
 }
 
 function git(cwd: string, args: string[]): string {

--- a/src/state.ts
+++ b/src/state.ts
@@ -35,6 +35,26 @@ export interface ReviewRunLease {
   expiresAt: string;
 }
 
+export type DaemonHeartbeatEvent = "daemon_cycle_start" | "daemon_cycle_complete" | "daemon_cycle_failed";
+
+export interface DaemonHeartbeatRecord {
+  cycle: number;
+  event: DaemonHeartbeatEvent;
+  dryRun: boolean;
+  recordedAt?: Date;
+  error?: string;
+}
+
+export interface StoredDaemonHeartbeatRecord {
+  cycle: number;
+  event: DaemonHeartbeatEvent;
+  dryRun: boolean;
+  recordedAt: string;
+  error?: string;
+  startedCycle?: number;
+  startedAt?: string;
+}
+
 export interface ProcessedCommandRecord {
   repo: string;
   pullNumber: number;
@@ -76,7 +96,17 @@ export class ReviewStateStore {
         started_at text not null,
         expires_at text not null
       );
+
+      create table if not exists daemon_heartbeat (
+        id integer primary key check (id = 1),
+        cycle integer,
+        event text,
+        dry_run integer,
+        recorded_at text,
+        error text
+      );
     `);
+    this.ensureDaemonHeartbeatColumns();
     this.db.exec(`
       create table if not exists processed_commands (
         repo text not null,
@@ -212,6 +242,54 @@ export class ReviewStateStore {
     this.db.prepare("delete from review_run_leases where lease_id = ?").run(leaseId);
   }
 
+  recordDaemonHeartbeat(record: DaemonHeartbeatRecord): void {
+    if (record.event === "daemon_cycle_start") {
+      this.db
+        .prepare(
+          `insert into daemon_heartbeat
+            (id, started_cycle, started_at)
+           values (1, ?, ?)
+           on conflict(id) do update set
+             started_cycle = excluded.started_cycle,
+             started_at = excluded.started_at`
+        )
+        .run(record.cycle, (record.recordedAt ?? new Date()).toISOString());
+      return;
+    }
+
+    this.db
+      .prepare(
+        `insert or replace into daemon_heartbeat
+          (id, cycle, event, dry_run, recorded_at, error, started_cycle, started_at)
+         values (
+           1, ?, ?, ?, ?, ?,
+           coalesce((select started_cycle from daemon_heartbeat where id = 1), ?),
+           coalesce((select started_at from daemon_heartbeat where id = 1), ?)
+         )`
+      )
+      .run(
+        record.cycle,
+        record.event,
+        record.dryRun ? 1 : 0,
+        (record.recordedAt ?? new Date()).toISOString(),
+        record.error ? redactSecrets(record.error) : null,
+        record.cycle,
+        (record.recordedAt ?? new Date()).toISOString()
+      );
+  }
+
+  getDaemonHeartbeat(): StoredDaemonHeartbeatRecord | undefined {
+    const row = this.db
+      .prepare(
+        `select cycle, event, dry_run, recorded_at, error, started_cycle, started_at
+         from daemon_heartbeat
+         where id = 1 and recorded_at is not null
+         limit 1`
+      )
+      .get() as DaemonHeartbeatRow | undefined;
+    return row ? mapDaemonHeartbeatRow(row) : undefined;
+  }
+
   hasProcessedCommand(repo: string, pullNumber: number, headSha: string, commentId: number): boolean {
     const row = this.db
       .prepare(
@@ -245,6 +323,19 @@ export class ReviewStateStore {
   close(): void {
     this.db.close();
   }
+
+  private ensureDaemonHeartbeatColumns(): void {
+    const columns = this.db
+      .prepare("pragma table_info(daemon_heartbeat)")
+      .all() as unknown as Array<{ name: string }>;
+    const names = new Set(columns.map((column) => column.name));
+    if (!names.has("started_cycle")) {
+      this.db.exec("alter table daemon_heartbeat add column started_cycle integer");
+    }
+    if (!names.has("started_at")) {
+      this.db.exec("alter table daemon_heartbeat add column started_at text");
+    }
+  }
 }
 
 function normalizeRetirementReason(reason: string): string {
@@ -268,6 +359,16 @@ interface ProcessedReviewRow {
   created_at: string;
 }
 
+interface DaemonHeartbeatRow {
+  cycle: number | null;
+  event: DaemonHeartbeatEvent | null;
+  dry_run: number | null;
+  recorded_at: string | null;
+  error: string | null;
+  started_cycle: number | null;
+  started_at: string | null;
+}
+
 function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRecord {
   return {
     repo: row.repo,
@@ -278,5 +379,17 @@ function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRe
     ...(row.review_url ? { reviewUrl: row.review_url } : {}),
     ...(row.error ? { error: row.error } : {}),
     createdAt: row.created_at
+  };
+}
+
+function mapDaemonHeartbeatRow(row: DaemonHeartbeatRow): StoredDaemonHeartbeatRecord {
+  return {
+    cycle: row.cycle!,
+    event: row.event!,
+    dryRun: row.dry_run === 1,
+    recordedAt: row.recorded_at!,
+    ...(row.error ? { error: row.error } : {}),
+    ...(row.started_cycle !== null ? { startedCycle: row.started_cycle } : {}),
+    ...(row.started_at ? { startedAt: row.started_at } : {})
   };
 }

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -17,6 +17,7 @@ describe("daemon cycle resilience", () => {
       runOnceImpl: async () => {
         throw new Error("ZCode failed before completion: spawnSync node ETIMEDOUT with ghp_1234567890abcdefghijklmnopqrstuvwx");
       },
+      recordHeartbeatImpl: () => undefined,
       stdout: (line) => stdout.push(line),
       stderr: (line) => stderr.push(line)
     });
@@ -38,5 +39,66 @@ describe("daemon cycle resilience", () => {
     });
     expect(failure.error).toContain("ETIMEDOUT");
     expect(failure.error).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+  });
+
+  it("records start and completion heartbeat events for successful cycles", async () => {
+    const heartbeats: string[] = [];
+
+    const result = await runDaemonCycle({
+      cycle: 2,
+      dryRun: false,
+      pilotRepos: ["electricsheephq/WorldOS"],
+      monitoredRepos: ["electricsheephq/WorldOS"],
+      canaryPulls: [],
+      commandsEnabled: false,
+      runOnceImpl: async () => ({
+        reposScanned: 1,
+        pullsSeen: 1,
+        reviewed: 0,
+        failed: 0,
+        skippedDraft: 0,
+        skippedCanary: 0,
+        skippedPolicy: 0,
+        skippedCommandStop: 0,
+        skippedCommandExplain: 0,
+        commandReviewRequested: 0,
+        skippedProcessed: 1,
+        skippedCapacity: 0,
+        skippedStaleHead: 0,
+        baselinedExisting: 0,
+        policySkips: []
+      }),
+      recordHeartbeatImpl: (event) => heartbeats.push(event),
+      stdout: () => undefined,
+      stderr: () => undefined
+    });
+
+    expect(result.ok).toBe(true);
+    expect(heartbeats).toEqual(["daemon_cycle_start", "daemon_cycle_complete"]);
+  });
+
+  it("records a failed heartbeat with the failure message", async () => {
+    const heartbeats: Array<{ event: string; error?: string }> = [];
+
+    const result = await runDaemonCycle({
+      cycle: 3,
+      dryRun: false,
+      pilotRepos: ["electricsheephq/WorldOS"],
+      monitoredRepos: ["electricsheephq/WorldOS"],
+      canaryPulls: [],
+      commandsEnabled: false,
+      runOnceImpl: async () => {
+        throw new Error("second timeout");
+      },
+      recordHeartbeatImpl: (event, error) => heartbeats.push({ event, ...(error ? { error } : {}) }),
+      stdout: () => undefined,
+      stderr: () => undefined
+    });
+
+    expect(result.ok).toBe(false);
+    expect(heartbeats).toEqual([
+      { event: "daemon_cycle_start" },
+      { event: "daemon_cycle_failed", error: "second timeout" }
+    ]);
   });
 });

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -29,6 +29,7 @@ describe("beta release status", () => {
         dryRun: false
       },
       database: { rowCount: 2, errorCount: 0 },
+      heartbeat: freshHeartbeat(),
       now: new Date("2026-07-01T00:00:00.000Z")
     });
 
@@ -59,6 +60,7 @@ describe("beta release status", () => {
         dryRun: false
       },
       database: { rowCount: 2, errorCount: 0 },
+      heartbeat: freshHeartbeat(),
       now: new Date("2026-07-01T00:00:00.000Z")
     });
 
@@ -85,6 +87,7 @@ describe("beta release status", () => {
         state: "running"
       },
       database: { rowCount: 2, errorCount: 0 },
+      heartbeat: freshHeartbeat(),
       now: new Date("2026-07-01T00:00:00.000Z")
     });
 
@@ -108,6 +111,7 @@ describe("beta release status", () => {
         dryRun: false
       },
       database: { rowCount: 2, errorCount: 0 },
+      heartbeat: freshHeartbeat(),
       now: new Date("2026-07-01T00:00:00.000Z")
     });
 
@@ -131,11 +135,93 @@ describe("beta release status", () => {
         dryRun: false
       },
       database: { rowCount: 21, errorCount: 0, skippedCount: 16 },
+      heartbeat: freshHeartbeat(),
       now: new Date("2026-07-01T00:00:00.000Z")
     });
 
     expect(status.ok).toBe(true);
     expect(status.gates).toContainEqual({ name: "live_db_no_errors", ok: true, detail: "0 blocking error row(s)" });
+    expect(status.gates).toContainEqual({
+      name: "daemon_heartbeat_recent",
+      ok: true,
+      detail: "fresh; age 1000ms; max 120000ms; event daemon_cycle_complete; cycle 5"
+    });
     expect(status.database.skippedCount).toBe(16);
   });
+
+  it("fails closed when the daemon heartbeat is missing", () => {
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false
+      },
+      database: { rowCount: 21, errorCount: 0, skippedCount: 16 },
+      heartbeat: { status: "missing", maxAgeMs: 120_000 },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.gates).toContainEqual({
+      name: "daemon_heartbeat_recent",
+      ok: false,
+      detail: "missing heartbeat row; max age 120000ms"
+    });
+  });
+
+  it("fails closed when the daemon heartbeat is stale", () => {
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false
+      },
+      database: { rowCount: 21, errorCount: 0, skippedCount: 16 },
+      heartbeat: {
+        status: "stale",
+        maxAgeMs: 120_000,
+        latestAt: "2026-06-30T23:57:00.000Z",
+        ageMs: 180_000,
+        cycle: 5,
+        event: "daemon_cycle_complete",
+        dryRun: false
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.gates).toContainEqual({
+      name: "daemon_heartbeat_recent",
+      ok: false,
+      detail: "stale; age 180000ms; max 120000ms; event daemon_cycle_complete; cycle 5"
+    });
+  });
 });
+
+function freshHeartbeat() {
+  return {
+    status: "fresh" as const,
+    maxAgeMs: 120_000,
+    latestAt: "2026-06-30T23:59:59.000Z",
+    ageMs: 1_000,
+    cycle: 5,
+    event: "daemon_cycle_complete",
+    dryRun: false
+  };
+}

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -125,6 +125,72 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("stores the latest daemon heartbeat as a singleton", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-daemon-heartbeat-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    store.recordDaemonHeartbeat({
+      cycle: 1,
+      event: "daemon_cycle_start",
+      dryRun: false,
+      recordedAt: new Date("2026-07-01T00:00:00.000Z")
+    });
+    store.recordDaemonHeartbeat({
+      cycle: 1,
+      event: "daemon_cycle_complete",
+      dryRun: false,
+      recordedAt: new Date("2026-07-01T00:00:05.000Z")
+    });
+
+    expect(store.getDaemonHeartbeat()).toEqual({
+      cycle: 1,
+      event: "daemon_cycle_complete",
+      dryRun: false,
+      recordedAt: "2026-07-01T00:00:05.000Z",
+      startedCycle: 1,
+      startedAt: "2026-07-01T00:00:00.000Z"
+    });
+    store.close();
+  });
+
+  it("does not treat a start-only heartbeat as a terminal daemon heartbeat", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-daemon-heartbeat-start-only-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    store.recordDaemonHeartbeat({
+      cycle: 7,
+      event: "daemon_cycle_start",
+      dryRun: false,
+      recordedAt: new Date("2026-07-01T00:01:00.000Z")
+    });
+
+    expect(store.getDaemonHeartbeat()).toBeUndefined();
+    store.close();
+  });
+
+  it("redacts daemon heartbeat errors", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-daemon-heartbeat-redact-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    store.recordDaemonHeartbeat({
+      cycle: 2,
+      event: "daemon_cycle_failed",
+      dryRun: false,
+      error: "request failed with ghp_1234567890abcdefghijklmnopqrstuvwx",
+      recordedAt: new Date("2026-07-01T00:00:10.000Z")
+    });
+
+    expect(store.getDaemonHeartbeat()).toMatchObject({
+      cycle: 2,
+      event: "daemon_cycle_failed",
+      error: "request failed with [redacted-secret]"
+    });
+    store.close();
+  });
+
   it("deduplicates processed command comments per repo, PR, head SHA, and comment id", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-command-state-"));
     roots.push(root);


### PR DESCRIPTION
## Summary\n- persist daemon cycle heartbeat metadata in the live SQLite state DB\n- record start plus terminal complete/failed heartbeat events without throwing out of the daemon loop\n- fail `release:status` when the latest terminal heartbeat is missing or older than two poll intervals\n- keep heartbeat errors redacted\n\nCloses part of #43.\n\n## Validation\n- `npm test -- tests/state.test.ts tests/daemon-loop.test.ts tests/release-status.test.ts`\n- `npm test`\n- `npm run build`\n\n## Runtime note\nAfter this lands, the first post-merge `release:status` may fail until launchd is restarted and a terminal daemon cycle completes, because older live DBs do not yet have a terminal heartbeat row. That is expected and should be recorded as pre-promotion state.