### PR TITLE
Reliability: retry expired provider cooldown heads

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { GitHubApi } from "./github.js";
 import { collectReleaseStatus } from "./release-status.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
 import { ReviewStateStore } from "./state.js";
-import { isSuccessfulRetryStatus, retryFailedHead, runOnce } from "./worker.js";
+import { isSuccessfulRetryStatus, retryFailedHead, retryProviderCooldowns, runOnce } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
 
 async function main(): Promise<void> {
@@ -129,6 +129,49 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "provider-cooldowns") {
+    const config = loadConfig(args.config);
+    const state = new ReviewStateStore(args["state-path"] ?? config.statePath);
+    try {
+      const expiredOnly = args["expired-only"] === "true";
+      const limit = args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined;
+      const rows = state.listProviderCooldownReviews({
+        repo: args.repo,
+        expiredOnly,
+        limit
+      });
+      console.log(JSON.stringify({
+        ok: true,
+        checkedAt: new Date().toISOString(),
+        expiredOnly,
+        ...(args.repo ? { repo: args.repo } : {}),
+        count: rows.length,
+        expiredCount: rows.filter((row) => row.expired).length,
+        rows
+      }, null, 2));
+    } finally {
+      state.close();
+    }
+    return;
+  }
+
+  if (command === "retry-provider-cooldowns") {
+    if (args["dry-run"] !== "true" && args["dry-run"] !== "false") {
+      throw new Error("retry-provider-cooldowns requires explicit --dry-run true or --dry-run false");
+    }
+    const result = await retryProviderCooldowns({
+      configPath: args.config,
+      repo: args.repo,
+      limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined,
+      expiredOnly: args["expired-only"] !== "false",
+      dryRun: args["dry-run"] === "true",
+      useZCode: args.zcode !== "false"
+    });
+    console.log(JSON.stringify(result, null, 2));
+    if (!result.ok) process.exitCode = 1;
+    return;
+  }
+
   if (command === "retire-failed") {
     if (!args.repo) throw new Error("--repo is required for retire-failed");
     if (!args.pr) throw new Error("--pr is required for retire-failed");
@@ -193,6 +236,12 @@ function parseArgs(argv: string[]): ParsedArgs {
   return parsed;
 }
 
+function parsePositiveInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) throw new Error(`${label} must be a positive integer`);
+  return parsed;
+}
+
 interface ParsedArgs {
   _: string[];
   config?: string;
@@ -203,7 +252,9 @@ interface ParsedArgs {
   "launchd-label"?: string;
   "state-path"?: string;
   "dry-run"?: string;
+  "expired-only"?: string;
   "head-sha"?: string;
+  limit?: string;
   zcode?: string;
   [key: string]: string | string[] | undefined;
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -42,6 +42,19 @@ export interface RepoProviderCooldownRecord {
   updatedAt: string;
 }
 
+export const PROVIDER_COOLDOWN_ERROR_PREFIX = "provider_rate_limit_cooldown_until=";
+
+export interface ParsedProviderCooldownError {
+  cooldownUntil: string;
+  reason?: string;
+}
+
+export interface ProviderCooldownReviewRecord extends StoredProcessedReviewRecord {
+  cooldownUntil: string;
+  reason?: string;
+  expired: boolean;
+}
+
 export type DaemonHeartbeatEvent = "daemon_cycle_start" | "daemon_cycle_complete" | "daemon_cycle_failed";
 
 export interface DaemonHeartbeatRecord {
@@ -290,6 +303,55 @@ export class ReviewStateStore {
     return cooldown;
   }
 
+  listProviderCooldownReviews(input: {
+    repo?: string;
+    now?: Date;
+    expiredOnly?: boolean;
+    limit?: number;
+  } = {}): ProviderCooldownReviewRecord[] {
+    if (input.limit !== undefined && (!Number.isInteger(input.limit) || input.limit < 1)) {
+      throw new Error("limit must be a positive integer");
+    }
+
+    const now = input.now ?? new Date();
+    const rows = (input.repo
+      ? this.db
+          .prepare(
+            `select repo, pull_number, head_sha, status, event, review_url, error, created_at
+             from processed_reviews
+             where repo = ? and status = 'skipped' and error like ?
+             order by datetime(created_at) asc`
+          )
+          .all(input.repo, `${PROVIDER_COOLDOWN_ERROR_PREFIX}%`)
+      : this.db
+          .prepare(
+            `select repo, pull_number, head_sha, status, event, review_url, error, created_at
+             from processed_reviews
+             where status = 'skipped' and error like ?
+             order by datetime(created_at) asc`
+          )
+          .all(`${PROVIDER_COOLDOWN_ERROR_PREFIX}%`)) as unknown as ProcessedReviewRow[];
+
+    const mapped = rows
+      .map((row) => {
+        const record = mapProcessedReviewRow(row);
+        const parsed = parseProviderCooldownError(record.error);
+        if (!parsed) return undefined;
+        const cooldownUntilMs = Date.parse(parsed.cooldownUntil);
+        const expired = Number.isFinite(cooldownUntilMs) && cooldownUntilMs <= now.getTime();
+        return {
+          ...record,
+          cooldownUntil: parsed.cooldownUntil,
+          ...(parsed.reason ? { reason: parsed.reason } : {}),
+          expired
+        };
+      })
+      .filter((record): record is ProviderCooldownReviewRecord => Boolean(record))
+      .filter((record) => !input.expiredOnly || record.expired);
+
+    return input.limit ? mapped.slice(0, input.limit) : mapped;
+  }
+
   recordDaemonHeartbeat(record: DaemonHeartbeatRecord): void {
     if (record.event === "daemon_cycle_start") {
       this.db
@@ -394,6 +456,19 @@ function normalizeRetirementReason(reason: string): string {
     .replaceAll(/^_+|_+$/g, "")
     .slice(0, 80);
   return normalized || "operator_acknowledged";
+}
+
+export function parseProviderCooldownError(error?: string): ParsedProviderCooldownError | undefined {
+  if (!error?.startsWith(PROVIDER_COOLDOWN_ERROR_PREFIX)) return undefined;
+  const [cooldownPart, ...rest] = error.split(";");
+  const cooldownUntil = cooldownPart?.slice(PROVIDER_COOLDOWN_ERROR_PREFIX.length).trim();
+  if (!cooldownUntil) return undefined;
+  const reasonPart = rest.map((part) => part.trim()).find((part) => part.startsWith("reason="));
+  const reason = reasonPart?.slice("reason=".length).trim();
+  return {
+    cooldownUntil,
+    ...(reason ? { reason } : {})
+  };
 }
 
 interface ProcessedReviewRow {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -20,7 +20,7 @@ import {
 } from "./repo-policy.js";
 import { ReviewRunBudget } from "./review-budget.js";
 import { redactSecrets } from "./secrets.js";
-import { ReviewStateStore, type ReviewRunLease } from "./state.js";
+import { parseProviderCooldownError, ReviewStateStore, type ReviewRunLease } from "./state.js";
 import { buildWalkthroughComment } from "./walkthrough.js";
 import { postWalkthroughComment, reviewBodyAfterWalkthroughPost } from "./walkthrough-post.js";
 import { buildReviewPrompt, runZCodeReview } from "./zcode.js";
@@ -64,7 +64,30 @@ export interface FailedHeadRetryTarget {
   repo: string;
   pullNumber: number;
   headSha: string;
+  previousStatus: "failed" | "skipped";
   previousError?: string;
+}
+
+export interface RetryProviderCooldownsResult {
+  ok: boolean;
+  checkedAt: string;
+  dryRun: boolean;
+  expiredOnly: boolean;
+  limit: number;
+  repo?: string;
+  candidates: number;
+  attempted: number;
+  results: RetryFailedHeadResult[];
+  summary: {
+    reviewed: number;
+    dryRun: number;
+    remainedCooldown: number;
+    failed: number;
+    skippedStaleHead: number;
+    skippedProcessed: number;
+    skippedCapacity: number;
+    other: number;
+  };
 }
 
 export type ReviewPullResult =
@@ -207,6 +230,89 @@ export async function retryFailedHead(options: {
   }
 }
 
+export async function retryProviderCooldowns(options: {
+  configPath?: string;
+  repo?: string;
+  limit?: number;
+  expiredOnly?: boolean;
+  dryRun: boolean;
+  useZCode?: boolean;
+}): Promise<RetryProviderCooldownsResult> {
+  const config = loadConfig(options.configPath);
+  const github = new GitHubApi(config.github);
+  const state = new ReviewStateStore(config.statePath);
+  const budget = new ReviewRunBudget(1);
+  try {
+    return await retryProviderCooldownsWithDeps({
+      config,
+      github,
+      state,
+      budget,
+      options,
+      reviewPullImpl: reviewPull
+    });
+  } finally {
+    state.close();
+  }
+}
+
+export async function retryProviderCooldownsWithDeps(input: {
+  config: BotConfig;
+  github: GitHubApi;
+  state: ReviewStateStore;
+  budget: ReviewRunBudget;
+  options: {
+    repo?: string;
+    limit?: number;
+    expiredOnly?: boolean;
+    dryRun: boolean;
+    useZCode?: boolean;
+  };
+  reviewPullImpl: (input: ReviewPullInput) => Promise<ReviewPullResult>;
+}): Promise<RetryProviderCooldownsResult> {
+  const limit = input.options.limit ?? 5;
+  if (!Number.isInteger(limit) || limit < 1) throw new Error("limit must be a positive integer");
+  const expiredOnly = input.options.expiredOnly ?? true;
+  const candidates = input.state.listProviderCooldownReviews({
+    repo: input.options.repo,
+    expiredOnly,
+    limit,
+    now: new Date()
+  });
+  const results: RetryFailedHeadResult[] = [];
+  for (const candidate of candidates) {
+    const result = await retryFailedHeadWithDeps({
+      config: input.config,
+      github: input.github,
+      state: input.state,
+      budget: input.budget,
+      options: {
+        repo: candidate.repo,
+        pullNumber: candidate.pullNumber,
+        headSha: candidate.headSha,
+        dryRun: input.options.dryRun,
+        useZCode: input.options.useZCode
+      },
+      reviewPullImpl: input.reviewPullImpl
+    });
+    results.push(result);
+  }
+
+  const summary = summarizeRetryProviderCooldownResults(results);
+  return {
+    ok: summary.failed === 0 && summary.skippedCapacity === 0,
+    checkedAt: new Date().toISOString(),
+    dryRun: input.options.dryRun,
+    expiredOnly,
+    limit,
+    ...(input.options.repo ? { repo: input.options.repo } : {}),
+    candidates: candidates.length,
+    attempted: results.length,
+    results,
+    summary
+  };
+}
+
 export async function retryFailedHeadWithDeps(input: {
   config: BotConfig;
   github: GitHubApi;
@@ -253,11 +359,11 @@ export async function retryFailedHeadWithDeps(input: {
       budget,
       processedHeadPolicy: "retry_failed_head"
     });
-      const retryStatus = options.dryRun && (status === "reviewed" || status === "reviewed_command") ? "dry_run" : status;
-      // A retry dry-run is a successful inspection, but the failed row must remain retryable for the later live run.
-      restoreFailedRetryRowIfNeeded({
-        state,
-        retryTarget,
+    const retryStatus = options.dryRun && (status === "reviewed" || status === "reviewed_command") ? "dry_run" : status;
+    // A retry dry-run is a successful inspection, but the original row must remain retryable for the later live run.
+    restoreFailedRetryRowIfNeeded({
+      state,
+      retryTarget,
       reason: retryStatus === "dry_run" ? "retry_dry_run" : `retry_did_not_review=${retryStatus}`
     });
     return {
@@ -310,11 +416,14 @@ export function restoreFailedRetryRowIfNeeded(input: {
   if (current?.status === "posted") return;
   if (current?.status === "failed") return;
 
+  const restoreAsProviderCooldown =
+    input.retryTarget.previousStatus === "skipped" &&
+    Boolean(parseProviderCooldownError(input.retryTarget.previousError));
   input.state.recordProcessed({
     repo: input.retryTarget.repo,
     pullNumber: input.retryTarget.pullNumber,
     headSha: input.retryTarget.headSha,
-    status: "failed",
+    status: restoreAsProviderCooldown ? "skipped" : "failed",
     error: input.retryTarget.previousError
       ? `${input.retryTarget.previousError}; ${input.reason}`
       : input.reason
@@ -346,6 +455,7 @@ export function prepareFailedHeadRetry(input: {
     repo: input.repo,
     pullNumber: input.pullNumber,
     headSha: input.headSha,
+    previousStatus: processed.status === "skipped" ? "skipped" : "failed",
     ...(processed.error ? { previousError: processed.error } : {})
   };
 }
@@ -419,7 +529,9 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision);
     if (input.processedHeadPolicy === "retry_failed_head") {
       const current = state.getProcessedReview(repo, pull.number, pull.head.sha);
-      if (current?.status !== "failed") return "skipped_processed";
+      if (current?.status !== "failed" && !isProviderCooldownProcessedReview(current ?? { status: "" })) {
+        return "skipped_processed";
+      }
       const liveBeforeReview = await github.getPull(repo, pull.number);
       const staleBeforeReview = detectStalePullHead({ expected: pull, live: liveBeforeReview, phase: "before_review" });
       if (staleBeforeReview) {
@@ -739,7 +851,50 @@ function recordProviderCooldownSkip(input: {
 }
 
 function isProviderCooldownProcessedReview(record: { status: string; error?: string }): boolean {
-  return record.status === "skipped" && Boolean(record.error?.startsWith("provider_rate_limit_cooldown_until="));
+  return record.status === "skipped" && Boolean(parseProviderCooldownError(record.error));
+}
+
+function summarizeRetryProviderCooldownResults(results: RetryFailedHeadResult[]): RetryProviderCooldownsResult["summary"] {
+  const summary: RetryProviderCooldownsResult["summary"] = {
+    reviewed: 0,
+    dryRun: 0,
+    remainedCooldown: 0,
+    failed: 0,
+    skippedStaleHead: 0,
+    skippedProcessed: 0,
+    skippedCapacity: 0,
+    other: 0
+  };
+  for (const result of results) {
+    switch (result.status) {
+      case "reviewed":
+      case "reviewed_command":
+        summary.reviewed += 1;
+        break;
+      case "dry_run":
+        summary.dryRun += 1;
+        break;
+      case "skipped_provider_cooldown":
+        summary.remainedCooldown += 1;
+        break;
+      case "failed":
+        summary.failed += 1;
+        break;
+      case "skipped_stale_head":
+        summary.skippedStaleHead += 1;
+        break;
+      case "skipped_processed":
+        summary.skippedProcessed += 1;
+        break;
+      case "skipped_capacity":
+        summary.skippedCapacity += 1;
+        break;
+      default:
+        summary.other += 1;
+        break;
+    }
+  }
+  return summary;
 }
 
 function retryFailureError(previousError: string | undefined, error: unknown): string {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { ReviewStateStore } from "../src/state.js";
+import { parseProviderCooldownError, ReviewStateStore } from "../src/state.js";
 
 describe("review state store", () => {
   const roots: string[] = [];
@@ -188,6 +188,57 @@ describe("review state store", () => {
       event: "daemon_cycle_failed",
       error: "request failed with [redacted-secret]"
     });
+    store.close();
+  });
+
+  it("parses and filters provider cooldown review rows by expiry", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-provider-cooldown-list-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    store.recordProcessed({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 219,
+      headSha: "expired-head",
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2026-07-01T00:15:00.000Z; reason=provider_rate_limit"
+    });
+    store.recordProcessed({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 220,
+      headSha: "active-head",
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2026-07-01T00:45:00.000Z; reason=provider_rate_limit"
+    });
+    store.recordProcessed({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 221,
+      headSha: "baseline-head",
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+
+    expect(parseProviderCooldownError("provider_rate_limit_cooldown_until=2026-07-01T00:15:00.000Z; reason=provider_rate_limit")).toEqual({
+      cooldownUntil: "2026-07-01T00:15:00.000Z",
+      reason: "provider_rate_limit"
+    });
+    expect(store.listProviderCooldownReviews({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      now: new Date("2026-07-01T00:30:00.000Z")
+    })).toHaveLength(2);
+    expect(store.listProviderCooldownReviews({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      expiredOnly: true,
+      now: new Date("2026-07-01T00:30:00.000Z")
+    })).toEqual([
+      expect.objectContaining({
+        pullNumber: 219,
+        headSha: "expired-head",
+        cooldownUntil: "2026-07-01T00:15:00.000Z",
+        reason: "provider_rate_limit",
+        expired: true
+      })
+    ]);
     store.close();
   });
 

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -15,6 +15,7 @@ import {
   recordProviderRateLimitCooldownIfNeeded,
   restoreFailedRetryRowIfNeeded,
   retryFailedHeadWithDeps,
+  retryProviderCooldownsWithDeps,
   reviewPull
 } from "../src/worker.js";
 
@@ -191,6 +192,147 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("does not retry active provider-cooldown heads in the expired-only bulk path", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-cooldown-active-bulk-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1236, "head-active-provider-cooldown");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2999-01-01T00:00:00.000Z; reason=provider_rate_limit"
+    });
+    let attempts = 0;
+
+    const result = await retryProviderCooldownsWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        dryRun: true,
+        expiredOnly: true
+      },
+      reviewPullImpl: async () => {
+        attempts += 1;
+        return "reviewed";
+      }
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      candidates: 0,
+      attempted: 0
+    });
+    expect(attempts).toBe(0);
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "skipped",
+      error: expect.stringContaining("provider_rate_limit_cooldown_until=2999-01-01T00:00:00.000Z")
+    });
+    state.close();
+  });
+
+  it("retries expired provider-cooldown heads and keeps dry-runs retryable as cooldown skips", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-cooldown-expired-bulk-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1237, "head-expired-provider-cooldown");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2000-01-01T00:00:00.000Z; reason=provider_rate_limit"
+    });
+
+    const result = await retryProviderCooldownsWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        dryRun: true,
+        expiredOnly: true
+      },
+      reviewPullImpl: async ({ state: retryState, repo, pull: retryPull }) => {
+        retryState.recordProcessed({
+          repo,
+          pullNumber: retryPull.number,
+          headSha: retryPull.head.sha,
+          status: "dry_run",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      }
+    });
+
+    expect(result.summary).toMatchObject({
+      dryRun: 1,
+      failed: 0,
+      remainedCooldown: 0
+    });
+    expect(result.results).toEqual([
+      expect.objectContaining({
+        pullNumber: 1237,
+        headSha: "head-expired-provider-cooldown",
+        status: "dry_run"
+      })
+    ]);
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "skipped",
+      error: expect.stringContaining("provider_rate_limit_cooldown_until=2000-01-01T00:00:00.000Z")
+    });
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)?.error).toContain("retry_dry_run");
+    state.close();
+  });
+
+  it("records a renewed provider cooldown when an expired bulk retry is still rate-limited", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-cooldown-renewed-bulk-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1238, "head-renewed-provider-cooldown");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2000-01-01T00:00:00.000Z; reason=provider_rate_limit"
+    });
+
+    const result = await retryProviderCooldownsWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        dryRun: false,
+        expiredOnly: true
+      },
+      reviewPullImpl: async () => {
+        throw new Error("ProviderBusinessError: [1302][Rate limit reached for requests]");
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.summary).toMatchObject({
+      remainedCooldown: 1,
+      failed: 0
+    });
+    expect(result.results[0]).toMatchObject({
+      status: "skipped_provider_cooldown"
+    });
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "skipped",
+      error: expect.stringContaining("provider_rate_limit_cooldown_until=")
+    });
+    state.close();
+  });
+
   it("preserves the failed row when retry review work is skipped for capacity", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-capacity-"));
     roots.push(root);
@@ -234,6 +376,7 @@ describe("worker review failures", () => {
       repo: "electricsheephq/WorldOS",
       pullNumber: 1227,
       headSha: "head-dry-run",
+      previousStatus: "failed" as const,
       previousError: "transient API timeout"
     };
     state.recordProcessed({
@@ -262,6 +405,7 @@ describe("worker review failures", () => {
       repo: "electricsheephq/WorldOS",
       pullNumber: 1228,
       headSha: "head-skip",
+      previousStatus: "failed" as const,
       previousError: "original failure"
     };
     state.recordProcessed({


### PR DESCRIPTION
## Summary
- add provider-cooldown row parsing/listing so expired cooldown skips are visible
- add a bounded `retry-provider-cooldowns` command for expired provider cooldown rows
- keep provider-cooldown dry-runs retryable as nonblocking skipped rows and classify renewed rate limits separately from hard failures

Closes #52.

## Validation
- `npm test -- tests/state.test.ts tests/worker-failure.test.ts`
- `npm run build`
- `npm test`
- `git diff --check`
- `npx tsx src/cli.ts provider-cooldowns --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --state-path /Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite --expired-only false --limit 10`

## Live status
- live launchd was green before this patch: `release:status ok=true` at head `f5fa2b84d35245ce9530327914eb7de2ef33de9b`
- current active cooldown row: `100yenadmin/Lossless-Codex-Orchestrator-LCO#219` until `2026-07-01T06:01:49.752Z`