### PR TITLE
fix: tighten issue enrichment scan guardrails

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -275,7 +275,8 @@ npx tsx src/cli.ts issue-enrichment-scan --config <config.json> --dry-run true -
 ```
 
 The scan does not use `pilotRepos`, does not post comments, and defaults to the
-configured recent-update lookback. Per-repo throttles live under
+larger of the configured recent-update lookback and burst window. Deferred rows
+include `nextEligibleAt` based on the configured cooldown. Per-repo throttles live under
 `issueEnrichment.repos.<owner/name>` and can cap `maxIssuesPerCycle`,
 `maxCommentsPerCycle`, burst thresholds, cooldown, and backlog behavior.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -694,7 +694,7 @@ async function main(): Promise<void> {
       canPostAsApp: github.canPostAsApp(),
       ...(args.repo ? { repo: parseSingleArg(args.repo, "--repo") } : {}),
       includeExisting: args["include-existing"] === "true",
-      ...(args.since ? { since: parseSingleArg(args.since, "--since") } : {})
+      ...(args.since ? { since: parseCanonicalIsoTimestamp(parseSingleArg(args.since, "--since"), "--since").toISOString() } : {})
     });
     if (args["output-dir"]) {
       const safeOutputDir = assertMemoryPacketOutputDirSafe(args["output-dir"], config.evidenceDir);

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -137,6 +137,7 @@ export interface IssueEnrichmentScanItem {
   action: IssueEnrichmentScanAction;
   reason: IssueEnrichmentScanReason;
   url?: string;
+  nextEligibleAt?: string;
 }
 
 const DEFAULT_REPO_SCAN_OPTIONS = {
@@ -238,12 +239,14 @@ export async function collectIssueEnrichmentScan(input: {
     const since = input.since ?? buildIssueScanSince({
       checkedAt,
       includeExisting: input.includeExisting === true || policy.throttle.processExistingOpenIssuesOnActivation,
-      lookbackMs: policy.throttle.lookbackMs
+      lookbackMs: policy.throttle.lookbackMs,
+      burstWindowMs: policy.throttle.burstWindowMs
     });
     let issues: GitHubRelatedIssueOrPull[] = [];
     try {
       issues = await input.reader.listIssuesForEnrichment(repo, {
         ...DEFAULT_REPO_SCAN_OPTIONS,
+        pageLimit: buildIssueScanPageLimit(policy.throttle),
         ...(since ? { since } : {})
       });
     } catch (error) {
@@ -270,7 +273,8 @@ export async function collectIssueEnrichmentScan(input: {
       repo,
       issues,
       throttle: policy.throttle,
-      postIssueComment: config.postIssueComment
+      postIssueComment: config.postIssueComment,
+      checkedAt
     });
     items.push(...issueItems);
     repoScans.push({
@@ -332,6 +336,7 @@ function planRepoIssueScan(input: {
   issues: GitHubRelatedIssueOrPull[];
   throttle: IssueEnrichmentThrottlePolicy;
   postIssueComment: boolean;
+  checkedAt: string;
 }): IssueEnrichmentScanItem[] {
   const eligible = input.issues
     .map((issue) => buildIssueEnrichmentDryRunOutput({
@@ -363,15 +368,15 @@ function planRepoIssueScan(input: {
       };
     }
     if (burstExceeded) {
-      return issueScanItem(input.repo, output.issueNumber, output.state, "deferred", "burst_threshold_exceeded", output.url);
+      return issueScanItem(input.repo, output.issueNumber, output.state, "deferred", "burst_threshold_exceeded", output.url, nextEligibleAt(input));
     }
     if (enriched >= input.throttle.maxIssuesPerCycle) {
-      return issueScanItem(input.repo, output.issueNumber, output.state, "deferred", "repo_max_issues_per_cycle", output.url);
+      return issueScanItem(input.repo, output.issueNumber, output.state, "deferred", "repo_max_issues_per_cycle", output.url, nextEligibleAt(input));
     }
     enriched += 1;
     if (input.postIssueComment) {
       if (comments >= input.throttle.maxCommentsPerCycle) {
-        return issueScanItem(input.repo, output.issueNumber, output.state, "deferred", "repo_max_comments_per_cycle", output.url);
+        return issueScanItem(input.repo, output.issueNumber, output.state, "deferred", "repo_max_comments_per_cycle", output.url, nextEligibleAt(input));
       }
       comments += 1;
       return issueScanItem(input.repo, output.issueNumber, output.state, "would_comment", "eligible", output.url);
@@ -386,7 +391,8 @@ function issueScanItem(
   state: string,
   action: IssueEnrichmentScanAction,
   reason: IssueEnrichmentScanReason,
-  url?: string
+  url?: string,
+  nextEligibleAtValue?: string
 ): IssueEnrichmentScanItem {
   return {
     repo,
@@ -394,7 +400,8 @@ function issueScanItem(
     state,
     action,
     reason,
-    ...(url ? { url } : {})
+    ...(url ? { url } : {}),
+    ...(nextEligibleAtValue ? { nextEligibleAt: nextEligibleAtValue } : {})
   };
 }
 
@@ -402,11 +409,23 @@ function buildIssueScanSince(input: {
   checkedAt: string;
   includeExisting: boolean;
   lookbackMs: number;
+  burstWindowMs: number;
 }): string | undefined {
   if (input.includeExisting) return undefined;
   const checkedAtMs = Date.parse(input.checkedAt);
   const baseMs = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
-  return new Date(baseMs - input.lookbackMs).toISOString();
+  return new Date(baseMs - Math.max(input.lookbackMs, input.burstWindowMs)).toISOString();
+}
+
+function buildIssueScanPageLimit(throttle: IssueEnrichmentThrottlePolicy): number {
+  const threshold = Math.max(throttle.maxIssuesPerCycle, throttle.maxIssuesPerBurst) + 1;
+  return Math.max(1, Math.min(10, Math.ceil(threshold / DEFAULT_REPO_SCAN_OPTIONS.perPage)));
+}
+
+function nextEligibleAt(input: { checkedAt: string; throttle: IssueEnrichmentThrottlePolicy }): string {
+  const checkedAtMs = Date.parse(input.checkedAt);
+  const baseMs = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
+  return new Date(baseMs + input.throttle.cooldownMs).toISOString();
 }
 
 function summarizeScan(repoScans: IssueEnrichmentRepoScan[]): IssueEnrichmentScanResult["summary"] {

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -182,6 +182,26 @@ describe("build-enrichment-comment issue CLI", () => {
       expect(requests.some((request) => request.path.startsWith("/repos/owner/pr-review-repo/issues?"))).toBe(false);
     });
   });
+
+  it("rejects invalid issue-enrichment scan since timestamps before calling GitHub", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueScanConfig(root, apiBaseUrl);
+
+      await expect(runCli([
+        "issue-enrichment-scan",
+        "--config",
+        configPath,
+        "--dry-run",
+        "true",
+        "--since",
+        "not-a-date"
+      ])).rejects.toMatchObject({
+        stderr: expect.stringContaining("--since must be a canonical ISO timestamp")
+      });
+      expect(requests).toHaveLength(0);
+    });
+  });
 });
 
 async function runCli(args: string[]) {

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -522,7 +522,88 @@ describe("sticky enrichment comments", () => {
       expect(scan.items.find((item) => item.issueNumber === 11)).toMatchObject({ action: "skipped", reason: "stale_issue_closed" });
       expect(scan.items.find((item) => item.issueNumber === 12)).toMatchObject({ action: "skipped", reason: "issue_is_pull_request" });
       expect(scan.items.find((item) => item.issueNumber === 13)).toMatchObject({ action: "deferred", reason: "repo_max_comments_per_cycle" });
+      expect(scan.items.find((item) => item.issueNumber === 13)).toMatchObject({
+        nextEligibleAt: "2026-07-03T01:00:00.000Z"
+      });
       expect(JSON.stringify(scan)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not call the reader for explicit repos outside the issue-enrichment allowlist", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-outside-allowlist-"));
+    try {
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        issueEnrichment: {
+          enabled: false,
+          postIssueComment: false,
+          allowlist: ["owner/allowed-repo"]
+        }
+      })}\n`);
+      let readerCalls = 0;
+
+      const scan = await collectIssueEnrichmentScan({
+        config: loadConfig(configPath),
+        dryRun: true,
+        repo: "owner/not-allowed",
+        reader: {
+          listIssuesForEnrichment: async () => {
+            readerCalls += 1;
+            return [];
+          }
+        }
+      });
+
+      expect(readerCalls).toBe(0);
+      expect(scan.summary).toMatchObject({ reposScanned: 0, reposSkipped: 1 });
+      expect(scan.repos[0]).toMatchObject({
+        repo: "owner/not-allowed",
+        allowed: false,
+        skipReason: "not_issue_enrichment_allowlisted"
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not call the reader for a disabled per-repo issue-enrichment override", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-disabled-repo-"));
+    try {
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        issueEnrichment: {
+          enabled: false,
+          postIssueComment: false,
+          allowlist: ["owner/disabled-repo"],
+          repos: {
+            "owner/disabled-repo": {
+              enabled: false
+            }
+          }
+        }
+      })}\n`);
+      let readerCalls = 0;
+
+      const scan = await collectIssueEnrichmentScan({
+        config: loadConfig(configPath),
+        dryRun: true,
+        reader: {
+          listIssuesForEnrichment: async () => {
+            readerCalls += 1;
+            return [];
+          }
+        }
+      });
+
+      expect(readerCalls).toBe(0);
+      expect(scan.summary).toMatchObject({ reposScanned: 0, reposSkipped: 1 });
+      expect(scan.repos[0]).toMatchObject({
+        repo: "owner/disabled-repo",
+        allowed: false,
+        skipReason: "issue_enrichment_repo_disabled"
+      });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -566,6 +647,49 @@ describe("sticky enrichment comments", () => {
         deferred: 3
       });
       expect(scan.items.every((item) => item.action === "deferred" && item.reason === "burst_threshold_exceeded")).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the burst window and enough pages to prove configured burst thresholds", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-burst-window-"));
+    try {
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: false,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 25,
+          maxCommentsPerCycle: 0,
+          cooldownMs: 600_000,
+          burstWindowMs: 3_600_000,
+          maxIssuesPerBurst: 150,
+          lookbackMs: 300_000,
+          processExistingOpenIssuesOnActivation: false
+        }
+      })}\n`);
+      const calls: Array<{ repo: string; since?: string; pageLimit?: number }> = [];
+
+      const scan = await collectIssueEnrichmentScan({
+        config: loadConfig(configPath),
+        dryRun: true,
+        checkedAt: "2026-07-03T12:00:00.000Z",
+        reader: {
+          listIssuesForEnrichment: async (repo, options) => {
+            calls.push({ repo, since: options?.since, pageLimit: options?.pageLimit });
+            return [];
+          }
+        }
+      });
+
+      expect(scan.ok).toBe(true);
+      expect(calls).toEqual([{
+        repo: "owner/issue-repo",
+        since: "2026-07-03T11:00:00.000Z",
+        pageLimit: 2
+      }]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -22,9 +22,11 @@ import {
   type OperatorDurableQueueSnapshot
 } from "../src/operator-cli.js";
 import type { IssueEnrichmentStatus } from "../src/issue-enrichment.js";
+import { buildIssueEnrichmentStatus } from "../src/issue-enrichment.js";
 import type { ReviewBudgetStatus } from "../src/review-budget.js";
 import type { ReleaseStatus } from "../src/release-status.js";
 import type { RepoProviderCooldownRecord } from "../src/state.js";
+import { loadConfig } from "../src/config.js";
 
 describe("operator CLI summaries", () => {
   const tempDirs: string[] = [];
@@ -135,6 +137,41 @@ describe("operator CLI summaries", () => {
       detail: "blocked: github_app_credentials_required_for_live_issue_comments"
     });
     expect(status.recommendedActions).toContain("resolve issue-enrichment blockers before enabling live issue comments");
+  });
+
+  it("surfaces issue enrichment blockers from a real config and App credential state", () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-status-config-"));
+    tempDirs.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      issueEnrichment: {
+        enabled: true,
+        postIssueComment: true,
+        allowlist: ["owner/issue-repo"]
+      }
+    })}\n`);
+
+    const status = buildOperatorStatus({
+      release: releaseStatus({ ok: true }),
+      coverage: coverageReport({ ok: true }),
+      agents: agentInventory({ ok: true }),
+      providerCooldowns: [],
+      durableQueue: durableQueueSnapshot({ ok: true, summary: cleanDurableQueueSummary() }),
+      issueEnrichment: buildIssueEnrichmentStatus({
+        config: loadConfig(configPath),
+        canPostAsApp: false,
+        checkedAt: "2026-07-03T00:00:00.000Z"
+      }),
+      checkedAt: "2026-07-03T00:00:00.000Z"
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.summary.issueEnrichmentState).toBe("blocked");
+    expect(status.gates).toContainEqual({
+      name: "issue_enrichment_ready",
+      ok: false,
+      detail: "blocked: github_app_credentials_required_for_live_issue_comments"
+    });
   });
 
   it("treats pending heads covered by durable queue work as healthy active runtime", () => {


### PR DESCRIPTION
## Summary

Closes #150.

This fixes the post-merge review findings from PR #149 before beta.8 promotion.

## Fixes

- Validates `issue-enrichment-scan --since` as a canonical ISO timestamp before any GitHub API call.
- Uses the larger of `lookbackMs` and `burstWindowMs` for the issue scan window.
- Computes the issue API page limit from the configured cycle/burst threshold so burst detection can actually prove thresholds above the first 100 returned issues.
- Adds `nextEligibleAt` to deferred scan rows using `cooldownMs`, making the cooldown knob observable in dry-run output without enabling live posting.
- Adds focused tests for explicit repos outside the issue allowlist, disabled per-repo overrides, real config-to-operator-status blocker wiring, invalid `--since`, and burst-window/page-limit behavior.

## Review thread sources

- https://github.com/electricsheephq/evaos-code-review-bot/pull/149#discussion_r3515736481
- https://github.com/electricsheephq/evaos-code-review-bot/pull/149#discussion_r3515736485
- https://github.com/electricsheephq/evaos-code-review-bot/pull/149#discussion_r3515736486
- https://github.com/electricsheephq/evaos-code-review-bot/pull/149#discussion_r3515736492

## Proof

- `npm test -- tests/enrichment-cli.test.ts tests/enrichment.test.ts tests/operator-cli.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`

## Non-goals

- No live issue comments.
- No GitHub App permission mutation.
- No issue backlog sweep.
