### PR TITLE
Harden issue enrichment activation throttles

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -280,6 +280,14 @@ include `nextEligibleAt` based on the configured cooldown. Per-repo throttles li
 `issueEnrichment.repos.<owner/name>` and can cap `maxIssuesPerCycle`,
 `maxCommentsPerCycle`, burst thresholds, cooldown, and backlog behavior.
 
+When the daemon first sees a newly allowlisted issue-enrichment repo with
+`processExistingOpenIssuesOnActivation: false`, it records a per-repo activation
+watermark and does not scan existing open issues on that cycle. Later cycles use
+that watermark as the repo-specific `since` boundary and advance it only after a
+successful non-truncated scan with no deferred or failed issue-enrichment rows.
+Explicit dry-run/backfill commands can still opt into existing issues with
+`includeExisting` / `--include-existing` style controls.
+
 ## Safety Boundaries
 
 Default operator commands are read-only. They can return nonzero when a gate is

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -103,6 +103,8 @@ export interface IssueEnrichmentScanResult {
     wouldEnrich: number;
     wouldComment: number;
     deferred: number;
+    baselinedRepos: number;
+    truncatedRepos: number;
   };
   repos: IssueEnrichmentRepoScan[];
   items: IssueEnrichmentScanItem[];
@@ -142,6 +144,8 @@ export interface IssueEnrichmentRepoScan {
   wouldEnrich: number;
   wouldComment: number;
   deferred: number;
+  baselined?: boolean;
+  truncated?: boolean;
   readFailure?: string;
   skipReason?: "not_issue_enrichment_allowlisted" | "issue_enrichment_repo_disabled";
 }
@@ -223,9 +227,11 @@ export async function collectIssueEnrichmentScan(input: {
   config: { issueEnrichment?: IssueEnrichmentConfig };
   reader: IssueEnrichmentReader;
   dryRun: boolean;
+  repos?: string[];
   repo?: string;
   includeExisting?: boolean;
   since?: string;
+  sinceByRepo?: Record<string, string>;
   canPostAsApp?: boolean;
   checkedAt?: string;
 }): Promise<IssueEnrichmentScanResult> {
@@ -236,7 +242,7 @@ export async function collectIssueEnrichmentScan(input: {
     canPostAsApp: input.canPostAsApp ?? false,
     checkedAt
   });
-  const repos = input.repo ? [input.repo] : config.allowlist;
+  const repos = input.repo ? [input.repo] : input.repos ?? config.allowlist;
   const repoScans: IssueEnrichmentRepoScan[] = [];
   const items: IssueEnrichmentScanItem[] = [];
 
@@ -261,17 +267,19 @@ export async function collectIssueEnrichmentScan(input: {
       continue;
     }
 
-    const since = input.since ?? buildIssueScanSince({
+    const since = input.since ?? input.sinceByRepo?.[repo] ?? buildIssueScanSince({
       checkedAt,
       includeExisting: input.includeExisting === true || policy.throttle.processExistingOpenIssuesOnActivation,
       lookbackMs: policy.throttle.lookbackMs,
       burstWindowMs: policy.throttle.burstWindowMs
     });
+    const pageLimit = buildIssueScanPageLimit(policy.throttle);
+    const perPage = DEFAULT_REPO_SCAN_OPTIONS.perPage;
     let issues: GitHubRelatedIssueOrPull[] = [];
     try {
       issues = await input.reader.listIssuesForEnrichment(repo, {
         ...DEFAULT_REPO_SCAN_OPTIONS,
-        pageLimit: buildIssueScanPageLimit(policy.throttle),
+        pageLimit,
         ...(since ? { since } : {})
       });
     } catch (error) {
@@ -315,7 +323,8 @@ export async function collectIssueEnrichmentScan(input: {
       skipped: issueItems.filter((item) => item.action === "skipped").length,
       wouldEnrich: issueItems.filter((item) => item.action === "would_enrich" || item.action === "would_comment").length,
       wouldComment: issueItems.filter((item) => item.action === "would_comment").length,
-      deferred: issueItems.filter((item) => item.action === "deferred").length
+      deferred: issueItems.filter((item) => item.action === "deferred").length,
+      truncated: issues.length >= pageLimit * perPage
     });
   }
 
@@ -334,7 +343,13 @@ export async function collectIssueEnrichmentScan(input: {
 
 export async function runIssueEnrichmentCycle(input: {
   config: { issueEnrichment?: IssueEnrichmentConfig };
-  state: Pick<ReviewStateStore, "getIssueEnrichmentRecord" | "recordIssueEnrichment">;
+  state: Pick<
+    ReviewStateStore,
+    "getIssueEnrichmentRecord" |
+    "recordIssueEnrichment" |
+    "getIssueEnrichmentRepoWatermark" |
+    "recordIssueEnrichmentRepoWatermark"
+  >;
   github: IssueEnrichmentCycleGithub;
   dryRun: boolean;
   repo?: string;
@@ -375,23 +390,95 @@ export async function runIssueEnrichmentCycle(input: {
     };
   }
 
+  const baselineRepos: IssueEnrichmentRepoScan[] = [];
+  const reposToScan: string[] = [];
+  const sinceByRepo: Record<string, string> = {};
+  const candidateRepos = input.repo ? [input.repo] : config.allowlist;
+  const canUseActivationWatermark = input.includeExisting !== true && input.since === undefined;
+  for (const repo of candidateRepos) {
+    const policy = resolveIssueEnrichmentRepoPolicy(config, repo);
+    if (!policy.allowed) {
+      reposToScan.push(repo);
+      continue;
+    }
+    if (!canUseActivationWatermark) {
+      reposToScan.push(repo);
+      continue;
+    }
+    const existingWatermark = input.state.getIssueEnrichmentRepoWatermark(repo);
+    if (existingWatermark) {
+      sinceByRepo[repo] = existingWatermark.lastCheckedAt;
+      reposToScan.push(repo);
+      continue;
+    }
+    if (policy.throttle.processExistingOpenIssuesOnActivation) {
+      reposToScan.push(repo);
+      continue;
+    }
+    if (!input.dryRun) {
+      input.state.recordIssueEnrichmentRepoWatermark({
+        repo,
+        activatedAt: checkedAt,
+        lastCheckedAt: checkedAt,
+        now: new Date(checkedAt)
+      });
+    }
+    baselineRepos.push({
+      repo,
+      ok: true,
+      allowed: true,
+      enabled: config.enabled,
+      postIssueComment: config.postIssueComment,
+      since: checkedAt,
+      throttle: policy.throttle,
+      issuesSeen: 0,
+      eligible: 0,
+      skipped: 0,
+      wouldEnrich: 0,
+      wouldComment: 0,
+      deferred: 0,
+      baselined: true,
+      truncated: false
+    });
+  }
+
   const issuesByKey = new Map<string, GitHubRelatedIssueOrPull>();
-  const scan = await collectIssueEnrichmentScan({
-    config: input.config,
-    reader: {
-      listIssuesForEnrichment: async (repo, options) => {
-        const issues = await input.github.listIssuesForEnrichment(repo, options);
-        for (const issue of issues) issuesByKey.set(issueKey(repo, issue.number), issue);
-        return issues;
-      }
-    },
-    dryRun: input.dryRun,
-    repo: input.repo,
-    includeExisting: input.includeExisting,
-    since: input.since,
-    canPostAsApp: input.github.canPostAsApp(),
-    checkedAt
-  });
+  const scanned = reposToScan.length
+    ? await collectIssueEnrichmentScan({
+        config: input.config,
+        reader: {
+          listIssuesForEnrichment: async (repo, options) => {
+            const issues = await input.github.listIssuesForEnrichment(repo, options);
+            for (const issue of issues) issuesByKey.set(issueKey(repo, issue.number), issue);
+            return issues;
+          }
+        },
+        dryRun: input.dryRun,
+        repos: reposToScan,
+        includeExisting: input.includeExisting,
+        since: input.since,
+        sinceByRepo,
+        canPostAsApp: input.github.canPostAsApp(),
+        checkedAt
+      })
+    : {
+        ok: true,
+        checkedAt,
+        dryRun: input.dryRun,
+        status,
+        summary: summarizeScan([]),
+        repos: [],
+        items: [],
+        recommendedActions: buildScanRecommendedActions(status, summarizeScan([]))
+      };
+  const combinedRepos = [...baselineRepos, ...scanned.repos];
+  const combinedSummary = summarizeScan(combinedRepos);
+  const scan: IssueEnrichmentScanResult = {
+    ...scanned,
+    summary: combinedSummary,
+    repos: combinedRepos,
+    recommendedActions: buildScanRecommendedActions(status, combinedSummary)
+  };
   const summary = {
     ...scan.summary,
     posted: 0,
@@ -500,6 +587,21 @@ export async function runIssueEnrichmentCycle(input: {
       });
       summary.failed += 1;
       items.push({ ...item, recordStatus: "failed", error: message });
+    }
+  }
+
+  if (!input.dryRun) {
+    for (const repo of scanned.repos) {
+      if (!repo.allowed || !repo.ok || repo.baselined) continue;
+      const repoItems = items.filter((item) => item.repo === repo.repo);
+      if (repo.truncated || repoItems.some((item) => item.recordStatus === "deferred" || item.recordStatus === "failed")) continue;
+      const existingWatermark = input.state.getIssueEnrichmentRepoWatermark(repo.repo);
+      input.state.recordIssueEnrichmentRepoWatermark({
+        repo: repo.repo,
+        activatedAt: existingWatermark?.activatedAt ?? checkedAt,
+        lastCheckedAt: checkedAt,
+        now: new Date(checkedAt)
+      });
     }
   }
 
@@ -635,7 +737,7 @@ function nextEligibleAt(input: { checkedAt: string; throttle: IssueEnrichmentThr
 
 function summarizeScan(repoScans: IssueEnrichmentRepoScan[]): IssueEnrichmentScanResult["summary"] {
   return {
-    reposScanned: repoScans.filter((repo) => repo.allowed).length,
+    reposScanned: repoScans.filter((repo) => repo.allowed && repo.baselined !== true).length,
     reposSkipped: repoScans.filter((repo) => !repo.allowed).length,
     readFailures: repoScans.filter((repo) => !repo.ok).length,
     issuesSeen: sum(repoScans, "issuesSeen"),
@@ -643,7 +745,9 @@ function summarizeScan(repoScans: IssueEnrichmentRepoScan[]): IssueEnrichmentSca
     skipped: sum(repoScans, "skipped"),
     wouldEnrich: sum(repoScans, "wouldEnrich"),
     wouldComment: sum(repoScans, "wouldComment"),
-    deferred: sum(repoScans, "deferred")
+    deferred: sum(repoScans, "deferred"),
+    baselinedRepos: repoScans.filter((repo) => repo.baselined === true).length,
+    truncatedRepos: repoScans.filter((repo) => repo.truncated === true).length
   };
 }
 
@@ -651,6 +755,7 @@ function buildScanRecommendedActions(status: IssueEnrichmentStatus, summary: Iss
   const actions = [];
   if (status.state === "blocked") actions.push("resolve issue-enrichment blockers before live issue comments");
   if (summary.deferred > 0) actions.push("inspect deferred issue-enrichment rows and adjust per-repo throttles only after dry-run review");
+  if (summary.truncatedRepos > 0) actions.push("inspect truncated issue-enrichment scans before advancing repo watermarks");
   if (summary.readFailures > 0) actions.push("run doctor and inspect GitHub App Issues permissions");
   return actions;
 }
@@ -676,6 +781,8 @@ function emptyCycleSummary(): IssueEnrichmentCycleResult["summary"] {
     wouldEnrich: 0,
     wouldComment: 0,
     deferred: 0,
+    baselinedRepos: 0,
+    truncatedRepos: 0,
     posted: 0,
     dryRunRecorded: 0,
     skippedRecorded: 0,

--- a/src/state.ts
+++ b/src/state.ts
@@ -272,6 +272,14 @@ export interface IssueEnrichmentRecord {
   updatedAt: string;
 }
 
+export interface IssueEnrichmentRepoWatermark {
+  repo: string;
+  activatedAt: string;
+  lastCheckedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface RecordIssueEnrichmentInput {
   repo: string;
   issueNumber: number;
@@ -281,6 +289,13 @@ export interface RecordIssueEnrichmentInput {
   commentUrl?: string;
   error?: string;
   nextEligibleAt?: string;
+  now?: Date;
+}
+
+export interface RecordIssueEnrichmentRepoWatermarkInput {
+  repo: string;
+  activatedAt: string;
+  lastCheckedAt: string;
   now?: Date;
 }
 
@@ -496,6 +511,14 @@ export class ReviewStateStore {
         on issue_enrichment_records (status, updated_at);
       create index if not exists idx_issue_enrichment_records_repo_status
         on issue_enrichment_records (repo, status);
+
+      create table if not exists issue_enrichment_repo_watermarks (
+        repo text primary key,
+        activated_at text not null,
+        last_checked_at text not null,
+        created_at text not null,
+        updated_at text not null
+      );
     `);
     this.ensureDaemonHeartbeatColumns();
     this.ensureReviewRunLeaseColumns();
@@ -786,6 +809,42 @@ export class ReviewStateStore {
       )
       .all(...params) as unknown as IssueEnrichmentRecordRow[];
     return rows.map(mapIssueEnrichmentRecordRow);
+  }
+
+  recordIssueEnrichmentRepoWatermark(input: RecordIssueEnrichmentRepoWatermarkInput): IssueEnrichmentRepoWatermark {
+    validateIssueEnrichmentRepoWatermarkInput(input);
+    const existing = this.getIssueEnrichmentRepoWatermark(input.repo);
+    const nowIso = (input.now ?? new Date()).toISOString();
+    this.db
+      .prepare(
+        `insert into issue_enrichment_repo_watermarks
+          (repo, activated_at, last_checked_at, created_at, updated_at)
+         values (?, ?, ?, ?, ?)
+         on conflict(repo) do update set
+           last_checked_at = excluded.last_checked_at,
+           updated_at = excluded.updated_at`
+      )
+      .run(
+        input.repo,
+        existing?.activatedAt ?? input.activatedAt,
+        input.lastCheckedAt,
+        existing?.createdAt ?? nowIso,
+        nowIso
+      );
+    return this.getIssueEnrichmentRepoWatermark(input.repo)!;
+  }
+
+  getIssueEnrichmentRepoWatermark(repo: string): IssueEnrichmentRepoWatermark | undefined {
+    validateRepoName(repo, "repo");
+    const row = this.db
+      .prepare(
+        `select repo, activated_at, last_checked_at, created_at, updated_at
+         from issue_enrichment_repo_watermarks
+         where repo = ?
+         limit 1`
+      )
+      .get(repo) as IssueEnrichmentRepoWatermarkRow | undefined;
+    return row ? mapIssueEnrichmentRepoWatermarkRow(row) : undefined;
   }
 
   retireFailedReview(input: RetireFailedReviewInput): StoredProcessedReviewRecord {
@@ -2026,6 +2085,19 @@ function validateIssueEnrichmentInput(input: RecordIssueEnrichmentInput): void {
   }
 }
 
+function validateIssueEnrichmentRepoWatermarkInput(input: RecordIssueEnrichmentRepoWatermarkInput): void {
+  validateRepoName(input.repo, "repo");
+  if (!isCanonicalIsoTimestamp(input.activatedAt)) {
+    throw new Error("activatedAt must be a canonical ISO timestamp");
+  }
+  if (!isCanonicalIsoTimestamp(input.lastCheckedAt)) {
+    throw new Error("lastCheckedAt must be a canonical ISO timestamp");
+  }
+  if (input.now !== undefined && !Number.isFinite(input.now.getTime())) {
+    throw new Error("now must be a valid Date");
+  }
+}
+
 function validateIssueEnrichmentStatus(status: IssueEnrichmentRecordStatus): void {
   if (!["dry_run", "posted", "skipped", "deferred", "failed"].includes(status)) {
     throw new Error("status must be a valid issue enrichment status");
@@ -2319,6 +2391,14 @@ interface IssueEnrichmentRecordRow {
   updated_at: string;
 }
 
+interface IssueEnrichmentRepoWatermarkRow {
+  repo: string;
+  activated_at: string;
+  last_checked_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
 function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRecord {
   return {
     repo: row.repo,
@@ -2358,6 +2438,16 @@ function mapIssueEnrichmentRecordRow(row: IssueEnrichmentRecordRow): IssueEnrich
     ...(row.comment_url ? { commentUrl: row.comment_url } : {}),
     ...(row.error ? { error: row.error } : {}),
     ...(row.next_eligible_at ? { nextEligibleAt: row.next_eligible_at } : {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function mapIssueEnrichmentRepoWatermarkRow(row: IssueEnrichmentRepoWatermarkRow): IssueEnrichmentRepoWatermark {
+  return {
+    repo: row.repo,
+    activatedAt: row.activated_at,
+    lastCheckedAt: row.last_checked_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at
   };

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -364,6 +364,8 @@ function successfulIssueEnrichmentCycleResult(): IssueEnrichmentCycleResult {
       wouldEnrich: 1,
       wouldComment: 0,
       deferred: 0,
+      baselinedRepos: 0,
+      truncatedRepos: 0,
       posted: 0,
       dryRunRecorded: 1,
       skippedRecorded: 0,

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -696,6 +696,155 @@ describe("sticky enrichment comments", () => {
     }
   });
 
+  it("omits issue scan since only for explicit backfill modes", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-backfill-"));
+    try {
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: false,
+          allowlist: ["owner/default-repo", "owner/backfill-repo"],
+          maxIssuesPerCycle: 5,
+          maxCommentsPerCycle: 0,
+          lookbackMs: 600_000,
+          burstWindowMs: 3_600_000,
+          processExistingOpenIssuesOnActivation: false,
+          repos: {
+            "owner/backfill-repo": {
+              processExistingOpenIssuesOnActivation: true
+            }
+          }
+        }
+      })}\n`);
+      const calls: Array<{ repo: string; since?: string }> = [];
+
+      const normal = await collectIssueEnrichmentScan({
+        config: loadConfig(configPath),
+        dryRun: true,
+        repo: "owner/default-repo",
+        checkedAt: "2026-07-03T12:00:00.000Z",
+        reader: {
+          listIssuesForEnrichment: async (repo, options) => {
+            calls.push({ repo, since: options?.since });
+            return [];
+          }
+        }
+      });
+      const explicitBackfill = await collectIssueEnrichmentScan({
+        config: loadConfig(configPath),
+        dryRun: true,
+        repo: "owner/default-repo",
+        includeExisting: true,
+        checkedAt: "2026-07-03T12:00:00.000Z",
+        reader: {
+          listIssuesForEnrichment: async (repo, options) => {
+            calls.push({ repo, since: options?.since });
+            return [];
+          }
+        }
+      });
+      const overrideBackfill = await collectIssueEnrichmentScan({
+        config: loadConfig(configPath),
+        dryRun: true,
+        repo: "owner/backfill-repo",
+        checkedAt: "2026-07-03T12:00:00.000Z",
+        reader: {
+          listIssuesForEnrichment: async (repo, options) => {
+            calls.push({ repo, since: options?.since });
+            return [];
+          }
+        }
+      });
+
+      expect(normal.ok).toBe(true);
+      expect(explicitBackfill.ok).toBe(true);
+      expect(overrideBackfill.ok).toBe(true);
+      expect(calls).toEqual([
+        { repo: "owner/default-repo", since: "2026-07-03T11:00:00.000Z" },
+        { repo: "owner/default-repo", since: undefined },
+        { repo: "owner/backfill-repo", since: undefined }
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("applies per-repo issue-enrichment throttles to defer bursts and comments", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-repo-throttle-"));
+    try {
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: true,
+          allowlist: ["owner/comment-capped-repo", "owner/burst-capped-repo"],
+          maxIssuesPerCycle: 10,
+          maxCommentsPerCycle: 10,
+          maxIssuesPerBurst: 10,
+          cooldownMs: 3_600_000,
+          repos: {
+            "owner/comment-capped-repo": {
+              maxIssuesPerCycle: 2,
+              maxCommentsPerCycle: 1,
+              cooldownMs: 120_000
+            },
+            "owner/burst-capped-repo": {
+              maxIssuesPerBurst: 1,
+              cooldownMs: 300_000
+            }
+          }
+        }
+      })}\n`);
+
+      const scan = await collectIssueEnrichmentScan({
+        config: loadConfig(configPath),
+        dryRun: true,
+        includeExisting: true,
+        checkedAt: "2026-07-03T12:00:00.000Z",
+        reader: {
+          listIssuesForEnrichment: async (repo) => [
+            { number: repo.endsWith("comment-capped-repo") ? 101 : 201, title: "Issue one", state: "open", body: "Acceptance criteria and owner present." },
+            { number: repo.endsWith("comment-capped-repo") ? 102 : 202, title: "Issue two", state: "open", body: "Acceptance criteria and owner present." }
+          ]
+        }
+      });
+
+      expect(scan.ok).toBe(true);
+      expect(scan.repos.find((repo) => repo.repo === "owner/comment-capped-repo")?.throttle).toMatchObject({
+        maxIssuesPerCycle: 2,
+        maxCommentsPerCycle: 1,
+        cooldownMs: 120_000
+      });
+      expect(scan.items.find((item) => item.issueNumber === 101)).toMatchObject({ action: "would_comment", reason: "eligible" });
+      expect(scan.items.find((item) => item.issueNumber === 102)).toMatchObject({
+        action: "deferred",
+        reason: "repo_max_comments_per_cycle",
+        nextEligibleAt: "2026-07-03T12:02:00.000Z"
+      });
+      expect(scan.repos.find((repo) => repo.repo === "owner/burst-capped-repo")?.throttle).toMatchObject({
+        maxIssuesPerBurst: 1,
+        cooldownMs: 300_000
+      });
+      expect(scan.items.filter((item) => item.repo === "owner/burst-capped-repo")).toEqual([
+        expect.objectContaining({
+          issueNumber: 201,
+          action: "deferred",
+          reason: "burst_threshold_exceeded",
+          nextEligibleAt: "2026-07-03T12:05:00.000Z"
+        }),
+        expect.objectContaining({
+          issueNumber: 202,
+          action: "deferred",
+          reason: "burst_threshold_exceeded",
+          nextEligibleAt: "2026-07-03T12:05:00.000Z"
+        })
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("records dry-run-only issue enrichment once per unchanged issue update", async () => {
     const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-dry-run-"));
     try {
@@ -757,6 +906,342 @@ describe("sticky enrichment comments", () => {
           issueUpdatedAt: "2026-07-03T01:00:00.000Z",
           reason: "dry_run_only"
         });
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("baselines a newly allowlisted repo before scanning issue history", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-baseline-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: false,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 5,
+          maxCommentsPerCycle: 0,
+          processExistingOpenIssuesOnActivation: false
+        }
+      })}\n`);
+      const state = new ReviewStateStore(statePath);
+      const calls: Array<{ since?: string }> = [];
+      try {
+        const first = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            listIssuesForEnrichment: async () => {
+              throw new Error("newly allowlisted repo should baseline before scanning old issues");
+            },
+            canPostAsApp: () => false,
+            upsertIssueComment: async () => {
+              throw new Error("should not post in dry-run-only mode");
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T04:00:00.000Z"
+        });
+
+        const second = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            listIssuesForEnrichment: async (_repo, options) => {
+              calls.push({ since: options?.since });
+              return [
+                {
+                  number: 71,
+                  title: "New issue after activation",
+                  state: "open",
+                  updated_at: "2026-07-03T04:01:00.000Z",
+                  body: "Acceptance criteria and owner present."
+                }
+              ];
+            },
+            canPostAsApp: () => false,
+            upsertIssueComment: async () => {
+              throw new Error("should not post in dry-run-only mode");
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T04:02:00.000Z"
+        });
+
+        expect(first.summary).toMatchObject({
+          reposScanned: 0,
+          issuesSeen: 0,
+          baselinedRepos: 1,
+          dryRunRecorded: 0,
+          failed: 0
+        });
+        expect(first.repos[0]).toMatchObject({
+          repo: "owner/issue-repo",
+          allowed: true,
+          baselined: true,
+          since: "2026-07-03T04:00:00.000Z"
+        });
+        expect(calls).toEqual([{ since: "2026-07-03T04:00:00.000Z" }]);
+        expect(second.summary).toMatchObject({ reposScanned: 1, issuesSeen: 1, dryRunRecorded: 1, failed: 0 });
+        expect(state.getIssueEnrichmentRepoWatermark("owner/issue-repo")).toMatchObject({
+          activatedAt: "2026-07-03T04:00:00.000Z",
+          lastCheckedAt: "2026-07-03T04:02:00.000Z"
+        });
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses explicit existing-issue activation backfill only once after a clean scan", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-backfill-once-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: false,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 5,
+          maxCommentsPerCycle: 0,
+          processExistingOpenIssuesOnActivation: true
+        }
+      })}\n`);
+      const state = new ReviewStateStore(statePath);
+      const calls: Array<{ since?: string }> = [];
+      try {
+        const first = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            listIssuesForEnrichment: async (_repo, options) => {
+              calls.push({ since: options?.since });
+              return [
+                {
+                  number: 81,
+                  title: "Existing issue",
+                  state: "open",
+                  updated_at: "2026-07-03T03:00:00.000Z",
+                  body: "Acceptance criteria and owner present."
+                }
+              ];
+            },
+            canPostAsApp: () => false,
+            upsertIssueComment: async () => {
+              throw new Error("should not post in dry-run-only mode");
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T04:00:00.000Z"
+        });
+        const second = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            listIssuesForEnrichment: async (_repo, options) => {
+              calls.push({ since: options?.since });
+              return [];
+            },
+            canPostAsApp: () => false,
+            upsertIssueComment: async () => {
+              throw new Error("should not post in dry-run-only mode");
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T04:05:00.000Z"
+        });
+
+        expect(first.summary).toMatchObject({ reposScanned: 1, dryRunRecorded: 1, failed: 0 });
+        expect(second.summary).toMatchObject({ reposScanned: 1, issuesSeen: 0, failed: 0 });
+        expect(calls).toEqual([{ since: undefined }, { since: "2026-07-03T04:00:00.000Z" }]);
+        expect(state.getIssueEnrichmentRepoWatermark("owner/issue-repo")).toMatchObject({
+          activatedAt: "2026-07-03T04:00:00.000Z",
+          lastCheckedAt: "2026-07-03T04:05:00.000Z"
+        });
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not advance issue enrichment watermarks past deferred or failed issue work", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-hold-watermark-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: true,
+          allowlist: ["owner/deferred-repo", "owner/failed-repo"],
+          maxIssuesPerCycle: 5,
+          maxCommentsPerCycle: 0,
+          cooldownMs: 60_000,
+          repos: {
+            "owner/failed-repo": {
+              maxCommentsPerCycle: 1
+            }
+          }
+        }
+      })}\n`);
+      const state = new ReviewStateStore(statePath);
+      state.recordIssueEnrichmentRepoWatermark({
+        repo: "owner/deferred-repo",
+        activatedAt: "2026-07-03T04:00:00.000Z",
+        lastCheckedAt: "2026-07-03T04:00:00.000Z",
+        now: new Date("2026-07-03T04:00:00.000Z")
+      });
+      state.recordIssueEnrichmentRepoWatermark({
+        repo: "owner/failed-repo",
+        activatedAt: "2026-07-03T04:00:00.000Z",
+        lastCheckedAt: "2026-07-03T04:00:00.000Z",
+        now: new Date("2026-07-03T04:00:00.000Z")
+      });
+      try {
+        const result = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            listIssuesForEnrichment: async (repo) => [
+              {
+                number: repo.endsWith("deferred-repo") ? 91 : 92,
+                title: "Needs enrichment",
+                state: "open",
+                updated_at: "2026-07-03T04:01:00.000Z",
+                body: "Acceptance criteria and owner present."
+              }
+            ],
+            canPostAsApp: () => true,
+            upsertIssueComment: async () => {
+              throw new Error("GitHub post failed");
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T04:05:00.000Z"
+        });
+
+        expect(result.summary).toMatchObject({ deferredRecorded: 1, failed: 1 });
+        expect(state.getIssueEnrichmentRecord("owner/deferred-repo", 91)).toMatchObject({ status: "deferred" });
+        expect(state.getIssueEnrichmentRecord("owner/failed-repo", 92)).toMatchObject({ status: "failed" });
+        expect(state.getIssueEnrichmentRepoWatermark("owner/deferred-repo")).toMatchObject({
+          lastCheckedAt: "2026-07-03T04:00:00.000Z"
+        });
+        expect(state.getIssueEnrichmentRepoWatermark("owner/failed-repo")).toMatchObject({
+          lastCheckedAt: "2026-07-03T04:00:00.000Z"
+        });
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not advance issue enrichment watermarks after saturated page-limited scans", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-truncated-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: false,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 1,
+          maxIssuesPerBurst: 1,
+          processExistingOpenIssuesOnActivation: false
+        }
+      })}\n`);
+      const state = new ReviewStateStore(statePath);
+      state.recordIssueEnrichmentRepoWatermark({
+        repo: "owner/issue-repo",
+        activatedAt: "2026-07-03T04:00:00.000Z",
+        lastCheckedAt: "2026-07-03T04:00:00.000Z",
+        now: new Date("2026-07-03T04:00:00.000Z")
+      });
+      try {
+        const result = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            listIssuesForEnrichment: async () =>
+              Array.from({ length: 100 }, (_, index) => ({
+                number: 200 + index,
+                title: `Closed issue ${index}`,
+                state: "closed",
+                updated_at: "2026-07-03T04:01:00.000Z",
+                body: "Closed."
+              })),
+            canPostAsApp: () => false,
+            upsertIssueComment: async () => {
+              throw new Error("should not post in dry-run-only mode");
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T04:05:00.000Z"
+        });
+
+        expect(result.summary).toMatchObject({ reposScanned: 1, truncatedRepos: 1, skippedRecorded: 100 });
+        expect(result.repos[0]).toMatchObject({ truncated: true });
+        expect(state.getIssueEnrichmentRepoWatermark("owner/issue-repo")).toMatchObject({
+          lastCheckedAt: "2026-07-03T04:00:00.000Z"
+        });
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not mutate issue enrichment watermarks during dry-run cycles", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-baseline-dry-run-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: false,
+          allowlist: ["owner/issue-repo"],
+          processExistingOpenIssuesOnActivation: false
+        }
+      })}\n`);
+      const state = new ReviewStateStore(statePath);
+      try {
+        const result = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            listIssuesForEnrichment: async () => {
+              throw new Error("dry-run baseline should not scan old issues");
+            },
+            canPostAsApp: () => false,
+            upsertIssueComment: async () => {
+              throw new Error("dry-run baseline should not post");
+            }
+          },
+          dryRun: true,
+          checkedAt: "2026-07-03T04:30:00.000Z"
+        });
+
+        expect(result.summary).toMatchObject({ reposScanned: 0, issuesSeen: 0, baselinedRepos: 1 });
+        expect(state.getIssueEnrichmentRepoWatermark("owner/issue-repo")).toBeUndefined();
       } finally {
         state.close();
       }

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -44,6 +44,40 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("stores issue enrichment activation separately from PR review activation", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-issue-enrichment-watermark-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    expect(store.getIssueEnrichmentRepoWatermark("electricsheephq/WorldOS")).toBeUndefined();
+
+    const first = store.recordIssueEnrichmentRepoWatermark({
+      repo: "electricsheephq/WorldOS",
+      activatedAt: "2026-07-03T00:00:00.000Z",
+      lastCheckedAt: "2026-07-03T00:00:00.000Z",
+      now: new Date("2026-07-03T00:00:01.000Z")
+    });
+    const advanced = store.recordIssueEnrichmentRepoWatermark({
+      repo: "electricsheephq/WorldOS",
+      activatedAt: "2026-07-03T01:00:00.000Z",
+      lastCheckedAt: "2026-07-03T00:05:00.000Z",
+      now: new Date("2026-07-03T00:05:01.000Z")
+    });
+
+    expect(first).toMatchObject({
+      repo: "electricsheephq/WorldOS",
+      activatedAt: "2026-07-03T00:00:00.000Z",
+      lastCheckedAt: "2026-07-03T00:00:00.000Z"
+    });
+    expect(advanced).toMatchObject({
+      repo: "electricsheephq/WorldOS",
+      activatedAt: "2026-07-03T00:00:00.000Z",
+      lastCheckedAt: "2026-07-03T00:05:00.000Z"
+    });
+    expect(store.hasRepoActivation("electricsheephq/WorldOS")).toBe(false);
+    store.close();
+  });
+
   it("persists review readiness transitions without touching updatedAt on no-op repeats", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-readiness-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- Add durable per-repo issue-enrichment watermarks separate from PR activation state.
- Baseline newly allowlisted issue-enrichment repos before scanning historical open issues when `processExistingOpenIssuesOnActivation=false`.
- Make explicit activation backfill one-shot after a clean scan; subsequent cycles use the stored repo `since` watermark.
- Hold watermarks when scans are truncated or when deferred/failed issue-enrichment rows remain, so work is not stranded behind `since`.

## Safety Boundary
Issue enrichment remains default-off. This PR does not enable live issue comments, does not add any repo to the issue-enrichment allowlist, and does not touch the PR review allowlist.

## Validation
- `npm test -- tests/enrichment.test.ts tests/state.test.ts tests/daemon-loop.test.ts --pool=forks --maxWorkers=1` => 67 tests passed.
- `npm test -- --pool=forks --maxWorkers=1` => 38 files / 431 tests passed.
- `npm run build` => passed.
- `git diff --check` => clean.
- Spec reviewer re-check: PASS.
- Code quality/runtime safety reviewer re-check: PASS.

Closes #154
