### PR TITLE
RepoSticky: add provider-aware review scheduler foundation

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -20,11 +20,12 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
 
 - `status`: aggregated operator health. Includes release gates, launchd,
   heartbeat, DB error/cooldown counts, coverage buckets, active/stale leases,
-  and recommended actions.
+  durable queue counts, and recommended actions.
 - `agents`: launchd, heartbeat, and review-run lease inventory. This is
   read-only; it does not restart, kill, prune, or retire anything.
 - `queue`: open PR-head coverage grouped into processed, provider-deferred,
-  pending review, skipped, stale-head, and read-failure buckets.
+  pending review, skipped, stale-head, and read-failure buckets. Also includes
+  durable `review_queue_jobs` rows when the state DB has the scheduler table.
 - `coverage`: raw coverage-audit report with the shorter operator command name.
 - `cooldowns`: provider cooldown review rows plus repo/global cooldown rows.
 - `why --repo <owner/name> --pr <number>`: scoped explanation for why one PR
@@ -51,6 +52,12 @@ Find open PR heads that still need review work:
 
 ```bash
 npx tsx src/cli.ts queue --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+```
+
+Inspect only durable provider-deferred jobs:
+
+```bash
+npx tsx src/cli.ts queue --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --state provider_deferred
 ```
 
 Explain one PR:

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -126,6 +126,8 @@ The release is green only when:
 - no blocking DB error rows exist
 - coverage audit has zero unprocessed eligible heads
 - provider cooldowns are either absent or active and named in release notes
+- durable queue jobs have zero failed rows and zero retryable provider-deferred
+  backlog
 
 Expired provider cooldown rows are backlog. Retry or retire stale/closed heads
 before calling the release green.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "evaos-code-review-bot",
       "version": "0.1.0",
+      "bin": {
+        "evaos-review-bot": "dist/src/cli.js"
+      },
       "devDependencies": {
         "@types/node": "^24.0.15",
         "tsx": "^4.20.3",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,12 +12,13 @@ import {
   collectOperatorLeases,
   collectOperatorProviderCooldowns,
   collectOperatorRepoProviderCooldowns,
+  collectOperatorReviewQueue,
   explainPullStatus,
   summarizeAgentInventory
 } from "./operator-cli.js";
 import { collectReleaseStatus } from "./release-status.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
-import { ReviewStateStore } from "./state.js";
+import { ReviewStateStore, type ReviewQueueJobState } from "./state.js";
 import { isSuccessfulRetryStatus, retryFailedHead, retryProviderCooldowns, runOnce } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
 
@@ -137,11 +138,16 @@ async function main(): Promise<void> {
       expiredOnly: false,
       limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
     });
+    const durableQueue = collectOperatorReviewQueue(args["state-path"] ?? config.statePath, {
+      repo: args.repo,
+      limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
+    });
     const status = buildOperatorStatus({
       release,
       coverage,
       agents,
-      providerCooldowns
+      providerCooldowns,
+      durableQueue
     });
     console.log(JSON.stringify(status, null, 2));
     if (!status.ok) process.exitCode = 1;
@@ -171,8 +177,14 @@ async function main(): Promise<void> {
     const config = loadConfig(args.config);
     const report = await collectCoverageReport(args, config);
     const queue = buildOperatorQueue(report);
-    console.log(JSON.stringify(queue, null, 2));
-    if (!queue.ok) process.exitCode = 1;
+    const durableQueue = collectOperatorReviewQueue(args["state-path"] ?? config.statePath, {
+      repo: args.repo,
+      state: parseReviewQueueJobState(args.state),
+      limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
+    });
+    const output = { ok: queue.ok && durableQueue.ok, coverage: queue, durableQueue };
+    console.log(JSON.stringify(output, null, 2));
+    if (!output.ok) process.exitCode = 1;
     return;
   }
 
@@ -472,6 +484,7 @@ function buildHelp() {
       "npx tsx src/cli.ts status --config /path/to/live.json --launchd-label com.electricsheephq.evaos-code-review-bot",
       "npx tsx src/cli.ts agents --config /path/to/live.json",
       "npx tsx src/cli.ts queue --config /path/to/live.json",
+      "npx tsx src/cli.ts queue --config /path/to/live.json --state provider_deferred",
       "npx tsx src/cli.ts why --config /path/to/live.json --repo owner/repo --pr 123",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ]
@@ -502,6 +515,25 @@ function parsePositiveInteger(value: string, label: string): number {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 1) throw new Error(`${label} must be a positive integer`);
   return parsed;
+}
+
+const REVIEW_QUEUE_JOB_STATES: ReviewQueueJobState[] = [
+  "queued",
+  "leased",
+  "running",
+  "provider_deferred",
+  "stale_retired",
+  "closed_retired",
+  "posted",
+  "failed"
+];
+
+function parseReviewQueueJobState(value?: string): ReviewQueueJobState | undefined {
+  if (!value) return undefined;
+  if (REVIEW_QUEUE_JOB_STATES.includes(value as ReviewQueueJobState)) {
+    return value as ReviewQueueJobState;
+  }
+  throw new Error(`--state must be one of: ${REVIEW_QUEUE_JOB_STATES.join(", ")}`);
 }
 
 function listJsonFiles(inputDir: string): string[] {
@@ -543,6 +575,7 @@ interface ParsedArgs {
   "output-dir"?: string;
   "output-root"?: string;
   limit?: string;
+  state?: string;
   zcode?: string;
   "active-only"?: string;
   "verify-current-heads"?: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,7 +182,7 @@ async function main(): Promise<void> {
       state: parseReviewQueueJobState(args.state),
       limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
     });
-    const output = { ok: queue.ok && durableQueue.ok, coverage: queue, durableQueue };
+    const output = { ok: queue.ok, coverage: queue, durableQueue };
     console.log(JSON.stringify(output, null, 2));
     if (!output.ok) process.exitCode = 1;
     return;
@@ -428,6 +428,7 @@ async function main(): Promise<void> {
         monitoredRepos,
         canaryPulls: config.canaryPulls ?? [],
         commandsEnabled: config.commands.enabled,
+        reviewSchedulerEnabled: config.reviewScheduler?.enabled === true,
         configPath: args.config
       });
       await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,7 +182,7 @@ async function main(): Promise<void> {
       state: parseReviewQueueJobState(args.state),
       limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
     });
-    const output = { ok: queue.ok, coverage: queue, durableQueue };
+    const output = { ...queue, ok: queue.ok, coverage: queue, durableQueue };
     console.log(JSON.stringify(output, null, 2));
     if (!output.ok) process.exitCode = 1;
     return;

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export interface BotConfig {
     ttlMs: number;
     headCountLimit: number;
   };
+  reviewScheduler?: ReviewSchedulerConfig;
   providerCooldown: {
     enabled: boolean;
     durationMs: number;
@@ -115,6 +116,24 @@ export interface CommandConfig {
   acknowledge: boolean;
 }
 
+export interface ReviewSchedulerConfig {
+  enabled: boolean;
+  maxProviderActive: number;
+  maxOrgActive: number;
+  maxRepoActive: number;
+  maxQueuedPerRepo: number;
+  manualCommandReserve: number;
+  backgroundPriority: number;
+  manualPriority: number;
+  providerThrottleBackoff: {
+    requestRateLimitBaseMs: number;
+    requestRateLimitMaxMs: number;
+    overloadBaseMs: number;
+    overloadMaxMs: number;
+    quotaBaseMs: number;
+  };
+}
+
 const DEFAULT_CONFIG: BotConfig = {
   pilotRepos: ["electricsheephq/WorldOS", "100yenadmin/evaOS-GUI"],
   pollIntervalMs: 90_000,
@@ -134,6 +153,23 @@ const DEFAULT_CONFIG: BotConfig = {
     enabled: false,
     ttlMs: 8 * 60 * 60_000,
     headCountLimit: 10
+  },
+  reviewScheduler: {
+    enabled: false,
+    maxProviderActive: 2,
+    maxOrgActive: 3,
+    maxRepoActive: 1,
+    maxQueuedPerRepo: 10,
+    manualCommandReserve: 1,
+    backgroundPriority: 50,
+    manualPriority: 10,
+    providerThrottleBackoff: {
+      requestRateLimitBaseMs: 30_000,
+      requestRateLimitMaxMs: 180_000,
+      overloadBaseMs: 60_000,
+      overloadMaxMs: 300_000,
+      quotaBaseMs: 30 * 60_000
+    }
   },
   providerCooldown: {
     enabled: true,
@@ -208,6 +244,9 @@ function validateConfig(config: BotConfig): void {
   validateBoolean(reviewerSessions.enabled, "config.reviewerSessions.enabled");
   validatePositiveInteger(reviewerSessions.ttlMs, "config.reviewerSessions.ttlMs");
   validatePositiveInteger(reviewerSessions.headCountLimit, "config.reviewerSessions.headCountLimit");
+  const reviewScheduler = config.reviewScheduler ?? DEFAULT_CONFIG.reviewScheduler!;
+  config.reviewScheduler = reviewScheduler;
+  validateReviewSchedulerConfig(reviewScheduler, "config.reviewScheduler");
   validateBoolean(config.providerCooldown.enabled, "config.providerCooldown.enabled");
   validatePositiveInteger(config.providerCooldown.durationMs, "config.providerCooldown.durationMs");
   validatePositiveInteger(config.providerCooldown.requestRateLimitDurationMs, "config.providerCooldown.requestRateLimitDurationMs");
@@ -304,6 +343,40 @@ function validateFinishingTouch(value: unknown, label: string): void {
   if (!isRecord(value)) throw new Error(`${label} must be an object`);
   validateBoolean(value.enabled, `${label}.enabled`);
   validateOptionalString(value.instructions, `${label}.instructions`);
+}
+
+function validateReviewSchedulerConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  validateBoolean(value.enabled, `${label}.enabled`);
+  validatePositiveInteger(value.maxProviderActive, `${label}.maxProviderActive`);
+  validatePositiveInteger(value.maxOrgActive, `${label}.maxOrgActive`);
+  validatePositiveInteger(value.maxRepoActive, `${label}.maxRepoActive`);
+  validatePositiveInteger(value.maxQueuedPerRepo, `${label}.maxQueuedPerRepo`);
+  validateNonNegativeInteger(value.manualCommandReserve, `${label}.manualCommandReserve`);
+  validateNonNegativeInteger(value.backgroundPriority, `${label}.backgroundPriority`);
+  validateNonNegativeInteger(value.manualPriority, `${label}.manualPriority`);
+  const maxProviderActive = Number(value.maxProviderActive);
+  const manualCommandReserve = Number(value.manualCommandReserve);
+  if (manualCommandReserve > maxProviderActive) {
+    throw new Error(`${label}.manualCommandReserve must be <= ${label}.maxProviderActive`);
+  }
+  const backoff = value.providerThrottleBackoff;
+  if (!isRecord(backoff)) throw new Error(`${label}.providerThrottleBackoff must be an object`);
+  validatePositiveInteger(backoff.requestRateLimitBaseMs, `${label}.providerThrottleBackoff.requestRateLimitBaseMs`);
+  validatePositiveInteger(backoff.requestRateLimitMaxMs, `${label}.providerThrottleBackoff.requestRateLimitMaxMs`);
+  validatePositiveInteger(backoff.overloadBaseMs, `${label}.providerThrottleBackoff.overloadBaseMs`);
+  validatePositiveInteger(backoff.overloadMaxMs, `${label}.providerThrottleBackoff.overloadMaxMs`);
+  validatePositiveInteger(backoff.quotaBaseMs, `${label}.providerThrottleBackoff.quotaBaseMs`);
+  const requestRateLimitBaseMs = Number(backoff.requestRateLimitBaseMs);
+  const requestRateLimitMaxMs = Number(backoff.requestRateLimitMaxMs);
+  const overloadBaseMs = Number(backoff.overloadBaseMs);
+  const overloadMaxMs = Number(backoff.overloadMaxMs);
+  if (requestRateLimitBaseMs > requestRateLimitMaxMs) {
+    throw new Error(`${label}.providerThrottleBackoff.requestRateLimitBaseMs must be <= requestRateLimitMaxMs`);
+  }
+  if (overloadBaseMs > overloadMaxMs) {
+    throw new Error(`${label}.providerThrottleBackoff.overloadBaseMs must be <= overloadMaxMs`);
+  }
 }
 
 function validatePathInstructions(value: unknown, label: string): void {

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,14 +124,6 @@ export interface ReviewSchedulerConfig {
   maxQueuedPerRepo: number;
   manualCommandReserve: number;
   backgroundPriority: number;
-  manualPriority: number;
-  providerThrottleBackoff: {
-    requestRateLimitBaseMs: number;
-    requestRateLimitMaxMs: number;
-    overloadBaseMs: number;
-    overloadMaxMs: number;
-    quotaBaseMs: number;
-  };
 }
 
 const DEFAULT_CONFIG: BotConfig = {
@@ -161,15 +153,7 @@ const DEFAULT_CONFIG: BotConfig = {
     maxRepoActive: 1,
     maxQueuedPerRepo: 10,
     manualCommandReserve: 1,
-    backgroundPriority: 50,
-    manualPriority: 10,
-    providerThrottleBackoff: {
-      requestRateLimitBaseMs: 30_000,
-      requestRateLimitMaxMs: 180_000,
-      overloadBaseMs: 60_000,
-      overloadMaxMs: 300_000,
-      quotaBaseMs: 30 * 60_000
-    }
+    backgroundPriority: 50
   },
   providerCooldown: {
     enabled: true,
@@ -354,28 +338,10 @@ function validateReviewSchedulerConfig(value: unknown, label: string): void {
   validatePositiveInteger(value.maxQueuedPerRepo, `${label}.maxQueuedPerRepo`);
   validateNonNegativeInteger(value.manualCommandReserve, `${label}.manualCommandReserve`);
   validateNonNegativeInteger(value.backgroundPriority, `${label}.backgroundPriority`);
-  validateNonNegativeInteger(value.manualPriority, `${label}.manualPriority`);
   const maxProviderActive = Number(value.maxProviderActive);
   const manualCommandReserve = Number(value.manualCommandReserve);
   if (manualCommandReserve > maxProviderActive) {
     throw new Error(`${label}.manualCommandReserve must be <= ${label}.maxProviderActive`);
-  }
-  const backoff = value.providerThrottleBackoff;
-  if (!isRecord(backoff)) throw new Error(`${label}.providerThrottleBackoff must be an object`);
-  validatePositiveInteger(backoff.requestRateLimitBaseMs, `${label}.providerThrottleBackoff.requestRateLimitBaseMs`);
-  validatePositiveInteger(backoff.requestRateLimitMaxMs, `${label}.providerThrottleBackoff.requestRateLimitMaxMs`);
-  validatePositiveInteger(backoff.overloadBaseMs, `${label}.providerThrottleBackoff.overloadBaseMs`);
-  validatePositiveInteger(backoff.overloadMaxMs, `${label}.providerThrottleBackoff.overloadMaxMs`);
-  validatePositiveInteger(backoff.quotaBaseMs, `${label}.providerThrottleBackoff.quotaBaseMs`);
-  const requestRateLimitBaseMs = Number(backoff.requestRateLimitBaseMs);
-  const requestRateLimitMaxMs = Number(backoff.requestRateLimitMaxMs);
-  const overloadBaseMs = Number(backoff.overloadBaseMs);
-  const overloadMaxMs = Number(backoff.overloadMaxMs);
-  if (requestRateLimitBaseMs > requestRateLimitMaxMs) {
-    throw new Error(`${label}.providerThrottleBackoff.requestRateLimitBaseMs must be <= requestRateLimitMaxMs`);
-  }
-  if (overloadBaseMs > overloadMaxMs) {
-    throw new Error(`${label}.providerThrottleBackoff.overloadBaseMs must be <= overloadMaxMs`);
   }
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,5 +1,6 @@
 import { formatDaemonLog } from "./daemon-log.js";
 import { loadConfig } from "./config.js";
+import { runScheduledCycle } from "./scheduler.js";
 import { ReviewStateStore, type DaemonHeartbeatEvent } from "./state.js";
 import { retryProviderCooldowns, runOnce, type RetryProviderCooldownsResult, type RunOnceResult } from "./worker.js";
 
@@ -31,7 +32,8 @@ export interface RunDaemonCycleOptions {
 export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<DaemonCycleResult> {
   const stdout = input.stdout ?? console.log;
   const stderr = input.stderr ?? console.error;
-  const runOnceImpl = input.runOnceImpl ?? runOnce;
+  const schedulerEnabled = input.runOnceImpl ? false : loadConfig(input.configPath).reviewScheduler?.enabled === true;
+  const runOnceImpl = input.runOnceImpl ?? (schedulerEnabled ? runScheduledCycle : runOnce);
   const retryProviderCooldownsImpl = input.retryProviderCooldownsImpl ?? retryProviderCooldowns;
   const recordHeartbeat = input.recordHeartbeatImpl ?? ((event: DaemonHeartbeatEvent, error?: string) => {
     recordDaemonHeartbeatFromConfig({
@@ -58,6 +60,14 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   try {
     const result = await runOnceImpl({ configPath: input.configPath, dryRun: input.dryRun });
     try {
+      if (schedulerEnabled) {
+        stdout(formatDaemonLog({
+          event: "daemon_provider_cooldown_retry_skipped",
+          cycle: input.cycle,
+          dryRun: input.dryRun,
+          reason: "review_scheduler_enabled"
+        }));
+      } else {
       const providerCooldownRetry = await retryProviderCooldownsImpl({
         configPath: input.configPath,
         dryRun: input.dryRun,
@@ -71,6 +81,7 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
         dryRun: input.dryRun,
         result: providerCooldownRetry
       }));
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       stderr(formatDaemonLog({

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -16,6 +16,7 @@ export interface RunDaemonCycleOptions {
   monitoredRepos: string[];
   canaryPulls: string[];
   commandsEnabled: boolean;
+  reviewSchedulerEnabled?: boolean;
   runOnceImpl?: (options: { configPath?: string; dryRun: boolean }) => Promise<RunOnceResult>;
   retryProviderCooldownsImpl?: (options: {
     configPath?: string;
@@ -32,7 +33,7 @@ export interface RunDaemonCycleOptions {
 export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<DaemonCycleResult> {
   const stdout = input.stdout ?? console.log;
   const stderr = input.stderr ?? console.error;
-  const schedulerEnabled = input.runOnceImpl ? false : loadConfig(input.configPath).reviewScheduler?.enabled === true;
+  const schedulerEnabled = input.runOnceImpl ? false : input.reviewSchedulerEnabled === true;
   const runOnceImpl = input.runOnceImpl ?? (schedulerEnabled ? runScheduledCycle : runOnce);
   const retryProviderCooldownsImpl = input.retryProviderCooldownsImpl ?? retryProviderCooldowns;
   const recordHeartbeat = input.recordHeartbeatImpl ?? ((event: DaemonHeartbeatEvent, error?: string) => {
@@ -60,14 +61,6 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   try {
     const result = await runOnceImpl({ configPath: input.configPath, dryRun: input.dryRun });
     try {
-      if (schedulerEnabled) {
-        stdout(formatDaemonLog({
-          event: "daemon_provider_cooldown_retry_skipped",
-          cycle: input.cycle,
-          dryRun: input.dryRun,
-          reason: "review_scheduler_enabled"
-        }));
-      } else {
       const providerCooldownRetry = await retryProviderCooldownsImpl({
         configPath: input.configPath,
         dryRun: input.dryRun,
@@ -81,7 +74,6 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
         dryRun: input.dryRun,
         result: providerCooldownRetry
       }));
-      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       stderr(formatDaemonLog({

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -33,7 +33,7 @@ export interface RunDaemonCycleOptions {
 export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<DaemonCycleResult> {
   const stdout = input.stdout ?? console.log;
   const stderr = input.stderr ?? console.error;
-  const schedulerEnabled = input.runOnceImpl ? false : input.reviewSchedulerEnabled === true;
+  const schedulerEnabled = input.reviewSchedulerEnabled === true;
   const runOnceImpl = input.runOnceImpl ?? (schedulerEnabled ? runScheduledCycle : runOnce);
   const retryProviderCooldownsImpl = input.retryProviderCooldownsImpl ?? retryProviderCooldowns;
   const recordHeartbeat = input.recordHeartbeatImpl ?? ((event: DaemonHeartbeatEvent, error?: string) => {
@@ -61,19 +61,28 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
   try {
     const result = await runOnceImpl({ configPath: input.configPath, dryRun: input.dryRun });
     try {
-      const providerCooldownRetry = await retryProviderCooldownsImpl({
-        configPath: input.configPath,
-        dryRun: input.dryRun,
-        expiredOnly: true,
-        limit: 1,
-        useZCode: true
-      });
-      stdout(formatDaemonLog({
-        event: "daemon_provider_cooldown_retry",
-        cycle: input.cycle,
-        dryRun: input.dryRun,
-        result: providerCooldownRetry
-      }));
+      if (schedulerEnabled) {
+        stdout(formatDaemonLog({
+          event: "daemon_provider_cooldown_retry_skipped",
+          cycle: input.cycle,
+          dryRun: input.dryRun,
+          reason: "review_scheduler_enabled"
+        }));
+      } else {
+        const providerCooldownRetry = await retryProviderCooldownsImpl({
+          configPath: input.configPath,
+          dryRun: input.dryRun,
+          expiredOnly: true,
+          limit: 1,
+          useZCode: true
+        });
+        stdout(formatDaemonLog({
+          event: "daemon_provider_cooldown_retry",
+          cycle: input.cycle,
+          dryRun: input.dryRun,
+          result: providerCooldownRetry
+        }));
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       stderr(formatDaemonLog({

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -13,6 +13,8 @@ import {
   parseProviderCooldownError,
   PROVIDER_COOLDOWN_ERROR_PREFIX,
   type ProviderCooldownReviewRecord,
+  type ReviewQueueJobRecord,
+  type ReviewQueueJobState,
   type RepoProviderCooldownRecord
 } from "./state.js";
 
@@ -32,6 +34,10 @@ export interface OperatorStatus {
     failedRows: number;
     expiredProviderCooldowns: number;
     activeProviderCooldowns: number;
+    queuedJobs: number;
+    runningJobs: number;
+    providerDeferredJobs: number;
+    failedQueueJobs: number;
   };
   gates: Array<{ name: string; ok: boolean; detail: string }>;
   recommendedActions: string[];
@@ -39,6 +45,7 @@ export interface OperatorStatus {
   coverage?: OperatorQueueSnapshot;
   agents: OperatorAgentInventory;
   providerCooldowns: ProviderCooldownReviewRecord[];
+  durableQueue?: OperatorDurableQueueSnapshot;
 }
 
 export interface OperatorLease {
@@ -98,6 +105,35 @@ export interface OperatorQueueSnapshot {
   readFailures: Array<{ repo: string; error: string; nextAction: string }>;
 }
 
+export interface OperatorDurableQueueSnapshot {
+  ok: boolean;
+  checkedAt: string;
+  summary: {
+    total: number;
+    queued: number;
+    leased: number;
+    running: number;
+    providerDeferred: number;
+    retryableProviderDeferred: number;
+    posted: number;
+    failed: number;
+    retired: number;
+  };
+  jobs: ReviewQueueJobRecord[];
+  byRepo: Array<{
+    repo: string;
+    total: number;
+    queued: number;
+    leased: number;
+    running: number;
+    providerDeferred: number;
+    retryableProviderDeferred: number;
+    posted: number;
+    failed: number;
+    retired: number;
+  }>;
+}
+
 export interface PullStatusExplanation {
   repo: string;
   pullNumber: number;
@@ -114,17 +150,21 @@ export function buildOperatorStatus(input: {
   coverage?: CoverageAuditReport;
   agents: OperatorAgentInventory;
   providerCooldowns?: ProviderCooldownReviewRecord[];
+  durableQueue?: OperatorDurableQueueSnapshot;
   checkedAt?: string;
 }): OperatorStatus {
   const queue = input.coverage ? buildOperatorQueue(input.coverage) : undefined;
   const providerCooldowns = input.providerCooldowns ?? [];
   const expiredProviderCooldowns = providerCooldowns.filter((cooldown) => cooldown.expired).length;
   const activeProviderCooldowns = providerCooldowns.length - expiredProviderCooldowns;
+  const durableQueue = input.durableQueue;
   const pendingHeads = queue?.summary.pending ?? 0;
   const providerDeferredHeads = queue?.summary.providerDeferred ?? 0;
   const readFailures = queue?.summary.readFailures ?? 0;
   const staleHeads = queue?.summary.staleHeads ?? 0;
   const failedRows = input.release.database.errorCount;
+  const failedQueueJobs = durableQueue?.summary.failed ?? 0;
+  const retryableProviderDeferredJobs = durableQueue?.summary.retryableProviderDeferred ?? 0;
 
   const gates = [
     ...input.release.gates,
@@ -149,6 +189,16 @@ export function buildOperatorStatus(input: {
       detail: input.agents.summary.staleLeases === 0
         ? "0 stale lease(s)"
         : `${input.agents.summary.staleLeases} stale lease(s)`
+    },
+    {
+      name: "durable_queue_no_failed_jobs",
+      ok: failedQueueJobs === 0,
+      detail: `${failedQueueJobs} failed durable queue job(s)`
+    },
+    {
+      name: "durable_queue_no_retryable_provider_deferred_jobs",
+      ok: retryableProviderDeferredJobs === 0,
+      detail: `${retryableProviderDeferredJobs} retryable provider-deferred durable queue job(s)`
     }
   ];
 
@@ -157,7 +207,9 @@ export function buildOperatorStatus(input: {
     ...(pendingHeads > 0 ? ["wait for daemon cycle or run scoped run-once"] : []),
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(staleHeads > 0 ? ["wait for next daemon cycle or run scoped coverage audit"] : []),
-    ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : [])
+    ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : []),
+    ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : [])
   ]);
 
   return {
@@ -175,14 +227,19 @@ export function buildOperatorStatus(input: {
       readFailures,
       failedRows,
       expiredProviderCooldowns,
-      activeProviderCooldowns
+      activeProviderCooldowns,
+      queuedJobs: durableQueue?.summary.queued ?? 0,
+      runningJobs: durableQueue?.summary.running ?? 0,
+      providerDeferredJobs: durableQueue?.summary.providerDeferred ?? 0,
+      failedQueueJobs
     },
     gates,
     recommendedActions,
     release: input.release,
     ...(queue ? { coverage: queue } : {}),
     agents: input.agents,
-    providerCooldowns
+    providerCooldowns,
+    ...(durableQueue ? { durableQueue } : {})
   };
 }
 
@@ -349,6 +406,44 @@ export function collectOperatorRepoProviderCooldowns(
       const cooldownUntilMs = Date.parse(cooldown.cooldownUntil);
       return Number.isFinite(cooldownUntilMs) && cooldownUntilMs > now.getTime();
     });
+  } finally {
+    db.close();
+  }
+}
+
+export function collectOperatorReviewQueue(
+  statePath: string,
+  input: { repo?: string; state?: ReviewQueueJobState; now?: Date; limit?: number } = {}
+): OperatorDurableQueueSnapshot {
+  const now = input.now ?? new Date();
+  if (!existsSync(statePath)) return emptyDurableQueue(now);
+  const db = new DatabaseSync(statePath, { readOnly: true });
+  try {
+    if (!hasTable(db, "review_queue_jobs")) return emptyDurableQueue(now);
+    const rows = (input.repo
+      ? db
+          .prepare(
+            `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+                    provider_id, priority, state, next_eligible_at, lease_id, session_id,
+                    comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+             from review_queue_jobs
+             where repo = ?
+             order by priority asc, datetime(created_at) asc`
+          )
+          .all(input.repo)
+      : db
+          .prepare(
+            `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+                    provider_id, priority, state, next_eligible_at, lease_id, session_id,
+                    comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+             from review_queue_jobs
+             order by priority asc, datetime(created_at) asc`
+          )
+          .all()) as unknown as ReviewQueueJobRow[];
+    const jobs = rows
+      .map(mapReviewQueueJobRow)
+      .filter((job) => !input.state || job.state === input.state);
+    return buildDurableQueueSnapshot(input.limit ? jobs.slice(0, input.limit) : jobs, now);
   } finally {
     db.close();
   }
@@ -533,6 +628,72 @@ function uniqueStrings(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))];
 }
 
+function emptyDurableQueue(now: Date): OperatorDurableQueueSnapshot {
+  return buildDurableQueueSnapshot([], now);
+}
+
+function buildDurableQueueSnapshot(jobs: ReviewQueueJobRecord[], now: Date): OperatorDurableQueueSnapshot {
+  const summary = summarizeDurableQueueJobs(jobs, now);
+  const repos = [...new Set(jobs.map((job) => job.repo))].sort();
+  return {
+    ok: summary.failed === 0 && summary.retryableProviderDeferred === 0,
+    checkedAt: now.toISOString(),
+    summary,
+    jobs,
+    byRepo: repos.map((repo) => ({
+      repo,
+      ...summarizeDurableQueueJobs(jobs.filter((job) => job.repo === repo), now)
+    }))
+  };
+}
+
+function summarizeDurableQueueJobs(jobs: ReviewQueueJobRecord[], now: Date): OperatorDurableQueueSnapshot["summary"] {
+  return {
+    total: jobs.length,
+    queued: jobs.filter((job) => job.state === "queued").length,
+    leased: jobs.filter((job) => job.state === "leased").length,
+    running: jobs.filter((job) => job.state === "running").length,
+    providerDeferred: jobs.filter((job) => job.state === "provider_deferred").length,
+    retryableProviderDeferred: jobs.filter((job) => job.state === "provider_deferred" && isRetryableQueueJob(job, now)).length,
+    posted: jobs.filter((job) => job.state === "posted").length,
+    failed: jobs.filter((job) => job.state === "failed").length,
+    retired: jobs.filter((job) => job.state === "stale_retired" || job.state === "closed_retired").length
+  };
+}
+
+function isRetryableQueueJob(job: ReviewQueueJobRecord, now: Date): boolean {
+  if (!job.nextEligibleAt) return true;
+  const nextEligibleAtMs = Date.parse(job.nextEligibleAt);
+  return !Number.isFinite(nextEligibleAtMs) || nextEligibleAtMs <= now.getTime();
+}
+
+function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
+  return {
+    jobId: row.job_id,
+    attemptId: row.attempt_id,
+    source: row.source,
+    lane: row.lane,
+    repo: row.repo,
+    org: row.org,
+    pullNumber: row.pull_number,
+    headSha: row.head_sha,
+    ...(row.base_sha ? { baseSha: row.base_sha } : {}),
+    ...(row.provider_id ? { providerId: row.provider_id } : {}),
+    priority: row.priority,
+    state: row.state,
+    ...(row.next_eligible_at ? { nextEligibleAt: row.next_eligible_at } : {}),
+    ...(row.lease_id ? { leaseId: row.lease_id } : {}),
+    ...(row.session_id ? { sessionId: row.session_id } : {}),
+    ...(row.comment_id ? { commentId: row.comment_id } : {}),
+    ...(row.review_url ? { reviewUrl: row.review_url } : {}),
+    ...(row.last_error ? { lastError: row.last_error } : {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    ...(row.started_at ? { startedAt: row.started_at } : {}),
+    ...(row.finished_at ? { finishedAt: row.finished_at } : {})
+  };
+}
+
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -567,4 +728,29 @@ interface RepoProviderCooldownRow {
   cooldown_until: string;
   reason: string;
   updated_at: string;
+}
+
+interface ReviewQueueJobRow {
+  job_id: string;
+  attempt_id: string;
+  source: ReviewQueueJobRecord["source"];
+  lane: ReviewQueueJobRecord["lane"];
+  repo: string;
+  org: string;
+  pull_number: number;
+  head_sha: string;
+  base_sha: string | null;
+  provider_id: string | null;
+  priority: number;
+  state: ReviewQueueJobState;
+  next_eligible_at: string | null;
+  lease_id: string | null;
+  session_id: string | null;
+  comment_id: number | null;
+  review_url: string | null;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+  started_at: string | null;
+  finished_at: string | null;
 }

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -443,7 +443,7 @@ export function collectOperatorReviewQueue(
     const jobs = rows
       .map(mapReviewQueueJobRow)
       .filter((job) => !input.state || job.state === input.state);
-    return buildDurableQueueSnapshot(input.limit ? jobs.slice(0, input.limit) : jobs, now);
+    return buildDurableQueueSnapshot(jobs, now, input.limit ? jobs.slice(0, input.limit) : jobs);
   } finally {
     db.close();
   }
@@ -632,14 +632,18 @@ function emptyDurableQueue(now: Date): OperatorDurableQueueSnapshot {
   return buildDurableQueueSnapshot([], now);
 }
 
-function buildDurableQueueSnapshot(jobs: ReviewQueueJobRecord[], now: Date): OperatorDurableQueueSnapshot {
+function buildDurableQueueSnapshot(
+  jobs: ReviewQueueJobRecord[],
+  now: Date,
+  visibleJobs: ReviewQueueJobRecord[] = jobs
+): OperatorDurableQueueSnapshot {
   const summary = summarizeDurableQueueJobs(jobs, now);
   const repos = [...new Set(jobs.map((job) => job.repo))].sort();
   return {
     ok: summary.failed === 0 && summary.retryableProviderDeferred === 0,
     checkedAt: now.toISOString(),
     summary,
-    jobs,
+    jobs: visibleJobs,
     byRepo: repos.map((repo) => ({
       repo,
       ...summarizeDurableQueueJobs(jobs.filter((job) => job.repo === repo), now)

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -33,6 +33,14 @@ export interface ReleaseDatabaseStatus {
   coveredExpiredProviderCooldownCount?: number;
   retryableExpiredProviderCooldownCount?: number;
   providerThrottleState?: "none" | "active" | "expired_retryable";
+  reviewQueueJobCount?: number;
+  queuedReviewQueueJobCount?: number;
+  leasedReviewQueueJobCount?: number;
+  runningReviewQueueJobCount?: number;
+  providerDeferredReviewQueueJobCount?: number;
+  retryableProviderDeferredReviewQueueJobCount?: number;
+  failedReviewQueueJobCount?: number;
+  reviewQueueJobsByRepo?: ReviewQueueRepoStatus[];
 }
 
 export interface ReviewerSessionRepoStatus {
@@ -40,6 +48,17 @@ export interface ReviewerSessionRepoStatus {
   total: number;
   active: number;
   expired: number;
+}
+
+export interface ReviewQueueRepoStatus {
+  repo: string;
+  total: number;
+  queued: number;
+  leased: number;
+  running: number;
+  providerDeferred: number;
+  retryableProviderDeferred: number;
+  failed: number;
 }
 
 export interface ReleaseHeartbeatStatus {
@@ -98,6 +117,8 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       (input.database.expiredProviderCooldownCount ?? 0) - (input.database.coveredExpiredProviderCooldownCount ?? 0)
     );
   const expiredProviderCooldownOk = retryableExpiredProviderCooldownCount === 0;
+  const failedQueueJobsOk = (input.database.failedReviewQueueJobCount ?? 0) === 0;
+  const retryableDeferredQueueJobsOk = (input.database.retryableProviderDeferredReviewQueueJobCount ?? 0) === 0;
   const heartbeatOk = input.heartbeat.status === "fresh";
   const retryProviderCooldownCommand =
     `npx tsx src/cli.ts retry-provider-cooldowns --config ${input.configPath} ` +
@@ -143,6 +164,18 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
         : `${describeProviderCooldownBacklog(input.database, providerThrottleState)}; retry: ${retryProviderCooldownCommand}`
     },
     {
+      name: "queue_no_failed_jobs",
+      ok: failedQueueJobsOk,
+      detail: `${input.database.failedReviewQueueJobCount ?? 0} failed durable queue job(s)`
+    },
+    {
+      name: "queue_no_retryable_provider_deferred_jobs",
+      ok: retryableDeferredQueueJobsOk,
+      detail:
+        `${input.database.retryableProviderDeferredReviewQueueJobCount ?? 0} retryable provider-deferred queue job(s)` +
+        describeReviewQueueCounts(input.database)
+    },
+    {
       name: "daemon_heartbeat_recent",
       ok: heartbeatOk,
       detail: describeHeartbeat(input.heartbeat)
@@ -163,7 +196,9 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     database: input.database,
     heartbeat: input.heartbeat,
     recommendedActions: expiredProviderCooldownOk
-      ? []
+      ? retryableDeferredQueueJobsOk
+        ? []
+        : ["inspect operator queue and retry provider-deferred jobs whose nextEligibleAt has expired"]
       : [
           retryProviderCooldownCommand,
           `npx tsx src/cli.ts provider-cooldowns --config ${input.configPath} --expired-only true`
@@ -284,6 +319,7 @@ function readDatabaseStatus(statePath: string, now: Date): ReleaseDatabaseStatus
         ? "expired_retryable"
         : "none";
     const reviewerSessions = readReviewerSessionCounts(db, now);
+    const reviewQueue = readReviewQueueCounts(db, now);
     return {
       rowCount: row.rowCount ?? 0,
       skippedCount: row.skippedCount ?? 0,
@@ -298,11 +334,89 @@ function readDatabaseStatus(statePath: string, now: Date): ReleaseDatabaseStatus
       coveredExpiredProviderCooldownCount,
       retryableExpiredProviderCooldownCount,
       providerThrottleState,
+      reviewQueueJobCount: reviewQueue.total,
+      queuedReviewQueueJobCount: reviewQueue.queued,
+      leasedReviewQueueJobCount: reviewQueue.leased,
+      runningReviewQueueJobCount: reviewQueue.running,
+      providerDeferredReviewQueueJobCount: reviewQueue.providerDeferred,
+      retryableProviderDeferredReviewQueueJobCount: reviewQueue.retryableProviderDeferred,
+      failedReviewQueueJobCount: reviewQueue.failed,
+      reviewQueueJobsByRepo: reviewQueue.byRepo,
       errorCount: row.errorCount ?? 0
     };
   } finally {
     db.close();
   }
+}
+
+function readReviewQueueCounts(
+  db: DatabaseSync,
+  now: Date
+): {
+  total: number;
+  queued: number;
+  leased: number;
+  running: number;
+  providerDeferred: number;
+  retryableProviderDeferred: number;
+  failed: number;
+  byRepo: ReviewQueueRepoStatus[];
+} {
+  const hasTable = db
+    .prepare("select 1 from sqlite_master where type = 'table' and name = 'review_queue_jobs' limit 1")
+    .get();
+  if (!hasTable) {
+    return { total: 0, queued: 0, leased: 0, running: 0, providerDeferred: 0, retryableProviderDeferred: 0, failed: 0, byRepo: [] };
+  }
+  const nowIso = now.toISOString();
+  const row = db
+    .prepare(
+      `select
+         count(*) as total,
+         sum(case when state = 'queued' then 1 else 0 end) as queued,
+         sum(case when state = 'leased' then 1 else 0 end) as leased,
+         sum(case when state = 'running' then 1 else 0 end) as running,
+         sum(case when state = 'provider_deferred' then 1 else 0 end) as providerDeferred,
+         sum(case when state = 'provider_deferred' and (next_eligible_at is null or datetime(next_eligible_at) <= datetime(?)) then 1 else 0 end) as retryableProviderDeferred,
+         sum(case when state = 'failed' then 1 else 0 end) as failed
+       from review_queue_jobs`
+    )
+    .get(nowIso) as QueueCountRow;
+  const byRepoRows = db
+    .prepare(
+      `select
+         repo,
+         count(*) as total,
+         sum(case when state = 'queued' then 1 else 0 end) as queued,
+         sum(case when state = 'leased' then 1 else 0 end) as leased,
+         sum(case when state = 'running' then 1 else 0 end) as running,
+         sum(case when state = 'provider_deferred' then 1 else 0 end) as providerDeferred,
+         sum(case when state = 'provider_deferred' and (next_eligible_at is null or datetime(next_eligible_at) <= datetime(?)) then 1 else 0 end) as retryableProviderDeferred,
+         sum(case when state = 'failed' then 1 else 0 end) as failed
+       from review_queue_jobs
+       group by repo
+       order by repo`
+    )
+    .all(nowIso) as unknown as Array<QueueCountRow & { repo: string }>;
+  return {
+    total: row.total ?? 0,
+    queued: row.queued ?? 0,
+    leased: row.leased ?? 0,
+    running: row.running ?? 0,
+    providerDeferred: row.providerDeferred ?? 0,
+    retryableProviderDeferred: row.retryableProviderDeferred ?? 0,
+    failed: row.failed ?? 0,
+    byRepo: byRepoRows.map((repoRow) => ({
+      repo: repoRow.repo,
+      total: repoRow.total ?? 0,
+      queued: repoRow.queued ?? 0,
+      leased: repoRow.leased ?? 0,
+      running: repoRow.running ?? 0,
+      providerDeferred: repoRow.providerDeferred ?? 0,
+      retryableProviderDeferred: repoRow.retryableProviderDeferred ?? 0,
+      failed: repoRow.failed ?? 0
+    }))
+  };
 }
 
 function readReviewerSessionCounts(
@@ -401,6 +515,19 @@ function describeProviderCooldownBacklog(
   return `${database.expiredProviderCooldownCount ?? 0} expired provider cooldown row(s); ${database.activeProviderCooldownCount ?? 0} active provider cooldown row(s)`;
 }
 
+function describeReviewQueueCounts(database: ReleaseDatabaseStatus): string {
+  const total = database.reviewQueueJobCount ?? 0;
+  if (total === 0) return "";
+  return (
+    `; queue total=${total}` +
+    ` queued=${database.queuedReviewQueueJobCount ?? 0}` +
+    ` leased=${database.leasedReviewQueueJobCount ?? 0}` +
+    ` running=${database.runningReviewQueueJobCount ?? 0}` +
+    ` provider_deferred=${database.providerDeferredReviewQueueJobCount ?? 0}` +
+    ` failed=${database.failedReviewQueueJobCount ?? 0}`
+  );
+}
+
 function inferProviderThrottleState(database: ReleaseDatabaseStatus): "none" | "active" | "expired_retryable" {
   if ((database.activeGlobalProviderCooldownCount ?? 0) > 0 || (database.activeProviderCooldownCount ?? 0) > 0) {
     return "active";
@@ -462,4 +589,14 @@ function describeHeartbeat(heartbeat: ReleaseHeartbeatStatus): string {
 
 function git(cwd: string, args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+interface QueueCountRow {
+  total?: number;
+  queued?: number | null;
+  leased?: number | null;
+  running?: number | null;
+  providerDeferred?: number | null;
+  retryableProviderDeferred?: number | null;
+  failed?: number | null;
 }

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -62,13 +62,17 @@ export interface ReviewQueueRepoStatus {
 }
 
 export interface ReleaseHeartbeatStatus {
-  status: "fresh" | "stale" | "missing";
+  status: "fresh" | "active" | "stale" | "missing";
   maxAgeMs: number;
+  activeMaxAgeMs?: number;
   latestAt?: string;
   ageMs?: number;
   cycle?: number;
   event?: string;
   dryRun?: boolean;
+  activeCycle?: number;
+  activeStartedAt?: string;
+  activeAgeMs?: number;
 }
 
 export interface ReleaseStatusInput {
@@ -119,7 +123,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const expiredProviderCooldownOk = retryableExpiredProviderCooldownCount === 0;
   const failedQueueJobsOk = (input.database.failedReviewQueueJobCount ?? 0) === 0;
   const retryableDeferredQueueJobsOk = (input.database.retryableProviderDeferredReviewQueueJobCount ?? 0) === 0;
-  const heartbeatOk = input.heartbeat.status === "fresh";
+  const heartbeatOk = input.heartbeat.status === "fresh" || input.heartbeat.status === "active";
   const retryProviderCooldownCommand =
     `npx tsx src/cli.ts retry-provider-cooldowns --config ${input.configPath} ` +
     "--expired-only true --dry-run false --zcode true";
@@ -228,7 +232,12 @@ export function collectReleaseStatus(input: {
     configPath,
     launchd: readLaunchdStatus(input.launchdLabel ?? "com.electricsheephq.evaos-code-review-bot"),
     database: readDatabaseStatus(input.statePath ?? config.statePath, now),
-    heartbeat: readHeartbeatStatus(input.statePath ?? config.statePath, config.pollIntervalMs * 2, now),
+    heartbeat: readHeartbeatStatus(
+      input.statePath ?? config.statePath,
+      config.pollIntervalMs * 2,
+      Math.max(config.pollIntervalMs * 2, (config.zcode.timeoutMs * 2) + 60_000),
+      now
+    ),
     now
   });
 }
@@ -536,7 +545,12 @@ function inferProviderThrottleState(database: ReleaseDatabaseStatus): "none" | "
   return "none";
 }
 
-function readHeartbeatStatus(statePath: string, maxAgeMs: number, now: Date): ReleaseHeartbeatStatus {
+function readHeartbeatStatus(
+  statePath: string,
+  maxAgeMs: number,
+  activeMaxAgeMs: number,
+  now: Date
+): ReleaseHeartbeatStatus {
   if (!existsSync(statePath)) return { status: "missing", maxAgeMs };
   const db = new DatabaseSync(statePath, { readOnly: true });
   try {
@@ -545,24 +559,58 @@ function readHeartbeatStatus(statePath: string, maxAgeMs: number, now: Date): Re
       .get();
     if (!table) return { status: "missing", maxAgeMs };
 
+    const columns = new Set(
+      (db.prepare("pragma table_info(daemon_heartbeat)").all() as unknown as Array<{ name: string }>)
+        .map((column) => column.name)
+    );
+    const startedCycleSelect = columns.has("started_cycle") ? "started_cycle" : "null as started_cycle";
+    const startedAtSelect = columns.has("started_at") ? "started_at" : "null as started_at";
     const row = db
       .prepare(
-        `select cycle, event, dry_run, recorded_at
+        `select cycle, event, dry_run, recorded_at, ${startedCycleSelect}, ${startedAtSelect}
          from daemon_heartbeat
-         where id = 1 and recorded_at is not null
+         where id = 1
          limit 1`
       )
-      .get() as { cycle: number; event: string; dry_run: number; recorded_at: string } | undefined;
+      .get() as {
+        cycle: number | null;
+        event: string | null;
+        dry_run: number | null;
+        recorded_at: string | null;
+        started_cycle: number | null;
+        started_at: string | null;
+      } | undefined;
     if (!row) return { status: "missing", maxAgeMs };
 
-    const latestTime = Date.parse(row.recorded_at);
+    const latestTime = row.recorded_at ? Date.parse(row.recorded_at) : NaN;
+    const activeStartedTime = row.started_at ? Date.parse(row.started_at) : NaN;
+    const hasActiveCycle =
+      Number.isFinite(activeStartedTime) &&
+      (!Number.isFinite(latestTime) || activeStartedTime > latestTime);
+    if (hasActiveCycle) {
+      const activeAgeMs = Math.max(0, now.getTime() - activeStartedTime);
+      return {
+        status: activeAgeMs <= activeMaxAgeMs ? "active" : "stale",
+        maxAgeMs,
+        activeMaxAgeMs,
+        ...(row.recorded_at ? { latestAt: row.recorded_at } : {}),
+        ...(Number.isFinite(latestTime) ? { ageMs: Math.max(0, now.getTime() - latestTime) } : {}),
+        ...(row.cycle !== null ? { cycle: row.cycle } : {}),
+        ...(row.event ? { event: row.event } : {}),
+        dryRun: row.dry_run === 1,
+        ...(row.started_cycle !== null ? { activeCycle: row.started_cycle } : {}),
+        ...(row.started_at ? { activeStartedAt: row.started_at } : {}),
+        activeAgeMs
+      };
+    }
+
     if (!Number.isFinite(latestTime)) {
       return {
         status: "stale",
         maxAgeMs,
-        latestAt: row.recorded_at,
-        cycle: row.cycle,
-        event: row.event,
+        ...(row.recorded_at ? { latestAt: row.recorded_at } : {}),
+        ...(row.cycle !== null ? { cycle: row.cycle } : {}),
+        ...(row.event ? { event: row.event } : {}),
         dryRun: row.dry_run === 1
       };
     }
@@ -570,10 +618,10 @@ function readHeartbeatStatus(statePath: string, maxAgeMs: number, now: Date): Re
     return {
       status: ageMs <= maxAgeMs ? "fresh" : "stale",
       maxAgeMs,
-      latestAt: row.recorded_at,
+      ...(row.recorded_at ? { latestAt: row.recorded_at } : {}),
       ageMs,
-      cycle: row.cycle,
-      event: row.event,
+      ...(row.cycle !== null ? { cycle: row.cycle } : {}),
+      ...(row.event ? { event: row.event } : {}),
       dryRun: row.dry_run === 1
     };
   } finally {
@@ -583,8 +631,19 @@ function readHeartbeatStatus(statePath: string, maxAgeMs: number, now: Date): Re
 
 function describeHeartbeat(heartbeat: ReleaseHeartbeatStatus): string {
   if (heartbeat.status === "missing") return `missing heartbeat row; max age ${heartbeat.maxAgeMs}ms`;
+  if (heartbeat.status === "active") {
+    const activeAge = heartbeat.activeAgeMs === undefined ? "unknown" : `${heartbeat.activeAgeMs}ms`;
+    return (
+      `active; active age ${activeAge}; max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; ` +
+      `started cycle ${heartbeat.activeCycle ?? "unknown"}; last event ${heartbeat.event ?? "unknown"}; ` +
+      `last cycle ${heartbeat.cycle ?? "unknown"}`
+    );
+  }
   const age = heartbeat.ageMs === undefined ? "unknown" : `${heartbeat.ageMs}ms`;
-  return `${heartbeat.status}; age ${age}; max ${heartbeat.maxAgeMs}ms; event ${heartbeat.event ?? "unknown"}; cycle ${heartbeat.cycle ?? "unknown"}`;
+  const activeSuffix = heartbeat.activeAgeMs === undefined
+    ? ""
+    : `; active age ${heartbeat.activeAgeMs}ms; active max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; active cycle ${heartbeat.activeCycle ?? "unknown"}`;
+  return `${heartbeat.status}; age ${age}; max ${heartbeat.maxAgeMs}ms; event ${heartbeat.event ?? "unknown"}; cycle ${heartbeat.cycle ?? "unknown"}${activeSuffix}`;
 }
 
 function git(cwd: string, args: string[]): string {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -163,6 +163,9 @@ function enqueuePullIfEligible(input: {
   if (!isCanaryAllowed(input.config, input.repo, input.pull.number)) return "skipped_canary";
   if (input.state.hasProcessed(input.repo, input.pull.number, input.pull.head.sha)) return "skipped_processed";
   if (hasActiveQueueJobForHead(input.state, input.repo, input.pull.number, input.pull.head.sha)) return "already_queued";
+  if (!hasRepoQueueCapacity(input.state, input.repo, input.config.reviewScheduler?.maxQueuedPerRepo ?? 10)) {
+    return "skipped_capacity";
+  }
 
   const activeRepoCooldown = input.state.getActiveRepoProviderCooldown(input.repo, input.now);
   if (activeRepoCooldown) {
@@ -175,10 +178,6 @@ function enqueuePullIfEligible(input: {
       now: input.now
     });
     return "provider_deferred";
-  }
-
-  if (!hasRepoQueueCapacity(input.state, input.repo, input.config.reviewScheduler?.maxQueuedPerRepo ?? 10)) {
-    return "skipped_capacity";
   }
 
   const enqueued = enqueueReviewJob(input);
@@ -263,7 +262,7 @@ async function runLeasedQueueJob(input: {
       useZCode: input.useZCode,
       budget: input.budget
     });
-    updateQueueJobAfterReviewStatus({ state: input.state, job: input.job, pull, status });
+    updateQueueJobAfterReviewStatus({ state: input.state, job: input.job, pull, status, dryRun: input.dryRun });
     return status;
   } catch (error) {
     if (recordProviderRateLimitCooldownIfNeeded({
@@ -274,7 +273,7 @@ async function runLeasedQueueJob(input: {
       error,
       now
     })) {
-      markQueueJobProviderDeferredFromProcessed({ state: input.state, job: input.job, pull });
+      markQueueJobProviderDeferredFromProcessed({ state: input.state, job: input.job, pull, now });
       return "skipped_provider_cooldown";
     }
     recordFailedReview({
@@ -298,6 +297,7 @@ function updateQueueJobAfterReviewStatus(input: {
   job: ReviewQueueJobRecord;
   pull: PullRequestSummary;
   status: ReviewPullResult;
+  dryRun: boolean;
 }): void {
   switch (input.status) {
     case "reviewed":
@@ -305,9 +305,9 @@ function updateQueueJobAfterReviewStatus(input: {
       const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
       input.state.updateReviewQueueJobState({
         jobId: input.job.jobId,
-        state: "posted",
+        state: input.dryRun ? "queued" : "posted",
         ...(processed?.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
-        lastError: input.status
+        lastError: input.dryRun ? "dry_run_completed_not_posted" : input.status
       });
       return;
     }
@@ -355,14 +355,19 @@ function markQueueJobProviderDeferredFromProcessed(input: {
   state: ReviewStateStore;
   job: ReviewQueueJobRecord;
   pull: PullRequestSummary;
+  now?: Date;
 }): void {
   const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
   const parsed = parseProviderCooldownError(processed?.error);
+  const repoCooldown = input.state.getActiveRepoProviderCooldown(input.job.repo, input.now);
+  const cooldownUntil = parsed?.cooldownUntil ?? repoCooldown?.cooldownUntil;
+  const reason = parsed?.reason ?? repoCooldown?.reason;
   input.state.updateReviewQueueJobState({
     jobId: input.job.jobId,
     state: "provider_deferred",
-    ...(parsed?.cooldownUntil ? { nextEligibleAt: parsed.cooldownUntil } : {}),
-    lastError: processed?.error ?? "provider_deferred_without_processed_row"
+    ...(cooldownUntil ? { nextEligibleAt: cooldownUntil } : {}),
+    lastError: processed?.error ??
+      (cooldownUntil ? `repo_provider_cooldown_until=${cooldownUntil}; reason=${reason ?? "provider_cooldown"}` : "provider_deferred_without_cooldown")
   });
 }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -12,7 +12,9 @@ import {
   activateRepoForNewOnlyReview,
   isCanaryAllowed,
   recordFailedReview,
+  classifyProviderError,
   recordProviderRateLimitCooldownIfNeeded,
+  providerCooldownDurationMs,
   reviewPull,
   type ReviewPullInput,
   type ReviewPullResult,
@@ -115,6 +117,7 @@ export async function runScheduledCycleWithDeps(input: {
     maxOrgActive: scheduler.maxOrgActive,
     maxRepoActive: scheduler.maxRepoActive,
     manualCommandReserve: scheduler.manualCommandReserve,
+    // Provider capacity is the global API throttle; org/repo caps only decide which jobs can spend that budget.
     limit: scheduler.maxProviderActive,
     leaseTtlMs: config.reviewConcurrency.leaseTtlMs,
     now
@@ -243,7 +246,7 @@ async function runLeasedQueueJob(input: {
     return "closed_retired";
   }
 
-  if (pull.head.sha !== input.job.headSha || pull.base.sha !== input.job.baseSha) {
+  if (pull.head.sha !== input.job.headSha || (input.job.baseSha && pull.base.sha !== input.job.baseSha)) {
     input.state.updateReviewQueueJobState({
       jobId: input.job.jobId,
       state: "stale_retired",
@@ -275,7 +278,7 @@ async function runLeasedQueueJob(input: {
       error,
       now
     })) {
-      markQueueJobProviderDeferredFromProcessed({ state: input.state, job: input.job, pull, now });
+      markQueueJobProviderDeferredFromProcessed({ state: input.state, job: input.job, pull, error, config: input.config, now });
       return "skipped_provider_cooldown";
     }
     recordFailedReview({
@@ -357,13 +360,18 @@ function markQueueJobProviderDeferredFromProcessed(input: {
   state: ReviewStateStore;
   job: ReviewQueueJobRecord;
   pull: PullRequestSummary;
+  error?: unknown;
+  config?: BotConfig;
   now?: Date;
 }): void {
   const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
+  const directCooldown = input.error && input.config
+    ? providerCooldownFromError(input.config, input.error, input.now ?? new Date())
+    : undefined;
   const parsed = parseProviderCooldownError(processed?.error);
   const repoCooldown = input.state.getActiveRepoProviderCooldown(input.job.repo, input.now);
-  const cooldownUntil = parsed?.cooldownUntil ?? repoCooldown?.cooldownUntil;
-  const reason = parsed?.reason ?? repoCooldown?.reason;
+  const cooldownUntil = directCooldown?.cooldownUntil ?? parsed?.cooldownUntil ?? repoCooldown?.cooldownUntil;
+  const reason = directCooldown?.reason ?? parsed?.reason ?? repoCooldown?.reason;
   input.state.updateReviewQueueJobState({
     jobId: input.job.jobId,
     state: "provider_deferred",
@@ -371,6 +379,15 @@ function markQueueJobProviderDeferredFromProcessed(input: {
     lastError: processed?.error ??
       (cooldownUntil ? `repo_provider_cooldown_until=${cooldownUntil}; reason=${reason ?? "provider_cooldown"}` : "provider_deferred_without_cooldown")
   });
+}
+
+function providerCooldownFromError(config: BotConfig, error: unknown, now: Date): { cooldownUntil: string; reason: string } | undefined {
+  const classification = classifyProviderError(error);
+  if (!classification.cooldown) return undefined;
+  return {
+    cooldownUntil: new Date(now.getTime() + providerCooldownDurationMs(config, classification)).toISOString(),
+    reason: classification.reason
+  };
 }
 
 function hasActiveQueueJobForHead(

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -116,6 +116,7 @@ export async function runScheduledCycleWithDeps(input: {
     maxRepoActive: scheduler.maxRepoActive,
     manualCommandReserve: scheduler.manualCommandReserve,
     limit: scheduler.maxProviderActive,
+    leaseTtlMs: config.reviewConcurrency.leaseTtlMs,
     now
   });
   result.queue.leased = leased.length;
@@ -260,7 +261,8 @@ async function runLeasedQueueJob(input: {
       pull,
       dryRun: input.dryRun,
       useZCode: input.useZCode,
-      budget: input.budget
+      budget: input.budget,
+      processedHeadPolicy: isProviderDeferredRetryJob(input.job) ? "retry_failed_head" : "normal"
     });
     updateQueueJobAfterReviewStatus({ state: input.state, job: input.job, pull, status, dryRun: input.dryRun });
     return status;
@@ -389,6 +391,15 @@ function hasRepoQueueCapacity(state: ReviewStateStore, repo: string, maxQueuedPe
     states: ["queued", "leased", "running", "provider_deferred"]
   });
   return active.length < maxQueuedPerRepo;
+}
+
+function isProviderDeferredRetryJob(job: ReviewQueueJobRecord): boolean {
+  return Boolean(
+    job.nextEligibleAt ||
+    parseProviderCooldownError(job.lastError) ||
+    job.lastError?.includes("repo_provider_cooldown_until=") ||
+    job.lastError === "provider_deferred_without_cooldown"
+  );
 }
 
 function applyEnqueueStatus(result: ScheduledRunResult, status: EnqueueStatus): void {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,0 +1,510 @@
+import { loadConfig, type BotConfig } from "./config.js";
+import { GitHubApi } from "./github.js";
+import { listReposToScan, resolveRepoProfile } from "./repo-policy.js";
+import { ReviewRunBudget } from "./review-budget.js";
+import {
+  parseProviderCooldownError,
+  ReviewStateStore,
+  type ReviewQueueJobRecord
+} from "./state.js";
+import type { PullRequestSummary } from "./types.js";
+import {
+  activateRepoForNewOnlyReview,
+  isCanaryAllowed,
+  recordFailedReview,
+  recordProviderRateLimitCooldownIfNeeded,
+  reviewPull,
+  type ReviewPullInput,
+  type ReviewPullResult,
+  type RunOnceOptions,
+  type RunOnceResult
+} from "./worker.js";
+
+export interface ScheduledRunResult extends RunOnceResult {
+  queue: {
+    enqueued: number;
+    alreadyQueued: number;
+    leased: number;
+    completed: number;
+    providerDeferred: number;
+    staleRetired: number;
+    closedRetired: number;
+    failedQueueJobs: number;
+    remainingQueued: number;
+  };
+}
+
+export interface SchedulerGitHubApi {
+  listOpenPulls(repo: string): Promise<PullRequestSummary[]>;
+  getPull(repo: string, pullNumber: number): Promise<PullRequestSummary>;
+}
+
+export async function runScheduledCycle(options: RunOnceOptions): Promise<ScheduledRunResult> {
+  const config = loadConfig(options.configPath);
+  const github = new GitHubApi(config.github);
+  const state = new ReviewStateStore(config.statePath);
+  try {
+    return await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options,
+      reviewPullImpl: reviewPull
+    });
+  } finally {
+    state.close();
+  }
+}
+
+export async function runScheduledCycleWithDeps(input: {
+  config: BotConfig;
+  github: SchedulerGitHubApi;
+  state: ReviewStateStore;
+  options: RunOnceOptions;
+  reviewPullImpl: (input: ReviewPullInput) => Promise<ReviewPullResult>;
+  now?: Date;
+}): Promise<ScheduledRunResult> {
+  const config = input.config;
+  const scheduler = config.reviewScheduler;
+  if (!scheduler?.enabled) {
+    throw new Error("runScheduledCycleWithDeps requires config.reviewScheduler.enabled=true");
+  }
+  const result = emptyScheduledRunResult();
+  const now = input.now ?? new Date();
+  const repos = input.options.repo ? [input.options.repo] : listReposToScan(config);
+  const providerId = config.zcode.providerId ?? config.zcode.model ?? "zcode";
+
+  for (const repo of repos) {
+    result.reposScanned += 1;
+    const repoPolicy = resolveRepoProfile(config, repo);
+    if (!repoPolicy.allowed) {
+      result.skippedPolicy += 1;
+      result.policySkips.push({ repo, reason: repoPolicy.reason });
+      continue;
+    }
+
+    const pulls = input.options.pullNumber
+      ? [await input.github.getPull(repo, input.options.pullNumber)]
+      : await input.github.listOpenPulls(repo);
+    result.pullsSeen += pulls.length;
+    const activation = activateRepoForNewOnlyReview({
+      config,
+      state: input.state,
+      repo,
+      pulls,
+      scopedPullNumber: input.options.pullNumber,
+      now
+    });
+    result.baselinedExisting += activation.baselined;
+
+    for (const pull of pulls) {
+      const enqueueStatus = enqueuePullIfEligible({
+        config,
+        state: input.state,
+        repo,
+        pull,
+        providerId,
+        now
+      });
+      applyEnqueueStatus(result, enqueueStatus);
+    }
+  }
+
+  const leased = input.state.leaseNextReviewQueueJobs({
+    maxProviderActive: scheduler.maxProviderActive,
+    maxOrgActive: scheduler.maxOrgActive,
+    maxRepoActive: scheduler.maxRepoActive,
+    manualCommandReserve: scheduler.manualCommandReserve,
+    limit: scheduler.maxProviderActive,
+    now
+  });
+  result.queue.leased = leased.length;
+
+  const budget = new ReviewRunBudget(Math.max(1, scheduler.maxProviderActive));
+  for (const job of leased) {
+    const status = await runLeasedQueueJob({
+      config,
+      github: input.github,
+      state: input.state,
+      job,
+      dryRun: input.options.dryRun,
+      useZCode: input.options.useZCode ?? true,
+      reviewPullImpl: input.reviewPullImpl,
+      budget,
+      now
+    });
+    applyReviewStatus(result, status);
+  }
+
+  result.queue.remainingQueued = input.state.listReviewQueueJobs({ states: ["queued", "provider_deferred"] }).length;
+  return result;
+}
+
+type EnqueueStatus =
+  | "enqueued"
+  | "already_queued"
+  | "skipped_draft"
+  | "skipped_canary"
+  | "skipped_processed"
+  | "skipped_capacity"
+  | "provider_deferred"
+  | "closed_retired";
+
+function enqueuePullIfEligible(input: {
+  config: BotConfig;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  providerId: string;
+  now: Date;
+}): EnqueueStatus {
+  if (isClosedPull(input.pull)) return "closed_retired";
+  if (input.config.skipDrafts && input.pull.draft) return "skipped_draft";
+  if (!isCanaryAllowed(input.config, input.repo, input.pull.number)) return "skipped_canary";
+  if (input.state.hasProcessed(input.repo, input.pull.number, input.pull.head.sha)) return "skipped_processed";
+  if (hasActiveQueueJobForHead(input.state, input.repo, input.pull.number, input.pull.head.sha)) return "already_queued";
+
+  const activeRepoCooldown = input.state.getActiveRepoProviderCooldown(input.repo, input.now);
+  if (activeRepoCooldown) {
+    const queued = enqueueReviewJob(input);
+    input.state.updateReviewQueueJobState({
+      jobId: queued.job.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: activeRepoCooldown.cooldownUntil,
+      lastError: `repo_provider_cooldown_until=${activeRepoCooldown.cooldownUntil}; reason=${activeRepoCooldown.reason}`,
+      now: input.now
+    });
+    return "provider_deferred";
+  }
+
+  if (!hasRepoQueueCapacity(input.state, input.repo, input.config.reviewScheduler?.maxQueuedPerRepo ?? 10)) {
+    return "skipped_capacity";
+  }
+
+  const enqueued = enqueueReviewJob(input);
+  return enqueued.enqueued ? "enqueued" : "already_queued";
+}
+
+function enqueueReviewJob(input: {
+  config: BotConfig;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  providerId: string;
+  now: Date;
+}) {
+  return input.state.enqueueReviewQueueJob({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    baseSha: input.pull.base.sha,
+    providerId: input.providerId,
+    priority: input.config.reviewScheduler?.backgroundPriority,
+    now: input.now
+  });
+}
+
+async function runLeasedQueueJob(input: {
+  config: BotConfig;
+  github: SchedulerGitHubApi;
+  state: ReviewStateStore;
+  job: ReviewQueueJobRecord;
+  dryRun: boolean;
+  useZCode: boolean;
+  reviewPullImpl: (input: ReviewPullInput) => Promise<ReviewPullResult>;
+  budget: ReviewRunBudget;
+  now?: Date;
+}): Promise<ReviewPullResult | "failed" | "closed_retired" | "stale_retired"> {
+  const now = input.now ?? new Date();
+  input.state.updateReviewQueueJobState({
+    jobId: input.job.jobId,
+    state: "running",
+    now
+  });
+
+  let pull: PullRequestSummary;
+  try {
+    pull = await input.github.getPull(input.job.repo, input.job.pullNumber);
+  } catch (error) {
+    input.state.updateReviewQueueJobState({
+      jobId: input.job.jobId,
+      state: "failed",
+      lastError: error instanceof Error ? error.message : String(error)
+    });
+    return "failed";
+  }
+
+  if (isClosedPull(pull)) {
+    input.state.updateReviewQueueJobState({
+      jobId: input.job.jobId,
+      state: "closed_retired",
+      lastError: `closed_or_merged_before_review state=${pull.state ?? "unknown"}`
+    });
+    return "closed_retired";
+  }
+
+  if (pull.head.sha !== input.job.headSha || pull.base.sha !== input.job.baseSha) {
+    input.state.updateReviewQueueJobState({
+      jobId: input.job.jobId,
+      state: "stale_retired",
+      lastError: `stale_head_before_review live=${pull.head.sha}`
+    });
+    return "stale_retired";
+  }
+
+  try {
+    const status = await input.reviewPullImpl({
+      config: input.config,
+      github: input.github as GitHubApi,
+      state: input.state,
+      repo: input.job.repo,
+      pull,
+      dryRun: input.dryRun,
+      useZCode: input.useZCode,
+      budget: input.budget
+    });
+    updateQueueJobAfterReviewStatus({ state: input.state, job: input.job, pull, status });
+    return status;
+  } catch (error) {
+    if (recordProviderRateLimitCooldownIfNeeded({
+      config: input.config,
+      state: input.state,
+      repo: input.job.repo,
+      pull,
+      error,
+      now
+    })) {
+      markQueueJobProviderDeferredFromProcessed({ state: input.state, job: input.job, pull });
+      return "skipped_provider_cooldown";
+    }
+    recordFailedReview({
+      config: input.config,
+      state: input.state,
+      repo: input.job.repo,
+      pull,
+      error
+    });
+    input.state.updateReviewQueueJobState({
+      jobId: input.job.jobId,
+      state: "failed",
+      lastError: error instanceof Error ? error.message : String(error)
+    });
+    return "failed";
+  }
+}
+
+function updateQueueJobAfterReviewStatus(input: {
+  state: ReviewStateStore;
+  job: ReviewQueueJobRecord;
+  pull: PullRequestSummary;
+  status: ReviewPullResult;
+}): void {
+  switch (input.status) {
+    case "reviewed":
+    case "reviewed_command": {
+      const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
+      input.state.updateReviewQueueJobState({
+        jobId: input.job.jobId,
+        state: "posted",
+        ...(processed?.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
+        lastError: input.status
+      });
+      return;
+    }
+    case "skipped_provider_cooldown":
+      markQueueJobProviderDeferredFromProcessed(input);
+      return;
+    case "skipped_stale_head":
+      input.state.updateReviewQueueJobState({
+        jobId: input.job.jobId,
+        state: "stale_retired",
+        lastError: "review_pull_returned_stale_head"
+      });
+      return;
+    case "skipped_processed":
+      input.state.updateReviewQueueJobState({
+        jobId: input.job.jobId,
+        state: "posted",
+        lastError: "processed_head_already_exists"
+      });
+      return;
+    case "skipped_capacity":
+      input.state.updateReviewQueueJobState({
+        jobId: input.job.jobId,
+        state: "queued",
+        lastError: "legacy_review_capacity_busy"
+      });
+      return;
+    case "skipped_draft":
+    case "skipped_canary":
+    case "skipped_policy":
+    case "skipped_command_stop":
+    case "skipped_command_explain":
+      input.state.updateReviewQueueJobState({
+        jobId: input.job.jobId,
+        state: "failed",
+        lastError: `unexpected_scheduler_review_status=${input.status}`
+      });
+      return;
+    default:
+      assertNever(input.status);
+  }
+}
+
+function markQueueJobProviderDeferredFromProcessed(input: {
+  state: ReviewStateStore;
+  job: ReviewQueueJobRecord;
+  pull: PullRequestSummary;
+}): void {
+  const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
+  const parsed = parseProviderCooldownError(processed?.error);
+  input.state.updateReviewQueueJobState({
+    jobId: input.job.jobId,
+    state: "provider_deferred",
+    ...(parsed?.cooldownUntil ? { nextEligibleAt: parsed.cooldownUntil } : {}),
+    lastError: processed?.error ?? "provider_deferred_without_processed_row"
+  });
+}
+
+function hasActiveQueueJobForHead(
+  state: ReviewStateStore,
+  repo: string,
+  pullNumber: number,
+  headSha: string
+): boolean {
+  return state.listReviewQueueJobs({
+    repo,
+    states: ["queued", "leased", "running", "provider_deferred"]
+  }).some((job) => job.pullNumber === pullNumber && job.headSha === headSha);
+}
+
+function hasRepoQueueCapacity(state: ReviewStateStore, repo: string, maxQueuedPerRepo: number): boolean {
+  const active = state.listReviewQueueJobs({
+    repo,
+    states: ["queued", "leased", "running", "provider_deferred"]
+  });
+  return active.length < maxQueuedPerRepo;
+}
+
+function applyEnqueueStatus(result: ScheduledRunResult, status: EnqueueStatus): void {
+  switch (status) {
+    case "enqueued":
+      result.queue.enqueued += 1;
+      break;
+    case "already_queued":
+      result.queue.alreadyQueued += 1;
+      break;
+    case "provider_deferred":
+      result.skippedProviderCooldown += 1;
+      result.queue.providerDeferred += 1;
+      break;
+    case "closed_retired":
+      result.queue.closedRetired += 1;
+      break;
+    case "skipped_draft":
+      result.skippedDraft += 1;
+      break;
+    case "skipped_canary":
+      result.skippedCanary += 1;
+      break;
+    case "skipped_processed":
+      result.skippedProcessed += 1;
+      break;
+    case "skipped_capacity":
+      result.skippedCapacity += 1;
+      break;
+    default:
+      assertNever(status);
+  }
+}
+
+function applyReviewStatus(result: ScheduledRunResult, status: ReviewPullResult | "failed" | "closed_retired" | "stale_retired"): void {
+  switch (status) {
+    case "reviewed":
+    case "reviewed_command":
+      result.reviewed += 1;
+      result.queue.completed += 1;
+      if (status === "reviewed_command") result.commandReviewRequested += 1;
+      break;
+    case "skipped_draft":
+      result.skippedDraft += 1;
+      break;
+    case "skipped_canary":
+      result.skippedCanary += 1;
+      break;
+    case "skipped_policy":
+      result.skippedPolicy += 1;
+      break;
+    case "skipped_command_stop":
+      result.skippedCommandStop += 1;
+      break;
+    case "skipped_command_explain":
+      result.skippedCommandExplain += 1;
+      break;
+    case "skipped_processed":
+      result.skippedProcessed += 1;
+      result.queue.completed += 1;
+      break;
+    case "skipped_capacity":
+      result.skippedCapacity += 1;
+      break;
+    case "skipped_provider_cooldown":
+      result.skippedProviderCooldown += 1;
+      result.queue.providerDeferred += 1;
+      break;
+    case "skipped_stale_head":
+    case "stale_retired":
+      result.skippedStaleHead += 1;
+      result.queue.staleRetired += 1;
+      break;
+    case "closed_retired":
+      result.queue.closedRetired += 1;
+      break;
+    case "failed":
+      result.failed += 1;
+      result.queue.failedQueueJobs += 1;
+      break;
+    default:
+      assertNever(status);
+  }
+}
+
+function emptyScheduledRunResult(): ScheduledRunResult {
+  return {
+    reposScanned: 0,
+    pullsSeen: 0,
+    reviewed: 0,
+    failed: 0,
+    skippedDraft: 0,
+    skippedCanary: 0,
+    skippedPolicy: 0,
+    skippedCommandStop: 0,
+    skippedCommandExplain: 0,
+    commandReviewRequested: 0,
+    skippedProcessed: 0,
+    skippedCapacity: 0,
+    skippedProviderCooldown: 0,
+    skippedStaleHead: 0,
+    baselinedExisting: 0,
+    policySkips: [],
+    queue: {
+      enqueued: 0,
+      alreadyQueued: 0,
+      leased: 0,
+      completed: 0,
+      providerDeferred: 0,
+      staleRetired: 0,
+      closedRetired: 0,
+      failedQueueJobs: 0,
+      remainingQueued: 0
+    }
+  };
+}
+
+function isClosedPull(pull: PullRequestSummary): boolean {
+  return Boolean(pull.state && pull.state !== "open");
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unexpected scheduler status: ${String(value)}`);
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -15,6 +15,17 @@ export type ReviewerSessionAssignmentReason =
   | "new_session"
   | "session_expired_new_session"
   | "manual_command_priority";
+export type ReviewQueueJobSource = "automatic" | "manual_command";
+export type ReviewQueueJobLane = "background" | "manual";
+export type ReviewQueueJobState =
+  | "queued"
+  | "leased"
+  | "running"
+  | "provider_deferred"
+  | "stale_retired"
+  | "closed_retired"
+  | "posted"
+  | "failed";
 
 export interface ProcessedReviewRecord {
   repo: string;
@@ -74,6 +85,35 @@ export interface ReviewerSessionJobRecord {
   finishedAt?: string;
   processedReviewStatus?: ProcessedStatus;
 }
+
+export interface ReviewQueueJobRecord {
+  jobId: string;
+  attemptId: string;
+  source: ReviewQueueJobSource;
+  lane: ReviewQueueJobLane;
+  repo: string;
+  org: string;
+  pullNumber: number;
+  headSha: string;
+  baseSha?: string;
+  providerId?: string;
+  priority: number;
+  state: ReviewQueueJobState;
+  nextEligibleAt?: string;
+  leaseId?: string;
+  sessionId?: string;
+  commentId?: number;
+  reviewUrl?: string;
+  lastError?: string;
+  createdAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+}
+
+export type ReviewQueueEnqueueResult =
+  | { enqueued: true; job: ReviewQueueJobRecord }
+  | { enqueued: false; reason: "already_queued"; job: ReviewQueueJobRecord };
 
 export type ReviewerSessionAssignResult =
   | {
@@ -222,6 +262,38 @@ export class ReviewStateStore {
         primary key (repo, pull_number, head_sha),
         foreign key (session_id) references reviewer_sessions(session_id)
       );
+
+      create table if not exists review_queue_jobs (
+        job_id text primary key,
+        attempt_id text not null unique,
+        source text not null,
+        lane text not null,
+        repo text not null,
+        org text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        base_sha text,
+        provider_id text,
+        priority integer not null,
+        state text not null,
+        next_eligible_at text,
+        lease_id text,
+        session_id text,
+        comment_id integer,
+        review_url text,
+        last_error text,
+        created_at text not null,
+        updated_at text not null,
+        started_at text,
+        finished_at text
+      );
+
+      create index if not exists idx_review_queue_jobs_state_priority
+        on review_queue_jobs (state, priority, created_at);
+      create index if not exists idx_review_queue_jobs_repo_state
+        on review_queue_jobs (repo, state);
+      create index if not exists idx_review_queue_jobs_provider_state
+        on review_queue_jobs (provider_id, state);
     `);
     this.ensureDaemonHeartbeatColumns();
     this.ensureReviewRunLeaseColumns();
@@ -573,6 +645,250 @@ export class ReviewStateStore {
       this.expireDrainedReviewerSessionIfComplete(existing.sessionId);
     }
     return updated;
+  }
+
+  enqueueReviewQueueJob(input: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    baseSha?: string;
+    source?: ReviewQueueJobSource;
+    lane?: ReviewQueueJobLane;
+    providerId?: string;
+    priority?: number;
+    attemptId?: string;
+    commentId?: number;
+    sessionId?: string;
+    now?: Date;
+  }): ReviewQueueEnqueueResult {
+    validateReviewQueueInput(input.repo, input.pullNumber, input.headSha, input.priority, input.commentId);
+    const nowIso = (input.now ?? new Date()).toISOString();
+    const source = input.source ?? "automatic";
+    const lane = input.lane ?? (source === "manual_command" ? "manual" : "background");
+    const priority = input.priority ?? (lane === "manual" ? 10 : 50);
+    const attemptId = input.attemptId ?? buildReviewQueueAttemptId({
+      source,
+      repo: input.repo,
+      pullNumber: input.pullNumber,
+      headSha: input.headSha,
+      commentId: input.commentId
+    });
+    const existing = this.getReviewQueueJobByAttemptId(attemptId);
+    if (existing) return { enqueued: false, reason: "already_queued", job: existing };
+
+    const jobId = randomUUID();
+    this.db
+      .prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+           provider_id, priority, state, session_id, comment_id, created_at, updated_at)
+         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?, ?, ?)`
+      )
+      .run(
+        jobId,
+        attemptId,
+        source,
+        lane,
+        input.repo,
+        repoOrg(input.repo),
+        input.pullNumber,
+        input.headSha,
+        input.baseSha ?? null,
+        input.providerId ?? null,
+        priority,
+        input.sessionId ?? null,
+        input.commentId ?? null,
+        nowIso,
+        nowIso
+      );
+    return { enqueued: true, job: this.getReviewQueueJob(jobId)! };
+  }
+
+  leaseNextReviewQueueJobs(input: {
+    maxProviderActive: number;
+    maxOrgActive: number;
+    maxRepoActive: number;
+    manualCommandReserve?: number;
+    limit?: number;
+    now?: Date;
+  }): ReviewQueueJobRecord[] {
+    validatePositiveQueueLimit(input.maxProviderActive, "maxProviderActive");
+    validatePositiveQueueLimit(input.maxOrgActive, "maxOrgActive");
+    validatePositiveQueueLimit(input.maxRepoActive, "maxRepoActive");
+    const manualCommandReserve = input.manualCommandReserve ?? 0;
+    if (!Number.isInteger(manualCommandReserve) || manualCommandReserve < 0) {
+      throw new Error("manualCommandReserve must be a non-negative integer");
+    }
+    if (manualCommandReserve > input.maxProviderActive) {
+      throw new Error("manualCommandReserve must be <= maxProviderActive");
+    }
+    const limit = input.limit ?? input.maxProviderActive;
+    validatePositiveQueueLimit(limit, "limit");
+    const nowIso = (input.now ?? new Date()).toISOString();
+    const eligible = this.listReviewQueueJobs()
+      .filter((job) => isQueueJobEligible(job, nowIso))
+      .sort(compareQueueJobsForLease);
+    const active = this.listReviewQueueJobs().filter((job) => job.state === "leased" || job.state === "running");
+    const providerActive = countBy(active, (job) => job.providerId ?? "default");
+    const orgActive = countBy(active, (job) => job.org);
+    const repoActive = countBy(active, (job) => job.repo);
+    const leased: ReviewQueueJobRecord[] = [];
+
+    this.db.exec("begin immediate");
+    try {
+      for (const [index, job] of eligible.entries()) {
+        if (leased.length >= limit) break;
+        const provider = job.providerId ?? "default";
+        const providerCount = (providerActive.get(provider) ?? 0);
+        if (providerCount >= input.maxProviderActive) continue;
+        if ((orgActive.get(job.org) ?? 0) >= input.maxOrgActive) continue;
+        if ((repoActive.get(job.repo) ?? 0) >= input.maxRepoActive) continue;
+        const manualEligibleAfterThisJob = eligible.slice(index + 1).some((candidate) => candidate.lane === "manual");
+        if (
+          job.lane === "background" &&
+          manualEligibleAfterThisJob &&
+          manualCommandReserve > 0 &&
+          providerCount >= input.maxProviderActive - manualCommandReserve
+        ) {
+          continue;
+        }
+
+        const leaseId = randomUUID();
+        this.db
+          .prepare(
+            `update review_queue_jobs
+             set state = 'leased', lease_id = ?, updated_at = ?
+             where job_id = ? and state in ('queued', 'provider_deferred')`
+          )
+          .run(leaseId, nowIso, job.jobId);
+        providerActive.set(provider, providerCount + 1);
+        orgActive.set(job.org, (orgActive.get(job.org) ?? 0) + 1);
+        repoActive.set(job.repo, (repoActive.get(job.repo) ?? 0) + 1);
+        leased.push(this.getReviewQueueJob(job.jobId)!);
+      }
+      this.db.exec("commit");
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+
+    return leased;
+  }
+
+  updateReviewQueueJobState(input: {
+    jobId: string;
+    state: ReviewQueueJobState;
+    nextEligibleAt?: string;
+    leaseId?: string;
+    clearLease?: boolean;
+    sessionId?: string;
+    reviewUrl?: string;
+    lastError?: string;
+    now?: Date;
+  }): ReviewQueueJobRecord {
+    const existing = this.getReviewQueueJob(input.jobId);
+    if (!existing) throw new Error(`No review queue job for jobId ${input.jobId}`);
+    const nowIso = (input.now ?? new Date()).toISOString();
+    const terminal = isTerminalQueueState(input.state);
+    const clearLease = input.clearLease ?? (
+      terminal ||
+      input.state === "queued" ||
+      input.state === "provider_deferred"
+    );
+    this.db
+      .prepare(
+        `update review_queue_jobs
+         set state = ?,
+             next_eligible_at = ?,
+             lease_id = case when ? then null else coalesce(?, lease_id) end,
+             session_id = coalesce(?, session_id),
+             review_url = coalesce(?, review_url),
+             last_error = coalesce(?, last_error),
+             updated_at = ?,
+             started_at = case when ? = 'running' and started_at is null then ? else started_at end,
+             finished_at = case when ? then ? else finished_at end
+         where job_id = ?`
+      )
+      .run(
+        input.state,
+        input.nextEligibleAt ?? null,
+        clearLease ? 1 : 0,
+        input.leaseId ?? null,
+        input.sessionId ?? null,
+        input.reviewUrl ?? null,
+        input.lastError ? redactSecrets(input.lastError) : null,
+        nowIso,
+        input.state,
+        nowIso,
+        terminal ? 1 : 0,
+        nowIso,
+        input.jobId
+      );
+    return this.getReviewQueueJob(input.jobId)!;
+  }
+
+  getReviewQueueJob(jobId: string): ReviewQueueJobRecord | undefined {
+    const row = this.db
+      .prepare(
+        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+                provider_id, priority, state, next_eligible_at, lease_id, session_id,
+                comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+         from review_queue_jobs
+         where job_id = ?
+         limit 1`
+      )
+      .get(jobId) as ReviewQueueJobRow | undefined;
+    return row ? mapReviewQueueJobRow(row) : undefined;
+  }
+
+  getReviewQueueJobByAttemptId(attemptId: string): ReviewQueueJobRecord | undefined {
+    const row = this.db
+      .prepare(
+        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+                provider_id, priority, state, next_eligible_at, lease_id, session_id,
+                comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+         from review_queue_jobs
+         where attempt_id = ?
+         limit 1`
+      )
+      .get(attemptId) as ReviewQueueJobRow | undefined;
+    return row ? mapReviewQueueJobRow(row) : undefined;
+  }
+
+  listReviewQueueJobs(input: {
+    repo?: string;
+    state?: ReviewQueueJobState;
+    states?: ReviewQueueJobState[];
+    limit?: number;
+  } = {}): ReviewQueueJobRecord[] {
+    if (input.limit !== undefined && (!Number.isInteger(input.limit) || input.limit < 1)) {
+      throw new Error("limit must be a positive integer");
+    }
+    const rows = (input.repo
+      ? this.db
+          .prepare(
+            `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+                    provider_id, priority, state, next_eligible_at, lease_id, session_id,
+                    comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+             from review_queue_jobs
+             where repo = ?
+             order by priority asc, datetime(created_at) asc`
+          )
+          .all(input.repo)
+      : this.db
+          .prepare(
+            `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+                    provider_id, priority, state, next_eligible_at, lease_id, session_id,
+                    comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+             from review_queue_jobs
+             order by priority asc, datetime(created_at) asc`
+          )
+          .all()) as unknown as ReviewQueueJobRow[];
+    const states = input.states ?? (input.state ? [input.state] : undefined);
+    const jobs = rows
+      .map(mapReviewQueueJobRow)
+      .filter((job) => !states || states.includes(job.state));
+    return input.limit ? jobs.slice(0, input.limit) : jobs;
   }
 
   expireReviewerSessions(now = new Date(), repo?: string): number {
@@ -936,6 +1252,72 @@ function validateReviewerSessionInput(ttlMs: number, headCountLimit: number, wor
   }
 }
 
+function validateReviewQueueInput(
+  repo: string,
+  pullNumber: number,
+  headSha: string,
+  priority?: number,
+  commentId?: number
+): void {
+  if (!repoOrg(repo)) throw new Error("repo must be an owner/repo name");
+  if (!Number.isInteger(pullNumber) || pullNumber < 1) throw new Error("pullNumber must be a positive integer");
+  if (!headSha.trim()) throw new Error("headSha must be non-empty");
+  if (priority !== undefined && (!Number.isInteger(priority) || priority < 0)) {
+    throw new Error("priority must be a non-negative integer");
+  }
+  if (commentId !== undefined && (!Number.isInteger(commentId) || commentId < 1)) {
+    throw new Error("commentId must be a positive integer");
+  }
+}
+
+function validatePositiveQueueLimit(value: number, label: string): void {
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${label} must be a positive integer`);
+}
+
+function buildReviewQueueAttemptId(input: {
+  source: ReviewQueueJobSource;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  commentId?: number;
+}): string {
+  if (input.source === "manual_command") {
+    return `manual:${input.repo}#${input.pullNumber}@${input.headSha}:${input.commentId ?? randomUUID()}`;
+  }
+  return `automatic:${input.repo}#${input.pullNumber}@${input.headSha}`;
+}
+
+function repoOrg(repo: string): string {
+  return repo.split("/")[0] ?? "";
+}
+
+function isQueueJobEligible(job: ReviewQueueJobRecord, nowIso: string): boolean {
+  if (job.state === "queued") return true;
+  if (job.state !== "provider_deferred") return false;
+  if (!job.nextEligibleAt) return true;
+  return Date.parse(job.nextEligibleAt) <= Date.parse(nowIso);
+}
+
+function compareQueueJobsForLease(left: ReviewQueueJobRecord, right: ReviewQueueJobRecord): number {
+  if (left.priority !== right.priority) return left.priority - right.priority;
+  const leftCreated = Date.parse(left.createdAt);
+  const rightCreated = Date.parse(right.createdAt);
+  return leftCreated - rightCreated;
+}
+
+function countBy<T>(items: T[], key: (item: T) => string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const value = key(item);
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function isTerminalQueueState(state: ReviewQueueJobState): boolean {
+  return state === "posted" || state === "failed" || state === "stale_retired" || state === "closed_retired";
+}
+
 export function parseProviderCooldownError(error?: string): ParsedProviderCooldownError | undefined {
   if (!error?.startsWith(PROVIDER_COOLDOWN_ERROR_PREFIX)) return undefined;
   const [cooldownPart, ...rest] = error.split(";");
@@ -1009,6 +1391,31 @@ interface ReviewerSessionJobRow {
   processed_review_status: ProcessedStatus | null;
 }
 
+interface ReviewQueueJobRow {
+  job_id: string;
+  attempt_id: string;
+  source: ReviewQueueJobSource;
+  lane: ReviewQueueJobLane;
+  repo: string;
+  org: string;
+  pull_number: number;
+  head_sha: string;
+  base_sha: string | null;
+  provider_id: string | null;
+  priority: number;
+  state: ReviewQueueJobState;
+  next_eligible_at: string | null;
+  lease_id: string | null;
+  session_id: string | null;
+  comment_id: number | null;
+  review_url: string | null;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+  started_at: string | null;
+  finished_at: string | null;
+}
+
 function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRecord {
   return {
     repo: row.repo,
@@ -1064,6 +1471,33 @@ function mapReviewerSessionJobRow(row: ReviewerSessionJobRow): ReviewerSessionJo
     ...(row.started_at ? { startedAt: row.started_at } : {}),
     ...(row.finished_at ? { finishedAt: row.finished_at } : {}),
     ...(row.processed_review_status ? { processedReviewStatus: row.processed_review_status } : {})
+  };
+}
+
+function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
+  return {
+    jobId: row.job_id,
+    attemptId: row.attempt_id,
+    source: row.source,
+    lane: row.lane,
+    repo: row.repo,
+    org: row.org,
+    pullNumber: row.pull_number,
+    headSha: row.head_sha,
+    ...(row.base_sha ? { baseSha: row.base_sha } : {}),
+    ...(row.provider_id ? { providerId: row.provider_id } : {}),
+    priority: row.priority,
+    state: row.state,
+    ...(row.next_eligible_at ? { nextEligibleAt: row.next_eligible_at } : {}),
+    ...(row.lease_id ? { leaseId: row.lease_id } : {}),
+    ...(row.session_id ? { sessionId: row.session_id } : {}),
+    ...(row.comment_id ? { commentId: row.comment_id } : {}),
+    ...(row.review_url ? { reviewUrl: row.review_url } : {}),
+    ...(row.last_error ? { lastError: row.last_error } : {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    ...(row.started_at ? { startedAt: row.started_at } : {}),
+    ...(row.finished_at ? { finishedAt: row.finished_at } : {})
   };
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -101,6 +101,7 @@ export interface ReviewQueueJobRecord {
   state: ReviewQueueJobState;
   nextEligibleAt?: string;
   leaseId?: string;
+  leaseExpiresAt?: string;
   sessionId?: string;
   commentId?: number;
   reviewUrl?: string;
@@ -278,6 +279,7 @@ export class ReviewStateStore {
         state text not null,
         next_eligible_at text,
         lease_id text,
+        lease_expires_at text,
         session_id text,
         comment_id integer,
         review_url text,
@@ -297,6 +299,7 @@ export class ReviewStateStore {
     `);
     this.ensureDaemonHeartbeatColumns();
     this.ensureReviewRunLeaseColumns();
+    this.ensureReviewQueueJobColumns();
     this.db.exec(`
       create table if not exists processed_commands (
         repo text not null,
@@ -671,6 +674,7 @@ export class ReviewStateStore {
       repo: input.repo,
       pullNumber: input.pullNumber,
       headSha: input.headSha,
+      baseSha: input.baseSha,
       commentId: input.commentId
     });
     const existing = this.getReviewQueueJobByAttemptId(attemptId);
@@ -710,6 +714,7 @@ export class ReviewStateStore {
     maxRepoActive: number;
     manualCommandReserve?: number;
     limit?: number;
+    leaseTtlMs?: number;
     now?: Date;
   }): ReviewQueueJobRecord[] {
     validatePositiveQueueLimit(input.maxProviderActive, "maxProviderActive");
@@ -724,11 +729,30 @@ export class ReviewStateStore {
     }
     const limit = input.limit ?? input.maxProviderActive;
     validatePositiveQueueLimit(limit, "limit");
+    const leaseTtlMs = input.leaseTtlMs ?? 15 * 60_000;
+    validatePositiveQueueLimit(leaseTtlMs, "leaseTtlMs");
     const nowIso = (input.now ?? new Date()).toISOString();
+    const legacyLeaseCutoffIso = new Date(Date.parse(nowIso) - leaseTtlMs).toISOString();
+    const leaseExpiresAt = new Date(Date.parse(nowIso) + leaseTtlMs).toISOString();
     const leased: ReviewQueueJobRecord[] = [];
 
     this.db.exec("begin immediate");
     try {
+      this.db
+        .prepare(
+          `update review_queue_jobs
+           set state = 'queued',
+               lease_id = null,
+               lease_expires_at = null,
+               last_error = 'queue_lease_expired_requeued',
+               updated_at = ?
+           where state in ('leased', 'running')
+             and (
+               (lease_expires_at is not null and datetime(lease_expires_at) <= datetime(?))
+               or (lease_expires_at is null and datetime(updated_at) <= datetime(?))
+             )`
+        )
+        .run(nowIso, nowIso, legacyLeaseCutoffIso);
       const jobs = this.listReviewQueueJobs();
       const eligible = jobs
         .filter((job) => isQueueJobEligible(job, nowIso))
@@ -759,10 +783,10 @@ export class ReviewStateStore {
         this.db
           .prepare(
             `update review_queue_jobs
-             set state = 'leased', lease_id = ?, updated_at = ?
+             set state = 'leased', lease_id = ?, lease_expires_at = ?, updated_at = ?
              where job_id = ? and state in ('queued', 'provider_deferred')`
           )
-          .run(leaseId, nowIso, job.jobId);
+          .run(leaseId, leaseExpiresAt, nowIso, job.jobId);
         providerActive.set(provider, providerCount + 1);
         orgActive.set(job.org, (orgActive.get(job.org) ?? 0) + 1);
         repoActive.set(job.repo, (repoActive.get(job.repo) ?? 0) + 1);
@@ -782,6 +806,7 @@ export class ReviewStateStore {
     state: ReviewQueueJobState;
     nextEligibleAt?: string;
     leaseId?: string;
+    leaseExpiresAt?: string;
     clearLease?: boolean;
     sessionId?: string;
     reviewUrl?: string;
@@ -803,6 +828,7 @@ export class ReviewStateStore {
          set state = ?,
              next_eligible_at = ?,
              lease_id = case when ? then null else coalesce(?, lease_id) end,
+             lease_expires_at = case when ? then null else coalesce(?, lease_expires_at) end,
              session_id = coalesce(?, session_id),
              review_url = coalesce(?, review_url),
              last_error = coalesce(?, last_error),
@@ -816,6 +842,8 @@ export class ReviewStateStore {
         input.nextEligibleAt ?? null,
         clearLease ? 1 : 0,
         input.leaseId ?? null,
+        clearLease ? 1 : 0,
+        input.leaseExpiresAt ?? null,
         input.sessionId ?? null,
         input.reviewUrl ?? null,
         input.lastError ? redactSecrets(input.lastError) : null,
@@ -833,7 +861,7 @@ export class ReviewStateStore {
     const row = this.db
       .prepare(
         `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
-                provider_id, priority, state, next_eligible_at, lease_id, session_id,
+                provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
          where job_id = ?
@@ -847,7 +875,7 @@ export class ReviewStateStore {
     const row = this.db
       .prepare(
         `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
-                provider_id, priority, state, next_eligible_at, lease_id, session_id,
+                provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
          from review_queue_jobs
          where attempt_id = ?
@@ -870,7 +898,7 @@ export class ReviewStateStore {
       ? this.db
           .prepare(
             `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
-                    provider_id, priority, state, next_eligible_at, lease_id, session_id,
+                    provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                     comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
              from review_queue_jobs
              where repo = ?
@@ -880,7 +908,7 @@ export class ReviewStateStore {
       : this.db
           .prepare(
             `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
-                    provider_id, priority, state, next_eligible_at, lease_id, session_id,
+                    provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
                     comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
              from review_queue_jobs
              order by priority asc, datetime(created_at) asc`
@@ -1220,6 +1248,13 @@ export class ReviewStateStore {
       this.db.exec("alter table review_run_leases add column owner_pid integer");
     }
   }
+
+  private ensureReviewQueueJobColumns(): void {
+    const columns = this.db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>;
+    if (!columns.some((column) => column.name === "lease_expires_at")) {
+      this.db.exec("alter table review_queue_jobs add column lease_expires_at text");
+    }
+  }
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -1281,12 +1316,13 @@ function buildReviewQueueAttemptId(input: {
   repo: string;
   pullNumber: number;
   headSha: string;
+  baseSha?: string;
   commentId?: number;
 }): string {
   if (input.source === "manual_command") {
     return `manual:${input.repo}#${input.pullNumber}@${input.headSha}:${input.commentId ?? randomUUID()}`;
   }
-  return `automatic:${input.repo}#${input.pullNumber}@${input.headSha}`;
+  return `automatic:${input.repo}#${input.pullNumber}@${input.headSha}:base=${input.baseSha ?? "unknown"}`;
 }
 
 function repoOrg(repo: string): string {
@@ -1297,7 +1333,9 @@ function isQueueJobEligible(job: ReviewQueueJobRecord, nowIso: string): boolean 
   if (job.state === "queued") return true;
   if (job.state !== "provider_deferred") return false;
   if (!job.nextEligibleAt) return true;
-  return Date.parse(job.nextEligibleAt) <= Date.parse(nowIso);
+  const nextEligibleAtMs = Date.parse(job.nextEligibleAt);
+  if (!Number.isFinite(nextEligibleAtMs)) return true;
+  return nextEligibleAtMs <= Date.parse(nowIso);
 }
 
 function compareQueueJobsForLease(left: ReviewQueueJobRecord, right: ReviewQueueJobRecord): number {
@@ -1408,6 +1446,7 @@ interface ReviewQueueJobRow {
   state: ReviewQueueJobState;
   next_eligible_at: string | null;
   lease_id: string | null;
+  lease_expires_at: string | null;
   session_id: string | null;
   comment_id: number | null;
   review_url: string | null;
@@ -1492,6 +1531,7 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     state: row.state,
     ...(row.next_eligible_at ? { nextEligibleAt: row.next_eligible_at } : {}),
     ...(row.lease_id ? { leaseId: row.lease_id } : {}),
+    ...(row.lease_expires_at ? { leaseExpiresAt: row.lease_expires_at } : {}),
     ...(row.session_id ? { sessionId: row.session_id } : {}),
     ...(row.comment_id ? { commentId: row.comment_id } : {}),
     ...(row.review_url ? { reviewUrl: row.review_url } : {}),

--- a/src/state.ts
+++ b/src/state.ts
@@ -761,6 +761,7 @@ export class ReviewStateStore {
       const providerActive = countBy(active, (job) => job.providerId ?? "default");
       const orgActive = countBy(active, (job) => job.org);
       const repoActive = countBy(active, (job) => job.repo);
+      const hasManualAfter = buildManualEligibilitySuffix(eligible);
 
       for (const [index, job] of eligible.entries()) {
         if (leased.length >= limit) break;
@@ -769,10 +770,9 @@ export class ReviewStateStore {
         if (providerCount >= input.maxProviderActive) continue;
         if ((orgActive.get(job.org) ?? 0) >= input.maxOrgActive) continue;
         if ((repoActive.get(job.repo) ?? 0) >= input.maxRepoActive) continue;
-        const manualEligibleAfterThisJob = eligible.slice(index + 1).some((candidate) => candidate.lane === "manual");
         if (
           job.lane === "background" &&
-          manualEligibleAfterThisJob &&
+          hasManualAfter[index] &&
           manualCommandReserve > 0 &&
           providerCount >= input.maxProviderActive - manualCommandReserve
         ) {
@@ -1343,6 +1343,16 @@ function compareQueueJobsForLease(left: ReviewQueueJobRecord, right: ReviewQueue
   const leftCreated = Date.parse(left.createdAt);
   const rightCreated = Date.parse(right.createdAt);
   return leftCreated - rightCreated;
+}
+
+function buildManualEligibilitySuffix(jobs: ReviewQueueJobRecord[]): boolean[] {
+  const hasManualAfter = new Array<boolean>(jobs.length).fill(false);
+  let seenManual = false;
+  for (let index = jobs.length - 1; index >= 0; index -= 1) {
+    hasManualAfter[index] = seenManual;
+    if (jobs[index]?.lane === "manual") seenManual = true;
+  }
+  return hasManualAfter;
 }
 
 function countBy<T>(items: T[], key: (item: T) => string): Map<string, number> {

--- a/src/state.ts
+++ b/src/state.ts
@@ -725,17 +725,19 @@ export class ReviewStateStore {
     const limit = input.limit ?? input.maxProviderActive;
     validatePositiveQueueLimit(limit, "limit");
     const nowIso = (input.now ?? new Date()).toISOString();
-    const eligible = this.listReviewQueueJobs()
-      .filter((job) => isQueueJobEligible(job, nowIso))
-      .sort(compareQueueJobsForLease);
-    const active = this.listReviewQueueJobs().filter((job) => job.state === "leased" || job.state === "running");
-    const providerActive = countBy(active, (job) => job.providerId ?? "default");
-    const orgActive = countBy(active, (job) => job.org);
-    const repoActive = countBy(active, (job) => job.repo);
     const leased: ReviewQueueJobRecord[] = [];
 
     this.db.exec("begin immediate");
     try {
+      const jobs = this.listReviewQueueJobs();
+      const eligible = jobs
+        .filter((job) => isQueueJobEligible(job, nowIso))
+        .sort(compareQueueJobsForLease);
+      const active = jobs.filter((job) => job.state === "leased" || job.state === "running");
+      const providerActive = countBy(active, (job) => job.providerId ?? "default");
+      const orgActive = countBy(active, (job) => job.org);
+      const repoActive = countBy(active, (job) => job.repo);
+
       for (const [index, job] of eligible.entries()) {
         if (leased.length >= limit) break;
         const provider = job.providerId ?? "default";

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -139,6 +139,55 @@ describe("daemon cycle resilience", () => {
     expect(events).toEqual(["false:1:true"]);
   });
 
+  it("skips the legacy provider cooldown retry lane when scheduler owns queue retries", async () => {
+    const stdout: string[] = [];
+    let retryCalled = false;
+
+    const result = await runDaemonCycle({
+      cycle: 5,
+      dryRun: false,
+      pilotRepos: ["electricsheephq/WorldOS"],
+      monitoredRepos: ["electricsheephq/WorldOS"],
+      canaryPulls: [],
+      commandsEnabled: false,
+      reviewSchedulerEnabled: true,
+      runOnceImpl: async () => ({
+        reposScanned: 1,
+        pullsSeen: 1,
+        reviewed: 0,
+        failed: 0,
+        skippedDraft: 0,
+        skippedCanary: 0,
+        skippedPolicy: 0,
+        skippedCommandStop: 0,
+        skippedCommandExplain: 0,
+        commandReviewRequested: 0,
+        skippedProcessed: 1,
+        skippedCapacity: 0,
+        skippedProviderCooldown: 0,
+        skippedStaleHead: 0,
+        baselinedExisting: 0,
+        policySkips: []
+      }),
+      retryProviderCooldownsImpl: async () => {
+        retryCalled = true;
+        throw new Error("legacy retry should not run");
+      },
+      recordHeartbeatImpl: () => undefined,
+      stdout: (line) => stdout.push(line),
+      stderr: () => undefined
+    });
+
+    expect(result.ok).toBe(true);
+    expect(retryCalled).toBe(false);
+    expect(stdout.map((line) => JSON.parse(line))).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        event: "daemon_provider_cooldown_retry_skipped",
+        reason: "review_scheduler_enabled"
+      })
+    ]));
+  });
+
   it("records a failed heartbeat with the failure message", async () => {
     const heartbeats: Array<{ event: string; error?: string }> = [];
 

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -9,6 +9,7 @@ import {
   buildOperatorStatus,
   collectOperatorLeases,
   collectOperatorRepoProviderCooldowns,
+  collectOperatorReviewQueue,
   explainPullStatus,
   summarizeAgentInventory,
   type OperatorAgentInventory
@@ -44,6 +45,7 @@ describe("operator CLI summaries", () => {
           expired: true
         }
       ],
+      durableQueue: durableQueueSnapshot(),
       checkedAt: "2026-07-01T00:30:00.000Z"
     });
 
@@ -56,7 +58,11 @@ describe("operator CLI summaries", () => {
       pendingHeads: 1,
       providerDeferredHeads: 1,
       readFailures: 1,
-      expiredProviderCooldowns: 1
+      expiredProviderCooldowns: 1,
+      queuedJobs: 1,
+      runningJobs: 1,
+      providerDeferredJobs: 1,
+      failedQueueJobs: 1
     });
     expect(status.gates).toContainEqual({
       name: "queue_no_pending_heads",
@@ -74,6 +80,8 @@ describe("operator CLI summaries", () => {
       detail: "0 stale head(s)"
     });
     expect(status.recommendedActions).toContain("retry cooldowns");
+    expect(status.recommendedActions).toContain("inspect operator queue failed jobs before promotion");
+    expect(status.recommendedActions).toContain("retry or requeue provider-deferred jobs whose nextEligibleAt has expired");
     expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
   });
 
@@ -170,6 +178,40 @@ describe("operator CLI summaries", () => {
         updatedAt: "2026-07-01T00:00:00.000Z"
       }
     ]);
+  });
+
+  it("summarizes durable review queue rows from the live state database", () => {
+    const statePath = createTempDatabase(tempDirs);
+    const db = new DatabaseSync(statePath);
+    try {
+      db.exec("create table review_queue_jobs (job_id text primary key, attempt_id text not null unique, source text not null, lane text not null, repo text not null, org text not null, pull_number integer not null, head_sha text not null, base_sha text, provider_id text, priority integer not null, state text not null, next_eligible_at text, lease_id text, session_id text, comment_id integer, review_url text, last_error text, created_at text not null, updated_at text not null, started_at text, finished_at text)");
+      insertQueueJob(db, "queued", "owner/repo", 1, "head-queued");
+      insertQueueJob(db, "running", "owner/repo", 2, "head-running");
+      insertQueueJob(db, "provider_deferred", "owner/repo", 3, "head-deferred", "2026-07-01T00:01:00.000Z");
+      insertQueueJob(db, "provider_deferred", "owner/other", 4, "head-wait", "2026-07-01T00:10:00.000Z");
+      insertQueueJob(db, "failed", "owner/other", 5, "head-failed");
+    } finally {
+      db.close();
+    }
+
+    const queue = collectOperatorReviewQueue(statePath, {
+      now: new Date("2026-07-01T00:05:00.000Z")
+    });
+
+    expect(queue.ok).toBe(false);
+    expect(queue.summary).toMatchObject({
+      total: 5,
+      queued: 1,
+      running: 1,
+      providerDeferred: 2,
+      retryableProviderDeferred: 1,
+      failed: 1
+    });
+    expect(queue.byRepo).toEqual([
+      expect.objectContaining({ repo: "owner/other", total: 2, providerDeferred: 1, retryableProviderDeferred: 0, failed: 1 }),
+      expect.objectContaining({ repo: "owner/repo", total: 3, queued: 1, running: 1, retryableProviderDeferred: 1 })
+    ]);
+    expect(collectOperatorReviewQueue(statePath, { repo: "owner/repo" }).jobs).toHaveLength(3);
   });
 
   it("builds queue buckets from coverage audit output", () => {
@@ -403,4 +445,51 @@ function agentInventory(input: Partial<OperatorAgentInventory>): OperatorAgentIn
     activeLeases: input.activeLeases ?? [],
     staleLeases: input.staleLeases ?? []
   };
+}
+
+function durableQueueSnapshot() {
+  return {
+    ok: false,
+    checkedAt: "2026-07-01T00:30:00.000Z",
+    summary: {
+      total: 4,
+      queued: 1,
+      leased: 0,
+      running: 1,
+      providerDeferred: 1,
+      retryableProviderDeferred: 1,
+      posted: 0,
+      failed: 1,
+      retired: 0
+    },
+    jobs: [],
+    byRepo: []
+  };
+}
+
+function insertQueueJob(
+  db: DatabaseSync,
+  state: string,
+  repo: string,
+  pullNumber: number,
+  headSha: string,
+  nextEligibleAt?: string
+): void {
+  db.prepare(
+    `insert into review_queue_jobs
+      (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+       priority, state, next_eligible_at, created_at, updated_at)
+     values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, ?, ?, ?, ?)`
+  ).run(
+    `${state}-${headSha}`,
+    `automatic:${repo}#${pullNumber}@${headSha}`,
+    repo,
+    repo.split("/")[0],
+    pullNumber,
+    headSha,
+    state,
+    nextEligibleAt ?? null,
+    "2026-07-01T00:00:00.000Z",
+    "2026-07-01T00:00:00.000Z"
+  );
 }

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -212,6 +212,17 @@ describe("operator CLI summaries", () => {
       expect.objectContaining({ repo: "owner/repo", total: 3, queued: 1, running: 1, retryableProviderDeferred: 1 })
     ]);
     expect(collectOperatorReviewQueue(statePath, { repo: "owner/repo" }).jobs).toHaveLength(3);
+
+    const limited = collectOperatorReviewQueue(statePath, {
+      now: new Date("2026-07-01T00:05:00.000Z"),
+      limit: 2
+    });
+    expect(limited.jobs).toHaveLength(2);
+    expect(limited.summary.total).toBe(5);
+    expect(limited.byRepo).toEqual([
+      expect.objectContaining({ repo: "owner/other", total: 2, failed: 1 }),
+      expect.objectContaining({ repo: "owner/repo", total: 3, queued: 1 })
+    ]);
   });
 
   it("builds queue buckets from coverage audit output", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -452,6 +452,120 @@ describe("beta release status", () => {
     ]);
   });
 
+  it("reports durable review queue counts and fails retryable deferred or failed jobs", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-review-queue-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      insertQueueJob(db, "queued", "electricsheephq/WorldOS", "queued-head");
+      insertQueueJob(db, "running", "electricsheephq/WorldOS", "running-head");
+      insertQueueJob(db, "provider_deferred", "100yenadmin/evaOS-GUI", "deferred-head", "2026-07-01T00:10:00.000Z");
+      insertQueueJob(db, "provider_deferred", "100yenadmin/evaOS-GUI", "retryable-head", "2026-07-01T00:01:00.000Z");
+      insertQueueJob(db, "failed", "100yenadmin/Lossless-Codex-Orchestrator-LCO", "failed-head");
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-01T00:05:00.000Z")
+    });
+
+    expect(status.database).toMatchObject({
+      reviewQueueJobCount: 5,
+      queuedReviewQueueJobCount: 1,
+      runningReviewQueueJobCount: 1,
+      providerDeferredReviewQueueJobCount: 2,
+      retryableProviderDeferredReviewQueueJobCount: 1,
+      failedReviewQueueJobCount: 1
+    });
+    expect(status.database.reviewQueueJobsByRepo).toEqual([
+      {
+        repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+        total: 1,
+        queued: 0,
+        leased: 0,
+        running: 0,
+        providerDeferred: 0,
+        retryableProviderDeferred: 0,
+        failed: 1
+      },
+      {
+        repo: "100yenadmin/evaOS-GUI",
+        total: 2,
+        queued: 0,
+        leased: 0,
+        running: 0,
+        providerDeferred: 2,
+        retryableProviderDeferred: 1,
+        failed: 0
+      },
+      {
+        repo: "electricsheephq/WorldOS",
+        total: 2,
+        queued: 1,
+        leased: 0,
+        running: 1,
+        providerDeferred: 0,
+        retryableProviderDeferred: 0,
+        failed: 0
+      }
+    ]);
+    expect(status.gates).toContainEqual({
+      name: "queue_no_failed_jobs",
+      ok: false,
+      detail: "1 failed durable queue job(s)"
+    });
+    expect(status.gates).toContainEqual({
+      name: "queue_no_retryable_provider_deferred_jobs",
+      ok: false,
+      detail: "1 retryable provider-deferred queue job(s); queue total=5 queued=1 leased=0 running=1 provider_deferred=2 failed=1"
+    });
+    expect(status.recommendedActions).toContain("inspect operator queue and retry provider-deferred jobs whose nextEligibleAt has expired");
+  });
+
   it("treats malformed provider cooldown timestamps as actionable backlog", () => {
     const root = mkdtempSync(join(tmpdir(), "release-status-db-invalid-cooldown-"));
     roots.push(root);
@@ -572,4 +686,29 @@ function freshHeartbeat() {
     event: "daemon_cycle_complete",
     dryRun: false
   };
+}
+
+function insertQueueJob(
+  db: DatabaseSync,
+  state: string,
+  repo: string,
+  headSha: string,
+  nextEligibleAt?: string
+): void {
+  db.prepare(
+    `insert into review_queue_jobs
+      (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+       priority, state, next_eligible_at, created_at, updated_at)
+     values (?, ?, 'automatic', 'background', ?, ?, 1, ?, 50, ?, ?, ?, ?)`
+  ).run(
+    `${state}-${headSha}`,
+    `automatic:${repo}#1@${headSha}`,
+    repo,
+    repo.split("/")[0],
+    headSha,
+    state,
+    nextEligibleAt ?? null,
+    "2026-07-01T00:00:00.000Z",
+    "2026-07-01T00:00:00.000Z"
+  );
 }

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -674,6 +674,46 @@ describe("beta release status", () => {
       detail: "stale; age 180000ms; max 120000ms; event daemon_cycle_complete; cycle 5"
     });
   });
+
+  it("treats a bounded active daemon cycle as a healthy heartbeat", () => {
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false
+      },
+      database: { rowCount: 21, errorCount: 0, skippedCount: 16 },
+      heartbeat: {
+        status: "active",
+        maxAgeMs: 120_000,
+        activeMaxAgeMs: 420_000,
+        latestAt: "2026-06-30T23:57:00.000Z",
+        ageMs: 180_000,
+        cycle: 5,
+        event: "daemon_cycle_complete",
+        dryRun: false,
+        activeCycle: 6,
+        activeStartedAt: "2026-06-30T23:59:00.000Z",
+        activeAgeMs: 60_000
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(true);
+    expect(status.gates).toContainEqual({
+      name: "daemon_heartbeat_recent",
+      ok: true,
+      detail: "active; active age 60000ms; max 420000ms; started cycle 6; last event daemon_cycle_complete; last cycle 5"
+    });
+  });
 });
 
 function freshHeartbeat() {

--- a/tests/review-scheduler-config.test.ts
+++ b/tests/review-scheduler-config.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadConfig } from "../src/config.js";
+
+describe("review scheduler config", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("loads disabled-by-default provider-aware queue settings", () => {
+    const config = loadConfig(writeConfig({}));
+
+    expect(config.reviewScheduler).toEqual({
+      enabled: false,
+      maxProviderActive: 2,
+      maxOrgActive: 3,
+      maxRepoActive: 1,
+      maxQueuedPerRepo: 10,
+      manualCommandReserve: 1,
+      backgroundPriority: 50,
+      manualPriority: 10,
+      providerThrottleBackoff: {
+        requestRateLimitBaseMs: 30_000,
+        requestRateLimitMaxMs: 180_000,
+        overloadBaseMs: 60_000,
+        overloadMaxMs: 300_000,
+        quotaBaseMs: 30 * 60_000
+      }
+    });
+  });
+
+  it("rejects scheduler settings that cannot preserve manual reserve capacity", () => {
+    expect(() => loadConfig(writeConfig({
+      reviewScheduler: {
+        maxProviderActive: 1,
+        manualCommandReserve: 2
+      }
+    }))).toThrow("config.reviewScheduler.manualCommandReserve must be <= config.reviewScheduler.maxProviderActive");
+  });
+
+  function writeConfig(overlay: Record<string, unknown>): string {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-scheduler-config-"));
+    roots.push(root);
+    const path = join(root, "config.json");
+    writeFileSync(path, `${JSON.stringify(overlay)}\n`);
+    return path;
+  }
+});

--- a/tests/review-scheduler-config.test.ts
+++ b/tests/review-scheduler-config.test.ts
@@ -21,15 +21,7 @@ describe("review scheduler config", () => {
       maxRepoActive: 1,
       maxQueuedPerRepo: 10,
       manualCommandReserve: 1,
-      backgroundPriority: 50,
-      manualPriority: 10,
-      providerThrottleBackoff: {
-        requestRateLimitBaseMs: 30_000,
-        requestRateLimitMaxMs: 180_000,
-        overloadBaseMs: 60_000,
-        overloadMaxMs: 300_000,
-        quotaBaseMs: 30 * 60_000
-      }
+      backgroundPriority: 50
     });
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -51,12 +51,14 @@ describe("provider-aware review scheduler", () => {
       enqueued: 10,
       leased: 2,
       completed: 2,
-      remainingQueued: 8
+      remainingQueued: 10
     });
     expect(reviewed).toHaveLength(2);
     expect(new Set(reviewed.map((entry) => entry.split("#")[0]))).toHaveLength(2);
-    expect(state.listReviewQueueJobs({ state: "posted" })).toHaveLength(2);
-    expect(state.listReviewQueueJobs({ state: "queued" })).toHaveLength(8);
+    expect(state.listReviewQueueJobs({ state: "posted" })).toHaveLength(0);
+    expect(state.listReviewQueueJobs({ state: "queued" })).toHaveLength(10);
+    expect(state.listReviewQueueJobs({ state: "queued" })
+      .filter((job) => job.lastError === "dry_run_completed_not_posted")).toHaveLength(2);
     state.close();
   });
 
@@ -157,7 +159,7 @@ describe("provider-aware review scheduler", () => {
       source: "manual_command",
       lane: "manual",
       commentId: 123,
-      priority: config.reviewScheduler!.manualPriority
+      priority: 10
     });
     const reviewed: string[] = [];
 
@@ -169,7 +171,7 @@ describe("provider-aware review scheduler", () => {
         ["org/repo-c", [pull("org/repo-c", 1, "c1")]]
       ])),
       state,
-      options: { dryRun: true, useZCode: false },
+      options: { dryRun: false, useZCode: false },
       reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
         reviewed.push(`${repo}#${reviewPull.number}`);
         reviewState.recordProcessed({
@@ -189,6 +191,41 @@ describe("provider-aware review scheduler", () => {
     expect(state.listReviewQueueJobs({ state: "posted" })).toEqual(expect.arrayContaining([
       expect.objectContaining({ repo: "org/repo-c", lane: "manual", commentId: 123 })
     ]));
+    state.close();
+  });
+
+  it("honors per-repo queue capacity before active provider cooldown enqueue", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-cooldown-capacity-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewScheduler!.maxQueuedPerRepo = 1;
+    const state = new ReviewStateStore(config.statePath);
+    state.recordRepoProviderCooldown({
+      repo: "org/repo-a",
+      cooldownUntil: new Date("2026-07-01T00:05:00.000Z"),
+      reason: "provider_request_rate_limit"
+    });
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "a1"), pull("org/repo-a", 2, "a2")]]
+      ])),
+      state,
+      options: { dryRun: true, useZCode: false },
+      reviewPullImpl: async () => "reviewed",
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.skippedProviderCooldown).toBe(1);
+    expect(result.skippedCapacity).toBe(1);
+    expect(state.listReviewQueueJobs({ repo: "org/repo-a" })).toEqual([
+      expect.objectContaining({
+        pullNumber: 1,
+        state: "provider_deferred",
+        nextEligibleAt: "2026-07-01T00:05:00.000Z"
+      })
+    ]);
     state.close();
   });
 });
@@ -220,15 +257,7 @@ function schedulerConfig(root: string, repos: string[]): BotConfig {
       maxRepoActive: 1,
       maxQueuedPerRepo: 10,
       manualCommandReserve: 1,
-      backgroundPriority: 50,
-      manualPriority: 10,
-      providerThrottleBackoff: {
-        requestRateLimitBaseMs: 30_000,
-        requestRateLimitMaxMs: 180_000,
-        overloadBaseMs: 60_000,
-        overloadMaxMs: 300_000,
-        quotaBaseMs: 30 * 60_000
-      }
+      backgroundPriority: 50
     },
     providerCooldown: {
       enabled: true,

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -205,6 +205,42 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("uses head-only stale detection for legacy queue jobs without a base SHA", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-missing-base-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    const state = new ReviewStateStore(config.statePath);
+    const job = state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: "head-a" }).job;
+    let attempts = 0;
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "head-a", "new-base")]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        attempts += 1;
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: `https://github.com/${repo}/pull/${reviewPull.number}#pullrequestreview-3`
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(attempts).toBe(1);
+    expect(result.skippedStaleHead).toBe(0);
+    expect(state.getReviewQueueJob(job.jobId)).toMatchObject({ state: "posted" });
+    state.close();
+  });
+
   it("reserves provider capacity for trusted manual-command queue jobs", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-manual-reserve-"));
     roots.push(root);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -108,6 +108,67 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("retries expired provider-deferred queue jobs with failed-head retry policy", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-provider-deferred-retry-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    const state = new ReviewStateStore(config.statePath);
+    state.recordProcessed({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "a1",
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2026-07-01T00:01:00.000Z; reason=provider_request_rate_limit"
+    });
+    const job = state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "a1",
+      baseSha: "base",
+      providerId: "zai",
+      now: new Date("2026-07-01T00:00:00.000Z")
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-01T00:01:00.000Z",
+      lastError: "provider_rate_limit_cooldown_until=2026-07-01T00:01:00.000Z; reason=provider_request_rate_limit",
+      now: new Date("2026-07-01T00:00:01.000Z")
+    });
+    const policies: Array<ReviewPullInput["processedHeadPolicy"]> = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "a1")]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull, processedHeadPolicy }) => {
+        policies.push(processedHeadPolicy);
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: `https://github.com/${repo}/pull/${reviewPull.number}#pullrequestreview-2`
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:01:01.000Z")
+    });
+
+    expect(result.reviewed).toBe(1);
+    expect(result.skippedProcessed).toBe(1);
+    expect(policies).toEqual(["retry_failed_head"]);
+    expect(state.getReviewQueueJob(job.jobId)).toMatchObject({
+      state: "posted",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-2"
+    });
+    state.close();
+  });
+
   it("retires stale and closed queued jobs before running review work", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-retire-"));
     roots.push(root);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1,0 +1,302 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { BotConfig } from "../src/config.js";
+import { runScheduledCycleWithDeps, type SchedulerGitHubApi } from "../src/scheduler.js";
+import { ReviewStateStore } from "../src/state.js";
+import type { PullRequestSummary } from "../src/types.js";
+import type { ReviewPullInput, ReviewPullResult } from "../src/worker.js";
+
+describe("provider-aware review scheduler", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("queues a multi-repo burst and leases up to provider capacity with per-repo caps", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-burst-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a", "org/repo-b", "org/repo-c", "org/repo-d"]);
+    const state = new ReviewStateStore(config.statePath);
+    const pullsByRepo = new Map([
+      ["org/repo-a", [pull("org/repo-a", 1, "a1"), pull("org/repo-a", 2, "a2"), pull("org/repo-a", 3, "a3")]],
+      ["org/repo-b", [pull("org/repo-b", 1, "b1"), pull("org/repo-b", 2, "b2"), pull("org/repo-b", 3, "b3")]],
+      ["org/repo-c", [pull("org/repo-c", 1, "c1"), pull("org/repo-c", 2, "c2")]],
+      ["org/repo-d", [pull("org/repo-d", 1, "d1"), pull("org/repo-d", 2, "d2")]]
+    ]);
+    const reviewed: string[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(pullsByRepo),
+      state,
+      options: { dryRun: true, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewed.push(`${repo}#${reviewPull.number}`);
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "dry_run",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.queue).toMatchObject({
+      enqueued: 10,
+      leased: 2,
+      completed: 2,
+      remainingQueued: 8
+    });
+    expect(reviewed).toHaveLength(2);
+    expect(new Set(reviewed.map((entry) => entry.split("#")[0]))).toHaveLength(2);
+    expect(state.listReviewQueueJobs({ state: "posted" })).toHaveLength(2);
+    expect(state.listReviewQueueJobs({ state: "queued" })).toHaveLength(8);
+    state.close();
+  });
+
+  it("records provider throttle on one repo without blocking an unrelated leased repo", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-provider-throttle-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a", "org/repo-b", "org/repo-c"]);
+    const state = new ReviewStateStore(config.statePath);
+    const pullsByRepo = new Map([
+      ["org/repo-a", [pull("org/repo-a", 1, "a1")]],
+      ["org/repo-b", [pull("org/repo-b", 1, "b1")]],
+      ["org/repo-c", [pull("org/repo-c", 1, "c1")]]
+    ]);
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(pullsByRepo),
+      state,
+      options: { dryRun: false, useZCode: true },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        if (repo === "org/repo-a") {
+          throw new Error("ProviderBusinessError: [1302][Rate limit reached for requests]");
+        }
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: `https://github.com/${repo}/pull/${reviewPull.number}#pullrequestreview-1`
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.reviewed).toBe(1);
+    expect(result.skippedProviderCooldown).toBe(1);
+    expect(state.getActiveRepoProviderCooldown("org/repo-a", new Date("2026-07-01T00:00:01.000Z"))).toBeDefined();
+    expect(state.getActiveRepoProviderCooldown("org/repo-b", new Date("2026-07-01T00:00:01.000Z"))).toBeUndefined();
+    expect(state.listReviewQueueJobs({ state: "provider_deferred" })).toEqual([
+      expect.objectContaining({ repo: "org/repo-a", pullNumber: 1, nextEligibleAt: "2026-07-01T00:01:30.000Z" })
+    ]);
+    expect(state.listReviewQueueJobs({ state: "posted" })).toEqual([
+      expect.objectContaining({ repo: "org/repo-b", pullNumber: 1 })
+    ]);
+    state.close();
+  });
+
+  it("retires stale and closed queued jobs before running review work", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-retire-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    const state = new ReviewStateStore(config.statePath);
+    state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: "old-a", baseSha: "base" });
+    state.enqueueReviewQueueJob({ repo: "org/repo-b", pullNumber: 2, headSha: "closed-b", baseSha: "base" });
+    let attempts = 0;
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "new-a")]],
+        ["org/repo-b", [pull("org/repo-b", 2, "closed-b", "base", { state: "closed" })]]
+      ])),
+      state,
+      options: { dryRun: true, useZCode: false },
+      reviewPullImpl: async () => {
+        attempts += 1;
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(attempts).toBe(0);
+    expect(result.queue.staleRetired).toBe(1);
+    expect(result.queue.closedRetired).toBe(1);
+    expect(state.listReviewQueueJobs({ state: "stale_retired" })).toEqual([
+      expect.objectContaining({ repo: "org/repo-a", headSha: "old-a" })
+    ]);
+    expect(state.listReviewQueueJobs({ state: "closed_retired" })).toEqual([
+      expect.objectContaining({ repo: "org/repo-b", headSha: "closed-b" })
+    ]);
+    state.close();
+  });
+
+  it("reserves provider capacity for trusted manual-command queue jobs", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-manual-reserve-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a", "org/repo-b", "org/repo-c"]);
+    const state = new ReviewStateStore(config.statePath);
+    state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: "a1", baseSha: "base" });
+    state.enqueueReviewQueueJob({ repo: "org/repo-b", pullNumber: 1, headSha: "b1", baseSha: "base" });
+    state.enqueueReviewQueueJob({
+      repo: "org/repo-c",
+      pullNumber: 1,
+      headSha: "c1",
+      baseSha: "base",
+      source: "manual_command",
+      lane: "manual",
+      commentId: 123,
+      priority: config.reviewScheduler!.manualPriority
+    });
+    const reviewed: string[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "a1")]],
+        ["org/repo-b", [pull("org/repo-b", 1, "b1")]],
+        ["org/repo-c", [pull("org/repo-c", 1, "c1")]]
+      ])),
+      state,
+      options: { dryRun: true, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewed.push(`${repo}#${reviewPull.number}`);
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "dry_run",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.queue.leased).toBe(2);
+    expect(reviewed).toContain("org/repo-c#1");
+    expect(state.listReviewQueueJobs({ state: "posted" })).toEqual(expect.arrayContaining([
+      expect.objectContaining({ repo: "org/repo-c", lane: "manual", commentId: 123 })
+    ]));
+    state.close();
+  });
+});
+
+function schedulerConfig(root: string, repos: string[]): BotConfig {
+  return {
+    pilotRepos: repos,
+    pollIntervalMs: 60_000,
+    skipDrafts: true,
+    workRoot: join(root, "work"),
+    statePath: join(root, "state.sqlite"),
+    evidenceDir: join(root, "evidence"),
+    activation: {
+      reviewExistingOpenPrsOnActivation: true
+    },
+    reviewConcurrency: {
+      maxActiveRuns: 2,
+      leaseTtlMs: 60_000
+    },
+    reviewerSessions: {
+      enabled: false,
+      ttlMs: 8 * 60 * 60_000,
+      headCountLimit: 10
+    },
+    reviewScheduler: {
+      enabled: true,
+      maxProviderActive: 2,
+      maxOrgActive: 3,
+      maxRepoActive: 1,
+      maxQueuedPerRepo: 10,
+      manualCommandReserve: 1,
+      backgroundPriority: 50,
+      manualPriority: 10,
+      providerThrottleBackoff: {
+        requestRateLimitBaseMs: 30_000,
+        requestRateLimitMaxMs: 180_000,
+        overloadBaseMs: 60_000,
+        overloadMaxMs: 300_000,
+        quotaBaseMs: 30 * 60_000
+      }
+    },
+    providerCooldown: {
+      enabled: true,
+      durationMs: 15 * 60_000,
+      requestRateLimitDurationMs: 90_000,
+      overloadDurationMs: 2 * 60_000,
+      quotaDurationMs: 30 * 60_000,
+      transientRetryAttempts: 0,
+      transientRetryBaseDelayMs: 1,
+      transientRetryMaxDelayMs: 1
+    },
+    walkthrough: {
+      enabled: false,
+      postIssueComment: false
+    },
+    commands: {
+      enabled: false,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: [],
+      acknowledge: false
+    },
+    zcode: {
+      cliPath: "/unused/zcode.cjs",
+      appConfigPath: "/unused/config.json",
+      model: "GLM-5.2",
+      providerId: "zai-coding-plan",
+      timeoutMs: 1,
+      maxPatchBytes: 1,
+      retryMaxRetries: 0
+    },
+    github: {}
+  };
+}
+
+function githubFromMap(pullsByRepo: Map<string, PullRequestSummary[]>): SchedulerGitHubApi {
+  return {
+    listOpenPulls: async (repo) => pullsByRepo.get(repo)?.filter((entry) => entry.state === undefined || entry.state === "open") ?? [],
+    getPull: async (repo, pullNumber) => {
+      const pull = pullsByRepo.get(repo)?.find((entry) => entry.number === pullNumber);
+      if (!pull) throw new Error(`missing pull ${repo}#${pullNumber}`);
+      return pull;
+    }
+  };
+}
+
+function pull(
+  repo: string,
+  number: number,
+  headSha: string,
+  baseSha = "base",
+  options: { state?: string; mergedAt?: string | null } = {}
+): PullRequestSummary {
+  return {
+    number,
+    title: `${repo} PR ${number}`,
+    draft: false,
+    ...(options.state ? { state: options.state } : {}),
+    ...(options.mergedAt !== undefined ? { merged_at: options.mergedAt } : {}),
+    head: {
+      sha: headSha,
+      ref: `pr-${number}`,
+      repo: { full_name: repo }
+    },
+    base: {
+      sha: baseSha,
+      ref: "main",
+      repo: { full_name: repo }
+    },
+    html_url: `https://github.com/${repo}/pull/${number}`
+  };
+}

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -428,6 +428,7 @@ describe("review state store", () => {
       repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
       pullNumber: 220,
       headSha: "head-a",
+      baseSha: "base-a",
       providerId: "builtin:zai-coding-plan",
       now: new Date("2026-07-01T00:00:00.000Z")
     });
@@ -435,8 +436,17 @@ describe("review state store", () => {
       repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
       pullNumber: 220,
       headSha: "head-a",
+      baseSha: "base-a",
       providerId: "builtin:zai-coding-plan",
       now: new Date("2026-07-01T00:00:01.000Z")
+    });
+    const sameHeadNewBase = store.enqueueReviewQueueJob({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 220,
+      headSha: "head-a",
+      baseSha: "base-b",
+      providerId: "builtin:zai-coding-plan",
+      now: new Date("2026-07-01T00:00:02.000Z")
     });
     const manual = store.enqueueReviewQueueJob({
       repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
@@ -444,13 +454,13 @@ describe("review state store", () => {
       headSha: "head-a",
       source: "manual_command",
       commentId: 9876,
-      now: new Date("2026-07-01T00:00:02.000Z")
+      now: new Date("2026-07-01T00:00:03.000Z")
     });
 
     expect(automatic).toMatchObject({
       enqueued: true,
       job: {
-        attemptId: "automatic:100yenadmin/Lossless-Codex-Orchestrator-LCO#220@head-a",
+        attemptId: "automatic:100yenadmin/Lossless-Codex-Orchestrator-LCO#220@head-a:base=base-a",
         lane: "background",
         priority: 50,
         state: "queued"
@@ -461,6 +471,12 @@ describe("review state store", () => {
       reason: "already_queued",
       job: { jobId: automatic.job.jobId }
     });
+    expect(sameHeadNewBase).toMatchObject({
+      enqueued: true,
+      job: {
+        attemptId: "automatic:100yenadmin/Lossless-Codex-Orchestrator-LCO#220@head-a:base=base-b"
+      }
+    });
     expect(manual).toMatchObject({
       enqueued: true,
       job: {
@@ -470,7 +486,7 @@ describe("review state store", () => {
         commentId: 9876
       }
     });
-    expect(store.listReviewQueueJobs({ repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO" })).toHaveLength(2);
+    expect(store.listReviewQueueJobs({ repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO" })).toHaveLength(3);
     store.close();
   });
 
@@ -527,6 +543,58 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("requeues expired durable queue leases before leasing new work", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-expired-lease-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const job = store.enqueueReviewQueueJob({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 89,
+      headSha: "head-a",
+      providerId: "zai",
+      now: new Date("2026-07-01T00:00:00.000Z")
+    }).job;
+
+    const firstLease = store.leaseNextReviewQueueJobs({
+      maxProviderActive: 1,
+      maxOrgActive: 1,
+      maxRepoActive: 1,
+      leaseTtlMs: 1_000,
+      now: new Date("2026-07-01T00:00:01.000Z")
+    });
+    expect(firstLease).toHaveLength(1);
+    expect(firstLease[0]).toMatchObject({
+      jobId: job.jobId,
+      state: "leased",
+      leaseExpiresAt: "2026-07-01T00:00:02.000Z"
+    });
+
+    expect(store.leaseNextReviewQueueJobs({
+      maxProviderActive: 1,
+      maxOrgActive: 1,
+      maxRepoActive: 1,
+      leaseTtlMs: 1_000,
+      now: new Date("2026-07-01T00:00:01.500Z")
+    })).toEqual([]);
+
+    const renewedLease = store.leaseNextReviewQueueJobs({
+      maxProviderActive: 1,
+      maxOrgActive: 1,
+      maxRepoActive: 1,
+      leaseTtlMs: 1_000,
+      now: new Date("2026-07-01T00:00:02.001Z")
+    });
+    expect(renewedLease).toHaveLength(1);
+    expect(renewedLease[0]).toMatchObject({
+      jobId: job.jobId,
+      state: "leased",
+      lastError: "queue_lease_expired_requeued",
+      leaseExpiresAt: "2026-07-01T00:00:03.001Z"
+    });
+    expect(renewedLease[0].leaseId).not.toEqual(firstLease[0].leaseId);
+    store.close();
+  });
+
   it("defers and later leases provider-deferred queue jobs after next eligible time", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-deferred-"));
     roots.push(root);
@@ -561,6 +629,37 @@ describe("review state store", () => {
     });
     expect(leased).toHaveLength(1);
     expect(leased[0]).toMatchObject({ jobId: job.jobId, state: "leased", lastError: "provider 1302 with [redacted-secret]" });
+    store.close();
+  });
+
+  it("treats malformed provider-deferred eligibility timestamps as retryable backlog", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-malformed-deferred-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const job = store.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1214,
+      headSha: "head-b",
+      providerId: "zai",
+      now: new Date("2026-07-01T00:00:00.000Z")
+    }).job;
+
+    store.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: "not-a-date",
+      lastError: "legacy provider cooldown",
+      now: new Date("2026-07-01T00:00:05.000Z")
+    });
+
+    expect(store.leaseNextReviewQueueJobs({
+      maxProviderActive: 1,
+      maxOrgActive: 1,
+      maxRepoActive: 1,
+      now: new Date("2026-07-01T00:00:10.000Z")
+    })).toEqual([
+      expect.objectContaining({ jobId: job.jobId, state: "leased" })
+    ]);
     store.close();
   });
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -419,6 +419,151 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("dedupes automatic queue attempts while preserving distinct manual attempts", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-attempts-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    const automatic = store.enqueueReviewQueueJob({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 220,
+      headSha: "head-a",
+      providerId: "builtin:zai-coding-plan",
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    const duplicateAutomatic = store.enqueueReviewQueueJob({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 220,
+      headSha: "head-a",
+      providerId: "builtin:zai-coding-plan",
+      now: new Date("2026-07-01T00:00:01.000Z")
+    });
+    const manual = store.enqueueReviewQueueJob({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 220,
+      headSha: "head-a",
+      source: "manual_command",
+      commentId: 9876,
+      now: new Date("2026-07-01T00:00:02.000Z")
+    });
+
+    expect(automatic).toMatchObject({
+      enqueued: true,
+      job: {
+        attemptId: "automatic:100yenadmin/Lossless-Codex-Orchestrator-LCO#220@head-a",
+        lane: "background",
+        priority: 50,
+        state: "queued"
+      }
+    });
+    expect(duplicateAutomatic).toMatchObject({
+      enqueued: false,
+      reason: "already_queued",
+      job: { jobId: automatic.job.jobId }
+    });
+    expect(manual).toMatchObject({
+      enqueued: true,
+      job: {
+        attemptId: "manual:100yenadmin/Lossless-Codex-Orchestrator-LCO#220@head-a:9876",
+        lane: "manual",
+        priority: 10,
+        commentId: 9876
+      }
+    });
+    expect(store.listReviewQueueJobs({ repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO" })).toHaveLength(2);
+    store.close();
+  });
+
+  it("leases bounded queue jobs by provider org repo and manual reserve", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-lease-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const now = new Date("2026-07-01T00:00:00.000Z");
+
+    const manual = store.enqueueReviewQueueJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 497,
+      headSha: "manual-head",
+      source: "manual_command",
+      commentId: 1,
+      providerId: "zai",
+      now
+    }).job;
+    const sameRepoBackground = store.enqueueReviewQueueJob({
+      repo: "100yenadmin/evaOS-GUI",
+      pullNumber: 498,
+      headSha: "same-repo-head",
+      providerId: "zai",
+      now
+    }).job;
+    const otherRepoBackground = store.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1214,
+      headSha: "world-head",
+      providerId: "zai",
+      now
+    }).job;
+    store.enqueueReviewQueueJob({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 88,
+      headSha: "bot-head",
+      providerId: "zai",
+      now
+    });
+
+    const leased = store.leaseNextReviewQueueJobs({
+      maxProviderActive: 2,
+      maxOrgActive: 2,
+      maxRepoActive: 1,
+      manualCommandReserve: 1,
+      limit: 3,
+      now: new Date("2026-07-01T00:00:10.000Z")
+    });
+
+    expect(leased.map((job) => job.jobId)).toEqual([manual.jobId, otherRepoBackground.jobId]);
+    expect(store.getReviewQueueJob(manual.jobId)).toMatchObject({ state: "leased", leaseId: expect.any(String) });
+    expect(store.getReviewQueueJob(otherRepoBackground.jobId)).toMatchObject({ state: "leased", leaseId: expect.any(String) });
+    expect(store.getReviewQueueJob(sameRepoBackground.jobId)).toMatchObject({ state: "queued" });
+    store.close();
+  });
+
+  it("defers and later leases provider-deferred queue jobs after next eligible time", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-deferred-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const job = store.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1214,
+      headSha: "head-a",
+      providerId: "zai",
+      now: new Date("2026-07-01T00:00:00.000Z")
+    }).job;
+
+    store.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-01T00:05:00.000Z",
+      lastError: "provider 1302 with ghp_1234567890abcdefghijklmnopqrstuvwx",
+      now: new Date("2026-07-01T00:00:05.000Z")
+    });
+    expect(store.leaseNextReviewQueueJobs({
+      maxProviderActive: 2,
+      maxOrgActive: 2,
+      maxRepoActive: 1,
+      now: new Date("2026-07-01T00:04:00.000Z")
+    })).toEqual([]);
+
+    const leased = store.leaseNextReviewQueueJobs({
+      maxProviderActive: 2,
+      maxOrgActive: 2,
+      maxRepoActive: 1,
+      now: new Date("2026-07-01T00:05:01.000Z")
+    });
+    expect(leased).toHaveLength(1);
+    expect(leased[0]).toMatchObject({ jobId: job.jobId, state: "leased", lastError: "provider 1302 with [redacted-secret]" });
+    store.close();
+  });
+
   it("stores the latest daemon heartbeat as a singleton", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-daemon-heartbeat-"));
     roots.push(root);


### PR DESCRIPTION
## Summary

Closes #83. Refs #78, #25, and #76.

This adds the provider-aware queue foundation behind `reviewScheduler.enabled=false` by default:

- adds durable `review_queue_jobs` state with automatic/manual attempt identity, queue leasing, provider/org/repo budgets, and terminal/deferred states
- adds a disabled-by-default `runScheduledCycle` daemon path that discovers eligible PR heads, leases bounded queue jobs, revalidates current heads, retires stale/closed jobs, and records provider-deferred jobs without pausing unrelated repos
- keeps legacy `runOnce` behavior for current live config unless scheduler is explicitly enabled
- exposes durable queue health through `status`, `queue --state <state>`, and `release:status` gates
- updates operator/release docs for durable queue visibility and release-health gates

## Validation

- `npm test -- tests/scheduler.test.ts tests/state.test.ts tests/operator-cli.test.ts tests/release-status.test.ts tests/review-scheduler-config.test.ts tests/daemon-loop.test.ts`: 6 files / 56 tests passed
- `npm test`: 27 files / 177 tests passed
- `npm run build`: passed
- `git diff --check`: passed

## Live Pre-PR Evidence

Current live worker remains on promoted `v0.3.3-beta.1` head `af457402767cf6a6598f0763789940964404f58e` and is still using legacy scheduling because this PR is not merged/promoted yet.

Evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/issue-83-provider-queue/`

- `live-release-status-before-pr.json`: `ok=true`, launchd running, DB error count 0, provider cooldown count 0
- `live-coverage-audit-before-pr.json`: `ok=true`, 19 repos scanned, 63 PRs seen, unprocessed 0, providerDeferred 0, readFailures 0
- `live-provider-cooldowns-expired-before-pr.json`: `count=0`, `expiredCount=0`

## Runtime Boundary

This PR does not enable scheduler mode in the active live config. Promotion should keep `reviewScheduler.enabled=false` until a separate dry-run/live opt-in gate is approved.
