### PR TITLE
Add v0.3.1-beta.1 release packet

### DIFF
--- a/docs/releases/v0.3.1-beta.1.md
+++ b/docs/releases/v0.3.1-beta.1.md
@@ -1,0 +1,80 @@
+# v0.3.1-beta.1
+
+- Release type: local beta patch
+- Tracking issue: `#76`
+- Implementation PR: `#77`
+- Implementation source SHA: `a7ce23c8f09c05f8bb0e2658cbbe116ba9a12e6c`
+- Release tag target: merged SHA of this release packet PR
+- Previous live release: `v0.3.0-beta.1` (`647461ef59203e8ce89c5411f2bb31449ce28270`)
+- Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- launchd label: `com.electricsheephq.evaos-code-review-bot`
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+- State DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
+- Evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/v0.3.1-beta.1/`
+- Monitor owner/window: implementing agent, first post-promotion health check
+- Rollback SHA/tag: `v0.3.0-beta.1`
+- Rollback command:
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard v0.3.0-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+## Purpose
+
+Promote provider throttle queue resilience after live beta cooldown rows made
+release status flap red during Z.ai request throttling. This patch keeps the
+daemon running, preserves single-review concurrency, and makes cooldown backlog
+state visible without treating an active provider throttle as weekly quota
+exhaustion.
+
+## Changes
+
+- Add global provider cooldown awareness to `release:status`.
+- Keep expired per-head cooldown rows release-green only while covered by an
+  active global provider cooldown.
+- Add a bounded daemon drain for expired provider cooldown rows after normal
+  review cycles.
+- Skip immediate retry attempts while a global provider cooldown is active.
+- Report eligible open PR heads as provider-deferred during active provider
+  cooldown instead of unprocessed misses.
+- Harden coverage audit against legacy read-only DBs that lack provider
+  cooldown tables.
+
+## Validation
+
+- PR `#77`: mergeable, clean, Socket checks green, no current-head review
+  threads.
+- `npm run build`
+- `npx vitest run tests/release-status.test.ts tests/coverage-audit.test.ts tests/worker-failure.test.ts tests/daemon-loop.test.ts tests/state.test.ts`
+- `npm test`
+- `git diff --check`
+
+## Runtime Caveats
+
+- This release does not expand monitored repos, App permissions, ZCode tools,
+  auto-merge, approvals, or command triggers.
+- Provider cooldown rows may still exist when Z.ai returns request throttling or
+  overload. `1302`/`1305` remain provider/request throttle signals, not weekly
+  usage exhaustion, unless plan-exhaustion evidence also exists.
+- The post-release gate must run `release:status`, `coverage-audit`, and
+  `provider-cooldowns --expired-only true` before this beta is called green.
+- If the provider is still actively cooling down but daemon health is good and
+  coverage has no unprocessed eligible heads, classify the release as yellow
+  and name the affected PR heads in the tracker.
+
+## Notes
+
+- What changed: provider throttle queue handling and release-health
+  interpretation.
+- What did not change: review posting policy, monitored allowlist, commands,
+  native ZCode skill mode, MCP access, or review concurrency.
+- Open follow-ups: continue #5/#14 allowlist-policy hardening and #9
+  eval/comparison after the provider queue is stable.


### PR DESCRIPTION
## Summary
- add the v0.3.1-beta.1 release packet for the provider throttle resilience patch
- document rollback to v0.3.0-beta.1 and post-release gates

Refs #76.

## Validation
- npm run build
- npm test
- git diff --check

## Release note
Docs-only release packet. After merge, tag the merged packet SHA as v0.3.1-beta.1 and promote through docs/beta-release-runbook.md.