### PR TITLE
Add tag-driven release governance runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ follow [docs/beta-release-runbook.md](docs/beta-release-runbook.md).
 Named release packets live under [docs/releases](docs/releases), starting with
 `v0.2.1-runtime-resilience`.
 
+Tag-driven release governance is defined in
+[docs/release-governance.md](docs/release-governance.md). Agents operating the
+release lane should use
+[docs/skills/release-operator.md](docs/skills/release-operator.md). A live beta
+promotion is not green unless it has an immutable Git tag, a GitHub prerelease,
+runtime status proof, and rollback instructions.
+
 ## Repo Profiles
 
 Use [docs/repo-profiles.md](docs/repo-profiles.md) to add repo-specific review

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -1,0 +1,156 @@
+# Release Governance Runbook
+
+This bot is a live beta agent. A live promotion is not complete until the
+source SHA is tied to an immutable Git tag, a GitHub Release, runtime evidence,
+and a rollback path.
+
+## Release Levels
+
+- `beta`: local launchd worker on the operator Mac, posting as the GitHub App
+  on the active allowlist. Beta releases are prereleases.
+- `stable`: future multi-operator or production rollout. Stable releases are
+  blocked until beta evidence proves low-noise behavior over labeled PRs.
+
+## Version Names
+
+Use semver prerelease tags for live beta promotions:
+
+```text
+v0.2.5-beta.1
+v0.2.5-beta.2
+v0.3.0-beta.1
+```
+
+Patch beta tags are for runtime/reliability fixes. Minor beta tags are for new
+reviewer behavior, policy shape, eval/capability expansion, or operator-facing
+workflow changes.
+
+## Cadence
+
+- Batch normal improvements into a daily beta promotion window when practical.
+- Ship urgent runtime safety fixes immediately as a patch beta.
+- Do not promote more than one live beta without updating the GitHub Release
+  surface.
+- Keep the launchd worker on a single promoted SHA. Do not describe rolling
+  `main` as a release.
+
+## Pre-Release Gate
+
+Before tagging:
+
+1. The implementation PR is merged to `main`.
+2. Required GitHub checks are green or the PR records a justified admin merge.
+3. Current-head review threads are resolved or explicitly non-actionable.
+4. Local focused validation named in the PR has passed.
+5. `docs/releases/<version>.md` exists and names:
+   - source SHA
+   - issue and PR links
+   - validation commands
+   - live config path
+   - rollback command
+   - known provider cooldown or runtime caveats
+6. `git status --short` is clean in the live checkout.
+
+## Tag And Release
+
+Create an annotated tag from the merged source SHA:
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin main --tags
+git checkout main
+git pull --ff-only origin main
+git tag -a vX.Y.Z-beta.N <source-sha> -m "vX.Y.Z-beta.N"
+git push origin vX.Y.Z-beta.N
+```
+
+Create the GitHub prerelease from the release packet:
+
+```bash
+gh release create vX.Y.Z-beta.N \
+  --repo electricsheephq/evaos-code-review-bot \
+  --title "vX.Y.Z-beta.N" \
+  --notes-file docs/releases/vX.Y.Z-beta.N.md \
+  --prerelease \
+  --target <source-sha>
+```
+
+If the release packet uses an internal filename such as
+`v0.2.5-restart-lease-hygiene.md`, either copy it to the exact tag filename or
+pass that file as `--notes-file` and include the tag name at the top.
+
+## Promote Live
+
+After the GitHub Release exists:
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin main --tags
+git checkout main
+git pull --ff-only origin main
+test "$(git rev-parse HEAD)" = "<source-sha>"
+launchctl bootout gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) /Users/lume/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+```
+
+## Post-Release Gate
+
+Run the status gate with App credentials set in the shell:
+
+```bash
+export EVAOS_REVIEW_BOT_APP_ID=4184532
+export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH=/Volumes/LEXAR/Codex/evaos-code-review-bot/secrets/evaos-code-review-bot.private-key.pem
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head <source-sha> \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+Also run:
+
+```bash
+npx tsx src/cli.ts coverage-audit \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+npx tsx src/cli.ts provider-cooldowns \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expired-only true
+```
+
+The release is green only when:
+
+- expected head matches the release tag target SHA
+- live checkout is clean
+- launchd is running with the active live config
+- daemon heartbeat is fresh
+- no blocking DB error rows exist
+- coverage audit has zero unprocessed eligible heads
+- provider cooldowns are either absent or active and named in release notes
+
+Expired provider cooldown rows are backlog. Retry or retire stale/closed heads
+before calling the release green.
+
+## Rollback
+
+Rollback is tag-first:
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard <previous-release-tag>
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+Record the rollback in the GitHub Release, the tracker issue, and any active
+incident issue.
+
+## Backfill Required
+
+Because early beta releases were promoted without tags, create a backfill issue
+for the current live SHA. The backfill must create the first prerelease tag and
+GitHub Release without rewriting history.

--- a/docs/skills/release-operator.md
+++ b/docs/skills/release-operator.md
@@ -1,0 +1,77 @@
+# evaOS Code Review Bot Release Operator Skill
+
+Use this skill when promoting, rolling back, auditing, or documenting a live
+beta release of `electricsheephq/evaos-code-review-bot`.
+
+## Operating Rule
+
+Do not call a live promotion complete unless it has:
+
+- a semver beta Git tag
+- a GitHub prerelease
+- a named source SHA
+- validation evidence
+- post-promotion `release:status`
+- rollback instructions
+
+If an emergency requires promoting before the tag/release layer, record the
+exception in the tracker issue and open a backfill issue before ending.
+
+## Default Release Flow
+
+1. Confirm the implementation PR is merged and checks are green.
+2. Sync the live checkout:
+   `git fetch origin main --tags && git checkout main && git pull --ff-only origin main`.
+3. Create or verify `docs/releases/<tag>.md`.
+4. Create an annotated tag at the merged SHA.
+5. Push the tag.
+6. Create a GitHub prerelease with the release packet as notes.
+7. Restart launchd.
+8. Run `release:status`, `coverage-audit`, and expired provider cooldown audit.
+9. Update the tracker issue and PR/release notes with the status result.
+
+## Required Commands
+
+```bash
+export EVAOS_REVIEW_BOT_APP_ID=4184532
+export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH=/Volumes/LEXAR/Codex/evaos-code-review-bot/secrets/evaos-code-review-bot.private-key.pem
+
+git fetch origin main --tags
+git checkout main
+git pull --ff-only origin main
+git tag -a <tag> <source-sha> -m "<tag>"
+git push origin <tag>
+gh release create <tag> \
+  --repo electricsheephq/evaos-code-review-bot \
+  --title "<tag>" \
+  --notes-file docs/releases/<tag>.md \
+  --prerelease \
+  --target <source-sha>
+
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head <source-sha> \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+## Failure Handling
+
+- If GitHub checks are pending, wait or set a short follow-up monitor.
+- If CodeRabbit or Codex posts actionable review, fix or explicitly reject it
+  before merge.
+- If launchd is stopped, restart and prove heartbeat.
+- If expired provider cooldown rows exist, run `retry-provider-cooldowns`.
+- If coverage audit reports unprocessed heads, do not call the release green.
+- If the provider is degraded but all affected heads are active deferrals,
+  call the release yellow and name the follow-up time.
+
+## Confidence Claim
+
+Use these words exactly:
+
+- `green`: tag/release exists, live status passes, coverage clean.
+- `yellow`: tag/release exists, daemon healthy, only active provider deferrals
+  or external provider degradation remain.
+- `red`: missing tag/release, stopped daemon, stale heartbeat, expired provider
+  backlog, unprocessed eligible heads, or blocking DB errors.


### PR DESCRIPTION
Closes #70.\n\n## Summary\n- adds a tag-driven release governance runbook for live beta promotions\n- adds a reusable release-operator skill artifact for agent/operator handoff\n- updates README to make tags, GitHub prereleases, runtime proof, and rollback instructions mandatory for green release claims\n\n## Follow-up\n- #71 tracks the first backfilled GitHub beta release tag for the current live agent SHA.\n\n## Validation\n- `git diff --check` -> passed\n- docs-only change; no runtime code changed\n