### PR TITLE
Classify queued heads in coverage audit

### DIFF
--- a/src/coverage-audit.ts
+++ b/src/coverage-audit.ts
@@ -4,6 +4,7 @@ import type { BotConfig } from "./config.js";
 import { listReposToScan, resolveRepoProfile, type RepoProfileSkipReason } from "./repo-policy.js";
 import {
   parseProviderCooldownError,
+  type ReviewQueueJobState,
   type RepoProviderCooldownRecord,
   type StoredProcessedReviewRecord
 } from "./state.js";
@@ -17,6 +18,7 @@ export interface CoverageAuditSummary {
   pullsSeen: number;
   processed: number;
   providerDeferred: number;
+  queued: number;
   unprocessed: number;
   skipped: number;
   staleHeads: number;
@@ -48,6 +50,17 @@ export interface CoverageUnprocessedEntry extends CoverageAuditPullEntry {
 export interface CoverageProviderDeferredEntry extends CoverageProcessedEntry {
   cooldownUntil: string;
   reason?: string;
+  updatedAt: string;
+}
+
+export interface CoverageQueuedEntry extends CoverageAuditPullEntry {
+  queueState: ReviewQueueJobState;
+  source: string;
+  lane: string;
+  priority: number;
+  createdAt: string;
+  updatedAt: string;
+  nextEligibleAt?: string;
 }
 
 export interface CoverageSkippedEntry {
@@ -83,6 +96,7 @@ export interface CoverageAuditReport {
   summary: CoverageAuditSummary;
   processed: CoverageProcessedEntry[];
   providerDeferred: CoverageProviderDeferredEntry[];
+  queued: CoverageQueuedEntry[];
   unprocessed: CoverageUnprocessedEntry[];
   skipped: CoverageSkippedEntry[];
   staleHeads: CoverageStaleHead[];
@@ -97,6 +111,14 @@ export interface CoverageGitHubApi {
 export interface CoverageStateLookup {
   getProcessedReview(repo: string, pullNumber: number, headSha: string): StoredProcessedReviewRecord | undefined;
   listProcessedReviewsForPull(repo: string, pullNumber: number): StoredProcessedReviewRecord[];
+  getActiveReviewQueueJob?(
+    repo: string,
+    pullNumber: number,
+    headSha: string,
+    baseSha: string,
+    now: Date,
+    leaseTtlMs: number
+  ): CoverageQueueJobCoverage | undefined;
   getActiveRepoProviderCooldown?(repo: string, now?: Date): RepoProviderCooldownRecord | undefined;
   getActiveProviderCooldown?(now?: Date): RepoProviderCooldownRecord | undefined;
 }
@@ -133,6 +155,36 @@ export class CoverageStateReader implements CoverageStateLookup {
       )
       .all(repo, pullNumber) as unknown as ProcessedReviewRow[];
     return rows.map(mapProcessedReviewRow);
+  }
+
+  getActiveReviewQueueJob(
+    repo: string,
+    pullNumber: number,
+    headSha: string,
+    baseSha: string,
+    now: Date,
+    leaseTtlMs: number
+  ): CoverageQueueJobCoverage | undefined {
+    if (!this.db) return undefined;
+    if (!this.hasReviewQueueJobsTable()) return undefined;
+    const hasBaseSha = this.hasReviewQueueJobsColumn("base_sha");
+    const hasLeaseExpiresAt = this.hasReviewQueueJobsColumn("lease_expires_at");
+    const rows = this.db
+      .prepare(
+        `select repo, pull_number, head_sha, source, lane, priority, state, next_eligible_at, last_error,
+                ${hasBaseSha ? "base_sha" : "null as base_sha"},
+                ${hasLeaseExpiresAt ? "lease_expires_at" : "null as lease_expires_at"},
+                created_at, updated_at
+         from review_queue_jobs
+         where repo = ?
+           and pull_number = ?
+           and head_sha = ?
+           and state in ('queued', 'leased', 'running', 'provider_deferred')
+         order by priority asc, datetime(created_at) asc`
+      )
+      .all(repo, pullNumber, headSha) as unknown as ReviewQueueJobCoverageRow[];
+    const row = rows.find((candidate) => isCoverageQueueJobCurrent(candidate, baseSha, now, leaseTtlMs));
+    return row ? mapReviewQueueJobCoverageRow(row) : undefined;
   }
 
   getActiveRepoProviderCooldown(repo: string, now = new Date()): RepoProviderCooldownRecord | undefined {
@@ -183,6 +235,21 @@ export class CoverageStateReader implements CoverageStateLookup {
         .get()
     );
   }
+
+  private hasReviewQueueJobsTable(): boolean {
+    if (!this.db) return false;
+    return Boolean(
+      this.db
+        .prepare("select 1 from sqlite_master where type = 'table' and name = 'review_queue_jobs' limit 1")
+        .get()
+    );
+  }
+
+  private hasReviewQueueJobsColumn(name: string): boolean {
+    if (!this.db) return false;
+    const columns = this.db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>;
+    return columns.some((column) => column.name === name);
+  }
 }
 
 export async function collectCoverageAudit(input: {
@@ -204,6 +271,7 @@ export async function collectCoverageAudit(input: {
       pullsSeen: 0,
       processed: 0,
       providerDeferred: 0,
+      queued: 0,
       unprocessed: 0,
       skipped: 0,
       staleHeads: 0,
@@ -211,6 +279,7 @@ export async function collectCoverageAudit(input: {
     },
     processed: [],
     providerDeferred: [],
+    queued: [],
     unprocessed: [],
     skipped: [],
     staleHeads: [],
@@ -290,12 +359,26 @@ export async function collectCoverageAudit(input: {
             pushSkipped(report, repo, livePull, "draft");
             continue;
           }
-          pushProcessedOrUnprocessed(report, input.state, repo, livePull, input.now ?? new Date());
+          pushProcessedOrUnprocessed(
+            report,
+            input.state,
+            repo,
+            livePull,
+            input.now ?? new Date(),
+            input.config.reviewConcurrency.leaseTtlMs
+          );
           continue;
         }
       }
 
-      pushProcessedOrUnprocessed(report, input.state, repo, pull, input.now ?? new Date());
+      pushProcessedOrUnprocessed(
+        report,
+        input.state,
+        repo,
+        pull,
+        input.now ?? new Date(),
+        input.config.reviewConcurrency.leaseTtlMs
+      );
     }
   }
 
@@ -308,10 +391,17 @@ function pushProcessedOrUnprocessed(
   state: CoverageStateLookup,
   repo: string,
   pull: PullRequestSummary,
-  now: Date
+  now: Date,
+  leaseTtlMs: number
 ): void {
   const processed = state.getProcessedReview(repo, pull.number, pull.head.sha);
+  const queued = state.getActiveReviewQueueJob?.(repo, pull.number, pull.head.sha, pull.base.sha, now, leaseTtlMs);
   if (processed) {
+    if (queued && isProcessedProviderCooldownSkip(processed)) {
+      pushQueuedCoverage(report, repo, pull, queued);
+      return;
+    }
+
     const entry: CoverageProcessedEntry = {
       ...pullEntry(repo, pull),
       status: processed.status,
@@ -327,10 +417,16 @@ function pushProcessedOrUnprocessed(
       report.providerDeferred.push({
         ...entry,
         cooldownUntil: providerCooldown.cooldownUntil,
-        ...(providerCooldown.reason ? { reason: providerCooldown.reason } : {})
+        ...(providerCooldown.reason ? { reason: providerCooldown.reason } : {}),
+        updatedAt: processed.createdAt
       });
       report.summary.providerDeferred += 1;
     }
+    return;
+  }
+
+  if (queued) {
+    pushQueuedCoverage(report, repo, pull, queued);
     return;
   }
 
@@ -341,6 +437,7 @@ function pushProcessedOrUnprocessed(
       status: "skipped",
       error: `repo_provider_cooldown_until=${repoCooldown.cooldownUntil}; reason=${repoCooldown.reason}`,
       createdAt: repoCooldown.updatedAt,
+      updatedAt: repoCooldown.updatedAt,
       cooldownUntil: repoCooldown.cooldownUntil,
       reason: repoCooldown.reason
     });
@@ -355,6 +452,7 @@ function pushProcessedOrUnprocessed(
       status: "skipped",
       error: `provider_cooldown_until=${providerCooldown.cooldownUntil}; reason=${providerCooldown.reason}`,
       createdAt: providerCooldown.updatedAt,
+      updatedAt: providerCooldown.updatedAt,
       cooldownUntil: providerCooldown.cooldownUntil,
       reason: providerCooldown.reason
     });
@@ -372,6 +470,39 @@ function pushProcessedOrUnprocessed(
   report.summary.unprocessed += 1;
 }
 
+function pushQueuedCoverage(
+  report: CoverageAuditReport,
+  repo: string,
+  pull: PullRequestSummary,
+  queued: CoverageQueueJobCoverage
+): void {
+  if (queued.queueState === "provider_deferred") {
+    report.providerDeferred.push({
+      ...pullEntry(repo, pull),
+      status: "skipped",
+      ...(queued.lastError ? { error: queued.lastError } : {}),
+      createdAt: queued.createdAt,
+      updatedAt: queued.updatedAt,
+      cooldownUntil: queued.nextEligibleAt ?? queued.updatedAt,
+      ...(queued.lastError ? extractProviderDeferredReason(queued.lastError) : {})
+    });
+    report.summary.providerDeferred += 1;
+    return;
+  }
+
+  report.queued.push({
+    ...pullEntry(repo, pull),
+    queueState: queued.queueState,
+    source: queued.source,
+    lane: queued.lane,
+    priority: queued.priority,
+    createdAt: queued.createdAt,
+    updatedAt: queued.updatedAt,
+    ...(queued.nextEligibleAt ? { nextEligibleAt: queued.nextEligibleAt } : {})
+  });
+  report.summary.queued += 1;
+}
+
 function activeProviderCooldown(
   processed: StoredProcessedReviewRecord,
   now: Date
@@ -385,6 +516,10 @@ function activeProviderCooldown(
     cooldownUntil: parsed.cooldownUntil,
     ...(parsed.reason ? { reason: parsed.reason } : {})
   };
+}
+
+function isProcessedProviderCooldownSkip(processed: StoredProcessedReviewRecord): boolean {
+  return processed.status === "skipped" && Boolean(processed.error && parseProviderCooldownError(processed.error));
 }
 
 function pushSkipped(
@@ -438,6 +573,33 @@ interface RepoProviderCooldownRow {
   updated_at: string;
 }
 
+interface ReviewQueueJobCoverageRow {
+  repo: string;
+  pull_number: number;
+  head_sha: string;
+  source: string;
+  lane: string;
+  priority: number;
+  state: ReviewQueueJobState;
+  next_eligible_at: string | null;
+  last_error: string | null;
+  base_sha: string | null;
+  lease_expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface CoverageQueueJobCoverage {
+  queueState: ReviewQueueJobState;
+  source: string;
+  lane: string;
+  priority: number;
+  createdAt: string;
+  updatedAt: string;
+  nextEligibleAt?: string;
+  lastError?: string;
+}
+
 function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRecord {
   return {
     repo: row.repo,
@@ -449,6 +611,47 @@ function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRe
     ...(row.error ? { error: row.error } : {}),
     createdAt: row.created_at
   };
+}
+
+function mapReviewQueueJobCoverageRow(row: ReviewQueueJobCoverageRow): CoverageQueueJobCoverage {
+  return {
+    queueState: row.state,
+    source: row.source,
+    lane: row.lane,
+    priority: row.priority,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    ...(row.next_eligible_at ? { nextEligibleAt: row.next_eligible_at } : {}),
+    ...(row.last_error ? { lastError: row.last_error } : {})
+  };
+}
+
+function isCoverageQueueJobCurrent(
+  row: ReviewQueueJobCoverageRow,
+  baseSha: string,
+  now: Date,
+  leaseTtlMs: number
+): boolean {
+  if (row.source === "automatic" && row.base_sha !== null && row.base_sha !== baseSha) return false;
+  if (row.state !== "leased" && row.state !== "running") return true;
+
+  if (row.lease_expires_at) {
+    const leaseExpiresAtMs = Date.parse(row.lease_expires_at);
+    return Number.isFinite(leaseExpiresAtMs) && leaseExpiresAtMs > now.getTime();
+  }
+
+  const updatedAtMs = Date.parse(row.updated_at);
+  return Number.isFinite(updatedAtMs) && updatedAtMs > now.getTime() - leaseTtlMs;
+}
+
+function extractProviderDeferredReason(error: string): { reason?: string } {
+  const reason = error
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith("reason="))
+    ?.slice("reason=".length)
+    .trim();
+  return { reason: reason || "provider_error" };
 }
 
 function mapRepoProviderCooldownRow(row: RepoProviderCooldownRow): RepoProviderCooldownRecord {

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -6,6 +6,7 @@ import type {
   CoverageAuditReport,
   CoverageProcessedEntry,
   CoverageProviderDeferredEntry,
+  CoverageQueuedEntry,
   CoverageSkippedEntry,
   CoverageStaleHead,
   CoverageUnprocessedEntry
@@ -176,6 +177,7 @@ export interface OperatorQueueSnapshot {
   summary: {
     processed: number;
     providerDeferred: number;
+    queued: number;
     pending: number;
     skipped: number;
     staleHeads: number;
@@ -183,6 +185,7 @@ export interface OperatorQueueSnapshot {
   };
   processed: OperatorQueueEntry[];
   providerDeferred: OperatorQueueEntry[];
+  queued: OperatorQueueEntry[];
   pending: OperatorQueueEntry[];
   skipped: OperatorQueueEntry[];
   staleHeads: OperatorQueueEntry[];
@@ -281,7 +284,14 @@ export interface PullStatusExplanation {
   reason?: string;
   reviewUrl?: string;
   error?: string;
-  nextAction: "none" | "wait_or_retry_provider_cooldown" | "run_or_wait_for_daemon" | "inspect_github_read_failure" | "run_scoped_coverage_audit";
+  nextEligibleAt?: string;
+  nextAction:
+    | "none"
+    | "wait_or_retry_provider_cooldown"
+    | "run_or_wait_for_daemon"
+    | "wait_for_durable_queue_worker"
+    | "inspect_github_read_failure"
+    | "run_scoped_coverage_audit";
 }
 
 export function buildOperatorStatus(input: {
@@ -849,6 +859,7 @@ export function buildOperatorQueue(report: CoverageAuditReport): OperatorQueueSn
     summary: {
       processed: report.processed.length,
       providerDeferred: report.providerDeferred.length,
+      queued: report.queued.length,
       pending: report.unprocessed.length,
       skipped: report.skipped.length,
       staleHeads: report.staleHeads.length,
@@ -856,6 +867,7 @@ export function buildOperatorQueue(report: CoverageAuditReport): OperatorQueueSn
     },
     processed: report.processed.map(processedQueueEntry),
     providerDeferred: report.providerDeferred.map(providerDeferredQueueEntry),
+    queued: report.queued.map(queuedQueueEntry),
     pending: report.unprocessed.map(pendingQueueEntry),
     skipped: report.skipped.map(skippedQueueEntry),
     staleHeads: report.staleHeads.map(staleHeadQueueEntry),
@@ -961,8 +973,30 @@ export function buildOperatorDashboard(input: {
       proofStatus: "pending_review",
       checkStatus: "not_collected",
       reason: redactSecrets(entry.reason ?? entry.error ?? "provider cooldown"),
-      updatedAt: entry.createdAt,
+      updatedAt: entry.updatedAt,
       nextAction: "wait for cooldown expiry or run retry-provider-cooldowns when expired"
+    });
+  }
+
+  for (const entry of input.coverage.queued) {
+    upsertDashboardItem(items, dashboardKey(entry.repo, entry.pullNumber, entry.headSha), {
+      repo: entry.repo,
+      pullNumber: entry.pullNumber,
+      headSha: entry.headSha,
+      title: entry.title,
+      url: entry.url,
+      status: "pending_review",
+      coverageState: "pending_review",
+      queueState: entry.queueState,
+      queueSource: entry.source as ReviewQueueJobRecord["source"],
+      queueLane: entry.lane as ReviewQueueJobRecord["lane"],
+      priority: entry.priority,
+      latestVerdict: entry.queueState,
+      proofStatus: "pending_review",
+      checkStatus: "not_collected",
+      ...(entry.nextEligibleAt ? { reason: `next eligible at ${entry.nextEligibleAt}` } : {}),
+      updatedAt: entry.updatedAt,
+      nextAction: "wait for durable queue worker to review this head"
     });
   }
 
@@ -1149,6 +1183,19 @@ export function explainPullStatus(
     };
   }
 
+  const queued = report.queued.find((entry) => entry.repo === repo && entry.pullNumber === pullNumber);
+  if (queued) {
+    return {
+      repo,
+      pullNumber,
+      state: "pending_review",
+      headSha: queued.headSha,
+      reason: `durable queue state ${queued.queueState}`,
+      ...(queued.nextEligibleAt ? { nextEligibleAt: queued.nextEligibleAt } : {}),
+      nextAction: "wait_for_durable_queue_worker"
+    };
+  }
+
   const pending = report.unprocessed.find((entry) => entry.repo === repo && entry.pullNumber === pullNumber);
   if (pending) {
     return {
@@ -1216,6 +1263,20 @@ function providerDeferredQueueEntry(entry: CoverageProviderDeferredEntry): Opera
     status: entry.status,
     reason: entry.reason ?? entry.error ?? "provider cooldown",
     nextAction: "wait for cooldown expiry or run retry-provider-cooldowns when expired"
+  };
+}
+
+function queuedQueueEntry(entry: CoverageQueuedEntry): OperatorQueueEntry {
+  return {
+    state: "pending_review",
+    repo: entry.repo,
+    pullNumber: entry.pullNumber,
+    headSha: entry.headSha,
+    title: entry.title,
+    url: entry.url,
+    status: entry.queueState,
+    ...(entry.nextEligibleAt ? { reason: `next eligible at ${entry.nextEligibleAt}` } : {}),
+    nextAction: "wait for durable queue worker to review this head"
   };
 }
 

--- a/tests/coverage-audit.test.ts
+++ b/tests/coverage-audit.test.ts
@@ -196,6 +196,472 @@ describe("coverage audit", () => {
     state.close();
   });
 
+  it("reports queued current heads separately from unprocessed misses", async () => {
+    const { root, state } = createState();
+    state.enqueueReviewQueueJob({
+      repo: "owner/allowed",
+      pullNumber: 15,
+      headSha: "head-queued",
+      baseSha: "base",
+      source: "automatic",
+      lane: "background",
+      providerId: "GLM-5.2",
+      now: new Date("2026-07-01T00:01:00.000Z")
+    });
+    state.close();
+    const reader = CoverageStateReader.open(join(root, "state.sqlite"));
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(15, "head-queued")]
+      } as unknown as GitHubApi,
+      state: reader,
+      now: new Date("2026-07-01T00:02:00.000Z")
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      queued: 1,
+      unprocessed: 0
+    });
+    expect(audit.queued).toEqual([
+      expect.objectContaining({
+        repo: "owner/allowed",
+        pullNumber: 15,
+        headSha: "head-queued",
+        queueState: "queued",
+        source: "automatic",
+        lane: "background",
+        priority: 50,
+        createdAt: "2026-07-01T00:01:00.000Z"
+      })
+    ]);
+    reader.close();
+  });
+
+  it("covers legacy automatic queue rows without a base sha", async () => {
+    const { root, state } = createState();
+    state.enqueueReviewQueueJob({
+      repo: "owner/allowed",
+      pullNumber: 21,
+      headSha: "head-legacy-queued",
+      source: "automatic",
+      lane: "background",
+      providerId: "GLM-5.2",
+      now: new Date("2026-07-01T00:01:00.000Z")
+    });
+    state.close();
+    const reader = CoverageStateReader.open(join(root, "state.sqlite"));
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(21, "head-legacy-queued", { baseSha: "new-base" })]
+      } as unknown as GitHubApi,
+      state: reader,
+      now: new Date("2026-07-01T00:02:00.000Z")
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      queued: 1,
+      unprocessed: 0
+    });
+    expect(audit.queued[0]).toMatchObject({
+      pullNumber: 21,
+      headSha: "head-legacy-queued",
+      queueState: "queued",
+      source: "automatic"
+    });
+    reader.close();
+  });
+
+  it("reports provider-deferred queue rows in the provider-deferred bucket", async () => {
+    const { root, state } = createState();
+    state.enqueueReviewQueueJob({
+      repo: "owner/allowed",
+      pullNumber: 22,
+      headSha: "head-provider-deferred",
+      baseSha: "base",
+      source: "automatic",
+      lane: "background",
+      providerId: "GLM-5.2",
+      now: new Date("2026-07-01T00:01:00.000Z")
+    });
+    state.close();
+    const db = new DatabaseSync(join(root, "state.sqlite"));
+    db.prepare(
+      `update review_queue_jobs
+       set state = 'provider_deferred',
+           next_eligible_at = ?,
+           last_error = ?,
+           updated_at = ?
+       where repo = ? and pull_number = ?`
+    ).run(
+      "2026-07-01T00:05:00.000Z",
+      "repo_provider_cooldown_until=2026-07-01T00:05:00.000Z; reason=provider_overloaded",
+      "2026-07-01T00:02:00.000Z",
+      "owner/allowed",
+      22
+    );
+    db.close();
+    const reader = CoverageStateReader.open(join(root, "state.sqlite"));
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(22, "head-provider-deferred")]
+      } as unknown as GitHubApi,
+      state: reader,
+      now: new Date("2026-07-01T00:03:00.000Z")
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      providerDeferred: 1,
+      queued: 0,
+      unprocessed: 0
+    });
+    expect(audit.providerDeferred[0]).toMatchObject({
+      pullNumber: 22,
+      headSha: "head-provider-deferred",
+      status: "skipped",
+      createdAt: "2026-07-01T00:01:00.000Z",
+      updatedAt: "2026-07-01T00:02:00.000Z",
+      cooldownUntil: "2026-07-01T00:05:00.000Z",
+      reason: "provider_overloaded"
+    });
+    reader.close();
+  });
+
+  it("falls back to a stable reason for provider-deferred queue rows with raw errors", async () => {
+    const { root, state } = createState();
+    state.enqueueReviewQueueJob({
+      repo: "owner/allowed",
+      pullNumber: 23,
+      headSha: "head-provider-error",
+      baseSha: "base",
+      source: "automatic",
+      lane: "background",
+      providerId: "GLM-5.2",
+      now: new Date("2026-07-01T00:01:00.000Z")
+    });
+    state.close();
+    const db = new DatabaseSync(join(root, "state.sqlite"));
+    db.prepare(
+      `update review_queue_jobs
+       set state = 'provider_deferred',
+           next_eligible_at = ?,
+           last_error = ?,
+           updated_at = ?
+       where repo = ? and pull_number = ?`
+    ).run(
+      "2026-07-01T00:05:00.000Z",
+      "HTTP 503 from provider",
+      "2026-07-01T00:02:00.000Z",
+      "owner/allowed",
+      23
+    );
+    db.close();
+    const reader = CoverageStateReader.open(join(root, "state.sqlite"));
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(23, "head-provider-error")]
+      } as unknown as GitHubApi,
+      state: reader,
+      now: new Date("2026-07-01T00:03:00.000Z")
+    });
+
+    expect(audit.providerDeferred[0]).toMatchObject({
+      pullNumber: 23,
+      headSha: "head-provider-error",
+      cooldownUntil: "2026-07-01T00:05:00.000Z",
+      reason: "provider_error",
+      error: "HTTP 503 from provider"
+    });
+    reader.close();
+  });
+
+  it("surfaces durable provider-deferred retries before provider-cooldown processed rows", async () => {
+    const { root, state } = createState();
+    state.recordProcessed({
+      repo: "owner/allowed",
+      pullNumber: 24,
+      headSha: "head-retry",
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2026-07-01T00:02:00.000Z; reason=provider_request_rate_limit"
+    });
+    state.enqueueReviewQueueJob({
+      repo: "owner/allowed",
+      pullNumber: 24,
+      headSha: "head-retry",
+      baseSha: "base",
+      source: "automatic",
+      lane: "background",
+      providerId: "GLM-5.2",
+      now: new Date("2026-07-01T00:01:00.000Z")
+    });
+    state.close();
+    const db = new DatabaseSync(join(root, "state.sqlite"));
+    db.prepare(
+      `update review_queue_jobs
+       set state = 'provider_deferred',
+           next_eligible_at = ?,
+           last_error = ?,
+           updated_at = ?
+       where repo = ? and pull_number = ?`
+    ).run(
+      "2026-07-01T00:05:00.000Z",
+      "repo_provider_cooldown_until=2026-07-01T00:05:00.000Z; reason=provider_overloaded",
+      "2026-07-01T00:02:00.000Z",
+      "owner/allowed",
+      24
+    );
+    db.close();
+    const reader = CoverageStateReader.open(join(root, "state.sqlite"));
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(24, "head-retry")]
+      } as unknown as GitHubApi,
+      state: reader,
+      now: new Date("2026-07-01T00:03:00.000Z")
+    });
+
+    expect(audit.summary).toMatchObject({
+      processed: 0,
+      providerDeferred: 1,
+      queued: 0,
+      unprocessed: 0
+    });
+    expect(audit.providerDeferred[0]).toMatchObject({
+      pullNumber: 24,
+      headSha: "head-retry",
+      createdAt: "2026-07-01T00:01:00.000Z",
+      updatedAt: "2026-07-01T00:02:00.000Z",
+      cooldownUntil: "2026-07-01T00:05:00.000Z",
+      reason: "provider_overloaded"
+    });
+    reader.close();
+  });
+
+  it("does not cover current heads with stale or terminal queue rows", async () => {
+    const { root, state } = createState();
+    state.enqueueReviewQueueJob({
+      repo: "owner/allowed",
+      pullNumber: 16,
+      headSha: "old-head",
+      baseSha: "base",
+      source: "automatic",
+      lane: "background"
+    });
+    state.enqueueReviewQueueJob({
+      repo: "owner/allowed",
+      pullNumber: 17,
+      headSha: "head-terminal",
+      baseSha: "base",
+      source: "automatic",
+      lane: "background"
+    });
+    state.close();
+    const db = new DatabaseSync(join(root, "state.sqlite"));
+    db.prepare("update review_queue_jobs set state = 'posted' where repo = ? and pull_number = ?")
+      .run("owner/allowed", 17);
+    db.close();
+    const reader = CoverageStateReader.open(join(root, "state.sqlite"));
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(16, "new-head"), pull(17, "head-terminal")]
+      } as unknown as GitHubApi,
+      state: reader
+    });
+
+    expect(audit.ok).toBe(false);
+    expect(audit.summary).toMatchObject({
+      queued: 0,
+      unprocessed: 2
+    });
+    expect(audit.unprocessed.map((entry) => `${entry.pullNumber}@${entry.headSha}`)).toEqual([
+      "16@new-head",
+      "17@head-terminal"
+    ]);
+    reader.close();
+  });
+
+  it("does not cover automatic queue rows from a different base sha", async () => {
+    const { root, state } = createState();
+    state.enqueueReviewQueueJob({
+      repo: "owner/allowed",
+      pullNumber: 18,
+      headSha: "head-same",
+      baseSha: "old-base",
+      source: "automatic",
+      lane: "background"
+    });
+    state.close();
+    const reader = CoverageStateReader.open(join(root, "state.sqlite"));
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(18, "head-same", { baseSha: "base" })]
+      } as unknown as GitHubApi,
+      state: reader
+    });
+
+    expect(audit.ok).toBe(false);
+    expect(audit.summary).toMatchObject({
+      queued: 0,
+      unprocessed: 1
+    });
+    expect(audit.unprocessed[0]).toMatchObject({ pullNumber: 18, headSha: "head-same" });
+    reader.close();
+  });
+
+  it("does not cover expired leased queue rows", async () => {
+    const { root, state } = createState();
+    state.enqueueReviewQueueJob({
+      repo: "owner/allowed",
+      pullNumber: 19,
+      headSha: "head-expired-lease",
+      baseSha: "base",
+      source: "automatic",
+      lane: "background",
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    state.close();
+    const db = new DatabaseSync(join(root, "state.sqlite"));
+    db.prepare(
+      `update review_queue_jobs
+       set state = 'leased',
+           lease_expires_at = ?,
+           updated_at = ?
+       where repo = ? and pull_number = ?`
+    ).run(
+      "2026-07-01T00:02:00.000Z",
+      "2026-07-01T00:01:00.000Z",
+      "owner/allowed",
+      19
+    );
+    db.close();
+    const reader = CoverageStateReader.open(join(root, "state.sqlite"));
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(19, "head-expired-lease")]
+      } as unknown as GitHubApi,
+      state: reader,
+      now: new Date("2026-07-01T00:03:00.000Z")
+    });
+
+    expect(audit.ok).toBe(false);
+    expect(audit.summary).toMatchObject({
+      queued: 0,
+      unprocessed: 1
+    });
+    expect(audit.unprocessed[0]).toMatchObject({ pullNumber: 19, headSha: "head-expired-lease" });
+    reader.close();
+  });
+
+  it("covers leased queue rows while their lease is still active", async () => {
+    const { root, state } = createState();
+    state.enqueueReviewQueueJob({
+      repo: "owner/allowed",
+      pullNumber: 20,
+      headSha: "head-active-lease",
+      baseSha: "base",
+      source: "automatic",
+      lane: "background",
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    state.close();
+    const db = new DatabaseSync(join(root, "state.sqlite"));
+    db.prepare(
+      `update review_queue_jobs
+       set state = 'leased',
+           lease_expires_at = ?,
+           updated_at = ?
+       where repo = ? and pull_number = ?`
+    ).run(
+      "2026-07-01T00:04:00.000Z",
+      "2026-07-01T00:01:00.000Z",
+      "owner/allowed",
+      20
+    );
+    db.close();
+    const reader = CoverageStateReader.open(join(root, "state.sqlite"));
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(20, "head-active-lease")]
+      } as unknown as GitHubApi,
+      state: reader,
+      now: new Date("2026-07-01T00:03:00.000Z")
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      queued: 1,
+      unprocessed: 0
+    });
+    expect(audit.queued[0]).toMatchObject({ pullNumber: 20, headSha: "head-active-lease", queueState: "leased" });
+    reader.close();
+  });
+
+  it("covers running queue rows while their lease is still active", async () => {
+    const { root, state } = createState();
+    state.enqueueReviewQueueJob({
+      repo: "owner/allowed",
+      pullNumber: 25,
+      headSha: "head-running",
+      baseSha: "base",
+      source: "automatic",
+      lane: "background",
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    state.close();
+    const db = new DatabaseSync(join(root, "state.sqlite"));
+    db.prepare(
+      `update review_queue_jobs
+       set state = 'running',
+           lease_expires_at = ?,
+           updated_at = ?
+       where repo = ? and pull_number = ?`
+    ).run(
+      "2026-07-01T00:04:00.000Z",
+      "2026-07-01T00:01:00.000Z",
+      "owner/allowed",
+      25
+    );
+    db.close();
+    const reader = CoverageStateReader.open(join(root, "state.sqlite"));
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(25, "head-running")]
+      } as unknown as GitHubApi,
+      state: reader,
+      now: new Date("2026-07-01T00:03:00.000Z")
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      queued: 1,
+      unprocessed: 0
+    });
+    expect(audit.queued[0]).toMatchObject({ pullNumber: 25, headSha: "head-running", queueState: "running" });
+    reader.close();
+  });
+
   it("supports canary and single-PR scoping without marking closed PRs as misses", async () => {
     const { root, state } = createState();
     let getPullCount = 0;
@@ -498,7 +964,7 @@ function minimalConfig(root: string): BotConfig {
 function pull(
   number: number,
   headSha: string,
-  options: { draft?: boolean; state?: string } = {}
+  options: { draft?: boolean; state?: string; baseSha?: string } = {}
 ): PullRequestSummary {
   return {
     number,
@@ -511,7 +977,7 @@ function pull(
       repo: { full_name: "owner/allowed" }
     },
     base: {
-      sha: "base",
+      sha: options.baseSha ?? "base",
       ref: "main",
       repo: { full_name: "owner/allowed" }
     },

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
-import type { CoverageAuditReport } from "../src/coverage-audit.js";
+import type { CoverageAuditReport, CoverageQueuedEntry } from "../src/coverage-audit.js";
 import {
   buildOperatorDashboard,
   buildRuntimeInventory,
@@ -397,6 +397,70 @@ describe("operator CLI summaries", () => {
     });
   });
 
+  it("maps coverage queued rows into dashboard metadata without losing cooldown timing", () => {
+    const dashboard = buildOperatorDashboard({
+      coverage: coverageReport({
+        ok: true,
+        queued: [
+          queuedEntry(6, "head-queued", {
+            queueState: "running",
+            source: "manual_command",
+            lane: "manual",
+            priority: 7,
+            nextEligibleAt: "2026-07-01T00:05:00.000Z",
+            updatedAt: "2026-07-01T00:02:00.000Z"
+          })
+        ]
+      }),
+      checkedAt: "2026-07-02T00:00:00.000Z"
+    });
+
+    expect(dashboard.ok).toBe(true);
+    expect(dashboard.items).toEqual([
+      expect.objectContaining({
+        repo: "owner/repo",
+        pullNumber: 6,
+        headSha: "head-queued",
+        status: "pending_review",
+        coverageState: "pending_review",
+        queueState: "running",
+        queueSource: "manual_command",
+        queueLane: "manual",
+        priority: 7,
+        latestVerdict: "running",
+        proofStatus: "pending_review",
+        reason: "next eligible at 2026-07-01T00:05:00.000Z",
+        updatedAt: "2026-07-01T00:02:00.000Z",
+        nextAction: "wait for durable queue worker to review this head"
+      })
+    ]);
+  });
+
+  it("uses provider-deferred coverage updatedAt for dashboard freshness", () => {
+    const dashboard = buildOperatorDashboard({
+      coverage: coverageReport({
+        ok: true,
+        providerDeferred: [
+          providerDeferredEntry(7, "head-provider", {
+            createdAt: "2026-07-01T00:01:00.000Z",
+            updatedAt: "2026-07-01T00:02:00.000Z"
+          })
+        ]
+      }),
+      checkedAt: "2026-07-02T00:00:00.000Z"
+    });
+
+    expect(dashboard.items).toEqual([
+      expect.objectContaining({
+        repo: "owner/repo",
+        pullNumber: 7,
+        status: "provider_deferred",
+        reason: "provider_request_rate_limit",
+        updatedAt: "2026-07-01T00:02:00.000Z"
+      })
+    ]);
+  });
+
   it("preserves the strongest blocked dashboard source when later sources are benign", () => {
     const dashboard = buildOperatorDashboard({
       coverage: coverageReport({ ok: true, processed: [processedEntry(7, "head-failed", "posted")] }),
@@ -715,6 +779,7 @@ describe("operator CLI summaries", () => {
     const queue = buildOperatorQueue(coverageReport({
       processed: [processedEntry(1, "head-posted", "posted")],
       providerDeferred: [providerDeferredEntry(2, "head-provider")],
+      queued: [queuedEntry(6, "head-queued")],
       unprocessed: [pullEntry(3, "head-pending")],
       skipped: [{ repo: "owner/repo", pullNumber: 4, headSha: "head-draft", reason: "draft" }],
       staleHeads: [{
@@ -731,12 +796,14 @@ describe("operator CLI summaries", () => {
     expect(queue.summary).toMatchObject({
       processed: 1,
       providerDeferred: 1,
+      queued: 1,
       pending: 1,
       skipped: 1,
       staleHeads: 1
     });
     expect(queue.pending[0]).toMatchObject({ pullNumber: 3, state: "pending_review" });
     expect(queue.providerDeferred[0]).toMatchObject({ pullNumber: 2, state: "provider_deferred" });
+    expect(queue.queued[0]).toMatchObject({ pullNumber: 6, state: "pending_review", status: "queued" });
   });
 
   it("reads review readiness rows from SQLite without creating or mutating state", () => {
@@ -772,6 +839,12 @@ describe("operator CLI summaries", () => {
     const report = coverageReport({
       processed: [processedEntry(1, "head-posted", "posted")],
       providerDeferred: [providerDeferredEntry(2, "head-cooldown")],
+      queued: [
+        queuedEntry(6, "head-queued", {
+          queueState: "running",
+          nextEligibleAt: "2026-07-01T00:05:00.000Z"
+        })
+      ],
       unprocessed: [pullEntry(3, "head-pending")],
       skipped: [{ repo: "owner/repo", pullNumber: 4, headSha: "head-draft", reason: "draft" }],
       readFailures: [{ repo: "owner/read-fail", error: "GitHub API failed" }]
@@ -788,6 +861,12 @@ describe("operator CLI summaries", () => {
     expect(explainPullStatus(report, "owner/repo", 3)).toMatchObject({
       state: "pending_review",
       nextAction: "run_or_wait_for_daemon"
+    });
+    expect(explainPullStatus(report, "owner/repo", 6)).toMatchObject({
+      state: "pending_review",
+      reason: "durable queue state running",
+      nextEligibleAt: "2026-07-01T00:05:00.000Z",
+      nextAction: "wait_for_durable_queue_worker"
     });
     expect(explainPullStatus(report, "owner/repo", 4)).toMatchObject({
       state: "skipped",
@@ -980,6 +1059,7 @@ function coverageReport(input: Partial<CoverageAuditReport>): CoverageAuditRepor
       pullsSeen: 0,
       processed: input.processed?.length ?? 0,
       providerDeferred: input.providerDeferred?.length ?? 0,
+      queued: input.queued?.length ?? 0,
       unprocessed: input.unprocessed?.length ?? 0,
       skipped: input.skipped?.length ?? 0,
       staleHeads: input.staleHeads?.length ?? 0,
@@ -987,6 +1067,7 @@ function coverageReport(input: Partial<CoverageAuditReport>): CoverageAuditRepor
     },
     processed: input.processed ?? [],
     providerDeferred: input.providerDeferred ?? [],
+    queued: input.queued ?? [],
     unprocessed: input.unprocessed ?? [],
     skipped: input.skipped ?? [],
     staleHeads: input.staleHeads ?? [],
@@ -995,6 +1076,7 @@ function coverageReport(input: Partial<CoverageAuditReport>): CoverageAuditRepor
   report.summary.pullsSeen =
     report.summary.processed +
     report.summary.providerDeferred +
+    report.summary.queued +
     report.summary.unprocessed +
     report.summary.skipped +
     report.summary.staleHeads;
@@ -1023,11 +1105,34 @@ function processedEntry(pullNumber: number, headSha: string, status: "posted" | 
   };
 }
 
-function providerDeferredEntry(pullNumber: number, headSha: string) {
+function providerDeferredEntry(
+  pullNumber: number,
+  headSha: string,
+  overrides: Partial<CoverageAuditReport["providerDeferred"][number]> = {}
+) {
   return {
     ...processedEntry(pullNumber, headSha, "skipped"),
     cooldownUntil: "2026-07-01T00:05:00.000Z",
-    reason: "provider_request_rate_limit"
+    reason: "provider_request_rate_limit",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    ...overrides
+  };
+}
+
+function queuedEntry(
+  pullNumber: number,
+  headSha: string,
+  overrides: Partial<CoverageQueuedEntry> = {}
+): CoverageQueuedEntry {
+  return {
+    ...pullEntry(pullNumber, headSha),
+    queueState: "queued" as const,
+    source: "automatic",
+    lane: "background",
+    priority: 50,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    ...overrides
   };
 }
 


### PR DESCRIPTION
## Summary

Closes #130.

Adds a queue-covered bucket to coverage-audit so current eligible PR heads with exact durable review_queue_jobs rows are reported as queued pending review instead of unprocessed misses.

## Changes

- Add summary.queued and queued entries to coverage-audit output.
- Read exact repo, pull_number, and head_sha queue rows from review_queue_jobs when state is queued, leased, running, or provider_deferred.
- Keep stale queue rows and terminal queue states fail-closed as unprocessed.
- Surface queued entries through operator queue, dashboard, and pull explanation paths.

## Validation

- npm test -- tests/coverage-audit.test.ts tests/operator-cli.test.ts
- npm run build
- git diff --check

## Proof boundary

This fixes operator coverage classification for queued current heads. It does not claim those heads were reviewed; it makes the pending queue state explicit until the worker completes them.