### PR TITLE
v0.2.3: report repo cooldowns in coverage audit

### DIFF
--- a/src/coverage-audit.ts
+++ b/src/coverage-audit.ts
@@ -2,7 +2,11 @@ import { existsSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import type { BotConfig } from "./config.js";
 import { listReposToScan, resolveRepoProfile, type RepoProfileSkipReason } from "./repo-policy.js";
-import { parseProviderCooldownError, type StoredProcessedReviewRecord } from "./state.js";
+import {
+  parseProviderCooldownError,
+  type RepoProviderCooldownRecord,
+  type StoredProcessedReviewRecord
+} from "./state.js";
 import { isCanaryAllowed } from "./worker.js";
 import type { PullRequestSummary } from "./types.js";
 
@@ -93,6 +97,7 @@ export interface CoverageGitHubApi {
 export interface CoverageStateLookup {
   getProcessedReview(repo: string, pullNumber: number, headSha: string): StoredProcessedReviewRecord | undefined;
   listProcessedReviewsForPull(repo: string, pullNumber: number): StoredProcessedReviewRecord[];
+  getActiveRepoProviderCooldown?(repo: string, now?: Date): RepoProviderCooldownRecord | undefined;
 }
 
 export class CoverageStateReader implements CoverageStateLookup {
@@ -127,6 +132,23 @@ export class CoverageStateReader implements CoverageStateLookup {
       )
       .all(repo, pullNumber) as unknown as ProcessedReviewRow[];
     return rows.map(mapProcessedReviewRow);
+  }
+
+  getActiveRepoProviderCooldown(repo: string, now = new Date()): RepoProviderCooldownRecord | undefined {
+    if (!this.db) return undefined;
+    const row = this.db
+      .prepare(
+        `select repo, cooldown_until, reason, updated_at
+         from repo_provider_cooldowns
+         where repo = ?
+         limit 1`
+      )
+      .get(repo) as RepoProviderCooldownRow | undefined;
+    if (!row) return undefined;
+    const cooldown = mapRepoProviderCooldownRow(row);
+    const cooldownUntilMs = Date.parse(cooldown.cooldownUntil);
+    if (!Number.isFinite(cooldownUntilMs) || cooldownUntilMs <= now.getTime()) return undefined;
+    return cooldown;
   }
 
   close(): void {
@@ -283,6 +305,20 @@ function pushProcessedOrUnprocessed(
     return;
   }
 
+  const repoCooldown = state.getActiveRepoProviderCooldown?.(repo, now);
+  if (repoCooldown) {
+    report.providerDeferred.push({
+      ...pullEntry(repo, pull),
+      status: "skipped",
+      error: `repo_provider_cooldown_until=${repoCooldown.cooldownUntil}; reason=${repoCooldown.reason}`,
+      createdAt: repoCooldown.updatedAt,
+      cooldownUntil: repoCooldown.cooldownUntil,
+      reason: repoCooldown.reason
+    });
+    report.summary.providerDeferred += 1;
+    return;
+  }
+
   report.unprocessed.push({
     ...pullEntry(repo, pull),
     previousProcessedHeads: state
@@ -352,6 +388,13 @@ interface ProcessedReviewRow {
   created_at: string;
 }
 
+interface RepoProviderCooldownRow {
+  repo: string;
+  cooldown_until: string;
+  reason: string;
+  updated_at: string;
+}
+
 function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRecord {
   return {
     repo: row.repo,
@@ -362,5 +405,14 @@ function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRe
     ...(row.review_url ? { reviewUrl: row.review_url } : {}),
     ...(row.error ? { error: row.error } : {}),
     createdAt: row.created_at
+  };
+}
+
+function mapRepoProviderCooldownRow(row: RepoProviderCooldownRow): RepoProviderCooldownRecord {
+  return {
+    repo: row.repo,
+    cooldownUntil: row.cooldown_until,
+    reason: row.reason,
+    updatedAt: row.updated_at
   };
 }

--- a/tests/coverage-audit.test.ts
+++ b/tests/coverage-audit.test.ts
@@ -126,6 +126,41 @@ describe("coverage audit", () => {
     state.close();
   });
 
+  it("reports eligible heads as provider-deferred under active repo cooldown even without a head row", async () => {
+    const { root, state } = createState();
+    state.recordRepoProviderCooldown({
+      repo: "owner/allowed",
+      cooldownUntil: new Date("2026-07-01T00:05:00.000Z"),
+      reason: "provider_request_rate_limit"
+    });
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(6, "head-repo-cooldown")]
+      } as unknown as GitHubApi,
+      state,
+      now: new Date("2026-07-01T00:04:00.000Z")
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      processed: 0,
+      providerDeferred: 1,
+      unprocessed: 0
+    });
+    expect(audit.providerDeferred).toEqual([
+      expect.objectContaining({
+        repo: "owner/allowed",
+        pullNumber: 6,
+        headSha: "head-repo-cooldown",
+        cooldownUntil: "2026-07-01T00:05:00.000Z",
+        reason: "provider_request_rate_limit"
+      })
+    ]);
+    state.close();
+  });
+
   it("supports canary and single-PR scoping without marking closed PRs as misses", async () => {
     const { root, state } = createState();
     let getPullCount = 0;


### PR DESCRIPTION
## Summary
- teach coverage-audit to treat active repo-level provider cooldowns as provider-deferred heads even before a per-head processed row exists
- include cooldownUntil/reason in the deferred entry
- keep expired repo cooldowns from hiding real unprocessed heads

Closes #64.

## Validation
- `npx vitest run tests/coverage-audit.test.ts` (9 tests)
- `npm run build`
- `npm test` (23 files, 123 tests)
- `git diff --check`

## Live evidence
- `100yenadmin/Lossless-Codex-Orchestrator-LCO#230` appeared unprocessed while the repo had active cooldown until `2026-07-01T08:03:19.061Z`.
- This patch makes that state visible as provider-deferred instead of a miss.