### PR TITLE
Fix dashboard historical stale filtering

### DIFF
--- a/docs/releases/v0.4.1-beta.3.md
+++ b/docs/releases/v0.4.1-beta.3.md
@@ -1,0 +1,77 @@
+# v0.4.1-beta.3
+
+- Release type: local beta dashboard current-health hotfix
+- Tracking issue: `#134`
+- Implementation PR: follow-up dashboard hotfix for `#136`
+- Release tag target: release packet commit for `v0.4.1-beta.3`
+- Previous live release: `v0.4.1-beta.2` (`055e84a818320ef2a6791acfc9848d1a8b3ad9f0`)
+- Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- launchd label: `com.electricsheephq.evaos-code-review-bot`
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+- State DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
+- Evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-02/v0.4.1-beta.3/`
+- Monitor owner/window: implementing agent, first post-promotion dashboard proof
+- Rollback SHA/tag: `v0.4.1-beta.2`
+- Rollback command:
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard v0.4.1-beta.2
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+## Purpose
+
+Complete the dashboard current-health fix from `v0.4.1-beta.2`.
+
+Post-promotion dashboard proof showed stale superseded rows whose durable queue
+state was `posted` still appeared in the default dashboard. Those rows are
+historical review records, not current-head health blockers.
+
+## Changes
+
+- Treat stale readiness rows as historical even when merged with terminal
+  `posted` queue metadata.
+- Preserve explicit history behavior: `dashboard --include-history true` or
+  `--status stale` still returns those rows.
+- Add regression coverage for stale posted rows matching the live failure shape.
+
+## Live Config Change
+
+None.
+
+This release keeps the `v0.4.1-beta.2` live config path-filter changes:
+
+- `electricsheephq/WorldOS`: `servers/**` visible.
+- `100yenadmin/Lossless-Codex-Orchestrator-LCO`: `packages/**` visible.
+
+No context/enrichment/calibration features are enabled.
+
+## Gates
+
+- Focused validation:
+  - `npm test -- tests/operator-cli.test.ts --pool=forks --maxWorkers=1`: 27 tests passed.
+  - `npm run build`: passed.
+- Post-release gates must re-run `release-status`, coverage audit, expired
+  provider cooldown audit, runtime inventory, `agents`, and default dashboard.
+
+## Runtime Notes
+
+- This hotfix changes read-only dashboard classification only.
+- It does not alter review posting, queue scheduling, ZCode invocation,
+  monitored repos, GitHub App permissions, live config, or target-repo mutation
+  behavior.
+
+## Notes
+
+- What changed: dashboard historical-stale filtering for superseded posted rows.
+- What did not change: all runtime review behavior and all feature activation
+  flags.
+- Open follow-ups: branch/ruleset enforcement for unresolved review-thread
+  merges; dry-run promotion decisions for current default-off context features.

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1510,8 +1510,12 @@ function summarizeDashboardItems(items: OperatorDashboardItem[]): OperatorDashbo
 
 function isHistoricalStaleDashboardItem(item: OperatorDashboardItem): boolean {
   if (item.coverageState === "stale_head") return false;
-  const statuses = dashboardStatuses(item);
-  return statuses.length > 0 && statuses.every((status) => status === "stale" || status === "stale_head" || status === "stale_retired");
+  const statuses = dashboardStatuses(item).filter((status) => status !== "posted");
+  return statuses.length > 0 && statuses.every(isHistoricalStaleStatus);
+}
+
+function isHistoricalStaleStatus(status: string): boolean {
+  return status === "stale" || status === "stale_head" || status === "stale_retired";
 }
 
 function isDashboardItemBlocked(item: OperatorDashboardItem): boolean {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -328,19 +328,39 @@ describe("operator CLI summaries", () => {
             headSha: "old-head",
             state: "stale_retired",
             lastError: "superseded_by_head=new-head"
+          }),
+          durableJob({
+            repo: "owner/repo",
+            pullNumber: 3,
+            headSha: "posted-old-head",
+            state: "posted",
+            lastError: "reviewed"
           })
         ],
-        summary: { total: 1, queued: 0, failed: 0, running: 0, providerDeferred: 0, retryableProviderDeferred: 0 }
+        summary: { total: 2, queued: 0, failed: 0, running: 0, providerDeferred: 0, retryableProviderDeferred: 0 }
       }),
-      readiness: [{
-        repo: "owner/repo",
-        pullNumber: 2,
-        headSha: "old-head",
-        state: "stale" as const,
-        reason: "superseded_by_head=new-head",
-        createdAt: "2026-07-01T00:00:00.000Z",
-        updatedAt: "2026-07-01T00:01:00.000Z"
-      }],
+      readiness: [
+        {
+          repo: "owner/repo",
+          pullNumber: 2,
+          headSha: "old-head",
+          state: "stale" as const,
+          reason: "superseded_by_head=new-head",
+          createdAt: "2026-07-01T00:00:00.000Z",
+          updatedAt: "2026-07-01T00:01:00.000Z"
+        },
+        {
+          repo: "owner/repo",
+          pullNumber: 3,
+          headSha: "posted-old-head",
+          state: "stale" as const,
+          reason: "superseded_by_head=posted-new-head",
+          event: "COMMENT" as const,
+          reviewUrl: "https://github.com/owner/repo/pull/3#pullrequestreview-1",
+          createdAt: "2026-07-01T00:00:00.000Z",
+          updatedAt: "2026-07-01T00:02:00.000Z"
+        }
+      ],
       checkedAt: "2026-07-02T00:00:00.000Z"
     };
 
@@ -350,7 +370,7 @@ describe("operator CLI summaries", () => {
       totalItems: 1,
       blockedItems: 0,
       staleHeads: 0,
-      hiddenHistoricalStale: 1
+      hiddenHistoricalStale: 2
     });
     expect(currentDashboard.items.map((item) => `${item.repo}#${item.pullNumber}:${item.status}`)).toEqual([
       "owner/repo#1:processed"
@@ -362,17 +382,15 @@ describe("operator CLI summaries", () => {
     });
     expect(historicalDashboard.ok).toBe(false);
     expect(historicalDashboard.summary).toMatchObject({
-      totalItems: 1,
-      blockedItems: 1,
-      staleHeads: 1,
+      totalItems: 2,
+      blockedItems: 2,
+      staleHeads: 2,
       hiddenHistoricalStale: 0
     });
-    expect(historicalDashboard.items[0]).toMatchObject({
-      repo: "owner/repo",
-      pullNumber: 2,
-      status: "stale",
-      readinessState: "stale"
-    });
+    expect(historicalDashboard.items.map((item) => `${item.repo}#${item.pullNumber}:${item.headSha}:${item.status}`)).toEqual([
+      "owner/repo#2:old-head:stale",
+      "owner/repo#3:posted-old-head:stale"
+    ]);
   });
 
   it("filters dashboard rows by repo, status, priority, and stale-head reason", () => {


### PR DESCRIPTION
## Summary

Follow-up for #134 after `v0.4.1-beta.2` dashboard proof found stale superseded rows still visible when they were merged with terminal `posted` queue metadata.

- hides stale readiness rows even when their durable queue state is `posted`
- keeps explicit history inspection working through `--include-history true` / stale filters
- adds a regression matching the live stale-posted row shape
- adds the `v0.4.1-beta.3` release packet

## Validation

```bash
npm test -- tests/operator-cli.test.ts --pool=forks --maxWorkers=1
npm run build
git diff --check
```
