### PR TITLE
v0.2.4: tune Z.ai transient cooldown policy

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -147,6 +147,12 @@ plan/package exhaustion uses separate codes such as `1308`, `1309`, and `1310`.
 Do not describe `1302`/`1305` as user quota exhaustion unless the evidence also
 proves an exhausted plan counter.
 
+Default beta policy is intentionally short for transient `1302`: four bounded
+jittered retries first, then a 90-second cooldown. Keep true quota/package
+cooldowns long. If a user-visible quota panel shows plenty of remaining usage,
+record that as supporting evidence for provider/request throttling, not as proof
+that the bot should disable cooldown handling.
+
 Keep provider cooldown rows visible in `release:status`, then retry after the
 cooldown expires or resolve the ZCode provider source. The bot should run with
 one in-flight ZCode review by default; live configs that override

--- a/docs/releases/v0.2.4-provider-cooldown-tuning.md
+++ b/docs/releases/v0.2.4-provider-cooldown-tuning.md
@@ -1,0 +1,41 @@
+# v0.2.4-provider-cooldown-tuning
+
+- Release type: local beta patch
+- Tracking issue: `#66`
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+
+## Purpose
+
+Reduce PR-review latency from transient Z.ai `1302` request throttling without
+misclassifying it as quota exhaustion. Official Z.ai error docs separate `1302`
+request-rate throttling and `1305` temporary overload from package/quota
+exhaustion codes such as `1308`, `1309`, `1310`, `1316`, and `1317`.
+
+## Changes
+
+- Keep review concurrency at one active ZCode review.
+- Increase transient provider retries from 2 to 4 attempts.
+- Use a wider jittered retry window: 2s base delay, capped at 20s.
+- Shorten `1302` request-rate cooldown from 5 minutes to 90 seconds.
+- Keep `1305` overload cooldown at 2 minutes.
+- Keep true quota/package exhaustion cooldown at 30 minutes.
+
+## Validation
+
+- `npx vitest run tests/worker-failure.test.ts tests/release-status.test.ts`
+- `npm run build`
+- `npm test`
+- Live post-promotion:
+  - `release:status`
+  - `coverage-audit`
+  - `provider-cooldowns --expired-only true`
+
+## Rollback
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin
+git checkout main
+git reset --hard <last-known-good-sha>
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+```

--- a/src/config.ts
+++ b/src/config.ts
@@ -128,12 +128,12 @@ const DEFAULT_CONFIG: BotConfig = {
   providerCooldown: {
     enabled: true,
     durationMs: 15 * 60_000,
-    requestRateLimitDurationMs: 5 * 60_000,
+    requestRateLimitDurationMs: 90_000,
     overloadDurationMs: 2 * 60_000,
     quotaDurationMs: 30 * 60_000,
-    transientRetryAttempts: 2,
-    transientRetryBaseDelayMs: 1_000,
-    transientRetryMaxDelayMs: 5_000
+    transientRetryAttempts: 4,
+    transientRetryBaseDelayMs: 2_000,
+    transientRetryMaxDelayMs: 20_000
   },
   walkthrough: {
     enabled: true,

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -73,9 +73,9 @@ describe("worker review failures", () => {
     expect(handled).toBe(true);
     expect(state.getProcessedReview("electricsheephq/WorldOS", 1234, "head-rate-limit")).toMatchObject({
       status: "skipped",
-      error: "provider_rate_limit_cooldown_until=2026-07-01T00:05:00.000Z; reason=provider_request_rate_limit"
+      error: "provider_rate_limit_cooldown_until=2026-07-01T00:01:30.000Z; reason=provider_request_rate_limit"
     });
-    expect(state.getActiveRepoProviderCooldown("electricsheephq/WorldOS", new Date("2026-07-01T00:04:00.000Z"))).toMatchObject({
+    expect(state.getActiveRepoProviderCooldown("electricsheephq/WorldOS", new Date("2026-07-01T00:01:00.000Z"))).toMatchObject({
       reason: "provider_request_rate_limit"
     });
     state.close();
@@ -110,7 +110,7 @@ describe("worker review failures", () => {
       retryable: false,
       cooldown: true
     });
-    expect(providerCooldownDurationMs(config, rateLimit)).toBe(5 * 60_000);
+    expect(providerCooldownDurationMs(config, rateLimit)).toBe(90_000);
     expect(providerCooldownDurationMs(config, overload)).toBe(2 * 60_000);
     expect(providerCooldownDurationMs(config, quota)).toBe(30 * 60_000);
   });
@@ -951,10 +951,10 @@ function minimalConfig(root: string): BotConfig {
     providerCooldown: {
       enabled: true,
       durationMs: 15 * 60_000,
-      requestRateLimitDurationMs: 5 * 60_000,
+      requestRateLimitDurationMs: 90_000,
       overloadDurationMs: 2 * 60_000,
       quotaDurationMs: 30 * 60_000,
-      transientRetryAttempts: 2,
+      transientRetryAttempts: 4,
       transientRetryBaseDelayMs: 1,
       transientRetryMaxDelayMs: 1
     },


### PR DESCRIPTION
Closes #66.\n\n## Summary\n- shorten transient Z.ai 1302 request-rate cooldown from 5 minutes to 90 seconds\n- increase bounded transient retries from 2 to 4 with wider jittered backoff\n- preserve 1305 overload and true quota/package cooldown separation\n- document the v0.2.4 beta release behavior and runbook guidance\n\n## Research Notes\n- Z.ai docs define 1302 as request-rate throttling, 1305 as temporary overload, and quota/package exhaustion separately as 1308/1309/1310/1316/1317.\n- Current community/GitHub reports show intermittent 1302/429 behavior on paid GLM plans even when visible usage is not exhausted.\n\n## Validation\n- `npx vitest run tests/worker-failure.test.ts tests/release-status.test.ts` -> 2 files / 35 tests passed\n- `npm run build` -> passed\n- `npm test` -> 24 files / 132 tests passed\n- `git diff --check` -> passed\n\n## Live Promotion Plan\nAfter merge: sync /Volumes/LEXAR/repos/evaos-code-review-bot to merged main, restart launchd, run release-status, coverage-audit, and provider-cooldowns.