### PR TITLE
Promote provider-aware scheduler config gate

### DIFF
--- a/docs/releases/v0.3.5-beta.1.md
+++ b/docs/releases/v0.3.5-beta.1.md
@@ -1,0 +1,161 @@
+# v0.3.5-beta.1
+
+## Summary
+
+Promotes the provider-aware scheduler from shipped foundation to active live beta config for `evaos-code-review-bot`.
+
+This release does not change review policy, monitored repos, GitHub App permissions, ZCode tools, native skills, MCP, repo memory, GitNexus context, auto-merge, approvals, or command triggers.
+
+- Release type: local beta config patch
+- Tracking issue: `#78`
+- Implementation issue: `#90`
+- Implementation PR: filled after PR creation
+- Implementation source SHA: existing scheduler foundation from `v0.3.4-beta.1`
+- Release tag target: release packet commit for `v0.3.5-beta.1`
+- Previous live release: `v0.3.4-beta.1` (`47511ba5fee7990dba0423f1eb7a27830b44288c`)
+- Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- launchd label: `com.electricsheephq.evaos-code-review-bot`
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+- State DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
+- Evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/v0.3.5-beta.1/`
+- Monitor owner/window: implementing agent, first post-promotion health check
+- Rollback SHA/tag: `v0.3.4-beta.1`
+
+## Live Config Change
+
+Enable the existing scheduler path in active live config:
+
+```json
+"reviewScheduler": {
+  "enabled": true,
+  "maxProviderActive": 1,
+  "maxOrgActive": 1,
+  "maxRepoActive": 1,
+  "maxQueuedPerRepo": 10,
+  "manualCommandReserve": 0,
+  "backgroundPriority": 50
+}
+```
+
+The live config keeps `reviewConcurrency.maxActiveRuns` at `1`.
+
+## Dry-Run Evidence
+
+Evidence path:
+
+```text
+/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/v0.3.5-beta.1/
+```
+
+Dry-run config:
+
+```text
+/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/v0.3.5-beta.1/scheduler-dry-run-config.json
+```
+
+Dry-run state DB:
+
+```text
+/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-dry-run-scheduler-v035.sqlite
+```
+
+Cycle 1 summary:
+
+- repos scanned: `19`
+- pulls seen: `62`
+- queued: `48`
+- leased: `1`
+- completed: `1`
+- failed: `0`
+- provider deferred: `0`
+- stale retired: `0`
+- closed retired: `0`
+
+Cycle 2 summary:
+
+- repos scanned: `19`
+- pulls seen: `62`
+- already queued: `47`
+- leased: `1`
+- completed: `1`
+- failed: `0`
+- provider deferred: `0`
+- stale retired: `0`
+- closed retired: `0`
+
+Dry-run DB counts after cycle 2:
+
+```text
+review_queue_jobs: posted=1, queued=47
+processed_reviews: dry_run=1
+repo_provider_cooldowns: 0
+reviewer_sessions: 0
+review_run_leases: 0
+```
+
+## Validation
+
+Preflight:
+
+- `npm run build` from isolated worktree: passed
+- `release-status` against live `v0.3.4-beta.1`: `ok=true`
+- `coverage-audit` with App credentials: `ok=true`, read failures `0`, unprocessed eligible heads `0`
+- `provider-cooldowns --expired-only true`: `count=0`, `expiredCount=0`
+
+Required post-promotion gates:
+
+```bash
+export EVAOS_REVIEW_BOT_APP_ID=4184532
+export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH=/Volumes/LEXAR/Codex/evaos-code-review-bot/secrets/evaos-code-review-bot.private-key.pem
+
+npm test
+npm run build
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head <release-source-sha> \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+npx tsx src/cli.ts coverage-audit \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+npx tsx src/cli.ts provider-cooldowns \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expired-only true
+npx tsx src/cli.ts status \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head <release-source-sha> \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+Green criteria:
+
+- launchd runs from the release source SHA
+- daemon heartbeat is fresh
+- durable queue has zero failed jobs
+- retryable provider-deferred backlog is zero
+- coverage audit has zero unprocessed eligible heads
+- provider cooldown expired backlog is zero
+- live logs show `reviewSchedulerEnabled: true` and provider cooldown retry skipped because scheduler owns queue/retry flow
+
+## Rollback
+
+Before editing live config, copy the previous config to:
+
+```text
+/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/v0.3.5-beta.1/active-installed-live.before-v0.3.5-beta.1.json
+```
+
+Rollback command:
+
+```bash
+cp /Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/v0.3.5-beta.1/active-installed-live.before-v0.3.5-beta.1.json \
+  /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+```
+
+If source rollback is also required, reset the live checkout to `v0.3.4-beta.1` and rerun `release:status`.
+
+## Known Boundaries
+
+- Existing open PR heads remain protected by processed-head/baseline rows; this release must not retroactively spam old heads.
+- The scheduler may create durable queue rows for newly eligible heads; that is expected.
+- Provider cooldown rows remain visible and actionable; expired rows are backlog.
+- #84 owns deeper runtime inventory and cleanup visibility after this activation.

--- a/docs/releases/v0.3.5-beta.1.md
+++ b/docs/releases/v0.3.5-beta.1.md
@@ -9,7 +9,7 @@ This release does not change review policy, monitored repos, GitHub App permissi
 - Release type: local beta config patch
 - Tracking issue: `#78`
 - Implementation issue: `#90`
-- Implementation PR: filled after PR creation
+- Implementation PR: `#91`
 - Implementation source SHA: existing scheduler foundation from `v0.3.4-beta.1`
 - Release tag target: release packet commit for `v0.3.5-beta.1`
 - Previous live release: `v0.3.4-beta.1` (`47511ba5fee7990dba0423f1eb7a27830b44288c`)

--- a/docs/releases/v0.3.5-beta.1.md
+++ b/docs/releases/v0.3.5-beta.1.md
@@ -2,7 +2,9 @@
 
 ## Summary
 
-Promotes the provider-aware scheduler from shipped foundation to active live beta config for `evaos-code-review-bot`.
+Defines and executes the promotion gate for turning the already-shipped provider-aware scheduler on in the active live beta config for `evaos-code-review-bot`.
+
+This packet is not proof that the scheduler is active until the post-merge tag, live config backup/edit, launchd restart, and post-promotion gates below are complete.
 
 This release does not change review policy, monitored repos, GitHub App permissions, ZCode tools, native skills, MCP, repo memory, GitNexus context, auto-merge, approvals, or command triggers.
 
@@ -10,8 +12,9 @@ This release does not change review policy, monitored repos, GitHub App permissi
 - Tracking issue: `#78`
 - Implementation issue: `#90`
 - Implementation PR: `#91`
-- Implementation source SHA: existing scheduler foundation from `v0.3.4-beta.1`
+- Scheduler foundation source SHA: `47511ba5fee7990dba0423f1eb7a27830b44288c`
 - Release tag target: release packet commit for `v0.3.5-beta.1`
+- Release source resolution: after the tag is created, use `git rev-list -n 1 v0.3.5-beta.1` as the exact source SHA for `release-status`, `status`, GitHub tracker updates, and rollback proof
 - Previous live release: `v0.3.4-beta.1` (`47511ba5fee7990dba0423f1eb7a27830b44288c`)
 - Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
 - launchd label: `com.electricsheephq.evaos-code-review-bot`
@@ -93,11 +96,14 @@ reviewer_sessions: 0
 review_run_leases: 0
 ```
 
+The `posted=1` queue state is from the isolated dry-run scheduler DB after a `dryRun=true`, `useZCode=false` run. It means one queued job reached the scheduler's terminal completion path in dry-run mode; it did not post a GitHub review, did not call ZCode, and did not mutate the live DB. Cycle 2 proved no duplicate enqueue/post storm: the remaining current heads were recognized as already queued and only one additional queued job was leased/completed.
+
 ## Validation
 
 Preflight:
 
 - `npm run build` from isolated worktree: passed
+- `doctor` with App credentials: required before promotion
 - `release-status` against live `v0.3.4-beta.1`: `ok=true`
 - `coverage-audit` with App credentials: `ok=true`, read failures `0`, unprocessed eligible heads `0`
 - `provider-cooldowns --expired-only true`: `count=0`, `expiredCount=0`
@@ -107,12 +113,15 @@ Required post-promotion gates:
 ```bash
 export EVAOS_REVIEW_BOT_APP_ID=4184532
 export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH=/Volumes/LEXAR/Codex/evaos-code-review-bot/secrets/evaos-code-review-bot.private-key.pem
+export EVAOS_REVIEW_BOT_RELEASE_SHA="$(git rev-list -n 1 v0.3.5-beta.1)"
 
 npm test
 npm run build
+npm run doctor -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
 npm run release:status -- \
   --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
-  --expected-head <release-source-sha> \
+  --expected-head "$EVAOS_REVIEW_BOT_RELEASE_SHA" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 npx tsx src/cli.ts coverage-audit \
   --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
@@ -121,7 +130,7 @@ npx tsx src/cli.ts provider-cooldowns \
   --expired-only true
 npx tsx src/cli.ts status \
   --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
-  --expected-head <release-source-sha> \
+  --expected-head "$EVAOS_REVIEW_BOT_RELEASE_SHA" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
@@ -148,10 +157,16 @@ Rollback command:
 ```bash
 cp /Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/v0.3.5-beta.1/active-installed-live.before-v0.3.5-beta.1.json \
   /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard v0.3.4-beta.1
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
-
-If source rollback is also required, reset the live checkout to `v0.3.4-beta.1` and rerun `release:status`.
 
 ## Known Boundaries
 


### PR DESCRIPTION
## Summary

Promotes #90 from scheduler foundation shipped in `v0.3.4-beta.1` toward active live config by adding the `v0.3.5-beta.1` release packet and dry-run proof.

## Dry-run proof

Evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/v0.3.5-beta.1/`

- Scheduler dry-run config uses isolated state DB and `reviewScheduler.enabled=true`.
- Cycle 1: 19 repos scanned, 62 pulls seen, 48 queued, 1 leased/completed, 0 failures, 0 provider deferrals.
- Cycle 2: 19 repos scanned, 62 pulls seen, 47 already queued, 1 leased/completed, 0 failures, 0 provider deferrals.
- DB counts after cycle 2: queue `posted=1`, `queued=47`; processed `dry_run=1`; cooldown/session/lease rows all `0`.

## Validation

- `npm test`: 184 passed
- `npm run build`: passed
- `git diff --check`: passed
- Preflight live `release-status`: `ok=true`
- Preflight live `coverage-audit`: `ok=true`, read failures `0`, unprocessed eligible heads `0`
- Preflight `provider-cooldowns --expired-only true`: `count=0`, `expiredCount=0`

## Live promotion boundary

This PR does not edit active live config by itself. After merge/tag/release, the release captain will back up `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`, add the bounded `reviewScheduler` block, restart launchd, and run the post-release gates.

Refs #90. #90 closes only after the live config promotion, launchd restart, and post-promotion gates pass.

