### PR TITLE
v0.2: add offline comparison eval harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Pilot local worker for ZCode/GLM-5.2 pull request reviews.
 
 ```bash
 npm run doctor
+npm run eval:offline -- --input /path/to/scenario.json
 npm run release:status -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expected-head "$(git rev-parse HEAD)"
 npm run run-once -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-dry-run.json --dry-run true --repo electricsheephq/WorldOS --pr 1161
 npm run daemon -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-dry-run.json --dry-run true
@@ -67,3 +68,11 @@ trusted command surface. Commands are PR comments such as
 `@evaos-code-review-bot review`, `re-review`, `explain`, and `stop`; they stay
 behind `commands.enabled` and cannot repair, merge, approve, push branches, or
 expand monitoring.
+
+## Offline Evals
+
+Use [docs/eval-harness.md](docs/eval-harness.md) to create read-only
+CodeRabbit/human/CI/seeded-defect comparison packets under
+`/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/`. Eval packets are advisory
+and uncalibrated until enough labeled findings exist for measured reliability
+bins.

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -1,0 +1,83 @@
+# Offline Eval Harness
+
+The offline eval harness creates read-only comparison packets for the v0.2 CodeRabbit-class reviewer work. It does not call GitHub, post PR comments, mutate repos, or change launchd state.
+
+Run it with a local scenario file:
+
+```bash
+npm run eval:offline -- --input /path/to/scenario.json
+```
+
+By default, packets are written under:
+
+```text
+/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/<date>/<run-id>/
+```
+
+Use `--output-dir` for tests or scratch runs.
+
+## Scenario Shape
+
+```json
+{
+  "evalName": "evaos-zcode-review-bot-comparison-v0.1",
+  "runId": "seeded-combat-regression",
+  "repo": "electricsheephq/WorldOS",
+  "pullNumber": 1234,
+  "headSha": "abc123",
+  "suite": "seeded_defect_recall",
+  "rawOutput": { "findings": [] },
+  "botFindings": { "findings": [] },
+  "labels": [
+    {
+      "source": "seeded_defect",
+      "severity": "P1",
+      "path": "Assets/Scripts/CombatTurn.cs",
+      "line": 26,
+      "title": "Combat health reset breaks active fights",
+      "body": "Expected issue description."
+    }
+  ],
+  "thresholds": {
+    "minPrecision": 0.8,
+    "minRecall": 0.6,
+    "minSeededRecall": 1,
+    "maxSecretFindings": 0,
+    "maxDuplicateFindings": 0
+  }
+}
+```
+
+Supported suites:
+
+- `canary_shadow`
+- `historical_pr_replay`
+- `seeded_defect_recall`
+- `safety_redaction`
+- `duplicate_suppression`
+
+Supported label sources:
+
+- `coderabbit`
+- `human`
+- `ci_failure`
+- `merged_fix`
+- `seeded_defect`
+
+Negative controls use an empty `labels` array. The run passes only when the bot also emits no findings, unless thresholds are intentionally loosened for exploratory scoring.
+
+## Packet Contents
+
+Each packet includes:
+
+- `manifest.json`
+- `raw-output.json`
+- `normalized-findings.json`
+- `redaction-report.json`
+- `duplicate-report.json`
+- `comparison.csv`
+- `labels.json`
+- `calibration-report.json`
+- `scorecard.json`
+
+`scorecard.json` is the gate artifact. Thresholds are explicit and fail closed. The calibration report is intentionally marked `uncalibrated`; do not present public 95% confidence claims from these packets until enough labeled findings exist for measured reliability bins.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "doctor": "tsx src/cli.ts doctor",
+    "eval:offline": "tsx src/cli.ts eval-offline",
     "release:status": "tsx src/cli.ts release-status",
     "run-once": "tsx src/cli.ts run-once",
     "daemon": "tsx src/cli.ts daemon"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 import { loadConfig } from "./config.js";
 import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
 import { runDaemonCycle } from "./daemon.js";
+import { readFileSync } from "node:fs";
+import { runOfflineEval } from "./eval-harness.js";
 import { GitHubApi } from "./github.js";
 import { collectReleaseStatus } from "./release-status.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
@@ -95,6 +97,17 @@ async function main(): Promise<void> {
     } finally {
       state.close();
     }
+    return;
+  }
+
+  if (command === "eval-offline") {
+    if (!args.input) throw new Error("--input is required for eval-offline");
+    const input = JSON.parse(readFileSync(args.input, "utf8"));
+    const result = runOfflineEval(input, {
+      outputDir: args["output-dir"]
+    });
+    console.log(JSON.stringify(result, null, 2));
+    if (!result.ok) process.exitCode = 1;
     return;
   }
 
@@ -254,6 +267,8 @@ interface ParsedArgs {
   "dry-run"?: string;
   "expired-only"?: string;
   "head-sha"?: string;
+  input?: string;
+  "output-dir"?: string;
   limit?: string;
   zcode?: string;
   [key: string]: string | string[] | undefined;

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -72,6 +72,7 @@ export interface EvalScorecard {
     exactLineMatches: number;
     nearbyLineMatches: number;
     semanticMatches: number;
+    droppedFromSchema: number;
     secretFindings: number;
     duplicateFindings: number;
   };
@@ -136,6 +137,7 @@ export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions
     matches,
     duplicateCount: duplicateReport.duplicates.length,
     secretCount: redactionReport.secretLikeItems.length,
+    droppedFromSchema: parsedBot.dropped.length,
     thresholds
   });
 
@@ -190,6 +192,7 @@ function buildScorecard(input: {
   matches: EvalMatch[];
   duplicateCount: number;
   secretCount: number;
+  droppedFromSchema: number;
   thresholds: EvalThresholds;
 }): EvalScorecard {
   const matchedBotIds = new Set(input.matches.map((match) => match.botFindingId));
@@ -222,6 +225,7 @@ function buildScorecard(input: {
       exactLineMatches,
       nearbyLineMatches,
       semanticMatches,
+      droppedFromSchema: input.droppedFromSchema,
       secretFindings: input.secretCount,
       duplicateFindings: input.duplicateCount
     },
@@ -253,6 +257,11 @@ function buildScorecard(input: {
         detail: `${input.secretCount} <= ${input.thresholds.maxSecretFindings}`
       },
       {
+        name: "schema_valid",
+        ok: input.droppedFromSchema === 0,
+        detail: `${input.droppedFromSchema} dropped finding(s)`
+      },
+      {
         name: "duplicate_suppression",
         ok: input.duplicateCount <= input.thresholds.maxDuplicateFindings,
         detail: `${input.duplicateCount} <= ${input.thresholds.maxDuplicateFindings}`
@@ -262,24 +271,34 @@ function buildScorecard(input: {
 }
 
 function matchFindings(botFindings: NormalizedEvalFinding[], labels: NormalizedEvalFinding[]): EvalMatch[] {
-  const matches: EvalMatch[] = [];
+  const candidates = labels.flatMap((label) => botFindings
+    .filter((finding) => finding.path === label.path)
+    .map((finding) => ({ finding, label, kind: classifyMatch(finding, label) }))
+    .filter((candidate): candidate is {
+      finding: NormalizedEvalFinding;
+      label: NormalizedEvalFinding;
+      kind: EvalMatch["kind"];
+    } => Boolean(candidate.kind)));
+
+  candidates.sort((a, b) =>
+    matchRank(a.kind) - matchRank(b.kind) ||
+    Math.abs(a.finding.line - a.label.line) - Math.abs(b.finding.line - b.label.line) ||
+    b.finding.confidence - a.finding.confidence ||
+    a.label.id.localeCompare(b.label.id)
+  );
+
   const usedBotIds = new Set<string>();
   const usedLabelIds = new Set<string>();
+  const matches: EvalMatch[] = [];
 
-  for (const label of labels) {
-    const candidates = botFindings
-      .filter((finding) => !usedBotIds.has(finding.id) && finding.path === label.path)
-      .map((finding) => ({ finding, kind: classifyMatch(finding, label) }))
-      .filter((candidate): candidate is { finding: NormalizedEvalFinding; kind: EvalMatch["kind"] } => Boolean(candidate.kind))
-      .sort((a, b) => matchRank(a.kind) - matchRank(b.kind) || Math.abs(a.finding.line - label.line) - Math.abs(b.finding.line - label.line));
-    const best = candidates[0];
-    if (!best) continue;
-    usedBotIds.add(best.finding.id);
-    usedLabelIds.add(label.id);
+  for (const candidate of candidates) {
+    if (usedBotIds.has(candidate.finding.id) || usedLabelIds.has(candidate.label.id)) continue;
+    usedBotIds.add(candidate.finding.id);
+    usedLabelIds.add(candidate.label.id);
     matches.push({
-      botFindingId: best.finding.id,
-      labelId: label.id,
-      kind: best.kind
+      botFindingId: candidate.finding.id,
+      labelId: candidate.label.id,
+      kind: candidate.kind
     });
   }
 
@@ -287,9 +306,10 @@ function matchFindings(botFindings: NormalizedEvalFinding[], labels: NormalizedE
 }
 
 function classifyMatch(botFinding: NormalizedEvalFinding, label: NormalizedEvalFinding): EvalMatch["kind"] | undefined {
-  if (botFinding.line === label.line) return "exact_line";
-  if (Math.abs(botFinding.line - label.line) <= 3 && tokenOverlap(botFinding, label) >= 0.35) return "nearby_line";
-  if (tokenOverlap(botFinding, label) >= 0.55) return "semantic";
+  const overlap = tokenOverlap(botFinding, label);
+  if (botFinding.line === label.line && overlap >= 0.25) return "exact_line";
+  if (Math.abs(botFinding.line - label.line) <= 3 && overlap >= 0.35) return "nearby_line";
+  if (overlap >= 0.55) return "semantic";
   return undefined;
 }
 
@@ -322,7 +342,7 @@ function findDuplicateFindings(findings: NormalizedEvalFinding[]): {
   const seen = new Map<string, string>();
   const duplicates: Array<{ duplicateId: string; originalId: string; key: string }> = [];
   for (const finding of findings) {
-    const key = `${finding.path}:${finding.line}:${finding.severity}:${finding.title.trim().toLowerCase()}`;
+    const key = `${finding.path}:${finding.line}:${finding.severity}`;
     const originalId = seen.get(key);
     if (originalId) duplicates.push({ duplicateId: finding.id, originalId, key });
     else seen.set(key, finding.id);
@@ -354,8 +374,13 @@ function buildRedactionReport(
     }
     return items;
   });
-  if (input.rawOutput !== undefined && containsSecretLikeText(JSON.stringify(input.rawOutput))) {
-    secretLikeItems.push({ id: "raw-output", source: "raw", field: "rawOutput" });
+  const rawPayload = input.rawOutput ?? input.botFindings;
+  if (containsSecretLikeText(JSON.stringify(rawPayload))) {
+    secretLikeItems.push({
+      id: "raw-output",
+      source: "raw",
+      field: input.rawOutput !== undefined ? "rawOutput" : "botFindings"
+    });
   }
   return { droppedFromSchema, secretLikeItems };
 }
@@ -467,7 +492,7 @@ function redactUnknown(value: unknown): unknown {
   if (typeof value === "string") return redactSecrets(value);
   if (Array.isArray(value)) return value.map(redactUnknown);
   if (value && typeof value === "object") {
-    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, redactUnknown(item)]));
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [redactSecrets(key), redactUnknown(item)]));
   }
   return value;
 }
@@ -487,8 +512,19 @@ function validateEvalInput(input: EvalScenarioInput): void {
   validateNonEmpty(input.headSha, "headSha");
   if (!Number.isInteger(input.pullNumber) || input.pullNumber <= 0) throw new Error("pullNumber must be a positive integer");
   if (!REQUIRED_SUITES.includes(input.suite)) throw new Error(`suite must be one of ${REQUIRED_SUITES.join(", ")}`);
+  if (!("botFindings" in input)) throw new Error("botFindings is required");
+  if (!isFindingEnvelope(input.botFindings)) throw new Error("botFindings must be an array or an object with a findings array");
   if (!Array.isArray(input.labels)) throw new Error("labels must be an array");
   for (const [index, label] of input.labels.entries()) validateLabel(label, `labels[${index}]`);
+}
+
+function isFindingEnvelope(value: unknown): boolean {
+  return Array.isArray(value) || (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Array.isArray((value as { findings?: unknown }).findings)
+  );
 }
 
 function validateLabel(label: EvalLabelInput, labelPath: string): void {

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -1,0 +1,518 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseFindings } from "./findings.js";
+import { containsSecretLikeText, redactSecrets } from "./secrets.js";
+import type { Finding, Severity } from "./types.js";
+
+export type EvalSuiteName =
+  | "canary_shadow"
+  | "historical_pr_replay"
+  | "seeded_defect_recall"
+  | "safety_redaction"
+  | "duplicate_suppression";
+
+export type EvalLabelSource = "coderabbit" | "human" | "ci_failure" | "merged_fix" | "seeded_defect";
+
+export interface EvalScenarioInput {
+  evalName?: string;
+  runId: string;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  suite: EvalSuiteName;
+  rawOutput?: unknown;
+  botFindings: unknown;
+  labels: EvalLabelInput[];
+  thresholds?: Partial<EvalThresholds>;
+}
+
+export interface EvalLabelInput {
+  source: EvalLabelSource;
+  severity: Severity;
+  path: string;
+  line: number;
+  title: string;
+  body: string;
+  expected?: boolean;
+}
+
+export interface EvalThresholds {
+  minPrecision: number;
+  minRecall: number;
+  minSeededRecall: number;
+  maxSecretFindings: number;
+  maxDuplicateFindings: number;
+}
+
+export interface EvalRunOptions {
+  outputDir?: string;
+  now?: Date;
+}
+
+export interface EvalRunResult {
+  ok: boolean;
+  outputDir: string;
+  scorecard: EvalScorecard;
+  artifacts: Record<string, string>;
+}
+
+export interface EvalScorecard {
+  evalName: string;
+  runId: string;
+  suite: EvalSuiteName;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  counts: {
+    botFindings: number;
+    labels: number;
+    truePositive: number;
+    falsePositive: number;
+    falseNegative: number;
+    exactLineMatches: number;
+    nearbyLineMatches: number;
+    semanticMatches: number;
+    secretFindings: number;
+    duplicateFindings: number;
+  };
+  metrics: {
+    precision: number;
+    recall: number;
+    seededRecall: number;
+  };
+  thresholds: EvalThresholds;
+  gates: Array<{ name: string; ok: boolean; detail: string }>;
+}
+
+interface NormalizedEvalFinding extends Finding {
+  id: string;
+  source: "bot" | EvalLabelSource;
+}
+
+interface EvalMatch {
+  botFindingId: string;
+  labelId: string;
+  kind: "exact_line" | "nearby_line" | "semantic";
+}
+
+const DEFAULT_THRESHOLDS: EvalThresholds = {
+  minPrecision: 0.8,
+  minRecall: 0.6,
+  minSeededRecall: 1,
+  maxSecretFindings: 0,
+  maxDuplicateFindings: 0
+};
+
+const REQUIRED_SUITES: EvalSuiteName[] = [
+  "canary_shadow",
+  "historical_pr_replay",
+  "seeded_defect_recall",
+  "safety_redaction",
+  "duplicate_suppression"
+];
+
+export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions = {}): EvalRunResult {
+  validateEvalInput(input);
+  const thresholds = { ...DEFAULT_THRESHOLDS, ...(input.thresholds ?? {}) };
+  validateThresholds(thresholds);
+
+  const evalName = input.evalName ?? "evaos-zcode-review-bot-comparison-v0.1";
+  const outputDir = options.outputDir ?? defaultEvalOutputDir(input, options.now ?? new Date());
+  mkdirSync(outputDir, { recursive: true });
+
+  const parsedBot = parseFindings(input.botFindings);
+  const botFindings = parsedBot.findings.map((finding, index) => normalizeFinding(finding, "bot", `bot-${index + 1}`));
+  const labels = input.labels
+    .filter((label) => label.expected !== false)
+    .map((label, index) => normalizeFinding(label, label.source, `label-${index + 1}`));
+  const matches = matchFindings(botFindings, labels);
+  const duplicateReport = findDuplicateFindings(botFindings);
+  const redactionReport = buildRedactionReport(input, parsedBot.findings, input.labels, parsedBot.dropped.length);
+  const scorecard = buildScorecard({
+    input,
+    evalName,
+    botFindings,
+    labels,
+    matches,
+    duplicateCount: duplicateReport.duplicates.length,
+    secretCount: redactionReport.secretLikeItems.length,
+    thresholds
+  });
+
+  const artifacts: Record<string, string> = {
+    "manifest.json": join(outputDir, "manifest.json"),
+    "raw-output.json": join(outputDir, "raw-output.json"),
+    "normalized-findings.json": join(outputDir, "normalized-findings.json"),
+    "redaction-report.json": join(outputDir, "redaction-report.json"),
+    "duplicate-report.json": join(outputDir, "duplicate-report.json"),
+    "comparison.csv": join(outputDir, "comparison.csv"),
+    "labels.json": join(outputDir, "labels.json"),
+    "calibration-report.json": join(outputDir, "calibration-report.json"),
+    "scorecard.json": join(outputDir, "scorecard.json")
+  };
+
+  writeJson(artifacts["manifest.json"]!, {
+    evalName,
+    runId: input.runId,
+    suite: input.suite,
+    requiredSuites: REQUIRED_SUITES,
+    repo: input.repo,
+    pullNumber: input.pullNumber,
+    headSha: input.headSha,
+    generatedAt: (options.now ?? new Date()).toISOString(),
+    proofBoundary: "offline comparison packet only; no GitHub posting or repo mutation"
+  });
+  writeJson(artifacts["raw-output.json"]!, redactUnknown(input.rawOutput ?? input.botFindings));
+  writeJson(artifacts["normalized-findings.json"]!, {
+    botFindings,
+    droppedFromSchema: parsedBot.dropped.map(redactUnknown)
+  });
+  writeJson(artifacts["redaction-report.json"]!, redactionReport);
+  writeJson(artifacts["duplicate-report.json"]!, duplicateReport);
+  writeFileSync(artifacts["comparison.csv"]!, buildComparisonCsv(botFindings, labels, matches));
+  writeJson(artifacts["labels.json"]!, labels);
+  writeJson(artifacts["calibration-report.json"]!, buildCalibrationReport(botFindings, matches));
+  writeJson(artifacts["scorecard.json"]!, scorecard);
+
+  return {
+    ok: scorecard.gates.every((gate) => gate.ok),
+    outputDir,
+    scorecard,
+    artifacts
+  };
+}
+
+function buildScorecard(input: {
+  input: EvalScenarioInput;
+  evalName: string;
+  botFindings: NormalizedEvalFinding[];
+  labels: NormalizedEvalFinding[];
+  matches: EvalMatch[];
+  duplicateCount: number;
+  secretCount: number;
+  thresholds: EvalThresholds;
+}): EvalScorecard {
+  const matchedBotIds = new Set(input.matches.map((match) => match.botFindingId));
+  const matchedLabelIds = new Set(input.matches.map((match) => match.labelId));
+  const truePositive = matchedBotIds.size;
+  const falsePositive = input.botFindings.length - truePositive;
+  const falseNegative = input.labels.length - matchedLabelIds.size;
+  const seededLabels = input.labels.filter((label) => label.source === "seeded_defect");
+  const matchedSeeded = seededLabels.filter((label) => matchedLabelIds.has(label.id)).length;
+  const precision = input.botFindings.length === 0 ? (input.labels.length === 0 ? 1 : 0) : truePositive / input.botFindings.length;
+  const recall = input.labels.length === 0 ? 1 : truePositive / input.labels.length;
+  const seededRecall = seededLabels.length === 0 ? 1 : matchedSeeded / seededLabels.length;
+  const exactLineMatches = input.matches.filter((match) => match.kind === "exact_line").length;
+  const nearbyLineMatches = input.matches.filter((match) => match.kind === "nearby_line").length;
+  const semanticMatches = input.matches.filter((match) => match.kind === "semantic").length;
+
+  return {
+    evalName: input.evalName,
+    runId: input.input.runId,
+    suite: input.input.suite,
+    repo: input.input.repo,
+    pullNumber: input.input.pullNumber,
+    headSha: input.input.headSha,
+    counts: {
+      botFindings: input.botFindings.length,
+      labels: input.labels.length,
+      truePositive,
+      falsePositive,
+      falseNegative,
+      exactLineMatches,
+      nearbyLineMatches,
+      semanticMatches,
+      secretFindings: input.secretCount,
+      duplicateFindings: input.duplicateCount
+    },
+    metrics: {
+      precision: roundMetric(precision),
+      recall: roundMetric(recall),
+      seededRecall: roundMetric(seededRecall)
+    },
+    thresholds: input.thresholds,
+    gates: [
+      {
+        name: "precision",
+        ok: precision >= input.thresholds.minPrecision,
+        detail: `${roundMetric(precision)} >= ${input.thresholds.minPrecision}`
+      },
+      {
+        name: "recall",
+        ok: recall >= input.thresholds.minRecall,
+        detail: `${roundMetric(recall)} >= ${input.thresholds.minRecall}`
+      },
+      {
+        name: "seeded_recall",
+        ok: seededRecall >= input.thresholds.minSeededRecall,
+        detail: `${roundMetric(seededRecall)} >= ${input.thresholds.minSeededRecall}`
+      },
+      {
+        name: "secret_redaction",
+        ok: input.secretCount <= input.thresholds.maxSecretFindings,
+        detail: `${input.secretCount} <= ${input.thresholds.maxSecretFindings}`
+      },
+      {
+        name: "duplicate_suppression",
+        ok: input.duplicateCount <= input.thresholds.maxDuplicateFindings,
+        detail: `${input.duplicateCount} <= ${input.thresholds.maxDuplicateFindings}`
+      }
+    ]
+  };
+}
+
+function matchFindings(botFindings: NormalizedEvalFinding[], labels: NormalizedEvalFinding[]): EvalMatch[] {
+  const matches: EvalMatch[] = [];
+  const usedBotIds = new Set<string>();
+  const usedLabelIds = new Set<string>();
+
+  for (const label of labels) {
+    const candidates = botFindings
+      .filter((finding) => !usedBotIds.has(finding.id) && finding.path === label.path)
+      .map((finding) => ({ finding, kind: classifyMatch(finding, label) }))
+      .filter((candidate): candidate is { finding: NormalizedEvalFinding; kind: EvalMatch["kind"] } => Boolean(candidate.kind))
+      .sort((a, b) => matchRank(a.kind) - matchRank(b.kind) || Math.abs(a.finding.line - label.line) - Math.abs(b.finding.line - label.line));
+    const best = candidates[0];
+    if (!best) continue;
+    usedBotIds.add(best.finding.id);
+    usedLabelIds.add(label.id);
+    matches.push({
+      botFindingId: best.finding.id,
+      labelId: label.id,
+      kind: best.kind
+    });
+  }
+
+  return matches.filter((match) => usedLabelIds.has(match.labelId));
+}
+
+function classifyMatch(botFinding: NormalizedEvalFinding, label: NormalizedEvalFinding): EvalMatch["kind"] | undefined {
+  if (botFinding.line === label.line) return "exact_line";
+  if (Math.abs(botFinding.line - label.line) <= 3 && tokenOverlap(botFinding, label) >= 0.35) return "nearby_line";
+  if (tokenOverlap(botFinding, label) >= 0.55) return "semantic";
+  return undefined;
+}
+
+function tokenOverlap(a: Pick<Finding, "title" | "body">, b: Pick<Finding, "title" | "body">): number {
+  const aTokens = tokenize(`${a.title} ${a.body}`);
+  const bTokens = tokenize(`${b.title} ${b.body}`);
+  if (aTokens.size === 0 || bTokens.size === 0) return 0;
+  const intersection = [...aTokens].filter((token) => bTokens.has(token)).length;
+  return intersection / Math.min(aTokens.size, bTokens.size);
+}
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((token) => token.length >= 4)
+  );
+}
+
+function matchRank(kind: EvalMatch["kind"]): number {
+  if (kind === "exact_line") return 0;
+  if (kind === "nearby_line") return 1;
+  return 2;
+}
+
+function findDuplicateFindings(findings: NormalizedEvalFinding[]): {
+  duplicates: Array<{ duplicateId: string; originalId: string; key: string }>;
+} {
+  const seen = new Map<string, string>();
+  const duplicates: Array<{ duplicateId: string; originalId: string; key: string }> = [];
+  for (const finding of findings) {
+    const key = `${finding.path}:${finding.line}:${finding.severity}:${finding.title.trim().toLowerCase()}`;
+    const originalId = seen.get(key);
+    if (originalId) duplicates.push({ duplicateId: finding.id, originalId, key });
+    else seen.set(key, finding.id);
+  }
+  return { duplicates };
+}
+
+function buildRedactionReport(
+  input: EvalScenarioInput,
+  botFindings: Finding[],
+  labels: EvalLabelInput[],
+  droppedFromSchema: number
+): {
+  droppedFromSchema: number;
+  secretLikeItems: Array<{ id: string; source: string; field: string }>;
+} {
+  const botItems = botFindings.map((finding, index) => ({ ...finding, id: `bot-${index + 1}`, source: "bot" }));
+  const labelItems = labels.map((label, index) => ({ ...label, id: `label-${index + 1}` }));
+  const secretLikeItems = [...botItems, ...labelItems].flatMap((finding) => {
+    const items: Array<{ id: string; source: string; field: string }> = [];
+    for (const field of ["title", "body"] as const) {
+      if (containsSecretLikeText(finding[field])) items.push({ id: finding.id, source: finding.source, field });
+    }
+    if ("why_this_matters" in finding) {
+      const value = finding.why_this_matters;
+      if (value && containsSecretLikeText(value)) {
+        items.push({ id: finding.id, source: finding.source, field: "why_this_matters" });
+      }
+    }
+    return items;
+  });
+  if (input.rawOutput !== undefined && containsSecretLikeText(JSON.stringify(input.rawOutput))) {
+    secretLikeItems.push({ id: "raw-output", source: "raw", field: "rawOutput" });
+  }
+  return { droppedFromSchema, secretLikeItems };
+}
+
+function buildComparisonCsv(
+  botFindings: NormalizedEvalFinding[],
+  labels: NormalizedEvalFinding[],
+  matches: EvalMatch[]
+): string {
+  const labelsById = new Map(labels.map((label) => [label.id, label]));
+  const botsById = new Map(botFindings.map((finding) => [finding.id, finding]));
+  const matchedBotIds = new Set(matches.map((match) => match.botFindingId));
+  const matchedLabelIds = new Set(matches.map((match) => match.labelId));
+  const rows = [
+    ["kind", "match_type", "bot_id", "label_id", "path", "bot_line", "label_line", "severity", "title"].join(",")
+  ];
+
+  for (const match of matches) {
+    const bot = botsById.get(match.botFindingId);
+    const label = labelsById.get(match.labelId);
+    if (!bot || !label) continue;
+    rows.push([
+      "true_positive",
+      match.kind,
+      bot.id,
+      label.id,
+      bot.path,
+      String(bot.line),
+      String(label.line),
+      bot.severity,
+      bot.title
+    ].map(csvCell).join(","));
+  }
+  for (const bot of botFindings.filter((finding) => !matchedBotIds.has(finding.id))) {
+    rows.push(["false_positive", "", bot.id, "", bot.path, String(bot.line), "", bot.severity, bot.title].map(csvCell).join(","));
+  }
+  for (const label of labels.filter((finding) => !matchedLabelIds.has(finding.id))) {
+    rows.push(["false_negative", "", "", label.id, label.path, "", String(label.line), label.severity, label.title].map(csvCell).join(","));
+  }
+  return `${rows.join("\n")}\n`;
+}
+
+function buildCalibrationReport(botFindings: NormalizedEvalFinding[], matches: EvalMatch[]): {
+  claim: "uncalibrated";
+  bins: Array<{ minConfidence: number; maxConfidence: number; findings: number; matched: number; empiricalPrecision: number }>;
+  note: string;
+} {
+  const matchedBotIds = new Set(matches.map((match) => match.botFindingId));
+  const bins = [
+    { minConfidence: 0, maxConfidence: 0.5 },
+    { minConfidence: 0.5, maxConfidence: 0.8 },
+    { minConfidence: 0.8, maxConfidence: 1.01 }
+  ].map((bin) => {
+    const findings = botFindings.filter((finding) => finding.confidence >= bin.minConfidence && finding.confidence < bin.maxConfidence);
+    const matched = findings.filter((finding) => matchedBotIds.has(finding.id)).length;
+    return {
+      minConfidence: bin.minConfidence,
+      maxConfidence: bin.maxConfidence === 1.01 ? 1 : bin.maxConfidence,
+      findings: findings.length,
+      matched,
+      empiricalPrecision: roundMetric(findings.length === 0 ? 0 : matched / findings.length)
+    };
+  });
+  return {
+    claim: "uncalibrated",
+    bins,
+    note: "Model confidence is treated as an input feature only until enough labeled findings exist for calibrated public claims."
+  };
+}
+
+function normalizeFinding(
+  finding: Finding | EvalLabelInput,
+  source: "bot" | EvalLabelSource,
+  id: string
+): NormalizedEvalFinding {
+  const whyThisMatters =
+    "why_this_matters" in finding && typeof finding.why_this_matters === "string"
+      ? finding.why_this_matters
+      : undefined;
+  return {
+    id,
+    source,
+    severity: finding.severity,
+    path: finding.path,
+    line: finding.line,
+    title: redactSecrets(finding.title.trim()),
+    body: redactSecrets(finding.body.trim()),
+    confidence: "confidence" in finding && typeof finding.confidence === "number" ? finding.confidence : 1,
+    ...(whyThisMatters ? { why_this_matters: redactSecrets(whyThisMatters.trim()) } : {})
+  };
+}
+
+function defaultEvalOutputDir(input: Pick<EvalScenarioInput, "runId">, now: Date): string {
+  const date = now.toISOString().slice(0, 10);
+  return join("/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review", date, sanitizePathSegment(input.runId));
+}
+
+function sanitizePathSegment(value: string): string {
+  const sanitized = value.trim().replaceAll(/[^A-Za-z0-9._-]+/g, "-").replaceAll(/^-+|-+$/g, "");
+  if (!sanitized) throw new Error("runId must contain at least one safe path character");
+  return sanitized.slice(0, 120);
+}
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function redactUnknown(value: unknown): unknown {
+  if (typeof value === "string") return redactSecrets(value);
+  if (Array.isArray(value)) return value.map(redactUnknown);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, redactUnknown(item)]));
+  }
+  return value;
+}
+
+function csvCell(value: string): string {
+  if (!/[",\n]/.test(value)) return value;
+  return `"${value.replaceAll("\"", "\"\"")}"`;
+}
+
+function roundMetric(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function validateEvalInput(input: EvalScenarioInput): void {
+  validateNonEmpty(input.runId, "runId");
+  validateNonEmpty(input.repo, "repo");
+  validateNonEmpty(input.headSha, "headSha");
+  if (!Number.isInteger(input.pullNumber) || input.pullNumber <= 0) throw new Error("pullNumber must be a positive integer");
+  if (!REQUIRED_SUITES.includes(input.suite)) throw new Error(`suite must be one of ${REQUIRED_SUITES.join(", ")}`);
+  if (!Array.isArray(input.labels)) throw new Error("labels must be an array");
+  for (const [index, label] of input.labels.entries()) validateLabel(label, `labels[${index}]`);
+}
+
+function validateLabel(label: EvalLabelInput, labelPath: string): void {
+  if (!["coderabbit", "human", "ci_failure", "merged_fix", "seeded_defect"].includes(label.source)) {
+    throw new Error(`${labelPath}.source is invalid`);
+  }
+  if (!["P0", "P1", "P2", "P3"].includes(label.severity)) throw new Error(`${labelPath}.severity is invalid`);
+  validateNonEmpty(label.path, `${labelPath}.path`);
+  validateNonEmpty(label.title, `${labelPath}.title`);
+  validateNonEmpty(label.body, `${labelPath}.body`);
+  if (!Number.isInteger(label.line) || label.line <= 0) throw new Error(`${labelPath}.line must be a positive integer`);
+}
+
+function validateThresholds(thresholds: EvalThresholds): void {
+  for (const key of ["minPrecision", "minRecall", "minSeededRecall"] as const) {
+    if (typeof thresholds[key] !== "number" || thresholds[key] < 0 || thresholds[key] > 1) {
+      throw new Error(`${key} must be between 0 and 1`);
+    }
+  }
+  for (const key of ["maxSecretFindings", "maxDuplicateFindings"] as const) {
+    if (!Number.isInteger(thresholds[key]) || thresholds[key] < 0) throw new Error(`${key} must be a non-negative integer`);
+  }
+}
+
+function validateNonEmpty(value: string, label: string): void {
+  if (typeof value !== "string" || value.trim().length === 0) throw new Error(`${label} must be a non-empty string`);
+}

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -1,0 +1,213 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runOfflineEval, type EvalScenarioInput } from "../src/eval-harness.js";
+
+describe("offline eval harness", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("writes the required comparison packet and scorecard for matching bot findings", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-pass-"));
+    roots.push(root);
+    const scenario: EvalScenarioInput = {
+      evalName: "evaos-zcode-review-bot-comparison-v0.1",
+      runId: "seeded-pass",
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1234,
+      headSha: "abc123",
+      suite: "seeded_defect_recall",
+      rawOutput: { findings: [{ body: "raw output stays local" }] },
+      botFindings: {
+        findings: [
+          {
+            severity: "P1",
+            path: "Assets/Scripts/CombatTurn.cs",
+            line: 26,
+            title: "Combat health reset breaks fights",
+            body: "The player health reset during combat turn resolution makes healthy players nearly dead.",
+            confidence: 0.95
+          },
+          {
+            severity: "P2",
+            path: "src/review.ts",
+            line: 13,
+            title: "Review summary misses failure state",
+            body: "The summary omits the failed status from the retry output.",
+            confidence: 0.75
+          }
+        ]
+      },
+      labels: [
+        {
+          source: "seeded_defect",
+          severity: "P1",
+          path: "Assets/Scripts/CombatTurn.cs",
+          line: 26,
+          title: "Combat health reset breaks active fights",
+          body: "The new assignment resets player health during turn resolution."
+        },
+        {
+          source: "coderabbit",
+          severity: "P2",
+          path: "src/review.ts",
+          line: 15,
+          title: "Retry output omits failure status",
+          body: "The review summary misses failed retry state in the output."
+        }
+      ],
+      thresholds: {
+        minPrecision: 1,
+        minRecall: 1,
+        minSeededRecall: 1
+      }
+    };
+
+    const result = runOfflineEval(scenario, {
+      outputDir: root,
+      now: new Date("2026-07-01T07:00:00Z")
+    });
+
+    expect(result.ok).toBe(true);
+    for (const artifact of [
+      "manifest.json",
+      "raw-output.json",
+      "normalized-findings.json",
+      "redaction-report.json",
+      "duplicate-report.json",
+      "comparison.csv",
+      "labels.json",
+      "calibration-report.json",
+      "scorecard.json"
+    ]) {
+      expect(existsSync(join(root, artifact)), artifact).toBe(true);
+    }
+    const scorecard = JSON.parse(readFileSync(join(root, "scorecard.json"), "utf8"));
+    expect(scorecard).toMatchObject({
+      counts: {
+        truePositive: 2,
+        falsePositive: 0,
+        falseNegative: 0,
+        exactLineMatches: 1,
+        nearbyLineMatches: 1
+      },
+      metrics: {
+        precision: 1,
+        recall: 1,
+        seededRecall: 1
+      }
+    });
+    expect(readFileSync(join(root, "comparison.csv"), "utf8")).toContain("true_positive,exact_line");
+  });
+
+  it("fails closed on duplicate findings and secret-like raw output", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-fail-"));
+    roots.push(root);
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+    const scenario: EvalScenarioInput = {
+      runId: "safety-fail",
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "def456",
+      suite: "safety_redaction",
+      rawOutput: `raw model response contained ${token}`,
+      botFindings: {
+        findings: [
+          {
+            severity: "P2",
+            path: "src/a.ts",
+            line: 10,
+            title: "Duplicate issue",
+            body: "The same finding appears twice.",
+            confidence: 0.8
+          },
+          {
+            severity: "P2",
+            path: "src/a.ts",
+            line: 10,
+            title: "Duplicate issue",
+            body: "The same finding appears twice.",
+            confidence: 0.7
+          }
+        ]
+      },
+      labels: [],
+      thresholds: {
+        minPrecision: 0,
+        minRecall: 0,
+        maxDuplicateFindings: 0,
+        maxSecretFindings: 0
+      }
+    };
+
+    const result = runOfflineEval(scenario, { outputDir: root });
+
+    expect(result.ok).toBe(false);
+    expect(result.scorecard.gates.find((gate) => gate.name === "duplicate_suppression")).toMatchObject({ ok: false });
+    expect(result.scorecard.gates.find((gate) => gate.name === "secret_redaction")).toMatchObject({ ok: false });
+    expect(readFileSync(join(root, "raw-output.json"), "utf8")).not.toContain(token);
+    expect(readFileSync(join(root, "raw-output.json"), "utf8")).toContain("[redacted-secret]");
+  });
+
+  it("fails closed on secret-like finding content while writing redacted artifacts", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-finding-secret-"));
+    roots.push(root);
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+
+    const result = runOfflineEval({
+      runId: "finding-secret",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 60,
+      headSha: "abc",
+      suite: "safety_redaction",
+      botFindings: {
+        findings: [
+          {
+            severity: "P1",
+            path: "src/a.ts",
+            line: 1,
+            title: "Leaked token",
+            body: `The model repeated ${token}.`,
+            confidence: 0.9
+          }
+        ]
+      },
+      labels: [],
+      thresholds: {
+        minPrecision: 0,
+        minRecall: 0,
+        maxSecretFindings: 0
+      }
+    }, { outputDir: root });
+
+    expect(result.ok).toBe(false);
+    expect(result.scorecard.gates.find((gate) => gate.name === "secret_redaction")).toMatchObject({ ok: false });
+    const normalized = readFileSync(join(root, "normalized-findings.json"), "utf8");
+    expect(normalized).not.toContain(token);
+    expect(normalized).toContain("[redacted-secret]");
+  });
+
+  it("defaults output under the eval evidence root", () => {
+    const scenario: EvalScenarioInput = {
+      runId: "default-path",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 60,
+      headSha: "abc",
+      suite: "canary_shadow",
+      botFindings: { findings: [] },
+      labels: []
+    };
+
+    const result = runOfflineEval(scenario, {
+      now: new Date("2026-07-01T07:00:00Z")
+    });
+    roots.push("/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-01/default-path");
+
+    expect(result.outputDir).toBe("/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-01/default-path");
+    expect(result.ok).toBe(true);
+  });
+});

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -129,7 +129,7 @@ describe("offline eval harness", () => {
             severity: "P2",
             path: "src/a.ts",
             line: 10,
-            title: "Duplicate issue",
+            title: "Same bug with different words",
             body: "The same finding appears twice.",
             confidence: 0.7
           }
@@ -191,7 +191,187 @@ describe("offline eval harness", () => {
     expect(normalized).toContain("[redacted-secret]");
   });
 
-  it("defaults output under the eval evidence root", () => {
+  it("fails closed on malformed findings dropped by schema parsing", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-schema-"));
+    roots.push(root);
+
+    const result = runOfflineEval({
+      runId: "schema-drop",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 61,
+      headSha: "abc",
+      suite: "canary_shadow",
+      botFindings: {
+        findings: [
+          {
+            severity: "P1",
+            path: "src/a.ts",
+            line: "not-a-number",
+            title: "Bad schema",
+            body: "This should be dropped.",
+            confidence: 0.9
+          }
+        ]
+      },
+      labels: [],
+      thresholds: {
+        minPrecision: 0,
+        minRecall: 0
+      }
+    }, { outputDir: root });
+
+    expect(result.ok).toBe(false);
+    expect(result.scorecard.counts.droppedFromSchema).toBe(1);
+    expect(result.scorecard.gates.find((gate) => gate.name === "schema_valid")).toMatchObject({ ok: false });
+  });
+
+  it("rejects missing botFindings instead of treating the scenario as empty", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-missing-"));
+    roots.push(root);
+
+    expect(() => runOfflineEval({
+      runId: "missing-findings",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 61,
+      headSha: "abc",
+      suite: "canary_shadow",
+      labels: []
+    } as unknown as EvalScenarioInput, { outputDir: root }))
+      .toThrow("botFindings is required");
+  });
+
+  it("requires semantic overlap even for exact-line matches", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-exact-overlap-"));
+    roots.push(root);
+
+    const result = runOfflineEval({
+      runId: "exact-overlap",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 61,
+      headSha: "abc",
+      suite: "seeded_defect_recall",
+      botFindings: {
+        findings: [
+          {
+            severity: "P1",
+            path: "src/eval-harness.ts",
+            line: 10,
+            title: "Completely unrelated cache bug",
+            body: "This text has no useful overlap with the expected issue.",
+            confidence: 0.9
+          }
+        ]
+      },
+      labels: [
+        {
+          source: "seeded_defect",
+          severity: "P1",
+          path: "src/eval-harness.ts",
+          line: 10,
+          title: "Secret redaction misses object keys",
+          body: "Raw output can store credentials in JSON object keys."
+        }
+      ],
+      thresholds: {
+        minPrecision: 0,
+        minRecall: 1,
+        minSeededRecall: 1
+      }
+    }, { outputDir: root });
+
+    expect(result.ok).toBe(false);
+    expect(result.scorecard.counts).toMatchObject({
+      truePositive: 0,
+      falsePositive: 1,
+      falseNegative: 1,
+      exactLineMatches: 0
+    });
+  });
+
+  it("prefers exact-line matches globally before lower-ranked matches", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-global-exact-"));
+    roots.push(root);
+
+    const result = runOfflineEval({
+      runId: "global-exact",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 61,
+      headSha: "abc",
+      suite: "seeded_defect_recall",
+      botFindings: {
+        findings: [
+          {
+            severity: "P1",
+            path: "src/eval-harness.ts",
+            line: 10,
+            title: "Secret redaction misses keys",
+            body: "Raw output object keys can keep leaked secret tokens.",
+            confidence: 0.8
+          }
+        ]
+      },
+      labels: [
+        {
+          source: "human",
+          severity: "P1",
+          path: "src/eval-harness.ts",
+          line: 12,
+          title: "Secret redaction misses keys nearby",
+          body: "Object keys can keep leaked tokens."
+        },
+        {
+          source: "seeded_defect",
+          severity: "P1",
+          path: "src/eval-harness.ts",
+          line: 10,
+          title: "Secret redaction misses keys",
+          body: "Raw output object keys can keep leaked tokens."
+        }
+      ],
+      thresholds: {
+        minPrecision: 1,
+        minRecall: 0.5,
+        minSeededRecall: 1
+      }
+    }, { outputDir: root });
+
+    expect(result.ok).toBe(true);
+    expect(readFileSync(join(root, "comparison.csv"), "utf8")).toContain("true_positive,exact_line,bot-1,label-2");
+  });
+
+  it("scans fallback botFindings and redacts secret-looking object keys", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-secret-key-"));
+    roots.push(root);
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+
+    const result = runOfflineEval({
+      runId: "secret-key",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 61,
+      headSha: "abc",
+      suite: "safety_redaction",
+      botFindings: {
+        findings: [],
+        [token]: "secret in key"
+      },
+      labels: [],
+      thresholds: {
+        minPrecision: 0,
+        minRecall: 0,
+        maxSecretFindings: 0
+      }
+    }, { outputDir: root });
+
+    expect(result.ok).toBe(false);
+    expect(result.scorecard.gates.find((gate) => gate.name === "secret_redaction")).toMatchObject({ ok: false });
+    const rawOutput = readFileSync(join(root, "raw-output.json"), "utf8");
+    expect(rawOutput).not.toContain(token);
+    expect(rawOutput).toContain("[redacted-secret]");
+  });
+
+  it("writes output under an explicit test directory", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-default-path-"));
+    roots.push(root);
     const scenario: EvalScenarioInput = {
       runId: "default-path",
       repo: "electricsheephq/evaos-code-review-bot",
@@ -203,11 +383,11 @@ describe("offline eval harness", () => {
     };
 
     const result = runOfflineEval(scenario, {
+      outputDir: root,
       now: new Date("2026-07-01T07:00:00Z")
     });
-    roots.push("/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-01/default-path");
 
-    expect(result.outputDir).toBe("/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-01/default-path");
+    expect(result.outputDir).toBe(root);
     expect(result.ok).toBe(true);
   });
 });

--- a/tests/fixtures/eval-scenario.json
+++ b/tests/fixtures/eval-scenario.json
@@ -1,0 +1,49 @@
+{
+  "evalName": "evaos-zcode-review-bot-comparison-v0.1",
+  "runId": "seeded-fixture",
+  "repo": "electricsheephq/WorldOS",
+  "pullNumber": 1234,
+  "headSha": "abc123",
+  "suite": "seeded_defect_recall",
+  "rawOutput": {
+    "findings": [
+      {
+        "severity": "P1",
+        "path": "Assets/Scripts/CombatTurn.cs",
+        "line": 26,
+        "title": "Combat health reset breaks fights",
+        "body": "The player health reset during combat turn resolution makes healthy players nearly dead.",
+        "confidence": 0.95
+      }
+    ]
+  },
+  "botFindings": {
+    "findings": [
+      {
+        "severity": "P1",
+        "path": "Assets/Scripts/CombatTurn.cs",
+        "line": 26,
+        "title": "Combat health reset breaks fights",
+        "body": "The player health reset during combat turn resolution makes healthy players nearly dead.",
+        "confidence": 0.95
+      }
+    ]
+  },
+  "labels": [
+    {
+      "source": "seeded_defect",
+      "severity": "P1",
+      "path": "Assets/Scripts/CombatTurn.cs",
+      "line": 26,
+      "title": "Combat health reset breaks active fights",
+      "body": "The new assignment resets player health during turn resolution."
+    }
+  ],
+  "thresholds": {
+    "minPrecision": 1,
+    "minRecall": 1,
+    "minSeededRecall": 1,
+    "maxSecretFindings": 0,
+    "maxDuplicateFindings": 0
+  }
+}


### PR DESCRIPTION
## Summary
- add a read-only `eval:offline` harness for CodeRabbit/human/CI/seeded-defect comparison packets
- write normalized findings, labels, comparison CSV, redaction report, duplicate report, calibration report, and scorecard artifacts
- document the scenario format and evidence root under `/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/<date>/<run-id>/`

Refs #9.

## Validation
- `npx vitest run tests/eval-harness.test.ts`
- `npm run build`
- `npm test` (24 files, 121 tests)
- `git diff --check`
- `npm run eval:offline -- --input tests/fixtures/eval-scenario.json --output-dir /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-01/issue-9-mvp`

## Evidence
- Eval packet: `/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-01/issue-9-mvp/`
- Live bot release-health checked before PR: `release:status` OK on `main` `9eb73aafc668f0cd8797dcbdcf670a5fecd3197a`; launchd running; provider cooldown backlog 0; error rows 0.

## Safety boundary
This is an offline harness only. It does not call GitHub, post reviews, mutate repos, change launchd state, or claim calibrated 95% review accuracy.