### PR TITLE
Add runtime inventory operator command

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -21,6 +21,12 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
 - `status`: aggregated operator health. Includes release gates, launchd,
   heartbeat, DB error/cooldown counts, coverage buckets, active/stale leases,
   durable queue counts, and recommended actions.
+- `runtime-inventory`: read-only runtime classifier for release operators. It
+  includes release status, coverage, durable queue work, provider cooldowns,
+  leases, heartbeat, and bot-owned process rows. It can classify the worker as
+  `healthy_active` when open PR heads are already covered by active queue work,
+  even if the stricter `status` command is nonzero because live PR churn exists.
+  JSON is the default; use `--human` for a compact operator summary.
 - `agents`: launchd, heartbeat, and review-run lease inventory. This is
   read-only; it does not restart, kill, prune, or retire anything.
 - `queue`: open PR-head coverage grouped into processed, provider-deferred,
@@ -40,6 +46,18 @@ Check whether the live bot is healthy:
 
 ```bash
 npx tsx src/cli.ts status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+Classify whether the bot is idle, healthy-active, or blocked:
+
+```bash
+npx tsx src/cli.ts runtime-inventory --json --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+Show the same runtime inventory as a short human summary:
+
+```bash
+npx tsx src/cli.ts runtime-inventory --human --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
 See whether review agents are active, idle, or stale:
@@ -77,6 +95,11 @@ npx tsx src/cli.ts cooldowns --config /Volumes/LEXAR/Codex/evaos-code-review-bot
 Default operator commands are read-only. They can return nonzero when a gate is
 unhealthy, but they do not mutate GitHub, launchd, config files, worktrees, or
 SQLite rows.
+
+`runtime-inventory` process rows are bounded to the bot launchd PID, commands
+containing the current bot repo path or launchd label, and children of those
+matched bot processes. It redacts token-like strings and does not inspect or
+print process environments.
 
 Mutating commands remain explicit:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,13 +7,16 @@ import { join } from "node:path";
 import { REQUIRED_SUITES, runOfflineEval } from "./eval-harness.js";
 import { GitHubApi } from "./github.js";
 import {
+  buildRuntimeInventory,
   buildOperatorQueue,
   buildOperatorStatus,
+  collectBotProcessInventory,
   collectOperatorLeases,
   collectOperatorProviderCooldowns,
   collectOperatorRepoProviderCooldowns,
   collectOperatorReviewQueue,
   explainPullStatus,
+  formatRuntimeInventoryHuman,
   summarizeAgentInventory
 } from "./operator-cli.js";
 import { collectReleaseStatus } from "./release-status.js";
@@ -151,6 +154,59 @@ async function main(): Promise<void> {
     });
     console.log(JSON.stringify(status, null, 2));
     if (!status.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "runtime-inventory") {
+    const config = loadConfig(args.config);
+    const release = collectReleaseStatus({
+      cwd: process.cwd(),
+      configPath: args.config,
+      expectedHead: args["expected-head"],
+      launchdLabel: args["launchd-label"],
+      statePath: args["state-path"]
+    });
+    const coverage = await collectCoverageReport(args, config);
+    const statePath = args["state-path"] ?? config.statePath;
+    const now = new Date();
+    const agents = summarizeAgentInventory({
+      launchd: release.launchd,
+      heartbeat: release.heartbeat,
+      leases: collectOperatorLeases(statePath),
+      now
+    });
+    const providerCooldowns = collectOperatorProviderCooldowns(statePath, {
+      repo: args.repo,
+      expiredOnly: false,
+      now
+    });
+    const repoProviderCooldowns = collectOperatorRepoProviderCooldowns(statePath, {
+      repo: args.repo,
+      activeOnly: args["active-only"] === "true",
+      now
+    });
+    const durableQueue = collectOperatorReviewQueue(statePath, {
+      repo: args.repo,
+      now
+    });
+    const processes = collectBotProcessInventory({
+      repoPath: process.cwd(),
+      launchdLabel: release.launchd.label,
+      launchdPid: release.launchd.pid,
+      now
+    });
+    const inventory = buildRuntimeInventory({
+      release,
+      coverage,
+      agents,
+      processes,
+      providerCooldowns,
+      repoProviderCooldowns,
+      durableQueue,
+      checkedAt: now.toISOString()
+    });
+    console.log(args.human === "true" ? formatRuntimeInventoryHuman(inventory) : JSON.stringify(inventory, null, 2));
+    if (!inventory.ok) process.exitCode = 1;
     return;
   }
 
@@ -461,6 +517,7 @@ function buildHelp() {
     commands: {
       operator: [
         "status",
+        "runtime-inventory",
         "agents",
         "queue",
         "coverage",
@@ -483,6 +540,8 @@ function buildHelp() {
     },
     examples: [
       "npx tsx src/cli.ts status --config /path/to/live.json --launchd-label com.electricsheephq.evaos-code-review-bot",
+      "npx tsx src/cli.ts runtime-inventory --config /path/to/live.json --launchd-label com.electricsheephq.evaos-code-review-bot",
+      "npx tsx src/cli.ts runtime-inventory --config /path/to/live.json --human",
       "npx tsx src/cli.ts agents --config /path/to/live.json",
       "npx tsx src/cli.ts queue --config /path/to/live.json",
       "npx tsx src/cli.ts queue --config /path/to/live.json --state provider_deferred",
@@ -579,6 +638,8 @@ interface ParsedArgs {
   state?: string;
   zcode?: string;
   "active-only"?: string;
+  human?: string;
+  json?: string;
   "verify-current-heads"?: string;
   [key: string]: string | string[] | undefined;
 }

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import type {
@@ -9,6 +10,7 @@ import type {
   CoverageUnprocessedEntry
 } from "./coverage-audit.js";
 import type { ReleaseHeartbeatStatus, ReleaseLaunchdStatus, ReleaseStatus } from "./release-status.js";
+import { redactSecrets } from "./secrets.js";
 import {
   parseProviderCooldownError,
   PROVIDER_COOLDOWN_ERROR_PREFIX,
@@ -46,6 +48,77 @@ export interface OperatorStatus {
   agents: OperatorAgentInventory;
   providerCooldowns: ProviderCooldownReviewRecord[];
   durableQueue?: OperatorDurableQueueSnapshot;
+}
+
+export interface RuntimeInventory {
+  ok: boolean;
+  checkedAt: string;
+  runtimeState: RuntimeClassification;
+  classification: RuntimeClassification;
+  summary: {
+    launchdState: ReleaseLaunchdStatus["state"];
+    heartbeatStatus: ReleaseHeartbeatStatus["status"];
+    activeLeases: number;
+    staleLeases: number;
+    activeQueueJobs: number;
+    queuedJobs: number;
+    runningJobs: number;
+    providerDeferredJobs: number;
+    failedQueueJobs: number;
+    retryableProviderDeferredJobs: number;
+    pendingHeads: number;
+    coveredPendingHeads: number;
+    uncoveredPendingHeads: number;
+    providerDeferredHeads: number;
+    staleHeads: number;
+    readFailures: number;
+    expiredProviderCooldowns: number;
+    retryableExpiredProviderCooldowns: number;
+    coveredExpiredProviderCooldowns: number;
+    activeProviderCooldowns: number;
+    repoCooldowns: number;
+    activeRepoCooldowns: number;
+    botProcesses: number;
+  };
+  gates: Array<{ name: string; ok: boolean; detail: string }>;
+  recommendedActions: string[];
+  activeWork: ReviewQueueJobRecord[];
+  uncoveredPendingHeads: OperatorQueueEntry[];
+  release: ReleaseStatus;
+  agents: OperatorAgentInventory;
+  processes?: RuntimeProcessInventory;
+  durableQueue?: OperatorDurableQueueSnapshot;
+  coverage?: OperatorQueueSnapshot;
+  providerCooldowns: ProviderCooldownReviewRecord[];
+  repoProviderCooldowns: RepoProviderCooldownRecord[];
+}
+
+export type RuntimeClassification = "healthy_idle" | "healthy_active" | "blocked";
+
+export interface RuntimeProcessRow {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+export interface RuntimeProcessRecord extends RuntimeProcessRow {
+  classification: "launchd_worker" | "repo_command" | "child_process";
+  matchedBy: string[];
+}
+
+export interface RuntimeProcessInventory {
+  ok: boolean;
+  checkedAt: string;
+  summary: {
+    total: number;
+    launchdPidMatched: number;
+    repoPathMatched: number;
+    launchdLabelMatched: number;
+    childProcessMatched: number;
+    errors: number;
+  };
+  processes: RuntimeProcessRecord[];
+  errors: string[];
 }
 
 export interface OperatorLease {
@@ -243,6 +316,252 @@ export function buildOperatorStatus(input: {
   };
 }
 
+export function buildRuntimeInventory(input: {
+  release: ReleaseStatus;
+  coverage?: CoverageAuditReport;
+  agents: OperatorAgentInventory;
+  processes?: RuntimeProcessInventory;
+  providerCooldowns?: ProviderCooldownReviewRecord[];
+  repoProviderCooldowns?: RepoProviderCooldownRecord[];
+  durableQueue?: OperatorDurableQueueSnapshot;
+  checkedAt?: string;
+}): RuntimeInventory {
+  const queue = input.coverage ? buildOperatorQueue(input.coverage) : undefined;
+  const durableQueue = input.durableQueue;
+  const providerCooldowns = input.providerCooldowns ?? [];
+  const repoProviderCooldowns = input.repoProviderCooldowns ?? [];
+  const activeWork = (durableQueue?.jobs ?? []).filter((job) =>
+    job.state === "queued" || job.state === "leased" || job.state === "running"
+  );
+  const uncoveredPendingHeads = (queue?.pending ?? []).filter((pending) =>
+    !activeWork.some((job) => sameHead(job, pending))
+  );
+  const coveredPendingHeads = (queue?.pending.length ?? 0) - uncoveredPendingHeads.length;
+  const expiredProviderCooldowns = providerCooldowns.filter((cooldown) => cooldown.expired).length;
+  const activeProviderCooldowns = providerCooldowns.length - expiredProviderCooldowns;
+  const checkedAtMs = Date.parse(input.checkedAt ?? input.release.checkedAt);
+  const nowMs = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
+  const activeRepoCooldowns = repoProviderCooldowns.filter((cooldown) => {
+    const cooldownUntilMs = Date.parse(cooldown.cooldownUntil);
+    return Number.isFinite(cooldownUntilMs) && cooldownUntilMs > nowMs;
+  }).length;
+  const coveredExpiredProviderCooldowns =
+    input.release.database.coveredExpiredProviderCooldownCount ??
+    (activeRepoCooldowns > 0 || activeProviderCooldowns > 0 ? expiredProviderCooldowns : 0);
+  const retryableExpiredProviderCooldowns =
+    input.release.database.retryableExpiredProviderCooldownCount ??
+    Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
+  const failedQueueJobs = durableQueue?.summary.failed ?? 0;
+  const retryableProviderDeferredJobs = durableQueue?.summary.retryableProviderDeferred ?? 0;
+  const providerDeferredJobs = durableQueue?.summary.providerDeferred ?? 0;
+  const readFailures = queue?.summary.readFailures ?? 0;
+  const staleHeads = queue?.summary.staleHeads ?? 0;
+  const providerDeferredHeads = queue?.summary.providerDeferred ?? 0;
+
+  const gates = [
+    ...input.release.gates,
+    {
+      name: "runtime_no_stale_leases",
+      ok: input.agents.summary.staleLeases === 0,
+      detail: `${input.agents.summary.staleLeases} stale lease(s)`
+    },
+    {
+      name: "runtime_no_failed_queue_jobs",
+      ok: failedQueueJobs === 0,
+      detail: `${failedQueueJobs} failed durable queue job(s)`
+    },
+    {
+      name: "runtime_no_retryable_provider_deferred_jobs",
+      ok: retryableProviderDeferredJobs === 0,
+      detail: `${retryableProviderDeferredJobs} retryable provider-deferred durable queue job(s)`
+    },
+    {
+      name: "runtime_pending_heads_covered",
+      ok: uncoveredPendingHeads.length === 0,
+      detail:
+        uncoveredPendingHeads.length === 0
+          ? `${coveredPendingHeads} pending head(s) covered by active durable queue work`
+          : `${uncoveredPendingHeads.length} pending head(s) without active durable queue work`
+    },
+    {
+      name: "runtime_no_read_failures",
+      ok: readFailures === 0,
+      detail: `${readFailures} read failure(s)`
+    },
+    {
+      name: "runtime_no_stale_heads",
+      ok: staleHeads === 0,
+      detail: `${staleHeads} stale head(s)`
+    },
+    {
+      name: "runtime_no_retryable_provider_cooldowns",
+      ok: retryableExpiredProviderCooldowns === 0,
+      detail:
+        `${retryableExpiredProviderCooldowns} retryable expired provider cooldown row(s)` +
+        (coveredExpiredProviderCooldowns > 0
+          ? `; ${coveredExpiredProviderCooldowns} covered by active provider/repo cooldown`
+          : "")
+    },
+    {
+      name: "runtime_process_inventory_available",
+      ok: input.processes?.ok ?? true,
+      detail: input.processes
+        ? `${input.processes.summary.total} bot-owned process(es), ${input.processes.summary.errors} process inventory error(s)`
+        : "not collected"
+    }
+  ];
+
+  const ok = gates.every((gate) => gate.ok);
+  const runtimeState: RuntimeClassification = !ok
+    ? "blocked"
+    : activeWork.length > 0 || coveredPendingHeads > 0 || providerDeferredJobs > 0
+      ? "healthy_active"
+      : "healthy_idle";
+
+  const recommendedActions = uniqueStrings([
+    ...input.release.recommendedActions,
+    ...(activeWork.length > 0 ? ["monitor active review work; avoid restarting a healthy in-flight run"] : []),
+    ...(uncoveredPendingHeads.length > 0 ? ["wait for daemon cycle or run scoped run-once for uncovered pending heads"] : []),
+    ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
+    ...(input.agents.summary.staleLeases > 0 ? ["inspect stale leases before restarting launchd"] : []),
+    ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
+    ...(retryableExpiredProviderCooldowns > 0 ? ["retry expired provider cooldowns or inspect provider health"] : [])
+  ]);
+
+  return {
+    ok,
+    checkedAt: input.checkedAt ?? input.release.checkedAt,
+    runtimeState,
+    classification: runtimeState,
+    summary: {
+      launchdState: input.release.launchd.state,
+      heartbeatStatus: input.release.heartbeat.status,
+      activeLeases: input.agents.summary.activeLeases,
+      staleLeases: input.agents.summary.staleLeases,
+      activeQueueJobs: activeWork.length,
+      queuedJobs: durableQueue?.summary.queued ?? 0,
+      runningJobs: durableQueue?.summary.running ?? 0,
+      providerDeferredJobs,
+      failedQueueJobs,
+      retryableProviderDeferredJobs,
+      pendingHeads: queue?.summary.pending ?? 0,
+      coveredPendingHeads,
+      uncoveredPendingHeads: uncoveredPendingHeads.length,
+      providerDeferredHeads,
+      staleHeads,
+      readFailures,
+      expiredProviderCooldowns,
+      retryableExpiredProviderCooldowns,
+      coveredExpiredProviderCooldowns,
+      activeProviderCooldowns,
+      repoCooldowns: repoProviderCooldowns.length,
+      activeRepoCooldowns,
+      botProcesses: input.processes?.summary.total ?? 0
+    },
+    gates,
+    recommendedActions,
+    activeWork,
+    uncoveredPendingHeads,
+    release: input.release,
+    agents: input.agents,
+    ...(input.processes ? { processes: input.processes } : {}),
+    ...(durableQueue ? { durableQueue } : {}),
+    ...(queue ? { coverage: queue } : {}),
+    providerCooldowns,
+    repoProviderCooldowns
+  };
+}
+
+export function collectBotProcessInventory(input: {
+  repoPath: string;
+  launchdLabel: string;
+  launchdPid?: number;
+  now?: Date;
+}): RuntimeProcessInventory {
+  const now = input.now ?? new Date();
+  const result = spawnSync("ps", ["-axo", "pid=,ppid=,command="], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024
+  });
+  if (result.status !== 0) {
+    const error = redactSecrets(result.stderr.trim() || `ps exited with status ${result.status ?? "unknown"}`);
+    return emptyProcessInventory(now, [error]);
+  }
+  const rows = parseProcessRows(result.stdout);
+  return buildProcessInventory(filterBotProcessRows(rows, input), now);
+}
+
+export function filterBotProcessRows(
+  rows: RuntimeProcessRow[],
+  input: { repoPath: string; launchdLabel: string; launchdPid?: number }
+): RuntimeProcessRecord[] {
+  const repoPath = input.repoPath.trim();
+  const launchdLabel = input.launchdLabel.trim();
+  const included = new Map<number, RuntimeProcessRecord>();
+
+  for (const row of rows) {
+    const matchedBy: string[] = [];
+    if (input.launchdPid !== undefined && row.pid === input.launchdPid) matchedBy.push("launchd_pid");
+    if (repoPath && row.command.includes(repoPath)) matchedBy.push("repo_path");
+    if (launchdLabel && row.command.includes(launchdLabel)) matchedBy.push("launchd_label");
+    if (matchedBy.length > 0) {
+      included.set(row.pid, runtimeProcessRecord(row, matchedBy));
+    }
+  }
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const row of rows) {
+      if (included.has(row.pid)) continue;
+      if (!included.has(row.ppid)) continue;
+      if (!looksLikeBotRuntimeChild(row.command)) continue;
+      included.set(row.pid, runtimeProcessRecord(row, ["child_of_bot_process"]));
+      changed = true;
+    }
+  }
+
+  return [...included.values()].sort((left, right) => left.pid - right.pid);
+}
+
+export function formatRuntimeInventoryHuman(inventory: RuntimeInventory): string {
+  const lines = [
+    `runtime: ${inventory.classification} (${inventory.ok ? "ok" : "blocked"})`,
+    `checkedAt: ${inventory.checkedAt}`,
+    `launchd: ${inventory.summary.launchdState}` +
+      (inventory.release.launchd.pid ? ` pid=${inventory.release.launchd.pid}` : "") +
+      (inventory.release.launchd.configPath ? ` config=${inventory.release.launchd.configPath}` : ""),
+    `heartbeat: ${inventory.summary.heartbeatStatus}` +
+      (inventory.release.heartbeat.cycle !== undefined ? ` cycle=${inventory.release.heartbeat.cycle}` : "") +
+      (inventory.release.heartbeat.ageMs !== undefined ? ` ageMs=${inventory.release.heartbeat.ageMs}` : ""),
+    `repo: ${inventory.release.repo.branch}@${inventory.release.repo.head}` +
+      (inventory.release.repo.dirtyFiles.length > 0 ? ` dirty=${inventory.release.repo.dirtyFiles.length}` : " clean"),
+    `queue: active=${inventory.summary.activeQueueJobs} queued=${inventory.summary.queuedJobs}` +
+      ` running=${inventory.summary.runningJobs} providerDeferred=${inventory.summary.providerDeferredJobs}` +
+      ` failed=${inventory.summary.failedQueueJobs}`,
+    `pending: total=${inventory.summary.pendingHeads} covered=${inventory.summary.coveredPendingHeads}` +
+      ` uncovered=${inventory.summary.uncoveredPendingHeads}`,
+    `cooldowns: expired=${inventory.summary.expiredProviderCooldowns}` +
+      ` retryable=${inventory.summary.retryableExpiredProviderCooldowns}` +
+      ` covered=${inventory.summary.coveredExpiredProviderCooldowns}` +
+      ` activeRepo=${inventory.summary.activeRepoCooldowns}`,
+    `processes: botOwned=${inventory.summary.botProcesses}`,
+    `leases: active=${inventory.summary.activeLeases} stale=${inventory.summary.staleLeases}`
+  ];
+
+  const failingGates = inventory.gates.filter((gate) => !gate.ok);
+  if (failingGates.length > 0) {
+    lines.push("failingGates:");
+    for (const gate of failingGates) lines.push(`- ${gate.name}: ${gate.detail}`);
+  }
+  if (inventory.recommendedActions.length > 0) {
+    lines.push("recommendedActions:");
+    for (const action of inventory.recommendedActions) lines.push(`- ${action}`);
+  }
+  return lines.join("\n");
+}
+
 export function summarizeAgentInventory(input: {
   launchd: ReleaseLaunchdStatus;
   heartbeat: ReleaseHeartbeatStatus;
@@ -420,12 +739,11 @@ export function collectOperatorReviewQueue(
   const db = new DatabaseSync(statePath, { readOnly: true });
   try {
     if (!hasTable(db, "review_queue_jobs")) return emptyDurableQueue(now);
+    const selectColumns = reviewQueueSelectColumns(db);
     const rows = (input.repo
       ? db
           .prepare(
-            `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
-                    provider_id, priority, state, next_eligible_at, lease_id, session_id,
-                    comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+            `${selectColumns}
              from review_queue_jobs
              where repo = ?
              order by priority asc, datetime(created_at) asc`
@@ -433,9 +751,7 @@ export function collectOperatorReviewQueue(
           .all(input.repo)
       : db
           .prepare(
-            `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
-                    provider_id, priority, state, next_eligible_at, lease_id, session_id,
-                    comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+            `${selectColumns}
              from review_queue_jobs
              order by priority asc, datetime(created_at) asc`
           )
@@ -671,6 +987,10 @@ function isRetryableQueueJob(job: ReviewQueueJobRecord, now: Date): boolean {
   return !Number.isFinite(nextEligibleAtMs) || nextEligibleAtMs <= now.getTime();
 }
 
+function sameHead(job: ReviewQueueJobRecord, pending: OperatorQueueEntry): boolean {
+  return job.repo === pending.repo && job.pullNumber === pending.pullNumber && job.headSha === pending.headSha;
+}
+
 function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
   return {
     jobId: row.job_id,
@@ -687,6 +1007,7 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
     state: row.state,
     ...(row.next_eligible_at ? { nextEligibleAt: row.next_eligible_at } : {}),
     ...(row.lease_id ? { leaseId: row.lease_id } : {}),
+    ...(row.lease_expires_at ? { leaseExpiresAt: row.lease_expires_at } : {}),
     ...(row.session_id ? { sessionId: row.session_id } : {}),
     ...(row.comment_id ? { commentId: row.comment_id } : {}),
     ...(row.review_url ? { reviewUrl: row.review_url } : {}),
@@ -714,6 +1035,94 @@ function hasTable(db: DatabaseSync, tableName: string): boolean {
       .prepare("select 1 from sqlite_master where type = 'table' and name = ? limit 1")
       .get(tableName)
   );
+}
+
+function hasColumn(db: DatabaseSync, tableName: string, columnName: string): boolean {
+  const columns = db.prepare(`pragma table_info(${tableName})`).all() as unknown as Array<{ name: string }>;
+  return columns.some((column) => column.name === columnName);
+}
+
+function reviewQueueSelectColumns(db: DatabaseSync): string {
+  const leaseExpiresAtColumn = hasColumn(db, "review_queue_jobs", "lease_expires_at")
+    ? "lease_expires_at"
+    : "null as lease_expires_at";
+  return `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+                 provider_id, priority, state, next_eligible_at, lease_id, ${leaseExpiresAtColumn}, session_id,
+                 comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at`;
+}
+
+function emptyProcessInventory(now: Date, errors: string[] = []): RuntimeProcessInventory {
+  return {
+    ok: errors.length === 0,
+    checkedAt: now.toISOString(),
+    summary: {
+      total: 0,
+      launchdPidMatched: 0,
+      repoPathMatched: 0,
+      launchdLabelMatched: 0,
+      childProcessMatched: 0,
+      errors: errors.length
+    },
+    processes: [],
+    errors
+  };
+}
+
+function buildProcessInventory(processes: RuntimeProcessRecord[], now: Date): RuntimeProcessInventory {
+  return {
+    ok: true,
+    checkedAt: now.toISOString(),
+    summary: {
+      total: processes.length,
+      launchdPidMatched: processes.filter((processRow) => processRow.matchedBy.includes("launchd_pid")).length,
+      repoPathMatched: processes.filter((processRow) => processRow.matchedBy.includes("repo_path")).length,
+      launchdLabelMatched: processes.filter((processRow) => processRow.matchedBy.includes("launchd_label")).length,
+      childProcessMatched: processes.filter((processRow) => processRow.matchedBy.includes("child_of_bot_process")).length,
+      errors: 0
+    },
+    processes,
+    errors: []
+  };
+}
+
+function parseProcessRows(stdout: string): RuntimeProcessRow[] {
+  return stdout
+    .split("\n")
+    .map((line) => {
+      const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.+?)\s*$/);
+      if (!match) return undefined;
+      return {
+        pid: Number(match[1]),
+        ppid: Number(match[2]),
+        command: match[3] ?? ""
+      };
+    })
+    .filter((row): row is RuntimeProcessRow =>
+      row !== undefined && Number.isInteger(row.pid) && Number.isInteger(row.ppid)
+    );
+}
+
+function runtimeProcessRecord(row: RuntimeProcessRow, matchedBy: string[]): RuntimeProcessRecord {
+  const classification: RuntimeProcessRecord["classification"] = matchedBy.includes("launchd_pid")
+    ? "launchd_worker"
+    : matchedBy.includes("child_of_bot_process")
+      ? "child_process"
+      : "repo_command";
+  return {
+    pid: row.pid,
+    ppid: row.ppid,
+    classification,
+    matchedBy,
+    command: truncateCommand(redactSecrets(row.command))
+  };
+}
+
+function looksLikeBotRuntimeChild(command: string): boolean {
+  return /\b(node|tsx|npm|zcode|evaos-review-bot)\b/i.test(command) || command.includes("zcode.cjs");
+}
+
+function truncateCommand(command: string): string {
+  return command.length > 240 ? `${command.slice(0, 237)}...` : command;
 }
 
 interface ProcessedReviewRow {
@@ -749,6 +1158,7 @@ interface ReviewQueueJobRow {
   state: ReviewQueueJobState;
   next_eligible_at: string | null;
   lease_id: string | null;
+  lease_expires_at: string | null;
   session_id: string | null;
   comment_id: number | null;
   review_url: string | null;

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -5,16 +5,21 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import type { CoverageAuditReport } from "../src/coverage-audit.js";
 import {
+  buildRuntimeInventory,
   buildOperatorQueue,
   buildOperatorStatus,
   collectOperatorLeases,
   collectOperatorRepoProviderCooldowns,
   collectOperatorReviewQueue,
   explainPullStatus,
+  filterBotProcessRows,
+  formatRuntimeInventoryHuman,
   summarizeAgentInventory,
-  type OperatorAgentInventory
+  type OperatorAgentInventory,
+  type OperatorDurableQueueSnapshot
 } from "../src/operator-cli.js";
 import type { ReleaseStatus } from "../src/release-status.js";
+import type { RepoProviderCooldownRecord } from "../src/state.js";
 
 describe("operator CLI summaries", () => {
   const tempDirs: string[] = [];
@@ -83,6 +88,172 @@ describe("operator CLI summaries", () => {
     expect(status.recommendedActions).toContain("inspect operator queue failed jobs before promotion");
     expect(status.recommendedActions).toContain("retry or requeue provider-deferred jobs whose nextEligibleAt has expired");
     expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+  });
+
+  it("treats pending heads covered by durable queue work as healthy active runtime", () => {
+    const statePath = createTempDatabase(tempDirs);
+    const db = new DatabaseSync(statePath);
+    try {
+      db.exec("create table review_queue_jobs (job_id text primary key, attempt_id text not null unique, source text not null, lane text not null, repo text not null, org text not null, pull_number integer not null, head_sha text not null, base_sha text, provider_id text, priority integer not null, state text not null, next_eligible_at text, lease_id text, lease_expires_at text, session_id text, comment_id integer, review_url text, last_error text, created_at text not null, updated_at text not null, started_at text, finished_at text)");
+      insertQueueJob(db, "running", "owner/repo", 3, "head-pending");
+      db.prepare("update review_queue_jobs set lease_id = ?, lease_expires_at = ? where job_id = ?")
+        .run("lease-active", "2026-07-01T00:10:00.000Z", "running-head-pending");
+    } finally {
+      db.close();
+    }
+
+    const inventory = buildRuntimeInventory({
+      release: releaseStatus({ ok: true }),
+      coverage: coverageReport({ unprocessed: [pullEntry(3, "head-pending")] }),
+      agents: agentInventory({
+        ok: true,
+        activeLeases: [lease("lease-active", "2026-07-01T00:00:00.000Z", "2026-07-01T00:10:00.000Z")]
+      }),
+      durableQueue: collectOperatorReviewQueue(statePath, { now: new Date("2026-07-01T00:05:00.000Z") }),
+      providerCooldowns: [],
+      repoProviderCooldowns: [],
+      checkedAt: "2026-07-01T00:05:00.000Z"
+    });
+
+    expect(inventory.ok).toBe(true);
+    expect(inventory.runtimeState).toBe("healthy_active");
+    expect(inventory.classification).toBe("healthy_active");
+    expect(inventory.summary).toMatchObject({
+      pendingHeads: 1,
+      coveredPendingHeads: 1,
+      uncoveredPendingHeads: 0,
+      activeQueueJobs: 1,
+      runningJobs: 1
+    });
+    expect(inventory.activeWork[0]).toMatchObject({
+      repo: "owner/repo",
+      pullNumber: 3,
+      headSha: "head-pending",
+      leaseExpiresAt: "2026-07-01T00:10:00.000Z"
+    });
+    expect(inventory.gates).toContainEqual({
+      name: "runtime_pending_heads_covered",
+      ok: true,
+      detail: "1 pending head(s) covered by active durable queue work"
+    });
+    expect(JSON.stringify(inventory)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+  });
+
+  it("flags uncovered pending heads as blocked runtime inventory", () => {
+    const inventory = buildRuntimeInventory({
+      release: releaseStatus({ ok: true }),
+      coverage: coverageReport({ unprocessed: [pullEntry(3, "head-pending")] }),
+      agents: agentInventory({ ok: true }),
+      durableQueue: durableQueueSnapshot({ ok: true, summary: { total: 0, queued: 0, running: 0, providerDeferred: 0, retryableProviderDeferred: 0, failed: 0 } }),
+      providerCooldowns: [],
+      repoProviderCooldowns: [],
+      checkedAt: "2026-07-01T00:05:00.000Z"
+    });
+
+    expect(inventory.ok).toBe(false);
+    expect(inventory.runtimeState).toBe("blocked");
+    expect(inventory.classification).toBe("blocked");
+    expect(inventory.summary.uncoveredPendingHeads).toBe(1);
+    expect(inventory.uncoveredPendingHeads[0]).toMatchObject({
+      repo: "owner/repo",
+      pullNumber: 3,
+      headSha: "head-pending"
+    });
+    expect(inventory.gates).toContainEqual({
+      name: "runtime_pending_heads_covered",
+      ok: false,
+      detail: "1 pending head(s) without active durable queue work"
+    });
+  });
+
+  it("keeps covered expired provider cooldown rows from blocking runtime inventory", () => {
+    const inventory = buildRuntimeInventory({
+      release: releaseStatus({
+        ok: true,
+        database: {
+          providerCooldownCount: 1,
+          expiredProviderCooldownCount: 1,
+          activeGlobalProviderCooldownCount: 1,
+          coveredExpiredProviderCooldownCount: 1,
+          retryableExpiredProviderCooldownCount: 0,
+          providerThrottleState: "active"
+        }
+      }),
+      coverage: coverageReport({ ok: true }),
+      agents: agentInventory({ ok: true }),
+      durableQueue: durableQueueSnapshot({ ok: true, summary: cleanDurableQueueSummary() }),
+      providerCooldowns: [
+        {
+          ...processedRecord(3, "head-cooldown", "skipped"),
+          cooldownUntil: "2026-07-01T00:01:00.000Z",
+          reason: "provider_request_rate_limit",
+          expired: true
+        }
+      ],
+      repoProviderCooldowns: [repoProviderCooldown("owner/repo", "2026-07-01T00:10:00.000Z")],
+      checkedAt: "2026-07-01T00:05:00.000Z"
+    });
+
+    expect(inventory.ok).toBe(true);
+    expect(inventory.summary).toMatchObject({
+      expiredProviderCooldowns: 1,
+      retryableExpiredProviderCooldowns: 0,
+      coveredExpiredProviderCooldowns: 1,
+      activeRepoCooldowns: 1
+    });
+    expect(inventory.gates).toContainEqual({
+      name: "runtime_no_retryable_provider_cooldowns",
+      ok: true,
+      detail: "0 retryable expired provider cooldown row(s); 1 covered by active provider/repo cooldown"
+    });
+    expect(inventory.recommendedActions).not.toContain("retry expired provider cooldowns or inspect provider health");
+  });
+
+  it("formats a concise human runtime inventory without leaking secrets", () => {
+    const inventory = buildRuntimeInventory({
+      release: releaseStatus({ ok: true }),
+      coverage: coverageReport({ ok: true }),
+      agents: agentInventory({ ok: true }),
+      durableQueue: durableQueueSnapshot({ ok: true, summary: cleanDurableQueueSummary() }),
+      providerCooldowns: [],
+      repoProviderCooldowns: [],
+      checkedAt: "2026-07-01T00:05:00.000Z"
+    });
+
+    const output = formatRuntimeInventoryHuman(inventory);
+
+    expect(output).toContain("runtime: healthy_idle (ok)");
+    expect(output).toContain("queue: active=0 queued=0 running=0 providerDeferred=0 failed=0");
+    expect(output).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+  });
+
+  it("filters runtime processes to bot-owned rows and redacts command text", () => {
+    const rows = [
+      { pid: 10, ppid: 1, command: "node /Volumes/LEXAR/repos/evaos-code-review-bot/dist/cli.js daemon --config live.json --token=ghp_123456789012345678901234" },
+      { pid: 11, ppid: 10, command: "node /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs --cwd /Volumes/LEXAR/repos/some-worktree" },
+      { pid: 12, ppid: 1, command: "node /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs --cwd /Users/lume/other" },
+      { pid: 13, ppid: 1, command: "node /tmp/not-the-bot.js" },
+      { pid: 14, ppid: 13, command: "node child-of-non-bot.js" },
+      { pid: 15, ppid: 1, command: "tsx src/cli.ts daemon --launchd-label com.electricsheephq.evaos-code-review-bot" }
+    ];
+
+    const processes = filterBotProcessRows(rows, {
+      repoPath: "/Volumes/LEXAR/repos/evaos-code-review-bot",
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      launchdPid: 10
+    });
+
+    expect(processes.map((processRow) => processRow.pid)).toEqual([10, 11, 15]);
+    expect(processes[0]).toMatchObject({
+      classification: "launchd_worker",
+      matchedBy: ["launchd_pid", "repo_path"]
+    });
+    expect(processes[1]).toMatchObject({
+      classification: "child_process",
+      matchedBy: ["child_of_bot_process"]
+    });
+    expect(JSON.stringify(processes)).not.toMatch(/ghp_123456789012345678901234/);
+    expect(JSON.stringify(processes)).toContain("[redacted-secret]");
   });
 
   it("summarizes active and stale agent leases without mutating runtime state", () => {
@@ -317,7 +488,13 @@ function createTempDatabase(tempDirs: string[]): string {
   return join(dir, "state.sqlite");
 }
 
-function releaseStatus(input: { ok: boolean; recommendedActions?: string[] }): ReleaseStatus {
+function releaseStatus(input: {
+  ok: boolean;
+  recommendedActions?: string[];
+  database?: Partial<ReleaseStatus["database"]>;
+}): ReleaseStatus {
+  const providerCooldownCount = input.database?.providerCooldownCount ?? (input.ok ? 0 : 1);
+  const expiredProviderCooldownCount = input.database?.expiredProviderCooldownCount ?? providerCooldownCount;
   return {
     ok: input.ok,
     checkedAt: "2026-07-01T00:30:00.000Z",
@@ -332,9 +509,10 @@ function releaseStatus(input: { ok: boolean; recommendedActions?: string[] }): R
     database: {
       rowCount: 10,
       errorCount: 0,
-      providerCooldownCount: 1,
-      expiredProviderCooldownCount: 1,
-      activeProviderCooldownCount: 0
+      providerCooldownCount,
+      expiredProviderCooldownCount,
+      activeProviderCooldownCount: 0,
+      ...input.database
     },
     heartbeat: {
       status: "fresh",
@@ -346,7 +524,15 @@ function releaseStatus(input: { ok: boolean; recommendedActions?: string[] }): R
       dryRun: false
     },
     recommendedActions: input.recommendedActions ?? [],
-    gates: [{ name: "provider_cooldown_backlog", ok: false, detail: "1 expired provider cooldown row(s)" }],
+    gates: [
+      {
+        name: "provider_cooldown_backlog",
+        ok: input.ok,
+        detail: input.ok
+          ? `${input.database?.retryableExpiredProviderCooldownCount ?? expiredProviderCooldownCount} expired provider cooldown row(s)`
+          : "1 expired provider cooldown row(s)"
+      }
+    ],
     rollback: {
       restartCommand: "launchctl kickstart -k gui/501/com.electricsheephq.evaos-code-review-bot",
       unloadCommand: "launchctl bootout gui/501 ~/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist"
@@ -424,6 +610,15 @@ function processedRecord(pullNumber: number, headSha: string, status: "posted" |
   };
 }
 
+function repoProviderCooldown(repo: string, cooldownUntil: string): RepoProviderCooldownRecord {
+  return {
+    repo,
+    cooldownUntil,
+    reason: "provider_request_rate_limit",
+    updatedAt: "2026-07-01T00:00:00.000Z"
+  };
+}
+
 function lease(
   leaseId: string,
   startedAt: string,
@@ -458,23 +653,42 @@ function agentInventory(input: Partial<OperatorAgentInventory>): OperatorAgentIn
   };
 }
 
-function durableQueueSnapshot() {
+function durableQueueSnapshot(input: {
+  ok?: boolean;
+  summary?: Partial<OperatorDurableQueueSnapshot["summary"]>;
+  jobs?: OperatorDurableQueueSnapshot["jobs"];
+  byRepo?: OperatorDurableQueueSnapshot["byRepo"];
+} = {}): OperatorDurableQueueSnapshot {
   return {
-    ok: false,
+    ok: input.ok ?? false,
     checkedAt: "2026-07-01T00:30:00.000Z",
     summary: {
-      total: 4,
-      queued: 1,
-      leased: 0,
-      running: 1,
-      providerDeferred: 1,
-      retryableProviderDeferred: 1,
-      posted: 0,
-      failed: 1,
-      retired: 0
+      total: input.summary?.total ?? 4,
+      queued: input.summary?.queued ?? 1,
+      leased: input.summary?.leased ?? 0,
+      running: input.summary?.running ?? 1,
+      providerDeferred: input.summary?.providerDeferred ?? 1,
+      retryableProviderDeferred: input.summary?.retryableProviderDeferred ?? 1,
+      posted: input.summary?.posted ?? 0,
+      failed: input.summary?.failed ?? 1,
+      retired: input.summary?.retired ?? 0
     },
-    jobs: [],
-    byRepo: []
+    jobs: input.jobs ?? [],
+    byRepo: input.byRepo ?? []
+  };
+}
+
+function cleanDurableQueueSummary(): Partial<OperatorDurableQueueSnapshot["summary"]> {
+  return {
+    total: 0,
+    queued: 0,
+    leased: 0,
+    running: 0,
+    providerDeferred: 0,
+    retryableProviderDeferred: 0,
+    posted: 0,
+    failed: 0,
+    retired: 0
   };
 }
 


### PR DESCRIPTION
## Summary

Adds a read-only `runtime-inventory` operator command for #84 so release operators can distinguish:

- `healthy_idle`: worker is up and no live work is pending.
- `healthy_active`: open PR heads are present but already covered by active durable queue work.
- `blocked`: launchd/config/heartbeat/queue/cooldown/read/process gates need action.

This keeps the stricter `status` command intact while adding a release-friendly classifier for live churn after scheduler activation.

## Changes

- Add `runtime-inventory` JSON output and `--human` summary mode.
- Include launchd, release head, heartbeat, leases, queue jobs, coverage, provider cooldowns, and bot-owned process inventory.
- Bound process matching to the launchd worker PID, current bot repo path, launchd label, and children of already-matched bot processes.
- Redact token/private-key-like command text before process rows are emitted.
- Treat expired processed cooldown rows as non-blocking when release status says they are covered by an active repo/global provider cooldown.
- Prevent `--limit` from changing runtime health verdict inputs.
- Document the distinction between `status` and `runtime-inventory`.

## Validation

- `npm test -- tests/operator-cli.test.ts`
- `npm run build`
- `git diff --check -- src/cli.ts src/operator-cli.ts tests/operator-cli.test.ts docs/operator-cli.md`
- Spec review subagent: no spec issues, #84 acceptance criteria met.
- Code quality review subagent: no issues; verified prior `--limit` and covered-cooldown findings are fixed.

## Runtime Smoke

Read-only smoke using the built worktree CLI from `/Volumes/LEXAR/repos/evaos-code-review-bot` showed the command renders correctly. It also found the live checkout currently has unrelated dirty files and is on `activate-commands-reposticky-sessions`, so live release gates are blocked outside this PR:

- `src/scheduler.ts`
- `src/worker.ts`
- `tests/scheduler.test.ts`

This PR does not touch live config, launchd, tags, or release state.

Closes #84.
Refs #78, #28, #3.
