### PR TITLE
Activate command-aware RepoSticky scheduler path

### DIFF
--- a/docs/maintainer-commands.md
+++ b/docs/maintainer-commands.md
@@ -53,12 +53,12 @@ Commands are deduped by:
 
 - repo
 - PR number
-- live head SHA
 - GitHub comment id
 
-Reprocessing the same command comment on the same head does nothing. A new push
-creates a new head SHA, so the same comment id is not treated as proof for the
-new head unless a trusted author comments again.
+Reprocessing the same command comment does nothing, including after a new push.
+A new head SHA needs a new trusted command comment. This keeps old `stop`
+comments from suppressing future pushes and keeps old `review` commands from
+silently re-triggering on new code.
 
 ## Evidence
 

--- a/docs/releases/v0.3.6-beta.1.md
+++ b/docs/releases/v0.3.6-beta.1.md
@@ -51,6 +51,8 @@ context, auto-merge, approvals, or broad finishing-touch generation.
   head is not automatically reviewed on the next polling cycle.
 - Treat command comments as single-use across a PR so old `stop` or `review`
   comments do not replay onto later head SHAs.
+- Surface scheduler comment-fetch failures as `commandFetchErrors` in cycle logs
+  so trusted command-channel degradation is visible without crashing the worker.
 - Attach scheduler jobs to repo-sticky reviewer session IDs when
   `reviewerSessions.enabled` is true and the job will perform a review.
 - Update reviewer session job lifecycle state as queue jobs run, complete,

--- a/docs/releases/v0.3.6-beta.1.md
+++ b/docs/releases/v0.3.6-beta.1.md
@@ -44,12 +44,15 @@ context, auto-merge, approvals, or broad finishing-touch generation.
 - Make the scheduler command-aware before processed-head suppression so trusted
   `review` and `re-review` comments can enqueue manual review jobs for current
   heads that already have a prior bot review.
-- Route trusted `stop` and `explain` comments through the manual queue without
-  reporting them as failed durable queue jobs.
+- Route trusted `stop` and `explain` comments through the manual queue as
+  terminal `command_recorded` jobs without reporting them as failed durable queue
+  jobs or posted reviews.
 - Persist `stop` commands as skipped processed-head rows so the stopped current
   head is not automatically reviewed on the next polling cycle.
+- Treat command comments as single-use across a PR so old `stop` or `review`
+  comments do not replay onto later head SHAs.
 - Attach scheduler jobs to repo-sticky reviewer session IDs when
-  `reviewerSessions.enabled` is true.
+  `reviewerSessions.enabled` is true and the job will perform a review.
 - Update reviewer session job lifecycle state as queue jobs run, complete,
   defer on provider cooldown, skip stale/closed/current-policy heads, or fail.
 - Add tests for command review on processed heads, stop-command terminal skips,
@@ -111,7 +114,8 @@ Make safety defaults explicit and activate only the proven narrow features:
 - `review` and `re-review` are review triggers only; they cannot repair, merge,
   approve, push branches, run tests, or widen repo permissions.
 - `stop` suppresses only the current PR head. A new push creates a new head SHA
-  and can be reviewed normally unless stopped again.
+  and can be reviewed normally unless stopped again with a new trusted command
+  comment.
 - RepoSticky sessions are accounting/session identity only in this release.
   They do not inject memory packets, GitNexus packets, previous conversations,
   native ZCode skills, MCP, or tools into the review prompt.

--- a/docs/releases/v0.3.6-beta.1.md
+++ b/docs/releases/v0.3.6-beta.1.md
@@ -1,0 +1,130 @@
+# v0.3.6-beta.1
+
+- Release type: local beta behavior/config patch
+- Tracking issues: `#78`, `#11`
+- Implementation PR: pending
+- Previous live release: `v0.3.5-beta.1` (`54d8e07923314b2a413b5efce5feff2c5151e6cb`)
+- Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- launchd label: `com.electricsheephq.evaos-code-review-bot`
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+- State DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
+- Evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/v0.3.6-beta.1/`
+- Monitor owner/window: implementing agent, first post-promotion health check
+- Rollback SHA/tag: `v0.3.5-beta.1`
+- Rollback command:
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard v0.3.5-beta.1
+cp /Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-01/v0.3.6-beta.1/active-installed-live.before-v0.3.6-beta.1.json \
+  /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+## Purpose
+
+Promote the first live-safe activation path for two features that were already
+partly built but not fully wired under the provider-aware scheduler:
+
+- maintainer command-triggered review control for trusted users
+- repo-sticky reviewer session accounting for scheduler jobs
+
+This release keeps live ZCode concurrency at one active run and does not enable
+repo mutation, native ZCode skills, MCP, memory packet injection, GitNexus
+context, auto-merge, approvals, or broad finishing-touch generation.
+
+## Changes
+
+- Make the scheduler command-aware before processed-head suppression so trusted
+  `review` and `re-review` comments can enqueue manual review jobs for current
+  heads that already have a prior bot review.
+- Route trusted `stop` and `explain` comments through the manual queue without
+  reporting them as failed durable queue jobs.
+- Persist `stop` commands as skipped processed-head rows so the stopped current
+  head is not automatically reviewed on the next polling cycle.
+- Attach scheduler jobs to repo-sticky reviewer session IDs when
+  `reviewerSessions.enabled` is true.
+- Update reviewer session job lifecycle state as queue jobs run, complete,
+  defer on provider cooldown, skip stale/closed/current-policy heads, or fail.
+- Add tests for command review on processed heads, stop-command terminal skips,
+  and scheduler-driven RepoSticky session reuse.
+
+## Live Config Change
+
+Make safety defaults explicit and activate only the proven narrow features:
+
+```json
+{
+  "reviewerSessions": {
+    "enabled": true,
+    "ttlMs": 28800000,
+    "headCountLimit": 10
+  },
+  "commands": {
+    "enabled": true,
+    "botMentions": ["@evaos-code-review-bot"],
+    "trustedAuthors": ["100yenadmin"],
+    "acknowledge": true
+  },
+  "providerCooldown": {
+    "enabled": true,
+    "durationMs": 900000,
+    "requestRateLimitDurationMs": 90000,
+    "overloadDurationMs": 120000,
+    "quotaDurationMs": 1800000,
+    "transientRetryAttempts": 4,
+    "transientRetryBaseDelayMs": 2000,
+    "transientRetryMaxDelayMs": 20000
+  },
+  "reviewScheduler": {
+    "manualCommandReserve": 1
+  }
+}
+```
+
+`reviewConcurrency.maxActiveRuns` remains `1`.
+
+## Gates
+
+- Focused tests:
+  - `npx vitest run tests/scheduler.test.ts tests/commands.test.ts tests/state.test.ts`
+- Build:
+  - `npm run build`
+- Required before promotion:
+  - `npm test`
+  - `npm run build`
+  - `npm run doctor -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+  - `npm run release:status -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expected-head "$(git rev-parse HEAD)" --launchd-label com.electricsheephq.evaos-code-review-bot`
+  - `npx tsx src/cli.ts coverage-audit --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+  - `npx tsx src/cli.ts provider-cooldowns --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expired-only true`
+  - dry-run command/RepoSticky proof against a scratch or current eligible PR without posting
+
+## Runtime Caveats
+
+- Commands are trusted-author only. Unauthorized command comments are ignored.
+- `review` and `re-review` are review triggers only; they cannot repair, merge,
+  approve, push branches, run tests, or widen repo permissions.
+- `stop` suppresses only the current PR head. A new push creates a new head SHA
+  and can be reviewed normally unless stopped again.
+- RepoSticky sessions are accounting/session identity only in this release.
+  They do not inject memory packets, GitNexus packets, previous conversations,
+  native ZCode skills, MCP, or tools into the review prompt.
+- `acknowledge: true` may create or update one marker-backed command status
+  comment for trusted commands.
+
+## Notes
+
+- What changed: scheduler command awareness, manual command queueing, stop
+  suppression, live RepoSticky session assignment, and explicit safety config.
+- What did not change: concurrency, monitored repos, GitHub App permissions,
+  ZCode read-only policy, posting policy, memory/GitNexus/skills, auto-merge,
+  or approvals.
+- Open follow-ups: broader finishing-touch commands remain in `#11`; durable
+  repo memory `#81`, GitNexus packets `#82`, lifecycle inventory `#84`, and
+  sticky-vs-cold eval `#85` remain open.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -584,6 +584,7 @@ const REVIEW_QUEUE_JOB_STATES: ReviewQueueJobState[] = [
   "provider_deferred",
   "stale_retired",
   "closed_retired",
+  "command_recorded",
   "posted",
   "failed"
 ];

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -188,6 +188,7 @@ export interface OperatorDurableQueueSnapshot {
     running: number;
     providerDeferred: number;
     retryableProviderDeferred: number;
+    commandRecorded: number;
     posted: number;
     failed: number;
     retired: number;
@@ -201,6 +202,7 @@ export interface OperatorDurableQueueSnapshot {
     running: number;
     providerDeferred: number;
     retryableProviderDeferred: number;
+    commandRecorded: number;
     posted: number;
     failed: number;
     retired: number;
@@ -975,6 +977,7 @@ function summarizeDurableQueueJobs(jobs: ReviewQueueJobRecord[], now: Date): Ope
     running: jobs.filter((job) => job.state === "running").length,
     providerDeferred: jobs.filter((job) => job.state === "provider_deferred").length,
     retryableProviderDeferred: jobs.filter((job) => job.state === "provider_deferred" && isRetryableQueueJob(job, now)).length,
+    commandRecorded: jobs.filter((job) => job.state === "command_recorded").length,
     posted: jobs.filter((job) => job.state === "posted").length,
     failed: jobs.filter((job) => job.state === "failed").length,
     retired: jobs.filter((job) => job.state === "stale_retired" || job.state === "closed_retired").length

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,13 +1,18 @@
 import { loadConfig, type BotConfig } from "./config.js";
+import { collectTrustedReviewCommands, decideCommandAction, type CommandDecision } from "./commands.js";
 import { GitHubApi } from "./github.js";
 import { listReposToScan, resolveRepoProfile } from "./repo-policy.js";
 import { ReviewRunBudget } from "./review-budget.js";
 import {
   parseProviderCooldownError,
   ReviewStateStore,
-  type ReviewQueueJobRecord
+  type ProcessedStatus,
+  type ReviewerSessionJobState,
+  type ReviewQueueJobRecord,
+  type ReviewQueueJobSource
 } from "./state.js";
 import type { PullRequestSummary } from "./types.js";
+import type { IssueCommentCommandSource } from "./commands.js";
 import {
   activateRepoForNewOnlyReview,
   isCanaryAllowed,
@@ -39,6 +44,7 @@ export interface ScheduledRunResult extends RunOnceResult {
 export interface SchedulerGitHubApi {
   listOpenPulls(repo: string): Promise<PullRequestSummary[]>;
   getPull(repo: string, pullNumber: number): Promise<PullRequestSummary>;
+  listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]>;
 }
 
 export async function runScheduledCycle(options: RunOnceOptions): Promise<ScheduledRunResult> {
@@ -100,8 +106,9 @@ export async function runScheduledCycleWithDeps(input: {
     result.baselinedExisting += activation.baselined;
 
     for (const pull of pulls) {
-      const enqueueStatus = enqueuePullIfEligible({
+      const enqueueStatus = await enqueuePullIfEligible({
         config,
+        github: input.github,
         state: input.state,
         repo,
         pull,
@@ -154,17 +161,25 @@ type EnqueueStatus =
   | "provider_deferred"
   | "closed_retired";
 
-function enqueuePullIfEligible(input: {
+async function enqueuePullIfEligible(input: {
   config: BotConfig;
+  github: SchedulerGitHubApi;
   state: ReviewStateStore;
   repo: string;
   pull: PullRequestSummary;
   providerId: string;
   now: Date;
-}): EnqueueStatus {
+}): Promise<EnqueueStatus> {
   if (isClosedPull(input.pull)) return "closed_retired";
   if (input.config.skipDrafts && input.pull.draft) return "skipped_draft";
   if (!isCanaryAllowed(input.config, input.repo, input.pull.number)) return "skipped_canary";
+
+  const commandDecision = await resolveSchedulerCommandDecision(input);
+  if (commandDecision.action !== "none") {
+    const queued = enqueueReviewJob(input, commandDecision);
+    return queued.enqueued ? "enqueued" : "already_queued";
+  }
+
   if (input.state.hasProcessed(input.repo, input.pull.number, input.pull.head.sha)) return "skipped_processed";
   if (hasActiveQueueJobForHead(input.state, input.repo, input.pull.number, input.pull.head.sha)) return "already_queued";
   if (!hasRepoQueueCapacity(input.state, input.repo, input.config.reviewScheduler?.maxQueuedPerRepo ?? 10)) {
@@ -195,16 +210,65 @@ function enqueueReviewJob(input: {
   pull: PullRequestSummary;
   providerId: string;
   now: Date;
-}) {
+}, commandDecision?: Exclude<CommandDecision, { action: "none"; shouldReview: false }>) {
+  const source: ReviewQueueJobSource = commandDecision ? "manual_command" : "automatic";
+  const sessionId = assignReviewerSessionForQueueJob(input, source)?.session?.sessionId;
   return input.state.enqueueReviewQueueJob({
     repo: input.repo,
     pullNumber: input.pull.number,
     headSha: input.pull.head.sha,
     baseSha: input.pull.base.sha,
+    source,
+    lane: source === "manual_command" ? "manual" : "background",
     providerId: input.providerId,
-    priority: input.config.reviewScheduler?.backgroundPriority,
+    priority: source === "manual_command" ? undefined : input.config.reviewScheduler?.backgroundPriority,
+    ...(commandDecision ? { commentId: commandDecision.commandId } : {}),
+    ...(sessionId ? { sessionId } : {}),
     now: input.now
   });
+}
+
+async function resolveSchedulerCommandDecision(input: {
+  config: BotConfig;
+  github: SchedulerGitHubApi;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+}): Promise<CommandDecision> {
+  if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
+  const comments = await input.github.listIssueComments(input.repo, input.pull.number);
+  const collected = collectTrustedReviewCommands(comments, input.config.commands);
+  return decideCommandAction({
+    commands: collected.commands,
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    hasProcessedCommand: (repo, pullNumber, headSha, commentId) =>
+      input.state.hasProcessedCommand(repo, pullNumber, headSha, commentId)
+  });
+}
+
+function assignReviewerSessionForQueueJob(input: {
+  config: BotConfig;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  providerId: string;
+  now: Date;
+}, source: ReviewQueueJobSource) {
+  if (!input.config.reviewerSessions?.enabled) return undefined;
+  const assignment = input.state.assignReviewerSessionJob({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    ttlMs: input.config.reviewerSessions.ttlMs,
+    headCountLimit: input.config.reviewerSessions.headCountLimit,
+    now: input.now,
+    model: input.config.zcode.model,
+    provider: input.providerId,
+    assignmentReason: source === "manual_command" ? "manual_command_priority" : undefined
+  });
+  return assignment.assigned || assignment.session ? assignment : undefined;
 }
 
 async function runLeasedQueueJob(input: {
@@ -234,6 +298,7 @@ async function runLeasedQueueJob(input: {
       state: "failed",
       lastError: error instanceof Error ? error.message : String(error)
     });
+    updateReviewerSessionJobFromQueueStatus(input, "failed", "failed");
     return "failed";
   }
 
@@ -243,6 +308,7 @@ async function runLeasedQueueJob(input: {
       state: "closed_retired",
       lastError: `closed_or_merged_before_review state=${pull.state ?? "unknown"}`
     });
+    updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
     return "closed_retired";
   }
 
@@ -252,8 +318,12 @@ async function runLeasedQueueJob(input: {
       state: "stale_retired",
       lastError: `stale_head_before_review live=${pull.head.sha}`
     });
+    updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
     return "stale_retired";
   }
+
+  const sessionId = ensureReviewerSessionForLeasedJob(input, now);
+  updateReviewerSessionJobFromQueueStatus({ ...input, job: { ...input.job, ...(sessionId ? { sessionId } : {}) } }, "running");
 
   try {
     const status = await input.reviewPullImpl({
@@ -268,6 +338,11 @@ async function runLeasedQueueJob(input: {
       processedHeadPolicy: isProviderDeferredRetryJob(input.job) ? "retry_failed_head" : "normal"
     });
     updateQueueJobAfterReviewStatus({ state: input.state, job: input.job, pull, status, dryRun: input.dryRun });
+    updateReviewerSessionJobAfterReviewStatus({
+      state: input.state,
+      job: { ...input.job, ...(sessionId ? { sessionId } : {}) },
+      status
+    });
     return status;
   } catch (error) {
     if (recordProviderRateLimitCooldownIfNeeded({
@@ -279,6 +354,7 @@ async function runLeasedQueueJob(input: {
       now
     })) {
       markQueueJobProviderDeferredFromProcessed({ state: input.state, job: input.job, pull, error, config: input.config, now });
+      updateReviewerSessionJobFromQueueStatus({ ...input, job: { ...input.job, ...(sessionId ? { sessionId } : {}) } }, "assigned");
       return "skipped_provider_cooldown";
     }
     recordFailedReview({
@@ -293,8 +369,85 @@ async function runLeasedQueueJob(input: {
       state: "failed",
       lastError: error instanceof Error ? error.message : String(error)
     });
+    updateReviewerSessionJobFromQueueStatus({ ...input, job: { ...input.job, ...(sessionId ? { sessionId } : {}) } }, "failed", "failed");
     return "failed";
   }
+}
+
+function ensureReviewerSessionForLeasedJob(input: {
+  config: BotConfig;
+  state: ReviewStateStore;
+  job: ReviewQueueJobRecord;
+  now?: Date;
+}, now: Date): string | undefined {
+  if (!input.config.reviewerSessions?.enabled) return input.job.sessionId;
+  if (input.job.sessionId) return input.job.sessionId;
+
+  const providerId = input.job.providerId ?? input.config.zcode.providerId ?? input.config.zcode.model ?? "zcode";
+  const assignment = input.state.assignReviewerSessionJob({
+    repo: input.job.repo,
+    pullNumber: input.job.pullNumber,
+    headSha: input.job.headSha,
+    ttlMs: input.config.reviewerSessions.ttlMs,
+    headCountLimit: input.config.reviewerSessions.headCountLimit,
+    now,
+    model: input.config.zcode.model,
+    provider: providerId,
+    assignmentReason: input.job.source === "manual_command" ? "manual_command_priority" : undefined
+  });
+  const sessionId = assignment.session?.sessionId;
+  if (sessionId) {
+    input.state.updateReviewQueueJobState({
+      jobId: input.job.jobId,
+      state: input.job.state,
+      sessionId,
+      clearLease: false,
+      now
+    });
+  }
+  return sessionId;
+}
+
+function updateReviewerSessionJobAfterReviewStatus(input: {
+  state: ReviewStateStore;
+  job: ReviewQueueJobRecord;
+  status: ReviewPullResult;
+}): void {
+  switch (input.status) {
+    case "reviewed":
+    case "reviewed_command":
+    case "skipped_processed":
+      updateReviewerSessionJobFromQueueStatus(input, "completed", "posted");
+      return;
+    case "skipped_provider_cooldown":
+    case "skipped_capacity":
+      updateReviewerSessionJobFromQueueStatus(input, "assigned");
+      return;
+    case "skipped_draft":
+    case "skipped_canary":
+    case "skipped_policy":
+    case "skipped_command_stop":
+    case "skipped_command_explain":
+    case "skipped_stale_head":
+      updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
+      return;
+    default:
+      assertNever(input.status);
+  }
+}
+
+function updateReviewerSessionJobFromQueueStatus(input: {
+  state: ReviewStateStore;
+  job: ReviewQueueJobRecord;
+}, jobState: ReviewerSessionJobState, processedReviewStatus?: ProcessedStatus): void {
+  if (!input.job.sessionId) return;
+  input.state.updateReviewerSessionJobState({
+    repo: input.job.repo,
+    pullNumber: input.job.pullNumber,
+    headSha: input.job.headSha,
+    jobState,
+    ...(processedReviewStatus ? { processedReviewStatus } : {})
+  });
 }
 
 function updateQueueJobAfterReviewStatus(input: {
@@ -343,12 +496,24 @@ function updateQueueJobAfterReviewStatus(input: {
     case "skipped_draft":
     case "skipped_canary":
     case "skipped_policy":
-    case "skipped_command_stop":
-    case "skipped_command_explain":
       input.state.updateReviewQueueJobState({
         jobId: input.job.jobId,
         state: "failed",
         lastError: `unexpected_scheduler_review_status=${input.status}`
+      });
+      return;
+    case "skipped_command_stop":
+      input.state.updateReviewQueueJobState({
+        jobId: input.job.jobId,
+        state: "posted",
+        lastError: "manual_command_stop_recorded"
+      });
+      return;
+    case "skipped_command_explain":
+      input.state.updateReviewQueueJobState({
+        jobId: input.job.jobId,
+        state: "posted",
+        lastError: "manual_command_explain_recorded"
       });
       return;
     default:

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -236,7 +236,12 @@ async function resolveSchedulerCommandDecision(input: {
   pull: PullRequestSummary;
 }): Promise<CommandDecision> {
   if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
-  const comments = await input.github.listIssueComments(input.repo, input.pull.number);
+  let comments: IssueCommentCommandSource[];
+  try {
+    comments = await input.github.listIssueComments(input.repo, input.pull.number);
+  } catch {
+    return { action: "none", shouldReview: false };
+  }
   const collected = collectTrustedReviewCommands(comments, input.config.commands);
   return decideCommandAction({
     commands: collected.commands,
@@ -341,7 +346,8 @@ async function runLeasedQueueJob(input: {
     updateReviewerSessionJobAfterReviewStatus({
       state: input.state,
       job: { ...input.job, ...(sessionId ? { sessionId } : {}) },
-      status
+      status,
+      dryRun: input.dryRun
     });
     return status;
   } catch (error) {
@@ -399,7 +405,7 @@ function ensureReviewerSessionForLeasedJob(input: {
   if (sessionId) {
     input.state.updateReviewQueueJobState({
       jobId: input.job.jobId,
-      state: input.job.state,
+      state: "running",
       sessionId,
       clearLease: false,
       now
@@ -412,12 +418,13 @@ function updateReviewerSessionJobAfterReviewStatus(input: {
   state: ReviewStateStore;
   job: ReviewQueueJobRecord;
   status: ReviewPullResult;
+  dryRun: boolean;
 }): void {
   switch (input.status) {
     case "reviewed":
     case "reviewed_command":
     case "skipped_processed":
-      updateReviewerSessionJobFromQueueStatus(input, "completed", "posted");
+      updateReviewerSessionJobFromQueueStatus(input, "completed", input.dryRun ? "dry_run" : "posted");
       return;
     case "skipped_provider_cooldown":
     case "skipped_capacity":

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -212,7 +212,9 @@ function enqueueReviewJob(input: {
   now: Date;
 }, commandDecision?: Exclude<CommandDecision, { action: "none"; shouldReview: false }>) {
   const source: ReviewQueueJobSource = commandDecision ? "manual_command" : "automatic";
-  const sessionId = assignReviewerSessionForQueueJob(input, source)?.session?.sessionId;
+  const sessionId = shouldAssignReviewerSession(commandDecision)
+    ? assignReviewerSessionForQueueJob(input, source, commandDecision)?.session?.sessionId
+    : undefined;
   return input.state.enqueueReviewQueueJob({
     repo: input.repo,
     pullNumber: input.pull.number,
@@ -253,6 +255,10 @@ async function resolveSchedulerCommandDecision(input: {
   });
 }
 
+function shouldAssignReviewerSession(commandDecision?: Exclude<CommandDecision, { action: "none"; shouldReview: false }>): boolean {
+  return !commandDecision || commandDecision.shouldReview;
+}
+
 function assignReviewerSessionForQueueJob(input: {
   config: BotConfig;
   state: ReviewStateStore;
@@ -260,7 +266,7 @@ function assignReviewerSessionForQueueJob(input: {
   pull: PullRequestSummary;
   providerId: string;
   now: Date;
-}, source: ReviewQueueJobSource) {
+}, source: ReviewQueueJobSource, commandDecision?: Exclude<CommandDecision, { action: "none"; shouldReview: false }>) {
   if (!input.config.reviewerSessions?.enabled) return undefined;
   const assignment = input.state.assignReviewerSessionJob({
     repo: input.repo,
@@ -271,7 +277,8 @@ function assignReviewerSessionForQueueJob(input: {
     now: input.now,
     model: input.config.zcode.model,
     provider: input.providerId,
-    assignmentReason: source === "manual_command" ? "manual_command_priority" : undefined
+    assignmentReason: source === "manual_command" ? "manual_command_priority" : undefined,
+    allowProcessed: commandDecision?.shouldReview === true
   });
   return assignment.assigned || assignment.session ? assignment : undefined;
 }
@@ -317,7 +324,10 @@ async function runLeasedQueueJob(input: {
     return "closed_retired";
   }
 
-  if (pull.head.sha !== input.job.headSha || (input.job.baseSha && pull.base.sha !== input.job.baseSha)) {
+  if (
+    pull.head.sha !== input.job.headSha ||
+    (input.job.source !== "manual_command" && input.job.baseSha && pull.base.sha !== input.job.baseSha)
+  ) {
     input.state.updateReviewQueueJobState({
       jobId: input.job.jobId,
       state: "stale_retired",
@@ -340,7 +350,8 @@ async function runLeasedQueueJob(input: {
       dryRun: input.dryRun,
       useZCode: input.useZCode,
       budget: input.budget,
-      processedHeadPolicy: isProviderDeferredRetryJob(input.job) ? "retry_failed_head" : "normal"
+      processedHeadPolicy: isProviderDeferredRetryJob(input.job) ? "retry_failed_head" : "normal",
+      ...(input.job.source === "manual_command" && input.job.commentId ? { commandCommentId: input.job.commentId } : {})
     });
     updateQueueJobAfterReviewStatus({ state: input.state, job: input.job, pull, status, dryRun: input.dryRun });
     updateReviewerSessionJobAfterReviewStatus({
@@ -388,6 +399,7 @@ function ensureReviewerSessionForLeasedJob(input: {
 }, now: Date): string | undefined {
   if (!input.config.reviewerSessions?.enabled) return input.job.sessionId;
   if (input.job.sessionId) return input.job.sessionId;
+  if (input.job.source === "manual_command") return undefined;
 
   const providerId = input.job.providerId ?? input.config.zcode.providerId ?? input.config.zcode.model ?? "zcode";
   const assignment = input.state.assignReviewerSessionJob({
@@ -398,8 +410,7 @@ function ensureReviewerSessionForLeasedJob(input: {
     headCountLimit: input.config.reviewerSessions.headCountLimit,
     now,
     model: input.config.zcode.model,
-    provider: providerId,
-    assignmentReason: input.job.source === "manual_command" ? "manual_command_priority" : undefined
+    provider: providerId
   });
   const sessionId = assignment.session?.sessionId;
   if (sessionId) {
@@ -512,14 +523,14 @@ function updateQueueJobAfterReviewStatus(input: {
     case "skipped_command_stop":
       input.state.updateReviewQueueJobState({
         jobId: input.job.jobId,
-        state: "posted",
+        state: "command_recorded",
         lastError: "manual_command_stop_recorded"
       });
       return;
     case "skipped_command_explain":
       input.state.updateReviewQueueJobState({
         jobId: input.job.jobId,
-        state: "posted",
+        state: "command_recorded",
         lastError: "manual_command_explain_recorded"
       });
       return;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -28,6 +28,7 @@ import {
 } from "./worker.js";
 
 export interface ScheduledRunResult extends RunOnceResult {
+  commandFetchErrors: number;
   queue: {
     enqueued: number;
     alreadyQueued: number;
@@ -113,7 +114,10 @@ export async function runScheduledCycleWithDeps(input: {
         repo,
         pull,
         providerId,
-        now
+        now,
+        onCommandFetchError: () => {
+          result.commandFetchErrors += 1;
+        }
       });
       applyEnqueueStatus(result, enqueueStatus);
     }
@@ -169,6 +173,7 @@ async function enqueuePullIfEligible(input: {
   pull: PullRequestSummary;
   providerId: string;
   now: Date;
+  onCommandFetchError?: () => void;
 }): Promise<EnqueueStatus> {
   if (isClosedPull(input.pull)) return "closed_retired";
   if (input.config.skipDrafts && input.pull.draft) return "skipped_draft";
@@ -236,12 +241,14 @@ async function resolveSchedulerCommandDecision(input: {
   state: ReviewStateStore;
   repo: string;
   pull: PullRequestSummary;
+  onCommandFetchError?: () => void;
 }): Promise<CommandDecision> {
   if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
   let comments: IssueCommentCommandSource[];
   try {
     comments = await input.github.listIssueComments(input.repo, input.pull.number);
   } catch {
+    input.onCommandFetchError?.();
     return { action: "none", shouldReview: false };
   }
   const collected = collectTrustedReviewCommands(comments, input.config.commands);
@@ -702,6 +709,7 @@ function emptyScheduledRunResult(): ScheduledRunResult {
     skippedProviderCooldown: 0,
     skippedStaleHead: 0,
     baselinedExisting: 0,
+    commandFetchErrors: 0,
     policySkips: [],
     queue: {
       enqueued: 0,

--- a/src/state.ts
+++ b/src/state.ts
@@ -24,6 +24,7 @@ export type ReviewQueueJobState =
   | "provider_deferred"
   | "stale_retired"
   | "closed_retired"
+  | "command_recorded"
   | "posted"
   | "failed";
 
@@ -455,6 +456,7 @@ export class ReviewStateStore {
     zcodeCliVersion?: string;
     repoFamily?: string;
     assignmentReason?: ReviewerSessionAssignmentReason;
+    allowProcessed?: boolean;
   }): ReviewerSessionAssignResult {
     validateReviewerSessionInput(input.ttlMs, input.headCountLimit, input.workerPid);
 
@@ -468,7 +470,7 @@ export class ReviewStateStore {
 
     this.db.exec("begin immediate");
     try {
-      if (this.hasProcessed(input.repo, input.pullNumber, input.headSha)) {
+      if (!input.allowProcessed && this.hasProcessed(input.repo, input.pullNumber, input.headSha)) {
         this.db.exec("commit");
         return { assigned: false, reason: "already_processed" };
       }
@@ -1199,10 +1201,11 @@ export class ReviewStateStore {
     const row = this.db
       .prepare(
         `select 1 from processed_commands
-         where repo = ? and pull_number = ? and head_sha = ? and comment_id = ?
+         where repo = ? and pull_number = ? and comment_id = ?
          limit 1`
       )
-      .get(repo, pullNumber, headSha, commentId);
+      .get(repo, pullNumber, commentId);
+    void headSha;
     return Boolean(row);
   }
 
@@ -1365,7 +1368,11 @@ function countBy<T>(items: T[], key: (item: T) => string): Map<string, number> {
 }
 
 function isTerminalQueueState(state: ReviewQueueJobState): boolean {
-  return state === "posted" || state === "failed" || state === "stale_retired" || state === "closed_retired";
+  return state === "posted" ||
+    state === "failed" ||
+    state === "stale_retired" ||
+    state === "closed_retired" ||
+    state === "command_recorded";
 }
 
 export function parseProviderCooldownError(error?: string): ParsedProviderCooldownError | undefined {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1222,6 +1222,16 @@ async function recordAndAcknowledgeCommandDecision(input: {
     url: input.commandDecision.command.url
   });
 
+  if (input.commandDecision.action === "stop") {
+    input.state.recordProcessed({
+      repo: input.repo,
+      pullNumber: input.pull.number,
+      headSha: input.pull.head.sha,
+      status: "skipped",
+      error: `manual_command_stop comment_id=${input.commandDecision.commandId}; author=${input.commandDecision.command.author}`
+    });
+  }
+
   if (input.config.commands.acknowledge && input.github.canPostAsApp()) {
     await input.github.upsertIssueComment({
       repo: input.repo,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -551,6 +551,7 @@ export interface ReviewPullInput {
   useZCode: boolean;
   budget?: ReviewRunBudget;
   processedHeadPolicy?: "normal" | "retry_failed_head";
+  commandCommentId?: number;
 }
 
 export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResult> {
@@ -1183,13 +1184,17 @@ async function resolvePullCommandDecision(input: {
   state: ReviewStateStore;
   repo: string;
   pull: PullRequestSummary;
+  commandCommentId?: number;
 }): Promise<CommandDecision> {
   if (!input.config.commands.enabled) return { action: "none", shouldReview: false };
 
   const comments = await input.github.listIssueComments(input.repo, input.pull.number);
   const collected = collectTrustedReviewCommands(comments, input.config.commands);
+  const commands = input.commandCommentId
+    ? collected.commands.filter((command) => command.commentId === input.commandCommentId)
+    : collected.commands;
   return decideCommandAction({
-    commands: collected.commands,
+    commands,
     repo: input.repo,
     pullNumber: input.pull.number,
     headSha: input.pull.head.sha,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1223,13 +1223,16 @@ async function recordAndAcknowledgeCommandDecision(input: {
   });
 
   if (input.commandDecision.action === "stop") {
-    input.state.recordProcessed({
-      repo: input.repo,
-      pullNumber: input.pull.number,
-      headSha: input.pull.head.sha,
-      status: "skipped",
-      error: `manual_command_stop comment_id=${input.commandDecision.commandId}; author=${input.commandDecision.command.author}`
-    });
+    const existing = input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha);
+    if (existing?.status !== "posted") {
+      input.state.recordProcessed({
+        repo: input.repo,
+        pullNumber: input.pull.number,
+        headSha: input.pull.head.sha,
+        status: "skipped",
+        error: `manual_command_stop comment_id=${input.commandDecision.commandId}; author=${input.commandDecision.command.author}`
+      });
+    }
   }
 
   if (input.config.commands.acknowledge && input.github.canPostAsApp()) {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -669,6 +669,7 @@ function durableQueueSnapshot(input: {
       running: input.summary?.running ?? 1,
       providerDeferred: input.summary?.providerDeferred ?? 1,
       retryableProviderDeferred: input.summary?.retryableProviderDeferred ?? 1,
+      commandRecorded: input.summary?.commandRecorded ?? 0,
       posted: input.summary?.posted ?? 0,
       failed: input.summary?.failed ?? 1,
       retired: input.summary?.retired ?? 0
@@ -686,6 +687,7 @@ function cleanDurableQueueSummary(): Partial<OperatorDurableQueueSnapshot["summa
     running: 0,
     providerDeferred: 0,
     retryableProviderDeferred: 0,
+    commandRecorded: 0,
     posted: 0,
     failed: 0,
     retired: 0

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -389,6 +389,93 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("does not let trusted stop commands clobber an existing posted review row", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-stop-posted-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    state.recordProcessed({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "a1",
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-original"
+    });
+    const pullMap = new Map([["org/repo-a", [pull("org/repo-a", 1, "a1")]]]);
+    const comments = new Map([
+      ["org/repo-a#1", [comment(334, "100yenadmin", "@evaos-code-review-bot stop")]]
+    ]);
+
+    await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(pullMap, comments),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: reviewPull,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(state.getProcessedReview("org/repo-a", 1, "a1")).toMatchObject({
+      status: "posted",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-original"
+    });
+    state.close();
+  });
+
+  it("keeps a comment fetch failure scoped to that pull instead of failing the scheduler cycle", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-fetch-failure-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a", "org/repo-b"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const pullMap = new Map([
+      ["org/repo-a", [pull("org/repo-a", 1, "a1")]],
+      ["org/repo-b", [pull("org/repo-b", 1, "b1")]]
+    ]);
+    const reviewed: string[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: {
+        ...githubFromMap(pullMap),
+        listIssueComments: async (repo, issueNumber) => {
+          if (repo === "org/repo-a" && issueNumber === 1) throw new Error("GitHub 500");
+          return [];
+        }
+      },
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewed.push(`${repo}#${reviewPull.number}`);
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.failed).toBe(0);
+    expect(reviewed).toHaveLength(2);
+    state.close();
+  });
+
   it("assigns scheduler jobs to reusable repo-sticky reviewer sessions when enabled", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-reposticky-"));
     roots.push(root);
@@ -425,7 +512,7 @@ describe("provider-aware review scheduler", () => {
     const jobs = state.listReviewQueueJobs({ repo: "org/repo-a" });
     expect(result.queue.enqueued).toBe(2);
     expect(result.queue.leased).toBe(1);
-    expect(new Set(jobs.map((job) => job.sessionId))).toHaveLength(1);
+    expect(new Set(jobs.map((job) => job.sessionId)).size).toBe(1);
     expect(state.listReviewerSessions({ repo: "org/repo-a" })).toEqual([
       expect.objectContaining({
         repo: "org/repo-a",
@@ -440,6 +527,49 @@ describe("provider-aware review scheduler", () => {
     });
     expect(state.getReviewerSessionJob("org/repo-a", 2, "a2")).toMatchObject({
       jobState: "assigned"
+    });
+    state.close();
+  });
+
+  it("preserves dry-run processed status in repo-sticky reviewer session jobs", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-reposticky-dry-run-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewerSessions = {
+      enabled: true,
+      ttlMs: 8 * 60 * 60_000,
+      headCountLimit: 10
+    };
+    const state = new ReviewStateStore(config.statePath);
+
+    await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "a1")]]
+      ])),
+      state,
+      options: { dryRun: true, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "dry_run",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(state.getReviewerSessionJob("org/repo-a", 1, "a1")).toMatchObject({
+      jobState: "completed",
+      processedReviewStatus: "dry_run"
+    });
+    const [queueJob] = state.listReviewQueueJobs();
+    expect(queueJob).toMatchObject({
+      state: "queued",
+      lastError: "dry_run_completed_not_posted"
     });
     state.close();
   });

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -108,6 +108,44 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("returns RepoSticky session jobs to assigned on provider cooldown", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-reposticky-provider-throttle-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewerSessions = {
+      enabled: true,
+      ttlMs: 8 * 60 * 60_000,
+      headCountLimit: 10
+    };
+    const state = new ReviewStateStore(config.statePath);
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "a1")]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: true },
+      reviewPullImpl: async () => {
+        throw new Error("ProviderBusinessError: [1302][Rate limit reached for requests]");
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.skippedProviderCooldown).toBe(1);
+    expect(state.listReviewQueueJobs({ state: "provider_deferred" })).toEqual([
+      expect.objectContaining({
+        repo: "org/repo-a",
+        pullNumber: 1,
+        nextEligibleAt: "2026-07-01T00:01:30.000Z"
+      })
+    ]);
+    expect(state.getReviewerSessionJob("org/repo-a", 1, "a1")).toMatchObject({
+      jobState: "assigned"
+    });
+    state.close();
+  });
+
   it("retries expired provider-deferred queue jobs with failed-head retry policy", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-provider-deferred-retry-"));
     roots.push(root);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -559,6 +559,7 @@ describe("provider-aware review scheduler", () => {
     });
 
     expect(result.failed).toBe(0);
+    expect(result.commandFetchErrors).toBe(1);
     expect(reviewed).toHaveLength(2);
     state.close();
   });

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -6,7 +6,7 @@ import type { BotConfig } from "../src/config.js";
 import { runScheduledCycleWithDeps, type SchedulerGitHubApi } from "../src/scheduler.js";
 import { ReviewStateStore } from "../src/state.js";
 import type { PullRequestSummary } from "../src/types.js";
-import type { ReviewPullInput, ReviewPullResult } from "../src/worker.js";
+import { reviewPull, type ReviewPullInput, type ReviewPullResult } from "../src/worker.js";
 
 describe("provider-aware review scheduler", () => {
   const roots: string[] = [];
@@ -291,6 +291,159 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("enqueues trusted command reviews even when the current head is already processed", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-processed-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    state.recordProcessed({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "a1",
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-old"
+    });
+    const pullMap = new Map([["org/repo-a", [pull("org/repo-a", 1, "a1")]]]);
+    const comments = new Map([
+      ["org/repo-a#1", [comment(222, "100yenadmin", "@evaos-code-review-bot re-review")]]
+    ]);
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(pullMap, comments),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-command"
+        });
+        return "reviewed_command";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.reviewed).toBe(1);
+    expect(result.commandReviewRequested).toBe(1);
+    expect(state.listReviewQueueJobs({ state: "posted" })).toEqual([
+      expect.objectContaining({
+        source: "manual_command",
+        lane: "manual",
+        commentId: 222,
+        repo: "org/repo-a",
+        pullNumber: 1
+      })
+    ]);
+    state.close();
+  });
+
+  it("records trusted stop commands as terminal skips for the current head", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-stop-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const pullMap = new Map([["org/repo-a", [pull("org/repo-a", 1, "a1")]]]);
+    const comments = new Map([
+      ["org/repo-a#1", [comment(333, "100yenadmin", "@evaos-code-review-bot stop")]]
+    ]);
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(pullMap, comments),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: reviewPull,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.skippedCommandStop).toBe(1);
+    expect(state.getProcessedReview("org/repo-a", 1, "a1")).toMatchObject({
+      status: "skipped",
+      error: expect.stringContaining("manual_command_stop")
+    });
+    expect(state.listReviewQueueJobs({ state: "posted" })).toEqual([
+      expect.objectContaining({
+        source: "manual_command",
+        lane: "manual",
+        commentId: 333,
+        lastError: "manual_command_stop_recorded"
+      })
+    ]);
+    state.close();
+  });
+
+  it("assigns scheduler jobs to reusable repo-sticky reviewer sessions when enabled", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-reposticky-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewerSessions = {
+      enabled: true,
+      ttlMs: 8 * 60 * 60_000,
+      headCountLimit: 10
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const pullMap = new Map([
+      ["org/repo-a", [pull("org/repo-a", 1, "a1"), pull("org/repo-a", 2, "a2")]]
+    ]);
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(pullMap),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: `https://github.com/${repo}/pull/${reviewPull.number}#pullrequestreview-sticky`
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    const jobs = state.listReviewQueueJobs({ repo: "org/repo-a" });
+    expect(result.queue.enqueued).toBe(2);
+    expect(result.queue.leased).toBe(1);
+    expect(new Set(jobs.map((job) => job.sessionId))).toHaveLength(1);
+    expect(state.listReviewerSessions({ repo: "org/repo-a" })).toEqual([
+      expect.objectContaining({
+        repo: "org/repo-a",
+        state: "active",
+        headCountUsed: 2,
+        provider: "zai-coding-plan"
+      })
+    ]);
+    expect(state.getReviewerSessionJob("org/repo-a", 1, "a1")).toMatchObject({
+      jobState: "completed",
+      processedReviewStatus: "posted"
+    });
+    expect(state.getReviewerSessionJob("org/repo-a", 2, "a2")).toMatchObject({
+      jobState: "assigned"
+    });
+    state.close();
+  });
+
   it("honors per-repo queue capacity before active provider cooldown enqueue", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-cooldown-capacity-"));
     roots.push(root);
@@ -389,14 +542,18 @@ function schedulerConfig(root: string, repos: string[]): BotConfig {
   };
 }
 
-function githubFromMap(pullsByRepo: Map<string, PullRequestSummary[]>): SchedulerGitHubApi {
+function githubFromMap(
+  pullsByRepo: Map<string, PullRequestSummary[]>,
+  commentsByPull = new Map<string, ReturnType<typeof comment>[]>()
+): SchedulerGitHubApi {
   return {
     listOpenPulls: async (repo) => pullsByRepo.get(repo)?.filter((entry) => entry.state === undefined || entry.state === "open") ?? [],
     getPull: async (repo, pullNumber) => {
       const pull = pullsByRepo.get(repo)?.find((entry) => entry.number === pullNumber);
       if (!pull) throw new Error(`missing pull ${repo}#${pullNumber}`);
       return pull;
-    }
+    },
+    listIssueComments: async (repo, issueNumber) => commentsByPull.get(`${repo}#${issueNumber}`) ?? []
   };
 }
 
@@ -424,5 +581,17 @@ function pull(
       repo: { full_name: repo }
     },
     html_url: `https://github.com/${repo}/pull/${number}`
+  };
+}
+
+function comment(id: number, login: string, body: string) {
+  return {
+    id,
+    body,
+    html_url: `https://github.test/comment/${id}`,
+    user: {
+      login,
+      type: login.endsWith("bot") ? "Bot" : "User"
+    }
   };
 }

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -378,7 +378,7 @@ describe("provider-aware review scheduler", () => {
       status: "skipped",
       error: expect.stringContaining("manual_command_stop")
     });
-    expect(state.listReviewQueueJobs({ state: "posted" })).toEqual([
+    expect(state.listReviewQueueJobs({ state: "command_recorded" })).toEqual([
       expect.objectContaining({
         source: "manual_command",
         lane: "manual",
@@ -386,6 +386,55 @@ describe("provider-aware review scheduler", () => {
         lastError: "manual_command_stop_recorded"
       })
     ]);
+    state.close();
+  });
+
+  it("does not replay an old processed stop command onto a new head", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-stop-new-head-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    state.recordProcessedCommand({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "old-head",
+      commentId: 335,
+      action: "stop",
+      status: "stopped",
+      author: "100yenadmin"
+    });
+    const pullMap = new Map([["org/repo-a", [pull("org/repo-a", 1, "new-head")]]]);
+    const comments = new Map([
+      ["org/repo-a#1", [comment(335, "100yenadmin", "@evaos-code-review-bot stop")]]
+    ]);
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(pullMap, comments),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.reviewed).toBe(1);
+    expect(result.skippedCommandStop).toBe(0);
+    expect(state.getProcessedReview("org/repo-a", 1, "new-head")).toMatchObject({ status: "posted" });
     state.close();
   });
 
@@ -531,6 +580,96 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("does not consume RepoSticky session head budget for stop or explain commands", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-reposticky-command-non-review-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    config.reviewerSessions = {
+      enabled: true,
+      ttlMs: 8 * 60 * 60_000,
+      headCountLimit: 10
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const pullMap = new Map([["org/repo-a", [pull("org/repo-a", 1, "a1")]]]);
+    const comments = new Map([
+      ["org/repo-a#1", [comment(336, "100yenadmin", "@evaos-code-review-bot explain")]]
+    ]);
+
+    await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(pullMap, comments),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: reviewPull,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(state.listReviewerSessions({ repo: "org/repo-a" })).toHaveLength(0);
+    const [recordedJob] = state.listReviewQueueJobs({ state: "command_recorded" });
+    expect(recordedJob).toMatchObject({ commentId: 336 });
+    expect(recordedJob?.sessionId).toBeUndefined();
+    state.close();
+  });
+
+  it("attaches processed-head re-review commands to RepoSticky sessions", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-reposticky-command-rereview-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    config.reviewerSessions = {
+      enabled: true,
+      ttlMs: 8 * 60 * 60_000,
+      headCountLimit: 10
+    };
+    const state = new ReviewStateStore(config.statePath);
+    state.recordProcessed({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "a1",
+      status: "posted",
+      event: "COMMENT"
+    });
+    const pullMap = new Map([["org/repo-a", [pull("org/repo-a", 1, "a1")]]]);
+    const comments = new Map([
+      ["org/repo-a#1", [comment(337, "100yenadmin", "@evaos-code-review-bot re-review")]]
+    ]);
+
+    await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(pullMap, comments),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed_command";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    const [job] = state.listReviewQueueJobs({ repo: "org/repo-a" });
+    expect(job).toMatchObject({ source: "manual_command", commentId: 337 });
+    expect(job.sessionId).toBeDefined();
+    expect(state.listReviewerSessions({ repo: "org/repo-a" })).toHaveLength(1);
+    state.close();
+  });
+
   it("preserves dry-run processed status in repo-sticky reviewer session jobs", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-reposticky-dry-run-"));
     roots.push(root);
@@ -571,6 +710,113 @@ describe("provider-aware review scheduler", () => {
       state: "queued",
       lastError: "dry_run_completed_not_posted"
     });
+    state.close();
+  });
+
+  it("binds manual queue jobs to their queued command comment id", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-manual-comment-binding-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "a1",
+      baseSha: "base",
+      source: "manual_command",
+      lane: "manual",
+      commentId: 401
+    });
+    const comments = new Map([
+      ["org/repo-a#1", [
+        comment(401, "100yenadmin", "@evaos-code-review-bot review"),
+        comment(402, "100yenadmin", "@evaos-code-review-bot stop")
+      ]]
+    ]);
+
+    const commandCommentIds: Array<number | undefined> = [];
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "a1")]]
+      ]), comments),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull, commandCommentId }) => {
+        commandCommentIds.push(commandCommentId);
+        reviewState.recordProcessedCommand({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          commentId: commandCommentId ?? 0,
+          action: "review",
+          status: "triggered",
+          author: "100yenadmin"
+        });
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed_command";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.reviewed).toBe(1);
+    expect(result.skippedCommandStop).toBe(0);
+    expect(commandCommentIds).toEqual([401]);
+    expect(state.hasProcessedCommand("org/repo-a", 1, "a1", 401)).toBe(true);
+    expect(state.hasProcessedCommand("org/repo-a", 1, "a1", 402)).toBe(false);
+    state.close();
+  });
+
+  it("does not stale-retire manual command jobs when only the base SHA changed", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-manual-base-drift-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    const state = new ReviewStateStore(config.statePath);
+    state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "a1",
+      baseSha: "old-base",
+      source: "manual_command",
+      lane: "manual",
+      commentId: 403
+    });
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "a1", "new-base")]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.reviewed).toBe(1);
+    expect(result.skippedStaleHead).toBe(0);
+    expect(state.listReviewQueueJobs({ state: "posted" })).toHaveLength(1);
     state.close();
   });
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -780,7 +780,7 @@ describe("review state store", () => {
     store.close();
   });
 
-  it("deduplicates processed command comments per repo, PR, head SHA, and comment id", () => {
+  it("deduplicates processed command comments per repo, PR, and comment id", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-command-state-"));
     roots.push(root);
     const store = new ReviewStateStore(join(root, "state.sqlite"));
@@ -796,7 +796,7 @@ describe("review state store", () => {
     });
 
     expect(store.hasProcessedCommand("electricsheephq/WorldOS", 1161, "head-a", 123)).toBe(true);
-    expect(store.hasProcessedCommand("electricsheephq/WorldOS", 1161, "head-b", 123)).toBe(false);
+    expect(store.hasProcessedCommand("electricsheephq/WorldOS", 1161, "head-b", 123)).toBe(true);
     expect(store.hasProcessedCommand("electricsheephq/WorldOS", 1161, "head-a", 124)).toBe(false);
     store.close();
   });


### PR DESCRIPTION
## Summary

- wire trusted maintainer commands into the provider-aware scheduler before processed-head suppression
- attach scheduler jobs to RepoSticky reviewer sessions when enabled
- make command stop/explain jobs terminal instead of failed queue rows
- add v0.3.6-beta.1 release packet for explicit live config promotion

## Validation

- npx vitest run tests/scheduler.test.ts tests/commands.test.ts tests/state.test.ts
- npm run build
- npm test
- git diff --check

Refs #78, #11