### PR TITLE
Harden review worktree path boundaries

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -13,6 +13,10 @@ The beta release unit is:
 - state DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
 - evidence root: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
 
+Packaged or non-source deployments must set
+`EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT` to the live operator checkout so
+review mirrors and worktrees cannot be planned inside or above that checkout.
+
 The beta release unit does not include expanding monitored repos, GitHub App
 permissions, ZCode tools, auto-merge, approvals, or repair behavior. Those need
 their own tracked issue, PR, dry-run evidence, and explicit promotion gate.

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import type { EnrichmentConfig } from "./enrichment.js";
 import type { GitNexusContextConfig } from "./gitnexus-context.js";
 import type { GitHubRelatedContextConfig } from "./github-related-context.js";
 import { DEFAULT_ISSUE_ENRICHMENT_CONFIG, type IssueEnrichmentConfig } from "./issue-enrichment.js";
-import { assertPathOutsideProtectedRoot, getInstalledPackageRoot } from "./path-safety.js";
+import { assertPathOutsideProtectedRoot, getProtectedCheckoutRoots } from "./path-safety.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
 
 export interface BotConfig {
@@ -613,7 +613,8 @@ function validateReviewSchedulerConfig(value: unknown, label: string): void {
 function validateWorkRootIsolation(config: BotConfig): void {
   assertPathOutsideProtectedRoot({
     path: config.workRoot,
-    protectedRoot: getInstalledPackageRoot(),
+    protectedRoot: undefined,
+    protectedRoots: getProtectedCheckoutRoots(),
     pathLabel: "config.workRoot",
     protectedRootLabel: "the current repository checkout"
   });

--- a/src/git.ts
+++ b/src/git.ts
@@ -20,14 +20,17 @@ export interface PullWorktreeInput {
   expectedHeadSha: string;
   workRoot: string;
   protectedCheckoutRoot?: string;
+  protectedCheckoutRoots?: string[];
 }
 
 export function planPullWorktreePaths(input: PullWorktreeInput): PullWorktreePathPlan {
-  assertWorkRootOutsideProtectedCheckout(input.workRoot, input.protectedCheckoutRoot);
   const safeRepo = input.repo.replace(/[^A-Za-z0-9_.-]+/g, "__");
   const mirrorPath = join(input.workRoot, "mirrors", `${safeRepo}.git`);
   const worktreePath = join(input.workRoot, "worktrees", `${safeRepo}__pr-${input.pullNumber}__${input.expectedHeadSha.slice(0, 12)}`);
   const repoUrl = `https://github.com/${input.repo}.git`;
+  assertReviewPathOutsideProtectedCheckout("workRoot", input.workRoot, input);
+  assertReviewPathOutsideProtectedCheckout("mirrorPath", mirrorPath, input);
+  assertReviewPathOutsideProtectedCheckout("worktreePath", worktreePath, input);
 
   return { mirrorPath, worktreePath, repoUrl };
 }
@@ -74,11 +77,12 @@ export function preparePullWorktree(input: PullWorktreeInput): PreparedWorktree 
   return { path: worktreePath, headSha: actualHeadSha };
 }
 
-function assertWorkRootOutsideProtectedCheckout(workRoot: string, protectedCheckoutRoot: string | undefined): void {
+function assertReviewPathOutsideProtectedCheckout(pathLabel: string, path: string, input: PullWorktreeInput): void {
   assertPathOutsideProtectedRoot({
-    path: workRoot,
-    protectedRoot: protectedCheckoutRoot,
-    pathLabel: "workRoot",
+    path,
+    protectedRoot: input.protectedCheckoutRoot,
+    protectedRoots: input.protectedCheckoutRoots,
+    pathLabel,
     protectedRootLabel: "the protected live checkout"
   });
 }

--- a/src/path-safety.ts
+++ b/src/path-safety.ts
@@ -1,12 +1,28 @@
 import { existsSync, realpathSync } from "node:fs";
-import { basename, dirname, isAbsolute, relative, resolve } from "node:path";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export interface PathBoundary {
   path: string;
   protectedRoot: string | undefined;
+  protectedRoots?: string[];
   pathLabel: string;
   protectedRootLabel: string;
+}
+
+interface SinglePathBoundary {
+  path: string;
+  protectedRoot: string;
+  pathLabel: string;
+  protectedRootLabel: string;
+}
+
+export function getProtectedCheckoutRoots(): string[] {
+  return uniqueDefinedPaths([
+    process.env.EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT,
+    findPackageRoot(process.cwd()),
+    getInstalledPackageRoot()
+  ]);
 }
 
 export function getInstalledPackageRoot(): string | undefined {
@@ -24,12 +40,24 @@ export function findPackageRoot(startPath: string): string | undefined {
 }
 
 export function assertPathOutsideProtectedRoot(boundary: PathBoundary): void {
-  if (!boundary.protectedRoot) return;
+  const roots = uniqueDefinedPaths([boundary.protectedRoot, ...(boundary.protectedRoots ?? [])]);
+  for (const protectedRoot of roots) {
+    assertPathOutsideSingleProtectedRoot({
+      path: boundary.path,
+      protectedRoot,
+      pathLabel: boundary.pathLabel,
+      protectedRootLabel: boundary.protectedRootLabel
+    });
+  }
+}
+
+function assertPathOutsideSingleProtectedRoot(boundary: SinglePathBoundary): void {
   const root = resolvePathFollowingExistingSymlinks(boundary.protectedRoot);
   const candidate = resolvePathFollowingExistingSymlinks(boundary.path);
   const rel = relative(root, candidate);
-  const insideProtectedRoot = rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
-  if (insideProtectedRoot) {
+  const reverseRel = relative(candidate, root);
+  const overlapsProtectedRoot = isSameOrChildRelativePath(rel) || isSameOrChildRelativePath(reverseRel);
+  if (overlapsProtectedRoot) {
     throw new Error(`${boundary.pathLabel} must be outside ${boundary.protectedRootLabel}; got ${boundary.path}`);
   }
 }
@@ -48,4 +76,25 @@ export function resolvePathFollowingExistingSymlinks(inputPath: string): string 
   }
 
   return resolve(realpathSync.native(current), ...missingSegments);
+}
+
+function isSameOrChildRelativePath(rel: string): boolean {
+  return rel === "" || (!isParentRelativePath(rel) && !isAbsolute(rel));
+}
+
+function isParentRelativePath(rel: string): boolean {
+  return rel === ".." || rel.startsWith(`..${sep}`);
+}
+
+function uniqueDefinedPaths(paths: Array<string | undefined>): string[] {
+  const seen = new Set<string>();
+  const output: string[] = [];
+  for (const path of paths) {
+    if (!path) continue;
+    const normalized = resolvePathFollowingExistingSymlinks(path);
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    output.push(normalized);
+  }
+  return output;
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -22,7 +22,7 @@ import {
 } from "./github-related-context.js";
 import { buildEnrichmentComment, postEnrichmentComment } from "./enrichment.js";
 import { GitHubApi } from "./github.js";
-import { getInstalledPackageRoot } from "./path-safety.js";
+import { getProtectedCheckoutRoots } from "./path-safety.js";
 import {
   buildPullFileFilterImpact,
   filterPullFilesForProfile,
@@ -701,7 +701,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       pullNumber: pull.number,
       expectedHeadSha: pull.head.sha,
       workRoot: config.workRoot,
-      protectedCheckoutRoot: getInstalledPackageRoot()
+      protectedCheckoutRoots: getProtectedCheckoutRoots()
     });
     const repoMemory = buildRepoMemoryContext({
       config,

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -59,4 +59,64 @@ describe("pull worktree path planning", () => {
       protectedCheckoutRoot: liveCheckout
     })).toThrow(/workRoot must be outside the protected live checkout/);
   });
+
+  it("rejects an in-checkout workRoot whose relative segment starts with dots", () => {
+    const liveCheckout = mkdtempSync(join(tmpdir(), "evaos-live-checkout-"));
+    roots.push(liveCheckout);
+
+    expect(() => planPullWorktreePaths({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 157,
+      expectedHeadSha: "a679792e7ed7517e7286507cfd7107511c2f60fb",
+      workRoot: join(liveCheckout, "..runtime"),
+      protectedCheckoutRoot: liveCheckout
+    })).toThrow(/workRoot must be outside the protected live checkout/);
+  });
+
+  it("rejects a workRoot that contains the protected live checkout", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    const liveCheckout = join(root, "repos", "evaos-code-review-bot");
+    mkdirSync(liveCheckout, { recursive: true });
+    roots.push(root);
+
+    expect(() => planPullWorktreePaths({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 157,
+      expectedHeadSha: "a679792e7ed7517e7286507cfd7107511c2f60fb",
+      workRoot: root,
+      protectedCheckoutRoot: liveCheckout
+    })).toThrow(/workRoot must be outside the protected live checkout/);
+  });
+
+  it("rejects a planned worktreePath that resolves through a symlink into the protected live checkout", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    const liveCheckout = mkdtempSync(join(tmpdir(), "evaos-live-checkout-"));
+    roots.push(root, liveCheckout);
+    const worktreesLink = join(root, "worktrees");
+    symlinkSync(liveCheckout, worktreesLink, "dir");
+
+    expect(() => planPullWorktreePaths({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 157,
+      expectedHeadSha: "a679792e7ed7517e7286507cfd7107511c2f60fb",
+      workRoot: root,
+      protectedCheckoutRoot: liveCheckout
+    })).toThrow(/worktreePath must be outside the protected live checkout/);
+  });
+
+  it("rejects a planned mirrorPath that resolves through a symlink into the protected live checkout", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    const liveCheckout = mkdtempSync(join(tmpdir(), "evaos-live-checkout-"));
+    roots.push(root, liveCheckout);
+    const mirrorsLink = join(root, "mirrors");
+    symlinkSync(liveCheckout, mirrorsLink, "dir");
+
+    expect(() => planPullWorktreePaths({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 157,
+      expectedHeadSha: "a679792e7ed7517e7286507cfd7107511c2f60fb",
+      workRoot: root,
+      protectedCheckoutRoot: liveCheckout
+    })).toThrow(/mirrorPath must be outside the protected live checkout/);
+  });
 });

--- a/tests/review-scheduler-config.test.ts
+++ b/tests/review-scheduler-config.test.ts
@@ -69,6 +69,26 @@ describe("review scheduler config", () => {
     }))).toThrow(/config\.workRoot must be outside the current repository checkout/);
   });
 
+  it("rejects a review workRoot inside an explicit protected checkout root", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-scheduler-protected-"));
+    roots.push(root);
+    const protectedRoot = join(root, "operator-checkout");
+    const oldProtectedRoot = process.env.EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT;
+    process.env.EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT = protectedRoot;
+
+    try {
+      expect(() => loadConfig(writeConfig({
+        workRoot: join(protectedRoot, "runtime")
+      }))).toThrow(/config\.workRoot must be outside the current repository checkout/);
+    } finally {
+      if (oldProtectedRoot === undefined) {
+        delete process.env.EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT;
+      } else {
+        process.env.EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT = oldProtectedRoot;
+      }
+    }
+  });
+
   it("allows reviews when workRoot is outside the live repository checkout", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-scheduler-runtime-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- follows up #159/#161 after release-blocking review comments found path-boundary gaps
- validates workRoot, derived mirrorPath, and derived worktreePath against protected checkout roots
- rejects reverse containment, dot-prefixed in-checkout paths like `..runtime`, and symlinked child directories that resolve into the checkout
- adds `EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT` as an explicit safety root for packaged/non-source deployments and documents it in the beta release runbook

## Validation
- red: `npm test -- tests/git.test.ts --pool=forks --maxWorkers=1` failed 4 new bypass regressions before implementation
- green: `npm test -- tests/git.test.ts tests/review-scheduler-config.test.ts --pool=forks --maxWorkers=1` (14 tests)
- green: `npm run build`
- green: `npm test -- --pool=forks --maxWorkers=1` (40 files / 450 tests)
- green: `git diff --check`

## Release note
Do not tag/promote `v0.4.2-beta.2` until this PR is merged and post-promotion runtime gates pass.