### PR TITLE
Fix covered provider cooldown status gate

### DIFF
--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -242,7 +242,7 @@ export function collectReleaseStatus(input: {
     expectedHead: input.expectedHead,
     configPath,
     launchd: readLaunchdStatus(input.launchdLabel ?? "com.electricsheephq.evaos-code-review-bot"),
-    database: readDatabaseStatus(statePath, now),
+    database: readDatabaseStatus(statePath, now, config.reviewConcurrency.leaseTtlMs),
     heartbeat: readHeartbeatStatus(
       statePath,
       config.pollIntervalMs * 2,
@@ -383,7 +383,7 @@ function readReviewQueueBudgetJobs(
   };
 }
 
-function readDatabaseStatus(statePath: string, now: Date): ReleaseDatabaseStatus {
+function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_000): ReleaseDatabaseStatus {
   if (!existsSync(statePath)) return { rowCount: 0, errorCount: 0 };
   const db = new DatabaseSync(statePath, { readOnly: true });
   try {
@@ -443,7 +443,7 @@ function readDatabaseStatus(statePath: string, now: Date): ReleaseDatabaseStatus
     const activeProviderCooldownCount = providerCooldowns.length - expiredProviderCooldownCount;
     const coveredByActiveQueueRetryProviderCooldownCount = activeGlobalProviderCooldowns.length > 0
       ? 0
-      : countExpiredProviderCooldownsCoveredByActiveQueueRetry(db, expiredProviderCooldowns, now);
+      : countExpiredProviderCooldownsCoveredByActiveQueueRetry(db, expiredProviderCooldowns, now, leaseTtlMs);
     const coveredExpiredProviderCooldownCount = activeGlobalProviderCooldowns.length > 0
       ? expiredProviderCooldownCount
       : coveredByActiveQueueRetryProviderCooldownCount;
@@ -624,7 +624,8 @@ interface ProviderCooldownCandidate {
 function countExpiredProviderCooldownsCoveredByActiveQueueRetry(
   db: DatabaseSync,
   cooldowns: ProviderCooldownCandidate[],
-  now: Date
+  now: Date,
+  leaseTtlMs: number
 ): number {
   if (cooldowns.length === 0) return 0;
   const hasTable = db
@@ -635,13 +636,22 @@ function countExpiredProviderCooldownsCoveredByActiveQueueRetry(
     (db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>)
       .map((column) => column.name)
   );
-  if (!columns.has("repo") || !columns.has("pull_number") || !columns.has("head_sha") || !columns.has("state")) {
+  if (
+    !columns.has("repo") ||
+    !columns.has("pull_number") ||
+    !columns.has("head_sha") ||
+    !columns.has("state") ||
+    !columns.has("updated_at")
+  ) {
     return 0;
   }
   const hasLeaseExpiresAt = columns.has("lease_expires_at");
   const leaseClause = hasLeaseExpiresAt
-    ? "and (lease_expires_at is null or datetime(lease_expires_at) > datetime(?))"
-    : "";
+    ? `and (
+         (lease_expires_at is not null and datetime(lease_expires_at) > datetime(?))
+         or (lease_expires_at is null and datetime(updated_at) > datetime(?))
+       )`
+    : "and datetime(updated_at) > datetime(?)";
   const query = db.prepare(
     `select 1
      from review_queue_jobs
@@ -653,12 +663,13 @@ function countExpiredProviderCooldownsCoveredByActiveQueueRetry(
      limit 1`
   );
   const nowIso = now.toISOString();
+  const legacyLeaseCutoffIso = new Date(now.getTime() - leaseTtlMs).toISOString();
   return cooldowns.filter((cooldown) => {
     const cooldownUntilMs = Date.parse(cooldown.cooldownUntil);
     if (!Number.isFinite(cooldownUntilMs) || cooldownUntilMs > now.getTime()) return false;
     const row = hasLeaseExpiresAt
-      ? query.get(cooldown.repo, cooldown.pullNumber, cooldown.headSha, nowIso)
-      : query.get(cooldown.repo, cooldown.pullNumber, cooldown.headSha);
+      ? query.get(cooldown.repo, cooldown.pullNumber, cooldown.headSha, nowIso, legacyLeaseCutoffIso)
+      : query.get(cooldown.repo, cooldown.pullNumber, cooldown.headSha, legacyLeaseCutoffIso);
     return Boolean(row);
   }).length;
 }

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -34,6 +34,7 @@ export interface ReleaseDatabaseStatus {
   expiredProviderCooldownCount?: number;
   activeGlobalProviderCooldownCount?: number;
   coveredExpiredProviderCooldownCount?: number;
+  coveredByActiveQueueRetryProviderCooldownCount?: number;
   retryableExpiredProviderCooldownCount?: number;
   providerThrottleState?: "none" | "active" | "expired_retryable";
   reviewQueueJobCount?: number;
@@ -410,26 +411,42 @@ function readDatabaseStatus(statePath: string, now: Date): ReleaseDatabaseStatus
       };
     const providerCooldownRows = db
       .prepare(
-        `select repo, error
+        `select repo, pull_number, head_sha, error
          from processed_reviews
          where status = 'skipped' and error like ?`
       )
-      .all(`${PROVIDER_COOLDOWN_ERROR_PREFIX}%`) as unknown as Array<{ repo: string; error: string | null }>;
+      .all(`${PROVIDER_COOLDOWN_ERROR_PREFIX}%`) as unknown as Array<{
+        repo: string;
+        pull_number: number;
+        head_sha: string;
+        error: string | null;
+      }>;
     const providerCooldowns = providerCooldownRows
       .map((providerRow) => {
         const parsed = parseProviderCooldownError(providerRow.error ?? undefined);
-        return parsed ? { repo: providerRow.repo, ...parsed } : undefined;
+        return parsed
+          ? {
+              repo: providerRow.repo,
+              pullNumber: providerRow.pull_number,
+              headSha: providerRow.head_sha,
+              ...parsed
+            }
+          : undefined;
       })
-      .filter((cooldown): cooldown is { repo: string; cooldownUntil: string; reason?: string } => Boolean(cooldown));
+      .filter((cooldown): cooldown is ProviderCooldownCandidate => Boolean(cooldown));
     const activeGlobalProviderCooldowns = readActiveGlobalProviderCooldowns(db, now);
-    const expiredProviderCooldownCount = providerCooldowns.filter((cooldown) => {
+    const expiredProviderCooldowns = providerCooldowns.filter((cooldown) => {
       const cooldownUntilMs = Date.parse(cooldown.cooldownUntil);
       return !Number.isFinite(cooldownUntilMs) || cooldownUntilMs <= now.getTime();
-    }).length;
+    });
+    const expiredProviderCooldownCount = expiredProviderCooldowns.length;
     const activeProviderCooldownCount = providerCooldowns.length - expiredProviderCooldownCount;
+    const coveredByActiveQueueRetryProviderCooldownCount = activeGlobalProviderCooldowns.length > 0
+      ? 0
+      : countExpiredProviderCooldownsCoveredByActiveQueueRetry(db, expiredProviderCooldowns, now);
     const coveredExpiredProviderCooldownCount = activeGlobalProviderCooldowns.length > 0
       ? expiredProviderCooldownCount
-      : 0;
+      : coveredByActiveQueueRetryProviderCooldownCount;
     const retryableExpiredProviderCooldownCount = expiredProviderCooldownCount - coveredExpiredProviderCooldownCount;
     const providerThrottleState = activeGlobalProviderCooldowns.length > 0 || activeProviderCooldownCount > 0
       ? "active"
@@ -450,6 +467,7 @@ function readDatabaseStatus(statePath: string, now: Date): ReleaseDatabaseStatus
       expiredProviderCooldownCount,
       activeGlobalProviderCooldownCount: activeGlobalProviderCooldowns.length,
       coveredExpiredProviderCooldownCount,
+      coveredByActiveQueueRetryProviderCooldownCount,
       retryableExpiredProviderCooldownCount,
       providerThrottleState,
       reviewQueueJobCount: reviewQueue.total,
@@ -595,6 +613,56 @@ function readReviewerSessionCounts(
   };
 }
 
+interface ProviderCooldownCandidate {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  cooldownUntil: string;
+  reason?: string;
+}
+
+function countExpiredProviderCooldownsCoveredByActiveQueueRetry(
+  db: DatabaseSync,
+  cooldowns: ProviderCooldownCandidate[],
+  now: Date
+): number {
+  if (cooldowns.length === 0) return 0;
+  const hasTable = db
+    .prepare("select 1 from sqlite_master where type = 'table' and name = 'review_queue_jobs' limit 1")
+    .get();
+  if (!hasTable) return 0;
+  const columns = new Set(
+    (db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>)
+      .map((column) => column.name)
+  );
+  if (!columns.has("repo") || !columns.has("pull_number") || !columns.has("head_sha") || !columns.has("state")) {
+    return 0;
+  }
+  const hasLeaseExpiresAt = columns.has("lease_expires_at");
+  const leaseClause = hasLeaseExpiresAt
+    ? "and (lease_expires_at is null or datetime(lease_expires_at) > datetime(?))"
+    : "";
+  const query = db.prepare(
+    `select 1
+     from review_queue_jobs
+     where repo = ?
+       and pull_number = ?
+       and head_sha = ?
+       and state in ('leased', 'running')
+       ${leaseClause}
+     limit 1`
+  );
+  const nowIso = now.toISOString();
+  return cooldowns.filter((cooldown) => {
+    const cooldownUntilMs = Date.parse(cooldown.cooldownUntil);
+    if (!Number.isFinite(cooldownUntilMs) || cooldownUntilMs > now.getTime()) return false;
+    const row = hasLeaseExpiresAt
+      ? query.get(cooldown.repo, cooldown.pullNumber, cooldown.headSha, nowIso)
+      : query.get(cooldown.repo, cooldown.pullNumber, cooldown.headSha);
+    return Boolean(row);
+  }).length;
+}
+
 function readActiveGlobalProviderCooldowns(db: DatabaseSync, now: Date): Array<{ repo: string; cooldownUntil: string }> {
   const hasTable = db
     .prepare("select 1 from sqlite_master where type = 'table' and name = 'repo_provider_cooldowns' limit 1")
@@ -614,9 +682,11 @@ function readActiveGlobalProviderCooldowns(db: DatabaseSync, now: Date): Array<{
 function describeProviderCooldownCounts(database: ReleaseDatabaseStatus): string {
   const total = database.providerCooldownCount ?? 0;
   if (total === 0) return "";
+  const covered = database.coveredExpiredProviderCooldownCount ?? 0;
   return (
     `; ${total} provider cooldown skip row(s)` +
-    ` (${database.activeProviderCooldownCount ?? 0} active, ${database.expiredProviderCooldownCount ?? 0} expired)`
+    ` (${database.activeProviderCooldownCount ?? 0} active, ${database.expiredProviderCooldownCount ?? 0} expired` +
+    `${covered > 0 ? `, ${covered} covered` : ""})`
   );
 }
 
@@ -624,10 +694,20 @@ function describeProviderCooldownBacklog(
   database: ReleaseDatabaseStatus,
   providerThrottleState = inferProviderThrottleState(database)
 ): string {
-  if (providerThrottleState === "active" && (database.coveredExpiredProviderCooldownCount ?? 0) > 0) {
+  const queueCovered = database.coveredByActiveQueueRetryProviderCooldownCount ?? 0;
+  const globallyCovered = Math.max(0, (database.coveredExpiredProviderCooldownCount ?? 0) - queueCovered);
+  if (providerThrottleState === "active" && globallyCovered > 0) {
     return (
-      `provider throttle active; ${database.coveredExpiredProviderCooldownCount} expired provider cooldown row(s) ` +
+      `provider throttle active; ${globallyCovered} expired provider cooldown row(s) ` +
       "deferred by active provider cooldown"
+    );
+  }
+  if (queueCovered > 0) {
+    const retryable = database.retryableExpiredProviderCooldownCount ?? 0;
+    return (
+      `${queueCovered} expired provider cooldown row(s) covered by active queue retry; ` +
+      `${retryable} retryable expired provider cooldown row(s); ` +
+      `${database.activeProviderCooldownCount ?? 0} active provider cooldown row(s)`
     );
   }
   return `${database.expiredProviderCooldownCount ?? 0} expired provider cooldown row(s); ${database.activeProviderCooldownCount ?? 0} active provider cooldown row(s)`;

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -595,6 +595,95 @@ describe("beta release status", () => {
     expect(status.gates.some((gate) => gate.name === "provider_cooldown_backlog" && !gate.ok)).toBe(true);
   });
 
+  it("does not cover expired provider cooldown rows with stale null queue leases", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-stale-null-lease-cooldown-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          lease_expires_at text,
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      db.prepare(
+        `insert into processed_reviews (repo, pull_number, head_sha, status, error)
+         values (?, ?, ?, 'skipped', ?)`
+      ).run(
+        "electricsheephq/WorldOS",
+        1127,
+        "stale-null-lease-head",
+        "provider_rate_limit_cooldown_until=2026-07-01T00:01:00.000Z; reason=provider_overloaded"
+      );
+      db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, lease_id, lease_expires_at, created_at, updated_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, 'running', ?, null, ?, ?)`
+      ).run(
+        "running-stale-null-lease-head",
+        "automatic:electricsheephq/WorldOS#1127@stale-null-lease-head",
+        "electricsheephq/WorldOS",
+        "electricsheephq",
+        1127,
+        "stale-null-lease-head",
+        "lease-without-expiry",
+        "2026-07-01T00:00:00.000Z",
+        "2026-07-01T00:00:00.000Z"
+      );
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-01T00:20:00.000Z")
+    });
+
+    expect(status.database.expiredProviderCooldownCount).toBe(1);
+    expect(status.database.coveredExpiredProviderCooldownCount).toBe(0);
+    expect(status.database.coveredByActiveQueueRetryProviderCooldownCount).toBe(0);
+    expect(status.database.retryableExpiredProviderCooldownCount).toBe(1);
+    expect(status.gates.some((gate) => gate.name === "provider_cooldown_backlog" && !gate.ok)).toBe(true);
+  });
+
   it("reports reviewer session counts from the live state database", () => {
     const root = mkdtempSync(join(tmpdir(), "release-status-reviewer-sessions-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -335,6 +335,266 @@ describe("beta release status", () => {
     expect(status.gates.some((gate) => gate.name === "provider_cooldown_backlog" && !gate.ok)).toBe(true);
   });
 
+  it("covers expired provider cooldown rows when the same head has an active queue retry", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-covered-cooldown-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      db.prepare(
+        `insert into processed_reviews (repo, pull_number, head_sha, status, error)
+         values (?, ?, ?, 'skipped', ?)`
+      ).run(
+        "electricsheephq/WorldOS",
+        1127,
+        "covered-head",
+        "provider_rate_limit_cooldown_until=2026-07-01T00:01:00.000Z; reason=provider_overloaded"
+      );
+      db.prepare(
+        `insert into processed_reviews (repo, pull_number, head_sha, status, error)
+         values (?, ?, ?, 'skipped', ?)`
+      ).run(
+        "electricsheephq/WorldOS",
+        1128,
+        "uncovered-head",
+        "provider_rate_limit_cooldown_until=2026-07-01T00:01:00.000Z; reason=provider_overloaded"
+      );
+      insertQueueJob(db, "running", "electricsheephq/WorldOS", "covered-head", undefined, { pullNumber: 1127 });
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-01T00:05:00.000Z")
+    });
+
+    const retryCommand =
+      "npx tsx src/cli.ts retry-provider-cooldowns --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expired-only true --dry-run false --zcode true";
+    expect(status.database.providerCooldownCount).toBe(2);
+    expect(status.database.expiredProviderCooldownCount).toBe(2);
+    expect(status.database.coveredExpiredProviderCooldownCount).toBe(1);
+    expect(status.database.coveredByActiveQueueRetryProviderCooldownCount).toBe(1);
+    expect(status.database.retryableExpiredProviderCooldownCount).toBe(1);
+    expect(status.gates).toContainEqual({
+      name: "provider_cooldown_backlog",
+      ok: false,
+      detail: `1 expired provider cooldown row(s) covered by active queue retry; 1 retryable expired provider cooldown row(s); 0 active provider cooldown row(s); retry: ${retryCommand}`
+    });
+  });
+
+  it("keeps release status green when all expired provider cooldown rows are covered by active queue retries", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-covered-cooldown-green-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      db.prepare(
+        `insert into processed_reviews (repo, pull_number, head_sha, status, error)
+         values (?, ?, ?, 'skipped', ?)`
+      ).run(
+        "electricsheephq/WorldOS",
+        1127,
+        "covered-head",
+        "provider_rate_limit_cooldown_until=2026-07-01T00:01:00.000Z; reason=provider_overloaded"
+      );
+      insertQueueJob(db, "running", "electricsheephq/WorldOS", "covered-head", undefined, { pullNumber: 1127 });
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-01T00:05:00.000Z")
+    });
+
+    expect(status.database.providerCooldownCount).toBe(1);
+    expect(status.database.expiredProviderCooldownCount).toBe(1);
+    expect(status.database.coveredExpiredProviderCooldownCount).toBe(1);
+    expect(status.database.coveredByActiveQueueRetryProviderCooldownCount).toBe(1);
+    expect(status.database.retryableExpiredProviderCooldownCount).toBe(0);
+    expect(status.gates).toContainEqual({
+      name: "provider_cooldown_backlog",
+      ok: true,
+      detail: "1 expired provider cooldown row(s) covered by active queue retry; 0 retryable expired provider cooldown row(s); 0 active provider cooldown row(s)"
+    });
+    expect(status.recommendedActions).not.toContain(
+      "npx tsx src/cli.ts retry-provider-cooldowns --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expired-only true --dry-run false --zcode true"
+    );
+  });
+
+  it("does not cover expired provider cooldown rows with expired queue leases", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-expired-lease-cooldown-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          lease_expires_at text,
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      db.prepare(
+        `insert into processed_reviews (repo, pull_number, head_sha, status, error)
+         values (?, ?, ?, 'skipped', ?)`
+      ).run(
+        "electricsheephq/WorldOS",
+        1127,
+        "expired-lease-head",
+        "provider_rate_limit_cooldown_until=2026-07-01T00:01:00.000Z; reason=provider_overloaded"
+      );
+      db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, lease_id, lease_expires_at, created_at, updated_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, 'leased', ?, ?, ?, ?)`
+      ).run(
+        "leased-expired-lease-head",
+        "automatic:electricsheephq/WorldOS#1127@expired-lease-head",
+        "electricsheephq/WorldOS",
+        "electricsheephq",
+        1127,
+        "expired-lease-head",
+        "lease-expired",
+        "2026-07-01T00:04:00.000Z",
+        "2026-07-01T00:00:00.000Z",
+        "2026-07-01T00:00:00.000Z"
+      );
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-01T00:05:00.000Z")
+    });
+
+    expect(status.database.expiredProviderCooldownCount).toBe(1);
+    expect(status.database.coveredExpiredProviderCooldownCount).toBe(0);
+    expect(status.database.coveredByActiveQueueRetryProviderCooldownCount).toBe(0);
+    expect(status.database.retryableExpiredProviderCooldownCount).toBe(1);
+    expect(status.gates.some((gate) => gate.name === "provider_cooldown_backlog" && !gate.ok)).toBe(true);
+  });
+
   it("reports reviewer session counts from the live state database", () => {
     const root = mkdtempSync(join(tmpdir(), "release-status-reviewer-sessions-"));
     roots.push(root);
@@ -856,18 +1116,21 @@ function insertQueueJob(
   state: string,
   repo: string,
   headSha: string,
-  nextEligibleAt?: string
+  nextEligibleAt?: string,
+  options: { pullNumber?: number } = {}
 ): void {
+  const pullNumber = options.pullNumber ?? 1;
   db.prepare(
     `insert into review_queue_jobs
       (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
        priority, state, next_eligible_at, created_at, updated_at)
-     values (?, ?, 'automatic', 'background', ?, ?, 1, ?, 50, ?, ?, ?, ?)`
+     values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, ?, ?, ?, ?)`
   ).run(
-    `${state}-${headSha}`,
-    `automatic:${repo}#1@${headSha}`,
+    `${state}-${pullNumber}-${headSha}`,
+    `automatic:${repo}#${pullNumber}@${headSha}`,
     repo,
     repo.split("/")[0],
+    pullNumber,
     headSha,
     state,
     nextEligibleAt ?? null,


### PR DESCRIPTION
## Summary

Fixes #128.

This patch keeps `release-status` green when an expired per-head provider cooldown row is already covered by active retry work for the exact same `{repo, pull_number, head_sha}`.

## Changes

- Select `pull_number` and `head_sha` when reading provider cooldown rows from `processed_reviews`.
- Count expired cooldown rows as covered only when a matching `review_queue_jobs` row is `leased` or `running`.
- Preserve fail-closed behavior for malformed cooldown timestamps, unmatched rows, terminal rows, and expired leases.
- Keep existing active global provider cooldown coverage behavior.

## Validation

- `npm test -- tests/release-status.test.ts`
- `npm run build`
- `git diff --check`

## Release Notes

This is release-gate/status semantics only. It does not change review scheduling, posting, ZCode invocation, provider cooldown duration, or live concurrency.
