### PR TITLE
Fix low-signal review filters and session health

### DIFF
--- a/config.active-profiles.example.json
+++ b/config.active-profiles.example.json
@@ -59,7 +59,7 @@
           "baseBranches": ["main"],
           "labels": ["!wip", "!do-not-review"]
         },
-        "pathFilters": ["Assets/**", "Packages/**", "ProjectSettings/**", "extensions/**", "qa/**", "src/**", "tests/**", "!Library/**", "!Temp/**"],
+        "pathFilters": ["Assets/**", "Packages/**", "ProjectSettings/**", "extensions/**", "qa/**", "servers/**", "src/**", "tests/**", "!Library/**", "!Temp/**"],
         "pathInstructions": {
           "Assets/**": ["Prioritize scene, prefab, save-state, asset-reference, and gameplay regressions."],
           "ProjectSettings/**": ["Treat build, platform, input, graphics, and release behavior changes as high risk."]
@@ -515,7 +515,7 @@
           "baseBranches": ["main"],
           "labels": ["!wip", "!do-not-review"]
         },
-        "pathFilters": ["src/**", "scripts/**", "tests/**", "docs/**", "package.json", "package-lock.json"],
+        "pathFilters": ["packages/**", "src/**", "scripts/**", "tests/**", "docs/**", "package.json", "package-lock.json"],
         "riskyPaths": ["src/**", "scripts/**"],
         "proofExpectations": ["Look for focused sanitizer, signature, orchestration, or fixture proof."],
         "validationHints": ["Call out evidence leakage, replay/collision risks, duplicate side effects, and brittle sanitizer logic."],

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -37,11 +37,14 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
 - `dashboard`: read-only PR review dashboard over coverage, durable queue,
   readiness lifecycle rows, GitHub PR links, and local evidence-path hints.
   Filter with `--repo`, `--status`, `--priority`, `--stale-head-reason`, and
-  `--limit`. Use `--job-limit` to cap durable-queue/readiness rows read from
-  SQLite before merging; `--limit` caps the final merged item list. JSON is the
-  default; use `--human` for a compact operator view. The command exits nonzero
-  when visible rows are blocked; healthy active rows are counted but do not fail
-  the gate by themselves.
+  `--limit`. By default the dashboard hides stale-only historical rows so the
+  operator gate reflects current-head health; use `--include-history true` or an
+  explicit stale status filter when investigating historical rows. Use
+  `--job-limit` to cap durable-queue/readiness rows read from SQLite before
+  merging; `--limit` caps the final merged item list. JSON is the default; use
+  `--human` for a compact operator view. The command exits nonzero when visible
+  rows are blocked; healthy active rows are counted but do not fail the gate by
+  themselves.
 - `budget-status`: read-only scheduler budget projection. Shows active counts,
   queued counts, would-lease jobs, delayed jobs, and deterministic delay reasons
   such as `provider_cooldown`, `provider_capacity`, `org_capacity`,
@@ -141,6 +144,12 @@ Show dashboard rows blocked on proof:
 
 ```bash
 npx tsx src/cli.ts dashboard --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --status blocked_on_proof
+```
+
+Include stale-only historical rows when diagnosing old heads:
+
+```bash
+npx tsx src/cli.ts dashboard --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --include-history true
 ```
 
 Show one repo as a short human dashboard:

--- a/docs/releases/v0.4.1-beta.2.md
+++ b/docs/releases/v0.4.1-beta.2.md
@@ -1,0 +1,117 @@
+# v0.4.1-beta.2
+
+- Release type: local beta incident patch for review-yield and runtime truth
+- Tracking issue: `#134`
+- Architecture tracker: `#78`
+- Implementation PR: `#136`
+- Release tag target: release packet commit for `v0.4.1-beta.2`
+- Previous live release: `v0.4.1-beta.1` (`66275a07d938ed90193086d3fba4f0f3005b5c22`)
+- Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- launchd label: `com.electricsheephq.evaos-code-review-bot`
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+- State DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
+- Evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-02/v0.4.1-beta.2/`
+- Monitor owner/window: implementing agent, first post-promotion health check
+- Rollback SHA/tag: `v0.4.1-beta.1`
+- Rollback command:
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard v0.4.1-beta.1
+cp /Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-02/v0.4.1-beta.2/active-installed-live.before-v0.4.1-beta.2.json \
+  /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+## Purpose
+
+Fix a live product/runtime quality incident where recent App-authored reviews
+were walkthrough-only despite nearby review surfaces finding actionable bugs.
+
+The audit proved the primary low-yield path was review-surface selection, not
+ZCode JSON parsing or deterministic-gate dropping: implementation files for
+WorldOS and LCO were filtered out before prompt construction.
+
+## Changes
+
+- Add WorldOS `servers/**` to active-profile path filters so server runtime
+  implementation and tests are reviewable.
+- Add LCO `packages/**` to active-profile path filters so package workspace
+  implementation changes are reviewable.
+- Add active-profile regression coverage for the exact WorldOS and LCO incident
+  file families.
+- Reconcile reviewer sessions at scheduler-cycle boundaries so expired sessions
+  and dead owner PIDs cannot remain indefinitely active.
+- Exclude reviewer sessions with dead worker PIDs from active release-status
+  counts.
+- Treat bounded active daemon heartbeats as healthy in `agents`.
+- Make `dashboard` default to current-health semantics by hiding stale-only
+  historical rows unless `--include-history true` or a stale filter is supplied.
+
+## Live Config Change
+
+Yes. This release updates only repo-profile path filters in
+`active-installed-live.json`:
+
+- `electricsheephq/WorldOS`: add `servers/**`.
+- `100yenadmin/Lossless-Codex-Orchestrator-LCO`: add `packages/**`.
+
+No other live config flags change. `githubRelatedContext.enabled`,
+`repoMemory.enabled`, `gitnexusContext.enabled`, `skillPacks.enabled`,
+`enrichment.enabled`, and calibration/eval activation remain off.
+`reviewConcurrency.maxActiveRuns` remains `1`.
+
+## Gates
+
+- Implementation PR:
+  - PR `#136`: GitHub checks green (`CodeRabbit`, `Socket Security: Project
+    Report`, `Socket Security: Pull Request Alerts`) before release promotion.
+  - CodeRabbit posted a rate-limit/status comment only; no current-head review
+    threads or actionable findings existed before release-packet publication.
+- Focused validation:
+  - `npm test -- tests/repo-policy.test.ts tests/operator-cli.test.ts tests/state.test.ts tests/release-status.test.ts tests/scheduler.test.ts --pool=forks --maxWorkers=1`: 137 tests passed.
+  - `npm run build`: passed.
+  - `git diff --check`: passed.
+- Audit evidence:
+  - Low-signal reviews had zero parser retries, zero dropped findings, and raw
+    ZCode output consistent with deterministic-gate output.
+  - WorldOS #1261 sent an empty effective diff because all changed files were
+    outside configured review filters.
+  - LCO #317/#320 omitted package implementation files because `packages/**`
+    was not visible to the active profile.
+  - WorldOS #1267 was not a low-yield sample; local DB classified it as
+    closed/retired before review.
+
+## Runtime Notes
+
+- This release does not enable repo memory, GitNexus context, GitHub related
+  context, skill packs, enrichment posting, native ZCode skills, MCP, shell,
+  web, auto-merge, approvals, or repo mutation.
+- The live config does not store GitHub credentials. Operator commands that
+  read GitHub directly still need App credentials or an explicit ephemeral
+  `GITHUB_TOKEN` in the shell.
+- The WorldOS merge-policy gap remains separate: bot status comments are
+  coordination only and do not block merges. Enforcing unresolved-review-thread
+  merges belongs to branch protection/rulesets or a future required bot check.
+- Historical stale dashboard rows remain inspectable with
+  `dashboard --include-history true`.
+
+## Notes
+
+- What changed: active review-surface filters, reviewer-session cleanup,
+  release/session health accounting, dashboard current-health defaults, and
+  focused regressions.
+- What did not change: monitored repos, GitHub App permissions, live
+  concurrency, posting policy, context/enrichment feature activation, native
+  skills/MCP/tools, auto-merge, approvals, labels/reviewers, or target-repo
+  mutation.
+- Open follow-ups: dry-run promotion decision for `githubRelatedContext`;
+  GitNexus fresh-index dry-runs before any live enablement; branch/ruleset
+  enforcement for unresolved review-thread merges; CodeRabbit rate-limit
+  review availability if a human wants an additional third-party review.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -307,6 +307,7 @@ async function main(): Promise<void> {
         ...(args.status ?? args.state ? { status: args.status ?? args.state } : {}),
         ...(args.priority ? { priority: parseNonNegativeInteger(args.priority, "--priority") } : {}),
         ...(args["stale-head-reason"] ? { staleHeadReason: args["stale-head-reason"] } : {}),
+        ...(args["include-history"] === "true" ? { includeHistory: true } : {}),
         ...(args.limit ? { limit: parsePositiveInteger(args.limit, "--limit") } : {})
       }
     });

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -197,6 +197,7 @@ export interface OperatorDashboardFilters {
   status?: string;
   priority?: number;
   staleHeadReason?: string;
+  includeHistory?: boolean;
   limit?: number;
 }
 
@@ -241,6 +242,7 @@ export interface OperatorDashboard {
     checkBlocks: number;
     failed: number;
     providerDeferred: number;
+    hiddenHistoricalStale: number;
   };
   items: OperatorDashboardItem[];
 }
@@ -673,7 +675,7 @@ export function summarizeAgentInventory(input: {
   }
 
   return {
-    ok: input.launchd.state === "running" && input.heartbeat.status === "fresh" && staleLeases.length === 0,
+    ok: input.launchd.state === "running" && isHealthyAgentHeartbeat(input.heartbeat) && staleLeases.length === 0,
     checkedAt: input.checkedAt ?? now.toISOString(),
     launchd: input.launchd,
     heartbeat: input.heartbeat,
@@ -1113,13 +1115,19 @@ export function buildOperatorDashboard(input: {
   const filtered = withEvidence
     .filter((item) => dashboardItemMatches(item, filters))
     .sort(compareDashboardItems);
-  const visible = filters.limit ? filtered.slice(0, filters.limit) : filtered;
+  const includeHistory = filters.includeHistory === true || Boolean(filters.status || filters.staleHeadReason);
+  const hiddenHistoricalStale = includeHistory ? 0 : filtered.filter(isHistoricalStaleDashboardItem).length;
+  const currentItems = includeHistory ? filtered : filtered.filter((item) => !isHistoricalStaleDashboardItem(item));
+  const visible = filters.limit ? currentItems.slice(0, filters.limit) : currentItems;
 
   return {
     ok: visible.every((item) => !isDashboardItemBlocked(item)),
     checkedAt,
     filters,
-    summary: summarizeDashboardItems(visible),
+    summary: {
+      ...summarizeDashboardItems(visible),
+      hiddenHistoricalStale
+    },
     items: visible
   };
 }
@@ -1446,6 +1454,7 @@ function compactDashboardFilters(filters: OperatorDashboardFilters): OperatorDas
     ...(filters.status ? { status: filters.status } : {}),
     ...(filters.priority !== undefined ? { priority: filters.priority } : {}),
     ...(filters.staleHeadReason ? { staleHeadReason: filters.staleHeadReason } : {}),
+    ...(filters.includeHistory === true ? { includeHistory: true } : {}),
     ...(filters.limit !== undefined ? { limit: filters.limit } : {})
   };
 }
@@ -1494,8 +1503,15 @@ function summarizeDashboardItems(items: OperatorDashboardItem[]): OperatorDashbo
     proofGaps: items.filter((item) => item.proofStatus === "blocked_on_proof").length,
     checkBlocks: items.filter((item) => item.checkStatus === "blocked_on_checks").length,
     failed: items.filter((item) => dashboardStatuses(item).includes("failed")).length,
-    providerDeferred: items.filter((item) => dashboardStatuses(item).includes("provider_deferred")).length
+    providerDeferred: items.filter((item) => dashboardStatuses(item).includes("provider_deferred")).length,
+    hiddenHistoricalStale: 0
   };
+}
+
+function isHistoricalStaleDashboardItem(item: OperatorDashboardItem): boolean {
+  if (item.coverageState === "stale_head") return false;
+  const statuses = dashboardStatuses(item);
+  return statuses.length > 0 && statuses.every((status) => status === "stale" || status === "stale_head" || status === "stale_retired");
 }
 
 function isDashboardItemBlocked(item: OperatorDashboardItem): boolean {
@@ -1515,6 +1531,10 @@ function isDashboardItemBlocked(item: OperatorDashboardItem): boolean {
 function dashboardStatuses(item: OperatorDashboardItem): string[] {
   return [item.status, item.coverageState, item.queueState, item.readinessState]
     .filter((status): status is string => Boolean(status));
+}
+
+function isHealthyAgentHeartbeat(heartbeat: ReleaseHeartbeatStatus): boolean {
+  return heartbeat.status === "fresh" || heartbeat.status === "active";
 }
 
 function isActiveDashboardStatus(status: string): boolean {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -563,54 +563,47 @@ function readReviewerSessionCounts(
     .prepare("select 1 from sqlite_master where type = 'table' and name = 'reviewer_sessions' limit 1")
     .get();
   if (!hasTable) return { total: 0, active: 0, expired: 0, byRepo: [] };
-  const activeSql = `
-    state in ('active', 'warming')
-    and datetime(expires_at) > datetime(?)
-    and head_count_used < head_count_limit
-  `;
-  const expiredSql = `
-    state = 'expired'
-    or datetime(expires_at) is null
-    or datetime(expires_at) <= datetime(?)
-    or head_count_used >= head_count_limit
-  `;
-  const row = db
+  const rows = db
     .prepare(
-      `select
-         count(*) as total,
-         sum(case when ${activeSql} then 1 else 0 end) as active,
-         sum(case when ${expiredSql} then 1 else 0 end) as expired
+      `select repo, state, expires_at, head_count_used, head_count_limit, worker_pid
        from reviewer_sessions`
     )
-    .get(now.toISOString(), now.toISOString()) as { total?: number; active?: number | null; expired?: number | null };
-  const byRepoRows = db
-    .prepare(
-      `select
-         repo,
-         count(*) as total,
-         sum(case when ${activeSql} then 1 else 0 end) as active,
-         sum(case when ${expiredSql} then 1 else 0 end) as expired
-       from reviewer_sessions
-       group by repo
-       order by repo`
-    )
-    .all(now.toISOString(), now.toISOString()) as unknown as Array<{
-      repo: string;
-      total?: number;
-      active?: number | null;
-      expired?: number | null;
-    }>;
+    .all() as unknown as ReviewerSessionCountRow[];
+  const byRepo = new Map<string, ReviewerSessionRepoStatus>();
+  for (const row of rows) {
+    const repoStatus = byRepo.get(row.repo) ?? { repo: row.repo, total: 0, active: 0, expired: 0 };
+    repoStatus.total += 1;
+    if (isReviewerSessionActiveForStatus(row, now)) repoStatus.active += 1;
+    if (isReviewerSessionExpiredForStatus(row, now)) repoStatus.expired += 1;
+    byRepo.set(row.repo, repoStatus);
+  }
   return {
-    total: row.total ?? 0,
-    active: row.active ?? 0,
-    expired: row.expired ?? 0,
-    byRepo: byRepoRows.map((repoRow) => ({
-      repo: repoRow.repo,
-      total: repoRow.total ?? 0,
-      active: repoRow.active ?? 0,
-      expired: repoRow.expired ?? 0
-    }))
+    total: rows.length,
+    active: rows.filter((row) => isReviewerSessionActiveForStatus(row, now)).length,
+    expired: rows.filter((row) => isReviewerSessionExpiredForStatus(row, now)).length,
+    byRepo: [...byRepo.values()].sort((left, right) => left.repo.localeCompare(right.repo))
   };
+}
+
+interface ReviewerSessionCountRow {
+  repo: string;
+  state: string;
+  expires_at: string | null;
+  head_count_used: number;
+  head_count_limit: number;
+  worker_pid: number | null;
+}
+
+function isReviewerSessionActiveForStatus(row: ReviewerSessionCountRow, now: Date): boolean {
+  if (row.state !== "active" && row.state !== "warming") return false;
+  if (row.worker_pid !== null && !isProcessAlive(row.worker_pid)) return false;
+  const expiresAtMs = row.expires_at ? Date.parse(row.expires_at) : Number.NaN;
+  return Number.isFinite(expiresAtMs) && expiresAtMs > now.getTime() && row.head_count_used < row.head_count_limit;
+}
+
+function isReviewerSessionExpiredForStatus(row: ReviewerSessionCountRow, now: Date): boolean {
+  const expiresAtMs = row.expires_at ? Date.parse(row.expires_at) : Number.NaN;
+  return row.state === "expired" || !Number.isFinite(expiresAtMs) || expiresAtMs <= now.getTime() || row.head_count_used >= row.head_count_limit;
 }
 
 interface ProviderCooldownCandidate {
@@ -848,6 +841,18 @@ function describeHeartbeat(heartbeat: ReleaseHeartbeatStatus): string {
 
 function git(cwd: string, args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = typeof error === "object" && error !== null && "code" in error
+      ? (error as { code?: unknown }).code
+      : undefined;
+    return code === "EPERM";
+  }
 }
 
 interface QueueCountRow {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -103,6 +103,9 @@ export async function runScheduledCycleWithDeps(input: {
   const eventClock = input.clock ?? (() => input.now ?? new Date());
   const repos = input.options.repo ? [input.options.repo] : listReposToScan(config);
   const providerId = config.zcode.providerId ?? config.zcode.model ?? "zcode";
+  if (config.reviewerSessions?.enabled) {
+    input.state.reconcileReviewerSessions(now, input.options.repo);
+  }
 
   for (const repo of repos) {
     result.reposScanned += 1;

--- a/src/state.ts
+++ b/src/state.ts
@@ -1280,6 +1280,38 @@ export class ReviewStateStore {
     return Number(result.changes);
   }
 
+  reconcileReviewerSessions(now = new Date(), repo?: string): { expired: number; failedDeadWorkers: number } {
+    const expired = this.expireReviewerSessions(now, repo);
+    const rows = (repo
+      ? this.db
+          .prepare(
+            `select session_id, worker_pid
+             from reviewer_sessions
+             where repo = ?
+               and state in ('warming', 'active', 'draining')
+               and worker_pid is not null`
+          )
+          .all(repo)
+      : this.db
+          .prepare(
+            `select session_id, worker_pid
+             from reviewer_sessions
+             where state in ('warming', 'active', 'draining')
+               and worker_pid is not null`
+          )
+          .all()) as unknown as Array<{ session_id: string; worker_pid: number | null }>;
+
+    let failedDeadWorkers = 0;
+    for (const row of rows) {
+      if (row.worker_pid === null || isProcessAlive(row.worker_pid)) continue;
+      const result = this.db
+        .prepare("update reviewer_sessions set state = 'failed', last_error = ? where session_id = ?")
+        .run(`owner_pid_not_alive:${row.worker_pid}`, row.session_id);
+      failedDeadWorkers += Number(result.changes);
+    }
+    return { expired, failedDeadWorkers };
+  }
+
   private pruneInactiveReviewRunLeases(): void {
     const rows = this.db
       .prepare("select lease_id, owner_pid from review_run_leases")

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -314,6 +314,67 @@ describe("operator CLI summaries", () => {
     expect(JSON.stringify(dashboard)).not.toMatch(/ghp_123456789012345678901234/);
   });
 
+  it("hides historical stale-only dashboard rows by default while preserving explicit history filters", () => {
+    const input = {
+      coverage: coverageReport({
+        ok: true,
+        processed: [processedEntry(1, "head-current", "posted")]
+      }),
+      durableQueue: durableQueueSnapshot({
+        jobs: [
+          durableJob({
+            repo: "owner/repo",
+            pullNumber: 2,
+            headSha: "old-head",
+            state: "stale_retired",
+            lastError: "superseded_by_head=new-head"
+          })
+        ],
+        summary: { total: 1, queued: 0, failed: 0, running: 0, providerDeferred: 0, retryableProviderDeferred: 0 }
+      }),
+      readiness: [{
+        repo: "owner/repo",
+        pullNumber: 2,
+        headSha: "old-head",
+        state: "stale" as const,
+        reason: "superseded_by_head=new-head",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-01T00:01:00.000Z"
+      }],
+      checkedAt: "2026-07-02T00:00:00.000Z"
+    };
+
+    const currentDashboard = buildOperatorDashboard(input);
+    expect(currentDashboard.ok).toBe(true);
+    expect(currentDashboard.summary).toMatchObject({
+      totalItems: 1,
+      blockedItems: 0,
+      staleHeads: 0,
+      hiddenHistoricalStale: 1
+    });
+    expect(currentDashboard.items.map((item) => `${item.repo}#${item.pullNumber}:${item.status}`)).toEqual([
+      "owner/repo#1:processed"
+    ]);
+
+    const historicalDashboard = buildOperatorDashboard({
+      ...input,
+      filters: { includeHistory: true, status: "stale" }
+    });
+    expect(historicalDashboard.ok).toBe(false);
+    expect(historicalDashboard.summary).toMatchObject({
+      totalItems: 1,
+      blockedItems: 1,
+      staleHeads: 1,
+      hiddenHistoricalStale: 0
+    });
+    expect(historicalDashboard.items[0]).toMatchObject({
+      repo: "owner/repo",
+      pullNumber: 2,
+      status: "stale",
+      readinessState: "stale"
+    });
+  });
+
   it("filters dashboard rows by repo, status, priority, and stale-head reason", () => {
     const input = {
       coverage: coverageReport({
@@ -662,6 +723,32 @@ describe("operator CLI summaries", () => {
       expect.objectContaining({ leaseId: "expired", staleReason: "expired" }),
       expect.objectContaining({ leaseId: "dead-owner", staleReason: "owner_not_running" })
     ]);
+  });
+
+  it("treats a bounded active heartbeat as healthy for live agent inventory", () => {
+    const inventory = summarizeAgentInventory({
+      launchd: { label: "com.electricsheephq.evaos-code-review-bot", state: "running", pid: 1234, dryRun: false },
+      heartbeat: {
+        status: "active",
+        maxAgeMs: 120_000,
+        activeMaxAgeMs: 660_000,
+        latestAt: "2026-07-01T00:00:10.000Z",
+        ageMs: 180_000,
+        cycle: 42,
+        event: "daemon_cycle_complete",
+        dryRun: false,
+        activeCycle: 43,
+        activeStartedAt: "2026-07-01T00:02:00.000Z",
+        activeAgeMs: 60_000
+      },
+      leases: [
+        lease("active", "2026-07-01T00:02:00.000Z", "2026-07-01T00:17:00.000Z", 1234, true)
+      ],
+      now: new Date("2026-07-01T00:03:00.000Z")
+    });
+
+    expect(inventory.ok).toBe(true);
+    expect(inventory.summary).toMatchObject({ activeLeases: 1, staleLeases: 0 });
   });
 
   it("prefers dead-owner lease diagnostics over expiry when both are true", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -778,6 +778,21 @@ describe("beta release status", () => {
         10,
         10
       );
+      db.prepare(
+        `insert into reviewer_sessions
+          (session_id, repo, state, started_at, last_used_at, expires_at, head_count_used, head_count_limit, worker_pid)
+         values (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        "dead-worker-active-session",
+        "electricsheephq/evaos-code-review-bot",
+        "active",
+        "2026-07-01T00:00:00.000Z",
+        "2026-07-01T00:00:10.000Z",
+        "2026-07-01T00:30:00.000Z",
+        1,
+        10,
+        999_999_999
+      );
     } finally {
       db.close();
     }
@@ -790,15 +805,18 @@ describe("beta release status", () => {
       now: new Date("2026-07-01T00:15:00.000Z")
     });
 
-    expect(status.database.reviewerSessionCount).toBe(4);
+    expect(status.database.reviewerSessionCount).toBe(5);
     expect(status.database.activeReviewerSessionCount).toBe(1);
     expect(status.database.expiredReviewerSessionCount).toBe(3);
-    expect(status.database.reviewerSessionsByRepo).toEqual([
-      { repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO", total: 1, active: 0, expired: 1 },
-      { repo: "100yenadmin/evaOS-GUI", total: 1, active: 1, expired: 0 },
-      { repo: "electricsheephq/WorldOS", total: 1, active: 0, expired: 1 },
-      { repo: "electricsheephq/evaos-code-review-bot", total: 1, active: 0, expired: 1 }
-    ]);
+    expect(status.database.reviewerSessionsByRepo).toHaveLength(4);
+    expect(status.database.reviewerSessionsByRepo).toEqual(
+      expect.arrayContaining([
+        { repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO", total: 1, active: 0, expired: 1 },
+        { repo: "100yenadmin/evaOS-GUI", total: 1, active: 1, expired: 0 },
+        { repo: "electricsheephq/WorldOS", total: 1, active: 0, expired: 1 },
+        { repo: "electricsheephq/evaos-code-review-bot", total: 2, active: 0, expired: 1 }
+      ])
+    );
   });
 
   it("reports durable review queue counts and fails retryable deferred or failed jobs", () => {

--- a/tests/repo-policy.test.ts
+++ b/tests/repo-policy.test.ts
@@ -413,7 +413,22 @@ describe("repo profile registry", () => {
     const cases = [
       {
         repo: "electricsheephq/WorldOS",
-        files: ["extensions/renderers/shared/room_recipes.json", "qa/export_scene_grid.py", "qa/seed_gfx_crypt_2room.py"]
+        files: [
+          "extensions/renderers/shared/room_recipes.json",
+          "qa/export_scene_grid.py",
+          "qa/seed_gfx_crypt_2room.py",
+          "servers/engine/combat_grid.py",
+          "servers/engine/server.py",
+          "servers/engine/tests/test_grid_los.py"
+        ]
+      },
+      {
+        repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+        files: [
+          "packages/runtime/src/review-runner.ts",
+          "packages/runtime/tests/review-runner.test.ts",
+          "src/index.ts"
+        ]
       },
       {
         repo: "100yenadmin/evaOS-GUI",

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1774,6 +1774,61 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("reconciles expired and dead reviewer sessions at scheduler cycle boundaries", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-reposticky-reconcile-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewerSessions = {
+      enabled: true,
+      ttlMs: 8 * 60 * 60_000,
+      headCountLimit: 10
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const expired = state.assignReviewerSessionJob({
+      repo: "org/repo-expired",
+      pullNumber: 1,
+      headSha: "expired-head",
+      ttlMs: 1_000,
+      headCountLimit: 10,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    const deadWorker = state.assignReviewerSessionJob({
+      repo: "org/repo-dead",
+      pullNumber: 2,
+      headSha: "dead-head",
+      ttlMs: 60_000,
+      headCountLimit: 10,
+      workerPid: 999_999_999,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    const healthy = state.assignReviewerSessionJob({
+      repo: "org/repo-healthy",
+      pullNumber: 3,
+      headSha: "healthy-head",
+      ttlMs: 60_000,
+      headCountLimit: 10,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    if (!expired.assigned || !deadWorker.assigned || !healthy.assigned) throw new Error("expected assignments");
+
+    await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([["org/repo-a", []]])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: reviewPull,
+      now: new Date("2026-07-01T00:00:02.000Z")
+    });
+
+    expect(state.getReviewerSession(expired.session.sessionId)).toMatchObject({ state: "expired" });
+    expect(state.getReviewerSession(deadWorker.session.sessionId)).toMatchObject({
+      state: "failed",
+      lastError: "owner_pid_not_alive:999999999"
+    });
+    expect(state.getReviewerSession(healthy.session.sessionId)).toMatchObject({ state: "active" });
+    state.close();
+  });
+
   it("does not consume RepoSticky session head budget for stop or explain commands", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-reposticky-command-non-review-"));
     roots.push(root);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -467,6 +467,51 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("globally reconciles expired and dead-worker reviewer sessions without same-repo assignment", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-reviewer-session-reconcile-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    const expired = store.assignReviewerSessionJob({
+      repo: "org/repo-expired",
+      pullNumber: 1,
+      headSha: "expired-head",
+      ttlMs: 1_000,
+      headCountLimit: 10,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    const deadWorker = store.assignReviewerSessionJob({
+      repo: "org/repo-dead",
+      pullNumber: 2,
+      headSha: "dead-head",
+      ttlMs: 60_000,
+      headCountLimit: 10,
+      workerPid: 999_999_999,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    const healthy = store.assignReviewerSessionJob({
+      repo: "org/repo-healthy",
+      pullNumber: 3,
+      headSha: "healthy-head",
+      ttlMs: 60_000,
+      headCountLimit: 10,
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    if (!expired.assigned || !deadWorker.assigned || !healthy.assigned) throw new Error("expected assignments");
+
+    expect(store.reconcileReviewerSessions(new Date("2026-07-01T00:00:02.000Z"))).toEqual({
+      expired: 1,
+      failedDeadWorkers: 1
+    });
+    expect(store.getReviewerSession(expired.session.sessionId)).toMatchObject({ state: "expired" });
+    expect(store.getReviewerSession(deadWorker.session.sessionId)).toMatchObject({
+      state: "failed",
+      lastError: "owner_pid_not_alive:999999999"
+    });
+    expect(store.getReviewerSession(healthy.session.sessionId)).toMatchObject({ state: "active" });
+    store.close();
+  });
+
   it("tracks reviewer session job lifecycle without calling ZCode", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-reviewer-session-jobs-"));
     roots.push(root);


### PR DESCRIPTION
## Summary

Fixes the two incident-class defects found in the low-signal/runtime audit:

- expands active-profile review surfaces so WorldOS `servers/**` and LCO `packages/**` implementation diffs are sent to review instead of producing empty/near-empty prompts
- reconciles reviewer sessions at scheduler boundaries and prevents dead worker PIDs from counting as active release health
- makes the operator dashboard default to current-health semantics by hiding stale-only historical rows unless `--include-history true` or a stale filter is requested
- treats bounded active daemon heartbeats as healthy in `agents`

Fixes #134.

## Evidence

The audit found the low-yield reviews were not JSON parsing, deterministic-gate, or dropped-finding failures. The raw output, gate output, and drop counts matched; the implementation files were omitted by repo-profile path filters.

The stale-session audit found active reviewer sessions can survive worker death/expiry until a future same-repo assignment touches them. This PR adds explicit reconciliation and release-status liveness accounting.

## Validation

```bash
npm test -- tests/repo-policy.test.ts tests/operator-cli.test.ts tests/state.test.ts tests/release-status.test.ts tests/scheduler.test.ts --pool=forks --maxWorkers=1
npm run build
```
