### PR TITLE
Record scheduler provider cooldowns at failure time

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -91,6 +91,7 @@ export async function runScheduledCycleWithDeps(input: {
   options: RunOnceOptions;
   reviewPullImpl: (input: ReviewPullInput) => Promise<ReviewPullResult>;
   now?: Date;
+  clock?: () => Date;
 }): Promise<ScheduledRunResult> {
   const config = input.config;
   const scheduler = config.reviewScheduler;
@@ -99,6 +100,7 @@ export async function runScheduledCycleWithDeps(input: {
   }
   const result = emptyScheduledRunResult();
   const now = input.now ?? new Date();
+  const eventClock = input.clock ?? (() => input.now ?? new Date());
   const repos = input.options.repo ? [input.options.repo] : listReposToScan(config);
   const providerId = config.zcode.providerId ?? config.zcode.model ?? "zcode";
 
@@ -184,7 +186,8 @@ export async function runScheduledCycleWithDeps(input: {
       onStatusCommentFailure: () => {
         result.statusCommentFailures += 1;
       },
-      now
+      now,
+      clock: eventClock
     });
     applyReviewStatus(result, status);
   }
@@ -596,6 +599,7 @@ async function runLeasedQueueJob(input: {
   budget: ReviewRunBudget;
   onStatusCommentFailure?: () => void;
   now?: Date;
+  clock?: () => Date;
 }): Promise<ReviewPullResult | "failed" | "closed_retired" | "stale_retired"> {
   const now = input.now ?? new Date();
   input.state.updateReviewQueueJobState({
@@ -793,22 +797,23 @@ async function runLeasedQueueJob(input: {
     });
     return status;
   } catch (error) {
+    const failureNow = input.clock?.() ?? now;
     if (recordProviderRateLimitCooldownIfNeeded({
       config: input.config,
       state: input.state,
       repo: input.job.repo,
       pull,
       error,
-      now
+      now: failureNow
     })) {
-      markQueueJobProviderDeferredFromProcessed({ state: input.state, job: input.job, pull, error, config: input.config, now });
+      markQueueJobProviderDeferredFromProcessed({ state: input.state, job: input.job, pull, error, config: input.config, now: failureNow });
       recordReadinessTransition({
         state: input.state,
         repo: input.job.repo,
         pull,
         readinessState: "provider_deferred",
         reason: "provider_rate_limit_cooldown",
-        now
+        now: failureNow
       });
       await syncReviewStatusComment({
         config: input.config,
@@ -819,7 +824,7 @@ async function runLeasedQueueJob(input: {
         state: "provider_deferred",
         details: "Provider cooldown recorded; see bot evidence for operator-only details.",
         onStatusCommentFailure: input.onStatusCommentFailure,
-        now
+        now: failureNow
       });
       updateReviewerSessionJobFromQueueStatus({ ...input, job: { ...input.job, ...(sessionId ? { sessionId } : {}) } }, "assigned");
       return "skipped_provider_cooldown";

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -440,6 +440,42 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("records scheduled provider cooldowns from failure handling time", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-provider-cooldown-completion-time-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    const state = new ReviewStateStore(config.statePath);
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: true },
+      reviewPullImpl: async () => {
+        throw new Error("ProviderBusinessError: [1302][Rate limit reached for requests]");
+      },
+      now: new Date("2026-07-02T00:00:00.000Z"),
+      clock: () => new Date("2026-07-02T00:03:00.000Z")
+    });
+
+    expect(result.skippedProviderCooldown).toBe(1);
+    expect(state.listReviewQueueJobs({ state: "provider_deferred" })).toEqual([
+      expect.objectContaining({
+        repo: "org/repo-a",
+        pullNumber: 1,
+        nextEligibleAt: "2026-07-02T00:04:30.000Z",
+        lastError: expect.stringContaining("provider_rate_limit_cooldown_until=2026-07-02T00:04:30.000Z")
+      })
+    ]);
+    expect(state.getProcessedReview("org/repo-a", 1, HEAD_A)).toMatchObject({
+      status: "skipped",
+      error: expect.stringContaining("provider_rate_limit_cooldown_until=2026-07-02T00:04:30.000Z")
+    });
+    state.close();
+  });
+
   it("marks a queued status failed when refetching the leased pull fails", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-refetch-failed-"));
     roots.push(root);


### PR DESCRIPTION
## Summary

Closes #126. Fixes scheduled-provider cooldown rows being recorded with a timestamp from the scheduler cycle start instead of the time the provider failure is actually handled.

When a ZCode/provider attempt takes longer than the short provider-overload cooldown window, the old behavior could write `provider_rate_limit_cooldown_until` and queue `next_eligible_at` values that were already expired. That made `release:status` flip red immediately after an otherwise contained provider-overload retry.

## Changes

- Add an injectable scheduler clock for event/failure handling time.
- Use failure-handling time for scheduled provider cooldown recording, queue `provider_deferred` state, readiness transition, and status-comment timestamp.
- Preserve deterministic tests by defaulting the injected clock to the provided scheduler `now` in tests and fresh wall-clock time in runtime.
- Add a regression test where cycle start is `T0`, provider failure is handled at `T0+3m`, and cooldown expiry becomes `T0+4m30s`.

## Validation

- `npm test -- tests/scheduler.test.ts` passed: 47 tests.
- `npm run build` passed.
- `git diff --check` passed.

## Runtime Note

This is a patch-beta candidate because it affects live `release:status` and provider-deferred retry behavior. It does not change live concurrency, monitored repos, GitHub App permissions, ZCode tools, or posting policy.
