### PR TITLE
[codex] Add first-class operator CLI

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -1,0 +1,85 @@
+# Operator CLI
+
+The bot has a JSON-first operator CLI for humans, manager agents, and reviewer
+agents. It is the preferred way to answer runtime questions before touching
+launchd, SQLite, or GitHub state by hand.
+
+Run commands from the repository checkout:
+
+```bash
+npx tsx src/cli.ts status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+After `npm run build`, the package also exposes:
+
+```bash
+evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+```
+
+## Commands
+
+- `status`: aggregated operator health. Includes release gates, launchd,
+  heartbeat, DB error/cooldown counts, coverage buckets, active/stale leases,
+  and recommended actions.
+- `agents`: launchd, heartbeat, and review-run lease inventory. This is
+  read-only; it does not restart, kill, prune, or retire anything.
+- `queue`: open PR-head coverage grouped into processed, provider-deferred,
+  pending review, skipped, stale-head, and read-failure buckets.
+- `coverage`: raw coverage-audit report with the shorter operator command name.
+- `cooldowns`: provider cooldown review rows plus repo/global cooldown rows.
+- `why --repo <owner/name> --pr <number>`: scoped explanation for why one PR
+  head is processed, pending, provider-deferred, skipped, blocked by a read
+  failure, or unknown.
+- `doctor`: auth/config readiness. Use this for GitHub App/ZCode readiness, not
+  runtime health.
+
+## Common Operator Flows
+
+Check whether the live bot is healthy:
+
+```bash
+npx tsx src/cli.ts status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+See whether review agents are active, idle, or stale:
+
+```bash
+npx tsx src/cli.ts agents --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+```
+
+Find open PR heads that still need review work:
+
+```bash
+npx tsx src/cli.ts queue --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+```
+
+Explain one PR:
+
+```bash
+npx tsx src/cli.ts why --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --repo 100yenadmin/Lossless-Codex-Orchestrator-LCO --pr 253
+```
+
+Inspect provider cooldowns:
+
+```bash
+npx tsx src/cli.ts cooldowns --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expired-only true
+```
+
+## Safety Boundaries
+
+Default operator commands are read-only. They can return nonzero when a gate is
+unhealthy, but they do not mutate GitHub, launchd, config files, worktrees, or
+SQLite rows.
+
+Mutating commands remain explicit:
+
+- `retry-provider-cooldowns --dry-run false`
+- `retry-failed --dry-run false`
+- `retire-failed`
+- `run-once --dry-run false`
+- `daemon --dry-run false`
+
+The CLI intentionally does not implement a global pause-all policy,
+one-at-a-time global queue policy, process killing, or Z.ai peak-hour blackout.
+Those belong to scheduler/session work and documented operator decisions, not
+hidden CLI side effects.

--- a/package.json
+++ b/package.json
@@ -3,12 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "bin": {
+    "evaos-review-bot": "dist/src/cli.js"
+  },
   "description": "Local ZCode-backed GitHub PR review bot pilot for evaOS repos.",
   "engines": {
     "node": ">=26"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "cli": "tsx src/cli.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "doctor": "tsx src/cli.ts doctor",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "postbuild": "chmod +x dist/src/cli.js",
     "cli": "tsx src/cli.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { loadConfig } from "./config.js";
 import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
 import { runDaemonCycle } from "./daemon.js";
@@ -5,6 +6,15 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { REQUIRED_SUITES, runOfflineEval } from "./eval-harness.js";
 import { GitHubApi } from "./github.js";
+import {
+  buildOperatorQueue,
+  buildOperatorStatus,
+  collectOperatorLeases,
+  collectOperatorProviderCooldowns,
+  collectOperatorRepoProviderCooldowns,
+  explainPullStatus,
+  summarizeAgentInventory
+} from "./operator-cli.js";
 import { collectReleaseStatus } from "./release-status.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
 import { ReviewStateStore } from "./state.js";
@@ -14,6 +24,11 @@ import { resolveZCodeProviderEnv } from "./zcode-env.js";
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const command = args._[0];
+
+  if (!command || command === "help" || command === "--help" || command === "-h") {
+    console.log(JSON.stringify(buildHelp(), null, 2));
+    return;
+  }
 
   if (command === "doctor") {
     const config = loadConfig(args.config);
@@ -98,6 +113,134 @@ async function main(): Promise<void> {
     } finally {
       state.close();
     }
+    return;
+  }
+
+  if (command === "status") {
+    const config = loadConfig(args.config);
+    const release = collectReleaseStatus({
+      cwd: process.cwd(),
+      configPath: args.config,
+      expectedHead: args["expected-head"],
+      launchdLabel: args["launchd-label"],
+      statePath: args["state-path"]
+    });
+    const coverage = await collectCoverageReport(args, config);
+    const agents = summarizeAgentInventory({
+      launchd: release.launchd,
+      heartbeat: release.heartbeat,
+      leases: collectOperatorLeases(args["state-path"] ?? config.statePath)
+    });
+    const providerCooldowns = collectOperatorProviderCooldowns(args["state-path"] ?? config.statePath, {
+      repo: args.repo,
+      expiredOnly: false,
+      limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
+    });
+    const status = buildOperatorStatus({
+      release,
+      coverage,
+      agents,
+      providerCooldowns
+    });
+    console.log(JSON.stringify(status, null, 2));
+    if (!status.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "agents") {
+    const config = loadConfig(args.config);
+    const release = collectReleaseStatus({
+      cwd: process.cwd(),
+      configPath: args.config,
+      expectedHead: args["expected-head"],
+      launchdLabel: args["launchd-label"],
+      statePath: args["state-path"]
+    });
+    const inventory = summarizeAgentInventory({
+      launchd: release.launchd,
+      heartbeat: release.heartbeat,
+      leases: collectOperatorLeases(args["state-path"] ?? config.statePath)
+    });
+    console.log(JSON.stringify(inventory, null, 2));
+    if (!inventory.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "queue") {
+    const config = loadConfig(args.config);
+    const report = await collectCoverageReport(args, config);
+    const queue = buildOperatorQueue(report);
+    console.log(JSON.stringify(queue, null, 2));
+    if (!queue.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "coverage") {
+    const config = loadConfig(args.config);
+    const report = await collectCoverageReport(args, config);
+    console.log(JSON.stringify(report, null, 2));
+    if (!report.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "cooldowns") {
+    const config = loadConfig(args.config);
+    const now = new Date();
+    const statePath = args["state-path"] ?? config.statePath;
+    const providerRows = collectOperatorProviderCooldowns(statePath, {
+      repo: args.repo,
+      expiredOnly: args["expired-only"] === "true",
+      limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined,
+      now
+    });
+    const repoCooldowns = collectOperatorRepoProviderCooldowns(statePath, {
+      activeOnly: args["active-only"] === "true",
+      now
+    });
+    const report = {
+      ok: providerRows.every((row) => !row.expired),
+      checkedAt: now.toISOString(),
+      filters: {
+        ...(args.repo ? { repo: args.repo } : {}),
+        expiredOnly: args["expired-only"] === "true",
+        activeOnly: args["active-only"] === "true"
+      },
+      summary: {
+        providerRows: providerRows.length,
+        expiredProviderRows: providerRows.filter((row) => row.expired).length,
+        activeProviderRows: providerRows.filter((row) => !row.expired).length,
+        repoCooldowns: repoCooldowns.length
+      },
+      providerRows,
+      repoCooldowns,
+      recommendedActions: providerRows.some((row) => row.expired)
+        ? [
+            `npx tsx src/cli.ts retry-provider-cooldowns --config ${args.config ?? "(default config)"} --expired-only true --dry-run false --zcode true`
+          ]
+        : []
+    };
+    console.log(JSON.stringify(report, null, 2));
+    if (!report.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "why") {
+    if (!args.repo) throw new Error("--repo is required for why");
+    if (!args.pr) throw new Error("--pr is required for why");
+    const config = loadConfig(args.config);
+    const report = await collectCoverageReport(args, config, true);
+    const explanation = explainPullStatus(report, args.repo, Number(args.pr));
+    console.log(JSON.stringify({
+      ok: !["read_failure", "unknown"].includes(explanation.state),
+      checkedAt: report.checkedAt,
+      explanation,
+      scopedCoverage: {
+        summary: report.summary,
+        staleHeads: report.staleHeads,
+        readFailures: report.readFailures
+      }
+    }, null, 2));
+    if (["read_failure", "unknown"].includes(explanation.state)) process.exitCode = 1;
     return;
   }
 
@@ -271,6 +414,59 @@ async function main(): Promise<void> {
   throw new Error(`Unknown command: ${command ?? "(missing)"}`);
 }
 
+async function collectCoverageReport(args: ParsedArgs, config = loadConfig(args.config), forceScoped = false) {
+  const github = new GitHubApi(config.github);
+  const state = CoverageStateReader.open(args["state-path"] ?? config.statePath);
+  try {
+    return await collectCoverageAudit({
+      config,
+      github,
+      state,
+      repo: args.repo,
+      pullNumber: args.pr ? Number(args.pr) : undefined,
+      verifyCurrentHeads: forceScoped ? true : args["verify-current-heads"] !== "false"
+    });
+  } finally {
+    state.close();
+  }
+}
+
+function buildHelp() {
+  return {
+    ok: true,
+    commands: {
+      operator: [
+        "status",
+        "agents",
+        "queue",
+        "coverage",
+        "cooldowns",
+        "why"
+      ],
+      existing: [
+        "doctor",
+        "release-status",
+        "coverage-audit",
+        "provider-cooldowns",
+        "retry-provider-cooldowns",
+        "retry-failed",
+        "retire-failed",
+        "run-once",
+        "daemon",
+        "eval-offline",
+        "eval-suite"
+      ]
+    },
+    examples: [
+      "npx tsx src/cli.ts status --config /path/to/live.json --launchd-label com.electricsheephq.evaos-code-review-bot",
+      "npx tsx src/cli.ts agents --config /path/to/live.json",
+      "npx tsx src/cli.ts queue --config /path/to/live.json",
+      "npx tsx src/cli.ts why --config /path/to/live.json --repo owner/repo --pr 123",
+      "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
+    ]
+  };
+}
+
 function parseArgs(argv: string[]): ParsedArgs {
   const parsed: ParsedArgs = { _: [] };
   for (let index = 0; index < argv.length; index += 1) {
@@ -337,6 +533,8 @@ interface ParsedArgs {
   "output-root"?: string;
   limit?: string;
   zcode?: string;
+  "active-only"?: string;
+  "verify-current-heads"?: string;
   [key: string]: string | string[] | undefined;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -194,6 +194,7 @@ async function main(): Promise<void> {
       now
     });
     const repoCooldowns = collectOperatorRepoProviderCooldowns(statePath, {
+      repo: args.repo,
       activeOnly: args["active-only"] === "true",
       now
     });
@@ -215,7 +216,7 @@ async function main(): Promise<void> {
       repoCooldowns,
       recommendedActions: providerRows.some((row) => row.expired)
         ? [
-            `npx tsx src/cli.ts retry-provider-cooldowns --config ${args.config ?? "(default config)"} --expired-only true --dry-run false --zcode true`
+            `npx tsx src/cli.ts retry-provider-cooldowns --config ${args.config ?? "(default config)"} --expired-only true --dry-run false${args.repo ? ` --repo ${args.repo}` : ""}`
           ]
         : []
     };
@@ -229,7 +230,11 @@ async function main(): Promise<void> {
     if (!args.pr) throw new Error("--pr is required for why");
     const config = loadConfig(args.config);
     const report = await collectCoverageReport(args, config, true);
-    const explanation = explainPullStatus(report, args.repo, Number(args.pr));
+    const repoWideReport = await collectCoverageReport({ ...args, pr: undefined }, config, true);
+    const repoWideExplanation = explainPullStatus(repoWideReport, args.repo, Number(args.pr));
+    const explanation = repoWideExplanation.state === "unknown"
+      ? explainPullStatus(report, args.repo, Number(args.pr))
+      : repoWideExplanation;
     console.log(JSON.stringify({
       ok: !["read_failure", "unknown"].includes(explanation.state),
       checkedAt: report.checkedAt,
@@ -238,6 +243,11 @@ async function main(): Promise<void> {
         summary: report.summary,
         staleHeads: report.staleHeads,
         readFailures: report.readFailures
+      },
+      repoCoverage: {
+        summary: repoWideReport.summary,
+        staleHeads: repoWideReport.staleHeads,
+        readFailures: repoWideReport.readFailures
       }
     }, null, 2));
     if (["read_failure", "unknown"].includes(explanation.state)) process.exitCode = 1;

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1,0 +1,548 @@
+import { existsSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import type {
+  CoverageAuditReport,
+  CoverageProcessedEntry,
+  CoverageProviderDeferredEntry,
+  CoverageSkippedEntry,
+  CoverageStaleHead,
+  CoverageUnprocessedEntry
+} from "./coverage-audit.js";
+import type { ReleaseHeartbeatStatus, ReleaseLaunchdStatus, ReleaseStatus } from "./release-status.js";
+import {
+  parseProviderCooldownError,
+  PROVIDER_COOLDOWN_ERROR_PREFIX,
+  type ProviderCooldownReviewRecord,
+  type RepoProviderCooldownRecord
+} from "./state.js";
+
+export interface OperatorStatus {
+  ok: boolean;
+  checkedAt: string;
+  summary: {
+    launchdState: ReleaseLaunchdStatus["state"];
+    heartbeatStatus: ReleaseHeartbeatStatus["status"];
+    activeLeases: number;
+    staleLeases: number;
+    pendingHeads: number;
+    providerDeferredHeads: number;
+    skippedHeads: number;
+    staleHeads: number;
+    readFailures: number;
+    failedRows: number;
+    expiredProviderCooldowns: number;
+    activeProviderCooldowns: number;
+  };
+  gates: Array<{ name: string; ok: boolean; detail: string }>;
+  recommendedActions: string[];
+  release: ReleaseStatus;
+  coverage?: OperatorQueueSnapshot;
+  agents: OperatorAgentInventory;
+  providerCooldowns: ProviderCooldownReviewRecord[];
+}
+
+export interface OperatorLease {
+  leaseId: string;
+  startedAt: string;
+  expiresAt: string;
+  ownerPid?: number;
+  ownerAlive?: boolean;
+}
+
+export interface OperatorLeaseWithState extends OperatorLease {
+  staleReason?: "expired" | "owner_not_running";
+}
+
+export interface OperatorAgentInventory {
+  ok: boolean;
+  checkedAt: string;
+  launchd: ReleaseLaunchdStatus;
+  heartbeat: ReleaseHeartbeatStatus;
+  summary: {
+    totalLeases: number;
+    activeLeases: number;
+    staleLeases: number;
+  };
+  activeLeases: OperatorLeaseWithState[];
+  staleLeases: OperatorLeaseWithState[];
+}
+
+export interface OperatorQueueEntry {
+  state: "processed" | "provider_deferred" | "pending_review" | "skipped" | "stale_head";
+  repo: string;
+  pullNumber?: number;
+  headSha?: string;
+  title?: string;
+  url?: string;
+  status?: string;
+  reason?: string;
+  nextAction: string;
+}
+
+export interface OperatorQueueSnapshot {
+  ok: boolean;
+  checkedAt: string;
+  summary: {
+    processed: number;
+    providerDeferred: number;
+    pending: number;
+    skipped: number;
+    staleHeads: number;
+    readFailures: number;
+  };
+  processed: OperatorQueueEntry[];
+  providerDeferred: OperatorQueueEntry[];
+  pending: OperatorQueueEntry[];
+  skipped: OperatorQueueEntry[];
+  staleHeads: OperatorQueueEntry[];
+  readFailures: Array<{ repo: string; error: string; nextAction: string }>;
+}
+
+export interface PullStatusExplanation {
+  repo: string;
+  pullNumber: number;
+  state: OperatorQueueEntry["state"] | "read_failure" | "unknown";
+  headSha?: string;
+  reason?: string;
+  reviewUrl?: string;
+  error?: string;
+  nextAction: "none" | "wait_or_retry_provider_cooldown" | "run_or_wait_for_daemon" | "inspect_github_read_failure" | "run_scoped_coverage_audit";
+}
+
+export function buildOperatorStatus(input: {
+  release: ReleaseStatus;
+  coverage?: CoverageAuditReport;
+  agents: OperatorAgentInventory;
+  providerCooldowns?: ProviderCooldownReviewRecord[];
+  checkedAt?: string;
+}): OperatorStatus {
+  const queue = input.coverage ? buildOperatorQueue(input.coverage) : undefined;
+  const providerCooldowns = input.providerCooldowns ?? [];
+  const expiredProviderCooldowns = providerCooldowns.filter((cooldown) => cooldown.expired).length;
+  const activeProviderCooldowns = providerCooldowns.length - expiredProviderCooldowns;
+  const pendingHeads = queue?.summary.pending ?? 0;
+  const providerDeferredHeads = queue?.summary.providerDeferred ?? 0;
+  const readFailures = queue?.summary.readFailures ?? 0;
+  const staleHeads = queue?.summary.staleHeads ?? 0;
+  const failedRows = input.release.database.errorCount;
+
+  const gates = [
+    ...input.release.gates,
+    {
+      name: "queue_no_pending_heads",
+      ok: pendingHeads === 0,
+      detail: pendingHeads === 0 ? "0 pending head(s)" : `${pendingHeads} pending head(s)`
+    },
+    {
+      name: "queue_no_read_failures",
+      ok: readFailures === 0,
+      detail: readFailures === 0 ? "0 read failure(s)" : `${readFailures} read failure(s)`
+    },
+    {
+      name: "agents_no_stale_leases",
+      ok: input.agents.summary.staleLeases === 0,
+      detail: input.agents.summary.staleLeases === 0
+        ? "0 stale lease(s)"
+        : `${input.agents.summary.staleLeases} stale lease(s)`
+    }
+  ];
+
+  const recommendedActions = uniqueStrings([
+    ...input.release.recommendedActions,
+    ...(pendingHeads > 0 ? ["wait for daemon cycle or run scoped run-once"] : []),
+    ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
+    ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : [])
+  ]);
+
+  return {
+    ok: gates.every((gate) => gate.ok),
+    checkedAt: input.checkedAt ?? input.release.checkedAt,
+    summary: {
+      launchdState: input.release.launchd.state,
+      heartbeatStatus: input.release.heartbeat.status,
+      activeLeases: input.agents.summary.activeLeases,
+      staleLeases: input.agents.summary.staleLeases,
+      pendingHeads,
+      providerDeferredHeads,
+      skippedHeads: queue?.summary.skipped ?? 0,
+      staleHeads,
+      readFailures,
+      failedRows,
+      expiredProviderCooldowns,
+      activeProviderCooldowns
+    },
+    gates,
+    recommendedActions,
+    release: input.release,
+    ...(queue ? { coverage: queue } : {}),
+    agents: input.agents,
+    providerCooldowns
+  };
+}
+
+export function summarizeAgentInventory(input: {
+  launchd: ReleaseLaunchdStatus;
+  heartbeat: ReleaseHeartbeatStatus;
+  leases: OperatorLease[];
+  now?: Date;
+  checkedAt?: string;
+}): OperatorAgentInventory {
+  const now = input.now ?? new Date();
+  const activeLeases: OperatorLeaseWithState[] = [];
+  const staleLeases: OperatorLeaseWithState[] = [];
+  for (const lease of input.leases) {
+    const expiresAtMs = Date.parse(lease.expiresAt);
+    if (Number.isFinite(expiresAtMs) && expiresAtMs <= now.getTime()) {
+      staleLeases.push({ ...lease, staleReason: "expired" });
+      continue;
+    }
+    if (lease.ownerAlive === false) {
+      staleLeases.push({ ...lease, staleReason: "owner_not_running" });
+      continue;
+    }
+    activeLeases.push(lease);
+  }
+
+  return {
+    ok: input.launchd.state === "running" && input.heartbeat.status === "fresh" && staleLeases.length === 0,
+    checkedAt: input.checkedAt ?? now.toISOString(),
+    launchd: input.launchd,
+    heartbeat: input.heartbeat,
+    summary: {
+      totalLeases: input.leases.length,
+      activeLeases: activeLeases.length,
+      staleLeases: staleLeases.length
+    },
+    activeLeases,
+    staleLeases
+  };
+}
+
+export function collectOperatorLeases(statePath: string): OperatorLease[] {
+  if (!existsSync(statePath)) return [];
+  const db = new DatabaseSync(statePath, { readOnly: true });
+  try {
+    const table = db
+      .prepare("select 1 from sqlite_master where type = 'table' and name = 'review_run_leases' limit 1")
+      .get();
+    if (!table) return [];
+    const rows = db
+      .prepare("select lease_id, started_at, expires_at, owner_pid from review_run_leases order by datetime(started_at) asc")
+      .all() as unknown as Array<{
+        lease_id: string;
+        started_at: string;
+        expires_at: string;
+        owner_pid: number | null;
+      }>;
+    return rows.map((row) => ({
+      leaseId: row.lease_id,
+      startedAt: row.started_at,
+      expiresAt: row.expires_at,
+      ...(row.owner_pid ? { ownerPid: row.owner_pid, ownerAlive: isProcessAlive(row.owner_pid) } : {})
+    }));
+  } finally {
+    db.close();
+  }
+}
+
+export function collectOperatorProviderCooldowns(
+  statePath: string,
+  input: { repo?: string; now?: Date; expiredOnly?: boolean; limit?: number } = {}
+): ProviderCooldownReviewRecord[] {
+  if (input.limit !== undefined && (!Number.isInteger(input.limit) || input.limit < 1)) {
+    throw new Error("limit must be a positive integer");
+  }
+  if (!existsSync(statePath)) return [];
+  const db = new DatabaseSync(statePath, { readOnly: true });
+  try {
+    if (!hasTable(db, "processed_reviews")) return [];
+    const rows = (input.repo
+      ? db
+          .prepare(
+            `select repo, pull_number, head_sha, status, event, review_url, error, created_at
+             from processed_reviews
+             where repo = ? and status = 'skipped' and error like ?
+             order by datetime(created_at) asc`
+          )
+          .all(input.repo, `${PROVIDER_COOLDOWN_ERROR_PREFIX}%`)
+      : db
+          .prepare(
+            `select repo, pull_number, head_sha, status, event, review_url, error, created_at
+             from processed_reviews
+             where status = 'skipped' and error like ?
+             order by datetime(created_at) asc`
+          )
+          .all(`${PROVIDER_COOLDOWN_ERROR_PREFIX}%`)) as unknown as ProcessedReviewRow[];
+    const now = input.now ?? new Date();
+    const mapped: ProviderCooldownReviewRecord[] = [];
+    for (const row of rows) {
+      const parsed = parseProviderCooldownError(row.error ?? undefined);
+      if (!parsed) continue;
+        const cooldownUntilMs = Date.parse(parsed.cooldownUntil);
+        const expired = !Number.isFinite(cooldownUntilMs) || cooldownUntilMs <= now.getTime();
+      const record: ProviderCooldownReviewRecord = {
+          repo: row.repo,
+          pullNumber: row.pull_number,
+          headSha: row.head_sha,
+        status: row.status as ProviderCooldownReviewRecord["status"],
+          ...(row.event ? { event: row.event } : {}),
+          ...(row.review_url ? { reviewUrl: row.review_url } : {}),
+          ...(row.error ? { error: row.error } : {}),
+          createdAt: row.created_at,
+          cooldownUntil: parsed.cooldownUntil,
+          ...(parsed.reason ? { reason: parsed.reason } : {}),
+          expired
+        };
+      if (!input.expiredOnly || record.expired) mapped.push(record);
+    }
+    return input.limit ? mapped.slice(0, input.limit) : mapped;
+  } finally {
+    db.close();
+  }
+}
+
+export function collectOperatorRepoProviderCooldowns(
+  statePath: string,
+  input: { activeOnly?: boolean; now?: Date } = {}
+): RepoProviderCooldownRecord[] {
+  if (!existsSync(statePath)) return [];
+  const db = new DatabaseSync(statePath, { readOnly: true });
+  try {
+    if (!hasTable(db, "repo_provider_cooldowns")) return [];
+    const rows = db
+      .prepare(
+        `select repo, cooldown_until, reason, updated_at
+         from repo_provider_cooldowns
+         order by datetime(cooldown_until) desc`
+      )
+      .all() as unknown as RepoProviderCooldownRow[];
+    const cooldowns = rows.map((row) => ({
+      repo: row.repo,
+      cooldownUntil: row.cooldown_until,
+      reason: row.reason,
+      updatedAt: row.updated_at
+    }));
+    if (!input.activeOnly) return cooldowns;
+    const now = input.now ?? new Date();
+    return cooldowns.filter((cooldown) => {
+      const cooldownUntilMs = Date.parse(cooldown.cooldownUntil);
+      return Number.isFinite(cooldownUntilMs) && cooldownUntilMs > now.getTime();
+    });
+  } finally {
+    db.close();
+  }
+}
+
+export function buildOperatorQueue(report: CoverageAuditReport): OperatorQueueSnapshot {
+  return {
+    ok: report.summary.unprocessed === 0 && report.summary.readFailures === 0 && report.summary.staleHeads === 0,
+    checkedAt: report.checkedAt,
+    summary: {
+      processed: report.processed.length,
+      providerDeferred: report.providerDeferred.length,
+      pending: report.unprocessed.length,
+      skipped: report.skipped.length,
+      staleHeads: report.staleHeads.length,
+      readFailures: report.readFailures.length
+    },
+    processed: report.processed.map(processedQueueEntry),
+    providerDeferred: report.providerDeferred.map(providerDeferredQueueEntry),
+    pending: report.unprocessed.map(pendingQueueEntry),
+    skipped: report.skipped.map(skippedQueueEntry),
+    staleHeads: report.staleHeads.map(staleHeadQueueEntry),
+    readFailures: report.readFailures.map((failure) => ({
+      ...failure,
+      nextAction: "inspect GitHub App installation/read permissions or network failure"
+    }))
+  };
+}
+
+export function explainPullStatus(
+  report: CoverageAuditReport,
+  repo: string,
+  pullNumber: number
+): PullStatusExplanation {
+  const processed = report.processed.find((entry) => entry.repo === repo && entry.pullNumber === pullNumber);
+  if (processed) {
+    return {
+      repo,
+      pullNumber,
+      state: "processed",
+      headSha: processed.headSha,
+      ...(processed.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
+      ...(processed.error ? { error: processed.error } : {}),
+      nextAction: "none"
+    };
+  }
+
+  const providerDeferred = report.providerDeferred.find((entry) => entry.repo === repo && entry.pullNumber === pullNumber);
+  if (providerDeferred) {
+    return {
+      repo,
+      pullNumber,
+      state: "provider_deferred",
+      headSha: providerDeferred.headSha,
+      ...(providerDeferred.reason ? { reason: providerDeferred.reason } : {}),
+      ...(providerDeferred.error ? { error: providerDeferred.error } : {}),
+      nextAction: "wait_or_retry_provider_cooldown"
+    };
+  }
+
+  const pending = report.unprocessed.find((entry) => entry.repo === repo && entry.pullNumber === pullNumber);
+  if (pending) {
+    return {
+      repo,
+      pullNumber,
+      state: "pending_review",
+      headSha: pending.headSha,
+      nextAction: "run_or_wait_for_daemon"
+    };
+  }
+
+  const skipped = report.skipped.find((entry) => entry.repo === repo && entry.pullNumber === pullNumber);
+  if (skipped) {
+    return {
+      repo,
+      pullNumber,
+      state: "skipped",
+      ...(skipped.headSha ? { headSha: skipped.headSha } : {}),
+      reason: skipped.reason,
+      nextAction: "none"
+    };
+  }
+
+  const staleHead = report.staleHeads.find((entry) => entry.repo === repo && entry.pullNumber === pullNumber);
+  if (staleHead) {
+    return {
+      repo,
+      pullNumber,
+      state: "stale_head",
+      headSha: staleHead.liveHeadSha,
+      reason: `expected ${staleHead.expectedHeadSha}, live ${staleHead.liveHeadSha}`,
+      nextAction: "run_or_wait_for_daemon"
+    };
+  }
+
+  const readFailure = report.readFailures.find((entry) => entry.repo === repo);
+  if (readFailure) {
+    return {
+      repo,
+      pullNumber,
+      state: "read_failure",
+      error: readFailure.error,
+      nextAction: "inspect_github_read_failure"
+    };
+  }
+
+  return {
+    repo,
+    pullNumber,
+    state: "unknown",
+    nextAction: "run_scoped_coverage_audit"
+  };
+}
+
+function processedQueueEntry(entry: CoverageProcessedEntry): OperatorQueueEntry {
+  return {
+    state: "processed",
+    repo: entry.repo,
+    pullNumber: entry.pullNumber,
+    headSha: entry.headSha,
+    title: entry.title,
+    url: entry.url,
+    status: entry.status,
+    ...(entry.error ? { reason: entry.error } : {}),
+    nextAction: "none"
+  };
+}
+
+function providerDeferredQueueEntry(entry: CoverageProviderDeferredEntry): OperatorQueueEntry {
+  return {
+    state: "provider_deferred",
+    repo: entry.repo,
+    pullNumber: entry.pullNumber,
+    headSha: entry.headSha,
+    title: entry.title,
+    url: entry.url,
+    status: entry.status,
+    reason: entry.reason ?? entry.error ?? "provider cooldown",
+    nextAction: "wait for cooldown expiry or run retry-provider-cooldowns when expired"
+  };
+}
+
+function pendingQueueEntry(entry: CoverageUnprocessedEntry): OperatorQueueEntry {
+  return {
+    state: "pending_review",
+    repo: entry.repo,
+    pullNumber: entry.pullNumber,
+    headSha: entry.headSha,
+    title: entry.title,
+    url: entry.url,
+    nextAction: "wait for daemon cycle or run scoped run-once"
+  };
+}
+
+function skippedQueueEntry(entry: CoverageSkippedEntry): OperatorQueueEntry {
+  return {
+    state: "skipped",
+    repo: entry.repo,
+    ...(entry.pullNumber !== undefined ? { pullNumber: entry.pullNumber } : {}),
+    ...(entry.headSha ? { headSha: entry.headSha } : {}),
+    ...(entry.title ? { title: entry.title } : {}),
+    ...(entry.url ? { url: entry.url } : {}),
+    reason: entry.reason,
+    nextAction: "none"
+  };
+}
+
+function staleHeadQueueEntry(entry: CoverageStaleHead): OperatorQueueEntry {
+  return {
+    state: "stale_head",
+    repo: entry.repo,
+    pullNumber: entry.pullNumber,
+    headSha: entry.liveHeadSha,
+    title: entry.title,
+    url: entry.url,
+    reason: `expected ${entry.expectedHeadSha}, live ${entry.liveHeadSha}`,
+    nextAction: "wait for next daemon cycle or run scoped coverage audit"
+  };
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasTable(db: DatabaseSync, tableName: string): boolean {
+  return Boolean(
+    db
+      .prepare("select 1 from sqlite_master where type = 'table' and name = ? limit 1")
+      .get(tableName)
+  );
+}
+
+interface ProcessedReviewRow {
+  repo: string;
+  pull_number: number;
+  head_sha: string;
+  status: string;
+  event: "COMMENT" | "REQUEST_CHANGES" | null;
+  review_url: string | null;
+  error: string | null;
+  created_at: string;
+}
+
+interface RepoProviderCooldownRow {
+  repo: string;
+  cooldown_until: string;
+  reason: string;
+  updated_at: string;
+}

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -139,6 +139,11 @@ export function buildOperatorStatus(input: {
       detail: readFailures === 0 ? "0 read failure(s)" : `${readFailures} read failure(s)`
     },
     {
+      name: "queue_no_stale_heads",
+      ok: staleHeads === 0,
+      detail: staleHeads === 0 ? "0 stale head(s)" : `${staleHeads} stale head(s)`
+    },
+    {
       name: "agents_no_stale_leases",
       ok: input.agents.summary.staleLeases === 0,
       detail: input.agents.summary.staleLeases === 0
@@ -151,6 +156,7 @@ export function buildOperatorStatus(input: {
     ...input.release.recommendedActions,
     ...(pendingHeads > 0 ? ["wait for daemon cycle or run scoped run-once"] : []),
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
+    ...(staleHeads > 0 ? ["wait for next daemon cycle or run scoped coverage audit"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : [])
   ]);
 
@@ -191,13 +197,13 @@ export function summarizeAgentInventory(input: {
   const activeLeases: OperatorLeaseWithState[] = [];
   const staleLeases: OperatorLeaseWithState[] = [];
   for (const lease of input.leases) {
+    if (lease.ownerAlive === false) {
+      staleLeases.push({ ...lease, staleReason: "owner_not_running" });
+      continue;
+    }
     const expiresAtMs = Date.parse(lease.expiresAt);
     if (Number.isFinite(expiresAtMs) && expiresAtMs <= now.getTime()) {
       staleLeases.push({ ...lease, staleReason: "expired" });
-      continue;
-    }
-    if (lease.ownerAlive === false) {
-      staleLeases.push({ ...lease, staleReason: "owner_not_running" });
       continue;
     }
     activeLeases.push(lease);
@@ -226,8 +232,14 @@ export function collectOperatorLeases(statePath: string): OperatorLease[] {
       .prepare("select 1 from sqlite_master where type = 'table' and name = 'review_run_leases' limit 1")
       .get();
     if (!table) return [];
+    const columns = db.prepare("pragma table_info(review_run_leases)").all() as unknown as Array<{ name: string }>;
+    const hasOwnerPid = columns.some((column) => column.name === "owner_pid");
     const rows = db
-      .prepare("select lease_id, started_at, expires_at, owner_pid from review_run_leases order by datetime(started_at) asc")
+      .prepare(
+        hasOwnerPid
+          ? "select lease_id, started_at, expires_at, owner_pid from review_run_leases order by datetime(started_at) asc"
+          : "select lease_id, started_at, expires_at, null as owner_pid from review_run_leases order by datetime(started_at) asc"
+      )
       .all() as unknown as Array<{
         lease_id: string;
         started_at: string;
@@ -303,19 +315,28 @@ export function collectOperatorProviderCooldowns(
 
 export function collectOperatorRepoProviderCooldowns(
   statePath: string,
-  input: { activeOnly?: boolean; now?: Date } = {}
+  input: { repo?: string; activeOnly?: boolean; now?: Date } = {}
 ): RepoProviderCooldownRecord[] {
   if (!existsSync(statePath)) return [];
   const db = new DatabaseSync(statePath, { readOnly: true });
   try {
     if (!hasTable(db, "repo_provider_cooldowns")) return [];
-    const rows = db
-      .prepare(
-        `select repo, cooldown_until, reason, updated_at
-         from repo_provider_cooldowns
-         order by datetime(cooldown_until) desc`
-      )
-      .all() as unknown as RepoProviderCooldownRow[];
+    const rows = (input.repo
+      ? db
+          .prepare(
+            `select repo, cooldown_until, reason, updated_at
+             from repo_provider_cooldowns
+             where repo = ?
+             order by datetime(cooldown_until) desc`
+          )
+          .all(input.repo)
+      : db
+          .prepare(
+            `select repo, cooldown_until, reason, updated_at
+             from repo_provider_cooldowns
+             order by datetime(cooldown_until) desc`
+          )
+          .all()) as unknown as RepoProviderCooldownRow[];
     const cooldowns = rows.map((row) => ({
       repo: row.repo,
       cooldownUntil: row.cooldown_until,
@@ -362,19 +383,6 @@ export function explainPullStatus(
   repo: string,
   pullNumber: number
 ): PullStatusExplanation {
-  const processed = report.processed.find((entry) => entry.repo === repo && entry.pullNumber === pullNumber);
-  if (processed) {
-    return {
-      repo,
-      pullNumber,
-      state: "processed",
-      headSha: processed.headSha,
-      ...(processed.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
-      ...(processed.error ? { error: processed.error } : {}),
-      nextAction: "none"
-    };
-  }
-
   const providerDeferred = report.providerDeferred.find((entry) => entry.repo === repo && entry.pullNumber === pullNumber);
   if (providerDeferred) {
     return {
@@ -385,6 +393,31 @@ export function explainPullStatus(
       ...(providerDeferred.reason ? { reason: providerDeferred.reason } : {}),
       ...(providerDeferred.error ? { error: providerDeferred.error } : {}),
       nextAction: "wait_or_retry_provider_cooldown"
+    };
+  }
+
+  const staleHead = report.staleHeads.find((entry) => entry.repo === repo && entry.pullNumber === pullNumber);
+  if (staleHead) {
+    return {
+      repo,
+      pullNumber,
+      state: "stale_head",
+      headSha: staleHead.liveHeadSha,
+      reason: `expected ${staleHead.expectedHeadSha}, live ${staleHead.liveHeadSha}`,
+      nextAction: "run_or_wait_for_daemon"
+    };
+  }
+
+  const processed = report.processed.find((entry) => entry.repo === repo && entry.pullNumber === pullNumber);
+  if (processed) {
+    return {
+      repo,
+      pullNumber,
+      state: "processed",
+      headSha: processed.headSha,
+      ...(processed.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
+      ...(processed.error ? { error: processed.error } : {}),
+      nextAction: "none"
     };
   }
 
@@ -408,18 +441,6 @@ export function explainPullStatus(
       ...(skipped.headSha ? { headSha: skipped.headSha } : {}),
       reason: skipped.reason,
       nextAction: "none"
-    };
-  }
-
-  const staleHead = report.staleHeads.find((entry) => entry.repo === repo && entry.pullNumber === pullNumber);
-  if (staleHead) {
-    return {
-      repo,
-      pullNumber,
-      state: "stale_head",
-      headSha: staleHead.liveHeadSha,
-      reason: `expected ${staleHead.expectedHeadSha}, live ${staleHead.liveHeadSha}`,
-      nextAction: "run_or_wait_for_daemon"
     };
   }
 
@@ -516,7 +537,8 @@ function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "EPERM") return true;
     return false;
   }
 }

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
 import type { CoverageAuditReport } from "../src/coverage-audit.js";
 import {
   buildOperatorQueue,
   buildOperatorStatus,
+  collectOperatorLeases,
+  collectOperatorRepoProviderCooldowns,
   explainPullStatus,
   summarizeAgentInventory,
   type OperatorAgentInventory
@@ -10,6 +16,14 @@ import {
 import type { ReleaseStatus } from "../src/release-status.js";
 
 describe("operator CLI summaries", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("combines release health, coverage, agents, and cooldown backlog into one operator status", () => {
     const status = buildOperatorStatus({
       release: releaseStatus({ ok: false, recommendedActions: ["retry cooldowns"] }),
@@ -54,6 +68,11 @@ describe("operator CLI summaries", () => {
       ok: false,
       detail: "1 stale lease(s)"
     });
+    expect(status.gates).toContainEqual({
+      name: "queue_no_stale_heads",
+      ok: true,
+      detail: "0 stale head(s)"
+    });
     expect(status.recommendedActions).toContain("retry cooldowns");
     expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
   });
@@ -84,6 +103,72 @@ describe("operator CLI summaries", () => {
     expect(inventory.staleLeases).toEqual([
       expect.objectContaining({ leaseId: "expired", staleReason: "expired" }),
       expect.objectContaining({ leaseId: "dead-owner", staleReason: "owner_not_running" })
+    ]);
+  });
+
+  it("prefers dead-owner lease diagnostics over expiry when both are true", () => {
+    const inventory = summarizeAgentInventory({
+      launchd: { label: "com.electricsheephq.evaos-code-review-bot", state: "running", pid: 1234, dryRun: false },
+      heartbeat: {
+        status: "fresh",
+        maxAgeMs: 120_000,
+        latestAt: "2026-07-01T00:00:10.000Z",
+        ageMs: 5_000,
+        cycle: 42,
+        event: "daemon_cycle_complete",
+        dryRun: false
+      },
+      leases: [
+        lease("expired-dead-owner", "2026-06-30T23:00:00.000Z", "2026-06-30T23:10:00.000Z", 999999, false)
+      ],
+      now: new Date("2026-07-01T00:01:00.000Z")
+    });
+
+    expect(inventory.staleLeases).toEqual([
+      expect.objectContaining({ leaseId: "expired-dead-owner", staleReason: "owner_not_running" })
+    ]);
+  });
+
+  it("reads lease inventories from pre-owner-pid state databases", () => {
+    const statePath = createTempDatabase(tempDirs);
+    const db = new DatabaseSync(statePath);
+    try {
+      db.exec("create table review_run_leases (lease_id text primary key, started_at text not null, expires_at text not null)");
+      db.prepare("insert into review_run_leases (lease_id, started_at, expires_at) values (?, ?, ?)")
+        .run("legacy", "2026-07-01T00:00:00.000Z", "2026-07-01T00:10:00.000Z");
+    } finally {
+      db.close();
+    }
+
+    expect(collectOperatorLeases(statePath)).toEqual([
+      {
+        leaseId: "legacy",
+        startedAt: "2026-07-01T00:00:00.000Z",
+        expiresAt: "2026-07-01T00:10:00.000Z"
+      }
+    ]);
+  });
+
+  it("scopes repo provider cooldown inventory to the requested repo", () => {
+    const statePath = createTempDatabase(tempDirs);
+    const db = new DatabaseSync(statePath);
+    try {
+      db.exec("create table repo_provider_cooldowns (repo text primary key, cooldown_until text not null, reason text not null, updated_at text not null)");
+      db.prepare("insert into repo_provider_cooldowns (repo, cooldown_until, reason, updated_at) values (?, ?, ?, ?)")
+        .run("owner/repo", "2026-07-01T00:05:00.000Z", "provider_request_rate_limit", "2026-07-01T00:00:00.000Z");
+      db.prepare("insert into repo_provider_cooldowns (repo, cooldown_until, reason, updated_at) values (?, ?, ?, ?)")
+        .run("owner/other", "2026-07-01T00:06:00.000Z", "provider_request_rate_limit", "2026-07-01T00:00:00.000Z");
+    } finally {
+      db.close();
+    }
+
+    expect(collectOperatorRepoProviderCooldowns(statePath, { repo: "owner/repo" })).toEqual([
+      {
+        repo: "owner/repo",
+        cooldownUntil: "2026-07-01T00:05:00.000Z",
+        reason: "provider_request_rate_limit",
+        updatedAt: "2026-07-01T00:00:00.000Z"
+      }
     ]);
   });
 
@@ -146,7 +231,38 @@ describe("operator CLI summaries", () => {
       nextAction: "run_scoped_coverage_audit"
     });
   });
+
+  it("prioritizes provider-deferred and stale-head explanations over processed rows", () => {
+    const report = coverageReport({
+      processed: [processedEntry(2, "head-cooldown", "skipped"), processedEntry(5, "old-head", "posted")],
+      providerDeferred: [providerDeferredEntry(2, "head-cooldown")],
+      staleHeads: [{
+        repo: "owner/repo",
+        pullNumber: 5,
+        expectedHeadSha: "old-head",
+        liveHeadSha: "new-head",
+        title: "stale",
+        url: "https://github.com/owner/repo/pull/5"
+      }]
+    });
+
+    expect(explainPullStatus(report, "owner/repo", 2)).toMatchObject({
+      state: "provider_deferred",
+      nextAction: "wait_or_retry_provider_cooldown"
+    });
+    expect(explainPullStatus(report, "owner/repo", 5)).toMatchObject({
+      state: "stale_head",
+      headSha: "new-head",
+      nextAction: "run_or_wait_for_daemon"
+    });
+  });
 });
+
+function createTempDatabase(tempDirs: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "evaos-operator-cli-"));
+  tempDirs.push(dir);
+  return join(dir, "state.sqlite");
+}
 
 function releaseStatus(input: { ok: boolean; recommendedActions?: string[] }): ReleaseStatus {
   return {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "vitest";
+import type { CoverageAuditReport } from "../src/coverage-audit.js";
+import {
+  buildOperatorQueue,
+  buildOperatorStatus,
+  explainPullStatus,
+  summarizeAgentInventory,
+  type OperatorAgentInventory
+} from "../src/operator-cli.js";
+import type { ReleaseStatus } from "../src/release-status.js";
+
+describe("operator CLI summaries", () => {
+  it("combines release health, coverage, agents, and cooldown backlog into one operator status", () => {
+    const status = buildOperatorStatus({
+      release: releaseStatus({ ok: false, recommendedActions: ["retry cooldowns"] }),
+      coverage: coverageReport({
+        unprocessed: [pullEntry(253, "head-pending")],
+        providerDeferred: [providerDeferredEntry(497, "head-deferred")],
+        readFailures: [{ repo: "owner/read-fail", error: "GitHub 404" }]
+      }),
+      agents: agentInventory({
+        activeLeases: [lease("lease-active", "2026-07-01T00:00:00.000Z", "2026-07-01T00:10:00.000Z")],
+        staleLeases: [lease("lease-stale", "2026-06-30T23:00:00.000Z", "2026-06-30T23:10:00.000Z")]
+      }),
+      providerCooldowns: [
+        {
+          ...processedRecord(253, "head-expired", "skipped"),
+          cooldownUntil: "2026-07-01T00:05:00.000Z",
+          reason: "provider_request_rate_limit",
+          expired: true
+        }
+      ],
+      checkedAt: "2026-07-01T00:30:00.000Z"
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.summary).toMatchObject({
+      launchdState: "running",
+      heartbeatStatus: "fresh",
+      activeLeases: 1,
+      staleLeases: 1,
+      pendingHeads: 1,
+      providerDeferredHeads: 1,
+      readFailures: 1,
+      expiredProviderCooldowns: 1
+    });
+    expect(status.gates).toContainEqual({
+      name: "queue_no_pending_heads",
+      ok: false,
+      detail: "1 pending head(s)"
+    });
+    expect(status.gates).toContainEqual({
+      name: "agents_no_stale_leases",
+      ok: false,
+      detail: "1 stale lease(s)"
+    });
+    expect(status.recommendedActions).toContain("retry cooldowns");
+    expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+  });
+
+  it("summarizes active and stale agent leases without mutating runtime state", () => {
+    const inventory = summarizeAgentInventory({
+      launchd: { label: "com.electricsheephq.evaos-code-review-bot", state: "running", pid: 1234, dryRun: false },
+      heartbeat: {
+        status: "fresh",
+        maxAgeMs: 120_000,
+        latestAt: "2026-07-01T00:00:10.000Z",
+        ageMs: 5_000,
+        cycle: 42,
+        event: "daemon_cycle_complete",
+        dryRun: false
+      },
+      leases: [
+        lease("active", "2026-07-01T00:00:00.000Z", "2026-07-01T00:10:00.000Z", 1234, true),
+        lease("expired", "2026-06-30T23:00:00.000Z", "2026-06-30T23:10:00.000Z", 1234, true),
+        lease("dead-owner", "2026-07-01T00:00:00.000Z", "2026-07-01T00:10:00.000Z", 999999, false)
+      ],
+      now: new Date("2026-07-01T00:01:00.000Z")
+    });
+
+    expect(inventory.ok).toBe(false);
+    expect(inventory.summary).toMatchObject({ totalLeases: 3, activeLeases: 1, staleLeases: 2 });
+    expect(inventory.activeLeases.map((entry) => entry.leaseId)).toEqual(["active"]);
+    expect(inventory.staleLeases).toEqual([
+      expect.objectContaining({ leaseId: "expired", staleReason: "expired" }),
+      expect.objectContaining({ leaseId: "dead-owner", staleReason: "owner_not_running" })
+    ]);
+  });
+
+  it("builds queue buckets from coverage audit output", () => {
+    const queue = buildOperatorQueue(coverageReport({
+      processed: [processedEntry(1, "head-posted", "posted")],
+      providerDeferred: [providerDeferredEntry(2, "head-provider")],
+      unprocessed: [pullEntry(3, "head-pending")],
+      skipped: [{ repo: "owner/repo", pullNumber: 4, headSha: "head-draft", reason: "draft" }],
+      staleHeads: [{
+        repo: "owner/repo",
+        pullNumber: 5,
+        expectedHeadSha: "old-head",
+        liveHeadSha: "new-head",
+        title: "stale",
+        url: "https://github.com/owner/repo/pull/5"
+      }]
+    }));
+
+    expect(queue.ok).toBe(false);
+    expect(queue.summary).toMatchObject({
+      processed: 1,
+      providerDeferred: 1,
+      pending: 1,
+      skipped: 1,
+      staleHeads: 1
+    });
+    expect(queue.pending[0]).toMatchObject({ pullNumber: 3, state: "pending_review" });
+    expect(queue.providerDeferred[0]).toMatchObject({ pullNumber: 2, state: "provider_deferred" });
+  });
+
+  it("explains why a PR head is or is not reviewed", () => {
+    const report = coverageReport({
+      processed: [processedEntry(1, "head-posted", "posted")],
+      providerDeferred: [providerDeferredEntry(2, "head-cooldown")],
+      unprocessed: [pullEntry(3, "head-pending")],
+      skipped: [{ repo: "owner/repo", pullNumber: 4, headSha: "head-draft", reason: "draft" }],
+      readFailures: [{ repo: "owner/read-fail", error: "GitHub API failed" }]
+    });
+
+    expect(explainPullStatus(report, "owner/repo", 1)).toMatchObject({
+      state: "processed",
+      nextAction: "none"
+    });
+    expect(explainPullStatus(report, "owner/repo", 2)).toMatchObject({
+      state: "provider_deferred",
+      nextAction: "wait_or_retry_provider_cooldown"
+    });
+    expect(explainPullStatus(report, "owner/repo", 3)).toMatchObject({
+      state: "pending_review",
+      nextAction: "run_or_wait_for_daemon"
+    });
+    expect(explainPullStatus(report, "owner/repo", 4)).toMatchObject({
+      state: "skipped",
+      reason: "draft",
+      nextAction: "none"
+    });
+    expect(explainPullStatus(report, "owner/missing", 9)).toMatchObject({
+      state: "unknown",
+      nextAction: "run_scoped_coverage_audit"
+    });
+  });
+});
+
+function releaseStatus(input: { ok: boolean; recommendedActions?: string[] }): ReleaseStatus {
+  return {
+    ok: input.ok,
+    checkedAt: "2026-07-01T00:30:00.000Z",
+    releaseUnit: {
+      channel: "local-beta",
+      sourceHead: "head",
+      branch: "main",
+      configPath: "/config/live.json"
+    },
+    repo: { branch: "main", head: "head", dirtyFiles: [] },
+    launchd: { label: "com.electricsheephq.evaos-code-review-bot", state: "running", pid: 1234, dryRun: false },
+    database: {
+      rowCount: 10,
+      errorCount: 0,
+      providerCooldownCount: 1,
+      expiredProviderCooldownCount: 1,
+      activeProviderCooldownCount: 0
+    },
+    heartbeat: {
+      status: "fresh",
+      maxAgeMs: 120_000,
+      latestAt: "2026-07-01T00:29:55.000Z",
+      ageMs: 5_000,
+      cycle: 12,
+      event: "daemon_cycle_complete",
+      dryRun: false
+    },
+    recommendedActions: input.recommendedActions ?? [],
+    gates: [{ name: "provider_cooldown_backlog", ok: false, detail: "1 expired provider cooldown row(s)" }],
+    rollback: {
+      restartCommand: "launchctl kickstart -k gui/501/com.electricsheephq.evaos-code-review-bot",
+      unloadCommand: "launchctl bootout gui/501 ~/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist"
+    }
+  };
+}
+
+function coverageReport(input: Partial<CoverageAuditReport>): CoverageAuditReport {
+  const report: CoverageAuditReport = {
+    ok: input.ok ?? false,
+    checkedAt: "2026-07-01T00:30:00.000Z",
+    summary: {
+      reposScanned: 1,
+      pullsSeen: 0,
+      processed: input.processed?.length ?? 0,
+      providerDeferred: input.providerDeferred?.length ?? 0,
+      unprocessed: input.unprocessed?.length ?? 0,
+      skipped: input.skipped?.length ?? 0,
+      staleHeads: input.staleHeads?.length ?? 0,
+      readFailures: input.readFailures?.length ?? 0
+    },
+    processed: input.processed ?? [],
+    providerDeferred: input.providerDeferred ?? [],
+    unprocessed: input.unprocessed ?? [],
+    skipped: input.skipped ?? [],
+    staleHeads: input.staleHeads ?? [],
+    readFailures: input.readFailures ?? []
+  };
+  report.summary.pullsSeen =
+    report.summary.processed +
+    report.summary.providerDeferred +
+    report.summary.unprocessed +
+    report.summary.skipped +
+    report.summary.staleHeads;
+  return report;
+}
+
+function pullEntry(pullNumber: number, headSha: string) {
+  return {
+    repo: "owner/repo",
+    pullNumber,
+    headSha,
+    title: `PR ${pullNumber}`,
+    url: `https://github.com/owner/repo/pull/${pullNumber}`,
+    draft: false,
+    state: "open",
+    previousProcessedHeads: []
+  };
+}
+
+function processedEntry(pullNumber: number, headSha: string, status: "posted" | "skipped") {
+  return {
+    ...pullEntry(pullNumber, headSha),
+    status,
+    event: status === "posted" ? "COMMENT" as const : undefined,
+    createdAt: "2026-07-01 00:00:00"
+  };
+}
+
+function providerDeferredEntry(pullNumber: number, headSha: string) {
+  return {
+    ...processedEntry(pullNumber, headSha, "skipped"),
+    cooldownUntil: "2026-07-01T00:05:00.000Z",
+    reason: "provider_request_rate_limit"
+  };
+}
+
+function processedRecord(pullNumber: number, headSha: string, status: "posted" | "skipped") {
+  return {
+    repo: "owner/repo",
+    pullNumber,
+    headSha,
+    status,
+    createdAt: "2026-07-01 00:00:00"
+  };
+}
+
+function lease(
+  leaseId: string,
+  startedAt: string,
+  expiresAt: string,
+  ownerPid = 1234,
+  ownerAlive = true
+) {
+  return { leaseId, startedAt, expiresAt, ownerPid, ownerAlive };
+}
+
+function agentInventory(input: Partial<OperatorAgentInventory>): OperatorAgentInventory {
+  return {
+    ok: input.ok ?? false,
+    checkedAt: "2026-07-01T00:30:00.000Z",
+    launchd: { label: "com.electricsheephq.evaos-code-review-bot", state: "running", pid: 1234, dryRun: false },
+    heartbeat: {
+      status: "fresh",
+      maxAgeMs: 120_000,
+      latestAt: "2026-07-01T00:29:55.000Z",
+      ageMs: 5_000,
+      cycle: 12,
+      event: "daemon_cycle_complete",
+      dryRun: false
+    },
+    summary: {
+      totalLeases: (input.activeLeases?.length ?? 0) + (input.staleLeases?.length ?? 0),
+      activeLeases: input.activeLeases?.length ?? 0,
+      staleLeases: input.staleLeases?.length ?? 0
+    },
+    activeLeases: input.activeLeases ?? [],
+    staleLeases: input.staleLeases ?? []
+  };
+}


### PR DESCRIPTION
## Summary

Adds a first-class JSON operator CLI for the review bot so humans, manager agents, and reviewer agents can answer operational questions without manually stitching together launchd output, release status, coverage audit, provider cooldown rows, and SQLite lease tables.

Closes #86.
Expands #84.
Supports the architecture track in #78.

## What Changed

- Added `src/operator-cli.ts` with pure operator summary builders for:
  - aggregate `status`
  - agent/lease inventory
  - queue buckets
  - provider cooldown reads
  - scoped `why` diagnostics
- Added new CLI commands in `src/cli.ts`:
  - `status`
  - `agents`
  - `queue`
  - `coverage`
  - `cooldowns`
  - `why --repo <owner/name> --pr <number>`
  - `help`
- Added `evaos-review-bot` package bin pointing at `dist/src/cli.js` after build.
- Added `docs/operator-cli.md` with user/manager/agent command examples and safety boundaries.
- Added focused tests for operator status, agent inventory, queue grouping, and why diagnostics.

## Safety Boundaries

The new operator commands are read-only by default. They do not post reviews, retry ZCode, restart launchd, kill processes, prune leases, mutate config, or write GitHub state.

Existing mutating commands remain explicit and separate, for example `retry-provider-cooldowns --dry-run false`, `retry-failed --dry-run false`, `retire-failed`, `run-once --dry-run false`, and `daemon --dry-run false`.

This PR intentionally does not implement global pause-all behavior, one-at-a-time global queueing, process killing, or Z.ai peak-hour blackout logic.

## Validation

- `npx vitest run tests/operator-cli.test.ts`
- `npm run build`
- `npm test` - 25 files, 154 tests passed

Read-only live smoke:

- `npx tsx src/cli.ts agents --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot`
  - returned running launchd, fresh heartbeat, zero active/stale leases
- `npx tsx src/cli.ts cooldowns --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expired-only true --limit 5`
  - returned JSON successfully without retrying or mutating cooldown rows
- `npx tsx src/cli.ts queue --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --repo electricsheephq/evaos-code-review-bot --verify-current-heads false`
  - returned an operator-visible GitHub App read failure for the bot repo; this is useful diagnostic output, not a mutation

## Follow-up

#80/#83 can build the deeper RepoSticky/session/queue substrate under this CLI surface. #84 can continue expanding runtime inventory once repo-sticky workers exist.
