### PR TITLE
Add machine-readable walkthrough markers

### DIFF
--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 import { categoryLabel, isRequestChangesEligible } from "./regression-taxonomy.js";
 import type {
@@ -14,9 +15,19 @@ import type {
 } from "./types.js";
 
 export const WALKTHROUGH_MARKER_PREFIX = "<!-- evaos-code-review-bot:walkthrough";
+export const WALKTHROUGH_STATE_MARKER_PREFIX = "<!-- evaos-code-review-bot:walkthrough-state";
+export const WALKTHROUGH_SCHEMA_VERSION = 1;
 
 const SEVERITY_LABELS: Severity[] = ["P0", "P1", "P2", "P3"];
 const MAX_CHANGED_FILE_ROWS = 25;
+const REPO_SLUG_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const HEAD_SHA_PATTERN = /^[0-9a-f]{40}$/i;
+const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/g;
+
+export function buildWalkthroughMarker(input: { repo: string; pullNumber: number }): string {
+  validateWalkthroughRepoPull(input);
+  return `${WALKTHROUGH_MARKER_PREFIX} repo=${input.repo} pr=${input.pullNumber} -->`;
+}
 
 export function buildWalkthroughComment(input: {
   repo: string;
@@ -29,7 +40,8 @@ export function buildWalkthroughComment(input: {
   proof?: ProofRequirementReport;
   postIssueComment?: boolean;
 }): WalkthroughComment {
-  const marker = `${WALKTHROUGH_MARKER_PREFIX} ${input.repo}#${input.pull.number} -->`;
+  validateWalkthroughIdentity({ repo: input.repo, pullNumber: input.pull.number, headSha: input.pull.head.sha });
+  const marker = buildWalkthroughMarker({ repo: input.repo, pullNumber: input.pull.number });
   const files = input.files.map((file) => summarizeFile(file, input.comments));
   const visibleFiles = files.slice(0, MAX_CHANGED_FILE_ROWS);
   const omittedFileCount = Math.max(0, files.length - visibleFiles.length);
@@ -41,11 +53,10 @@ export function buildWalkthroughComment(input: {
   const highSeverity = severityCounts.P0 + severityCounts.P1;
   const requestChangesEligible = input.comments.filter(isRequestChangesEligible).length;
 
-  const body = [
-    marker,
+  const visibleBody = [
     "## Walkthrough",
     "",
-    `PR: ${input.repo}#${input.pull.number} - ${input.pull.title}`,
+    `PR: ${input.repo}#${input.pull.number} - ${formatInlinePublicText(input.pull.title)}`,
     `Head: \`${input.pull.head.sha}\` into \`${input.pull.base.ref}\`. Review event: \`${input.event}\`.`,
     "",
     `Estimated review effort: ${effort.score}/5 (~${effort.minutes} min)`,
@@ -89,12 +100,59 @@ export function buildWalkthroughComment(input: {
     checklistItem(proofChecklistPassed(input.validation, input.proof), "Required behavior proof is present or not applicable."),
     checklistItem(true, "Labels and reviewers are suggestions only; the bot did not auto-apply them.")
   ].join("\n");
+  const redactedBody = redactSecrets(visibleBody);
+  const walkthroughHash = hashWalkthrough(redactedBody);
+  const stateMarker = buildWalkthroughStateMarker({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    verdict: input.event,
+    walkthroughHash
+  });
 
   return {
     marker,
-    body: redactSecrets(body),
+    body: [marker, stateMarker, redactedBody].join("\n"),
     postIssueComment: input.postIssueComment ?? false
   };
+}
+
+function buildWalkthroughStateMarker(input: {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  verdict: ReviewEvent;
+  walkthroughHash: string;
+}): string {
+  validateWalkthroughIdentity(input);
+  if (!/^[0-9a-f]{64}$/i.test(input.walkthroughHash)) {
+    throw new Error(`Invalid walkthrough hash: ${input.walkthroughHash}`);
+  }
+  return `${WALKTHROUGH_STATE_MARKER_PREFIX} version=${WALKTHROUGH_SCHEMA_VERSION} repo=${input.repo} pr=${input.pullNumber} sha=${input.headSha} verdict=${input.verdict} hash=${input.walkthroughHash} -->`;
+}
+
+function validateWalkthroughIdentity(input: { repo: string; pullNumber: number; headSha: string }): void {
+  validateWalkthroughRepoPull(input);
+  if (!HEAD_SHA_PATTERN.test(input.headSha)) throw new Error(`Invalid walkthrough head SHA: ${input.headSha}`);
+}
+
+function validateWalkthroughRepoPull(input: { repo: string; pullNumber: number }): void {
+  if (!REPO_SLUG_PATTERN.test(input.repo)) throw new Error(`Invalid walkthrough repo slug: ${input.repo}`);
+  if (!Number.isInteger(input.pullNumber) || input.pullNumber <= 0) {
+    throw new Error(`Invalid walkthrough pull number: ${input.pullNumber}`);
+  }
+}
+
+function hashWalkthrough(body: string): string {
+  return createHash("sha256").update(body, "utf8").digest("hex");
+}
+
+function formatInlinePublicText(value: string | undefined): string {
+  return redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]"))
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^#{1,6}\s+/, "")
+    .slice(0, 200);
 }
 
 function summarizeFile(file: PullFilePatch, comments: ReviewComment[]): {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -86,7 +86,7 @@ describe("GitHub App read authentication", () => {
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
-    const marker = "<!-- evaos-code-review-bot:walkthrough owner/repo#42 -->";
+    const marker = "<!-- evaos-code-review-bot:walkthrough repo=owner/repo pr=42 -->";
     const calls: Array<{ url: string; method: string; authorization?: string; body?: unknown }> = [];
     globalThis.fetch = vi.fn(async (url, init) => {
       const method = init?.method ?? "GET";
@@ -143,7 +143,7 @@ describe("GitHub App read authentication", () => {
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
 
-    const marker = "<!-- evaos-code-review-bot:walkthrough owner/repo#42 -->";
+    const marker = "<!-- evaos-code-review-bot:walkthrough repo=owner/repo pr=42 -->";
     const calls: Array<{ url: string; method: string; authorization?: string; body?: unknown }> = [];
     globalThis.fetch = vi.fn(async (url, init) => {
       const method = init?.method ?? "GET";

--- a/tests/walkthrough-post.test.ts
+++ b/tests/walkthrough-post.test.ts
@@ -26,7 +26,7 @@ describe("walkthrough comment posting", () => {
       pullNumber: 42,
       evidenceDir,
       walkthrough: {
-        marker: "<!-- evaos-code-review-bot:walkthrough owner/repo#42 -->",
+        marker: "<!-- evaos-code-review-bot:walkthrough repo=owner/repo pr=42 -->",
         body: "body",
         postIssueComment: true
       }
@@ -53,7 +53,7 @@ describe("walkthrough comment posting", () => {
       pullNumber: 42,
       evidenceDir,
       walkthrough: {
-        marker: "<!-- evaos-code-review-bot:walkthrough owner/repo#42 -->",
+        marker: "<!-- evaos-code-review-bot:walkthrough repo=owner/repo pr=42 -->",
         body: "body",
         postIssueComment: true
       }
@@ -68,7 +68,7 @@ describe("walkthrough comment posting", () => {
       reviewBodyAfterWalkthroughPost({
         summary: "compact summary",
         walkthrough: {
-          marker: "<!-- evaos-code-review-bot:walkthrough owner/repo#42 -->",
+          marker: "<!-- evaos-code-review-bot:walkthrough repo=owner/repo pr=42 -->",
           body: "walkthrough body",
           postIssueComment: true
         },
@@ -82,7 +82,7 @@ describe("walkthrough comment posting", () => {
       reviewBodyAfterWalkthroughPost({
         summary: "compact summary",
         walkthrough: {
-          marker: "<!-- evaos-code-review-bot:walkthrough owner/repo#42 -->",
+          marker: "<!-- evaos-code-review-bot:walkthrough repo=owner/repo pr=42 -->",
           body: "walkthrough body",
           postIssueComment: true
         },

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { buildWalkthroughComment, WALKTHROUGH_MARKER_PREFIX } from "../src/walkthrough.js";
+import {
+  buildWalkthroughComment,
+  buildWalkthroughMarker,
+  WALKTHROUGH_MARKER_PREFIX,
+  WALKTHROUGH_SCHEMA_VERSION,
+  WALKTHROUGH_STATE_MARKER_PREFIX
+} from "../src/walkthrough.js";
 import type { PullFilePatch, PullRequestSummary, ReviewComment } from "../src/types.js";
+
+const HEAD_A = "a".repeat(40);
+const HEAD_B = "b".repeat(40);
 
 const pull: PullRequestSummary = {
   number: 42,
@@ -8,7 +17,7 @@ const pull: PullRequestSummary = {
   draft: false,
   body: "Closes #17 and compares with #12.",
   head: {
-    sha: "abc123def456",
+    sha: HEAD_A,
     ref: "fix/save-rollback",
     repo: { full_name: "electricsheephq/WorldOS" }
   },
@@ -120,8 +129,9 @@ describe("walkthrough comment rendering", () => {
     });
 
     expect(walkthroughAgain).toEqual(walkthrough);
-    expect(walkthrough.marker).toBe(`${WALKTHROUGH_MARKER_PREFIX} electricsheephq/WorldOS#42 -->`);
+    expect(walkthrough.marker).toBe(`${WALKTHROUGH_MARKER_PREFIX} repo=electricsheephq/WorldOS pr=42 -->`);
     expect(walkthrough.body).toContain(walkthrough.marker);
+    expect(walkthrough.body).toMatch(new RegExp(`${WALKTHROUGH_STATE_MARKER_PREFIX} version=${WALKTHROUGH_SCHEMA_VERSION} repo=electricsheephq/WorldOS pr=42 sha=${HEAD_A} verdict=REQUEST_CHANGES hash=[0-9a-f]{64} -->`));
     expect(walkthrough.body).toContain("## Walkthrough");
     expect(walkthrough.body).toContain("| `Assets/Scripts/SaveGameController.cs` | modified | +44/-8 | Unity/gameplay state | Elevated: validated P1 finding |");
     expect(walkthrough.body).toContain("Estimated review effort: 2/5");
@@ -136,6 +146,36 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("REQUEST_CHANGES");
   });
 
+  it("uses one sticky walkthrough marker per PR while updating head-specific state metadata", () => {
+    const first = buildWalkthroughComment({
+      repo: "electricsheephq/WorldOS",
+      pull,
+      files: [{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0 }],
+      comments: [],
+      dropped: [],
+      event: "COMMENT",
+      postIssueComment: true
+    });
+    const second = buildWalkthroughComment({
+      repo: "electricsheephq/WorldOS",
+      pull: {
+        ...pull,
+        head: { ...pull.head, sha: HEAD_B }
+      },
+      files: [{ filename: "src/a.ts", status: "modified", additions: 4, deletions: 2 }],
+      comments: [],
+      dropped: [],
+      event: "REQUEST_CHANGES",
+      postIssueComment: true
+    });
+
+    expect(first.marker).toBe(second.marker);
+    expect(first.marker).toBe(buildWalkthroughMarker({ repo: "electricsheephq/WorldOS", pullNumber: 42 }));
+    expect(first.body).toContain(`sha=${HEAD_A} verdict=COMMENT`);
+    expect(second.body).toContain(`sha=${HEAD_B} verdict=REQUEST_CHANGES`);
+    expect(first.body).not.toEqual(second.body);
+  });
+
   it("handles empty reviews gracefully and redacts secret-like metadata", () => {
     const secret = ["super", "secret", "token"].join("-");
     const walkthrough = buildWalkthroughComment({
@@ -145,7 +185,7 @@ describe("walkthrough comment rendering", () => {
         number: 497,
         title: `Docs only ${secret}`,
         body: "No linked issue.",
-        head: { ...pull.head, sha: "deadbeef" }
+        head: { ...pull.head, sha: HEAD_B }
       },
       files: [{ filename: "docs/review.md", status: "modified", additions: 3, deletions: 1, changes: 4 }],
       comments: [],
@@ -158,6 +198,23 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("- [x] Required behavior proof is present or not applicable.");
     expect(walkthrough.body).not.toContain(secret);
     expect(walkthrough.body).toMatch(/Docs only \[redacted-secret\]/);
+  });
+
+  it("strips user-authored hidden comments before rendering public walkthrough text", () => {
+    const walkthrough = buildWalkthroughComment({
+      repo: "electricsheephq/WorldOS",
+      pull: {
+        ...pull,
+        title: "Fix save <!-- evaos-code-review-bot:walkthrough repo=evil/repo pr=1 --> rollback"
+      },
+      files: [{ filename: "docs/review.md", status: "modified", additions: 3, deletions: 1 }],
+      comments: [],
+      dropped: [],
+      event: "COMMENT"
+    });
+
+    expect(walkthrough.body).toContain("Fix save [hidden comment removed] rollback");
+    expect(walkthrough.body).not.toContain("repo=evil/repo");
   });
 
   it("keeps the comment-secret checklist passing when secret-like findings were dropped", () => {


### PR DESCRIPTION
## Summary
- add a stable PR-level walkthrough marker for sticky comment upserts
- add a versioned head-specific walkthrough state marker with body hash, verdict, repo, PR, and SHA metadata
- redact/hash visible walkthrough content before composing bot-owned hidden markers
- strip user-authored HTML comments from rendered PR title text to avoid marker injection

Refs #20.

## Validation
- `npm test -- tests/walkthrough.test.ts tests/walkthrough-post.test.ts tests/github-app-read.test.ts`
- `npm run build`
- `git diff --check`

## Runtime boundary
- No live config expansion in this PR. `walkthrough.postIssueComment` remains controlled by config; this only makes the comment identity/state schema durable when that path is enabled.