### PR TITLE
Add eval promotion confidence gate

### DIFF
--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -138,7 +138,21 @@ Each packet includes:
 - `calibration-report.json`
 - `scorecard.json`
 
-`scorecard.json` is the gate artifact. Thresholds are explicit and fail closed. The calibration report is intentionally marked `uncalibrated`; do not present public 95% confidence claims from these packets until enough labeled findings exist for measured reliability bins.
+`scorecard.json` is the scenario gate artifact. Thresholds are explicit and fail
+closed. The calibration report is intentionally marked `uncalibrated`; do not
+present public 95% confidence claims from these packets until enough labeled
+findings exist for measured reliability bins. Calibration bins include empirical
+precision and Wilson lower bounds, but public display remains `uncalibrated`
+until the public-display policy is satisfied.
+
+`eval-suite` also writes two root artifacts under `--output-root`:
+
+- `suite-summary.json`
+- `promotion-decision.md`
+
+`promotion-decision.md` is the human-readable proof boundary for #8/#26/#85. It
+must say whether calibrated public confidence remains disabled, why, and what
+evidence is missing before any stronger confidence display can be considered.
 
 `manifest.json` records the effective thresholds, scenario mode, optional
 scenario source, artifact inventory with SHA-256 digests, metadata counts, and

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
 import { runDaemonCycle } from "./daemon.js";
 import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, parse as parsePath, resolve, sep } from "node:path";
-import { REQUIRED_SUITES, runOfflineEval } from "./eval-harness.js";
+import { assertEvalOutputDirSafe, buildEvalPromotionDecisionMarkdown, REQUIRED_SUITES, runOfflineEval } from "./eval-harness.js";
 import { buildEnrichmentComment, buildIssueEnrichmentDryRunOutput } from "./enrichment.js";
 import { GitHubApi } from "./github.js";
 import { buildGitNexusContextPacket } from "./gitnexus-context.js";
@@ -731,6 +731,7 @@ async function main(): Promise<void> {
   if (command === "eval-suite") {
     if (!args["input-dir"]) throw new Error("--input-dir is required for eval-suite");
     if (!args["output-root"]) throw new Error("--output-root is required for eval-suite");
+    const outputRoot = assertEvalOutputDirSafe(args["output-root"]);
     const scenarioFiles = listJsonFiles(args["input-dir"]);
     const seenRunIds = new Map<string, string>();
     const results = scenarioFiles.map((scenarioPath) => {
@@ -744,7 +745,7 @@ async function main(): Promise<void> {
         return {
           scenarioPath,
           ...runOfflineEval(input, {
-            outputDir: join(args["output-root"]!, runId)
+            outputDir: join(outputRoot, runId)
           })
         };
       } catch (error) {
@@ -764,6 +765,15 @@ async function main(): Promise<void> {
       missingSuites,
       results
     };
+    mkdirSync(outputRoot, { recursive: true });
+    writeFileSync(join(outputRoot, "suite-summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+    const scorecards = results.flatMap((result) => "scorecard" in result ? [result.scorecard] : []);
+    writeFileSync(join(outputRoot, "promotion-decision.md"), buildEvalPromotionDecisionMarkdown({
+      ok: summary.ok,
+      scenarioCount: summary.scenarioCount,
+      missingSuites,
+      scorecards
+    }));
     console.log(JSON.stringify(summary, null, 2));
     if (!summary.ok) process.exitCode = 1;
     return;

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -122,14 +122,59 @@ export interface EvalScorecard {
     inlinePreviews: number;
     ciMetadata: number;
     mergedFixes: number;
+    p0p1Labels: number;
   };
   metrics: {
     precision: number;
     recall: number;
     seededRecall: number;
+    maxWilsonLowerBound: number;
   };
   thresholds: EvalThresholds;
   gates: Array<{ name: string; ok: boolean; detail: string }>;
+}
+
+export interface EvalCalibrationReport {
+  claim: "uncalibrated" | "calibrated";
+  bins: Array<{
+    minConfidence: number;
+    maxConfidence: number;
+    findings: number;
+    matched: number;
+    empiricalPrecision: number;
+    wilsonLowerBound: number;
+    publicLabel: "uncalibrated" | "calibrated";
+  }>;
+  publicDisplayPolicy: EvalPublicDisplayPolicy;
+  promotion: {
+    eligible: boolean;
+    reason: EvalPromotionReason;
+  };
+  note: string;
+}
+
+export interface EvalPublicDisplayPolicy {
+  defaultLabel: "uncalibrated";
+  minWilsonLowerBound: number;
+  minLabeledFindings: number;
+  minP0P1Labels: number;
+  minNegativeControlScenarios: number;
+}
+
+export type EvalPromotionReason =
+  | "eligible"
+  | "insufficient_labeled_findings"
+  | "insufficient_p0_p1_labels"
+  | "insufficient_negative_controls"
+  | "wilson_lower_bound_below_threshold"
+  | "suite_failed"
+  | "missing_required_suites";
+
+export interface EvalSuitePromotionInput {
+  ok: boolean;
+  scenarioCount: number;
+  missingSuites: EvalSuiteName[];
+  scorecards: EvalScorecard[];
 }
 
 interface NormalizedEvalFinding extends Finding {
@@ -150,6 +195,14 @@ const DEFAULT_THRESHOLDS: EvalThresholds = {
   minSeededRecall: 1,
   maxSecretFindings: 0,
   maxDuplicateFindings: 0
+};
+
+export const PUBLIC_CONFIDENCE_POLICY: EvalPublicDisplayPolicy = {
+  defaultLabel: "uncalibrated",
+  minWilsonLowerBound: 0.95,
+  minLabeledFindings: 100,
+  minP0P1Labels: 30,
+  minNegativeControlScenarios: 10
 };
 
 export const REQUIRED_SUITES: EvalSuiteName[] = [
@@ -224,7 +277,7 @@ export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions
   writeJson(artifacts["duplicate-report.json"]!, duplicateReport);
   writeFileSync(artifacts["comparison.csv"]!, buildComparisonCsv(botFindings, labels, matches));
   writeJson(artifacts["labels.json"]!, labels);
-  writeJson(artifacts["calibration-report.json"]!, buildCalibrationReport(botFindings, matches));
+  writeJson(artifacts["calibration-report.json"]!, buildCalibrationReport(botFindings, labels, matches));
   writeJson(artifacts["scorecard.json"]!, scorecard);
   writeJson(artifacts["manifest.json"]!, {
     evalName,
@@ -283,6 +336,8 @@ function buildScorecard(input: {
   const precision = input.botFindings.length === 0 ? (input.labels.length === 0 ? 1 : 0) : truePositive / input.botFindings.length;
   const recall = input.labels.length === 0 ? 1 : truePositive / input.labels.length;
   const seededRecall = seededLabels.length === 0 ? 1 : matchedSeeded / seededLabels.length;
+  const p0p1Labels = input.labels.filter((label) => label.severity === "P0" || label.severity === "P1").length;
+  const maxWilsonLowerBound = maxRawWilsonLowerBound(input.botFindings, input.matches);
   const exactLineMatches = input.matches.filter((match) => match.kind === "exact_line").length;
   const nearbyLineMatches = input.matches.filter((match) => match.kind === "nearby_line").length;
   const semanticMatches = input.matches.filter((match) => match.kind === "semantic").length;
@@ -315,12 +370,14 @@ function buildScorecard(input: {
       duplicateFindings: input.duplicateCount,
       inlinePreviews: input.inlinePreviewCount,
       ciMetadata: input.ciMetadataCount,
-      mergedFixes: input.mergedFixCount
+      mergedFixes: input.mergedFixCount,
+      p0p1Labels
     },
     metrics: {
       precision: roundMetric(precision),
       recall: roundMetric(recall),
-      seededRecall: roundMetric(seededRecall)
+      seededRecall: roundMetric(seededRecall),
+      maxWilsonLowerBound
     },
     thresholds: input.thresholds,
     gates: [
@@ -586,32 +643,130 @@ function buildComparisonCsv(
   return `${rows.join("\n")}\n`;
 }
 
-function buildCalibrationReport(botFindings: NormalizedEvalFinding[], matches: EvalMatch[]): {
-  claim: "uncalibrated";
-  bins: Array<{ minConfidence: number; maxConfidence: number; findings: number; matched: number; empiricalPrecision: number }>;
-  note: string;
-} {
+function buildCalibrationReport(
+  botFindings: NormalizedEvalFinding[],
+  labels: NormalizedEvalFinding[],
+  matches: EvalMatch[]
+): EvalCalibrationReport {
+  const bins = confidenceBins(botFindings, matches);
+  const promotionReason = choosePromotionReason({
+    labeledFindings: labels.length,
+    p0p1Labels: labels.filter((label) => label.severity === "P0" || label.severity === "P1").length,
+    negativeControlScenarios: labels.length === 0 ? 1 : 0,
+    bestWilsonLowerBound: maxRawWilsonLowerBound(botFindings, matches)
+  });
+  return {
+    claim: "uncalibrated",
+    bins,
+    publicDisplayPolicy: PUBLIC_CONFIDENCE_POLICY,
+    promotion: {
+      eligible: promotionReason === "eligible",
+      reason: promotionReason
+    },
+    note: "Model confidence is treated as an input feature only until enough labeled findings exist for measured reliability bins. Public comments must show uncalibrated unless the promotion policy passes."
+  };
+}
+
+function confidenceBins(botFindings: NormalizedEvalFinding[], matches: EvalMatch[]): EvalCalibrationReport["bins"] {
   const matchedBotIds = new Set(matches.map((match) => match.botFindingId));
-  const bins = [
+  return [
     { minConfidence: 0, maxConfidence: 0.5 },
     { minConfidence: 0.5, maxConfidence: 0.8 },
     { minConfidence: 0.8, maxConfidence: 1.01 }
   ].map((bin) => {
     const findings = botFindings.filter((finding) => finding.confidence >= bin.minConfidence && finding.confidence < bin.maxConfidence);
     const matched = findings.filter((finding) => matchedBotIds.has(finding.id)).length;
+    const wilsonLowerBound = wilsonLowerBound95(matched, findings.length);
     return {
       minConfidence: bin.minConfidence,
       maxConfidence: bin.maxConfidence === 1.01 ? 1 : bin.maxConfidence,
       findings: findings.length,
       matched,
-      empiricalPrecision: roundMetric(findings.length === 0 ? 0 : matched / findings.length)
+      empiricalPrecision: roundMetric(findings.length === 0 ? 0 : matched / findings.length),
+      wilsonLowerBound: roundMetric(wilsonLowerBound),
+      publicLabel: "uncalibrated" as const
     };
   });
-  return {
-    claim: "uncalibrated",
-    bins,
-    note: "Model confidence is treated as an input feature only until enough labeled findings exist for calibrated public claims."
-  };
+}
+
+function maxRawWilsonLowerBound(botFindings: NormalizedEvalFinding[], matches: EvalMatch[]): number {
+  const matchedBotIds = new Set(matches.map((match) => match.botFindingId));
+  return Math.max(0, ...[
+    { minConfidence: 0, maxConfidence: 0.5 },
+    { minConfidence: 0.5, maxConfidence: 0.8 },
+    { minConfidence: 0.8, maxConfidence: 1.01 }
+  ].map((bin) => {
+    const findings = botFindings.filter((finding) => finding.confidence >= bin.minConfidence && finding.confidence < bin.maxConfidence);
+    const matched = findings.filter((finding) => matchedBotIds.has(finding.id)).length;
+    return wilsonLowerBound95(matched, findings.length);
+  }));
+}
+
+export function buildEvalPromotionDecisionMarkdown(input: EvalSuitePromotionInput): string {
+  const labeledFindings = input.scorecards.reduce((sum, scorecard) => sum + scorecard.counts.labels, 0);
+  const p0p1Labels = input.scorecards.reduce((sum, scorecard) => sum + scorecard.counts.p0p1Labels, 0);
+  const negativeControlScenarios = input.scorecards.filter((scorecard) => scorecard.counts.labels === 0).length;
+  const maxWilsonLowerBound = input.scorecards.reduce((max, scorecard) => Math.max(max, scorecard.metrics.maxWilsonLowerBound), 0);
+  const reason = !input.ok
+    ? input.missingSuites.length > 0
+      ? "missing_required_suites"
+      : "suite_failed"
+    : choosePromotionReason({
+      labeledFindings,
+      p0p1Labels,
+      negativeControlScenarios,
+      bestWilsonLowerBound: maxWilsonLowerBound
+    });
+  const eligible = reason === "eligible";
+  const decision = eligible ? "advisory promotion eligible" : "not enough evidence";
+
+  return [
+    "# Eval Promotion Decision",
+    "",
+    `Decision: ${decision}`,
+    `Calibrated public confidence: ${eligible ? "eligible for explicit review" : "disabled"}`,
+    "",
+    "## Evidence Counts",
+    "",
+    `- Scenario count: ${input.scenarioCount}`,
+    `- Required suites missing: ${input.missingSuites.length ? input.missingSuites.join(", ") : "none"}`,
+    `- Labeled findings: ${labeledFindings} / ${PUBLIC_CONFIDENCE_POLICY.minLabeledFindings}`,
+    `- P0/P1 labels: ${p0p1Labels} / ${PUBLIC_CONFIDENCE_POLICY.minP0P1Labels}`,
+    `- Negative-control scenarios: ${negativeControlScenarios} / ${PUBLIC_CONFIDENCE_POLICY.minNegativeControlScenarios}`,
+    `- Best Wilson lower bound: ${roundMetric(maxWilsonLowerBound)} / ${PUBLIC_CONFIDENCE_POLICY.minWilsonLowerBound}`,
+    "",
+    "## Reason",
+    "",
+    `- ${reason}`,
+    "",
+    "## Proof Boundary",
+    "",
+    "This packet is an offline eval artifact. It does not enable public calibrated percentages, change live review posting, or prove broad CodeRabbit parity.",
+    ""
+  ].join("\n");
+}
+
+function choosePromotionReason(input: {
+  labeledFindings: number;
+  p0p1Labels: number;
+  negativeControlScenarios: number;
+  bestWilsonLowerBound: number;
+}): EvalPromotionReason {
+  if (input.labeledFindings < PUBLIC_CONFIDENCE_POLICY.minLabeledFindings) return "insufficient_labeled_findings";
+  if (input.p0p1Labels < PUBLIC_CONFIDENCE_POLICY.minP0P1Labels) return "insufficient_p0_p1_labels";
+  if (input.negativeControlScenarios < PUBLIC_CONFIDENCE_POLICY.minNegativeControlScenarios) return "insufficient_negative_controls";
+  if (input.bestWilsonLowerBound < PUBLIC_CONFIDENCE_POLICY.minWilsonLowerBound) return "wilson_lower_bound_below_threshold";
+  return "eligible";
+}
+
+function wilsonLowerBound95(successes: number, total: number): number {
+  if (total <= 0) return 0;
+  const z = 1.96;
+  const p = successes / total;
+  const denominator = 1 + z ** 2 / total;
+  const centre = p + z ** 2 / (2 * total);
+  const margin = z * Math.sqrt((p * (1 - p) + z ** 2 / (4 * total)) / total);
+  return Math.max(0, (centre - margin) / denominator);
 }
 
 function buildInlinePreviews(
@@ -713,16 +868,21 @@ function sha256File(path: string): string {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
-function guardOutputDir(outputDir: string): void {
+export function assertEvalOutputDirSafe(outputDir: string): string {
   const resolvedOutput = resolve(outputDir);
   const gitRoot = findGitRoot(process.cwd());
-  if (!gitRoot) return;
+  if (!gitRoot) return resolvedOutput;
   const realOutput = resolveRealPathForPotentialOutput(resolvedOutput);
   const realGitRoot = realpathSync(gitRoot);
   const relation = relative(realGitRoot, realOutput);
   if (relation === "" || (!relation.startsWith("..") && !isAbsolute(relation))) {
     throw new Error("outputDir must not be inside the current git checkout; write eval packets under /Volumes/LEXAR/Codex/evals or a temp directory");
   }
+  return resolvedOutput;
+}
+
+function guardOutputDir(outputDir: string): void {
+  assertEvalOutputDirSafe(outputDir);
 }
 
 function resolveRealPathForPotentialOutput(path: string): string {

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -130,6 +130,30 @@ describe("offline eval harness", () => {
     const labels = JSON.parse(readFileSync(join(root, "labels.json"), "utf8"));
     expect(labels[1].evidence).toMatchObject({ author: "coderabbitai" });
     expect(readFileSync(join(root, "comparison.csv"), "utf8")).toContain("true_positive,exact_line");
+    const calibration = JSON.parse(readFileSync(join(root, "calibration-report.json"), "utf8"));
+    expect(calibration).toMatchObject({
+      claim: "uncalibrated",
+      publicDisplayPolicy: {
+        defaultLabel: "uncalibrated",
+        minWilsonLowerBound: 0.95,
+        minLabeledFindings: 100,
+        minP0P1Labels: 30,
+        minNegativeControlScenarios: 10
+      },
+      promotion: {
+        eligible: false,
+        reason: "insufficient_labeled_findings"
+      }
+    });
+    expect(calibration.bins[2]).toMatchObject({
+      minConfidence: 0.8,
+      maxConfidence: 1,
+      findings: 1,
+      matched: 1,
+      empiricalPrecision: 1,
+      publicLabel: "uncalibrated"
+    });
+    expect(calibration.bins[2].wilsonLowerBound).toBeLessThan(0.95);
   });
 
   it("fails closed on duplicate findings and secret-like raw output", () => {
@@ -661,6 +685,99 @@ describe("offline eval harness", () => {
 
     expect(result.ok).toBe(false);
     expect(result.scorecard.gates.find((gate) => gate.name === "suite_requirements")).toMatchObject({ ok: false });
+  });
+
+  it("keeps raw Wilson lower bounds for promotion gating instead of rounded display values", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-eval-harness-wilson-boundary-"));
+    roots.push(root);
+    const botFindings = Array.from({ length: 109 }, (_, index) => ({
+      severity: "P1" as const,
+      path: "src/calibration.ts",
+      line: (index + 1) * 10,
+      title: `Boundary finding ${index + 1}`,
+      body: `Boundary regression finding ${index + 1} should preserve raw Wilson math.`,
+      confidence: 0.9
+    }));
+    const labels = botFindings.slice(0, 108).map((finding, index) => ({
+      source: "human" as const,
+      severity: finding.severity,
+      path: finding.path,
+      line: finding.line,
+      title: finding.title,
+      body: finding.body,
+      sourceId: `label-${index + 1}`
+    }));
+
+    const result = runOfflineEval({
+      runId: "wilson-boundary",
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 8,
+      headSha: "boundary",
+      suite: "canary_shadow",
+      botFindings: { findings: botFindings },
+      labels,
+      thresholds: {
+        minPrecision: 0.8,
+        minRecall: 0.6
+      }
+    }, { outputDir: root });
+
+    expect(result.ok).toBe(true);
+    expect(result.scorecard.metrics.maxWilsonLowerBound).toBeLessThan(0.95);
+    expect(result.scorecard.metrics.maxWilsonLowerBound).toBeGreaterThan(0.949);
+    const calibration = JSON.parse(readFileSync(join(root, "calibration-report.json"), "utf8"));
+    expect(calibration.bins[2].wilsonLowerBound).toBe(0.95);
+  });
+
+  it("writes suite-level summary and promotion decision artifacts for eval-suite", () => {
+    const fixtureDir = join(process.cwd(), "tests/fixtures/eval-suite-scenarios");
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-eval-suite-success-output-"));
+    roots.push(outputRoot);
+
+    const output = execFileSync("npx", [
+      "tsx",
+      "src/cli.ts",
+      "eval-suite",
+      "--input-dir",
+      fixtureDir,
+      "--output-root",
+      outputRoot
+    ], { cwd: process.cwd(), encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+
+    const summary = JSON.parse(output);
+    expect(summary.ok).toBe(true);
+    expect(existsSync(join(outputRoot, "suite-summary.json"))).toBe(true);
+    expect(readFileSync(join(outputRoot, "suite-summary.json"), "utf8")).toContain("missingSuites");
+    const promotionDecision = readFileSync(join(outputRoot, "promotion-decision.md"), "utf8");
+    expect(promotionDecision).toContain("# Eval Promotion Decision");
+    expect(promotionDecision).toContain("Decision: not enough evidence");
+    expect(promotionDecision).toContain("Calibrated public confidence: disabled");
+  });
+
+  it("rejects eval-suite output roots inside the checkout before writing root artifacts", () => {
+    const fixtureDir = join(process.cwd(), "tests/fixtures/eval-suite-scenarios");
+    const outputRoot = join(process.cwd(), ".tmp-eval-suite-output-inside-checkout");
+    roots.push(outputRoot);
+    rmSync(outputRoot, { recursive: true, force: true });
+
+    let stderr = "";
+    try {
+      execFileSync("npx", [
+        "tsx",
+        "src/cli.ts",
+        "eval-suite",
+        "--input-dir",
+        fixtureDir,
+        "--output-root",
+        outputRoot
+      ], { cwd: process.cwd(), encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    } catch (error) {
+      stderr = String((error as { stderr?: string }).stderr ?? "");
+    }
+
+    expect(stderr).toContain("outputDir must not be inside the current git checkout");
+    expect(existsSync(join(outputRoot, "suite-summary.json"))).toBe(false);
+    expect(existsSync(join(outputRoot, "promotion-decision.md"))).toBe(false);
   });
 
   it("reports duplicate runIds as structured eval-suite failures", () => {


### PR DESCRIPTION
## Summary

Adds the first confidence-calibration promotion gate to the offline eval harness:

- adds Wilson lower bounds and public-display policy metadata to `calibration-report.json`
- keeps every public confidence result `uncalibrated` unless evidence thresholds pass
- writes `suite-summary.json` and `promotion-decision.md` at the `eval-suite` output root
- rejects `eval-suite --output-root` inside the active checkout before writing root artifacts
- documents the proof boundary for #8/#26/#85

This is measurement substrate only. It does not enable live calibrated confidence, sticky-vs-cold replay, live posting changes, provider calls, launchd changes, or CodeRabbit parity claims.

## Evidence

- Eval packet: `/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-03/issue-8-26-85-calibration/`
- Promotion decision: public confidence disabled; 5 labeled findings / 100, 2 P0/P1 labels / 30, 3 negative controls / 10, best Wilson lower bound 0.438 / 0.95.

## Validation

- `npm test -- tests/eval-harness.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `npm test -- --pool=forks --maxWorkers=1`
- `git diff --check`
- `npm run eval:suite -- --input-dir tests/fixtures/eval-suite-scenarios --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-03/issue-8-26-85-calibration`

## Follow-ups

- Continue #85 with sticky-vs-cold paired scorecards.
- Continue #26 with larger CodeRabbit/human/CI/merged-fix replay collection.
- Continue #8 with public display integration only after evidence thresholds pass.
