### PR TITLE
Add read-only operator dashboard

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -37,8 +37,11 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
 - `dashboard`: read-only PR review dashboard over coverage, durable queue,
   readiness lifecycle rows, GitHub PR links, and local evidence-path hints.
   Filter with `--repo`, `--status`, `--priority`, `--stale-head-reason`, and
-  `--limit`. JSON is the default; use `--human` for a compact operator view.
-  The command exits nonzero when visible rows are blocked or still active.
+  `--limit`. Use `--job-limit` to cap durable-queue/readiness rows read from
+  SQLite before merging; `--limit` caps the final merged item list. JSON is the
+  default; use `--human` for a compact operator view. The command exits nonzero
+  when visible rows are blocked; healthy active rows are counted but do not fail
+  the gate by themselves.
 - `budget-status`: read-only scheduler budget projection. Shows active counts,
   queued counts, would-lease jobs, delayed jobs, and deterministic delay reasons
   such as `provider_cooldown`, `provider_capacity`, `org_capacity`,

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -34,6 +34,11 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
   pending review, skipped, stale-head, and read-failure buckets. Also includes
   durable `review_queue_jobs` rows and budget delay reasons when the state DB
   has the scheduler table.
+- `dashboard`: read-only PR review dashboard over coverage, durable queue,
+  readiness lifecycle rows, GitHub PR links, and local evidence-path hints.
+  Filter with `--repo`, `--status`, `--priority`, `--stale-head-reason`, and
+  `--limit`. JSON is the default; use `--human` for a compact operator view.
+  The command exits nonzero when visible rows are blocked or still active.
 - `budget-status`: read-only scheduler budget projection. Shows active counts,
   queued counts, would-lease jobs, delayed jobs, and deterministic delay reasons
   such as `provider_cooldown`, `provider_capacity`, `org_capacity`,
@@ -84,6 +89,24 @@ Inspect only durable provider-deferred jobs:
 
 ```bash
 npx tsx src/cli.ts queue --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --state provider_deferred
+```
+
+Show the review dashboard:
+
+```bash
+npx tsx src/cli.ts dashboard --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+```
+
+Show dashboard rows blocked on proof:
+
+```bash
+npx tsx src/cli.ts dashboard --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --status blocked_on_proof
+```
+
+Show one repo as a short human dashboard:
+
+```bash
+npx tsx src/cli.ts dashboard --human --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --repo electricsheephq/evaos-code-review-bot
 ```
 
 Inspect only the scheduler budget projection:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { join } from "node:path";
 import { REQUIRED_SUITES, runOfflineEval } from "./eval-harness.js";
 import { GitHubApi } from "./github.js";
 import {
+  buildOperatorDashboard,
   buildRuntimeInventory,
   buildOperatorQueue,
   buildOperatorStatus,
@@ -14,8 +15,10 @@ import {
   collectOperatorLeases,
   collectOperatorProviderCooldowns,
   collectOperatorRepoProviderCooldowns,
+  collectOperatorReviewReadiness,
   collectOperatorReviewQueue,
   explainPullStatus,
+  formatOperatorDashboardHuman,
   formatRuntimeInventoryHuman,
   summarizeAgentInventory
 } from "./operator-cli.js";
@@ -274,6 +277,34 @@ async function main(): Promise<void> {
     const output = { ...queue, ok: queue.ok, coverage: queue, durableQueue, ...collectQueueBudget(args) };
     console.log(JSON.stringify(output, null, 2));
     if (!output.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "dashboard") {
+    const config = loadConfig(args.config);
+    const report = await collectCoverageReport(args, config);
+    const statePath = args["state-path"] ?? config.statePath;
+    const dashboard = buildOperatorDashboard({
+      coverage: report,
+      durableQueue: collectOperatorReviewQueue(statePath, {
+        repo: args.repo,
+        limit: args["job-limit"] ? parsePositiveInteger(args["job-limit"], "--job-limit") : undefined
+      }),
+      readiness: collectOperatorReviewReadiness(statePath, {
+        repo: args.repo,
+        limit: args["job-limit"] ? parsePositiveInteger(args["job-limit"], "--job-limit") : undefined
+      }),
+      evidenceDir: config.evidenceDir,
+      filters: {
+        ...(args.repo ? { repo: args.repo } : {}),
+        ...(args.status ?? args.state ? { status: args.status ?? args.state } : {}),
+        ...(args.priority ? { priority: parsePositiveInteger(args.priority, "--priority") } : {}),
+        ...(args["stale-head-reason"] ? { staleHeadReason: args["stale-head-reason"] } : {}),
+        ...(args.limit ? { limit: parsePositiveInteger(args.limit, "--limit") } : {})
+      }
+    });
+    console.log(args.human === "true" ? formatOperatorDashboardHuman(dashboard) : JSON.stringify(dashboard, null, 2));
+    if (!dashboard.ok) process.exitCode = 1;
     return;
   }
 
@@ -574,6 +605,7 @@ function buildHelp() {
         "runtime-inventory",
         "agents",
         "queue",
+        "dashboard",
         "budget-status",
         "coverage",
         "cooldowns",
@@ -600,6 +632,8 @@ function buildHelp() {
       "npx tsx src/cli.ts agents --config /path/to/live.json",
       "npx tsx src/cli.ts queue --config /path/to/live.json",
       "npx tsx src/cli.ts queue --config /path/to/live.json --state provider_deferred",
+      "npx tsx src/cli.ts dashboard --config /path/to/live.json --status blocked_on_proof",
+      "npx tsx src/cli.ts dashboard --config /path/to/live.json --human",
       "npx tsx src/cli.ts budget-status --config /path/to/live.json",
       "npx tsx src/cli.ts why --config /path/to/live.json --repo owner/repo --pr 123",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
@@ -696,6 +730,9 @@ interface ParsedArgs {
   "budget-job-limit"?: string;
   "job-limit"?: string;
   state?: string;
+  status?: string;
+  priority?: string;
+  "stale-head-reason"?: string;
   zcode?: string;
   "active-only"?: string;
   human?: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -298,7 +298,7 @@ async function main(): Promise<void> {
       filters: {
         ...(args.repo ? { repo: args.repo } : {}),
         ...(args.status ?? args.state ? { status: args.status ?? args.state } : {}),
-        ...(args.priority ? { priority: parsePositiveInteger(args.priority, "--priority") } : {}),
+        ...(args.priority ? { priority: parseNonNegativeInteger(args.priority, "--priority") } : {}),
         ...(args["stale-head-reason"] ? { staleHeadReason: args["stale-head-reason"] } : {}),
         ...(args.limit ? { limit: parsePositiveInteger(args.limit, "--limit") } : {})
       }
@@ -664,6 +664,12 @@ function parseArgs(argv: string[]): ParsedArgs {
 function parsePositiveInteger(value: string, label: string): number {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 1) throw new Error(`${label} must be a positive integer`);
+  return parsed;
+}
+
+function parseNonNegativeInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) throw new Error(`${label} must be a non-negative integer`);
   return parsed;
 }
 

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -928,21 +928,23 @@ export function buildOperatorDashboard(input: {
   const items = new Map<string, OperatorDashboardItem>();
 
   for (const entry of input.coverage.processed) {
+    const processedFailed = entry.status === "failed";
+    const processedError = entry.error ? redactSecrets(entry.error) : undefined;
     upsertDashboardItem(items, dashboardKey(entry.repo, entry.pullNumber, entry.headSha), {
       repo: entry.repo,
       pullNumber: entry.pullNumber,
       headSha: entry.headSha,
       title: entry.title,
       url: entry.url,
-      status: "processed",
+      status: processedFailed ? "failed" : "processed",
       coverageState: "processed",
       latestVerdict: entry.event ?? entry.status,
-      proofStatus: entry.reviewUrl ? "covered_by_review" : "processed_without_review_url",
+      proofStatus: processedFailed ? "failed" : entry.reviewUrl ? "covered_by_review" : "processed_without_review_url",
       checkStatus: "not_collected",
       ...(entry.reviewUrl ? { reviewUrl: entry.reviewUrl } : {}),
-      ...(entry.error ? { reason: redactSecrets(entry.error) } : {}),
+      ...(processedError ? { reason: processedError, lastError: processedError } : {}),
       updatedAt: entry.createdAt,
-      nextAction: "none"
+      nextAction: processedFailed ? "inspect failure evidence and retry or retire the head" : "none"
     });
   }
 

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type {
   CoverageAuditReport,
@@ -15,7 +16,10 @@ import { redactSecrets } from "./secrets.js";
 import {
   parseProviderCooldownError,
   PROVIDER_COOLDOWN_ERROR_PREFIX,
+  type ProcessedCommandAction,
   type ProviderCooldownReviewRecord,
+  type ReviewReadinessRecord,
+  type ReviewReadinessState,
   type ReviewQueueJobRecord,
   type ReviewQueueJobState,
   type RepoProviderCooldownRecord
@@ -183,6 +187,59 @@ export interface OperatorQueueSnapshot {
   skipped: OperatorQueueEntry[];
   staleHeads: OperatorQueueEntry[];
   readFailures: Array<{ repo: string; error: string; nextAction: string }>;
+}
+
+export interface OperatorDashboardFilters {
+  repo?: string;
+  status?: string;
+  priority?: number;
+  staleHeadReason?: string;
+  limit?: number;
+}
+
+export interface OperatorDashboardItem {
+  repo: string;
+  pullNumber?: number;
+  headSha?: string;
+  title?: string;
+  url?: string;
+  status: string;
+  coverageState?: OperatorQueueEntry["state"] | "read_failure";
+  queueState?: ReviewQueueJobState;
+  queueSource?: ReviewQueueJobRecord["source"];
+  queueLane?: ReviewQueueJobRecord["lane"];
+  readinessState?: ReviewReadinessState;
+  priority?: number;
+  latestVerdict?: string;
+  lastCommand?: ProcessedCommandAction;
+  commandCommentId?: number;
+  proofStatus: string;
+  checkStatus: string;
+  staleHeadReason?: string;
+  reviewUrl?: string;
+  evidencePath?: string;
+  reason?: string;
+  lastError?: string;
+  updatedAt?: string;
+  nextAction: string;
+}
+
+export interface OperatorDashboard {
+  ok: boolean;
+  checkedAt: string;
+  filters: OperatorDashboardFilters;
+  summary: {
+    totalItems: number;
+    blockedItems: number;
+    activeReviews: number;
+    commandTriggered: number;
+    staleHeads: number;
+    proofGaps: number;
+    checkBlocks: number;
+    failed: number;
+    providerDeferred: number;
+  };
+  items: OperatorDashboardItem[];
 }
 
 export interface OperatorDurableQueueSnapshot {
@@ -809,6 +866,244 @@ export function buildOperatorQueue(report: CoverageAuditReport): OperatorQueueSn
   };
 }
 
+export function collectOperatorReviewReadiness(
+  statePath: string,
+  input: { repo?: string; state?: ReviewReadinessState; limit?: number } = {}
+): ReviewReadinessRecord[] {
+  if (!existsSync(statePath)) return [];
+  const db = new DatabaseSync(statePath, { readOnly: true });
+  try {
+    if (!hasTable(db, "review_readiness")) return [];
+    const predicates: string[] = [];
+    const params: Array<string | number> = [];
+    if (input.repo) {
+      predicates.push("repo = ?");
+      params.push(input.repo);
+    }
+    if (input.state) {
+      predicates.push("state = ?");
+      params.push(input.state);
+    }
+    const where = predicates.length ? `where ${predicates.join(" and ")}` : "";
+    const limit = input.limit ? " limit ?" : "";
+    if (input.limit) params.push(input.limit);
+    const rows = db
+      .prepare(
+        `select repo, pull_number, head_sha, state, reason, event, review_url,
+                command_action, command_comment_id, created_at, updated_at
+         from review_readiness
+         ${where}
+         order by datetime(updated_at) desc
+         ${limit}`
+      )
+      .all(...params) as unknown as ReviewReadinessRow[];
+    return rows.map((row) => ({
+      repo: row.repo,
+      pullNumber: row.pull_number,
+      headSha: row.head_sha,
+      state: row.state,
+      ...(row.reason ? { reason: row.reason } : {}),
+      ...(row.event ? { event: row.event } : {}),
+      ...(row.review_url ? { reviewUrl: row.review_url } : {}),
+      ...(row.command_action ? { commandAction: row.command_action } : {}),
+      ...(row.command_comment_id ? { commandCommentId: row.command_comment_id } : {}),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    }));
+  } finally {
+    db.close();
+  }
+}
+
+export function buildOperatorDashboard(input: {
+  coverage: CoverageAuditReport;
+  durableQueue?: OperatorDurableQueueSnapshot;
+  readiness?: ReviewReadinessRecord[];
+  evidenceDir?: string;
+  filters?: OperatorDashboardFilters;
+  checkedAt?: string;
+}): OperatorDashboard {
+  const checkedAt = input.checkedAt ?? input.coverage.checkedAt;
+  const filters = compactDashboardFilters(input.filters ?? {});
+  const items = new Map<string, OperatorDashboardItem>();
+
+  for (const entry of input.coverage.processed) {
+    upsertDashboardItem(items, dashboardKey(entry.repo, entry.pullNumber, entry.headSha), {
+      repo: entry.repo,
+      pullNumber: entry.pullNumber,
+      headSha: entry.headSha,
+      title: entry.title,
+      url: entry.url,
+      status: "processed",
+      coverageState: "processed",
+      latestVerdict: entry.event ?? entry.status,
+      proofStatus: entry.reviewUrl ? "covered_by_review" : "processed_without_review_url",
+      checkStatus: "not_collected",
+      ...(entry.reviewUrl ? { reviewUrl: entry.reviewUrl } : {}),
+      ...(entry.error ? { reason: redactSecrets(entry.error) } : {}),
+      updatedAt: entry.createdAt,
+      nextAction: "none"
+    });
+  }
+
+  for (const entry of input.coverage.providerDeferred) {
+    upsertDashboardItem(items, dashboardKey(entry.repo, entry.pullNumber, entry.headSha), {
+      repo: entry.repo,
+      pullNumber: entry.pullNumber,
+      headSha: entry.headSha,
+      title: entry.title,
+      url: entry.url,
+      status: "provider_deferred",
+      coverageState: "provider_deferred",
+      latestVerdict: "provider_deferred",
+      proofStatus: "pending_review",
+      checkStatus: "not_collected",
+      reason: redactSecrets(entry.reason ?? entry.error ?? "provider cooldown"),
+      updatedAt: entry.createdAt,
+      nextAction: "wait for cooldown expiry or run retry-provider-cooldowns when expired"
+    });
+  }
+
+  for (const entry of input.coverage.unprocessed) {
+    upsertDashboardItem(items, dashboardKey(entry.repo, entry.pullNumber, entry.headSha), {
+      repo: entry.repo,
+      pullNumber: entry.pullNumber,
+      headSha: entry.headSha,
+      title: entry.title,
+      url: entry.url,
+      status: "pending_review",
+      coverageState: "pending_review",
+      latestVerdict: "pending_review",
+      proofStatus: "pending_review",
+      checkStatus: "not_collected",
+      nextAction: "wait for daemon cycle or run scoped run-once"
+    });
+  }
+
+  for (const entry of input.coverage.skipped) {
+    upsertDashboardItem(items, dashboardKey(entry.repo, entry.pullNumber, entry.headSha), {
+      repo: entry.repo,
+      ...(entry.pullNumber !== undefined ? { pullNumber: entry.pullNumber } : {}),
+      ...(entry.headSha ? { headSha: entry.headSha } : {}),
+      ...(entry.title ? { title: entry.title } : {}),
+      ...(entry.url ? { url: entry.url } : {}),
+      status: "skipped",
+      coverageState: "skipped",
+      latestVerdict: "skipped",
+      proofStatus: "skipped",
+      checkStatus: "not_collected",
+      reason: redactSecrets(entry.reason),
+      nextAction: "none"
+    });
+  }
+
+  for (const entry of input.coverage.staleHeads) {
+    const reason = `expected ${entry.expectedHeadSha}, live ${entry.liveHeadSha}`;
+    upsertDashboardItem(items, dashboardKey(entry.repo, entry.pullNumber, entry.liveHeadSha), {
+      repo: entry.repo,
+      pullNumber: entry.pullNumber,
+      headSha: entry.liveHeadSha,
+      title: entry.title,
+      url: entry.url,
+      status: "stale_head",
+      coverageState: "stale_head",
+      latestVerdict: "stale_head",
+      proofStatus: "stale_head",
+      checkStatus: "not_collected",
+      staleHeadReason: reason,
+      reason,
+      nextAction: "wait for next daemon cycle or run scoped coverage audit"
+    });
+  }
+
+  for (const failure of input.coverage.readFailures) {
+    upsertDashboardItem(items, dashboardKey(failure.repo), {
+      repo: failure.repo,
+      status: "read_failure",
+      coverageState: "read_failure",
+      latestVerdict: "read_failure",
+      proofStatus: "unknown",
+      checkStatus: "unknown",
+      reason: redactSecrets(failure.error),
+      nextAction: "inspect GitHub App installation/read permissions or network failure"
+    });
+  }
+
+  for (const job of input.durableQueue?.jobs ?? []) {
+    upsertDashboardItem(items, dashboardKey(job.repo, job.pullNumber, job.headSha), {
+      repo: job.repo,
+      pullNumber: job.pullNumber,
+      headSha: job.headSha,
+      url: githubPullUrl(job.repo, job.pullNumber),
+      status: queueStatus(job),
+      queueState: job.state,
+      queueSource: job.source,
+      queueLane: job.lane,
+      priority: job.priority,
+      latestVerdict: job.state,
+      proofStatus: proofStatusForQueue(job),
+      checkStatus: "not_collected",
+      ...(job.reviewUrl ? { reviewUrl: job.reviewUrl } : {}),
+      ...(job.lastError ? { lastError: redactSecrets(job.lastError) } : {}),
+      updatedAt: job.updatedAt,
+      nextAction: nextActionForQueue(job)
+    });
+  }
+
+  for (const readiness of input.readiness ?? []) {
+    upsertDashboardItem(items, dashboardKey(readiness.repo, readiness.pullNumber, readiness.headSha), {
+      repo: readiness.repo,
+      pullNumber: readiness.pullNumber,
+      headSha: readiness.headSha,
+      url: githubPullUrl(readiness.repo, readiness.pullNumber),
+      status: readiness.state,
+      readinessState: readiness.state,
+      latestVerdict: readiness.event ?? readiness.state,
+      proofStatus: proofStatusForReadiness(readiness),
+      checkStatus: checkStatusForReadiness(readiness),
+      ...(readiness.reason ? { reason: redactSecrets(readiness.reason) } : {}),
+      ...(readiness.reviewUrl ? { reviewUrl: readiness.reviewUrl } : {}),
+      ...(readiness.commandAction ? { lastCommand: readiness.commandAction } : {}),
+      ...(readiness.commandCommentId ? { commandCommentId: readiness.commandCommentId } : {}),
+      updatedAt: readiness.updatedAt,
+      nextAction: nextActionForReadiness(readiness)
+    });
+  }
+
+  const withEvidence = [...items.values()].map((item) => ({
+    ...item,
+    ...(input.evidenceDir ? { evidencePath: evidencePathForItem(input.evidenceDir, checkedAt, item) } : {})
+  }));
+  const filtered = withEvidence
+    .filter((item) => dashboardItemMatches(item, filters))
+    .sort(compareDashboardItems);
+  const visible = filters.limit ? filtered.slice(0, filters.limit) : filtered;
+
+  return {
+    ok: visible.every((item) => !isDashboardItemBlocked(item)),
+    checkedAt,
+    filters,
+    summary: summarizeDashboardItems(visible),
+    items: visible
+  };
+}
+
+export function formatOperatorDashboardHuman(dashboard: OperatorDashboard): string {
+  const lines = [
+    `dashboard: ${dashboard.ok ? "ok" : "blocked"} total=${dashboard.summary.totalItems} active=${dashboard.summary.activeReviews} blocked=${dashboard.summary.blockedItems} stale=${dashboard.summary.staleHeads} proofGaps=${dashboard.summary.proofGaps} providerDeferred=${dashboard.summary.providerDeferred} failed=${dashboard.summary.failed}`
+  ];
+  for (const item of dashboard.items.slice(0, 20)) {
+    const pull = item.pullNumber ? `#${item.pullNumber}` : "";
+    const priority = item.priority !== undefined ? ` p=${item.priority}` : "";
+    const command = item.lastCommand ? ` command=${item.lastCommand}` : "";
+    const reason = item.reason ? ` reason=${item.reason}` : "";
+    lines.push(`${item.status}: ${item.repo}${pull}${priority}${command} next=${item.nextAction}${reason}`);
+    if (item.url) lines.push(`  pr: ${item.url}`);
+    if (item.evidencePath) lines.push(`  evidence: ${item.evidencePath}`);
+  }
+  return redactSecrets(lines.join("\n"));
+}
+
 export function explainPullStatus(
   report: CoverageAuditReport,
   repo: string,
@@ -1040,6 +1335,225 @@ function mapReviewQueueJobRow(row: ReviewQueueJobRow): ReviewQueueJobRecord {
   };
 }
 
+function upsertDashboardItem(
+  items: Map<string, OperatorDashboardItem>,
+  key: string,
+  patch: OperatorDashboardItem
+): void {
+  const existing = items.get(key);
+  if (!existing) {
+    items.set(key, patch);
+    return;
+  }
+  items.set(key, {
+    ...existing,
+    ...patch,
+    title: patch.title ?? existing.title,
+    url: patch.url ?? existing.url,
+    coverageState: patch.coverageState ?? existing.coverageState,
+    queueState: patch.queueState ?? existing.queueState,
+    queueSource: patch.queueSource ?? existing.queueSource,
+    queueLane: patch.queueLane ?? existing.queueLane,
+    readinessState: patch.readinessState ?? existing.readinessState,
+    priority: patch.priority ?? existing.priority,
+    latestVerdict: patch.latestVerdict ?? existing.latestVerdict,
+    lastCommand: patch.lastCommand ?? existing.lastCommand,
+    commandCommentId: patch.commandCommentId ?? existing.commandCommentId,
+    staleHeadReason: patch.staleHeadReason ?? existing.staleHeadReason,
+    reviewUrl: patch.reviewUrl ?? existing.reviewUrl,
+    evidencePath: patch.evidencePath ?? existing.evidencePath,
+    reason: patch.reason ?? existing.reason,
+    lastError: patch.lastError ?? existing.lastError,
+    updatedAt: latestTimestamp(existing.updatedAt, patch.updatedAt),
+    nextAction: patch.nextAction ?? existing.nextAction
+  });
+}
+
+function dashboardKey(repo: string, pullNumber?: number, headSha?: string): string {
+  return `${repo}#${pullNumber ?? "repo"}@${headSha ?? "repo"}`;
+}
+
+function compactDashboardFilters(filters: OperatorDashboardFilters): OperatorDashboardFilters {
+  return {
+    ...(filters.repo ? { repo: filters.repo } : {}),
+    ...(filters.status ? { status: filters.status } : {}),
+    ...(filters.priority !== undefined ? { priority: filters.priority } : {}),
+    ...(filters.staleHeadReason ? { staleHeadReason: filters.staleHeadReason } : {}),
+    ...(filters.limit !== undefined ? { limit: filters.limit } : {})
+  };
+}
+
+function dashboardItemMatches(item: OperatorDashboardItem, filters: OperatorDashboardFilters): boolean {
+  if (filters.repo && item.repo !== filters.repo) return false;
+  if (filters.status) {
+    const statuses = [item.status, item.coverageState, item.queueState, item.readinessState].filter(Boolean);
+    if (!statuses.includes(filters.status)) return false;
+  }
+  if (filters.priority !== undefined && item.priority !== filters.priority) return false;
+  if (filters.staleHeadReason && !item.staleHeadReason?.includes(filters.staleHeadReason)) return false;
+  return true;
+}
+
+function compareDashboardItems(left: OperatorDashboardItem, right: OperatorDashboardItem): number {
+  const leftPriority = left.priority ?? Number.POSITIVE_INFINITY;
+  const rightPriority = right.priority ?? Number.POSITIVE_INFINITY;
+  const priority = leftPriority === rightPriority ? 0 : leftPriority - rightPriority;
+  if (priority !== 0) return priority;
+  const severity = dashboardSeverityRank(left) - dashboardSeverityRank(right);
+  if (severity !== 0) return severity;
+  const repo = left.repo.localeCompare(right.repo);
+  if (repo !== 0) return repo;
+  return (left.pullNumber ?? 0) - (right.pullNumber ?? 0);
+}
+
+function dashboardSeverityRank(item: OperatorDashboardItem): number {
+  if (item.status === "failed") return 0;
+  if (item.status === "needs_fix" || item.status === "awaiting_re_review") return 1;
+  if (item.status === "blocked_on_proof" || item.status === "blocked_on_checks") return 1;
+  if (item.status === "provider_deferred") return 2;
+  if (item.status === "stale_head" || item.status === "stale") return 3;
+  if (isActiveDashboardStatus(item.status)) return 4;
+  if (item.status === "processed" || item.status === "ready_for_human") return 9;
+  return 5;
+}
+
+function summarizeDashboardItems(items: OperatorDashboardItem[]): OperatorDashboard["summary"] {
+  return {
+    totalItems: items.length,
+    blockedItems: items.filter(isDashboardItemBlocked).length,
+    activeReviews: items.filter((item) => isActiveDashboardStatus(item.status)).length,
+    commandTriggered: items.filter((item) => item.lastCommand || item.queueSource === "manual_command").length,
+    staleHeads: items.filter((item) => item.status === "stale_head" || item.status === "stale").length,
+    proofGaps: items.filter((item) => item.proofStatus === "blocked_on_proof").length,
+    checkBlocks: items.filter((item) => item.checkStatus === "blocked_on_checks").length,
+    failed: items.filter((item) => item.status === "failed").length,
+    providerDeferred: items.filter((item) => item.status === "provider_deferred").length
+  };
+}
+
+function isDashboardItemBlocked(item: OperatorDashboardItem): boolean {
+  return item.status === "failed" ||
+    item.status === "provider_deferred" ||
+    item.status === "stale_head" ||
+    item.status === "stale" ||
+    item.status === "read_failure" ||
+    item.status === "blocked_on_checks" ||
+    item.status === "blocked_on_proof" ||
+    item.status === "needs_fix" ||
+    item.status === "awaiting_re_review" ||
+    isActiveDashboardStatus(item.status);
+}
+
+function isActiveDashboardStatus(status: string): boolean {
+  return status === "pending_review" ||
+    status === "queued" ||
+    status === "leased" ||
+    status === "running" ||
+    status === "reviewing" ||
+    status === "command_recorded";
+}
+
+function queueStatus(job: ReviewQueueJobRecord): string {
+  if (job.state === "posted") return "processed";
+  if (job.state === "closed_retired" || job.state === "stale_retired") return "skipped";
+  return job.state;
+}
+
+function proofStatusForQueue(job: ReviewQueueJobRecord): string {
+  if (job.state === "posted") return job.reviewUrl ? "covered_by_review" : "processed_without_review_url";
+  if (job.state === "failed") return "failed";
+  if (job.state === "stale_retired") return "stale_head";
+  if (job.state === "closed_retired") return "skipped";
+  return "pending_review";
+}
+
+function proofStatusForReadiness(readiness: ReviewReadinessRecord): string {
+  if (readiness.state === "blocked_on_proof") return "blocked_on_proof";
+  if (readiness.state === "blocked_on_checks") return "pending_check";
+  if (readiness.state === "ready_for_human" || readiness.state === "needs_fix") {
+    return readiness.reviewUrl ? "covered_by_review" : "review_ready";
+  }
+  if (readiness.state === "failed") return "failed";
+  if (readiness.state === "skipped" || readiness.state === "closed") return "skipped";
+  if (readiness.state === "stale") return "stale_head";
+  return "pending_review";
+}
+
+function checkStatusForReadiness(readiness: ReviewReadinessRecord): string {
+  if (readiness.state === "blocked_on_checks") return "blocked_on_checks";
+  return "not_collected";
+}
+
+function nextActionForQueue(job: ReviewQueueJobRecord): string {
+  if (job.state === "queued" || job.state === "leased" || job.state === "running") return "wait for daemon cycle";
+  if (job.state === "provider_deferred") return "wait for cooldown expiry or retry provider-deferred queue job";
+  if (job.state === "failed") return "inspect failure evidence and retry or retire the head";
+  if (job.state === "command_recorded") return "wait for daemon cycle or inspect command-triggered run";
+  return "none";
+}
+
+function nextActionForReadiness(readiness: ReviewReadinessRecord): string {
+  if (readiness.state === "command_recorded") return "wait for daemon cycle or inspect command-triggered run";
+  if (readiness.state === "queued" || readiness.state === "reviewing") return "wait for daemon cycle";
+  if (readiness.state === "awaiting_re_review") return "wait for trusted re-review command or new head";
+  if (readiness.state === "provider_deferred") return "wait for cooldown expiry or retry provider-deferred queue job";
+  if (readiness.state === "blocked_on_proof") return "collect required proof before merge-ready claim";
+  if (readiness.state === "blocked_on_checks") return "wait for or inspect required checks";
+  if (readiness.state === "needs_fix") return "wait for author fixes or review the requested changes";
+  if (readiness.state === "failed") return "inspect failure evidence and retry or retire the head";
+  if (readiness.state === "stale") return "wait for next daemon cycle or run scoped coverage audit";
+  return "none";
+}
+
+function evidencePathForItem(evidenceDir: string, checkedAt: string, item: OperatorDashboardItem): string | undefined {
+  if (!item.pullNumber || !item.headSha) return undefined;
+  const repoKey = item.repo.replace("/", "__");
+  const pullKey = `pr-${item.pullNumber}`;
+  const matchingPath = findExistingEvidencePath(evidenceDir, repoKey, pullKey, item.headSha);
+  if (matchingPath) return matchingPath;
+  const date = checkedAt.slice(0, 10);
+  return join(evidenceDir, date, repoKey, pullKey, item.headSha);
+}
+
+function findExistingEvidencePath(
+  evidenceDir: string,
+  repoKey: string,
+  pullKey: string,
+  headSha: string
+): string | undefined {
+  try {
+    if (!existsSync(evidenceDir)) return undefined;
+    const dateDirs = readdirSync(evidenceDir)
+      .map((entry) => join(evidenceDir, entry))
+      .filter((path) => {
+        try {
+          return statSync(path).isDirectory();
+        } catch {
+          return false;
+        }
+      })
+      .sort()
+      .reverse();
+    for (const dateDir of dateDirs) {
+      const candidate = join(dateDir, repoKey, pullKey, headSha);
+      if (existsSync(candidate)) return candidate;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function githubPullUrl(repo: string, pullNumber: number): string {
+  return `https://github.com/${repo}/pull/${pullNumber}`;
+}
+
+function latestTimestamp(left?: string, right?: string): string | undefined {
+  if (!left) return right;
+  if (!right) return left;
+  return Date.parse(right) > Date.parse(left) ? right : left;
+}
+
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -1188,4 +1702,18 @@ interface ReviewQueueJobRow {
   updated_at: string;
   started_at: string | null;
   finished_at: string | null;
+}
+
+interface ReviewReadinessRow {
+  repo: string;
+  pull_number: number;
+  head_sha: string;
+  state: ReviewReadinessState;
+  reason: string | null;
+  event: "COMMENT" | "REQUEST_CHANGES" | null;
+  review_url: string | null;
+  command_action: ProcessedCommandAction | null;
+  command_comment_id: number | null;
+  created_at: string;
+  updated_at: string;
 }

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1092,7 +1092,7 @@ export function formatOperatorDashboardHuman(dashboard: OperatorDashboard): stri
   const lines = [
     `dashboard: ${dashboard.ok ? "ok" : "blocked"} total=${dashboard.summary.totalItems} active=${dashboard.summary.activeReviews} blocked=${dashboard.summary.blockedItems} stale=${dashboard.summary.staleHeads} proofGaps=${dashboard.summary.proofGaps} providerDeferred=${dashboard.summary.providerDeferred} failed=${dashboard.summary.failed}`
   ];
-  for (const item of dashboard.items.slice(0, 20)) {
+  for (const item of dashboard.items) {
     const pull = item.pullNumber ? `#${item.pullNumber}` : "";
     const priority = item.priority !== undefined ? ` p=${item.priority}` : "";
     const command = item.lastCommand ? ` command=${item.lastCommand}` : "";
@@ -1345,9 +1345,11 @@ function upsertDashboardItem(
     items.set(key, patch);
     return;
   }
+  const dominant = dashboardSeverityRank(patch) <= dashboardSeverityRank(existing) ? patch : existing;
   items.set(key, {
     ...existing,
     ...patch,
+    status: dominant.status,
     title: patch.title ?? existing.title,
     url: patch.url ?? existing.url,
     coverageState: patch.coverageState ?? existing.coverageState,
@@ -1356,16 +1358,18 @@ function upsertDashboardItem(
     queueLane: patch.queueLane ?? existing.queueLane,
     readinessState: patch.readinessState ?? existing.readinessState,
     priority: patch.priority ?? existing.priority,
-    latestVerdict: patch.latestVerdict ?? existing.latestVerdict,
+    latestVerdict: dominant.latestVerdict ?? patch.latestVerdict ?? existing.latestVerdict,
     lastCommand: patch.lastCommand ?? existing.lastCommand,
     commandCommentId: patch.commandCommentId ?? existing.commandCommentId,
     staleHeadReason: patch.staleHeadReason ?? existing.staleHeadReason,
     reviewUrl: patch.reviewUrl ?? existing.reviewUrl,
     evidencePath: patch.evidencePath ?? existing.evidencePath,
-    reason: patch.reason ?? existing.reason,
+    proofStatus: dominant.proofStatus,
+    checkStatus: dominant.checkStatus,
+    reason: dominant.reason ?? patch.reason ?? existing.reason,
     lastError: patch.lastError ?? existing.lastError,
     updatedAt: latestTimestamp(existing.updatedAt, patch.updatedAt),
-    nextAction: patch.nextAction ?? existing.nextAction
+    nextAction: dominant.nextAction
   });
 }
 
@@ -1421,27 +1425,33 @@ function summarizeDashboardItems(items: OperatorDashboardItem[]): OperatorDashbo
   return {
     totalItems: items.length,
     blockedItems: items.filter(isDashboardItemBlocked).length,
-    activeReviews: items.filter((item) => isActiveDashboardStatus(item.status)).length,
+    activeReviews: items.filter((item) => dashboardStatuses(item).some(isActiveDashboardStatus)).length,
     commandTriggered: items.filter((item) => item.lastCommand || item.queueSource === "manual_command").length,
-    staleHeads: items.filter((item) => item.status === "stale_head" || item.status === "stale").length,
+    staleHeads: items.filter((item) => dashboardStatuses(item).some((status) => status === "stale_head" || status === "stale")).length,
     proofGaps: items.filter((item) => item.proofStatus === "blocked_on_proof").length,
     checkBlocks: items.filter((item) => item.checkStatus === "blocked_on_checks").length,
-    failed: items.filter((item) => item.status === "failed").length,
-    providerDeferred: items.filter((item) => item.status === "provider_deferred").length
+    failed: items.filter((item) => dashboardStatuses(item).includes("failed")).length,
+    providerDeferred: items.filter((item) => dashboardStatuses(item).includes("provider_deferred")).length
   };
 }
 
 function isDashboardItemBlocked(item: OperatorDashboardItem): boolean {
-  return item.status === "failed" ||
-    item.status === "provider_deferred" ||
-    item.status === "stale_head" ||
-    item.status === "stale" ||
-    item.status === "read_failure" ||
-    item.status === "blocked_on_checks" ||
-    item.status === "blocked_on_proof" ||
-    item.status === "needs_fix" ||
-    item.status === "awaiting_re_review" ||
-    isActiveDashboardStatus(item.status);
+  return dashboardStatuses(item).some((status) =>
+    status === "failed" ||
+    status === "provider_deferred" ||
+    status === "stale_head" ||
+    status === "stale" ||
+    status === "read_failure" ||
+    status === "blocked_on_checks" ||
+    status === "blocked_on_proof" ||
+    status === "needs_fix" ||
+    status === "awaiting_re_review"
+  );
+}
+
+function dashboardStatuses(item: OperatorDashboardItem): string[] {
+  return [item.status, item.coverageState, item.queueState, item.readinessState]
+    .filter((status): status is string => Boolean(status));
 }
 
 function isActiveDashboardStatus(status: string): boolean {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -280,7 +280,8 @@ describe("operator CLI summaries", () => {
     expect(dashboard.ok).toBe(false);
     expect(dashboard.summary).toMatchObject({
       totalItems: 5,
-      blockedItems: 4,
+      blockedItems: 3,
+      activeReviews: 1,
       commandTriggered: 1,
       staleHeads: 1,
       proofGaps: 1
@@ -331,9 +332,10 @@ describe("operator CLI summaries", () => {
       durableQueue: durableQueueSnapshot({
         jobs: [
           durableJob({ repo: "owner/repo", pullNumber: 2, headSha: "head-pending", state: "queued", priority: 5 }),
-          durableJob({ repo: "owner/other", pullNumber: 4, headSha: "head-failed", state: "failed", priority: 10 })
+          durableJob({ repo: "owner/other", pullNumber: 4, headSha: "head-failed", state: "failed", priority: 10 }),
+          durableJob({ repo: "owner/repo", pullNumber: 6, headSha: "head-zero", state: "queued", priority: 0 })
         ],
-        summary: { total: 2, queued: 1, failed: 1, running: 0, providerDeferred: 0, retryableProviderDeferred: 0 }
+        summary: { total: 3, queued: 2, failed: 1, running: 0, providerDeferred: 0, retryableProviderDeferred: 0 }
       }),
       checkedAt: "2026-07-02T00:00:00.000Z"
     };
@@ -362,15 +364,96 @@ describe("operator CLI summaries", () => {
 
     const priorityDashboard = buildOperatorDashboard({
       ...input,
-      filters: { priority: 5 }
+      filters: { priority: 0 }
     });
     expect(priorityDashboard.items).toEqual([
       expect.objectContaining({
         repo: "owner/repo",
-        pullNumber: 2,
-        priority: 5
+        pullNumber: 6,
+        priority: 0
       })
     ]);
+  });
+
+  it("keeps healthy active dashboard rows visible without failing the gate", () => {
+    const dashboard = buildOperatorDashboard({
+      coverage: coverageReport({ ok: false, unprocessed: [pullEntry(2, "head-pending")] }),
+      durableQueue: durableQueueSnapshot({
+        jobs: [durableJob({ repo: "owner/repo", pullNumber: 2, headSha: "head-pending", state: "queued", priority: 5 })],
+        summary: { total: 1, queued: 1, failed: 0, running: 0, providerDeferred: 0, retryableProviderDeferred: 0 }
+      }),
+      checkedAt: "2026-07-02T00:00:00.000Z"
+    });
+
+    expect(dashboard.ok).toBe(true);
+    expect(dashboard.summary).toMatchObject({
+      totalItems: 1,
+      activeReviews: 1,
+      blockedItems: 0
+    });
+    expect(dashboard.items[0]).toMatchObject({
+      status: "queued",
+      nextAction: "wait for daemon cycle"
+    });
+  });
+
+  it("preserves the strongest blocked dashboard source when later sources are benign", () => {
+    const dashboard = buildOperatorDashboard({
+      coverage: coverageReport({ ok: true, processed: [processedEntry(7, "head-failed", "posted")] }),
+      durableQueue: durableQueueSnapshot({
+        jobs: [durableJob({ repo: "owner/repo", pullNumber: 7, headSha: "head-failed", state: "failed", priority: 10 })],
+        summary: { total: 1, queued: 0, failed: 1, running: 0, providerDeferred: 0, retryableProviderDeferred: 0 }
+      }),
+      readiness: [{
+        repo: "owner/repo",
+        pullNumber: 7,
+        headSha: "head-failed",
+        state: "ready_for_human",
+        reason: "review posted",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-01T00:05:00.000Z"
+      }, {
+        repo: "owner/repo",
+        pullNumber: 8,
+        headSha: "head-proof",
+        state: "blocked_on_proof",
+        reason: "missing proof",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-01T00:06:00.000Z"
+      }],
+      checkedAt: "2026-07-02T00:00:00.000Z"
+    });
+
+    expect(dashboard.ok).toBe(false);
+    expect(dashboard.items).toEqual([
+      expect.objectContaining({
+        repo: "owner/repo",
+        pullNumber: 7,
+        status: "failed",
+        queueState: "failed",
+        readinessState: "ready_for_human",
+        nextAction: "inspect failure evidence and retry or retire the head"
+      }),
+      expect.objectContaining({
+        repo: "owner/repo",
+        pullNumber: 8,
+        status: "blocked_on_proof"
+      })
+    ]);
+  });
+
+  it("renders every dashboard row in the human formatter", () => {
+    const dashboard = buildOperatorDashboard({
+      coverage: coverageReport({
+        ok: true,
+        processed: Array.from({ length: 21 }, (_, index) => processedEntry(index + 1, `head-${index + 1}`, "posted"))
+      }),
+      checkedAt: "2026-07-02T00:00:00.000Z"
+    });
+
+    const output = formatOperatorDashboardHuman(dashboard);
+
+    expect(output).toContain("owner/repo#21");
   });
 
   it("gives needs-fix dashboard rows a concrete next action", () => {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -5,14 +5,17 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import type { CoverageAuditReport } from "../src/coverage-audit.js";
 import {
+  buildOperatorDashboard,
   buildRuntimeInventory,
   buildOperatorQueue,
   buildOperatorStatus,
   collectOperatorLeases,
   collectOperatorRepoProviderCooldowns,
+  collectOperatorReviewReadiness,
   collectOperatorReviewQueue,
   explainPullStatus,
   filterBotProcessRows,
+  formatOperatorDashboardHuman,
   formatRuntimeInventoryHuman,
   summarizeAgentInventory,
   type OperatorAgentInventory,
@@ -229,6 +232,172 @@ describe("operator CLI summaries", () => {
     expect(output).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
   });
 
+  it("builds a read-only dashboard over coverage, durable queue, readiness, and evidence links", () => {
+    const dashboard = buildOperatorDashboard({
+      coverage: coverageReport({
+        ok: false,
+        processed: [processedEntry(1, "head-posted", "posted")],
+        unprocessed: [pullEntry(2, "head-pending")],
+        staleHeads: [{
+          repo: "owner/repo",
+          pullNumber: 3,
+          expectedHeadSha: "old-head",
+          liveHeadSha: "new-head",
+          title: "stale",
+          url: "https://github.com/owner/repo/pull/3"
+        }]
+      }),
+      durableQueue: durableQueueSnapshot({
+        jobs: [
+          durableJob({ repo: "owner/repo", pullNumber: 2, headSha: "head-pending", state: "queued", priority: 5, source: "manual_command", lane: "manual" }),
+          durableJob({ repo: "owner/other", pullNumber: 4, headSha: "head-failed", state: "failed", priority: 10, lastError: "ZCode failed ghp_123456789012345678901234" })
+        ],
+        summary: { total: 2, queued: 1, failed: 1, running: 0, providerDeferred: 0, retryableProviderDeferred: 0 }
+      }),
+      readiness: [{
+        repo: "owner/repo",
+        pullNumber: 2,
+        headSha: "head-pending",
+        state: "command_recorded",
+        reason: "trusted command requested re-review",
+        commandAction: "re-review",
+        commandCommentId: 12345,
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-01T00:01:00.000Z"
+      }, {
+        repo: "owner/other",
+        pullNumber: 5,
+        headSha: "head-proof",
+        state: "blocked_on_proof",
+        reason: "missing proof artifact",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-01T00:02:00.000Z"
+      }],
+      evidenceDir: "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence",
+      checkedAt: "2026-07-02T00:00:00.000Z"
+    });
+
+    expect(dashboard.ok).toBe(false);
+    expect(dashboard.summary).toMatchObject({
+      totalItems: 5,
+      blockedItems: 4,
+      commandTriggered: 1,
+      staleHeads: 1,
+      proofGaps: 1
+    });
+    expect(dashboard.items.map((item) => `${item.repo}#${item.pullNumber}:${item.status}`)).toEqual([
+      "owner/repo#2:command_recorded",
+      "owner/other#4:failed",
+      "owner/other#5:blocked_on_proof",
+      "owner/repo#3:stale_head",
+      "owner/repo#1:processed"
+    ]);
+    expect(dashboard.items[0]).toMatchObject({
+      repo: "owner/repo",
+      pullNumber: 2,
+      headSha: "head-pending",
+      priority: 5,
+      queueState: "queued",
+      queueSource: "manual_command",
+      readinessState: "command_recorded",
+      lastCommand: "re-review",
+      proofStatus: "pending_review",
+      nextAction: "wait for daemon cycle or inspect command-triggered run"
+    });
+    expect(dashboard.items[0].url).toBe("https://github.com/owner/repo/pull/2");
+    expect(dashboard.items[0].evidencePath).toBe(
+      "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-02/owner__repo/pr-2/head-pending"
+    );
+    expect(dashboard.items[1].lastError).toBe("ZCode failed [redacted-secret]");
+    expect(formatOperatorDashboardHuman(dashboard)).toContain("dashboard: blocked total=5");
+    expect(JSON.stringify(dashboard)).not.toMatch(/ghp_123456789012345678901234/);
+  });
+
+  it("filters dashboard rows by repo, status, priority, and stale-head reason", () => {
+    const input = {
+      coverage: coverageReport({
+        ok: false,
+        processed: [processedEntry(1, "head-posted", "posted")],
+        unprocessed: [pullEntry(2, "head-pending")],
+        staleHeads: [{
+          repo: "owner/repo",
+          pullNumber: 3,
+          expectedHeadSha: "old-head",
+          liveHeadSha: "new-head",
+          title: "stale",
+          url: "https://github.com/owner/repo/pull/3"
+        }]
+      }),
+      durableQueue: durableQueueSnapshot({
+        jobs: [
+          durableJob({ repo: "owner/repo", pullNumber: 2, headSha: "head-pending", state: "queued", priority: 5 }),
+          durableJob({ repo: "owner/other", pullNumber: 4, headSha: "head-failed", state: "failed", priority: 10 })
+        ],
+        summary: { total: 2, queued: 1, failed: 1, running: 0, providerDeferred: 0, retryableProviderDeferred: 0 }
+      }),
+      checkedAt: "2026-07-02T00:00:00.000Z"
+    };
+    const staleDashboard = buildOperatorDashboard({
+      ...input,
+      filters: {
+        repo: "owner/repo",
+        status: "stale_head",
+        staleHeadReason: "live new-head"
+      }
+    });
+
+    expect(staleDashboard.items).toEqual([
+      expect.objectContaining({
+        repo: "owner/repo",
+        pullNumber: 3,
+        status: "stale_head",
+        staleHeadReason: "expected old-head, live new-head"
+      })
+    ]);
+    expect(staleDashboard.filters).toEqual({
+      repo: "owner/repo",
+      status: "stale_head",
+      staleHeadReason: "live new-head"
+    });
+
+    const priorityDashboard = buildOperatorDashboard({
+      ...input,
+      filters: { priority: 5 }
+    });
+    expect(priorityDashboard.items).toEqual([
+      expect.objectContaining({
+        repo: "owner/repo",
+        pullNumber: 2,
+        priority: 5
+      })
+    ]);
+  });
+
+  it("gives needs-fix dashboard rows a concrete next action", () => {
+    const dashboard = buildOperatorDashboard({
+      coverage: coverageReport({ ok: true }),
+      readiness: [{
+        repo: "owner/repo",
+        pullNumber: 9,
+        headSha: "head-needs-fix",
+        state: "needs_fix",
+        reason: "REQUEST_CHANGES review posted",
+        event: "REQUEST_CHANGES",
+        reviewUrl: "https://github.com/owner/repo/pull/9#pullrequestreview-2",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-01T00:06:00.000Z"
+      }],
+      checkedAt: "2026-07-02T00:00:00.000Z"
+    });
+
+    expect(dashboard.ok).toBe(false);
+    expect(dashboard.items[0]).toMatchObject({
+      status: "needs_fix",
+      latestVerdict: "REQUEST_CHANGES",
+      nextAction: "wait for author fixes or review the requested changes"
+    });
+  });
+
   it("filters runtime processes to bot-owned rows and redacts command text", () => {
     const rows = [
       { pid: 10, ppid: 1, command: "node /Volumes/LEXAR/repos/evaos-code-review-bot/dist/cli.js daemon --config live.json --token=ghp_123456789012345678901234" },
@@ -424,6 +593,35 @@ describe("operator CLI summaries", () => {
     });
     expect(queue.pending[0]).toMatchObject({ pullNumber: 3, state: "pending_review" });
     expect(queue.providerDeferred[0]).toMatchObject({ pullNumber: 2, state: "provider_deferred" });
+  });
+
+  it("reads review readiness rows from SQLite without creating or mutating state", () => {
+    const statePath = createTempDatabase(tempDirs);
+    const db = new DatabaseSync(statePath);
+    try {
+      db.exec("create table review_readiness (repo text not null, pull_number integer not null, head_sha text not null, state text not null, reason text, event text, review_url text, command_action text, command_comment_id integer, created_at text not null, updated_at text not null, primary key (repo, pull_number, head_sha))");
+      db.prepare("insert into review_readiness (repo, pull_number, head_sha, state, reason, event, review_url, command_action, command_comment_id, created_at, updated_at) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+        .run("owner/repo", 7, "head-ready", "ready_for_human", "review posted", "COMMENT", "https://github.com/owner/repo/pull/7#pullrequestreview-1", null, null, "2026-07-01T00:00:00.000Z", "2026-07-01T00:05:00.000Z");
+      db.prepare("insert into review_readiness (repo, pull_number, head_sha, state, reason, event, review_url, command_action, command_comment_id, created_at, updated_at) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+        .run("owner/other", 8, "head-command", "command_recorded", "manual review requested", null, null, "review", 999, "2026-07-01T00:00:00.000Z", "2026-07-01T00:04:00.000Z");
+    } finally {
+      db.close();
+    }
+
+    expect(collectOperatorReviewReadiness(statePath, { repo: "owner/repo" })).toEqual([
+      {
+        repo: "owner/repo",
+        pullNumber: 7,
+        headSha: "head-ready",
+        state: "ready_for_human",
+        reason: "review posted",
+        event: "COMMENT",
+        reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-1",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-01T00:05:00.000Z"
+      }
+    ]);
+    expect(collectOperatorReviewReadiness(join(tmpdir(), "missing-evaos-state.sqlite"))).toEqual([]);
   });
 
   it("explains why a PR head is or is not reviewed", () => {
@@ -780,6 +978,32 @@ function cleanDurableQueueSummary(): Partial<OperatorDurableQueueSnapshot["summa
     posted: 0,
     failed: 0,
     retired: 0
+  };
+}
+
+function durableJob(input: Partial<OperatorDurableQueueSnapshot["jobs"][number]> & {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  state: OperatorDurableQueueSnapshot["jobs"][number]["state"];
+}): OperatorDurableQueueSnapshot["jobs"][number] {
+  return {
+    jobId: `${input.state}-${input.headSha}`,
+    attemptId: `${input.state}:${input.repo}#${input.pullNumber}@${input.headSha}`,
+    source: input.source ?? "automatic",
+    lane: input.lane ?? "background",
+    repo: input.repo,
+    org: input.repo.split("/")[0]!,
+    pullNumber: input.pullNumber,
+    headSha: input.headSha,
+    providerId: input.providerId ?? "zai",
+    priority: input.priority ?? 50,
+    state: input.state,
+    ...(input.nextEligibleAt ? { nextEligibleAt: input.nextEligibleAt } : {}),
+    ...(input.reviewUrl ? { reviewUrl: input.reviewUrl } : {}),
+    ...(input.lastError ? { lastError: input.lastError } : {}),
+    createdAt: input.createdAt ?? "2026-07-01T00:00:00.000Z",
+    updatedAt: input.updatedAt ?? "2026-07-01T00:00:00.000Z"
   };
 }
 

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -442,6 +442,67 @@ describe("operator CLI summaries", () => {
     ]);
   });
 
+  it("keeps blocked-on-proof readiness above processed coverage for the same head", () => {
+    const dashboard = buildOperatorDashboard({
+      coverage: coverageReport({ ok: true, processed: [processedEntry(8, "head-proof", "posted")] }),
+      readiness: [{
+        repo: "owner/repo",
+        pullNumber: 8,
+        headSha: "head-proof",
+        state: "blocked_on_proof",
+        reason: "missing proof",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-01T00:06:00.000Z"
+      }],
+      checkedAt: "2026-07-02T00:00:00.000Z"
+    });
+
+    expect(dashboard.ok).toBe(false);
+    expect(dashboard.items).toEqual([
+      expect.objectContaining({
+        repo: "owner/repo",
+        pullNumber: 8,
+        status: "blocked_on_proof",
+        coverageState: "processed",
+        readinessState: "blocked_on_proof",
+        proofStatus: "blocked_on_proof",
+        nextAction: "collect required proof before merge-ready claim"
+      })
+    ]);
+  });
+
+  it("surfaces failed processed coverage rows as blocked dashboard failures", () => {
+    const dashboard = buildOperatorDashboard({
+      coverage: coverageReport({
+        ok: true,
+        processed: [{
+          ...processedEntry(10, "head-failed", "failed"),
+          error: "ZCode failed ghp_123456789012345678901234"
+        }]
+      }),
+      checkedAt: "2026-07-02T00:00:00.000Z"
+    });
+
+    expect(dashboard.ok).toBe(false);
+    expect(dashboard.summary).toMatchObject({
+      totalItems: 1,
+      blockedItems: 1,
+      failed: 1
+    });
+    expect(dashboard.items).toEqual([
+      expect.objectContaining({
+        repo: "owner/repo",
+        pullNumber: 10,
+        status: "failed",
+        coverageState: "processed",
+        proofStatus: "failed",
+        lastError: "ZCode failed [redacted-secret]",
+        nextAction: "inspect failure evidence and retry or retire the head"
+      })
+    ]);
+    expect(JSON.stringify(dashboard)).not.toMatch(/ghp_123456789012345678901234/);
+  });
+
   it("renders every dashboard row in the human formatter", () => {
     const dashboard = buildOperatorDashboard({
       coverage: coverageReport({
@@ -953,7 +1014,7 @@ function pullEntry(pullNumber: number, headSha: string) {
   };
 }
 
-function processedEntry(pullNumber: number, headSha: string, status: "posted" | "skipped") {
+function processedEntry(pullNumber: number, headSha: string, status: "posted" | "skipped" | "failed") {
   return {
     ...pullEntry(pullNumber, headSha),
     status,


### PR DESCRIPTION
## Summary
- adds a JSON-first `dashboard` operator command over coverage, durable queue, readiness, GitHub PR links, and evidence-path hints
- supports repo/status/priority/stale-head-reason filters plus human output
- keeps the dashboard read-only and exits nonzero for visible blocked/active rows

Closes #27.

## Validation
- `npm test -- tests/operator-cli.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`
- live smoke: `npm run cli -- dashboard --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --repo electricsheephq/evaos-code-review-bot --limit 3 --human`
- live smoke: `npm run cli -- dashboard --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --status needs_fix --limit 2 --human`