### PR TITLE
Tolerate minimal state doubles in baseline guard

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -37,7 +37,8 @@ import {
   isActivationBaselineProcessedReview,
   parseProviderCooldownError,
   ReviewStateStore,
-  type ReviewRunLease
+  type ReviewRunLease,
+  type StoredProcessedReviewRecord
 } from "./state.js";
 import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "./validation-selector.js";
 import { buildWalkthroughComment } from "./walkthrough.js";
@@ -582,7 +583,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   if (config.skipDrafts && pull.draft) return "skipped_draft";
   if (!isCanaryAllowed(config, repo, pull.number)) return "skipped_canary";
 
-  const processed = state.getProcessedReview(repo, pull.number, pull.head.sha);
+  const processed = getProcessedReviewIfAvailable(state, repo, pull.number, pull.head.sha);
   if (
     input.processedHeadPolicy !== "retry_failed_head" &&
     !input.allowActivationBaselineCommandLookup &&
@@ -847,6 +848,16 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     if (lease) state.releaseReviewRunLease(lease.leaseId);
     budget.finish();
   }
+}
+
+function getProcessedReviewIfAvailable(
+  state: ReviewStateStore,
+  repo: string,
+  pullNumber: number,
+  headSha: string
+): StoredProcessedReviewRecord | undefined {
+  const lookup = (state as Partial<Pick<ReviewStateStore, "getProcessedReview">>).getProcessedReview;
+  return typeof lookup === "function" ? lookup.call(state, repo, pullNumber, headSha) : undefined;
 }
 
 export function activateRepoForNewOnlyReview(input: {


### PR DESCRIPTION
## Summary
- makes the activation-baseline guard in `reviewPull` tolerate minimal state doubles that do not implement `getProcessedReview`
- preserves the real `ReviewStateStore` activation-baseline behavior from #143
- unblocks the v0.4.1-beta.5 full release test gate

Fixes #145.

## Validation
- `npm test -- tests/review-budget.test.ts` (8 passed)
- `npm test -- tests/worker-failure.test.ts` (36 passed)
- `npm run build`

Evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-03/`

## Proof Boundary
Compatibility hotfix only. No live config changes, no issue-enrichment rollout, no repo allowlist expansion.