### PR TITLE
Fix self-repo review worktree isolation

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -10,7 +10,7 @@
     "maxActiveRuns": 5,
     "leaseTtlMs": 900000
   },
-  "workRoot": "/Volumes/LEXAR/repos/evaos-code-review-bot/runtime",
+  "workRoot": "/Volumes/LEXAR/repos/evaos-code-review-bot-runtime",
   "statePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews.sqlite",
   "evidenceDir": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence",
   "issueEnrichment": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import type { EnrichmentConfig } from "./enrichment.js";
 import type { GitNexusContextConfig } from "./gitnexus-context.js";
 import type { GitHubRelatedContextConfig } from "./github-related-context.js";
 import { DEFAULT_ISSUE_ENRICHMENT_CONFIG, type IssueEnrichmentConfig } from "./issue-enrichment.js";
+import { assertPathOutsideProtectedRoot, getInstalledPackageRoot } from "./path-safety.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
 
 export interface BotConfig {
@@ -156,7 +157,7 @@ const DEFAULT_CONFIG: BotConfig = {
   pilotRepos: ["electricsheephq/WorldOS", "100yenadmin/evaOS-GUI"],
   pollIntervalMs: 90_000,
   skipDrafts: true,
-  workRoot: "/Volumes/LEXAR/repos/evaos-code-review-bot/runtime",
+  workRoot: "/Volumes/LEXAR/repos/evaos-code-review-bot-runtime",
   statePath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews.sqlite",
   evidenceDir: "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence",
   canaryPulls: undefined,
@@ -298,6 +299,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function validateConfig(config: BotConfig): void {
   validateStringArray(config.pilotRepos, "config.pilotRepos");
   for (const repo of config.pilotRepos) validateRepoName(repo, "config.pilotRepos");
+  validateNonEmptyString(config.workRoot, "config.workRoot");
+  validateWorkRootIsolation(config);
   if (config.canaryPulls !== undefined) {
     validateStringArray(config.canaryPulls, "config.canaryPulls");
     for (const canary of config.canaryPulls) validateCanaryPull(canary, "config.canaryPulls");
@@ -607,6 +610,15 @@ function validateReviewSchedulerConfig(value: unknown, label: string): void {
   }
 }
 
+function validateWorkRootIsolation(config: BotConfig): void {
+  assertPathOutsideProtectedRoot({
+    path: config.workRoot,
+    protectedRoot: getInstalledPackageRoot(),
+    pathLabel: "config.workRoot",
+    protectedRootLabel: "the current repository checkout"
+  });
+}
+
 function validatePathInstructions(value: unknown, label: string): void {
   if (value === undefined) return;
   if (!isRecord(value)) throw new Error(`${label} must be an object`);
@@ -614,6 +626,10 @@ function validatePathInstructions(value: unknown, label: string): void {
     if (!pathPattern.trim()) throw new Error(`${label} keys must be non-empty path patterns`);
     validateStringArray(instructions, `${label}.${pathPattern}`);
   }
+}
+
+function validateNonEmptyString(value: unknown, label: string): void {
+  if (typeof value !== "string" || value.trim().length === 0) throw new Error(`${label} must be a non-empty string`);
 }
 
 function validateOptionalString(value: unknown, label: string): void {

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,22 +1,39 @@
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import { assertPathOutsideProtectedRoot } from "./path-safety.js";
 
 export interface PreparedWorktree {
   path: string;
   headSha: string;
 }
 
-export function preparePullWorktree(input: {
+export interface PullWorktreePathPlan {
+  mirrorPath: string;
+  worktreePath: string;
+  repoUrl: string;
+}
+
+export interface PullWorktreeInput {
   repo: string;
   pullNumber: number;
   expectedHeadSha: string;
   workRoot: string;
-}): PreparedWorktree {
+  protectedCheckoutRoot?: string;
+}
+
+export function planPullWorktreePaths(input: PullWorktreeInput): PullWorktreePathPlan {
+  assertWorkRootOutsideProtectedCheckout(input.workRoot, input.protectedCheckoutRoot);
   const safeRepo = input.repo.replace(/[^A-Za-z0-9_.-]+/g, "__");
   const mirrorPath = join(input.workRoot, "mirrors", `${safeRepo}.git`);
   const worktreePath = join(input.workRoot, "worktrees", `${safeRepo}__pr-${input.pullNumber}__${input.expectedHeadSha.slice(0, 12)}`);
   const repoUrl = `https://github.com/${input.repo}.git`;
+
+  return { mirrorPath, worktreePath, repoUrl };
+}
+
+export function preparePullWorktree(input: PullWorktreeInput): PreparedWorktree {
+  const { mirrorPath, worktreePath, repoUrl } = planPullWorktreePaths(input);
 
   mkdirSync(join(input.workRoot, "mirrors"), { recursive: true });
   mkdirSync(join(input.workRoot, "worktrees"), { recursive: true });
@@ -55,6 +72,15 @@ export function preparePullWorktree(input: {
   }
 
   return { path: worktreePath, headSha: actualHeadSha };
+}
+
+function assertWorkRootOutsideProtectedCheckout(workRoot: string, protectedCheckoutRoot: string | undefined): void {
+  assertPathOutsideProtectedRoot({
+    path: workRoot,
+    protectedRoot: protectedCheckoutRoot,
+    pathLabel: "workRoot",
+    protectedRootLabel: "the protected live checkout"
+  });
 }
 
 export function assertGitClean(worktreePath: string): void {

--- a/src/path-safety.ts
+++ b/src/path-safety.ts
@@ -1,0 +1,51 @@
+import { existsSync, realpathSync } from "node:fs";
+import { basename, dirname, isAbsolute, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface PathBoundary {
+  path: string;
+  protectedRoot: string | undefined;
+  pathLabel: string;
+  protectedRootLabel: string;
+}
+
+export function getInstalledPackageRoot(): string | undefined {
+  return findPackageRoot(dirname(fileURLToPath(import.meta.url)));
+}
+
+export function findPackageRoot(startPath: string): string | undefined {
+  let current = resolvePathFollowingExistingSymlinks(startPath);
+  while (true) {
+    if (existsSync(resolve(current, "package.json"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+export function assertPathOutsideProtectedRoot(boundary: PathBoundary): void {
+  if (!boundary.protectedRoot) return;
+  const root = resolvePathFollowingExistingSymlinks(boundary.protectedRoot);
+  const candidate = resolvePathFollowingExistingSymlinks(boundary.path);
+  const rel = relative(root, candidate);
+  const insideProtectedRoot = rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  if (insideProtectedRoot) {
+    throw new Error(`${boundary.pathLabel} must be outside ${boundary.protectedRootLabel}; got ${boundary.path}`);
+  }
+}
+
+export function resolvePathFollowingExistingSymlinks(inputPath: string): string {
+  const absolutePath = resolve(inputPath);
+  if (existsSync(absolutePath)) return realpathSync.native(absolutePath);
+
+  let current = absolutePath;
+  const missingSegments: string[] = [];
+  while (!existsSync(current)) {
+    const parent = dirname(current);
+    if (parent === current) return absolutePath;
+    missingSegments.unshift(basename(current));
+    current = parent;
+  }
+
+  return resolve(realpathSync.native(current), ...missingSegments);
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -22,6 +22,7 @@ import {
 } from "./github-related-context.js";
 import { buildEnrichmentComment, postEnrichmentComment } from "./enrichment.js";
 import { GitHubApi } from "./github.js";
+import { getInstalledPackageRoot } from "./path-safety.js";
 import {
   buildPullFileFilterImpact,
   filterPullFilesForProfile,
@@ -699,7 +700,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       repo,
       pullNumber: pull.number,
       expectedHeadSha: pull.head.sha,
-      workRoot: config.workRoot
+      workRoot: config.workRoot,
+      protectedCheckoutRoot: getInstalledPackageRoot()
     });
     const repoMemory = buildRepoMemoryContext({
       config,

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -1,0 +1,62 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { planPullWorktreePaths } from "../src/git.js";
+
+describe("pull worktree path planning", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("rejects a review workRoot inside the protected live checkout", () => {
+    const liveCheckout = mkdtempSync(join(tmpdir(), "evaos-live-checkout-"));
+    roots.push(liveCheckout);
+
+    expect(() => planPullWorktreePaths({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 157,
+      expectedHeadSha: "a679792e7ed7517e7286507cfd7107511c2f60fb",
+      workRoot: join(liveCheckout, "runtime"),
+      protectedCheckoutRoot: liveCheckout
+    })).toThrow(/workRoot must be outside the protected live checkout/);
+  });
+
+  it("keeps self-repo review paths outside the protected live checkout", () => {
+    const liveCheckout = mkdtempSync(join(tmpdir(), "evaos-live-checkout-"));
+    const isolatedRoot = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    roots.push(liveCheckout, isolatedRoot);
+
+    const paths = planPullWorktreePaths({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 157,
+      expectedHeadSha: "a679792e7ed7517e7286507cfd7107511c2f60fb",
+      workRoot: isolatedRoot,
+      protectedCheckoutRoot: liveCheckout
+    });
+
+    expect(paths.mirrorPath.startsWith(liveCheckout)).toBe(false);
+    expect(paths.worktreePath.startsWith(liveCheckout)).toBe(false);
+    expect(paths.worktreePath).toContain("electricsheephq__evaos-code-review-bot__pr-157__a679792e7ed7");
+  });
+
+  it("rejects a review workRoot symlinked into the protected live checkout", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    const liveCheckout = mkdtempSync(join(tmpdir(), "evaos-live-checkout-"));
+    roots.push(root, liveCheckout);
+    const insideLiveCheckout = join(liveCheckout, "runtime-target");
+    mkdirSync(insideLiveCheckout);
+    const runtimeLink = join(root, "runtime-link");
+    symlinkSync(insideLiveCheckout, runtimeLink, "dir");
+
+    expect(() => planPullWorktreePaths({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 157,
+      expectedHeadSha: "a679792e7ed7517e7286507cfd7107511c2f60fb",
+      workRoot: runtimeLink,
+      protectedCheckoutRoot: liveCheckout
+    })).toThrow(/workRoot must be outside the protected live checkout/);
+  });
+});

--- a/tests/review-scheduler-config.test.ts
+++ b/tests/review-scheduler-config.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -50,6 +50,34 @@ describe("review scheduler config", () => {
     expect(() => loadConfig(writeConfig({ github: { apiBaseUrl: 42 } }))).toThrow(/config\.github\.apiBaseUrl/);
     expect(() => loadConfig(writeConfig({ github: { botLogin: 42 } }))).toThrow(/config\.github\.botLogin/);
     expect(() => loadConfig(writeConfig({ github: { requestTimeoutMs: 0 } }))).toThrow(/config\.github\.requestTimeoutMs/);
+  });
+
+  it("rejects a review workRoot inside the live repository checkout", () => {
+    expect(() => loadConfig(writeConfig({
+      workRoot: join(process.cwd(), "runtime")
+    }))).toThrow(/config\.workRoot must be outside the current repository checkout/);
+  });
+
+  it("rejects a review workRoot symlinked into the live repository checkout", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-scheduler-runtime-"));
+    roots.push(root);
+    const link = join(root, "runtime-link");
+    symlinkSync(process.cwd(), link, "dir");
+
+    expect(() => loadConfig(writeConfig({
+      workRoot: link
+    }))).toThrow(/config\.workRoot must be outside the current repository checkout/);
+  });
+
+  it("allows reviews when workRoot is outside the live repository checkout", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-scheduler-runtime-"));
+    roots.push(root);
+
+    const config = loadConfig(writeConfig({
+      workRoot: join(root, "runtime")
+    }));
+
+    expect(config.workRoot).toBe(join(root, "runtime"));
   });
 
   function writeConfig(overlay: Record<string, unknown>): string {


### PR DESCRIPTION
## Summary
- fixes #159 by moving the default review workRoot outside the live checkout
- adds a shared realpath-aware path boundary guard for config loading and PR worktree planning
- protects review worktree creation using the installed package root instead of process.cwd(), including symlink regressions

## Validation
- npm test -- tests/review-scheduler-config.test.ts tests/git.test.ts tests/git-clean.test.ts --pool=forks --maxWorkers=1
- npm run build
- npm test -- --pool=forks --maxWorkers=1
- git diff --check

## Release notes
- Runtime config was already live-mitigated to /Volumes/LEXAR/repos/evaos-code-review-bot-runtime; this PR makes that the code default and enforces it.