### PR TITLE
feat: gate issue enrichment scans

### DIFF
--- a/config.active-profiles.example.json
+++ b/config.active-profiles.example.json
@@ -30,6 +30,19 @@
     "trustedAuthors": ["100yenadmin"],
     "acknowledge": false
   },
+  "issueEnrichment": {
+    "enabled": false,
+    "postIssueComment": false,
+    "allowlist": [],
+    "maxIssuesPerCycle": 5,
+    "maxCommentsPerCycle": 0,
+    "cooldownMs": 3600000,
+    "burstWindowMs": 3600000,
+    "maxIssuesPerBurst": 10,
+    "lookbackMs": 600000,
+    "processExistingOpenIssuesOnActivation": false,
+    "repos": {}
+  },
   "gitnexusContext": {
     "enabled": false,
     "packetVersion": "gitnexus-context-packet-v0.1",

--- a/config.example.json
+++ b/config.example.json
@@ -13,6 +13,27 @@
   "workRoot": "/Volumes/LEXAR/repos/evaos-code-review-bot/runtime",
   "statePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews.sqlite",
   "evidenceDir": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence",
+  "issueEnrichment": {
+    "enabled": false,
+    "postIssueComment": false,
+    "allowlist": [],
+    "maxIssuesPerCycle": 5,
+    "maxCommentsPerCycle": 0,
+    "cooldownMs": 3600000,
+    "burstWindowMs": 3600000,
+    "maxIssuesPerBurst": 10,
+    "lookbackMs": 600000,
+    "processExistingOpenIssuesOnActivation": false,
+    "repos": {
+      "electricsheephq/evaos-code-review-bot": {
+        "enabled": false,
+        "maxIssuesPerCycle": 3,
+        "maxCommentsPerCycle": 1,
+        "maxIssuesPerBurst": 8,
+        "processExistingOpenIssuesOnActivation": false
+      }
+    }
+  },
   "commands": {
     "enabled": false,
     "botMentions": ["@evaos-code-review-bot"],

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -12,6 +12,16 @@ Required repository permissions:
 - Actions: read
 - Metadata: read
 
+Optional issue-enrichment permissions, gated by `issueEnrichment`:
+
+- Issues: read, only for dry-run/operator issue enrichment reads.
+- Issues: write, only after a tracked rollout explicitly enables App-authored
+  sticky issue enrichment comments on an `issueEnrichment.allowlist` repo.
+
+Do not add Issues permissions merely because a repository is in the PR review
+monitor list. Issue enrichment has a separate allowlist and per-repo throttles
+because milestone or planning days can create large issue bursts.
+
 Install the app only on:
 
 - `electricsheephq/WorldOS`

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -96,6 +96,12 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
   JSON/Markdown with the bot-owned marker and rendered comment when not skipped.
   This command never posts comments, auto-applies labels, assigns reviewers,
   calls ZCode, or mutates GitHub state.
+- `issue-enrichment-scan`: dry-run scans only `issueEnrichment.allowlist`, not
+  the PR monitor allowlist. It lists recently updated issues by default, skips
+  closed issues and PR-shaped issue records, applies per-repo throttles, and
+  reports would-comment/deferred rows without posting comments. Use
+  `--include-existing true` only for an explicit scoped audit; do not use it as
+  the default live posture for repos with large historic issue backlogs.
 - `doctor`: auth/config readiness. Use this for GitHub App/ZCode readiness, not
   runtime health.
 
@@ -261,6 +267,17 @@ issues.
 Issue mode requires an authenticated token or GitHub App installation with
 Issues read access. Live App-authored issue comments require Issues write
 permission and must not be enabled until that permission expansion is tracked.
+
+Dry-run scan issue enrichment against the separate issue allowlist:
+
+```bash
+npx tsx src/cli.ts issue-enrichment-scan --config <config.json> --dry-run true --output-dir <configured-evidence-dir>/issue-enrichment/scan
+```
+
+The scan does not use `pilotRepos`, does not post comments, and defaults to the
+configured recent-update lookback. Per-repo throttles live under
+`issueEnrichment.repos.<owner/name>` and can cap `maxIssuesPerCycle`,
+`maxCommentsPerCycle`, burst thresholds, cooldown, and backlog behavior.
 
 ## Safety Boundaries
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { buildEnrichmentComment, buildIssueEnrichmentDryRunOutput } from "./enri
 import { GitHubApi } from "./github.js";
 import { buildGitNexusContextPacket } from "./gitnexus-context.js";
 import { buildGitHubRelatedContextPacket } from "./github-related-context.js";
+import { buildIssueEnrichmentStatus, collectIssueEnrichmentScan } from "./issue-enrichment.js";
 import {
   buildOperatorDashboard,
   buildRuntimeInventory,
@@ -75,8 +76,13 @@ async function main(): Promise<void> {
         });
       }
     }
+    const issueEnrichment = buildIssueEnrichmentStatus({
+      config,
+      canPostAsApp: github.canPostAsApp()
+    });
+    const ok = readChecks.every((check) => check.ok) && issueEnrichment.ok;
     console.log(JSON.stringify({
-      ok: readChecks.every((check) => check.ok),
+      ok,
       pilotRepos: config.pilotRepos,
       monitoredRepos,
       canaryPulls: config.canaryPulls ?? [],
@@ -85,6 +91,7 @@ async function main(): Promise<void> {
       reviewConcurrency: config.reviewConcurrency,
       reviewerSessions: config.reviewerSessions,
       repoMemory: config.repoMemory,
+      issueEnrichment,
       commandsEnabled: config.commands.enabled,
       statePath: config.statePath,
       workRoot: config.workRoot,
@@ -96,7 +103,7 @@ async function main(): Promise<void> {
         readChecks
       }
     }, null, 2));
-    if (readChecks.some((check) => !check.ok)) process.exitCode = 1;
+    if (!ok) process.exitCode = 1;
     return;
   }
 
@@ -190,12 +197,18 @@ async function main(): Promise<void> {
       repo: args.repo,
       limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
     });
+    const github = new GitHubApi(config.github);
     const status = buildOperatorStatus({
       release,
       coverage,
       agents,
       providerCooldowns,
-      durableQueue
+      durableQueue,
+      issueEnrichment: buildIssueEnrichmentStatus({
+        config,
+        canPostAsApp: github.canPostAsApp(),
+        checkedAt: release.checkedAt
+      })
     });
     console.log(JSON.stringify(status, null, 2));
     if (!status.ok) process.exitCode = 1;
@@ -234,6 +247,7 @@ async function main(): Promise<void> {
       repo: args.repo,
       now
     });
+    const github = new GitHubApi(config.github);
     const processes = collectBotProcessInventory({
       repoPath: process.cwd(),
       launchdLabel: release.launchd.label,
@@ -248,6 +262,11 @@ async function main(): Promise<void> {
       providerCooldowns,
       repoProviderCooldowns,
       durableQueue,
+      issueEnrichment: buildIssueEnrichmentStatus({
+        config,
+        canPostAsApp: github.canPostAsApp(),
+        checkedAt: now.toISOString()
+      }),
       checkedAt: now.toISOString()
     });
     console.log(args.human === "true" ? formatRuntimeInventoryHuman(inventory) : JSON.stringify(inventory, null, 2));
@@ -596,7 +615,6 @@ async function main(): Promise<void> {
     const config = loadConfig(args.config);
     const github = new GitHubApi(config.github);
     const repoPolicy = resolveRepoProfile(config, repo);
-    if (!repoPolicy.allowed) throw new Error(`Repo ${repo} is skipped by policy: ${repoPolicy.reason}`);
     const enrichmentConfig = config.enrichment!;
     if (args.issue) {
       const issueNumber = parsePositiveInteger(parseSingleArg(args.issue, "--issue"), "--issue");
@@ -605,8 +623,8 @@ async function main(): Promise<void> {
       const output = buildIssueEnrichmentDryRunOutput({
         repo,
         issue,
-        suggestedLabels: repoPolicy.profile.suggestedLabels,
-        suggestedOwners: repoPolicy.profile.suggestedReviewers,
+        suggestedLabels: repoPolicy.allowed ? repoPolicy.profile.suggestedLabels : undefined,
+        suggestedOwners: repoPolicy.allowed ? repoPolicy.profile.suggestedReviewers : undefined,
         validationSuggestions: ["Confirm owner, acceptance criteria, and validation evidence before implementation."],
         maxRelatedRefs: enrichmentConfig.maxRelatedRefs,
         maxSuggestions: enrichmentConfig.maxSuggestions
@@ -620,6 +638,7 @@ async function main(): Promise<void> {
       console.log(redactSecrets(JSON.stringify(output, null, 2)));
       return;
     }
+    if (!repoPolicy.allowed) throw new Error(`Repo ${repo} is skipped by policy: ${repoPolicy.reason}`);
     const prArg = parseSingleArg(args.pr ?? [], "--pr");
     const pullNumber = parsePositiveInteger(prArg, "--pr");
     const pull = await github.getPull(repo, pullNumber);
@@ -660,6 +679,30 @@ async function main(): Promise<void> {
       writeFileSync(join(safeOutputDir, "enrichment.md"), enrichment.body);
     }
     console.log(redactSecrets(JSON.stringify(output, null, 2)));
+    return;
+  }
+
+  if (command === "issue-enrichment-scan") {
+    const config = loadConfig(args.config);
+    const dryRun = args["dry-run"] !== "false";
+    if (!dryRun) throw new Error("issue-enrichment-scan currently supports dry-run only; live issue comments require a separate promotion gate");
+    const github = new GitHubApi(config.github);
+    const scan = await collectIssueEnrichmentScan({
+      config,
+      reader: github,
+      dryRun,
+      canPostAsApp: github.canPostAsApp(),
+      ...(args.repo ? { repo: parseSingleArg(args.repo, "--repo") } : {}),
+      includeExisting: args["include-existing"] === "true",
+      ...(args.since ? { since: parseSingleArg(args.since, "--since") } : {})
+    });
+    if (args["output-dir"]) {
+      const safeOutputDir = assertMemoryPacketOutputDirSafe(args["output-dir"], config.evidenceDir);
+      mkdirSync(safeOutputDir, { recursive: true });
+      writeFileSync(join(safeOutputDir, "issue-enrichment-scan.json"), `${redactSecrets(JSON.stringify(scan, null, 2))}\n`);
+    }
+    console.log(redactSecrets(JSON.stringify(scan, null, 2)));
+    if (!scan.ok) process.exitCode = 1;
     return;
   }
 
@@ -903,6 +946,7 @@ function buildHelp() {
         "build-github-related-context-packet",
         "build-skill-pack",
         "build-enrichment-comment",
+        "issue-enrichment-scan",
         "provider-cooldowns",
         "retry-provider-cooldowns",
         "retry-failed",
@@ -930,6 +974,7 @@ function buildHelp() {
       "npx tsx src/cli.ts build-skill-pack --config /path/to/live.json --output-dir /path/to/evidence",
       "npx tsx src/cli.ts build-enrichment-comment --config /path/to/live.json --repo owner/repo --pr 123 --output-dir /path/to/evidence",
       "npx tsx src/cli.ts build-enrichment-comment --config /path/to/live.json --repo owner/repo --issue 456 --output-dir /path/to/evidence",
+      "npx tsx src/cli.ts issue-enrichment-scan --config /path/to/live.json --dry-run true --output-dir /path/to/evidence",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ]
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import type { EnrichmentConfig } from "./enrichment.js";
 import type { GitNexusContextConfig } from "./gitnexus-context.js";
 import type { GitHubRelatedContextConfig } from "./github-related-context.js";
+import { DEFAULT_ISSUE_ENRICHMENT_CONFIG, type IssueEnrichmentConfig } from "./issue-enrichment.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
 
 export interface BotConfig {
@@ -47,6 +48,7 @@ export interface BotConfig {
   githubRelatedContext?: GitHubRelatedContextConfig;
   skillPacks?: SkillPackContextConfig;
   enrichment?: EnrichmentConfig;
+  issueEnrichment?: IssueEnrichmentConfig;
   repoProfiles?: RepoProfilesConfig;
   commands: CommandConfig;
   zcode: {
@@ -250,6 +252,7 @@ const DEFAULT_CONFIG: BotConfig = {
     maxRelatedRefs: 8,
     maxSuggestions: 8
   },
+  issueEnrichment: DEFAULT_ISSUE_ENRICHMENT_CONFIG,
   commands: {
     enabled: false,
     botMentions: ["@evaos-code-review-bot"],
@@ -340,6 +343,9 @@ function validateConfig(config: BotConfig): void {
   const enrichment = config.enrichment ?? DEFAULT_CONFIG.enrichment!;
   config.enrichment = enrichment;
   validateEnrichmentConfig(enrichment, "config.enrichment");
+  const issueEnrichment = config.issueEnrichment ?? DEFAULT_CONFIG.issueEnrichment!;
+  config.issueEnrichment = issueEnrichment;
+  validateIssueEnrichmentConfig(issueEnrichment, "config.issueEnrichment");
   validateBoolean(config.commands.enabled, "config.commands.enabled");
   validateStringArray(config.commands.botMentions, "config.commands.botMentions");
   validateStringArray(config.commands.trustedAuthors, "config.commands.trustedAuthors");
@@ -465,6 +471,53 @@ function validateEnrichmentConfig(value: unknown, label: string): void {
   }
   validatePositiveInteger(value.maxRelatedRefs, `${label}.maxRelatedRefs`);
   validatePositiveInteger(value.maxSuggestions, `${label}.maxSuggestions`);
+}
+
+function validateIssueEnrichmentConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  validateBoolean(value.enabled, `${label}.enabled`);
+  validateBoolean(value.postIssueComment, `${label}.postIssueComment`);
+  validateStringArray(value.allowlist, `${label}.allowlist`);
+  const allowlist = value.allowlist as string[];
+  for (const repo of allowlist) validateRepoName(repo, `${label}.allowlist`);
+  validatePositiveInteger(value.maxIssuesPerCycle, `${label}.maxIssuesPerCycle`);
+  validateNonNegativeInteger(value.maxCommentsPerCycle, `${label}.maxCommentsPerCycle`);
+  validatePositiveInteger(value.cooldownMs, `${label}.cooldownMs`);
+  validatePositiveInteger(value.burstWindowMs, `${label}.burstWindowMs`);
+  validatePositiveInteger(value.maxIssuesPerBurst, `${label}.maxIssuesPerBurst`);
+  validatePositiveInteger(value.lookbackMs, `${label}.lookbackMs`);
+  validateBoolean(value.processExistingOpenIssuesOnActivation, `${label}.processExistingOpenIssuesOnActivation`);
+  if (typeof value.maxIssuesPerCycle === "number" && typeof value.maxCommentsPerCycle === "number" && value.maxCommentsPerCycle > value.maxIssuesPerCycle) {
+    throw new Error(`${label}.maxCommentsPerCycle must be <= ${label}.maxIssuesPerCycle`);
+  }
+  if (value.repos !== undefined) {
+    if (!isRecord(value.repos)) throw new Error(`${label}.repos must be an object`);
+    for (const [repo, override] of Object.entries(value.repos)) {
+      validateRepoName(repo, `${label}.repos`);
+      validateIssueEnrichmentRepoOverride(override, `${label}.repos.${repo}`);
+    }
+  }
+}
+
+function validateIssueEnrichmentRepoOverride(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  if (value.enabled !== undefined) validateBoolean(value.enabled, `${label}.enabled`);
+  if (value.maxIssuesPerCycle !== undefined) validatePositiveInteger(value.maxIssuesPerCycle, `${label}.maxIssuesPerCycle`);
+  if (value.maxCommentsPerCycle !== undefined) validateNonNegativeInteger(value.maxCommentsPerCycle, `${label}.maxCommentsPerCycle`);
+  if (value.cooldownMs !== undefined) validatePositiveInteger(value.cooldownMs, `${label}.cooldownMs`);
+  if (value.burstWindowMs !== undefined) validatePositiveInteger(value.burstWindowMs, `${label}.burstWindowMs`);
+  if (value.maxIssuesPerBurst !== undefined) validatePositiveInteger(value.maxIssuesPerBurst, `${label}.maxIssuesPerBurst`);
+  if (value.lookbackMs !== undefined) validatePositiveInteger(value.lookbackMs, `${label}.lookbackMs`);
+  if (value.processExistingOpenIssuesOnActivation !== undefined) {
+    validateBoolean(value.processExistingOpenIssuesOnActivation, `${label}.processExistingOpenIssuesOnActivation`);
+  }
+  if (
+    typeof value.maxIssuesPerCycle === "number" &&
+    typeof value.maxCommentsPerCycle === "number" &&
+    value.maxCommentsPerCycle > value.maxIssuesPerCycle
+  ) {
+    throw new Error(`${label}.maxCommentsPerCycle must be <= ${label}.maxIssuesPerCycle`);
+  }
 }
 
 function validateProfileRecord(record: Record<string, RepoProfileConfig> | undefined, label: string): void {

--- a/src/github.ts
+++ b/src/github.ts
@@ -94,6 +94,37 @@ export class GitHubApi {
     }
   }
 
+  async listIssuesForEnrichment(
+    repo: string,
+    options: {
+      state?: "open" | "closed" | "all";
+      since?: string;
+      perPage?: number;
+      pageLimit?: number;
+    } = {}
+  ): Promise<GitHubRelatedIssueOrPull[]> {
+    const issues: GitHubRelatedIssueOrPull[] = [];
+    const state = options.state ?? "all";
+    const perPage = options.perPage ?? 100;
+    const pageLimit = options.pageLimit ?? 1;
+    for (let page = 1; page <= pageLimit; page += 1) {
+      const params = new URLSearchParams({
+        state,
+        sort: "updated",
+        direction: "desc",
+        per_page: String(perPage),
+        page: String(page)
+      });
+      if (options.since) params.set("since", options.since);
+      const chunk = await this.request<GitHubRelatedIssueOrPull[]>(`/repos/${repo}/issues?${params.toString()}`, {
+        token: await this.getReadToken(repo)
+      });
+      issues.push(...chunk);
+      if (chunk.length < perPage) return issues;
+    }
+    return issues;
+  }
+
   async createReview(input: {
     repo: string;
     pullNumber: number;

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -1,0 +1,439 @@
+import { buildIssueEnrichmentDryRunOutput } from "./enrichment.js";
+import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
+import { redactSecrets } from "./secrets.js";
+
+export interface IssueEnrichmentConfig {
+  enabled: boolean;
+  postIssueComment: boolean;
+  allowlist: string[];
+  maxIssuesPerCycle: number;
+  maxCommentsPerCycle: number;
+  cooldownMs: number;
+  burstWindowMs: number;
+  maxIssuesPerBurst: number;
+  lookbackMs: number;
+  processExistingOpenIssuesOnActivation: boolean;
+  repos?: Record<string, IssueEnrichmentRepoOverride>;
+}
+
+export const DEFAULT_ISSUE_ENRICHMENT_CONFIG: IssueEnrichmentConfig = {
+  enabled: false,
+  postIssueComment: false,
+  allowlist: [],
+  maxIssuesPerCycle: 5,
+  maxCommentsPerCycle: 0,
+  cooldownMs: 60 * 60_000,
+  burstWindowMs: 60 * 60_000,
+  maxIssuesPerBurst: 10,
+  lookbackMs: 10 * 60_000,
+  processExistingOpenIssuesOnActivation: false,
+  repos: {}
+};
+
+export interface IssueEnrichmentRepoOverride {
+  enabled?: boolean;
+  maxIssuesPerCycle?: number;
+  maxCommentsPerCycle?: number;
+  cooldownMs?: number;
+  burstWindowMs?: number;
+  maxIssuesPerBurst?: number;
+  lookbackMs?: number;
+  processExistingOpenIssuesOnActivation?: boolean;
+}
+
+export interface IssueEnrichmentStatus {
+  ok: boolean;
+  checkedAt: string;
+  state: "disabled" | "dry_run_only" | "ready" | "blocked";
+  enabled: boolean;
+  postIssueComment: boolean;
+  separateAllowlist: true;
+  allowlist: string[];
+  throttleDefaults: IssueEnrichmentThrottlePolicy;
+  repoOverrides: Array<{ repo: string } & IssueEnrichmentRepoOverride>;
+  blockers: IssueEnrichmentBlocker[];
+}
+
+export interface IssueEnrichmentThrottlePolicy {
+  maxIssuesPerCycle: number;
+  maxCommentsPerCycle: number;
+  cooldownMs: number;
+  burstWindowMs: number;
+  maxIssuesPerBurst: number;
+  lookbackMs: number;
+  processExistingOpenIssuesOnActivation: boolean;
+}
+
+export type IssueEnrichmentBlocker =
+  | "issue_enrichment_disabled"
+  | "issue_enrichment_allowlist_empty"
+  | "issue_enrichment_live_posting_disabled"
+  | "github_app_credentials_required_for_live_issue_comments";
+
+export interface IssueEnrichmentReader {
+  listIssuesForEnrichment(
+    repo: string,
+    options?: {
+      state?: "open" | "closed" | "all";
+      since?: string;
+      perPage?: number;
+      pageLimit?: number;
+    }
+  ): Promise<GitHubRelatedIssueOrPull[]>;
+}
+
+export interface IssueEnrichmentScanResult {
+  ok: boolean;
+  checkedAt: string;
+  dryRun: boolean;
+  status: IssueEnrichmentStatus;
+  summary: {
+    reposScanned: number;
+    reposSkipped: number;
+    readFailures: number;
+    issuesSeen: number;
+    eligible: number;
+    skipped: number;
+    wouldEnrich: number;
+    wouldComment: number;
+    deferred: number;
+  };
+  repos: IssueEnrichmentRepoScan[];
+  items: IssueEnrichmentScanItem[];
+  recommendedActions: string[];
+}
+
+export interface IssueEnrichmentRepoScan {
+  repo: string;
+  ok: boolean;
+  allowed: boolean;
+  enabled: boolean;
+  postIssueComment: boolean;
+  since?: string;
+  throttle: IssueEnrichmentThrottlePolicy;
+  issuesSeen: number;
+  eligible: number;
+  skipped: number;
+  wouldEnrich: number;
+  wouldComment: number;
+  deferred: number;
+  readFailure?: string;
+  skipReason?: "not_issue_enrichment_allowlisted" | "issue_enrichment_repo_disabled";
+}
+
+export type IssueEnrichmentScanAction = "would_enrich" | "would_comment" | "skipped" | "deferred";
+export type IssueEnrichmentScanReason =
+  | "eligible"
+  | "stale_issue_closed"
+  | "issue_is_pull_request"
+  | "repo_max_issues_per_cycle"
+  | "repo_max_comments_per_cycle"
+  | "burst_threshold_exceeded";
+
+export interface IssueEnrichmentScanItem {
+  repo: string;
+  issueNumber: number;
+  state: string;
+  action: IssueEnrichmentScanAction;
+  reason: IssueEnrichmentScanReason;
+  url?: string;
+}
+
+const DEFAULT_REPO_SCAN_OPTIONS = {
+  state: "all" as const,
+  perPage: 100,
+  pageLimit: 1
+};
+
+export function buildIssueEnrichmentStatus(input: {
+  config: { issueEnrichment?: IssueEnrichmentConfig };
+  canPostAsApp: boolean;
+  checkedAt?: string;
+}): IssueEnrichmentStatus {
+  const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
+  const blockers: IssueEnrichmentBlocker[] = [];
+  if (!config.enabled) blockers.push("issue_enrichment_disabled");
+  if (config.allowlist.length === 0) blockers.push("issue_enrichment_allowlist_empty");
+  if (!config.postIssueComment) blockers.push("issue_enrichment_live_posting_disabled");
+  if (config.enabled && config.postIssueComment && !input.canPostAsApp) {
+    blockers.push("github_app_credentials_required_for_live_issue_comments");
+  }
+
+  const blocking = blockers.filter((blocker) =>
+    blocker === "github_app_credentials_required_for_live_issue_comments" ||
+    (config.enabled && blocker === "issue_enrichment_allowlist_empty")
+  );
+  const state = !config.enabled
+    ? "disabled"
+    : blocking.length > 0
+      ? "blocked"
+      : config.postIssueComment
+        ? "ready"
+        : "dry_run_only";
+
+  return {
+    ok: blocking.length === 0,
+    checkedAt: input.checkedAt ?? new Date().toISOString(),
+    state,
+    enabled: config.enabled,
+    postIssueComment: config.postIssueComment,
+    separateAllowlist: true,
+    allowlist: [...config.allowlist],
+    throttleDefaults: {
+      maxIssuesPerCycle: config.maxIssuesPerCycle,
+      maxCommentsPerCycle: config.maxCommentsPerCycle,
+      cooldownMs: config.cooldownMs,
+      burstWindowMs: config.burstWindowMs,
+      maxIssuesPerBurst: config.maxIssuesPerBurst,
+      lookbackMs: config.lookbackMs,
+      processExistingOpenIssuesOnActivation: config.processExistingOpenIssuesOnActivation
+    },
+    repoOverrides: Object.entries(config.repos ?? {}).map(([repo, override]) => ({ repo, ...override })),
+    blockers
+  };
+}
+
+export async function collectIssueEnrichmentScan(input: {
+  config: { issueEnrichment?: IssueEnrichmentConfig };
+  reader: IssueEnrichmentReader;
+  dryRun: boolean;
+  repo?: string;
+  includeExisting?: boolean;
+  since?: string;
+  canPostAsApp?: boolean;
+  checkedAt?: string;
+}): Promise<IssueEnrichmentScanResult> {
+  const checkedAt = input.checkedAt ?? new Date().toISOString();
+  const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
+  const status = buildIssueEnrichmentStatus({
+    config: input.config,
+    canPostAsApp: input.canPostAsApp ?? false,
+    checkedAt
+  });
+  const repos = input.repo ? [input.repo] : config.allowlist;
+  const repoScans: IssueEnrichmentRepoScan[] = [];
+  const items: IssueEnrichmentScanItem[] = [];
+
+  for (const repo of repos) {
+    const policy = resolveIssueEnrichmentRepoPolicy(config, repo);
+    if (!policy.allowed) {
+      repoScans.push({
+        repo,
+        ok: true,
+        allowed: false,
+        enabled: false,
+        postIssueComment: config.postIssueComment,
+        throttle: policy.throttle,
+        issuesSeen: 0,
+        eligible: 0,
+        skipped: 0,
+        wouldEnrich: 0,
+        wouldComment: 0,
+        deferred: 0,
+        skipReason: policy.reason
+      });
+      continue;
+    }
+
+    const since = input.since ?? buildIssueScanSince({
+      checkedAt,
+      includeExisting: input.includeExisting === true || policy.throttle.processExistingOpenIssuesOnActivation,
+      lookbackMs: policy.throttle.lookbackMs
+    });
+    let issues: GitHubRelatedIssueOrPull[] = [];
+    try {
+      issues = await input.reader.listIssuesForEnrichment(repo, {
+        ...DEFAULT_REPO_SCAN_OPTIONS,
+        ...(since ? { since } : {})
+      });
+    } catch (error) {
+      repoScans.push({
+        repo,
+        ok: false,
+        allowed: true,
+        enabled: config.enabled,
+        postIssueComment: config.postIssueComment,
+        ...(since ? { since } : {}),
+        throttle: policy.throttle,
+        issuesSeen: 0,
+        eligible: 0,
+        skipped: 0,
+        wouldEnrich: 0,
+        wouldComment: 0,
+        deferred: 0,
+        readFailure: redactSecrets(error instanceof Error ? error.message : String(error))
+      });
+      continue;
+    }
+
+    const issueItems = planRepoIssueScan({
+      repo,
+      issues,
+      throttle: policy.throttle,
+      postIssueComment: config.postIssueComment
+    });
+    items.push(...issueItems);
+    repoScans.push({
+      repo,
+      ok: true,
+      allowed: true,
+      enabled: config.enabled,
+      postIssueComment: config.postIssueComment,
+      ...(since ? { since } : {}),
+      throttle: policy.throttle,
+      issuesSeen: issues.length,
+      eligible: issueItems.filter((item) => item.reason === "eligible" || item.reason.startsWith("repo_max") || item.reason === "burst_threshold_exceeded").length,
+      skipped: issueItems.filter((item) => item.action === "skipped").length,
+      wouldEnrich: issueItems.filter((item) => item.action === "would_enrich" || item.action === "would_comment").length,
+      wouldComment: issueItems.filter((item) => item.action === "would_comment").length,
+      deferred: issueItems.filter((item) => item.action === "deferred").length
+    });
+  }
+
+  const summary = summarizeScan(repoScans);
+  return {
+    ok: summary.readFailures === 0,
+    checkedAt,
+    dryRun: input.dryRun,
+    status,
+    summary,
+    repos: repoScans,
+    items,
+    recommendedActions: buildScanRecommendedActions(status, summary)
+  };
+}
+
+export function resolveIssueEnrichmentRepoPolicy(
+  config: IssueEnrichmentConfig,
+  repo: string
+): {
+  allowed: boolean;
+  reason?: "not_issue_enrichment_allowlisted" | "issue_enrichment_repo_disabled";
+  throttle: IssueEnrichmentThrottlePolicy;
+} {
+  const override = config.repos?.[repo];
+  const throttle = {
+    maxIssuesPerCycle: override?.maxIssuesPerCycle ?? config.maxIssuesPerCycle,
+    maxCommentsPerCycle: override?.maxCommentsPerCycle ?? config.maxCommentsPerCycle,
+    cooldownMs: override?.cooldownMs ?? config.cooldownMs,
+    burstWindowMs: override?.burstWindowMs ?? config.burstWindowMs,
+    maxIssuesPerBurst: override?.maxIssuesPerBurst ?? config.maxIssuesPerBurst,
+    lookbackMs: override?.lookbackMs ?? config.lookbackMs,
+    processExistingOpenIssuesOnActivation:
+      override?.processExistingOpenIssuesOnActivation ?? config.processExistingOpenIssuesOnActivation
+  };
+  if (!config.allowlist.includes(repo)) return { allowed: false, reason: "not_issue_enrichment_allowlisted", throttle };
+  if (override?.enabled === false) return { allowed: false, reason: "issue_enrichment_repo_disabled", throttle };
+  return { allowed: true, throttle };
+}
+
+function planRepoIssueScan(input: {
+  repo: string;
+  issues: GitHubRelatedIssueOrPull[];
+  throttle: IssueEnrichmentThrottlePolicy;
+  postIssueComment: boolean;
+}): IssueEnrichmentScanItem[] {
+  const eligible = input.issues
+    .map((issue) => buildIssueEnrichmentDryRunOutput({
+      repo: input.repo,
+      issue,
+      maxRelatedRefs: 8,
+      maxSuggestions: 8
+    }))
+    .filter((output) => !output.skipped);
+  const burstExceeded = eligible.length > input.throttle.maxIssuesPerBurst;
+  let enriched = 0;
+  let comments = 0;
+
+  return input.issues.map((issue) => {
+    const output = buildIssueEnrichmentDryRunOutput({
+      repo: input.repo,
+      issue,
+      maxRelatedRefs: 8,
+      maxSuggestions: 8
+    });
+    if (output.skipped) {
+      return {
+        repo: input.repo,
+        issueNumber: output.issueNumber,
+        state: output.state,
+        action: "skipped",
+        reason: output.reason,
+        ...(output.url ? { url: output.url } : {})
+      };
+    }
+    if (burstExceeded) {
+      return issueScanItem(input.repo, output.issueNumber, output.state, "deferred", "burst_threshold_exceeded", output.url);
+    }
+    if (enriched >= input.throttle.maxIssuesPerCycle) {
+      return issueScanItem(input.repo, output.issueNumber, output.state, "deferred", "repo_max_issues_per_cycle", output.url);
+    }
+    enriched += 1;
+    if (input.postIssueComment) {
+      if (comments >= input.throttle.maxCommentsPerCycle) {
+        return issueScanItem(input.repo, output.issueNumber, output.state, "deferred", "repo_max_comments_per_cycle", output.url);
+      }
+      comments += 1;
+      return issueScanItem(input.repo, output.issueNumber, output.state, "would_comment", "eligible", output.url);
+    }
+    return issueScanItem(input.repo, output.issueNumber, output.state, "would_enrich", "eligible", output.url);
+  });
+}
+
+function issueScanItem(
+  repo: string,
+  issueNumber: number,
+  state: string,
+  action: IssueEnrichmentScanAction,
+  reason: IssueEnrichmentScanReason,
+  url?: string
+): IssueEnrichmentScanItem {
+  return {
+    repo,
+    issueNumber,
+    state,
+    action,
+    reason,
+    ...(url ? { url } : {})
+  };
+}
+
+function buildIssueScanSince(input: {
+  checkedAt: string;
+  includeExisting: boolean;
+  lookbackMs: number;
+}): string | undefined {
+  if (input.includeExisting) return undefined;
+  const checkedAtMs = Date.parse(input.checkedAt);
+  const baseMs = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
+  return new Date(baseMs - input.lookbackMs).toISOString();
+}
+
+function summarizeScan(repoScans: IssueEnrichmentRepoScan[]): IssueEnrichmentScanResult["summary"] {
+  return {
+    reposScanned: repoScans.filter((repo) => repo.allowed).length,
+    reposSkipped: repoScans.filter((repo) => !repo.allowed).length,
+    readFailures: repoScans.filter((repo) => !repo.ok).length,
+    issuesSeen: sum(repoScans, "issuesSeen"),
+    eligible: sum(repoScans, "eligible"),
+    skipped: sum(repoScans, "skipped"),
+    wouldEnrich: sum(repoScans, "wouldEnrich"),
+    wouldComment: sum(repoScans, "wouldComment"),
+    deferred: sum(repoScans, "deferred")
+  };
+}
+
+function buildScanRecommendedActions(status: IssueEnrichmentStatus, summary: IssueEnrichmentScanResult["summary"]): string[] {
+  const actions = [];
+  if (status.state === "blocked") actions.push("resolve issue-enrichment blockers before live issue comments");
+  if (summary.deferred > 0) actions.push("inspect deferred issue-enrichment rows and adjust per-repo throttles only after dry-run review");
+  if (summary.readFailures > 0) actions.push("run doctor and inspect GitHub App Issues permissions");
+  return actions;
+}
+
+function sum<T extends keyof Pick<IssueEnrichmentRepoScan, "issuesSeen" | "eligible" | "skipped" | "wouldEnrich" | "wouldComment" | "deferred">>(
+  repos: IssueEnrichmentRepoScan[],
+  field: T
+): number {
+  return repos.reduce((total, repo) => total + repo[field], 0);
+}

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -11,6 +11,7 @@ import type {
   CoverageStaleHead,
   CoverageUnprocessedEntry
 } from "./coverage-audit.js";
+import type { IssueEnrichmentStatus } from "./issue-enrichment.js";
 import type { ReviewBudgetStatus } from "./review-budget.js";
 import type { ReleaseHeartbeatStatus, ReleaseLaunchdStatus, ReleaseStatus } from "./release-status.js";
 import { redactSecrets } from "./secrets.js";
@@ -48,6 +49,7 @@ export interface OperatorStatus {
     failedQueueJobs: number;
     budgetWouldLeaseJobs: number;
     budgetDelayedJobs: number;
+    issueEnrichmentState?: IssueEnrichmentStatus["state"];
   };
   gates: Array<{ name: string; ok: boolean; detail: string }>;
   recommendedActions: string[];
@@ -57,6 +59,7 @@ export interface OperatorStatus {
   agents: OperatorAgentInventory;
   providerCooldowns: ProviderCooldownReviewRecord[];
   durableQueue?: OperatorDurableQueueSnapshot;
+  issueEnrichment?: IssueEnrichmentStatus;
 }
 
 export interface RuntimeInventory {
@@ -90,6 +93,7 @@ export interface RuntimeInventory {
     repoCooldowns: number;
     activeRepoCooldowns: number;
     botProcesses: number;
+    issueEnrichmentState?: IssueEnrichmentStatus["state"];
   };
   gates: Array<{ name: string; ok: boolean; detail: string }>;
   recommendedActions: string[];
@@ -103,6 +107,7 @@ export interface RuntimeInventory {
   coverage?: OperatorQueueSnapshot;
   providerCooldowns: ProviderCooldownReviewRecord[];
   repoProviderCooldowns: RepoProviderCooldownRecord[];
+  issueEnrichment?: IssueEnrichmentStatus;
 }
 
 export type RuntimeClassification = "healthy_idle" | "healthy_active" | "blocked";
@@ -302,6 +307,7 @@ export function buildOperatorStatus(input: {
   agents: OperatorAgentInventory;
   providerCooldowns?: ProviderCooldownReviewRecord[];
   durableQueue?: OperatorDurableQueueSnapshot;
+  issueEnrichment?: IssueEnrichmentStatus;
   checkedAt?: string;
 }): OperatorStatus {
   const queue = input.coverage ? buildOperatorQueue(input.coverage) : undefined;
@@ -317,6 +323,7 @@ export function buildOperatorStatus(input: {
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
   const retryableProviderDeferredJobs = durableQueue?.summary.retryableProviderDeferred ?? 0;
   const budget = input.release.budget;
+  const issueEnrichment = input.issueEnrichment;
 
   const gates = [
     ...input.release.gates,
@@ -351,7 +358,16 @@ export function buildOperatorStatus(input: {
       name: "durable_queue_no_retryable_provider_deferred_jobs",
       ok: retryableProviderDeferredJobs === 0,
       detail: `${retryableProviderDeferredJobs} retryable provider-deferred durable queue job(s)`
-    }
+    },
+    ...(issueEnrichment
+      ? [{
+          name: "issue_enrichment_ready",
+          ok: issueEnrichment.ok,
+          detail: issueEnrichment.ok
+            ? `${issueEnrichment.state}; allowlist=${issueEnrichment.allowlist.length}; liveComments=${issueEnrichment.postIssueComment}`
+            : `${issueEnrichment.state}: ${issueEnrichment.blockers.join(", ")}`
+        }]
+      : [])
   ];
 
   const recommendedActions = uniqueStrings([
@@ -361,7 +377,8 @@ export function buildOperatorStatus(input: {
     ...(staleHeads > 0 ? ["wait for next daemon cycle or run scoped coverage audit"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : []),
     ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
-    ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : [])
+    ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
+    ...(issueEnrichment && !issueEnrichment.ok ? ["resolve issue-enrichment blockers before enabling live issue comments"] : [])
   ]);
 
   return {
@@ -385,7 +402,8 @@ export function buildOperatorStatus(input: {
       providerDeferredJobs: durableQueue?.summary.providerDeferred ?? 0,
       failedQueueJobs,
       budgetWouldLeaseJobs: budget?.wouldLeaseCount ?? 0,
-      budgetDelayedJobs: budget?.delayedCount ?? 0
+      budgetDelayedJobs: budget?.delayedCount ?? 0,
+      ...(issueEnrichment ? { issueEnrichmentState: issueEnrichment.state } : {})
     },
     gates,
     recommendedActions,
@@ -394,7 +412,8 @@ export function buildOperatorStatus(input: {
     ...(queue ? { coverage: queue } : {}),
     agents: input.agents,
     providerCooldowns,
-    ...(durableQueue ? { durableQueue } : {})
+    ...(durableQueue ? { durableQueue } : {}),
+    ...(issueEnrichment ? { issueEnrichment } : {})
   };
 }
 
@@ -406,6 +425,7 @@ export function buildRuntimeInventory(input: {
   providerCooldowns?: ProviderCooldownReviewRecord[];
   repoProviderCooldowns?: RepoProviderCooldownRecord[];
   durableQueue?: OperatorDurableQueueSnapshot;
+  issueEnrichment?: IssueEnrichmentStatus;
   checkedAt?: string;
 }): RuntimeInventory {
   const queue = input.coverage ? buildOperatorQueue(input.coverage) : undefined;
@@ -440,6 +460,7 @@ export function buildRuntimeInventory(input: {
   const staleHeads = queue?.summary.staleHeads ?? 0;
   const providerDeferredHeads = queue?.summary.providerDeferred ?? 0;
   const budget = input.release.budget;
+  const issueEnrichment = input.issueEnrichment;
 
   const gates = [
     ...input.release.gates,
@@ -491,7 +512,16 @@ export function buildRuntimeInventory(input: {
       detail: input.processes
         ? `${input.processes.summary.total} bot-owned process(es), ${input.processes.summary.errors} process inventory error(s)`
         : "not collected"
-    }
+    },
+    ...(issueEnrichment
+      ? [{
+          name: "runtime_issue_enrichment_ready",
+          ok: issueEnrichment.ok,
+          detail: issueEnrichment.ok
+            ? `${issueEnrichment.state}; allowlist=${issueEnrichment.allowlist.length}; liveComments=${issueEnrichment.postIssueComment}`
+            : `${issueEnrichment.state}: ${issueEnrichment.blockers.join(", ")}`
+        }]
+      : [])
   ];
 
   const ok = gates.every((gate) => gate.ok);
@@ -509,7 +539,8 @@ export function buildRuntimeInventory(input: {
     ...(input.agents.summary.staleLeases > 0 ? ["inspect stale leases before restarting launchd"] : []),
     ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
-    ...(retryableExpiredProviderCooldowns > 0 ? ["retry expired provider cooldowns or inspect provider health"] : [])
+    ...(retryableExpiredProviderCooldowns > 0 ? ["retry expired provider cooldowns or inspect provider health"] : []),
+    ...(issueEnrichment && !issueEnrichment.ok ? ["resolve issue-enrichment blockers before enabling live issue comments"] : [])
   ]);
 
   return {
@@ -542,7 +573,8 @@ export function buildRuntimeInventory(input: {
       activeProviderCooldowns,
       repoCooldowns: repoProviderCooldowns.length,
       activeRepoCooldowns,
-      botProcesses: input.processes?.summary.total ?? 0
+      botProcesses: input.processes?.summary.total ?? 0,
+      ...(issueEnrichment ? { issueEnrichmentState: issueEnrichment.state } : {})
     },
     gates,
     recommendedActions,
@@ -555,7 +587,8 @@ export function buildRuntimeInventory(input: {
     ...(durableQueue ? { durableQueue } : {}),
     ...(queue ? { coverage: queue } : {}),
     providerCooldowns,
-    repoProviderCooldowns
+    repoProviderCooldowns,
+    ...(issueEnrichment ? { issueEnrichment } : {})
   };
 }
 

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -131,6 +131,57 @@ describe("build-enrichment-comment issue CLI", () => {
       });
     });
   });
+
+  it("dry-run scans only the separate issue-enrichment allowlist with throttled output", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const outputDir = join(root, "evidence", "issue-scan");
+      const configPath = writeIssueScanConfig(root, apiBaseUrl);
+
+      const { stdout } = await runCli([
+        "issue-enrichment-scan",
+        "--config",
+        configPath,
+        "--dry-run",
+        "true",
+        "--include-existing",
+        "true",
+        "--output-dir",
+        outputDir
+      ]);
+      const parsed = JSON.parse(stdout);
+
+      expect(parsed.summary).toMatchObject({
+        reposScanned: 1,
+        issuesSeen: 4,
+        eligible: 2,
+        skipped: 2,
+        wouldComment: 1,
+        deferred: 1
+      });
+      expect(parsed.items).toContainEqual(expect.objectContaining({
+        repo: "owner/issue-repo",
+        issueNumber: 18,
+        action: "skipped",
+        reason: "stale_issue_closed"
+      }));
+      expect(parsed.items).toContainEqual(expect.objectContaining({
+        repo: "owner/issue-repo",
+        issueNumber: 19,
+        action: "skipped",
+        reason: "issue_is_pull_request"
+      }));
+      expect(parsed.items).toContainEqual(expect.objectContaining({
+        repo: "owner/issue-repo",
+        issueNumber: 20,
+        action: "deferred",
+        reason: "repo_max_comments_per_cycle"
+      }));
+      expect(readFileSync(join(outputDir, "issue-enrichment-scan.json"), "utf8")).toContain("\"repo\": \"owner/issue-repo\"");
+      expect(requests.some((request) => request.path.startsWith("/repos/owner/issue-repo/issues?"))).toBe(true);
+      expect(requests.some((request) => request.path.startsWith("/repos/owner/pr-review-repo/issues?"))).toBe(false);
+    });
+  });
 });
 
 async function runCli(args: string[]) {
@@ -178,6 +229,32 @@ function writeConfig(root: string, apiBaseUrl: string): string {
           suggestedReviewers: ["owner-a"]
         }
       }
+    }
+  }, null, 2)}\n`);
+  return path;
+}
+
+function writeIssueScanConfig(root: string, apiBaseUrl: string): string {
+  const path = join(root, "config.json");
+  writeFileSync(path, `${JSON.stringify({
+    pilotRepos: ["owner/pr-review-repo"],
+    statePath: join(root, "state.sqlite"),
+    evidenceDir: join(root, "evidence"),
+    github: {
+      token: "test-token",
+      apiBaseUrl
+    },
+    issueEnrichment: {
+      enabled: false,
+      postIssueComment: true,
+      allowlist: ["owner/issue-repo"],
+      maxIssuesPerCycle: 3,
+      maxCommentsPerCycle: 1,
+      cooldownMs: 3_600_000,
+      burstWindowMs: 3_600_000,
+      maxIssuesPerBurst: 10,
+      lookbackMs: 600_000,
+      processExistingOpenIssuesOnActivation: false
     }
   }, null, 2)}\n`);
   return path;
@@ -231,6 +308,41 @@ function routeMockGitHub(request: IncomingMessage, response: ServerResponse): vo
   }
   if (request.url === "/repos/owner/repo/issues/404") {
     respondJson(response, 404, { message: "Not Found" });
+    return;
+  }
+  const parsed = new URL(request.url ?? "/", "https://github.test");
+  if (parsed.pathname === "/repos/owner/issue-repo/issues") {
+    respondJson(response, 200, [
+      {
+        number: 17,
+        title: "Open issue",
+        state: "open",
+        html_url: "https://github.test/owner/issue-repo/issues/17",
+        body: "Acceptance criteria and owner are present."
+      },
+      {
+        number: 18,
+        title: "Closed issue",
+        state: "closed",
+        html_url: "https://github.test/owner/issue-repo/issues/18",
+        body: "Done."
+      },
+      {
+        number: 19,
+        title: "PR shaped issue",
+        state: "open",
+        html_url: "https://github.test/owner/issue-repo/pull/19",
+        pull_request: {},
+        body: "Pull request record."
+      },
+      {
+        number: 20,
+        title: "Another open issue",
+        state: "open",
+        html_url: "https://github.test/owner/issue-repo/issues/20",
+        body: "Acceptance criteria and owner are present."
+      }
+    ]);
     return;
   }
   respondJson(response, 404, { message: `unexpected path ${request.url}` });

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -14,6 +14,7 @@ import {
   postEnrichmentComment
 } from "../src/enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js";
+import { buildIssueEnrichmentStatus, collectIssueEnrichmentScan } from "../src/issue-enrichment.js";
 import type { PullFilePatch, PullRequestSummary } from "../src/types.js";
 
 const HEAD_A = "a".repeat(40);
@@ -38,6 +39,95 @@ describe("sticky enrichment comments", () => {
       postIssueComment: false,
       packetVersion: "enrichment-comment-v0.1"
     });
+    expect(loadConfig().issueEnrichment).toMatchObject({
+      enabled: false,
+      postIssueComment: false,
+      allowlist: [],
+      maxIssuesPerCycle: 5,
+      maxCommentsPerCycle: 0,
+      maxIssuesPerBurst: 10,
+      processExistingOpenIssuesOnActivation: false
+    });
+  });
+
+  it("keeps issue enrichment allowlist and throttles separate from PR monitoring", () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-config-"));
+    try {
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        pilotRepos: ["owner/pr-review-repo"],
+        issueEnrichment: {
+          enabled: false,
+          postIssueComment: false,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 2,
+          maxCommentsPerCycle: 1,
+          cooldownMs: 3_600_000,
+          burstWindowMs: 3_600_000,
+          maxIssuesPerBurst: 8,
+          lookbackMs: 600_000,
+          processExistingOpenIssuesOnActivation: false,
+          repos: {
+            "owner/issue-repo": {
+              maxIssuesPerCycle: 3,
+              maxCommentsPerCycle: 2
+            }
+          }
+        }
+      })}\n`);
+
+      const config = loadConfig(configPath);
+      const issueConfig = config.issueEnrichment;
+      expect(issueConfig).toBeDefined();
+
+      expect(config.pilotRepos).toEqual(["owner/pr-review-repo"]);
+      expect(issueConfig?.allowlist).toEqual(["owner/issue-repo"]);
+      expect(issueConfig?.allowlist).not.toContain("owner/pr-review-repo");
+      expect(issueConfig?.repos?.["owner/issue-repo"]).toMatchObject({
+        maxIssuesPerCycle: 3,
+        maxCommentsPerCycle: 2
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reports issue enrichment blockers without failing when the lane is disabled", () => {
+    const disabled = buildIssueEnrichmentStatus({
+      config: loadConfig(),
+      canPostAsApp: false
+    });
+
+    expect(disabled).toMatchObject({
+      ok: true,
+      state: "disabled",
+      separateAllowlist: true,
+      allowlist: [],
+      blockers: ["issue_enrichment_disabled", "issue_enrichment_allowlist_empty", "issue_enrichment_live_posting_disabled"]
+    });
+
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-status-"));
+    try {
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: true,
+          allowlist: ["owner/issue-repo"]
+        }
+      })}\n`);
+
+      const enabled = buildIssueEnrichmentStatus({
+        config: loadConfig(configPath),
+        canPostAsApp: false
+      });
+
+      expect(enabled.ok).toBe(false);
+      expect(enabled.state).toBe("blocked");
+      expect(enabled.blockers).toContain("github_app_credentials_required_for_live_issue_comments");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("renders a stable marker with head-specific state and suggestion-only text", () => {
@@ -380,6 +470,105 @@ describe("sticky enrichment comments", () => {
     expect(comment.body).not.toContain("Suggested labels: Bug");
     expect(comment.body).toContain("Suggested owners: owner-a, owner-b, owner-c.");
     expect(comment.body).not.toContain("owner-d");
+  });
+
+  it("dry-run scans only the issue-enrichment allowlist and skips closed issues and PR-shaped issues", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-scan-"));
+    try {
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        pilotRepos: ["owner/pr-review-repo"],
+        issueEnrichment: {
+          enabled: false,
+          postIssueComment: true,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 3,
+          maxCommentsPerCycle: 1,
+          maxIssuesPerBurst: 10,
+          processExistingOpenIssuesOnActivation: false
+        }
+      })}\n`);
+      const reposScanned: string[] = [];
+
+      const scan = await collectIssueEnrichmentScan({
+        config: loadConfig(configPath),
+        dryRun: true,
+        includeExisting: true,
+        checkedAt: "2026-07-03T00:00:00.000Z",
+        reader: {
+          listIssuesForEnrichment: async (repo) => {
+            reposScanned.push(repo);
+            return [
+              { number: 10, title: "New issue", state: "open", body: "Acceptance criteria and owner present." },
+              { number: 11, title: "Closed issue", state: "closed", body: "Done." },
+              { number: 12, title: "PR issue", state: "open", pull_request: {}, body: "Pull request record." },
+              { number: 13, title: "Another new issue", state: "open", body: "Acceptance criteria and owner present." }
+            ];
+          }
+        }
+      });
+
+      expect(reposScanned).toEqual(["owner/issue-repo"]);
+      expect(reposScanned).not.toContain("owner/pr-review-repo");
+      expect(scan.ok).toBe(true);
+      expect(scan.summary).toMatchObject({
+        reposScanned: 1,
+        issuesSeen: 4,
+        eligible: 2,
+        skipped: 2,
+        wouldComment: 1,
+        deferred: 1
+      });
+      expect(scan.items.find((item) => item.issueNumber === 11)).toMatchObject({ action: "skipped", reason: "stale_issue_closed" });
+      expect(scan.items.find((item) => item.issueNumber === 12)).toMatchObject({ action: "skipped", reason: "issue_is_pull_request" });
+      expect(scan.items.find((item) => item.issueNumber === 13)).toMatchObject({ action: "deferred", reason: "repo_max_comments_per_cycle" });
+      expect(JSON.stringify(scan)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("defers large issue bursts instead of enriching every issue in a milestone filing wave", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-burst-"));
+    try {
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: false,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 5,
+          maxCommentsPerCycle: 2,
+          maxIssuesPerBurst: 2
+        }
+      })}\n`);
+
+      const scan = await collectIssueEnrichmentScan({
+        config: loadConfig(configPath),
+        dryRun: true,
+        includeExisting: true,
+        checkedAt: "2026-07-03T00:00:00.000Z",
+        reader: {
+          listIssuesForEnrichment: async () => [
+            { number: 20, title: "Issue 20", state: "open", body: "Acceptance criteria and owner present." },
+            { number: 21, title: "Issue 21", state: "open", body: "Acceptance criteria and owner present." },
+            { number: 22, title: "Issue 22", state: "open", body: "Acceptance criteria and owner present." }
+          ]
+        }
+      });
+
+      expect(scan.ok).toBe(true);
+      expect(scan.summary).toMatchObject({
+        issuesSeen: 3,
+        eligible: 3,
+        wouldEnrich: 0,
+        wouldComment: 0,
+        deferred: 3
+      });
+      expect(scan.items.every((item) => item.action === "deferred" && item.reason === "burst_threshold_exceeded")).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -21,6 +21,7 @@ import {
   type OperatorAgentInventory,
   type OperatorDurableQueueSnapshot
 } from "../src/operator-cli.js";
+import type { IssueEnrichmentStatus } from "../src/issue-enrichment.js";
 import type { ReviewBudgetStatus } from "../src/review-budget.js";
 import type { ReleaseStatus } from "../src/release-status.js";
 import type { RepoProviderCooldownRecord } from "../src/state.js";
@@ -92,6 +93,48 @@ describe("operator CLI summaries", () => {
     expect(status.recommendedActions).toContain("inspect operator queue failed jobs before promotion");
     expect(status.recommendedActions).toContain("retry or requeue provider-deferred jobs whose nextEligibleAt has expired");
     expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+  });
+
+  it("surfaces issue enrichment live-post blockers in operator status", () => {
+    const issueEnrichment: IssueEnrichmentStatus = {
+      ok: false,
+      checkedAt: "2026-07-03T00:00:00.000Z",
+      state: "blocked",
+      enabled: true,
+      postIssueComment: true,
+      separateAllowlist: true,
+      allowlist: ["owner/issue-repo"],
+      throttleDefaults: {
+        maxIssuesPerCycle: 5,
+        maxCommentsPerCycle: 2,
+        cooldownMs: 3_600_000,
+        burstWindowMs: 3_600_000,
+        maxIssuesPerBurst: 10,
+        lookbackMs: 600_000,
+        processExistingOpenIssuesOnActivation: false
+      },
+      repoOverrides: [],
+      blockers: ["github_app_credentials_required_for_live_issue_comments"]
+    };
+
+    const status = buildOperatorStatus({
+      release: releaseStatus({ ok: true }),
+      coverage: coverageReport({ ok: true }),
+      agents: agentInventory({ ok: true }),
+      providerCooldowns: [],
+      durableQueue: durableQueueSnapshot({ ok: true, summary: cleanDurableQueueSummary() }),
+      issueEnrichment,
+      checkedAt: "2026-07-03T00:00:00.000Z"
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.summary.issueEnrichmentState).toBe("blocked");
+    expect(status.gates).toContainEqual({
+      name: "issue_enrichment_ready",
+      ok: false,
+      detail: "blocked: github_app_credentials_required_for_live_issue_comments"
+    });
+    expect(status.recommendedActions).toContain("resolve issue-enrichment blockers before enabling live issue comments");
   });
 
   it("treats pending heads covered by durable queue work as healthy active runtime", () => {


### PR DESCRIPTION
## Summary

Closes #135 for the safe code/config foundation: issue enrichment now has a separate default-off allowlist, throttle policy, dry-run scan command, and operator status visibility. It does not enable live issue polling or App-authored issue comments.

## What changed

- Added `issueEnrichment` config with an empty allowlist by default, per-repo overrides, max issues/comments per cycle, burst threshold, lookback, cooldown, and explicit historical-backlog behavior.
- Added `issue-enrichment-scan` as a dry-run-only CLI that reads only `issueEnrichment.allowlist`, skips closed issues and PR-shaped issue records, and reports deferred rows when throttles/burst thresholds apply.
- Added GitHub issue listing through the App/token read path for the scan command.
- Added doctor/status/runtime visibility for issue-enrichment state and live-post blockers.
- Documented the separate issue-enrichment permission/allowlist boundary.

## Proof

- `npm test -- tests/enrichment-cli.test.ts tests/enrichment.test.ts tests/github-app-read.test.ts tests/operator-cli.test.ts tests/review-scheduler-config.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`

## Live evidence

Evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-03/issue-135-app-token/`

- Active config scan: `reposScanned: 0`, `allowlist: []`, no issue reads or comments.
- Scoped temporary issue allowlist for `electricsheephq/evaos-code-review-bot` failed closed with GitHub App `403 Resource not accessible by integration` for Issues API reads.
- Chrome App-permission UI could not be completed from this Codex session because the Chrome extension backend was not discoverable; this PR preserves the blocker in code/status instead of silently rolling out.

## Non-goals

- No live issue comments.
- No App permission mutation.
- No reuse of `pilotRepos` for issues.
- No labels, assignees, reviewers, milestones, Notion, or Linear mutations.
