### PR TITLE
Reliability: surface expired provider cooldown backlog

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -95,10 +95,13 @@ banner to stdout.
   launchd dry-run mode, state DB row count, and error count.
 - launchd emits a fresh heartbeat after restart.
 - live DB has no unexpected error rows.
-- provider cooldown rows are allowed only when they are explicit
-  `provider_rate_limit_cooldown_until=...` skips with a follow-up retry issue or
-  retry plan. They prove provider degradation was contained; they do not prove
-  the affected PR head was reviewed.
+- active provider cooldown rows are allowed only when they are explicit
+  `provider_rate_limit_cooldown_until=...` skips with a named affected PR head
+  and cooldown expiry. They prove provider degradation was contained; they do
+  not prove the affected PR head was reviewed.
+- expired provider cooldown rows must be retried or closed/stale-skipped before
+  the release packet is considered clean. `release:status` should report these
+  as `provider_cooldown_backlog` with a retry command.
 - `coverage-audit` has zero unprocessed eligible heads unless every miss is
   explained in the release packet.
 - GitHub tracker issue records source SHA, config path, launchd proof, DB proof,
@@ -141,7 +144,23 @@ Provider cooldown rows are not failed rows. They mean the provider was
 rate-limited before ZCode produced a review. Keep them visible in
 `release:status`, then retry after the cooldown expires or resolve the ZCode
 provider entitlement/rate-limit source. A release may be green with provider
-cooldown rows only when the packet names the affected PR head and follow-up.
+cooldown rows only when all provider cooldown rows are still active and the
+packet names the affected PR head and follow-up.
+
+Expired cooldown rows are actionable backlog. Run:
+
+```bash
+npx tsx src/cli.ts retry-provider-cooldowns \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expired-only true \
+  --dry-run false \
+  --zcode true
+```
+
+Then re-run `release:status`, `provider-cooldowns --expired-only true`, and
+`coverage-audit`. If the retry produces a fresh provider cooldown, record the
+new expiry and keep monitoring; if the PR closed or the head is stale, confirm
+that the retry recorded `skipped_closed` or `skipped_stale_head`.
 
 ## Rollback
 
@@ -179,8 +198,8 @@ For each beta promotion, record:
 - `coverage-audit` summary.
 - launchd stdout heartbeat lines after restart.
 - live DB row/error count.
-- provider cooldown rows, if any, with affected repo, PR, head SHA, and
-  cooldown expiry.
+- provider cooldown rows, if any, with affected repo, PR, head SHA, cooldown
+  expiry, active/expired count, retry command, and retry result.
 - rollback SHA and command.
 - next monitoring action or heartbeat.
 

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2,6 +2,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import { loadConfig } from "./config.js";
+import { parseProviderCooldownError, PROVIDER_COOLDOWN_ERROR_PREFIX } from "./state.js";
 
 export interface ReleaseRepoStatus {
   branch: string;
@@ -22,6 +23,8 @@ export interface ReleaseDatabaseStatus {
   errorCount: number;
   skippedCount?: number;
   providerCooldownCount?: number;
+  activeProviderCooldownCount?: number;
+  expiredProviderCooldownCount?: number;
 }
 
 export interface ReleaseHeartbeatStatus {
@@ -57,6 +60,7 @@ export interface ReleaseStatus {
   launchd: ReleaseLaunchdStatus;
   database: ReleaseDatabaseStatus;
   heartbeat: ReleaseHeartbeatStatus;
+  recommendedActions: string[];
   gates: Array<{ name: string; ok: boolean; detail: string }>;
   rollback: {
     restartCommand: string;
@@ -71,7 +75,11 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const launchdRunningOk = input.launchd.state === "running";
   const launchdConfigOk = input.launchd.configPath === input.configPath;
   const dbOk = input.database.errorCount === 0;
+  const expiredProviderCooldownOk = (input.database.expiredProviderCooldownCount ?? 0) === 0;
   const heartbeatOk = input.heartbeat.status === "fresh";
+  const retryProviderCooldownCommand =
+    `npx tsx src/cli.ts retry-provider-cooldowns --config ${input.configPath} ` +
+    "--expired-only true --dry-run false --zcode true";
   const gates = [
     {
       name: "expected_head",
@@ -103,7 +111,14 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       ok: dbOk,
       detail:
         `${input.database.errorCount} blocking error row(s)` +
-        (input.database.providerCooldownCount ? `; ${input.database.providerCooldownCount} provider cooldown skip row(s)` : "")
+        describeProviderCooldownCounts(input.database)
+    },
+    {
+      name: "provider_cooldown_backlog",
+      ok: expiredProviderCooldownOk,
+      detail: expiredProviderCooldownOk
+        ? describeProviderCooldownBacklog(input.database)
+        : `${describeProviderCooldownBacklog(input.database)}; retry: ${retryProviderCooldownCommand}`
     },
     {
       name: "daemon_heartbeat_recent",
@@ -125,6 +140,12 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     launchd: input.launchd,
     database: input.database,
     heartbeat: input.heartbeat,
+    recommendedActions: expiredProviderCooldownOk
+      ? []
+      : [
+          retryProviderCooldownCommand,
+          `npx tsx src/cli.ts provider-cooldowns --config ${input.configPath} --expired-only true`
+        ],
     gates,
     rollback: {
       restartCommand: `launchctl kickstart -k gui/$(id -u)/${input.launchd.label}`,
@@ -148,7 +169,7 @@ export function collectReleaseStatus(input: {
     expectedHead: input.expectedHead,
     configPath,
     launchd: readLaunchdStatus(input.launchdLabel ?? "com.electricsheephq.evaos-code-review-bot"),
-    database: readDatabaseStatus(input.statePath ?? config.statePath),
+    database: readDatabaseStatus(input.statePath ?? config.statePath, now),
     heartbeat: readHeartbeatStatus(input.statePath ?? config.statePath, config.pollIntervalMs * 2, now),
     now
   });
@@ -185,7 +206,7 @@ function readLaunchdStatus(label: string): ReleaseLaunchdStatus {
   };
 }
 
-function readDatabaseStatus(statePath: string): ReleaseDatabaseStatus {
+function readDatabaseStatus(statePath: string, now: Date): ReleaseDatabaseStatus {
   if (!existsSync(statePath)) return { rowCount: 0, errorCount: 0 };
   const db = new DatabaseSync(statePath, { readOnly: true });
   try {
@@ -211,15 +232,45 @@ function readDatabaseStatus(statePath: string): ReleaseDatabaseStatus {
         providerCooldownCount?: number | null;
         errorCount?: number | null;
       };
+    const providerCooldownRows = db
+      .prepare(
+        `select error
+         from processed_reviews
+         where status = 'skipped' and error like ?`
+      )
+      .all(`${PROVIDER_COOLDOWN_ERROR_PREFIX}%`) as unknown as Array<{ error: string | null }>;
+    const providerCooldowns = providerCooldownRows
+      .map((providerRow) => parseProviderCooldownError(providerRow.error ?? undefined))
+      .filter((cooldown): cooldown is NonNullable<typeof cooldown> => Boolean(cooldown));
+    const expiredProviderCooldownCount = providerCooldowns.filter((cooldown) => {
+      const cooldownUntilMs = Date.parse(cooldown.cooldownUntil);
+      return !Number.isFinite(cooldownUntilMs) || cooldownUntilMs <= now.getTime();
+    }).length;
+    const activeProviderCooldownCount = providerCooldowns.length - expiredProviderCooldownCount;
     return {
       rowCount: row.rowCount ?? 0,
       skippedCount: row.skippedCount ?? 0,
       providerCooldownCount: row.providerCooldownCount ?? 0,
+      activeProviderCooldownCount,
+      expiredProviderCooldownCount,
       errorCount: row.errorCount ?? 0
     };
   } finally {
     db.close();
   }
+}
+
+function describeProviderCooldownCounts(database: ReleaseDatabaseStatus): string {
+  const total = database.providerCooldownCount ?? 0;
+  if (total === 0) return "";
+  return (
+    `; ${total} provider cooldown skip row(s)` +
+    ` (${database.activeProviderCooldownCount ?? 0} active, ${database.expiredProviderCooldownCount ?? 0} expired)`
+  );
+}
+
+function describeProviderCooldownBacklog(database: ReleaseDatabaseStatus): string {
+  return `${database.expiredProviderCooldownCount ?? 0} expired provider cooldown row(s); ${database.activeProviderCooldownCount ?? 0} active provider cooldown row(s)`;
 }
 
 function readHeartbeatStatus(statePath: string, maxAgeMs: number, now: Date): ReleaseHeartbeatStatus {

--- a/src/state.ts
+++ b/src/state.ts
@@ -338,7 +338,7 @@ export class ReviewStateStore {
         const parsed = parseProviderCooldownError(record.error);
         if (!parsed) return undefined;
         const cooldownUntilMs = Date.parse(parsed.cooldownUntil);
-        const expired = Number.isFinite(cooldownUntilMs) && cooldownUntilMs <= now.getTime();
+        const expired = !Number.isFinite(cooldownUntilMs) || cooldownUntilMs <= now.getTime();
         return {
           ...record,
           cooldownUntil: parsed.cooldownUntil,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -344,6 +344,25 @@ export async function retryFailedHeadWithDeps(input: {
       status: "skipped_closed"
     };
   }
+  if (pull.head.sha !== options.headSha) {
+    const retryTarget = prepareRetryTargetFromProcessedRow({
+      state,
+      repo: options.repo,
+      pullNumber: options.pullNumber,
+      headSha: options.headSha
+    });
+    restoreFailedRetryRowIfNeeded({
+      state,
+      retryTarget,
+      reason: "retry_did_not_review=skipped_stale_head"
+    });
+    return {
+      repo: options.repo,
+      pullNumber: options.pullNumber,
+      headSha: options.headSha,
+      status: "skipped_stale_head"
+    };
+  }
   const retryTarget = prepareFailedHeadRetry({
     state,
     repo: options.repo,
@@ -452,6 +471,15 @@ export function prepareFailedHeadRetry(input: {
     throw new Error(`Refusing retry for stale head: requested=${input.headSha} live=${input.livePull.head.sha}`);
   }
 
+  return prepareRetryTargetFromProcessedRow(input);
+}
+
+function prepareRetryTargetFromProcessedRow(input: {
+  state: Pick<ReviewStateStore, "getProcessedReview">;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+}): FailedHeadRetryTarget {
   const processed = input.state.getProcessedReview(input.repo, input.pullNumber, input.headSha);
   if (!processed) {
     throw new Error(`No processed review row exists for ${input.repo}#${input.pullNumber}@${input.headSha}`);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -2,8 +2,9 @@ import { mkdirSync } from "node:fs";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
-import { buildReleaseStatus } from "../src/release-status.js";
+import { buildReleaseStatus, collectReleaseStatus } from "../src/release-status.js";
 
 describe("beta release status", () => {
   const roots: string[] = [];
@@ -149,7 +150,7 @@ describe("beta release status", () => {
     expect(status.database.skippedCount).toBe(16);
   });
 
-  it("reports provider cooldown skips without treating them as blocking DB errors", () => {
+  it("reports active provider cooldown skips without treating them as blocking DB errors", () => {
     const status = buildReleaseStatus({
       repo: {
         branch: "main",
@@ -164,7 +165,14 @@ describe("beta release status", () => {
         configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
         dryRun: false
       },
-      database: { rowCount: 21, errorCount: 0, skippedCount: 16, providerCooldownCount: 1 },
+      database: {
+        rowCount: 21,
+        errorCount: 0,
+        skippedCount: 16,
+        providerCooldownCount: 1,
+        activeProviderCooldownCount: 1,
+        expiredProviderCooldownCount: 0
+      },
       heartbeat: freshHeartbeat(),
       now: new Date("2026-07-01T00:00:00.000Z")
     });
@@ -173,8 +181,165 @@ describe("beta release status", () => {
     expect(status.gates).toContainEqual({
       name: "live_db_no_errors",
       ok: true,
-      detail: "0 blocking error row(s); 1 provider cooldown skip row(s)"
+      detail: "0 blocking error row(s); 1 provider cooldown skip row(s) (1 active, 0 expired)"
     });
+    expect(status.gates).toContainEqual({
+      name: "provider_cooldown_backlog",
+      ok: true,
+      detail: "0 expired provider cooldown row(s); 1 active provider cooldown row(s)"
+    });
+    expect(status.recommendedActions).toEqual([]);
+  });
+
+  it("fails the provider cooldown backlog gate and recommends exact retry commands for expired rows", () => {
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false
+      },
+      database: {
+        rowCount: 21,
+        errorCount: 0,
+        skippedCount: 16,
+        providerCooldownCount: 2,
+        activeProviderCooldownCount: 1,
+        expiredProviderCooldownCount: 1
+      },
+      heartbeat: freshHeartbeat(),
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    const retryCommand =
+      "npx tsx src/cli.ts retry-provider-cooldowns --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expired-only true --dry-run false --zcode true";
+    expect(status.ok).toBe(false);
+    expect(status.gates).toContainEqual({
+      name: "provider_cooldown_backlog",
+      ok: false,
+      detail: `1 expired provider cooldown row(s); 1 active provider cooldown row(s); retry: ${retryCommand}`
+    });
+    expect(status.recommendedActions).toContain(retryCommand);
+  });
+
+  it("counts active and expired provider cooldown rows from the live state database", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-db-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const expiredUntil = new Date(Date.now() - 60_000).toISOString();
+    const activeUntil = new Date(Date.now() + 60_000).toISOString();
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table daemon_heartbeat (
+          id integer primary key check (id = 1),
+          cycle integer,
+          event text,
+          dry_run integer,
+          recorded_at text,
+          error text
+        );
+      `);
+      db.prepare(
+        `insert into processed_reviews (repo, pull_number, head_sha, status, error)
+         values (?, ?, ?, 'skipped', ?)`
+      ).run(
+        "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+        220,
+        "expired-head",
+        `provider_rate_limit_cooldown_until=${expiredUntil}; reason=provider_rate_limit`
+      );
+      db.prepare(
+        `insert into processed_reviews (repo, pull_number, head_sha, status, error)
+         values (?, ?, ?, 'skipped', ?)`
+      ).run(
+        "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+        220,
+        "active-head",
+        `provider_rate_limit_cooldown_until=${activeUntil}; reason=provider_rate_limit`
+      );
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot"
+    });
+
+    expect(status.database.providerCooldownCount).toBe(2);
+    expect(status.database.expiredProviderCooldownCount).toBe(1);
+    expect(status.database.activeProviderCooldownCount).toBe(1);
+    expect(status.recommendedActions[0]).toBe(
+      "npx tsx src/cli.ts retry-provider-cooldowns --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expired-only true --dry-run false --zcode true"
+    );
+    expect(status.gates.some((gate) => gate.name === "provider_cooldown_backlog" && !gate.ok)).toBe(true);
+  });
+
+  it("treats malformed provider cooldown timestamps as actionable backlog", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-db-invalid-cooldown-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+      `);
+      db.prepare(
+        `insert into processed_reviews (repo, pull_number, head_sha, status, error)
+         values (?, ?, ?, 'skipped', ?)`
+      ).run(
+        "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+        220,
+        "malformed-head",
+        "provider_rate_limit_cooldown_until=not-a-date; reason=provider_rate_limit"
+      );
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot"
+    });
+
+    expect(status.database.providerCooldownCount).toBe(1);
+    expect(status.database.expiredProviderCooldownCount).toBe(1);
+    expect(status.database.activeProviderCooldownCount).toBe(0);
+    expect(status.gates.some((gate) => gate.name === "provider_cooldown_backlog" && !gate.ok)).toBe(true);
   });
 
   it("fails closed when the daemon heartbeat is missing", () => {

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -290,6 +290,78 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("skips stale expired provider-cooldown candidates and continues bulk retrying current heads", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-cooldown-stale-bulk-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const currentPull = pullSummary(1240, "head-current-provider-cooldown");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: currentPull.number,
+      headSha: "head-stale-provider-cooldown",
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2000-01-01T00:00:00.000Z; reason=provider_rate_limit"
+    });
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: currentPull.number,
+      headSha: currentPull.head.sha,
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2000-01-01T00:00:00.000Z; reason=provider_rate_limit"
+    });
+    let attempts = 0;
+
+    const result = await retryProviderCooldownsWithDeps({
+      config,
+      github: retryGithub(currentPull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        dryRun: true,
+        expiredOnly: true
+      },
+      reviewPullImpl: async ({ state: retryState, repo, pull: retryPull }) => {
+        attempts += 1;
+        retryState.recordProcessed({
+          repo,
+          pullNumber: retryPull.number,
+          headSha: retryPull.head.sha,
+          status: "dry_run",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.summary).toMatchObject({
+      skippedStaleHead: 1,
+      dryRun: 1,
+      failed: 0
+    });
+    expect(result.results).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        headSha: "head-stale-provider-cooldown",
+        status: "skipped_stale_head"
+      }),
+      expect.objectContaining({
+        headSha: "head-current-provider-cooldown",
+        status: "dry_run"
+      })
+    ]));
+    expect(attempts).toBe(1);
+    expect(state.getProcessedReview("electricsheephq/WorldOS", currentPull.number, "head-stale-provider-cooldown")).toMatchObject({
+      status: "skipped",
+      error: expect.stringContaining("retry_did_not_review=skipped_stale_head")
+    });
+    expect(state.getProcessedReview("electricsheephq/WorldOS", currentPull.number, currentPull.head.sha)).toMatchObject({
+      status: "skipped",
+      error: expect.stringContaining("retry_dry_run")
+    });
+    state.close();
+  });
+
   it("records a renewed provider cooldown when an expired bulk retry is still rate-limited", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-cooldown-renewed-bulk-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- split provider cooldown rows into active vs expired counts in `release-status`
- add a `provider_cooldown_backlog` gate and exact retry commands when expired cooldown rows exist
- update the beta release runbook so active cooldowns are documented and expired cooldowns are retried before a release packet is considered clean

Closes #57.

## Validation
- `npx vitest run tests/release-status.test.ts`
- `npm run build`
- `npm test`

## Runtime note
Live daemon was separately verified before this PR from `/Volumes/LEXAR/repos/evaos-code-review-bot` at `f0124386c0f612156fee63cc5d5fd77b1bf06a2a`; this PR does not mutate live config or launchd state.
