### PR TITLE
Expose deterministic review budget status

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -23,15 +23,23 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
   durable queue counts, and recommended actions.
 - `runtime-inventory`: read-only runtime classifier for release operators. It
   includes release status, coverage, durable queue work, provider cooldowns,
-  leases, heartbeat, and bot-owned process rows. It can classify the worker as
-  `healthy_active` when open PR heads are already covered by active queue work,
-  even if the stricter `status` command is nonzero because live PR churn exists.
-  JSON is the default; use `--human` for a compact operator summary.
+  budget status, leases, heartbeat, and bot-owned process rows. It can classify
+  the worker as `healthy_active` when open PR heads are already covered by
+  active queue work, even if the stricter `status` command is nonzero because
+  live PR churn exists. JSON is the default; use `--human` for a compact
+  operator summary.
 - `agents`: launchd, heartbeat, and review-run lease inventory. This is
   read-only; it does not restart, kill, prune, or retire anything.
 - `queue`: open PR-head coverage grouped into processed, provider-deferred,
   pending review, skipped, stale-head, and read-failure buckets. Also includes
-  durable `review_queue_jobs` rows when the state DB has the scheduler table.
+  durable `review_queue_jobs` rows and budget delay reasons when the state DB
+  has the scheduler table.
+- `budget-status`: read-only scheduler budget projection. Shows active counts,
+  queued counts, would-lease jobs, delayed jobs, and deterministic delay reasons
+  such as `provider_cooldown`, `provider_capacity`, `org_capacity`,
+  `repo_capacity`, `manual_reserve`, and `lease_limit`. Broad status commands
+  include only compact budget counts and reason histograms; use this command for
+  capped row-level details.
 - `coverage`: raw coverage-audit report with the shorter operator command name.
 - `cooldowns`: provider cooldown review rows plus repo/global cooldown rows.
 - `why --repo <owner/name> --pr <number>`: scoped explanation for why one PR
@@ -77,6 +85,16 @@ Inspect only durable provider-deferred jobs:
 ```bash
 npx tsx src/cli.ts queue --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --state provider_deferred
 ```
+
+Inspect only the scheduler budget projection:
+
+```bash
+npx tsx src/cli.ts budget-status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+Use `--limit <n>` to cap returned `wouldLease`/`delayed` rows and
+`--job-limit <n>` to cap the queue rows read for projection. The output includes
+truncation metadata when either cap is hit.
 
 Explain one PR:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,8 +19,9 @@ import {
   formatRuntimeInventoryHuman,
   summarizeAgentInventory
 } from "./operator-cli.js";
-import { collectReleaseStatus } from "./release-status.js";
+import { collectReleaseStatus, type ReleaseStatus } from "./release-status.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
+import { redactSecrets } from "./secrets.js";
 import { ReviewStateStore, type ReviewQueueJobState } from "./state.js";
 import { isSuccessfulRetryStatus, retryFailedHead, retryProviderCooldowns, runOnce } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
@@ -122,11 +123,13 @@ async function main(): Promise<void> {
       budgetDetailLimit,
       budgetJobLimit
     });
+    const ok = status.budget?.enabled === true && status.budget.details.inputJobsTruncated !== true;
     console.log(JSON.stringify({
-      ok: true,
+      ok,
       checkedAt: status.checkedAt,
       budget: status.budget
     }, null, 2));
+    if (!ok) process.exitCode = 1;
     return;
   }
 
@@ -261,13 +264,6 @@ async function main(): Promise<void> {
 
   if (command === "queue") {
     const config = loadConfig(args.config);
-    const release = collectReleaseStatus({
-      cwd: process.cwd(),
-      configPath: args.config,
-      expectedHead: args["expected-head"],
-      launchdLabel: args["launchd-label"],
-      statePath: args["state-path"]
-    });
     const report = await collectCoverageReport(args, config);
     const queue = buildOperatorQueue(report);
     const durableQueue = collectOperatorReviewQueue(args["state-path"] ?? config.statePath, {
@@ -275,7 +271,7 @@ async function main(): Promise<void> {
       state: parseReviewQueueJobState(args.state),
       limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
     });
-    const output = { ...queue, ok: queue.ok, coverage: queue, durableQueue, budget: release.budget };
+    const output = { ...queue, ok: queue.ok, coverage: queue, durableQueue, ...collectQueueBudget(args) };
     console.log(JSON.stringify(output, null, 2));
     if (!output.ok) process.exitCode = 1;
     return;
@@ -545,6 +541,27 @@ async function collectCoverageReport(args: ParsedArgs, config = loadConfig(args.
     });
   } finally {
     state.close();
+  }
+}
+
+function collectQueueBudget(args: ParsedArgs): {
+  budget?: ReleaseStatus["budget"];
+  budgetError?: string;
+} {
+  try {
+    return {
+      budget: collectReleaseStatus({
+        cwd: process.cwd(),
+        configPath: args.config,
+        expectedHead: args["expected-head"],
+        launchdLabel: args["launchd-label"],
+        statePath: args["state-path"]
+      }).budget
+    };
+  } catch (error) {
+    return {
+      budgetError: redactSecrets(error instanceof Error ? error.message : String(error))
+    };
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,15 +88,45 @@ async function main(): Promise<void> {
   }
 
   if (command === "release-status") {
+    const budgetDetailLimit = args["budget-detail-limit"]
+      ? parsePositiveInteger(args["budget-detail-limit"], "--budget-detail-limit")
+      : undefined;
+    const budgetJobLimit = args["budget-job-limit"]
+      ? parsePositiveInteger(args["budget-job-limit"], "--budget-job-limit")
+      : undefined;
     const status = collectReleaseStatus({
       cwd: process.cwd(),
       configPath: args.config,
       expectedHead: args["expected-head"],
       launchdLabel: args["launchd-label"],
-      statePath: args["state-path"]
+      statePath: args["state-path"],
+      budgetDetails: args["budget-details"] === "true",
+      ...(budgetDetailLimit !== undefined ? { budgetDetailLimit } : {}),
+      ...(budgetJobLimit !== undefined ? { budgetJobLimit } : {})
     });
     console.log(JSON.stringify(status, null, 2));
     if (!status.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "budget-status") {
+    const budgetDetailLimit = args.limit ? parsePositiveInteger(args.limit, "--limit") : 50;
+    const budgetJobLimit = args["job-limit"] ? parsePositiveInteger(args["job-limit"], "--job-limit") : 1_000;
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      configPath: args.config,
+      expectedHead: args["expected-head"],
+      launchdLabel: args["launchd-label"],
+      statePath: args["state-path"],
+      budgetDetails: true,
+      budgetDetailLimit,
+      budgetJobLimit
+    });
+    console.log(JSON.stringify({
+      ok: true,
+      checkedAt: status.checkedAt,
+      budget: status.budget
+    }, null, 2));
     return;
   }
 
@@ -231,6 +261,13 @@ async function main(): Promise<void> {
 
   if (command === "queue") {
     const config = loadConfig(args.config);
+    const release = collectReleaseStatus({
+      cwd: process.cwd(),
+      configPath: args.config,
+      expectedHead: args["expected-head"],
+      launchdLabel: args["launchd-label"],
+      statePath: args["state-path"]
+    });
     const report = await collectCoverageReport(args, config);
     const queue = buildOperatorQueue(report);
     const durableQueue = collectOperatorReviewQueue(args["state-path"] ?? config.statePath, {
@@ -238,7 +275,7 @@ async function main(): Promise<void> {
       state: parseReviewQueueJobState(args.state),
       limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
     });
-    const output = { ...queue, ok: queue.ok, coverage: queue, durableQueue };
+    const output = { ...queue, ok: queue.ok, coverage: queue, durableQueue, budget: release.budget };
     console.log(JSON.stringify(output, null, 2));
     if (!output.ok) process.exitCode = 1;
     return;
@@ -520,6 +557,7 @@ function buildHelp() {
         "runtime-inventory",
         "agents",
         "queue",
+        "budget-status",
         "coverage",
         "cooldowns",
         "why"
@@ -545,6 +583,7 @@ function buildHelp() {
       "npx tsx src/cli.ts agents --config /path/to/live.json",
       "npx tsx src/cli.ts queue --config /path/to/live.json",
       "npx tsx src/cli.ts queue --config /path/to/live.json --state provider_deferred",
+      "npx tsx src/cli.ts budget-status --config /path/to/live.json",
       "npx tsx src/cli.ts why --config /path/to/live.json --repo owner/repo --pr 123",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ]
@@ -636,6 +675,9 @@ interface ParsedArgs {
   "output-dir"?: string;
   "output-root"?: string;
   limit?: string;
+  "budget-detail-limit"?: string;
+  "budget-job-limit"?: string;
+  "job-limit"?: string;
   state?: string;
   zcode?: string;
   "active-only"?: string;

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -9,6 +9,7 @@ import type {
   CoverageStaleHead,
   CoverageUnprocessedEntry
 } from "./coverage-audit.js";
+import type { ReviewBudgetStatus } from "./review-budget.js";
 import type { ReleaseHeartbeatStatus, ReleaseLaunchdStatus, ReleaseStatus } from "./release-status.js";
 import { redactSecrets } from "./secrets.js";
 import {
@@ -40,10 +41,13 @@ export interface OperatorStatus {
     runningJobs: number;
     providerDeferredJobs: number;
     failedQueueJobs: number;
+    budgetWouldLeaseJobs: number;
+    budgetDelayedJobs: number;
   };
   gates: Array<{ name: string; ok: boolean; detail: string }>;
   recommendedActions: string[];
   release: ReleaseStatus;
+  budget?: ReviewBudgetStatus;
   coverage?: OperatorQueueSnapshot;
   agents: OperatorAgentInventory;
   providerCooldowns: ProviderCooldownReviewRecord[];
@@ -66,6 +70,8 @@ export interface RuntimeInventory {
     providerDeferredJobs: number;
     failedQueueJobs: number;
     retryableProviderDeferredJobs: number;
+    budgetWouldLeaseJobs: number;
+    budgetDelayedJobs: number;
     pendingHeads: number;
     coveredPendingHeads: number;
     uncoveredPendingHeads: number;
@@ -85,6 +91,7 @@ export interface RuntimeInventory {
   activeWork: ReviewQueueJobRecord[];
   uncoveredPendingHeads: OperatorQueueEntry[];
   release: ReleaseStatus;
+  budget?: ReviewBudgetStatus;
   agents: OperatorAgentInventory;
   processes?: RuntimeProcessInventory;
   durableQueue?: OperatorDurableQueueSnapshot;
@@ -240,6 +247,7 @@ export function buildOperatorStatus(input: {
   const failedRows = input.release.database.errorCount;
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
   const retryableProviderDeferredJobs = durableQueue?.summary.retryableProviderDeferred ?? 0;
+  const budget = input.release.budget;
 
   const gates = [
     ...input.release.gates,
@@ -306,11 +314,14 @@ export function buildOperatorStatus(input: {
       queuedJobs: durableQueue?.summary.queued ?? 0,
       runningJobs: durableQueue?.summary.running ?? 0,
       providerDeferredJobs: durableQueue?.summary.providerDeferred ?? 0,
-      failedQueueJobs
+      failedQueueJobs,
+      budgetWouldLeaseJobs: budget?.wouldLeaseCount ?? 0,
+      budgetDelayedJobs: budget?.delayedCount ?? 0
     },
     gates,
     recommendedActions,
     release: input.release,
+    ...(budget ? { budget } : {}),
     ...(queue ? { coverage: queue } : {}),
     agents: input.agents,
     providerCooldowns,
@@ -359,6 +370,7 @@ export function buildRuntimeInventory(input: {
   const readFailures = queue?.summary.readFailures ?? 0;
   const staleHeads = queue?.summary.staleHeads ?? 0;
   const providerDeferredHeads = queue?.summary.providerDeferred ?? 0;
+  const budget = input.release.budget;
 
   const gates = [
     ...input.release.gates,
@@ -447,6 +459,8 @@ export function buildRuntimeInventory(input: {
       providerDeferredJobs,
       failedQueueJobs,
       retryableProviderDeferredJobs,
+      budgetWouldLeaseJobs: budget?.wouldLeaseCount ?? 0,
+      budgetDelayedJobs: budget?.delayedCount ?? 0,
       pendingHeads: queue?.summary.pending ?? 0,
       coveredPendingHeads,
       uncoveredPendingHeads: uncoveredPendingHeads.length,
@@ -466,6 +480,7 @@ export function buildRuntimeInventory(input: {
     activeWork,
     uncoveredPendingHeads,
     release: input.release,
+    ...(budget ? { budget } : {}),
     agents: input.agents,
     ...(input.processes ? { processes: input.processes } : {}),
     ...(durableQueue ? { durableQueue } : {}),
@@ -542,6 +557,9 @@ export function formatRuntimeInventoryHuman(inventory: RuntimeInventory): string
     `queue: active=${inventory.summary.activeQueueJobs} queued=${inventory.summary.queuedJobs}` +
       ` running=${inventory.summary.runningJobs} providerDeferred=${inventory.summary.providerDeferredJobs}` +
       ` failed=${inventory.summary.failedQueueJobs}`,
+    `budget: wouldLease=${inventory.summary.budgetWouldLeaseJobs}` +
+      ` delayed=${inventory.summary.budgetDelayedJobs}` +
+      ` delayedByReason=${JSON.stringify(inventory.budget?.delayedByReason ?? {})}`,
     `pending: total=${inventory.summary.pendingHeads} covered=${inventory.summary.coveredPendingHeads}` +
       ` uncovered=${inventory.summary.uncoveredPendingHeads}`,
     `cooldowns: expired=${inventory.summary.expiredProviderCooldowns}` +

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -341,10 +341,7 @@ function readReviewQueueBudgetJobs(
   );
   const select = (column: string, fallback = "null") =>
     columns.has(column) ? column : `${fallback} as ${column}`;
-  const limitClause = limit === undefined ? "" : " limit ?";
-  const query = db
-    .prepare(
-      `select
+  const selectRows = `select
          job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
          ${select("base_sha")},
          ${select("provider_id")},
@@ -359,15 +356,28 @@ function readReviewQueueBudgetJobs(
          created_at, updated_at,
          ${select("started_at")},
          ${select("finished_at")}
-       from review_queue_jobs
-       where state in ('queued', 'leased', 'running', 'provider_deferred')
+       from review_queue_jobs`;
+  const activeRows = db
+    .prepare(
+      `${selectRows}
+       where state in ('leased', 'running')
+       order by priority asc, datetime(created_at) asc`
+    )
+    .all() as unknown as ReviewBudgetQueueJobRow[];
+  const limitClause = limit === undefined ? "" : " limit ?";
+  const pendingQuery = db
+    .prepare(
+      `${selectRows}
+       where state in ('queued', 'provider_deferred')
        order by priority asc, datetime(created_at) asc${limitClause}`
     );
-  const rows = (limit === undefined ? query.all() : query.all(limit + 1)) as unknown as ReviewBudgetQueueJobRow[];
-  const truncated = limit !== undefined && rows.length > limit;
-  const visibleRows = truncated ? rows.slice(0, limit) : rows;
+  const pendingRows = (limit === undefined
+    ? pendingQuery.all()
+    : pendingQuery.all(limit + 1)) as unknown as ReviewBudgetQueueJobRow[];
+  const truncated = limit !== undefined && pendingRows.length > limit;
+  const visiblePendingRows = truncated ? pendingRows.slice(0, limit) : pendingRows;
   return {
-    jobs: visibleRows.map(mapReviewBudgetQueueJobRow),
+    jobs: [...activeRows, ...visiblePendingRows].map(mapReviewBudgetQueueJobRow),
     truncated
   };
 }

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2,7 +2,10 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import { loadConfig } from "./config.js";
+import { buildReviewBudgetStatus, type ReviewBudgetStatus } from "./review-budget.js";
 import { parseProviderCooldownError, PROVIDER_COOLDOWN_ERROR_PREFIX } from "./state.js";
+import type { BotConfig } from "./config.js";
+import type { ReviewQueueJobRecord } from "./state.js";
 
 export interface ReleaseRepoStatus {
   branch: string;
@@ -82,6 +85,7 @@ export interface ReleaseStatusInput {
   launchd: ReleaseLaunchdStatus;
   database: ReleaseDatabaseStatus;
   heartbeat: ReleaseHeartbeatStatus;
+  budget?: ReviewBudgetStatus;
   now?: Date;
 }
 
@@ -98,6 +102,7 @@ export interface ReleaseStatus {
   launchd: ReleaseLaunchdStatus;
   database: ReleaseDatabaseStatus;
   heartbeat: ReleaseHeartbeatStatus;
+  budget?: ReviewBudgetStatus;
   recommendedActions: string[];
   gates: Array<{ name: string; ok: boolean; detail: string }>;
   rollback: {
@@ -199,6 +204,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     launchd: input.launchd,
     database: input.database,
     heartbeat: input.heartbeat,
+    ...(input.budget ? { budget: input.budget } : {}),
     recommendedActions: expiredProviderCooldownOk
       ? retryableDeferredQueueJobsOk
         ? []
@@ -221,23 +227,32 @@ export function collectReleaseStatus(input: {
   expectedHead?: string;
   launchdLabel?: string;
   statePath?: string;
+  budgetDetails?: boolean;
+  budgetDetailLimit?: number;
+  budgetJobLimit?: number;
   now?: Date;
 }): ReleaseStatus {
   const config = loadConfig(input.configPath);
   const configPath = input.configPath ?? "(default config)";
   const now = input.now ?? new Date();
+  const statePath = input.statePath ?? config.statePath;
   return buildReleaseStatus({
     repo: readRepoStatus(input.cwd),
     expectedHead: input.expectedHead,
     configPath,
     launchd: readLaunchdStatus(input.launchdLabel ?? "com.electricsheephq.evaos-code-review-bot"),
-    database: readDatabaseStatus(input.statePath ?? config.statePath, now),
+    database: readDatabaseStatus(statePath, now),
     heartbeat: readHeartbeatStatus(
-      input.statePath ?? config.statePath,
+      statePath,
       config.pollIntervalMs * 2,
       Math.max(config.pollIntervalMs * 2, (config.zcode.timeoutMs * 2) + 60_000),
       now
     ),
+    budget: readReviewBudgetStatus(statePath, config, now, {
+      includeDetails: input.budgetDetails === true,
+      detailLimit: input.budgetDetailLimit,
+      jobLimit: input.budgetJobLimit ?? 1_000
+    }),
     now
   });
 }
@@ -270,6 +285,90 @@ function readLaunchdStatus(label: string): ReleaseLaunchdStatus {
     ...(pidText ? { pid: Number(pidText) } : {}),
     ...(configMatch?.[1] ? { configPath: configMatch[1].trim() } : {}),
     ...(dryRunMatch?.[1] ? { dryRun: dryRunMatch[1].trim() !== "false" } : {})
+  };
+}
+
+function readReviewBudgetStatus(
+  statePath: string,
+  config: BotConfig,
+  now: Date,
+  options: {
+    includeDetails: boolean;
+    detailLimit?: number;
+    jobLimit?: number;
+  }
+): ReviewBudgetStatus {
+  if (!existsSync(statePath)) {
+    return buildReviewBudgetStatus({
+      config,
+      jobs: [],
+      now,
+      includeDetails: options.includeDetails,
+      ...(options.detailLimit !== undefined ? { detailLimit: options.detailLimit } : {}),
+      ...(options.jobLimit !== undefined ? { inputJobLimit: options.jobLimit } : {}),
+      inputJobsTruncated: false
+    });
+  }
+  const db = new DatabaseSync(statePath, { readOnly: true });
+  try {
+    const queueJobs = readReviewQueueBudgetJobs(db, options.jobLimit);
+    return buildReviewBudgetStatus({
+      config,
+      jobs: queueJobs.jobs,
+      now,
+      includeDetails: options.includeDetails,
+      ...(options.detailLimit !== undefined ? { detailLimit: options.detailLimit } : {}),
+      ...(options.jobLimit !== undefined ? { inputJobLimit: options.jobLimit } : {}),
+      inputJobsTruncated: queueJobs.truncated
+    });
+  } finally {
+    db.close();
+  }
+}
+
+function readReviewQueueBudgetJobs(
+  db: DatabaseSync,
+  limit?: number
+): { jobs: ReviewQueueJobRecord[]; truncated: boolean } {
+  const hasTable = db
+    .prepare("select 1 from sqlite_master where type = 'table' and name = 'review_queue_jobs' limit 1")
+    .get();
+  if (!hasTable) return { jobs: [], truncated: false };
+
+  const columns = new Set(
+    (db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>)
+      .map((column) => column.name)
+  );
+  const select = (column: string, fallback = "null") =>
+    columns.has(column) ? column : `${fallback} as ${column}`;
+  const limitClause = limit === undefined ? "" : " limit ?";
+  const query = db
+    .prepare(
+      `select
+         job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+         ${select("base_sha")},
+         ${select("provider_id")},
+         priority, state,
+         ${select("next_eligible_at")},
+         ${select("lease_id")},
+         ${select("lease_expires_at")},
+         ${select("session_id")},
+         ${select("comment_id")},
+         ${select("review_url")},
+         ${select("last_error")},
+         created_at, updated_at,
+         ${select("started_at")},
+         ${select("finished_at")}
+       from review_queue_jobs
+       where state in ('queued', 'leased', 'running', 'provider_deferred')
+       order by priority asc, datetime(created_at) asc${limitClause}`
+    );
+  const rows = (limit === undefined ? query.all() : query.all(limit + 1)) as unknown as ReviewBudgetQueueJobRow[];
+  const truncated = limit !== undefined && rows.length > limit;
+  const visibleRows = truncated ? rows.slice(0, limit) : rows;
+  return {
+    jobs: visibleRows.map(mapReviewBudgetQueueJobRow),
+    truncated
   };
 }
 
@@ -658,4 +757,58 @@ interface QueueCountRow {
   providerDeferred?: number | null;
   retryableProviderDeferred?: number | null;
   failed?: number | null;
+}
+
+interface ReviewBudgetQueueJobRow {
+  job_id: string;
+  attempt_id: string;
+  source: ReviewQueueJobRecord["source"];
+  lane: ReviewQueueJobRecord["lane"];
+  repo: string;
+  org: string;
+  pull_number: number;
+  head_sha: string;
+  base_sha?: string | null;
+  provider_id?: string | null;
+  priority: number;
+  state: ReviewQueueJobRecord["state"];
+  next_eligible_at?: string | null;
+  lease_id?: string | null;
+  lease_expires_at?: string | null;
+  session_id?: string | null;
+  comment_id?: number | null;
+  review_url?: string | null;
+  last_error?: string | null;
+  created_at: string;
+  updated_at: string;
+  started_at?: string | null;
+  finished_at?: string | null;
+}
+
+function mapReviewBudgetQueueJobRow(row: ReviewBudgetQueueJobRow): ReviewQueueJobRecord {
+  return {
+    jobId: row.job_id,
+    attemptId: row.attempt_id,
+    source: row.source,
+    lane: row.lane,
+    repo: row.repo,
+    org: row.org,
+    pullNumber: row.pull_number,
+    headSha: row.head_sha,
+    ...(row.base_sha ? { baseSha: row.base_sha } : {}),
+    ...(row.provider_id ? { providerId: row.provider_id } : {}),
+    priority: row.priority,
+    state: row.state,
+    ...(row.next_eligible_at ? { nextEligibleAt: row.next_eligible_at } : {}),
+    ...(row.lease_id ? { leaseId: row.lease_id } : {}),
+    ...(row.lease_expires_at ? { leaseExpiresAt: row.lease_expires_at } : {}),
+    ...(row.session_id ? { sessionId: row.session_id } : {}),
+    ...(row.comment_id !== null && row.comment_id !== undefined ? { commentId: row.comment_id } : {}),
+    ...(row.review_url ? { reviewUrl: row.review_url } : {}),
+    ...(row.last_error ? { lastError: row.last_error } : {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    ...(row.started_at ? { startedAt: row.started_at } : {}),
+    ...(row.finished_at ? { finishedAt: row.finished_at } : {})
+  };
 }

--- a/src/review-budget.ts
+++ b/src/review-budget.ts
@@ -1,3 +1,107 @@
+import type { BotConfig } from "./config.js";
+import type { ReviewQueueJobRecord } from "./state.js";
+
+export type ReviewQueueDelayReason =
+  | "provider_cooldown"
+  | "provider_capacity"
+  | "org_capacity"
+  | "repo_capacity"
+  | "manual_reserve"
+  | "lease_limit";
+
+export interface ReviewBudgetDelay {
+  reason: ReviewQueueDelayReason;
+  jobId: string;
+  source: ReviewQueueJobRecord["source"];
+  lane: ReviewQueueJobRecord["lane"];
+  repo: string;
+  org: string;
+  pullNumber: number;
+  headSha: string;
+  providerId: string;
+  priority: number;
+  state: ReviewQueueJobRecord["state"];
+  nextEligibleAt?: string;
+}
+
+export interface ReviewBudgetCandidate {
+  jobId: string;
+  source: ReviewQueueJobRecord["source"];
+  lane: ReviewQueueJobRecord["lane"];
+  repo: string;
+  org: string;
+  pullNumber: number;
+  headSha: string;
+  providerId: string;
+  priority: number;
+}
+
+export interface ReviewBudgetCapacity {
+  name: string;
+  active: number;
+  limit: number;
+  remaining: number;
+}
+
+export interface ReviewBudgetStatus {
+  enabled: boolean;
+  checkedAt: string;
+  config: {
+    reviewConcurrency: {
+      maxActiveRuns: number;
+      leaseTtlMs: number;
+    };
+    scheduler: {
+      enabled: boolean;
+      maxProviderActive: number;
+      maxOrgActive: number;
+      maxRepoActive: number;
+      maxQueuedPerRepo: number;
+      manualCommandReserve: number;
+      backgroundPriority: number;
+    };
+  };
+  active: {
+    total: number;
+    leased: number;
+    running: number;
+    manual: number;
+    background: number;
+    byProvider: ReviewBudgetCapacity[];
+    byOrg: ReviewBudgetCapacity[];
+    byRepo: ReviewBudgetCapacity[];
+  };
+  queued: {
+    total: number;
+    manual: number;
+    background: number;
+    providerDeferred: number;
+    retryableProviderDeferred: number;
+  };
+  manualReserve: {
+    configured: number;
+    activeManual: number;
+    queuedManual: number;
+    reservedSlotsOpen: number;
+    backgroundSlotsAvailableBeforeReserve: number;
+  };
+  wouldLeaseCount: number;
+  delayedCount: number;
+  details: {
+    included: boolean;
+    detailLimit?: number;
+    wouldLeaseReturned: number;
+    delayedReturned: number;
+    detailsTruncated: boolean;
+    inputJobs: number;
+    inputJobLimit?: number;
+    inputJobsTruncated?: boolean;
+  };
+  wouldLease: ReviewBudgetCandidate[];
+  delayed: ReviewBudgetDelay[];
+  delayedByReason: Partial<Record<ReviewQueueDelayReason, number>>;
+}
+
 export class ReviewRunBudget {
   private readonly maxRuns: number;
   private currentRuns = 0;
@@ -21,4 +125,268 @@ export class ReviewRunBudget {
   finish(): void {
     this.currentRuns = Math.max(0, this.currentRuns - 1);
   }
+}
+
+export function buildReviewBudgetStatus(input: {
+  config: BotConfig;
+  jobs: ReviewQueueJobRecord[];
+  now?: Date;
+  includeDetails?: boolean;
+  detailLimit?: number;
+  inputJobLimit?: number;
+  inputJobsTruncated?: boolean;
+}): ReviewBudgetStatus {
+  const now = input.now ?? new Date();
+  const includeDetails = input.includeDetails ?? true;
+  const detailLimit = input.detailLimit;
+  const scheduler = input.config.reviewScheduler ?? {
+    enabled: false,
+    maxProviderActive: input.config.reviewConcurrency.maxActiveRuns,
+    maxOrgActive: input.config.reviewConcurrency.maxActiveRuns,
+    maxRepoActive: 1,
+    maxQueuedPerRepo: 10,
+    manualCommandReserve: 0,
+    backgroundPriority: 50
+  };
+  const jobs = input.jobs.map((job) =>
+    normalizeExpiredLeaseJob(job, now, input.config.reviewConcurrency.leaseTtlMs)
+  );
+  const active = jobs.filter((job) => isActiveQueueJob(job));
+  const activeProvider = countBy(active, (job) => providerKey(job));
+  const activeOrg = countBy(active, (job) => job.org);
+  const activeRepo = countBy(active, (job) => job.repo);
+  const queued = jobs.filter((job) => job.state === "queued" || job.state === "provider_deferred");
+  const manualQueued = queued.filter((job) => job.lane === "manual").length;
+  const activeManual = active.filter((job) => job.lane === "manual").length;
+
+  const delayed: ReviewBudgetDelay[] = [];
+  for (const job of queued) {
+    if (job.state === "provider_deferred" && !isProviderDeferredEligible(job, now)) {
+      delayed.push(delay(job, "provider_cooldown"));
+    }
+  }
+
+  const eligible = queued
+    .filter((job) => job.state === "queued" || isProviderDeferredEligible(job, now))
+    .sort(compareQueueJobsForBudget);
+  const hasManualAfter = buildManualEligibilitySuffix(eligible);
+  const wouldLease: ReviewBudgetCandidate[] = [];
+  const simulatedProviderActive = new Map(activeProvider);
+  const simulatedOrgActive = new Map(activeOrg);
+  const simulatedRepoActive = new Map(activeRepo);
+
+  for (const [index, job] of eligible.entries()) {
+    const provider = providerKey(job);
+    const providerCount = simulatedProviderActive.get(provider) ?? 0;
+    const orgCount = simulatedOrgActive.get(job.org) ?? 0;
+    const repoCount = simulatedRepoActive.get(job.repo) ?? 0;
+    if (wouldLease.length >= scheduler.maxProviderActive) {
+      delayed.push(delay(job, "lease_limit"));
+      continue;
+    }
+    if (providerCount >= scheduler.maxProviderActive) {
+      delayed.push(delay(job, "provider_capacity"));
+      continue;
+    }
+    if (orgCount >= scheduler.maxOrgActive) {
+      delayed.push(delay(job, "org_capacity"));
+      continue;
+    }
+    if (repoCount >= scheduler.maxRepoActive) {
+      delayed.push(delay(job, "repo_capacity"));
+      continue;
+    }
+    if (
+      job.lane === "background" &&
+      hasManualAfter[index] &&
+      scheduler.manualCommandReserve > 0 &&
+      providerCount >= scheduler.maxProviderActive - scheduler.manualCommandReserve
+    ) {
+      delayed.push(delay(job, "manual_reserve"));
+      continue;
+    }
+
+    wouldLease.push(candidate(job));
+    simulatedProviderActive.set(provider, providerCount + 1);
+    simulatedOrgActive.set(job.org, orgCount + 1);
+    simulatedRepoActive.set(job.repo, repoCount + 1);
+  }
+
+  const delayedByReason: Partial<Record<ReviewQueueDelayReason, number>> = {};
+  for (const entry of delayed) {
+    delayedByReason[entry.reason] = (delayedByReason[entry.reason] ?? 0) + 1;
+  }
+  const returnedWouldLease = includeDetails ? applyDetailLimit(wouldLease, detailLimit) : [];
+  const returnedDelayed = includeDetails ? applyDetailLimit(delayed, detailLimit) : [];
+  const detailsTruncated =
+    returnedWouldLease.length < wouldLease.length ||
+    returnedDelayed.length < delayed.length ||
+    input.inputJobsTruncated === true;
+
+  return {
+    enabled: scheduler.enabled,
+    checkedAt: now.toISOString(),
+    config: {
+      reviewConcurrency: {
+        maxActiveRuns: input.config.reviewConcurrency.maxActiveRuns,
+        leaseTtlMs: input.config.reviewConcurrency.leaseTtlMs
+      },
+      scheduler: {
+        enabled: scheduler.enabled,
+        maxProviderActive: scheduler.maxProviderActive,
+        maxOrgActive: scheduler.maxOrgActive,
+        maxRepoActive: scheduler.maxRepoActive,
+        maxQueuedPerRepo: scheduler.maxQueuedPerRepo,
+        manualCommandReserve: scheduler.manualCommandReserve,
+        backgroundPriority: scheduler.backgroundPriority
+      }
+    },
+    active: {
+      total: active.length,
+      leased: active.filter((job) => job.state === "leased").length,
+      running: active.filter((job) => job.state === "running").length,
+      manual: active.filter((job) => job.lane === "manual").length,
+      background: active.filter((job) => job.lane === "background").length,
+      byProvider: capacityRows(activeProvider, scheduler.maxProviderActive),
+      byOrg: capacityRows(activeOrg, scheduler.maxOrgActive),
+      byRepo: capacityRows(activeRepo, scheduler.maxRepoActive)
+    },
+    queued: {
+      total: queued.length,
+      manual: manualQueued,
+      background: queued.filter((job) => job.lane === "background").length,
+      providerDeferred: queued.filter((job) => job.state === "provider_deferred").length,
+      retryableProviderDeferred: queued.filter((job) =>
+        job.state === "provider_deferred" && isProviderDeferredEligible(job, now)
+      ).length
+    },
+    manualReserve: {
+      configured: scheduler.manualCommandReserve,
+      activeManual,
+      queuedManual: manualQueued,
+      reservedSlotsOpen: Math.max(0, scheduler.manualCommandReserve - activeManual),
+      backgroundSlotsAvailableBeforeReserve: Math.max(
+        0,
+        scheduler.maxProviderActive - scheduler.manualCommandReserve - active.length
+      )
+    },
+    wouldLeaseCount: wouldLease.length,
+    delayedCount: delayed.length,
+    details: {
+      included: includeDetails,
+      ...(detailLimit !== undefined ? { detailLimit } : {}),
+      wouldLeaseReturned: returnedWouldLease.length,
+      delayedReturned: returnedDelayed.length,
+      detailsTruncated,
+      inputJobs: input.jobs.length,
+      ...(input.inputJobLimit !== undefined ? { inputJobLimit: input.inputJobLimit } : {}),
+      ...(input.inputJobsTruncated !== undefined ? { inputJobsTruncated: input.inputJobsTruncated } : {})
+    },
+    wouldLease: returnedWouldLease,
+    delayed: returnedDelayed,
+    delayedByReason
+  };
+}
+
+function isActiveQueueJob(job: ReviewQueueJobRecord): boolean {
+  return job.state === "leased" || job.state === "running";
+}
+
+function normalizeExpiredLeaseJob(job: ReviewQueueJobRecord, now: Date, leaseTtlMs: number): ReviewQueueJobRecord {
+  if (!isActiveQueueJob(job)) return job;
+  if (!isExpiredLeaseJob(job, now, leaseTtlMs)) return job;
+  const normalized: ReviewQueueJobRecord = {
+    ...job,
+    state: "queued",
+    lastError: "queue_lease_expired_requeued",
+    updatedAt: now.toISOString()
+  };
+  delete normalized.leaseId;
+  delete normalized.leaseExpiresAt;
+  return normalized;
+}
+
+function isExpiredLeaseJob(job: ReviewQueueJobRecord, now: Date, leaseTtlMs: number): boolean {
+  if (job.leaseExpiresAt) {
+    const leaseExpiresAtMs = Date.parse(job.leaseExpiresAt);
+    return Number.isFinite(leaseExpiresAtMs) && leaseExpiresAtMs <= now.getTime();
+  }
+  const updatedAtMs = Date.parse(job.updatedAt);
+  return Number.isFinite(updatedAtMs) && updatedAtMs <= now.getTime() - leaseTtlMs;
+}
+
+function providerKey(job: ReviewQueueJobRecord): string {
+  return job.providerId ?? "default";
+}
+
+function isProviderDeferredEligible(job: ReviewQueueJobRecord, now: Date): boolean {
+  if (job.state !== "provider_deferred") return true;
+  if (!job.nextEligibleAt) return true;
+  const eligibleAtMs = Date.parse(job.nextEligibleAt);
+  return !Number.isFinite(eligibleAtMs) || eligibleAtMs <= now.getTime();
+}
+
+function compareQueueJobsForBudget(left: ReviewQueueJobRecord, right: ReviewQueueJobRecord): number {
+  if (left.priority !== right.priority) return left.priority - right.priority;
+  const created = Date.parse(left.createdAt) - Date.parse(right.createdAt);
+  if (created !== 0) return created;
+  return left.jobId.localeCompare(right.jobId);
+}
+
+function buildManualEligibilitySuffix(jobs: ReviewQueueJobRecord[]): boolean[] {
+  const result = new Array<boolean>(jobs.length).fill(false);
+  let seenManual = false;
+  for (let index = jobs.length - 1; index >= 0; index -= 1) {
+    result[index] = seenManual;
+    if (jobs[index]?.lane === "manual") seenManual = true;
+  }
+  return result;
+}
+
+function candidate(job: ReviewQueueJobRecord): ReviewBudgetCandidate {
+  return {
+    jobId: job.jobId,
+    source: job.source,
+    lane: job.lane,
+    repo: job.repo,
+    org: job.org,
+    pullNumber: job.pullNumber,
+    headSha: job.headSha,
+    providerId: providerKey(job),
+    priority: job.priority
+  };
+}
+
+function delay(job: ReviewQueueJobRecord, reason: ReviewQueueDelayReason): ReviewBudgetDelay {
+  return {
+    ...candidate(job),
+    reason,
+    state: job.state,
+    ...(job.nextEligibleAt ? { nextEligibleAt: job.nextEligibleAt } : {})
+  };
+}
+
+function capacityRows(counts: Map<string, number>, limit: number): ReviewBudgetCapacity[] {
+  return [...counts.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, active]) => ({
+      name,
+      active,
+      limit,
+      remaining: Math.max(0, limit - active)
+    }));
+}
+
+function applyDetailLimit<T>(items: T[], limit?: number): T[] {
+  if (limit === undefined) return items;
+  return items.slice(0, Math.max(0, limit));
+}
+
+function countBy<T>(items: T[], key: (item: T) => string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const itemKey = key(item);
+    counts.set(itemKey, (counts.get(itemKey) ?? 0) + 1);
+  }
+  return counts;
 }

--- a/src/review-budget.ts
+++ b/src/review-budget.ts
@@ -180,29 +180,19 @@ export function buildReviewBudgetStatus(input: {
     const providerCount = simulatedProviderActive.get(provider) ?? 0;
     const orgCount = simulatedOrgActive.get(job.org) ?? 0;
     const repoCount = simulatedRepoActive.get(job.repo) ?? 0;
+    const capacityReason = capacityDelayReason(job, {
+      scheduler,
+      providerCount,
+      orgCount,
+      repoCount,
+      hasManualAfter: hasManualAfter[index] ?? false
+    });
+    if (capacityReason) {
+      delayed.push(delay(job, capacityReason));
+      continue;
+    }
     if (wouldLease.length >= scheduler.maxProviderActive) {
       delayed.push(delay(job, "lease_limit"));
-      continue;
-    }
-    if (providerCount >= scheduler.maxProviderActive) {
-      delayed.push(delay(job, "provider_capacity"));
-      continue;
-    }
-    if (orgCount >= scheduler.maxOrgActive) {
-      delayed.push(delay(job, "org_capacity"));
-      continue;
-    }
-    if (repoCount >= scheduler.maxRepoActive) {
-      delayed.push(delay(job, "repo_capacity"));
-      continue;
-    }
-    if (
-      job.lane === "background" &&
-      hasManualAfter[index] &&
-      scheduler.manualCommandReserve > 0 &&
-      providerCount >= scheduler.maxProviderActive - scheduler.manualCommandReserve
-    ) {
-      delayed.push(delay(job, "manual_reserve"));
       continue;
     }
 
@@ -330,7 +320,31 @@ function compareQueueJobsForBudget(left: ReviewQueueJobRecord, right: ReviewQueu
   if (left.priority !== right.priority) return left.priority - right.priority;
   const created = Date.parse(left.createdAt) - Date.parse(right.createdAt);
   if (created !== 0) return created;
-  return left.jobId.localeCompare(right.jobId);
+  return 0;
+}
+
+function capacityDelayReason(
+  job: ReviewQueueJobRecord,
+  input: {
+    scheduler: NonNullable<BotConfig["reviewScheduler"]>;
+    providerCount: number;
+    orgCount: number;
+    repoCount: number;
+    hasManualAfter: boolean;
+  }
+): ReviewQueueDelayReason | undefined {
+  if (input.providerCount >= input.scheduler.maxProviderActive) return "provider_capacity";
+  if (input.orgCount >= input.scheduler.maxOrgActive) return "org_capacity";
+  if (input.repoCount >= input.scheduler.maxRepoActive) return "repo_capacity";
+  if (
+    job.lane === "background" &&
+    input.hasManualAfter &&
+    input.scheduler.manualCommandReserve > 0 &&
+    input.providerCount >= input.scheduler.maxProviderActive - input.scheduler.manualCommandReserve
+  ) {
+    return "manual_reserve";
+  }
+  return undefined;
 }
 
 function buildManualEligibilitySuffix(jobs: ReviewQueueJobRecord[]): boolean[] {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -2,7 +2,12 @@ import { loadConfig, type BotConfig } from "./config.js";
 import { collectTrustedReviewCommands, decideCommandAction, type CommandDecision } from "./commands.js";
 import { GitHubApi } from "./github.js";
 import { listReposToScan, resolveRepoProfile } from "./repo-policy.js";
-import { ReviewRunBudget } from "./review-budget.js";
+import {
+  buildReviewBudgetStatus,
+  ReviewRunBudget,
+  type ReviewBudgetStatus,
+  type ReviewQueueDelayReason
+} from "./review-budget.js";
 import {
   parseProviderCooldownError,
   ReviewStateStore,
@@ -39,6 +44,8 @@ export interface ScheduledRunResult extends RunOnceResult {
     closedRetired: number;
     failedQueueJobs: number;
     remainingQueued: number;
+    delayedByReason: Partial<Record<ReviewQueueDelayReason, number>>;
+    budget?: ReviewBudgetStatus;
   };
 }
 
@@ -122,6 +129,14 @@ export async function runScheduledCycleWithDeps(input: {
       applyEnqueueStatus(result, enqueueStatus);
     }
   }
+
+  result.queue.budget = buildReviewBudgetStatus({
+    config,
+    jobs: input.state.listReviewQueueJobs(),
+    now,
+    includeDetails: false
+  });
+  result.queue.delayedByReason = result.queue.budget.delayedByReason;
 
   const leased = input.state.leaseNextReviewQueueJobs({
     maxProviderActive: scheduler.maxProviderActive,
@@ -720,7 +735,8 @@ function emptyScheduledRunResult(): ScheduledRunResult {
       staleRetired: 0,
       closedRetired: 0,
       failedQueueJobs: 0,
-      remainingQueued: 0
+      remainingQueued: 0,
+      delayedByReason: {}
     }
   };
 }

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -18,6 +18,7 @@ import {
   type OperatorAgentInventory,
   type OperatorDurableQueueSnapshot
 } from "../src/operator-cli.js";
+import type { ReviewBudgetStatus } from "../src/review-budget.js";
 import type { ReleaseStatus } from "../src/release-status.js";
 import type { RepoProviderCooldownRecord } from "../src/state.js";
 
@@ -211,7 +212,7 @@ describe("operator CLI summaries", () => {
 
   it("formats a concise human runtime inventory without leaking secrets", () => {
     const inventory = buildRuntimeInventory({
-      release: releaseStatus({ ok: true }),
+      release: releaseStatus({ ok: true, budget: reviewBudgetStatus() }),
       coverage: coverageReport({ ok: true }),
       agents: agentInventory({ ok: true }),
       durableQueue: durableQueueSnapshot({ ok: true, summary: cleanDurableQueueSummary() }),
@@ -224,6 +225,7 @@ describe("operator CLI summaries", () => {
 
     expect(output).toContain("runtime: healthy_idle (ok)");
     expect(output).toContain("queue: active=0 queued=0 running=0 providerDeferred=0 failed=0");
+    expect(output).toContain("budget: wouldLease=1 delayed=1 delayedByReason={\"manual_reserve\":1}");
     expect(output).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
   });
 
@@ -492,6 +494,7 @@ function releaseStatus(input: {
   ok: boolean;
   recommendedActions?: string[];
   database?: Partial<ReleaseStatus["database"]>;
+  budget?: ReviewBudgetStatus;
 }): ReleaseStatus {
   const providerCooldownCount = input.database?.providerCooldownCount ?? (input.ok ? 0 : 1);
   const expiredProviderCooldownCount = input.database?.expiredProviderCooldownCount ?? providerCooldownCount;
@@ -514,6 +517,7 @@ function releaseStatus(input: {
       activeProviderCooldownCount: 0,
       ...input.database
     },
+    ...(input.budget ? { budget: input.budget } : {}),
     heartbeat: {
       status: "fresh",
       maxAgeMs: 120_000,
@@ -536,6 +540,91 @@ function releaseStatus(input: {
     rollback: {
       restartCommand: "launchctl kickstart -k gui/501/com.electricsheephq.evaos-code-review-bot",
       unloadCommand: "launchctl bootout gui/501 ~/Library/LaunchAgents/com.electricsheephq.evaos-code-review-bot.plist"
+    }
+  };
+}
+
+function reviewBudgetStatus(): ReviewBudgetStatus {
+  return {
+    enabled: true,
+    checkedAt: "2026-07-01T00:30:00.000Z",
+    config: {
+      reviewConcurrency: {
+        maxActiveRuns: 1,
+        leaseTtlMs: 60_000
+      },
+      scheduler: {
+        enabled: true,
+        maxProviderActive: 1,
+        maxOrgActive: 1,
+        maxRepoActive: 1,
+        maxQueuedPerRepo: 10,
+        manualCommandReserve: 1,
+        backgroundPriority: 50
+      }
+    },
+    active: {
+      total: 0,
+      leased: 0,
+      running: 0,
+      manual: 0,
+      background: 0,
+      byProvider: [],
+      byOrg: [],
+      byRepo: []
+    },
+    queued: {
+      total: 2,
+      manual: 1,
+      background: 1,
+      providerDeferred: 0,
+      retryableProviderDeferred: 0
+    },
+    manualReserve: {
+      configured: 1,
+      activeManual: 0,
+      queuedManual: 1,
+      reservedSlotsOpen: 1,
+      backgroundSlotsAvailableBeforeReserve: 0
+    },
+    wouldLeaseCount: 1,
+    delayedCount: 1,
+    details: {
+      included: true,
+      detailLimit: 50,
+      wouldLeaseReturned: 1,
+      delayedReturned: 1,
+      detailsTruncated: false,
+      inputJobs: 2,
+      inputJobLimit: 1_000,
+      inputJobsTruncated: false
+    },
+    wouldLease: [{
+      jobId: "manual-job",
+      source: "manual_command",
+      lane: "manual",
+      repo: "owner/repo",
+      org: "owner",
+      pullNumber: 7,
+      headSha: "head-manual",
+      providerId: "zai",
+      priority: 40
+    }],
+    delayed: [{
+      reason: "manual_reserve",
+      jobId: "background-job",
+      source: "automatic",
+      lane: "background",
+      repo: "owner/repo",
+      org: "owner",
+      pullNumber: 8,
+      headSha: "head-background",
+      providerId: "zai",
+      priority: 30,
+      state: "queued"
+    }],
+    delayedByReason: {
+      manual_reserve: 1
     }
   };
 }

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -604,14 +604,14 @@ describe("beta release status", () => {
       included: true,
       detailLimit: 1,
       inputJobLimit: 3,
-      inputJobsTruncated: true,
+      inputJobsTruncated: false,
       detailsTruncated: true
     });
     expect(detailedStatus.budget?.wouldLease.length).toBeLessThanOrEqual(1);
     expect(detailedStatus.budget?.delayed.length).toBeLessThanOrEqual(1);
   });
 
-  it("filters terminal queue rows before applying the budget row cap", () => {
+  it("filters terminal queue rows and preserves active jobs before applying the budget row cap", () => {
     const root = mkdtempSync(join(tmpdir(), "release-status-budget-cap-terminal-"));
     roots.push(root);
     const dbPath = join(root, "reviews.sqlite");
@@ -657,7 +657,9 @@ describe("beta release status", () => {
       `);
       insertQueueJob(db, "posted", "owner/repo", "terminal-posted");
       insertQueueJob(db, "failed", "owner/repo", "terminal-failed");
-      insertQueueJob(db, "running", "owner/repo", "live-running");
+      insertQueueJob(db, "queued", "owner/repo-a", "queued-a");
+      insertQueueJob(db, "queued", "owner/repo-b", "queued-b");
+      insertQueueJob(db, "running", "owner/repo-c", "live-running");
     } finally {
       db.close();
     }
@@ -676,10 +678,13 @@ describe("beta release status", () => {
         total: 1,
         running: 1
       },
+      queued: {
+        total: 1
+      },
       details: {
-        inputJobs: 1,
+        inputJobs: 2,
         inputJobLimit: 1,
-        inputJobsTruncated: false
+        inputJobsTruncated: true
       }
     });
   });

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -532,7 +532,7 @@ describe("beta release status", () => {
         retryableProviderDeferred: 1
       },
       delayedByReason: {
-        provider_capacity: 1,
+        repo_capacity: 1,
         provider_cooldown: 1
       },
       wouldLeaseCount: 1,

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -521,6 +521,31 @@ describe("beta release status", () => {
       retryableProviderDeferredReviewQueueJobCount: 1,
       failedReviewQueueJobCount: 1
     });
+    expect(status.budget).toMatchObject({
+      active: {
+        total: 1,
+        running: 1
+      },
+      queued: {
+        total: 3,
+        providerDeferred: 2,
+        retryableProviderDeferred: 1
+      },
+      delayedByReason: {
+        provider_capacity: 1,
+        provider_cooldown: 1
+      },
+      wouldLeaseCount: 1,
+      delayedCount: 2,
+      details: {
+        included: false,
+        wouldLeaseReturned: 0,
+        delayedReturned: 0,
+        detailsTruncated: true
+      },
+      wouldLease: [],
+      delayed: []
+    });
     expect(status.database.reviewQueueJobsByRepo).toEqual([
       {
         repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
@@ -564,6 +589,99 @@ describe("beta release status", () => {
       detail: "1 retryable provider-deferred queue job(s); queue total=5 queued=1 leased=0 running=1 provider_deferred=2 failed=1"
     });
     expect(status.recommendedActions).toContain("inspect operator queue and retry provider-deferred jobs whose nextEligibleAt has expired");
+
+    const detailedStatus = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      budgetDetails: true,
+      budgetDetailLimit: 1,
+      budgetJobLimit: 3,
+      now: new Date("2026-07-01T00:05:00.000Z")
+    });
+    expect(detailedStatus.budget?.details).toMatchObject({
+      included: true,
+      detailLimit: 1,
+      inputJobLimit: 3,
+      inputJobsTruncated: true,
+      detailsTruncated: true
+    });
+    expect(detailedStatus.budget?.wouldLease.length).toBeLessThanOrEqual(1);
+    expect(detailedStatus.budget?.delayed.length).toBeLessThanOrEqual(1);
+  });
+
+  it("filters terminal queue rows before applying the budget row cap", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-budget-cap-terminal-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      insertQueueJob(db, "posted", "owner/repo", "terminal-posted");
+      insertQueueJob(db, "failed", "owner/repo", "terminal-failed");
+      insertQueueJob(db, "running", "owner/repo", "live-running");
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      budgetJobLimit: 1,
+      now: new Date("2026-07-01T00:05:00.000Z")
+    });
+
+    expect(status.budget).toMatchObject({
+      active: {
+        total: 1,
+        running: 1
+      },
+      details: {
+        inputJobs: 1,
+        inputJobLimit: 1,
+        inputJobsTruncated: false
+      }
+    });
   });
 
   it("treats malformed provider cooldown timestamps as actionable backlog", () => {

--- a/tests/review-budget.test.ts
+++ b/tests/review-budget.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { BotConfig } from "../src/config.js";
 import type { GitHubApi } from "../src/github.js";
-import { ReviewRunBudget } from "../src/review-budget.js";
-import { ReviewStateStore } from "../src/state.js";
+import { buildReviewBudgetStatus, ReviewRunBudget } from "../src/review-budget.js";
+import { ReviewStateStore, type ReviewQueueJobRecord } from "../src/state.js";
 import type { PullRequestSummary } from "../src/types.js";
 import { reviewPull } from "../src/worker.js";
 
@@ -67,6 +67,131 @@ describe("review run budget", () => {
 
     expect(status).toBe("skipped_capacity");
     expect(budget.activeRuns).toBe(1);
+  });
+
+  it("falls back to concurrency settings when scheduler config is absent", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-budget-status-fallback-"));
+    roots.push(root);
+
+    const status = buildReviewBudgetStatus({
+      config: minimalConfig(root),
+      jobs: [],
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.enabled).toBe(false);
+    expect(status.config.scheduler).toMatchObject({
+      enabled: false,
+      maxProviderActive: 5,
+      maxOrgActive: 5,
+      maxRepoActive: 1
+    });
+  });
+
+  it("explains provider cooldown, active capacity, repo caps, and manual reserve delays", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-budget-status-"));
+    roots.push(root);
+    const config = {
+      ...minimalConfig(root),
+      reviewScheduler: {
+        enabled: true,
+        maxProviderActive: 2,
+        maxOrgActive: 10,
+        maxRepoActive: 1,
+        maxQueuedPerRepo: 10,
+        manualCommandReserve: 1,
+        backgroundPriority: 50
+      }
+    };
+    const now = new Date("2026-07-01T00:00:00.000Z");
+    const jobs = [
+      queueJob("active-a", { repo: "owner/repo-a", state: "running", priority: 10 }),
+      queueJob("repo-cap", { repo: "owner/repo-a", state: "queued", priority: 20 }),
+      queueJob("manual-reserve", { repo: "owner/repo-b", state: "queued", priority: 30 }),
+      queueJob("manual-slot", { repo: "owner/repo-c", state: "queued", lane: "manual", source: "manual_command", priority: 40 }),
+      queueJob("cooldown", {
+        repo: "owner/repo-d",
+        state: "provider_deferred",
+        priority: 50,
+        nextEligibleAt: "2026-07-01T00:05:00.000Z"
+      })
+    ];
+
+    const status = buildReviewBudgetStatus({ config, jobs, now });
+
+    expect(status.active.total).toBe(1);
+    expect(status.queued).toMatchObject({
+      total: 4,
+      manual: 1,
+      background: 3,
+      providerDeferred: 1,
+      retryableProviderDeferred: 0
+    });
+    expect(status.wouldLease.map((entry) => entry.jobId)).toEqual(["manual-slot"]);
+    expect(status.delayedByReason).toMatchObject({
+      repo_capacity: 1,
+      manual_reserve: 1,
+      provider_cooldown: 1
+    });
+    expect(status.manualReserve).toMatchObject({
+      configured: 1,
+      activeManual: 0,
+      queuedManual: 1,
+      reservedSlotsOpen: 1,
+      backgroundSlotsAvailableBeforeReserve: 0
+    });
+  });
+
+  it("does not count expired leased or running jobs against active capacity", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-budget-expired-lease-"));
+    roots.push(root);
+    const config = {
+      ...minimalConfig(root),
+      reviewConcurrency: {
+        maxActiveRuns: 1,
+        leaseTtlMs: 60_000
+      },
+      reviewScheduler: {
+        enabled: true,
+        maxProviderActive: 1,
+        maxOrgActive: 1,
+        maxRepoActive: 1,
+        maxQueuedPerRepo: 10,
+        manualCommandReserve: 0,
+        backgroundPriority: 50
+      }
+    };
+
+    const status = buildReviewBudgetStatus({
+      config,
+      now: new Date("2026-07-01T00:05:00.000Z"),
+      jobs: [
+        queueJob("expired-running", {
+          repo: "owner/repo-a",
+          state: "running",
+          leaseId: "old-lease",
+          leaseExpiresAt: "2026-07-01T00:04:00.000Z",
+          priority: 10
+        }),
+        queueJob("fresh-queued", {
+          repo: "owner/repo-b",
+          state: "queued",
+          priority: 20
+        })
+      ]
+    });
+
+    expect(status.active.total).toBe(0);
+    expect(status.queued.total).toBe(2);
+    expect(status.wouldLease).toEqual([
+      expect.objectContaining({
+        jobId: "expired-running",
+        repo: "owner/repo-a"
+      })
+    ]);
+    expect(status.delayedByReason).toEqual({
+      lease_limit: 1
+    });
   });
 
   it("uses SQLite leases to cap overlapping worker entrypoints", async () => {
@@ -170,5 +295,40 @@ function pull(number: number, sha: string): PullRequestSummary {
       }
     },
     html_url: `https://github.test/owner/repo/pull/${number}`
+  };
+}
+
+function queueJob(
+  jobId: string,
+  input: Partial<ReviewQueueJobRecord> & {
+    repo: string;
+    state: ReviewQueueJobRecord["state"];
+  }
+): ReviewQueueJobRecord {
+  const [org] = input.repo.split("/");
+  return {
+    jobId,
+    attemptId: `attempt-${jobId}`,
+    source: input.source ?? "automatic",
+    lane: input.lane ?? "background",
+    repo: input.repo,
+    org: input.org ?? org ?? "owner",
+    pullNumber: input.pullNumber ?? 1,
+    headSha: input.headSha ?? `head-${jobId}`,
+    ...(input.baseSha ? { baseSha: input.baseSha } : {}),
+    providerId: input.providerId ?? "zai-coding-plan",
+    priority: input.priority ?? 50,
+    state: input.state,
+    ...(input.nextEligibleAt ? { nextEligibleAt: input.nextEligibleAt } : {}),
+    ...(input.leaseId ? { leaseId: input.leaseId } : {}),
+    ...(input.leaseExpiresAt ? { leaseExpiresAt: input.leaseExpiresAt } : {}),
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+    ...(input.commentId ? { commentId: input.commentId } : {}),
+    ...(input.reviewUrl ? { reviewUrl: input.reviewUrl } : {}),
+    ...(input.lastError ? { lastError: input.lastError } : {}),
+    createdAt: input.createdAt ?? "2026-07-01T00:00:00.000Z",
+    updatedAt: input.updatedAt ?? "2026-07-01T00:00:00.000Z",
+    ...(input.startedAt ? { startedAt: input.startedAt } : {}),
+    ...(input.finishedAt ? { finishedAt: input.finishedAt } : {})
   };
 }

--- a/tests/review-budget.test.ts
+++ b/tests/review-budget.test.ts
@@ -190,7 +190,7 @@ describe("review run budget", () => {
       })
     ]);
     expect(status.delayedByReason).toEqual({
-      lease_limit: 1
+      provider_capacity: 1
     });
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -53,6 +53,15 @@ describe("provider-aware review scheduler", () => {
       completed: 2,
       remainingQueued: 10
     });
+    expect(result.queue.budget?.wouldLeaseCount).toBe(2);
+    expect(result.queue.budget?.delayedCount).toBe(8);
+    expect(result.queue.budget?.details.included).toBe(false);
+    expect(result.queue.budget?.wouldLease).toHaveLength(0);
+    expect(result.queue.budget?.delayed).toHaveLength(0);
+    expect((result.queue.delayedByReason.lease_limit ?? 0) + (result.queue.delayedByReason.repo_capacity ?? 0)).toBe(8);
+    expect(Object.keys(result.queue.delayedByReason).sort()).toEqual(
+      expect.arrayContaining(["lease_limit"])
+    );
     expect(reviewed).toHaveLength(2);
     expect(new Set(reviewed.map((entry) => entry.split("#")[0]))).toHaveLength(2);
     expect(state.listReviewQueueJobs({ state: "posted" })).toHaveLength(0);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -58,9 +58,9 @@ describe("provider-aware review scheduler", () => {
     expect(result.queue.budget?.details.included).toBe(false);
     expect(result.queue.budget?.wouldLease).toHaveLength(0);
     expect(result.queue.budget?.delayed).toHaveLength(0);
-    expect((result.queue.delayedByReason.lease_limit ?? 0) + (result.queue.delayedByReason.repo_capacity ?? 0)).toBe(8);
+    expect(Object.values(result.queue.delayedByReason).reduce((total, count) => total + count, 0)).toBe(8);
     expect(Object.keys(result.queue.delayedByReason).sort()).toEqual(
-      expect.arrayContaining(["lease_limit"])
+      expect.arrayContaining(["provider_capacity"])
     );
     expect(reviewed).toHaveLength(2);
     expect(new Set(reviewed.map((entry) => entry.split("#")[0]))).toHaveLength(2);


### PR DESCRIPTION
## Summary
- Adds a deterministic review budget projection for provider/org/repo/manual-reserve capacity and delayed-reason accounting.
- Threads compact budget summaries into scheduler results, release status, operator status, runtime inventory, and queue output.
- Adds `budget-status` for capped row-level detail; broad status commands stay summary-only and bounded.

Closes #25.

## Safety / Scope
- No live config changes.
- No scheduler leasing rewrite or scheduling-order change.
- No ZCode tool, skill, memory, GitHub permission, auto-merge, or mutation-policy expansion.
- Live `reviewConcurrency.maxActiveRuns=1` default remains unchanged.

## Validation
- `npm test -- tests/review-budget.test.ts tests/scheduler.test.ts tests/release-status.test.ts tests/operator-cli.test.ts` -> 57 passed
- `npm run build` -> passed
- `npm test` -> 222 passed
- Spec compliance subagent review -> approved
- Code quality/runtime safety subagent review -> approved

## Notes
- `release-status` now includes compact budget counts and reason histograms only.
- `budget-status --limit <n> --job-limit <n>` is the explicit detailed path with truncation metadata.
