### PR TITLE
Add repo-sticky reviewer session state

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,6 +52,7 @@ async function main(): Promise<void> {
       repoProfilesEnabled: Boolean(config.repoProfiles),
       activation: config.activation,
       reviewConcurrency: config.reviewConcurrency,
+      reviewerSessions: config.reviewerSessions,
       commandsEnabled: config.commands.enabled,
       statePath: config.statePath,
       workRoot: config.workRoot,

--- a/src/config.ts
+++ b/src/config.ts
@@ -204,6 +204,7 @@ function validateConfig(config: BotConfig): void {
   validatePositiveInteger(config.reviewConcurrency.maxActiveRuns, "config.reviewConcurrency.maxActiveRuns");
   validatePositiveInteger(config.reviewConcurrency.leaseTtlMs, "config.reviewConcurrency.leaseTtlMs");
   const reviewerSessions = config.reviewerSessions ?? DEFAULT_CONFIG.reviewerSessions!;
+  config.reviewerSessions = reviewerSessions;
   validateBoolean(reviewerSessions.enabled, "config.reviewerSessions.enabled");
   validatePositiveInteger(reviewerSessions.ttlMs, "config.reviewerSessions.ttlMs");
   validatePositiveInteger(reviewerSessions.headCountLimit, "config.reviewerSessions.headCountLimit");

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,11 @@ export interface BotConfig {
     maxActiveRuns: number;
     leaseTtlMs: number;
   };
+  reviewerSessions?: {
+    enabled: boolean;
+    ttlMs: number;
+    headCountLimit: number;
+  };
   providerCooldown: {
     enabled: boolean;
     durationMs: number;
@@ -125,6 +130,11 @@ const DEFAULT_CONFIG: BotConfig = {
     maxActiveRuns: 1,
     leaseTtlMs: 15 * 60_000
   },
+  reviewerSessions: {
+    enabled: false,
+    ttlMs: 8 * 60 * 60_000,
+    headCountLimit: 10
+  },
   providerCooldown: {
     enabled: true,
     durationMs: 15 * 60_000,
@@ -193,6 +203,10 @@ function validateConfig(config: BotConfig): void {
   validateBoolean(config.activation.reviewExistingOpenPrsOnActivation, "config.activation.reviewExistingOpenPrsOnActivation");
   validatePositiveInteger(config.reviewConcurrency.maxActiveRuns, "config.reviewConcurrency.maxActiveRuns");
   validatePositiveInteger(config.reviewConcurrency.leaseTtlMs, "config.reviewConcurrency.leaseTtlMs");
+  const reviewerSessions = config.reviewerSessions ?? DEFAULT_CONFIG.reviewerSessions!;
+  validateBoolean(reviewerSessions.enabled, "config.reviewerSessions.enabled");
+  validatePositiveInteger(reviewerSessions.ttlMs, "config.reviewerSessions.ttlMs");
+  validatePositiveInteger(reviewerSessions.headCountLimit, "config.reviewerSessions.headCountLimit");
   validateBoolean(config.providerCooldown.enabled, "config.providerCooldown.enabled");
   validatePositiveInteger(config.providerCooldown.durationMs, "config.providerCooldown.durationMs");
   validatePositiveInteger(config.providerCooldown.requestRateLimitDurationMs, "config.providerCooldown.requestRateLimitDurationMs");

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -301,28 +301,29 @@ function readReviewerSessionCounts(db: DatabaseSync, now: Date): { total: number
     .prepare("select 1 from sqlite_master where type = 'table' and name = 'reviewer_sessions' limit 1")
     .get();
   if (!hasTable) return { total: 0, active: 0, expired: 0 };
-  const rows = db
-    .prepare("select state, expires_at, head_count_used, head_count_limit from reviewer_sessions")
-    .all() as unknown as Array<{
-      state: string;
-      expires_at: string;
-      head_count_used: number;
-      head_count_limit: number;
-    }>;
-  const active = rows.filter((row) => {
-    const expiresAtMs = Date.parse(row.expires_at);
-    return (
-      (row.state === "active" || row.state === "warming") &&
-      Number.isFinite(expiresAtMs) &&
-      expiresAtMs > now.getTime() &&
-      row.head_count_used < row.head_count_limit
-    );
-  }).length;
-  const expired = rows.filter((row) => {
-    const expiresAtMs = Date.parse(row.expires_at);
-    return row.state === "expired" || !Number.isFinite(expiresAtMs) || expiresAtMs <= now.getTime();
-  }).length;
-  return { total: rows.length, active, expired };
+  const row = db
+    .prepare(
+      `select
+         count(*) as total,
+         sum(case
+           when state in ('active', 'warming')
+            and datetime(expires_at) > datetime(?)
+            and head_count_used < head_count_limit
+           then 1 else 0 end) as active,
+         sum(case
+           when state = 'expired'
+             or datetime(expires_at) is null
+             or datetime(expires_at) <= datetime(?)
+             or head_count_used >= head_count_limit
+           then 1 else 0 end) as expired
+       from reviewer_sessions`
+    )
+    .get(now.toISOString(), now.toISOString()) as { total?: number; active?: number | null; expired?: number | null };
+  return {
+    total: row.total ?? 0,
+    active: row.active ?? 0,
+    expired: row.expired ?? 0
+  };
 }
 
 function readActiveGlobalProviderCooldowns(db: DatabaseSync, now: Date): Array<{ repo: string; cooldownUntil: string }> {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -22,6 +22,9 @@ export interface ReleaseDatabaseStatus {
   rowCount: number;
   errorCount: number;
   skippedCount?: number;
+  reviewerSessionCount?: number;
+  activeReviewerSessionCount?: number;
+  expiredReviewerSessionCount?: number;
   providerCooldownCount?: number;
   activeProviderCooldownCount?: number;
   expiredProviderCooldownCount?: number;
@@ -171,10 +174,11 @@ export function collectReleaseStatus(input: {
   expectedHead?: string;
   launchdLabel?: string;
   statePath?: string;
+  now?: Date;
 }): ReleaseStatus {
   const config = loadConfig(input.configPath);
   const configPath = input.configPath ?? "(default config)";
-  const now = new Date();
+  const now = input.now ?? new Date();
   return buildReleaseStatus({
     repo: readRepoStatus(input.cwd),
     expectedHead: input.expectedHead,
@@ -271,9 +275,13 @@ function readDatabaseStatus(statePath: string, now: Date): ReleaseDatabaseStatus
       : retryableExpiredProviderCooldownCount > 0
         ? "expired_retryable"
         : "none";
+    const reviewerSessions = readReviewerSessionCounts(db, now);
     return {
       rowCount: row.rowCount ?? 0,
       skippedCount: row.skippedCount ?? 0,
+      reviewerSessionCount: reviewerSessions.total,
+      activeReviewerSessionCount: reviewerSessions.active,
+      expiredReviewerSessionCount: reviewerSessions.expired,
       providerCooldownCount: row.providerCooldownCount ?? 0,
       activeProviderCooldownCount,
       expiredProviderCooldownCount,
@@ -286,6 +294,35 @@ function readDatabaseStatus(statePath: string, now: Date): ReleaseDatabaseStatus
   } finally {
     db.close();
   }
+}
+
+function readReviewerSessionCounts(db: DatabaseSync, now: Date): { total: number; active: number; expired: number } {
+  const hasTable = db
+    .prepare("select 1 from sqlite_master where type = 'table' and name = 'reviewer_sessions' limit 1")
+    .get();
+  if (!hasTable) return { total: 0, active: 0, expired: 0 };
+  const rows = db
+    .prepare("select state, expires_at, head_count_used, head_count_limit from reviewer_sessions")
+    .all() as unknown as Array<{
+      state: string;
+      expires_at: string;
+      head_count_used: number;
+      head_count_limit: number;
+    }>;
+  const active = rows.filter((row) => {
+    const expiresAtMs = Date.parse(row.expires_at);
+    return (
+      (row.state === "active" || row.state === "warming") &&
+      Number.isFinite(expiresAtMs) &&
+      expiresAtMs > now.getTime() &&
+      row.head_count_used < row.head_count_limit
+    );
+  }).length;
+  const expired = rows.filter((row) => {
+    const expiresAtMs = Date.parse(row.expires_at);
+    return row.state === "expired" || !Number.isFinite(expiresAtMs) || expiresAtMs <= now.getTime();
+  }).length;
+  return { total: rows.length, active, expired };
 }
 
 function readActiveGlobalProviderCooldowns(db: DatabaseSync, now: Date): Array<{ repo: string; cooldownUntil: string }> {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -25,6 +25,7 @@ export interface ReleaseDatabaseStatus {
   reviewerSessionCount?: number;
   activeReviewerSessionCount?: number;
   expiredReviewerSessionCount?: number;
+  reviewerSessionsByRepo?: ReviewerSessionRepoStatus[];
   providerCooldownCount?: number;
   activeProviderCooldownCount?: number;
   expiredProviderCooldownCount?: number;
@@ -32,6 +33,13 @@ export interface ReleaseDatabaseStatus {
   coveredExpiredProviderCooldownCount?: number;
   retryableExpiredProviderCooldownCount?: number;
   providerThrottleState?: "none" | "active" | "expired_retryable";
+}
+
+export interface ReviewerSessionRepoStatus {
+  repo: string;
+  total: number;
+  active: number;
+  expired: number;
 }
 
 export interface ReleaseHeartbeatStatus {
@@ -282,6 +290,7 @@ function readDatabaseStatus(statePath: string, now: Date): ReleaseDatabaseStatus
       reviewerSessionCount: reviewerSessions.total,
       activeReviewerSessionCount: reviewerSessions.active,
       expiredReviewerSessionCount: reviewerSessions.expired,
+      reviewerSessionsByRepo: reviewerSessions.byRepo,
       providerCooldownCount: row.providerCooldownCount ?? 0,
       activeProviderCooldownCount,
       expiredProviderCooldownCount,
@@ -296,33 +305,61 @@ function readDatabaseStatus(statePath: string, now: Date): ReleaseDatabaseStatus
   }
 }
 
-function readReviewerSessionCounts(db: DatabaseSync, now: Date): { total: number; active: number; expired: number } {
+function readReviewerSessionCounts(
+  db: DatabaseSync,
+  now: Date
+): { total: number; active: number; expired: number; byRepo: ReviewerSessionRepoStatus[] } {
   const hasTable = db
     .prepare("select 1 from sqlite_master where type = 'table' and name = 'reviewer_sessions' limit 1")
     .get();
-  if (!hasTable) return { total: 0, active: 0, expired: 0 };
+  if (!hasTable) return { total: 0, active: 0, expired: 0, byRepo: [] };
+  const activeSql = `
+    state in ('active', 'warming')
+    and datetime(expires_at) > datetime(?)
+    and head_count_used < head_count_limit
+  `;
+  const expiredSql = `
+    state = 'expired'
+    or datetime(expires_at) is null
+    or datetime(expires_at) <= datetime(?)
+    or head_count_used >= head_count_limit
+  `;
   const row = db
     .prepare(
       `select
          count(*) as total,
-         sum(case
-           when state in ('active', 'warming')
-            and datetime(expires_at) > datetime(?)
-            and head_count_used < head_count_limit
-           then 1 else 0 end) as active,
-         sum(case
-           when state = 'expired'
-             or datetime(expires_at) is null
-             or datetime(expires_at) <= datetime(?)
-             or head_count_used >= head_count_limit
-           then 1 else 0 end) as expired
+         sum(case when ${activeSql} then 1 else 0 end) as active,
+         sum(case when ${expiredSql} then 1 else 0 end) as expired
        from reviewer_sessions`
     )
     .get(now.toISOString(), now.toISOString()) as { total?: number; active?: number | null; expired?: number | null };
+  const byRepoRows = db
+    .prepare(
+      `select
+         repo,
+         count(*) as total,
+         sum(case when ${activeSql} then 1 else 0 end) as active,
+         sum(case when ${expiredSql} then 1 else 0 end) as expired
+       from reviewer_sessions
+       group by repo
+       order by repo`
+    )
+    .all(now.toISOString(), now.toISOString()) as unknown as Array<{
+      repo: string;
+      total?: number;
+      active?: number | null;
+      expired?: number | null;
+    }>;
   return {
     total: row.total ?? 0,
     active: row.active ?? 0,
-    expired: row.expired ?? 0
+    expired: row.expired ?? 0,
+    byRepo: byRepoRows.map((repoRow) => ({
+      repo: repoRow.repo,
+      total: repoRow.total ?? 0,
+      active: repoRow.active ?? 0,
+      expired: repoRow.expired ?? 0
+    }))
   };
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -443,7 +443,7 @@ export class ReviewStateStore {
         .run(session.sessionId, input.repo, input.pullNumber, input.headSha, assignmentReason, nowIso);
 
       const nextHeadCount = session.headCountUsed + 1;
-      const nextState: ReviewerSessionState = nextHeadCount >= session.headCountLimit ? "expired" : "active";
+      const nextState: ReviewerSessionState = nextHeadCount >= session.headCountLimit ? "draining" : "active";
       this.db
         .prepare(
           `update reviewer_sessions
@@ -568,7 +568,11 @@ export class ReviewStateStore {
         input.pullNumber,
         input.headSha
       );
-    return this.getReviewerSessionJob(input.repo, input.pullNumber, input.headSha)!;
+    const updated = this.getReviewerSessionJob(input.repo, input.pullNumber, input.headSha)!;
+    if (input.jobState === "completed" || input.jobState === "skipped" || input.jobState === "failed") {
+      this.expireDrainedReviewerSessionIfComplete(existing.sessionId);
+    }
+    return updated;
   }
 
   expireReviewerSessions(now = new Date(), repo?: string): number {
@@ -579,16 +583,16 @@ export class ReviewStateStore {
             `update reviewer_sessions
              set state = 'expired'
              where repo = ?
-               and state in ('warming', 'active')
-               and (expires_at <= ? or head_count_used >= head_count_limit)`
+               and state in ('warming', 'active', 'draining')
+               and (expires_at <= ? or (state in ('warming', 'active') and head_count_used >= head_count_limit))`
           )
           .run(repo, nowIso)
       : this.db
           .prepare(
             `update reviewer_sessions
              set state = 'expired'
-             where state in ('warming', 'active')
-               and (expires_at <= ? or head_count_used >= head_count_limit)`
+             where state in ('warming', 'active', 'draining')
+               and (expires_at <= ? or (state in ('warming', 'active') and head_count_used >= head_count_limit))`
           )
           .run(nowIso);
     return Number(result.changes);
@@ -643,6 +647,21 @@ export class ReviewStateStore {
         input.zcodeCliVersion ?? null
       );
     return this.getReviewerSession(sessionId)!;
+  }
+
+  private expireDrainedReviewerSessionIfComplete(sessionId: string): void {
+    const session = this.getReviewerSession(sessionId);
+    if (session?.state !== "draining") return;
+    const row = this.db
+      .prepare(
+        `select count(*) as activeJobCount
+         from reviewer_session_jobs
+         where session_id = ?
+           and job_state not in ('completed', 'skipped', 'failed')`
+      )
+      .get(sessionId) as { activeJobCount?: number };
+    if ((row.activeJobCount ?? 0) > 0) return;
+    this.db.prepare("update reviewer_sessions set state = 'expired' where session_id = ?").run(sessionId);
   }
 
   private getReusableReviewerSession(repo: string, now = new Date()): ReviewerSessionRecord | undefined {

--- a/src/state.ts
+++ b/src/state.ts
@@ -647,7 +647,7 @@ export class ReviewStateStore {
 
   private getReusableReviewerSession(repo: string, now = new Date()): ReviewerSessionRecord | undefined {
     const nowIso = now.toISOString();
-    const row = this.db
+    const rows = this.db
       .prepare(
         `select session_id, repo, repo_family, state, started_at, last_used_at, expires_at,
                 head_count_used, head_count_limit, worker_pid, model, provider, zcode_cli_version,
@@ -657,11 +657,20 @@ export class ReviewStateStore {
            and state in ('warming', 'active')
            and expires_at > ?
            and head_count_used < head_count_limit
-         order by datetime(last_used_at) desc
-         limit 1`
+         order by datetime(last_used_at) desc`
       )
-      .get(repo, nowIso) as ReviewerSessionRow | undefined;
-    return row ? mapReviewerSessionRow(row) : undefined;
+      .all(repo, nowIso) as unknown as ReviewerSessionRow[];
+    for (const row of rows) {
+      const session = mapReviewerSessionRow(row);
+      if (session.workerPid !== undefined && !isProcessAlive(session.workerPid)) {
+        this.db
+          .prepare("update reviewer_sessions set state = 'failed', last_error = ? where session_id = ?")
+          .run(`owner_pid_not_alive:${session.workerPid}`, session.sessionId);
+        continue;
+      }
+      return session;
+    }
+    return undefined;
   }
 
   private hasReviewerSessionForRepo(repo: string): boolean {

--- a/src/state.ts
+++ b/src/state.ts
@@ -146,6 +146,7 @@ export class ReviewStateStore {
   constructor(dbPath: string) {
     mkdirSync(dirname(dbPath), { recursive: true });
     this.db = new DatabaseSync(dbPath);
+    this.db.exec("pragma foreign_keys = on");
     this.db.exec(`
       create table if not exists processed_reviews (
         repo text not null,
@@ -382,31 +383,35 @@ export class ReviewStateStore {
   }): ReviewerSessionAssignResult {
     validateReviewerSessionInput(input.ttlMs, input.headCountLimit, input.workerPid);
 
-    if (this.hasProcessed(input.repo, input.pullNumber, input.headSha)) {
-      return { assigned: false, reason: "already_processed" };
-    }
-
-    const existingJob = this.getReviewerSessionJob(input.repo, input.pullNumber, input.headSha);
-    if (existingJob) {
-      return {
-        assigned: false,
-        reason: "already_assigned",
-        session: this.getReviewerSession(existingJob.sessionId),
-        job: existingJob
-      };
-    }
-
     const now = input.now ?? new Date();
     const nowIso = now.toISOString();
     const expiresAt = new Date(now.getTime() + input.ttlMs).toISOString();
     const workerPid = input.workerPid ?? process.pid;
     let assignmentReason = input.assignmentReason;
-    const hadPreviousRepoSession = this.listReviewerSessions({ repo: input.repo }).length > 0;
-    let session = this.getReusableReviewerSession(input.repo, now);
+    let session: ReviewerSessionRecord | undefined;
+    let assignedJob: ReviewerSessionJobRecord | undefined;
 
     this.db.exec("begin immediate");
     try {
-      this.expireReviewerSessions(now);
+      if (this.hasProcessed(input.repo, input.pullNumber, input.headSha)) {
+        this.db.exec("commit");
+        return { assigned: false, reason: "already_processed" };
+      }
+
+      const existingJob = this.getReviewerSessionJob(input.repo, input.pullNumber, input.headSha);
+      if (existingJob) {
+        const result: ReviewerSessionAssignResult = {
+          assigned: false,
+          reason: "already_assigned",
+          session: this.getReviewerSession(existingJob.sessionId),
+          job: existingJob
+        };
+        this.db.exec("commit");
+        return result;
+      }
+
+      const hadPreviousRepoSession = this.hasReviewerSessionForRepo(input.repo);
+      const expiredRepoSessions = this.expireReviewerSessions(now, input.repo);
       session = this.getReusableReviewerSession(input.repo, now);
       if (!session) {
         session = this.createReviewerSession({
@@ -423,7 +428,8 @@ export class ReviewStateStore {
           provider: input.provider,
           zcodeCliVersion: input.zcodeCliVersion
         });
-        assignmentReason = assignmentReason ?? (hadPreviousRepoSession ? "session_expired_new_session" : "new_session");
+        assignmentReason =
+          assignmentReason ?? (hadPreviousRepoSession || expiredRepoSessions > 0 ? "session_expired_new_session" : "new_session");
       } else {
         assignmentReason = assignmentReason ?? "same_repo_active_session";
       }
@@ -445,18 +451,18 @@ export class ReviewStateStore {
            where session_id = ?`
         )
         .run(nextHeadCount, nowIso, nextState, session.sessionId);
+      assignedJob = this.getReviewerSessionJob(input.repo, input.pullNumber, input.headSha)!;
       this.db.exec("commit");
     } catch (error) {
       this.db.exec("rollback");
       throw error;
     }
 
-    const job = this.getReviewerSessionJob(input.repo, input.pullNumber, input.headSha)!;
     return {
       assigned: true,
-      session: this.getReviewerSession(job.sessionId)!,
-      job,
-      assignmentReason: job.assignmentReason
+      session: this.getReviewerSession(assignedJob!.sessionId)!,
+      job: assignedJob!,
+      assignmentReason: assignedJob!.assignmentReason
     };
   }
 
@@ -493,7 +499,7 @@ export class ReviewStateStore {
     activeOnly?: boolean;
     now?: Date;
   } = {}): ReviewerSessionRecord[] {
-    if (input.activeOnly) this.expireReviewerSessions(input.now ?? new Date());
+    const nowMs = (input.now ?? new Date()).getTime();
     const rows = (input.repo
       ? this.db
           .prepare(
@@ -517,7 +523,16 @@ export class ReviewStateStore {
     return rows
       .map(mapReviewerSessionRow)
       .filter((session) => !input.state || session.state === input.state)
-      .filter((session) => !input.activeOnly || session.state === "active" || session.state === "warming");
+      .filter((session) => {
+        if (!input.activeOnly) return true;
+        const expiresAtMs = Date.parse(session.expiresAt);
+        return (
+          (session.state === "active" || session.state === "warming") &&
+          Number.isFinite(expiresAtMs) &&
+          expiresAtMs > nowMs &&
+          session.headCountUsed < session.headCountLimit
+        );
+      });
   }
 
   updateReviewerSessionJobState(input: {
@@ -556,16 +571,26 @@ export class ReviewStateStore {
     return this.getReviewerSessionJob(input.repo, input.pullNumber, input.headSha)!;
   }
 
-  expireReviewerSessions(now = new Date()): number {
+  expireReviewerSessions(now = new Date(), repo?: string): number {
     const nowIso = now.toISOString();
-    const result = this.db
-      .prepare(
-        `update reviewer_sessions
-         set state = 'expired'
-         where state in ('warming', 'active')
-           and (expires_at <= ? or head_count_used >= head_count_limit)`
-      )
-      .run(nowIso);
+    const result = repo
+      ? this.db
+          .prepare(
+            `update reviewer_sessions
+             set state = 'expired'
+             where repo = ?
+               and state in ('warming', 'active')
+               and (expires_at <= ? or head_count_used >= head_count_limit)`
+          )
+          .run(repo, nowIso)
+      : this.db
+          .prepare(
+            `update reviewer_sessions
+             set state = 'expired'
+             where state in ('warming', 'active')
+               and (expires_at <= ? or head_count_used >= head_count_limit)`
+          )
+          .run(nowIso);
     return Number(result.changes);
   }
 
@@ -637,6 +662,11 @@ export class ReviewStateStore {
       )
       .get(repo, nowIso) as ReviewerSessionRow | undefined;
     return row ? mapReviewerSessionRow(row) : undefined;
+  }
+
+  private hasReviewerSessionForRepo(repo: string): boolean {
+    const row = this.db.prepare("select 1 from reviewer_sessions where repo = ? limit 1").get(repo);
+    return Boolean(row);
   }
 
   recordRepoProviderCooldown(input: { repo: string; cooldownUntil: Date; reason: string }): RepoProviderCooldownRecord {

--- a/src/state.ts
+++ b/src/state.ts
@@ -8,6 +8,13 @@ import type { ReviewEvent } from "./types.js";
 export type ProcessedStatus = "dry_run" | "posted" | "skipped" | "failed";
 export type ProcessedCommandAction = "review" | "re-review" | "explain" | "stop";
 export type ProcessedCommandStatus = "triggered" | "explained" | "stopped" | "ignored";
+export type ReviewerSessionState = "warming" | "active" | "draining" | "expired" | "failed";
+export type ReviewerSessionJobState = "assigned" | "running" | "completed" | "skipped" | "failed";
+export type ReviewerSessionAssignmentReason =
+  | "same_repo_active_session"
+  | "new_session"
+  | "session_expired_new_session"
+  | "manual_command_priority";
 
 export interface ProcessedReviewRecord {
   repo: string;
@@ -35,6 +42,52 @@ export interface ReviewRunLease {
   expiresAt: string;
   ownerPid: number;
 }
+
+export interface ReviewerSessionRecord {
+  sessionId: string;
+  repo: string;
+  repoFamily?: string;
+  state: ReviewerSessionState;
+  startedAt: string;
+  lastUsedAt: string;
+  expiresAt: string;
+  headCountUsed: number;
+  headCountLimit: number;
+  workerPid?: number;
+  model?: string;
+  provider?: string;
+  zcodeCliVersion?: string;
+  memoryPacketSha?: string;
+  gitnexusPacketSha?: string;
+  lastError?: string;
+}
+
+export interface ReviewerSessionJobRecord {
+  sessionId: string;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  jobState: ReviewerSessionJobState;
+  assignmentReason: ReviewerSessionAssignmentReason;
+  createdAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  processedReviewStatus?: ProcessedStatus;
+}
+
+export type ReviewerSessionAssignResult =
+  | {
+      assigned: true;
+      session: ReviewerSessionRecord;
+      job: ReviewerSessionJobRecord;
+      assignmentReason: ReviewerSessionAssignmentReason;
+    }
+  | {
+      assigned: false;
+      reason: "already_processed" | "already_assigned";
+      session?: ReviewerSessionRecord;
+      job?: ReviewerSessionJobRecord;
+    };
 
 export interface RepoProviderCooldownRecord {
   repo: string;
@@ -133,6 +186,40 @@ export class ReviewStateStore {
         dry_run integer,
         recorded_at text,
         error text
+      );
+
+      create table if not exists reviewer_sessions (
+        session_id text primary key,
+        repo text not null,
+        repo_family text,
+        state text not null,
+        started_at text not null,
+        last_used_at text not null,
+        expires_at text not null,
+        head_count_used integer not null,
+        head_count_limit integer not null,
+        worker_pid integer,
+        model text,
+        provider text,
+        zcode_cli_version text,
+        memory_packet_sha text,
+        gitnexus_packet_sha text,
+        last_error text
+      );
+
+      create table if not exists reviewer_session_jobs (
+        session_id text not null,
+        repo text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        job_state text not null,
+        assignment_reason text not null,
+        created_at text not null,
+        started_at text,
+        finished_at text,
+        processed_review_status text,
+        primary key (repo, pull_number, head_sha),
+        foreign key (session_id) references reviewer_sessions(session_id)
       );
     `);
     this.ensureDaemonHeartbeatColumns();
@@ -279,6 +366,209 @@ export class ReviewStateStore {
     this.db.prepare("delete from review_run_leases where lease_id = ?").run(leaseId);
   }
 
+  assignReviewerSessionJob(input: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    ttlMs: number;
+    headCountLimit: number;
+    now?: Date;
+    workerPid?: number;
+    model?: string;
+    provider?: string;
+    zcodeCliVersion?: string;
+    repoFamily?: string;
+    assignmentReason?: ReviewerSessionAssignmentReason;
+  }): ReviewerSessionAssignResult {
+    validateReviewerSessionInput(input.ttlMs, input.headCountLimit, input.workerPid);
+
+    if (this.hasProcessed(input.repo, input.pullNumber, input.headSha)) {
+      return { assigned: false, reason: "already_processed" };
+    }
+
+    const existingJob = this.getReviewerSessionJob(input.repo, input.pullNumber, input.headSha);
+    if (existingJob) {
+      return {
+        assigned: false,
+        reason: "already_assigned",
+        session: this.getReviewerSession(existingJob.sessionId),
+        job: existingJob
+      };
+    }
+
+    const now = input.now ?? new Date();
+    const nowIso = now.toISOString();
+    const expiresAt = new Date(now.getTime() + input.ttlMs).toISOString();
+    const workerPid = input.workerPid ?? process.pid;
+    let assignmentReason = input.assignmentReason;
+    const hadPreviousRepoSession = this.listReviewerSessions({ repo: input.repo }).length > 0;
+    let session = this.getReusableReviewerSession(input.repo, now);
+
+    this.db.exec("begin immediate");
+    try {
+      this.expireReviewerSessions(now);
+      session = this.getReusableReviewerSession(input.repo, now);
+      if (!session) {
+        session = this.createReviewerSession({
+          repo: input.repo,
+          repoFamily: input.repoFamily,
+          state: "active",
+          startedAt: nowIso,
+          lastUsedAt: nowIso,
+          expiresAt,
+          headCountUsed: 0,
+          headCountLimit: input.headCountLimit,
+          workerPid,
+          model: input.model,
+          provider: input.provider,
+          zcodeCliVersion: input.zcodeCliVersion
+        });
+        assignmentReason = assignmentReason ?? (hadPreviousRepoSession ? "session_expired_new_session" : "new_session");
+      } else {
+        assignmentReason = assignmentReason ?? "same_repo_active_session";
+      }
+
+      this.db
+        .prepare(
+          `insert into reviewer_session_jobs
+            (session_id, repo, pull_number, head_sha, job_state, assignment_reason, created_at)
+           values (?, ?, ?, ?, 'assigned', ?, ?)`
+        )
+        .run(session.sessionId, input.repo, input.pullNumber, input.headSha, assignmentReason, nowIso);
+
+      const nextHeadCount = session.headCountUsed + 1;
+      const nextState: ReviewerSessionState = nextHeadCount >= session.headCountLimit ? "expired" : "active";
+      this.db
+        .prepare(
+          `update reviewer_sessions
+           set head_count_used = ?, last_used_at = ?, state = ?
+           where session_id = ?`
+        )
+        .run(nextHeadCount, nowIso, nextState, session.sessionId);
+      this.db.exec("commit");
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+
+    const job = this.getReviewerSessionJob(input.repo, input.pullNumber, input.headSha)!;
+    return {
+      assigned: true,
+      session: this.getReviewerSession(job.sessionId)!,
+      job,
+      assignmentReason: job.assignmentReason
+    };
+  }
+
+  getReviewerSession(sessionId: string): ReviewerSessionRecord | undefined {
+    const row = this.db
+      .prepare(
+        `select session_id, repo, repo_family, state, started_at, last_used_at, expires_at,
+                head_count_used, head_count_limit, worker_pid, model, provider, zcode_cli_version,
+                memory_packet_sha, gitnexus_packet_sha, last_error
+         from reviewer_sessions
+         where session_id = ?
+         limit 1`
+      )
+      .get(sessionId) as ReviewerSessionRow | undefined;
+    return row ? mapReviewerSessionRow(row) : undefined;
+  }
+
+  getReviewerSessionJob(repo: string, pullNumber: number, headSha: string): ReviewerSessionJobRecord | undefined {
+    const row = this.db
+      .prepare(
+        `select session_id, repo, pull_number, head_sha, job_state, assignment_reason,
+                created_at, started_at, finished_at, processed_review_status
+         from reviewer_session_jobs
+         where repo = ? and pull_number = ? and head_sha = ?
+         limit 1`
+      )
+      .get(repo, pullNumber, headSha) as ReviewerSessionJobRow | undefined;
+    return row ? mapReviewerSessionJobRow(row) : undefined;
+  }
+
+  listReviewerSessions(input: {
+    repo?: string;
+    state?: ReviewerSessionState;
+    activeOnly?: boolean;
+    now?: Date;
+  } = {}): ReviewerSessionRecord[] {
+    if (input.activeOnly) this.expireReviewerSessions(input.now ?? new Date());
+    const rows = (input.repo
+      ? this.db
+          .prepare(
+            `select session_id, repo, repo_family, state, started_at, last_used_at, expires_at,
+                    head_count_used, head_count_limit, worker_pid, model, provider, zcode_cli_version,
+                    memory_packet_sha, gitnexus_packet_sha, last_error
+             from reviewer_sessions
+             where repo = ?
+             order by datetime(last_used_at) desc`
+          )
+          .all(input.repo)
+      : this.db
+          .prepare(
+            `select session_id, repo, repo_family, state, started_at, last_used_at, expires_at,
+                    head_count_used, head_count_limit, worker_pid, model, provider, zcode_cli_version,
+                    memory_packet_sha, gitnexus_packet_sha, last_error
+             from reviewer_sessions
+             order by datetime(last_used_at) desc`
+          )
+          .all()) as unknown as ReviewerSessionRow[];
+    return rows
+      .map(mapReviewerSessionRow)
+      .filter((session) => !input.state || session.state === input.state)
+      .filter((session) => !input.activeOnly || session.state === "active" || session.state === "warming");
+  }
+
+  updateReviewerSessionJobState(input: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    jobState: ReviewerSessionJobState;
+    processedReviewStatus?: ProcessedStatus;
+    now?: Date;
+  }): ReviewerSessionJobRecord {
+    const existing = this.getReviewerSessionJob(input.repo, input.pullNumber, input.headSha);
+    if (!existing) {
+      throw new Error(`No reviewer session job for ${input.repo}#${input.pullNumber}@${input.headSha}`);
+    }
+    const timestamp = (input.now ?? new Date()).toISOString();
+    this.db
+      .prepare(
+        `update reviewer_session_jobs
+         set job_state = ?,
+             started_at = case when ? = 'running' and started_at is null then ? else started_at end,
+             finished_at = case when ? in ('completed', 'skipped', 'failed') then ? else finished_at end,
+             processed_review_status = coalesce(?, processed_review_status)
+         where repo = ? and pull_number = ? and head_sha = ?`
+      )
+      .run(
+        input.jobState,
+        input.jobState,
+        timestamp,
+        input.jobState,
+        timestamp,
+        input.processedReviewStatus ?? null,
+        input.repo,
+        input.pullNumber,
+        input.headSha
+      );
+    return this.getReviewerSessionJob(input.repo, input.pullNumber, input.headSha)!;
+  }
+
+  expireReviewerSessions(now = new Date()): number {
+    const nowIso = now.toISOString();
+    const result = this.db
+      .prepare(
+        `update reviewer_sessions
+         set state = 'expired'
+         where state in ('warming', 'active')
+           and (expires_at <= ? or head_count_used >= head_count_limit)`
+      )
+      .run(nowIso);
+    return Number(result.changes);
+  }
+
   private pruneInactiveReviewRunLeases(): void {
     const rows = this.db
       .prepare("select lease_id, owner_pid from review_run_leases")
@@ -288,6 +578,65 @@ export class ReviewStateStore {
         this.db.prepare("delete from review_run_leases where lease_id = ?").run(row.lease_id);
       }
     }
+  }
+
+  private createReviewerSession(input: {
+    repo: string;
+    repoFamily?: string;
+    state: ReviewerSessionState;
+    startedAt: string;
+    lastUsedAt: string;
+    expiresAt: string;
+    headCountUsed: number;
+    headCountLimit: number;
+    workerPid?: number;
+    model?: string;
+    provider?: string;
+    zcodeCliVersion?: string;
+  }): ReviewerSessionRecord {
+    const sessionId = randomUUID();
+    this.db
+      .prepare(
+        `insert into reviewer_sessions
+          (session_id, repo, repo_family, state, started_at, last_used_at, expires_at,
+           head_count_used, head_count_limit, worker_pid, model, provider, zcode_cli_version)
+         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        sessionId,
+        input.repo,
+        input.repoFamily ?? null,
+        input.state,
+        input.startedAt,
+        input.lastUsedAt,
+        input.expiresAt,
+        input.headCountUsed,
+        input.headCountLimit,
+        input.workerPid ?? null,
+        input.model ?? null,
+        input.provider ?? null,
+        input.zcodeCliVersion ?? null
+      );
+    return this.getReviewerSession(sessionId)!;
+  }
+
+  private getReusableReviewerSession(repo: string, now = new Date()): ReviewerSessionRecord | undefined {
+    const nowIso = now.toISOString();
+    const row = this.db
+      .prepare(
+        `select session_id, repo, repo_family, state, started_at, last_used_at, expires_at,
+                head_count_used, head_count_limit, worker_pid, model, provider, zcode_cli_version,
+                memory_packet_sha, gitnexus_packet_sha, last_error
+         from reviewer_sessions
+         where repo = ?
+           and state in ('warming', 'active')
+           and expires_at > ?
+           and head_count_used < head_count_limit
+         order by datetime(last_used_at) desc
+         limit 1`
+      )
+      .get(repo, nowIso) as ReviewerSessionRow | undefined;
+    return row ? mapReviewerSessionRow(row) : undefined;
   }
 
   recordRepoProviderCooldown(input: { repo: string; cooldownUntil: Date; reason: string }): RepoProviderCooldownRecord {
@@ -519,6 +868,16 @@ function normalizeRetirementReason(reason: string): string {
   return normalized || "operator_acknowledged";
 }
 
+function validateReviewerSessionInput(ttlMs: number, headCountLimit: number, workerPid?: number): void {
+  if (!Number.isInteger(ttlMs)) throw new Error("ttlMs must be an integer");
+  if (ttlMs < 1) throw new Error("ttlMs must be at least 1");
+  if (!Number.isInteger(headCountLimit)) throw new Error("headCountLimit must be an integer");
+  if (headCountLimit < 1) throw new Error("headCountLimit must be at least 1");
+  if (workerPid !== undefined && (!Number.isInteger(workerPid) || workerPid < 1)) {
+    throw new Error("workerPid must be a positive integer");
+  }
+}
+
 export function parseProviderCooldownError(error?: string): ParsedProviderCooldownError | undefined {
   if (!error?.startsWith(PROVIDER_COOLDOWN_ERROR_PREFIX)) return undefined;
   const [cooldownPart, ...rest] = error.split(";");
@@ -560,6 +919,38 @@ interface RepoProviderCooldownRow {
   updated_at: string;
 }
 
+interface ReviewerSessionRow {
+  session_id: string;
+  repo: string;
+  repo_family: string | null;
+  state: ReviewerSessionState;
+  started_at: string;
+  last_used_at: string;
+  expires_at: string;
+  head_count_used: number;
+  head_count_limit: number;
+  worker_pid: number | null;
+  model: string | null;
+  provider: string | null;
+  zcode_cli_version: string | null;
+  memory_packet_sha: string | null;
+  gitnexus_packet_sha: string | null;
+  last_error: string | null;
+}
+
+interface ReviewerSessionJobRow {
+  session_id: string;
+  repo: string;
+  pull_number: number;
+  head_sha: string;
+  job_state: ReviewerSessionJobState;
+  assignment_reason: ReviewerSessionAssignmentReason;
+  created_at: string;
+  started_at: string | null;
+  finished_at: string | null;
+  processed_review_status: ProcessedStatus | null;
+}
+
 function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRecord {
   return {
     repo: row.repo,
@@ -579,6 +970,42 @@ function mapRepoProviderCooldownRow(row: RepoProviderCooldownRow): RepoProviderC
     cooldownUntil: row.cooldown_until,
     reason: row.reason,
     updatedAt: row.updated_at
+  };
+}
+
+function mapReviewerSessionRow(row: ReviewerSessionRow): ReviewerSessionRecord {
+  return {
+    sessionId: row.session_id,
+    repo: row.repo,
+    ...(row.repo_family ? { repoFamily: row.repo_family } : {}),
+    state: row.state,
+    startedAt: row.started_at,
+    lastUsedAt: row.last_used_at,
+    expiresAt: row.expires_at,
+    headCountUsed: row.head_count_used,
+    headCountLimit: row.head_count_limit,
+    ...(row.worker_pid ? { workerPid: row.worker_pid } : {}),
+    ...(row.model ? { model: row.model } : {}),
+    ...(row.provider ? { provider: row.provider } : {}),
+    ...(row.zcode_cli_version ? { zcodeCliVersion: row.zcode_cli_version } : {}),
+    ...(row.memory_packet_sha ? { memoryPacketSha: row.memory_packet_sha } : {}),
+    ...(row.gitnexus_packet_sha ? { gitnexusPacketSha: row.gitnexus_packet_sha } : {}),
+    ...(row.last_error ? { lastError: row.last_error } : {})
+  };
+}
+
+function mapReviewerSessionJobRow(row: ReviewerSessionJobRow): ReviewerSessionJobRecord {
+  return {
+    sessionId: row.session_id,
+    repo: row.repo,
+    pullNumber: row.pull_number,
+    headSha: row.head_sha,
+    jobState: row.job_state,
+    assignmentReason: row.assignment_reason,
+    createdAt: row.created_at,
+    ...(row.started_at ? { startedAt: row.started_at } : {}),
+    ...(row.finished_at ? { finishedAt: row.finished_at } : {}),
+    ...(row.processed_review_status ? { processedReviewStatus: row.processed_review_status } : {})
   };
 }
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -401,6 +401,34 @@ describe("beta release status", () => {
         10,
         10
       );
+      db.prepare(
+        `insert into reviewer_sessions
+          (session_id, repo, state, started_at, last_used_at, expires_at, head_count_used, head_count_limit)
+         values (?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        "stale-active-session",
+        "electricsheephq/WorldOS",
+        "active",
+        "2026-07-01T00:00:00.000Z",
+        "2026-07-01T00:00:10.000Z",
+        "2026-07-01T00:10:00.000Z",
+        1,
+        10
+      );
+      db.prepare(
+        `insert into reviewer_sessions
+          (session_id, repo, state, started_at, last_used_at, expires_at, head_count_used, head_count_limit)
+         values (?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        "limit-reached-active-session",
+        "electricsheephq/evaos-code-review-bot",
+        "active",
+        "2026-07-01T00:00:00.000Z",
+        "2026-07-01T00:00:10.000Z",
+        "2026-07-01T00:30:00.000Z",
+        10,
+        10
+      );
     } finally {
       db.close();
     }
@@ -413,9 +441,9 @@ describe("beta release status", () => {
       now: new Date("2026-07-01T00:15:00.000Z")
     });
 
-    expect(status.database.reviewerSessionCount).toBe(2);
+    expect(status.database.reviewerSessionCount).toBe(4);
     expect(status.database.activeReviewerSessionCount).toBe(1);
-    expect(status.database.expiredReviewerSessionCount).toBe(1);
+    expect(status.database.expiredReviewerSessionCount).toBe(3);
     expect(status.gates.every((gate) => gate.name !== "reviewer_sessions")).toBe(true);
   });
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -335,6 +335,90 @@ describe("beta release status", () => {
     expect(status.gates.some((gate) => gate.name === "provider_cooldown_backlog" && !gate.ok)).toBe(true);
   });
 
+  it("reports reviewer session counts from the live state database", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-reviewer-sessions-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table reviewer_sessions (
+          session_id text primary key,
+          repo text not null,
+          repo_family text,
+          state text not null,
+          started_at text not null,
+          last_used_at text not null,
+          expires_at text not null,
+          head_count_used integer not null,
+          head_count_limit integer not null,
+          worker_pid integer,
+          model text,
+          provider text,
+          zcode_cli_version text,
+          memory_packet_sha text,
+          gitnexus_packet_sha text,
+          last_error text
+        );
+      `);
+      db.prepare(
+        `insert into reviewer_sessions
+          (session_id, repo, state, started_at, last_used_at, expires_at, head_count_used, head_count_limit)
+         values (?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        "active-session",
+        "100yenadmin/evaOS-GUI",
+        "active",
+        "2026-07-01T00:00:00.000Z",
+        "2026-07-01T00:00:10.000Z",
+        "2026-07-01T00:30:00.000Z",
+        1,
+        10
+      );
+      db.prepare(
+        `insert into reviewer_sessions
+          (session_id, repo, state, started_at, last_used_at, expires_at, head_count_used, head_count_limit)
+         values (?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        "expired-session",
+        "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+        "expired",
+        "2026-07-01T00:00:00.000Z",
+        "2026-07-01T00:00:10.000Z",
+        "2026-07-01T00:10:00.000Z",
+        10,
+        10
+      );
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-01T00:15:00.000Z")
+    });
+
+    expect(status.database.reviewerSessionCount).toBe(2);
+    expect(status.database.activeReviewerSessionCount).toBe(1);
+    expect(status.database.expiredReviewerSessionCount).toBe(1);
+    expect(status.gates.every((gate) => gate.name !== "reviewer_sessions")).toBe(true);
+  });
+
   it("treats malformed provider cooldown timestamps as actionable backlog", () => {
     const root = mkdtempSync(join(tmpdir(), "release-status-db-invalid-cooldown-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -436,7 +436,7 @@ describe("beta release status", () => {
     const status = collectReleaseStatus({
       cwd: process.cwd(),
       statePath: dbPath,
-      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      configPath: undefined,
       launchdLabel: "com.electricsheephq.evaos-code-review-bot",
       now: new Date("2026-07-01T00:15:00.000Z")
     });
@@ -444,7 +444,12 @@ describe("beta release status", () => {
     expect(status.database.reviewerSessionCount).toBe(4);
     expect(status.database.activeReviewerSessionCount).toBe(1);
     expect(status.database.expiredReviewerSessionCount).toBe(3);
-    expect(status.gates.every((gate) => gate.name !== "reviewer_sessions")).toBe(true);
+    expect(status.database.reviewerSessionsByRepo).toEqual([
+      { repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO", total: 1, active: 0, expired: 1 },
+      { repo: "100yenadmin/evaOS-GUI", total: 1, active: 1, expired: 0 },
+      { repo: "electricsheephq/WorldOS", total: 1, active: 0, expired: 1 },
+      { repo: "electricsheephq/evaos-code-review-bot", total: 1, active: 0, expired: 1 }
+    ]);
   });
 
   it("treats malformed provider cooldown timestamps as actionable backlog", () => {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -155,6 +155,204 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("assigns repo-sticky reviewer session jobs and reuses active sessions for the same repo", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-reviewer-session-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    const first = store.assignReviewerSessionJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "head-a",
+      ttlMs: 60_000,
+      headCountLimit: 3,
+      now: new Date("2026-07-01T00:00:00.000Z"),
+      model: "GLM-5.2",
+      provider: "builtin:zai-coding-plan"
+    });
+    const second = store.assignReviewerSessionJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 498,
+      headSha: "head-b",
+      ttlMs: 60_000,
+      headCountLimit: 3,
+      now: new Date("2026-07-01T00:00:10.000Z")
+    });
+
+    expect(first).toMatchObject({
+      assigned: true,
+      assignmentReason: "new_session",
+      job: { jobState: "assigned" }
+    });
+    expect(second).toMatchObject({
+      assigned: true,
+      assignmentReason: "same_repo_active_session"
+    });
+    expect(first.assigned && second.assigned && second.session.sessionId).toBe(first.assigned && first.session.sessionId);
+    expect(store.listReviewerSessions({ repo: "100yenadmin/evaOS-GUI" })).toEqual([
+      expect.objectContaining({
+        repo: "100yenadmin/evaOS-GUI",
+        state: "active",
+        headCountUsed: 2,
+        headCountLimit: 3,
+        model: "GLM-5.2",
+        provider: "builtin:zai-coding-plan"
+      })
+    ]);
+    store.close();
+  });
+
+  it("keeps repo-sticky reviewer sessions isolated by repo", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-reviewer-session-repo-isolation-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    const gui = store.assignReviewerSessionJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "gui-head",
+      ttlMs: 60_000,
+      headCountLimit: 10,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    const lco = store.assignReviewerSessionJob({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 253,
+      headSha: "lco-head",
+      ttlMs: 60_000,
+      headCountLimit: 10,
+      now: new Date("2026-07-01T00:00:01.000Z")
+    });
+
+    expect(gui.assigned && lco.assigned && gui.session.sessionId).not.toBe(lco.assigned && lco.session.sessionId);
+    expect(store.listReviewerSessions()).toHaveLength(2);
+    store.close();
+  });
+
+  it("does not create session jobs for already processed or already assigned heads", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-reviewer-session-dedupe-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    store.recordProcessed({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "processed-head",
+      status: "posted",
+      event: "COMMENT"
+    });
+
+    expect(store.assignReviewerSessionJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "processed-head",
+      ttlMs: 60_000,
+      headCountLimit: 10
+    })).toEqual({ assigned: false, reason: "already_processed" });
+
+    const first = store.assignReviewerSessionJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "new-head",
+      ttlMs: 60_000,
+      headCountLimit: 10,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    const duplicate = store.assignReviewerSessionJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "new-head",
+      ttlMs: 60_000,
+      headCountLimit: 10,
+      now: new Date("2026-07-01T00:00:01.000Z")
+    });
+
+    expect(first).toMatchObject({ assigned: true });
+    expect(duplicate).toMatchObject({
+      assigned: false,
+      reason: "already_assigned",
+      job: expect.objectContaining({ headSha: "new-head" })
+    });
+    store.close();
+  });
+
+  it("expires reviewer sessions by TTL or head-count limit before new assignments", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-reviewer-session-expiry-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    const first = store.assignReviewerSessionJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "head-a",
+      ttlMs: 1_000,
+      headCountLimit: 1,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    const second = store.assignReviewerSessionJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 498,
+      headSha: "head-b",
+      ttlMs: 60_000,
+      headCountLimit: 10,
+      now: new Date("2026-07-01T00:00:02.000Z")
+    });
+
+    expect(first).toMatchObject({
+      assigned: true,
+      session: expect.objectContaining({ state: "expired", headCountUsed: 1, headCountLimit: 1 })
+    });
+    expect(second).toMatchObject({ assigned: true, assignmentReason: "session_expired_new_session" });
+    expect(first.assigned && second.assigned && first.session.sessionId).not.toBe(second.assigned && second.session.sessionId);
+    expect(store.listReviewerSessions({ state: "expired" })).toHaveLength(1);
+    expect(store.listReviewerSessions({ activeOnly: true, now: new Date("2026-07-01T00:00:02.000Z") })).toHaveLength(1);
+    store.close();
+  });
+
+  it("tracks reviewer session job lifecycle without calling ZCode", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-reviewer-session-jobs-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    store.assignReviewerSessionJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "head-a",
+      ttlMs: 60_000,
+      headCountLimit: 10,
+      assignmentReason: "manual_command_priority",
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    const running = store.updateReviewerSessionJobState({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "head-a",
+      jobState: "running",
+      now: new Date("2026-07-01T00:00:01.000Z")
+    });
+    const completed = store.updateReviewerSessionJobState({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "head-a",
+      jobState: "completed",
+      processedReviewStatus: "posted",
+      now: new Date("2026-07-01T00:00:10.000Z")
+    });
+
+    expect(running).toMatchObject({
+      jobState: "running",
+      assignmentReason: "manual_command_priority",
+      startedAt: "2026-07-01T00:00:01.000Z"
+    });
+    expect(completed).toMatchObject({
+      jobState: "completed",
+      processedReviewStatus: "posted",
+      startedAt: "2026-07-01T00:00:01.000Z",
+      finishedAt: "2026-07-01T00:00:10.000Z"
+    });
+    store.close();
+  });
+
   it("stores the latest daemon heartbeat as a singleton", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-daemon-heartbeat-"));
     roots.push(root);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -309,6 +309,27 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("filters active reviewer sessions without mutating stale rows from read APIs", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-reviewer-session-active-read-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    store.assignReviewerSessionJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "head-a",
+      ttlMs: 1_000,
+      headCountLimit: 10,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(store.listReviewerSessions({ activeOnly: true, now: new Date("2026-07-01T00:00:02.000Z") })).toHaveLength(0);
+    expect(store.listReviewerSessions({ state: "active" })).toHaveLength(1);
+    expect(store.expireReviewerSessions(new Date("2026-07-01T00:00:02.000Z"), "100yenadmin/evaOS-GUI")).toBe(1);
+    expect(store.listReviewerSessions({ state: "expired" })).toHaveLength(1);
+    store.close();
+  });
+
   it("tracks reviewer session job lifecycle without calling ZCode", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-reviewer-session-jobs-"));
     roots.push(root);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -188,7 +188,8 @@ describe("review state store", () => {
       assigned: true,
       assignmentReason: "same_repo_active_session"
     });
-    expect(first.assigned && second.assigned && second.session.sessionId).toBe(first.assigned && first.session.sessionId);
+    if (!first.assigned || !second.assigned) throw new Error("expected both session assignments to succeed");
+    expect(second.session.sessionId).toBe(first.session.sessionId);
     expect(store.listReviewerSessions({ repo: "100yenadmin/evaOS-GUI" })).toEqual([
       expect.objectContaining({
         repo: "100yenadmin/evaOS-GUI",
@@ -224,7 +225,8 @@ describe("review state store", () => {
       now: new Date("2026-07-01T00:00:01.000Z")
     });
 
-    expect(gui.assigned && lco.assigned && gui.session.sessionId).not.toBe(lco.assigned && lco.session.sessionId);
+    if (!gui.assigned || !lco.assigned) throw new Error("expected both repo session assignments to succeed");
+    expect(gui.session.sessionId).not.toBe(lco.session.sessionId);
     expect(store.listReviewerSessions()).toHaveLength(2);
     store.close();
   });
@@ -303,9 +305,43 @@ describe("review state store", () => {
       session: expect.objectContaining({ state: "expired", headCountUsed: 1, headCountLimit: 1 })
     });
     expect(second).toMatchObject({ assigned: true, assignmentReason: "session_expired_new_session" });
-    expect(first.assigned && second.assigned && first.session.sessionId).not.toBe(second.assigned && second.session.sessionId);
+    if (!first.assigned || !second.assigned) throw new Error("expected both session assignments to succeed");
+    expect(first.session.sessionId).not.toBe(second.session.sessionId);
     expect(store.listReviewerSessions({ state: "expired" })).toHaveLength(1);
     expect(store.listReviewerSessions({ activeOnly: true, now: new Date("2026-07-01T00:00:02.000Z") })).toHaveLength(1);
+    store.close();
+  });
+
+  it("does not reuse reviewer sessions owned by dead workers", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-reviewer-session-dead-worker-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    const first = store.assignReviewerSessionJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "head-a",
+      ttlMs: 60_000,
+      headCountLimit: 10,
+      workerPid: 999_999_999,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    const second = store.assignReviewerSessionJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 498,
+      headSha: "head-b",
+      ttlMs: 60_000,
+      headCountLimit: 10,
+      now: new Date("2026-07-01T00:00:01.000Z")
+    });
+
+    if (!first.assigned || !second.assigned) throw new Error("expected both session assignments to succeed");
+    expect(second.session.sessionId).not.toBe(first.session.sessionId);
+    expect(store.getReviewerSession(first.session.sessionId)).toMatchObject({
+      state: "failed",
+      lastError: "owner_pid_not_alive:999999999"
+    });
+    expect(store.listReviewerSessions({ activeOnly: true, now: new Date("2026-07-01T00:00:01.000Z") })).toHaveLength(1);
     store.close();
   });
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -287,7 +287,7 @@ describe("review state store", () => {
       repo: "100yenadmin/evaOS-GUI",
       pullNumber: 497,
       headSha: "head-a",
-      ttlMs: 1_000,
+      ttlMs: 60_000,
       headCountLimit: 1,
       now: new Date("2026-07-01T00:00:00.000Z")
     });
@@ -302,11 +302,20 @@ describe("review state store", () => {
 
     expect(first).toMatchObject({
       assigned: true,
-      session: expect.objectContaining({ state: "expired", headCountUsed: 1, headCountLimit: 1 })
+      session: expect.objectContaining({ state: "draining", headCountUsed: 1, headCountLimit: 1 })
     });
     expect(second).toMatchObject({ assigned: true, assignmentReason: "session_expired_new_session" });
     if (!first.assigned || !second.assigned) throw new Error("expected both session assignments to succeed");
     expect(first.session.sessionId).not.toBe(second.session.sessionId);
+    expect(store.getReviewerSession(first.session.sessionId)).toMatchObject({ state: "draining" });
+    store.updateReviewerSessionJobState({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "head-a",
+      jobState: "completed",
+      processedReviewStatus: "posted",
+      now: new Date("2026-07-01T00:00:03.000Z")
+    });
     expect(store.listReviewerSessions({ state: "expired" })).toHaveLength(1);
     expect(store.listReviewerSessions({ activeOnly: true, now: new Date("2026-07-01T00:00:02.000Z") })).toHaveLength(1);
     store.close();


### PR DESCRIPTION
## Summary
- add durable reviewer session and reviewer session job schema/state APIs
- add safe reviewer session config defaults, disabled by default
- expose reviewer session config in doctor and session counts in release-status database summary
- cover same-repo reuse, repo isolation, dedupe, expiry, job lifecycle, and release-status visibility

Closes #80.

## Validation
- npm run build
- npm test
- npx vitest run tests/state.test.ts tests/release-status.test.ts
- git diff --check

## Notes
This PR is intentionally accounting/status only. It does not change prompt contents, ZCode invocation, posting behavior, provider queue scheduling, GitNexus context, memory injection, monitored repos, or live review concurrency. #83 owns queue scheduling and #84 owns deeper runtime inventory.