### PR TITLE
Add default-off issue enrichment scheduler lane

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import {
   buildOperatorQueue,
   buildOperatorStatus,
   collectBotProcessInventory,
+  collectOperatorIssueEnrichmentRuntime,
   collectOperatorLeases,
   collectOperatorProviderCooldowns,
   collectOperatorRepoProviderCooldowns,
@@ -197,6 +198,10 @@ async function main(): Promise<void> {
       repo: args.repo,
       limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
     });
+    const issueEnrichmentRuntime = collectOperatorIssueEnrichmentRuntime(args["state-path"] ?? config.statePath, {
+      repo: args.repo,
+      limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
+    });
     const github = new GitHubApi(config.github);
     const status = buildOperatorStatus({
       release,
@@ -208,7 +213,8 @@ async function main(): Promise<void> {
         config,
         canPostAsApp: github.canPostAsApp(),
         checkedAt: release.checkedAt
-      })
+      }),
+      issueEnrichmentRuntime
     });
     console.log(JSON.stringify(status, null, 2));
     if (!status.ok) process.exitCode = 1;
@@ -247,6 +253,10 @@ async function main(): Promise<void> {
       repo: args.repo,
       now
     });
+    const issueEnrichmentRuntime = collectOperatorIssueEnrichmentRuntime(statePath, {
+      repo: args.repo,
+      now
+    });
     const github = new GitHubApi(config.github);
     const processes = collectBotProcessInventory({
       repoPath: process.cwd(),
@@ -267,6 +277,7 @@ async function main(): Promise<void> {
         canPostAsApp: github.canPostAsApp(),
         checkedAt: now.toISOString()
       }),
+      issueEnrichmentRuntime,
       checkedAt: now.toISOString()
     });
     console.log(args.human === "true" ? formatRuntimeInventoryHuman(inventory) : JSON.stringify(inventory, null, 2));
@@ -875,6 +886,7 @@ async function main(): Promise<void> {
         canaryPulls: config.canaryPulls ?? [],
         commandsEnabled: config.commands.enabled,
         reviewSchedulerEnabled: config.reviewScheduler?.enabled === true,
+        issueEnrichmentEnabled: config.issueEnrichment?.enabled === true,
         configPath: args.config
       });
       await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,5 +1,7 @@
 import { formatDaemonLog } from "./daemon-log.js";
 import { loadConfig } from "./config.js";
+import { GitHubApi } from "./github.js";
+import { runIssueEnrichmentCycle, type IssueEnrichmentCycleResult } from "./issue-enrichment.js";
 import { runScheduledCycle } from "./scheduler.js";
 import { ReviewStateStore, type DaemonHeartbeatEvent } from "./state.js";
 import { retryProviderCooldowns, runOnce, type RetryProviderCooldownsResult, type RunOnceResult } from "./worker.js";
@@ -17,6 +19,7 @@ export interface RunDaemonCycleOptions {
   canaryPulls: string[];
   commandsEnabled: boolean;
   reviewSchedulerEnabled?: boolean;
+  issueEnrichmentEnabled?: boolean;
   runOnceImpl?: (options: { configPath?: string; dryRun: boolean }) => Promise<RunOnceResult>;
   retryProviderCooldownsImpl?: (options: {
     configPath?: string;
@@ -25,6 +28,7 @@ export interface RunDaemonCycleOptions {
     dryRun: boolean;
     useZCode?: boolean;
   }) => Promise<RetryProviderCooldownsResult>;
+  issueEnrichmentCycleImpl?: (options: { configPath?: string; dryRun: boolean }) => Promise<IssueEnrichmentCycleResult>;
   recordHeartbeatImpl?: (event: DaemonHeartbeatEvent, error?: string) => void;
   stdout?: (line: string) => void;
   stderr?: (line: string) => void;
@@ -93,6 +97,30 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
         error: message
       }));
     }
+    if (input.issueEnrichmentEnabled === true) {
+      const issueEnrichmentCycleImpl = input.issueEnrichmentCycleImpl ?? runIssueEnrichmentCycleFromConfig;
+      try {
+        const issueEnrichment = await issueEnrichmentCycleImpl({
+          configPath: input.configPath,
+          dryRun: input.dryRun
+        });
+        stdout(formatDaemonLog({
+          event: "daemon_issue_enrichment",
+          cycle: input.cycle,
+          dryRun: input.dryRun,
+          result: issueEnrichment
+        }));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        stderr(formatDaemonLog({
+          event: "daemon_issue_enrichment_failed",
+          level: "error",
+          cycle: input.cycle,
+          dryRun: input.dryRun,
+          error: message
+        }));
+      }
+    }
     stdout(formatDaemonLog({
       event: "daemon_cycle_complete",
       cycle: input.cycle,
@@ -112,6 +140,21 @@ export async function runDaemonCycle(input: RunDaemonCycleOptions): Promise<Daem
     }));
     recordHeartbeat("daemon_cycle_failed", message);
     return { ok: false, error: message };
+  }
+}
+
+async function runIssueEnrichmentCycleFromConfig(input: { configPath?: string; dryRun: boolean }): Promise<IssueEnrichmentCycleResult> {
+  const config = loadConfig(input.configPath);
+  const state = new ReviewStateStore(config.statePath);
+  try {
+    return await runIssueEnrichmentCycle({
+      config,
+      state,
+      github: new GitHubApi(config.github),
+      dryRun: input.dryRun
+    });
+  } finally {
+    state.close();
   }
 }
 

--- a/src/github-related-context.ts
+++ b/src/github-related-context.ts
@@ -34,6 +34,7 @@ export interface GitHubRelatedIssueOrPull {
   title?: string | null;
   state?: string | null;
   html_url?: string | null;
+  updated_at?: string | null;
   pull_request?: unknown;
   body?: string | null;
   user?: { login?: string | null } | null;

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -1,6 +1,12 @@
-import { buildIssueEnrichmentDryRunOutput } from "./enrichment.js";
+import {
+  buildIssueEnrichmentComment,
+  buildIssueEnrichmentDryRunOutput,
+  postEnrichmentComment,
+  type EnrichmentCommentGithub
+} from "./enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
 import { redactSecrets } from "./secrets.js";
+import type { IssueEnrichmentRecord, IssueEnrichmentRecordStatus, ReviewStateStore } from "./state.js";
 
 export interface IssueEnrichmentConfig {
   enabled: boolean;
@@ -102,6 +108,25 @@ export interface IssueEnrichmentScanResult {
   items: IssueEnrichmentScanItem[];
   recommendedActions: string[];
 }
+
+export interface IssueEnrichmentCycleResult extends Omit<IssueEnrichmentScanResult, "summary" | "items"> {
+  summary: IssueEnrichmentScanResult["summary"] & {
+    posted: number;
+    dryRunRecorded: number;
+    skippedRecorded: number;
+    deferredRecorded: number;
+    alreadyProcessed: number;
+    failed: number;
+  };
+  items: Array<IssueEnrichmentScanItem & {
+    recordStatus?: IssueEnrichmentRecordStatus;
+    commentUrl?: string;
+    error?: string;
+    skippedExisting?: boolean;
+  }>;
+}
+
+export type IssueEnrichmentCycleGithub = IssueEnrichmentReader & EnrichmentCommentGithub;
 
 export interface IssueEnrichmentRepoScan {
   repo: string;
@@ -307,6 +332,186 @@ export async function collectIssueEnrichmentScan(input: {
   };
 }
 
+export async function runIssueEnrichmentCycle(input: {
+  config: { issueEnrichment?: IssueEnrichmentConfig };
+  state: Pick<ReviewStateStore, "getIssueEnrichmentRecord" | "recordIssueEnrichment">;
+  github: IssueEnrichmentCycleGithub;
+  dryRun: boolean;
+  repo?: string;
+  includeExisting?: boolean;
+  since?: string;
+  checkedAt?: string;
+}): Promise<IssueEnrichmentCycleResult> {
+  const checkedAt = input.checkedAt ?? new Date().toISOString();
+  const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
+  const status = buildIssueEnrichmentStatus({
+    config: input.config,
+    canPostAsApp: input.github.canPostAsApp(),
+    checkedAt
+  });
+  if (!config.enabled) {
+    return {
+      ok: true,
+      checkedAt,
+      dryRun: input.dryRun,
+      status,
+      summary: emptyCycleSummary(),
+      repos: [],
+      items: [],
+      recommendedActions: buildScanRecommendedActions(status, emptyCycleSummary())
+    };
+  }
+  if (status.state === "blocked") {
+    const summary = emptyCycleSummary();
+    return {
+      ok: false,
+      checkedAt,
+      dryRun: input.dryRun,
+      status,
+      summary,
+      repos: [],
+      items: [],
+      recommendedActions: buildScanRecommendedActions(status, summary)
+    };
+  }
+
+  const issuesByKey = new Map<string, GitHubRelatedIssueOrPull>();
+  const scan = await collectIssueEnrichmentScan({
+    config: input.config,
+    reader: {
+      listIssuesForEnrichment: async (repo, options) => {
+        const issues = await input.github.listIssuesForEnrichment(repo, options);
+        for (const issue of issues) issuesByKey.set(issueKey(repo, issue.number), issue);
+        return issues;
+      }
+    },
+    dryRun: input.dryRun,
+    repo: input.repo,
+    includeExisting: input.includeExisting,
+    since: input.since,
+    canPostAsApp: input.github.canPostAsApp(),
+    checkedAt
+  });
+  const summary = {
+    ...scan.summary,
+    posted: 0,
+    dryRunRecorded: 0,
+    skippedRecorded: 0,
+    deferredRecorded: 0,
+    alreadyProcessed: 0,
+    failed: 0
+  };
+  const items: IssueEnrichmentCycleResult["items"] = [];
+
+  for (const item of scan.items) {
+    const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
+    const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
+    const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
+    if (existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt)) {
+      summary.alreadyProcessed += 1;
+      items.push({ ...item, skippedExisting: true, recordStatus: existing.status });
+      continue;
+    }
+    if (input.dryRun) {
+      items.push({ ...item });
+      continue;
+    }
+
+    if (item.action === "skipped") {
+      input.state.recordIssueEnrichment({
+        repo: item.repo,
+        issueNumber: item.issueNumber,
+        issueUpdatedAt,
+        status: "skipped",
+        reason: item.reason,
+        now: new Date(checkedAt)
+      });
+      summary.skippedRecorded += 1;
+      items.push({ ...item, recordStatus: "skipped" });
+      continue;
+    }
+
+    if (item.action === "deferred") {
+      input.state.recordIssueEnrichment({
+        repo: item.repo,
+        issueNumber: item.issueNumber,
+        issueUpdatedAt,
+        status: "deferred",
+        reason: item.reason,
+        nextEligibleAt: item.nextEligibleAt,
+        now: new Date(checkedAt)
+      });
+      summary.deferredRecorded += 1;
+      items.push({ ...item, recordStatus: "deferred" });
+      continue;
+    }
+
+    if (!config.postIssueComment || item.action === "would_enrich") {
+      input.state.recordIssueEnrichment({
+        repo: item.repo,
+        issueNumber: item.issueNumber,
+        issueUpdatedAt,
+        status: "dry_run",
+        reason: "dry_run_only",
+        now: new Date(checkedAt)
+      });
+      summary.dryRunRecorded += 1;
+      items.push({ ...item, recordStatus: "dry_run" });
+      continue;
+    }
+
+    try {
+      if (!issue) throw new Error(`Issue metadata missing for ${item.repo}#${item.issueNumber}`);
+      const enrichment = buildIssueEnrichmentComment({
+        repo: item.repo,
+        issue,
+        postIssueComment: true
+      });
+      const post = await postEnrichmentComment({
+        enabled: true,
+        dryRun: false,
+        github: input.github,
+        repo: item.repo,
+        pullNumber: item.issueNumber,
+        enrichment
+      });
+      if (!post.posted) throw new Error(`issue enrichment comment not posted: ${post.reason}`);
+      const commentUrl = post.html_url ? redactSecrets(post.html_url) : undefined;
+      input.state.recordIssueEnrichment({
+        repo: item.repo,
+        issueNumber: item.issueNumber,
+        issueUpdatedAt,
+        status: "posted",
+        ...(commentUrl ? { commentUrl } : {}),
+        now: new Date(checkedAt)
+      });
+      summary.posted += 1;
+      items.push({ ...item, recordStatus: "posted", ...(commentUrl ? { commentUrl } : {}) });
+    } catch (error) {
+      const message = redactSecrets(error instanceof Error ? error.message : String(error));
+      input.state.recordIssueEnrichment({
+        repo: item.repo,
+        issueNumber: item.issueNumber,
+        issueUpdatedAt,
+        status: "failed",
+        reason: "post_failed",
+        error: message,
+        now: new Date(checkedAt)
+      });
+      summary.failed += 1;
+      items.push({ ...item, recordStatus: "failed", error: message });
+    }
+  }
+
+  return {
+    ...scan,
+    ok: scan.ok && summary.failed === 0,
+    summary,
+    items,
+    recommendedActions: buildCycleRecommendedActions(scan.recommendedActions, summary)
+  };
+}
+
 export function resolveIssueEnrichmentRepoPolicy(
   config: IssueEnrichmentConfig,
   repo: string
@@ -448,6 +653,61 @@ function buildScanRecommendedActions(status: IssueEnrichmentStatus, summary: Iss
   if (summary.deferred > 0) actions.push("inspect deferred issue-enrichment rows and adjust per-repo throttles only after dry-run review");
   if (summary.readFailures > 0) actions.push("run doctor and inspect GitHub App Issues permissions");
   return actions;
+}
+
+function buildCycleRecommendedActions(
+  scanActions: string[],
+  summary: IssueEnrichmentCycleResult["summary"]
+): string[] {
+  const actions = [...scanActions];
+  if (summary.failed > 0) actions.push("inspect failed issue-enrichment rows before enabling live issue comments");
+  if (summary.posted > 0) actions.push("verify App-authored sticky issue comments before expanding the issue-enrichment allowlist");
+  return [...new Set(actions)];
+}
+
+function emptyCycleSummary(): IssueEnrichmentCycleResult["summary"] {
+  return {
+    reposScanned: 0,
+    reposSkipped: 0,
+    readFailures: 0,
+    issuesSeen: 0,
+    eligible: 0,
+    skipped: 0,
+    wouldEnrich: 0,
+    wouldComment: 0,
+    deferred: 0,
+    posted: 0,
+    dryRunRecorded: 0,
+    skippedRecorded: 0,
+    deferredRecorded: 0,
+    alreadyProcessed: 0,
+    failed: 0
+  };
+}
+
+function canonicalIssueUpdatedAt(issue: GitHubRelatedIssueOrPull | undefined, checkedAt: string): string {
+  const candidate = issue?.updated_at ?? checkedAt;
+  const parsed = Date.parse(candidate);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : checkedAt;
+}
+
+function shouldSkipIssueEnrichmentRecord(
+  existing: IssueEnrichmentRecord,
+  issueUpdatedAt: string,
+  checkedAt: string
+): boolean {
+  if (existing.issueUpdatedAt !== issueUpdatedAt) return false;
+  if (existing.status === "failed") return false;
+  if (existing.status === "deferred" && existing.nextEligibleAt) {
+    const nextEligibleAt = Date.parse(existing.nextEligibleAt);
+    const now = Date.parse(checkedAt);
+    if (Number.isFinite(nextEligibleAt) && Number.isFinite(now) && nextEligibleAt <= now) return false;
+  }
+  return true;
+}
+
+function issueKey(repo: string, issueNumber: number): string {
+  return `${repo}#${issueNumber}`;
 }
 
 function sum<T extends keyof Pick<IssueEnrichmentRepoScan, "issuesSeen" | "eligible" | "skipped" | "wouldEnrich" | "wouldComment" | "deferred">>(

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -18,6 +18,7 @@ import { redactSecrets } from "./secrets.js";
 import {
   parseProviderCooldownError,
   PROVIDER_COOLDOWN_ERROR_PREFIX,
+  type IssueEnrichmentRecordStatus,
   type ProcessedCommandAction,
   type ProviderCooldownReviewRecord,
   type ReviewReadinessRecord,
@@ -50,6 +51,7 @@ export interface OperatorStatus {
     budgetWouldLeaseJobs: number;
     budgetDelayedJobs: number;
     issueEnrichmentState?: IssueEnrichmentStatus["state"];
+    issueEnrichmentRuntimeState?: OperatorIssueEnrichmentRuntimeState;
   };
   gates: Array<{ name: string; ok: boolean; detail: string }>;
   recommendedActions: string[];
@@ -60,6 +62,7 @@ export interface OperatorStatus {
   providerCooldowns: ProviderCooldownReviewRecord[];
   durableQueue?: OperatorDurableQueueSnapshot;
   issueEnrichment?: IssueEnrichmentStatus;
+  issueEnrichmentRuntime?: OperatorIssueEnrichmentRuntime;
 }
 
 export interface RuntimeInventory {
@@ -94,6 +97,7 @@ export interface RuntimeInventory {
     activeRepoCooldowns: number;
     botProcesses: number;
     issueEnrichmentState?: IssueEnrichmentStatus["state"];
+    issueEnrichmentRuntimeState?: OperatorIssueEnrichmentRuntimeState;
   };
   gates: Array<{ name: string; ok: boolean; detail: string }>;
   recommendedActions: string[];
@@ -108,9 +112,41 @@ export interface RuntimeInventory {
   providerCooldowns: ProviderCooldownReviewRecord[];
   repoProviderCooldowns: RepoProviderCooldownRecord[];
   issueEnrichment?: IssueEnrichmentStatus;
+  issueEnrichmentRuntime?: OperatorIssueEnrichmentRuntime;
 }
 
 export type RuntimeClassification = "healthy_idle" | "healthy_active" | "blocked";
+export type OperatorIssueEnrichmentRuntimeState = "disabled" | "idle" | "deferred" | "error";
+
+export interface OperatorIssueEnrichmentRuntimeRecord {
+  repo: string;
+  issueNumber: number;
+  status: IssueEnrichmentRecordStatus;
+  issueUpdatedAt?: string;
+  reason?: string;
+  commentUrl?: string;
+  error?: string;
+  nextEligibleAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  retryable: boolean;
+}
+
+export interface OperatorIssueEnrichmentRuntime {
+  ok: boolean;
+  checkedAt: string;
+  state: OperatorIssueEnrichmentRuntimeState;
+  summary: {
+    total: number;
+    dryRun: number;
+    posted: number;
+    skipped: number;
+    deferred: number;
+    retryableDeferred: number;
+    failed: number;
+  };
+  records: OperatorIssueEnrichmentRuntimeRecord[];
+}
 
 export interface RuntimeProcessRow {
   pid: number;
@@ -308,6 +344,7 @@ export function buildOperatorStatus(input: {
   providerCooldowns?: ProviderCooldownReviewRecord[];
   durableQueue?: OperatorDurableQueueSnapshot;
   issueEnrichment?: IssueEnrichmentStatus;
+  issueEnrichmentRuntime?: OperatorIssueEnrichmentRuntime;
   checkedAt?: string;
 }): OperatorStatus {
   const queue = input.coverage ? buildOperatorQueue(input.coverage) : undefined;
@@ -324,6 +361,10 @@ export function buildOperatorStatus(input: {
   const retryableProviderDeferredJobs = durableQueue?.summary.retryableProviderDeferred ?? 0;
   const budget = input.release.budget;
   const issueEnrichment = input.issueEnrichment;
+  const issueEnrichmentRuntime = input.issueEnrichmentRuntime;
+  const issueEnrichmentRuntimeState = displayIssueEnrichmentRuntimeState(issueEnrichment, issueEnrichmentRuntime);
+  const issueEnrichmentRuntimeFailed = issueEnrichmentRuntime?.summary.failed ?? 0;
+  const issueEnrichmentRuntimeRetryableDeferred = issueEnrichmentRuntime?.summary.retryableDeferred ?? 0;
 
   const gates = [
     ...input.release.gates,
@@ -367,6 +408,20 @@ export function buildOperatorStatus(input: {
             ? `${issueEnrichment.state}; allowlist=${issueEnrichment.allowlist.length}; liveComments=${issueEnrichment.postIssueComment}`
             : `${issueEnrichment.state}: ${issueEnrichment.blockers.join(", ")}`
         }]
+      : []),
+    ...(issueEnrichmentRuntime
+      ? [
+          {
+            name: "issue_enrichment_runtime_no_failed_records",
+            ok: issueEnrichmentRuntimeFailed === 0,
+            detail: `${issueEnrichmentRuntimeFailed} failed issue-enrichment record(s)`
+          },
+          {
+            name: "issue_enrichment_runtime_no_retryable_deferred_records",
+            ok: issueEnrichmentRuntimeRetryableDeferred === 0,
+            detail: `${issueEnrichmentRuntimeRetryableDeferred} retryable deferred issue-enrichment record(s)`
+          }
+        ]
       : [])
   ];
 
@@ -378,7 +433,9 @@ export function buildOperatorStatus(input: {
     ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : []),
     ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
-    ...(issueEnrichment && !issueEnrichment.ok ? ["resolve issue-enrichment blockers before enabling live issue comments"] : [])
+    ...(issueEnrichment && !issueEnrichment.ok ? ["resolve issue-enrichment blockers before enabling live issue comments"] : []),
+    ...(issueEnrichmentRuntimeFailed > 0 ? ["inspect failed issue-enrichment records before promotion"] : []),
+    ...(issueEnrichmentRuntimeRetryableDeferred > 0 ? ["retry or inspect deferred issue-enrichment records"] : [])
   ]);
 
   return {
@@ -403,7 +460,8 @@ export function buildOperatorStatus(input: {
       failedQueueJobs,
       budgetWouldLeaseJobs: budget?.wouldLeaseCount ?? 0,
       budgetDelayedJobs: budget?.delayedCount ?? 0,
-      ...(issueEnrichment ? { issueEnrichmentState: issueEnrichment.state } : {})
+      ...(issueEnrichment ? { issueEnrichmentState: issueEnrichment.state } : {}),
+      ...(issueEnrichmentRuntimeState ? { issueEnrichmentRuntimeState } : {})
     },
     gates,
     recommendedActions,
@@ -413,7 +471,8 @@ export function buildOperatorStatus(input: {
     agents: input.agents,
     providerCooldowns,
     ...(durableQueue ? { durableQueue } : {}),
-    ...(issueEnrichment ? { issueEnrichment } : {})
+    ...(issueEnrichment ? { issueEnrichment } : {}),
+    ...(issueEnrichmentRuntime ? { issueEnrichmentRuntime } : {})
   };
 }
 
@@ -426,6 +485,7 @@ export function buildRuntimeInventory(input: {
   repoProviderCooldowns?: RepoProviderCooldownRecord[];
   durableQueue?: OperatorDurableQueueSnapshot;
   issueEnrichment?: IssueEnrichmentStatus;
+  issueEnrichmentRuntime?: OperatorIssueEnrichmentRuntime;
   checkedAt?: string;
 }): RuntimeInventory {
   const queue = input.coverage ? buildOperatorQueue(input.coverage) : undefined;
@@ -461,6 +521,10 @@ export function buildRuntimeInventory(input: {
   const providerDeferredHeads = queue?.summary.providerDeferred ?? 0;
   const budget = input.release.budget;
   const issueEnrichment = input.issueEnrichment;
+  const issueEnrichmentRuntime = input.issueEnrichmentRuntime;
+  const issueEnrichmentRuntimeState = displayIssueEnrichmentRuntimeState(issueEnrichment, issueEnrichmentRuntime);
+  const issueEnrichmentRuntimeFailed = issueEnrichmentRuntime?.summary.failed ?? 0;
+  const issueEnrichmentRuntimeRetryableDeferred = issueEnrichmentRuntime?.summary.retryableDeferred ?? 0;
 
   const gates = [
     ...input.release.gates,
@@ -521,6 +585,20 @@ export function buildRuntimeInventory(input: {
             ? `${issueEnrichment.state}; allowlist=${issueEnrichment.allowlist.length}; liveComments=${issueEnrichment.postIssueComment}`
             : `${issueEnrichment.state}: ${issueEnrichment.blockers.join(", ")}`
         }]
+      : []),
+    ...(issueEnrichmentRuntime
+      ? [
+          {
+            name: "runtime_issue_enrichment_no_failed_records",
+            ok: issueEnrichmentRuntimeFailed === 0,
+            detail: `${issueEnrichmentRuntimeFailed} failed issue-enrichment record(s)`
+          },
+          {
+            name: "runtime_issue_enrichment_no_retryable_deferred_records",
+            ok: issueEnrichmentRuntimeRetryableDeferred === 0,
+            detail: `${issueEnrichmentRuntimeRetryableDeferred} retryable deferred issue-enrichment record(s)`
+          }
+        ]
       : [])
   ];
 
@@ -540,7 +618,9 @@ export function buildRuntimeInventory(input: {
     ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
     ...(retryableExpiredProviderCooldowns > 0 ? ["retry expired provider cooldowns or inspect provider health"] : []),
-    ...(issueEnrichment && !issueEnrichment.ok ? ["resolve issue-enrichment blockers before enabling live issue comments"] : [])
+    ...(issueEnrichment && !issueEnrichment.ok ? ["resolve issue-enrichment blockers before enabling live issue comments"] : []),
+    ...(issueEnrichmentRuntimeFailed > 0 ? ["inspect failed issue-enrichment records before promotion"] : []),
+    ...(issueEnrichmentRuntimeRetryableDeferred > 0 ? ["retry or inspect deferred issue-enrichment records"] : [])
   ]);
 
   return {
@@ -574,7 +654,8 @@ export function buildRuntimeInventory(input: {
       repoCooldowns: repoProviderCooldowns.length,
       activeRepoCooldowns,
       botProcesses: input.processes?.summary.total ?? 0,
-      ...(issueEnrichment ? { issueEnrichmentState: issueEnrichment.state } : {})
+      ...(issueEnrichment ? { issueEnrichmentState: issueEnrichment.state } : {}),
+      ...(issueEnrichmentRuntimeState ? { issueEnrichmentRuntimeState } : {})
     },
     gates,
     recommendedActions,
@@ -588,7 +669,8 @@ export function buildRuntimeInventory(input: {
     ...(queue ? { coverage: queue } : {}),
     providerCooldowns,
     repoProviderCooldowns,
-    ...(issueEnrichment ? { issueEnrichment } : {})
+    ...(issueEnrichment ? { issueEnrichment } : {}),
+    ...(issueEnrichmentRuntime ? { issueEnrichmentRuntime } : {})
   };
 }
 
@@ -668,6 +750,10 @@ export function formatRuntimeInventoryHuman(inventory: RuntimeInventory): string
       ` retryable=${inventory.summary.retryableExpiredProviderCooldowns}` +
       ` covered=${inventory.summary.coveredExpiredProviderCooldowns}` +
       ` activeRepo=${inventory.summary.activeRepoCooldowns}`,
+    `issueEnrichment: config=${inventory.summary.issueEnrichmentState ?? "unknown"}` +
+      ` runtime=${inventory.summary.issueEnrichmentRuntimeState ?? "unknown"}` +
+      ` failed=${inventory.issueEnrichmentRuntime?.summary.failed ?? 0}` +
+      ` deferred=${inventory.issueEnrichmentRuntime?.summary.deferred ?? 0}`,
     `processes: botOwned=${inventory.summary.botProcesses}`,
     `leases: active=${inventory.summary.activeLeases} stale=${inventory.summary.staleLeases}`
   ];
@@ -806,6 +892,64 @@ export function collectOperatorProviderCooldowns(
       if (!input.expiredOnly || record.expired) mapped.push(record);
     }
     return input.limit ? mapped.slice(0, input.limit) : mapped;
+  } finally {
+    db.close();
+  }
+}
+
+export function collectOperatorIssueEnrichmentRuntime(
+  statePath: string,
+  input: { repo?: string; now?: Date; limit?: number } = {}
+): OperatorIssueEnrichmentRuntime {
+  const checkedAt = (input.now ?? new Date()).toISOString();
+  if (input.limit !== undefined && (!Number.isInteger(input.limit) || input.limit < 1)) {
+    throw new Error("limit must be a positive integer");
+  }
+  if (!existsSync(statePath)) return emptyIssueEnrichmentRuntime(checkedAt);
+  const db = new DatabaseSync(statePath, { readOnly: true });
+  try {
+    if (!hasTable(db, "issue_enrichment_records")) return emptyIssueEnrichmentRuntime(checkedAt);
+    const rows = (input.repo
+      ? db
+          .prepare(
+            `select repo, issue_number, issue_updated_at, status, reason, comment_url, error,
+                    next_eligible_at, created_at, updated_at
+             from issue_enrichment_records
+             where repo = ?
+             order by datetime(updated_at) desc`
+          )
+          .all(input.repo)
+      : db
+          .prepare(
+            `select repo, issue_number, issue_updated_at, status, reason, comment_url, error,
+                    next_eligible_at, created_at, updated_at
+             from issue_enrichment_records
+             order by datetime(updated_at) desc`
+          )
+          .all()) as unknown as IssueEnrichmentRecordRow[];
+    const allRecords = rows.map((row) => mapIssueEnrichmentRuntimeRow(row, checkedAt));
+    const records = input.limit ? allRecords.slice(0, input.limit) : allRecords;
+    const summary = {
+      total: allRecords.length,
+      dryRun: allRecords.filter((record) => record.status === "dry_run").length,
+      posted: allRecords.filter((record) => record.status === "posted").length,
+      skipped: allRecords.filter((record) => record.status === "skipped").length,
+      deferred: allRecords.filter((record) => record.status === "deferred").length,
+      retryableDeferred: allRecords.filter((record) => record.status === "deferred" && record.retryable).length,
+      failed: allRecords.filter((record) => record.status === "failed").length
+    };
+    const state: OperatorIssueEnrichmentRuntimeState = summary.failed > 0
+      ? "error"
+      : summary.deferred > 0
+        ? "deferred"
+        : "idle";
+    return {
+      ok: summary.failed === 0 && summary.retryableDeferred === 0,
+      checkedAt,
+      state,
+      summary,
+      records
+    };
   } finally {
     db.close();
   }
@@ -1407,6 +1551,59 @@ function isRetryableQueueJob(job: ReviewQueueJobRecord, now: Date): boolean {
   return !Number.isFinite(nextEligibleAtMs) || nextEligibleAtMs <= now.getTime();
 }
 
+function emptyIssueEnrichmentRuntime(checkedAt: string): OperatorIssueEnrichmentRuntime {
+  return {
+    ok: true,
+    checkedAt,
+    state: "idle",
+    summary: {
+      total: 0,
+      dryRun: 0,
+      posted: 0,
+      skipped: 0,
+      deferred: 0,
+      retryableDeferred: 0,
+      failed: 0
+    },
+    records: []
+  };
+}
+
+function displayIssueEnrichmentRuntimeState(
+  issueEnrichment: IssueEnrichmentStatus | undefined,
+  runtime: OperatorIssueEnrichmentRuntime | undefined
+): OperatorIssueEnrichmentRuntimeState | undefined {
+  if (!runtime) return issueEnrichment?.enabled === false ? "disabled" : undefined;
+  if (issueEnrichment?.enabled === false && runtime.summary.total === 0) return "disabled";
+  return runtime.state;
+}
+
+function mapIssueEnrichmentRuntimeRow(
+  row: IssueEnrichmentRecordRow,
+  checkedAt: string
+): OperatorIssueEnrichmentRuntimeRecord {
+  const nextEligibleAtMs = row.next_eligible_at ? Date.parse(row.next_eligible_at) : Number.NaN;
+  const checkedAtMs = Date.parse(checkedAt);
+  const retryable =
+    row.status === "deferred" &&
+    (!row.next_eligible_at ||
+      !Number.isFinite(nextEligibleAtMs) ||
+      (Number.isFinite(checkedAtMs) && nextEligibleAtMs <= checkedAtMs));
+  return {
+    repo: row.repo,
+    issueNumber: row.issue_number,
+    status: row.status,
+    ...(row.issue_updated_at ? { issueUpdatedAt: row.issue_updated_at } : {}),
+    ...(row.reason ? { reason: redactSecrets(row.reason) } : {}),
+    ...(row.comment_url ? { commentUrl: redactSecrets(row.comment_url) } : {}),
+    ...(row.error ? { error: redactSecrets(row.error) } : {}),
+    ...(row.next_eligible_at ? { nextEligibleAt: row.next_eligible_at } : {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    retryable
+  };
+}
+
 function sameHead(job: ReviewQueueJobRecord, pending: OperatorQueueEntry): boolean {
   return job.repo === pending.repo && job.pullNumber === pending.pullNumber && job.headSha === pending.headSha;
 }
@@ -1806,6 +2003,19 @@ interface RepoProviderCooldownRow {
   repo: string;
   cooldown_until: string;
   reason: string;
+  updated_at: string;
+}
+
+interface IssueEnrichmentRecordRow {
+  repo: string;
+  issue_number: number;
+  issue_updated_at: string | null;
+  status: IssueEnrichmentRecordStatus;
+  reason: string | null;
+  comment_url: string | null;
+  error: string | null;
+  next_eligible_at: string | null;
+  created_at: string;
   updated_at: string;
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -47,6 +47,7 @@ export type RepoMemoryNoteKind =
   | "false_positive"
   | "review_outcome"
   | "proof_preference";
+export type IssueEnrichmentRecordStatus = "dry_run" | "posted" | "skipped" | "deferred" | "failed";
 const REPO_MEMORY_NOTE_KINDS: RepoMemoryNoteKind[] = ["policy_note", "machine_fact", "false_positive", "review_outcome", "proof_preference"];
 
 export interface ProcessedReviewRecord {
@@ -258,6 +259,31 @@ export interface RecordRepoMemoryNoteInput {
   now?: Date;
 }
 
+export interface IssueEnrichmentRecord {
+  repo: string;
+  issueNumber: number;
+  issueUpdatedAt?: string;
+  status: IssueEnrichmentRecordStatus;
+  reason?: string;
+  commentUrl?: string;
+  error?: string;
+  nextEligibleAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RecordIssueEnrichmentInput {
+  repo: string;
+  issueNumber: number;
+  issueUpdatedAt?: string;
+  status: IssueEnrichmentRecordStatus;
+  reason?: string;
+  commentUrl?: string;
+  error?: string;
+  nextEligibleAt?: string;
+  now?: Date;
+}
+
 export interface ListRepoMemoryNotesInput {
   repo: string;
   includeExpired?: boolean;
@@ -451,6 +477,25 @@ export class ReviewStateStore {
 
       create index if not exists idx_repo_memory_packet_builds_repo_generated
         on repo_memory_packet_builds (repo, generated_at);
+
+      create table if not exists issue_enrichment_records (
+        repo text not null,
+        issue_number integer not null,
+        issue_updated_at text,
+        status text not null,
+        reason text,
+        comment_url text,
+        error text,
+        next_eligible_at text,
+        created_at text not null,
+        updated_at text not null,
+        primary key (repo, issue_number)
+      );
+
+      create index if not exists idx_issue_enrichment_records_status
+        on issue_enrichment_records (status, updated_at);
+      create index if not exists idx_issue_enrichment_records_repo_status
+        on issue_enrichment_records (repo, status);
     `);
     this.ensureDaemonHeartbeatColumns();
     this.ensureReviewRunLeaseColumns();
@@ -651,6 +696,96 @@ export class ReviewStateStore {
       )
       .all(...params) as unknown as ReviewReadinessRow[];
     return rows.map(mapReviewReadinessRow);
+  }
+
+  recordIssueEnrichment(input: RecordIssueEnrichmentInput): IssueEnrichmentRecord {
+    validateIssueEnrichmentInput(input);
+    const existing = this.getIssueEnrichmentRecord(input.repo, input.issueNumber);
+    const nowIso = (input.now ?? new Date()).toISOString();
+    const reason = input.reason ? redactSecrets(input.reason).trim().slice(0, 500) : undefined;
+    const commentUrl = input.commentUrl ? redactSecrets(input.commentUrl).trim().slice(0, 500) : undefined;
+    const error = input.error ? redactSecrets(input.error).trim().slice(0, 1_000) : undefined;
+    const nextEligibleAt = input.nextEligibleAt ? new Date(Date.parse(input.nextEligibleAt)).toISOString() : undefined;
+    this.db
+      .prepare(
+        `insert into issue_enrichment_records
+          (repo, issue_number, issue_updated_at, status, reason, comment_url, error,
+           next_eligible_at, created_at, updated_at)
+         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         on conflict(repo, issue_number) do update set
+           issue_updated_at = excluded.issue_updated_at,
+           status = excluded.status,
+           reason = excluded.reason,
+           comment_url = excluded.comment_url,
+           error = excluded.error,
+           next_eligible_at = excluded.next_eligible_at,
+           updated_at = excluded.updated_at`
+      )
+      .run(
+        input.repo,
+        input.issueNumber,
+        input.issueUpdatedAt ?? null,
+        input.status,
+        reason ?? null,
+        commentUrl ?? null,
+        error ?? null,
+        nextEligibleAt ?? null,
+        existing?.createdAt ?? nowIso,
+        nowIso
+      );
+    return this.getIssueEnrichmentRecord(input.repo, input.issueNumber)!;
+  }
+
+  getIssueEnrichmentRecord(repo: string, issueNumber: number): IssueEnrichmentRecord | undefined {
+    validateRepoIssue(repo, issueNumber);
+    const row = this.db
+      .prepare(
+        `select repo, issue_number, issue_updated_at, status, reason, comment_url, error,
+                next_eligible_at, created_at, updated_at
+         from issue_enrichment_records
+         where repo = ? and issue_number = ?
+         limit 1`
+      )
+      .get(repo, issueNumber) as IssueEnrichmentRecordRow | undefined;
+    return row ? mapIssueEnrichmentRecordRow(row) : undefined;
+  }
+
+  listIssueEnrichmentRecords(input: {
+    repo?: string;
+    status?: IssueEnrichmentRecordStatus;
+    statuses?: IssueEnrichmentRecordStatus[];
+    limit?: number;
+  } = {}): IssueEnrichmentRecord[] {
+    if (input.repo) validateRepoName(input.repo, "repo");
+    if (input.limit !== undefined && (!Number.isInteger(input.limit) || input.limit < 1)) {
+      throw new Error("limit must be a positive integer");
+    }
+    const statuses = input.statuses ?? (input.status ? [input.status] : undefined);
+    if (statuses?.length) statuses.forEach((status) => validateIssueEnrichmentStatus(status));
+    const predicates: string[] = [];
+    const params: Array<string | number> = [];
+    if (input.repo) {
+      predicates.push("repo = ?");
+      params.push(input.repo);
+    }
+    if (statuses?.length) {
+      predicates.push(`status in (${statuses.map(() => "?").join(", ")})`);
+      params.push(...statuses);
+    }
+    const where = predicates.length ? `where ${predicates.join(" and ")}` : "";
+    const limit = input.limit ? " limit ?" : "";
+    if (input.limit) params.push(input.limit);
+    const rows = this.db
+      .prepare(
+        `select repo, issue_number, issue_updated_at, status, reason, comment_url, error,
+                next_eligible_at, created_at, updated_at
+         from issue_enrichment_records
+         ${where}
+         order by datetime(updated_at) desc
+         ${limit}`
+      )
+      .all(...params) as unknown as IssueEnrichmentRecordRow[];
+    return rows.map(mapIssueEnrichmentRecordRow);
   }
 
   retireFailedReview(input: RetireFailedReviewInput): StoredProcessedReviewRecord {
@@ -1865,6 +2000,43 @@ function validateReviewQueueInput(
   }
 }
 
+function validateIssueEnrichmentInput(input: RecordIssueEnrichmentInput): void {
+  validateRepoIssue(input.repo, input.issueNumber);
+  validateIssueEnrichmentStatus(input.status);
+  if (input.issueUpdatedAt !== undefined && !isCanonicalIsoTimestamp(input.issueUpdatedAt)) {
+    throw new Error("issueUpdatedAt must be a canonical ISO timestamp");
+  }
+  if (input.nextEligibleAt !== undefined && !Number.isFinite(Date.parse(input.nextEligibleAt))) {
+    throw new Error("nextEligibleAt must be an ISO timestamp");
+  }
+  if (input.now !== undefined && !Number.isFinite(input.now.getTime())) {
+    throw new Error("now must be a valid Date");
+  }
+  const metadataText = [
+    input.repo,
+    String(input.issueNumber),
+    input.issueUpdatedAt ?? "",
+    input.reason ?? "",
+    input.commentUrl ?? "",
+    input.error ?? "",
+    input.nextEligibleAt ?? ""
+  ].join("\n");
+  if (containsSecretLikeText(metadataText)) {
+    throw new Error(`Refusing to store issue enrichment metadata for ${input.repo}#${input.issueNumber}: secret-like metadata detected`);
+  }
+}
+
+function validateIssueEnrichmentStatus(status: IssueEnrichmentRecordStatus): void {
+  if (!["dry_run", "posted", "skipped", "deferred", "failed"].includes(status)) {
+    throw new Error("status must be a valid issue enrichment status");
+  }
+}
+
+function validateRepoIssue(repo: string, issueNumber: number): void {
+  validateRepoName(repo, "repo");
+  if (!Number.isInteger(issueNumber) || issueNumber < 1) throw new Error("issueNumber must be a positive integer");
+}
+
 function validateRepoMemoryNoteInput(input: RecordRepoMemoryNoteInput): void {
   if (!input.noteId.trim()) throw new Error("noteId must be non-empty");
   validateRepoName(input.repo, "repo");
@@ -2134,6 +2306,19 @@ interface RepoMemoryPacketBuildRow {
   memory_root: string | null;
 }
 
+interface IssueEnrichmentRecordRow {
+  repo: string;
+  issue_number: number;
+  issue_updated_at: string | null;
+  status: IssueEnrichmentRecordStatus;
+  reason: string | null;
+  comment_url: string | null;
+  error: string | null;
+  next_eligible_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRecord {
   return {
     repo: row.repo,
@@ -2158,6 +2343,21 @@ function mapReviewReadinessRow(row: ReviewReadinessRow): ReviewReadinessRecord {
     ...(row.review_url ? { reviewUrl: row.review_url } : {}),
     ...(row.command_action ? { commandAction: row.command_action } : {}),
     ...(row.command_comment_id ? { commandCommentId: row.command_comment_id } : {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function mapIssueEnrichmentRecordRow(row: IssueEnrichmentRecordRow): IssueEnrichmentRecord {
+  return {
+    repo: row.repo,
+    issueNumber: row.issue_number,
+    ...(row.issue_updated_at ? { issueUpdatedAt: row.issue_updated_at } : {}),
+    status: row.status,
+    ...(row.reason ? { reason: row.reason } : {}),
+    ...(row.comment_url ? { commentUrl: row.comment_url } : {}),
+    ...(row.error ? { error: row.error } : {}),
+    ...(row.next_eligible_at ? { nextEligibleAt: row.next_eligible_at } : {}),
     createdAt: row.created_at,
     updatedAt: row.updated_at
   };

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { runDaemonCycle } from "../src/daemon.js";
+import type { IssueEnrichmentCycleResult } from "../src/issue-enrichment.js";
 
 describe("daemon cycle resilience", () => {
   it("logs runtime cycle failures without throwing out of the daemon loop", async () => {
@@ -233,4 +234,145 @@ describe("daemon cycle resilience", () => {
       { event: "daemon_cycle_failed", error: "second timeout" }
     ]);
   });
+
+  it("runs and logs the issue enrichment cycle when the default-off lane is enabled", async () => {
+    const stdout: string[] = [];
+    let issueCycleCalled = false;
+
+    const result = await runDaemonCycle({
+      cycle: 9,
+      dryRun: false,
+      pilotRepos: ["electricsheephq/WorldOS"],
+      monitoredRepos: ["electricsheephq/WorldOS"],
+      canaryPulls: [],
+      commandsEnabled: false,
+      reviewSchedulerEnabled: true,
+      issueEnrichmentEnabled: true,
+      runOnceImpl: async () => successfulRunOnceResult(),
+      issueEnrichmentCycleImpl: async (options) => {
+        issueCycleCalled = options.dryRun === false;
+        return successfulIssueEnrichmentCycleResult();
+      },
+      recordHeartbeatImpl: () => undefined,
+      stdout: (line) => stdout.push(line),
+      stderr: () => undefined
+    });
+
+    expect(result.ok).toBe(true);
+    expect(issueCycleCalled).toBe(true);
+    expect(stdout.map((line) => JSON.parse(line))).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        event: "daemon_issue_enrichment",
+        cycle: 9,
+        result: expect.objectContaining({
+          summary: expect.objectContaining({
+            reposScanned: 1,
+            dryRunRecorded: 1
+          })
+        })
+      })
+    ]));
+  });
+
+  it("keeps the daemon cycle healthy when issue enrichment fails", async () => {
+    const stderr: string[] = [];
+
+    const result = await runDaemonCycle({
+      cycle: 10,
+      dryRun: false,
+      pilotRepos: ["electricsheephq/WorldOS"],
+      monitoredRepos: ["electricsheephq/WorldOS"],
+      canaryPulls: [],
+      commandsEnabled: false,
+      reviewSchedulerEnabled: true,
+      issueEnrichmentEnabled: true,
+      runOnceImpl: async () => successfulRunOnceResult(),
+      issueEnrichmentCycleImpl: async () => {
+        throw new Error("issue enrichment failed with ghp_1234567890abcdefghijklmnopqrstuvwx");
+      },
+      recordHeartbeatImpl: () => undefined,
+      stdout: () => undefined,
+      stderr: (line) => stderr.push(line)
+    });
+
+    expect(result.ok).toBe(true);
+    expect(stderr).toHaveLength(1);
+    const failure = JSON.parse(stderr[0]!);
+    expect(failure).toMatchObject({
+      event: "daemon_issue_enrichment_failed",
+      level: "error",
+      cycle: 10
+    });
+    expect(failure.error).toContain("issue enrichment failed");
+    expect(failure.error).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+  });
 });
+
+function successfulRunOnceResult() {
+  return {
+    reposScanned: 1,
+    pullsSeen: 1,
+    reviewed: 0,
+    failed: 0,
+    skippedDraft: 0,
+    skippedCanary: 0,
+    skippedPolicy: 0,
+    skippedCommandStop: 0,
+    skippedCommandExplain: 0,
+    commandReviewRequested: 0,
+    skippedProcessed: 1,
+    skippedCapacity: 0,
+    skippedProviderCooldown: 0,
+    skippedStaleHead: 0,
+    baselinedExisting: 0,
+    policySkips: []
+  };
+}
+
+function successfulIssueEnrichmentCycleResult(): IssueEnrichmentCycleResult {
+  return {
+    ok: true,
+    checkedAt: "2026-07-03T04:00:00.000Z",
+    dryRun: false,
+    status: {
+      ok: true,
+      checkedAt: "2026-07-03T04:00:00.000Z",
+      state: "dry_run_only",
+      enabled: true,
+      postIssueComment: false,
+      separateAllowlist: true,
+      allowlist: ["owner/repo"],
+      throttleDefaults: {
+        maxIssuesPerCycle: 5,
+        maxCommentsPerCycle: 0,
+        cooldownMs: 3_600_000,
+        burstWindowMs: 3_600_000,
+        maxIssuesPerBurst: 10,
+        lookbackMs: 600_000,
+        processExistingOpenIssuesOnActivation: false
+      },
+      repoOverrides: [],
+      blockers: ["issue_enrichment_live_posting_disabled"]
+    },
+    summary: {
+      reposScanned: 1,
+      reposSkipped: 0,
+      readFailures: 0,
+      issuesSeen: 1,
+      eligible: 1,
+      skipped: 0,
+      wouldEnrich: 1,
+      wouldComment: 0,
+      deferred: 0,
+      posted: 0,
+      dryRunRecorded: 1,
+      skippedRecorded: 0,
+      deferredRecorded: 0,
+      alreadyProcessed: 0,
+      failed: 0
+    },
+    repos: [],
+    items: [],
+    recommendedActions: []
+  };
+}

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -14,7 +14,8 @@ import {
   postEnrichmentComment
 } from "../src/enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js";
-import { buildIssueEnrichmentStatus, collectIssueEnrichmentScan } from "../src/issue-enrichment.js";
+import { buildIssueEnrichmentStatus, collectIssueEnrichmentScan, runIssueEnrichmentCycle } from "../src/issue-enrichment.js";
+import { ReviewStateStore } from "../src/state.js";
 import type { PullFilePatch, PullRequestSummary } from "../src/types.js";
 
 const HEAD_A = "a".repeat(40);
@@ -690,6 +691,292 @@ describe("sticky enrichment comments", () => {
         since: "2026-07-03T11:00:00.000Z",
         pageLimit: 2
       }]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("records dry-run-only issue enrichment once per unchanged issue update", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-dry-run-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: false,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 5,
+          maxCommentsPerCycle: 0,
+          processExistingOpenIssuesOnActivation: true
+        }
+      })}\n`);
+      const state = new ReviewStateStore(statePath);
+      try {
+        const issue: GitHubRelatedIssueOrPull = {
+          number: 31,
+          title: "Add issue enrichment scheduler",
+          state: "open",
+          updated_at: "2026-07-03T01:00:00.000Z",
+          body: "Acceptance criteria and owner present."
+        };
+        const reader = { listIssuesForEnrichment: async () => [issue] };
+
+        const first = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            ...reader,
+            canPostAsApp: () => false,
+            upsertIssueComment: async () => {
+              throw new Error("should not post in dry-run-only mode");
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T01:05:00.000Z"
+        });
+        const second = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            ...reader,
+            canPostAsApp: () => false,
+            upsertIssueComment: async () => {
+              throw new Error("should not post in dry-run-only mode");
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T01:06:00.000Z"
+        });
+
+        expect(first.summary).toMatchObject({ dryRunRecorded: 1, alreadyProcessed: 0, posted: 0, failed: 0 });
+        expect(second.summary).toMatchObject({ dryRunRecorded: 0, alreadyProcessed: 1, posted: 0, failed: 0 });
+        expect(state.getIssueEnrichmentRecord("owner/issue-repo", 31)).toMatchObject({
+          status: "dry_run",
+          issueUpdatedAt: "2026-07-03T01:00:00.000Z",
+          reason: "dry_run_only"
+        });
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("posts sticky issue enrichment when live comments are explicitly enabled and skips unchanged reruns", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-post-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: true,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 5,
+          maxCommentsPerCycle: 2,
+          processExistingOpenIssuesOnActivation: true
+        }
+      })}\n`);
+      const state = new ReviewStateStore(statePath);
+      const posts: Array<{ issueNumber: number; marker: string; body: string }> = [];
+      try {
+        const issue: GitHubRelatedIssueOrPull = {
+          number: 41,
+          title: "Route issue enrichment #10",
+          state: "open",
+          updated_at: "2026-07-03T02:00:00.000Z",
+          html_url: "https://github.test/owner/issue-repo/issues/41",
+          body: "Acceptance criteria and owner present."
+        };
+        const github = {
+          listIssuesForEnrichment: async () => [issue],
+          canPostAsApp: () => true,
+          upsertIssueComment: async (input: { issueNumber: number; marker: string; body: string }) => {
+            posts.push(input);
+            return { action: "created" as const, id: 4100, html_url: `https://github.test/comment/${posts.length}` };
+          }
+        };
+
+        const first = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github,
+          dryRun: false,
+          checkedAt: "2026-07-03T02:05:00.000Z"
+        });
+        const second = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github,
+          dryRun: false,
+          checkedAt: "2026-07-03T02:06:00.000Z"
+        });
+
+        expect(first.summary).toMatchObject({ posted: 1, alreadyProcessed: 0, failed: 0 });
+        expect(second.summary).toMatchObject({ posted: 0, alreadyProcessed: 1, failed: 0 });
+        expect(posts).toHaveLength(1);
+        expect(posts[0]!.marker).toContain("issue=41");
+        expect(posts[0]!.body).toContain("## evaOS issue enrichment");
+        expect(state.getIssueEnrichmentRecord("owner/issue-repo", 41)).toMatchObject({
+          status: "posted",
+          issueUpdatedAt: "2026-07-03T02:00:00.000Z",
+          commentUrl: "https://github.test/comment/1"
+        });
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed without scanning or posting when live issue comments lack App credentials", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-missing-app-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: true,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 5,
+          maxCommentsPerCycle: 2,
+          processExistingOpenIssuesOnActivation: true
+        }
+      })}\n`);
+      const state = new ReviewStateStore(statePath);
+      try {
+        const result = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            listIssuesForEnrichment: async () => {
+              throw new Error("should not scan when live issue comments are blocked");
+            },
+            canPostAsApp: () => false,
+            upsertIssueComment: async () => {
+              throw new Error("should not post without App credentials");
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T02:10:00.000Z"
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.status.state).toBe("blocked");
+        expect(result.status.blockers).toContain("github_app_credentials_required_for_live_issue_comments");
+        expect(result.summary).toMatchObject({
+          reposScanned: 0,
+          issuesSeen: 0,
+          posted: 0,
+          failed: 0
+        });
+        expect(result.items).toEqual([]);
+        expect(state.listIssueEnrichmentRecords()).toEqual([]);
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("records redacted issue-enrichment posting failures without leaking provider tokens", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-post-fail-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: true,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 5,
+          maxCommentsPerCycle: 2,
+          processExistingOpenIssuesOnActivation: true
+        }
+      })}\n`);
+      const state = new ReviewStateStore(statePath);
+      try {
+        const issue: GitHubRelatedIssueOrPull = {
+          number: 61,
+          title: "Handle post failure",
+          state: "open",
+          updated_at: "2026-07-03T02:20:00.000Z",
+          body: "Acceptance criteria and owner present."
+        };
+        const result = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            listIssuesForEnrichment: async () => [issue],
+            canPostAsApp: () => true,
+            upsertIssueComment: async () => {
+              throw new Error("GitHub rejected comment with ghp_1234567890abcdefghijklmnopqrstuvwx");
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T02:25:00.000Z"
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.summary).toMatchObject({ posted: 0, failed: 1 });
+        expect(result.items[0]).toMatchObject({ recordStatus: "failed" });
+        expect(result.items[0]!.error).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+        const record = state.getIssueEnrichmentRecord("owner/issue-repo", 61);
+        expect(record).toMatchObject({
+          status: "failed",
+          reason: "post_failed"
+        });
+        expect(record?.error).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps disabled issue enrichment as a no-op with no state writes", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-disabled-"));
+    try {
+      const statePath = join(root, "state.sqlite");
+      const state = new ReviewStateStore(statePath);
+      try {
+        const result = await runIssueEnrichmentCycle({
+          config: loadConfig(),
+          state,
+          github: {
+            listIssuesForEnrichment: async () => {
+              throw new Error("disabled issue enrichment should not scan");
+            },
+            canPostAsApp: () => false,
+            upsertIssueComment: async () => {
+              throw new Error("disabled issue enrichment should not post");
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T03:00:00.000Z"
+        });
+
+        expect(result.summary).toMatchObject({
+          reposScanned: 0,
+          issuesSeen: 0,
+          posted: 0,
+          dryRunRecorded: 0,
+          failed: 0
+        });
+        expect(state.listIssueEnrichmentRecords()).toEqual([]);
+      } finally {
+        state.close();
+      }
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -9,6 +9,7 @@ import {
   buildRuntimeInventory,
   buildOperatorQueue,
   buildOperatorStatus,
+  collectOperatorIssueEnrichmentRuntime,
   collectOperatorLeases,
   collectOperatorRepoProviderCooldowns,
   collectOperatorReviewReadiness,
@@ -172,6 +173,188 @@ describe("operator CLI summaries", () => {
       ok: false,
       detail: "blocked: github_app_credentials_required_for_live_issue_comments"
     });
+  });
+
+  it("reports issue enrichment runtime records separately from PR queue health", () => {
+    const statePath = createTempDatabase(tempDirs);
+    const db = new DatabaseSync(statePath);
+    try {
+      db.exec(`
+        create table issue_enrichment_records (
+          repo text not null,
+          issue_number integer not null,
+          issue_updated_at text,
+          status text not null,
+          reason text,
+          comment_url text,
+          error text,
+          next_eligible_at text,
+          created_at text not null,
+          updated_at text not null,
+          primary key (repo, issue_number)
+        )
+      `);
+      db
+        .prepare(
+          `insert into issue_enrichment_records
+            (repo, issue_number, issue_updated_at, status, reason, next_eligible_at, created_at, updated_at)
+           values (?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          "owner/issue-repo",
+          51,
+          "2026-07-03T04:00:00.000Z",
+          "deferred",
+          "repo_max_comments_per_cycle",
+          "2026-07-03T05:00:00.000Z",
+          "2026-07-03T04:05:00.000Z",
+          "2026-07-03T04:05:00.000Z"
+        );
+      db
+        .prepare(
+          `insert into issue_enrichment_records
+            (repo, issue_number, issue_updated_at, status, error, created_at, updated_at)
+           values (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          "owner/issue-repo",
+          52,
+          "2026-07-03T04:10:00.000Z",
+          "failed",
+          "comment failed with [REDACTED_TOKEN]",
+          "2026-07-03T04:11:00.000Z",
+          "2026-07-03T04:11:00.000Z"
+        );
+    } finally {
+      db.close();
+    }
+
+    const issueEnrichmentRuntime = collectOperatorIssueEnrichmentRuntime(statePath, {
+      now: new Date("2026-07-03T04:30:00.000Z")
+    });
+    const status = buildOperatorStatus({
+      release: releaseStatus({ ok: true }),
+      coverage: coverageReport({ ok: true }),
+      agents: agentInventory({ ok: true }),
+      providerCooldowns: [],
+      durableQueue: durableQueueSnapshot({ ok: true, summary: cleanDurableQueueSummary() }),
+      issueEnrichment: issueEnrichmentStatus({ state: "dry_run_only", ok: true }),
+      issueEnrichmentRuntime,
+      checkedAt: "2026-07-03T04:30:00.000Z"
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.summary).toMatchObject({
+      issueEnrichmentState: "dry_run_only",
+      issueEnrichmentRuntimeState: "error"
+    });
+    expect(status.issueEnrichmentRuntime?.summary).toMatchObject({
+      total: 2,
+      deferred: 1,
+      failed: 1,
+      retryableDeferred: 0
+    });
+    expect(status.gates).toContainEqual({
+      name: "issue_enrichment_runtime_no_failed_records",
+      ok: false,
+      detail: "1 failed issue-enrichment record(s)"
+    });
+    expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+  });
+
+  it("reports default-off issue enrichment runtime as disabled when there are no issue records", () => {
+    const statePath = createTempDatabase(tempDirs);
+    const issueEnrichmentRuntime = collectOperatorIssueEnrichmentRuntime(statePath, {
+      now: new Date("2026-07-03T04:30:00.000Z")
+    });
+    const status = buildOperatorStatus({
+      release: releaseStatus({ ok: true }),
+      coverage: coverageReport({ ok: true }),
+      agents: agentInventory({ ok: true }),
+      providerCooldowns: [],
+      durableQueue: durableQueueSnapshot({ ok: true, summary: cleanDurableQueueSummary() }),
+      issueEnrichment: issueEnrichmentStatus({
+        state: "disabled",
+        enabled: false,
+        ok: true
+      }),
+      issueEnrichmentRuntime,
+      checkedAt: "2026-07-03T04:30:00.000Z"
+    });
+
+    expect(status.summary).toMatchObject({
+      issueEnrichmentState: "disabled",
+      issueEnrichmentRuntimeState: "disabled"
+    });
+    expect(status.issueEnrichmentRuntime?.summary.total).toBe(0);
+  });
+
+  it("keeps issue enrichment runtime health totals independent of displayed record limits", () => {
+    const statePath = createTempDatabase(tempDirs);
+    const db = new DatabaseSync(statePath);
+    try {
+      db.exec(`
+        create table issue_enrichment_records (
+          repo text not null,
+          issue_number integer not null,
+          issue_updated_at text,
+          status text not null,
+          reason text,
+          comment_url text,
+          error text,
+          next_eligible_at text,
+          created_at text not null,
+          updated_at text not null,
+          primary key (repo, issue_number)
+        )
+      `);
+      db
+        .prepare(
+          `insert into issue_enrichment_records
+            (repo, issue_number, issue_updated_at, status, created_at, updated_at)
+           values (?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          "owner/issue-repo",
+          71,
+          "2026-07-03T05:00:00.000Z",
+          "posted",
+          "2026-07-03T05:10:00.000Z",
+          "2026-07-03T05:10:00.000Z"
+        );
+      db
+        .prepare(
+          `insert into issue_enrichment_records
+            (repo, issue_number, issue_updated_at, status, error, created_at, updated_at)
+           values (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          "owner/issue-repo",
+          72,
+          "2026-07-03T04:00:00.000Z",
+          "failed",
+          "older failure",
+          "2026-07-03T04:10:00.000Z",
+          "2026-07-03T04:10:00.000Z"
+        );
+    } finally {
+      db.close();
+    }
+
+    const issueEnrichmentRuntime = collectOperatorIssueEnrichmentRuntime(statePath, {
+      now: new Date("2026-07-03T05:30:00.000Z"),
+      limit: 1
+    });
+
+    expect(issueEnrichmentRuntime.records).toHaveLength(1);
+    expect(issueEnrichmentRuntime.records[0]).toMatchObject({ issueNumber: 71, status: "posted" });
+    expect(issueEnrichmentRuntime.summary).toMatchObject({
+      total: 2,
+      posted: 1,
+      failed: 1
+    });
+    expect(issueEnrichmentRuntime.ok).toBe(false);
+    expect(issueEnrichmentRuntime.state).toBe("error");
   });
 
   it("treats pending heads covered by durable queue work as healthy active runtime", () => {
@@ -1435,6 +1618,29 @@ function agentInventory(input: Partial<OperatorAgentInventory>): OperatorAgentIn
     },
     activeLeases: input.activeLeases ?? [],
     staleLeases: input.staleLeases ?? []
+  };
+}
+
+function issueEnrichmentStatus(input: Partial<IssueEnrichmentStatus> = {}): IssueEnrichmentStatus {
+  return {
+    ok: input.ok ?? true,
+    checkedAt: input.checkedAt ?? "2026-07-03T04:30:00.000Z",
+    state: input.state ?? "dry_run_only",
+    enabled: input.enabled ?? true,
+    postIssueComment: input.postIssueComment ?? false,
+    separateAllowlist: true,
+    allowlist: input.allowlist ?? ["owner/issue-repo"],
+    throttleDefaults: input.throttleDefaults ?? {
+      maxIssuesPerCycle: 5,
+      maxCommentsPerCycle: 0,
+      cooldownMs: 3_600_000,
+      burstWindowMs: 3_600_000,
+      maxIssuesPerBurst: 10,
+      lookbackMs: 600_000,
+      processExistingOpenIssuesOnActivation: false
+    },
+    repoOverrides: input.repoOverrides ?? [],
+    blockers: input.blockers ?? []
   };
 }
 


### PR DESCRIPTION
## Summary

Closes #152. Adds the next safe #10 issue-enrichment slice:

- adds durable `issue_enrichment_records` state keyed by repo + issue number
- adds `runIssueEnrichmentCycle` for default-off issue enrichment scheduling
- gates daemon execution behind `issueEnrichment.enabled === true`
- fails closed before scanning/posting when live issue comments lack App credentials
- records dry-run/skipped/deferred/posted/failed outcomes without touching PR queue state
- exposes issue-enrichment runtime health separately from PR queue health in `status` and `runtime-inventory`

## Safety boundaries

- active defaults remain disabled, empty allowlist, `postIssueComment=false`
- PR monitoring allowlist remains separate from `issueEnrichment.allowlist`
- live issue comments require explicit issue-enrichment config plus App posting credentials
- no labels, reviewers, assignments, Notion/Linear writes, or target-repo mutations
- CLI `issue-enrichment-scan` remains dry-run only

## Validation

- `npm test -- tests/enrichment.test.ts tests/daemon-loop.test.ts tests/operator-cli.test.ts --pool=forks --maxWorkers=1`
  - 63 passed
- `npm run build`
- `npm test -- --pool=forks --maxWorkers=1`
  - 423 passed
- `git diff --check`
- spec review subagent: PASS after missing-App-credentials fail-closed fix
- code quality/safety review subagent: PASS; non-blocking limit/redaction suggestions addressed

## Release note

This PR should ship as the next beta after remote CI/review passes. Keep active live config with issue enrichment disabled unless a separate permission/config rollout is approved.
