### PR TITLE
Add sticky review status comments

### DIFF
--- a/docs/review-status-comments.md
+++ b/docs/review-status-comments.md
@@ -29,6 +29,7 @@ Supported states:
 - `provider_deferred`
 - `stale_head`
 - `closed_or_merged_before_review`
+- `skipped`
 - `failed`
 
 `provider_deferred` is not a settled state. It means the provider cooldown lane
@@ -39,10 +40,10 @@ the live head's queued or in-progress status. This intentionally follows the
 same broad pattern used by CodeRabbit and ClawSweeper: acknowledge quickly,
 then edit a durable comment into the final state.
 
-Manual `review` / `re-review` commands may move directly from `queued` to
-`completed`; command acknowledgement/state lives in the separate command lane.
-Non-review commands such as `stop` and `explain` do not create review status
-comments.
+Manual `review` / `re-review` commands intentionally use a quieter lifecycle
+and may move directly from `queued` to `completed`; command
+acknowledgement/state lives in the separate command lane. Non-review commands
+such as `stop` and `explain` do not create review status comments.
 
 This is a soft coordination signal for humans and agents. It does not block
 GitHub merges by itself. Requiring the bot before merge should be implemented
@@ -53,4 +54,6 @@ Operator status includes `statusCommentFailures`. A non-zero value means the
 sticky status lane could not post or edit at least one comment, usually because
 App credentials were unavailable or GitHub rejected the upsert. The review run
 may still complete, but operators should treat the coordination signal as
-degraded until the next green release/status cycle.
+degraded until the next green release/status cycle. Token-mode deployments
+without GitHub App credentials should keep `reviewStatusComment.enabled=false`
+or expect `missing_app_credentials` failures while the lane is enabled.

--- a/docs/review-status-comments.md
+++ b/docs/review-status-comments.md
@@ -1,0 +1,37 @@
+# Review Status Comments
+
+`evaos-code-review-bot` can post one App-authored status comment per PR head as
+soon as that head enters the durable review queue. The comment is marker-backed
+and edited in place as the head moves through the review lifecycle.
+
+The identity marker is stable for one repo, pull request, and head SHA:
+
+```html
+<!-- evaos-code-review-bot:review-status repo=OWNER/REPO pr=123 sha=HEAD_SHA -->
+```
+
+The mutable state marker is updated with each lifecycle state:
+
+```html
+<!-- evaos-code-review-bot:review-status-state status=queued updated_at=... -->
+```
+
+Supported states:
+
+- `queued`
+- `in_progress`
+- `completed`
+- `provider_deferred`
+- `stale_head`
+- `closed_or_merged_before_review`
+- `failed`
+
+The marker is head-specific so a stale worker for an older head cannot overwrite
+the live head's queued or in-progress status. This intentionally follows the
+same broad pattern used by CodeRabbit and ClawSweeper: acknowledge quickly,
+then edit a durable comment into the final state.
+
+This is a soft coordination signal for humans and agents. It does not block
+GitHub merges by itself. Requiring the bot before merge should be implemented
+later with a dedicated GitHub Check and branch protection after the comment lane
+has proven quiet.

--- a/docs/review-status-comments.md
+++ b/docs/review-status-comments.md
@@ -4,6 +4,11 @@
 soon as that head enters the durable review queue. The comment is marker-backed
 and edited in place as the head moves through the review lifecycle.
 
+The lane is default-off in the built-in config. Enable it only through explicit
+runtime config after a dry-run/release-status gate. Rollback is setting
+`reviewStatusComment.enabled=false`, redeploying the config, restarting launchd,
+and confirming the next `release:status` cycle is green.
+
 The identity marker is stable for one repo, pull request, and head SHA:
 
 ```html
@@ -25,6 +30,9 @@ Supported states:
 - `stale_head`
 - `closed_or_merged_before_review`
 - `failed`
+
+`provider_deferred` is not a settled state. It means the provider cooldown lane
+still intends to retry later; agents should keep waiting or inspect bot status.
 
 The marker is head-specific so a stale worker for an older head cannot overwrite
 the live head's queued or in-progress status. This intentionally follows the

--- a/docs/review-status-comments.md
+++ b/docs/review-status-comments.md
@@ -39,6 +39,11 @@ the live head's queued or in-progress status. This intentionally follows the
 same broad pattern used by CodeRabbit and ClawSweeper: acknowledge quickly,
 then edit a durable comment into the final state.
 
+Manual `review` / `re-review` commands may move directly from `queued` to
+`completed`; command acknowledgement/state lives in the separate command lane.
+Non-review commands such as `stop` and `explain` do not create review status
+comments.
+
 This is a soft coordination signal for humans and agents. It does not block
 GitHub merges by itself. Requiring the bot before merge should be implemented
 later with a dedicated GitHub Check and branch protection after the comment lane

--- a/docs/review-status-comments.md
+++ b/docs/review-status-comments.md
@@ -48,3 +48,9 @@ This is a soft coordination signal for humans and agents. It does not block
 GitHub merges by itself. Requiring the bot before merge should be implemented
 later with a dedicated GitHub Check and branch protection after the comment lane
 has proven quiet.
+
+Operator status includes `statusCommentFailures`. A non-zero value means the
+sticky status lane could not post or edit at least one comment, usually because
+App credentials were unavailable or GitHub rejected the upsert. The review run
+may still complete, but operators should treat the coordination signal as
+degraded until the next green release/status cycle.

--- a/docs/review-status-comments.md
+++ b/docs/review-status-comments.md
@@ -32,8 +32,9 @@ Supported states:
 - `skipped`
 - `failed`
 
-`provider_deferred` is not a settled state. It means the provider cooldown lane
-still intends to retry later; agents should keep waiting or inspect bot status.
+`provider_deferred` is not a settled state. It means provider availability,
+provider cooldown, or worker capacity still intends to retry later; agents
+should keep waiting or inspect bot status.
 
 The marker is head-specific so a stale worker for an older head cannot overwrite
 the live head's queued or in-progress status. This intentionally follows the

--- a/docs/review-status-comments.md
+++ b/docs/review-status-comments.md
@@ -53,8 +53,9 @@ has proven quiet.
 
 Operator status includes `statusCommentFailures`. A non-zero value means the
 sticky status lane could not post or edit at least one comment, usually because
-App credentials were unavailable or GitHub rejected the upsert. The review run
-may still complete, but operators should treat the coordination signal as
-degraded until the next green release/status cycle. Token-mode deployments
-without GitHub App credentials should keep `reviewStatusComment.enabled=false`
-or expect `missing_app_credentials` failures while the lane is enabled.
+App credentials were unavailable, comment construction failed, or GitHub
+rejected the upsert. The review run may still complete, but operators should
+treat the coordination signal as degraded until the next green release/status
+cycle. Token-mode deployments without GitHub App credentials should keep
+`reviewStatusComment.enabled=false` or expect `missing_app_credentials` failures
+while the lane is enabled.

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,9 @@ export interface BotConfig {
     enabled: boolean;
     postIssueComment: boolean;
   };
+  reviewStatusComment?: {
+    enabled: boolean;
+  };
   repoProfiles?: RepoProfilesConfig;
   commands: CommandConfig;
   zcode: {
@@ -169,6 +172,9 @@ const DEFAULT_CONFIG: BotConfig = {
     enabled: true,
     postIssueComment: false
   },
+  reviewStatusComment: {
+    enabled: true
+  },
   commands: {
     enabled: false,
     botMentions: ["@evaos-code-review-bot"],
@@ -241,6 +247,9 @@ function validateConfig(config: BotConfig): void {
   validatePositiveInteger(config.providerCooldown.transientRetryMaxDelayMs, "config.providerCooldown.transientRetryMaxDelayMs");
   validateBoolean(config.walkthrough.enabled, "config.walkthrough.enabled");
   validateBoolean(config.walkthrough.postIssueComment, "config.walkthrough.postIssueComment");
+  const reviewStatusComment = config.reviewStatusComment ?? DEFAULT_CONFIG.reviewStatusComment!;
+  config.reviewStatusComment = reviewStatusComment;
+  validateBoolean(reviewStatusComment.enabled, "config.reviewStatusComment.enabled");
   validateBoolean(config.commands.enabled, "config.commands.enabled");
   validateStringArray(config.commands.botMentions, "config.commands.botMentions");
   validateStringArray(config.commands.trustedAuthors, "config.commands.trustedAuthors");

--- a/src/config.ts
+++ b/src/config.ts
@@ -173,7 +173,7 @@ const DEFAULT_CONFIG: BotConfig = {
     postIssueComment: false
   },
   reviewStatusComment: {
-    enabled: true
+    enabled: false
   },
   commands: {
     enabled: false,

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -22,7 +22,7 @@ export interface ReviewStatusCommentGithub {
 
 export type ReviewStatusCommentPostResult =
   | { posted: true; action: "created" | "updated"; html_url?: string; id: number; state: ReviewStatusCommentState }
-  | { posted: false; reason: "disabled" | "dry_run" | "missing_app_credentials" | "upsert_failed"; state: ReviewStatusCommentState; error?: string };
+  | { posted: false; reason: "disabled" | "dry_run" | "missing_app_credentials" | "build_failed" | "upsert_failed"; state: ReviewStatusCommentState; error?: string };
 
 export interface BuildReviewStatusCommentInput {
   repo: string;
@@ -103,8 +103,19 @@ export async function postReviewStatusComment(input: {
   if (input.dryRun) return { posted: false, reason: "dry_run", state: input.state };
   if (!input.github.canPostAsApp()) return { posted: false, reason: "missing_app_credentials", state: input.state };
 
+  let comment: ReturnType<typeof buildReviewStatusComment>;
   try {
-    const comment = buildReviewStatusComment(input);
+    comment = buildReviewStatusComment(input);
+  } catch (error) {
+    return {
+      posted: false,
+      reason: "build_failed",
+      state: input.state,
+      error: redactSecrets(error instanceof Error ? error.message : String(error))
+    };
+  }
+
+  try {
     const result = await input.github.upsertIssueComment({
       repo: input.repo,
       issueNumber: input.pullNumber,

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -37,12 +37,16 @@ export interface BuildReviewStatusCommentInput {
 
 export const REVIEW_STATUS_MARKER_PREFIX = "<!-- evaos-code-review-bot:review-status";
 const REVIEW_STATUS_STATE_MARKER_PREFIX = "<!-- evaos-code-review-bot:review-status-state";
+const REPO_SLUG_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const HEAD_SHA_PATTERN = /^[0-9a-f]{6,64}$/i;
+const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/g;
 
 export function buildReviewStatusMarker(input: {
   repo: string;
   pullNumber: number;
   headSha: string;
 }): string {
+  validateMarkerIdentity(input);
   return `${REVIEW_STATUS_MARKER_PREFIX} repo=${input.repo} pr=${input.pullNumber} sha=${input.headSha} -->`;
 }
 
@@ -52,23 +56,24 @@ export function buildReviewStatusComment(input: BuildReviewStatusCommentInput): 
 } {
   const marker = buildReviewStatusMarker(input);
   const updatedAt = (input.now ?? new Date()).toISOString();
-  const title = input.pullTitle ? ` - ${input.pullTitle}` : "";
+  const title = formatInlinePublicText(input.pullTitle);
+  const details = sanitizePublicText(input.details);
   const lines = [
     marker,
     `${REVIEW_STATUS_STATE_MARKER_PREFIX} status=${input.state} updated_at=${updatedAt} -->`,
     "",
     `## evaOS review status: ${formatStatus(input.state)}`,
     "",
-    `PR: ${input.repo}#${input.pullNumber}${title}`,
+    `PR: ${input.repo}#${input.pullNumber}${title ? ` - ${title}` : ""}`,
     `Head: \`${input.headSha}\``,
     `Updated: ${updatedAt}`,
     "",
     statusMessage(input),
     "",
-    "Automation note: agents should wait for this comment to reach `completed`, `stale_head`, `closed_or_merged_before_review`, `provider_deferred`, or `failed` before treating evaOS review as settled for this head.",
+    "Automation note: agents should wait for this comment to reach `completed`, `stale_head`, `closed_or_merged_before_review`, or `failed` before treating evaOS review as settled for this head. `provider_deferred` means evaOS still intends to retry.",
     ...(input.pullUrl ? ["", `PR URL: ${input.pullUrl}`] : []),
     ...(input.reviewUrl ? ["", `Review URL: ${input.reviewUrl}`] : []),
-    ...(input.details ? ["", `Details: ${input.details}`] : [])
+    ...(details ? ["", `Details: ${details}`] : [])
   ];
 
   return {
@@ -116,6 +121,23 @@ export async function postReviewStatusComment(input: {
 
 function formatStatus(state: ReviewStatusCommentState): string {
   return state.replaceAll("_", " ");
+}
+
+function validateMarkerIdentity(input: { repo: string; pullNumber: number; headSha: string }): void {
+  if (!REPO_SLUG_PATTERN.test(input.repo)) throw new Error(`Invalid review status repo slug: ${input.repo}`);
+  if (!Number.isInteger(input.pullNumber) || input.pullNumber <= 0) {
+    throw new Error(`Invalid review status pull number: ${input.pullNumber}`);
+  }
+  if (!HEAD_SHA_PATTERN.test(input.headSha)) throw new Error(`Invalid review status head SHA: ${input.headSha}`);
+}
+
+function sanitizePublicText(value: string | undefined): string {
+  if (!value) return "";
+  return redactSecrets(value.replace(HTML_COMMENT_PATTERN, "[hidden comment removed]")).trim();
+}
+
+function formatInlinePublicText(value: string | undefined): string {
+  return sanitizePublicText(value).replace(/\s+/g, " ").trim();
 }
 
 function statusMessage(input: BuildReviewStatusCommentInput): string {

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -140,7 +140,11 @@ function sanitizePublicText(value: string | undefined): string {
 }
 
 function formatInlinePublicText(value: string | undefined): string {
-  return sanitizePublicText(value).replace(/\s+/g, " ").trim();
+  return sanitizePublicText(value)
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^#{1,6}\s+/, "")
+    .slice(0, 200);
 }
 
 function statusMessage(input: BuildReviewStatusCommentInput): string {
@@ -152,7 +156,7 @@ function statusMessage(input: BuildReviewStatusCommentInput): string {
     case "completed":
       return "evaOS review completed for this PR head.";
     case "provider_deferred":
-      return "evaOS review is deferred because the model provider is temporarily unavailable or rate-limited. The worker will retry according to cooldown policy.";
+      return "evaOS review is deferred because the model provider or worker capacity is temporarily unavailable. The worker will retry according to cooldown policy.";
     case "stale_head":
       return "evaOS review stopped because this queued head is no longer the live PR head.";
     case "closed_or_merged_before_review":

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -102,8 +102,8 @@ export async function postReviewStatusComment(input: {
   if (input.dryRun) return { posted: false, reason: "dry_run", state: input.state };
   if (!input.github.canPostAsApp()) return { posted: false, reason: "missing_app_credentials", state: input.state };
 
-  const comment = buildReviewStatusComment(input);
   try {
+    const comment = buildReviewStatusComment(input);
     const result = await input.github.upsertIssueComment({
       repo: input.repo,
       issueNumber: input.pullNumber,

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -58,6 +58,8 @@ export function buildReviewStatusComment(input: BuildReviewStatusCommentInput): 
   const updatedAt = (input.now ?? new Date()).toISOString();
   const title = formatInlinePublicText(input.pullTitle);
   const details = sanitizePublicText(input.details);
+  const pullUrl = sanitizePublicText(input.pullUrl);
+  const reviewUrl = sanitizePublicText(input.reviewUrl);
   const lines = [
     marker,
     `${REVIEW_STATUS_STATE_MARKER_PREFIX} status=${input.state} updated_at=${updatedAt} -->`,
@@ -71,8 +73,8 @@ export function buildReviewStatusComment(input: BuildReviewStatusCommentInput): 
     statusMessage(input),
     "",
     "Automation note: agents should wait for this comment to reach `completed`, `stale_head`, `closed_or_merged_before_review`, or `failed` before treating evaOS review as settled for this head. `provider_deferred` means evaOS still intends to retry.",
-    ...(input.pullUrl ? ["", `PR URL: ${input.pullUrl}`] : []),
-    ...(input.reviewUrl ? ["", `Review URL: ${input.reviewUrl}`] : []),
+    ...(pullUrl ? ["", `PR URL: ${pullUrl}`] : []),
+    ...(reviewUrl ? ["", `Review URL: ${reviewUrl}`] : []),
     ...(details ? ["", `Details: ${details}`] : [])
   ];
 

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -7,6 +7,7 @@ export type ReviewStatusCommentState =
   | "provider_deferred"
   | "stale_head"
   | "closed_or_merged_before_review"
+  | "skipped"
   | "failed";
 
 export interface ReviewStatusCommentGithub {
@@ -72,7 +73,7 @@ export function buildReviewStatusComment(input: BuildReviewStatusCommentInput): 
     "",
     statusMessage(input),
     "",
-    "Automation note: agents should wait for this comment to reach `completed`, `stale_head`, `closed_or_merged_before_review`, or `failed` before treating evaOS review as settled for this head. `provider_deferred` means evaOS still intends to retry.",
+    "Automation note: agents should wait for this comment to reach `completed`, `stale_head`, `closed_or_merged_before_review`, `skipped`, or `failed` before treating evaOS review as settled for this head. `provider_deferred` means evaOS still intends to retry.",
     ...(pullUrl ? ["", `PR URL: ${pullUrl}`] : []),
     ...(reviewUrl ? ["", `Review URL: ${reviewUrl}`] : []),
     ...(details ? ["", `Details: ${details}`] : [])
@@ -156,6 +157,8 @@ function statusMessage(input: BuildReviewStatusCommentInput): string {
       return "evaOS review stopped because this queued head is no longer the live PR head.";
     case "closed_or_merged_before_review":
       return "evaOS review stopped because the PR closed or merged before this queued head could be reviewed.";
+    case "skipped":
+      return "evaOS review was intentionally skipped for this head because current repo, PR, or policy state says it should not run.";
     case "failed":
       return "evaOS review failed for this head and needs retry or operator attention.";
     default:

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -1,0 +1,144 @@
+import { redactSecrets } from "./secrets.js";
+
+export type ReviewStatusCommentState =
+  | "queued"
+  | "in_progress"
+  | "completed"
+  | "provider_deferred"
+  | "stale_head"
+  | "closed_or_merged_before_review"
+  | "failed";
+
+export interface ReviewStatusCommentGithub {
+  canPostAsApp(): boolean;
+  upsertIssueComment(input: {
+    repo: string;
+    issueNumber: number;
+    marker: string;
+    body: string;
+  }): Promise<{ action: "created" | "updated"; html_url?: string; id: number }>;
+}
+
+export type ReviewStatusCommentPostResult =
+  | { posted: true; action: "created" | "updated"; html_url?: string; id: number; state: ReviewStatusCommentState }
+  | { posted: false; reason: "disabled" | "dry_run" | "missing_app_credentials" | "upsert_failed"; state: ReviewStatusCommentState; error?: string };
+
+export interface BuildReviewStatusCommentInput {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  state: ReviewStatusCommentState;
+  pullTitle?: string;
+  pullUrl?: string;
+  reviewUrl?: string;
+  details?: string;
+  now?: Date;
+}
+
+export const REVIEW_STATUS_MARKER_PREFIX = "<!-- evaos-code-review-bot:review-status";
+const REVIEW_STATUS_STATE_MARKER_PREFIX = "<!-- evaos-code-review-bot:review-status-state";
+
+export function buildReviewStatusMarker(input: {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+}): string {
+  return `${REVIEW_STATUS_MARKER_PREFIX} repo=${input.repo} pr=${input.pullNumber} sha=${input.headSha} -->`;
+}
+
+export function buildReviewStatusComment(input: BuildReviewStatusCommentInput): {
+  marker: string;
+  body: string;
+} {
+  const marker = buildReviewStatusMarker(input);
+  const updatedAt = (input.now ?? new Date()).toISOString();
+  const title = input.pullTitle ? ` - ${input.pullTitle}` : "";
+  const lines = [
+    marker,
+    `${REVIEW_STATUS_STATE_MARKER_PREFIX} status=${input.state} updated_at=${updatedAt} -->`,
+    "",
+    `## evaOS review status: ${formatStatus(input.state)}`,
+    "",
+    `PR: ${input.repo}#${input.pullNumber}${title}`,
+    `Head: \`${input.headSha}\``,
+    `Updated: ${updatedAt}`,
+    "",
+    statusMessage(input),
+    "",
+    "Automation note: agents should wait for this comment to reach `completed`, `stale_head`, `closed_or_merged_before_review`, `provider_deferred`, or `failed` before treating evaOS review as settled for this head.",
+    ...(input.pullUrl ? ["", `PR URL: ${input.pullUrl}`] : []),
+    ...(input.reviewUrl ? ["", `Review URL: ${input.reviewUrl}`] : []),
+    ...(input.details ? ["", `Details: ${input.details}`] : [])
+  ];
+
+  return {
+    marker,
+    body: redactSecrets(lines.join("\n"))
+  };
+}
+
+export async function postReviewStatusComment(input: {
+  enabled: boolean;
+  dryRun: boolean;
+  github: ReviewStatusCommentGithub;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  state: ReviewStatusCommentState;
+  pullTitle?: string;
+  pullUrl?: string;
+  reviewUrl?: string;
+  details?: string;
+  now?: Date;
+}): Promise<ReviewStatusCommentPostResult> {
+  if (!input.enabled) return { posted: false, reason: "disabled", state: input.state };
+  if (input.dryRun) return { posted: false, reason: "dry_run", state: input.state };
+  if (!input.github.canPostAsApp()) return { posted: false, reason: "missing_app_credentials", state: input.state };
+
+  const comment = buildReviewStatusComment(input);
+  try {
+    const result = await input.github.upsertIssueComment({
+      repo: input.repo,
+      issueNumber: input.pullNumber,
+      marker: comment.marker,
+      body: comment.body
+    });
+    return { posted: true, state: input.state, ...result };
+  } catch (error) {
+    return {
+      posted: false,
+      reason: "upsert_failed",
+      state: input.state,
+      error: redactSecrets(error instanceof Error ? error.message : String(error))
+    };
+  }
+}
+
+function formatStatus(state: ReviewStatusCommentState): string {
+  return state.replaceAll("_", " ");
+}
+
+function statusMessage(input: BuildReviewStatusCommentInput): string {
+  switch (input.state) {
+    case "queued":
+      return "This PR head has entered the evaOS review queue. No final evaOS review has posted for this head yet.";
+    case "in_progress":
+      return "evaOS review is running for this PR head.";
+    case "completed":
+      return "evaOS review completed for this PR head.";
+    case "provider_deferred":
+      return "evaOS review is deferred because the model provider is temporarily unavailable or rate-limited. The worker will retry according to cooldown policy.";
+    case "stale_head":
+      return "evaOS review stopped because this queued head is no longer the live PR head.";
+    case "closed_or_merged_before_review":
+      return "evaOS review stopped because the PR closed or merged before this queued head could be reviewed.";
+    case "failed":
+      return "evaOS review failed for this head and needs retry or operator attention.";
+    default:
+      return assertNever(input.state);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled review status comment state: ${String(value)}`);
+}

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -38,7 +38,7 @@ export interface BuildReviewStatusCommentInput {
 export const REVIEW_STATUS_MARKER_PREFIX = "<!-- evaos-code-review-bot:review-status";
 const REVIEW_STATUS_STATE_MARKER_PREFIX = "<!-- evaos-code-review-bot:review-status-state";
 const REPO_SLUG_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
-const HEAD_SHA_PATTERN = /^[0-9a-f]{6,64}$/i;
+const HEAD_SHA_PATTERN = /^[0-9a-f]{40}$/i;
 const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/g;
 
 export function buildReviewStatusMarker(input: {

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -81,7 +81,7 @@ export function buildReviewStatusComment(input: BuildReviewStatusCommentInput): 
 
   return {
     marker,
-    body: redactSecrets(lines.join("\n"))
+    body: lines.join("\n")
   };
 }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -305,10 +305,11 @@ async function retireSupersededQueueJobsForPull(input: {
   now: Date;
   onStatusCommentFailure?: () => void;
 }): Promise<void> {
-  const jobs = input.state.listReviewQueueJobs({
+  const jobs = input.state.listReviewQueueJobsForPull({
     repo: input.repo,
+    pullNumber: input.pull.number,
     states: ["queued", "provider_deferred"]
-  }).filter((job) => job.pullNumber === input.pull.number && job.headSha !== input.pull.head.sha);
+  }).filter((job) => job.headSha !== input.pull.head.sha);
 
   for (const job of jobs) {
     input.state.updateReviewQueueJobState({
@@ -341,10 +342,11 @@ async function retireQueuedJobsForClosedPull(input: {
   now: Date;
   onStatusCommentFailure?: () => void;
 }): Promise<void> {
-  const jobs = input.state.listReviewQueueJobs({
+  const jobs = input.state.listReviewQueueJobsForPull({
     repo: input.repo,
+    pullNumber: input.pull.number,
     states: ["queued", "provider_deferred"]
-  }).filter((job) => job.pullNumber === input.pull.number);
+  });
 
   for (const job of jobs) {
     input.state.updateReviewQueueJobState({
@@ -689,7 +691,7 @@ function reviewResultStatusCommentState(status: ReviewPullResult): ReviewStatusC
     case "skipped_stale_head":
       return "stale_head";
     case "skipped_capacity":
-      return "queued";
+      return undefined;
     case "skipped_draft":
     case "skipped_canary":
     case "skipped_policy":

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -190,6 +190,7 @@ async function enqueuePullIfEligible(input: {
 
   const commandDecision = await resolveSchedulerCommandDecision(input);
   if (commandDecision.action !== "none") {
+    await retireSupersededQueueJobsForPull(input);
     const queued = enqueueReviewJob(input, commandDecision);
     if (queued.enqueued && commandDecision.shouldReview) {
       await syncReviewStatusComment({
@@ -205,6 +206,7 @@ async function enqueuePullIfEligible(input: {
     return queued.enqueued ? "enqueued" : "already_queued";
   }
 
+  await retireSupersededQueueJobsForPull(input);
   if (input.state.hasProcessed(input.repo, input.pull.number, input.pull.head.sha)) return "skipped_processed";
   if (hasActiveQueueJobForHead(input.state, input.repo, input.pull.number, input.pull.head.sha)) return "already_queued";
   if (!hasRepoQueueCapacity(input.state, input.repo, input.config.reviewScheduler?.maxQueuedPerRepo ?? 10)) {
@@ -229,7 +231,7 @@ async function enqueuePullIfEligible(input: {
         repo: input.repo,
         pull: input.pull,
         state: "provider_deferred",
-        details: `repo_provider_cooldown_until=${activeRepoCooldown.cooldownUntil}; reason=${activeRepoCooldown.reason}`,
+        details: "Provider cooldown is active for this repo.",
         now: input.now
       });
     }
@@ -276,6 +278,40 @@ function enqueueReviewJob(input: {
     ...(sessionId ? { sessionId } : {}),
     now: input.now
   });
+}
+
+async function retireSupersededQueueJobsForPull(input: {
+  config: BotConfig;
+  github: SchedulerGitHubApi;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  dryRun: boolean;
+  now: Date;
+}): Promise<void> {
+  const jobs = input.state.listReviewQueueJobs({
+    repo: input.repo,
+    states: ["queued", "provider_deferred"]
+  }).filter((job) => job.pullNumber === input.pull.number && job.headSha !== input.pull.head.sha);
+
+  for (const job of jobs) {
+    input.state.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "stale_retired",
+      lastError: `superseded_by_head=${input.pull.head.sha}`,
+      now: input.now
+    });
+    await syncReviewStatusComment({
+      config: input.config,
+      github: input.github,
+      dryRun: input.dryRun,
+      repo: input.repo,
+      pull: pullForQueueJob(job, input.pull),
+      state: "stale_head",
+      details: "Superseded by a newer PR head.",
+      now: input.now
+    });
+  }
 }
 
 async function resolveSchedulerCommandDecision(input: {
@@ -355,6 +391,16 @@ async function runLeasedQueueJob(input: {
   try {
     pull = await input.github.getPull(input.job.repo, input.job.pullNumber);
   } catch (error) {
+    await syncReviewStatusComment({
+      config: input.config,
+      github: input.github,
+      dryRun: input.dryRun,
+      repo: input.job.repo,
+      pull: pullForQueueJobWithoutLive(input.job),
+      state: "failed",
+      details: "GitHub refetch failed; see bot evidence for operator-only details.",
+      now
+    });
     input.state.updateReviewQueueJobState({
       jobId: input.job.jobId,
       state: "failed",
@@ -384,10 +430,7 @@ async function runLeasedQueueJob(input: {
     return "closed_retired";
   }
 
-  if (
-    pull.head.sha !== input.job.headSha ||
-    (input.job.source !== "manual_command" && input.job.baseSha && pull.base.sha !== input.job.baseSha)
-  ) {
+  if (pull.head.sha !== input.job.headSha) {
     await syncReviewStatusComment({
       config: input.config,
       github: input.github,
@@ -409,15 +452,17 @@ async function runLeasedQueueJob(input: {
 
   const sessionId = ensureReviewerSessionForLeasedJob(input, now);
   updateReviewerSessionJobFromQueueStatus({ ...input, job: { ...input.job, ...(sessionId ? { sessionId } : {}) } }, "running");
-  await syncReviewStatusComment({
-    config: input.config,
-    github: input.github,
-    dryRun: input.dryRun,
-    repo: input.job.repo,
-    pull,
-    state: "in_progress",
-    now
-  });
+  if (input.job.source !== "manual_command") {
+    await syncReviewStatusComment({
+      config: input.config,
+      github: input.github,
+      dryRun: input.dryRun,
+      repo: input.job.repo,
+      pull,
+      state: "in_progress",
+      now
+    });
+  }
 
   try {
     const status = await input.reviewPullImpl({
@@ -467,7 +512,7 @@ async function runLeasedQueueJob(input: {
         repo: input.job.repo,
         pull,
         state: "provider_deferred",
-        details: error instanceof Error ? error.message : String(error),
+        details: "Provider cooldown recorded; see bot evidence for operator-only details.",
         now
       });
       updateReviewerSessionJobFromQueueStatus({ ...input, job: { ...input.job, ...(sessionId ? { sessionId } : {}) } }, "assigned");
@@ -492,7 +537,7 @@ async function runLeasedQueueJob(input: {
       repo: input.job.repo,
       pull,
       state: "failed",
-      details: error instanceof Error ? error.message : String(error),
+      details: "Review failed; see bot evidence for operator-only details.",
       now
     });
     updateReviewerSessionJobFromQueueStatus({ ...input, job: { ...input.job, ...(sessionId ? { sessionId } : {}) } }, "failed", "failed");
@@ -549,7 +594,6 @@ async function syncReviewStatusCommentForReviewResult(input: {
     pull: input.pull,
     state: nextState,
     ...(processed?.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
-    ...(processed?.error ? { details: processed.error } : {}),
     now: input.now
   });
 }
@@ -592,6 +636,30 @@ function pullForQueueJob(job: ReviewQueueJobRecord, livePull: PullRequestSummary
           }
         }
       : {})
+  };
+}
+
+function pullForQueueJobWithoutLive(job: ReviewQueueJobRecord): PullRequestSummary {
+  return {
+    number: job.pullNumber,
+    title: "",
+    draft: false,
+    state: "open",
+    head: {
+      sha: job.headSha,
+      ref: job.headSha,
+      repo: {
+        full_name: job.repo
+      }
+    },
+    base: {
+      sha: job.baseSha ?? "",
+      ref: "",
+      repo: {
+        full_name: job.repo
+      }
+    },
+    html_url: `https://github.com/${job.repo}/pull/${job.pullNumber}`
   };
 }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -693,6 +693,7 @@ function reviewResultStatusCommentState(status: ReviewPullResult): ReviewStatusC
     case "skipped_draft":
     case "skipped_canary":
     case "skipped_policy":
+      return "failed";
     case "skipped_command_stop":
     case "skipped_command_explain":
       return undefined;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -336,6 +336,7 @@ async function retireSupersededQueueJobsForPull(input: {
       lastError: `superseded_by_head=${input.pull.head.sha}`,
       now: input.now
     });
+    updateReviewerSessionJobFromQueueStatus({ state: input.state, job }, "skipped", "skipped");
     await syncReviewStatusComment({
       config: input.config,
       github: input.github,
@@ -373,6 +374,7 @@ async function retireQueuedJobsForClosedPull(input: {
       lastError: `closed_or_merged_before_review state=${input.pull.state ?? "unknown"}`,
       now: input.now
     });
+    updateReviewerSessionJobFromQueueStatus({ state: input.state, job }, "skipped", "skipped");
     await syncReviewStatusComment({
       config: input.config,
       github: input.github,

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -202,7 +202,9 @@ async function enqueuePullIfEligible(input: {
 
   const commandDecision = await resolveSchedulerCommandDecision(input);
   if (commandDecision.action !== "none") {
-    await retireSupersededQueueJobsForPull(input);
+    if (commandDecision.shouldReview) {
+      await retireSupersededQueueJobsForPull(input);
+    }
     const queued = enqueueReviewJob(input, commandDecision);
     if (queued.enqueued && commandDecision.shouldReview) {
       await syncReviewStatusComment({

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -20,6 +20,7 @@ import {
   type ProcessedStatus,
   type ReviewerSessionJobState,
   type ReviewQueueJobRecord,
+  type ReviewQueueJobState,
   type ReviewQueueJobSource
 } from "./state.js";
 import type { PullRequestSummary } from "./types.js";
@@ -486,6 +487,13 @@ async function runLeasedQueueJob(input: {
   }
 
   if (isClosedPull(pull)) {
+    input.state.updateReviewQueueJobState({
+      jobId: input.job.jobId,
+      state: "closed_retired",
+      lastError: `closed_or_merged_before_review state=${pull.state ?? "unknown"}`,
+      now
+    });
+    updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
     await syncReviewStatusComment({
       config: input.config,
       github: input.github,
@@ -497,16 +505,17 @@ async function runLeasedQueueJob(input: {
       onStatusCommentFailure: input.onStatusCommentFailure,
       now
     });
-    input.state.updateReviewQueueJobState({
-      jobId: input.job.jobId,
-      state: "closed_retired",
-      lastError: `closed_or_merged_before_review state=${pull.state ?? "unknown"}`
-    });
-    updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
     return "closed_retired";
   }
 
   if (pull.head.sha !== input.job.headSha) {
+    input.state.updateReviewQueueJobState({
+      jobId: input.job.jobId,
+      state: "stale_retired",
+      lastError: `stale_head_before_review live=${pull.head.sha}`,
+      now
+    });
+    updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
     await syncReviewStatusComment({
       config: input.config,
       github: input.github,
@@ -518,12 +527,6 @@ async function runLeasedQueueJob(input: {
       onStatusCommentFailure: input.onStatusCommentFailure,
       now
     });
-    input.state.updateReviewQueueJobState({
-      jobId: input.job.jobId,
-      state: "stale_retired",
-      lastError: `stale_head_before_review live=${pull.head.sha}`
-    });
-    updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
     return "stale_retired";
   }
 
@@ -697,9 +700,9 @@ async function syncReviewStatusCommentForReviewResult(input: {
   onStatusCommentFailure?: () => void;
   now?: Date;
 }): Promise<void> {
-  const nextState = reviewResultStatusCommentState(input.status);
-  if (!nextState) return;
   const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
+  const nextState = reviewResultStatusCommentState(input.status, processed?.status);
+  if (!nextState) return;
   await syncReviewStatusComment({
     config: input.config,
     github: input.github,
@@ -713,12 +716,13 @@ async function syncReviewStatusCommentForReviewResult(input: {
   });
 }
 
-function reviewResultStatusCommentState(status: ReviewPullResult): ReviewStatusCommentState | undefined {
+function reviewResultStatusCommentState(status: ReviewPullResult, processedStatus?: ProcessedStatus): ReviewStatusCommentState | undefined {
   switch (status) {
     case "reviewed":
     case "reviewed_command":
-    case "skipped_processed":
       return "completed";
+    case "skipped_processed":
+      return reviewStatusCommentStateForProcessedStatus(processedStatus);
     case "skipped_provider_cooldown":
       return "provider_deferred";
     case "skipped_stale_head":
@@ -826,9 +830,14 @@ function updateReviewerSessionJobAfterReviewStatus(input: {
   switch (input.status) {
     case "reviewed":
     case "reviewed_command":
-    case "skipped_processed":
       updateReviewerSessionJobFromQueueStatus(input, "completed", input.dryRun ? "dry_run" : "posted");
       return;
+    case "skipped_processed": {
+      const processed = input.state.getProcessedReview(input.job.repo, input.job.pullNumber, input.job.headSha);
+      const sessionState = reviewerSessionJobStateForProcessedStatus(processed?.status);
+      updateReviewerSessionJobFromQueueStatus(input, sessionState, processed?.status ?? (input.dryRun ? "dry_run" : "posted"));
+      return;
+    }
     case "skipped_provider_cooldown":
     case "skipped_capacity":
       updateReviewerSessionJobFromQueueStatus(input, "assigned");
@@ -890,10 +899,12 @@ function updateQueueJobAfterReviewStatus(input: {
       });
       return;
     case "skipped_processed":
+      const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
       input.state.updateReviewQueueJobState({
         jobId: input.job.jobId,
-        state: "posted",
-        lastError: "processed_head_already_exists"
+        state: reviewQueueJobStateForProcessedStatus(processed?.status, input.dryRun),
+        ...(processed?.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
+        lastError: `processed_head_already_${processed?.status ?? "unknown"}`
       });
       return;
     case "skipped_capacity":
@@ -928,6 +939,54 @@ function updateQueueJobAfterReviewStatus(input: {
       return;
     default:
       assertNever(input.status);
+  }
+}
+
+function reviewStatusCommentStateForProcessedStatus(status: ProcessedStatus | undefined): ReviewStatusCommentState {
+  switch (status) {
+    case "posted":
+    case "dry_run":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "skipped":
+      return "skipped";
+    case undefined:
+      return "completed";
+    default:
+      return assertNever(status);
+  }
+}
+
+function reviewQueueJobStateForProcessedStatus(status: ProcessedStatus | undefined, dryRun: boolean): ReviewQueueJobState {
+  switch (status) {
+    case "posted":
+      return "posted";
+    case "dry_run":
+      return "queued";
+    case "failed":
+    case "skipped":
+      return "failed";
+    case undefined:
+      return dryRun ? "queued" : "posted";
+    default:
+      return assertNever(status);
+  }
+}
+
+function reviewerSessionJobStateForProcessedStatus(status: ProcessedStatus | undefined): ReviewerSessionJobState {
+  switch (status) {
+    case "posted":
+    case "dry_run":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "skipped":
+      return "skipped";
+    case undefined:
+      return "completed";
+    default:
+      return assertNever(status);
   }
 }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -520,6 +520,17 @@ async function runLeasedQueueJob(input: {
       now
     });
     updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
+    await syncReviewStatusComment({
+      config: input.config,
+      github: input.github,
+      dryRun: input.dryRun,
+      repo: input.job.repo,
+      pull: pullForQueueJob(input.job, pull),
+      state: "stale_head",
+      details: `base_changed live=${pull.base.sha}`,
+      onStatusCommentFailure: input.onStatusCommentFailure,
+      now
+    });
     return "stale_retired";
   }
 
@@ -653,7 +664,11 @@ async function syncReviewStatusComment(input: {
 }
 
 function isStatusCommentFailure(result: ReviewStatusCommentPostResult): boolean {
-  return !result.posted && (result.reason === "missing_app_credentials" || result.reason === "upsert_failed");
+  return !result.posted && (
+    result.reason === "missing_app_credentials" ||
+    result.reason === "build_failed" ||
+    result.reason === "upsert_failed"
+  );
 }
 
 async function syncReviewStatusCommentForReviewResult(input: {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -697,7 +697,7 @@ function reviewResultStatusCommentState(status: ReviewPullResult): ReviewStatusC
     case "skipped_draft":
     case "skipped_canary":
     case "skipped_policy":
-      return "failed";
+      return "skipped";
     case "skipped_command_stop":
     case "skipped_command_explain":
       return undefined;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -5,6 +5,7 @@ import { listReposToScan, resolveRepoProfile } from "./repo-policy.js";
 import {
   postReviewStatusComment,
   type ReviewStatusCommentGithub,
+  type ReviewStatusCommentPostResult,
   type ReviewStatusCommentState
 } from "./review-status-comment.js";
 import { ReviewRunBudget } from "./review-budget.js";
@@ -34,6 +35,7 @@ import {
 
 export interface ScheduledRunResult extends RunOnceResult {
   commandFetchErrors: number;
+  statusCommentFailures: number;
   queue: {
     enqueued: number;
     alreadyQueued: number;
@@ -123,6 +125,9 @@ export async function runScheduledCycleWithDeps(input: {
         providerId,
         now,
         dryRun: input.options.dryRun,
+        onStatusCommentFailure: () => {
+          result.statusCommentFailures += 1;
+        },
         onCommandFetchError: () => {
           result.commandFetchErrors += 1;
         }
@@ -154,6 +159,9 @@ export async function runScheduledCycleWithDeps(input: {
       useZCode: input.options.useZCode ?? true,
       reviewPullImpl: input.reviewPullImpl,
       budget,
+      onStatusCommentFailure: () => {
+        result.statusCommentFailures += 1;
+      },
       now
     });
     applyReviewStatus(result, status);
@@ -182,9 +190,13 @@ async function enqueuePullIfEligible(input: {
   providerId: string;
   now: Date;
   dryRun: boolean;
+  onStatusCommentFailure?: () => void;
   onCommandFetchError?: () => void;
 }): Promise<EnqueueStatus> {
-  if (isClosedPull(input.pull)) return "closed_retired";
+  if (isClosedPull(input.pull)) {
+    await retireQueuedJobsForClosedPull(input);
+    return "closed_retired";
+  }
   if (input.config.skipDrafts && input.pull.draft) return "skipped_draft";
   if (!isCanaryAllowed(input.config, input.repo, input.pull.number)) return "skipped_canary";
 
@@ -200,6 +212,7 @@ async function enqueuePullIfEligible(input: {
         repo: input.repo,
         pull: input.pull,
         state: "queued",
+        onStatusCommentFailure: input.onStatusCommentFailure,
         now: input.now
       });
     }
@@ -232,6 +245,7 @@ async function enqueuePullIfEligible(input: {
         pull: input.pull,
         state: "provider_deferred",
         details: "Provider cooldown is active for this repo.",
+        onStatusCommentFailure: input.onStatusCommentFailure,
         now: input.now
       });
     }
@@ -247,6 +261,7 @@ async function enqueuePullIfEligible(input: {
       repo: input.repo,
       pull: input.pull,
       state: "queued",
+      onStatusCommentFailure: input.onStatusCommentFailure,
       now: input.now
     });
   }
@@ -288,6 +303,7 @@ async function retireSupersededQueueJobsForPull(input: {
   pull: PullRequestSummary;
   dryRun: boolean;
   now: Date;
+  onStatusCommentFailure?: () => void;
 }): Promise<void> {
   const jobs = input.state.listReviewQueueJobs({
     repo: input.repo,
@@ -309,6 +325,43 @@ async function retireSupersededQueueJobsForPull(input: {
       pull: pullForQueueJob(job, input.pull),
       state: "stale_head",
       details: "Superseded by a newer PR head.",
+      onStatusCommentFailure: input.onStatusCommentFailure,
+      now: input.now
+    });
+  }
+}
+
+async function retireQueuedJobsForClosedPull(input: {
+  config: BotConfig;
+  github: SchedulerGitHubApi;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  dryRun: boolean;
+  now: Date;
+  onStatusCommentFailure?: () => void;
+}): Promise<void> {
+  const jobs = input.state.listReviewQueueJobs({
+    repo: input.repo,
+    states: ["queued", "provider_deferred"]
+  }).filter((job) => job.pullNumber === input.pull.number);
+
+  for (const job of jobs) {
+    input.state.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "closed_retired",
+      lastError: `closed_or_merged_before_review state=${input.pull.state ?? "unknown"}`,
+      now: input.now
+    });
+    await syncReviewStatusComment({
+      config: input.config,
+      github: input.github,
+      dryRun: input.dryRun,
+      repo: input.repo,
+      pull: pullForQueueJob(job, input.pull),
+      state: "closed_or_merged_before_review",
+      details: `state=${input.pull.state ?? "unknown"}`,
+      onStatusCommentFailure: input.onStatusCommentFailure,
       now: input.now
     });
   }
@@ -378,6 +431,7 @@ async function runLeasedQueueJob(input: {
   useZCode: boolean;
   reviewPullImpl: (input: ReviewPullInput) => Promise<ReviewPullResult>;
   budget: ReviewRunBudget;
+  onStatusCommentFailure?: () => void;
   now?: Date;
 }): Promise<ReviewPullResult | "failed" | "closed_retired" | "stale_retired"> {
   const now = input.now ?? new Date();
@@ -399,6 +453,7 @@ async function runLeasedQueueJob(input: {
       pull: pullForQueueJobWithoutLive(input.job),
       state: "failed",
       details: "GitHub refetch failed; see bot evidence for operator-only details.",
+      onStatusCommentFailure: input.onStatusCommentFailure,
       now
     });
     input.state.updateReviewQueueJobState({
@@ -419,6 +474,7 @@ async function runLeasedQueueJob(input: {
       pull: pullForQueueJob(input.job, pull),
       state: "closed_or_merged_before_review",
       details: `state=${pull.state ?? "unknown"}`,
+      onStatusCommentFailure: input.onStatusCommentFailure,
       now
     });
     input.state.updateReviewQueueJobState({
@@ -439,12 +495,24 @@ async function runLeasedQueueJob(input: {
       pull: pullForQueueJob(input.job, pull),
       state: "stale_head",
       details: `live=${pull.head.sha}`,
+      onStatusCommentFailure: input.onStatusCommentFailure,
       now
     });
     input.state.updateReviewQueueJobState({
       jobId: input.job.jobId,
       state: "stale_retired",
       lastError: `stale_head_before_review live=${pull.head.sha}`
+    });
+    updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
+    return "stale_retired";
+  }
+
+  if (input.job.source !== "manual_command" && input.job.baseSha && pull.base.sha !== input.job.baseSha) {
+    input.state.updateReviewQueueJobState({
+      jobId: input.job.jobId,
+      state: "stale_retired",
+      lastError: `base_changed_before_review live=${pull.base.sha}`,
+      now
     });
     updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
     return "stale_retired";
@@ -460,6 +528,7 @@ async function runLeasedQueueJob(input: {
       repo: input.job.repo,
       pull,
       state: "in_progress",
+      onStatusCommentFailure: input.onStatusCommentFailure,
       now
     });
   }
@@ -486,6 +555,7 @@ async function runLeasedQueueJob(input: {
       pull,
       status,
       state: input.state,
+      onStatusCommentFailure: input.onStatusCommentFailure,
       now
     });
     updateReviewerSessionJobAfterReviewStatus({
@@ -513,6 +583,7 @@ async function runLeasedQueueJob(input: {
         pull,
         state: "provider_deferred",
         details: "Provider cooldown recorded; see bot evidence for operator-only details.",
+        onStatusCommentFailure: input.onStatusCommentFailure,
         now
       });
       updateReviewerSessionJobFromQueueStatus({ ...input, job: { ...input.job, ...(sessionId ? { sessionId } : {}) } }, "assigned");
@@ -538,6 +609,7 @@ async function runLeasedQueueJob(input: {
       pull,
       state: "failed",
       details: "Review failed; see bot evidence for operator-only details.",
+      onStatusCommentFailure: input.onStatusCommentFailure,
       now
     });
     updateReviewerSessionJobFromQueueStatus({ ...input, job: { ...input.job, ...(sessionId ? { sessionId } : {}) } }, "failed", "failed");
@@ -554,11 +626,12 @@ async function syncReviewStatusComment(input: {
   state: ReviewStatusCommentState;
   reviewUrl?: string;
   details?: string;
+  onStatusCommentFailure?: () => void;
   now?: Date;
 }): Promise<void> {
   if (!isReviewStatusCommentGithub(input.github)) return;
-  await postReviewStatusComment({
-    enabled: input.config.reviewStatusComment?.enabled ?? true,
+  const result = await postReviewStatusComment({
+    enabled: input.config.reviewStatusComment?.enabled ?? false,
     dryRun: input.dryRun,
     github: input.github,
     repo: input.repo,
@@ -571,6 +644,11 @@ async function syncReviewStatusComment(input: {
     ...(input.details ? { details: input.details } : {}),
     now: input.now
   });
+  if (isStatusCommentFailure(result)) input.onStatusCommentFailure?.();
+}
+
+function isStatusCommentFailure(result: ReviewStatusCommentPostResult): boolean {
+  return !result.posted && (result.reason === "missing_app_credentials" || result.reason === "upsert_failed");
 }
 
 async function syncReviewStatusCommentForReviewResult(input: {
@@ -581,6 +659,7 @@ async function syncReviewStatusCommentForReviewResult(input: {
   pull: PullRequestSummary;
   status: ReviewPullResult;
   state: ReviewStateStore;
+  onStatusCommentFailure?: () => void;
   now?: Date;
 }): Promise<void> {
   const nextState = reviewResultStatusCommentState(input.status);
@@ -594,6 +673,7 @@ async function syncReviewStatusCommentForReviewResult(input: {
     pull: input.pull,
     state: nextState,
     ...(processed?.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
+    onStatusCommentFailure: input.onStatusCommentFailure,
     now: input.now
   });
 }
@@ -979,6 +1059,7 @@ function emptyScheduledRunResult(): ScheduledRunResult {
     skippedStaleHead: 0,
     baselinedExisting: 0,
     commandFetchErrors: 0,
+    statusCommentFailures: 0,
     policySkips: [],
     queue: {
       enqueued: 0,

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -449,6 +449,13 @@ async function runLeasedQueueJob(input: {
   try {
     pull = await input.github.getPull(input.job.repo, input.job.pullNumber);
   } catch (error) {
+    input.state.updateReviewQueueJobState({
+      jobId: input.job.jobId,
+      state: "failed",
+      lastError: error instanceof Error ? error.message : String(error),
+      now
+    });
+    updateReviewerSessionJobFromQueueStatus(input, "failed", "failed");
     await syncReviewStatusComment({
       config: input.config,
       github: input.github,
@@ -460,12 +467,6 @@ async function runLeasedQueueJob(input: {
       onStatusCommentFailure: input.onStatusCommentFailure,
       now
     });
-    input.state.updateReviewQueueJobState({
-      jobId: input.job.jobId,
-      state: "failed",
-      lastError: error instanceof Error ? error.message : String(error)
-    });
-    updateReviewerSessionJobFromQueueStatus(input, "failed", "failed");
     return "failed";
   }
 
@@ -693,7 +694,7 @@ function reviewResultStatusCommentState(status: ReviewPullResult): ReviewStatusC
     case "skipped_stale_head":
       return "stale_head";
     case "skipped_capacity":
-      return undefined;
+      return "provider_deferred";
     case "skipped_draft":
     case "skipped_canary":
     case "skipped_policy":

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -2,6 +2,11 @@ import { loadConfig, type BotConfig } from "./config.js";
 import { collectTrustedReviewCommands, decideCommandAction, type CommandDecision } from "./commands.js";
 import { GitHubApi } from "./github.js";
 import { listReposToScan, resolveRepoProfile } from "./repo-policy.js";
+import {
+  postReviewStatusComment,
+  type ReviewStatusCommentGithub,
+  type ReviewStatusCommentState
+} from "./review-status-comment.js";
 import { ReviewRunBudget } from "./review-budget.js";
 import {
   parseProviderCooldownError,
@@ -46,6 +51,8 @@ export interface SchedulerGitHubApi {
   listOpenPulls(repo: string): Promise<PullRequestSummary[]>;
   getPull(repo: string, pullNumber: number): Promise<PullRequestSummary>;
   listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]>;
+  canPostAsApp?: ReviewStatusCommentGithub["canPostAsApp"];
+  upsertIssueComment?: ReviewStatusCommentGithub["upsertIssueComment"];
 }
 
 export async function runScheduledCycle(options: RunOnceOptions): Promise<ScheduledRunResult> {
@@ -115,6 +122,7 @@ export async function runScheduledCycleWithDeps(input: {
         pull,
         providerId,
         now,
+        dryRun: input.options.dryRun,
         onCommandFetchError: () => {
           result.commandFetchErrors += 1;
         }
@@ -173,6 +181,7 @@ async function enqueuePullIfEligible(input: {
   pull: PullRequestSummary;
   providerId: string;
   now: Date;
+  dryRun: boolean;
   onCommandFetchError?: () => void;
 }): Promise<EnqueueStatus> {
   if (isClosedPull(input.pull)) return "closed_retired";
@@ -182,6 +191,17 @@ async function enqueuePullIfEligible(input: {
   const commandDecision = await resolveSchedulerCommandDecision(input);
   if (commandDecision.action !== "none") {
     const queued = enqueueReviewJob(input, commandDecision);
+    if (queued.enqueued && commandDecision.shouldReview) {
+      await syncReviewStatusComment({
+        config: input.config,
+        github: input.github,
+        dryRun: input.dryRun,
+        repo: input.repo,
+        pull: input.pull,
+        state: "queued",
+        now: input.now
+      });
+    }
     return queued.enqueued ? "enqueued" : "already_queued";
   }
 
@@ -201,10 +221,33 @@ async function enqueuePullIfEligible(input: {
       lastError: `repo_provider_cooldown_until=${activeRepoCooldown.cooldownUntil}; reason=${activeRepoCooldown.reason}`,
       now: input.now
     });
+    if (queued.enqueued) {
+      await syncReviewStatusComment({
+        config: input.config,
+        github: input.github,
+        dryRun: input.dryRun,
+        repo: input.repo,
+        pull: input.pull,
+        state: "provider_deferred",
+        details: `repo_provider_cooldown_until=${activeRepoCooldown.cooldownUntil}; reason=${activeRepoCooldown.reason}`,
+        now: input.now
+      });
+    }
     return "provider_deferred";
   }
 
   const enqueued = enqueueReviewJob(input);
+  if (enqueued.enqueued) {
+    await syncReviewStatusComment({
+      config: input.config,
+      github: input.github,
+      dryRun: input.dryRun,
+      repo: input.repo,
+      pull: input.pull,
+      state: "queued",
+      now: input.now
+    });
+  }
   return enqueued.enqueued ? "enqueued" : "already_queued";
 }
 
@@ -322,6 +365,16 @@ async function runLeasedQueueJob(input: {
   }
 
   if (isClosedPull(pull)) {
+    await syncReviewStatusComment({
+      config: input.config,
+      github: input.github,
+      dryRun: input.dryRun,
+      repo: input.job.repo,
+      pull: pullForQueueJob(input.job, pull),
+      state: "closed_or_merged_before_review",
+      details: `state=${pull.state ?? "unknown"}`,
+      now
+    });
     input.state.updateReviewQueueJobState({
       jobId: input.job.jobId,
       state: "closed_retired",
@@ -335,6 +388,16 @@ async function runLeasedQueueJob(input: {
     pull.head.sha !== input.job.headSha ||
     (input.job.source !== "manual_command" && input.job.baseSha && pull.base.sha !== input.job.baseSha)
   ) {
+    await syncReviewStatusComment({
+      config: input.config,
+      github: input.github,
+      dryRun: input.dryRun,
+      repo: input.job.repo,
+      pull: pullForQueueJob(input.job, pull),
+      state: "stale_head",
+      details: `live=${pull.head.sha}`,
+      now
+    });
     input.state.updateReviewQueueJobState({
       jobId: input.job.jobId,
       state: "stale_retired",
@@ -346,6 +409,15 @@ async function runLeasedQueueJob(input: {
 
   const sessionId = ensureReviewerSessionForLeasedJob(input, now);
   updateReviewerSessionJobFromQueueStatus({ ...input, job: { ...input.job, ...(sessionId ? { sessionId } : {}) } }, "running");
+  await syncReviewStatusComment({
+    config: input.config,
+    github: input.github,
+    dryRun: input.dryRun,
+    repo: input.job.repo,
+    pull,
+    state: "in_progress",
+    now
+  });
 
   try {
     const status = await input.reviewPullImpl({
@@ -361,6 +433,16 @@ async function runLeasedQueueJob(input: {
       ...(input.job.source === "manual_command" && input.job.commentId ? { commandCommentId: input.job.commentId } : {})
     });
     updateQueueJobAfterReviewStatus({ state: input.state, job: input.job, pull, status, dryRun: input.dryRun });
+    await syncReviewStatusCommentForReviewResult({
+      config: input.config,
+      github: input.github,
+      dryRun: input.dryRun,
+      job: input.job,
+      pull,
+      status,
+      state: input.state,
+      now
+    });
     updateReviewerSessionJobAfterReviewStatus({
       state: input.state,
       job: { ...input.job, ...(sessionId ? { sessionId } : {}) },
@@ -378,6 +460,16 @@ async function runLeasedQueueJob(input: {
       now
     })) {
       markQueueJobProviderDeferredFromProcessed({ state: input.state, job: input.job, pull, error, config: input.config, now });
+      await syncReviewStatusComment({
+        config: input.config,
+        github: input.github,
+        dryRun: input.dryRun,
+        repo: input.job.repo,
+        pull,
+        state: "provider_deferred",
+        details: error instanceof Error ? error.message : String(error),
+        now
+      });
       updateReviewerSessionJobFromQueueStatus({ ...input, job: { ...input.job, ...(sessionId ? { sessionId } : {}) } }, "assigned");
       return "skipped_provider_cooldown";
     }
@@ -393,9 +485,118 @@ async function runLeasedQueueJob(input: {
       state: "failed",
       lastError: error instanceof Error ? error.message : String(error)
     });
+    await syncReviewStatusComment({
+      config: input.config,
+      github: input.github,
+      dryRun: input.dryRun,
+      repo: input.job.repo,
+      pull,
+      state: "failed",
+      details: error instanceof Error ? error.message : String(error),
+      now
+    });
     updateReviewerSessionJobFromQueueStatus({ ...input, job: { ...input.job, ...(sessionId ? { sessionId } : {}) } }, "failed", "failed");
     return "failed";
   }
+}
+
+async function syncReviewStatusComment(input: {
+  config: BotConfig;
+  github: SchedulerGitHubApi;
+  dryRun: boolean;
+  repo: string;
+  pull: PullRequestSummary;
+  state: ReviewStatusCommentState;
+  reviewUrl?: string;
+  details?: string;
+  now?: Date;
+}): Promise<void> {
+  if (!isReviewStatusCommentGithub(input.github)) return;
+  await postReviewStatusComment({
+    enabled: input.config.reviewStatusComment?.enabled ?? true,
+    dryRun: input.dryRun,
+    github: input.github,
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    state: input.state,
+    pullTitle: input.pull.title,
+    pullUrl: input.pull.html_url,
+    ...(input.reviewUrl ? { reviewUrl: input.reviewUrl } : {}),
+    ...(input.details ? { details: input.details } : {}),
+    now: input.now
+  });
+}
+
+async function syncReviewStatusCommentForReviewResult(input: {
+  config: BotConfig;
+  github: SchedulerGitHubApi;
+  dryRun: boolean;
+  job: ReviewQueueJobRecord;
+  pull: PullRequestSummary;
+  status: ReviewPullResult;
+  state: ReviewStateStore;
+  now?: Date;
+}): Promise<void> {
+  const nextState = reviewResultStatusCommentState(input.status);
+  if (!nextState) return;
+  const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
+  await syncReviewStatusComment({
+    config: input.config,
+    github: input.github,
+    dryRun: input.dryRun,
+    repo: input.job.repo,
+    pull: input.pull,
+    state: nextState,
+    ...(processed?.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
+    ...(processed?.error ? { details: processed.error } : {}),
+    now: input.now
+  });
+}
+
+function reviewResultStatusCommentState(status: ReviewPullResult): ReviewStatusCommentState | undefined {
+  switch (status) {
+    case "reviewed":
+    case "reviewed_command":
+    case "skipped_processed":
+      return "completed";
+    case "skipped_provider_cooldown":
+      return "provider_deferred";
+    case "skipped_stale_head":
+      return "stale_head";
+    case "skipped_capacity":
+      return "queued";
+    case "skipped_draft":
+    case "skipped_canary":
+    case "skipped_policy":
+    case "skipped_command_stop":
+    case "skipped_command_explain":
+      return undefined;
+    default:
+      return assertNever(status);
+  }
+}
+
+function pullForQueueJob(job: ReviewQueueJobRecord, livePull: PullRequestSummary): PullRequestSummary {
+  return {
+    ...livePull,
+    head: {
+      ...livePull.head,
+      sha: job.headSha
+    },
+    ...(job.baseSha
+      ? {
+          base: {
+            ...livePull.base,
+            sha: job.baseSha
+          }
+        }
+      : {})
+  };
+}
+
+function isReviewStatusCommentGithub(github: SchedulerGitHubApi): github is SchedulerGitHubApi & ReviewStatusCommentGithub {
+  return typeof github.canPostAsApp === "function" && typeof github.upsertIssueComment === "function";
 }
 
 function ensureReviewerSessionForLeasedJob(input: {

--- a/src/state.ts
+++ b/src/state.ts
@@ -923,6 +923,43 @@ export class ReviewStateStore {
     return input.limit ? jobs.slice(0, input.limit) : jobs;
   }
 
+  listReviewQueueJobsForPull(input: {
+    repo: string;
+    pullNumber: number;
+    state?: ReviewQueueJobState;
+    states?: ReviewQueueJobState[];
+    limit?: number;
+  }): ReviewQueueJobRecord[] {
+    if (input.limit !== undefined && (!Number.isInteger(input.limit) || input.limit < 1)) {
+      throw new Error("limit must be a positive integer");
+    }
+    const states = input.states ?? (input.state ? [input.state] : undefined);
+    const statePredicate = states?.length
+      ? ` and state in (${states.map(() => "?").join(", ")})`
+      : "";
+    const limitPredicate = input.limit ? " limit ?" : "";
+    const params = [
+      input.repo,
+      input.pullNumber,
+      ...(states ?? []),
+      ...(input.limit ? [input.limit] : [])
+    ];
+    const rows = this.db
+      .prepare(
+        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+                provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
+                comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+         from review_queue_jobs
+         where repo = ?
+           and pull_number = ?
+           ${statePredicate}
+         order by priority asc, datetime(created_at) asc
+         ${limitPredicate}`
+      )
+      .all(...params) as unknown as ReviewQueueJobRow[];
+    return rows.map(mapReviewQueueJobRow);
+  }
+
   expireReviewerSessions(now = new Date(), repo?: string): number {
     const nowIso = now.toISOString();
     const result = repo

--- a/src/state.ts
+++ b/src/state.ts
@@ -685,6 +685,10 @@ export class ReviewStateStore {
     if (existing && !isTerminalQueueState(existing.state)) {
       return { enqueued: false, reason: "already_queued", job: existing };
     }
+    const existingRetry = existing ? this.getActiveReviewQueueRetryJobByAttemptId(attemptId) : undefined;
+    if (existingRetry) {
+      return { enqueued: false, reason: "already_queued", job: existingRetry };
+    }
     const queueAttemptId = existing ? `${attemptId}:after-terminal:${randomUUID()}` : attemptId;
 
     const jobId = randomUUID();
@@ -889,6 +893,23 @@ export class ReviewStateStore {
          limit 1`
       )
       .get(attemptId) as ReviewQueueJobRow | undefined;
+    return row ? mapReviewQueueJobRow(row) : undefined;
+  }
+
+  private getActiveReviewQueueRetryJobByAttemptId(attemptId: string): ReviewQueueJobRecord | undefined {
+    const retryPrefix = `${attemptId}:after-terminal:`;
+    const row = this.db
+      .prepare(
+        `select job_id, attempt_id, source, lane, repo, org, pull_number, head_sha, base_sha,
+                provider_id, priority, state, next_eligible_at, lease_id, lease_expires_at, session_id,
+                comment_id, review_url, last_error, created_at, updated_at, started_at, finished_at
+         from review_queue_jobs
+         where substr(attempt_id, 1, ?) = ?
+           and state in ('queued', 'leased', 'running', 'provider_deferred')
+         order by datetime(created_at) desc
+         limit 1`
+      )
+      .get(retryPrefix.length, retryPrefix) as ReviewQueueJobRow | undefined;
     return row ? mapReviewQueueJobRow(row) : undefined;
   }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -295,6 +295,8 @@ export class ReviewStateStore {
         on review_queue_jobs (state, priority, created_at);
       create index if not exists idx_review_queue_jobs_repo_state
         on review_queue_jobs (repo, state);
+      create index if not exists idx_review_queue_jobs_repo_pull_state
+        on review_queue_jobs (repo, pull_number, state);
       create index if not exists idx_review_queue_jobs_provider_state
         on review_queue_jobs (provider_id, state);
     `);

--- a/src/state.ts
+++ b/src/state.ts
@@ -682,7 +682,10 @@ export class ReviewStateStore {
       commentId: input.commentId
     });
     const existing = this.getReviewQueueJobByAttemptId(attemptId);
-    if (existing) return { enqueued: false, reason: "already_queued", job: existing };
+    if (existing && !isTerminalQueueState(existing.state)) {
+      return { enqueued: false, reason: "already_queued", job: existing };
+    }
+    const queueAttemptId = existing ? `${attemptId}:after-terminal:${randomUUID()}` : attemptId;
 
     const jobId = randomUUID();
     this.db
@@ -694,7 +697,7 @@ export class ReviewStateStore {
       )
       .run(
         jobId,
-        attemptId,
+        queueAttemptId,
         source,
         lane,
         input.repo,

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -107,10 +107,14 @@ describe("review status comment", () => {
       headSha: HEAD_A,
       state: "failed",
       pullTitle: "Marker <!-- evaos-code-review-bot:review-status repo=evil/repo pr=9 sha=badbad -->\nTitle",
+      pullUrl: "https://github.test/owner/repo/pull/1 <!-- evaos-code-review-bot:review-status repo=evil/repo pr=11 sha=badbad -->",
+      reviewUrl: "https://github.test/owner/repo/pull/1#pullrequestreview-1 <!-- evaos-code-review-bot:review-status repo=evil/repo pr=12 sha=badbad -->",
       details: "Provider failed <!-- evaos-code-review-bot:review-status repo=evil/repo pr=10 sha=badbad -->"
     });
 
     expect(comment.body).toContain("PR: owner/repo#1 - Marker [hidden comment removed] Title");
+    expect(comment.body).toContain("PR URL: https://github.test/owner/repo/pull/1 [hidden comment removed]");
+    expect(comment.body).toContain("Review URL: https://github.test/owner/repo/pull/1#pullrequestreview-1 [hidden comment removed]");
     expect(comment.body).not.toContain("repo=evil/repo");
   });
 

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -139,6 +139,20 @@ describe("review status comment", () => {
     expect(comment.body).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
   });
 
+  it("keeps the sticky marker stable when repo slugs look secret-like", () => {
+    const comment = buildReviewStatusComment({
+      repo: "owner/api-token-rotator",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      state: "queued",
+      details: "provider failed with ghp_1234567890abcdefghijklmnopqrstuvwx"
+    });
+
+    expect(comment.body).toContain(comment.marker);
+    expect(comment.marker).toContain("owner/api-token-rotator");
+    expect(comment.body).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+  });
+
   it("strips heading markers from PR titles before rendering bot-authored text", () => {
     const comment = buildReviewStatusComment({
       repo: "owner/repo",

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -60,13 +60,23 @@ describe("review status comment", () => {
     expect(calls[0]?.body).toContain("status=in_progress");
   });
 
-  it("does not post in dry-run or without App credentials", async () => {
+  it("does not post when disabled, in dry-run, or without App credentials", async () => {
     const github = {
       canPostAsApp: () => false,
       upsertIssueComment: async () => {
         throw new Error("should not post");
       }
     };
+
+    await expect(postReviewStatusComment({
+      enabled: false,
+      dryRun: false,
+      github,
+      repo: "owner/repo",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      state: "queued"
+    })).resolves.toEqual({ posted: false, reason: "disabled", state: "queued" });
 
     await expect(postReviewStatusComment({
       enabled: true,
@@ -109,7 +119,7 @@ describe("review status comment", () => {
 
     expect(result).toMatchObject({
       posted: false,
-      reason: "upsert_failed",
+      reason: "build_failed",
       state: "queued"
     });
     if (result.posted) throw new Error("expected best-effort failure");

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -129,6 +129,19 @@ describe("review status comment", () => {
     expect(comment.body).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
   });
 
+  it("strips heading markers from PR titles before rendering bot-authored text", () => {
+    const comment = buildReviewStatusComment({
+      repo: "owner/repo",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      state: "queued",
+      pullTitle: "## Merge me"
+    });
+
+    expect(comment.body).toContain("PR: owner/repo#1 - Merge me");
+    expect(comment.body).not.toContain(" - ## Merge me");
+  });
+
   it("strips hidden comment markers from user-controlled public text", () => {
     const comment = buildReviewStatusComment({
       repo: "owner/repo",

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -5,18 +5,20 @@ import {
   postReviewStatusComment
 } from "../src/review-status-comment.js";
 
+const HEAD_A = "a".repeat(40);
+
 describe("review status comment", () => {
   it("builds a stable identity marker and mutable state marker", () => {
     const comment = buildReviewStatusComment({
       repo: "owner/repo",
       pullNumber: 274,
-      headSha: "abc123",
+      headSha: HEAD_A,
       state: "queued",
       pullTitle: "Fast PR",
       now: new Date("2026-07-02T00:00:00.000Z")
     });
 
-    expect(comment.marker).toBe("<!-- evaos-code-review-bot:review-status repo=owner/repo pr=274 sha=abc123 -->");
+    expect(comment.marker).toBe(`<!-- evaos-code-review-bot:review-status repo=owner/repo pr=274 sha=${HEAD_A} -->`);
     expect(comment.body).toContain(comment.marker);
     expect(comment.body).toContain("<!-- evaos-code-review-bot:review-status-state status=queued updated_at=2026-07-02T00:00:00.000Z -->");
     expect(comment.body).toContain("evaOS review status: queued");
@@ -25,10 +27,10 @@ describe("review status comment", () => {
   });
 
   it("uses the same marker when state changes for the same head", () => {
-    const marker = buildReviewStatusMarker({ repo: "owner/repo", pullNumber: 274, headSha: "abc123" });
-    expect(buildReviewStatusComment({ repo: "owner/repo", pullNumber: 274, headSha: "abc123", state: "queued" }).marker)
+    const marker = buildReviewStatusMarker({ repo: "owner/repo", pullNumber: 274, headSha: HEAD_A });
+    expect(buildReviewStatusComment({ repo: "owner/repo", pullNumber: 274, headSha: HEAD_A, state: "queued" }).marker)
       .toBe(marker);
-    expect(buildReviewStatusComment({ repo: "owner/repo", pullNumber: 274, headSha: "abc123", state: "completed" }).marker)
+    expect(buildReviewStatusComment({ repo: "owner/repo", pullNumber: 274, headSha: HEAD_A, state: "completed" }).marker)
       .toBe(marker);
   });
 
@@ -46,14 +48,14 @@ describe("review status comment", () => {
       },
       repo: "owner/repo",
       pullNumber: 274,
-      headSha: "abc123",
+      headSha: HEAD_A,
       state: "in_progress",
       now: new Date("2026-07-02T00:00:00.000Z")
     });
 
     expect(result).toMatchObject({ posted: true, action: "created", id: 123, state: "in_progress" });
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.marker).toBe("<!-- evaos-code-review-bot:review-status repo=owner/repo pr=274 sha=abc123 -->");
+    expect(calls[0]?.marker).toBe(`<!-- evaos-code-review-bot:review-status repo=owner/repo pr=274 sha=${HEAD_A} -->`);
     expect(calls[0]?.body).toContain("status=in_progress");
   });
 
@@ -71,7 +73,7 @@ describe("review status comment", () => {
       github,
       repo: "owner/repo",
       pullNumber: 1,
-      headSha: "abc123",
+      headSha: HEAD_A,
       state: "queued"
     })).resolves.toEqual({ posted: false, reason: "dry_run", state: "queued" });
 
@@ -81,7 +83,7 @@ describe("review status comment", () => {
       github,
       repo: "owner/repo",
       pullNumber: 1,
-      headSha: "abc123",
+      headSha: HEAD_A,
       state: "queued"
     })).resolves.toEqual({ posted: false, reason: "missing_app_credentials", state: "queued" });
   });
@@ -90,7 +92,7 @@ describe("review status comment", () => {
     const comment = buildReviewStatusComment({
       repo: "owner/repo",
       pullNumber: 1,
-      headSha: "abc123",
+      headSha: HEAD_A,
       state: "failed",
       details: "provider failed with ghp_1234567890abcdefghijklmnopqrstuvwx"
     });
@@ -102,7 +104,7 @@ describe("review status comment", () => {
     const comment = buildReviewStatusComment({
       repo: "owner/repo",
       pullNumber: 1,
-      headSha: "abcdef",
+      headSha: HEAD_A,
       state: "failed",
       pullTitle: "Marker <!-- evaos-code-review-bot:review-status repo=evil/repo pr=9 sha=badbad -->\nTitle",
       details: "Provider failed <!-- evaos-code-review-bot:review-status repo=evil/repo pr=10 sha=badbad -->"
@@ -113,9 +115,9 @@ describe("review status comment", () => {
   });
 
   it("rejects invalid marker identity values", () => {
-    expect(() => buildReviewStatusMarker({ repo: "owner/repo with space", pullNumber: 1, headSha: "abcdef" }))
+    expect(() => buildReviewStatusMarker({ repo: "owner/repo with space", pullNumber: 1, headSha: HEAD_A }))
       .toThrow("Invalid review status repo slug");
-    expect(() => buildReviewStatusMarker({ repo: "owner/repo", pullNumber: 0, headSha: "abcdef" }))
+    expect(() => buildReviewStatusMarker({ repo: "owner/repo", pullNumber: 0, headSha: HEAD_A }))
       .toThrow("Invalid review status pull number");
     expect(() => buildReviewStatusMarker({ repo: "owner/repo", pullNumber: 1, headSha: "not-a-sha" }))
       .toThrow("Invalid review status head SHA");

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReviewStatusComment,
+  buildReviewStatusMarker,
+  postReviewStatusComment
+} from "../src/review-status-comment.js";
+
+describe("review status comment", () => {
+  it("builds a stable identity marker and mutable state marker", () => {
+    const comment = buildReviewStatusComment({
+      repo: "owner/repo",
+      pullNumber: 274,
+      headSha: "abc123",
+      state: "queued",
+      pullTitle: "Fast PR",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(comment.marker).toBe("<!-- evaos-code-review-bot:review-status repo=owner/repo pr=274 sha=abc123 -->");
+    expect(comment.body).toContain(comment.marker);
+    expect(comment.body).toContain("<!-- evaos-code-review-bot:review-status-state status=queued updated_at=2026-07-02T00:00:00.000Z -->");
+    expect(comment.body).toContain("evaOS review status: queued");
+    expect(comment.body).toContain("agents should wait");
+  });
+
+  it("uses the same marker when state changes for the same head", () => {
+    const marker = buildReviewStatusMarker({ repo: "owner/repo", pullNumber: 274, headSha: "abc123" });
+    expect(buildReviewStatusComment({ repo: "owner/repo", pullNumber: 274, headSha: "abc123", state: "queued" }).marker)
+      .toBe(marker);
+    expect(buildReviewStatusComment({ repo: "owner/repo", pullNumber: 274, headSha: "abc123", state: "completed" }).marker)
+      .toBe(marker);
+  });
+
+  it("posts through marker-backed upsert when enabled", async () => {
+    const calls: Array<{ marker: string; body: string }> = [];
+    const result = await postReviewStatusComment({
+      enabled: true,
+      dryRun: false,
+      github: {
+        canPostAsApp: () => true,
+        upsertIssueComment: async (input) => {
+          calls.push({ marker: input.marker, body: input.body });
+          return { action: "created", id: 123, html_url: "https://github.test/comment/123" };
+        }
+      },
+      repo: "owner/repo",
+      pullNumber: 274,
+      headSha: "abc123",
+      state: "in_progress",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result).toMatchObject({ posted: true, action: "created", id: 123, state: "in_progress" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.marker).toBe("<!-- evaos-code-review-bot:review-status repo=owner/repo pr=274 sha=abc123 -->");
+    expect(calls[0]?.body).toContain("status=in_progress");
+  });
+
+  it("does not post in dry-run or without App credentials", async () => {
+    const github = {
+      canPostAsApp: () => false,
+      upsertIssueComment: async () => {
+        throw new Error("should not post");
+      }
+    };
+
+    await expect(postReviewStatusComment({
+      enabled: true,
+      dryRun: true,
+      github,
+      repo: "owner/repo",
+      pullNumber: 1,
+      headSha: "abc123",
+      state: "queued"
+    })).resolves.toEqual({ posted: false, reason: "dry_run", state: "queued" });
+
+    await expect(postReviewStatusComment({
+      enabled: true,
+      dryRun: false,
+      github,
+      repo: "owner/repo",
+      pullNumber: 1,
+      headSha: "abc123",
+      state: "queued"
+    })).resolves.toEqual({ posted: false, reason: "missing_app_credentials", state: "queued" });
+  });
+
+  it("redacts secret-like details before posting", () => {
+    const comment = buildReviewStatusComment({
+      repo: "owner/repo",
+      pullNumber: 1,
+      headSha: "abc123",
+      state: "failed",
+      details: "provider failed with ghp_1234567890abcdefghijklmnopqrstuvwx"
+    });
+
+    expect(comment.body).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+  });
+});

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -23,6 +23,7 @@ describe("review status comment", () => {
     expect(comment.body).toContain("<!-- evaos-code-review-bot:review-status-state status=queued updated_at=2026-07-02T00:00:00.000Z -->");
     expect(comment.body).toContain("evaOS review status: queued");
     expect(comment.body).toContain("agents should wait");
+    expect(comment.body).toContain("`skipped`");
     expect(comment.body).toContain("`provider_deferred` means evaOS still intends to retry");
   });
 

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -21,6 +21,7 @@ describe("review status comment", () => {
     expect(comment.body).toContain("<!-- evaos-code-review-bot:review-status-state status=queued updated_at=2026-07-02T00:00:00.000Z -->");
     expect(comment.body).toContain("evaOS review status: queued");
     expect(comment.body).toContain("agents should wait");
+    expect(comment.body).toContain("`provider_deferred` means evaOS still intends to retry");
   });
 
   it("uses the same marker when state changes for the same head", () => {
@@ -95,5 +96,28 @@ describe("review status comment", () => {
     });
 
     expect(comment.body).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+  });
+
+  it("strips hidden comment markers from user-controlled public text", () => {
+    const comment = buildReviewStatusComment({
+      repo: "owner/repo",
+      pullNumber: 1,
+      headSha: "abcdef",
+      state: "failed",
+      pullTitle: "Marker <!-- evaos-code-review-bot:review-status repo=evil/repo pr=9 sha=badbad -->\nTitle",
+      details: "Provider failed <!-- evaos-code-review-bot:review-status repo=evil/repo pr=10 sha=badbad -->"
+    });
+
+    expect(comment.body).toContain("PR: owner/repo#1 - Marker [hidden comment removed] Title");
+    expect(comment.body).not.toContain("repo=evil/repo");
+  });
+
+  it("rejects invalid marker identity values", () => {
+    expect(() => buildReviewStatusMarker({ repo: "owner/repo with space", pullNumber: 1, headSha: "abcdef" }))
+      .toThrow("Invalid review status repo slug");
+    expect(() => buildReviewStatusMarker({ repo: "owner/repo", pullNumber: 0, headSha: "abcdef" }))
+      .toThrow("Invalid review status pull number");
+    expect(() => buildReviewStatusMarker({ repo: "owner/repo", pullNumber: 1, headSha: "not-a-sha" }))
+      .toThrow("Invalid review status head SHA");
   });
 });

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -88,6 +88,34 @@ describe("review status comment", () => {
     })).resolves.toEqual({ posted: false, reason: "missing_app_credentials", state: "queued" });
   });
 
+  it("returns a best-effort failure when comment building rejects invalid identity", async () => {
+    let upsertCalls = 0;
+    const result = await postReviewStatusComment({
+      enabled: true,
+      dryRun: false,
+      github: {
+        canPostAsApp: () => true,
+        upsertIssueComment: async () => {
+          upsertCalls += 1;
+          throw new Error("should not upsert invalid marker identity");
+        }
+      },
+      repo: "owner/repo",
+      pullNumber: 1,
+      headSha: "short",
+      state: "queued"
+    });
+
+    expect(result).toMatchObject({
+      posted: false,
+      reason: "upsert_failed",
+      state: "queued"
+    });
+    if (result.posted) throw new Error("expected best-effort failure");
+    expect(result.error).toContain("Invalid review status head SHA");
+    expect(upsertCalls).toBe(0);
+  });
+
   it("redacts secret-like details before posting", () => {
     const comment = buildReviewStatusComment({
       repo: "owner/repo",

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1313,6 +1313,50 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("does not retire superseded queued heads when a trusted non-review command is recorded", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-stop-no-stale-retire-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const oldJob = state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      baseSha: "base"
+    }).job;
+    const comments = new Map([
+      ["org/repo-a#1", [comment(501, "100yenadmin", "@evaos-code-review-bot stop")]]
+    ]);
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_B)]]
+      ]), comments, statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => "skipped_command_stop",
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.skippedCommandStop).toBe(1);
+    expect(result.queue.staleRetired).toBe(0);
+    expect(statusCalls).toHaveLength(0);
+    expect(state.getReviewQueueJob(oldJob.jobId)).toMatchObject({ state: "queued" });
+    expect(state.listReviewQueueJobs({ state: "command_recorded" })).toEqual([
+      expect.objectContaining({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_B, commentId: 501 })
+    ]);
+    state.close();
+  });
+
   it("does not stale-retire manual command jobs when only the base SHA changed", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-manual-base-drift-"));
     roots.push(root);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -62,6 +62,137 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("posts a sticky status comment from queued through completed for a live queued head", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-completed-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "a1")]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-status"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.reviewed).toBe(1);
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "completed"]);
+    expect(new Set(statusCalls.map((call) => call.marker))).toEqual(new Set([
+      "<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=a1 -->"
+    ]));
+    expect(statusCalls.at(-1)?.body).toContain("https://github.com/org/repo-a/pull/1#pullrequestreview-status");
+    state.close();
+  });
+
+  it("updates sticky status to provider_deferred when a leased review hits provider cooldown", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-provider-deferred-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "a1")]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: true },
+      reviewPullImpl: async () => {
+        throw new Error("ProviderBusinessError: [1302][Rate limit reached for requests]");
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.skippedProviderCooldown).toBe(1);
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "provider_deferred"]);
+    expect(statusCalls.at(-1)?.body).toContain("temporarily unavailable or rate-limited");
+    state.close();
+  });
+
+  it("updates sticky status for stale and closed queued heads before running review work", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-retire-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: "old-a", baseSha: "base" });
+    state.enqueueReviewQueueJob({ repo: "org/repo-b", pullNumber: 2, headSha: "closed-b", baseSha: "base" });
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "new-a")]],
+        ["org/repo-b", [pull("org/repo-b", 2, "closed-b", "base", { state: "closed" })]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("should not review retired jobs");
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.queue.staleRetired).toBe(1);
+    expect(result.queue.closedRetired).toBe(1);
+    expect(statusCalls.map(statusFromBody).sort()).toEqual(["closed_or_merged_before_review", "stale_head"]);
+    expect(statusCalls.map((call) => call.marker).sort()).toEqual([
+      "<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=old-a -->",
+      "<!-- evaos-code-review-bot:review-status repo=org/repo-b pr=2 sha=closed-b -->"
+    ]);
+    state.close();
+  });
+
+  it("does not post sticky status comments during dry-run scheduler cycles", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-dry-run-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const statusCalls: StatusCommentCall[] = [];
+
+    await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "a1")]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: true, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "dry_run",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(statusCalls).toHaveLength(0);
+    state.close();
+  });
+
   it("records provider throttle on one repo without blocking an unrelated leased repo", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-provider-throttle-"));
     roots.push(root);
@@ -938,6 +1069,9 @@ function schedulerConfig(root: string, repos: string[]): BotConfig {
       enabled: false,
       postIssueComment: false
     },
+    reviewStatusComment: {
+      enabled: false
+    },
     commands: {
       enabled: false,
       botMentions: ["@evaos-code-review-bot"],
@@ -959,7 +1093,8 @@ function schedulerConfig(root: string, repos: string[]): BotConfig {
 
 function githubFromMap(
   pullsByRepo: Map<string, PullRequestSummary[]>,
-  commentsByPull = new Map<string, ReturnType<typeof comment>[]>()
+  commentsByPull = new Map<string, ReturnType<typeof comment>[]>(),
+  statusCalls?: StatusCommentCall[]
 ): SchedulerGitHubApi {
   return {
     listOpenPulls: async (repo) => pullsByRepo.get(repo)?.filter((entry) => entry.state === undefined || entry.state === "open") ?? [],
@@ -968,8 +1103,30 @@ function githubFromMap(
       if (!pull) throw new Error(`missing pull ${repo}#${pullNumber}`);
       return pull;
     },
-    listIssueComments: async (repo, issueNumber) => commentsByPull.get(`${repo}#${issueNumber}`) ?? []
+    listIssueComments: async (repo, issueNumber) => commentsByPull.get(`${repo}#${issueNumber}`) ?? [],
+    ...(statusCalls
+      ? {
+          canPostAsApp: () => true,
+          upsertIssueComment: async (input: StatusCommentCall) => {
+            statusCalls.push(input);
+            return { action: statusCalls.filter((call) => call.marker === input.marker).length === 1 ? "created" as const : "updated" as const, id: statusCalls.length };
+          }
+        }
+      : {})
   };
+}
+
+interface StatusCommentCall {
+  repo: string;
+  issueNumber: number;
+  marker: string;
+  body: string;
+}
+
+function statusFromBody(call: StatusCommentCall): string {
+  const match = call.body.match(/review-status-state status=([^ ]+)/);
+  if (!match?.[1]) throw new Error(`missing status marker in ${call.body}`);
+  return match[1];
 }
 
 function pull(

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -397,6 +397,139 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("sets terminal failed status when a queued job becomes policy-skipped after in-progress", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-policy-skip-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => "skipped_policy",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.skippedPolicy).toBe(1);
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "failed"]);
+    expect(state.listReviewQueueJobs({ state: "failed" })).toHaveLength(1);
+    state.close();
+  });
+
+  it("retires superseded queue jobs even when status comments are disabled", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-disabled-status-superseded-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = false;
+    const state = new ReviewStateStore(config.statePath);
+    const oldJob = state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      baseSha: "base"
+    }).job;
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_B)]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.reviewed).toBe(1);
+    expect(result.statusCommentFailures).toBe(0);
+    expect(state.getReviewQueueJob(oldJob.jobId)).toMatchObject({
+      state: "stale_retired",
+      lastError: `superseded_by_head=${HEAD_B}`
+    });
+    state.close();
+  });
+
+  it("retires closed queue jobs even when status comments are disabled", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-disabled-status-closed-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    config.reviewStatusComment!.enabled = false;
+    const state = new ReviewStateStore(config.statePath);
+    const oldJob = state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      baseSha: "base"
+    }).job;
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A, "base", { state: "closed" })]]
+      ])),
+      state,
+      options: { repo: "org/repo-a", pullNumber: 1, dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("should not review closed pull");
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.queue.closedRetired).toBe(1);
+    expect(result.statusCommentFailures).toBe(0);
+    expect(state.getReviewQueueJob(oldJob.jobId)).toMatchObject({ state: "closed_retired" });
+    state.close();
+  });
+
+  it("posts stale_head for a leased job whose head no longer matches the live pull", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-leased-head-mismatch-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      baseSha: "base"
+    });
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_B)]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("should not review stale head");
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.skippedStaleHead).toBe(1);
+    expect(statusCalls.map(statusFromBody)).toEqual(["stale_head"]);
+    expect(statusCalls[0]?.marker).toBe(`<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=${HEAD_A} -->`);
+    expect(state.listReviewQueueJobs({ state: "stale_retired" })).toHaveLength(1);
+    state.close();
+  });
+
   it("records provider throttle on one repo without blocking an unrelated leased repo", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-provider-throttle-"));
     roots.push(root);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -73,7 +73,7 @@ describe("provider-aware review scheduler", () => {
     const result = await runScheduledCycleWithDeps({
       config,
       github: githubFromMap(new Map([
-        ["org/repo-a", [pull("org/repo-a", 1, "a1")]]
+        ["org/repo-a", [pull("org/repo-a", 1, "abc123")]]
       ]), new Map(), statusCalls),
       state,
       options: { dryRun: false, useZCode: false },
@@ -94,7 +94,7 @@ describe("provider-aware review scheduler", () => {
     expect(result.reviewed).toBe(1);
     expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "completed"]);
     expect(new Set(statusCalls.map((call) => call.marker))).toEqual(new Set([
-      "<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=a1 -->"
+      "<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=abc123 -->"
     ]));
     expect(statusCalls.at(-1)?.body).toContain("https://github.com/org/repo-a/pull/1#pullrequestreview-status");
     state.close();
@@ -111,7 +111,7 @@ describe("provider-aware review scheduler", () => {
     const result = await runScheduledCycleWithDeps({
       config,
       github: githubFromMap(new Map([
-        ["org/repo-a", [pull("org/repo-a", 1, "a1")]]
+        ["org/repo-a", [pull("org/repo-a", 1, "abc123")]]
       ]), new Map(), statusCalls),
       state,
       options: { dryRun: false, useZCode: true },
@@ -124,6 +124,40 @@ describe("provider-aware review scheduler", () => {
     expect(result.skippedProviderCooldown).toBe(1);
     expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "provider_deferred"]);
     expect(statusCalls.at(-1)?.body).toContain("temporarily unavailable or rate-limited");
+    expect(statusCalls.at(-1)?.body).not.toContain("ProviderBusinessError");
+    state.close();
+  });
+
+  it("marks a queued status failed when refetching the leased pull fails", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-refetch-failed-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: "abc123", baseSha: "base" });
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: {
+        ...githubFromMap(new Map(), new Map(), statusCalls),
+        getPull: async () => {
+          throw new Error("GitHub API fetch failed for /repos/org/repo-a/pulls/1: internal host detail");
+        }
+      },
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("should not review failed refetch");
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.failed).toBe(1);
+    expect(statusCalls.map(statusFromBody)).toEqual(["failed"]);
+    expect(statusCalls[0]?.body).toContain("GitHub refetch failed; see bot evidence");
+    expect(statusCalls[0]?.body).not.toContain("internal host detail");
+    expect(state.listReviewQueueJobs({ state: "failed" })).toHaveLength(1);
     state.close();
   });
 
@@ -133,15 +167,15 @@ describe("provider-aware review scheduler", () => {
     const config = schedulerConfig(root, []);
     config.reviewStatusComment!.enabled = true;
     const state = new ReviewStateStore(config.statePath);
-    state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: "old-a", baseSha: "base" });
-    state.enqueueReviewQueueJob({ repo: "org/repo-b", pullNumber: 2, headSha: "closed-b", baseSha: "base" });
+    state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: "abc123", baseSha: "base" });
+    state.enqueueReviewQueueJob({ repo: "org/repo-b", pullNumber: 2, headSha: "fedcba", baseSha: "base" });
     const statusCalls: StatusCommentCall[] = [];
 
     const result = await runScheduledCycleWithDeps({
       config,
       github: githubFromMap(new Map([
-        ["org/repo-a", [pull("org/repo-a", 1, "new-a")]],
-        ["org/repo-b", [pull("org/repo-b", 2, "closed-b", "base", { state: "closed" })]]
+        ["org/repo-a", [pull("org/repo-a", 1, "def456")]],
+        ["org/repo-b", [pull("org/repo-b", 2, "fedcba", "base", { state: "closed" })]]
       ]), new Map(), statusCalls),
       state,
       options: { dryRun: false, useZCode: false },
@@ -155,9 +189,61 @@ describe("provider-aware review scheduler", () => {
     expect(result.queue.closedRetired).toBe(1);
     expect(statusCalls.map(statusFromBody).sort()).toEqual(["closed_or_merged_before_review", "stale_head"]);
     expect(statusCalls.map((call) => call.marker).sort()).toEqual([
-      "<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=old-a -->",
-      "<!-- evaos-code-review-bot:review-status repo=org/repo-b pr=2 sha=closed-b -->"
+      "<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=abc123 -->",
+      "<!-- evaos-code-review-bot:review-status repo=org/repo-b pr=2 sha=fedcba -->"
     ]);
+    state.close();
+  });
+
+  it("retires superseded queued status comments when a newer head is enqueued", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-superseded-head-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const oldJob = state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "abc123",
+      baseSha: "base"
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: oldJob.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-02T00:05:00.000Z",
+      lastError: "provider cooldown",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "def456")]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.reviewed).toBe(1);
+    expect(state.getReviewQueueJob(oldJob.jobId)).toMatchObject({
+      state: "stale_retired",
+      lastError: "superseded_by_head=def456"
+    });
+    expect(statusCalls.map(statusFromBody)).toEqual(["stale_head", "queued", "in_progress", "completed"]);
+    expect(statusCalls[0]?.marker).toBe("<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=abc123 -->");
+    expect(statusCalls.at(-1)?.marker).toBe("<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=def456 -->");
     state.close();
   });
 
@@ -172,7 +258,7 @@ describe("provider-aware review scheduler", () => {
     await runScheduledCycleWithDeps({
       config,
       github: githubFromMap(new Map([
-        ["org/repo-a", [pull("org/repo-a", 1, "a1")]]
+        ["org/repo-a", [pull("org/repo-a", 1, "abc123")]]
       ]), new Map(), statusCalls),
       state,
       options: { dryRun: true, useZCode: false },
@@ -190,6 +276,46 @@ describe("provider-aware review scheduler", () => {
     });
 
     expect(statusCalls).toHaveLength(0);
+    state.close();
+  });
+
+  it("does not throw or upsert status comments when App credentials are absent", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-token-mode-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    let upsertCalls = 0;
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: {
+        ...githubFromMap(new Map([
+          ["org/repo-a", [pull("org/repo-a", 1, "abc123")]]
+        ])),
+        canPostAsApp: () => false,
+        upsertIssueComment: async () => {
+          upsertCalls += 1;
+          throw new Error("should not upsert without App credentials");
+        }
+      },
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.reviewed).toBe(1);
+    expect(upsertCalls).toBe(0);
     state.close();
   });
 
@@ -986,6 +1112,47 @@ describe("provider-aware review scheduler", () => {
 
     expect(result.reviewed).toBe(1);
     expect(result.skippedStaleHead).toBe(0);
+    expect(state.listReviewQueueJobs({ state: "posted" })).toHaveLength(1);
+    state.close();
+  });
+
+  it("does not stale-retire automatic jobs when only the base SHA changed", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-automatic-base-drift-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "abc123",
+      baseSha: "old-base"
+    });
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "abc123", "new-base")]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.reviewed).toBe(1);
+    expect(result.skippedStaleHead).toBe(0);
+    expect(statusCalls.map(statusFromBody)).toEqual(["in_progress", "completed"]);
     expect(state.listReviewQueueJobs({ state: "posted" })).toHaveLength(1);
     state.close();
   });

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -422,6 +422,33 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("does not regress an in-progress status back to queued when legacy capacity is busy", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-capacity-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => "skipped_capacity",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.skippedCapacity).toBe(1);
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress"]);
+    expect(state.listReviewQueueJobs({ state: "queued" })).toEqual([
+      expect.objectContaining({ lastError: "legacy_review_capacity_busy" })
+    ]);
+    state.close();
+  });
+
   it("retires superseded queue jobs even when status comments are disabled", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-disabled-status-superseded-"));
     roots.push(root);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -210,6 +210,100 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("persists terminal queue state before posting stale or closed sticky status comments", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-retire-ordering-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const staleJob = state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, baseSha: "base" }).job;
+    const closedJob = state.enqueueReviewQueueJob({ repo: "org/repo-b", pullNumber: 2, headSha: HEAD_F, baseSha: "base" }).job;
+    const observedStates = new Map<string, string | undefined>();
+    const statusCalls: StatusCommentCall[] = [];
+    const baseGithub = githubFromMap(new Map([
+      ["org/repo-a", [pull("org/repo-a", 1, HEAD_D)]],
+      ["org/repo-b", [pull("org/repo-b", 2, HEAD_F, "base", { state: "closed" })]]
+    ]), new Map(), statusCalls);
+
+    await runScheduledCycleWithDeps({
+      config,
+      github: {
+        ...baseGithub,
+        upsertIssueComment: async (input) => {
+          statusCalls.push(input);
+          const status = statusFromBody(input);
+          if (status === "stale_head") {
+            observedStates.set(status, state.getReviewQueueJob(staleJob.jobId)?.state);
+          }
+          if (status === "closed_or_merged_before_review") {
+            observedStates.set(status, state.getReviewQueueJob(closedJob.jobId)?.state);
+          }
+          return { action: statusCalls.filter((call) => call.marker === input.marker).length === 1 ? "created" : "updated", id: statusCalls.length };
+        }
+      },
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("should not review retired jobs");
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(observedStates.get("stale_head")).toBe("stale_retired");
+    expect(observedStates.get("closed_or_merged_before_review")).toBe("closed_retired");
+    expect(statusCalls.map(statusFromBody).sort()).toEqual(["closed_or_merged_before_review", "stale_head"]);
+    state.close();
+  });
+
+  it("maps duplicate processed-head status comments from the stored processed outcome", async () => {
+    const scenarios = [
+      { processedStatus: "posted", expectedStatus: "completed", expectedQueueState: "posted" },
+      { processedStatus: "dry_run", expectedStatus: "completed", expectedQueueState: "queued" },
+      { processedStatus: "failed", expectedStatus: "failed", expectedQueueState: "failed" },
+      { processedStatus: "skipped", expectedStatus: "skipped", expectedQueueState: "failed" }
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const root = mkdtempSync(join(tmpdir(), `evaos-scheduler-status-processed-${scenario.processedStatus}-`));
+      roots.push(root);
+      const config = schedulerConfig(root, ["org/repo-a"]);
+      config.reviewStatusComment!.enabled = true;
+      const state = new ReviewStateStore(config.statePath);
+      state.recordProcessed({
+        repo: "org/repo-a",
+        pullNumber: 1,
+        headSha: HEAD_A,
+        status: scenario.processedStatus,
+        ...(scenario.processedStatus === "posted"
+          ? { event: "COMMENT" as const, reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-existing" }
+          : {})
+      });
+      const job = state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, baseSha: "base" }).job;
+      const statusCalls: StatusCommentCall[] = [];
+
+      await runScheduledCycleWithDeps({
+        config,
+        github: githubFromMap(new Map([
+          ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
+        ]), new Map(), statusCalls),
+        state,
+        options: { dryRun: false, useZCode: false },
+        reviewPullImpl: async () => "skipped_processed",
+        now: new Date("2026-07-02T00:00:00.000Z")
+      });
+
+      expect(statusCalls.map(statusFromBody)).toEqual(["in_progress", scenario.expectedStatus]);
+      expect(state.getReviewQueueJob(job.jobId)).toMatchObject({
+        state: scenario.expectedQueueState,
+        lastError: `processed_head_already_${scenario.processedStatus}`
+      });
+      if (scenario.processedStatus === "posted") {
+        expect(statusCalls.at(-1)?.body).toContain("https://github.com/org/repo-a/pull/1#pullrequestreview-existing");
+      }
+      state.close();
+    }
+  });
+
   it("retires superseded queued status comments when a newer head is enqueued", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-superseded-head-"));
     roots.push(root);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -255,6 +255,68 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("settles RepoSticky session jobs when scan-time retirement supersedes or closes queued jobs", async () => {
+    const scenarios = [
+      { name: "superseded", pull: pull("org/repo-a", 1, HEAD_B), expectedQueueState: "stale_retired" },
+      { name: "closed", pull: pull("org/repo-a", 1, HEAD_A, "base", { state: "closed" }), expectedQueueState: "closed_retired" }
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const root = mkdtempSync(join(tmpdir(), `evaos-scheduler-session-retire-${scenario.name}-`));
+      roots.push(root);
+      const config = schedulerConfig(root, ["org/repo-a"]);
+      config.reviewerSessions = {
+        enabled: true,
+        ttlMs: 8 * 60 * 60_000,
+        headCountLimit: 10
+      };
+      const state = new ReviewStateStore(config.statePath);
+      const assignment = state.assignReviewerSessionJob({
+        repo: "org/repo-a",
+        pullNumber: 1,
+        headSha: HEAD_A,
+        ttlMs: config.reviewerSessions.ttlMs,
+        headCountLimit: config.reviewerSessions.headCountLimit,
+        now: new Date("2026-07-02T00:00:00.000Z")
+      });
+      if (!assignment.assigned) throw new Error("expected test session assignment");
+      const job = state.enqueueReviewQueueJob({
+        repo: "org/repo-a",
+        pullNumber: 1,
+        headSha: HEAD_A,
+        baseSha: "base",
+        sessionId: assignment.session.sessionId
+      }).job;
+
+      await runScheduledCycleWithDeps({
+        config,
+        github: githubFromMap(new Map([["org/repo-a", [scenario.pull]]])),
+        state,
+        options: scenario.name === "closed"
+          ? { repo: "org/repo-a", pullNumber: 1, dryRun: false, useZCode: false }
+          : { dryRun: false, useZCode: false },
+        reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+          reviewState.recordProcessed({
+            repo,
+            pullNumber: reviewPull.number,
+            headSha: reviewPull.head.sha,
+            status: "posted",
+            event: "COMMENT"
+          });
+          return "reviewed";
+        },
+        now: new Date("2026-07-02T00:01:00.000Z")
+      });
+
+      expect(state.getReviewQueueJob(job.jobId)).toMatchObject({ state: scenario.expectedQueueState });
+      expect(state.getReviewerSessionJob("org/repo-a", 1, HEAD_A)).toMatchObject({
+        jobState: "skipped",
+        processedReviewStatus: "skipped"
+      });
+      state.close();
+    }
+  });
+
   it("maps duplicate processed-head status comments from the stored processed outcome", async () => {
     const scenarios = [
       { processedStatus: "posted", expectedStatus: "completed", expectedQueueState: "posted" },

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -129,7 +129,7 @@ describe("provider-aware review scheduler", () => {
 
     expect(result.skippedProviderCooldown).toBe(1);
     expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "provider_deferred"]);
-    expect(statusCalls.at(-1)?.body).toContain("temporarily unavailable or rate-limited");
+    expect(statusCalls.at(-1)?.body).toContain("temporarily unavailable");
     expect(statusCalls.at(-1)?.body).not.toContain("ProviderBusinessError");
     state.close();
   });
@@ -422,7 +422,7 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
-  it("does not regress an in-progress status back to queued when legacy capacity is busy", async () => {
+  it("moves in-progress status to provider_deferred when legacy capacity is busy", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-capacity-"));
     roots.push(root);
     const config = schedulerConfig(root, ["org/repo-a"]);
@@ -442,7 +442,7 @@ describe("provider-aware review scheduler", () => {
     });
 
     expect(result.skippedCapacity).toBe(1);
-    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress"]);
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "provider_deferred"]);
     expect(state.listReviewQueueJobs({ state: "queued" })).toEqual([
       expect.objectContaining({ lastError: "legacy_review_capacity_busy" })
     ]);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1401,7 +1401,7 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
-  it("stale-retires automatic base-drift jobs without posting a terminal same-head status", async () => {
+  it("stale-retires automatic base-drift jobs and posts a terminal same-head status", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-automatic-base-drift-"));
     roots.push(root);
     const config = schedulerConfig(root, []);
@@ -1437,7 +1437,7 @@ describe("provider-aware review scheduler", () => {
 
     expect(result.reviewed).toBe(0);
     expect(result.skippedStaleHead).toBe(1);
-    expect(statusCalls).toHaveLength(0);
+    expect(statusCalls.map(statusFromBody)).toEqual(["stale_head"]);
     expect(state.listReviewQueueJobs({ state: "stale_retired" })).toEqual([
       expect.objectContaining({ lastError: "base_changed_before_review live=new-base" })
     ]);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -8,6 +8,12 @@ import { ReviewStateStore } from "../src/state.js";
 import type { PullRequestSummary } from "../src/types.js";
 import { reviewPull, type ReviewPullInput, type ReviewPullResult } from "../src/worker.js";
 
+const HEAD_A = "a".repeat(40);
+const HEAD_B = "b".repeat(40);
+const HEAD_C = "c".repeat(40);
+const HEAD_D = "d".repeat(40);
+const HEAD_F = "f".repeat(40);
+
 describe("provider-aware review scheduler", () => {
   const roots: string[] = [];
 
@@ -73,7 +79,7 @@ describe("provider-aware review scheduler", () => {
     const result = await runScheduledCycleWithDeps({
       config,
       github: githubFromMap(new Map([
-        ["org/repo-a", [pull("org/repo-a", 1, "abc123")]]
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
       ]), new Map(), statusCalls),
       state,
       options: { dryRun: false, useZCode: false },
@@ -94,7 +100,7 @@ describe("provider-aware review scheduler", () => {
     expect(result.reviewed).toBe(1);
     expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "completed"]);
     expect(new Set(statusCalls.map((call) => call.marker))).toEqual(new Set([
-      "<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=abc123 -->"
+      `<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=${HEAD_A} -->`
     ]));
     expect(statusCalls.at(-1)?.body).toContain("https://github.com/org/repo-a/pull/1#pullrequestreview-status");
     state.close();
@@ -111,7 +117,7 @@ describe("provider-aware review scheduler", () => {
     const result = await runScheduledCycleWithDeps({
       config,
       github: githubFromMap(new Map([
-        ["org/repo-a", [pull("org/repo-a", 1, "abc123")]]
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
       ]), new Map(), statusCalls),
       state,
       options: { dryRun: false, useZCode: true },
@@ -134,7 +140,7 @@ describe("provider-aware review scheduler", () => {
     const config = schedulerConfig(root, []);
     config.reviewStatusComment!.enabled = true;
     const state = new ReviewStateStore(config.statePath);
-    state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: "abc123", baseSha: "base" });
+    state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, baseSha: "base" });
     const statusCalls: StatusCommentCall[] = [];
 
     const result = await runScheduledCycleWithDeps({
@@ -167,15 +173,15 @@ describe("provider-aware review scheduler", () => {
     const config = schedulerConfig(root, []);
     config.reviewStatusComment!.enabled = true;
     const state = new ReviewStateStore(config.statePath);
-    state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: "abc123", baseSha: "base" });
-    state.enqueueReviewQueueJob({ repo: "org/repo-b", pullNumber: 2, headSha: "fedcba", baseSha: "base" });
+    state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, baseSha: "base" });
+    state.enqueueReviewQueueJob({ repo: "org/repo-b", pullNumber: 2, headSha: HEAD_F, baseSha: "base" });
     const statusCalls: StatusCommentCall[] = [];
 
     const result = await runScheduledCycleWithDeps({
       config,
       github: githubFromMap(new Map([
-        ["org/repo-a", [pull("org/repo-a", 1, "def456")]],
-        ["org/repo-b", [pull("org/repo-b", 2, "fedcba", "base", { state: "closed" })]]
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_D)]],
+        ["org/repo-b", [pull("org/repo-b", 2, HEAD_F, "base", { state: "closed" })]]
       ]), new Map(), statusCalls),
       state,
       options: { dryRun: false, useZCode: false },
@@ -189,8 +195,8 @@ describe("provider-aware review scheduler", () => {
     expect(result.queue.closedRetired).toBe(1);
     expect(statusCalls.map(statusFromBody).sort()).toEqual(["closed_or_merged_before_review", "stale_head"]);
     expect(statusCalls.map((call) => call.marker).sort()).toEqual([
-      "<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=abc123 -->",
-      "<!-- evaos-code-review-bot:review-status repo=org/repo-b pr=2 sha=fedcba -->"
+      `<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=${HEAD_A} -->`,
+      `<!-- evaos-code-review-bot:review-status repo=org/repo-b pr=2 sha=${HEAD_F} -->`
     ]);
     state.close();
   });
@@ -204,7 +210,7 @@ describe("provider-aware review scheduler", () => {
     const oldJob = state.enqueueReviewQueueJob({
       repo: "org/repo-a",
       pullNumber: 1,
-      headSha: "abc123",
+      headSha: HEAD_A,
       baseSha: "base"
     }).job;
     state.updateReviewQueueJobState({
@@ -219,7 +225,7 @@ describe("provider-aware review scheduler", () => {
     const result = await runScheduledCycleWithDeps({
       config,
       github: githubFromMap(new Map([
-        ["org/repo-a", [pull("org/repo-a", 1, "def456")]]
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_D)]]
       ]), new Map(), statusCalls),
       state,
       options: { dryRun: false, useZCode: false },
@@ -239,11 +245,44 @@ describe("provider-aware review scheduler", () => {
     expect(result.reviewed).toBe(1);
     expect(state.getReviewQueueJob(oldJob.jobId)).toMatchObject({
       state: "stale_retired",
-      lastError: "superseded_by_head=def456"
+      lastError: `superseded_by_head=${HEAD_D}`
     });
     expect(statusCalls.map(statusFromBody)).toEqual(["stale_head", "queued", "in_progress", "completed"]);
-    expect(statusCalls[0]?.marker).toBe("<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=abc123 -->");
-    expect(statusCalls.at(-1)?.marker).toBe("<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=def456 -->");
+    expect(statusCalls[0]?.marker).toBe(`<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=${HEAD_A} -->`);
+    expect(statusCalls.at(-1)?.marker).toBe(`<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=${HEAD_D} -->`);
+    state.close();
+  });
+
+  it("retires queued status comments when a scoped pull is already closed", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-closed-scan-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const oldJob = state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      baseSha: "base"
+    }).job;
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A, "base", { state: "closed" })]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { repo: "org/repo-a", pullNumber: 1, dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("should not review closed pull");
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.queue.closedRetired).toBe(1);
+    expect(state.getReviewQueueJob(oldJob.jobId)).toMatchObject({ state: "closed_retired" });
+    expect(statusCalls.map(statusFromBody)).toEqual(["closed_or_merged_before_review"]);
     state.close();
   });
 
@@ -258,7 +297,7 @@ describe("provider-aware review scheduler", () => {
     await runScheduledCycleWithDeps({
       config,
       github: githubFromMap(new Map([
-        ["org/repo-a", [pull("org/repo-a", 1, "abc123")]]
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
       ]), new Map(), statusCalls),
       state,
       options: { dryRun: true, useZCode: false },
@@ -291,7 +330,7 @@ describe("provider-aware review scheduler", () => {
       config,
       github: {
         ...githubFromMap(new Map([
-          ["org/repo-a", [pull("org/repo-a", 1, "abc123")]]
+          ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
         ])),
         canPostAsApp: () => false,
         upsertIssueComment: async () => {
@@ -315,7 +354,46 @@ describe("provider-aware review scheduler", () => {
     });
 
     expect(result.reviewed).toBe(1);
+    expect(result.statusCommentFailures).toBe(3);
     expect(upsertCalls).toBe(0);
+    state.close();
+  });
+
+  it("counts status-comment upsert failures without failing the review", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-upsert-failure-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: {
+        ...githubFromMap(new Map([
+          ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
+        ])),
+        canPostAsApp: () => true,
+        upsertIssueComment: async () => {
+          throw new Error("GitHub API 500");
+        }
+      },
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.reviewed).toBe(1);
+    expect(result.statusCommentFailures).toBe(3);
     state.close();
   });
 
@@ -1116,7 +1194,7 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
-  it("does not stale-retire automatic jobs when only the base SHA changed", async () => {
+  it("stale-retires automatic base-drift jobs without posting a terminal same-head status", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-automatic-base-drift-"));
     roots.push(root);
     const config = schedulerConfig(root, []);
@@ -1125,7 +1203,7 @@ describe("provider-aware review scheduler", () => {
     state.enqueueReviewQueueJob({
       repo: "org/repo-a",
       pullNumber: 1,
-      headSha: "abc123",
+      headSha: HEAD_A,
       baseSha: "old-base"
     });
     const statusCalls: StatusCommentCall[] = [];
@@ -1133,7 +1211,7 @@ describe("provider-aware review scheduler", () => {
     const result = await runScheduledCycleWithDeps({
       config,
       github: githubFromMap(new Map([
-        ["org/repo-a", [pull("org/repo-a", 1, "abc123", "new-base")]]
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A, "new-base")]]
       ]), new Map(), statusCalls),
       state,
       options: { dryRun: false, useZCode: false },
@@ -1150,10 +1228,12 @@ describe("provider-aware review scheduler", () => {
       now: new Date("2026-07-01T00:00:00.000Z")
     });
 
-    expect(result.reviewed).toBe(1);
-    expect(result.skippedStaleHead).toBe(0);
-    expect(statusCalls.map(statusFromBody)).toEqual(["in_progress", "completed"]);
-    expect(state.listReviewQueueJobs({ state: "posted" })).toHaveLength(1);
+    expect(result.reviewed).toBe(0);
+    expect(result.skippedStaleHead).toBe(1);
+    expect(statusCalls).toHaveLength(0);
+    expect(state.listReviewQueueJobs({ state: "stale_retired" })).toEqual([
+      expect.objectContaining({ lastError: "base_changed_before_review live=new-base" })
+    ]);
     state.close();
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -397,7 +397,7 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
-  it("sets terminal failed status when a queued job becomes policy-skipped after in-progress", async () => {
+  it("sets terminal skipped status when a queued job becomes policy-skipped after in-progress", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-policy-skip-"));
     roots.push(root);
     const config = schedulerConfig(root, ["org/repo-a"]);
@@ -417,7 +417,7 @@ describe("provider-aware review scheduler", () => {
     });
 
     expect(result.skippedPolicy).toBe(1);
-    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "failed"]);
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "skipped"]);
     expect(state.listReviewQueueJobs({ state: "failed" })).toHaveLength(1);
     state.close();
   });
@@ -834,23 +834,25 @@ describe("provider-aware review scheduler", () => {
       trustedAuthors: ["100yenadmin"],
       acknowledge: false
     };
+    config.reviewStatusComment!.enabled = true;
     const state = new ReviewStateStore(config.statePath);
     state.recordProcessed({
       repo: "org/repo-a",
       pullNumber: 1,
-      headSha: "a1",
+      headSha: HEAD_A,
       status: "posted",
       event: "COMMENT",
       reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-old"
     });
-    const pullMap = new Map([["org/repo-a", [pull("org/repo-a", 1, "a1")]]]);
+    const pullMap = new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]);
     const comments = new Map([
       ["org/repo-a#1", [comment(222, "100yenadmin", "@evaos-code-review-bot re-review")]]
     ]);
+    const statusCalls: StatusCommentCall[] = [];
 
     const result = await runScheduledCycleWithDeps({
       config,
-      github: githubFromMap(pullMap, comments),
+      github: githubFromMap(pullMap, comments, statusCalls),
       state,
       options: { dryRun: false, useZCode: false },
       reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
@@ -869,6 +871,7 @@ describe("provider-aware review scheduler", () => {
 
     expect(result.reviewed).toBe(1);
     expect(result.commandReviewRequested).toBe(1);
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "completed"]);
     expect(state.listReviewQueueJobs({ state: "posted" })).toEqual([
       expect.objectContaining({
         source: "manual_command",

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -515,6 +515,13 @@ describe("review state store", () => {
       baseSha: "base-a",
       now: new Date("2026-07-01T00:02:00.000Z")
     });
+    const third = store.enqueueReviewQueueJob({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 220,
+      headSha: "head-a",
+      baseSha: "base-a",
+      now: new Date("2026-07-01T00:03:00.000Z")
+    });
 
     expect(second).toMatchObject({
       enqueued: true,
@@ -526,6 +533,11 @@ describe("review state store", () => {
       }
     });
     expect(second.job.attemptId).toContain(":after-terminal:");
+    expect(third).toMatchObject({
+      enqueued: false,
+      reason: "already_queued",
+      job: { jobId: second.job.jobId }
+    });
     expect(store.listReviewQueueJobs({ repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO" })).toHaveLength(2);
     store.close();
   });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -490,6 +490,46 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("allows same-attempt queue jobs to be re-enqueued after terminal retirement", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-terminal-reenqueue-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const first = store.enqueueReviewQueueJob({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 220,
+      headSha: "head-a",
+      baseSha: "base-a",
+      now: new Date("2026-07-01T00:00:00.000Z")
+    }).job;
+    store.updateReviewQueueJobState({
+      jobId: first.jobId,
+      state: "stale_retired",
+      lastError: "superseded_by_head=head-b",
+      now: new Date("2026-07-01T00:01:00.000Z")
+    });
+
+    const second = store.enqueueReviewQueueJob({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 220,
+      headSha: "head-a",
+      baseSha: "base-a",
+      now: new Date("2026-07-01T00:02:00.000Z")
+    });
+
+    expect(second).toMatchObject({
+      enqueued: true,
+      job: {
+        repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+        pullNumber: 220,
+        headSha: "head-a",
+        state: "queued"
+      }
+    });
+    expect(second.job.attemptId).toContain(":after-terminal:");
+    expect(store.listReviewQueueJobs({ repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO" })).toHaveLength(2);
+    store.close();
+  });
+
   it("leases bounded queue jobs by provider org repo and manual reserve", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-lease-"));
     roots.push(root);


### PR DESCRIPTION
## Summary

Closes #95.

Adds a marker-backed, App-authored review status comment for each PR head when it enters the durable review queue. The scheduler now updates that same head-specific comment through:

- `queued`
- `in_progress`
- `completed`
- `provider_deferred`
- `stale_head`
- `closed_or_merged_before_review`
- `failed`

The identity marker is stable for `repo + PR + head SHA`, while the mutable state marker is edited in place. That avoids duplicate comments for the same head and prevents stale old-head workers from overwriting the live head's status.

## Why

Fast agent PRs can open and merge before the slower ZCode review finishes. LCO #274 showed this: CodeRabbit posted visible status within seconds, while evaOS review arrived after the PR was already merged. This adds the same kind of visible coordination signal so humans and agents can wait for evaOS review to settle.

## ClawSweeper / CodeRabbit comparison

Adversarial comparison against ClawSweeper:

- Matches the durable-comment pattern: hidden marker, public status, in-place edits.
- Matches the stale-head safety intent: status is tied to the PR head SHA, so old heads cannot clobber newer head status.
- Preserves separation between visible prose and machine-readable markers.
- Does not yet match ClawSweeper's webhook fast-ack latency; this PR is scheduler-side acknowledgement when the durable queue sees the head.
- Does not add hard merge blocking. A required GitHub Check should be a separate rollout after this comment lane proves quiet.

## Validation

- `npm test -- tests/review-status-comment.test.ts tests/scheduler.test.ts`
- `npm run build`
- `npm test`
- `git diff --cached --check`

Full suite result: 31 test files / 227 tests passed.
