### PR TITLE
Guard pre-activation PR heads

### DIFF
--- a/src/activation-policy.ts
+++ b/src/activation-policy.ts
@@ -1,0 +1,21 @@
+import type { BotConfig } from "./config.js";
+import type { PullRequestSummary } from "./types.js";
+
+export interface RepoActivationLookup {
+  getRepoActivation?(repo: string): { activatedAt: string } | undefined;
+}
+
+export function isPreActivationExistingPull(input: {
+  config: Pick<BotConfig, "activation">;
+  state: RepoActivationLookup;
+  repo: string;
+  pull: PullRequestSummary;
+}): boolean {
+  if (input.config.activation.reviewExistingOpenPrsOnActivation) return false;
+  const activation = input.state.getRepoActivation?.(input.repo);
+  if (!activation || !input.pull.created_at) return false;
+  const activatedAtMs = Date.parse(activation.activatedAt);
+  const pullCreatedAtMs = Date.parse(input.pull.created_at);
+  if (!Number.isFinite(activatedAtMs) || !Number.isFinite(pullCreatedAtMs)) return false;
+  return pullCreatedAtMs <= activatedAtMs;
+}

--- a/src/activation-policy.ts
+++ b/src/activation-policy.ts
@@ -1,8 +1,13 @@
 import type { BotConfig } from "./config.js";
+import { ACTIVATION_BASELINE_EXISTING_HEAD_ERROR } from "./state.js";
 import type { PullRequestSummary } from "./types.js";
 
 export interface RepoActivationLookup {
   getRepoActivation?(repo: string): { activatedAt: string } | undefined;
+  listProcessedReviewsForPull?(
+    repo: string,
+    pullNumber: number
+  ): { status: string; error?: string }[];
 }
 
 export function isPreActivationExistingPull(input: {
@@ -17,5 +22,8 @@ export function isPreActivationExistingPull(input: {
   const activatedAtMs = Date.parse(activation.activatedAt);
   const pullCreatedAtMs = Date.parse(input.pull.created_at);
   if (!Number.isFinite(activatedAtMs) || !Number.isFinite(pullCreatedAtMs)) return false;
-  return pullCreatedAtMs <= activatedAtMs;
+  if (pullCreatedAtMs > activatedAtMs) return false;
+  return Boolean(input.state.listProcessedReviewsForPull?.(input.repo, input.pull.number).some((record) =>
+    record.status === "skipped" && record.error === ACTIVATION_BASELINE_EXISTING_HEAD_ERROR
+  ));
 }

--- a/src/coverage-audit.ts
+++ b/src/coverage-audit.ts
@@ -1,10 +1,12 @@
 import { existsSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
+import { isPreActivationExistingPull } from "./activation-policy.js";
 import type { BotConfig } from "./config.js";
 import { listReposToScan, resolveRepoProfile, type RepoProfileSkipReason } from "./repo-policy.js";
 import {
   isActivationBaselineProcessedReview,
   parseProviderCooldownError,
+  type RepoActivationRecord,
   type ReviewQueueJobState,
   type RepoProviderCooldownRecord,
   type StoredProcessedReviewRecord
@@ -12,7 +14,7 @@ import {
 import { isCanaryAllowed } from "./worker.js";
 import type { PullRequestSummary } from "./types.js";
 
-export type CoverageSkipReason = RepoProfileSkipReason | "draft" | "closed" | "canary";
+export type CoverageSkipReason = RepoProfileSkipReason | "draft" | "closed" | "canary" | "activation_baseline_existing_pr";
 
 export interface CoverageAuditSummary {
   reposScanned: number;
@@ -112,6 +114,7 @@ export interface CoverageGitHubApi {
 export interface CoverageStateLookup {
   getProcessedReview(repo: string, pullNumber: number, headSha: string): StoredProcessedReviewRecord | undefined;
   listProcessedReviewsForPull(repo: string, pullNumber: number): StoredProcessedReviewRecord[];
+  getRepoActivation?(repo: string): RepoActivationRecord | undefined;
   getActiveReviewQueueJob?(
     repo: string,
     pullNumber: number,
@@ -156,6 +159,20 @@ export class CoverageStateReader implements CoverageStateLookup {
       )
       .all(repo, pullNumber) as unknown as ProcessedReviewRow[];
     return rows.map(mapProcessedReviewRow);
+  }
+
+  getRepoActivation(repo: string): RepoActivationRecord | undefined {
+    if (!this.db) return undefined;
+    if (!this.hasRepoActivationWatermarksTable()) return undefined;
+    const row = this.db
+      .prepare(
+        `select repo, activated_at, created_at
+         from repo_activation_watermarks
+         where repo = ?
+         limit 1`
+      )
+      .get(repo) as RepoActivationRow | undefined;
+    return row ? mapRepoActivationRow(row) : undefined;
   }
 
   getActiveReviewQueueJob(
@@ -246,6 +263,15 @@ export class CoverageStateReader implements CoverageStateLookup {
     );
   }
 
+  private hasRepoActivationWatermarksTable(): boolean {
+    if (!this.db) return false;
+    return Boolean(
+      this.db
+        .prepare("select 1 from sqlite_master where type = 'table' and name = 'repo_activation_watermarks' limit 1")
+        .get()
+    );
+  }
+
   private hasReviewQueueJobsColumn(name: string): boolean {
     if (!this.db) return false;
     const columns = this.db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>;
@@ -328,6 +354,13 @@ export async function collectCoverageAudit(input: {
       }
       if (!isCanaryAllowed(input.config, repo, pull.number)) {
         pushSkipped(report, repo, pull, "canary");
+        continue;
+      }
+      if (
+        !input.state.getProcessedReview(repo, pull.number, pull.head.sha) &&
+        isPreActivationExistingPull({ config: input.config, state: input.state, repo, pull })
+      ) {
+        pushSkipped(report, repo, pull, "activation_baseline_existing_pr");
         continue;
       }
 
@@ -593,6 +626,12 @@ interface RepoProviderCooldownRow {
   updated_at: string;
 }
 
+interface RepoActivationRow {
+  repo: string;
+  activated_at: string;
+  created_at: string;
+}
+
 interface ReviewQueueJobCoverageRow {
   repo: string;
   pull_number: number;
@@ -629,6 +668,14 @@ function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRe
     ...(row.event ? { event: row.event } : {}),
     ...(row.review_url ? { reviewUrl: row.review_url } : {}),
     ...(row.error ? { error: row.error } : {}),
+    createdAt: row.created_at
+  };
+}
+
+function mapRepoActivationRow(row: RepoActivationRow): RepoActivationRecord {
+  return {
+    repo: row.repo,
+    activatedAt: row.activated_at,
     createdAt: row.created_at
   };
 }

--- a/src/coverage-audit.ts
+++ b/src/coverage-audit.ts
@@ -356,6 +356,19 @@ export async function collectCoverageAudit(input: {
         pushSkipped(report, repo, pull, "canary");
         continue;
       }
+      const now = input.now ?? new Date();
+      const queued = input.state.getActiveReviewQueueJob?.(
+        repo,
+        pull.number,
+        pull.head.sha,
+        pull.base.sha,
+        now,
+        input.config.reviewConcurrency.leaseTtlMs
+      );
+      if (queued) {
+        pushQueuedCoverage(report, repo, pull, queued);
+        continue;
+      }
       if (
         !input.state.getProcessedReview(repo, pull.number, pull.head.sha) &&
         isPreActivationExistingPull({ config: input.config, state: input.state, repo, pull })
@@ -364,7 +377,6 @@ export async function collectCoverageAudit(input: {
         continue;
       }
 
-      const now = input.now ?? new Date();
       if (
         input.verifyCurrentHeads &&
         input.pullNumber === undefined &&

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -265,11 +265,13 @@ async function enqueuePullIfEligible(input: {
       pull: input.pull
     })
   ) {
+    await retireSupersededQueueJobsForPull(input);
     recordActivationBaselineExistingHead(input.state, input.repo, input.pull);
     backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
     return "skipped_processed";
   }
   if (!input.allowActivationBaselineCommandLookup && isActivationBaselineProcessedReview(processed)) {
+    await retireSupersededQueueJobsForPull(input);
     backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
     return "skipped_processed";
   }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1162,6 +1162,9 @@ function readinessStateForProcessedStatus(
 function readinessReasonForProcessedHead(processed: { status: ProcessedStatus; error?: string }): string {
   const providerCooldown = parseProviderCooldownError(processed.error);
   if (providerCooldown) return `processed_head_provider_deferred: ${providerCooldown.reason ?? "provider_cooldown"}`;
+  if (processed.status === "skipped" && processed.error === ACTIVATION_BASELINE_EXISTING_HEAD_ERROR) {
+    return ACTIVATION_BASELINE_EXISTING_HEAD_ERROR;
+  }
   return `processed_head_already_${processed.status}`;
 }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,3 +1,4 @@
+import { isPreActivationExistingPull } from "./activation-policy.js";
 import { loadConfig, type BotConfig } from "./config.js";
 import { collectTrustedReviewCommands, decideCommandAction, type CommandDecision } from "./commands.js";
 import { GitHubApi } from "./github.js";
@@ -15,6 +16,7 @@ import {
   type ReviewQueueDelayReason
 } from "./review-budget.js";
 import {
+  ACTIVATION_BASELINE_EXISTING_HEAD_ERROR,
   isActivationBaselineProcessedReview,
   parseProviderCooldownError,
   ReviewStateStore,
@@ -253,6 +255,20 @@ async function enqueuePullIfEligible(input: {
   }
 
   const processed = input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha);
+  if (
+    !input.allowActivationBaselineCommandLookup &&
+    !processed &&
+    isPreActivationExistingPull({
+      config: input.config,
+      state: input.state,
+      repo: input.repo,
+      pull: input.pull
+    })
+  ) {
+    recordActivationBaselineExistingHead(input.state, input.repo, input.pull);
+    backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
+    return "skipped_processed";
+  }
   if (!input.allowActivationBaselineCommandLookup && isActivationBaselineProcessedReview(processed)) {
     backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
     return "skipped_processed";
@@ -365,6 +381,17 @@ async function enqueuePullIfEligible(input: {
     });
   }
   return enqueued.enqueued ? "enqueued" : "already_queued";
+}
+
+function recordActivationBaselineExistingHead(state: ReviewStateStore, repo: string, pull: PullRequestSummary): void {
+  if (state.hasProcessed(repo, pull.number, pull.head.sha)) return;
+  state.recordProcessed({
+    repo,
+    pullNumber: pull.number,
+    headSha: pull.head.sha,
+    status: "skipped",
+    error: ACTIVATION_BASELINE_EXISTING_HEAD_ERROR
+  });
 }
 
 function enqueueReviewJob(input: {

--- a/src/state.ts
+++ b/src/state.ts
@@ -63,6 +63,12 @@ export interface StoredProcessedReviewRecord extends ProcessedReviewRecord {
   createdAt: string;
 }
 
+export interface RepoActivationRecord {
+  repo: string;
+  activatedAt: string;
+  createdAt: string;
+}
+
 export const ACTIVATION_BASELINE_EXISTING_HEAD_ERROR = "activation_baseline_existing_head";
 
 export function isActivationBaselineProcessedReview(
@@ -671,8 +677,19 @@ export class ReviewStateStore {
   }
 
   hasRepoActivation(repo: string): boolean {
-    const row = this.db.prepare("select 1 from repo_activation_watermarks where repo = ? limit 1").get(repo);
-    return Boolean(row);
+    return Boolean(this.getRepoActivation(repo));
+  }
+
+  getRepoActivation(repo: string): RepoActivationRecord | undefined {
+    const row = this.db
+      .prepare(
+        `select repo, activated_at, created_at
+         from repo_activation_watermarks
+         where repo = ?
+         limit 1`
+      )
+      .get(repo) as RepoActivationRow | undefined;
+    return row ? mapRepoActivationRow(row) : undefined;
   }
 
   recordRepoActivation(repo: string, activatedAt = new Date().toISOString()): void {
@@ -1996,6 +2013,12 @@ interface ProcessedReviewRow {
   created_at: string;
 }
 
+interface RepoActivationRow {
+  repo: string;
+  activated_at: string;
+  created_at: string;
+}
+
 interface DaemonHeartbeatRow {
   cycle: number | null;
   event: DaemonHeartbeatEvent | null;
@@ -2146,6 +2169,14 @@ function mapRepoProviderCooldownRow(row: RepoProviderCooldownRow): RepoProviderC
     cooldownUntil: row.cooldown_until,
     reason: row.reason,
     updatedAt: row.updated_at
+  };
+}
+
+function mapRepoActivationRow(row: RepoActivationRow): RepoActivationRecord {
+  return {
+    repo: row.repo,
+    activatedAt: row.activated_at,
+    createdAt: row.created_at
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export interface PullRequestSummary {
   title: string;
   draft: boolean;
   state?: string;
+  created_at?: string | null;
   merged_at?: string | null;
   body?: string | null;
   head: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -592,6 +592,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     isPreActivationExistingPull({ config, state, repo, pull })
   ) {
     recordActivationBaselineExistingHead(state, repo, pull);
+    backfillActivationBaselineReadinessFromProcessedHead(state, repo, pull);
     return "skipped_processed";
   }
   if (
@@ -868,6 +869,24 @@ function recordActivationBaselineExistingHead(state: ReviewStateStore, repo: str
     headSha: pull.head.sha,
     status: "skipped",
     error: ACTIVATION_BASELINE_EXISTING_HEAD_ERROR
+  });
+}
+
+function backfillActivationBaselineReadinessFromProcessedHead(
+  state: ReviewStateStore,
+  repo: string,
+  pull: PullRequestSummary
+): void {
+  const processed = getProcessedReviewIfAvailable(state, repo, pull.number, pull.head.sha);
+  if (!isActivationBaselineProcessedReview(processed)) return;
+  const existing = state.getReviewReadiness(repo, pull.number, pull.head.sha);
+  if (existing?.state === "skipped" && existing.reason === ACTIVATION_BASELINE_EXISTING_HEAD_ERROR) return;
+  state.recordReviewReadiness({
+    repo,
+    pullNumber: pull.number,
+    headSha: pull.head.sha,
+    state: "skipped",
+    reason: ACTIVATION_BASELINE_EXISTING_HEAD_ERROR
   });
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { isPreActivationExistingPull } from "./activation-policy.js";
 import {
   buildCommandStatusBody,
   buildCommandStatusMarker,
@@ -587,6 +588,15 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   if (
     input.processedHeadPolicy !== "retry_failed_head" &&
     !input.allowActivationBaselineCommandLookup &&
+    !processed &&
+    isPreActivationExistingPull({ config, state, repo, pull })
+  ) {
+    recordActivationBaselineExistingHead(state, repo, pull);
+    return "skipped_processed";
+  }
+  if (
+    input.processedHeadPolicy !== "retry_failed_head" &&
+    !input.allowActivationBaselineCommandLookup &&
     isActivationBaselineProcessedReview(processed)
   ) {
     return "skipped_processed";
@@ -848,6 +858,17 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     if (lease) state.releaseReviewRunLease(lease.leaseId);
     budget.finish();
   }
+}
+
+function recordActivationBaselineExistingHead(state: ReviewStateStore, repo: string, pull: PullRequestSummary): void {
+  if (state.hasProcessed(repo, pull.number, pull.head.sha)) return;
+  state.recordProcessed({
+    repo,
+    pullNumber: pull.number,
+    headSha: pull.head.sha,
+    status: "skipped",
+    error: ACTIVATION_BASELINE_EXISTING_HEAD_ERROR
+  });
 }
 
 function getProcessedReviewIfAvailable(

--- a/tests/coverage-audit.test.ts
+++ b/tests/coverage-audit.test.ts
@@ -886,6 +886,57 @@ describe("coverage audit", () => {
     state.close();
   });
 
+  it("reports queued manual review jobs before activation-baseline skips", async () => {
+    const { root, state } = createState();
+    state.recordRepoActivation("owner/allowed", "2026-07-02T16:58:09.555Z");
+    state.recordProcessed({
+      repo: "owner/allowed",
+      pullNumber: 23,
+      headSha: "old-baselined-head",
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+    state.enqueueReviewQueueJob({
+      repo: "owner/allowed",
+      pullNumber: 23,
+      headSha: "new-head-on-old-pr",
+      baseSha: "base",
+      source: "manual_command",
+      lane: "manual",
+      commentId: 555
+    });
+    state.close();
+    const reader = CoverageStateReader.open(join(root, "state.sqlite"));
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [
+          pull(23, "new-head-on-old-pr", { createdAt: "2026-06-30T05:34:43Z" })
+        ]
+      } as unknown as GitHubApi,
+      state: reader,
+      now: new Date("2026-07-02T17:45:00.000Z")
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      queued: 1,
+      skipped: 0,
+      unprocessed: 0
+    });
+    expect(audit.queued).toEqual([
+      expect.objectContaining({
+        repo: "owner/allowed",
+        pullNumber: 23,
+        headSha: "new-head-on-old-pr",
+        queueState: "queued"
+      })
+    ]);
+    expect(audit.skipped).toEqual([]);
+    reader.close();
+  });
+
   it("still re-reads non-baseline processed heads during current-head verification", async () => {
     const { root, state } = createState();
     state.recordProcessed({

--- a/tests/coverage-audit.test.ts
+++ b/tests/coverage-audit.test.ts
@@ -841,6 +841,51 @@ describe("coverage audit", () => {
     state.close();
   });
 
+  it("skips new heads on PRs created before repo activation", async () => {
+    const { root, state } = createState();
+    state.recordRepoActivation("owner/allowed", "2026-07-02T16:58:09.555Z");
+    state.recordProcessed({
+      repo: "owner/allowed",
+      pullNumber: 23,
+      headSha: "old-baselined-head",
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [
+          pull(23, "new-head-on-old-pr", { createdAt: "2026-06-30T05:34:43Z" }),
+          pull(24, "new-head-on-new-pr", { createdAt: "2026-07-02T17:39:37Z" })
+        ]
+      } as unknown as GitHubApi,
+      state
+    });
+
+    expect(audit.ok).toBe(false);
+    expect(audit.summary).toMatchObject({
+      skipped: 1,
+      unprocessed: 1
+    });
+    expect(audit.skipped).toEqual([
+      expect.objectContaining({
+        repo: "owner/allowed",
+        pullNumber: 23,
+        headSha: "new-head-on-old-pr",
+        reason: "activation_baseline_existing_pr"
+      })
+    ]);
+    expect(audit.unprocessed).toEqual([
+      expect.objectContaining({
+        repo: "owner/allowed",
+        pullNumber: 24,
+        headSha: "new-head-on-new-pr"
+      })
+    ]);
+    state.close();
+  });
+
   it("still re-reads non-baseline processed heads during current-head verification", async () => {
     const { root, state } = createState();
     state.recordProcessed({
@@ -1049,13 +1094,14 @@ function minimalConfig(root: string): BotConfig {
 function pull(
   number: number,
   headSha: string,
-  options: { draft?: boolean; state?: string; baseSha?: string } = {}
+  options: { draft?: boolean; state?: string; baseSha?: string; createdAt?: string } = {}
 ): PullRequestSummary {
   return {
     number,
     title: `PR ${number}`,
     draft: options.draft ?? false,
     state: options.state ?? "open",
+    ...(options.createdAt ? { created_at: options.createdAt } : {}),
     head: {
       sha: headSha,
       ref: `pr-${number}`,

--- a/tests/review-activation.test.ts
+++ b/tests/review-activation.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { isPreActivationExistingPull } from "../src/activation-policy.js";
 import { ReviewStateStore } from "../src/state.js";
 import type { PullRequestSummary } from "../src/types.js";
 import { activateRepoForNewOnlyReview } from "../src/worker.js";
@@ -127,6 +128,56 @@ describe("new-only repo activation", () => {
   });
 });
 
+describe("pre-activation pull detection", () => {
+  it("treats reviewExistingOpenPrsOnActivation=true as an explicit override", () => {
+    expect(isPreActivationExistingPull({
+      config: newOnlyConfig({ reviewExistingOpenPrsOnActivation: true }),
+      state: { getRepoActivation: () => ({ activatedAt: "2026-07-02T16:58:09.555Z" }) },
+      repo: "Martian-Engineering/lossless-claw",
+      pull: pull(950, "new-head", false, "2026-06-30T05:34:43Z")
+    })).toBe(false);
+  });
+
+  it("fails open when activation or pull dates are unavailable or invalid", () => {
+    const config = newOnlyConfig({ reviewExistingOpenPrsOnActivation: false });
+    const repo = "Martian-Engineering/lossless-claw";
+
+    expect(isPreActivationExistingPull({
+      config,
+      state: { getRepoActivation: () => undefined },
+      repo,
+      pull: pull(950, "new-head", false, "2026-06-30T05:34:43Z")
+    })).toBe(false);
+    expect(isPreActivationExistingPull({
+      config,
+      state: { getRepoActivation: () => ({ activatedAt: "2026-07-02T16:58:09.555Z" }) },
+      repo,
+      pull: pull(950, "new-head")
+    })).toBe(false);
+    expect(isPreActivationExistingPull({
+      config,
+      state: { getRepoActivation: () => ({ activatedAt: "not-a-date" }) },
+      repo,
+      pull: pull(950, "new-head", false, "2026-06-30T05:34:43Z")
+    })).toBe(false);
+    expect(isPreActivationExistingPull({
+      config,
+      state: { getRepoActivation: () => ({ activatedAt: "2026-07-02T16:58:09.555Z" }) },
+      repo,
+      pull: pull(950, "new-head", false, "not-a-date")
+    })).toBe(false);
+  });
+
+  it("detects PRs created before activation when new-only review is active", () => {
+    expect(isPreActivationExistingPull({
+      config: newOnlyConfig({ reviewExistingOpenPrsOnActivation: false }),
+      state: { getRepoActivation: () => ({ activatedAt: "2026-07-02T16:58:09.555Z" }) },
+      repo: "Martian-Engineering/lossless-claw",
+      pull: pull(950, "new-head", false, "2026-06-30T05:34:43Z")
+    })).toBe(true);
+  });
+});
+
 function createStore(roots: string[]): ReviewStateStore {
   const root = mkdtempSync(join(tmpdir(), "evaos-review-activation-"));
   roots.push(root);
@@ -146,11 +197,12 @@ function newOnlyConfig(overrides: {
   };
 }
 
-function pull(number: number, sha: string, draft = false): PullRequestSummary {
+function pull(number: number, sha: string, draft = false, createdAt?: string): PullRequestSummary {
   return {
     number,
     title: `PR ${number}`,
     draft,
+    ...(createdAt ? { created_at: createdAt } : {}),
     head: {
       sha,
       ref: `pr-${number}`

--- a/tests/review-activation.test.ts
+++ b/tests/review-activation.test.ts
@@ -132,7 +132,7 @@ describe("pre-activation pull detection", () => {
   it("treats reviewExistingOpenPrsOnActivation=true as an explicit override", () => {
     expect(isPreActivationExistingPull({
       config: newOnlyConfig({ reviewExistingOpenPrsOnActivation: true }),
-      state: { getRepoActivation: () => ({ activatedAt: "2026-07-02T16:58:09.555Z" }) },
+      state: baselinedState("2026-07-02T16:58:09.555Z"),
       repo: "Martian-Engineering/lossless-claw",
       pull: pull(950, "new-head", false, "2026-06-30T05:34:43Z")
     })).toBe(false);
@@ -150,7 +150,7 @@ describe("pre-activation pull detection", () => {
     })).toBe(false);
     expect(isPreActivationExistingPull({
       config,
-      state: { getRepoActivation: () => ({ activatedAt: "2026-07-02T16:58:09.555Z" }) },
+      state: baselinedState("2026-07-02T16:58:09.555Z"),
       repo,
       pull: pull(950, "new-head")
     })).toBe(false);
@@ -162,16 +162,28 @@ describe("pre-activation pull detection", () => {
     })).toBe(false);
     expect(isPreActivationExistingPull({
       config,
-      state: { getRepoActivation: () => ({ activatedAt: "2026-07-02T16:58:09.555Z" }) },
+      state: baselinedState("2026-07-02T16:58:09.555Z"),
       repo,
       pull: pull(950, "new-head", false, "not-a-date")
+    })).toBe(false);
+  });
+
+  it("fails open when no activation-baseline row proves the pull existed at activation", () => {
+    expect(isPreActivationExistingPull({
+      config: newOnlyConfig({ reviewExistingOpenPrsOnActivation: false }),
+      state: {
+        getRepoActivation: () => ({ activatedAt: "2026-07-02T16:58:09.555Z" }),
+        listProcessedReviewsForPull: () => []
+      },
+      repo: "Martian-Engineering/lossless-claw",
+      pull: pull(960, "new-head", false, "2026-07-02T16:58:08.000Z")
     })).toBe(false);
   });
 
   it("detects PRs created before activation when new-only review is active", () => {
     expect(isPreActivationExistingPull({
       config: newOnlyConfig({ reviewExistingOpenPrsOnActivation: false }),
-      state: { getRepoActivation: () => ({ activatedAt: "2026-07-02T16:58:09.555Z" }) },
+      state: baselinedState("2026-07-02T16:58:09.555Z"),
       repo: "Martian-Engineering/lossless-claw",
       pull: pull(950, "new-head", false, "2026-06-30T05:34:43Z")
     })).toBe(true);
@@ -194,6 +206,18 @@ function newOnlyConfig(overrides: {
     activation: {
       reviewExistingOpenPrsOnActivation: overrides.reviewExistingOpenPrsOnActivation ?? false
     }
+  };
+}
+
+function baselinedState(activatedAt: string) {
+  return {
+    getRepoActivation: () => ({ activatedAt }),
+    listProcessedReviewsForPull: () => [
+      {
+        status: "skipped",
+        error: "activation_baseline_existing_head"
+      }
+    ]
   };
 }
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -2338,6 +2338,55 @@ describe("provider-aware review scheduler", () => {
     ]);
     state.close();
   });
+
+  it("skips pre-activation PRs when their head changes after repo activation", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-preactivation-head-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.activation.reviewExistingOpenPrsOnActivation = false;
+    const state = new ReviewStateStore(config.statePath);
+    state.recordRepoActivation("org/repo-a", "2026-07-02T16:58:09.555Z");
+    state.recordProcessed({
+      repo: "org/repo-a",
+      pullNumber: 950,
+      headSha: "old-baselined-head",
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+    const reviewed: string[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        [
+          "org/repo-a",
+          [
+            pull("org/repo-a", 950, "new-head-on-old-pr", "base", { createdAt: "2026-06-30T05:34:43Z" }),
+            pull("org/repo-a", 960, "new-head-on-new-pr", "base", { createdAt: "2026-07-02T17:39:37Z" })
+          ]
+        ]
+      ])),
+      state,
+      options: { dryRun: true, useZCode: false },
+      reviewPullImpl: async ({ repo, pull: reviewPull }) => {
+        reviewed.push(`${repo}#${reviewPull.number}`);
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T17:45:00.000Z")
+    });
+
+    expect(result.skippedProcessed).toBe(1);
+    expect(result.queue.enqueued).toBe(1);
+    expect(state.getProcessedReview("org/repo-a", 950, "new-head-on-old-pr")).toMatchObject({
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+    expect(state.listReviewQueueJobs({ repo: "org/repo-a" })).toEqual([
+      expect.objectContaining({ pullNumber: 960, headSha: "new-head-on-new-pr", state: "queued" })
+    ]);
+    expect(reviewed).toEqual(["org/repo-a#960"]);
+    state.close();
+  });
 });
 
 function schedulerConfig(root: string, repos: string[]): BotConfig {
@@ -2448,13 +2497,14 @@ function pull(
   number: number,
   headSha: string,
   baseSha = "base",
-  options: { state?: string; mergedAt?: string | null } = {}
+  options: { state?: string; mergedAt?: string | null; createdAt?: string } = {}
 ): PullRequestSummary {
   return {
     number,
     title: `${repo} PR ${number}`,
     draft: false,
     ...(options.state ? { state: options.state } : {}),
+    ...(options.createdAt ? { created_at: options.createdAt } : {}),
     ...(options.mergedAt !== undefined ? { merged_at: options.mergedAt } : {}),
     head: {
       sha: headSha,

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -2455,6 +2455,62 @@ describe("provider-aware review scheduler", () => {
     expect(reviewed).toEqual(["org/repo-a#960"]);
     state.close();
   });
+
+  it("retires stale queued heads before skipping changed pre-activation PRs", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-preactivation-retire-stale-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.activation.reviewExistingOpenPrsOnActivation = false;
+    const state = new ReviewStateStore(config.statePath);
+    state.recordRepoActivation("org/repo-a", "2026-07-02T16:58:09.555Z");
+    state.recordProcessed({
+      repo: "org/repo-a",
+      pullNumber: 950,
+      headSha: "old-baselined-head",
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+    state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 950,
+      headSha: "old-queued-head",
+      baseSha: "base",
+      source: "manual_command",
+      lane: "manual",
+      commentId: 777
+    });
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        [
+          "org/repo-a",
+          [pull("org/repo-a", 950, "new-head-on-old-pr", "base", { createdAt: "2026-06-30T05:34:43Z" })]
+        ]
+      ])),
+      state,
+      options: { dryRun: true, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("pre-activation skipped heads should not run review work");
+      },
+      now: new Date("2026-07-02T17:45:00.000Z")
+    });
+
+    expect(result.skippedProcessed).toBe(1);
+    expect(state.listReviewQueueJobs({ state: "stale_retired" })).toEqual([
+      expect.objectContaining({
+        repo: "org/repo-a",
+        pullNumber: 950,
+        headSha: "old-queued-head",
+        lastError: "superseded_by_head=new-head-on-old-pr"
+      })
+    ]);
+    expect(state.getReviewReadiness("org/repo-a", 950, "old-queued-head")).toMatchObject({
+      state: "stale",
+      reason: "superseded_by_head=new-head-on-old-pr"
+    });
+    state.close();
+  });
 });
 
 function schedulerConfig(root: string, repos: string[]): BotConfig {

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1648,6 +1648,74 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("allows scoped trusted commands for new heads on pre-activation PRs", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-preactivation-new-head-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.activation.reviewExistingOpenPrsOnActivation = false;
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    state.recordRepoActivation("org/repo-a", "2026-07-02T16:58:09.555Z");
+    state.recordProcessed({
+      repo: "org/repo-a",
+      pullNumber: 950,
+      headSha: "old-baselined-head",
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+    const comments = new Map([
+      ["org/repo-a#950", [comment(555, "100yenadmin", "@evaos-code-review-bot review")]]
+    ]);
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(
+        new Map([[
+          "org/repo-a",
+          [pull("org/repo-a", 950, "new-head-on-old-pr", "base", { createdAt: "2026-06-30T05:34:43Z" })]
+        ]]),
+        comments
+      ),
+      state,
+      options: { repo: "org/repo-a", pullNumber: 950, dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: "https://github.com/org/repo-a/pull/950#pullrequestreview-scoped"
+        });
+        return "reviewed_command";
+      },
+      now: new Date("2026-07-02T17:45:00.000Z")
+    });
+
+    expect(result.commandReviewRequested).toBe(1);
+    expect(result.reviewed).toBe(1);
+    expect(result.skippedProcessed).toBe(0);
+    expect(state.listReviewQueueJobs({ state: "posted" })).toEqual([
+      expect.objectContaining({
+        repo: "org/repo-a",
+        pullNumber: 950,
+        headSha: "new-head-on-old-pr",
+        source: "manual_command",
+        commentId: 555
+      })
+    ]);
+    expect(state.getProcessedReview("org/repo-a", 950, "new-head-on-old-pr")).toMatchObject({
+      status: "posted",
+      event: "COMMENT"
+    });
+    state.close();
+  });
+
   it("records trusted stop commands as terminal skips for the current head", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-command-stop-"));
     roots.push(root);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -2449,6 +2449,10 @@ describe("provider-aware review scheduler", () => {
       status: "skipped",
       error: "activation_baseline_existing_head"
     });
+    expect(state.getReviewReadiness("org/repo-a", 950, "new-head-on-old-pr")).toMatchObject({
+      state: "skipped",
+      reason: "activation_baseline_existing_head"
+    });
     expect(state.listReviewQueueJobs({ repo: "org/repo-a" })).toEqual([
       expect.objectContaining({ pullNumber: 960, headSha: "new-head-on-new-pr", state: "queued" })
     ]);

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -1138,6 +1138,55 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("skips pre-activation PRs with new heads before fetching commands", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-preactivation-command-skip-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1231, "new-head-on-old-pr", "base", { createdAt: "2026-06-30T05:34:43Z" });
+    state.recordRepoActivation("electricsheephq/WorldOS", "2026-07-02T16:58:09.555Z");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: "old-baselined-head",
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+    let issueCommentReads = 0;
+
+    const result = await reviewPull({
+      config,
+      github: {
+        listIssueComments: async () => {
+          issueCommentReads += 1;
+          throw new Error("pre-activation PR heads should not read issue comments");
+        },
+        listPullFiles: async () => {
+          throw new Error("pre-activation PR heads should not fetch files");
+        }
+      } as unknown as GitHubApi,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: false
+    });
+
+    expect(result).toBe("skipped_processed");
+    expect(issueCommentReads).toBe(0);
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "skipped",
+      error: "activation_baseline_existing_head"
+    });
+    state.close();
+  });
+
   it("restores a failed row after a retry dry-run records dry_run", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-dry-run-"));
     roots.push(root);
@@ -1497,7 +1546,7 @@ function pullSummary(
   number: number,
   headSha: string,
   baseSha = "base",
-  options: { state?: string; mergedAt?: string | null; body?: string | null } = {}
+  options: { state?: string; mergedAt?: string | null; body?: string | null; createdAt?: string } = {}
 ): PullRequestSummary {
   return {
     number,
@@ -1505,6 +1554,7 @@ function pullSummary(
     draft: false,
     ...(options.body !== undefined ? { body: options.body } : {}),
     ...(options.state ? { state: options.state } : {}),
+    ...(options.createdAt ? { created_at: options.createdAt } : {}),
     ...(options.mergedAt !== undefined ? { merged_at: options.mergedAt } : {}),
     head: {
       sha: headSha,

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -1184,6 +1184,10 @@ describe("worker review failures", () => {
       status: "skipped",
       error: "activation_baseline_existing_head"
     });
+    expect(state.getReviewReadiness("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      state: "skipped",
+      reason: "activation_baseline_existing_head"
+    });
     state.close();
   });
 


### PR DESCRIPTION
## Summary

Fixes #147.

This hardens repo activation semantics for repos with a large historical PR backlog. If a repo has already been activated with `reviewExistingOpenPrsOnActivation: false`, PRs created before that activation remain baselined even when their head SHA changes later. Background scans should only treat genuinely post-activation PRs as new review candidates unless a trusted scoped/manual command explicitly targets a historical PR.

## What Changed

- Added an activation policy helper keyed on PR `created_at` versus the repo activation watermark.
- Exposed repo activation timestamps from the state store and read-only coverage state reader.
- Updated coverage audit to classify pre-activation changed heads as `activation_baseline_existing_pr` instead of unprocessed misses.
- Updated scheduler and run-once worker paths to record the current head as `activation_baseline_existing_head` and skip background command/file reads for pre-activation PRs.
- Added regression coverage for coverage-audit, scheduler, and worker paths.

## Validation

- `npm test -- tests/coverage-audit.test.ts tests/scheduler.test.ts tests/worker-failure.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- Temp `lossless-claw` proof config after fix:
  - evidence: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-03/lossless-claw-addback/coverage-audit-temp-20-repos-after-fix-2.json`
  - 20 repos scanned, 128 PRs seen, 109 processed, 17 skipped, 1 unprocessed, 0 stale heads, 0 read failures
  - remaining unprocessed: `Martian-Engineering/lossless-claw#960`, created after activation and therefore expected
  - `lossless-claw#950` moved to `activation_baseline_existing_pr` because it was created before activation

## Live Safety

No live config changes in this PR. `Martian-Engineering/lossless-claw` remains excluded until this lands, is released, and the add-back proof is rerun on `main`.
