### PR TITLE
Prepare v0.3.0-beta.1 release packet

### DIFF
--- a/docs/releases/v0.3.0-beta.1.md
+++ b/docs/releases/v0.3.0-beta.1.md
@@ -1,0 +1,66 @@
+# v0.3.0-beta.1
+
+- Release type: local beta minor
+- Tracking issue: `#9`
+- Implementation PR: `#74`
+- Feature source SHA: `d6beffbf136311a2fe5e0c3007e4f8a0d9a91f88`
+- Previous live release: `v0.2.5-beta.1` (`05376ba196168729508f21054d2aa02a9f1793b2`)
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+
+## Purpose
+
+Promote the first comparison eval packet harness for the v0.2
+CodeRabbit-class reviewer roadmap. This release does not broaden the live
+reviewer allowlist or enable new write behavior; it adds the offline scoring
+surface needed to compare bot findings against CodeRabbit comments, human
+labels, CI evidence, merged-fix evidence, seeded defects, duplicate suppression,
+and safety redaction fixtures.
+
+## Changes
+
+- Add `eval-suite` batch execution for the five required eval suites.
+- Write packet artifacts for inline previews, CI metadata, merged fixes,
+  manifests, labels, scorecards, calibration reports, duplicate reports, and
+  redaction reports.
+- Require all five suites before a batch run can report `ok: true`.
+- Prevent suite packet output from writing inside a git checkout, including
+  symlinked parent paths.
+- Treat duplicate `runId` values as structured per-scenario failures instead
+  of silently overwriting evidence.
+- Keep loosened thresholds limited to explicit exploratory mode.
+
+## Validation
+
+- `npm run build`
+- `npx vitest run tests/eval-harness.test.ts`
+- `npm test`
+- `npm run eval:suite -- --input-dir tests/fixtures/eval-suite-scenarios --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-01/issue-9-premerge-091633`
+
+Fresh pre-merge evidence:
+
+- GitHub PR `#74`: mergeable, clean, approved, checks green.
+- Current unresolved review threads: none.
+- Eval packet: `/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-01/issue-9-premerge-091633`
+
+## Runtime Caveats
+
+- This release is primarily eval/CLI capability expansion, not a new live
+  review-posting behavior.
+- Z.ai transient provider cooldowns may still appear as request throttling or
+  provider overload; they are not treated as weekly quota exhaustion.
+- Provider cooldown backlog must be empty or active and named during the
+  post-release gate before calling the live release green.
+
+## Rollback
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard v0.2.5-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```


### PR DESCRIPTION
## Summary
- add the release governance packet for v0.3.0-beta.1
- document #74/#9 eval-suite promotion evidence and rollback to v0.2.5-beta.1
- keep the existing v0.2.5-beta.1 tag untouched

## Validation
- git diff --check

Refs #9
Refs #3