### PR TITLE
Hide terminal dashboard history by default

### DIFF
--- a/docs/releases/v0.4.1-beta.4.md
+++ b/docs/releases/v0.4.1-beta.4.md
@@ -1,0 +1,46 @@
+# v0.4.1-beta.4
+
+- Release type: local beta dashboard terminal-row hotfix
+- Tracking issue: `#134`
+- Release tag target: release packet commit for `v0.4.1-beta.4`
+- Previous live release: `v0.4.1-beta.3` (`e545d5047648f19838de0e2857683a67b6b34e82`)
+- Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- launchd label: `com.electricsheephq.evaos-code-review-bot`
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+- State DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
+- Evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-02/v0.4.1-beta.4/`
+- Rollback SHA/tag: `v0.4.1-beta.3`
+
+## Purpose
+
+Finish the current-health dashboard cleanup by hiding terminal retired queue
+rows from the default dashboard. Post-`v0.4.1-beta.3` proof showed a
+`closed_retired` provider-deferred row still blocked the default operator view
+even though the PR had already been retired as closed.
+
+## Changes
+
+- Hide `closed_retired` and `stale_retired` queue rows from the default
+  dashboard unless explicit history filters are requested.
+- Preserve explicit history views for terminal rows.
+- Add regression coverage for `closed_retired` plus provider-deferred readiness,
+  matching the live row shape that blocked beta.3 dashboard proof.
+
+## Live Config Change
+
+None.
+
+## Gates
+
+- Focused validation:
+  - `npm test -- tests/operator-cli.test.ts --pool=forks --maxWorkers=1`: 28 tests passed.
+  - `npm run build`: passed.
+- Post-release gates must re-run `release-status`, coverage audit, expired
+  provider cooldown audit, runtime inventory, `agents`, and default dashboard.
+
+## Runtime Notes
+
+- This hotfix changes read-only dashboard classification only.
+- It does not alter review posting, queue scheduling, ZCode invocation,
+  monitored repos, GitHub App permissions, live config, or target-repo mutation
+  behavior.

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1510,6 +1510,7 @@ function summarizeDashboardItems(items: OperatorDashboardItem[]): OperatorDashbo
 
 function isHistoricalStaleDashboardItem(item: OperatorDashboardItem): boolean {
   if (item.coverageState === "stale_head") return false;
+  if (item.queueState === "closed_retired" || item.queueState === "stale_retired") return true;
   const statuses = dashboardStatuses(item).filter((status) => status !== "posted");
   return statuses.length > 0 && statuses.every(isHistoricalStaleStatus);
 }

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -393,6 +393,70 @@ describe("operator CLI summaries", () => {
     ]);
   });
 
+  it("hides terminal retired dashboard rows by default while preserving explicit history filters", () => {
+    const input = {
+      coverage: coverageReport({
+        ok: true,
+        processed: [processedEntry(1, "head-current", "posted")]
+      }),
+      durableQueue: durableQueueSnapshot({
+        jobs: [
+          durableJob({
+            repo: "owner/repo",
+            pullNumber: 4,
+            headSha: "closed-provider-head",
+            state: "closed_retired",
+            lastError: "operator_retired_closed_pr_after_release_gate; previous_error=repo_provider_cooldown_until=2026-07-02T09:33:32.245Z"
+          })
+        ],
+        summary: { total: 1, queued: 0, failed: 0, running: 0, providerDeferred: 0, retryableProviderDeferred: 0 }
+      }),
+      readiness: [
+        {
+          repo: "owner/repo",
+          pullNumber: 4,
+          headSha: "closed-provider-head",
+          state: "provider_deferred" as const,
+          reason: "active_queue_job_provider_deferred: repo_provider_cooldown_until=2026-07-02T09:33:32.245Z",
+          createdAt: "2026-07-01T00:00:00.000Z",
+          updatedAt: "2026-07-01T00:02:00.000Z"
+        }
+      ],
+      checkedAt: "2026-07-02T00:00:00.000Z"
+    };
+
+    const currentDashboard = buildOperatorDashboard(input);
+    expect(currentDashboard.ok).toBe(true);
+    expect(currentDashboard.summary).toMatchObject({
+      totalItems: 1,
+      blockedItems: 0,
+      providerDeferred: 0,
+      hiddenHistoricalStale: 1
+    });
+    expect(currentDashboard.items.map((item) => `${item.repo}#${item.pullNumber}:${item.status}`)).toEqual([
+      "owner/repo#1:processed"
+    ]);
+
+    const historicalDashboard = buildOperatorDashboard({
+      ...input,
+      filters: { includeHistory: true, status: "provider_deferred" }
+    });
+    expect(historicalDashboard.ok).toBe(false);
+    expect(historicalDashboard.summary).toMatchObject({
+      totalItems: 1,
+      blockedItems: 1,
+      providerDeferred: 1,
+      hiddenHistoricalStale: 0
+    });
+    expect(historicalDashboard.items[0]).toMatchObject({
+      repo: "owner/repo",
+      pullNumber: 4,
+      headSha: "closed-provider-head",
+      status: "provider_deferred",
+      queueState: "closed_retired"
+    });
+  });
+
   it("filters dashboard rows by repo, status, priority, and stale-head reason", () => {
     const input = {
       coverage: coverageReport({


### PR DESCRIPTION
## Summary

Final dashboard current-health follow-up for #134.

After `v0.4.1-beta.3`, stale historical rows were hidden, but a terminal `closed_retired` row merged with provider-deferred readiness still blocked the default dashboard. This PR hides terminal retired queue rows by default while preserving explicit history filters.

## Validation

```bash
npm test -- tests/operator-cli.test.ts --pool=forks --maxWorkers=1
npm run build
git diff --check
```
