### PR TITLE
Add review readiness lifecycle state

### DIFF
--- a/docs/review-status-comments.md
+++ b/docs/review-status-comments.md
@@ -63,8 +63,8 @@ Readiness states:
 - `blocked_on_proof`: reserved for future evidence/proof-gated readiness.
 - `ready_for_human`: the head has a non-blocking bot review or dry-run result.
 - `provider_deferred`: capacity or provider cooldown deferred the head.
-- `stale`: the queued head was superseded or the base/head changed before
-  review.
+- `stale`: an older head was superseded by a newer PR head, or the queued
+  head's base/head changed before review.
 - `closed`: the PR closed or merged before review work completed.
 - `command_recorded`: a trusted non-review command such as `explain` was
   recorded.

--- a/docs/review-status-comments.md
+++ b/docs/review-status-comments.md
@@ -46,6 +46,38 @@ and may move directly from `queued` to `completed`; command
 acknowledgement/state lives in the separate command lane. Non-review commands
 such as `stop` and `explain` do not create review status comments.
 
+## Durable Readiness State
+
+The worker also persists one machine-readable `review_readiness` row per repo,
+PR, and head SHA. This row is the durable state-machine source for operators and
+future dashboards; the public sticky comment remains only a human coordination
+surface.
+
+Readiness states:
+
+- `queued`: a review job was accepted into the durable queue.
+- `reviewing`: a leased queue job is currently running review work.
+- `needs_fix`: a posted or dry-run review ended in `REQUEST_CHANGES`.
+- `awaiting_re_review`: a trusted `re-review` command was accepted.
+- `blocked_on_checks`: reserved for future check-gated readiness.
+- `blocked_on_proof`: reserved for future evidence/proof-gated readiness.
+- `ready_for_human`: the head has a non-blocking bot review or dry-run result.
+- `provider_deferred`: capacity or provider cooldown deferred the head.
+- `stale`: the queued head was superseded or the base/head changed before
+  review.
+- `closed`: the PR closed or merged before review work completed.
+- `command_recorded`: a trusted non-review command such as `explain` was
+  recorded.
+- `skipped`: policy, draft, canary, or trusted `stop` skipped the head.
+- `failed`: GitHub refetch, review execution, or worker failure stopped the
+  head.
+
+No-op scheduler cycles preserve `updated_at`. In practice this means duplicate
+processed-head scans do not create fresh readiness events and should not trigger
+new comments. Manual command metadata (`command_action`, `command_comment_id`)
+is retained across the later terminal transition so operators can connect
+`ready_for_human` or `needs_fix` back to the command that requested it.
+
 This is a soft coordination signal for humans and agents. It does not block
 GitHub merges by itself. Requiring the bot before merge should be implemented
 later with a dedicated GitHub Check and branch protection after the comment lane

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -274,7 +274,11 @@ async function enqueuePullIfEligible(input: {
     backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
     return "skipped_processed";
   }
-  if (hasActiveQueueJobForHead(input.state, input.repo, input.pull.number, input.pull.head.sha)) return "already_queued";
+  const activeQueueJob = getActiveQueueJobForHead(input.state, input.repo, input.pull.number, input.pull.head.sha);
+  if (activeQueueJob) {
+    backfillReadinessFromActiveQueueJob(input.state, input.repo, input.pull, activeQueueJob, input.now);
+    return "already_queued";
+  }
   if (!hasRepoQueueCapacity(input.state, input.repo, input.config.reviewScheduler?.maxQueuedPerRepo ?? 10)) {
     recordReadinessTransition({
       state: input.state,
@@ -397,6 +401,7 @@ function recordReadinessForEnqueue(input: {
     reason,
     ...(input.commandAction ? { commandAction: input.commandAction } : {}),
     ...(input.commandCommentId ? { commandCommentId: input.commandCommentId } : {}),
+    ...(isManual ? {} : { clearCommandMetadata: true }),
     now: input.now
   });
 }
@@ -973,7 +978,7 @@ function backfillReadinessFromProcessedHead(
   const processed = state.getProcessedReview(repo, pull.number, pull.head.sha);
   if (!processed) return;
   const existing = state.getReviewReadiness(repo, pull.number, pull.head.sha);
-  const targetState = readinessStateForProcessedStatus(processed.status, processed.event);
+  const targetState = readinessStateForProcessedStatus(processed.status, processed.event, processed.error);
   if (
     existing?.state === targetState &&
     (!processed.event || existing.event === processed.event) &&
@@ -986,9 +991,29 @@ function backfillReadinessFromProcessedHead(
     repo,
     pull,
     readinessState: targetState,
-    reason: `processed_head_already_${processed.status}`,
+    reason: readinessReasonForProcessedHead(processed),
     ...(processed.event ? { event: processed.event } : {}),
     ...(processed.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
+    now
+  });
+}
+
+function backfillReadinessFromActiveQueueJob(
+  state: ReviewStateStore,
+  repo: string,
+  pull: PullRequestSummary,
+  job: ReviewQueueJobRecord,
+  now: Date
+): void {
+  const readinessState = readinessStateForActiveQueueJob(job);
+  recordReadinessTransition({
+    state,
+    repo,
+    pull,
+    readinessState,
+    reason: readinessReasonForActiveQueueJob(job),
+    ...(job.source === "manual_command" && job.commentId ? { commandCommentId: job.commentId } : {}),
+    ...(job.source === "manual_command" ? {} : { clearCommandMetadata: true }),
     now
   });
 }
@@ -1061,8 +1086,10 @@ function readinessReasonForReviewResult(
 
 function readinessStateForProcessedStatus(
   status?: ProcessedStatus,
-  event?: ReviewEvent
+  event?: ReviewEvent,
+  error?: string
 ): ReviewReadinessState {
+  if (parseProviderCooldownError(error)) return "provider_deferred";
   switch (status) {
     case "posted":
     case "dry_run":
@@ -1078,6 +1105,22 @@ function readinessStateForProcessedStatus(
   }
 }
 
+function readinessReasonForProcessedHead(processed: { status: ProcessedStatus; error?: string }): string {
+  const providerCooldown = parseProviderCooldownError(processed.error);
+  if (providerCooldown) return `processed_head_provider_deferred: ${providerCooldown.reason ?? "provider_cooldown"}`;
+  return `processed_head_already_${processed.status}`;
+}
+
+function readinessStateForActiveQueueJob(job: ReviewQueueJobRecord): ReviewReadinessState {
+  if (job.state === "provider_deferred") return "provider_deferred";
+  if (job.state === "leased" || job.state === "running") return "reviewing";
+  return "queued";
+}
+
+function readinessReasonForActiveQueueJob(job: ReviewQueueJobRecord): string {
+  return job.lastError ? `active_queue_job_${job.state}: ${job.lastError}` : `active_queue_job_${job.state}`;
+}
+
 function recordReadinessTransition(input: {
   state: ReviewStateStore;
   repo: string;
@@ -1088,6 +1131,7 @@ function recordReadinessTransition(input: {
   reviewUrl?: string;
   commandAction?: ProcessedCommandAction;
   commandCommentId?: number;
+  clearCommandMetadata?: boolean;
   now: Date;
 }): void {
   input.state.recordReviewReadiness({
@@ -1100,6 +1144,7 @@ function recordReadinessTransition(input: {
     ...(input.reviewUrl ? { reviewUrl: input.reviewUrl } : {}),
     ...(input.commandAction ? { commandAction: input.commandAction } : {}),
     ...(input.commandCommentId ? { commandCommentId: input.commandCommentId } : {}),
+    ...(input.clearCommandMetadata ? { clearCommandMetadata: true } : {}),
     now: input.now
   });
 }
@@ -1393,10 +1438,19 @@ function hasActiveQueueJobForHead(
   pullNumber: number,
   headSha: string
 ): boolean {
+  return Boolean(getActiveQueueJobForHead(state, repo, pullNumber, headSha));
+}
+
+function getActiveQueueJobForHead(
+  state: ReviewStateStore,
+  repo: string,
+  pullNumber: number,
+  headSha: string
+): ReviewQueueJobRecord | undefined {
   return state.listReviewQueueJobs({
     repo,
     states: ["queued", "leased", "running", "provider_deferred"]
-  }).some((job) => job.pullNumber === pullNumber && job.headSha === headSha);
+  }).find((job) => job.pullNumber === pullNumber && job.headSha === headSha);
 }
 
 function hasRepoQueueCapacity(state: ReviewStateStore, repo: string, maxQueuedPerRepo: number): boolean {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1021,6 +1021,7 @@ function backfillReadinessFromActiveQueueJob(
 function shouldMarkJobReviewing(state: ReviewStateStore, job: ReviewQueueJobRecord): boolean {
   if (job.source !== "manual_command") return true;
   const existing = state.getReviewReadiness(job.repo, job.pullNumber, job.headSha);
+  // Only stop/explain commands suppress reviewing because they do not perform review work.
   return existing?.commandAction !== "stop" && existing?.commandAction !== "explain";
 }
 
@@ -1042,9 +1043,10 @@ function readinessStateForReviewResult(
       return "stale";
     case "skipped_draft":
     case "skipped_canary":
-    case "skipped_policy":
     case "skipped_command_stop":
       return "skipped";
+    case "skipped_policy":
+      return "failed";
     case "skipped_command_explain":
       return undefined;
     default:
@@ -1074,7 +1076,7 @@ function readinessReasonForReviewResult(
     case "skipped_canary":
       return "canary_policy";
     case "skipped_policy":
-      return "repo_policy";
+      return "unexpected_scheduler_review_status=skipped_policy";
     case "skipped_command_stop":
       return "manual_command_stop";
     case "skipped_command_explain":

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -407,9 +407,17 @@ function markSupersededReadinessRowsForPull(
   pull: PullRequestSummary,
   now: Date
 ): void {
-  for (const readiness of state.listReviewReadiness({ repo, pullNumber: pull.number })) {
+  const supersedableStates: ReviewReadinessState[] = [
+    "queued",
+    "reviewing",
+    "needs_fix",
+    "awaiting_re_review",
+    "ready_for_human",
+    "provider_deferred",
+    "command_recorded"
+  ];
+  for (const readiness of state.listReviewReadiness({ repo, pullNumber: pull.number, states: supersedableStates })) {
     if (readiness.headSha === pull.head.sha) continue;
-    if (readiness.state === "stale" || readiness.state === "closed") continue;
     state.recordReviewReadiness({
       repo,
       pullNumber: pull.number,
@@ -601,10 +609,11 @@ async function runLeasedQueueJob(input: {
   try {
     pull = await input.github.getPull(input.job.repo, input.job.pullNumber);
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     input.state.updateReviewQueueJobState({
       jobId: input.job.jobId,
       state: "failed",
-      lastError: error instanceof Error ? error.message : String(error),
+      lastError: errorMessage,
       now
     });
     recordReadinessTransition({
@@ -612,7 +621,7 @@ async function runLeasedQueueJob(input: {
       repo: input.job.repo,
       pull: pullForQueueJobWithoutLive(input.job),
       readinessState: "failed",
-      reason: "github_refetch_failed",
+      reason: `github_refetch_failed: ${errorMessage}`,
       now
     });
     updateReviewerSessionJobFromQueueStatus(input, "failed", "failed");
@@ -813,17 +822,18 @@ async function runLeasedQueueJob(input: {
       pull,
       error
     });
+    const errorMessage = error instanceof Error ? error.message : String(error);
     input.state.updateReviewQueueJobState({
       jobId: input.job.jobId,
       state: "failed",
-      lastError: error instanceof Error ? error.message : String(error)
+      lastError: errorMessage
     });
     recordReadinessTransition({
       state: input.state,
       repo: input.job.repo,
       pull,
       readinessState: "failed",
-      reason: "review_failed",
+      reason: `review_failed: ${errorMessage}`,
       now
     });
     await syncReviewStatusComment({
@@ -984,7 +994,7 @@ function backfillReadinessFromProcessedHead(
 }
 
 function shouldMarkJobReviewing(state: ReviewStateStore, job: ReviewQueueJobRecord): boolean {
-  if (job.source === "manual_command") return false;
+  if (job.source !== "manual_command") return true;
   const existing = state.getReviewReadiness(job.repo, job.pullNumber, job.headSha);
   return existing?.commandAction !== "stop" && existing?.commandAction !== "explain";
 }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -18,12 +18,14 @@ import {
   parseProviderCooldownError,
   ReviewStateStore,
   type ProcessedStatus,
+  type ProcessedCommandAction,
+  type ReviewReadinessState,
   type ReviewerSessionJobState,
   type ReviewQueueJobRecord,
   type ReviewQueueJobState,
   type ReviewQueueJobSource
 } from "./state.js";
-import type { PullRequestSummary } from "./types.js";
+import type { PullRequestSummary, ReviewEvent } from "./types.js";
 import type { IssueCommentCommandSource } from "./commands.js";
 import {
   activateRepoForNewOnlyReview,
@@ -213,8 +215,29 @@ async function enqueuePullIfEligible(input: {
     await retireQueuedJobsForClosedPull(input);
     return "closed_retired";
   }
-  if (input.config.skipDrafts && input.pull.draft) return "skipped_draft";
-  if (!isCanaryAllowed(input.config, input.repo, input.pull.number)) return "skipped_canary";
+  markSupersededReadinessRowsForPull(input.state, input.repo, input.pull, input.now);
+  if (input.config.skipDrafts && input.pull.draft) {
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.repo,
+      pull: input.pull,
+      readinessState: "skipped",
+      reason: "draft_pr",
+      now: input.now
+    });
+    return "skipped_draft";
+  }
+  if (!isCanaryAllowed(input.config, input.repo, input.pull.number)) {
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.repo,
+      pull: input.pull,
+      readinessState: "skipped",
+      reason: "canary_policy",
+      now: input.now
+    });
+    return "skipped_canary";
+  }
 
   const commandDecision = await resolveSchedulerCommandDecision(input);
   if (commandDecision.action !== "none") {
@@ -222,6 +245,15 @@ async function enqueuePullIfEligible(input: {
       await retireSupersededQueueJobsForPull(input);
     }
     const queued = enqueueReviewJob(input, commandDecision);
+    recordReadinessForEnqueue({
+      state: input.state,
+      repo: input.repo,
+      pull: input.pull,
+      source: "manual_command",
+      commandAction: commandDecision.action,
+      commandCommentId: commandDecision.commandId,
+      now: input.now
+    });
     if (queued.enqueued && commandDecision.shouldReview) {
       await syncReviewStatusComment({
         config: input.config,
@@ -238,9 +270,20 @@ async function enqueuePullIfEligible(input: {
   }
 
   await retireSupersededQueueJobsForPull(input);
-  if (input.state.hasProcessed(input.repo, input.pull.number, input.pull.head.sha)) return "skipped_processed";
+  if (input.state.hasProcessed(input.repo, input.pull.number, input.pull.head.sha)) {
+    backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
+    return "skipped_processed";
+  }
   if (hasActiveQueueJobForHead(input.state, input.repo, input.pull.number, input.pull.head.sha)) return "already_queued";
   if (!hasRepoQueueCapacity(input.state, input.repo, input.config.reviewScheduler?.maxQueuedPerRepo ?? 10)) {
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.repo,
+      pull: input.pull,
+      readinessState: "provider_deferred",
+      reason: "repo_queue_capacity_full",
+      now: input.now
+    });
     return "skipped_capacity";
   }
 
@@ -252,6 +295,14 @@ async function enqueuePullIfEligible(input: {
       state: "provider_deferred",
       nextEligibleAt: activeRepoCooldown.cooldownUntil,
       lastError: `repo_provider_cooldown_until=${activeRepoCooldown.cooldownUntil}; reason=${activeRepoCooldown.reason}`,
+      now: input.now
+    });
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.repo,
+      pull: input.pull,
+      readinessState: "provider_deferred",
+      reason: "repo_provider_cooldown_active",
       now: input.now
     });
     if (queued.enqueued) {
@@ -271,6 +322,13 @@ async function enqueuePullIfEligible(input: {
   }
 
   const enqueued = enqueueReviewJob(input);
+  recordReadinessForEnqueue({
+    state: input.state,
+    repo: input.repo,
+    pull: input.pull,
+    source: "automatic",
+    now: input.now
+  });
   if (enqueued.enqueued) {
     await syncReviewStatusComment({
       config: input.config,
@@ -313,6 +371,56 @@ function enqueueReviewJob(input: {
   });
 }
 
+function recordReadinessForEnqueue(input: {
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  source: ReviewQueueJobSource;
+  commandAction?: ProcessedCommandAction;
+  commandCommentId?: number;
+  now: Date;
+}): void {
+  const isManual = input.source === "manual_command";
+  const readinessState: ReviewReadinessState =
+    isManual && input.commandAction === "re-review" ? "awaiting_re_review" :
+    isManual && input.commandAction === "stop" ? "skipped" :
+    isManual && input.commandAction === "explain" ? "command_recorded" :
+    "queued";
+  const reason = isManual && input.commandAction
+    ? `trusted_${input.commandAction.replace("-", "_")}_command`
+    : "automatic_enqueue";
+  recordReadinessTransition({
+    state: input.state,
+    repo: input.repo,
+    pull: input.pull,
+    readinessState,
+    reason,
+    ...(input.commandAction ? { commandAction: input.commandAction } : {}),
+    ...(input.commandCommentId ? { commandCommentId: input.commandCommentId } : {}),
+    now: input.now
+  });
+}
+
+function markSupersededReadinessRowsForPull(
+  state: ReviewStateStore,
+  repo: string,
+  pull: PullRequestSummary,
+  now: Date
+): void {
+  for (const readiness of state.listReviewReadiness({ repo, pullNumber: pull.number })) {
+    if (readiness.headSha === pull.head.sha) continue;
+    if (readiness.state === "stale" || readiness.state === "closed") continue;
+    state.recordReviewReadiness({
+      repo,
+      pullNumber: pull.number,
+      headSha: readiness.headSha,
+      state: "stale",
+      reason: `superseded_by_head=${pull.head.sha}`,
+      now
+    });
+  }
+}
+
 async function retireSupersededQueueJobsForPull(input: {
   config: BotConfig;
   github: SchedulerGitHubApi;
@@ -334,6 +442,14 @@ async function retireSupersededQueueJobsForPull(input: {
       jobId: job.jobId,
       state: "stale_retired",
       lastError: `superseded_by_head=${input.pull.head.sha}`,
+      now: input.now
+    });
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.repo,
+      pull: pullForQueueJob(job, input.pull),
+      readinessState: "stale",
+      reason: `superseded_by_head=${input.pull.head.sha}`,
       now: input.now
     });
     updateReviewerSessionJobFromQueueStatus({ state: input.state, job }, "skipped", "skipped");
@@ -372,6 +488,14 @@ async function retireQueuedJobsForClosedPull(input: {
       jobId: job.jobId,
       state: "closed_retired",
       lastError: `closed_or_merged_before_review state=${input.pull.state ?? "unknown"}`,
+      now: input.now
+    });
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.repo,
+      pull: pullForQueueJob(job, input.pull),
+      readinessState: "closed",
+      reason: `closed_or_merged_before_review state=${input.pull.state ?? "unknown"}`,
       now: input.now
     });
     updateReviewerSessionJobFromQueueStatus({ state: input.state, job }, "skipped", "skipped");
@@ -462,6 +586,16 @@ async function runLeasedQueueJob(input: {
     state: "running",
     now
   });
+  if (shouldMarkJobReviewing(input.state, input.job)) {
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.job.repo,
+      pull: pullForQueueJobWithoutLive(input.job),
+      readinessState: "reviewing",
+      reason: "queue_job_running",
+      now
+    });
+  }
 
   let pull: PullRequestSummary;
   try {
@@ -471,6 +605,14 @@ async function runLeasedQueueJob(input: {
       jobId: input.job.jobId,
       state: "failed",
       lastError: error instanceof Error ? error.message : String(error),
+      now
+    });
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.job.repo,
+      pull: pullForQueueJobWithoutLive(input.job),
+      readinessState: "failed",
+      reason: "github_refetch_failed",
       now
     });
     updateReviewerSessionJobFromQueueStatus(input, "failed", "failed");
@@ -495,6 +637,14 @@ async function runLeasedQueueJob(input: {
       lastError: `closed_or_merged_before_review state=${pull.state ?? "unknown"}`,
       now
     });
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.job.repo,
+      pull: pullForQueueJob(input.job, pull),
+      readinessState: "closed",
+      reason: `closed_or_merged_before_review state=${pull.state ?? "unknown"}`,
+      now
+    });
     updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
     await syncReviewStatusComment({
       config: input.config,
@@ -517,6 +667,14 @@ async function runLeasedQueueJob(input: {
       lastError: `stale_head_before_review live=${pull.head.sha}`,
       now
     });
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.job.repo,
+      pull: pullForQueueJob(input.job, pull),
+      readinessState: "stale",
+      reason: `stale_head_before_review live=${pull.head.sha}`,
+      now
+    });
     updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
     await syncReviewStatusComment({
       config: input.config,
@@ -537,6 +695,14 @@ async function runLeasedQueueJob(input: {
       jobId: input.job.jobId,
       state: "stale_retired",
       lastError: `base_changed_before_review live=${pull.base.sha}`,
+      now
+    });
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.job.repo,
+      pull: pullForQueueJob(input.job, pull),
+      readinessState: "stale",
+      reason: `base_changed_before_review live=${pull.base.sha}`,
       now
     });
     updateReviewerSessionJobFromQueueStatus(input, "skipped", "skipped");
@@ -583,6 +749,13 @@ async function runLeasedQueueJob(input: {
       ...(input.job.source === "manual_command" && input.job.commentId ? { commandCommentId: input.job.commentId } : {})
     });
     updateQueueJobAfterReviewStatus({ state: input.state, job: input.job, pull, status, dryRun: input.dryRun });
+    syncReadinessForReviewResult({
+      state: input.state,
+      job: input.job,
+      pull,
+      status,
+      now
+    });
     await syncReviewStatusCommentForReviewResult({
       config: input.config,
       github: input.github,
@@ -611,6 +784,14 @@ async function runLeasedQueueJob(input: {
       now
     })) {
       markQueueJobProviderDeferredFromProcessed({ state: input.state, job: input.job, pull, error, config: input.config, now });
+      recordReadinessTransition({
+        state: input.state,
+        repo: input.job.repo,
+        pull,
+        readinessState: "provider_deferred",
+        reason: "provider_rate_limit_cooldown",
+        now
+      });
       await syncReviewStatusComment({
         config: input.config,
         github: input.github,
@@ -636,6 +817,14 @@ async function runLeasedQueueJob(input: {
       jobId: input.job.jobId,
       state: "failed",
       lastError: error instanceof Error ? error.message : String(error)
+    });
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.job.repo,
+      pull,
+      readinessState: "failed",
+      reason: "review_failed",
+      now
     });
     await syncReviewStatusComment({
       config: input.config,
@@ -741,6 +930,168 @@ function reviewResultStatusCommentState(status: ReviewPullResult, processedStatu
     default:
       return assertNever(status);
   }
+}
+
+function syncReadinessForReviewResult(input: {
+  state: ReviewStateStore;
+  job: ReviewQueueJobRecord;
+  pull: PullRequestSummary;
+  status: ReviewPullResult;
+  now: Date;
+}): void {
+  const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
+  const readinessState = readinessStateForReviewResult(input.status, processed?.status, processed?.event);
+  if (!readinessState) return;
+  recordReadinessTransition({
+    state: input.state,
+    repo: input.job.repo,
+    pull: input.pull,
+    readinessState,
+    reason: readinessReasonForReviewResult(input.status, processed?.status, processed?.event),
+    ...(processed?.event ? { event: processed.event } : {}),
+    ...(processed?.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
+    now: input.now
+  });
+}
+
+function backfillReadinessFromProcessedHead(
+  state: ReviewStateStore,
+  repo: string,
+  pull: PullRequestSummary,
+  now: Date
+): void {
+  const processed = state.getProcessedReview(repo, pull.number, pull.head.sha);
+  if (!processed) return;
+  const existing = state.getReviewReadiness(repo, pull.number, pull.head.sha);
+  const targetState = readinessStateForProcessedStatus(processed.status, processed.event);
+  if (
+    existing?.state === targetState &&
+    (!processed.event || existing.event === processed.event) &&
+    (!processed.reviewUrl || existing.reviewUrl === processed.reviewUrl)
+  ) {
+    return;
+  }
+  recordReadinessTransition({
+    state,
+    repo,
+    pull,
+    readinessState: targetState,
+    reason: `processed_head_already_${processed.status}`,
+    ...(processed.event ? { event: processed.event } : {}),
+    ...(processed.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
+    now
+  });
+}
+
+function shouldMarkJobReviewing(state: ReviewStateStore, job: ReviewQueueJobRecord): boolean {
+  if (job.source === "manual_command") return false;
+  const existing = state.getReviewReadiness(job.repo, job.pullNumber, job.headSha);
+  return existing?.commandAction !== "stop" && existing?.commandAction !== "explain";
+}
+
+function readinessStateForReviewResult(
+  status: ReviewPullResult,
+  processedStatus?: ProcessedStatus,
+  event?: ReviewEvent
+): ReviewReadinessState | undefined {
+  switch (status) {
+    case "reviewed":
+    case "reviewed_command":
+      return event === "REQUEST_CHANGES" ? "needs_fix" : "ready_for_human";
+    case "skipped_processed":
+      return readinessStateForProcessedStatus(processedStatus, event);
+    case "skipped_provider_cooldown":
+    case "skipped_capacity":
+      return "provider_deferred";
+    case "skipped_stale_head":
+      return "stale";
+    case "skipped_draft":
+    case "skipped_canary":
+    case "skipped_policy":
+    case "skipped_command_stop":
+      return "skipped";
+    case "skipped_command_explain":
+      return undefined;
+    default:
+      return assertNever(status);
+  }
+}
+
+function readinessReasonForReviewResult(
+  status: ReviewPullResult,
+  processedStatus?: ProcessedStatus,
+  event?: ReviewEvent
+): string {
+  switch (status) {
+    case "reviewed":
+    case "reviewed_command":
+      return event === "REQUEST_CHANGES" ? "request_changes_review_posted" : "comment_review_posted";
+    case "skipped_processed":
+      return `processed_head_already_${processedStatus ?? "unknown"}`;
+    case "skipped_provider_cooldown":
+      return "provider_cooldown";
+    case "skipped_capacity":
+      return "review_capacity_busy";
+    case "skipped_stale_head":
+      return "stale_head";
+    case "skipped_draft":
+      return "draft_pr";
+    case "skipped_canary":
+      return "canary_policy";
+    case "skipped_policy":
+      return "repo_policy";
+    case "skipped_command_stop":
+      return "manual_command_stop";
+    case "skipped_command_explain":
+      return "manual_command_explain";
+    default:
+      return assertNever(status);
+  }
+}
+
+function readinessStateForProcessedStatus(
+  status?: ProcessedStatus,
+  event?: ReviewEvent
+): ReviewReadinessState {
+  switch (status) {
+    case "posted":
+    case "dry_run":
+      return event === "REQUEST_CHANGES" ? "needs_fix" : "ready_for_human";
+    case "failed":
+      return "failed";
+    case "skipped":
+      return "skipped";
+    case undefined:
+      return "ready_for_human";
+    default:
+      return assertNever(status);
+  }
+}
+
+function recordReadinessTransition(input: {
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  readinessState: ReviewReadinessState;
+  reason: string;
+  event?: ReviewEvent;
+  reviewUrl?: string;
+  commandAction?: ProcessedCommandAction;
+  commandCommentId?: number;
+  now: Date;
+}): void {
+  input.state.recordReviewReadiness({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    state: input.readinessState,
+    reason: input.reason,
+    ...(input.event ? { event: input.event } : {}),
+    ...(input.reviewUrl ? { reviewUrl: input.reviewUrl } : {}),
+    ...(input.commandAction ? { commandAction: input.commandAction } : {}),
+    ...(input.commandCommentId ? { commandCommentId: input.commandCommentId } : {}),
+    now: input.now
+  });
 }
 
 function pullForQueueJob(job: ReviewQueueJobRecord, livePull: PullRequestSummary): PullRequestSummary {

--- a/src/state.ts
+++ b/src/state.ts
@@ -27,6 +27,20 @@ export type ReviewQueueJobState =
   | "command_recorded"
   | "posted"
   | "failed";
+export type ReviewReadinessState =
+  | "queued"
+  | "reviewing"
+  | "needs_fix"
+  | "awaiting_re_review"
+  | "blocked_on_checks"
+  | "blocked_on_proof"
+  | "ready_for_human"
+  | "provider_deferred"
+  | "stale"
+  | "closed"
+  | "command_recorded"
+  | "skipped"
+  | "failed";
 
 export interface ProcessedReviewRecord {
   repo: string;
@@ -111,6 +125,20 @@ export interface ReviewQueueJobRecord {
   updatedAt: string;
   startedAt?: string;
   finishedAt?: string;
+}
+
+export interface ReviewReadinessRecord {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  state: ReviewReadinessState;
+  reason?: string;
+  event?: ReviewEvent;
+  reviewUrl?: string;
+  commandAction?: ProcessedCommandAction;
+  commandCommentId?: number;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export type ReviewQueueEnqueueResult =
@@ -299,6 +327,26 @@ export class ReviewStateStore {
         on review_queue_jobs (repo, pull_number, state);
       create index if not exists idx_review_queue_jobs_provider_state
         on review_queue_jobs (provider_id, state);
+
+      create table if not exists review_readiness (
+        repo text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        state text not null,
+        reason text,
+        event text,
+        review_url text,
+        command_action text,
+        command_comment_id integer,
+        created_at text not null,
+        updated_at text not null,
+        primary key (repo, pull_number, head_sha)
+      );
+
+      create index if not exists idx_review_readiness_state
+        on review_readiness (state, updated_at);
+      create index if not exists idx_review_readiness_repo_pull
+        on review_readiness (repo, pull_number, updated_at);
     `);
     this.ensureDaemonHeartbeatColumns();
     this.ensureReviewRunLeaseColumns();
@@ -366,6 +414,125 @@ export class ReviewStateStore {
         record.reviewUrl ?? null,
         record.error ?? null
       );
+  }
+
+  getReviewReadiness(repo: string, pullNumber: number, headSha: string): ReviewReadinessRecord | undefined {
+    const row = this.db
+      .prepare(
+        `select repo, pull_number, head_sha, state, reason, event, review_url,
+                command_action, command_comment_id, created_at, updated_at
+         from review_readiness
+         where repo = ? and pull_number = ? and head_sha = ?
+         limit 1`
+      )
+      .get(repo, pullNumber, headSha) as ReviewReadinessRow | undefined;
+    return row ? mapReviewReadinessRow(row) : undefined;
+  }
+
+  recordReviewReadiness(input: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    state: ReviewReadinessState;
+    reason?: string;
+    event?: ReviewEvent;
+    reviewUrl?: string;
+    commandAction?: ProcessedCommandAction;
+    commandCommentId?: number;
+    now?: Date;
+  }): ReviewReadinessRecord {
+    validateReviewQueueInput(input.repo, input.pullNumber, input.headSha, undefined, input.commandCommentId);
+    const existing = this.getReviewReadiness(input.repo, input.pullNumber, input.headSha);
+    const reason = input.reason ? redactSecrets(input.reason).trim().slice(0, 500) : undefined;
+    const event = input.event ?? existing?.event;
+    const reviewUrl = input.reviewUrl ? redactSecrets(input.reviewUrl).trim().slice(0, 500) : existing?.reviewUrl;
+    const commandAction = input.commandAction ?? existing?.commandAction;
+    const commandCommentId = input.commandCommentId ?? existing?.commandCommentId;
+
+    if (
+      existing &&
+      existing.state === input.state &&
+      existing.reason === reason &&
+      existing.event === event &&
+      existing.reviewUrl === reviewUrl &&
+      existing.commandAction === commandAction &&
+      existing.commandCommentId === commandCommentId
+    ) {
+      return existing;
+    }
+
+    const nowIso = (input.now ?? new Date()).toISOString();
+    this.db
+      .prepare(
+        `insert into review_readiness
+          (repo, pull_number, head_sha, state, reason, event, review_url,
+           command_action, command_comment_id, created_at, updated_at)
+         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         on conflict(repo, pull_number, head_sha) do update set
+           state = excluded.state,
+           reason = excluded.reason,
+           event = excluded.event,
+           review_url = excluded.review_url,
+           command_action = excluded.command_action,
+           command_comment_id = excluded.command_comment_id,
+           updated_at = excluded.updated_at`
+      )
+      .run(
+        input.repo,
+        input.pullNumber,
+        input.headSha,
+        input.state,
+        reason ?? null,
+        event ?? null,
+        reviewUrl ?? null,
+        commandAction ?? null,
+        commandCommentId ?? null,
+        existing?.createdAt ?? nowIso,
+        nowIso
+      );
+    return this.getReviewReadiness(input.repo, input.pullNumber, input.headSha)!;
+  }
+
+  listReviewReadiness(input: {
+    repo?: string;
+    pullNumber?: number;
+    state?: ReviewReadinessState;
+    states?: ReviewReadinessState[];
+    limit?: number;
+  } = {}): ReviewReadinessRecord[] {
+    if (input.limit !== undefined && (!Number.isInteger(input.limit) || input.limit < 1)) {
+      throw new Error("limit must be a positive integer");
+    }
+    const states = input.states ?? (input.state ? [input.state] : undefined);
+    const predicates: string[] = [];
+    const params: Array<string | number> = [];
+    if (input.repo) {
+      predicates.push("repo = ?");
+      params.push(input.repo);
+    }
+    if (input.pullNumber !== undefined) {
+      if (!Number.isInteger(input.pullNumber) || input.pullNumber < 1) throw new Error("pullNumber must be a positive integer");
+      predicates.push("pull_number = ?");
+      params.push(input.pullNumber);
+    }
+    if (states?.length) {
+      predicates.push(`state in (${states.map(() => "?").join(", ")})`);
+      params.push(...states);
+    }
+    const where = predicates.length ? `where ${predicates.join(" and ")}` : "";
+    const limit = input.limit ? " limit ?" : "";
+    if (input.limit) params.push(input.limit);
+    const rows = this.db
+      .prepare(
+        `select repo, pull_number, head_sha, state, reason, event, review_url,
+                command_action, command_comment_id, created_at, updated_at
+         from review_readiness
+         ${where}
+         order by datetime(updated_at) desc
+         ${limit}`
+      )
+      .all(...params) as unknown as ReviewReadinessRow[];
+    return rows.map(mapReviewReadinessRow);
   }
 
   retireFailedReview(input: RetireFailedReviewInput): StoredProcessedReviewRecord {
@@ -1537,6 +1704,20 @@ interface ReviewQueueJobRow {
   finished_at: string | null;
 }
 
+interface ReviewReadinessRow {
+  repo: string;
+  pull_number: number;
+  head_sha: string;
+  state: ReviewReadinessState;
+  reason: string | null;
+  event: ReviewEvent | null;
+  review_url: string | null;
+  command_action: ProcessedCommandAction | null;
+  command_comment_id: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
 function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRecord {
   return {
     repo: row.repo,
@@ -1547,6 +1728,22 @@ function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRe
     ...(row.review_url ? { reviewUrl: row.review_url } : {}),
     ...(row.error ? { error: row.error } : {}),
     createdAt: row.created_at
+  };
+}
+
+function mapReviewReadinessRow(row: ReviewReadinessRow): ReviewReadinessRecord {
+  return {
+    repo: row.repo,
+    pullNumber: row.pull_number,
+    headSha: row.head_sha,
+    state: row.state,
+    ...(row.reason ? { reason: row.reason } : {}),
+    ...(row.event ? { event: row.event } : {}),
+    ...(row.review_url ? { reviewUrl: row.review_url } : {}),
+    ...(row.command_action ? { commandAction: row.command_action } : {}),
+    ...(row.command_comment_id ? { commandCommentId: row.command_comment_id } : {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
   };
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -442,55 +442,68 @@ export class ReviewStateStore {
     now?: Date;
   }): ReviewReadinessRecord {
     validateReviewQueueInput(input.repo, input.pullNumber, input.headSha, undefined, input.commandCommentId);
-    const existing = this.getReviewReadiness(input.repo, input.pullNumber, input.headSha);
-    const reason = input.reason ? redactSecrets(input.reason).trim().slice(0, 500) : undefined;
-    const event = input.event ?? existing?.event;
-    const reviewUrl = input.reviewUrl ? redactSecrets(input.reviewUrl).trim().slice(0, 500) : existing?.reviewUrl;
-    const commandAction = input.commandAction ?? existing?.commandAction;
-    const commandCommentId = input.commandCommentId ?? existing?.commandCommentId;
+    this.db.exec("begin immediate");
+    try {
+      const existing = this.getReviewReadiness(input.repo, input.pullNumber, input.headSha);
+      const reason = input.reason ? redactSecrets(input.reason).trim().slice(0, 500) : undefined;
+      const event = input.event ?? existing?.event;
+      const reviewUrl = input.reviewUrl ? redactSecrets(input.reviewUrl).trim().slice(0, 500) : existing?.reviewUrl;
+      const commandAction = input.commandAction ?? existing?.commandAction;
+      const commandCommentId = input.commandCommentId ?? existing?.commandCommentId;
 
-    if (
-      existing &&
-      existing.state === input.state &&
-      existing.reason === reason &&
-      existing.event === event &&
-      existing.reviewUrl === reviewUrl &&
-      existing.commandAction === commandAction &&
-      existing.commandCommentId === commandCommentId
-    ) {
-      return existing;
+      if (
+        existing &&
+        existing.state === input.state &&
+        existing.reason === reason &&
+        existing.event === event &&
+        existing.reviewUrl === reviewUrl &&
+        existing.commandAction === commandAction &&
+        existing.commandCommentId === commandCommentId
+      ) {
+        this.db.exec("commit");
+        return existing;
+      }
+
+      const nowIso = (input.now ?? new Date()).toISOString();
+      this.db
+        .prepare(
+          `insert into review_readiness
+            (repo, pull_number, head_sha, state, reason, event, review_url,
+             command_action, command_comment_id, created_at, updated_at)
+           values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           on conflict(repo, pull_number, head_sha) do update set
+             state = excluded.state,
+             reason = excluded.reason,
+             event = excluded.event,
+             review_url = excluded.review_url,
+             command_action = excluded.command_action,
+             command_comment_id = excluded.command_comment_id,
+             updated_at = excluded.updated_at`
+        )
+        .run(
+          input.repo,
+          input.pullNumber,
+          input.headSha,
+          input.state,
+          reason ?? null,
+          event ?? null,
+          reviewUrl ?? null,
+          commandAction ?? null,
+          commandCommentId ?? null,
+          existing?.createdAt ?? nowIso,
+          nowIso
+        );
+      const readiness = this.getReviewReadiness(input.repo, input.pullNumber, input.headSha)!;
+      this.db.exec("commit");
+      return readiness;
+    } catch (error) {
+      try {
+        this.db.exec("rollback");
+      } catch {
+        // Ignore rollback failures so the original SQLite error remains visible.
+      }
+      throw error;
     }
-
-    const nowIso = (input.now ?? new Date()).toISOString();
-    this.db
-      .prepare(
-        `insert into review_readiness
-          (repo, pull_number, head_sha, state, reason, event, review_url,
-           command_action, command_comment_id, created_at, updated_at)
-         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-         on conflict(repo, pull_number, head_sha) do update set
-           state = excluded.state,
-           reason = excluded.reason,
-           event = excluded.event,
-           review_url = excluded.review_url,
-           command_action = excluded.command_action,
-           command_comment_id = excluded.command_comment_id,
-           updated_at = excluded.updated_at`
-      )
-      .run(
-        input.repo,
-        input.pullNumber,
-        input.headSha,
-        input.state,
-        reason ?? null,
-        event ?? null,
-        reviewUrl ?? null,
-        commandAction ?? null,
-        commandCommentId ?? null,
-        existing?.createdAt ?? nowIso,
-        nowIso
-      );
-    return this.getReviewReadiness(input.repo, input.pullNumber, input.headSha)!;
   }
 
   listReviewReadiness(input: {

--- a/src/state.ts
+++ b/src/state.ts
@@ -439,6 +439,7 @@ export class ReviewStateStore {
     reviewUrl?: string;
     commandAction?: ProcessedCommandAction;
     commandCommentId?: number;
+    clearCommandMetadata?: boolean;
     now?: Date;
   }): ReviewReadinessRecord {
     validateReviewQueueInput(input.repo, input.pullNumber, input.headSha, undefined, input.commandCommentId);
@@ -448,8 +449,8 @@ export class ReviewStateStore {
       const reason = input.reason ? redactSecrets(input.reason).trim().slice(0, 500) : undefined;
       const event = input.event ?? existing?.event;
       const reviewUrl = input.reviewUrl ? redactSecrets(input.reviewUrl).trim().slice(0, 500) : existing?.reviewUrl;
-      const commandAction = input.commandAction ?? existing?.commandAction;
-      const commandCommentId = input.commandCommentId ?? existing?.commandCommentId;
+      const commandAction = input.clearCommandMetadata ? undefined : input.commandAction ?? existing?.commandAction;
+      const commandCommentId = input.clearCommandMetadata ? undefined : input.commandCommentId ?? existing?.commandCommentId;
 
       if (
         existing &&

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -942,6 +942,10 @@ describe("provider-aware review scheduler", () => {
     expect(result.skippedPolicy).toBe(1);
     expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "skipped"]);
     expect(state.listReviewQueueJobs({ state: "failed" })).toHaveLength(1);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "failed",
+      reason: "unexpected_scheduler_review_status=skipped_policy"
+    });
     state.close();
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -748,6 +748,10 @@ describe("provider-aware review scheduler", () => {
 
     expect(result.queue.closedRetired).toBe(1);
     expect(state.getReviewQueueJob(oldJob.jobId)).toMatchObject({ state: "closed_retired" });
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "closed",
+      reason: "closed_or_merged_before_review state=closed"
+    });
     expect(statusCalls.map(statusFromBody)).toEqual(["closed_or_merged_before_review"]);
     state.close();
   });
@@ -781,6 +785,11 @@ describe("provider-aware review scheduler", () => {
     });
 
     expect(statusCalls).toHaveLength(0);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "ready_for_human",
+      reason: "comment_review_posted",
+      event: "COMMENT"
+    });
     state.close();
   });
 
@@ -2002,6 +2011,10 @@ describe("provider-aware review scheduler", () => {
     expect(state.listReviewQueueJobs({ state: "stale_retired" })).toEqual([
       expect.objectContaining({ lastError: "base_changed_before_review live=new-base" })
     ]);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "stale",
+      reason: "base_changed_before_review live=new-base"
+    });
     state.close();
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -351,6 +351,47 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("backfills readiness for already-active queue jobs", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-readiness-active-job-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    const state = new ReviewStateStore(config.statePath);
+    const job = state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      baseSha: "base",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-02T00:15:00.000Z",
+      lastError: "provider_rate_limit_cooldown_until=2026-07-02T00:15:00.000Z; reason=provider_request_rate_limit",
+      now: new Date("2026-07-02T00:00:01.000Z")
+    });
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("active queue jobs must not enqueue duplicate work");
+      },
+      now: new Date("2026-07-02T00:05:00.000Z")
+    });
+
+    expect(result.queue.enqueued).toBe(0);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "provider_deferred",
+      reason: expect.stringContaining("active_queue_job_provider_deferred")
+    });
+    state.close();
+  });
+
   it("updates sticky status to provider_deferred when a leased review hits provider cooldown", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-provider-deferred-"));
     roots.push(root);
@@ -379,6 +420,22 @@ describe("provider-aware review scheduler", () => {
     expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
       state: "provider_deferred",
       reason: "provider_rate_limit_cooldown"
+    });
+
+    await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: true },
+      reviewPullImpl: async () => {
+        throw new Error("provider-deferred processed heads must not rerun before retry");
+      },
+      now: new Date("2026-07-02T00:01:00.000Z")
+    });
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "provider_deferred"
     });
     state.close();
   });
@@ -1630,6 +1687,31 @@ describe("provider-aware review scheduler", () => {
       commandAction: "explain",
       commandCommentId: 336
     });
+
+    await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(pullMap, comments),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:01:00.000Z")
+    });
+    const readinessAfterAutomaticReview = state.getReviewReadiness("org/repo-a", 1, "a1");
+    expect(readinessAfterAutomaticReview).toMatchObject({
+      state: "ready_for_human",
+      reason: "comment_review_posted"
+    });
+    expect(readinessAfterAutomaticReview?.commandAction).toBeUndefined();
+    expect(readinessAfterAutomaticReview?.commandCommentId).toBeUndefined();
     state.close();
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -74,6 +74,7 @@ describe("provider-aware review scheduler", () => {
     expect(state.listReviewQueueJobs({ state: "queued" })).toHaveLength(10);
     expect(state.listReviewQueueJobs({ state: "queued" })
       .filter((job) => job.lastError === "dry_run_completed_not_posted")).toHaveLength(2);
+    expect(state.listReviewReadiness({ states: ["queued"] }).length).toBeGreaterThan(0);
     state.close();
   });
 
@@ -84,6 +85,7 @@ describe("provider-aware review scheduler", () => {
     config.reviewStatusComment!.enabled = true;
     const state = new ReviewStateStore(config.statePath);
     const statusCalls: StatusCommentCall[] = [];
+    const readinessObservedDuringReview: string[] = [];
 
     const result = await runScheduledCycleWithDeps({
       config,
@@ -93,6 +95,7 @@ describe("provider-aware review scheduler", () => {
       state,
       options: { dryRun: false, useZCode: false },
       reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        readinessObservedDuringReview.push(reviewState.getReviewReadiness(repo, reviewPull.number, reviewPull.head.sha)?.state ?? "missing");
         reviewState.recordProcessed({
           repo,
           pullNumber: reviewPull.number,
@@ -107,11 +110,244 @@ describe("provider-aware review scheduler", () => {
     });
 
     expect(result.reviewed).toBe(1);
+    expect(readinessObservedDuringReview).toEqual(["reviewing"]);
     expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "completed"]);
     expect(new Set(statusCalls.map((call) => call.marker))).toEqual(new Set([
       `<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=${HEAD_A} -->`
     ]));
     expect(statusCalls.at(-1)?.body).toContain("https://github.com/org/repo-a/pull/1#pullrequestreview-status");
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "ready_for_human",
+      reason: "comment_review_posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-status"
+    });
+    state.close();
+  });
+
+  it("persists REQUEST_CHANGES reviews as needs_fix readiness", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-readiness-needs-fix-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    const state = new ReviewStateStore(config.statePath);
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "REQUEST_CHANGES",
+          reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-blocking"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.reviewed).toBe(1);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "needs_fix",
+      reason: "request_changes_review_posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-blocking"
+    });
+    state.close();
+  });
+
+  it("preserves readiness state on duplicate processed-head scheduler cycles", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-readiness-duplicate-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const statusCalls: StatusCommentCall[] = [];
+    const github = githubFromMap(new Map([
+      ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
+    ]), new Map(), statusCalls);
+
+    const first = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-first"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+    const readiness = state.getReviewReadiness("org/repo-a", 1, HEAD_A);
+
+    const second = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("duplicate processed heads must not run review work");
+      },
+      now: new Date("2026-07-02T00:05:00.000Z")
+    });
+
+    expect(first.reviewed).toBe(1);
+    expect(second.skippedProcessed).toBe(1);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toEqual(readiness);
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "completed"]);
+    state.close();
+  });
+
+  it("marks older readiness rows stale when a newer PR head is scanned", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-readiness-superseded-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    const state = new ReviewStateStore(config.statePath);
+    state.recordReviewReadiness({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      state: "needs_fix",
+      reason: "request_changes_review_posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-old",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_B)]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-new"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T00:05:00.000Z")
+    });
+
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "stale",
+      reason: `superseded_by_head=${HEAD_B}`,
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-old"
+    });
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_B)).toMatchObject({
+      state: "ready_for_human",
+      reason: "comment_review_posted"
+    });
+    state.close();
+  });
+
+  it("marks older readiness rows stale even when the new head is skipped by canary policy", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-readiness-canary-superseded-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.canaryPulls = ["org/repo-a#99"];
+    const state = new ReviewStateStore(config.statePath);
+    state.recordReviewReadiness({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      state: "ready_for_human",
+      reason: "comment_review_posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-old",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_B)]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("canary-skipped heads must not run review work");
+      },
+      now: new Date("2026-07-02T00:05:00.000Z")
+    });
+
+    expect(result.skippedCanary).toBe(1);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "stale",
+      reason: `superseded_by_head=${HEAD_B}`,
+      event: "COMMENT",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-old"
+    });
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_B)).toMatchObject({
+      state: "skipped",
+      reason: "canary_policy"
+    });
+    state.close();
+  });
+
+  it("repairs non-terminal readiness rows from processed review truth", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-readiness-backfill-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    const state = new ReviewStateStore(config.statePath);
+    state.recordProcessed({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      status: "posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-existing"
+    });
+    state.recordReviewReadiness({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      state: "reviewing",
+      reason: "queue_job_running",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("processed heads must not run review work");
+      },
+      now: new Date("2026-07-02T00:05:00.000Z")
+    });
+
+    expect(result.skippedProcessed).toBe(1);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "needs_fix",
+      reason: "processed_head_already_posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-existing",
+      updatedAt: "2026-07-02T00:05:00.000Z"
+    });
     state.close();
   });
 
@@ -1058,6 +1294,7 @@ describe("provider-aware review scheduler", () => {
       ["org/repo-a#1", [comment(222, "100yenadmin", "@evaos-code-review-bot re-review")]]
     ]);
     const statusCalls: StatusCommentCall[] = [];
+    const readinessObservedDuringCommandReview: string[] = [];
 
     const result = await runScheduledCycleWithDeps({
       config,
@@ -1065,6 +1302,8 @@ describe("provider-aware review scheduler", () => {
       state,
       options: { dryRun: false, useZCode: false },
       reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        const readiness = reviewState.getReviewReadiness(repo, reviewPull.number, reviewPull.head.sha);
+        readinessObservedDuringCommandReview.push(`${readiness?.state ?? "missing"}:${readiness?.reason ?? "missing"}`);
         reviewState.recordProcessed({
           repo,
           pullNumber: reviewPull.number,
@@ -1080,7 +1319,14 @@ describe("provider-aware review scheduler", () => {
 
     expect(result.reviewed).toBe(1);
     expect(result.commandReviewRequested).toBe(1);
+    expect(readinessObservedDuringCommandReview).toEqual(["awaiting_re_review:trusted_re_review_command"]);
     expect(statusCalls.map(statusFromBody)).toEqual(["queued", "completed"]);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "ready_for_human",
+      reason: "comment_review_posted",
+      commandAction: "re-review",
+      commandCommentId: 222
+    });
     expect(state.listReviewQueueJobs({ state: "posted" })).toEqual([
       expect.objectContaining({
         source: "manual_command",
@@ -1122,6 +1368,12 @@ describe("provider-aware review scheduler", () => {
     expect(state.getProcessedReview("org/repo-a", 1, "a1")).toMatchObject({
       status: "skipped",
       error: expect.stringContaining("manual_command_stop")
+    });
+    expect(state.getReviewReadiness("org/repo-a", 1, "a1")).toMatchObject({
+      state: "skipped",
+      reason: "manual_command_stop",
+      commandAction: "stop",
+      commandCommentId: 333
     });
     expect(state.listReviewQueueJobs({ state: "command_recorded" })).toEqual([
       expect.objectContaining({
@@ -1360,6 +1612,12 @@ describe("provider-aware review scheduler", () => {
     const [recordedJob] = state.listReviewQueueJobs({ state: "command_recorded" });
     expect(recordedJob).toMatchObject({ commentId: 336 });
     expect(recordedJob?.sessionId).toBeUndefined();
+    expect(state.getReviewReadiness("org/repo-a", 1, "a1")).toMatchObject({
+      state: "command_recorded",
+      reason: "trusted_explain_command",
+      commandAction: "explain",
+      commandCommentId: 336
+    });
     state.close();
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -376,6 +376,10 @@ describe("provider-aware review scheduler", () => {
     expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "provider_deferred"]);
     expect(statusCalls.at(-1)?.body).toContain("temporarily unavailable");
     expect(statusCalls.at(-1)?.body).not.toContain("ProviderBusinessError");
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "provider_deferred",
+      reason: "provider_rate_limit_cooldown"
+    });
     state.close();
   });
 
@@ -409,6 +413,10 @@ describe("provider-aware review scheduler", () => {
     expect(statusCalls[0]?.body).toContain("GitHub refetch failed; see bot evidence");
     expect(statusCalls[0]?.body).not.toContain("internal host detail");
     expect(state.listReviewQueueJobs({ state: "failed" })).toHaveLength(1);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "failed",
+      reason: expect.stringContaining("github_refetch_failed: GitHub API fetch failed")
+    });
     state.close();
   });
 
@@ -825,6 +833,10 @@ describe("provider-aware review scheduler", () => {
     expect(state.listReviewQueueJobs({ state: "failed" })).toEqual([
       expect.objectContaining({ lastError: "synthetic review failure after in-progress status" })
     ]);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "failed",
+      reason: "review_failed: synthetic review failure after in-progress status"
+    });
 
     const second = await runScheduledCycleWithDeps({
       config,
@@ -1319,7 +1331,7 @@ describe("provider-aware review scheduler", () => {
 
     expect(result.reviewed).toBe(1);
     expect(result.commandReviewRequested).toBe(1);
-    expect(readinessObservedDuringCommandReview).toEqual(["awaiting_re_review:trusted_re_review_command"]);
+    expect(readinessObservedDuringCommandReview).toEqual(["reviewing:queue_job_running"]);
     expect(statusCalls.map(statusFromBody)).toEqual(["queued", "completed"]);
     expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
       state: "ready_for_human",

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -44,6 +44,98 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("persists review readiness transitions without touching updatedAt on no-op repeats", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-readiness-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    const queued = store.recordReviewReadiness({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1236,
+      headSha: "head-a",
+      state: "queued",
+      reason: "automatic_enqueue",
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    const repeated = store.recordReviewReadiness({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1236,
+      headSha: "head-a",
+      state: "queued",
+      reason: "automatic_enqueue",
+      now: new Date("2026-07-01T00:01:00.000Z")
+    });
+    const reviewed = store.recordReviewReadiness({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1236,
+      headSha: "head-a",
+      state: "needs_fix",
+      reason: "request_changes_review_posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/1236#pullrequestreview-1",
+      now: new Date("2026-07-01T00:02:00.000Z")
+    });
+    const stale = store.recordReviewReadiness({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1236,
+      headSha: "head-a",
+      state: "stale",
+      reason: "superseded_by_head=head-b",
+      now: new Date("2026-07-01T00:03:00.000Z")
+    });
+
+    expect(queued).toMatchObject({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 1236,
+      headSha: "head-a",
+      state: "queued",
+      reason: "automatic_enqueue"
+    });
+    expect(repeated.updatedAt).toBe(queued.updatedAt);
+    expect(reviewed).toMatchObject({
+      state: "needs_fix",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/1236#pullrequestreview-1"
+    });
+    expect(stale).toMatchObject({
+      state: "stale",
+      reason: "superseded_by_head=head-b",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/1236#pullrequestreview-1"
+    });
+    expect(reviewed.createdAt).toBe(queued.createdAt);
+    expect(reviewed.updatedAt).toBe("2026-07-01T00:02:00.000Z");
+    expect(stale.createdAt).toBe(queued.createdAt);
+    expect(stale.updatedAt).toBe("2026-07-01T00:03:00.000Z");
+    expect(store.listReviewReadiness({ states: ["stale"] })).toEqual([stale]);
+    store.close();
+  });
+
+  it("records command metadata on review readiness rows", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-readiness-command-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    const readiness = store.recordReviewReadiness({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 289,
+      headSha: "head-command",
+      state: "awaiting_re_review",
+      reason: "trusted_re_review_command",
+      commandAction: "re-review",
+      commandCommentId: 222,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(readiness).toMatchObject({
+      state: "awaiting_re_review",
+      commandAction: "re-review",
+      commandCommentId: 222
+    });
+    expect(store.getReviewReadiness("100yenadmin/Lossless-Codex-Orchestrator-LCO", 289, "head-command")).toEqual(readiness);
+    store.close();
+  });
+
   it("retires an exact failed head into a nonblocking historical skip", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-state-retire-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- add durable `review_readiness` state rows per repo/PR/head for queued, reviewing, needs-fix, re-review, terminal, skipped, stale, provider-deferred, and failed states
- wire scheduler transitions so processed rows can repair stuck non-terminal readiness and older heads are marked stale when a newer head appears
- document the readiness table and add regression coverage for duplicate/no-op cycles, command metadata, superseded heads, and REQUEST_CHANGES routing

Closes #21

## Validation
- `npm test -- tests/scheduler.test.ts tests/state.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`

## Notes
- `blocked_on_checks` and `blocked_on_proof` are reserved state values for later check/proof gates; this slice does not change merge behavior or add repair/merge actions.
- `tsc --exactOptionalPropertyTypes true --noEmit` was attempted as an advisory probe after review feedback; it is not a current project gate and fails on many pre-existing optional-property call sites outside this patch.