### PR TITLE
Add GitNexus context packets

### DIFF
--- a/config.active-profiles.example.json
+++ b/config.active-profiles.example.json
@@ -30,6 +30,23 @@
     "trustedAuthors": ["100yenadmin"],
     "acknowledge": false
   },
+  "gitnexusContext": {
+    "enabled": false,
+    "packetVersion": "gitnexus-context-packet-v0.1",
+    "maxPacketBytes": 40000,
+    "maxRelatedItems": 8,
+    "queryLimit": 3,
+    "commandTimeoutMs": 10000,
+    "maxCommandOutputBytes": 8000,
+    "includeStaleContext": false,
+    "repoAliases": {
+      "electricsheephq/WorldOS": "worldos",
+      "electricsheephq/evaos-code-review-bot": "evaos-code-review-bot",
+      "100yenadmin/evaOS-GUI": "evaos-gui",
+      "100yenadmin/Lossless-Codex-Orchestrator-LCO": "lossless-codex-orchestrator-lco"
+    },
+    "generatedPathPatterns": ["dist/**", "build/**", "coverage/**", "Library/**", "Temp/**", "**/*.min.js", "**/*.bundle.js", "**/*.lock"]
+  },
   "repoProfiles": {
     "enableOrgFallbacks": false,
     "repos": {

--- a/config.example.json
+++ b/config.example.json
@@ -19,6 +19,21 @@
     "trustedAuthors": ["100yenadmin"],
     "acknowledge": false
   },
+  "gitnexusContext": {
+    "enabled": false,
+    "packetVersion": "gitnexus-context-packet-v0.1",
+    "maxPacketBytes": 40000,
+    "maxRelatedItems": 8,
+    "queryLimit": 3,
+    "commandTimeoutMs": 10000,
+    "maxCommandOutputBytes": 8000,
+    "includeStaleContext": false,
+    "repoAliases": {
+      "electricsheephq/WorldOS": "worldos",
+      "100yenadmin/evaOS-GUI": "evaos-gui"
+    },
+    "generatedPathPatterns": ["dist/**", "build/**", "coverage/**", "Library/**", "Temp/**", "**/*.min.js", "**/*.bundle.js", "**/*.lock"]
+  },
   "repoProfiles": {
     "enableOrgFallbacks": false,
     "repos": {

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -60,6 +60,15 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
   and a redaction report. Use `--output-dir <path>` to write
   `repo-memory-packet.json` and `repo-memory-packet.md` evidence. This command
   does not call GitHub or ZCode and does not enable prompt memory by itself.
+- `build-gitnexus-context-packet --repo <owner/name> --pr <number>`: compiles
+  a read-only GitNexus advisory context packet for one PR. It reads GitHub PR
+  metadata/files, probes `gitnexus list`, optionally runs bounded `gitnexus
+  query` calls when a fresh matching alias is found, and emits JSON/Markdown
+  with the packet SHA, byte/token estimates, changed files, omitted context,
+  index freshness, degraded-mode reason, and redaction report. Use
+  `--output-dir <path>` to write `gitnexus-context-packet.json` and
+  `gitnexus-context-packet.md` evidence. This command never posts comments,
+  calls ZCode, runs tests, or indexes repositories.
 - `doctor`: auth/config readiness. Use this for GitHub App/ZCode readiness, not
   runtime health.
 
@@ -150,6 +159,16 @@ npx tsx src/cli.ts build-memory-packet --config <config.json> --repo electricshe
 Use `--fingerprint <finding-fingerprint>` to include exact-match false-positive
 notes, `--format markdown` for Markdown-only output, or `--record-build true`
 when the packet SHA should be recorded in SQLite provenance.
+
+Build a GitNexus context packet for dry-run evidence:
+
+```bash
+npx tsx src/cli.ts build-gitnexus-context-packet --config <config.json> --repo electricsheephq/evaos-code-review-bot --pr 102 --output-dir <configured-evidence-dir>/gitnexus-context/evaos-code-review-bot-pr-102
+```
+
+Missing or stale GitNexus indexes produce `degradedMode: true` packets and do
+not block baseline review. Secret-like GitNexus output fails closed and writes a
+redacted `gitnexus-context-packet-error.json` evidence file.
 
 ## Safety Boundaries
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSyn
 import { basename, dirname, join, parse as parsePath, resolve, sep } from "node:path";
 import { REQUIRED_SUITES, runOfflineEval } from "./eval-harness.js";
 import { GitHubApi } from "./github.js";
+import { buildGitNexusContextPacket } from "./gitnexus-context.js";
 import {
   buildOperatorDashboard,
   buildRuntimeInventory,
@@ -461,6 +462,52 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "build-gitnexus-context-packet") {
+    if (!args.repo) throw new Error("--repo is required for build-gitnexus-context-packet");
+    if (!args.pr) throw new Error("--pr is required for build-gitnexus-context-packet");
+    const repo = parseSingleArg(args.repo, "--repo");
+    const pullNumber = parsePositiveInteger(parseSingleArg(args.pr, "--pr"), "--pr");
+    const config = loadConfig(args.config);
+    const generatedAt = args["generated-at"] ?? new Date().toISOString();
+    parseCanonicalIsoTimestamp(generatedAt, "--generated-at");
+    const gitnexusConfig = config.gitnexusContext!;
+    const github = new GitHubApi(config.github);
+    const pull = await github.getPull(repo, pullNumber);
+    const files = await github.listPullFiles(repo, pullNumber);
+    const result = buildGitNexusContextPacket({
+      repo,
+      pull,
+      files,
+      config: {
+        ...gitnexusConfig,
+        enabled: true,
+        ...(args["max-bytes"] ? { maxPacketBytes: parsePositiveInteger(parseSingleArg(args["max-bytes"], "--max-bytes"), "--max-bytes") } : {}),
+        ...(args["max-related-items"]
+          ? { maxRelatedItems: parsePositiveInteger(parseSingleArg(args["max-related-items"], "--max-related-items"), "--max-related-items") }
+          : {}),
+        ...(args["query-limit"] ? { queryLimit: parsePositiveInteger(parseSingleArg(args["query-limit"], "--query-limit"), "--query-limit") } : {})
+      },
+      generatedAt
+    });
+    if (args["output-dir"]) {
+      const safeOutputDir = assertMemoryPacketOutputDirSafe(args["output-dir"], config.evidenceDir);
+      mkdirSync(safeOutputDir, { recursive: true });
+      const jsonName = result.ok ? "gitnexus-context-packet.json" : "gitnexus-context-packet-error.json";
+      writeFileSync(join(safeOutputDir, jsonName), `${redactSecrets(JSON.stringify(result, null, 2))}\n`);
+      if (result.ok) writeFileSync(join(safeOutputDir, "gitnexus-context-packet.md"), result.packet.markdown);
+    }
+    const format = args.format ?? "json";
+    if (format === "markdown") {
+      console.log(result.ok ? result.packet.markdown : JSON.stringify(result, null, 2));
+    } else if (format === "both" && result.ok) {
+      console.log(`${JSON.stringify(result, null, 2)}\n\n${result.packet.markdown}`);
+    } else {
+      console.log(JSON.stringify(result, null, 2));
+    }
+    if (!result.ok) process.exitCode = 1;
+    return;
+  }
+
   if (command === "eval-offline") {
     if (!args.input) throw new Error("--input is required for eval-offline");
     const input = JSON.parse(readFileSync(args.input, "utf8"));
@@ -690,6 +737,7 @@ function buildHelp() {
         "release-status",
         "coverage-audit",
         "build-memory-packet",
+        "build-gitnexus-context-packet",
         "provider-cooldowns",
         "retry-provider-cooldowns",
         "retry-failed",
@@ -712,6 +760,7 @@ function buildHelp() {
       "npx tsx src/cli.ts budget-status --config /path/to/live.json",
       "npx tsx src/cli.ts why --config /path/to/live.json --repo owner/repo --pr 123",
       "npx tsx src/cli.ts build-memory-packet --config /path/to/live.json --repo owner/repo --output-dir /path/to/evidence",
+      "npx tsx src/cli.ts build-gitnexus-context-packet --config /path/to/live.json --repo owner/repo --pr 123 --output-dir /path/to/evidence",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ]
   };
@@ -747,6 +796,11 @@ function parseNonNegativeInteger(value: string, label: string): number {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 0) throw new Error(`${label} must be a non-negative integer`);
   return parsed;
+}
+
+function parseSingleArg(value: string | string[], label: string): string {
+  if (Array.isArray(value)) throw new Error(`${label} must be provided once`);
+  return value;
 }
 
 function parseCanonicalIsoTimestamp(value: string, label: string): Date {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import type { GitNexusContextConfig } from "./gitnexus-context.js";
 
 export interface BotConfig {
   pilotRepos: string[];
@@ -39,6 +40,7 @@ export interface BotConfig {
     enabled: boolean;
   };
   repoMemory?: RepoMemoryConfig;
+  gitnexusContext?: GitNexusContextConfig;
   repoProfiles?: RepoProfilesConfig;
   commands: CommandConfig;
   zcode: {
@@ -193,6 +195,27 @@ const DEFAULT_CONFIG: BotConfig = {
     maxStateNotes: 20,
     includeStaleNotes: false
   },
+  gitnexusContext: {
+    enabled: false,
+    packetVersion: "gitnexus-context-packet-v0.1",
+    maxPacketBytes: 40_000,
+    maxRelatedItems: 8,
+    queryLimit: 3,
+    commandTimeoutMs: 10_000,
+    maxCommandOutputBytes: 8_000,
+    includeStaleContext: false,
+    repoAliases: {},
+    generatedPathPatterns: [
+      "dist/**",
+      "build/**",
+      "coverage/**",
+      "Library/**",
+      "Temp/**",
+      "**/*.min.js",
+      "**/*.bundle.js",
+      "**/*.lock"
+    ]
+  },
   commands: {
     enabled: false,
     botMentions: ["@evaos-code-review-bot"],
@@ -271,6 +294,9 @@ function validateConfig(config: BotConfig): void {
   const repoMemory = config.repoMemory ?? DEFAULT_CONFIG.repoMemory!;
   config.repoMemory = repoMemory;
   validateRepoMemoryConfig(repoMemory, "config.repoMemory");
+  const gitnexusContext = config.gitnexusContext ?? DEFAULT_CONFIG.gitnexusContext!;
+  config.gitnexusContext = gitnexusContext;
+  validateGitNexusContextConfig(gitnexusContext, "config.gitnexusContext");
   validateBoolean(config.commands.enabled, "config.commands.enabled");
   validateStringArray(config.commands.botMentions, "config.commands.botMentions");
   validateStringArray(config.commands.trustedAuthors, "config.commands.trustedAuthors");
@@ -302,6 +328,34 @@ function validateRepoMemoryConfig(value: unknown, label: string): void {
   validatePositiveInteger(value.maxPacketBytes, `${label}.maxPacketBytes`);
   validatePositiveInteger(value.maxStateNotes, `${label}.maxStateNotes`);
   validateBoolean(value.includeStaleNotes, `${label}.includeStaleNotes`);
+}
+
+function validateGitNexusContextConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  validateBoolean(value.enabled, `${label}.enabled`);
+  validateOptionalString(value.packetVersion, `${label}.packetVersion`);
+  if (typeof value.packetVersion !== "string" || value.packetVersion.trim().length === 0) {
+    throw new Error(`${label}.packetVersion must be a non-empty string`);
+  }
+  validatePositiveInteger(value.maxPacketBytes, `${label}.maxPacketBytes`);
+  validatePositiveInteger(value.maxRelatedItems, `${label}.maxRelatedItems`);
+  validatePositiveInteger(value.queryLimit, `${label}.queryLimit`);
+  validatePositiveInteger(value.commandTimeoutMs, `${label}.commandTimeoutMs`);
+  validatePositiveInteger(value.maxCommandOutputBytes, `${label}.maxCommandOutputBytes`);
+  validateBoolean(value.includeStaleContext, `${label}.includeStaleContext`);
+  validateOptionalStringArray(value.generatedPathPatterns, `${label}.generatedPathPatterns`);
+  if (!Array.isArray(value.generatedPathPatterns)) {
+    throw new Error(`${label}.generatedPathPatterns must be an array of non-empty strings`);
+  }
+  if (value.repoAliases !== undefined) {
+    if (!isRecord(value.repoAliases)) throw new Error(`${label}.repoAliases must be an object`);
+    for (const [repo, alias] of Object.entries(value.repoAliases)) {
+      validateRepoName(repo, `${label}.repoAliases`);
+      if (typeof alias !== "string" || alias.trim().length === 0) {
+        throw new Error(`${label}.repoAliases.${repo} must be a non-empty string`);
+      }
+    }
+  }
 }
 
 function validateProfileRecord(record: Record<string, RepoProfileConfig> | undefined, label: string): void {

--- a/src/gitnexus-context.ts
+++ b/src/gitnexus-context.ts
@@ -1,0 +1,634 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { basename } from "node:path";
+import { containsSecretLikeText, redactSecrets } from "./secrets.js";
+import type { PullFilePatch, PullRequestSummary } from "./types.js";
+
+export const GITNEXUS_CONTEXT_PACKET_VERSION = "gitnexus-context-packet-v0.1";
+export const GITNEXUS_CONTEXT_ADVISORY_LINE =
+  "This GitNexus packet is advisory. Current PR diff, checkout files, and GitHub metadata remain authoritative.";
+
+export interface GitNexusContextConfig {
+  enabled: boolean;
+  packetVersion: string;
+  maxPacketBytes: number;
+  maxRelatedItems: number;
+  queryLimit: number;
+  commandTimeoutMs: number;
+  maxCommandOutputBytes: number;
+  includeStaleContext: boolean;
+  repoAliases?: Record<string, string>;
+  generatedPathPatterns: string[];
+}
+
+export interface GitNexusIndexRecord {
+  alias: string;
+  path?: string;
+  indexedAt?: string;
+  commit?: string;
+}
+
+export interface GitNexusChangedFileContext {
+  path: string;
+  status?: string;
+  additions?: number;
+  deletions?: number;
+  changes?: number;
+  generated: boolean;
+  symbolHints: string[];
+  changedExportedSymbols: string[];
+}
+
+export interface GitNexusRelatedContext {
+  id: string;
+  query: string;
+  reason: string;
+  command: string[];
+  outputPreview: string;
+  byteEstimate: number;
+}
+
+export interface GitNexusOmittedContext {
+  id: string;
+  reason: "generated_path" | "budget_exceeded" | "query_failed" | "stale_index" | "missing_index";
+  detail: string;
+}
+
+export interface GitNexusContextRedactionReport {
+  ok: boolean;
+  blockedSources: Array<{
+    id: string;
+    redactedPreview: string;
+  }>;
+  checkedSources: number;
+}
+
+export interface GitNexusContextPacket {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  baseSha: string;
+  packetVersion: string;
+  generatedAt: string;
+  sha256: string;
+  byteEstimate: number;
+  tokenEstimate: number;
+  advisory: string;
+  gitnexus: {
+    alias?: string;
+    indexCommit?: string;
+    indexedAt?: string;
+    indexPath?: string;
+    freshness: "fresh" | "stale" | "missing" | "unknown";
+    degradedMode: boolean;
+    degradedReason?: string;
+  };
+  changedFiles: GitNexusChangedFileContext[];
+  relatedContext: GitNexusRelatedContext[];
+  omittedContext: GitNexusOmittedContext[];
+  markdown: string;
+  redactionReportSha256: string;
+}
+
+export type GitNexusContextBuildResult =
+  | {
+      ok: true;
+      packet: GitNexusContextPacket;
+      redactionReport: GitNexusContextRedactionReport;
+    }
+  | {
+      ok: false;
+      error: string;
+      redactionReport: GitNexusContextRedactionReport;
+      omittedContext: GitNexusOmittedContext[];
+    };
+
+export interface BuildGitNexusContextPacketInput {
+  repo: string;
+  pull: PullRequestSummary;
+  files: PullFilePatch[];
+  config: GitNexusContextConfig;
+  generatedAt?: string;
+  commandRunner?: GitNexusCommandRunner;
+  gitnexusListText?: string;
+}
+
+export interface GitNexusCommandResult {
+  ok: boolean;
+  stdout: string;
+  stderr?: string;
+  error?: string;
+  timedOut?: boolean;
+}
+
+export type GitNexusCommandRunner = (args: string[], options: {
+  timeoutMs: number;
+  maxOutputBytes: number;
+}) => GitNexusCommandResult;
+
+export function buildGitNexusContextPacket(input: BuildGitNexusContextPacketInput): GitNexusContextBuildResult {
+  validateConfig(input.config);
+  parseRepoName(input.repo);
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+  const generatedAtMs = Date.parse(generatedAt);
+  if (!Number.isFinite(generatedAtMs)) throw new Error("generatedAt must be an ISO timestamp");
+
+  const commandRunner = input.commandRunner ?? runGitNexusCommand;
+  const listResult = input.gitnexusListText !== undefined
+    ? { ok: true, stdout: input.gitnexusListText }
+    : commandRunner(["list"], {
+      timeoutMs: input.config.commandTimeoutMs,
+      maxOutputBytes: input.config.maxCommandOutputBytes
+    });
+  const redactionSources: Array<{ id: string; text: string }> = [];
+  const omittedContext: GitNexusOmittedContext[] = [];
+  const changedFiles = input.files
+    .map((file) => mapChangedFile(file, input.config.generatedPathPatterns))
+    .sort((left, right) => left.path.localeCompare(right.path));
+  for (const file of changedFiles.filter((file) => file.generated)) {
+    omittedContext.push({
+      id: `file:${file.path}`,
+      reason: "generated_path",
+      detail: "Generated/build artifact path excluded from GitNexus query selection."
+    });
+  }
+
+  let indexes: GitNexusIndexRecord[] = [];
+  let alias: string | undefined;
+  let index: GitNexusIndexRecord | undefined;
+  let freshness: GitNexusContextPacket["gitnexus"]["freshness"] = "unknown";
+  let degradedReason: string | undefined;
+
+  if (!listResult.ok) {
+    degradedReason = describeCommandFailure("gitnexus list", listResult);
+    freshness = "unknown";
+  } else {
+    redactionSources.push({ id: "gitnexus:list", text: listResult.stdout });
+    indexes = parseGitNexusList(listResult.stdout);
+    alias = resolveGitNexusAlias(input.repo, indexes, input.config.repoAliases);
+    index = alias ? indexes.find((candidate) => candidate.alias === alias) : undefined;
+    if (!index) {
+      freshness = "missing";
+      degradedReason = "No matching GitNexus index alias was found for this repository.";
+      omittedContext.push({ id: "gitnexus:index", reason: "missing_index", detail: degradedReason });
+    } else {
+      freshness = classifyIndexFreshness(index.commit, input.pull);
+      if (freshness === "stale") {
+        degradedReason = `GitNexus index commit ${index.commit ?? "unknown"} does not match PR base/head.`;
+        omittedContext.push({ id: `gitnexus:${index.alias}`, reason: "stale_index", detail: degradedReason });
+      }
+    }
+  }
+
+  const relatedContext: GitNexusRelatedContext[] = [];
+  const canQuery = Boolean(alias) && (freshness === "fresh" || input.config.includeStaleContext);
+  if (canQuery) {
+    const queryFiles = changedFiles.filter((file) => !file.generated).slice(0, input.config.maxRelatedItems);
+    for (const file of queryFiles) {
+      const query = buildFileQuery(file);
+      const args = [
+        "query",
+        query,
+        "--repo",
+        alias!,
+        "--limit",
+        String(input.config.queryLimit),
+        "--max-tokens",
+        String(Math.max(200, Math.floor(input.config.maxCommandOutputBytes / 4)))
+      ];
+      const result = commandRunner(args, {
+        timeoutMs: input.config.commandTimeoutMs,
+        maxOutputBytes: input.config.maxCommandOutputBytes
+      });
+      if (!result.ok) {
+        omittedContext.push({
+          id: `query:${file.path}`,
+          reason: "query_failed",
+          detail: describeCommandFailure(args.join(" "), result)
+        });
+        continue;
+      }
+      redactionSources.push({ id: `query:${file.path}`, text: result.stdout });
+      const outputPreview = truncateByBytes(redactSecrets(result.stdout).trim(), input.config.maxCommandOutputBytes);
+      if (outputPreview) {
+        relatedContext.push({
+          id: `query:${file.path}`,
+          query,
+          reason: `Related GitNexus flows for changed file ${file.path}.`,
+          command: ["gitnexus", ...args],
+          outputPreview,
+          byteEstimate: Buffer.byteLength(outputPreview, "utf8")
+        });
+      }
+    }
+  }
+
+  const preRenderReport = buildRedactionReport(redactionSources);
+  if (!preRenderReport.ok) {
+    return {
+      ok: false,
+      error: "GitNexus context packet blocked: secret-like text detected in GitNexus output.",
+      redactionReport: preRenderReport,
+      omittedContext
+    };
+  }
+
+  const packetBase = {
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    baseSha: input.pull.base.sha,
+    packetVersion: input.config.packetVersion,
+    generatedAt,
+    advisory: GITNEXUS_CONTEXT_ADVISORY_LINE,
+    gitnexus: {
+      ...(alias ? { alias } : {}),
+      ...(index?.commit ? { indexCommit: index.commit } : {}),
+      ...(index?.indexedAt ? { indexedAt: index.indexedAt } : {}),
+      ...(index?.path ? { indexPath: index.path } : {}),
+      freshness,
+      degradedMode: freshness !== "fresh",
+      ...(degradedReason ? { degradedReason } : {})
+    },
+    changedFiles,
+    omittedContext
+  };
+
+  const budgeted = renderWithinBudget({
+    ...packetBase,
+    relatedContext
+  }, input.config.maxPacketBytes);
+  const postRenderReport = buildRedactionReport([{ id: "packet:markdown", text: budgeted.markdown }]);
+  const redactionReport = mergeRedactionReports(preRenderReport, postRenderReport);
+  if (!postRenderReport.ok) {
+    return {
+      ok: false,
+      error: "GitNexus context packet blocked: secret-like text survived packet rendering.",
+      redactionReport,
+      omittedContext: budgeted.omittedContext
+    };
+  }
+  if (Buffer.byteLength(budgeted.markdown, "utf8") > input.config.maxPacketBytes) {
+    const budgetExceeded: GitNexusOmittedContext = {
+      id: "packet:markdown",
+      reason: "budget_exceeded",
+      detail: "Base GitNexus context packet exceeded the configured byte budget."
+    };
+    return {
+      ok: false,
+      error: `GitNexus context packet exceeded maxPacketBytes (${Buffer.byteLength(budgeted.markdown, "utf8")} > ${input.config.maxPacketBytes}).`,
+      redactionReport,
+      omittedContext: [...budgeted.omittedContext, budgetExceeded].sort(compareOmittedContext)
+    };
+  }
+
+  const packet: GitNexusContextPacket = {
+    ...packetBase,
+    relatedContext: budgeted.relatedContext,
+    omittedContext: budgeted.omittedContext,
+    markdown: budgeted.markdown,
+    sha256: sha256(budgeted.markdown),
+    byteEstimate: Buffer.byteLength(budgeted.markdown, "utf8"),
+    tokenEstimate: Math.max(1, Math.ceil(Buffer.byteLength(budgeted.markdown, "utf8") / 4)),
+    redactionReportSha256: sha256(JSON.stringify(redactionReport))
+  };
+  return { ok: true, packet, redactionReport };
+}
+
+export function formatGitNexusContextPacketMarkdown(packet: GitNexusContextPacket): string {
+  return packet.markdown;
+}
+
+export function parseGitNexusList(text: string): GitNexusIndexRecord[] {
+  const records: GitNexusIndexRecord[] = [];
+  let current: GitNexusIndexRecord | undefined;
+  for (const rawLine of text.split(/\r?\n/)) {
+    const aliasMatch = rawLine.match(/^  ([^\s].*?)(?:\s{2,}\(.+\))?\s*$/);
+    if (aliasMatch && !rawLine.includes(":")) {
+      if (aliasMatch[1]!.trim().startsWith("Indexed Repositories")) continue;
+      current = { alias: aliasMatch[1]!.trim() };
+      records.push(current);
+      continue;
+    }
+    if (!current) continue;
+    const pathMatch = rawLine.match(/^\s+Path:\s+(.+?)\s*$/);
+    if (pathMatch) current.path = pathMatch[1]!;
+    const indexedMatch = rawLine.match(/^\s+Indexed:\s+(.+?)\s*$/);
+    if (indexedMatch) current.indexedAt = indexedMatch[1]!;
+    const commitMatch = rawLine.match(/^\s+Commit:\s+([A-Fa-f0-9]+)\s*$/);
+    if (commitMatch) current.commit = commitMatch[1]!.toLowerCase();
+  }
+  return records.sort((left, right) => left.alias.localeCompare(right.alias));
+}
+
+function renderWithinBudget(input: {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  baseSha: string;
+  packetVersion: string;
+  generatedAt: string;
+  advisory: string;
+  gitnexus: GitNexusContextPacket["gitnexus"];
+  changedFiles: GitNexusChangedFileContext[];
+  relatedContext: GitNexusRelatedContext[];
+  omittedContext: GitNexusOmittedContext[];
+}, maxPacketBytes: number): {
+  markdown: string;
+  relatedContext: GitNexusRelatedContext[];
+  omittedContext: GitNexusOmittedContext[];
+} {
+  const relatedContext = [...input.relatedContext].sort((left, right) => left.id.localeCompare(right.id));
+  const omittedContext = [...input.omittedContext].sort(compareOmittedContext);
+  for (;;) {
+    const markdown = renderMarkdown({ ...input, relatedContext, omittedContext });
+    if (Buffer.byteLength(markdown, "utf8") <= maxPacketBytes || relatedContext.length === 0) {
+      return { markdown, relatedContext, omittedContext };
+    }
+    const omitted = relatedContext.pop()!;
+    omittedContext.push({
+      id: omitted.id,
+      reason: "budget_exceeded",
+      detail: `Dropped related GitNexus output to keep packet under ${maxPacketBytes} bytes.`
+    });
+    omittedContext.sort(compareOmittedContext);
+  }
+}
+
+function renderMarkdown(input: {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  baseSha: string;
+  packetVersion: string;
+  generatedAt: string;
+  advisory: string;
+  gitnexus: GitNexusContextPacket["gitnexus"];
+  changedFiles: GitNexusChangedFileContext[];
+  relatedContext: GitNexusRelatedContext[];
+  omittedContext: GitNexusOmittedContext[];
+}): string {
+  const parts = [
+    "# GitNexus context packet",
+    "",
+    `Repository: ${input.repo}`,
+    `Pull request: #${input.pullNumber}`,
+    `Head SHA: ${input.headSha}`,
+    `Base SHA: ${input.baseSha}`,
+    `Packet version: ${input.packetVersion}`,
+    `Generated at: ${input.generatedAt}`,
+    "",
+    input.advisory,
+    "",
+    "## GitNexus index",
+    "",
+    `Alias: ${input.gitnexus.alias ?? "not-found"}`,
+    `Freshness: ${input.gitnexus.freshness}`,
+    `Degraded mode: ${input.gitnexus.degradedMode ? "true" : "false"}`,
+    ...(input.gitnexus.indexCommit ? [`Index commit: ${input.gitnexus.indexCommit}`] : []),
+    ...(input.gitnexus.indexedAt ? [`Indexed at: ${input.gitnexus.indexedAt}`] : []),
+    ...(input.gitnexus.indexPath ? [`Index path: ${input.gitnexus.indexPath}`] : []),
+    ...(input.gitnexus.degradedReason ? [`Degraded reason: ${input.gitnexus.degradedReason}`] : []),
+    "",
+    "## Changed files",
+    "",
+    ...input.changedFiles.map((file) =>
+      [
+        `- ${file.path}${file.status ? ` (${file.status})` : ""}${file.generated ? " [generated excluded]" : ""}`,
+        file.changedExportedSymbols.length ? `changed exports: ${file.changedExportedSymbols.join(", ")}` : undefined,
+        file.symbolHints.length ? `symbol hints: ${file.symbolHints.join(", ")}` : undefined
+      ].filter(Boolean).join("; ")
+    )
+  ];
+
+  if (input.relatedContext.length) {
+    parts.push("", "## Related GitNexus context");
+    for (const context of input.relatedContext) {
+      parts.push(
+        "",
+        `### ${context.id}`,
+        "",
+        `Query: ${context.query}`,
+        `Reason: ${context.reason}`,
+        "",
+        "```text",
+        context.outputPreview,
+        "```"
+      );
+    }
+  }
+
+  if (input.omittedContext.length) {
+    parts.push("", "## Omitted context");
+    for (const omitted of input.omittedContext) {
+      parts.push("", `- ${omitted.id}: ${omitted.reason}; ${omitted.detail}`);
+    }
+  }
+
+  return `${parts.join("\n").trim()}\n`;
+}
+
+function mapChangedFile(file: PullFilePatch, generatedPathPatterns: string[]): GitNexusChangedFileContext {
+  const changedExportedSymbols = extractChangedExportedSymbols(file.patch);
+  const fallbackHint = symbolHintForPath(file.filename);
+  const symbolHints = [...new Set([...changedExportedSymbols, ...(fallbackHint ? [fallbackHint] : [])])].sort();
+  return {
+    path: file.filename,
+    ...(file.status ? { status: file.status } : {}),
+    ...(file.additions !== undefined ? { additions: file.additions } : {}),
+    ...(file.deletions !== undefined ? { deletions: file.deletions } : {}),
+    ...(file.changes !== undefined ? { changes: file.changes } : {}),
+    generated: isGeneratedPath(file.filename, generatedPathPatterns),
+    symbolHints,
+    changedExportedSymbols
+  };
+}
+
+function buildFileQuery(file: GitNexusChangedFileContext): string {
+  return file.symbolHints.length ? `${file.path} ${file.symbolHints.join(" ")}` : file.path;
+}
+
+export function extractChangedExportedSymbols(patch: string | null | undefined): string[] {
+  if (!patch) return [];
+  const symbols = new Set<string>();
+  for (const rawLine of patch.split(/\r?\n/)) {
+    if (!rawLine.startsWith("+") || rawLine.startsWith("+++")) continue;
+    const line = rawLine.slice(1).trim();
+    const symbol = matchExportedSymbol(line);
+    if (symbol) symbols.add(symbol);
+  }
+  return [...symbols].sort();
+}
+
+function matchExportedSymbol(line: string): string | undefined {
+  const patterns = [
+    /^export\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\b/,
+    /^export\s+(?:const|let|var)\s+([A-Za-z_$][\w$]*)\b/,
+    /^export\s+(?:class|interface|type|enum)\s+([A-Za-z_$][\w$]*)\b/,
+    /^export\s*\{\s*([^}]+)\s*\}/
+  ];
+  const direct = patterns.slice(0, 3).map((pattern) => line.match(pattern)).find(Boolean);
+  if (direct?.[1]) return direct[1];
+  const named = line.match(patterns[3]!);
+  if (!named?.[1]) return undefined;
+  return named[1]
+    .split(",")
+    .map((part) => part.trim().split(/\s+as\s+/i)[0]?.trim())
+    .find((part) => part && /^[A-Za-z_$][\w$]*$/.test(part));
+}
+
+function symbolHintForPath(path: string): string | undefined {
+  const name = basename(path).replace(/\.[^.]+$/, "");
+  const cleaned = name.replace(/[^A-Za-z0-9_ -]/g, " ").replace(/\s+/g, " ").trim();
+  return cleaned || undefined;
+}
+
+function resolveGitNexusAlias(
+  repo: string,
+  indexes: GitNexusIndexRecord[],
+  repoAliases: Record<string, string> | undefined
+): string | undefined {
+  const explicit = repoAliases?.[repo];
+  if (explicit && indexes.some((index) => index.alias === explicit)) return explicit;
+  const [, repoName] = parseRepoName(repo);
+  const normalizedRepoName = normalizeName(repoName);
+  const normalizedFullName = normalizeName(repo);
+  const candidates = indexes.filter((index) => {
+    const normalizedAlias = normalizeName(index.alias);
+    const normalizedPath = index.path ? normalizeName(basename(index.path)) : "";
+    return normalizedAlias === normalizedRepoName ||
+      normalizedAlias === normalizedFullName ||
+      normalizedPath === normalizedRepoName ||
+      normalizedPath === normalizedFullName;
+  });
+  return candidates.sort((left, right) => scoreAlias(repoName, left) - scoreAlias(repoName, right) || left.alias.localeCompare(right.alias))[0]?.alias;
+}
+
+function scoreAlias(repoName: string, index: GitNexusIndexRecord): number {
+  if (index.alias === repoName) return 0;
+  if (index.alias.toLowerCase() === repoName.toLowerCase()) return 1;
+  if (normalizeName(index.alias) === normalizeName(repoName)) return 2;
+  return 3;
+}
+
+function classifyIndexFreshness(commit: string | undefined, pull: PullRequestSummary): GitNexusContextPacket["gitnexus"]["freshness"] {
+  if (!commit) return "unknown";
+  if (commitMatches(commit, pull.base.sha) || commitMatches(commit, pull.head.sha)) return "fresh";
+  return "stale";
+}
+
+function commitMatches(indexCommit: string, sha: string): boolean {
+  const normalizedIndex = indexCommit.toLowerCase();
+  const normalizedSha = sha.toLowerCase();
+  return normalizedSha.startsWith(normalizedIndex) || normalizedIndex.startsWith(normalizedSha);
+}
+
+function isGeneratedPath(path: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => matchesPathPattern(path, pattern));
+}
+
+function matchesPathPattern(path: string, pattern: string): boolean {
+  const normalizedPath = path.replaceAll("\\", "/");
+  const normalizedPattern = pattern.replaceAll("\\", "/");
+  if (normalizedPattern.endsWith("/**")) {
+    return normalizedPath.startsWith(normalizedPattern.slice(0, -3));
+  }
+  if (normalizedPattern.startsWith("**/*.")) {
+    return normalizedPath.endsWith(normalizedPattern.slice(4));
+  }
+  if (normalizedPattern.startsWith("*.")) {
+    return basename(normalizedPath).endsWith(normalizedPattern.slice(1));
+  }
+  if (normalizedPattern.includes("*")) {
+    const regex = new RegExp(`^${escapeRegex(normalizedPattern).replaceAll("\\*", ".*")}$`);
+    return regex.test(normalizedPath);
+  }
+  return normalizedPath === normalizedPattern;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+function runGitNexusCommand(args: string[], options: { timeoutMs: number; maxOutputBytes: number }): GitNexusCommandResult {
+  const result = spawnSync("gitnexus", args, {
+    encoding: "utf8",
+    timeout: options.timeoutMs,
+    maxBuffer: options.maxOutputBytes
+  });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  return {
+    ok: result.status === 0 && !result.error,
+    stdout: truncateByBytes(stdout, options.maxOutputBytes),
+    stderr: truncateByBytes(stderr, options.maxOutputBytes),
+    ...(result.error ? { error: result.error.message } : {}),
+    ...(result.signal === "SIGTERM" || result.error?.name === "TimeoutError" ? { timedOut: true } : {})
+  };
+}
+
+function describeCommandFailure(command: string, result: GitNexusCommandResult): string {
+  if (result.timedOut) return `${command} timed out.`;
+  if (result.error) return `${command} failed: ${redactSecrets(result.error)}`;
+  const stderr = redactSecrets(result.stderr ?? "").trim();
+  return stderr ? `${command} failed: ${stderr.slice(0, 300)}` : `${command} failed.`;
+}
+
+function buildRedactionReport(sources: Array<{ id: string; text: string }>): GitNexusContextRedactionReport {
+  const blockedSources = sources
+    .filter((source) => containsSecretLikeText(source.text))
+    .map((source) => ({
+      id: redactSecrets(source.id),
+      redactedPreview: redactSecrets(source.text).slice(0, 500)
+    }));
+  return {
+    ok: blockedSources.length === 0,
+    blockedSources,
+    checkedSources: sources.length
+  };
+}
+
+function mergeRedactionReports(
+  first: GitNexusContextRedactionReport,
+  second: GitNexusContextRedactionReport
+): GitNexusContextRedactionReport {
+  return {
+    ok: first.ok && second.ok,
+    blockedSources: [...first.blockedSources, ...second.blockedSources],
+    checkedSources: first.checkedSources + second.checkedSources
+  };
+}
+
+function compareOmittedContext(left: GitNexusOmittedContext, right: GitNexusOmittedContext): number {
+  return left.id.localeCompare(right.id) || left.reason.localeCompare(right.reason);
+}
+
+function truncateByBytes(text: string, maxBytes: number): string {
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
+  let output = text;
+  while (Buffer.byteLength(output, "utf8") > maxBytes) output = output.slice(0, -1);
+  return `${output}\n[truncated]`;
+}
+
+function normalizeName(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function parseRepoName(repo: string): [string, string] {
+  const [owner, name, extra] = repo.split("/");
+  if (extra !== undefined || !owner || !name) throw new Error("repo must be an owner/repo name");
+  return [owner, name];
+}
+
+function validateConfig(config: GitNexusContextConfig): void {
+  if (!Number.isInteger(config.maxPacketBytes) || config.maxPacketBytes < 1) {
+    throw new Error("maxPacketBytes must be a positive integer");
+  }
+  for (const field of ["maxRelatedItems", "queryLimit", "commandTimeoutMs", "maxCommandOutputBytes"] as const) {
+    if (!Number.isInteger(config[field]) || config[field] < 1) throw new Error(`${field} must be a positive integer`);
+  }
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9,6 +9,11 @@ import {
 } from "./commands.js";
 import { loadConfig, type BotConfig } from "./config.js";
 import { assertGitClean, preparePullWorktree } from "./git.js";
+import {
+  buildGitNexusContextPacket,
+  type GitNexusCommandRunner,
+  type GitNexusContextPacket
+} from "./gitnexus-context.js";
 import { GitHubApi } from "./github.js";
 import {
   buildPullFileFilterImpact,
@@ -25,7 +30,7 @@ import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "
 import { buildWalkthroughComment } from "./walkthrough.js";
 import { postWalkthroughComment, reviewBodyAfterWalkthroughPost } from "./walkthrough-post.js";
 import { buildReviewPrompt, runZCodeReview } from "./zcode.js";
-import type { PullRequestSummary, ReviewPlan } from "./types.js";
+import type { PullFilePatch, PullRequestSummary, ReviewPlan } from "./types.js";
 
 export interface RunOnceOptions {
   configPath?: string;
@@ -650,6 +655,13 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       repo,
       evidenceDir
     });
+    const gitnexusContext = buildGitNexusContext({
+      config,
+      repo,
+      pull,
+      files: reviewFiles,
+      evidenceDir
+    });
 
     const prompt = buildReviewPrompt({
       repo,
@@ -657,6 +669,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       files: reviewFiles,
       repoProfile: repoPolicy.profile,
       ...(repoMemory.packet ? { repoMemoryPacket: repoMemory.packet } : {}),
+      ...(gitnexusContext.packet ? { gitnexusContextPacket: gitnexusContext.packet } : {}),
       maxPatchBytes: config.zcode.maxPatchBytes
     });
     writeFileSync(join(evidenceDir, "repo-profile.json"), `${JSON.stringify(repoPolicy.profile, null, 2)}\n`);
@@ -923,6 +936,44 @@ function isRepoMemoryNoteExpired(note: { expiresAt?: string }, now: Date): boole
   if (!note.expiresAt) return false;
   const expiresAtMs = Date.parse(note.expiresAt);
   return !Number.isFinite(expiresAtMs) || expiresAtMs <= now.getTime();
+}
+
+export function buildGitNexusContext(input: {
+  config: BotConfig;
+  repo: string;
+  pull: PullRequestSummary;
+  files: PullFilePatch[];
+  evidenceDir: string;
+  commandRunner?: GitNexusCommandRunner;
+  gitnexusListText?: string;
+}): { packet?: GitNexusContextPacket } {
+  const gitnexusConfig = input.config.gitnexusContext;
+  if (!gitnexusConfig?.enabled) return {};
+
+  const packetResult = buildGitNexusContextPacket({
+    repo: input.repo,
+    pull: input.pull,
+    files: input.files,
+    config: gitnexusConfig,
+    ...(input.commandRunner ? { commandRunner: input.commandRunner } : {}),
+    ...(input.gitnexusListText !== undefined ? { gitnexusListText: input.gitnexusListText } : {})
+  });
+
+  if (!packetResult.ok) {
+    writeRedactedJson(join(input.evidenceDir, "gitnexus-context-packet-error.json"), packetResult);
+    if (isGitNexusContextBudgetFailure(packetResult)) return {};
+    throw new Error(`GitNexus context packet failed closed: ${packetResult.error}`);
+  }
+
+  writeRedactedJson(join(input.evidenceDir, "gitnexus-context-packet.json"), packetResult);
+  writeFileSync(join(input.evidenceDir, "gitnexus-context-packet.md"), packetResult.packet.markdown);
+  return { packet: packetResult.packet };
+}
+
+function isGitNexusContextBudgetFailure(packetResult: ReturnType<typeof buildGitNexusContextPacket>): boolean {
+  return !packetResult.ok &&
+    packetResult.redactionReport.ok &&
+    packetResult.omittedContext.some((source) => source.reason === "budget_exceeded");
 }
 
 function recordStaleHeadSkip(input: {

--- a/src/zcode.ts
+++ b/src/zcode.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, rmdirSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseFindings } from "./findings.js";
+import type { GitNexusContextPacket } from "./gitnexus-context.js";
 import type { RepoMemoryPacket } from "./repo-memory.js";
 import { buildRepoProfilePromptSection, type ResolvedRepoProfile } from "./repo-policy.js";
 import { redactSecrets } from "./secrets.js";
@@ -20,6 +21,7 @@ export function buildReviewPrompt(input: {
   files: PullFilePatch[];
   repoProfile?: ResolvedRepoProfile;
   repoMemoryPacket?: Pick<RepoMemoryPacket, "sha256" | "byteEstimate" | "tokenEstimate" | "markdown">;
+  gitnexusContextPacket?: Pick<GitNexusContextPacket, "sha256" | "byteEstimate" | "tokenEstimate" | "markdown" | "gitnexus">;
   maxPatchBytes?: number;
 }): string {
   const fileList = input.files.map((file) => `- ${file.filename}`).join("\n");
@@ -50,11 +52,25 @@ export function buildReviewPrompt(input: {
     "",
     ...(input.repoProfile ? [buildRepoProfilePromptSection(input.repoProfile), ""] : []),
     ...(input.repoMemoryPacket ? [buildRepoMemoryPromptSection(input.repoMemoryPacket), ""] : []),
+    ...(input.gitnexusContextPacket ? [buildGitNexusContextPromptSection(input.gitnexusContextPacket), ""] : []),
     "Files:",
     fileList,
     "",
     "Diff:",
     patches
+  ].join("\n");
+}
+
+function buildGitNexusContextPromptSection(
+  packet: Pick<GitNexusContextPacket, "sha256" | "byteEstimate" | "tokenEstimate" | "markdown" | "gitnexus">
+): string {
+  return [
+    "GitNexus context packet (advisory; feature-flagged context):",
+    `Packet SHA-256: ${packet.sha256}`,
+    `Packet budget: ${packet.byteEstimate} bytes; approx ${packet.tokenEstimate} tokens`,
+    `GitNexus freshness: ${packet.gitnexus.freshness}; degraded=${packet.gitnexus.degradedMode ? "true" : "false"}`,
+    "",
+    packet.markdown.trim()
   ].join("\n");
 }
 

--- a/tests/gitnexus-context.test.ts
+++ b/tests/gitnexus-context.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from "vitest";
+import { loadConfig } from "../src/config.js";
+import {
+  buildGitNexusContextPacket,
+  extractChangedExportedSymbols,
+  parseGitNexusList,
+  type GitNexusCommandRunner,
+  type GitNexusContextConfig
+} from "../src/gitnexus-context.js";
+import { buildReviewPrompt } from "../src/zcode.js";
+import type { PullFilePatch, PullRequestSummary } from "../src/types.js";
+
+describe("GitNexus context packets", () => {
+  const repo = "electricsheephq/evaos-code-review-bot";
+  const generatedAt = "2026-07-02T00:00:00.000Z";
+  const pull = pullRequest({
+    number: 102,
+    headSha: "d239e3b15ab26f9bdcfef25e0036e57598e1f8ce",
+    baseSha: "833eaccf9403a1d33a46eb0fb38889f3571974a1"
+  });
+
+  it("parses GitNexus list output into deterministic index records", () => {
+    expect(parseGitNexusList(gitnexusList([{ alias: "evaos-code-review-bot", commit: "d239e3b" }]))).toEqual([
+      {
+        alias: "evaos-code-review-bot",
+        path: "/Volumes/LEXAR/repos/evaos-code-review-bot",
+        indexedAt: "7/2/2026, 2:29:04 PM",
+        commit: "d239e3b"
+      }
+    ]);
+  });
+
+  it("builds a missing-index degraded packet without querying GitNexus", () => {
+    const result = buildGitNexusContextPacket({
+      repo,
+      pull,
+      files: [{ filename: "src/worker.ts", status: "modified", additions: 2, deletions: 1, changes: 3 }],
+      config: config(),
+      generatedAt,
+      gitnexusListText: gitnexusList([{ alias: "worldos", commit: "073339d" }]),
+      commandRunner: failOnQueryRunner()
+    });
+    const repeated = buildGitNexusContextPacket({
+      repo,
+      pull,
+      files: [{ filename: "src/worker.ts", status: "modified", additions: 2, deletions: 1, changes: 3 }],
+      config: config(),
+      generatedAt,
+      gitnexusListText: gitnexusList([{ alias: "worldos", commit: "073339d" }]),
+      commandRunner: failOnQueryRunner()
+    });
+
+    expect(result.ok).toBe(true);
+    expect(repeated.ok).toBe(true);
+    if (!result.ok || !repeated.ok) throw new Error("expected packet builds to pass");
+    expect(result.packet.sha256).toBe(repeated.packet.sha256);
+    expect(result.packet.gitnexus).toMatchObject({
+      freshness: "missing",
+      degradedMode: true
+    });
+    expect(result.packet.relatedContext).toEqual([]);
+    expect(result.packet.omittedContext).toEqual([
+      expect.objectContaining({ id: "gitnexus:index", reason: "missing_index" })
+    ]);
+    expect(result.packet.markdown).toContain("Current PR diff, checkout files, and GitHub metadata remain authoritative");
+  });
+
+  it("includes bounded related context for a fresh matching index", () => {
+    const runner = queryRunner({
+      "src/worker.ts buildGitNexusContext reviewPull worker": "Process ReviewPull -> buildReviewPrompt -> runZCodeReview\nsrc/worker.ts coordinates review evidence writes."
+    });
+    const result = buildGitNexusContextPacket({
+      repo,
+      pull,
+      files: [
+        {
+          filename: "src/worker.ts",
+          status: "modified",
+          additions: 2,
+          deletions: 1,
+          changes: 3,
+          patch: [
+            "@@ -1,2 +1,4 @@",
+            "+export function buildGitNexusContext() {",
+            "+export async function reviewPull() {"
+          ].join("\n")
+        },
+        { filename: "dist/bundle.js", status: "modified", additions: 50, deletions: 0, changes: 50 }
+      ],
+      config: config({ repoAliases: { [repo]: "evaos-code-review-bot" } }),
+      generatedAt,
+      gitnexusListText: gitnexusList([{ alias: "evaos-code-review-bot", commit: pull.base.sha.slice(0, 7) }]),
+      commandRunner: runner
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected packet build to pass");
+    expect(result.packet.gitnexus).toMatchObject({
+      alias: "evaos-code-review-bot",
+      freshness: "fresh",
+      degradedMode: false
+    });
+    expect(result.packet.relatedContext).toHaveLength(1);
+    expect(result.packet.relatedContext[0]).toMatchObject({
+      id: "query:src/worker.ts",
+      query: "src/worker.ts buildGitNexusContext reviewPull worker"
+    });
+    expect(result.packet.changedFiles.find((file) => file.path === "src/worker.ts")).toMatchObject({
+      path: "src/worker.ts",
+      changedExportedSymbols: ["buildGitNexusContext", "reviewPull"],
+      symbolHints: ["buildGitNexusContext", "reviewPull", "worker"]
+    });
+    expect(result.packet.markdown).toContain("changed exports: buildGitNexusContext, reviewPull");
+    expect(result.packet.omittedContext).toEqual([
+      expect.objectContaining({ id: "file:dist/bundle.js", reason: "generated_path" })
+    ]);
+    expect(result.packet.byteEstimate).toBe(Buffer.byteLength(result.packet.markdown, "utf8"));
+    expect(result.packet.sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("marks stale indexes degraded and skips queries unless stale context is enabled", () => {
+    const result = buildGitNexusContextPacket({
+      repo,
+      pull,
+      files: [{ filename: "src/worker.ts", status: "modified" }],
+      config: config({ repoAliases: { [repo]: "evaos-code-review-bot" } }),
+      generatedAt,
+      gitnexusListText: gitnexusList([{ alias: "evaos-code-review-bot", commit: "0000000" }]),
+      commandRunner: failOnQueryRunner()
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected packet build to pass");
+    expect(result.packet.gitnexus).toMatchObject({
+      freshness: "stale",
+      degradedMode: true
+    });
+    expect(result.packet.relatedContext).toEqual([]);
+    expect(result.packet.omittedContext).toEqual([
+      expect.objectContaining({ id: "gitnexus:evaos-code-review-bot", reason: "stale_index" })
+    ]);
+  });
+
+  it("extracts changed exported symbols from added patch lines", () => {
+    expect(extractChangedExportedSymbols([
+      "@@ -1 +1 @@",
+      "+export function plainFunction() {}",
+      "+export async function asyncFunction() {}",
+      "+export const constantValue = 1;",
+      "+export type PacketShape = {};",
+      "+export interface PacketContract {}",
+      "+export class PacketBuilder {}",
+      "+export enum PacketMode {}",
+      "+export { localName as exportedName, directName };",
+      "+++ b/src/file.ts",
+      "-export function oldSymbol() {}"
+    ].join("\n"))).toEqual([
+      "PacketBuilder",
+      "PacketContract",
+      "PacketMode",
+      "PacketShape",
+      "asyncFunction",
+      "constantValue",
+      "localName",
+      "plainFunction"
+    ]);
+  });
+
+  it("drops related context before exceeding the packet byte budget", () => {
+    const result = buildGitNexusContextPacket({
+      repo,
+      pull,
+      files: [
+        { filename: "src/worker.ts", status: "modified" },
+        { filename: "src/zcode.ts", status: "modified" }
+      ],
+      config: config({
+        repoAliases: { [repo]: "evaos-code-review-bot" },
+        maxPacketBytes: 1_300,
+        maxCommandOutputBytes: 2_000
+      }),
+      generatedAt,
+      gitnexusListText: gitnexusList([{ alias: "evaos-code-review-bot", commit: pull.head.sha.slice(0, 7) }]),
+      commandRunner: queryRunner({
+        "src/worker.ts worker": "worker ".repeat(400),
+        "src/zcode.ts zcode": "zcode ".repeat(400)
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected packet build to pass");
+    expect(result.packet.byteEstimate).toBeLessThanOrEqual(1_300);
+    expect(result.packet.omittedContext.some((item) => item.reason === "budget_exceeded")).toBe(true);
+  });
+
+  it("fails closed and redacts evidence when GitNexus output contains secret-like text", () => {
+    const result = buildGitNexusContextPacket({
+      repo,
+      pull,
+      files: [{ filename: "src/worker.ts", status: "modified" }],
+      config: config({ repoAliases: { [repo]: "evaos-code-review-bot" } }),
+      generatedAt,
+      gitnexusListText: gitnexusList([{ alias: "evaos-code-review-bot", commit: pull.head.sha.slice(0, 7) }]),
+      commandRunner: queryRunner({
+        "src/worker.ts worker": "Leaked token ghp_123456789012345678901234 in an indexed comment."
+      })
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected packet build to fail closed");
+    expect(result.error).toContain("secret-like");
+    expect(JSON.stringify(result)).not.toContain("ghp_123456789012345678901234");
+    expect(JSON.stringify(result)).toContain("[redacted-secret]");
+  });
+
+  it("adds GitNexus context to the review prompt as advisory context", () => {
+    const result = buildGitNexusContextPacket({
+      repo,
+      pull,
+      files: [{ filename: "src/worker.ts", status: "modified" }],
+      config: config({ repoAliases: { [repo]: "evaos-code-review-bot" } }),
+      generatedAt,
+      gitnexusListText: gitnexusList([{ alias: "evaos-code-review-bot", commit: pull.head.sha.slice(0, 7) }]),
+      commandRunner: queryRunner({ "src/worker.ts worker": "worker review flow" })
+    });
+    if (!result.ok) throw new Error("expected packet build to pass");
+
+    const prompt = buildReviewPrompt({
+      repo,
+      pull,
+      files: [{ filename: "src/worker.ts", patch: "@@ -1 +1 @@\n-old\n+new" }],
+      gitnexusContextPacket: result.packet
+    });
+
+    expect(prompt).toContain("GitNexus context packet (advisory; feature-flagged context):");
+    expect(prompt).toContain(result.packet.sha256);
+    expect(prompt).toContain("GitNexus freshness: fresh; degraded=false");
+    expect(prompt).toContain("Current PR diff, checkout files, and GitHub metadata remain authoritative");
+  });
+
+  it("loads default-off GitNexus context config", () => {
+    const loaded = loadConfig();
+
+    expect(loaded.gitnexusContext).toMatchObject({
+      enabled: false,
+      packetVersion: "gitnexus-context-packet-v0.1",
+      includeStaleContext: false
+    });
+  });
+});
+
+function config(overrides: Partial<GitNexusContextConfig> = {}): GitNexusContextConfig {
+  return {
+    enabled: true,
+    packetVersion: "gitnexus-context-packet-v0.1",
+    maxPacketBytes: 40_000,
+    maxRelatedItems: 8,
+    queryLimit: 3,
+    commandTimeoutMs: 10_000,
+    maxCommandOutputBytes: 8_000,
+    includeStaleContext: false,
+    repoAliases: {},
+    generatedPathPatterns: ["dist/**", "build/**", "coverage/**", "Library/**", "Temp/**", "**/*.min.js", "**/*.bundle.js", "**/*.lock"],
+    ...overrides
+  };
+}
+
+function pullRequest(input: { number: number; headSha: string; baseSha: string }): PullRequestSummary {
+  return {
+    number: input.number,
+    title: "Test PR",
+    draft: false,
+    head: {
+      sha: input.headSha,
+      ref: "feature/test",
+      repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+    },
+    base: {
+      sha: input.baseSha,
+      ref: "main",
+      repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+    },
+    html_url: `https://github.com/electricsheephq/evaos-code-review-bot/pull/${input.number}`
+  };
+}
+
+function gitnexusList(records: Array<{ alias: string; commit: string }>): string {
+  return [
+    "",
+    `  Indexed Repositories (${records.length})`,
+    "",
+    ...records.flatMap((record) => [
+      `  ${record.alias}`,
+      `    Path:    /Volumes/LEXAR/repos/${record.alias}`,
+      "    Indexed: 7/2/2026, 2:29:04 PM",
+      `    Commit:  ${record.commit}`,
+      "    Stats:   10 files, 20 symbols, 30 edges",
+      "    Clusters:   4",
+      "    Processes:  5",
+      ""
+    ])
+  ].join("\n");
+}
+
+function queryRunner(outputs: Record<string, string>): GitNexusCommandRunner {
+  return (args) => {
+    if (args[0] !== "query") return { ok: true, stdout: "" };
+    const query = args[1] ?? "";
+    return {
+      ok: true,
+      stdout: outputs[query] ?? `No context for ${query}.`
+    };
+  };
+}
+
+function failOnQueryRunner(): GitNexusCommandRunner {
+  return (args) => {
+    if (args[0] === "query") throw new Error("query should not be called");
+    return { ok: true, stdout: "" };
+  };
+}

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -3,12 +3,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { BotConfig } from "../src/config.js";
+import type { GitNexusCommandRunner } from "../src/gitnexus-context.js";
 import type { GitHubApi } from "../src/github.js";
 import { ReviewRunBudget } from "../src/review-budget.js";
 import { ReviewStateStore } from "../src/state.js";
 import type { PullRequestSummary } from "../src/types.js";
 import {
   buildRepoMemoryContext,
+  buildGitNexusContext,
   classifyProviderError,
   isSuccessfulRetryStatus,
   localDateFolder,
@@ -218,6 +220,135 @@ describe("worker review failures", () => {
     expect(context.packet?.sources.map((source) => source.id)).toContain("policy-survives");
     expect(context.packet?.markdown).toContain("Prompt memory should still include current policy notes.");
     state.close();
+  });
+
+  it("writes GitNexus context packet evidence when the provider degrades cleanly", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-gitnexus-context-"));
+    roots.push(root);
+    const evidenceDir = join(root, "evidence");
+    mkdirSync(evidenceDir, { recursive: true });
+    const config: BotConfig = {
+      ...minimalConfig(root),
+      gitnexusContext: {
+        enabled: true,
+        packetVersion: "gitnexus-context-packet-v0.1",
+        maxPacketBytes: 12_000,
+        maxRelatedItems: 4,
+        queryLimit: 2,
+        commandTimeoutMs: 1_000,
+        maxCommandOutputBytes: 2_000,
+        includeStaleContext: false,
+        repoAliases: {},
+        generatedPathPatterns: ["dist/**"]
+      }
+    };
+
+    const context = buildGitNexusContext({
+      config,
+      repo: "electricsheephq/WorldOS",
+      pull: pullSummary(1128, "head", "base"),
+      files: [{ filename: "src/worker.ts", status: "modified" }],
+      evidenceDir,
+      gitnexusListText: workerGitNexusList([{ alias: "evaos-code-review-bot", commit: "d239e3b" }]),
+      commandRunner: failOnGitNexusQueryRunner()
+    });
+
+    expect(context.packet).toBeDefined();
+    expect(context.packet?.gitnexus).toMatchObject({
+      freshness: "missing",
+      degradedMode: true
+    });
+    expect(readFileSync(join(evidenceDir, "gitnexus-context-packet.md"), "utf8")).toContain("Degraded mode: true");
+    const evidence = JSON.parse(readFileSync(join(evidenceDir, "gitnexus-context-packet.json"), "utf8"));
+    expect(evidence).toMatchObject({
+      ok: true,
+      packet: {
+        gitnexus: {
+          freshness: "missing",
+          degradedMode: true
+        }
+      }
+    });
+  });
+
+  it("degrades over-budget GitNexus context to no context packet", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-gitnexus-budget-"));
+    roots.push(root);
+    const evidenceDir = join(root, "evidence");
+    mkdirSync(evidenceDir, { recursive: true });
+    const config: BotConfig = {
+      ...minimalConfig(root),
+      gitnexusContext: {
+        enabled: true,
+        packetVersion: "gitnexus-context-packet-v0.1",
+        maxPacketBytes: 10,
+        maxRelatedItems: 4,
+        queryLimit: 2,
+        commandTimeoutMs: 1_000,
+        maxCommandOutputBytes: 2_000,
+        includeStaleContext: false,
+        repoAliases: {},
+        generatedPathPatterns: []
+      }
+    };
+
+    const context = buildGitNexusContext({
+      config,
+      repo: "electricsheephq/WorldOS",
+      pull: pullSummary(1128, "head", "base"),
+      files: [{ filename: "src/worker.ts", status: "modified" }],
+      evidenceDir,
+      gitnexusListText: workerGitNexusList([{ alias: "worldos", commit: "base" }]),
+      commandRunner: queryRunner({ "src/worker.ts worker": "worker context" })
+    });
+
+    expect(context.packet).toBeUndefined();
+    const error = JSON.parse(readFileSync(join(evidenceDir, "gitnexus-context-packet-error.json"), "utf8"));
+    expect(error).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("maxPacketBytes")
+    });
+    expect(error.omittedContext).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "packet:markdown", reason: "budget_exceeded" })
+    ]));
+  });
+
+  it("fails closed and redacts evidence when GitNexus context contains secrets", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-gitnexus-secret-"));
+    roots.push(root);
+    const evidenceDir = join(root, "evidence");
+    const secretValue = "ghp_123456789012345678901234";
+    mkdirSync(evidenceDir, { recursive: true });
+    const config: BotConfig = {
+      ...minimalConfig(root),
+      gitnexusContext: {
+        enabled: true,
+        packetVersion: "gitnexus-context-packet-v0.1",
+        maxPacketBytes: 12_000,
+        maxRelatedItems: 4,
+        queryLimit: 2,
+        commandTimeoutMs: 1_000,
+        maxCommandOutputBytes: 2_000,
+        includeStaleContext: false,
+        repoAliases: {},
+        generatedPathPatterns: []
+      }
+    };
+
+    expect(() =>
+      buildGitNexusContext({
+        config,
+        repo: "electricsheephq/WorldOS",
+        pull: pullSummary(1128, "b".repeat(40), "a".repeat(40)),
+        files: [{ filename: "src/worker.ts", status: "modified" }],
+        evidenceDir,
+        gitnexusListText: workerGitNexusList([{ alias: "worldos", commit: "a".repeat(7) }]),
+        commandRunner: queryRunner({ "src/worker.ts worker": `Leaked ${secretValue}` })
+      })
+    ).toThrow(/GitNexus context packet failed closed/);
+    const error = readFileSync(join(evidenceDir, "gitnexus-context-packet-error.json"), "utf8");
+    expect(error).toContain("[redacted-secret]");
+    expect(error).not.toContain(secretValue);
   });
 
   it("classifies provider throttle, overload, and true quota separately", () => {
@@ -1198,6 +1329,38 @@ function pullSummary(
       repo: { full_name: "electricsheephq/WorldOS" }
     },
     html_url: `https://github.com/electricsheephq/WorldOS/pull/${number}`
+  };
+}
+
+function workerGitNexusList(records: Array<{ alias: string; commit: string }>): string {
+  return [
+    "",
+    `  Indexed Repositories (${records.length})`,
+    "",
+    ...records.flatMap((record) => [
+      `  ${record.alias}`,
+      `    Path:    /Volumes/LEXAR/repos/${record.alias}`,
+      "    Indexed: 7/2/2026, 2:29:04 PM",
+      `    Commit:  ${record.commit}`,
+      "    Stats:   10 files, 20 symbols, 30 edges",
+      "    Clusters:   4",
+      "    Processes:  5",
+      ""
+    ])
+  ].join("\n");
+}
+
+function queryRunner(outputs: Record<string, string>): GitNexusCommandRunner {
+  return (args) => {
+    if (args[0] !== "query") return { ok: true, stdout: "" };
+    return { ok: true, stdout: outputs[args[1] ?? ""] ?? "" };
+  };
+}
+
+function failOnGitNexusQueryRunner(): GitNexusCommandRunner {
+  return (args) => {
+    if (args[0] === "query") throw new Error("GitNexus query should not run in degraded mode");
+    return { ok: true, stdout: "" };
   };
 }
 


### PR DESCRIPTION
## Summary

Closes #82. Adds a default-off GitNexus advisory context packet provider for PR reviews. The packet builder records GitNexus index freshness, changed files, changed exported symbols where available, bounded related context, degraded-mode reasons, omitted-context reasons, SHA-256 provenance, byte/token estimates, and redaction status.

## Changes

- Add `gitnexusContext` config with conservative default-off settings.
- Add `build-gitnexus-context-packet` CLI dry-run command.
- Add read-only GitNexus packet builder with missing/stale degraded mode, generated-path exclusion, budget enforcement, and secret fail-closed behavior.
- Integrate GitNexus packets into worker evidence and ZCode prompt as advisory context only.
- Document the operator command and safety boundaries.

## Validation

- `npm test` passed: 33 files / 308 tests.
- `npm run build` passed.
- `git diff --check` passed.
- CLI dry-run evidence generated for `electricsheephq/evaos-code-review-bot#102` at `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-02/gitnexus-context/pr-102/`; current bot repo is missing from GitNexus and correctly produced `degradedMode: true`.

## Proof Boundary

This PR proves safe packet generation and advisory prompt/evidence plumbing. It does not enable GitNexus context in live config, does not index repositories, does not widen ZCode tools, and does not claim review-quality uplift until later eval gates (#85/#26/#8).
