### PR TITLE
Reliability: cool down ZCode provider rate limits

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,10 @@ export interface BotConfig {
     maxActiveRuns: number;
     leaseTtlMs: number;
   };
+  providerCooldown: {
+    enabled: boolean;
+    durationMs: number;
+  };
   walkthrough: {
     enabled: boolean;
     postIssueComment: boolean;
@@ -115,6 +119,10 @@ const DEFAULT_CONFIG: BotConfig = {
     maxActiveRuns: 5,
     leaseTtlMs: 15 * 60_000
   },
+  providerCooldown: {
+    enabled: true,
+    durationMs: 15 * 60_000
+  },
   walkthrough: {
     enabled: true,
     postIssueComment: false
@@ -173,6 +181,8 @@ function validateConfig(config: BotConfig): void {
   validateBoolean(config.activation.reviewExistingOpenPrsOnActivation, "config.activation.reviewExistingOpenPrsOnActivation");
   validatePositiveInteger(config.reviewConcurrency.maxActiveRuns, "config.reviewConcurrency.maxActiveRuns");
   validatePositiveInteger(config.reviewConcurrency.leaseTtlMs, "config.reviewConcurrency.leaseTtlMs");
+  validateBoolean(config.providerCooldown.enabled, "config.providerCooldown.enabled");
+  validatePositiveInteger(config.providerCooldown.durationMs, "config.providerCooldown.durationMs");
   validateBoolean(config.walkthrough.enabled, "config.walkthrough.enabled");
   validateBoolean(config.walkthrough.postIssueComment, "config.walkthrough.postIssueComment");
   validateBoolean(config.commands.enabled, "config.commands.enabled");

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -21,6 +21,7 @@ export interface ReleaseDatabaseStatus {
   rowCount: number;
   errorCount: number;
   skippedCount?: number;
+  providerCooldownCount?: number;
 }
 
 export interface ReleaseHeartbeatStatus {
@@ -100,7 +101,9 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     {
       name: "live_db_no_errors",
       ok: dbOk,
-      detail: `${input.database.errorCount} blocking error row(s)`
+      detail:
+        `${input.database.errorCount} blocking error row(s)` +
+        (input.database.providerCooldownCount ? `; ${input.database.providerCooldownCount} provider cooldown skip row(s)` : "")
     },
     {
       name: "daemon_heartbeat_recent",
@@ -191,16 +194,27 @@ function readDatabaseStatus(statePath: string): ReleaseDatabaseStatus {
         `select count(*) as rowCount,
                 sum(case when status = 'skipped' then 1 else 0 end) as skippedCount,
                 sum(case
+                  when status = 'skipped' and error like 'provider_rate_limit_cooldown_until=%' then 1
+                  else 0
+                end) as providerCooldownCount,
+                sum(case
                   when status = 'failed' then 1
+                  when status = 'skipped' and error like 'provider_rate_limit_cooldown_until=%' then 0
                   when status != 'skipped' and error is not null and error != '' then 1
                   else 0
                 end) as errorCount
            from processed_reviews`
       )
-      .get() as { rowCount?: number; skippedCount?: number | null; errorCount?: number | null };
+      .get() as {
+        rowCount?: number;
+        skippedCount?: number | null;
+        providerCooldownCount?: number | null;
+        errorCount?: number | null;
+      };
     return {
       rowCount: row.rowCount ?? 0,
       skippedCount: row.skippedCount ?? 0,
+      providerCooldownCount: row.providerCooldownCount ?? 0,
       errorCount: row.errorCount ?? 0
     };
   } finally {

--- a/src/state.ts
+++ b/src/state.ts
@@ -35,6 +35,13 @@ export interface ReviewRunLease {
   expiresAt: string;
 }
 
+export interface RepoProviderCooldownRecord {
+  repo: string;
+  cooldownUntil: string;
+  reason: string;
+  updatedAt: string;
+}
+
 export type DaemonHeartbeatEvent = "daemon_cycle_start" | "daemon_cycle_complete" | "daemon_cycle_failed";
 
 export interface DaemonHeartbeatRecord {
@@ -95,6 +102,13 @@ export class ReviewStateStore {
         lease_id text primary key,
         started_at text not null,
         expires_at text not null
+      );
+
+      create table if not exists repo_provider_cooldowns (
+        repo text primary key,
+        cooldown_until text not null,
+        reason text not null,
+        updated_at text not null default (datetime('now'))
       );
 
       create table if not exists daemon_heartbeat (
@@ -242,6 +256,40 @@ export class ReviewStateStore {
     this.db.prepare("delete from review_run_leases where lease_id = ?").run(leaseId);
   }
 
+  recordRepoProviderCooldown(input: { repo: string; cooldownUntil: Date; reason: string }): RepoProviderCooldownRecord {
+    this.db
+      .prepare(
+        `insert into repo_provider_cooldowns (repo, cooldown_until, reason, updated_at)
+         values (?, ?, ?, datetime('now'))
+         on conflict(repo) do update set
+           cooldown_until = excluded.cooldown_until,
+           reason = excluded.reason,
+           updated_at = datetime('now')`
+      )
+      .run(input.repo, input.cooldownUntil.toISOString(), redactSecrets(input.reason));
+    return this.getRepoProviderCooldown(input.repo)!;
+  }
+
+  getRepoProviderCooldown(repo: string): RepoProviderCooldownRecord | undefined {
+    const row = this.db
+      .prepare(
+        `select repo, cooldown_until, reason, updated_at
+         from repo_provider_cooldowns
+         where repo = ?
+         limit 1`
+      )
+      .get(repo) as RepoProviderCooldownRow | undefined;
+    return row ? mapRepoProviderCooldownRow(row) : undefined;
+  }
+
+  getActiveRepoProviderCooldown(repo: string, now = new Date()): RepoProviderCooldownRecord | undefined {
+    const cooldown = this.getRepoProviderCooldown(repo);
+    if (!cooldown) return undefined;
+    const cooldownUntil = Date.parse(cooldown.cooldownUntil);
+    if (!Number.isFinite(cooldownUntil) || cooldownUntil <= now.getTime()) return undefined;
+    return cooldown;
+  }
+
   recordDaemonHeartbeat(record: DaemonHeartbeatRecord): void {
     if (record.event === "daemon_cycle_start") {
       this.db
@@ -369,6 +417,13 @@ interface DaemonHeartbeatRow {
   started_at: string | null;
 }
 
+interface RepoProviderCooldownRow {
+  repo: string;
+  cooldown_until: string;
+  reason: string;
+  updated_at: string;
+}
+
 function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRecord {
   return {
     repo: row.repo,
@@ -379,6 +434,15 @@ function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRe
     ...(row.review_url ? { reviewUrl: row.review_url } : {}),
     ...(row.error ? { error: row.error } : {}),
     createdAt: row.created_at
+  };
+}
+
+function mapRepoProviderCooldownRow(row: RepoProviderCooldownRow): RepoProviderCooldownRecord {
+  return {
+    repo: row.repo,
+    cooldownUntil: row.cooldown_until,
+    reason: row.reason,
+    updatedAt: row.updated_at
   };
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -47,6 +47,7 @@ export interface RunOnceResult {
   commandReviewRequested: number;
   skippedProcessed: number;
   skippedCapacity: number;
+  skippedProviderCooldown: number;
   skippedStaleHead: number;
   baselinedExisting: number;
   policySkips: { repo: string; reason: string }[];
@@ -76,6 +77,7 @@ export type ReviewPullResult =
   | "skipped_command_explain"
   | "skipped_processed"
   | "skipped_capacity"
+  | "skipped_provider_cooldown"
   | "skipped_stale_head";
 
 export function isSuccessfulRetryStatus(status: RetryFailedHeadResult["status"]): boolean {
@@ -92,6 +94,7 @@ export function isSuccessfulRetryStatus(status: RetryFailedHeadResult["status"])
     case "skipped_command_stop":
     case "skipped_command_explain":
     case "skipped_capacity":
+    case "skipped_provider_cooldown":
     case "skipped_stale_head":
       return false;
     default:
@@ -117,6 +120,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
     commandReviewRequested: 0,
     skippedProcessed: 0,
     skippedCapacity: 0,
+    skippedProviderCooldown: 0,
     skippedStaleHead: 0,
     baselinedExisting: 0,
     policySkips: []
@@ -157,6 +161,10 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             budget
           });
         } catch (error) {
+          if (recordProviderRateLimitCooldownIfNeeded({ config, state, repo, pull, error })) {
+            result.skippedProviderCooldown += 1;
+            continue;
+          }
           recordFailedReview({ config, state, repo, pull, error });
           result.failed += 1;
           continue;
@@ -170,6 +178,7 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
         if (status === "reviewed_command") result.commandReviewRequested += 1;
         if (status === "skipped_processed") result.skippedProcessed += 1;
         if (status === "skipped_capacity") result.skippedCapacity += 1;
+        if (status === "skipped_provider_cooldown") result.skippedProviderCooldown += 1;
         if (status === "skipped_stale_head") result.skippedStaleHead += 1;
       }
     }
@@ -258,6 +267,20 @@ export async function retryFailedHeadWithDeps(input: {
       status: retryStatus
     };
   } catch (error) {
+    if (recordProviderRateLimitCooldownIfNeeded({
+      config,
+      state,
+      repo: options.repo,
+      pull,
+      error: retryFailureError(retryTarget.previousError, error)
+    })) {
+      return {
+        repo: options.repo,
+        pullNumber: options.pullNumber,
+        headSha: options.headSha,
+        status: "skipped_provider_cooldown"
+      };
+    }
     recordFailedReview({
       config,
       state,
@@ -313,9 +336,9 @@ export function prepareFailedHeadRetry(input: {
   if (!processed) {
     throw new Error(`No processed review row exists for ${input.repo}#${input.pullNumber}@${input.headSha}`);
   }
-  if (processed.status !== "failed") {
+  if (processed.status !== "failed" && !isProviderCooldownProcessedReview(processed)) {
     throw new Error(
-      `Refusing retry for ${input.repo}#${input.pullNumber}@${input.headSha}: status is ${processed.status}, not failed`
+      `Refusing retry for ${input.repo}#${input.pullNumber}@${input.headSha}: status is ${processed.status}, not failed/provider-cooldown`
     );
   }
 
@@ -372,6 +395,19 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     state.hasProcessed(repo, pull.number, pull.head.sha)
   ) {
     return "skipped_processed";
+  }
+  const activeCooldown = config.providerCooldown.enabled && typeof state.getActiveRepoProviderCooldown === "function"
+    ? state.getActiveRepoProviderCooldown(repo)
+    : undefined;
+  if (activeCooldown && input.processedHeadPolicy !== "retry_failed_head") {
+    recordProviderCooldownSkip({
+      state,
+      repo,
+      pull,
+      cooldownUntil: activeCooldown.cooldownUntil,
+      reason: activeCooldown.reason
+    });
+    return "skipped_provider_cooldown";
   }
   const budget = input.budget ?? new ReviewRunBudget(config.reviewConcurrency.maxActiveRuns);
   if (!budget.tryStart()) return "skipped_capacity";
@@ -640,6 +676,70 @@ export function recordFailedReview(input: {
     status: "failed",
     error: errorMessage
   });
+}
+
+export function recordProviderRateLimitCooldownIfNeeded(input: {
+  config: BotConfig;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  error: unknown;
+  now?: Date;
+}): boolean {
+  if (!input.config.providerCooldown.enabled) return false;
+  const classification = classifyProviderRateLimitError(input.error);
+  if (!classification.rateLimited) return false;
+
+  const now = input.now ?? new Date();
+  const cooldownUntil = new Date(now.getTime() + input.config.providerCooldown.durationMs);
+  input.state.recordRepoProviderCooldown({
+    repo: input.repo,
+    cooldownUntil,
+    reason: classification.reason
+  });
+  recordProviderCooldownSkip({
+    state: input.state,
+    repo: input.repo,
+    pull: input.pull,
+    cooldownUntil: cooldownUntil.toISOString(),
+    reason: classification.reason
+  });
+  return true;
+}
+
+export function classifyProviderRateLimitError(error: unknown): { rateLimited: boolean; reason: string } {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+  const rateLimited =
+    normalized.includes("rate limit") ||
+    normalized.includes("rate_limit_error") ||
+    normalized.includes("providercode: '1302'") ||
+    normalized.includes('providercode: "1302"') ||
+    normalized.includes("[1302]");
+  return {
+    rateLimited,
+    reason: rateLimited ? "provider_rate_limit" : "not_provider_rate_limit"
+  };
+}
+
+function recordProviderCooldownSkip(input: {
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  cooldownUntil: string;
+  reason: string;
+}): void {
+  input.state.recordProcessed({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    status: "skipped",
+    error: `provider_rate_limit_cooldown_until=${input.cooldownUntil}; reason=${redactSecrets(input.reason)}`
+  });
+}
+
+function isProviderCooldownProcessedReview(record: { status: string; error?: string }): boolean {
+  return record.status === "skipped" && Boolean(record.error?.startsWith("provider_rate_limit_cooldown_until="));
 }
 
 function retryFailureError(previousError: string | undefined, error: unknown): string {

--- a/tests/coverage-audit.test.ts
+++ b/tests/coverage-audit.test.ts
@@ -320,6 +320,10 @@ function minimalConfig(root: string): BotConfig {
       maxActiveRuns: 1,
       leaseTtlMs: 60_000
     },
+    providerCooldown: {
+      enabled: true,
+      durationMs: 15 * 60_000
+    },
     walkthrough: {
       enabled: false,
       postIssueComment: false

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -64,6 +64,7 @@ describe("daemon cycle resilience", () => {
         commandReviewRequested: 0,
         skippedProcessed: 1,
         skippedCapacity: 0,
+        skippedProviderCooldown: 0,
         skippedStaleHead: 0,
         baselinedExisting: 0,
         policySkips: []

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -149,6 +149,34 @@ describe("beta release status", () => {
     expect(status.database.skippedCount).toBe(16);
   });
 
+  it("reports provider cooldown skips without treating them as blocking DB errors", () => {
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false
+      },
+      database: { rowCount: 21, errorCount: 0, skippedCount: 16, providerCooldownCount: 1 },
+      heartbeat: freshHeartbeat(),
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(true);
+    expect(status.gates).toContainEqual({
+      name: "live_db_no_errors",
+      ok: true,
+      detail: "0 blocking error row(s); 1 provider cooldown skip row(s)"
+    });
+  });
+
   it("fails closed when the daemon heartbeat is missing", () => {
     const status = buildReleaseStatus({
       repo: {

--- a/tests/review-budget.test.ts
+++ b/tests/review-budget.test.ts
@@ -121,6 +121,10 @@ function minimalConfig(root: string): BotConfig {
       maxActiveRuns: 5,
       leaseTtlMs: 60_000
     },
+    providerCooldown: {
+      enabled: true,
+      durationMs: 15 * 60_000
+    },
     walkthrough: {
       enabled: false,
       postIssueComment: false

--- a/tests/stale-head.test.ts
+++ b/tests/stale-head.test.ts
@@ -88,6 +88,10 @@ function minimalConfig(root: string): BotConfig {
       maxActiveRuns: 1,
       leaseTtlMs: 60_000
     },
+    providerCooldown: {
+      enabled: true,
+      durationMs: 15 * 60_000
+    },
     walkthrough: {
       enabled: false,
       postIssueComment: false

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -12,6 +12,7 @@ import {
   localDateFolder,
   prepareFailedHeadRetry,
   recordFailedReview,
+  recordProviderRateLimitCooldownIfNeeded,
   restoreFailedRetryRowIfNeeded,
   retryFailedHeadWithDeps,
   reviewPull
@@ -46,6 +47,33 @@ describe("worker review failures", () => {
     );
     expect(evidence).toContain("ETIMEDOUT");
     expect(evidence).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+    state.close();
+  });
+
+  it("records provider rate limits as cooldown skips instead of hard failures", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-cooldown-"));
+    roots.push(root);
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = minimalConfig(root);
+    const pull = pullSummary(1234, "head-rate-limit");
+
+    const handled = recordProviderRateLimitCooldownIfNeeded({
+      config,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      error: new Error("ProviderBusinessError: [1302][Rate limit reached for requests]"),
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(handled).toBe(true);
+    expect(state.getProcessedReview("electricsheephq/WorldOS", 1234, "head-rate-limit")).toMatchObject({
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2026-07-01T00:15:00.000Z; reason=provider_rate_limit"
+    });
+    expect(state.getActiveRepoProviderCooldown("electricsheephq/WorldOS", new Date("2026-07-01T00:10:00.000Z"))).toMatchObject({
+      reason: "provider_rate_limit"
+    });
     state.close();
   });
 
@@ -134,7 +162,32 @@ describe("worker review failures", () => {
       pullNumber: 1225,
       headSha: "head-posted",
       livePull: pullSummary(1225, "head-posted")
-    })).toThrow("status is posted, not failed");
+    })).toThrow("status is posted, not failed/provider-cooldown");
+    state.close();
+  });
+
+  it("allows retry for provider-cooldown skipped heads", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-cooldown-retry-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1235,
+      headSha: "head-provider-cooldown",
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2026-07-01T00:15:00.000Z; reason=provider_rate_limit"
+    });
+
+    expect(prepareFailedHeadRetry({
+      state,
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1235,
+      headSha: "head-provider-cooldown",
+      livePull: pullSummary(1235, "head-provider-cooldown")
+    })).toMatchObject({
+      previousError: "provider_rate_limit_cooldown_until=2026-07-01T00:15:00.000Z; reason=provider_rate_limit"
+    });
     state.close();
   });
 
@@ -472,6 +525,7 @@ describe("worker review failures", () => {
     expect(isSuccessfulRetryStatus("skipped_processed")).toBe(true);
     expect(isSuccessfulRetryStatus("failed")).toBe(false);
     expect(isSuccessfulRetryStatus("skipped_capacity")).toBe(false);
+    expect(isSuccessfulRetryStatus("skipped_provider_cooldown")).toBe(false);
     expect(isSuccessfulRetryStatus("skipped_stale_head")).toBe(false);
   });
 });
@@ -490,6 +544,10 @@ function minimalConfig(root: string): BotConfig {
     reviewConcurrency: {
       maxActiveRuns: 1,
       leaseTtlMs: 60_000
+    },
+    providerCooldown: {
+      enabled: true,
+      durationMs: 15 * 60_000
     },
     walkthrough: {
       enabled: false,


### PR DESCRIPTION
## Summary\n- Adds repo-level provider cooldown state for ZCode provider rate-limit errors.\n- Converts provider quota failures into explicit provider cooldown skip rows instead of hard failed rows.\n- Keeps retry/backfill support for provider-cooldown skipped heads.\n- Reports provider cooldown skip counts in release-status while preserving heartbeat and failed-row gates.\n\nCloses #49.\n\n## Validation\n- npm test -- tests/worker-failure.test.ts tests/release-status.test.ts tests/state.test.ts\n- npm run build\n- npm test\n- git diff --check\n\n## Live incident context\nThis is driven by live ZCode provider rate-limit failures on 100yenadmin/Lossless-Codex-Orchestrator-LCO#219 while launchd was otherwise running and heartbeat healthy.