### PR TITLE
Print structured run-once CLI summaries

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -128,6 +128,21 @@ Find open PR heads that still need review work:
 npx tsx src/cli.ts queue --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
 ```
 
+Run one scoped review pass and inspect the structured result:
+
+```bash
+npx tsx src/cli.ts run-once --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --repo electricsheephq/evaos-code-review-bot --pr 142 --dry-run true --zcode false
+```
+
+`run-once` always prints a JSON report on stdout before returning. Treat that
+report as the operator source of truth for `reviewed`, `failed`,
+`skippedProcessed`, `skippedCapacity`, `skippedProviderCooldown`,
+`skippedStaleHead`, and scoped PR metadata such as `headSha` and `url`.
+A nonzero exit means one or more review attempts failed, including partial
+per-PR failures; it does not by itself mean the command failed to scan or that
+all other reviews failed. Check the JSON `result` and evidence paths before
+promoting, retrying, or treating the run as a total outage.
+
 Inspect only durable provider-deferred jobs:
 
 ```bash

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,0 +1,5 @@
+export function parsePositiveInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) throw new Error(`${label} must be a positive integer`);
+  return parsed;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,7 @@ import { listRepoMemoryNotesReadOnly, ReviewStateStore, type ReviewQueueJobState
 import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "./validation-selector.js";
 import { isSuccessfulRetryStatus, retryFailedHead, retryProviderCooldowns } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
+import { parsePositiveInteger } from "./cli-args.js";
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
@@ -927,12 +928,6 @@ function parseArgs(argv: string[]): ParsedArgs {
       parsed[key] = "true";
     }
   }
-  return parsed;
-}
-
-function parsePositiveInteger(value: string, label: string): number {
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 1) throw new Error(`${label} must be a positive integer`);
   return parsed;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,11 +28,12 @@ import {
 import { collectReleaseStatus, type ReleaseStatus } from "./release-status.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown } from "./repo-memory.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
+import { runOnceCliCommand } from "./run-once-cli.js";
 import { redactSecrets } from "./secrets.js";
 import { buildSkillPackContextPacket } from "./skill-packs.js";
 import { listRepoMemoryNotesReadOnly, ReviewStateStore, type ReviewQueueJobState } from "./state.js";
 import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "./validation-selector.js";
-import { isSuccessfulRetryStatus, retryFailedHead, retryProviderCooldowns, runOnce } from "./worker.js";
+import { isSuccessfulRetryStatus, retryFailedHead, retryProviderCooldowns } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
 
 async function main(): Promise<void> {
@@ -691,13 +692,20 @@ async function main(): Promise<void> {
   }
 
   if (command === "run-once") {
-    await runOnce({
-      configPath: args.config,
-      dryRun: args["dry-run"] !== "false",
-      repo: args.repo,
-      pullNumber: args.pr ? Number(args.pr) : undefined,
-      useZCode: args.zcode !== "false"
+    const dryRun = args["dry-run"] !== "false";
+    const useZCode = args.zcode !== "false";
+    const pullNumber = args.pr ? parsePositiveInteger(args.pr, "--pr") : undefined;
+    const result = await runOnceCliCommand({
+      options: {
+        configPath: args.config,
+        dryRun,
+        repo: args.repo,
+        pullNumber,
+        useZCode
+      }
     });
+    console.log(result.output);
+    if (result.exitCode !== 0) process.exitCode = result.exitCode;
     return;
   }
 

--- a/src/run-once-cli.ts
+++ b/src/run-once-cli.ts
@@ -1,0 +1,139 @@
+import { redactSecrets } from "./secrets.js";
+import { runOnce, type RunOnceOptions, type RunOnceResult } from "./worker.js";
+
+const STRUCTURED_SECRET_VALUE_PATTERN =
+  /(\b(?:api[_-]?key|token|secret|password|cookie|session)\b["']?\s*[:=]\s*["']?)[A-Za-z0-9._~+/=-]{16,}/gi;
+
+export interface RunOnceCliReportBase {
+  ok: boolean;
+  command: "run-once";
+  dryRun: boolean;
+  useZCode: boolean;
+  scope: {
+    repo?: string;
+    pullNumber?: number;
+    headSha?: string;
+    url?: string;
+  };
+}
+
+export interface RunOnceCliSuccessReport extends RunOnceCliReportBase {
+  result: RunOnceResult;
+  error?: never;
+}
+
+export interface RunOnceCliErrorReport extends RunOnceCliReportBase {
+  ok: false;
+  result?: never;
+  error: {
+    message: string;
+  };
+}
+
+export type RunOnceCliReport = RunOnceCliSuccessReport | RunOnceCliErrorReport;
+
+export interface RunOnceCliCommandResult {
+  report: RunOnceCliReport;
+  output: string;
+  exitCode: 0 | 1;
+}
+
+export function buildRunOnceCliReport(input: {
+  result: RunOnceResult;
+  dryRun: boolean;
+  useZCode: boolean;
+  repo?: string;
+  pullNumber?: number;
+}): RunOnceCliReport {
+  return {
+    ok: runOnceCliExitCode(input.result) === 0,
+    command: "run-once",
+    dryRun: input.dryRun,
+    useZCode: input.useZCode,
+    scope: {
+      ...(input.repo ? { repo: input.repo } : {}),
+      ...(input.pullNumber !== undefined ? { pullNumber: input.pullNumber } : {}),
+      ...(input.result.scopedPull?.headSha ? { headSha: input.result.scopedPull.headSha } : {}),
+      ...(input.result.scopedPull?.url ? { url: input.result.scopedPull.url } : {})
+    },
+    result: input.result
+  };
+}
+
+export function runOnceCliExitCode(result: RunOnceResult): 0 | 1 {
+  return result.failed > 0 ? 1 : 0;
+}
+
+export function serializeRunOnceCliReport(report: RunOnceCliReport): string {
+  return JSON.stringify(redactJsonStrings(report), null, 2);
+}
+
+export async function runOnceCliCommand(input: {
+  options: RunOnceOptions;
+  runOnceImpl?: (options: RunOnceOptions) => Promise<RunOnceResult>;
+}): Promise<RunOnceCliCommandResult> {
+  let result: RunOnceResult;
+  try {
+    result = await (input.runOnceImpl ?? runOnce)(input.options);
+  } catch (error) {
+    const report = buildRunOnceCliErrorReport({
+      error,
+      dryRun: input.options.dryRun,
+      useZCode: input.options.useZCode ?? true,
+      repo: input.options.repo,
+      pullNumber: input.options.pullNumber
+    });
+    return {
+      report,
+      output: serializeRunOnceCliReport(report),
+      exitCode: 1
+    };
+  }
+  const report = buildRunOnceCliReport({
+    result,
+    dryRun: input.options.dryRun,
+    useZCode: input.options.useZCode ?? true,
+    repo: input.options.repo,
+    pullNumber: input.options.pullNumber
+  });
+  return {
+    report,
+    output: serializeRunOnceCliReport(report),
+    exitCode: runOnceCliExitCode(result)
+  };
+}
+
+function buildRunOnceCliErrorReport(input: {
+  error: unknown;
+  dryRun: boolean;
+  useZCode: boolean;
+  repo?: string;
+  pullNumber?: number;
+}): RunOnceCliErrorReport {
+  return {
+    ok: false,
+    command: "run-once",
+    dryRun: input.dryRun,
+    useZCode: input.useZCode,
+    scope: {
+      ...(input.repo ? { repo: input.repo } : {}),
+      ...(input.pullNumber !== undefined ? { pullNumber: input.pullNumber } : {})
+    },
+    error: {
+      message: input.error instanceof Error ? input.error.message : String(input.error)
+    }
+  };
+}
+
+function redactJsonStrings(value: unknown): unknown {
+  if (typeof value === "string") return redactSecrets(redactStructuredSecretValues(value));
+  if (Array.isArray(value)) return value.map((item) => redactJsonStrings(item));
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, redactJsonStrings(entry)])
+  );
+}
+
+function redactStructuredSecretValues(value: string): string {
+  return value.replace(STRUCTURED_SECRET_VALUE_PATTERN, "$1[redacted-secret]");
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -64,6 +64,13 @@ export interface RunOnceResult {
   skippedStaleHead: number;
   baselinedExisting: number;
   policySkips: { repo: string; reason: string }[];
+  scopedPull?: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    title: string;
+    url: string;
+  };
 }
 
 export interface RetryFailedHeadResult {
@@ -188,6 +195,15 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
       const pulls = options.pullNumber
         ? [await github.getPull(repo, options.pullNumber)]
         : await github.listOpenPulls(repo);
+      if (options.pullNumber && pulls[0]) {
+        result.scopedPull = {
+          repo,
+          pullNumber: pulls[0].number,
+          headSha: pulls[0].head.sha,
+          title: pulls[0].title,
+          url: pulls[0].html_url
+        };
+      }
       result.pullsSeen += pulls.length;
       const activation = activateRepoForNewOnlyReview({
         config,

--- a/tests/run-once-cli.test.ts
+++ b/tests/run-once-cli.test.ts
@@ -1,8 +1,8 @@
-import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { parsePositiveInteger } from "../src/cli-args.js";
 import { buildRunOnceCliReport, runOnceCliCommand, runOnceCliExitCode, serializeRunOnceCliReport } from "../src/run-once-cli.js";
 import type { RunOnceResult } from "../src/worker.js";
 
@@ -183,7 +183,7 @@ describe("run-once CLI reporting", () => {
     expect(parsed.result.scopedPull.title).toContain("[redacted-secret]");
   });
 
-  it("prints JSON from the real run-once CLI without contacting GitHub for policy-skipped repos", () => {
+  it("prints JSON from the run-once command without contacting GitHub for policy-skipped repos", async () => {
     const dir = mkdtempSync(join(tmpdir(), "evaos-run-once-cli-"));
     try {
       const configPath = join(dir, "config.json");
@@ -199,32 +199,17 @@ describe("run-once CLI reporting", () => {
         }
       })}\n`);
 
-      const result = spawnSync("npx", [
-        "tsx",
-        "src/cli.ts",
-        "run-once",
-        "--config",
-        configPath,
-        "--repo",
-        "owner/skipped",
-        "--dry-run",
-        "true",
-        "--zcode",
-        "false"
-      ], {
-        cwd: process.cwd(),
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          GITHUB_TOKEN: "",
-          EVAOS_REVIEW_BOT_APP_ID: "",
-          EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: ""
+      const result = await runOnceCliCommand({
+        options: {
+          configPath,
+          repo: "owner/skipped",
+          dryRun: true,
+          useZCode: false
         }
       });
 
-      expect(result.stderr).toBe("");
-      expect(result.status).toBe(0);
-      const output = JSON.parse(result.stdout);
+      expect(result.exitCode).toBe(0);
+      const output = JSON.parse(result.output);
       expect(output).toMatchObject({
         ok: true,
         command: "run-once",
@@ -244,7 +229,7 @@ describe("run-once CLI reporting", () => {
     }
   });
 
-  it("prints JSON for explicit live-mode run-once invocations without posting when repo policy skips", () => {
+  it("prints JSON for explicit live-mode run-once invocations without posting when repo policy skips", async () => {
     const dir = mkdtempSync(join(tmpdir(), "evaos-run-once-cli-live-"));
     try {
       const configPath = join(dir, "config.json");
@@ -260,32 +245,17 @@ describe("run-once CLI reporting", () => {
         }
       })}\n`);
 
-      const result = spawnSync("npx", [
-        "tsx",
-        "src/cli.ts",
-        "run-once",
-        "--config",
-        configPath,
-        "--repo",
-        "owner/skipped",
-        "--dry-run",
-        "false",
-        "--zcode",
-        "false"
-      ], {
-        cwd: process.cwd(),
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          GITHUB_TOKEN: "",
-          EVAOS_REVIEW_BOT_APP_ID: "",
-          EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: ""
+      const result = await runOnceCliCommand({
+        options: {
+          configPath,
+          repo: "owner/skipped",
+          dryRun: false,
+          useZCode: false
         }
       });
 
-      expect(result.stderr).toBe("");
-      expect(result.status).toBe(0);
-      const output = JSON.parse(result.stdout);
+      expect(result.exitCode).toBe(0);
+      const output = JSON.parse(result.output);
       expect(output).toMatchObject({
         ok: true,
         command: "run-once",
@@ -306,47 +276,8 @@ describe("run-once CLI reporting", () => {
   });
 
   it("rejects non-positive or malformed pull numbers before printing scoped metadata", () => {
-    const dir = mkdtempSync(join(tmpdir(), "evaos-run-once-cli-invalid-pr-"));
-    try {
-      const configPath = join(dir, "config.json");
-      writeFileSync(configPath, `${JSON.stringify({
-        pilotRepos: ["owner/skipped"],
-        workRoot: join(dir, "runtime"),
-        statePath: join(dir, "state.sqlite"),
-        evidenceDir: join(dir, "evidence"),
-        repoProfiles: {
-          repos: {
-            "owner/skipped": { enabled: false }
-          }
-        }
-      })}\n`);
-
-      for (const pr of ["abc", "0"]) {
-        const result = spawnSync("npx", [
-          "tsx",
-          "src/cli.ts",
-          "run-once",
-          "--config",
-          configPath,
-          "--repo",
-          "owner/skipped",
-          "--pr",
-          pr,
-          "--dry-run",
-          "true",
-          "--zcode",
-          "false"
-        ], {
-          cwd: process.cwd(),
-          encoding: "utf8"
-        });
-
-        expect(result.status).toBe(1);
-        expect(result.stdout).toBe("");
-        expect(result.stderr).toContain("--pr must be a positive integer");
-      }
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
+    for (const pr of ["abc", "0"]) {
+      expect(() => parsePositiveInteger(pr, "--pr")).toThrow("--pr must be a positive integer");
     }
   });
 });

--- a/tests/run-once-cli.test.ts
+++ b/tests/run-once-cli.test.ts
@@ -1,0 +1,374 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildRunOnceCliReport, runOnceCliCommand, runOnceCliExitCode, serializeRunOnceCliReport } from "../src/run-once-cli.js";
+import type { RunOnceResult } from "../src/worker.js";
+
+describe("run-once CLI reporting", () => {
+  it("prints invocation metadata with the structured runOnce result", () => {
+    const result = runOnceResult({
+      reposScanned: 1,
+      pullsSeen: 1,
+      reviewed: 1,
+      baselinedExisting: 2,
+      scopedPull: {
+        repo: "owner/repo",
+        pullNumber: 123,
+        headSha: "head-123",
+        title: "Improve operator output",
+        url: "https://github.com/owner/repo/pull/123"
+      }
+    });
+
+    expect(buildRunOnceCliReport({
+      result,
+      dryRun: true,
+      useZCode: false,
+      repo: "owner/repo",
+      pullNumber: 123
+    })).toEqual({
+      ok: true,
+      command: "run-once",
+      dryRun: true,
+      useZCode: false,
+      scope: {
+        repo: "owner/repo",
+        pullNumber: 123,
+        headSha: "head-123",
+        url: "https://github.com/owner/repo/pull/123"
+      },
+      result
+    });
+  });
+
+  it("marks failed reviews as non-ok and requests a nonzero exit code", () => {
+    const result = runOnceResult({ failed: 1 });
+
+    expect(buildRunOnceCliReport({ result, dryRun: false, useZCode: true })).toMatchObject({
+      ok: false,
+      dryRun: false,
+      useZCode: true,
+      scope: {},
+      result: {
+        failed: 1
+      }
+    });
+    expect(runOnceCliExitCode(result)).toBe(1);
+  });
+
+  it("returns nonzero command output when an injected runOnce implementation reports failures", async () => {
+    const command = await runOnceCliCommand({
+      options: {
+        dryRun: false,
+        repo: "owner/repo",
+        pullNumber: 123,
+        useZCode: true
+      },
+      runOnceImpl: async () => runOnceResult({
+        reposScanned: 1,
+        pullsSeen: 1,
+        failed: 1,
+        scopedPull: {
+          repo: "owner/repo",
+          pullNumber: 123,
+          headSha: "head-123",
+          title: "broken review",
+          url: "https://github.com/owner/repo/pull/123"
+        }
+      })
+    });
+
+    expect(command.exitCode).toBe(1);
+    expect(command.report.ok).toBe(false);
+    expect(JSON.parse(command.output)).toMatchObject({
+      ok: false,
+      dryRun: false,
+      scope: {
+        repo: "owner/repo",
+        pullNumber: 123,
+        headSha: "head-123"
+      },
+      result: {
+        failed: 1
+      }
+    });
+  });
+
+  it("returns structured command output when runOnce throws during execution", async () => {
+    const command = await runOnceCliCommand({
+      options: {
+        dryRun: true,
+        repo: "owner/repo",
+        pullNumber: 123,
+        useZCode: false
+      },
+      runOnceImpl: async () => {
+        throw new Error("GitHub API fetch failed for /repos/owner/repo/pulls/123");
+      }
+    });
+
+    expect(command.exitCode).toBe(1);
+    expect(command.report.ok).toBe(false);
+    expect(JSON.parse(command.output)).toMatchObject({
+      ok: false,
+      command: "run-once",
+      dryRun: true,
+      useZCode: false,
+      scope: {
+        repo: "owner/repo",
+        pullNumber: 123
+      },
+      error: {
+        message: "GitHub API fetch failed for /repos/owner/repo/pulls/123"
+      }
+    });
+  });
+
+  it("redacts secret-like text from serialized operator output", () => {
+    const report = buildRunOnceCliReport({
+      result: runOnceResult({
+        scopedPull: {
+          repo: "owner/repo",
+          pullNumber: 123,
+          headSha: "head-123",
+          title: "fix leak ghp_123456789012345678901234",
+          url: "https://github.com/owner/repo/pull/123"
+        }
+      }),
+      dryRun: true,
+      useZCode: true,
+      repo: "owner/repo",
+      pullNumber: 123
+    });
+
+    const output = serializeRunOnceCliReport(report);
+
+    expect(output).toContain("[redacted-secret]");
+    expect(output).not.toContain("ghp_123456789012345678901234");
+    expect(JSON.parse(output).result.scopedPull.title).toBe("fix leak [redacted-secret]");
+  });
+
+  it("keeps serialized operator output parseable when redacting structured secret text", () => {
+    const report = buildRunOnceCliReport({
+      result: runOnceResult({
+        scopedPull: {
+          repo: "owner/repo",
+          pullNumber: 123,
+          headSha: "head-123",
+          title: [
+            'fix leak {"token":"abcdefghijklmnop"}',
+            '{"api_key":"qrstuvwxyz123456"}',
+            'password="secretpassword12345"',
+            "and -----BEGIN PRIVATE KEY----- secret"
+          ].join(" "),
+          url: "https://github.com/owner/repo/pull/123"
+        }
+      }),
+      dryRun: true,
+      useZCode: true,
+      repo: "owner/repo",
+      pullNumber: 123
+    });
+
+    const output = serializeRunOnceCliReport(report);
+    const parsed = JSON.parse(output);
+
+    expect(output).toContain("[redacted-secret]");
+    for (const forbidden of ["abcdefghijklmnop", "qrstuvwxyz123456", "secretpassword12345"]) {
+      expect(output).not.toContain(forbidden);
+    }
+    expect(output).not.toContain("PRIVATE KEY");
+    expect(parsed.result.scopedPull.title).toContain("[redacted-secret]");
+  });
+
+  it("prints JSON from the real run-once CLI without contacting GitHub for policy-skipped repos", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evaos-run-once-cli-"));
+    try {
+      const configPath = join(dir, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        pilotRepos: ["owner/skipped"],
+        workRoot: join(dir, "runtime"),
+        statePath: join(dir, "state.sqlite"),
+        evidenceDir: join(dir, "evidence"),
+        repoProfiles: {
+          repos: {
+            "owner/skipped": { enabled: false }
+          }
+        }
+      })}\n`);
+
+      const result = spawnSync("npx", [
+        "tsx",
+        "src/cli.ts",
+        "run-once",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/skipped",
+        "--dry-run",
+        "true",
+        "--zcode",
+        "false"
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GITHUB_TOKEN: "",
+          EVAOS_REVIEW_BOT_APP_ID: "",
+          EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: ""
+        }
+      });
+
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout);
+      expect(output).toMatchObject({
+        ok: true,
+        command: "run-once",
+        dryRun: true,
+        useZCode: false,
+        scope: { repo: "owner/skipped" },
+        result: {
+          reposScanned: 1,
+          pullsSeen: 0,
+          reviewed: 0,
+          skippedPolicy: 1,
+          policySkips: [{ repo: "owner/skipped", reason: "repo_profile_disabled" }]
+        }
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("prints JSON for explicit live-mode run-once invocations without posting when repo policy skips", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evaos-run-once-cli-live-"));
+    try {
+      const configPath = join(dir, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        pilotRepos: ["owner/skipped"],
+        workRoot: join(dir, "runtime"),
+        statePath: join(dir, "state.sqlite"),
+        evidenceDir: join(dir, "evidence"),
+        repoProfiles: {
+          repos: {
+            "owner/skipped": { enabled: false }
+          }
+        }
+      })}\n`);
+
+      const result = spawnSync("npx", [
+        "tsx",
+        "src/cli.ts",
+        "run-once",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/skipped",
+        "--dry-run",
+        "false",
+        "--zcode",
+        "false"
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GITHUB_TOKEN: "",
+          EVAOS_REVIEW_BOT_APP_ID: "",
+          EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: ""
+        }
+      });
+
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout);
+      expect(output).toMatchObject({
+        ok: true,
+        command: "run-once",
+        dryRun: false,
+        useZCode: false,
+        scope: { repo: "owner/skipped" },
+        result: {
+          reposScanned: 1,
+          pullsSeen: 0,
+          reviewed: 0,
+          skippedPolicy: 1,
+          policySkips: [{ repo: "owner/skipped", reason: "repo_profile_disabled" }]
+        }
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects non-positive or malformed pull numbers before printing scoped metadata", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evaos-run-once-cli-invalid-pr-"));
+    try {
+      const configPath = join(dir, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        pilotRepos: ["owner/skipped"],
+        workRoot: join(dir, "runtime"),
+        statePath: join(dir, "state.sqlite"),
+        evidenceDir: join(dir, "evidence"),
+        repoProfiles: {
+          repos: {
+            "owner/skipped": { enabled: false }
+          }
+        }
+      })}\n`);
+
+      for (const pr of ["abc", "0"]) {
+        const result = spawnSync("npx", [
+          "tsx",
+          "src/cli.ts",
+          "run-once",
+          "--config",
+          configPath,
+          "--repo",
+          "owner/skipped",
+          "--pr",
+          pr,
+          "--dry-run",
+          "true",
+          "--zcode",
+          "false"
+        ], {
+          cwd: process.cwd(),
+          encoding: "utf8"
+        });
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toContain("--pr must be a positive integer");
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+function runOnceResult(overrides: Partial<RunOnceResult> = {}): RunOnceResult {
+  return {
+    reposScanned: 0,
+    pullsSeen: 0,
+    reviewed: 0,
+    failed: 0,
+    skippedDraft: 0,
+    skippedCanary: 0,
+    skippedPolicy: 0,
+    skippedCommandStop: 0,
+    skippedCommandExplain: 0,
+    commandReviewRequested: 0,
+    skippedProcessed: 0,
+    skippedCapacity: 0,
+    skippedProviderCooldown: 0,
+    skippedStaleHead: 0,
+    baselinedExisting: 0,
+    policySkips: [],
+    ...overrides
+  };
+}

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -83,4 +83,18 @@ describe("secret redaction", () => {
     expect(containsSecretLikeText(benignCustomerLabel)).toBe(false);
     expect(redactSecrets(`${customerId}\n${ssn}`)).not.toMatch(/cus_12345678901234567890|123-45-6789/);
   });
+
+  it("keeps already-stringified JSON parseable after redaction", () => {
+    const output = redactSecrets(JSON.stringify({
+      ok: true,
+      token: "abcdefghijklmnop",
+      message: "status payload"
+    }, null, 2));
+
+    const parsed = JSON.parse(output);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.message).toBe("status payload");
+    expect(typeof parsed.token).toBe("string");
+  });
 });


### PR DESCRIPTION
## Summary

- Print structured JSON from `run-once` instead of exiting silently.
- Include run mode, ZCode mode, scoped repo/PR/head metadata when available, and the existing `RunOnceResult` counters.
- Redact operator output before JSON serialization, validate `--pr` before scoped metadata is printed, and emit structured error envelopes for scoped execution failures.

Closes #141.

## Test Plan

- [x] `git diff --check`
- [x] `npm test -- tests/run-once-cli.test.ts tests/operator-cli.test.ts tests/secrets.test.ts --pool=forks --maxWorkers=1`
- [x] `npm run build`
- [x] Manual policy-skipped dry-run and explicit live-mode CLI smoke outputs saved under `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-02/issue-141-run-once-summary/smoke/`
- [x] Isolated authenticated PR #142 dry-run smoke saved under `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-02/issue-141-run-once-summary/live-cli-smoke/`
- [x] Isolated missing-PR error-envelope smoke saved under `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-02/issue-141-run-once-summary/live-cli-smoke/`

## Adversarial Review

Four read-only adversarial reviewers ran before and after PR publication.

- Fixed P2 malformed `--pr` scoped metadata risk with `parsePositiveInteger` and regression coverage.
- Fixed P2 command-level failure-exit coverage gap with injectable `runOnceCliCommand` test.
- Fixed P1/P2 secret-like metadata leak and JSON-corruption risks with pre-serialization string redaction and token/api_key/password/private-key regression coverage.
- Fixed P2 scoped execution failure path so PR fetch errors return structured JSON on stdout with exit code 1.
- Added shared-redactor regression coverage so existing `redactSecrets(JSON.stringify(...))` callers remain parseable.
- Final blockers-only rereview found no new >=95 confidence blockers.

## Current Gate

- Current head: `05e5ec613082da3c2605a36f7223698e86acb603`
- GitHub checks: Socket Security and CodeRabbit check statuses are green.
- Review threads: zero current actionable review threads.
- evaOS bot: current head is queued/covered by durable queue work; old `aa52f2554f6f05ea10f4e8adbac8db556dfa10c6` job retired as stale after the amend.

## Evidence

- `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-02/issue-141-run-once-summary/summary.md`
