### PR TITLE
Avoid historical reads for activation-baselined heads

### DIFF
--- a/src/coverage-audit.ts
+++ b/src/coverage-audit.ts
@@ -3,6 +3,7 @@ import { DatabaseSync } from "node:sqlite";
 import type { BotConfig } from "./config.js";
 import { listReposToScan, resolveRepoProfile, type RepoProfileSkipReason } from "./repo-policy.js";
 import {
+  isActivationBaselineProcessedReview,
   parseProviderCooldownError,
   type ReviewQueueJobState,
   type RepoProviderCooldownRecord,
@@ -330,7 +331,16 @@ export async function collectCoverageAudit(input: {
         continue;
       }
 
-      if (input.verifyCurrentHeads && input.pullNumber === undefined) {
+      const now = input.now ?? new Date();
+      if (
+        input.verifyCurrentHeads &&
+        input.pullNumber === undefined &&
+        shouldVerifyCurrentHead({
+          state: input.state,
+          repo,
+          pull
+        })
+      ) {
         let livePull: PullRequestSummary;
         try {
           livePull = await input.github.getPull(repo, pull.number);
@@ -364,7 +374,7 @@ export async function collectCoverageAudit(input: {
             input.state,
             repo,
             livePull,
-            input.now ?? new Date(),
+            now,
             input.config.reviewConcurrency.leaseTtlMs
           );
           continue;
@@ -376,7 +386,7 @@ export async function collectCoverageAudit(input: {
         input.state,
         repo,
         pull,
-        input.now ?? new Date(),
+        now,
         input.config.reviewConcurrency.leaseTtlMs
       );
     }
@@ -384,6 +394,16 @@ export async function collectCoverageAudit(input: {
 
   report.ok = report.summary.unprocessed === 0 && report.summary.readFailures === 0;
   return report;
+}
+
+function shouldVerifyCurrentHead(input: {
+  state: CoverageStateLookup;
+  repo: string;
+  pull: PullRequestSummary;
+}): boolean {
+  const { state, repo, pull } = input;
+  if (isActivationBaselineProcessedReview(state.getProcessedReview(repo, pull.number, pull.head.sha))) return false;
+  return true;
 }
 
 function pushProcessedOrUnprocessed(

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -15,6 +15,7 @@ import {
   type ReviewQueueDelayReason
 } from "./review-budget.js";
 import {
+  isActivationBaselineProcessedReview,
   parseProviderCooldownError,
   ReviewStateStore,
   type ProcessedStatus,
@@ -140,6 +141,7 @@ export async function runScheduledCycleWithDeps(input: {
         providerId,
         now,
         dryRun: input.options.dryRun,
+        allowActivationBaselineCommandLookup: input.options.pullNumber !== undefined,
         onStatusCommentFailure: () => {
           result.statusCommentFailures += 1;
         },
@@ -218,6 +220,7 @@ async function enqueuePullIfEligible(input: {
   providerId: string;
   now: Date;
   dryRun: boolean;
+  allowActivationBaselineCommandLookup?: boolean;
   onStatusCommentFailure?: () => void;
   onCommandFetchError?: () => void;
 }): Promise<EnqueueStatus> {
@@ -247,6 +250,12 @@ async function enqueuePullIfEligible(input: {
       now: input.now
     });
     return "skipped_canary";
+  }
+
+  const processed = input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha);
+  if (!input.allowActivationBaselineCommandLookup && isActivationBaselineProcessedReview(processed)) {
+    backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
+    return "skipped_processed";
   }
 
   const commandDecision = await resolveSchedulerCommandDecision(input);
@@ -280,7 +289,7 @@ async function enqueuePullIfEligible(input: {
   }
 
   await retireSupersededQueueJobsForPull(input);
-  if (input.state.hasProcessed(input.repo, input.pull.number, input.pull.head.sha)) {
+  if (processed || input.state.hasProcessed(input.repo, input.pull.number, input.pull.head.sha)) {
     backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
     return "skipped_processed";
   }
@@ -771,6 +780,7 @@ async function runLeasedQueueJob(input: {
       useZCode: input.useZCode,
       budget: input.budget,
       processedHeadPolicy: isProviderDeferredRetryJob(input.job) ? "retry_failed_head" : "normal",
+      allowActivationBaselineCommandLookup: input.job.source === "manual_command",
       ...(input.job.source === "manual_command" && input.job.commentId ? { commandCommentId: input.job.commentId } : {})
     });
     updateQueueJobAfterReviewStatus({ state: input.state, job: input.job, pull, status, dryRun: input.dryRun });

--- a/src/state.ts
+++ b/src/state.ts
@@ -63,6 +63,14 @@ export interface StoredProcessedReviewRecord extends ProcessedReviewRecord {
   createdAt: string;
 }
 
+export const ACTIVATION_BASELINE_EXISTING_HEAD_ERROR = "activation_baseline_existing_head";
+
+export function isActivationBaselineProcessedReview(
+  processed: Pick<StoredProcessedReviewRecord, "status" | "error"> | undefined
+): boolean {
+  return processed?.status === "skipped" && processed.error === ACTIVATION_BASELINE_EXISTING_HEAD_ERROR;
+}
+
 export interface RetireFailedReviewInput {
   repo: string;
   pullNumber: number;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -32,7 +32,13 @@ import { buildRepoMemoryPacket, readRepoMemoryMarkdown, type RepoMemoryPacket } 
 import { ReviewRunBudget } from "./review-budget.js";
 import { redactSecrets } from "./secrets.js";
 import { buildSkillPackContextPacket, type SkillPackContextPacket } from "./skill-packs.js";
-import { parseProviderCooldownError, ReviewStateStore, type ReviewRunLease } from "./state.js";
+import {
+  ACTIVATION_BASELINE_EXISTING_HEAD_ERROR,
+  isActivationBaselineProcessedReview,
+  parseProviderCooldownError,
+  ReviewStateStore,
+  type ReviewRunLease
+} from "./state.js";
 import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "./validation-selector.js";
 import { buildWalkthroughComment } from "./walkthrough.js";
 import { postWalkthroughComment, reviewBodyAfterWalkthroughPost } from "./walkthrough-post.js";
@@ -208,7 +214,8 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
             pull,
             dryRun: options.dryRun,
             useZCode: options.useZCode ?? true,
-            budget
+            budget,
+            allowActivationBaselineCommandLookup: options.pullNumber !== undefined
           });
         } catch (error) {
           if (recordProviderRateLimitCooldownIfNeeded({ config, state, repo, pull, error })) {
@@ -565,6 +572,7 @@ export interface ReviewPullInput {
   budget?: ReviewRunBudget;
   processedHeadPolicy?: "normal" | "retry_failed_head";
   commandCommentId?: number;
+  allowActivationBaselineCommandLookup?: boolean;
 }
 
 export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResult> {
@@ -573,6 +581,15 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   if (!repoPolicy.allowed) return "skipped_policy";
   if (config.skipDrafts && pull.draft) return "skipped_draft";
   if (!isCanaryAllowed(config, repo, pull.number)) return "skipped_canary";
+
+  const processed = state.getProcessedReview(repo, pull.number, pull.head.sha);
+  if (
+    input.processedHeadPolicy !== "retry_failed_head" &&
+    !input.allowActivationBaselineCommandLookup &&
+    isActivationBaselineProcessedReview(processed)
+  ) {
+    return "skipped_processed";
+  }
 
   const commandDecision = await resolvePullCommandDecision({ config, github, state, repo, pull });
   if (commandDecision.action === "stop") {
@@ -597,7 +614,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   if (
     input.processedHeadPolicy !== "retry_failed_head" &&
     !commandReviewRequested &&
-    state.hasProcessed(repo, pull.number, pull.head.sha)
+    (processed || state.hasProcessed(repo, pull.number, pull.head.sha))
   ) {
     return "skipped_processed";
   }
@@ -860,7 +877,7 @@ export function activateRepoForNewOnlyReview(input: {
       pullNumber: pull.number,
       headSha: pull.head.sha,
       status: "skipped",
-      error: "activation_baseline_existing_head"
+      error: ACTIVATION_BASELINE_EXISTING_HEAD_ERROR
     });
     baselined += 1;
   }

--- a/tests/coverage-audit.test.ts
+++ b/tests/coverage-audit.test.ts
@@ -799,14 +799,98 @@ describe("coverage audit", () => {
     state.close();
   });
 
+  it("does not re-read activation-baselined heads during current-head verification", async () => {
+    const { root, state } = createState();
+    state.recordProcessed({
+      repo: "owner/allowed",
+      pullNumber: 20,
+      headSha: "baseline-head-20",
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+    state.recordProcessed({
+      repo: "owner/allowed",
+      pullNumber: 21,
+      headSha: "baseline-head-21",
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+    let getPullCount = 0;
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(20, "baseline-head-20"), pull(21, "baseline-head-21")],
+        getPull: async () => {
+          getPullCount += 1;
+          throw new Error("baselined heads should not be re-read");
+        }
+      } as unknown as GitHubApi,
+      state,
+      verifyCurrentHeads: true
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      processed: 2,
+      unprocessed: 0,
+      readFailures: 0
+    });
+    expect(getPullCount).toBe(0);
+    expect(audit.processed.map((entry) => entry.pullNumber)).toEqual([20, 21]);
+    state.close();
+  });
+
+  it("still re-reads non-baseline processed heads during current-head verification", async () => {
+    const { root, state } = createState();
+    state.recordProcessed({
+      repo: "owner/allowed",
+      pullNumber: 22,
+      headSha: "reviewed-old-head",
+      status: "posted",
+      event: "COMMENT"
+    });
+    let getPullCount = 0;
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(22, "reviewed-old-head")],
+        getPull: async () => {
+          getPullCount += 1;
+          return pull(22, "new-unprocessed-head");
+        }
+      } as unknown as GitHubApi,
+      state,
+      verifyCurrentHeads: true
+    });
+
+    expect(audit.ok).toBe(false);
+    expect(getPullCount).toBe(1);
+    expect(audit.summary).toMatchObject({
+      staleHeads: 1,
+      unprocessed: 1
+    });
+    expect(audit.unprocessed[0]).toMatchObject({
+      pullNumber: 22,
+      headSha: "new-unprocessed-head",
+      previousProcessedHeads: ["reviewed-old-head"]
+    });
+    state.close();
+  });
+
   it("re-reads unprocessed open candidates and reports stale heads separately", async () => {
     const { root, state } = createState();
+    let getPullCount = 0;
 
     const audit = await collectCoverageAudit({
       config: minimalConfig(root),
       github: {
         listOpenPulls: async () => [pull(10, "old-head")],
-        getPull: async () => pull(10, "new-head")
+        getPull: async () => {
+          getPullCount += 1;
+          return pull(10, "new-head");
+        }
       } as unknown as GitHubApi,
       state,
       verifyCurrentHeads: true
@@ -826,6 +910,7 @@ describe("coverage audit", () => {
       })
     ]);
     expect(audit.unprocessed.map((entry) => entry.headSha)).toEqual(["new-head"]);
+    expect(getPullCount).toBe(1);
     state.close();
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1535,6 +1535,119 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("does not fetch commands for activation-baselined existing heads", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-baseline-skip-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.activation.reviewExistingOpenPrsOnActivation = false;
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    let issueCommentReads = 0;
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: {
+        ...githubFromMap(new Map([[
+          "org/repo-a",
+          [pull("org/repo-a", 1, "historical-a"), pull("org/repo-a", 2, "historical-b")]
+        ]])),
+        listIssueComments: async () => {
+          issueCommentReads += 1;
+          throw new Error("activation-baselined heads should not read issue comments");
+        }
+      },
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("activation-baselined heads should not be reviewed");
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.baselinedExisting).toBe(2);
+    expect(result.skippedProcessed).toBe(2);
+    expect(result.commandFetchErrors).toBe(0);
+    expect(result.queue.enqueued).toBe(0);
+    expect(result.queue.leased).toBe(0);
+    expect(issueCommentReads).toBe(0);
+    expect(state.getProcessedReview("org/repo-a", 1, "historical-a")).toMatchObject({
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+    state.close();
+  });
+
+  it("allows scoped trusted commands for activation-baselined heads", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-baseline-scoped-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.activation.reviewExistingOpenPrsOnActivation = false;
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    state.recordProcessed({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "historical-a",
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+    const comments = new Map([
+      ["org/repo-a#1", [comment(444, "100yenadmin", "@evaos-code-review-bot review")]]
+    ]);
+    let issueCommentReads = 0;
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: {
+        ...githubFromMap(
+          new Map([["org/repo-a", [pull("org/repo-a", 1, "historical-a")]]]),
+          comments
+        ),
+        listIssueComments: async (repo, issueNumber) => {
+          issueCommentReads += 1;
+          return comments.get(`${repo}#${issueNumber}`) ?? [];
+        }
+      },
+      state,
+      options: { repo: "org/repo-a", pullNumber: 1, dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-scoped"
+        });
+        return "reviewed_command";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(result.commandReviewRequested).toBe(1);
+    expect(result.reviewed).toBe(1);
+    expect(issueCommentReads).toBe(1);
+    expect(state.listReviewQueueJobs({ state: "posted" })).toEqual([
+      expect.objectContaining({
+        repo: "org/repo-a",
+        pullNumber: 1,
+        source: "manual_command",
+        commentId: 444
+      })
+    ]);
+    state.close();
+  });
+
   it("records trusted stop commands as terminal skips for the current head", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-stop-"));
     roots.push(root);

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -1094,6 +1094,50 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("skips activation-baselined heads before fetching commands", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-baseline-command-skip-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1230, "head-baselined");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+    let issueCommentReads = 0;
+
+    const result = await reviewPull({
+      config,
+      github: {
+        listIssueComments: async () => {
+          issueCommentReads += 1;
+          throw new Error("activation-baselined heads should not read issue comments");
+        },
+        listPullFiles: async () => {
+          throw new Error("activation-baselined heads should not fetch files");
+        }
+      } as unknown as GitHubApi,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: false
+    });
+
+    expect(result).toBe("skipped_processed");
+    expect(issueCommentReads).toBe(0);
+    state.close();
+  });
+
   it("restores a failed row after a retry dry-run records dry_run", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-dry-run-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- skips current-head re-read in coverage audit when a PR head is already covered by processed/queue/cooldown state
- short-circuits `activation_baseline_existing_head` rows before scheduler/worker command-comment lookup
- preserves trusted manual re-review for real posted heads while keeping historical activation-baselined PRs quiet

Fixes #143.

## Proof Boundary
This fixes the new-repo activation/audit bug that made repos with many existing open PRs look like historical review sweeps. It does not enable live issue enrichment, issue polling, all-org rollout, or GitHub App permission expansion.

## Validation
- `npm test -- tests/coverage-audit.test.ts tests/scheduler.test.ts` (71 passed)
- `npm test -- tests/worker-failure.test.ts` (36 passed)
- `npm run build`

Evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-03/`

## Runtime Note
`Martian-Engineering/lossless-claw` remains temporarily excluded from the live PR-monitor config while this fix is reviewed/released. Re-add only after App-token read health and release gates pass.