### PR TITLE
v0.2.2: harden ZCode provider retry handling

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -141,9 +141,17 @@ repo through the tracked allowlist/policy lane when the provider is repeatedly
 rate-limited.
 
 Provider cooldown rows are not failed rows. They mean the provider was
-rate-limited before ZCode produced a review. Keep them visible in
-`release:status`, then retry after the cooldown expires or resolve the ZCode
-provider entitlement/rate-limit source. A release may be green with provider
+rate-limited or overloaded before ZCode produced a review. Z.ai provider code
+`1302` is request-rate throttling, `1305` is temporary overload, and true
+plan/package exhaustion uses separate codes such as `1308`, `1309`, and `1310`.
+Do not describe `1302`/`1305` as user quota exhaustion unless the evidence also
+proves an exhausted plan counter.
+
+Keep provider cooldown rows visible in `release:status`, then retry after the
+cooldown expires or resolve the ZCode provider source. The bot should run with
+one in-flight ZCode review by default; live configs that override
+`reviewConcurrency.maxActiveRuns` must set it to `1` unless a later release
+proves a higher concurrency is safe. A release may be green with provider
 cooldown rows only when all provider cooldown rows are still active and the
 packet names the affected PR head and follow-up.
 

--- a/docs/releases/v0.2.2-provider-retry.md
+++ b/docs/releases/v0.2.2-provider-retry.md
@@ -1,0 +1,59 @@
+# v0.2.2-provider-retry
+
+- Release type: local beta patch
+- Source SHA: pending merge
+- Tracking issue: `#62`
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+
+## Purpose
+
+Reduce false release friction and PR-review latency from ZCode provider `429`
+responses. Z.ai code `1302` is request throttling and code `1305` is temporary
+overload; neither proves weekly/tool quota exhaustion by itself.
+
+## Changes
+
+- Classify ZCode provider responses by provider code:
+  - `1302`: `provider_request_rate_limit`
+  - `1305`: `provider_overloaded`
+  - `1308`, `1309`, `1310`, `1316`, `1317`: `provider_quota_exhausted`
+- Retry transient provider throttle/overload failures before recording a hard
+  cooldown.
+- Record `provider-retry.json` evidence with attempt count, provider code,
+  provider request id when available, retryability, and chosen delay.
+- Default ZCode review concurrency is one in-flight review.
+- Use shorter cooldown defaults for request throttling and overload than for
+  true quota/package exhaustion.
+
+## Promotion Notes
+
+Before restart, verify live config does not override the new safe concurrency:
+
+```bash
+jq '.reviewConcurrency' /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+```
+
+If it still sets `maxActiveRuns` above `1`, patch it to `1` before promotion.
+
+## Validation
+
+- `npx vitest run tests/worker-failure.test.ts tests/release-status.test.ts tests/review-budget.test.ts tests/coverage-audit.test.ts`
+- `npm run build`
+- `npm test`
+- `git diff --check`
+- Live post-promotion:
+  - `release:status`
+  - `coverage-audit`
+  - `provider-cooldowns --expired-only true`
+  - retry current active provider cooldowns after expiry
+
+## Rollback
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin
+git checkout main
+git reset --hard <last-known-good-sha>
+npm run build
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+```

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,12 @@ export interface BotConfig {
   providerCooldown: {
     enabled: boolean;
     durationMs: number;
+    requestRateLimitDurationMs: number;
+    overloadDurationMs: number;
+    quotaDurationMs: number;
+    transientRetryAttempts: number;
+    transientRetryBaseDelayMs: number;
+    transientRetryMaxDelayMs: number;
   };
   walkthrough: {
     enabled: boolean;
@@ -116,12 +122,18 @@ const DEFAULT_CONFIG: BotConfig = {
     reviewExistingOpenPrsOnActivation: false
   },
   reviewConcurrency: {
-    maxActiveRuns: 5,
+    maxActiveRuns: 1,
     leaseTtlMs: 15 * 60_000
   },
   providerCooldown: {
     enabled: true,
-    durationMs: 15 * 60_000
+    durationMs: 15 * 60_000,
+    requestRateLimitDurationMs: 5 * 60_000,
+    overloadDurationMs: 2 * 60_000,
+    quotaDurationMs: 30 * 60_000,
+    transientRetryAttempts: 2,
+    transientRetryBaseDelayMs: 1_000,
+    transientRetryMaxDelayMs: 5_000
   },
   walkthrough: {
     enabled: true,
@@ -183,6 +195,12 @@ function validateConfig(config: BotConfig): void {
   validatePositiveInteger(config.reviewConcurrency.leaseTtlMs, "config.reviewConcurrency.leaseTtlMs");
   validateBoolean(config.providerCooldown.enabled, "config.providerCooldown.enabled");
   validatePositiveInteger(config.providerCooldown.durationMs, "config.providerCooldown.durationMs");
+  validatePositiveInteger(config.providerCooldown.requestRateLimitDurationMs, "config.providerCooldown.requestRateLimitDurationMs");
+  validatePositiveInteger(config.providerCooldown.overloadDurationMs, "config.providerCooldown.overloadDurationMs");
+  validatePositiveInteger(config.providerCooldown.quotaDurationMs, "config.providerCooldown.quotaDurationMs");
+  validateNonNegativeInteger(config.providerCooldown.transientRetryAttempts, "config.providerCooldown.transientRetryAttempts");
+  validatePositiveInteger(config.providerCooldown.transientRetryBaseDelayMs, "config.providerCooldown.transientRetryBaseDelayMs");
+  validatePositiveInteger(config.providerCooldown.transientRetryMaxDelayMs, "config.providerCooldown.transientRetryMaxDelayMs");
   validateBoolean(config.walkthrough.enabled, "config.walkthrough.enabled");
   validateBoolean(config.walkthrough.postIssueComment, "config.walkthrough.postIssueComment");
   validateBoolean(config.commands.enabled, "config.commands.enabled");

--- a/src/coverage-audit.ts
+++ b/src/coverage-audit.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import type { BotConfig } from "./config.js";
 import { listReposToScan, resolveRepoProfile, type RepoProfileSkipReason } from "./repo-policy.js";
-import type { StoredProcessedReviewRecord } from "./state.js";
+import { parseProviderCooldownError, type StoredProcessedReviewRecord } from "./state.js";
 import { isCanaryAllowed } from "./worker.js";
 import type { PullRequestSummary } from "./types.js";
 
@@ -12,6 +12,7 @@ export interface CoverageAuditSummary {
   reposScanned: number;
   pullsSeen: number;
   processed: number;
+  providerDeferred: number;
   unprocessed: number;
   skipped: number;
   staleHeads: number;
@@ -38,6 +39,11 @@ export interface CoverageProcessedEntry extends CoverageAuditPullEntry {
 
 export interface CoverageUnprocessedEntry extends CoverageAuditPullEntry {
   previousProcessedHeads: string[];
+}
+
+export interface CoverageProviderDeferredEntry extends CoverageProcessedEntry {
+  cooldownUntil: string;
+  reason?: string;
 }
 
 export interface CoverageSkippedEntry {
@@ -72,6 +78,7 @@ export interface CoverageAuditReport {
   scopedPullNumber?: number;
   summary: CoverageAuditSummary;
   processed: CoverageProcessedEntry[];
+  providerDeferred: CoverageProviderDeferredEntry[];
   unprocessed: CoverageUnprocessedEntry[];
   skipped: CoverageSkippedEntry[];
   staleHeads: CoverageStaleHead[];
@@ -145,12 +152,14 @@ export async function collectCoverageAudit(input: {
       reposScanned: 0,
       pullsSeen: 0,
       processed: 0,
+      providerDeferred: 0,
       unprocessed: 0,
       skipped: 0,
       staleHeads: 0,
       readFailures: 0
     },
     processed: [],
+    providerDeferred: [],
     unprocessed: [],
     skipped: [],
     staleHeads: [],
@@ -230,12 +239,12 @@ export async function collectCoverageAudit(input: {
             pushSkipped(report, repo, livePull, "draft");
             continue;
           }
-          pushProcessedOrUnprocessed(report, input.state, repo, livePull);
+          pushProcessedOrUnprocessed(report, input.state, repo, livePull, input.now ?? new Date());
           continue;
         }
       }
 
-      pushProcessedOrUnprocessed(report, input.state, repo, pull);
+      pushProcessedOrUnprocessed(report, input.state, repo, pull, input.now ?? new Date());
     }
   }
 
@@ -247,19 +256,30 @@ function pushProcessedOrUnprocessed(
   report: CoverageAuditReport,
   state: CoverageStateLookup,
   repo: string,
-  pull: PullRequestSummary
+  pull: PullRequestSummary,
+  now: Date
 ): void {
   const processed = state.getProcessedReview(repo, pull.number, pull.head.sha);
   if (processed) {
-    report.processed.push({
+    const entry: CoverageProcessedEntry = {
       ...pullEntry(repo, pull),
       status: processed.status,
       ...(processed.event ? { event: processed.event } : {}),
       ...(processed.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
       ...(processed.error ? { error: processed.error } : {}),
       createdAt: processed.createdAt
-    });
+    };
+    report.processed.push(entry);
     report.summary.processed += 1;
+    const providerCooldown = activeProviderCooldown(processed, now);
+    if (providerCooldown) {
+      report.providerDeferred.push({
+        ...entry,
+        cooldownUntil: providerCooldown.cooldownUntil,
+        ...(providerCooldown.reason ? { reason: providerCooldown.reason } : {})
+      });
+      report.summary.providerDeferred += 1;
+    }
     return;
   }
 
@@ -271,6 +291,21 @@ function pushProcessedOrUnprocessed(
       .map((record) => record.headSha)
   });
   report.summary.unprocessed += 1;
+}
+
+function activeProviderCooldown(
+  processed: StoredProcessedReviewRecord,
+  now: Date
+): { cooldownUntil: string; reason?: string } | undefined {
+  if (processed.status !== "skipped" || !processed.error) return undefined;
+  const parsed = parseProviderCooldownError(processed.error);
+  if (!parsed) return undefined;
+  const cooldownUntilMs = Date.parse(parsed.cooldownUntil);
+  if (!Number.isFinite(cooldownUntilMs) || cooldownUntilMs <= now.getTime()) return undefined;
+  return {
+    cooldownUntil: parsed.cooldownUntil,
+    ...(parsed.reason ? { reason: parsed.reason } : {})
+  };
 }
 
 function pushSkipped(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -91,6 +91,18 @@ export interface RetryProviderCooldownsResult {
   };
 }
 
+export type ProviderErrorCategory = "none" | "request_rate_limit" | "overloaded" | "quota_exhausted";
+
+export interface ProviderErrorClassification {
+  category: ProviderErrorCategory;
+  providerCode?: string;
+  providerRequestId?: string;
+  retryAfterMs?: number;
+  reason: string;
+  retryable: boolean;
+  cooldown: boolean;
+}
+
 export type ReviewPullResult =
   | "reviewed"
   | "reviewed_command"
@@ -617,16 +629,11 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     writeFileSync(join(evidenceDir, "review-prompt.txt"), redactSecrets(prompt));
 
     const zcodeResult = input.useZCode
-      ? runZCodeReview({
-          cwd: worktree.path,
+      ? await runZCodeReviewWithProviderRetry({
+          config,
+          worktreePath: worktree.path,
           prompt,
-          cliPath: config.zcode.cliPath,
-          appConfigPath: config.zcode.appConfigPath,
-          model: config.zcode.model,
-          providerId: config.zcode.providerId,
-          evidenceDir,
-          timeoutMs: config.zcode.timeoutMs,
-          retryMaxRetries: config.zcode.retryMaxRetries
+          evidenceDir
         })
       : { findings: [], droppedFromSchema: [], rawResponse: "{\"findings\":[]}" };
 
@@ -846,11 +853,11 @@ export function recordProviderRateLimitCooldownIfNeeded(input: {
   now?: Date;
 }): boolean {
   if (!input.config.providerCooldown.enabled) return false;
-  const classification = classifyProviderRateLimitError(input.error);
-  if (!classification.rateLimited) return false;
+  const classification = classifyProviderError(input.error);
+  if (!classification.cooldown) return false;
 
   const now = input.now ?? new Date();
-  const cooldownUntil = new Date(now.getTime() + input.config.providerCooldown.durationMs);
+  const cooldownUntil = new Date(now.getTime() + providerCooldownDurationMs(input.config, classification));
   input.state.recordRepoProviderCooldown({
     repo: input.repo,
     cooldownUntil,
@@ -866,19 +873,187 @@ export function recordProviderRateLimitCooldownIfNeeded(input: {
   return true;
 }
 
-export function classifyProviderRateLimitError(error: unknown): { rateLimited: boolean; reason: string } {
+export function classifyProviderError(error: unknown): ProviderErrorClassification {
   const message = error instanceof Error ? error.message : String(error);
   const normalized = message.toLowerCase();
-  const rateLimited =
+  const providerCode = extractProviderCode(message);
+  const providerRequestId = extractProviderRequestId(message);
+  const retryAfterMs = extractRetryAfterMs(message);
+  const requestRateLimited =
     normalized.includes("rate limit") ||
     normalized.includes("rate_limit_error") ||
     normalized.includes("providercode: '1302'") ||
     normalized.includes('providercode: "1302"') ||
-    normalized.includes("[1302]");
-  return {
-    rateLimited,
-    reason: rateLimited ? "provider_rate_limit" : "not_provider_rate_limit"
+    normalized.includes("[1302]") ||
+    providerCode === "1302";
+  const overloaded =
+    normalized.includes("temporarily overloaded") ||
+    normalized.includes("overloaded_error") ||
+    normalized.includes("providercode: '1305'") ||
+    normalized.includes('providercode: "1305"') ||
+    normalized.includes("[1305]") ||
+    providerCode === "1305";
+  const quotaExhausted =
+    normalized.includes("usage limit reached") ||
+    normalized.includes("weekly/monthly limit exhausted") ||
+    normalized.includes("package has expired") ||
+    ["1308", "1309", "1310", "1316", "1317"].includes(providerCode ?? "");
+  const base = {
+    ...(providerCode ? { providerCode } : {}),
+    ...(providerRequestId ? { providerRequestId } : {}),
+    ...(retryAfterMs ? { retryAfterMs } : {})
   };
+  if (quotaExhausted) {
+    return { ...base, category: "quota_exhausted", reason: "provider_quota_exhausted", retryable: false, cooldown: true };
+  }
+  if (overloaded) {
+    return { ...base, category: "overloaded", reason: "provider_overloaded", retryable: true, cooldown: true };
+  }
+  if (requestRateLimited) {
+    return { ...base, category: "request_rate_limit", reason: "provider_request_rate_limit", retryable: true, cooldown: true };
+  }
+  return {
+    ...base,
+    category: "none",
+    reason: "not_provider_retryable",
+    retryable: false,
+    cooldown: false
+  };
+}
+
+export function providerCooldownDurationMs(config: BotConfig, classification: ProviderErrorClassification): number {
+  if (classification.category === "request_rate_limit") return config.providerCooldown.requestRateLimitDurationMs;
+  if (classification.category === "overloaded") return config.providerCooldown.overloadDurationMs;
+  if (classification.category === "quota_exhausted") return config.providerCooldown.quotaDurationMs;
+  return config.providerCooldown.durationMs;
+}
+
+async function runZCodeReviewWithProviderRetry(input: {
+  config: BotConfig;
+  worktreePath: string;
+  prompt: string;
+  evidenceDir: string;
+}): Promise<ReturnType<typeof runZCodeReview>> {
+  return runWithProviderRetry({
+    config: input.config,
+    evidenceDir: input.evidenceDir,
+    operation: () => runZCodeReview({
+      cwd: input.worktreePath,
+      prompt: input.prompt,
+      cliPath: input.config.zcode.cliPath,
+      appConfigPath: input.config.zcode.appConfigPath,
+      model: input.config.zcode.model,
+      providerId: input.config.zcode.providerId,
+      evidenceDir: input.evidenceDir,
+      timeoutMs: input.config.zcode.timeoutMs,
+      retryMaxRetries: input.config.zcode.retryMaxRetries
+    })
+  });
+}
+
+export async function runWithProviderRetry<T>(input: {
+  config: BotConfig;
+  evidenceDir: string;
+  operation: () => T | Promise<T>;
+}): Promise<T> {
+  let lastError: unknown;
+  const maxAttempts = Math.max(1, input.config.providerCooldown.transientRetryAttempts + 1);
+  const attempts: Array<{
+    attempt: number;
+    providerCode?: string;
+    providerRequestId?: string;
+    retryAfterMs?: number;
+    category: ProviderErrorCategory;
+    reason: string;
+    retryable: boolean;
+    nextDelayMs?: number;
+    final?: boolean;
+  }> = [];
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const result = await input.operation();
+      if (attempts.length > 0) {
+        attempts.push({ attempt, category: "none", reason: "success_after_retry", retryable: false, final: true });
+        writeProviderRetryEvidence(input.evidenceDir, attempts);
+      }
+      return result;
+    } catch (error) {
+      lastError = error;
+      const classification = classifyProviderError(error);
+      const shouldRetry = classification.retryable && attempt < maxAttempts;
+      const nextDelayMs = shouldRetry ? providerRetryDelayMs(input.config, attempt, classification.retryAfterMs) : undefined;
+      attempts.push({
+        attempt,
+        ...(classification.providerCode ? { providerCode: classification.providerCode } : {}),
+        ...(classification.providerRequestId ? { providerRequestId: classification.providerRequestId } : {}),
+        ...(classification.retryAfterMs ? { retryAfterMs: classification.retryAfterMs } : {}),
+        category: classification.category,
+        reason: classification.reason,
+        retryable: classification.retryable,
+        ...(nextDelayMs !== undefined ? { nextDelayMs } : {}),
+        final: !shouldRetry
+      });
+      writeProviderRetryEvidence(input.evidenceDir, attempts);
+      if (!shouldRetry) break;
+      await sleep(nextDelayMs);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+function providerRetryDelayMs(config: BotConfig, attempt: number, retryAfterMs?: number): number {
+  const base = config.providerCooldown.transientRetryBaseDelayMs;
+  const max = config.providerCooldown.transientRetryMaxDelayMs;
+  if (retryAfterMs !== undefined) return Math.min(max, Math.max(1, retryAfterMs));
+  const exponential = base * 2 ** Math.max(0, attempt - 1);
+  const jitter = Math.floor(Math.random() * Math.max(1, Math.floor(base / 2)));
+  return Math.min(max, exponential + jitter);
+}
+
+function writeProviderRetryEvidence(evidenceDir: string, attempts: unknown): void {
+  mkdirSync(evidenceDir, { recursive: true });
+  writeFileSync(join(evidenceDir, "provider-retry.json"), `${JSON.stringify(attempts, null, 2)}\n`);
+}
+
+function extractProviderCode(message: string): string | undefined {
+  return (
+    message.match(/providerCode:\s*['"]?(\d{4})['"]?/)?.[1] ??
+    message.match(/"code"\s*:\s*"(\d{4})"/)?.[1] ??
+    message.match(/\[(\d{4})\]/)?.[1]
+  );
+}
+
+function extractProviderRequestId(message: string): string | undefined {
+  return (
+    message.match(/providerRequestId:\s*['"]([^'"]+)['"]/)?.[1] ??
+    message.match(/request_id['"]?\s*:\s*['"]([^'"]+)['"]/)?.[1]
+  );
+}
+
+function extractRetryAfterMs(message: string): number | undefined {
+  const numeric =
+    message.match(/retry-after['"]?\s*[:=]\s*['"]?(\d+(?:\.\d+)?)['"]?/i)?.[1] ??
+    message.match(/retryAfterMs['"]?\s*[:=]\s*['"]?(\d+(?:\.\d+)?)['"]?/i)?.[1];
+  if (numeric !== undefined) {
+    const value = Number(numeric);
+    if (Number.isFinite(value) && value > 0) {
+      return message.toLowerCase().includes("retryafterms") ? Math.ceil(value) : Math.ceil(value * 1000);
+    }
+  }
+
+  const date = message.match(/retry-after['"]?\s*[:=]\s*['"]?([^'",\n}]+)/i)?.[1];
+  if (!date) return undefined;
+  const parsed = Date.parse(date);
+  if (!Number.isFinite(parsed)) return undefined;
+  const delayMs = parsed - Date.now();
+  return delayMs > 0 ? Math.ceil(delayMs) : undefined;
+}
+
+function sleep(ms: number | undefined): Promise<void> {
+  if (!ms || ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function recordProviderCooldownSkip(input: {

--- a/tests/coverage-audit.test.ts
+++ b/tests/coverage-audit.test.ts
@@ -89,6 +89,43 @@ describe("coverage audit", () => {
     state.close();
   });
 
+  it("separately reports active provider-deferred heads", async () => {
+    const { root, state } = createState();
+    state.recordProcessed({
+      repo: "owner/allowed",
+      pullNumber: 5,
+      headSha: "head-cooldown",
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2026-07-01T00:05:00.000Z; reason=provider_request_rate_limit"
+    });
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(5, "head-cooldown")]
+      } as unknown as GitHubApi,
+      state,
+      now: new Date("2026-07-01T00:04:00.000Z")
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      processed: 1,
+      providerDeferred: 1,
+      unprocessed: 0
+    });
+    expect(audit.providerDeferred).toEqual([
+      expect.objectContaining({
+        repo: "owner/allowed",
+        pullNumber: 5,
+        headSha: "head-cooldown",
+        cooldownUntil: "2026-07-01T00:05:00.000Z",
+        reason: "provider_request_rate_limit"
+      })
+    ]);
+    state.close();
+  });
+
   it("supports canary and single-PR scoping without marking closed PRs as misses", async () => {
     const { root, state } = createState();
     let getPullCount = 0;
@@ -322,7 +359,13 @@ function minimalConfig(root: string): BotConfig {
     },
     providerCooldown: {
       enabled: true,
-      durationMs: 15 * 60_000
+      durationMs: 15 * 60_000,
+      requestRateLimitDurationMs: 5 * 60_000,
+      overloadDurationMs: 2 * 60_000,
+      quotaDurationMs: 30 * 60_000,
+      transientRetryAttempts: 2,
+      transientRetryBaseDelayMs: 1,
+      transientRetryMaxDelayMs: 1
     },
     walkthrough: {
       enabled: false,

--- a/tests/review-budget.test.ts
+++ b/tests/review-budget.test.ts
@@ -123,7 +123,13 @@ function minimalConfig(root: string): BotConfig {
     },
     providerCooldown: {
       enabled: true,
-      durationMs: 15 * 60_000
+      durationMs: 15 * 60_000,
+      requestRateLimitDurationMs: 5 * 60_000,
+      overloadDurationMs: 2 * 60_000,
+      quotaDurationMs: 30 * 60_000,
+      transientRetryAttempts: 2,
+      transientRetryBaseDelayMs: 1,
+      transientRetryMaxDelayMs: 1
     },
     walkthrough: {
       enabled: false,

--- a/tests/stale-head.test.ts
+++ b/tests/stale-head.test.ts
@@ -90,7 +90,13 @@ function minimalConfig(root: string): BotConfig {
     },
     providerCooldown: {
       enabled: true,
-      durationMs: 15 * 60_000
+      durationMs: 15 * 60_000,
+      requestRateLimitDurationMs: 5 * 60_000,
+      overloadDurationMs: 2 * 60_000,
+      quotaDurationMs: 30 * 60_000,
+      transientRetryAttempts: 2,
+      transientRetryBaseDelayMs: 1,
+      transientRetryMaxDelayMs: 1
     },
     walkthrough: {
       enabled: false,

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -8,15 +8,18 @@ import { ReviewRunBudget } from "../src/review-budget.js";
 import { ReviewStateStore } from "../src/state.js";
 import type { PullRequestSummary } from "../src/types.js";
 import {
+  classifyProviderError,
   isSuccessfulRetryStatus,
   localDateFolder,
   prepareFailedHeadRetry,
+  providerCooldownDurationMs,
   recordFailedReview,
   recordProviderRateLimitCooldownIfNeeded,
   restoreFailedRetryRowIfNeeded,
   retryFailedHeadWithDeps,
   retryProviderCooldownsWithDeps,
-  reviewPull
+  reviewPull,
+  runWithProviderRetry
 } from "../src/worker.js";
 
 describe("worker review failures", () => {
@@ -70,12 +73,140 @@ describe("worker review failures", () => {
     expect(handled).toBe(true);
     expect(state.getProcessedReview("electricsheephq/WorldOS", 1234, "head-rate-limit")).toMatchObject({
       status: "skipped",
-      error: "provider_rate_limit_cooldown_until=2026-07-01T00:15:00.000Z; reason=provider_rate_limit"
+      error: "provider_rate_limit_cooldown_until=2026-07-01T00:05:00.000Z; reason=provider_request_rate_limit"
     });
-    expect(state.getActiveRepoProviderCooldown("electricsheephq/WorldOS", new Date("2026-07-01T00:10:00.000Z"))).toMatchObject({
-      reason: "provider_rate_limit"
+    expect(state.getActiveRepoProviderCooldown("electricsheephq/WorldOS", new Date("2026-07-01T00:04:00.000Z"))).toMatchObject({
+      reason: "provider_request_rate_limit"
     });
     state.close();
+  });
+
+  it("classifies provider throttle, overload, and true quota separately", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-classify-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const rateLimit = classifyProviderError(new Error("ProviderBusinessError: [1302][Rate limit reached for requests] providerRequestId: 'req-1'"));
+    const overload = classifyProviderError(new Error("ProviderBusinessError: [1305][The service may be temporarily overloaded, please try again later]"));
+    const quota = classifyProviderError(new Error("ProviderBusinessError: [1310][Weekly/Monthly Limit Exhausted]"));
+
+    expect(rateLimit).toMatchObject({
+      category: "request_rate_limit",
+      providerCode: "1302",
+      reason: "provider_request_rate_limit",
+      retryable: true,
+      cooldown: true
+    });
+    expect(overload).toMatchObject({
+      category: "overloaded",
+      providerCode: "1305",
+      reason: "provider_overloaded",
+      retryable: true,
+      cooldown: true
+    });
+    expect(quota).toMatchObject({
+      category: "quota_exhausted",
+      providerCode: "1310",
+      reason: "provider_quota_exhausted",
+      retryable: false,
+      cooldown: true
+    });
+    expect(providerCooldownDurationMs(config, rateLimit)).toBe(5 * 60_000);
+    expect(providerCooldownDurationMs(config, overload)).toBe(2 * 60_000);
+    expect(providerCooldownDurationMs(config, quota)).toBe(30 * 60_000);
+  });
+
+  it("retries transient provider throttles before surfacing failure", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-retry-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    let attempts = 0;
+
+    const result = await runWithProviderRetry({
+      config,
+      evidenceDir: join(root, "evidence"),
+      operation: () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error("ProviderBusinessError: [1302][Rate limit reached for requests] providerRequestId: 'req-retry'");
+        }
+        return "ok";
+      }
+    });
+
+    expect(result).toBe("ok");
+    expect(attempts).toBe(2);
+    const evidence = JSON.parse(readFileSync(join(root, "evidence", "provider-retry.json"), "utf8"));
+    expect(evidence).toMatchObject([
+      {
+        attempt: 1,
+        category: "request_rate_limit",
+        providerCode: "1302",
+        reason: "provider_request_rate_limit",
+        retryable: true
+      },
+      {
+        attempt: 2,
+        category: "none",
+        reason: "success_after_retry",
+        final: true
+      }
+    ]);
+  });
+
+  it("records Retry-After hints in provider retry evidence", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-retry-after-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    let attempts = 0;
+
+    const result = await runWithProviderRetry({
+      config,
+      evidenceDir: join(root, "evidence"),
+      operation: () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error("ProviderBusinessError: [1305][temporarily overloaded] retry-after: 0.001");
+        }
+        return "ok";
+      }
+    });
+
+    expect(result).toBe("ok");
+    const evidence = JSON.parse(readFileSync(join(root, "evidence", "provider-retry.json"), "utf8"));
+    expect(evidence[0]).toMatchObject({
+      attempt: 1,
+      category: "overloaded",
+      providerCode: "1305",
+      retryAfterMs: 1,
+      nextDelayMs: 1
+    });
+  });
+
+  it("does not retry true quota exhaustion provider errors", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-no-retry-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    let attempts = 0;
+
+    await expect(runWithProviderRetry({
+      config,
+      evidenceDir: join(root, "evidence"),
+      operation: () => {
+        attempts += 1;
+        throw new Error("ProviderBusinessError: [1310][Weekly/Monthly Limit Exhausted]");
+      }
+    })).rejects.toThrow("1310");
+
+    expect(attempts).toBe(1);
+    const evidence = JSON.parse(readFileSync(join(root, "evidence", "provider-retry.json"), "utf8"));
+    expect(evidence[0]).toMatchObject({
+      attempt: 1,
+      category: "quota_exhausted",
+      providerCode: "1310",
+      reason: "provider_quota_exhausted",
+      retryable: false,
+      final: true
+    });
   });
 
   it("prepares exactly one failed current head for retry without deleting the failure row", () => {
@@ -819,7 +950,13 @@ function minimalConfig(root: string): BotConfig {
     },
     providerCooldown: {
       enabled: true,
-      durationMs: 15 * 60_000
+      durationMs: 15 * 60_000,
+      requestRateLimitDurationMs: 5 * 60_000,
+      overloadDurationMs: 2 * 60_000,
+      quotaDurationMs: 30 * 60_000,
+      transientRetryAttempts: 2,
+      transientRetryBaseDelayMs: 1,
+      transientRetryMaxDelayMs: 1
     },
     walkthrough: {
       enabled: false,


### PR DESCRIPTION
## Summary
- classify ZCode provider errors by code instead of treating all 429s as generic quota exhaustion
- retry transient 1302 request-throttle and 1305 overload errors before recording cooldown rows
- record Retry-After hints in provider retry evidence when the provider exposes them
- default bot ZCode concurrency to one in-flight review and document live-config promotion requirements
- write `provider-retry.json` attempt evidence for retryable provider failures
- surface active provider-deferred heads separately in coverage-audit output

Closes #62.

## Validation
- `npx vitest run tests/worker-failure.test.ts tests/release-status.test.ts tests/review-budget.test.ts tests/coverage-audit.test.ts` (48 tests)
- `npm run build`
- `npm test` (23 files, 122 tests)
- `git diff --check`

## Live evidence / diagnosis
- User quota screenshot showed ZCode plan counters were healthy: 5h 99%, weekly 95%, tool calls 99%.
- Z.ai docs distinguish request throttle/temporary overload (`1302`, `1305`) from true plan/package exhaustion (`1308`, `1309`, `1310`).
- Live bot renewed provider cooldown on #61 after retry, and active cooldowns were present for LCO #226, WorldOS #1234, and bot #61.

## Promotion note
After merge, patch `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json` so `reviewConcurrency.maxActiveRuns` is `1`, then sync/restart launchd and run release-status, coverage-audit, and provider-cooldowns proof.

## External references
- Z.ai error docs: https://docs.z.ai/api-reference/api-code
- Community reports of 1302 with normal quota / low concurrency: https://github.com/anomalyco/opencode/issues/8618 and https://github.com/anomalyco/opencode/issues/14535