### PR TITLE
Docs: add NeonDiff public community funnel

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,34 @@
+name: Bug report
+description: Report a NeonDiff product bug, bad review, crash, or wrong output.
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened, and what did you expect?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: Package version, tag, or commit SHA.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Include commands, config shape, and repo/PR shape with public-safe or redacted evidence only.
+      placeholder: Do not paste tokens, private keys, private diffs, customer data, or credentials.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Public-safe evidence
+      description: Redacted logs, JSON fields, screenshots without private data, or evidence refs.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/electricsheephq/evaos-code-review-bot/security
+    about: Report vulnerabilities, secrets, credentials, or private repo data privately.
+  - name: NeonDiff roadmap
+    url: https://github.com/electricsheephq/evaos-code-review-bot/issues/103
+    about: Public product roadmap and proof boundaries.

--- a/.github/ISSUE_TEMPLATE/docs_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_bug_report.yml
@@ -1,0 +1,26 @@
+name: Docs bug report
+description: Report missing, stale, or contradictory NeonDiff documentation.
+title: "[docs]: "
+labels: ["docs"]
+body:
+  - type: input
+    id: path
+    attributes:
+      label: Affected doc path or URL
+      placeholder: README.md, docs/SETUP.md, https://www.neondiff.com/...
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is confusing, stale, wrong, or unsafe?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected wording or behavior
+      description: Include public-safe examples only. Do not include tokens, credentials, or private repo data.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: Suggest a NeonDiff capability or product improvement.
+title: "[feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: user_story
+    attributes:
+      label: User story
+      description: Who needs this and what problem does it solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_behavior
+    attributes:
+      label: Proposed behavior
+      description: Describe the smallest useful behavior and any public-safe evidence.
+    validations:
+      required: true
+  - type: textarea
+    id: safety
+    attributes:
+      label: Safety boundary
+      description: What should this not do? Mention secrets, tokens, credentials, live posting, or repo mutation risks if relevant.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/license_setup_confusion.yml
+++ b/.github/ISSUE_TEMPLATE/license_setup_confusion.yml
@@ -1,0 +1,26 @@
+name: License or setup confusion
+description: Ask about public/private repo licensing, install, update entitlement, or setup docs.
+title: "[license/setup]: "
+labels: ["license", "docs"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What licensing, public/private repo, install, or update behavior is unclear?
+    validations:
+      required: true
+  - type: input
+    id: doc
+    attributes:
+      label: Current doc or page
+      placeholder: README.md, docs/SETUP.md, https://www.neondiff.com/...
+    validations:
+      required: true
+  - type: textarea
+    id: safe_context
+    attributes:
+      label: Public-safe context
+      description: Redact license keys, tokens, credentials, private repo names, and customer data.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/provider_request.yml
+++ b/.github/ISSUE_TEMPLATE/provider_request.yml
@@ -1,0 +1,26 @@
+name: Provider or adapter request
+description: Request a model/provider/runtime adapter.
+title: "[provider]: "
+labels: ["provider-registry", "enhancement"]
+body:
+  - type: input
+    id: provider
+    attributes:
+      label: Provider or runtime
+      placeholder: Ollama, OpenAI-compatible endpoint, Anthropic, Gemini...
+    validations:
+      required: true
+  - type: textarea
+    id: auth
+    attributes:
+      label: Auth and data boundary
+      description: Explain key handling, local/cloud behavior, and what code or diff data would leave the machine.
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Evidence available
+      description: Public-safe docs, API refs, redacted smoke output, or known failure modes. Do not paste tokens or credentials.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/unsafe_review_report.yml
+++ b/.github/ISSUE_TEMPLATE/unsafe_review_report.yml
@@ -1,0 +1,33 @@
+name: Unsafe review report
+description: Report unsafe review behavior, posting, redaction, stale-head, or permission issues.
+title: "[unsafe-review]: "
+labels: ["bug", "regression-hardening"]
+body:
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Unsafe behavior
+      description: What did NeonDiff do or nearly do?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Include repo/PR/head SHA only if public-safe or redacted. Say whether this was dry-run or live.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Redacted JSON/log/comment evidence only. Do not paste tokens, credentials, private diffs, or secrets.
+    validations:
+      required: true
+  - type: checkboxes
+    id: boundary
+    attributes:
+      label: Boundary check
+      options:
+        - label: I removed private keys, provider tokens, license keys, credentials, and private customer data.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+## What Problem This Solves
+
+Closes #<issue>
+
+## User Impact
+
+Describe the user, maintainer, or agent workflow this improves.
+
+## Implementation Notes
+
+- 
+
+## Validation
+
+- [ ] Failing test, smoke, or eval was added/updated first.
+- [ ] Focused validation:
+- [ ] `npm test`:
+- [ ] `npm run build`:
+- [ ] GitHub CI/review-bot follow-up:
+
+## Safety Boundary
+
+- [ ] No GitHub App permission expansion.
+- [ ] No live worker restart, launchd mutation, or beta promotion.
+- [ ] No package publish, GitHub Release, or repo visibility change.
+- [ ] No secrets, tokens, credentials, raw private diffs, or customer data in the PR.
+- [ ] Claims stay within the source-available beta boundary.
+
+## Evidence
+
+Link public-safe evidence only. Use summaries, counts, refs, hashes, command
+names, and redacted logs. Do not paste private keys, provider tokens, license
+keys, credentials, raw private diffs, or customer data.
+
+## Agent-Authored PR
+
+- [ ] This PR was authored or materially edited by an AI agent.
+- [ ] If checked, the agent updated the issue before handoff/pause and listed restricted actions not performed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# NeonDiff Agent Instructions
+
+## Repository Agent Quick Start
+
+If you are a coding agent working in this repository:
+
+1. Read README.md for the public product promise and proof boundary.
+2. Read CONTRIBUTING.md for issue routing, validation, evidence, and PR
+   expectations.
+3. Read docs/SETUP.md before changing install, GitHub App, provider, daemon, or
+   first-run behavior.
+4. Read SECURITY.md before touching vulnerability reporting, secrets, auth,
+   posting policy, or private-data handling.
+5. Create or reuse a GitHub issue before meaningful implementation work.
+6. Write or update a failing test, smoke, or eval scenario before the minimal
+   implementation.
+7. Do not commit GitHub App private keys, provider tokens, license keys,
+   customer data, private logs, local SQLite DBs, cookies, connector URLs, or
+   credentials.
+8. Do not restart launchd, promote a live beta, expand GitHub App permissions,
+   flip repo visibility, publish packages, or create GitHub Releases unless the
+   issue explicitly scopes that action.
+9. Update the issue before handoff, merge, pause, or external-review wait.
+
+## Source-Available Product Boundary
+
+- NeonDiff is source-available beta software.
+- Public open-source repos are free.
+- Private and commercial repos require a paid license.
+- License keys support paid/private usage and update entitlement.
+- Exact license text, public/private grants, and commercial terms are governed
+  by https://github.com/electricsheephq/evaos-code-review-bot/issues/104.
+
+Do not claim open-source/MIT status, public launch completion, GA readiness,
+CodeRabbit parity, enterprise readiness, or legal adequacy from this file.
+
+## Shared Owned-Repo Policy
+
+- GitHub issues and PRs are implementation truth.
+- The NeonDiff public product roadmap is #103.
+- Public CLI/package setup is #107.
+- Agent-first docs are #113.
+- Website changes live in `electricsheephq/neon-diff-agent`, not this repo.
+- Before merge, release, or readiness claims, query current-head review threads
+  and separate resolvable review threads from top-level bot comments and check
+  annotations.
+- P0-P2 current actionable review threads block merge/release unless fixed,
+  proven false-positive, or explicitly escalated.
+
+## Validation Rules
+
+- Prefer a focused failing test first, then the minimal implementation.
+- Run the narrowest relevant local test before broader validation.
+- Use `npm test` and `npm run build` before PR readiness unless CI is the
+  recorded validation path.
+- For review-behavior changes, include dry-run evidence and current-head proof.
+- Keep evidence public-safe: summaries, counts, refs, hashes, setup states, and
+  command names are fine; raw secrets, raw private diffs, private logs, keys,
+  tokens, and customer data are not.
+
+## Public Documentation Placement
+
+- Keep README.md as the public landing page: product value, install, setup,
+  first dry-run review, safety boundaries, and links.
+- Keep first-run detail in docs/SETUP.md.
+- Keep operator commands in docs/operator-cli.md.
+- Keep live beta promotion in docs/beta-release-runbook.md and
+  docs/release-governance.md.
+- Keep issue routing and contribution rules in CONTRIBUTING.md.
+- Keep agent-specific repository behavior in this AGENTS.md.
+
+Do not put long release ledgers, local-only raw command dumps, internal live
+paths without context, or active sprint churn into the README.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Code of Conduct
+
+NeonDiff should be useful to developers, maintainers, and agents without making
+the review loop more hostile.
+
+## Expected Behavior
+
+- Be respectful and specific.
+- Assume good intent, then verify with evidence.
+- Keep feedback focused on code, docs, safety, and product behavior.
+- Use public-safe examples.
+- Respect maintainer decisions about scope, licensing, release gates, and safety
+  boundaries.
+
+## Unacceptable Behavior
+
+- Harassment, threats, or personal attacks.
+- Posting secrets, private repo data, customer data, or credentials.
+- Pressuring maintainers to bypass safety gates, release gates, license
+  boundaries, or review-thread resolution.
+- Misrepresenting NeonDiff as open-source, GA, enterprise-ready, or accuracy
+  calibrated when the proof does not support that claim.
+
+## Enforcement
+
+Maintainers may edit, hide, or remove comments, issues, or PRs that violate
+this code. Serious or repeated violations may lead to blocked participation.
+
+Security-sensitive content should be moved to the private reporting path in
+SECURITY.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,139 @@
+# Contributing
+
+Thanks for helping make NeonDiff useful, safe, and honest. NeonDiff is a
+source-available beta for local-first AI pull-request review, so strong
+contributions are focused, test-backed, and careful about public claims.
+
+## Quick Links
+
+- [Setup guide](docs/SETUP.md)
+- [Repository agent instructions](AGENTS.md)
+- [Operator CLI](docs/operator-cli.md)
+- [GitHub App setup](docs/github-app-setup.md)
+- [Security policy](SECURITY.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Product roadmap](https://github.com/electricsheephq/evaos-code-review-bot/issues/103)
+
+## Issue Routing
+
+Use the GitHub issue forms and keep one problem per issue.
+
+| Situation | Use | Required evidence |
+| --- | --- | --- |
+| Product bug, bad review, crash, or wrong output | Bug report | Version/SHA, command, repo/PR shape, expected result, actual result, redacted logs |
+| Missing, stale, or contradictory docs | Docs bug report | Affected path, current wording, expected wording, setup impact |
+| New capability or product improvement | Feature request | User story, proposed behavior, alternatives, safety boundary |
+| Provider, model, or runtime adapter | Provider request | Provider/runtime, auth shape, data sent, failure modes, proof available |
+| License, public/private repo, or setup confusion | License/setup confusion | Question, current doc path, expected answer, no secrets |
+| Unsafe review behavior | Unsafe review report | Repo/PR/head SHA, whether dry-run happened, posted/suppressed behavior, redacted evidence |
+
+Security vulnerabilities should be reported privately through
+[SECURITY.md](SECURITY.md), not as public issues.
+
+## Before You Open A PR
+
+1. Create or reuse a GitHub issue and include `Closes #<issue>` or
+   `Related: #<issue>` in the PR.
+2. Read [docs/SETUP.md](docs/SETUP.md) before changing install, auth, provider,
+   daemon, or first-run behavior.
+3. Write or update a failing test, smoke, or eval scenario before implementing
+   non-trivial behavior.
+4. Keep the PR focused on one user-visible or maintainer-visible problem.
+5. Keep product claims inside the documented source-available beta boundary.
+
+Good First Contributions:
+
+- docs setup gaps and clearer troubleshooting
+- redacted fixture improvements
+- CLI help wording
+- issue template improvements
+- tests for secret redaction, stale-head behavior, setup status, and docs claims
+- small repo-profile or policy examples that do not expand live monitoring
+
+Avoid refactor-only PRs unless a maintainer linked the refactor to an active
+issue.
+
+## Development
+
+```bash
+npm install
+npm run build
+npm test
+```
+
+For fast iteration, run the focused test file that owns your change before the
+full suite. Prefer GitHub CI for heavyweight validation.
+
+Do not commit GitHub App private keys, provider API keys, license keys, tokens,
+cookies, raw customer data, raw private logs, raw SQLite DBs, screenshots with
+private data, connector URLs, or local launchd secrets.
+
+## Validation And Evidence
+
+Every meaningful PR should name the proof it ran:
+
+- failing test, smoke, or eval scenario used to define the change
+- focused validation command
+- `npm test` and `npm run build`, or why CI is the right place for heavier validation
+- dry-run review evidence when the change affects review behavior
+- evidence path such as `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/YYYY-MM-DD/issue-<number>/`
+
+Evidence should contain public-safe summaries, counts, refs, hashes, setup
+status, blocker codes, and command names. It must not contain secrets, raw PR
+diffs from private repos, raw customer logs, credentials, or private keys.
+
+## Agent-Authored Contributions
+
+Agent-authored PRs are welcome when the agent leaves a human-reviewable trail.
+If a coding agent authored or materially edited the PR:
+
+- say so in the PR body
+- keep the issue updated before handoff, merge, or pause
+- include the exact focused validation commands
+- summarize safety boundaries and restricted actions not performed
+- resolve or reply to bot review conversations after addressing them
+- do not claim live worker promotion, public launch, CodeRabbit parity, or
+  customer readiness unless the matching proof gates pass
+
+Agents should read [AGENTS.md](AGENTS.md) before editing this repository.
+
+## Pull Request Expectations
+
+- Preserve source-available beta wording unless #104 is updated with approved license text.
+- Preserve public open-source repos free and private/commercial repos paid.
+- Preserve dry-run before live posting.
+- Preserve current-head duplicate suppression and stale-head checks.
+- Preserve secret-looking finding suppression.
+- Add or update tests for review behavior, setup status, docs claims, release
+  gates, or scorecards when those surfaces change.
+- Do not add auto-merge, branch repair, approval reviews, hidden GitHub writes,
+  hosted model resale, or broader repo monitoring without a separate issue and
+  proof boundary.
+
+## Review Threads
+
+Review conversations are author-owned. If a bot or human leaves an actionable
+thread:
+
+- verify it against current code before changing anything
+- fix real issues with focused tests
+- explain false positives with concrete file/test evidence
+- reply with the terminal outcome
+- resolve the thread when the concern is handled
+
+Do not leave "fixed" bot threads for maintainers to clean up.
+
+## Safety Boundaries
+
+NeonDiff is local-first and source-available. Public contributions must not
+widen these claims without explicit evidence:
+
+- no open-source/MIT claim
+- no public launch claim while the repo remains private
+- no final legal/license adequacy until #104 closes
+- no enterprise/customer-ready security claim
+- no calibrated review-accuracy claim before labeled evals prove it
+- no live worker restart or launchd promotion from a docs PR
+- no GitHub App permission expansion without a tracked rollout
+
+When in doubt, file a design issue first.

--- a/README.md
+++ b/README.md
@@ -1,85 +1,162 @@
-# evaOS Code Review Bot - CODENAME "OpenRabbit"
+# NeonDiff
 
-Code review agents are getting expensive. This is an OpenSource replacement for CodeRabbit and Copilot. 
+**NeonDiff is a local-first AI PR reviewer for teams and agents that want the
+review loop without handing every diff to a hosted review SaaS.**
 
-## Safety Defaults
+Use it when you want a GitHub App to review pull requests from a local worker,
+with your GitHub installation, your provider keys, your repo policy, and
+public-safe evidence for every live posting decision.
 
-- Reviews only the allowlisted pilot repos in `config.example.json`.
-- Skips draft PRs by default.
-- Posts at most one review per `{repo, pr, head_sha}`.
-- Never submits `APPROVE`.
-- Uses `REQUEST_CHANGES` only for validated P0/P1 findings.
-- Drops findings that cannot be placed on current RIGHT-side diff lines.
-- Drops secret-looking findings instead of redacting and posting them.
-- Re-fetches PR state before command-triggered review, before planning comments, and before live posting; stale-head output is recorded and skipped.
-- Redacts secret-looking material from local evidence logs before writing them.
-- Verifies the ZCode worktree is clean, including untracked files, after every review run.
-- Caps ZCode prompt patch bytes and kills long ZCode runs with `zcode.timeoutMs`.
-- Installs a temporary per-worktree ZCode policy that allows read-only file tools, disables Bash/mutation/subagents, then restores/removes it before the clean check.
-- Sets `ZCODE_MODEL_RETRY_MAX_RETRIES=0` by default so provider rate limits fail fast instead of multiplying requests.
-- Resolves repo profiles before review; once profiles are configured, unknown or disabled repos skip closed before GitHub PR fetches.
-- Writes `filter-impact.json` evidence for profile path filters and always preserves common safety-critical root/workflow/config files unless explicitly excluded.
-- Schema-validates repo policy, allowlist, canary, pre-merge check, and finishing-touch config before runtime use.
-- Keeps maintainer PR-comment commands disabled by default; when enabled, only configured trusted authors can steer read-only reviews.
+Public open-source repos are free. Private and commercial repos require a paid
+NeonDiff license. NeonDiff is a source-available beta, not an open-source or
+GA release.
 
-## Commands
+[Website](https://www.neondiff.com) · [Setup](docs/SETUP.md) ·
+[Contributing](CONTRIBUTING.md) · [Agent Instructions](AGENTS.md) ·
+[Security](SECURITY.md) · [Code of Conduct](CODE_OF_CONDUCT.md) ·
+[Roadmap](https://github.com/electricsheephq/evaos-code-review-bot/issues/103) ·
+[License Boundary](https://github.com/electricsheephq/evaos-code-review-bot/issues/104)
+
+## Why It Matters
+
+AI-built software has made PR volume and review fatigue worse. NeonDiff is built
+for the opposite posture: run locally, read only the pull request it is asked to
+review, post only current-head comments, and keep provider/model cost under the
+user's control.
+
+The current implementation grew from the internal evaOS review bot. This repo is
+now the NeonDiff implementation surface; older internal naming is legacy
+operator history, not the public product name.
+
+## What It Does
+
+NeonDiff currently provides:
+
+- a GitHub App based pull-request reviewer
+- current-head duplicate suppression for `{repo, pr, head_sha}`
+- dry-run review output before live posting
+- inline finding placement only on current RIGHT-side diff lines
+- secret-looking finding suppression
+- stale-head checks before command-triggered review, planning, and posting
+- local evidence logs with secret redaction
+- repo profile and policy configuration
+- JSON-first operator commands for status, queue, dashboard, cooldowns, and why
+- offline eval packets for comparing seeded defects, CI, human review, and bot findings
+
+It intentionally does not approve PRs, merge branches, push repairs, expand
+GitHub permissions by profile alone, or claim calibrated review accuracy before
+evals prove it.
+
+## Install
+
+Requirements:
+
+- Node.js 26 or newer
+- npm
+- a GitHub App installed on the repos you want to review
+- a model/provider path configured locally, such as GLM/Z.ai, Ollama, or a
+  future OpenAI-compatible provider slot
+
+Source checkout install for the current beta:
 
 ```bash
-npm run doctor
-npm run eval:offline -- --input /path/to/scenario.json
-npm run release:status -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expected-head "$(git rev-parse HEAD)"
-npm run run-once -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-dry-run.json --dry-run true --repo electricsheephq/WorldOS --pr 1161
-npm run daemon -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-dry-run.json --dry-run true
+git clone https://github.com/electricsheephq/evaos-code-review-bot.git neondiff
+cd neondiff
+npm install
+npm run build
 ```
 
-Posting reviews requires a GitHub App installed on the pilot repos:
+The public CLI package and final binary name are tracked in
+[issue #107](https://github.com/electricsheephq/evaos-code-review-bot/issues/107).
+Until that closes, use the repo scripts shown in [docs/SETUP.md](docs/SETUP.md)
+and [docs/operator-cli.md](docs/operator-cli.md).
+
+## Set Up
+
+Follow [docs/SETUP.md](docs/SETUP.md) for the full first-run path. The short
+version is:
 
 ```bash
-export EVAOS_REVIEW_BOT_APP_ID=...
-export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH=/path/to/private-key.pem
-npm run run-once -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-live.json --dry-run false
+cp config.example.json config.local.json
+export EVAOS_REVIEW_BOT_APP_ID="<github-app-id>"
+export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
+npm run doctor -- --config config.local.json
 ```
 
-The worker derives transient ZCode CLI model environment from the existing ZCode app config at `/Volumes/LEXAR/zcode/.zcode/v2/config.json`; it does not copy the Z.ai API key into this repository.
+Do not store the GitHub App private key, provider API key, license key, tokens,
+or customer data in this repository. Keep local config, secrets, state DBs, and
+evidence outside git.
 
-## Live Beta Releases
+## First Dry-Run Review
 
-The live launchd worker is a local beta release surface, not just whatever
-`main` happens to contain. Before promoting a merged PR to the live worker,
-follow [docs/beta-release-runbook.md](docs/beta-release-runbook.md).
-Named release packets live under [docs/releases](docs/releases), starting with
-`v0.2.1-runtime-resilience`.
+Run a dry-run review before any live posting:
 
-Tag-driven release governance is defined in
-[docs/release-governance.md](docs/release-governance.md). Agents operating the
-release lane should use
-[docs/skills/release-operator.md](docs/skills/release-operator.md). A live beta
-promotion is not green unless it has an immutable Git tag, a GitHub prerelease,
-runtime status proof, and rollback instructions.
+```bash
+npm run run-once -- \
+  --config config.local.json \
+  --repo owner/name \
+  --pr 123 \
+  --dry-run true \
+  --zcode false
+```
 
-## Repo Profiles
+Inspect the JSON result and evidence path. Only switch to `--dry-run false`
+after setup checks, focused tests, and the relevant GitHub issue record the
+exact repo, PR, head SHA, config path, and public-safe evidence.
 
-Use [docs/repo-profiles.md](docs/repo-profiles.md) to add repo-specific review
-guidance, risky paths, proof expectations, and path filters. Profiles are
-prompt/config metadata only; they do not expand GitHub permissions, live
-monitoring, ZCode tools, approvals, or repair behavior by themselves.
+## Agent And Maintainer Workflow
 
-`config.active-profiles.example.json` is the tracked template for the current
-19-repo active monitor profile set. Validate it, dry-run it, and promote through
-the beta release runbook before copying any profile block into live config.
+If you are contributing as an AI coding agent:
 
-## Maintainer Commands
+1. Read [AGENTS.md](AGENTS.md).
+2. Reuse or create a GitHub issue before meaningful work.
+3. Write a failing test, smoke, or docs/eval gate before implementation.
+4. Keep the PR linked to the issue with `Closes #<issue>` or `Related: #<issue>`.
+5. Record validation and evidence without raw secrets, raw customer data, or
+   private logs.
 
-Use [docs/maintainer-commands.md](docs/maintainer-commands.md) for the dormant
-trusted command surface. Commands are PR comments such as
-`@evaos-code-review-bot review`, `re-review`, `explain`, and `stop`; they stay
-behind `commands.enabled` and cannot repair, merge, approve, push branches, or
-expand monitoring.
+Useful public-product issues:
 
-## Offline Evals
+- [#103 NeonDiff public product roadmap](https://github.com/electricsheephq/evaos-code-review-bot/issues/103)
+- [#104 license and commercial boundary](https://github.com/electricsheephq/evaos-code-review-bot/issues/104)
+- [#107 CLI package and local daemon public install flow](https://github.com/electricsheephq/evaos-code-review-bot/issues/107)
+- [#113 agent-first CLI and API documentation contract](https://github.com/electricsheephq/evaos-code-review-bot/issues/113)
 
-Use [docs/eval-harness.md](docs/eval-harness.md) to create read-only
-CodeRabbit/human/CI/seeded-defect comparison packets under
-`/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/`. Eval packets are advisory
-and uncalibrated until enough labeled findings exist for measured reliability
-bins.
+## Safety Boundaries
+
+Default behavior:
+
+- review only configured repos
+- skip draft PRs by default
+- at most one review per `{repo, pr, head_sha}`
+- never submit `APPROVE`
+- request changes only for validated high-severity findings
+- suppress secret-looking findings instead of posting redacted secrets
+- re-fetch PR state before live operations
+- keep ZCode/model tools read-only during review
+- fail closed when credentials, provider readiness, repo policy, or current-head
+  proof is missing
+
+Not claimed:
+
+- public launch is complete
+- final legal/license adequacy
+- hosted review service
+- auto-merge or branch repair
+- generic GitHub issue mutation
+- enterprise or customer-ready security
+- calibrated CodeRabbit-level accuracy
+- desktop client readiness
+
+## Roadmap Vs Shipped
+
+The current repo is a source-available beta implementation. The public MVP is
+tracked in [#103](https://github.com/electricsheephq/evaos-code-review-bot/issues/103).
+Provider registry, `.neondiff.yml`, public CLI packaging, license activation,
+desktop client, wiki exports, marketplace packaging, and confidence calibration
+each have separate issues and must not be treated as shipped until their PRs and
+proof gates close.
+
+For live beta operation, use [docs/beta-release-runbook.md](docs/beta-release-runbook.md)
+and [docs/release-governance.md](docs/release-governance.md). Documentation-only
+changes do not restart launchd or promote a release by themselves.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+NeonDiff is local-first review infrastructure. It handles GitHub App
+credentials, provider configuration, PR metadata, diffs, local evidence, and
+review comments, so security reports should be handled privately.
+
+## Supported Surface
+
+This repository is a source-available beta. Security review applies to the
+current `main` branch and active prerelease/live-beta branches linked from
+GitHub issues.
+
+## Reporting A Vulnerability
+
+Do not open a public issue for vulnerabilities, secrets, credential exposure,
+private PR content, or customer data.
+
+Report privately to the maintainers with:
+
+- affected commit, tag, or branch
+- affected command or runtime surface
+- minimal reproduction steps
+- whether live posting, GitHub App auth, provider auth, license handling, or
+  local evidence is involved
+- redacted logs only
+
+Never include private keys, provider tokens, license keys, raw private diffs,
+customer logs, cookies, or connector URLs in a public issue or PR.
+
+## Public Issue Boundary
+
+Use public issues for docs bugs, setup confusion, provider requests, feature
+requests, and public-safe unsafe-review reports. If a report contains secrets
+or private repo data, move it to the private security channel first.
+
+## Safety Defaults
+
+Security-sensitive contributions must preserve these defaults:
+
+- dry-run before live review posting
+- current-head duplicate suppression
+- stale-head checks before posting
+- secret-looking finding suppression
+- configured repo allowlists
+- no approval reviews by default
+- no branch repair, auto-merge, or hidden GitHub mutation
+- no GitHub App permission expansion without a tracked issue and proof gate

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,142 @@
+# NeonDiff Setup
+
+This guide is the first-run path for the current source-available beta. It uses
+the checked-out repository scripts until the public CLI package and final
+`neondiff` binary are completed in issue #107.
+
+## Requirements
+
+- Node.js 26 or newer
+- npm
+- GitHub App credentials for the repos you want to review
+- a provider/model path available on the machine running the worker
+- optional NeonDiff license key for private or commercial repo use
+
+Public open-source repos are free. Private and commercial repos require a paid
+license. Final license wording is tracked in issue #104.
+
+## 1. Install From Source
+
+```bash
+git clone https://github.com/electricsheephq/evaos-code-review-bot.git neondiff
+cd neondiff
+npm install
+npm run build
+```
+
+## 2. Create A GitHub App
+
+Create a GitHub App for NeonDiff and install it only on repos you intend to
+review.
+
+Required repository permissions:
+
+- Contents: read
+- Pull requests: read/write
+- Checks: read
+- Actions: read
+- Metadata: read
+
+Optional issue-enrichment permissions are separate from PR review and should not
+be enabled just because a repo is monitored:
+
+- Issues: read, only for dry-run/operator issue enrichment reads
+- Issues: write, only after a tracked rollout enables sticky issue comments
+
+Save the generated private key outside the repository.
+
+```bash
+export EVAOS_REVIEW_BOT_APP_ID="<github-app-id>"
+export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
+```
+
+## 3. Configure Provider And License
+
+Copy the example config and edit it for your local repo allowlist, provider
+path, state path, and evidence path:
+
+```bash
+cp config.example.json config.local.json
+```
+
+For the current internal provider path, the worker derives transient ZCode/GLM
+environment from the local app config referenced by `config.local.json`. Do not
+copy provider API keys into this repository.
+
+If you are reviewing private or commercial repos, set your license key through
+the configured local secret path or environment used by your operator wrapper.
+Do not paste license keys into tracked config.
+
+## 4. Check Readiness
+
+Run doctor with the config you intend to use:
+
+```bash
+npm run doctor -- --config config.local.json
+```
+
+The doctor output is JSON. Check:
+
+- `ok`
+- `github.readMode`
+- each `github.readChecks[]`
+- provider readiness
+- repo policy allow/skip state
+
+## 5. Run A Dry-Run Review
+
+Use a known repo, PR number, and current head. A dry-run review should produce
+structured output and evidence without posting comments:
+
+```bash
+npm run run-once -- \
+  --config config.local.json \
+  --repo owner/name \
+  --pr 123 \
+  --dry-run true \
+  --zcode false
+```
+
+Do not run with `--dry-run false` until dry-run evidence, focused tests, and
+the relevant issue explicitly approve the exact repo, PR, head SHA, and config
+path.
+
+## 6. Inspect Daemon And Status
+
+Before touching launchd, use JSON status commands:
+
+```bash
+npm run cli -- status --json --config config.local.json
+npm run cli -- queue --config config.local.json
+npm run cli -- dashboard --config config.local.json --limit 10
+```
+
+After `npm run build`, the local package also exposes the current beta binary:
+
+```bash
+./dist/src/cli.js status --config config.local.json
+```
+
+Launchd and live beta promotion are advanced operator tasks. Use
+[docs/launchd.md](launchd.md), [docs/operator-cli.md](operator-cli.md), and
+[docs/beta-release-runbook.md](beta-release-runbook.md) only after dry-run proof
+passes.
+
+## Troubleshooting
+
+- `doctor` cannot read repos: verify GitHub App installation, app ID, private
+  key path, and repo permissions.
+- Provider calls fail: verify local provider config outside this repository and
+  inspect redacted provider errors only.
+- Review says stale head: re-fetch the PR head and rerun against the current
+  SHA; do not post stale findings.
+- Evidence contains sensitive material: stop, remove the unsafe artifact from
+  shareable evidence, and file a security/private follow-up.
+- Private repo review is blocked: verify license setup and repo policy before
+  widening permissions.
+
+## What Setup Does Not Prove
+
+Setup does not prove public launch, final legal adequacy, calibrated review
+accuracy, enterprise readiness, desktop client readiness, package publishing, or
+live beta promotion. Those are separate issues and release gates.

--- a/evals/scorecards/v1.0/public-community-readiness-review.json
+++ b/evals/scorecards/v1.0/public-community-readiness-review.json
@@ -1,0 +1,22 @@
+{
+  "id": "public-community-readiness-review",
+  "version": "v1.0",
+  "surface": "NeonDiff source-available beta repository",
+  "current_score": "pass",
+  "reviewed_at": "2026-07-03",
+  "claim_class": "pr_ready",
+  "pass_criteria": [
+    "README is NeonDiff-first and links setup, contributing, agent instructions, security, code of conduct, roadmap, and license boundary.",
+    "CONTRIBUTING gives humans and coding agents issue routing, validation, evidence, and safety boundaries.",
+    "AGENTS gives repository agents a concise first-read checklist and source-available product boundary.",
+    "Issue templates and PR template collect public-safe evidence and warn against secrets, tokens, credentials, and private data.",
+    "Setup guide documents GitHub App permissions, provider setup, config, dry-run review, daemon/status checks, and troubleshooting.",
+    "Docs avoid open-source, MIT, GA, CodeRabbit parity, enterprise-ready, and public-launch-complete claims."
+  ],
+  "proof_boundary": "This scorecard proves repo/docs public beta review readiness only. It does not prove public launch, final legal adequacy, package publishing, GitHub Release readiness, review accuracy, CodeRabbit parity, live worker promotion, or star growth.",
+  "remaining_gaps": [
+    "Final license text remains gated by issue #104.",
+    "Public CLI package and final binary name remain gated by issue #107.",
+    "Website docs and license portal remain in electricsheephq/neon-diff-agent issues #1, #2, and #3."
+  ]
+}

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -1,0 +1,179 @@
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+describe("NeonDiff public community funnel", () => {
+  it("README is NeonDiff-first and routes users to setup, contribution, agent, security, and roadmap docs", () => {
+    const readme = read("README.md");
+
+    for (const required of [
+      /^# NeonDiff/m,
+      /local-first AI PR reviewer/i,
+      /https:\/\/www\.neondiff\.com/i,
+      /docs\/SETUP\.md/i,
+      /CONTRIBUTING\.md/i,
+      /AGENTS\.md/i,
+      /SECURITY\.md/i,
+      /CODE_OF_CONDUCT\.md/i,
+      /public open-source repos.*free/i,
+      /private.*commercial.*paid/i,
+      /source-available beta/i,
+      /GitHub App/i,
+      /dry-run review/i,
+      /electricsheephq\/evaos-code-review-bot\/issues\/103/i,
+      /electricsheephq\/evaos-code-review-bot\/issues\/104/i,
+      /electricsheephq\/evaos-code-review-bot\/issues\/107/i,
+      /electricsheephq\/evaos-code-review-bot\/issues\/113/i
+    ]) {
+      expect(readme).toMatch(required);
+    }
+
+    for (const forbidden of [
+      /OpenSource replacement/i,
+      /MIT License/i,
+      /CodeRabbit parity/i,
+      /enterprise-ready/i,
+      /production-ready/i,
+      /public repo launched/i
+    ]) {
+      expect(readme).not.toMatch(forbidden);
+    }
+  });
+
+  it("setup guide gives a first-run path without hiding safety prerequisites in operator runbooks", () => {
+    const setup = read("docs/SETUP.md");
+
+    for (const required of [
+      /^# NeonDiff Setup/m,
+      /Requirements/i,
+      /GitHub App/i,
+      /Contents: read/i,
+      /Pull requests: read\/write/i,
+      /provider/i,
+      /license/i,
+      /config/i,
+      /dry-run/i,
+      /daemon/i,
+      /status --json/i,
+      /Troubleshooting/i,
+      /Do not run.*dry-run false/i
+    ]) {
+      expect(setup).toMatch(required);
+    }
+
+    expect(setup).not.toMatch(/BEGIN (RSA|OPENSSH|PRIVATE) KEY|ghp_|github_pat_|sk-[A-Za-z0-9]/);
+  });
+
+  it("CONTRIBUTING and AGENTS are useful to humans and coding agents", () => {
+    const contributing = read("CONTRIBUTING.md");
+    const agents = read("AGENTS.md");
+
+    for (const required of [
+      /^# Contributing/m,
+      /Quick Links/i,
+      /Issue Routing/i,
+      /Before You Open A PR/i,
+      /Agent-Authored Contributions/i,
+      /Validation/i,
+      /Evidence/i,
+      /Review Threads/i,
+      /Good First Contributions/i,
+      /Safety Boundaries/i,
+      /docs\/SETUP\.md/i,
+      /AGENTS\.md/i,
+      /SECURITY\.md/i,
+      /CODE_OF_CONDUCT\.md/i,
+      /Closes #<issue>/i,
+      /secret/i,
+      /dry-run/i
+    ]) {
+      expect(contributing).toMatch(required);
+    }
+
+    for (const required of [
+      /^# NeonDiff Agent Instructions/m,
+      /Repository Agent Quick Start/i,
+      /Read README\.md/i,
+      /Read CONTRIBUTING\.md/i,
+      /Read docs\/SETUP\.md/i,
+      /Create or reuse a GitHub issue/i,
+      /Write or update a failing test/i,
+      /Do not commit.*tokens/i,
+      /Do not restart launchd/i,
+      /source-available/i,
+      /Update the issue before handoff/i
+    ]) {
+      expect(agents).toMatch(required);
+    }
+  });
+
+  it("GitHub issue and PR templates exist and require public-safe evidence", () => {
+    for (const path of [
+      "CODE_OF_CONDUCT.md",
+      "SECURITY.md",
+      "CONTRIBUTING.md",
+      "AGENTS.md",
+      ".github/PULL_REQUEST_TEMPLATE.md",
+      ".github/ISSUE_TEMPLATE/config.yml",
+      ".github/ISSUE_TEMPLATE/bug_report.yml",
+      ".github/ISSUE_TEMPLATE/docs_bug_report.yml",
+      ".github/ISSUE_TEMPLATE/feature_request.yml",
+      ".github/ISSUE_TEMPLATE/provider_request.yml",
+      ".github/ISSUE_TEMPLATE/license_setup_confusion.yml",
+      ".github/ISSUE_TEMPLATE/unsafe_review_report.yml"
+    ]) {
+      expect(existsSync(path), `${path} must exist`).toBe(true);
+    }
+
+    const forms = [
+      read(".github/ISSUE_TEMPLATE/bug_report.yml"),
+      read(".github/ISSUE_TEMPLATE/docs_bug_report.yml"),
+      read(".github/ISSUE_TEMPLATE/feature_request.yml"),
+      read(".github/ISSUE_TEMPLATE/provider_request.yml"),
+      read(".github/ISSUE_TEMPLATE/license_setup_confusion.yml"),
+      read(".github/ISSUE_TEMPLATE/unsafe_review_report.yml")
+    ];
+
+    for (const form of forms) {
+      expect(form).toMatch(/body:/);
+      expect(form).toMatch(/validations:\n\s+required: true/);
+      expect(form).toMatch(/public-safe|redacted|secret|token|credential/i);
+    }
+
+    const pr = read(".github/PULL_REQUEST_TEMPLATE.md");
+    for (const required of [
+      /What Problem This Solves/i,
+      /User Impact/i,
+      /Validation/i,
+      /Safety Boundary/i,
+      /Evidence/i,
+      /Closes #<issue>/i,
+      /agent-authored/i,
+      /live worker/i
+    ]) {
+      expect(pr).toMatch(required);
+    }
+  });
+
+  it("public readiness scorecard records proof boundary and launch limits", () => {
+    const scorecardPath = "evals/scorecards/v1.0/public-community-readiness-review.json";
+    expect(existsSync(scorecardPath), `${scorecardPath} must exist`).toBe(true);
+    const scorecard = JSON.parse(read(scorecardPath)) as {
+      current_score?: string;
+      surface?: string;
+      pass_criteria?: string[];
+      proof_boundary?: string;
+    };
+
+    expect(scorecard.current_score).toBe("pass");
+    expect(scorecard.surface).toBe("NeonDiff source-available beta repository");
+    expect(JSON.stringify(scorecard.pass_criteria)).toMatch(/README/i);
+    expect(JSON.stringify(scorecard.pass_criteria)).toMatch(/CONTRIBUTING/i);
+    expect(JSON.stringify(scorecard.pass_criteria)).toMatch(/AGENTS/i);
+    expect(JSON.stringify(scorecard.pass_criteria)).toMatch(/issue templates/i);
+    expect(String(scorecard.proof_boundary)).toMatch(/does not prove public launch/i);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Closes #113
Related: #103, #104, #107
Related website lanes: electricsheephq/neon-diff-agent#1, electricsheephq/neon-diff-agent#2, electricsheephq/neon-diff-agent#3

NeonDiff had a mature internal operator surface, but the repo landing page was still evaOS/OpenRabbit-era and missing the public setup/contribution/agent funnel. This PR makes the repo ready for source-available beta review without flipping visibility, publishing packages, or claiming GA.

## User Impact

- README now leads with NeonDiff, local-first review, setup, dry-run review, and safety boundaries.
- Contributors and coding agents get CONTRIBUTING.md, AGENTS.md, SECURITY.md, CODE_OF_CONDUCT.md, issue forms, and a PR template.
- First-run setup is documented in docs/SETUP.md while live beta/launchd release operations stay in operator runbooks.
- Public claims are bounded: source-available beta, public open-source repos free, private/commercial repos paid, exact license text still gated by #104.

## Validation

- Red test first: `npx vitest run tests/public-community-funnel.test.ts` failed on stale README and missing docs/templates.
- Focused validation: `npx vitest run tests/public-community-funnel.test.ts` passed.
- Full validation: `npm test` passed, 39 files / 439 tests.
- Build: `npm run build` passed.
- Public claim scan: passed for README, setup, contributing, agent, security, templates, scorecard, and tests.

Evidence packet: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-03/neondiff-community-funnel/`

## Safety Boundary

- No public repo visibility flip.
- No npm publish or GitHub Release.
- No live worker restart, launchd mutation, or beta promotion.
- No GitHub App permission change.
- No legal advice or final license text beyond #104.
- No CodeRabbit parity, enterprise readiness, GA, or public-launch-complete claim.
- No website code changes in this PR.

## Agent-Authored PR

This PR was authored by Codex. Restricted actions not performed: live worker control, launchd mutation, package publish, release creation, repo visibility changes, and GitHub App permission changes.