### PR TITLE
Reliability: retire stale provider cooldown retries

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -449,14 +449,22 @@ export function restoreFailedRetryRowIfNeeded(input: {
   const restoreAsProviderCooldown =
     input.retryTarget.previousStatus === "skipped" &&
     Boolean(parseProviderCooldownError(input.retryTarget.previousError));
+  const retireStaleProviderCooldown =
+    restoreAsProviderCooldown &&
+    input.reason === "retry_did_not_review=skipped_stale_head";
+  const previousError = input.retryTarget.previousError
+    ? `${retireStaleProviderCooldown ? "; previous_error=" : ""}${input.retryTarget.previousError}`
+    : "";
   input.state.recordProcessed({
     repo: input.retryTarget.repo,
     pullNumber: input.retryTarget.pullNumber,
     headSha: input.retryTarget.headSha,
     status: restoreAsProviderCooldown ? "skipped" : "failed",
-    error: input.retryTarget.previousError
-      ? `${input.retryTarget.previousError}; ${input.reason}`
-      : input.reason
+    error: retireStaleProviderCooldown
+      ? `provider_cooldown_retry_stale_head; ${input.reason}${previousError}`
+      : input.retryTarget.previousError
+        ? `${input.retryTarget.previousError}; ${input.reason}`
+        : input.reason
   });
 }
 

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -351,10 +351,16 @@ describe("worker review failures", () => {
       })
     ]));
     expect(attempts).toBe(1);
-    expect(state.getProcessedReview("electricsheephq/WorldOS", currentPull.number, "head-stale-provider-cooldown")).toMatchObject({
+    const staleRetryRow = state.getProcessedReview("electricsheephq/WorldOS", currentPull.number, "head-stale-provider-cooldown");
+    expect(staleRetryRow).toMatchObject({
       status: "skipped",
-      error: expect.stringContaining("retry_did_not_review=skipped_stale_head")
+      error: expect.stringContaining("provider_cooldown_retry_stale_head")
     });
+    expect(staleRetryRow?.error).toContain("retry_did_not_review=skipped_stale_head");
+    expect(staleRetryRow?.error).not.toMatch(/^provider_rate_limit_cooldown_until=/);
+    expect(state.listProviderCooldownReviews({ expiredOnly: true }).map((row) => row.headSha)).toEqual([
+      "head-current-provider-cooldown"
+    ]);
     expect(state.getProcessedReview("electricsheephq/WorldOS", currentPull.number, currentPull.head.sha)).toMatchObject({
       status: "skipped",
       error: expect.stringContaining("retry_dry_run")


### PR DESCRIPTION
## Summary
- retires stale provider-cooldown retry rows out of the provider cooldown backlog instead of preserving the provider_rate_limit_cooldown_until prefix
- keeps stale retry evidence on the processed row so the operator can see why it was skipped
- strengthens the bulk retry regression to prove stale rows disappear from expired provider cooldown listings while current heads remain retryable

Closes #59

## Validation
- npx vitest run tests/worker-failure.test.ts tests/release-status.test.ts
- npm run build
- git diff --check
- npm test

## Release note
This is a beta runtime health hotfix for the v0.2.1 release gate: after merge/promote, rerun retry-provider-cooldowns and release-status to clear the stale LCO expired backlog.