### PR TITLE
Docs: define beta patch release cadence

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The worker derives transient ZCode CLI model environment from the existing ZCode
 The live launchd worker is a local beta release surface, not just whatever
 `main` happens to contain. Before promoting a merged PR to the live worker,
 follow [docs/beta-release-runbook.md](docs/beta-release-runbook.md).
+Named release packets live under [docs/releases](docs/releases), starting with
+`v0.2.1-runtime-resilience`.
 
 ## Repo Profiles
 

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -23,9 +23,37 @@ their own tracked issue, PR, dry-run evidence, and explicit promotion gate.
   fix requires a patch beta.
 - Prefer small beta releases after each merged PR that changes live reviewer
   behavior.
+- Cut a named patch beta whenever a change touches launchd behavior,
+  `release:status`, state DB interpretation, retry/backfill semantics, provider
+  failure handling, monitored repos, App auth, posting policy, ZCode invocation,
+  or duplicate-suppression behavior.
+- Documentation-only PRs may be merged without restarting launchd, but the live
+  checkout must still be fast-forwarded and `release:status` must be recorded
+  with the new source SHA so the release surface is not stale.
+- Use the next patch name only after the previous packet is linked from the
+  tracker issue. For this sprint, the runtime-resilience packet is
+  `v0.2.1-runtime-resilience`.
 - Keep the live daemon scoped to the current active config until the allowlist
   issue and App-install gates pass.
 - Do not let launchd run an unrecorded or stale checkout after a merge.
+
+## Patch vs Sprint Branch
+
+Continue on the same sprint branch when the change is still local, unmerged, or
+purely refines the same unpromoted behavior.
+
+Cut a patch beta after merge when any of these are true:
+
+- live launchd needs a restart to pick up source changes,
+- the worker may post, skip, retry, or suppress a different set of PR heads,
+- release-health interpretation changes,
+- state rows are migrated, retired, or reclassified,
+- a runtime incident was fixed or explicitly contained,
+- the next maintainer needs a stable rollback SHA.
+
+Do not bundle unrelated fixes into a patch beta just because the daemon is
+already being restarted. File a follow-up issue and keep the release packet
+bounded to what was actually promoted.
 
 ## Promotion Flow
 
@@ -53,6 +81,10 @@ If the first `release:status` fails only because launchd is still on the
 previous head before restart, record that as pre-promotion state. The
 post-restart `release:status` must pass before calling the beta promoted.
 
+Prefer `npx tsx src/cli.ts release-status ...` when writing machine-readable JSON
+to an evidence file, because `npm run release:status` prepends npm's command
+banner to stdout.
+
 ## Required Gates
 
 - GitHub PR merged to `main` with checks green and no current-head actionable
@@ -63,6 +95,12 @@ post-restart `release:status` must pass before calling the beta promoted.
   launchd dry-run mode, state DB row count, and error count.
 - launchd emits a fresh heartbeat after restart.
 - live DB has no unexpected error rows.
+- provider cooldown rows are allowed only when they are explicit
+  `provider_rate_limit_cooldown_until=...` skips with a follow-up retry issue or
+  retry plan. They prove provider degradation was contained; they do not prove
+  the affected PR head was reviewed.
+- `coverage-audit` has zero unprocessed eligible heads unless every miss is
+  explained in the release packet.
 - GitHub tracker issue records source SHA, config path, launchd proof, DB proof,
   rollback command, and next action.
 
@@ -99,6 +137,12 @@ Do not retire an active failed current head. Use `retry-failed` or disable the
 repo through the tracked allowlist/policy lane when the provider is repeatedly
 rate-limited.
 
+Provider cooldown rows are not failed rows. They mean the provider was
+rate-limited before ZCode produced a review. Keep them visible in
+`release:status`, then retry after the cooldown expires or resolve the ZCode
+provider entitlement/rate-limit source. A release may be green with provider
+cooldown rows only when the packet names the affected PR head and follow-up.
+
 ## Rollback
 
 Default rollback is to restart the existing launchd job after checking out the
@@ -128,13 +172,57 @@ launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.electricsheephq.evaos-
 For each beta promotion, record:
 
 - GitHub PR and merge commit.
+- release name, release type, owner, and monitor window.
 - `release:status` JSON before and after restart.
 - `npm test` and `npm run build` result.
+- `doctor` app-auth/readiness summary.
+- `coverage-audit` summary.
 - launchd stdout heartbeat lines after restart.
 - live DB row/error count.
+- provider cooldown rows, if any, with affected repo, PR, head SHA, and
+  cooldown expiry.
 - rollback SHA and command.
 - next monitoring action or heartbeat.
 
 Keep raw evidence under `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
 or session notes. Do not paste secrets, private keys, tokens, cookies, raw
 customer data, or long logs into GitHub comments.
+
+## Release Packet Template
+
+Use this shape in `docs/releases/<release-name>.md` or in the GitHub tracker
+when a docs file is not warranted:
+
+```markdown
+# <release-name>
+
+- Release type:
+- Source SHA:
+- Merged PRs:
+- Live checkout:
+- launchd label:
+- launchd PID:
+- Live config:
+- State DB:
+- Evidence path:
+- Monitor owner/window:
+- Rollback SHA:
+- Rollback command:
+
+## Gates
+
+- PR checks/reviews:
+- Build/tests:
+- release-status:
+- doctor:
+- coverage-audit:
+- heartbeat:
+- DB state:
+- provider cooldown rows:
+
+## Notes
+
+- What changed:
+- What did not change:
+- Open follow-ups:
+```

--- a/docs/releases/v0.2.1-runtime-resilience.md
+++ b/docs/releases/v0.2.1-runtime-resilience.md
@@ -1,0 +1,85 @@
+# v0.2.1-runtime-resilience
+
+- Release type: local beta patch
+- Source SHA: `3137e7bbfe29db02732f84e968570879e0b16abc`
+- Merged PRs:
+  - `#48` retire historical failed heads with exact evidence
+  - `#50` heartbeat-backed release-status gate
+  - `#51` repo-level ZCode provider cooldown handling
+- Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- launchd label: `com.electricsheephq.evaos-code-review-bot`
+- launchd PID at promotion proof: `42074`
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+- State DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
+- Evidence paths:
+  - `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/release-status-retire-failed-pr48/`
+  - `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/heartbeat-release-status-pr50/`
+  - `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/provider-cooldown-pr51/`
+- Monitor owner/window: implementing agent, first 24 hours after promotion
+- Rollback SHA: previous known-good `82c3ab44aec67c7a85116729ce51925a8e201db7` for PR #50 behavior, or `cd8ae3680807ce3d013bdebf14f7aa06b02f17ed` before heartbeat/provider-cooldown hardening
+- Rollback command:
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin
+git checkout main
+git reset --hard <rollback-sha>
+npm run build
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+```
+
+## Gates
+
+- PR checks/reviews:
+  - PR #50 checks green; CodeRabbit review completed without actionable review threads.
+  - PR #51 checks green; CodeRabbit posted only a rate-limit notice, with no review threads.
+- Build/tests:
+  - `npm run build` passed from the live checkout after promotion.
+  - `npm test` passed from the live checkout: 23 files, 108 tests.
+- release-status:
+  - Final proof: `ok=true`.
+  - Expected head matched `3137e7bbfe29db02732f84e968570879e0b16abc`.
+  - Checkout was clean on `main`.
+  - launchd config matched `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`.
+  - DB had `errorCount=0` and `providerCooldownCount=1`.
+- doctor:
+  - `ok=true`.
+  - `readMode=app_installation`.
+  - `canPostAsApp=true`.
+  - 19 monitored repos readable with 0 failed reads.
+- coverage-audit:
+  - `ok=true`.
+  - 19 repos scanned.
+  - 65 PRs seen.
+  - 61 processed.
+  - 0 unprocessed eligible heads.
+  - 0 stale heads.
+  - 0 read failures.
+- heartbeat:
+  - Final proof had fresh daemon heartbeat from cycle 3 at `2026-07-01T05:49:40.605Z`.
+- DB state:
+  - Historical closed LCO failed rows from the earlier outage were retired only after coverage evidence.
+  - Active failed rows were cleared or reclassified.
+- provider cooldown rows:
+  - `100yenadmin/Lossless-Codex-Orchestrator-LCO#219`
+  - head `ae931a6ac3cfe8bc5f928fa01a9b374160da99ca`
+  - status `skipped`
+  - reason `provider_rate_limit`
+  - cooldown until `2026-07-01T06:01:49.752Z`
+
+## Notes
+
+- What changed:
+  - One PR failure can no longer kill the daemon loop without a heartbeat trail.
+  - `release:status` now fails when daemon heartbeat is missing or stale.
+  - Provider rate-limit failures are explicit provider-cooldown skips instead of blocking failed rows.
+  - Release-status reports provider cooldown rows separately from blocking errors.
+- What did not change:
+  - The bot still does not approve PRs.
+  - The bot still does not mutate pilot repos.
+  - The bot still does not claim a review happened when ZCode was rate-limited.
+  - The monitor list, App permissions, and command surface were not expanded by this release.
+- Open follow-ups:
+  - Issue `#52`: automatically retry expired provider-cooldown heads.
+  - Continue `#5` and `#14` durable allowlist/policy hardening.
+  - Continue `#9` eval/comparison after policy foundations.


### PR DESCRIPTION
## Summary
- Tightens the beta release runbook with patch cadence, patch-vs-sprint rules, provider-cooldown handling, and release packet requirements.
- Adds the first concrete release packet: `v0.2.1-runtime-resilience`.
- Links release packets from the README.

Closes #44.

## Validation
- `git diff --check`
- Docs/runbook review against #44 acceptance criteria

## Notes
Docs-only change. Per the runbook, live checkout should still be fast-forwarded after merge and `release:status` recorded, but launchd restart is not required unless source code changes.
