### PR TITLE
Reliability: skip closed provider cooldown retries

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface PullRequestSummary {
   title: string;
   draft: boolean;
   state?: string;
+  merged_at?: string | null;
   body?: string | null;
   head: {
     sha: string;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -57,7 +57,7 @@ export interface RetryFailedHeadResult {
   repo: string;
   pullNumber: number;
   headSha: string;
-  status: ReviewPullResult | "failed" | "dry_run";
+  status: ReviewPullResult | "failed" | "dry_run" | "skipped_closed";
 }
 
 export interface FailedHeadRetryTarget {
@@ -85,6 +85,7 @@ export interface RetryProviderCooldownsResult {
     failed: number;
     skippedStaleHead: number;
     skippedProcessed: number;
+    skippedClosed: number;
     skippedCapacity: number;
     other: number;
   };
@@ -109,6 +110,7 @@ export function isSuccessfulRetryStatus(status: RetryFailedHeadResult["status"])
     case "reviewed_command":
     case "dry_run":
     case "skipped_processed":
+    case "skipped_closed":
       return true;
     case "failed":
     case "skipped_draft":
@@ -333,6 +335,15 @@ export async function retryFailedHeadWithDeps(input: {
     throw new Error(`Refusing retry for repo skipped by policy: ${options.repo} (${repoPolicy.reason})`);
   }
   const pull = await github.getPull(options.repo, options.pullNumber);
+  if (isClosedPull(pull)) {
+    recordClosedRetrySkip({ state, repo: options.repo, pull, headSha: options.headSha });
+    return {
+      repo: options.repo,
+      pullNumber: options.pullNumber,
+      headSha: options.headSha,
+      status: "skipped_closed"
+    };
+  }
   const retryTarget = prepareFailedHeadRetry({
     state,
     repo: options.repo,
@@ -862,6 +873,7 @@ function summarizeRetryProviderCooldownResults(results: RetryFailedHeadResult[])
     failed: 0,
     skippedStaleHead: 0,
     skippedProcessed: 0,
+    skippedClosed: 0,
     skippedCapacity: 0,
     other: 0
   };
@@ -886,6 +898,9 @@ function summarizeRetryProviderCooldownResults(results: RetryFailedHeadResult[])
       case "skipped_processed":
         summary.skippedProcessed += 1;
         break;
+      case "skipped_closed":
+        summary.skippedClosed += 1;
+        break;
       case "skipped_capacity":
         summary.skippedCapacity += 1;
         break;
@@ -895,6 +910,29 @@ function summarizeRetryProviderCooldownResults(results: RetryFailedHeadResult[])
     }
   }
   return summary;
+}
+
+function isClosedPull(pull: PullRequestSummary): boolean {
+  return Boolean(pull.state && pull.state !== "open");
+}
+
+function recordClosedRetrySkip(input: {
+  state: Pick<ReviewStateStore, "getProcessedReview" | "recordProcessed">;
+  repo: string;
+  pull: PullRequestSummary;
+  headSha: string;
+}): void {
+  const previous = input.state.getProcessedReview(input.repo, input.pull.number, input.headSha);
+  const state = input.pull.state ?? "unknown";
+  const mergedAt = input.pull.merged_at ? `; merged_at=${input.pull.merged_at}` : "";
+  const previousError = previous?.error ? `; previous_error=${redactSecrets(previous.error)}` : "";
+  input.state.recordProcessed({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.headSha,
+    status: "skipped",
+    error: `closed_pr_retry_skip: state=${state}${mergedAt}${previousError}`
+  });
 }
 
 function retryFailureError(previousError: string | undefined, error: unknown): string {

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -333,6 +333,55 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("skips closed provider-cooldown retry candidates without running review work", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-cooldown-closed-bulk-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1239, "head-closed-provider-cooldown", "base", {
+      state: "closed",
+      mergedAt: "2026-07-01T06:00:00Z"
+    });
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2000-01-01T00:00:00.000Z; reason=provider_rate_limit"
+    });
+    let attempts = 0;
+
+    const result = await retryProviderCooldownsWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        dryRun: false,
+        expiredOnly: true
+      },
+      reviewPullImpl: async () => {
+        attempts += 1;
+        return "reviewed";
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.summary).toMatchObject({
+      skippedClosed: 1,
+      failed: 0
+    });
+    expect(result.results[0]).toMatchObject({
+      status: "skipped_closed"
+    });
+    expect(attempts).toBe(0);
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "skipped",
+      error: expect.stringContaining("closed_pr_retry_skip: state=closed; merged_at=2026-07-01T06:00:00Z")
+    });
+    state.close();
+  });
+
   it("preserves the failed row when retry review work is skipped for capacity", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-capacity-"));
     roots.push(root);
@@ -667,6 +716,7 @@ describe("worker review failures", () => {
     expect(isSuccessfulRetryStatus("reviewed_command")).toBe(true);
     expect(isSuccessfulRetryStatus("dry_run")).toBe(true);
     expect(isSuccessfulRetryStatus("skipped_processed")).toBe(true);
+    expect(isSuccessfulRetryStatus("skipped_closed")).toBe(true);
     expect(isSuccessfulRetryStatus("failed")).toBe(false);
     expect(isSuccessfulRetryStatus("skipped_capacity")).toBe(false);
     expect(isSuccessfulRetryStatus("skipped_provider_cooldown")).toBe(false);
@@ -715,11 +765,18 @@ function minimalConfig(root: string): BotConfig {
   };
 }
 
-function pullSummary(number: number, headSha: string, baseSha = "base"): PullRequestSummary {
+function pullSummary(
+  number: number,
+  headSha: string,
+  baseSha = "base",
+  options: { state?: string; mergedAt?: string | null } = {}
+): PullRequestSummary {
   return {
     number,
     title: `PR ${number}`,
     draft: false,
+    ...(options.state ? { state: options.state } : {}),
+    ...(options.mergedAt !== undefined ? { merged_at: options.mergedAt } : {}),
     head: {
       sha: headSha,
       ref: `pr-${number}`,


### PR DESCRIPTION
## Summary
- add an explicit `skipped_closed` retry result for provider-cooldown rows whose PR is no longer open
- record closed/merged provider-cooldown retry rows as nonblocking historical skips
- prevent operator backfill commands from running ZCode or posting reviews on closed PRs

Closes #55.

## Validation
- `npm test -- tests/worker-failure.test.ts`
- `npm run build`
- `git diff --check`
- `npm test`

## Context
LCO #219 had an expired provider-cooldown row but was already merged before live backfill. This patch makes that path safe by default.