### PR TITLE
v0.2.5: prune stale review run leases

### DIFF
--- a/docs/releases/v0.2.5-restart-lease-hygiene.md
+++ b/docs/releases/v0.2.5-restart-lease-hygiene.md
@@ -1,0 +1,27 @@
+# v0.2.5-restart-lease-hygiene
+
+- Release type: local beta patch
+- Tracking issue: `#68`
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+
+## Purpose
+
+Prevent controlled launchd promotions from stranding a capacity lease for the
+full review lease TTL after the old worker process is killed.
+
+## Changes
+
+- Store `owner_pid` on each `review_run_leases` row.
+- Prune expired leases before capacity checks.
+- Prune leases whose owner PID no longer exists before capacity checks.
+- Prune legacy ownerless leases created by older beta versions.
+
+## Validation
+
+- `npx vitest run tests/state.test.ts tests/review-budget.test.ts tests/worker-failure.test.ts`
+- `npm run build`
+- `npm test`
+- Live post-promotion:
+  - `release:status`
+  - `retry-provider-cooldowns --expired-only true`
+  - `coverage-audit`

--- a/src/state.ts
+++ b/src/state.ts
@@ -33,6 +33,7 @@ export interface RetireFailedReviewInput {
 export interface ReviewRunLease {
   leaseId: string;
   expiresAt: string;
+  ownerPid: number;
 }
 
 export interface RepoProviderCooldownRecord {
@@ -114,7 +115,8 @@ export class ReviewStateStore {
       create table if not exists review_run_leases (
         lease_id text primary key,
         started_at text not null,
-        expires_at text not null
+        expires_at text not null,
+        owner_pid integer
       );
 
       create table if not exists repo_provider_cooldowns (
@@ -134,6 +136,7 @@ export class ReviewStateStore {
       );
     `);
     this.ensureDaemonHeartbeatColumns();
+    this.ensureReviewRunLeaseColumns();
     this.db.exec(`
       create table if not exists processed_commands (
         repo text not null,
@@ -237,11 +240,17 @@ export class ReviewStateStore {
       .run(repo, activatedAt);
   }
 
-  tryAcquireReviewRunLease(maxActiveRuns: number, leaseTtlMs: number, now = new Date()): ReviewRunLease | undefined {
+  tryAcquireReviewRunLease(
+    maxActiveRuns: number,
+    leaseTtlMs: number,
+    now = new Date(),
+    ownerPid = process.pid
+  ): ReviewRunLease | undefined {
     if (!Number.isInteger(maxActiveRuns)) throw new Error("maxActiveRuns must be an integer");
     if (maxActiveRuns < 1) throw new Error("maxActiveRuns must be at least 1");
     if (!Number.isInteger(leaseTtlMs)) throw new Error("leaseTtlMs must be an integer");
     if (leaseTtlMs < 1) throw new Error("leaseTtlMs must be at least 1");
+    if (!Number.isInteger(ownerPid) || ownerPid < 1) throw new Error("ownerPid must be a positive integer");
 
     const leaseId = randomUUID();
     const startedAt = now.toISOString();
@@ -249,16 +258,17 @@ export class ReviewStateStore {
     this.db.exec("begin immediate");
     try {
       this.db.prepare("delete from review_run_leases where expires_at <= ?").run(startedAt);
+      this.pruneInactiveReviewRunLeases();
       const row = this.db.prepare("select count(*) as count from review_run_leases").get() as { count: number };
       if (row.count >= maxActiveRuns) {
         this.db.exec("commit");
         return undefined;
       }
       this.db
-        .prepare("insert into review_run_leases (lease_id, started_at, expires_at) values (?, ?, ?)")
-        .run(leaseId, startedAt, expiresAt);
+        .prepare("insert into review_run_leases (lease_id, started_at, expires_at, owner_pid) values (?, ?, ?, ?)")
+        .run(leaseId, startedAt, expiresAt, ownerPid);
       this.db.exec("commit");
-      return { leaseId, expiresAt };
+      return { leaseId, expiresAt, ownerPid };
     } catch (error) {
       this.db.exec("rollback");
       throw error;
@@ -267,6 +277,17 @@ export class ReviewStateStore {
 
   releaseReviewRunLease(leaseId: string): void {
     this.db.prepare("delete from review_run_leases where lease_id = ?").run(leaseId);
+  }
+
+  private pruneInactiveReviewRunLeases(): void {
+    const rows = this.db
+      .prepare("select lease_id, owner_pid from review_run_leases")
+      .all() as unknown as Array<{ lease_id: string; owner_pid: number | null }>;
+    for (const row of rows) {
+      if (row.owner_pid === null || !isProcessAlive(row.owner_pid)) {
+        this.db.prepare("delete from review_run_leases where lease_id = ?").run(row.lease_id);
+      }
+    }
   }
 
   recordRepoProviderCooldown(input: { repo: string; cooldownUntil: Date; reason: string }): RepoProviderCooldownRecord {
@@ -445,6 +466,25 @@ export class ReviewStateStore {
     if (!names.has("started_at")) {
       this.db.exec("alter table daemon_heartbeat add column started_at text");
     }
+  }
+
+  private ensureReviewRunLeaseColumns(): void {
+    const columns = this.db.prepare("pragma table_info(review_run_leases)").all() as unknown as Array<{ name: string }>;
+    if (!columns.some((column) => column.name === "owner_pid")) {
+      this.db.exec("alter table review_run_leases add column owner_pid integer");
+    }
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = typeof error === "object" && error !== null && "code" in error
+      ? (error as { code?: unknown }).code
+      : undefined;
+    return code === "EPERM";
   }
 }
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { parseProviderCooldownError, ReviewStateStore } from "../src/state.js";
 
@@ -122,6 +123,35 @@ describe("review state store", () => {
 
     expect(store.tryAcquireReviewRunLease(1, 1_000, new Date("2026-07-01T00:00:00.000Z"))).toBeDefined();
     expect(store.tryAcquireReviewRunLease(1, 1_000, new Date("2026-07-01T00:00:02.000Z"))).toBeDefined();
+    store.close();
+  });
+
+  it("prunes dead-owner review leases before enforcing capacity", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-state-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    expect(store.tryAcquireReviewRunLease(1, 60_000, new Date("2026-07-01T00:00:00.000Z"), 999_999_999)).toBeDefined();
+    const next = store.tryAcquireReviewRunLease(1, 60_000, new Date("2026-07-01T00:00:01.000Z"));
+
+    expect(next).toBeDefined();
+    expect(next?.ownerPid).toBe(process.pid);
+    store.close();
+  });
+
+  it("prunes legacy ownerless review leases before enforcing capacity", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-state-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const store = new ReviewStateStore(dbPath);
+    const db = new DatabaseSync(dbPath);
+    db.prepare("insert into review_run_leases (lease_id, started_at, expires_at) values (?, ?, ?)")
+      .run("legacy-ownerless", "2026-07-01T00:00:00.000Z", "2026-07-01T00:15:00.000Z");
+
+    expect(store.tryAcquireReviewRunLease(1, 60_000, new Date("2026-07-01T00:00:01.000Z"))).toBeDefined();
+    const rows = db.prepare("select lease_id from review_run_leases where lease_id = ?").all("legacy-ownerless");
+    expect(rows).toHaveLength(0);
+    db.close();
     store.close();
   });
 


### PR DESCRIPTION
Closes #68.\n\n## Summary\n- add `owner_pid` to review run leases\n- prune expired, dead-owner, and legacy ownerless leases before capacity checks\n- keep active same-process leases protected so concurrency remains capped\n- add v0.2.5 release notes\n\n## Validation\n- `npx vitest run tests/state.test.ts tests/review-budget.test.ts tests/worker-failure.test.ts` -> 3 files / 42 tests passed\n- `npm run build` -> passed\n- `npm test` -> 24 files / 134 tests passed\n- `git diff --check` -> passed\n\n## Live Promotion Plan\nAfter merge: sync /Volumes/LEXAR/repos/evaos-code-review-bot to merged main, restart launchd, rerun release-status, retry expired cooldowns, and run coverage-audit.