### PR TITLE
Add issue enrichment dry-run support

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -233,6 +233,7 @@ Closed issues are reported as `skipped: true` with reason
 `stale_issue_closed`. PR-shaped issue records are reported as `skipped: true`
 with reason `issue_is_pull_request`. No Markdown body is written for skipped
 issues.
+
 Issue mode requires an authenticated token or GitHub App installation with
 Issues read access. Live App-authored issue comments require Issues write
 permission and must not be enabled until that permission expansion is tracked.

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -84,12 +84,15 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
   Use `--output-dir <path>` to write `skill-pack-context-packet.json` and
   `skill-pack-context-packet.md` evidence. This command never enables native
   ZCode skills, MCP, tools, shell, web, memory, agents, or writes.
-- `build-enrichment-comment --repo <owner/name> --pr <number>`: builds the
-  sticky PR enrichment comment body for dry-run inspection. It reads GitHub PR
-  metadata/files, current policy, changed-surface validation, and proof
-  requirements, then emits JSON/Markdown with the bot-owned marker and rendered
-  comment. This command never posts comments, auto-applies labels, assigns
-  reviewers, calls ZCode, or mutates GitHub state.
+- `build-enrichment-comment --repo <owner/name> --pr <number>` or
+  `--issue <number>`: builds the sticky PR or issue enrichment comment body for
+  dry-run inspection. PR mode reads GitHub PR metadata/files, current policy,
+  changed-surface validation, and proof requirements. Issue mode reads GitHub
+  issue metadata, skips closed issues as `stale_issue_closed`, and skips
+  PR-shaped issue records as `issue_is_pull_request`. Both modes emit
+  JSON/Markdown with the bot-owned marker and rendered comment when not skipped.
+  This command never posts comments, auto-applies labels, assigns reviewers,
+  calls ZCode, or mutates GitHub state.
 - `doctor`: auth/config readiness. Use this for GitHub App/ZCode readiness, not
   runtime health.
 
@@ -219,6 +222,20 @@ npx tsx src/cli.ts build-enrichment-comment --config <config.json> --repo electr
 
 The dry-run output includes the hidden sticky marker used for future update
 behavior, but it does not post the comment or apply suggested labels/reviewers.
+
+Build a sticky issue enrichment comment for dry-run evidence:
+
+```bash
+npx tsx src/cli.ts build-enrichment-comment --config <config.json> --repo electricsheephq/evaos-code-review-bot --issue 10 --output-dir <configured-evidence-dir>/enrichment/evaos-code-review-bot-issue-10
+```
+
+Closed issues are reported as `skipped: true` with reason
+`stale_issue_closed`. PR-shaped issue records are reported as `skipped: true`
+with reason `issue_is_pull_request`. No Markdown body is written for skipped
+issues.
+Issue mode requires an authenticated token or GitHub App installation with
+Issues read access. Live App-authored issue comments require Issues write
+permission and must not be enabled until that permission expansion is tracked.
 
 ## Safety Boundaries
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { runDaemonCycle } from "./daemon.js";
 import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, parse as parsePath, resolve, sep } from "node:path";
 import { REQUIRED_SUITES, runOfflineEval } from "./eval-harness.js";
-import { buildEnrichmentComment } from "./enrichment.js";
+import { buildEnrichmentComment, buildIssueEnrichmentDryRunOutput } from "./enrichment.js";
 import { GitHubApi } from "./github.js";
 import { buildGitNexusContextPacket } from "./gitnexus-context.js";
 import { buildGitHubRelatedContextPacket } from "./github-related-context.js";
@@ -588,15 +588,39 @@ async function main(): Promise<void> {
 
   if (command === "build-enrichment-comment") {
     if (!args.repo) throw new Error("--repo is required for build-enrichment-comment");
-    if (!args.pr) throw new Error("--pr is required for build-enrichment-comment");
+    if (Boolean(args.pr) === Boolean(args.issue)) throw new Error("exactly one of --pr or --issue is required for build-enrichment-comment");
     const repo = parseSingleArg(args.repo, "--repo");
-    const pullNumber = parsePositiveInteger(parseSingleArg(args.pr, "--pr"), "--pr");
     const config = loadConfig(args.config);
     const github = new GitHubApi(config.github);
-    const pull = await github.getPull(repo, pullNumber);
-    const files = await github.listPullFiles(repo, pullNumber);
     const repoPolicy = resolveRepoProfile(config, repo);
     if (!repoPolicy.allowed) throw new Error(`Repo ${repo} is skipped by policy: ${repoPolicy.reason}`);
+    const enrichmentConfig = config.enrichment!;
+    if (args.issue) {
+      const issueNumber = parsePositiveInteger(parseSingleArg(args.issue, "--issue"), "--issue");
+      const issue = await github.getIssueOrPull(repo, issueNumber);
+      if (!issue) throw new Error(`Issue ${repo}#${issueNumber} was not found or is not readable`);
+      const output = buildIssueEnrichmentDryRunOutput({
+        repo,
+        issue,
+        suggestedLabels: repoPolicy.profile.suggestedLabels,
+        suggestedOwners: repoPolicy.profile.suggestedReviewers,
+        validationSuggestions: ["Confirm owner, acceptance criteria, and validation evidence before implementation."],
+        maxRelatedRefs: enrichmentConfig.maxRelatedRefs,
+        maxSuggestions: enrichmentConfig.maxSuggestions
+      });
+      if (args["output-dir"]) {
+        const safeOutputDir = assertMemoryPacketOutputDirSafe(args["output-dir"], config.evidenceDir);
+        mkdirSync(safeOutputDir, { recursive: true });
+        writeFileSync(join(safeOutputDir, "enrichment-comment.json"), `${redactSecrets(JSON.stringify(output, null, 2))}\n`);
+        if (!output.skipped) writeFileSync(join(safeOutputDir, "enrichment.md"), output.body);
+      }
+      console.log(redactSecrets(JSON.stringify(output, null, 2)));
+      return;
+    }
+    const prArg = parseSingleArg(args.pr ?? [], "--pr");
+    const pullNumber = parsePositiveInteger(prArg, "--pr");
+    const pull = await github.getPull(repo, pullNumber);
+    const files = await github.listPullFiles(repo, pullNumber);
     const validation = buildChangedSurfaceValidationReport({
       repo,
       pull,
@@ -604,7 +628,6 @@ async function main(): Promise<void> {
       profile: repoPolicy.profile
     });
     const proof = evaluateProofRequirements({ pull, validation });
-    const enrichmentConfig = config.enrichment!;
     const enrichment = buildEnrichmentComment({
       repo,
       pull,
@@ -896,6 +919,7 @@ function buildHelp() {
       "npx tsx src/cli.ts build-github-related-context-packet --config /path/to/live.json --repo owner/repo --pr 123 --output-dir /path/to/evidence",
       "npx tsx src/cli.ts build-skill-pack --config /path/to/live.json --output-dir /path/to/evidence",
       "npx tsx src/cli.ts build-enrichment-comment --config /path/to/live.json --repo owner/repo --pr 123 --output-dir /path/to/evidence",
+      "npx tsx src/cli.ts build-enrichment-comment --config /path/to/live.json --repo owner/repo --issue 456 --output-dir /path/to/evidence",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ]
   };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -597,7 +597,7 @@ async function main(): Promise<void> {
     const enrichmentConfig = config.enrichment!;
     if (args.issue) {
       const issueNumber = parsePositiveInteger(parseSingleArg(args.issue, "--issue"), "--issue");
-      const issue = await github.getIssueOrPull(repo, issueNumber);
+      const issue = await github.getIssueOrPull(repo, issueNumber, { tolerateUnreadable: true });
       if (!issue) throw new Error(`Issue ${repo}#${issueNumber} was not found or is not readable`);
       const output = buildIssueEnrichmentDryRunOutput({
         repo,

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,9 @@ export interface BotConfig {
     appId?: string;
     privateKeyPath?: string;
     token?: string;
+    apiBaseUrl?: string;
+    botLogin?: string;
+    requestTimeoutMs?: number;
   };
 }
 
@@ -344,6 +347,9 @@ function validateConfig(config: BotConfig): void {
   validatePositiveInteger(config.zcode.timeoutMs, "config.zcode.timeoutMs");
   validatePositiveInteger(config.zcode.maxPatchBytes, "config.zcode.maxPatchBytes");
   validateNonNegativeInteger(config.zcode.retryMaxRetries, "config.zcode.retryMaxRetries");
+  validateOptionalString(config.github.apiBaseUrl, "config.github.apiBaseUrl");
+  validateOptionalString(config.github.botLogin, "config.github.botLogin");
+  if (config.github.requestTimeoutMs !== undefined) validatePositiveInteger(config.github.requestTimeoutMs, "config.github.requestTimeoutMs");
 
   if (!config.repoProfiles) return;
 

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { redactSecrets } from "./secrets.js";
+import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
 import type {
   EnrichmentComment as PlanEnrichmentComment,
   EnrichmentCommentPostResult as PlanEnrichmentCommentPostResult,
@@ -28,6 +29,27 @@ export interface EnrichmentConfig {
 export type EnrichmentComment = PlanEnrichmentComment;
 export type EnrichmentCommentPostResult = PlanEnrichmentCommentPostResult;
 
+export type IssueEnrichmentDryRunOutput =
+  | {
+      ok: true;
+      skipped: true;
+      reason: "stale_issue_closed" | "issue_is_pull_request";
+      repo: string;
+      issueNumber: number;
+      state: string;
+      url?: string;
+    }
+  | {
+      ok: true;
+      skipped: false;
+      repo: string;
+      issueNumber: number;
+      state: string;
+      marker: string;
+      url?: string;
+      body: string;
+    };
+
 export interface EnrichmentCommentGithub {
   canPostAsApp(): boolean;
   upsertIssueComment(input: {
@@ -41,6 +63,11 @@ export interface EnrichmentCommentGithub {
 export function buildEnrichmentMarker(input: { repo: string; pullNumber: number }): string {
   validateRepoPull(input);
   return `${ENRICHMENT_MARKER_PREFIX} repo=${input.repo} pr=${input.pullNumber} -->`;
+}
+
+export function buildIssueEnrichmentMarker(input: { repo: string; issueNumber: number }): string {
+  validateRepoIssue(input);
+  return `${ENRICHMENT_MARKER_PREFIX} repo=${input.repo} issue=${input.issueNumber} -->`;
 }
 
 export function buildEnrichmentComment(input: {
@@ -103,6 +130,112 @@ export function buildEnrichmentComment(input: {
   };
 }
 
+export function buildIssueEnrichmentComment(input: {
+  repo: string;
+  issue: GitHubRelatedIssueOrPull;
+  suggestedLabels?: string[];
+  suggestedOwners?: string[];
+  validationSuggestions?: string[];
+  maxRelatedRefs?: number;
+  maxSuggestions?: number;
+  postIssueComment?: boolean;
+}): EnrichmentComment {
+  validateRepoIssue({ repo: input.repo, issueNumber: input.issue.number });
+  const skip = classifyIssueEnrichmentSkip(input.issue);
+  if (skip) throw new Error(`Cannot build issue enrichment for ${input.repo}#${input.issue.number}: ${skip.reason}`);
+  const state = normalizeIssueState(input.issue);
+  const marker = buildIssueEnrichmentMarker({ repo: input.repo, issueNumber: input.issue.number });
+  const relatedRefs = extractRelatedRefs(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`).slice(0, input.maxRelatedRefs ?? 8);
+  const existingLabels = unique(normalizeIssueLabels(input.issue.labels));
+  const existingLabelKeys = new Set(existingLabels.map((label) => label.toLowerCase()));
+  const suggestedLabels = unique([
+    ...(input.suggestedLabels ?? []),
+    ...suggestLabelsFromIssue(input.issue)
+  ]).filter((label) => !existingLabelKeys.has(label.toLowerCase())).slice(0, input.maxSuggestions ?? 8);
+  const owners = unique(input.suggestedOwners ?? []).slice(0, input.maxSuggestions ?? 8);
+  const validationSuggestions = unique(input.validationSuggestions ?? []).slice(0, input.maxSuggestions ?? 8);
+  const gaps = inferIssueAcceptanceGaps(input.issue);
+  const visibleBody = [
+    "## evaOS issue enrichment",
+    "",
+    `Issue: ${input.repo}#${input.issue.number} - ${formatInlinePublicText(input.issue.title ?? "(untitled)")}`,
+    `State: \`${state}\`${input.issue.milestone?.title ? `; milestone: \`${formatInlinePublicText(input.issue.milestone.title)}\`` : ""}`,
+    "",
+    `Related issues/PRs: ${relatedRefs.length ? relatedRefs.join(", ") : "none detected from issue metadata"}.`,
+    `Existing labels: ${existingLabels.length ? existingLabels.join(", ") : "none"}.`,
+    `Suggested labels: ${suggestedLabels.length ? suggestedLabels.join(", ") : "none"}.`,
+    `Suggested owners: ${owners.length ? owners.join(", ") : "none"}.`,
+    "",
+    "### Validation suggestions",
+    "",
+    ...(validationSuggestions.length ? validationSuggestions.map((item) => `- ${formatPublicText(item)}`) : ["- Confirm owner, acceptance criteria, and validation evidence before implementation."]),
+    "",
+    "### Triage gaps",
+    "",
+    ...(gaps.length ? gaps.map((item) => `- ${item}`) : ["- No obvious issue triage gap detected from issue metadata."]),
+    "",
+    "No labels, owners, reviewers, or roadmap fields were changed by this bot."
+  ].join("\n");
+  const redactedVisibleBody = redactSecrets(visibleBody);
+  const stateMarker = buildIssueStateMarker({
+    repo: input.repo,
+    issueNumber: input.issue.number,
+    state,
+    bodyHash: hashBody(redactedVisibleBody)
+  });
+
+  return {
+    marker,
+    body: [marker, stateMarker, redactedVisibleBody].join("\n"),
+    postIssueComment: input.postIssueComment ?? false
+  };
+}
+
+export function buildIssueEnrichmentDryRunOutput(input: {
+  repo: string;
+  issue: GitHubRelatedIssueOrPull;
+  suggestedLabels?: string[];
+  suggestedOwners?: string[];
+  validationSuggestions?: string[];
+  maxRelatedRefs?: number;
+  maxSuggestions?: number;
+}): IssueEnrichmentDryRunOutput {
+  validateRepoIssue({ repo: input.repo, issueNumber: input.issue.number });
+  const state = normalizeIssueState(input.issue);
+  const skip = classifyIssueEnrichmentSkip(input.issue);
+  if (skip) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: skip.reason,
+      repo: input.repo,
+      issueNumber: input.issue.number,
+      state,
+      ...(input.issue.html_url ? { url: redactSecrets(input.issue.html_url) } : {})
+    };
+  }
+  const enrichment = buildIssueEnrichmentComment({
+    repo: input.repo,
+    issue: input.issue,
+    suggestedLabels: input.suggestedLabels,
+    suggestedOwners: input.suggestedOwners,
+    validationSuggestions: input.validationSuggestions,
+    maxRelatedRefs: input.maxRelatedRefs,
+    maxSuggestions: input.maxSuggestions,
+    postIssueComment: false
+  });
+  return {
+    ok: true,
+    skipped: false,
+    repo: input.repo,
+    issueNumber: input.issue.number,
+    state,
+    marker: enrichment.marker,
+    ...(input.issue.html_url ? { url: redactSecrets(input.issue.html_url) } : {}),
+    body: enrichment.body
+  };
+}
+
 export async function postEnrichmentComment(input: {
   enabled: boolean;
   dryRun: boolean;
@@ -136,6 +269,13 @@ function buildStateMarker(input: { repo: string; pullNumber: number; headSha: st
   return `${ENRICHMENT_STATE_MARKER_PREFIX} version=${ENRICHMENT_SCHEMA_VERSION} repo=${input.repo} pr=${input.pullNumber} sha=${input.headSha} hash=${input.bodyHash} -->`;
 }
 
+function buildIssueStateMarker(input: { repo: string; issueNumber: number; state: string; bodyHash: string }): string {
+  validateRepoIssue(input);
+  if (!/^[0-9a-f]{64}$/i.test(input.bodyHash)) throw new Error(`Invalid enrichment body hash: ${input.bodyHash}`);
+  const state = normalizeIssueState({ state: input.state, number: input.issueNumber });
+  return `${ENRICHMENT_STATE_MARKER_PREFIX} version=${ENRICHMENT_SCHEMA_VERSION} repo=${input.repo} issue=${input.issueNumber} state=${state} hash=${input.bodyHash} -->`;
+}
+
 function validateIdentity(input: { repo: string; pullNumber: number; headSha: string }): void {
   validateRepoPull(input);
   if (!HEAD_SHA_PATTERN.test(input.headSha)) throw new Error(`Invalid enrichment head SHA: ${input.headSha}`);
@@ -144,6 +284,11 @@ function validateIdentity(input: { repo: string; pullNumber: number; headSha: st
 function validateRepoPull(input: { repo: string; pullNumber: number }): void {
   if (!REPO_SLUG_PATTERN.test(input.repo)) throw new Error(`Invalid enrichment repo slug: ${input.repo}`);
   if (!Number.isInteger(input.pullNumber) || input.pullNumber <= 0) throw new Error(`Invalid enrichment pull number: ${input.pullNumber}`);
+}
+
+function validateRepoIssue(input: { repo: string; issueNumber: number }): void {
+  if (!REPO_SLUG_PATTERN.test(input.repo)) throw new Error(`Invalid enrichment repo slug: ${input.repo}`);
+  if (!Number.isInteger(input.issueNumber) || input.issueNumber <= 0) throw new Error(`Invalid enrichment issue number: ${input.issueNumber}`);
 }
 
 function extractRelatedRefs(text: string): string[] {
@@ -161,11 +306,48 @@ function suggestLabelsFromFiles(files: PullFilePatch[]): string[] {
   return [...labels];
 }
 
+function suggestLabelsFromIssue(issue: GitHubRelatedIssueOrPull): string[] {
+  const text = `${issue.title ?? ""}\n${issue.body ?? ""}`.toLowerCase();
+  const labels = new Set<string>();
+  if (/\bbug|regression|broken|error|failure\b/.test(text)) labels.add("bug");
+  if (/\bsecurity|auth|token|secret|permission\b/.test(text)) labels.add("security");
+  if (/\bdocs?|readme|runbook\b/.test(text)) labels.add("docs");
+  if (/\btest|coverage|fixture|eval\b/.test(text)) labels.add("tests");
+  if (/\bsupport|customer|incident|escalation\b/.test(text)) labels.add("support");
+  return [...labels];
+}
+
+function normalizeIssueLabels(labels: GitHubRelatedIssueOrPull["labels"]): string[] {
+  return (labels ?? []).map((label) => typeof label === "string" ? label : label.name ?? "").filter(Boolean);
+}
+
+function classifyIssueEnrichmentSkip(issue: GitHubRelatedIssueOrPull): { reason: "stale_issue_closed" | "issue_is_pull_request" } | undefined {
+  if (issue.pull_request) return { reason: "issue_is_pull_request" };
+  if (normalizeIssueState(issue).toLowerCase() !== "open") return { reason: "stale_issue_closed" };
+  return undefined;
+}
+
+function normalizeIssueState(issue: Pick<GitHubRelatedIssueOrPull, "state" | "number">): string {
+  return formatInlinePublicText(issue.state ?? "unknown") || "unknown";
+}
+
 function inferAcceptanceGaps(pull: PullRequestSummary): string[] {
   const body = pull.body ?? "";
   const gaps: string[] = [];
   if (!/\b(acceptance|checklist|test plan|validation|proof)\b/i.test(body)) {
     gaps.push("Acceptance criteria or validation evidence not detected in PR body.");
+  }
+  return gaps;
+}
+
+function inferIssueAcceptanceGaps(issue: GitHubRelatedIssueOrPull): string[] {
+  const body = issue.body ?? "";
+  const gaps: string[] = [];
+  if (!/\b(acceptance|checklist|test plan|validation|proof|done when)\b/i.test(body)) {
+    gaps.push("Acceptance criteria or validation evidence not detected in issue body.");
+  }
+  if (!/\b(owner|assignee|reviewer|responsible)\b/i.test(body)) {
+    gaps.push("Owner or reviewer signal not detected in issue body.");
   }
   return gaps;
 }

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -147,9 +147,9 @@ export function buildIssueEnrichmentComment(input: {
   const state = eligibility.state;
   const marker = buildIssueEnrichmentMarker({ repo: input.repo, issueNumber: input.issue.number });
   const relatedRefs = extractRelatedRefs(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`).slice(0, input.maxRelatedRefs ?? 8);
-  const existingLabels = unique(normalizeIssueLabels(input.issue.labels));
+  const existingLabels = uniqueCaseInsensitive(normalizeIssueLabels(input.issue.labels));
   const existingLabelKeys = new Set(existingLabels.map(normalizedSuggestionKey));
-  const suggestedLabels = unique([
+  const suggestedLabels = uniqueCaseInsensitive([
     ...(input.suggestedLabels ?? []),
     ...suggestLabelsFromIssue(input.issue)
   ]).filter((label) => !existingLabelKeys.has(normalizedSuggestionKey(label))).slice(0, input.maxSuggestions ?? 8);
@@ -369,6 +369,10 @@ function formatPublicText(value: string | undefined): string {
 }
 
 function unique(values: string[]): string[] {
+  return [...new Set(values.map((value) => formatPublicText(value)).filter(Boolean))];
+}
+
+function uniqueCaseInsensitive(values: string[]): string[] {
   const seen = new Set<string>();
   const result: string[] = [];
   for (const value of values) {

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -336,7 +336,7 @@ function getIssueEnrichmentEligibility(issue: GitHubRelatedIssueOrPull): {
 function normalizeIssueState(issue: Pick<GitHubRelatedIssueOrPull, "state" | "number">): string {
   const normalized = formatInlinePublicText(issue.state ?? "unknown").toLowerCase() || "unknown";
   if (normalized === "open" || normalized === "closed") return normalized;
-  return normalized;
+  return "unknown";
 }
 
 function inferAcceptanceGaps(pull: PullRequestSummary): string[] {

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -148,11 +148,11 @@ export function buildIssueEnrichmentComment(input: {
   const marker = buildIssueEnrichmentMarker({ repo: input.repo, issueNumber: input.issue.number });
   const relatedRefs = extractRelatedRefs(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`).slice(0, input.maxRelatedRefs ?? 8);
   const existingLabels = unique(normalizeIssueLabels(input.issue.labels));
-  const existingLabelKeys = new Set(existingLabels.map((label) => label.toLowerCase()));
+  const existingLabelKeys = new Set(existingLabels.map(normalizedSuggestionKey));
   const suggestedLabels = unique([
     ...(input.suggestedLabels ?? []),
     ...suggestLabelsFromIssue(input.issue)
-  ]).filter((label) => !existingLabelKeys.has(label.toLowerCase())).slice(0, input.maxSuggestions ?? 8);
+  ]).filter((label) => !existingLabelKeys.has(normalizedSuggestionKey(label))).slice(0, input.maxSuggestions ?? 8);
   const owners = unique(input.suggestedOwners ?? []).slice(0, input.maxSuggestions ?? 8);
   const validationSuggestions = unique(input.validationSuggestions ?? []).slice(0, input.maxSuggestions ?? 8);
   const gaps = inferIssueAcceptanceGaps(input.issue);
@@ -374,12 +374,16 @@ function unique(values: string[]): string[] {
   for (const value of values) {
     const formatted = formatPublicText(value);
     if (!formatted) continue;
-    const key = formatted.toLowerCase();
+    const key = normalizedSuggestionKey(formatted);
     if (seen.has(key)) continue;
     seen.add(key);
     result.push(formatted);
   }
   return result;
+}
+
+function normalizedSuggestionKey(value: string): string {
+  return formatPublicText(value).toLowerCase();
 }
 
 function hashBody(value: string): string {

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -28,12 +28,13 @@ export interface EnrichmentConfig {
 
 export type EnrichmentComment = PlanEnrichmentComment;
 export type EnrichmentCommentPostResult = PlanEnrichmentCommentPostResult;
+type IssueEnrichmentSkipReason = "stale_issue_closed" | "issue_is_pull_request";
 
 export type IssueEnrichmentDryRunOutput =
   | {
       ok: true;
       skipped: true;
-      reason: "stale_issue_closed" | "issue_is_pull_request";
+      reason: IssueEnrichmentSkipReason;
       repo: string;
       issueNumber: number;
       state: string;
@@ -141,9 +142,9 @@ export function buildIssueEnrichmentComment(input: {
   postIssueComment?: boolean;
 }): EnrichmentComment {
   validateRepoIssue({ repo: input.repo, issueNumber: input.issue.number });
-  const skip = classifyIssueEnrichmentSkip(input.issue);
-  if (skip) throw new Error(`Cannot build issue enrichment for ${input.repo}#${input.issue.number}: ${skip.reason}`);
-  const state = normalizeIssueState(input.issue);
+  const eligibility = getIssueEnrichmentEligibility(input.issue);
+  if (eligibility.skip) throw new Error(`Cannot build issue enrichment for ${input.repo}#${input.issue.number}: ${eligibility.skip.reason}`);
+  const state = eligibility.state;
   const marker = buildIssueEnrichmentMarker({ repo: input.repo, issueNumber: input.issue.number });
   const relatedRefs = extractRelatedRefs(`${input.issue.title ?? ""}\n${input.issue.body ?? ""}`).slice(0, input.maxRelatedRefs ?? 8);
   const existingLabels = unique(normalizeIssueLabels(input.issue.labels));
@@ -201,8 +202,9 @@ export function buildIssueEnrichmentDryRunOutput(input: {
   maxSuggestions?: number;
 }): IssueEnrichmentDryRunOutput {
   validateRepoIssue({ repo: input.repo, issueNumber: input.issue.number });
-  const state = normalizeIssueState(input.issue);
-  const skip = classifyIssueEnrichmentSkip(input.issue);
+  const eligibility = getIssueEnrichmentEligibility(input.issue);
+  const state = eligibility.state;
+  const skip = eligibility.skip;
   if (skip) {
     return {
       ok: true,
@@ -321,14 +323,20 @@ function normalizeIssueLabels(labels: GitHubRelatedIssueOrPull["labels"]): strin
   return (labels ?? []).map((label) => typeof label === "string" ? label : label.name ?? "").filter(Boolean);
 }
 
-function classifyIssueEnrichmentSkip(issue: GitHubRelatedIssueOrPull): { reason: "stale_issue_closed" | "issue_is_pull_request" } | undefined {
-  if (issue.pull_request) return { reason: "issue_is_pull_request" };
-  if (normalizeIssueState(issue).toLowerCase() !== "open") return { reason: "stale_issue_closed" };
-  return undefined;
+function getIssueEnrichmentEligibility(issue: GitHubRelatedIssueOrPull): {
+  state: string;
+  skip?: { reason: IssueEnrichmentSkipReason };
+} {
+  const state = normalizeIssueState(issue);
+  if (issue.pull_request) return { state, skip: { reason: "issue_is_pull_request" } };
+  if (state === "closed") return { state, skip: { reason: "stale_issue_closed" } };
+  return { state };
 }
 
 function normalizeIssueState(issue: Pick<GitHubRelatedIssueOrPull, "state" | "number">): string {
-  return formatInlinePublicText(issue.state ?? "unknown") || "unknown";
+  const normalized = formatInlinePublicText(issue.state ?? "unknown").toLowerCase() || "unknown";
+  if (normalized === "open" || normalized === "closed") return normalized;
+  return normalized;
 }
 
 function inferAcceptanceGaps(pull: PullRequestSummary): string[] {

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -369,7 +369,17 @@ function formatPublicText(value: string | undefined): string {
 }
 
 function unique(values: string[]): string[] {
-  return [...new Set(values.map((value) => formatPublicText(value)).filter(Boolean))];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const formatted = formatPublicText(value);
+    if (!formatted) continue;
+    const key = formatted.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(formatted);
+  }
+  return result;
 }
 
 function hashBody(value: string): string {

--- a/src/github.ts
+++ b/src/github.ts
@@ -2,6 +2,7 @@ import { createSign } from "node:crypto";
 import { readFileSync } from "node:fs";
 import type { IssueCommentCommandSource } from "./commands.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
+import { redactSecrets } from "./secrets.js";
 import type { PullFilePatch, PullRequestSummary, ReviewComment, ReviewEvent } from "./types.js";
 
 export interface GitHubApiOptions {
@@ -221,7 +222,7 @@ export class GitHubApi {
 
     if (!response.ok) {
       const text = await response.text();
-      throw new Error(`GitHub API ${response.status} ${response.statusText} for ${path}: ${text.slice(0, 400)}`);
+      throw new Error(`GitHub API ${response.status} ${response.statusText} for ${path}: ${redactSecrets(text).slice(0, 400)}`);
     }
 
     return (await response.json()) as T;

--- a/src/github.ts
+++ b/src/github.ts
@@ -76,10 +76,17 @@ export class GitHubApi {
     }
   }
 
-  async getIssueOrPull(repo: string, issueNumber: number): Promise<GitHubRelatedIssueOrPull> {
-    return this.request<GitHubRelatedIssueOrPull>(`/repos/${repo}/issues/${issueNumber}`, {
-      token: await this.getReadToken(repo)
-    });
+  async getIssueOrPull(repo: string, issueNumber: number): Promise<GitHubRelatedIssueOrPull | undefined> {
+    const path = `/repos/${repo}/issues/${issueNumber}`;
+    try {
+      return await this.request<GitHubRelatedIssueOrPull>(path, {
+        token: await this.getReadToken(repo)
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes(`for ${path}:`) && /\bGitHub API (403|404)\b/.test(message)) return undefined;
+      throw error;
+    }
   }
 
   async createReview(input: {

--- a/src/github.ts
+++ b/src/github.ts
@@ -236,7 +236,7 @@ function isIssueLookupMissingOrUnreadable(message: string, path: string): boolea
   if (!/\bGitHub API 403\b/.test(message)) return false;
   if (/\b(rate limit|abuse|secondary rate limit)\b/i.test(message)) return false;
   const responseBody = message.slice(markerIndex + marker.length);
-  return /\b(Resource not accessible by integration|Not Found)\b/i.test(responseBody);
+  return /\bResource not accessible by integration\b/i.test(responseBody);
 }
 
 interface IssueCommentSummary {

--- a/src/github.ts
+++ b/src/github.ts
@@ -76,7 +76,11 @@ export class GitHubApi {
     }
   }
 
-  async getIssueOrPull(repo: string, issueNumber: number): Promise<GitHubRelatedIssueOrPull | undefined> {
+  async getIssueOrPull(
+    repo: string,
+    issueNumber: number,
+    options: { tolerateUnreadable?: boolean } = {}
+  ): Promise<GitHubRelatedIssueOrPull | undefined> {
     const path = `/repos/${repo}/issues/${issueNumber}`;
     try {
       return await this.request<GitHubRelatedIssueOrPull>(path, {
@@ -84,7 +88,7 @@ export class GitHubApi {
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      if (isIssueLookupMissingOrUnreadable(message, path)) return undefined;
+      if (options.tolerateUnreadable && isIssueLookupMissingOrUnreadable(message, path)) return undefined;
       throw error;
     }
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -229,11 +229,14 @@ export class GitHubApi {
 }
 
 function isIssueLookupMissingOrUnreadable(message: string, path: string): boolean {
-  if (!message.includes(`for ${path}:`)) return false;
+  const marker = `for ${path}:`;
+  const markerIndex = message.indexOf(marker);
+  if (markerIndex === -1) return false;
   if (/\bGitHub API 404\b/.test(message)) return true;
   if (!/\bGitHub API 403\b/.test(message)) return false;
   if (/\b(rate limit|abuse|secondary rate limit)\b/i.test(message)) return false;
-  return /\b(Resource not accessible by integration|Not Found|Forbidden)\b/i.test(message);
+  const responseBody = message.slice(markerIndex + marker.length);
+  return /\b(Resource not accessible by integration|Not Found)\b/i.test(responseBody);
 }
 
 interface IssueCommentSummary {

--- a/src/github.ts
+++ b/src/github.ts
@@ -84,7 +84,7 @@ export class GitHubApi {
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      if (message.includes(`for ${path}:`) && /\bGitHub API (403|404)\b/.test(message)) return undefined;
+      if (isIssueLookupMissingOrUnreadable(message, path)) return undefined;
       throw error;
     }
   }
@@ -222,6 +222,14 @@ export class GitHubApi {
 
     return (await response.json()) as T;
   }
+}
+
+function isIssueLookupMissingOrUnreadable(message: string, path: string): boolean {
+  if (!message.includes(`for ${path}:`)) return false;
+  if (/\bGitHub API 404\b/.test(message)) return true;
+  if (!/\bGitHub API 403\b/.test(message)) return false;
+  if (/\b(rate limit|abuse|secondary rate limit)\b/i.test(message)) return false;
+  return /\b(Resource not accessible by integration|Not Found|Forbidden)\b/i.test(message);
 }
 
 interface IssueCommentSummary {

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -1,12 +1,15 @@
 import { execFile } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
+const tsxCliPath = require.resolve("tsx/cli");
 
 describe("build-enrichment-comment issue CLI", () => {
   const roots: string[] = [];
@@ -131,7 +134,7 @@ describe("build-enrichment-comment issue CLI", () => {
 });
 
 async function runCli(args: string[]) {
-  return execFileAsync(process.execPath, ["./node_modules/.bin/tsx", "src/cli.ts", ...args], {
+  return execFileAsync(process.execPath, [tsxCliPath, "src/cli.ts", ...args], {
     cwd: process.cwd(),
     encoding: "utf8",
     env: {

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -37,7 +37,10 @@ describe("build-enrichment-comment issue CLI", () => {
 
       expect(parsed).toMatchObject({ ok: true, skipped: false, repo: "owner/repo", issueNumber: 17 });
       expect(readFileSync(join(outputDir, "enrichment-comment.json"), "utf8")).toContain("\"issueNumber\": 17");
-      expect(readFileSync(join(outputDir, "enrichment.md"), "utf8")).toContain("## evaOS issue enrichment");
+      const markdown = readFileSync(join(outputDir, "enrichment.md"), "utf8");
+      expect(markdown).toContain("## evaOS issue enrichment");
+      expect(markdown).toContain("Confirm owner, acceptance criteria, and validation evidence before implementation.");
+      expect(markdown).not.toContain("Proof status:");
       expect(requests).toContainEqual({
         method: "GET",
         path: "/repos/owner/repo/issues/17",

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -1,0 +1,236 @@
+import { execFile } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+describe("build-enrichment-comment issue CLI", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("writes JSON and Markdown for open issue dry runs", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const evidenceDir = join(root, "evidence");
+      const outputDir = join(evidenceDir, "issue-open");
+      const configPath = writeConfig(root, apiBaseUrl);
+
+      const { stdout } = await runCli([
+        "build-enrichment-comment",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/repo",
+        "--issue",
+        "17",
+        "--output-dir",
+        outputDir
+      ]);
+      const parsed = JSON.parse(stdout);
+
+      expect(parsed).toMatchObject({ ok: true, skipped: false, repo: "owner/repo", issueNumber: 17 });
+      expect(readFileSync(join(outputDir, "enrichment-comment.json"), "utf8")).toContain("\"issueNumber\": 17");
+      expect(readFileSync(join(outputDir, "enrichment.md"), "utf8")).toContain("## evaOS issue enrichment");
+      expect(requests).toContainEqual({
+        method: "GET",
+        path: "/repos/owner/repo/issues/17",
+        authorization: "Bearer test-token"
+      });
+    });
+  });
+
+  it("writes only JSON for skipped issue dry runs", async () => {
+    await withMockGitHub(async ({ apiBaseUrl }) => {
+      const root = createRoot(roots);
+      const evidenceDir = join(root, "evidence");
+      const outputDir = join(evidenceDir, "issue-closed");
+      const configPath = writeConfig(root, apiBaseUrl);
+
+      const { stdout } = await runCli([
+        "build-enrichment-comment",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/repo",
+        "--issue",
+        "18",
+        "--output-dir",
+        outputDir
+      ]);
+      const parsed = JSON.parse(stdout);
+
+      expect(parsed).toMatchObject({ ok: true, skipped: true, reason: "stale_issue_closed" });
+      expect(existsSync(join(outputDir, "enrichment-comment.json"))).toBe(true);
+      expect(existsSync(join(outputDir, "enrichment.md"))).toBe(false);
+    });
+  });
+
+  it("surfaces unreadable issues through the friendly operator error", async () => {
+    await withMockGitHub(async ({ apiBaseUrl }) => {
+      const root = createRoot(roots);
+      const configPath = writeConfig(root, apiBaseUrl);
+
+      await expect(runCli([
+        "build-enrichment-comment",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/repo",
+        "--issue",
+        "404"
+      ])).rejects.toMatchObject({
+        stderr: expect.stringContaining("Issue owner/repo#404 was not found or is not readable")
+      });
+    });
+  });
+
+  it("requires exactly one PR or issue target", async () => {
+    await expect(runCli([
+      "build-enrichment-comment",
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "1",
+      "--issue",
+      "17"
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining("exactly one of --pr or --issue is required")
+    });
+  });
+
+  it("rejects issue output directories outside the configured evidence dir", async () => {
+    await withMockGitHub(async ({ apiBaseUrl }) => {
+      const root = createRoot(roots);
+      const configPath = writeConfig(root, apiBaseUrl);
+
+      await expect(runCli([
+        "build-enrichment-comment",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/repo",
+        "--issue",
+        "17",
+        "--output-dir",
+        join(root, "not-evidence")
+      ])).rejects.toMatchObject({
+        stderr: expect.stringMatching(/configured evidenceDir|repository checkout/)
+      });
+    });
+  });
+});
+
+async function runCli(args: string[]) {
+  return execFileAsync(process.execPath, ["./node_modules/.bin/tsx", "src/cli.ts", ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      EVAOS_REVIEW_BOT_APP_ID: "",
+      EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: "",
+      GITHUB_TOKEN: "test-token"
+    },
+    maxBuffer: 1024 * 1024
+  });
+}
+
+function createRoot(roots: string[]): string {
+  const root = mkdtempSync(join(tmpdir(), "enrichment-cli-"));
+  roots.push(root);
+  return root;
+}
+
+function writeConfig(root: string, apiBaseUrl: string): string {
+  const path = join(root, "config.json");
+  writeFileSync(path, `${JSON.stringify({
+    pilotRepos: ["owner/repo"],
+    statePath: join(root, "state.sqlite"),
+    evidenceDir: join(root, "evidence"),
+    github: {
+      token: "test-token",
+      apiBaseUrl
+    },
+    enrichment: {
+      enabled: false,
+      postIssueComment: false,
+      packetVersion: "enrichment-comment-v0.1",
+      maxRelatedRefs: 2,
+      maxSuggestions: 2
+    },
+    repoProfiles: {
+      repos: {
+        "owner/repo": {
+          enabled: true,
+          suggestedLabels: ["triage"],
+          suggestedReviewers: ["owner-a"]
+        }
+      }
+    }
+  }, null, 2)}\n`);
+  return path;
+}
+
+async function withMockGitHub(
+  callback: (input: { apiBaseUrl: string; requests: Array<{ method: string; path: string; authorization?: string }> }) => Promise<void>
+): Promise<void> {
+  const requests: Array<{ method: string; path: string; authorization?: string }> = [];
+  const server = createServer((request, response) => {
+    const method = request.method ?? "GET";
+    const path = request.url ?? "/";
+    requests.push({ method, path, authorization: request.headers.authorization });
+    routeMockGitHub(request, response);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("mock GitHub server did not bind to a TCP port");
+  try {
+    await callback({ apiBaseUrl: `http://127.0.0.1:${address.port}`, requests });
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+}
+
+function routeMockGitHub(request: IncomingMessage, response: ServerResponse): void {
+  if (request.method !== "GET") {
+    respondJson(response, 405, { message: "method not allowed" });
+    return;
+  }
+  if (request.url === "/repos/owner/repo/issues/17") {
+    respondJson(response, 200, {
+      number: 17,
+      title: "Open issue #11 #12 #13",
+      state: "open",
+      html_url: "https://github.test/owner/repo/issues/17",
+      body: "Acceptance criteria and owner are present.",
+      labels: [{ name: "support" }]
+    });
+    return;
+  }
+  if (request.url === "/repos/owner/repo/issues/18") {
+    respondJson(response, 200, {
+      number: 18,
+      title: "Closed issue",
+      state: "closed",
+      html_url: "https://github.test/owner/repo/issues/18",
+      body: "Done."
+    });
+    return;
+  }
+  if (request.url === "/repos/owner/repo/issues/404") {
+    respondJson(response, 404, { message: "Not Found" });
+    return;
+  }
+  respondJson(response, 404, { message: `unexpected path ${request.url}` });
+}
+
+function respondJson(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, { "Content-Type": "application/json" });
+  response.end(JSON.stringify(body));
+}

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -228,9 +228,17 @@ describe("sticky enrichment comments", () => {
       pull_request: {},
       body: "This is a pull request record."
     };
+    const closedPullRequestIssue: GitHubRelatedIssueOrPull = {
+      number: 92,
+      title: "Closed PR shaped issue",
+      state: "closed",
+      pull_request: {},
+      body: "This is a closed pull request record."
+    };
 
     expect(() => buildIssueEnrichmentComment({ repo: "electricsheephq/evaos-code-review-bot", issue: closedIssue })).toThrow("stale_issue_closed");
     expect(() => buildIssueEnrichmentComment({ repo: "electricsheephq/evaos-code-review-bot", issue: pullRequestIssue })).toThrow("issue_is_pull_request");
+    expect(() => buildIssueEnrichmentComment({ repo: "electricsheephq/evaos-code-review-bot", issue: closedPullRequestIssue })).toThrow("issue_is_pull_request");
   });
 
   it("includes issue URL on successful issue enrichment dry runs", () => {
@@ -357,20 +365,21 @@ describe("sticky enrichment comments", () => {
     const comment = buildIssueEnrichmentComment({
       repo: "electricsheephq/evaos-code-review-bot",
       issue,
-      suggestedLabels: ["Bug", "runtime", "docs", "tests"],
-      suggestedOwners: ["owner-a", "owner-b", "owner-c"],
+      suggestedLabels: ["Bug", "runtime", "Runtime", "docs", "tests"],
+      suggestedOwners: ["owner-a", "owner-b", "owner-c", "owner-d"],
       maxRelatedRefs: 2,
-      maxSuggestions: 2
+      maxSuggestions: 3
     });
 
     const relatedRefsLine = comment.body.split("\n").find((line) => line.startsWith("Related issues/PRs:"));
     expect(relatedRefsLine).toBe("Related issues/PRs: #1, #2.");
     expect(relatedRefsLine).not.toContain("#3");
     expect(comment.body).toContain("Existing labels: bug.");
-    expect(comment.body).toContain("Suggested labels: runtime, docs.");
+    expect(comment.body).toContain("Suggested labels: runtime, docs, tests.");
+    expect(comment.body).not.toContain("Suggested labels: runtime, Runtime");
     expect(comment.body).not.toContain("Suggested labels: Bug");
-    expect(comment.body).toContain("Suggested owners: owner-a, owner-b.");
-    expect(comment.body).not.toContain("owner-c");
+    expect(comment.body).toContain("Suggested owners: owner-a, owner-b, owner-c.");
+    expect(comment.body).not.toContain("owner-d");
   });
 });
 

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -204,6 +204,7 @@ describe("sticky enrichment comments", () => {
     expect(comment.marker).toBe(buildIssueEnrichmentMarker({ repo: "electricsheephq/evaos-code-review-bot", issueNumber: 88 }));
     expect(comment.body).toContain(`${ENRICHMENT_MARKER_PREFIX} repo=electricsheephq/evaos-code-review-bot issue=88 -->`);
     expect(comment.body).toContain(`${ENRICHMENT_STATE_MARKER_PREFIX} version=1 repo=electricsheephq/evaos-code-review-bot issue=88 state=open`);
+    expect(comment.body).toMatch(/^<!-- evaos-code-review-bot:enrichment repo=electricsheephq\/evaos-code-review-bot issue=88 -->\n<!-- evaos-code-review-bot:enrichment-state version=1 repo=electricsheephq\/evaos-code-review-bot issue=88 state=open hash=[0-9a-f]{64} -->\n## evaOS issue enrichment/);
     expect(comment.body).toContain("Issue: electricsheephq/evaos-code-review-bot#88 - Triage support escalation #22");
     expect(comment.body).toContain("Related issues/PRs: #22");
     expect(comment.body).toContain("Existing labels: support");

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -6,10 +6,14 @@ import { loadConfig } from "../src/config.js";
 import {
   buildEnrichmentComment,
   buildEnrichmentMarker,
+  buildIssueEnrichmentComment,
+  buildIssueEnrichmentDryRunOutput,
+  buildIssueEnrichmentMarker,
   ENRICHMENT_MARKER_PREFIX,
   ENRICHMENT_STATE_MARKER_PREFIX,
   postEnrichmentComment
 } from "../src/enrichment.js";
+import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js";
 import type { PullFilePatch, PullRequestSummary } from "../src/types.js";
 
 const HEAD_A = "a".repeat(40);
@@ -174,6 +178,139 @@ describe("sticky enrichment comments", () => {
     } finally {
       rmSync(evidenceDir, { recursive: true, force: true });
     }
+  });
+
+  it("renders sticky issue enrichment with suggestion-only text and redaction", () => {
+    const issue: GitHubRelatedIssueOrPull = {
+      number: 88,
+      title: "Triage support escalation #22",
+      state: "open",
+      html_url: "https://github.test/electricsheephq/evaos-code-review-bot/issues/88",
+      body: "Customer path missing validation evidence. ghp_123456789012345678901234",
+      user: { login: "issue-author" },
+      labels: [{ name: "support" }],
+      milestone: { title: "v0.2" }
+    };
+
+    const comment = buildIssueEnrichmentComment({
+      repo: "electricsheephq/evaos-code-review-bot",
+      issue,
+      suggestedLabels: ["triage", "support"],
+      suggestedOwners: ["runtime-owner"],
+      validationSuggestions: ["Confirm owner and acceptance criteria before implementation."],
+      postIssueComment: true
+    });
+
+    expect(comment.marker).toBe(buildIssueEnrichmentMarker({ repo: "electricsheephq/evaos-code-review-bot", issueNumber: 88 }));
+    expect(comment.body).toContain(`${ENRICHMENT_MARKER_PREFIX} repo=electricsheephq/evaos-code-review-bot issue=88 -->`);
+    expect(comment.body).toContain(`${ENRICHMENT_STATE_MARKER_PREFIX} version=1 repo=electricsheephq/evaos-code-review-bot issue=88 state=open`);
+    expect(comment.body).toContain("Issue: electricsheephq/evaos-code-review-bot#88 - Triage support escalation #22");
+    expect(comment.body).toContain("Related issues/PRs: #22");
+    expect(comment.body).toContain("Existing labels: support");
+    expect(comment.body).toContain("Suggested labels: triage");
+    expect(comment.body).toContain("Suggested owners: runtime-owner");
+    expect(comment.body).toContain("No labels, owners, reviewers, or roadmap fields were changed by this bot.");
+    expect(comment.body).not.toContain("ghp_123456789012345678901234");
+  });
+
+  it("rejects stale or pull-request-shaped issues at the comment builder boundary", () => {
+    const closedIssue: GitHubRelatedIssueOrPull = {
+      number: 90,
+      title: "Closed",
+      state: "closed",
+      body: "Done"
+    };
+    const pullRequestIssue: GitHubRelatedIssueOrPull = {
+      number: 91,
+      title: "PR shaped issue",
+      state: "open",
+      pull_request: {},
+      body: "This is a pull request record."
+    };
+
+    expect(() => buildIssueEnrichmentComment({ repo: "electricsheephq/evaos-code-review-bot", issue: closedIssue })).toThrow("stale_issue_closed");
+    expect(() => buildIssueEnrichmentComment({ repo: "electricsheephq/evaos-code-review-bot", issue: pullRequestIssue })).toThrow("issue_is_pull_request");
+  });
+
+  it("includes issue URL on successful issue enrichment dry runs", () => {
+    const issue: GitHubRelatedIssueOrPull = {
+      number: 92,
+      title: "Open issue",
+      state: "open",
+      html_url: "https://github.test/electricsheephq/evaos-code-review-bot/issues/92",
+      body: "Acceptance criteria present."
+    };
+
+    const output = buildIssueEnrichmentDryRunOutput({
+      repo: "electricsheephq/evaos-code-review-bot",
+      issue,
+      maxRelatedRefs: 8,
+      maxSuggestions: 8
+    });
+
+    expect(output).toMatchObject({
+      ok: true,
+      skipped: false,
+      repo: "electricsheephq/evaos-code-review-bot",
+      issueNumber: 92,
+      state: "open",
+      url: "https://github.test/electricsheephq/evaos-code-review-bot/issues/92"
+    });
+  });
+
+  it("skips stale closed issues for issue enrichment dry runs", () => {
+    const issue: GitHubRelatedIssueOrPull = {
+      number: 89,
+      title: "Already handled",
+      state: "closed",
+      html_url: "https://github.test/electricsheephq/evaos-code-review-bot/issues/89",
+      body: "Done"
+    };
+
+    const output = buildIssueEnrichmentDryRunOutput({
+      repo: "electricsheephq/evaos-code-review-bot",
+      issue,
+      maxRelatedRefs: 8,
+      maxSuggestions: 8
+    });
+
+    expect(output).toMatchObject({
+      ok: true,
+      skipped: true,
+      reason: "stale_issue_closed",
+      repo: "electricsheephq/evaos-code-review-bot",
+      issueNumber: 89,
+      state: "closed"
+    });
+    expect(JSON.stringify(output)).not.toContain("body");
+  });
+
+  it("skips pull-request-shaped issues for issue enrichment dry runs", () => {
+    const issue: GitHubRelatedIssueOrPull = {
+      number: 93,
+      title: "Actually a pull request",
+      state: "open",
+      html_url: "https://github.test/electricsheephq/evaos-code-review-bot/pull/93",
+      pull_request: {},
+      body: "PR payload"
+    };
+
+    const output = buildIssueEnrichmentDryRunOutput({
+      repo: "electricsheephq/evaos-code-review-bot",
+      issue,
+      maxRelatedRefs: 8,
+      maxSuggestions: 8
+    });
+
+    expect(output).toMatchObject({
+      ok: true,
+      skipped: true,
+      reason: "issue_is_pull_request",
+      repo: "electricsheephq/evaos-code-review-bot",
+      issueNumber: 93,
+      state: "open"
+    });
+    expect(JSON.stringify(output)).not.toContain("body");
   });
 });
 

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -341,7 +341,7 @@ describe("sticky enrichment comments", () => {
     });
 
     expect(openOutput).toMatchObject({ skipped: false, state: "open" });
-    expect(unknownOutput).toMatchObject({ skipped: false, state: "needs-triage" });
+    expect(unknownOutput).toMatchObject({ skipped: false, state: "unknown" });
   });
 
   it("caps issue enrichment related refs, labels, and owners", () => {

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -312,6 +312,65 @@ describe("sticky enrichment comments", () => {
     });
     expect(JSON.stringify(output)).not.toContain("body");
   });
+
+  it("normalizes issue state casing without treating unknown states as closed", () => {
+    const uppercaseOpen: GitHubRelatedIssueOrPull = {
+      number: 94,
+      title: "Uppercase open issue",
+      state: "OPEN",
+      body: "Acceptance criteria present."
+    };
+    const unknownState: GitHubRelatedIssueOrPull = {
+      number: 95,
+      title: "Unknown state issue",
+      state: "needs-triage",
+      body: "Acceptance criteria present."
+    };
+
+    const openOutput = buildIssueEnrichmentDryRunOutput({
+      repo: "electricsheephq/evaos-code-review-bot",
+      issue: uppercaseOpen,
+      maxRelatedRefs: 8,
+      maxSuggestions: 8
+    });
+    const unknownOutput = buildIssueEnrichmentDryRunOutput({
+      repo: "electricsheephq/evaos-code-review-bot",
+      issue: unknownState,
+      maxRelatedRefs: 8,
+      maxSuggestions: 8
+    });
+
+    expect(openOutput).toMatchObject({ skipped: false, state: "open" });
+    expect(unknownOutput).toMatchObject({ skipped: false, state: "needs-triage" });
+  });
+
+  it("caps issue enrichment related refs, labels, and owners", () => {
+    const issue: GitHubRelatedIssueOrPull = {
+      number: 96,
+      title: "Runtime regression #1 #2 #3",
+      state: "open",
+      body: "Bug docs test support references #4 #5 #6.",
+      labels: [{ name: "bug" }]
+    };
+
+    const comment = buildIssueEnrichmentComment({
+      repo: "electricsheephq/evaos-code-review-bot",
+      issue,
+      suggestedLabels: ["Bug", "runtime", "docs", "tests"],
+      suggestedOwners: ["owner-a", "owner-b", "owner-c"],
+      maxRelatedRefs: 2,
+      maxSuggestions: 2
+    });
+
+    const relatedRefsLine = comment.body.split("\n").find((line) => line.startsWith("Related issues/PRs:"));
+    expect(relatedRefsLine).toBe("Related issues/PRs: #1, #2.");
+    expect(relatedRefsLine).not.toContain("#3");
+    expect(comment.body).toContain("Existing labels: bug.");
+    expect(comment.body).toContain("Suggested labels: runtime, docs.");
+    expect(comment.body).not.toContain("Suggested labels: Bug");
+    expect(comment.body).toContain("Suggested owners: owner-a, owner-b.");
+    expect(comment.body).not.toContain("owner-c");
+  });
 });
 
 function extractStateHash(body: string): string {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -202,6 +202,26 @@ describe("GitHub App read authentication", () => {
     await expect(github.getIssueOrPull("owner/repo", 403, { tolerateUnreadable: true })).rejects.toThrow(/SAML enforcement/);
   });
 
+  it("redacts secret-like text from rethrown GitHub response bodies", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-issue-redacted-error-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    const leakedToken = "ghp_123456789012345678901234567890123456";
+
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: `SAML enforcement ${leakedToken}` }, 403, "Forbidden");
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath, token: "fallback-token" });
+    await expect(github.getIssueOrPull("owner/repo", 403, { tolerateUnreadable: true })).rejects.toThrow("[redacted-secret]");
+    await expect(github.getIssueOrPull("owner/repo", 403, { tolerateUnreadable: true })).rejects.not.toThrow(leakedToken);
+  });
+
   it("updates an existing marked PR walkthrough comment with the App token", async () => {
     const root = mkdtempSync(join(tmpdir(), "github-app-comment-"));
     roots.push(root);

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -166,6 +166,24 @@ describe("GitHub App read authentication", () => {
     await expect(github.getIssueOrPull("owner/repo", 403, { tolerateUnreadable: true })).rejects.toThrow(/SAML enforcement/);
   });
 
+  it("does not treat the 403 reason phrase as an unreadable issue body", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-issue-status-text-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "SAML enforcement blocks this installation" }, 403, "Forbidden");
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath, token: "fallback-token" });
+    await expect(github.getIssueOrPull("owner/repo", 403, { tolerateUnreadable: true })).rejects.toThrow(/SAML enforcement/);
+  });
+
   it("updates an existing marked PR walkthrough comment with the App token", async () => {
     const root = mkdtempSync(join(tmpdir(), "github-app-comment-"));
     roots.push(root);
@@ -278,9 +296,10 @@ describe("GitHub App read authentication", () => {
   });
 });
 
-function jsonResponse(body: unknown, status = 200): Response {
+function jsonResponse(body: unknown, status = 200, statusText = ""): Response {
   return new Response(JSON.stringify(body), {
     status,
+    statusText,
     headers: { "Content-Type": "application/json" }
   });
 }

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -148,6 +148,24 @@ describe("GitHub App read authentication", () => {
     await expect(github.getIssueOrPull("owner/repo", 403)).rejects.toThrow(/rate limit/i);
   });
 
+  it("rethrows non-allowlisted 403 issue lookup errors even when unreadable lookups are tolerated", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-issue-forbidden-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "SAML enforcement blocks this installation" }, 403);
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath, token: "fallback-token" });
+    await expect(github.getIssueOrPull("owner/repo", 403, { tolerateUnreadable: true })).rejects.toThrow(/SAML enforcement/);
+  });
+
   it("updates an existing marked PR walkthrough comment with the App token", async () => {
     const root = mkdtempSync(join(tmpdir(), "github-app-comment-"));
     roots.push(root);

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -126,7 +126,8 @@ describe("GitHub App read authentication", () => {
     }) as typeof fetch;
 
     const github = new GitHubApi({ appId: "4184532", privateKeyPath, token: "fallback-token" });
-    await expect(github.getIssueOrPull("owner/repo", 404)).resolves.toBeUndefined();
+    await expect(github.getIssueOrPull("owner/repo", 404, { tolerateUnreadable: true })).resolves.toBeUndefined();
+    await expect(github.getIssueOrPull("owner/repo", 404)).rejects.toThrow(/Resource not accessible by integration/);
   });
 
   it("does not hide rate-limited issue lookups as unreadable", async () => {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -105,10 +105,28 @@ describe("GitHub App read authentication", () => {
     const github = new GitHubApi({ appId: "4184532", privateKeyPath, token: "fallback-token" });
     const issue = await github.getIssueOrPull("owner/repo", 17);
 
-    expect(issue.title).toBe("Linked issue");
+    expect(issue?.title).toBe("Linked issue");
     const readCall = calls.find((call) => call.url.endsWith("/repos/owner/repo/issues/17"));
     expect(readCall?.authorization).toBe("Bearer installation-token");
     expect(readCall?.authorization).not.toBe("Bearer fallback-token");
+  });
+
+  it("returns undefined for unreadable issue lookups", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-issue-missing-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      if (String(url).endsWith("/repos/owner/repo/issues/404")) return jsonResponse({ message: "Resource not accessible by integration" }, 403);
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath, token: "fallback-token" });
+    await expect(github.getIssueOrPull("owner/repo", 404)).resolves.toBeUndefined();
   });
 
   it("updates an existing marked PR walkthrough comment with the App token", async () => {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -129,6 +129,24 @@ describe("GitHub App read authentication", () => {
     await expect(github.getIssueOrPull("owner/repo", 404)).resolves.toBeUndefined();
   });
 
+  it("does not hide rate-limited issue lookups as unreadable", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-issue-rate-limit-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "API rate limit exceeded for installation" }, 403);
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath, token: "fallback-token" });
+    await expect(github.getIssueOrPull("owner/repo", 403)).rejects.toThrow(/rate limit/i);
+  });
+
   it("updates an existing marked PR walkthrough comment with the App token", async () => {
     const root = mkdtempSync(join(tmpdir(), "github-app-comment-"));
     roots.push(root);

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -184,6 +184,24 @@ describe("GitHub App read authentication", () => {
     await expect(github.getIssueOrPull("owner/repo", 403, { tolerateUnreadable: true })).rejects.toThrow(/SAML enforcement/);
   });
 
+  it("does not treat incidental Not Found text in a 403 body as an unreadable issue", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-issue-403-not-found-text-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/app/installations/123/access_tokens")) return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      if (String(url).endsWith("/repos/owner/repo/issues/403")) return jsonResponse({ message: "SAML enforcement blocks this installation; nested error: Not Found" }, 403, "Forbidden");
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath, token: "fallback-token" });
+    await expect(github.getIssueOrPull("owner/repo", 403, { tolerateUnreadable: true })).rejects.toThrow(/SAML enforcement/);
+  });
+
   it("updates an existing marked PR walkthrough comment with the App token", async () => {
     const root = mkdtempSync(join(tmpdir(), "github-app-comment-"));
     roots.push(root);

--- a/tests/review-scheduler-config.test.ts
+++ b/tests/review-scheduler-config.test.ts
@@ -34,6 +34,24 @@ describe("review scheduler config", () => {
     }))).toThrow("config.reviewScheduler.manualCommandReserve must be <= config.reviewScheduler.maxProviderActive");
   });
 
+  it("validates optional GitHub API client settings", () => {
+    expect(loadConfig(writeConfig({
+      github: {
+        apiBaseUrl: "https://api.github.test",
+        botLogin: "evaos-code-review-bot[bot]",
+        requestTimeoutMs: 1_000
+      }
+    })).github).toMatchObject({
+      apiBaseUrl: "https://api.github.test",
+      botLogin: "evaos-code-review-bot[bot]",
+      requestTimeoutMs: 1_000
+    });
+
+    expect(() => loadConfig(writeConfig({ github: { apiBaseUrl: 42 } }))).toThrow(/config\.github\.apiBaseUrl/);
+    expect(() => loadConfig(writeConfig({ github: { botLogin: 42 } }))).toThrow(/config\.github\.botLogin/);
+    expect(() => loadConfig(writeConfig({ github: { requestTimeoutMs: 0 } }))).toThrow(/config\.github\.requestTimeoutMs/);
+  });
+
   function writeConfig(overlay: Record<string, unknown>): string {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-scheduler-config-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- Adds `build-enrichment-comment --issue` dry-run support with bot-owned issue markers, rendered state hash, related-ref/label/owner suggestions, and redacted Markdown/JSON evidence.
- Skips PR-shaped issues and closed/stale issues without writing Markdown bodies.
- Documents the issue-enrichment operator flow and the live App permission boundary.

## Proof Boundary
Refs #10, but does not close it yet. Live App-authored issue enrichment is blocked until #135 expands/approves GitHub App Issues permissions and wires live issue monitoring/comment posting behind config gates.

## Validation
- `npm run build`
- `npm test -- tests/enrichment.test.ts tests/operator-cli.test.ts` (31 tests)
- `npm test` (36 files / 355 tests)
- `git diff --check`
- Dry-run issue evidence: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-02/v0.4.1-beta.2/enrichment/evaos-code-review-bot-issue-10/`
- Stale issue skip evidence: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-02/v0.4.1-beta.2/enrichment/evaos-code-review-bot-issue-7-closed/`
- App permission blocker evidence: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-02/v0.4.1-beta.2/enrichment/app-permission-check/`

## Review Notes
- This PR does not enable posting, polling, labels, reviewers, owners, Notion, or Linear mutation.
- Replacement review agent found no blocking findings on the changed files; one earlier review agent hit an external usage limit and was replaced.
