### PR TITLE
Complete eval suite packet harness

### DIFF
--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -16,6 +16,10 @@ npm run eval:suite -- \
   --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/local-suite
 ```
 
+The suite command exits non-zero when any scenario fails, when two scenarios use
+the same `runId`, when a `runId` is not a safe path segment, or when any required
+suite is missing from the input directory.
+
 By default, packets are written under:
 
 ```text

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -8,6 +8,14 @@ Run it with a local scenario file:
 npm run eval:offline -- --input /path/to/scenario.json
 ```
 
+Run the checked-in local suite fixtures:
+
+```bash
+npm run eval:suite -- \
+  --input-dir tests/fixtures/eval-suite-scenarios \
+  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/local-suite
+```
+
 By default, packets are written under:
 
 ```text
@@ -26,8 +34,41 @@ Use `--output-dir` for tests or scratch runs.
   "pullNumber": 1234,
   "headSha": "abc123",
   "suite": "seeded_defect_recall",
+  "mode": "gating",
+  "scenarioSource": {
+    "path": "tests/fixtures/eval-suite-scenarios/seeded_defect_recall.json",
+    "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
   "rawOutput": { "findings": [] },
   "botFindings": { "findings": [] },
+  "inlinePreviews": [
+    {
+      "path": "Assets/Scripts/CombatTurn.cs",
+      "line": 26,
+      "side": "RIGHT",
+      "severity": "P1",
+      "title": "Inline preview title",
+      "body": "Redacted comment body preview."
+    }
+  ],
+  "ciMetadata": [
+    {
+      "provider": "github-actions",
+      "name": "test",
+      "status": "failure",
+      "conclusion": "Relevant check summary",
+      "url": "https://github.com/org/repo/actions/runs/1"
+    }
+  ],
+  "mergedFixes": [
+    {
+      "repo": "electricsheephq/WorldOS",
+      "pullNumber": 1205,
+      "mergeSha": "abc123",
+      "path": "Assets/Scripts/CombatTurn.cs",
+      "summary": "Fix diff used as historical label evidence."
+    }
+  ],
   "labels": [
     {
       "source": "seeded_defect",
@@ -35,7 +76,13 @@ Use `--output-dir` for tests or scratch runs.
       "path": "Assets/Scripts/CombatTurn.cs",
       "line": 26,
       "title": "Combat health reset breaks active fights",
-      "body": "Expected issue description."
+      "body": "Expected issue description.",
+      "sourceId": "seed-combat-health-reset",
+      "sourceUrl": "https://github.com/org/repo/pull/123#discussion_r1",
+      "author": "coderabbitai",
+      "checkName": "test",
+      "mergeSha": "abc123",
+      "diffSummary": "Human-readable merged-fix evidence."
     }
   ],
   "thresholds": {
@@ -66,6 +113,10 @@ Supported label sources:
 
 Negative controls use an empty `labels` array. The run passes only when the bot also emits no findings, unless thresholds are intentionally loosened for exploratory scoring.
 
+`mode` defaults to `gating`. Gating scenarios may tighten thresholds, but cannot
+silently loosen below the harness defaults. Use `mode: "exploratory"` for scout
+or negative-control runs that intentionally set lower precision/recall gates.
+
 ## Packet Contents
 
 Each packet includes:
@@ -73,6 +124,9 @@ Each packet includes:
 - `manifest.json`
 - `raw-output.json`
 - `normalized-findings.json`
+- `inline-previews.json`
+- `ci-metadata.json`
+- `merged-fixes.json`
 - `redaction-report.json`
 - `duplicate-report.json`
 - `comparison.csv`
@@ -81,3 +135,8 @@ Each packet includes:
 - `scorecard.json`
 
 `scorecard.json` is the gate artifact. Thresholds are explicit and fail closed. The calibration report is intentionally marked `uncalibrated`; do not present public 95% confidence claims from these packets until enough labeled findings exist for measured reliability bins.
+
+`manifest.json` records the effective thresholds, scenario mode, optional
+scenario source, artifact inventory with SHA-256 digests, metadata counts, and
+the proof boundary. The harness rejects output directories inside the active git
+checkout so eval packets do not mutate the repo being evaluated.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "vitest",
     "doctor": "tsx src/cli.ts doctor",
     "eval:offline": "tsx src/cli.ts eval-offline",
+    "eval:suite": "tsx src/cli.ts eval-suite",
     "release:status": "tsx src/cli.ts release-status",
     "run-once": "tsx src/cli.ts run-once",
     "daemon": "tsx src/cli.ts daemon"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
 import { runDaemonCycle } from "./daemon.js";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { runOfflineEval } from "./eval-harness.js";
+import { REQUIRED_SUITES, runOfflineEval } from "./eval-harness.js";
 import { GitHubApi } from "./github.js";
 import { collectReleaseStatus } from "./release-status.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
@@ -140,10 +140,12 @@ async function main(): Promise<void> {
       }
     });
     const suites = [...new Set(results.flatMap((result) => "scorecard" in result ? [result.scorecard.suite] : []))].sort();
+    const missingSuites = REQUIRED_SUITES.filter((suite) => !suites.includes(suite));
     const summary = {
-      ok: results.every((result) => result.ok),
+      ok: results.every((result) => result.ok) && missingSuites.length === 0,
       scenarioCount: results.length,
       suites,
+      missingSuites,
       results
     };
     console.log(JSON.stringify(summary, null, 2));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,17 +116,30 @@ async function main(): Promise<void> {
     if (!args["input-dir"]) throw new Error("--input-dir is required for eval-suite");
     if (!args["output-root"]) throw new Error("--output-root is required for eval-suite");
     const scenarioFiles = listJsonFiles(args["input-dir"]);
+    const seenRunIds = new Map<string, string>();
     const results = scenarioFiles.map((scenarioPath) => {
-      const input = JSON.parse(readFileSync(scenarioPath, "utf8"));
-      input.scenarioSource = input.scenarioSource ?? { path: scenarioPath };
-      return {
-        scenarioPath,
-        ...runOfflineEval(input, {
-          outputDir: join(args["output-root"]!, input.runId)
-        })
-      };
+      try {
+        const input = JSON.parse(readFileSync(scenarioPath, "utf8"));
+        const runId = validateScenarioRunId(input, scenarioPath);
+        const duplicatePath = seenRunIds.get(runId);
+        if (duplicatePath) throw new Error(`duplicate runId "${runId}" already used by ${duplicatePath}`);
+        seenRunIds.set(runId, scenarioPath);
+        input.scenarioSource = input.scenarioSource ?? { path: scenarioPath };
+        return {
+          scenarioPath,
+          ...runOfflineEval(input, {
+            outputDir: join(args["output-root"]!, runId)
+          })
+        };
+      } catch (error) {
+        return {
+          scenarioPath,
+          ok: false,
+          error: error instanceof Error ? error.message : String(error)
+        };
+      }
     });
-    const suites = [...new Set(results.map((result) => result.scorecard.suite))].sort();
+    const suites = [...new Set(results.flatMap((result) => "scorecard" in result ? [result.scorecard.suite] : []))].sort();
     const summary = {
       ok: results.every((result) => result.ok),
       scenarioCount: results.length,
@@ -287,6 +300,21 @@ function listJsonFiles(inputDir: string): string[] {
     .map((entry) => join(inputDir, entry))
     .filter((path) => statSync(path).isFile() && path.endsWith(".json"))
     .sort();
+}
+
+function validateScenarioRunId(input: unknown, scenarioPath: string): string {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error(`${scenarioPath}: scenario must be a JSON object`);
+  }
+  const runId = (input as { runId?: unknown }).runId;
+  if (typeof runId !== "string" || runId.trim().length === 0) {
+    throw new Error(`${scenarioPath}: runId must be a non-empty string`);
+  }
+  const trimmed = runId.trim();
+  if (!/^[A-Za-z0-9._-]+$/.test(trimmed) || trimmed === "." || trimmed === "..") {
+    throw new Error(`${scenarioPath}: runId must be a safe path segment`);
+  }
+  return trimmed;
 }
 
 interface ParsedArgs {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,8 @@
 import { loadConfig } from "./config.js";
 import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
 import { runDaemonCycle } from "./daemon.js";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 import { runOfflineEval } from "./eval-harness.js";
 import { GitHubApi } from "./github.js";
 import { collectReleaseStatus } from "./release-status.js";
@@ -108,6 +109,32 @@ async function main(): Promise<void> {
     });
     console.log(JSON.stringify(result, null, 2));
     if (!result.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "eval-suite") {
+    if (!args["input-dir"]) throw new Error("--input-dir is required for eval-suite");
+    if (!args["output-root"]) throw new Error("--output-root is required for eval-suite");
+    const scenarioFiles = listJsonFiles(args["input-dir"]);
+    const results = scenarioFiles.map((scenarioPath) => {
+      const input = JSON.parse(readFileSync(scenarioPath, "utf8"));
+      input.scenarioSource = input.scenarioSource ?? { path: scenarioPath };
+      return {
+        scenarioPath,
+        ...runOfflineEval(input, {
+          outputDir: join(args["output-root"]!, input.runId)
+        })
+      };
+    });
+    const suites = [...new Set(results.map((result) => result.scorecard.suite))].sort();
+    const summary = {
+      ok: results.every((result) => result.ok),
+      scenarioCount: results.length,
+      suites,
+      results
+    };
+    console.log(JSON.stringify(summary, null, 2));
+    if (!summary.ok) process.exitCode = 1;
     return;
   }
 
@@ -255,6 +282,13 @@ function parsePositiveInteger(value: string, label: string): number {
   return parsed;
 }
 
+function listJsonFiles(inputDir: string): string[] {
+  return readdirSync(inputDir)
+    .map((entry) => join(inputDir, entry))
+    .filter((path) => statSync(path).isFile() && path.endsWith(".json"))
+    .sort();
+}
+
 interface ParsedArgs {
   _: string[];
   config?: string;
@@ -268,7 +302,9 @@ interface ParsedArgs {
   "expired-only"?: string;
   "head-sha"?: string;
   input?: string;
+  "input-dir"?: string;
   "output-dir"?: string;
+  "output-root"?: string;
   limit?: string;
   zcode?: string;
   [key: string]: string | string[] | undefined;

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -152,7 +152,7 @@ const DEFAULT_THRESHOLDS: EvalThresholds = {
   maxDuplicateFindings: 0
 };
 
-const REQUIRED_SUITES: EvalSuiteName[] = [
+export const REQUIRED_SUITES: EvalSuiteName[] = [
   "canary_shadow",
   "historical_pr_replay",
   "seeded_defect_recall",

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -1,5 +1,6 @@
-import { mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { parseFindings } from "./findings.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 import type { Finding, Severity } from "./types.js";
@@ -20,8 +21,13 @@ export interface EvalScenarioInput {
   pullNumber: number;
   headSha: string;
   suite: EvalSuiteName;
+  mode?: "gating" | "exploratory";
+  scenarioSource?: EvalScenarioSourceInput;
   rawOutput?: unknown;
   botFindings: unknown;
+  inlinePreviews?: EvalInlinePreviewInput[];
+  ciMetadata?: EvalCiMetadataInput[];
+  mergedFixes?: EvalMergedFixInput[];
   labels: EvalLabelInput[];
   thresholds?: Partial<EvalThresholds>;
 }
@@ -33,7 +39,45 @@ export interface EvalLabelInput {
   line: number;
   title: string;
   body: string;
+  sourceId?: string;
+  sourceUrl?: string;
+  author?: string;
+  checkName?: string;
+  mergeSha?: string;
+  diffSummary?: string;
   expected?: boolean;
+}
+
+export interface EvalScenarioSourceInput {
+  path: string;
+  sha256?: string;
+}
+
+export interface EvalInlinePreviewInput {
+  path: string;
+  line: number;
+  side?: "RIGHT" | "LEFT";
+  severity?: Severity;
+  title: string;
+  body: string;
+  confidence?: number;
+}
+
+export interface EvalCiMetadataInput {
+  provider: string;
+  name: string;
+  status: "success" | "failure" | "neutral" | "cancelled" | "skipped" | "timed_out" | "action_required" | "pending";
+  conclusion?: string;
+  url?: string;
+  summary?: string;
+}
+
+export interface EvalMergedFixInput {
+  repo: string;
+  pullNumber: number;
+  mergeSha: string;
+  path?: string;
+  summary: string;
 }
 
 export interface EvalThresholds {
@@ -75,6 +119,9 @@ export interface EvalScorecard {
     droppedFromSchema: number;
     secretFindings: number;
     duplicateFindings: number;
+    inlinePreviews: number;
+    ciMetadata: number;
+    mergedFixes: number;
   };
   metrics: {
     precision: number;
@@ -88,6 +135,7 @@ export interface EvalScorecard {
 interface NormalizedEvalFinding extends Finding {
   id: string;
   source: "bot" | EvalLabelSource;
+  evidence?: Record<string, string>;
 }
 
 interface EvalMatch {
@@ -116,9 +164,11 @@ export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions
   validateEvalInput(input);
   const thresholds = { ...DEFAULT_THRESHOLDS, ...(input.thresholds ?? {}) };
   validateThresholds(thresholds);
+  validateThresholdPolicy(input.mode ?? "gating", input.thresholds ?? {});
 
   const evalName = input.evalName ?? "evaos-zcode-review-bot-comparison-v0.1";
   const outputDir = options.outputDir ?? defaultEvalOutputDir(input, options.now ?? new Date());
+  guardOutputDir(outputDir);
   mkdirSync(outputDir, { recursive: true });
 
   const parsedBot = parseFindings(input.botFindings);
@@ -126,6 +176,9 @@ export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions
   const labels = input.labels
     .filter((label) => label.expected !== false)
     .map((label, index) => normalizeFinding(label, label.source, `label-${index + 1}`));
+  const inlinePreviews = buildInlinePreviews(input.inlinePreviews, botFindings);
+  const ciMetadata = normalizeCiMetadata(input.ciMetadata ?? []);
+  const mergedFixes = normalizeMergedFixes(input.mergedFixes ?? []);
   const matches = matchFindings(botFindings, labels);
   const duplicateReport = findDuplicateFindings(botFindings);
   const redactionReport = buildRedactionReport(input, parsedBot.findings, input.labels, parsedBot.dropped.length);
@@ -138,6 +191,9 @@ export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions
     duplicateCount: duplicateReport.duplicates.length,
     secretCount: redactionReport.secretLikeItems.length,
     droppedFromSchema: parsedBot.dropped.length,
+    inlinePreviewCount: inlinePreviews.length,
+    ciMetadataCount: ciMetadata.length,
+    mergedFixCount: mergedFixes.length,
     thresholds
   });
 
@@ -145,6 +201,9 @@ export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions
     "manifest.json": join(outputDir, "manifest.json"),
     "raw-output.json": join(outputDir, "raw-output.json"),
     "normalized-findings.json": join(outputDir, "normalized-findings.json"),
+    "inline-previews.json": join(outputDir, "inline-previews.json"),
+    "ci-metadata.json": join(outputDir, "ci-metadata.json"),
+    "merged-fixes.json": join(outputDir, "merged-fixes.json"),
     "redaction-report.json": join(outputDir, "redaction-report.json"),
     "duplicate-report.json": join(outputDir, "duplicate-report.json"),
     "comparison.csv": join(outputDir, "comparison.csv"),
@@ -153,28 +212,44 @@ export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions
     "scorecard.json": join(outputDir, "scorecard.json")
   };
 
-  writeJson(artifacts["manifest.json"]!, {
-    evalName,
-    runId: input.runId,
-    suite: input.suite,
-    requiredSuites: REQUIRED_SUITES,
-    repo: input.repo,
-    pullNumber: input.pullNumber,
-    headSha: input.headSha,
-    generatedAt: (options.now ?? new Date()).toISOString(),
-    proofBoundary: "offline comparison packet only; no GitHub posting or repo mutation"
-  });
   writeJson(artifacts["raw-output.json"]!, redactUnknown(input.rawOutput ?? input.botFindings));
   writeJson(artifacts["normalized-findings.json"]!, {
     botFindings,
     droppedFromSchema: parsedBot.dropped.map(redactUnknown)
   });
+  writeJson(artifacts["inline-previews.json"]!, inlinePreviews);
+  writeJson(artifacts["ci-metadata.json"]!, ciMetadata);
+  writeJson(artifacts["merged-fixes.json"]!, mergedFixes);
   writeJson(artifacts["redaction-report.json"]!, redactionReport);
   writeJson(artifacts["duplicate-report.json"]!, duplicateReport);
   writeFileSync(artifacts["comparison.csv"]!, buildComparisonCsv(botFindings, labels, matches));
   writeJson(artifacts["labels.json"]!, labels);
   writeJson(artifacts["calibration-report.json"]!, buildCalibrationReport(botFindings, matches));
   writeJson(artifacts["scorecard.json"]!, scorecard);
+  writeJson(artifacts["manifest.json"]!, {
+    evalName,
+    artifactVersion: "0.2",
+    runId: input.runId,
+    suite: input.suite,
+    mode: input.mode ?? "gating",
+    requiredSuites: REQUIRED_SUITES,
+    repo: input.repo,
+    pullNumber: input.pullNumber,
+    headSha: input.headSha,
+    scenarioSource: input.scenarioSource ? redactUnknown(input.scenarioSource) : undefined,
+    negativeControl: labels.length === 0,
+    thresholds,
+    artifactInventory: Object.entries(artifacts)
+      .filter(([name]) => name !== "manifest.json")
+      .map(([name, path]) => ({ name, sha256: sha256File(path) })),
+    metadataCounts: {
+      inlinePreviews: inlinePreviews.length,
+      ciMetadata: ciMetadata.length,
+      mergedFixes: mergedFixes.length
+    },
+    generatedAt: (options.now ?? new Date()).toISOString(),
+    proofBoundary: "offline comparison packet only; no GitHub posting or repo mutation"
+  });
 
   return {
     ok: scorecard.gates.every((gate) => gate.ok),
@@ -193,6 +268,9 @@ function buildScorecard(input: {
   duplicateCount: number;
   secretCount: number;
   droppedFromSchema: number;
+  inlinePreviewCount: number;
+  ciMetadataCount: number;
+  mergedFixCount: number;
   thresholds: EvalThresholds;
 }): EvalScorecard {
   const matchedBotIds = new Set(input.matches.map((match) => match.botFindingId));
@@ -208,6 +286,13 @@ function buildScorecard(input: {
   const exactLineMatches = input.matches.filter((match) => match.kind === "exact_line").length;
   const nearbyLineMatches = input.matches.filter((match) => match.kind === "nearby_line").length;
   const semanticMatches = input.matches.filter((match) => match.kind === "semantic").length;
+  const suiteGate = evaluateSuiteRequirements({
+    suite: input.input.suite,
+    labels: input.labels,
+    thresholds: input.thresholds,
+    ciMetadataCount: input.ciMetadataCount,
+    mergedFixCount: input.mergedFixCount
+  });
 
   return {
     evalName: input.evalName,
@@ -227,7 +312,10 @@ function buildScorecard(input: {
       semanticMatches,
       droppedFromSchema: input.droppedFromSchema,
       secretFindings: input.secretCount,
-      duplicateFindings: input.duplicateCount
+      duplicateFindings: input.duplicateCount,
+      inlinePreviews: input.inlinePreviewCount,
+      ciMetadata: input.ciMetadataCount,
+      mergedFixes: input.mergedFixCount
     },
     metrics: {
       precision: roundMetric(precision),
@@ -265,9 +353,51 @@ function buildScorecard(input: {
         name: "duplicate_suppression",
         ok: input.duplicateCount <= input.thresholds.maxDuplicateFindings,
         detail: `${input.duplicateCount} <= ${input.thresholds.maxDuplicateFindings}`
+      },
+      {
+        name: "suite_requirements",
+        ok: suiteGate.ok,
+        detail: suiteGate.detail
       }
     ]
   };
+}
+
+function evaluateSuiteRequirements(input: {
+  suite: EvalSuiteName;
+  labels: NormalizedEvalFinding[];
+  thresholds: EvalThresholds;
+  ciMetadataCount: number;
+  mergedFixCount: number;
+}): { ok: boolean; detail: string } {
+  if (input.suite === "seeded_defect_recall") {
+    const seeded = input.labels.filter((label) => label.source === "seeded_defect").length;
+    return {
+      ok: seeded > 0,
+      detail: `${seeded} seeded_defect label(s)`
+    };
+  }
+  if (input.suite === "historical_pr_replay") {
+    const comparisonLabels = input.labels.filter((label) => label.source !== "seeded_defect").length;
+    const evidenceItems = comparisonLabels + input.ciMetadataCount + input.mergedFixCount;
+    return {
+      ok: comparisonLabels > 0 && evidenceItems > 0,
+      detail: `${comparisonLabels} comparison label(s), ${input.ciMetadataCount} CI item(s), ${input.mergedFixCount} merged-fix item(s)`
+    };
+  }
+  if (input.suite === "safety_redaction") {
+    return {
+      ok: input.thresholds.maxSecretFindings === 0,
+      detail: `maxSecretFindings=${input.thresholds.maxSecretFindings}`
+    };
+  }
+  if (input.suite === "duplicate_suppression") {
+    return {
+      ok: input.thresholds.maxDuplicateFindings === 0,
+      detail: `maxDuplicateFindings=${input.thresholds.maxDuplicateFindings}`
+    };
+  }
+  return { ok: true, detail: "canary shadow suite has no extra fixture requirement" };
 }
 
 function matchFindings(botFindings: NormalizedEvalFinding[], labels: NormalizedEvalFinding[]): EvalMatch[] {
@@ -306,6 +436,7 @@ function matchFindings(botFindings: NormalizedEvalFinding[], labels: NormalizedE
 }
 
 function classifyMatch(botFinding: NormalizedEvalFinding, label: NormalizedEvalFinding): EvalMatch["kind"] | undefined {
+  if (botFinding.severity !== label.severity) return undefined;
   const overlap = tokenOverlap(botFinding, label);
   if (botFinding.line === label.line && overlap >= 0.25) return "exact_line";
   if (Math.abs(botFinding.line - label.line) <= 3 && overlap >= 0.35) return "nearby_line";
@@ -347,6 +478,24 @@ function findDuplicateFindings(findings: NormalizedEvalFinding[]): {
     if (originalId) duplicates.push({ duplicateId: finding.id, originalId, key });
     else seen.set(key, finding.id);
   }
+  const duplicateIds = new Set(duplicates.map((duplicate) => duplicate.duplicateId));
+  for (let index = 0; index < findings.length; index += 1) {
+    const finding = findings[index]!;
+    if (duplicateIds.has(finding.id)) continue;
+    for (const prior of findings.slice(0, index)) {
+      if (finding.path !== prior.path || finding.severity !== prior.severity) continue;
+      if (finding.line === prior.line) continue;
+      if (Math.abs(finding.line - prior.line) > 3) continue;
+      if (tokenOverlap(finding, prior) < 0.55) continue;
+      duplicateIds.add(finding.id);
+      duplicates.push({
+        duplicateId: finding.id,
+        originalId: prior.id,
+        key: `${finding.path}:${prior.line}-${finding.line}:${finding.severity}:nearby_semantic`
+      });
+      break;
+    }
+  }
   return { duplicates };
 }
 
@@ -381,6 +530,19 @@ function buildRedactionReport(
       source: "raw",
       field: input.rawOutput !== undefined ? "rawOutput" : "botFindings"
     });
+  }
+  for (const [source, value] of [
+    ["inlinePreviews", input.inlinePreviews ?? []],
+    ["ciMetadata", input.ciMetadata ?? []],
+    ["mergedFixes", input.mergedFixes ?? []]
+  ] as const) {
+    if (containsSecretLikeText(JSON.stringify(value))) {
+      secretLikeItems.push({
+        id: source,
+        source: "metadata",
+        field: source
+      });
+    }
   }
   return { droppedFromSchema, secretLikeItems };
 }
@@ -451,6 +613,51 @@ function buildCalibrationReport(botFindings: NormalizedEvalFinding[], matches: E
   };
 }
 
+function buildInlinePreviews(
+  inputPreviews: EvalInlinePreviewInput[] | undefined,
+  botFindings: NormalizedEvalFinding[]
+): EvalInlinePreviewInput[] {
+  const previews = inputPreviews ?? botFindings.map((finding) => ({
+    path: finding.path,
+    line: finding.line,
+    side: "RIGHT" as const,
+    severity: finding.severity,
+    title: finding.title,
+    body: finding.body,
+    confidence: finding.confidence
+  }));
+  return previews.map((preview) => ({
+    path: preview.path,
+    line: preview.line,
+    side: preview.side ?? "RIGHT",
+    severity: preview.severity,
+    title: redactSecrets(preview.title.trim()),
+    body: redactSecrets(preview.body.trim()),
+    ...(typeof preview.confidence === "number" ? { confidence: preview.confidence } : {})
+  }));
+}
+
+function normalizeCiMetadata(items: EvalCiMetadataInput[]): EvalCiMetadataInput[] {
+  return items.map((item) => ({
+    provider: redactSecrets(item.provider.trim()),
+    name: redactSecrets(item.name.trim()),
+    status: item.status,
+    ...(item.conclusion ? { conclusion: redactSecrets(item.conclusion.trim()) } : {}),
+    ...(item.url ? { url: redactSecrets(item.url.trim()) } : {}),
+    ...(item.summary ? { summary: redactSecrets(item.summary.trim()) } : {})
+  }));
+}
+
+function normalizeMergedFixes(items: EvalMergedFixInput[]): EvalMergedFixInput[] {
+  return items.map((item) => ({
+    repo: item.repo.trim(),
+    pullNumber: item.pullNumber,
+    mergeSha: item.mergeSha.trim(),
+    ...(item.path ? { path: item.path.trim() } : {}),
+    summary: redactSecrets(item.summary.trim())
+  }));
+}
+
 function normalizeFinding(
   finding: Finding | EvalLabelInput,
   source: "bot" | EvalLabelSource,
@@ -460,6 +667,7 @@ function normalizeFinding(
     "why_this_matters" in finding && typeof finding.why_this_matters === "string"
       ? finding.why_this_matters
       : undefined;
+  const evidence = buildLabelEvidence(finding);
   return {
     id,
     source,
@@ -469,8 +677,20 @@ function normalizeFinding(
     title: redactSecrets(finding.title.trim()),
     body: redactSecrets(finding.body.trim()),
     confidence: "confidence" in finding && typeof finding.confidence === "number" ? finding.confidence : 1,
-    ...(whyThisMatters ? { why_this_matters: redactSecrets(whyThisMatters.trim()) } : {})
+    ...(whyThisMatters ? { why_this_matters: redactSecrets(whyThisMatters.trim()) } : {}),
+    ...(evidence ? { evidence } : {})
   };
+}
+
+function buildLabelEvidence(finding: Finding | EvalLabelInput): Record<string, string> | undefined {
+  const evidence: Record<string, string> = {};
+  const candidate = finding as unknown as Record<string, unknown>;
+  for (const field of ["sourceId", "sourceUrl", "author", "checkName", "mergeSha", "diffSummary"] as const) {
+    if (typeof candidate[field] === "string" && candidate[field].trim().length > 0) {
+      evidence[field] = redactSecrets(candidate[field].trim());
+    }
+  }
+  return Object.keys(evidence).length > 0 ? evidence : undefined;
 }
 
 function defaultEvalOutputDir(input: Pick<EvalScenarioInput, "runId">, now: Date): string {
@@ -486,6 +706,34 @@ function sanitizePathSegment(value: string): string {
 
 function writeJson(path: string, value: unknown): void {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function sha256File(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function guardOutputDir(outputDir: string): void {
+  const resolvedOutput = resolve(outputDir);
+  const gitRoot = findGitRoot(process.cwd());
+  if (!gitRoot) return;
+  const relation = relative(gitRoot, resolvedOutput);
+  if (relation === "" || (!relation.startsWith("..") && !isAbsolute(relation))) {
+    throw new Error("outputDir must not be inside the current git checkout; write eval packets under /Volumes/LEXAR/Codex/evals or a temp directory");
+  }
+}
+
+function findGitRoot(start: string): string | undefined {
+  let cursor = resolve(start);
+  for (;;) {
+    const gitPath = join(cursor, ".git");
+    if (existsSync(gitPath)) {
+      const stat = statSync(gitPath);
+      if (stat.isDirectory() || stat.isFile()) return cursor;
+    }
+    const parent = dirname(cursor);
+    if (parent === cursor) return undefined;
+    cursor = parent;
+  }
 }
 
 function redactUnknown(value: unknown): unknown {
@@ -514,8 +762,16 @@ function validateEvalInput(input: EvalScenarioInput): void {
   if (!REQUIRED_SUITES.includes(input.suite)) throw new Error(`suite must be one of ${REQUIRED_SUITES.join(", ")}`);
   if (!("botFindings" in input)) throw new Error("botFindings is required");
   if (!isFindingEnvelope(input.botFindings)) throw new Error("botFindings must be an array or an object with a findings array");
+  if (input.mode !== undefined && !["gating", "exploratory"].includes(input.mode)) throw new Error("mode must be gating or exploratory");
+  if (input.scenarioSource !== undefined) validateScenarioSource(input.scenarioSource);
   if (!Array.isArray(input.labels)) throw new Error("labels must be an array");
+  if (input.inlinePreviews !== undefined && !Array.isArray(input.inlinePreviews)) throw new Error("inlinePreviews must be an array");
+  if (input.ciMetadata !== undefined && !Array.isArray(input.ciMetadata)) throw new Error("ciMetadata must be an array");
+  if (input.mergedFixes !== undefined && !Array.isArray(input.mergedFixes)) throw new Error("mergedFixes must be an array");
   for (const [index, label] of input.labels.entries()) validateLabel(label, `labels[${index}]`);
+  for (const [index, preview] of (input.inlinePreviews ?? []).entries()) validateInlinePreview(preview, `inlinePreviews[${index}]`);
+  for (const [index, item] of (input.ciMetadata ?? []).entries()) validateCiMetadata(item, `ciMetadata[${index}]`);
+  for (const [index, item] of (input.mergedFixes ?? []).entries()) validateMergedFix(item, `mergedFixes[${index}]`);
 }
 
 function isFindingEnvelope(value: unknown): boolean {
@@ -536,6 +792,47 @@ function validateLabel(label: EvalLabelInput, labelPath: string): void {
   validateNonEmpty(label.title, `${labelPath}.title`);
   validateNonEmpty(label.body, `${labelPath}.body`);
   if (!Number.isInteger(label.line) || label.line <= 0) throw new Error(`${labelPath}.line must be a positive integer`);
+  for (const field of ["sourceId", "sourceUrl", "author", "checkName", "mergeSha", "diffSummary"] as const) {
+    if (label[field] !== undefined && typeof label[field] !== "string") throw new Error(`${labelPath}.${field} must be a string`);
+  }
+}
+
+function validateScenarioSource(source: EvalScenarioSourceInput): void {
+  validateNonEmpty(source.path, "scenarioSource.path");
+  if (source.sha256 !== undefined && !/^[a-f0-9]{64}$/i.test(source.sha256)) throw new Error("scenarioSource.sha256 must be a sha256 hex digest");
+}
+
+function validateInlinePreview(preview: EvalInlinePreviewInput, labelPath: string): void {
+  validateNonEmpty(preview.path, `${labelPath}.path`);
+  validateNonEmpty(preview.title, `${labelPath}.title`);
+  validateNonEmpty(preview.body, `${labelPath}.body`);
+  if (!Number.isInteger(preview.line) || preview.line <= 0) throw new Error(`${labelPath}.line must be a positive integer`);
+  if (preview.side !== undefined && !["RIGHT", "LEFT"].includes(preview.side)) throw new Error(`${labelPath}.side is invalid`);
+  if (preview.severity !== undefined && !["P0", "P1", "P2", "P3"].includes(preview.severity)) {
+    throw new Error(`${labelPath}.severity is invalid`);
+  }
+  if (preview.confidence !== undefined && (typeof preview.confidence !== "number" || preview.confidence < 0 || preview.confidence > 1)) {
+    throw new Error(`${labelPath}.confidence must be between 0 and 1`);
+  }
+}
+
+function validateCiMetadata(item: EvalCiMetadataInput, labelPath: string): void {
+  validateNonEmpty(item.provider, `${labelPath}.provider`);
+  validateNonEmpty(item.name, `${labelPath}.name`);
+  if (!["success", "failure", "neutral", "cancelled", "skipped", "timed_out", "action_required", "pending"].includes(item.status)) {
+    throw new Error(`${labelPath}.status is invalid`);
+  }
+  for (const field of ["conclusion", "url", "summary"] as const) {
+    if (item[field] !== undefined && typeof item[field] !== "string") throw new Error(`${labelPath}.${field} must be a string`);
+  }
+}
+
+function validateMergedFix(item: EvalMergedFixInput, labelPath: string): void {
+  validateNonEmpty(item.repo, `${labelPath}.repo`);
+  validateNonEmpty(item.mergeSha, `${labelPath}.mergeSha`);
+  validateNonEmpty(item.summary, `${labelPath}.summary`);
+  if (!Number.isInteger(item.pullNumber) || item.pullNumber <= 0) throw new Error(`${labelPath}.pullNumber must be a positive integer`);
+  if (item.path !== undefined && typeof item.path !== "string") throw new Error(`${labelPath}.path must be a string`);
 }
 
 function validateThresholds(thresholds: EvalThresholds): void {
@@ -546,6 +843,20 @@ function validateThresholds(thresholds: EvalThresholds): void {
   }
   for (const key of ["maxSecretFindings", "maxDuplicateFindings"] as const) {
     if (!Number.isInteger(thresholds[key]) || thresholds[key] < 0) throw new Error(`${key} must be a non-negative integer`);
+  }
+}
+
+function validateThresholdPolicy(mode: "gating" | "exploratory", thresholds: Partial<EvalThresholds>): void {
+  if (mode === "exploratory") return;
+  for (const key of ["minPrecision", "minRecall", "minSeededRecall"] as const) {
+    if (thresholds[key] !== undefined && thresholds[key] < DEFAULT_THRESHOLDS[key]) {
+      throw new Error(`${key} below the default requires mode="exploratory"`);
+    }
+  }
+  for (const key of ["maxSecretFindings", "maxDuplicateFindings"] as const) {
+    if (thresholds[key] !== undefined && thresholds[key] > DEFAULT_THRESHOLDS[key]) {
+      throw new Error(`${key} above the default requires mode="exploratory"`);
+    }
   }
 }
 

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { parseFindings } from "./findings.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
@@ -379,10 +379,10 @@ function evaluateSuiteRequirements(input: {
   }
   if (input.suite === "historical_pr_replay") {
     const comparisonLabels = input.labels.filter((label) => label.source !== "seeded_defect").length;
-    const evidenceItems = comparisonLabels + input.ciMetadataCount + input.mergedFixCount;
+    const evidenceItems = input.ciMetadataCount + input.mergedFixCount;
     return {
       ok: comparisonLabels > 0 && evidenceItems > 0,
-      detail: `${comparisonLabels} comparison label(s), ${input.ciMetadataCount} CI item(s), ${input.mergedFixCount} merged-fix item(s)`
+      detail: `${comparisonLabels} comparison label(s), ${input.ciMetadataCount} CI evidence item(s), ${input.mergedFixCount} merged-fix evidence item(s)`
     };
   }
   if (input.suite === "safety_redaction") {
@@ -532,6 +532,7 @@ function buildRedactionReport(
     });
   }
   for (const [source, value] of [
+    ["labelEvidence", labels.map(extractLabelEvidenceForScan)],
     ["inlinePreviews", input.inlinePreviews ?? []],
     ["ciMetadata", input.ciMetadata ?? []],
     ["mergedFixes", input.mergedFixes ?? []]
@@ -650,10 +651,10 @@ function normalizeCiMetadata(items: EvalCiMetadataInput[]): EvalCiMetadataInput[
 
 function normalizeMergedFixes(items: EvalMergedFixInput[]): EvalMergedFixInput[] {
   return items.map((item) => ({
-    repo: item.repo.trim(),
+    repo: redactSecrets(item.repo.trim()),
     pullNumber: item.pullNumber,
-    mergeSha: item.mergeSha.trim(),
-    ...(item.path ? { path: item.path.trim() } : {}),
+    mergeSha: redactSecrets(item.mergeSha.trim()),
+    ...(item.path ? { path: redactSecrets(item.path.trim()) } : {}),
     summary: redactSecrets(item.summary.trim())
   }));
 }
@@ -716,10 +717,26 @@ function guardOutputDir(outputDir: string): void {
   const resolvedOutput = resolve(outputDir);
   const gitRoot = findGitRoot(process.cwd());
   if (!gitRoot) return;
-  const relation = relative(gitRoot, resolvedOutput);
+  const realOutput = resolveRealPathForPotentialOutput(resolvedOutput);
+  const realGitRoot = realpathSync(gitRoot);
+  const relation = relative(realGitRoot, realOutput);
   if (relation === "" || (!relation.startsWith("..") && !isAbsolute(relation))) {
     throw new Error("outputDir must not be inside the current git checkout; write eval packets under /Volumes/LEXAR/Codex/evals or a temp directory");
   }
+}
+
+function resolveRealPathForPotentialOutput(path: string): string {
+  const resolved = resolve(path);
+  if (existsSync(resolved)) return realpathSync(resolved);
+  const segments: string[] = [];
+  let cursor = resolved;
+  while (!existsSync(cursor)) {
+    const parent = dirname(cursor);
+    if (parent === cursor) return resolved;
+    segments.unshift(cursor.slice(parent.length + 1));
+    cursor = parent;
+  }
+  return resolve(realpathSync(cursor), ...segments);
 }
 
 function findGitRoot(start: string): string | undefined {
@@ -743,6 +760,14 @@ function redactUnknown(value: unknown): unknown {
     return Object.fromEntries(Object.entries(value).map(([key, item]) => [redactSecrets(key), redactUnknown(item)]));
   }
   return value;
+}
+
+function extractLabelEvidenceForScan(label: EvalLabelInput): Record<string, unknown> {
+  return Object.fromEntries(
+    (["sourceId", "sourceUrl", "author", "checkName", "mergeSha", "diffSummary"] as const)
+      .filter((field) => label[field] !== undefined)
+      .map((field) => [field, label[field]])
+  );
 }
 
 function csvCell(value: string): string {

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -494,6 +495,7 @@ describe("offline eval harness", () => {
       pullNumber: 9,
       headSha: "abc",
       suite: "seeded_defect_recall",
+      mode: "exploratory",
       botFindings: {
         findings: [{
           severity: "P2",
@@ -581,5 +583,122 @@ describe("offline eval harness", () => {
       labels: []
     }, { outputDir: join(process.cwd(), ".eval-output") }))
       .toThrow("outputDir must not be inside the current git checkout");
+  });
+
+  it("rejects output under a symlinked repo checkout path", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-symlink-"));
+    roots.push(root);
+    const link = join(root, "repo-link");
+    symlinkSync(process.cwd(), link, "dir");
+
+    expect(() => runOfflineEval({
+      runId: "symlink-output",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 9,
+      headSha: "abc",
+      suite: "canary_shadow",
+      botFindings: { findings: [] },
+      labels: []
+    }, { outputDir: join(link, ".eval-output") }))
+      .toThrow("outputDir must not be inside the current git checkout");
+  });
+
+  it("counts secret-like label evidence in the redaction gate", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-label-evidence-secret-"));
+    roots.push(root);
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+
+    const result = runOfflineEval({
+      runId: "label-evidence-secret",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 9,
+      headSha: "abc",
+      suite: "safety_redaction",
+      mode: "exploratory",
+      botFindings: { findings: [] },
+      labels: [{
+        source: "human",
+        severity: "P2",
+        path: "src/a.ts",
+        line: 1,
+        title: "Secret in label evidence",
+        body: "The label metadata contains a token.",
+        sourceUrl: `https://github.test/review?token=${token}`,
+        expected: false
+      }],
+      thresholds: {
+        minPrecision: 0,
+        minRecall: 0,
+        maxSecretFindings: 0
+      }
+    }, { outputDir: root });
+
+    expect(result.ok).toBe(false);
+    expect(result.scorecard.gates.find((gate) => gate.name === "secret_redaction")).toMatchObject({ ok: false });
+    expect(readFileSync(join(root, "labels.json"), "utf8")).not.toContain(token);
+  });
+
+  it("requires external evidence metadata for historical replay suite", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-historical-evidence-"));
+    roots.push(root);
+
+    const result = runOfflineEval({
+      runId: "historical-no-evidence",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 9,
+      headSha: "abc",
+      suite: "historical_pr_replay",
+      botFindings: { findings: [] },
+      labels: [{
+        source: "human",
+        severity: "P2",
+        path: "src/a.ts",
+        line: 1,
+        title: "Human comparison label",
+        body: "A comparison label without CI or merged-fix evidence."
+      }]
+    }, { outputDir: root });
+
+    expect(result.ok).toBe(false);
+    expect(result.scorecard.gates.find((gate) => gate.name === "suite_requirements")).toMatchObject({ ok: false });
+  });
+
+  it("reports duplicate runIds as structured eval-suite failures", () => {
+    const inputDir = mkdtempSync(join(tmpdir(), "evaos-eval-suite-duplicates-input-"));
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-eval-suite-duplicates-output-"));
+    roots.push(inputDir, outputRoot);
+    const scenario = {
+      runId: "duplicate-run",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 9,
+      headSha: "abc",
+      suite: "canary_shadow",
+      botFindings: { findings: [] },
+      labels: []
+    };
+    writeFileSync(join(inputDir, "a.json"), `${JSON.stringify(scenario)}\n`);
+    writeFileSync(join(inputDir, "b.json"), `${JSON.stringify(scenario)}\n`);
+
+    let output = "";
+    try {
+      execFileSync("npx", [
+        "tsx",
+        "src/cli.ts",
+        "eval-suite",
+        "--input-dir",
+        inputDir,
+        "--output-root",
+        outputRoot
+      ], { cwd: process.cwd(), encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    } catch (error) {
+      output = String((error as { stdout?: string }).stdout ?? "");
+    }
+
+    const summary = JSON.parse(output);
+    expect(summary.ok).toBe(false);
+    expect(summary.results[1]).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("duplicate runId")
+    });
   });
 });

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -701,4 +701,43 @@ describe("offline eval harness", () => {
       error: expect.stringContaining("duplicate runId")
     });
   });
+
+  it("fails eval-suite when a required suite fixture is missing", () => {
+    const inputDir = mkdtempSync(join(tmpdir(), "evaos-eval-suite-missing-input-"));
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-eval-suite-missing-output-"));
+    roots.push(inputDir, outputRoot);
+    writeFileSync(join(inputDir, "canary.json"), `${JSON.stringify({
+      runId: "canary-only",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 9,
+      headSha: "abc",
+      suite: "canary_shadow",
+      botFindings: { findings: [] },
+      labels: []
+    })}\n`);
+
+    let output = "";
+    try {
+      execFileSync("npx", [
+        "tsx",
+        "src/cli.ts",
+        "eval-suite",
+        "--input-dir",
+        inputDir,
+        "--output-root",
+        outputRoot
+      ], { cwd: process.cwd(), encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    } catch (error) {
+      output = String((error as { stdout?: string }).stdout ?? "");
+    }
+
+    const summary = JSON.parse(output);
+    expect(summary.ok).toBe(false);
+    expect(summary.missingSuites).toEqual([
+      "historical_pr_replay",
+      "seeded_defect_recall",
+      "safety_redaction",
+      "duplicate_suppression"
+    ]);
+  });
 });

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -49,7 +49,8 @@ describe("offline eval harness", () => {
           path: "Assets/Scripts/CombatTurn.cs",
           line: 26,
           title: "Combat health reset breaks active fights",
-          body: "The new assignment resets player health during turn resolution."
+          body: "The new assignment resets player health during turn resolution.",
+          sourceId: "seed-combat-health-reset"
         },
         {
           source: "coderabbit",
@@ -57,7 +58,9 @@ describe("offline eval harness", () => {
           path: "src/review.ts",
           line: 15,
           title: "Retry output omits failure status",
-          body: "The review summary misses failed retry state in the output."
+          body: "The review summary misses failed retry state in the output.",
+          sourceUrl: "https://github.com/electricsheephq/WorldOS/pull/1234#discussion_r1",
+          author: "coderabbitai"
         }
       ],
       thresholds: {
@@ -77,6 +80,9 @@ describe("offline eval harness", () => {
       "manifest.json",
       "raw-output.json",
       "normalized-findings.json",
+      "inline-previews.json",
+      "ci-metadata.json",
+      "merged-fixes.json",
       "redaction-report.json",
       "duplicate-report.json",
       "comparison.csv",
@@ -101,6 +107,27 @@ describe("offline eval harness", () => {
         seededRecall: 1
       }
     });
+    expect(scorecard.counts.inlinePreviews).toBe(2);
+    const manifest = JSON.parse(readFileSync(join(root, "manifest.json"), "utf8"));
+    expect(manifest).toMatchObject({
+      artifactVersion: "0.2",
+      mode: "gating",
+      thresholds: {
+        minPrecision: 1,
+        minRecall: 1,
+        minSeededRecall: 1,
+        maxSecretFindings: 0,
+        maxDuplicateFindings: 0
+      },
+      metadataCounts: {
+        inlinePreviews: 2,
+        ciMetadata: 0,
+        mergedFixes: 0
+      }
+    });
+    expect(manifest.artifactInventory.length).toBe(11);
+    const labels = JSON.parse(readFileSync(join(root, "labels.json"), "utf8"));
+    expect(labels[1].evidence).toMatchObject({ author: "coderabbitai" });
     expect(readFileSync(join(root, "comparison.csv"), "utf8")).toContain("true_positive,exact_line");
   });
 
@@ -114,6 +141,7 @@ describe("offline eval harness", () => {
       pullNumber: 497,
       headSha: "def456",
       suite: "safety_redaction",
+      mode: "exploratory",
       rawOutput: `raw model response contained ${token}`,
       botFindings: {
         findings: [
@@ -164,6 +192,7 @@ describe("offline eval harness", () => {
       pullNumber: 60,
       headSha: "abc",
       suite: "safety_redaction",
+      mode: "exploratory",
       botFindings: {
         findings: [
           {
@@ -201,6 +230,7 @@ describe("offline eval harness", () => {
       pullNumber: 61,
       headSha: "abc",
       suite: "canary_shadow",
+      mode: "exploratory",
       botFindings: {
         findings: [
           {
@@ -250,6 +280,7 @@ describe("offline eval harness", () => {
       pullNumber: 61,
       headSha: "abc",
       suite: "seeded_defect_recall",
+      mode: "exploratory",
       botFindings: {
         findings: [
           {
@@ -298,6 +329,7 @@ describe("offline eval harness", () => {
       pullNumber: 61,
       headSha: "abc",
       suite: "seeded_defect_recall",
+      mode: "exploratory",
       botFindings: {
         findings: [
           {
@@ -350,6 +382,7 @@ describe("offline eval harness", () => {
       pullNumber: 61,
       headSha: "abc",
       suite: "safety_redaction",
+      mode: "exploratory",
       botFindings: {
         findings: [],
         [token]: "secret in key"
@@ -389,5 +422,164 @@ describe("offline eval harness", () => {
 
     expect(result.outputDir).toBe(root);
     expect(result.ok).toBe(true);
+  });
+
+  it("runs a complete local fixture set across every required suite", () => {
+    const fixtureDir = join(process.cwd(), "tests/fixtures/eval-suite-scenarios");
+    const expectedSuites = [
+      "canary_shadow",
+      "historical_pr_replay",
+      "seeded_defect_recall",
+      "safety_redaction",
+      "duplicate_suppression"
+    ];
+
+    for (const suite of expectedSuites) {
+      const root = mkdtempSync(join(tmpdir(), `evaos-eval-harness-${suite}-`));
+      roots.push(root);
+      const scenario = JSON.parse(readFileSync(join(fixtureDir, `${suite}.json`), "utf8")) as EvalScenarioInput;
+      const result = runOfflineEval(scenario, { outputDir: root });
+
+      expect(result.ok, suite).toBe(true);
+      expect(result.scorecard.suite).toBe(suite);
+      expect(existsSync(join(root, "inline-previews.json")), suite).toBe(true);
+      expect(existsSync(join(root, "ci-metadata.json")), suite).toBe(true);
+      expect(existsSync(join(root, "merged-fixes.json")), suite).toBe(true);
+    }
+  });
+
+  it("rejects loosened gating thresholds unless the scenario is exploratory", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-threshold-policy-"));
+    roots.push(root);
+
+    expect(() => runOfflineEval({
+      runId: "unsafe-threshold",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 9,
+      headSha: "abc",
+      suite: "canary_shadow",
+      botFindings: { findings: [] },
+      labels: [],
+      thresholds: {
+        minPrecision: 0
+      }
+    }, { outputDir: root })).toThrow('minPrecision below the default requires mode="exploratory"');
+  });
+
+  it("rejects seeded defect recall scenarios with no seeded labels", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-seeded-requirement-"));
+    roots.push(root);
+
+    const result = runOfflineEval({
+      runId: "missing-seeded-label",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 9,
+      headSha: "abc",
+      suite: "seeded_defect_recall",
+      botFindings: { findings: [] },
+      labels: []
+    }, { outputDir: root });
+
+    expect(result.ok).toBe(false);
+    expect(result.scorecard.gates.find((gate) => gate.name === "suite_requirements")).toMatchObject({ ok: false });
+  });
+
+  it("does not match findings when severity differs from the label", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-severity-"));
+    roots.push(root);
+
+    const result = runOfflineEval({
+      runId: "severity-mismatch",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 9,
+      headSha: "abc",
+      suite: "seeded_defect_recall",
+      botFindings: {
+        findings: [{
+          severity: "P2",
+          path: "src/a.ts",
+          line: 10,
+          title: "Dangerous retry loop",
+          body: "The retry loop can repeat a dangerous operation.",
+          confidence: 0.9
+        }]
+      },
+      labels: [{
+        source: "seeded_defect",
+        severity: "P1",
+        path: "src/a.ts",
+        line: 10,
+        title: "Dangerous retry loop",
+        body: "The retry loop can repeat a dangerous operation."
+      }],
+      thresholds: {
+        minPrecision: 0.8,
+        minRecall: 1,
+        minSeededRecall: 1
+      }
+    }, { outputDir: root });
+
+    expect(result.ok).toBe(false);
+    expect(result.scorecard.counts).toMatchObject({
+      truePositive: 0,
+      falsePositive: 1,
+      falseNegative: 1
+    });
+  });
+
+  it("detects nearby semantic duplicate findings", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-nearby-duplicate-"));
+    roots.push(root);
+
+    const result = runOfflineEval({
+      runId: "nearby-duplicate",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 9,
+      headSha: "abc",
+      suite: "duplicate_suppression",
+      mode: "exploratory",
+      botFindings: {
+        findings: [
+          {
+            severity: "P2",
+            path: "src/a.ts",
+            line: 10,
+            title: "Retry failure state omitted",
+            body: "The retry output omits failed provider state from the summary.",
+            confidence: 0.8
+          },
+          {
+            severity: "P2",
+            path: "src/a.ts",
+            line: 12,
+            title: "Retry failure state omitted again",
+            body: "The retry output omits failed provider state from the summary.",
+            confidence: 0.7
+          }
+        ]
+      },
+      labels: [],
+      thresholds: {
+        minPrecision: 0,
+        minRecall: 0,
+        maxDuplicateFindings: 0
+      }
+    }, { outputDir: root });
+
+    expect(result.ok).toBe(false);
+    expect(result.scorecard.counts.duplicateFindings).toBe(1);
+  });
+
+  it("rejects output under the repo checkout", () => {
+    expect(() => runOfflineEval({
+      runId: "repo-output",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 9,
+      headSha: "abc",
+      suite: "canary_shadow",
+      botFindings: { findings: [] },
+      labels: []
+    }, { outputDir: join(process.cwd(), ".eval-output") }))
+      .toThrow("outputDir must not be inside the current git checkout");
   });
 });

--- a/tests/fixtures/eval-suite-scenarios/canary_shadow.json
+++ b/tests/fixtures/eval-suite-scenarios/canary_shadow.json
@@ -1,0 +1,19 @@
+{
+  "evalName": "evaos-zcode-review-bot-comparison-v0.2",
+  "runId": "canary-shadow-fixture",
+  "repo": "electricsheephq/WorldOS",
+  "pullNumber": 1161,
+  "headSha": "canary123",
+  "suite": "canary_shadow",
+  "botFindings": {
+    "findings": []
+  },
+  "labels": [],
+  "thresholds": {
+    "minPrecision": 1,
+    "minRecall": 1,
+    "minSeededRecall": 1,
+    "maxSecretFindings": 0,
+    "maxDuplicateFindings": 0
+  }
+}

--- a/tests/fixtures/eval-suite-scenarios/duplicate_suppression.json
+++ b/tests/fixtures/eval-suite-scenarios/duplicate_suppression.json
@@ -1,0 +1,19 @@
+{
+  "evalName": "evaos-zcode-review-bot-comparison-v0.2",
+  "runId": "duplicate-suppression-fixture",
+  "repo": "electricsheephq/evaos-code-review-bot",
+  "pullNumber": 9,
+  "headSha": "duplicate123",
+  "suite": "duplicate_suppression",
+  "botFindings": {
+    "findings": []
+  },
+  "labels": [],
+  "thresholds": {
+    "minPrecision": 1,
+    "minRecall": 1,
+    "minSeededRecall": 1,
+    "maxSecretFindings": 0,
+    "maxDuplicateFindings": 0
+  }
+}

--- a/tests/fixtures/eval-suite-scenarios/historical_pr_replay.json
+++ b/tests/fixtures/eval-suite-scenarios/historical_pr_replay.json
@@ -1,0 +1,145 @@
+{
+  "evalName": "evaos-zcode-review-bot-comparison-v0.2",
+  "runId": "historical-pr-replay-fixture",
+  "repo": "electricsheephq/evaos-code-review-bot",
+  "pullNumber": 61,
+  "headSha": "historical123",
+  "suite": "historical_pr_replay",
+  "rawOutput": {
+    "findings": [
+      {
+        "severity": "P1",
+        "path": "src/eval-harness.ts",
+        "line": 42,
+        "title": "Schema drop hides failed review output",
+        "body": "Malformed findings must fail the schema gate instead of disappearing from the scorecard.",
+        "confidence": 0.92
+      },
+      {
+        "severity": "P2",
+        "path": "src/eval-harness.ts",
+        "line": 88,
+        "title": "Calibration report must stay uncalibrated",
+        "body": "The public confidence claim must remain uncalibrated until enough human labels exist.",
+        "confidence": 0.81
+      },
+      {
+        "severity": "P2",
+        "path": "src/worker.ts",
+        "line": 214,
+        "title": "Provider timeout must record failed row",
+        "body": "A provider timeout must record a failed row so coverage audit can backfill the missed pull request.",
+        "confidence": 0.84
+      },
+      {
+        "severity": "P3",
+        "path": "docs/eval-harness.md",
+        "line": 19,
+        "title": "Eval docs omit merged fix evidence",
+        "body": "Historical replay docs should name the merged fix evidence used as a comparison baseline.",
+        "confidence": 0.73
+      }
+    ]
+  },
+  "botFindings": {
+    "findings": [
+      {
+        "severity": "P1",
+        "path": "src/eval-harness.ts",
+        "line": 42,
+        "title": "Schema drop hides failed review output",
+        "body": "Malformed findings must fail the schema gate instead of disappearing from the scorecard.",
+        "confidence": 0.92
+      },
+      {
+        "severity": "P2",
+        "path": "src/eval-harness.ts",
+        "line": 88,
+        "title": "Calibration report must stay uncalibrated",
+        "body": "The public confidence claim must remain uncalibrated until enough human labels exist.",
+        "confidence": 0.81
+      },
+      {
+        "severity": "P2",
+        "path": "src/worker.ts",
+        "line": 214,
+        "title": "Provider timeout must record failed row",
+        "body": "A provider timeout must record a failed row so coverage audit can backfill the missed pull request.",
+        "confidence": 0.84
+      },
+      {
+        "severity": "P3",
+        "path": "docs/eval-harness.md",
+        "line": 19,
+        "title": "Eval docs omit merged fix evidence",
+        "body": "Historical replay docs should name the merged fix evidence used as a comparison baseline.",
+        "confidence": 0.73
+      }
+    ]
+  },
+  "ciMetadata": [
+    {
+      "provider": "github-actions",
+      "name": "test",
+      "status": "failure",
+      "conclusion": "vitest failure reproduced the schema drop",
+      "url": "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/1"
+    }
+  ],
+  "mergedFixes": [
+    {
+      "repo": "electricsheephq/evaos-code-review-bot",
+      "pullNumber": 61,
+      "mergeSha": "2475728d82634203bd62e9be62c1bb71885144f3",
+      "path": "src/eval-harness.ts",
+      "summary": "Merged fix made dropped schema findings fail the scorecard."
+    }
+  ],
+  "labels": [
+    {
+      "source": "coderabbit",
+      "severity": "P1",
+      "path": "src/eval-harness.ts",
+      "line": 42,
+      "title": "Schema drop hides failed review output",
+      "body": "Malformed findings must fail the schema gate instead of disappearing from the scorecard.",
+      "sourceUrl": "https://github.com/electricsheephq/evaos-code-review-bot/pull/61#discussion_r1",
+      "author": "coderabbitai"
+    },
+    {
+      "source": "human",
+      "severity": "P2",
+      "path": "src/eval-harness.ts",
+      "line": 88,
+      "title": "Calibration report must stay uncalibrated",
+      "body": "The public confidence claim must remain uncalibrated until enough human labels exist.",
+      "author": "100yenadmin"
+    },
+    {
+      "source": "ci_failure",
+      "severity": "P2",
+      "path": "src/worker.ts",
+      "line": 214,
+      "title": "Provider timeout must record failed row",
+      "body": "A provider timeout must record a failed row so coverage audit can backfill the missed pull request.",
+      "checkName": "test"
+    },
+    {
+      "source": "merged_fix",
+      "severity": "P3",
+      "path": "docs/eval-harness.md",
+      "line": 19,
+      "title": "Eval docs omit merged fix evidence",
+      "body": "Historical replay docs should name the merged fix evidence used as a comparison baseline.",
+      "mergeSha": "2475728d82634203bd62e9be62c1bb71885144f3",
+      "diffSummary": "Documented merged-fix evidence in the eval packet."
+    }
+  ],
+  "thresholds": {
+    "minPrecision": 1,
+    "minRecall": 1,
+    "minSeededRecall": 1,
+    "maxSecretFindings": 0,
+    "maxDuplicateFindings": 0
+  }
+}

--- a/tests/fixtures/eval-suite-scenarios/safety_redaction.json
+++ b/tests/fixtures/eval-suite-scenarios/safety_redaction.json
@@ -1,0 +1,19 @@
+{
+  "evalName": "evaos-zcode-review-bot-comparison-v0.2",
+  "runId": "safety-redaction-fixture",
+  "repo": "electricsheephq/evaos-code-review-bot",
+  "pullNumber": 9,
+  "headSha": "safety123",
+  "suite": "safety_redaction",
+  "botFindings": {
+    "findings": []
+  },
+  "labels": [],
+  "thresholds": {
+    "minPrecision": 1,
+    "minRecall": 1,
+    "minSeededRecall": 1,
+    "maxSecretFindings": 0,
+    "maxDuplicateFindings": 0
+  }
+}

--- a/tests/fixtures/eval-suite-scenarios/seeded_defect_recall.json
+++ b/tests/fixtures/eval-suite-scenarios/seeded_defect_recall.json
@@ -1,0 +1,38 @@
+{
+  "evalName": "evaos-zcode-review-bot-comparison-v0.2",
+  "runId": "seeded-defect-recall-fixture",
+  "repo": "electricsheephq/WorldOS",
+  "pullNumber": 1234,
+  "headSha": "seeded123",
+  "suite": "seeded_defect_recall",
+  "botFindings": {
+    "findings": [
+      {
+        "severity": "P1",
+        "path": "Assets/Scripts/CombatTurn.cs",
+        "line": 26,
+        "title": "Combat health reset breaks fights",
+        "body": "The player health reset during combat turn resolution makes active fights nearly fail.",
+        "confidence": 0.95
+      }
+    ]
+  },
+  "labels": [
+    {
+      "source": "seeded_defect",
+      "severity": "P1",
+      "path": "Assets/Scripts/CombatTurn.cs",
+      "line": 26,
+      "title": "Combat health reset breaks active fights",
+      "body": "The new assignment resets player health during turn resolution.",
+      "sourceId": "seed-combat-health-reset"
+    }
+  ],
+  "thresholds": {
+    "minPrecision": 1,
+    "minRecall": 1,
+    "minSeededRecall": 1,
+    "maxSecretFindings": 0,
+    "maxDuplicateFindings": 0
+  }
+}


### PR DESCRIPTION
Closes #9.

## Summary
- expand offline eval packets with inline previews, CI metadata, merged-fix evidence, label source metadata, artifact inventory, and scenario mode
- add suite-specific gates, severity-aware matching, nearby semantic duplicate detection, and a repo-output guard
- add `eval:suite` plus checked-in fixtures for all five required suites

## Validation
- `npx vitest run tests/eval-harness.test.ts` -> 15/15
- `npm run build`
- `npm run eval:suite -- --input-dir tests/fixtures/eval-suite-scenarios --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-01/issue-9-suite-packets-155650` -> 5/5 suites
- `npm test` -> 24 files / 140 tests
- `git diff --check`

Evidence: `/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-01/issue-9-suite-packets-155650`

Release note: this PR is eval/offline harness work. If promoted live, use `docs/release-governance.md`; do not retag `v0.2.5-beta.1`.