### PR TITLE
Harden provider cooldown queue handling

### DIFF
--- a/src/coverage-audit.ts
+++ b/src/coverage-audit.ts
@@ -98,6 +98,7 @@ export interface CoverageStateLookup {
   getProcessedReview(repo: string, pullNumber: number, headSha: string): StoredProcessedReviewRecord | undefined;
   listProcessedReviewsForPull(repo: string, pullNumber: number): StoredProcessedReviewRecord[];
   getActiveRepoProviderCooldown?(repo: string, now?: Date): RepoProviderCooldownRecord | undefined;
+  getActiveProviderCooldown?(now?: Date): RepoProviderCooldownRecord | undefined;
 }
 
 export class CoverageStateReader implements CoverageStateLookup {
@@ -136,6 +137,7 @@ export class CoverageStateReader implements CoverageStateLookup {
 
   getActiveRepoProviderCooldown(repo: string, now = new Date()): RepoProviderCooldownRecord | undefined {
     if (!this.db) return undefined;
+    if (!this.hasRepoProviderCooldownTable()) return undefined;
     const row = this.db
       .prepare(
         `select repo, cooldown_until, reason, updated_at
@@ -151,8 +153,35 @@ export class CoverageStateReader implements CoverageStateLookup {
     return cooldown;
   }
 
+  getActiveProviderCooldown(now = new Date()): RepoProviderCooldownRecord | undefined {
+    if (!this.db) return undefined;
+    if (!this.hasRepoProviderCooldownTable()) return undefined;
+    const rows = this.db
+      .prepare(
+        `select repo, cooldown_until, reason, updated_at
+         from repo_provider_cooldowns
+         order by datetime(cooldown_until) desc`
+      )
+      .all() as unknown as RepoProviderCooldownRow[];
+    return rows
+      .map(mapRepoProviderCooldownRow)
+      .find((cooldown) => {
+        const cooldownUntilMs = Date.parse(cooldown.cooldownUntil);
+        return Number.isFinite(cooldownUntilMs) && cooldownUntilMs > now.getTime();
+      });
+  }
+
   close(): void {
     this.db?.close();
+  }
+
+  private hasRepoProviderCooldownTable(): boolean {
+    if (!this.db) return false;
+    return Boolean(
+      this.db
+        .prepare("select 1 from sqlite_master where type = 'table' and name = 'repo_provider_cooldowns' limit 1")
+        .get()
+    );
   }
 }
 
@@ -314,6 +343,20 @@ function pushProcessedOrUnprocessed(
       createdAt: repoCooldown.updatedAt,
       cooldownUntil: repoCooldown.cooldownUntil,
       reason: repoCooldown.reason
+    });
+    report.summary.providerDeferred += 1;
+    return;
+  }
+
+  const providerCooldown = state.getActiveProviderCooldown?.(now);
+  if (providerCooldown) {
+    report.providerDeferred.push({
+      ...pullEntry(repo, pull),
+      status: "skipped",
+      error: `provider_cooldown_until=${providerCooldown.cooldownUntil}; reason=${providerCooldown.reason}`,
+      createdAt: providerCooldown.updatedAt,
+      cooldownUntil: providerCooldown.cooldownUntil,
+      reason: providerCooldown.reason
     });
     report.summary.providerDeferred += 1;
     return;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,7 +1,7 @@
 import { formatDaemonLog } from "./daemon-log.js";
 import { loadConfig } from "./config.js";
 import { ReviewStateStore, type DaemonHeartbeatEvent } from "./state.js";
-import { runOnce, type RunOnceResult } from "./worker.js";
+import { retryProviderCooldowns, runOnce, type RetryProviderCooldownsResult, type RunOnceResult } from "./worker.js";
 
 export type DaemonCycleResult =
   | { ok: true; result: RunOnceResult }
@@ -16,6 +16,13 @@ export interface RunDaemonCycleOptions {
   canaryPulls: string[];
   commandsEnabled: boolean;
   runOnceImpl?: (options: { configPath?: string; dryRun: boolean }) => Promise<RunOnceResult>;
+  retryProviderCooldownsImpl?: (options: {
+    configPath?: string;
+    limit?: number;
+    expiredOnly?: boolean;
+    dryRun: boolean;
+    useZCode?: boolean;
+  }) => Promise<RetryProviderCooldownsResult>;
   recordHeartbeatImpl?: (event: DaemonHeartbeatEvent, error?: string) => void;
   stdout?: (line: string) => void;
   stderr?: (line: string) => void;
@@ -25,6 +32,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   const stdout = input.stdout ?? console.log;
   const stderr = input.stderr ?? console.error;
   const runOnceImpl = input.runOnceImpl ?? runOnce;
+  const retryProviderCooldownsImpl = input.retryProviderCooldownsImpl ?? retryProviderCooldowns;
   const recordHeartbeat = input.recordHeartbeatImpl ?? ((event: DaemonHeartbeatEvent, error?: string) => {
     recordDaemonHeartbeatFromConfig({
       configPath: input.configPath,
@@ -49,6 +57,30 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
 
   try {
     const result = await runOnceImpl({ configPath: input.configPath, dryRun: input.dryRun });
+    try {
+      const providerCooldownRetry = await retryProviderCooldownsImpl({
+        configPath: input.configPath,
+        dryRun: input.dryRun,
+        expiredOnly: true,
+        limit: 1,
+        useZCode: true
+      });
+      stdout(formatDaemonLog({
+        event: "daemon_provider_cooldown_retry",
+        cycle: input.cycle,
+        dryRun: input.dryRun,
+        result: providerCooldownRetry
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      stderr(formatDaemonLog({
+        event: "daemon_provider_cooldown_retry_failed",
+        level: "error",
+        cycle: input.cycle,
+        dryRun: input.dryRun,
+        error: message
+      }));
+    }
     stdout(formatDaemonLog({
       event: "daemon_cycle_complete",
       cycle: input.cycle,

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -25,6 +25,10 @@ export interface ReleaseDatabaseStatus {
   providerCooldownCount?: number;
   activeProviderCooldownCount?: number;
   expiredProviderCooldownCount?: number;
+  activeGlobalProviderCooldownCount?: number;
+  coveredExpiredProviderCooldownCount?: number;
+  retryableExpiredProviderCooldownCount?: number;
+  providerThrottleState?: "none" | "active" | "expired_retryable";
 }
 
 export interface ReleaseHeartbeatStatus {
@@ -75,7 +79,14 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const launchdRunningOk = input.launchd.state === "running";
   const launchdConfigOk = input.launchd.configPath === input.configPath;
   const dbOk = input.database.errorCount === 0;
-  const expiredProviderCooldownOk = (input.database.expiredProviderCooldownCount ?? 0) === 0;
+  const providerThrottleState = input.database.providerThrottleState ?? inferProviderThrottleState(input.database);
+  const retryableExpiredProviderCooldownCount =
+    input.database.retryableExpiredProviderCooldownCount ??
+    Math.max(
+      0,
+      (input.database.expiredProviderCooldownCount ?? 0) - (input.database.coveredExpiredProviderCooldownCount ?? 0)
+    );
+  const expiredProviderCooldownOk = retryableExpiredProviderCooldownCount === 0;
   const heartbeatOk = input.heartbeat.status === "fresh";
   const retryProviderCooldownCommand =
     `npx tsx src/cli.ts retry-provider-cooldowns --config ${input.configPath} ` +
@@ -117,8 +128,8 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       name: "provider_cooldown_backlog",
       ok: expiredProviderCooldownOk,
       detail: expiredProviderCooldownOk
-        ? describeProviderCooldownBacklog(input.database)
-        : `${describeProviderCooldownBacklog(input.database)}; retry: ${retryProviderCooldownCommand}`
+        ? describeProviderCooldownBacklog(input.database, providerThrottleState)
+        : `${describeProviderCooldownBacklog(input.database, providerThrottleState)}; retry: ${retryProviderCooldownCommand}`
     },
     {
       name: "daemon_heartbeat_recent",
@@ -234,30 +245,63 @@ function readDatabaseStatus(statePath: string, now: Date): ReleaseDatabaseStatus
       };
     const providerCooldownRows = db
       .prepare(
-        `select error
+        `select repo, error
          from processed_reviews
          where status = 'skipped' and error like ?`
       )
-      .all(`${PROVIDER_COOLDOWN_ERROR_PREFIX}%`) as unknown as Array<{ error: string | null }>;
+      .all(`${PROVIDER_COOLDOWN_ERROR_PREFIX}%`) as unknown as Array<{ repo: string; error: string | null }>;
     const providerCooldowns = providerCooldownRows
-      .map((providerRow) => parseProviderCooldownError(providerRow.error ?? undefined))
-      .filter((cooldown): cooldown is NonNullable<typeof cooldown> => Boolean(cooldown));
+      .map((providerRow) => {
+        const parsed = parseProviderCooldownError(providerRow.error ?? undefined);
+        return parsed ? { repo: providerRow.repo, ...parsed } : undefined;
+      })
+      .filter((cooldown): cooldown is { repo: string; cooldownUntil: string; reason?: string } => Boolean(cooldown));
+    const activeGlobalProviderCooldowns = readActiveGlobalProviderCooldowns(db, now);
     const expiredProviderCooldownCount = providerCooldowns.filter((cooldown) => {
       const cooldownUntilMs = Date.parse(cooldown.cooldownUntil);
       return !Number.isFinite(cooldownUntilMs) || cooldownUntilMs <= now.getTime();
     }).length;
     const activeProviderCooldownCount = providerCooldowns.length - expiredProviderCooldownCount;
+    const coveredExpiredProviderCooldownCount = activeGlobalProviderCooldowns.length > 0
+      ? expiredProviderCooldownCount
+      : 0;
+    const retryableExpiredProviderCooldownCount = expiredProviderCooldownCount - coveredExpiredProviderCooldownCount;
+    const providerThrottleState = activeGlobalProviderCooldowns.length > 0 || activeProviderCooldownCount > 0
+      ? "active"
+      : retryableExpiredProviderCooldownCount > 0
+        ? "expired_retryable"
+        : "none";
     return {
       rowCount: row.rowCount ?? 0,
       skippedCount: row.skippedCount ?? 0,
       providerCooldownCount: row.providerCooldownCount ?? 0,
       activeProviderCooldownCount,
       expiredProviderCooldownCount,
+      activeGlobalProviderCooldownCount: activeGlobalProviderCooldowns.length,
+      coveredExpiredProviderCooldownCount,
+      retryableExpiredProviderCooldownCount,
+      providerThrottleState,
       errorCount: row.errorCount ?? 0
     };
   } finally {
     db.close();
   }
+}
+
+function readActiveGlobalProviderCooldowns(db: DatabaseSync, now: Date): Array<{ repo: string; cooldownUntil: string }> {
+  const hasTable = db
+    .prepare("select 1 from sqlite_master where type = 'table' and name = 'repo_provider_cooldowns' limit 1")
+    .get();
+  if (!hasTable) return [];
+  const rows = db
+    .prepare("select repo, cooldown_until from repo_provider_cooldowns")
+    .all() as unknown as Array<{ repo: string; cooldown_until: string }>;
+  return rows
+    .map((row) => ({ repo: row.repo, cooldownUntil: row.cooldown_until }))
+    .filter((row) => {
+      const cooldownUntilMs = Date.parse(row.cooldownUntil);
+      return Number.isFinite(cooldownUntilMs) && cooldownUntilMs > now.getTime();
+    });
 }
 
 function describeProviderCooldownCounts(database: ReleaseDatabaseStatus): string {
@@ -269,8 +313,25 @@ function describeProviderCooldownCounts(database: ReleaseDatabaseStatus): string
   );
 }
 
-function describeProviderCooldownBacklog(database: ReleaseDatabaseStatus): string {
+function describeProviderCooldownBacklog(
+  database: ReleaseDatabaseStatus,
+  providerThrottleState = inferProviderThrottleState(database)
+): string {
+  if (providerThrottleState === "active" && (database.coveredExpiredProviderCooldownCount ?? 0) > 0) {
+    return (
+      `provider throttle active; ${database.coveredExpiredProviderCooldownCount} expired provider cooldown row(s) ` +
+      "deferred by active provider cooldown"
+    );
+  }
   return `${database.expiredProviderCooldownCount ?? 0} expired provider cooldown row(s); ${database.activeProviderCooldownCount ?? 0} active provider cooldown row(s)`;
+}
+
+function inferProviderThrottleState(database: ReleaseDatabaseStatus): "none" | "active" | "expired_retryable" {
+  if ((database.activeGlobalProviderCooldownCount ?? 0) > 0 || (database.activeProviderCooldownCount ?? 0) > 0) {
+    return "active";
+  }
+  if ((database.expiredProviderCooldownCount ?? 0) > 0) return "expired_retryable";
+  return "none";
 }
 
 function readHeartbeatStatus(statePath: string, maxAgeMs: number, now: Date): ReleaseHeartbeatStatus {

--- a/src/state.ts
+++ b/src/state.ts
@@ -324,6 +324,27 @@ export class ReviewStateStore {
     return cooldown;
   }
 
+  getActiveProviderCooldown(now = new Date()): RepoProviderCooldownRecord | undefined {
+    return this.listRepoProviderCooldowns({ activeOnly: true, now })[0];
+  }
+
+  listRepoProviderCooldowns(input: { activeOnly?: boolean; now?: Date } = {}): RepoProviderCooldownRecord[] {
+    const now = input.now ?? new Date();
+    const rows = this.db
+      .prepare(
+        `select repo, cooldown_until, reason, updated_at
+         from repo_provider_cooldowns
+         order by datetime(cooldown_until) desc`
+      )
+      .all() as unknown as RepoProviderCooldownRow[];
+    const cooldowns = rows.map(mapRepoProviderCooldownRow);
+    if (!input.activeOnly) return cooldowns;
+    return cooldowns.filter((cooldown) => {
+      const cooldownUntilMs = Date.parse(cooldown.cooldownUntil);
+      return Number.isFinite(cooldownUntilMs) && cooldownUntilMs > now.getTime();
+    });
+  }
+
   listProviderCooldownReviews(input: {
     repo?: string;
     now?: Date;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -293,6 +293,28 @@ export async function retryProviderCooldownsWithDeps(input: {
     limit,
     now: new Date()
   });
+  const activeProviderCooldown = input.state.getActiveProviderCooldown(new Date());
+  if (expiredOnly && candidates.length > 0 && activeProviderCooldown) {
+    const results = candidates.map((candidate) => ({
+      repo: candidate.repo,
+      pullNumber: candidate.pullNumber,
+      headSha: candidate.headSha,
+      status: "skipped_provider_cooldown" as const
+    }));
+    const summary = summarizeRetryProviderCooldownResults(results);
+    return {
+      ok: true,
+      checkedAt: new Date().toISOString(),
+      dryRun: input.options.dryRun,
+      expiredOnly,
+      limit,
+      ...(input.options.repo ? { repo: input.options.repo } : {}),
+      candidates: candidates.length,
+      attempted: 0,
+      results,
+      summary
+    };
+  }
   const results: RetryFailedHeadResult[] = [];
   for (const candidate of candidates) {
     const result = await retryFailedHeadWithDeps({

--- a/tests/coverage-audit.test.ts
+++ b/tests/coverage-audit.test.ts
@@ -161,6 +161,41 @@ describe("coverage audit", () => {
     state.close();
   });
 
+  it("reports eligible heads as provider-deferred under an active global provider cooldown", async () => {
+    const { root, state } = createState();
+    state.recordRepoProviderCooldown({
+      repo: "owner/other",
+      cooldownUntil: new Date("2026-07-01T00:05:00.000Z"),
+      reason: "provider_request_rate_limit"
+    });
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(13, "head-global-cooldown")]
+      } as unknown as GitHubApi,
+      state,
+      now: new Date("2026-07-01T00:04:00.000Z")
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      processed: 0,
+      providerDeferred: 1,
+      unprocessed: 0
+    });
+    expect(audit.providerDeferred).toEqual([
+      expect.objectContaining({
+        repo: "owner/allowed",
+        pullNumber: 13,
+        headSha: "head-global-cooldown",
+        cooldownUntil: "2026-07-01T00:05:00.000Z",
+        reason: "provider_request_rate_limit"
+      })
+    ]);
+    state.close();
+  });
+
   it("supports canary and single-PR scoping without marking closed PRs as misses", async () => {
     const { root, state } = createState();
     let getPullCount = 0;
@@ -260,6 +295,42 @@ describe("coverage audit", () => {
     expect(audit.unprocessed[0]?.previousProcessedHeads).toEqual([]);
     expect(existsSync(statePath)).toBe(false);
     expect(existsSync(join(root, "missing"))).toBe(false);
+  });
+
+  it("treats legacy DBs without provider cooldown tables as normal unprocessed coverage", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-coverage-legacy-db-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const db = new DatabaseSync(statePath);
+    db.exec(`
+      create table processed_reviews (
+        repo text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        status text not null,
+        event text,
+        review_url text,
+        error text,
+        created_at text not null
+      )
+    `);
+    db.close();
+    const state = CoverageStateReader.open(statePath);
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(14, "head-14")]
+      } as unknown as GitHubApi,
+      state
+    });
+
+    expect(audit.ok).toBe(false);
+    expect(audit.summary).toMatchObject({
+      providerDeferred: 0,
+      unprocessed: 1
+    });
+    state.close();
   });
 
   it("re-reads unprocessed open candidates and reports stale heads separately", async () => {

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -78,6 +78,67 @@ describe("daemon cycle resilience", () => {
     expect(heartbeats).toEqual(["daemon_cycle_start", "daemon_cycle_complete"]);
   });
 
+  it("runs one bounded provider cooldown drain after successful review cycles", async () => {
+    const events: string[] = [];
+
+    const result = await runDaemonCycle({
+      cycle: 4,
+      dryRun: false,
+      pilotRepos: ["electricsheephq/WorldOS"],
+      monitoredRepos: ["electricsheephq/WorldOS"],
+      canaryPulls: [],
+      commandsEnabled: false,
+      runOnceImpl: async () => ({
+        reposScanned: 1,
+        pullsSeen: 1,
+        reviewed: 0,
+        failed: 0,
+        skippedDraft: 0,
+        skippedCanary: 0,
+        skippedPolicy: 0,
+        skippedCommandStop: 0,
+        skippedCommandExplain: 0,
+        commandReviewRequested: 0,
+        skippedProcessed: 1,
+        skippedCapacity: 0,
+        skippedProviderCooldown: 0,
+        skippedStaleHead: 0,
+        baselinedExisting: 0,
+        policySkips: []
+      }),
+      retryProviderCooldownsImpl: async (options) => {
+        events.push(`${options.dryRun}:${options.limit}:${options.expiredOnly}`);
+        return {
+          ok: true,
+          checkedAt: "2026-07-01T00:00:00.000Z",
+          dryRun: options.dryRun,
+          expiredOnly: options.expiredOnly ?? true,
+          limit: options.limit ?? 1,
+          candidates: 1,
+          attempted: 0,
+          results: [],
+          summary: {
+            reviewed: 0,
+            dryRun: 0,
+            remainedCooldown: 1,
+            failed: 0,
+            skippedStaleHead: 0,
+            skippedProcessed: 0,
+            skippedClosed: 0,
+            skippedCapacity: 0,
+            other: 0
+          }
+        };
+      },
+      recordHeartbeatImpl: () => undefined,
+      stdout: () => undefined,
+      stderr: () => undefined
+    });
+
+    expect(result.ok).toBe(true);
+    expect(events).toEqual(["false:1:true"]);
+  });
+
   it("records a failed heartbeat with the failure message", async () => {
     const heartbeats: Array<{ event: string; error?: string }> = [];
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -229,6 +229,44 @@ describe("beta release status", () => {
     expect(status.recommendedActions).toContain(retryCommand);
   });
 
+  it("keeps release status green when expired per-head cooldowns are covered by an active provider throttle", () => {
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false
+      },
+      database: {
+        rowCount: 21,
+        errorCount: 0,
+        skippedCount: 16,
+        providerCooldownCount: 2,
+        activeProviderCooldownCount: 1,
+        expiredProviderCooldownCount: 1,
+        providerThrottleState: "active",
+        coveredExpiredProviderCooldownCount: 1
+      },
+      heartbeat: freshHeartbeat(),
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(true);
+    expect(status.gates).toContainEqual({
+      name: "provider_cooldown_backlog",
+      ok: true,
+      detail: "provider throttle active; 1 expired provider cooldown row(s) deferred by active provider cooldown"
+    });
+    expect(status.recommendedActions).toEqual([]);
+  });
+
   it("counts active and expired provider cooldown rows from the live state database", () => {
     const root = mkdtempSync(join(tmpdir(), "release-status-db-"));
     roots.push(root);

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -366,6 +366,62 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("does not immediately retry expired provider-cooldown heads while a global provider cooldown is active", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-cooldown-global-active-bulk-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1236, "head-expired-provider-cooldown");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2000-01-01T00:00:00.000Z; reason=provider_rate_limit"
+    });
+    state.recordRepoProviderCooldown({
+      repo: "100yenadmin/evaOS-GUI",
+      cooldownUntil: new Date("2999-01-01T00:00:00.000Z"),
+      reason: "provider_request_rate_limit"
+    });
+    let attempts = 0;
+
+    const result = await retryProviderCooldownsWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        dryRun: false,
+        expiredOnly: true
+      },
+      reviewPullImpl: async () => {
+        attempts += 1;
+        return "reviewed";
+      }
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      candidates: 1,
+      attempted: 0,
+      summary: {
+        remainedCooldown: 1,
+        failed: 0
+      }
+    });
+    expect(result.results).toEqual([
+      expect.objectContaining({
+        repo: "electricsheephq/WorldOS",
+        pullNumber: 1236,
+        headSha: "head-expired-provider-cooldown",
+        status: "skipped_provider_cooldown"
+      })
+    ]);
+    expect(attempts).toBe(0);
+    state.close();
+  });
+
   it("retries expired provider-cooldown heads and keeps dry-runs retryable as cooldown skips", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-cooldown-expired-bulk-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- add global provider cooldown awareness to release-status and coverage-audit so expired per-head rows do not flap releases red while the provider is actively cooling down
- add bounded daemon drain for expired provider cooldown rows after successful review cycles
- skip immediate retry attempts while a global provider cooldown is active, preserving retry/backfill without duplicate posting
- harden coverage-audit against legacy read-only DBs without provider cooldown tables

Closes #76.

## Validation
- npm run build
- npx vitest run tests/release-status.test.ts tests/coverage-audit.test.ts tests/worker-failure.test.ts tests/daemon-loop.test.ts tests/state.test.ts
- npm test
- git diff --check

## Release note
Runtime resilience beta patch candidate. Future promotion should use the release governance runbook; this PR does not tag or promote by itself.