### PR TITLE
feat(eval): add sticky-vs-cold comparison runner

### DIFF
--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -126,7 +126,8 @@ The current CLI accepts one paired scenario at a time, so normal single-run
 packets cannot reach `runtime_safe_candidate` with the default evidence-volume
 thresholds. That stronger decision is reserved for a future batch/aggregate
 runner or an explicitly configured evidence packet that proves enough paired
-scenarios, labels, negative controls, and provider-attempt observations.
+scenarios, labels, negative controls, provider-attempt observations, and fresh
+sticky context.
 
 Supported label sources:
 
@@ -195,10 +196,11 @@ non-loosenable default policy. The decision is:
 - `advisory` when the paired comparison is clean but measured evidence is still
   too small for runtime-safe promotion.
 - `runtime_safe_candidate` only when paired scenarios, labels, P0/P1 labels,
-  negative controls, and provider-attempt evidence meet the configured thresholds.
-  With the current single-input CLI, this requires future batch aggregation;
-  caller-provided sticky-vs-cold thresholds cannot loosen the default promotion
-  policy, and this must not be used as a public calibrated-confidence claim.
+  negative controls, provider-attempt evidence, and explicit fresh sticky context
+  meet the configured thresholds. With the current single-input CLI, this
+  requires future batch aggregation; caller-provided sticky-vs-cold thresholds
+  cannot loosen the default promotion policy, and this must not be used as a
+  public calibrated-confidence claim.
 
 `manifest.json` records the effective thresholds, scenario mode, optional
 scenario source, artifact inventory with SHA-256 digests, metadata counts, and

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -16,6 +16,14 @@ npm run eval:suite -- \
   --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/local-suite
 ```
 
+Run the paired sticky-vs-cold fixture:
+
+```bash
+npm run eval:sticky-vs-cold -- \
+  --input tests/fixtures/sticky-vs-cold/seeded_quality_packet.json \
+  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold-seeded-quality
+```
+
 The suite command exits non-zero when any scenario fails, when two scenarios use
 the same `runId`, when a `runId` is not a safe path segment, or when any required
 suite is missing from the input directory.
@@ -107,6 +115,13 @@ Supported suites:
 - `safety_redaction`
 - `duplicate_suppression`
 
+Sticky-vs-cold scenarios are paired wrappers around normal offline scenarios.
+They run one cold packet and one sticky packet for the same repo, PR, head SHA,
+and suite, then write side-by-side deltas and a conservative decision. They do
+not enable public confidence percentages; the default output is `advisory`
+unless the sticky packet regresses safety/quality gates or enough measured
+runtime-safe evidence exists.
+
 Supported label sources:
 
 - `coderabbit`
@@ -153,6 +168,25 @@ until the public-display policy is satisfied.
 `promotion-decision.md` is the human-readable proof boundary for #8/#26/#85. It
 must say whether calibrated public confidence remains disabled, why, and what
 evidence is missing before any stronger confidence display can be considered.
+
+`eval-sticky-vs-cold` writes paired packet artifacts under `--output-root`:
+
+- `cold/` normal offline eval packet
+- `sticky/` normal offline eval packet
+- `sticky-vs-cold-summary.json`
+- `sticky-vs-cold-report.md`
+
+The sticky-vs-cold summary compares precision, recall, seeded recall, true/false
+positives, false negatives, schema drops, duplicate findings, secret findings,
+and optional runtime metrics such as provider attempts, latency, and token
+counts. The decision is:
+
+- `not_enough_evidence` when sticky fails packet gates or regresses configured
+  safety/quality thresholds.
+- `advisory` when the paired comparison is clean but measured evidence is still
+  too small for runtime-safe promotion.
+- `runtime_safe_candidate` only when paired scenarios, labels, P0/P1 labels,
+  negative controls, and provider-attempt evidence meet the configured thresholds.
 
 `manifest.json` records the effective thresholds, scenario mode, optional
 scenario source, artifact inventory with SHA-256 digests, metadata counts, and

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -129,6 +129,10 @@ runner or an explicitly configured evidence packet that proves enough paired
 scenarios, labels, negative controls, provider-attempt observations, and fresh
 sticky context.
 
+An empty sticky-vs-cold label set is not counted as negative-control evidence by
+itself. The wrapper must set `negativeControl: true`, and declared
+negative-control wrappers may not include expected labels.
+
 Supported label sources:
 
 - `coderabbit`

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -117,10 +117,16 @@ Supported suites:
 
 Sticky-vs-cold scenarios are paired wrappers around normal offline scenarios.
 They run one cold packet and one sticky packet for the same repo, PR, head SHA,
-and suite, then write side-by-side deltas and a conservative decision. They do
-not enable public confidence percentages; the default output is `advisory`
-unless the sticky packet regresses safety/quality gates or enough measured
-runtime-safe evidence exists.
+suite, and expected label baseline, then write side-by-side deltas and a
+conservative decision. They do not enable public confidence percentages; the
+default output is `advisory` unless the sticky packet regresses safety/quality
+gates or enough measured runtime-safe evidence exists.
+
+The current CLI accepts one paired scenario at a time, so normal single-run
+packets cannot reach `runtime_safe_candidate` with the default evidence-volume
+thresholds. That stronger decision is reserved for a future batch/aggregate
+runner or an explicitly configured evidence packet that proves enough paired
+scenarios, labels, negative controls, and provider-attempt observations.
 
 Supported label sources:
 
@@ -179,7 +185,10 @@ evidence is missing before any stronger confidence display can be considered.
 The sticky-vs-cold summary compares precision, recall, seeded recall, true/false
 positives, false negatives, schema drops, duplicate findings, secret findings,
 and optional runtime metrics such as provider attempts, latency, and token
-counts. The decision is:
+counts. The wrapper rejects different cold/sticky expected labels and fails
+closed when sticky recall, seeded recall, false negatives, false positives,
+secret findings, duplicate findings, or schema drops regress beyond the
+non-loosenable default policy. The decision is:
 
 - `not_enough_evidence` when sticky fails packet gates or regresses configured
   safety/quality thresholds.
@@ -187,6 +196,9 @@ counts. The decision is:
   too small for runtime-safe promotion.
 - `runtime_safe_candidate` only when paired scenarios, labels, P0/P1 labels,
   negative controls, and provider-attempt evidence meet the configured thresholds.
+  With the current single-input CLI, this requires future batch aggregation;
+  caller-provided sticky-vs-cold thresholds cannot loosen the default promotion
+  policy, and this must not be used as a public calibrated-confidence claim.
 
 `manifest.json` records the effective thresholds, scenario mode, optional
 scenario source, artifact inventory with SHA-256 digests, metadata counts, and

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -148,7 +148,10 @@ Supported label sources:
 - `merged_fix`
 - `seeded_defect`
 
-Negative controls use an empty `labels` array. The run passes only when the bot also emits no findings, unless thresholds are intentionally loosened for exploratory scoring.
+Negative controls use an empty `labels` array. In sticky-vs-cold packets, a
+declared negative control only counts and only passes when both cold and sticky
+packets emit zero findings, even when the inner packets use exploratory
+thresholds.
 
 `mode` defaults to `gating`. Gating scenarios may tighten thresholds, but cannot
 silently loosen below the harness defaults. Use `mode: "exploratory"` for scout

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -127,7 +127,9 @@ packets cannot reach `runtime_safe_candidate` with the default evidence-volume
 thresholds. That stronger decision is reserved for a future batch/aggregate
 runner or an explicitly configured evidence packet that proves enough paired
 scenarios, labels, negative controls, provider-attempt observations, and fresh
-sticky context.
+sticky context. Fresh sticky context requires both `staleContext: false` and a
+`repoMemoryAgeSeconds` value no older than the default 24-hour freshness cap;
+missing age evidence keeps the result advisory-only.
 
 An empty sticky-vs-cold label set is not counted as negative-control evidence by
 itself. The wrapper must set `negativeControl: true`, and declared
@@ -200,11 +202,12 @@ non-loosenable default policy. The decision is:
 - `advisory` when the paired comparison is clean but measured evidence is still
   too small for runtime-safe promotion.
 - `runtime_safe_candidate` only when paired scenarios, labels, P0/P1 labels,
-  negative controls, provider-attempt evidence, and explicit fresh sticky context
-  meet the configured thresholds. With the current single-input CLI, this
-  requires future batch aggregation; caller-provided sticky-vs-cold thresholds
-  cannot loosen the default promotion policy, and this must not be used as a
-  public calibrated-confidence claim.
+  negative controls, provider-attempt evidence, explicit fresh sticky context,
+  and repo-memory age evidence meet the configured thresholds. With the current
+  single-input CLI, this requires future batch aggregation; caller-provided
+  sticky-vs-cold thresholds cannot loosen the default promotion policy or
+  freshness cap, and this must not be used as a public calibrated-confidence
+  claim.
 
 `manifest.json` records the effective thresholds, scenario mode, optional
 scenario source, artifact inventory with SHA-256 digests, metadata counts, and

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -131,6 +131,11 @@ sticky context. Fresh sticky context requires both `staleContext: false` and a
 `repoMemoryAgeSeconds` value no older than the default 24-hour freshness cap;
 missing age evidence keeps the result advisory-only.
 
+The sticky-vs-cold output root must be empty before a run starts. The runner
+rejects non-empty roots instead of deleting them, so stale artifacts cannot
+survive into a new evidence packet and the CLI cannot accidentally remove a
+broader eval directory.
+
 An empty sticky-vs-cold label set is not counted as negative-control evidence by
 itself. The wrapper must set `negativeControl: true`, and declared
 negative-control wrappers may not include expected labels.
@@ -198,7 +203,8 @@ secret findings, duplicate findings, or schema drops regress beyond the
 non-loosenable default policy. The decision is:
 
 - `not_enough_evidence` when sticky fails packet gates or regresses configured
-  safety/quality thresholds.
+  safety/quality thresholds, misses a label matched by the cold baseline, or
+  contains any secret-like finding.
 - `advisory` when the paired comparison is clean but measured evidence is still
   too small for runtime-safe promotion.
 - `runtime_safe_candidate` only when paired scenarios, labels, P0/P1 labels,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "doctor": "tsx src/cli.ts doctor",
     "eval:offline": "tsx src/cli.ts eval-offline",
     "eval:suite": "tsx src/cli.ts eval-suite",
+    "eval:sticky-vs-cold": "tsx src/cli.ts eval-sticky-vs-cold",
     "release:status": "tsx src/cli.ts release-status",
     "run-once": "tsx src/cli.ts run-once",
     "daemon": "tsx src/cli.ts daemon"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -883,6 +883,7 @@ async function main(): Promise<void> {
   if (command === "eval-sticky-vs-cold") {
     if (!args.input) throw new Error("--input is required for eval-sticky-vs-cold");
     if (!args["output-root"]) throw new Error("--output-root is required for eval-sticky-vs-cold");
+    assertEvalOutputDirSafe(args["output-root"]);
     const input = readJsonInput(args.input, "--input") as Parameters<typeof runStickyVsColdEval>[0];
     const result = runStickyVsColdEval(input, {
       outputRoot: args["output-root"]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -883,7 +883,7 @@ async function main(): Promise<void> {
   if (command === "eval-sticky-vs-cold") {
     if (!args.input) throw new Error("--input is required for eval-sticky-vs-cold");
     if (!args["output-root"]) throw new Error("--output-root is required for eval-sticky-vs-cold");
-    const input = JSON.parse(readFileSync(args.input, "utf8"));
+    const input = readJsonInput(args.input, "--input") as Parameters<typeof runStickyVsColdEval>[0];
     const result = runStickyVsColdEval(input, {
       outputRoot: args["output-root"]
     });
@@ -1251,6 +1251,15 @@ function parseReviewQueueJobState(value?: string): ReviewQueueJobState | undefin
     return value as ReviewQueueJobState;
   }
   throw new Error(`--state must be one of: ${REVIEW_QUEUE_JOB_STATES.join(", ")}`);
+}
+
+function readJsonInput(path: string, flagName: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`failed to parse ${flagName} ${path}: ${detail}`);
+  }
 }
 
 function listJsonFiles(inputDir: string): string[] {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,13 @@ import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
 import { runDaemonCycle } from "./daemon.js";
 import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, parse as parsePath, resolve, sep } from "node:path";
-import { assertEvalOutputDirSafe, buildEvalPromotionDecisionMarkdown, REQUIRED_SUITES, runOfflineEval } from "./eval-harness.js";
+import {
+  assertEvalOutputDirSafe,
+  buildEvalPromotionDecisionMarkdown,
+  REQUIRED_SUITES,
+  runOfflineEval,
+  runStickyVsColdEval
+} from "./eval-harness.js";
 import { buildEnrichmentComment, buildIssueEnrichmentDryRunOutput } from "./enrichment.js";
 import {
   buildFinishingTouchDraft,
@@ -874,6 +880,18 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "eval-sticky-vs-cold") {
+    if (!args.input) throw new Error("--input is required for eval-sticky-vs-cold");
+    if (!args["output-root"]) throw new Error("--output-root is required for eval-sticky-vs-cold");
+    const input = JSON.parse(readFileSync(args.input, "utf8"));
+    const result = runStickyVsColdEval(input, {
+      outputRoot: args["output-root"]
+    });
+    console.log(JSON.stringify(result.summary, null, 2));
+    if (!result.ok) process.exitCode = 1;
+    return;
+  }
+
   if (command === "run-once") {
     const dryRun = args["dry-run"] !== "false";
     const useZCode = args.zcode !== "false";
@@ -1072,7 +1090,8 @@ function buildHelp() {
         "run-once",
         "daemon",
         "eval-offline",
-        "eval-suite"
+        "eval-suite",
+        "eval-sticky-vs-cold"
       ]
     },
     examples: [
@@ -1093,6 +1112,7 @@ function buildHelp() {
       "npx tsx src/cli.ts build-enrichment-comment --config /path/to/live.json --repo owner/repo --pr 123 --output-dir /path/to/evidence",
       "npx tsx src/cli.ts build-enrichment-comment --config /path/to/live.json --repo owner/repo --issue 456 --output-dir /path/to/evidence",
       "npx tsx src/cli.ts issue-enrichment-scan --config /path/to/live.json --dry-run true --output-dir /path/to/evidence",
+      "npx tsx src/cli.ts eval-sticky-vs-cold --input /path/to/sticky-vs-cold.json --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold",
       "npx tsx src/cli.ts finishing-touch-dry-run --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD --current-head HEAD --comment-id 456 --author maintainer --trusted-authors maintainer --body '@evaos-code-review-bot explain risk'",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ]

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -505,11 +505,12 @@ function buildStickyVsColdSummary(input: {
     coldRuntime: input.input.coldRuntime,
     stickyRuntime: input.input.stickyRuntime
   });
+  const negativeControlClean = hasCleanNegativeControlEvidence(input.cold.scorecard, input.sticky.scorecard);
   const evidenceCounts = {
     pairedScenarios: 1,
     labeledFindings: input.sticky.scorecard.counts.labels,
     p0p1Labels: input.sticky.scorecard.counts.p0p1Labels,
-    negativeControlScenarios: input.input.negativeControl === true ? 1 : 0
+    negativeControlScenarios: input.input.negativeControl === true && negativeControlClean ? 1 : 0
   };
   const gates = buildStickyVsColdGates({
     cold: input.cold,
@@ -517,7 +518,8 @@ function buildStickyVsColdSummary(input: {
     deltas,
     thresholds: input.thresholds,
     coldRuntime: input.input.coldRuntime,
-    stickyRuntime: input.input.stickyRuntime
+    stickyRuntime: input.input.stickyRuntime,
+    negativeControl: input.input.negativeControl
   });
   const ok = gates.every((gate) => gate.ok);
   const providerAttemptsComparable =
@@ -613,6 +615,7 @@ function buildStickyVsColdGates(input: {
   thresholds: StickyVsColdThresholds;
   coldRuntime?: StickyVsColdRuntimeMetrics;
   stickyRuntime?: StickyVsColdRuntimeMetrics;
+  negativeControl?: boolean;
 }): StickyVsColdSummary["gates"] {
   const providerAttemptsComparable =
     typeof input.coldRuntime?.providerAttempts === "number" &&
@@ -624,6 +627,7 @@ function buildStickyVsColdGates(input: {
   const stickyMatchedLabelSet = new Set(input.sticky.scorecard.matchedLabelKeys);
   const missingColdMatchesInSticky = input.cold.scorecard.matchedLabelKeys
     .filter((labelKey) => !stickyMatchedLabelSet.has(labelKey));
+  const negativeControlClean = hasCleanNegativeControlEvidence(input.cold.scorecard, input.sticky.scorecard);
   return [
     {
       name: "sticky_packet_ok",
@@ -636,6 +640,18 @@ function buildStickyVsColdGates(input: {
       ok: input.sticky.scorecard.counts.secretFindings === 0,
       status: input.sticky.scorecard.counts.secretFindings === 0 ? "pass" : "fail",
       detail: `${input.sticky.scorecard.counts.secretFindings} sticky secret-like finding(s)`
+    },
+    {
+      name: "negative_control_clean",
+      ok: input.negativeControl !== true || negativeControlClean,
+      status: input.negativeControl === true
+        ? negativeControlClean ? "pass" : "fail"
+        : "skip",
+      detail: input.negativeControl === true
+        ? negativeControlClean
+          ? "declared negative control has zero cold/sticky labels, findings, and false positives"
+          : "declared negative control must have zero cold/sticky labels, findings, and false positives"
+        : "SKIPPED: scenario is not declared as a negative control"
     },
     {
       name: "no_secret_regression",
@@ -780,6 +796,14 @@ function buildStickyVsColdGates(input: {
       detail: input.cold.ok ? "cold packet gates passed" : "cold packet gates failed; paired comparison cannot pass"
     }
   ];
+}
+
+function hasCleanNegativeControlEvidence(cold: EvalScorecard, sticky: EvalScorecard): boolean {
+  return [cold, sticky].every((scorecard) =>
+    scorecard.counts.labels === 0 &&
+    scorecard.counts.botFindings === 0 &&
+    scorecard.counts.falsePositive === 0
+  );
 }
 
 function buildStickyVsColdReport(summary: StickyVsColdSummary): string {

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -1527,6 +1527,8 @@ function validateStickyVsColdInput(input: StickyVsColdScenarioInput): void {
   if (!input.sticky || typeof input.sticky !== "object") throw new Error("sticky scenario is required");
   validateEvalInput(input.cold);
   validateEvalInput(input.sticky);
+  validateEvalScenarioThresholdPolicy(input.cold, "cold");
+  validateEvalScenarioThresholdPolicy(input.sticky, "sticky");
   if (input.scenarioSource !== undefined) validateScenarioSource(input.scenarioSource);
   if (input.coldRuntime !== undefined) validateStickyRuntimeMetrics(input.coldRuntime, "coldRuntime");
   if (input.stickyRuntime !== undefined) validateStickyRuntimeMetrics(input.stickyRuntime, "stickyRuntime");
@@ -1543,6 +1545,17 @@ function validateStickyVsColdInput(input: StickyVsColdScenarioInput): void {
   validateEquivalentExpectedLabels(input.cold.labels, input.sticky.labels);
   if (input.negativeControl === true && expectedLabelKeys(input.sticky.labels).length > 0) {
     throw new Error("negativeControl sticky-vs-cold scenarios must not include expected labels");
+  }
+}
+
+function validateEvalScenarioThresholdPolicy(input: EvalScenarioInput, labelPath: string): void {
+  const thresholds = { ...DEFAULT_THRESHOLDS, ...(input.thresholds ?? {}) };
+  try {
+    validateThresholds(thresholds);
+    validateThresholdPolicy(input.mode ?? "gating", input.thresholds ?? {});
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`${labelPath}.${detail}`);
   }
 }
 

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -100,6 +100,106 @@ export interface EvalRunResult {
   artifacts: Record<string, string>;
 }
 
+export interface StickyVsColdRuntimeMetrics {
+  providerAttempts?: number;
+  latencyMs?: number;
+  promptTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  providerCooldowns?: number;
+  memoryPacketSha?: string;
+  gitnexusPacketSha?: string;
+  stickySessionId?: string;
+  repoMemoryAgeSeconds?: number;
+  staleContext?: boolean;
+  notes?: string[];
+}
+
+export interface StickyVsColdThresholds {
+  maxFalsePositiveDelta: number;
+  maxSecretFindingDelta: number;
+  maxDuplicateFindingDelta: number;
+  maxSchemaDropDelta: number;
+  requireProviderAttemptsNotHigher: boolean;
+  minRuntimeSafeScenarios: number;
+  minRuntimeSafeLabeledFindings: number;
+  minRuntimeSafeP0P1Labels: number;
+  minRuntimeSafeNegativeControls: number;
+}
+
+export interface StickyVsColdScenarioInput {
+  evalName?: string;
+  runId: string;
+  scenarioSource?: EvalScenarioSourceInput;
+  cold: EvalScenarioInput;
+  sticky: EvalScenarioInput;
+  coldRuntime?: StickyVsColdRuntimeMetrics;
+  stickyRuntime?: StickyVsColdRuntimeMetrics;
+  thresholds?: Partial<StickyVsColdThresholds>;
+}
+
+export type StickyVsColdDecision = "advisory" | "runtime_safe_candidate" | "not_enough_evidence";
+
+export interface StickyVsColdEvalResult {
+  ok: boolean;
+  outputRoot: string;
+  cold: EvalRunResult;
+  sticky: EvalRunResult;
+  summary: StickyVsColdSummary;
+  artifacts: Record<string, string>;
+}
+
+export interface StickyVsColdSummary {
+  evalName: string;
+  artifactVersion: "0.1";
+  runId: string;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  suite: EvalSuiteName;
+  decision: StickyVsColdDecision;
+  ok: boolean;
+  publicConfidence: "uncalibrated";
+  generatedAt: string;
+  scenarioSource?: unknown;
+  packets: {
+    cold: { outputDir: string; ok: boolean; scorecard: EvalScorecard };
+    sticky: { outputDir: string; ok: boolean; scorecard: EvalScorecard };
+  };
+  deltas: {
+    precision: number;
+    recall: number;
+    seededRecall: number;
+    truePositive: number;
+    falsePositive: number;
+    falseNegative: number;
+    botFindings: number;
+    secretFindings: number;
+    duplicateFindings: number;
+    droppedFromSchema: number;
+    providerAttempts?: number;
+    latencyMs?: number;
+    promptTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    providerCooldowns?: number;
+  };
+  context: {
+    coldRuntime?: unknown;
+    stickyRuntime?: unknown;
+  };
+  evidenceCounts: {
+    pairedScenarios: number;
+    labeledFindings: number;
+    p0p1Labels: number;
+    negativeControlScenarios: number;
+  };
+  thresholds: StickyVsColdThresholds;
+  gates: Array<{ name: string; ok: boolean; detail: string }>;
+  artifactInventory: Array<{ name: string; sha256: string }>;
+  proofBoundary: string;
+}
+
 export interface EvalScorecard {
   evalName: string;
   runId: string;
@@ -213,6 +313,18 @@ export const REQUIRED_SUITES: EvalSuiteName[] = [
   "duplicate_suppression"
 ];
 
+const DEFAULT_STICKY_VS_COLD_THRESHOLDS: StickyVsColdThresholds = {
+  maxFalsePositiveDelta: 0,
+  maxSecretFindingDelta: 0,
+  maxDuplicateFindingDelta: 0,
+  maxSchemaDropDelta: 0,
+  requireProviderAttemptsNotHigher: true,
+  minRuntimeSafeScenarios: 30,
+  minRuntimeSafeLabeledFindings: PUBLIC_CONFIDENCE_POLICY.minLabeledFindings,
+  minRuntimeSafeP0P1Labels: PUBLIC_CONFIDENCE_POLICY.minP0P1Labels,
+  minRuntimeSafeNegativeControls: PUBLIC_CONFIDENCE_POLICY.minNegativeControlScenarios
+};
+
 export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions = {}): EvalRunResult {
   validateEvalInput(input);
   const thresholds = { ...DEFAULT_THRESHOLDS, ...(input.thresholds ?? {}) };
@@ -310,6 +422,290 @@ export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions
     scorecard,
     artifacts
   };
+}
+
+export function runStickyVsColdEval(
+  input: StickyVsColdScenarioInput,
+  options: { outputRoot?: string; now?: Date } = {}
+): StickyVsColdEvalResult {
+  validateStickyVsColdInput(input);
+  const now = options.now ?? new Date();
+  const evalName = input.evalName ?? "evaos-zcode-review-bot-sticky-vs-cold-v0.1";
+  const thresholds = { ...DEFAULT_STICKY_VS_COLD_THRESHOLDS, ...(input.thresholds ?? {}) };
+  validateStickyVsColdThresholds(thresholds);
+  const outputRoot = options.outputRoot ?? defaultStickyVsColdOutputRoot(input, now);
+  guardOutputDir(outputRoot);
+  mkdirSync(outputRoot, { recursive: true });
+
+  const cold = runOfflineEval(input.cold, {
+    outputDir: join(outputRoot, "cold"),
+    now
+  });
+  const sticky = runOfflineEval(input.sticky, {
+    outputDir: join(outputRoot, "sticky"),
+    now
+  });
+
+  const summaryPath = join(outputRoot, "sticky-vs-cold-summary.json");
+  const reportPath = join(outputRoot, "sticky-vs-cold-report.md");
+  const summary = buildStickyVsColdSummary({
+    input,
+    evalName,
+    cold,
+    sticky,
+    thresholds,
+    now
+  });
+  writeFileSync(reportPath, buildStickyVsColdReport(summary));
+  const artifactInventory = [
+    { name: "sticky-vs-cold-report.md", sha256: sha256File(reportPath) },
+    { name: "cold/scorecard.json", sha256: sha256File(cold.artifacts["scorecard.json"]!) },
+    { name: "sticky/scorecard.json", sha256: sha256File(sticky.artifacts["scorecard.json"]!) },
+    { name: "cold/manifest.json", sha256: sha256File(cold.artifacts["manifest.json"]!) },
+    { name: "sticky/manifest.json", sha256: sha256File(sticky.artifacts["manifest.json"]!) }
+  ];
+  const finalSummary = { ...summary, artifactInventory };
+  writeJson(summaryPath, finalSummary);
+
+  return {
+    ok: finalSummary.ok,
+    outputRoot,
+    cold,
+    sticky,
+    summary: finalSummary,
+    artifacts: {
+      "sticky-vs-cold-summary.json": summaryPath,
+      "sticky-vs-cold-report.md": reportPath
+    }
+  };
+}
+
+function buildStickyVsColdSummary(input: {
+  input: StickyVsColdScenarioInput;
+  evalName: string;
+  cold: EvalRunResult;
+  sticky: EvalRunResult;
+  thresholds: StickyVsColdThresholds;
+  now: Date;
+}): StickyVsColdSummary {
+  const deltas = buildStickyVsColdDeltas({
+    cold: input.cold.scorecard,
+    sticky: input.sticky.scorecard,
+    coldRuntime: input.input.coldRuntime,
+    stickyRuntime: input.input.stickyRuntime
+  });
+  const evidenceCounts = {
+    pairedScenarios: 1,
+    labeledFindings: input.sticky.scorecard.counts.labels,
+    p0p1Labels: input.sticky.scorecard.counts.p0p1Labels,
+    negativeControlScenarios: input.sticky.scorecard.counts.labels === 0 ? 1 : 0
+  };
+  const gates = buildStickyVsColdGates({
+    cold: input.cold,
+    sticky: input.sticky,
+    deltas,
+    thresholds: input.thresholds,
+    coldRuntime: input.input.coldRuntime,
+    stickyRuntime: input.input.stickyRuntime
+  });
+  const ok = gates.every((gate) => gate.ok);
+  const providerAttemptsComparable =
+    typeof input.input.coldRuntime?.providerAttempts === "number" &&
+    typeof input.input.stickyRuntime?.providerAttempts === "number";
+  const runtimeSafeEvidence =
+    ok &&
+    providerAttemptsComparable &&
+    evidenceCounts.pairedScenarios >= input.thresholds.minRuntimeSafeScenarios &&
+    evidenceCounts.labeledFindings >= input.thresholds.minRuntimeSafeLabeledFindings &&
+    evidenceCounts.p0p1Labels >= input.thresholds.minRuntimeSafeP0P1Labels &&
+    evidenceCounts.negativeControlScenarios >= input.thresholds.minRuntimeSafeNegativeControls;
+  const decision: StickyVsColdDecision = ok
+    ? runtimeSafeEvidence
+      ? "runtime_safe_candidate"
+      : "advisory"
+    : "not_enough_evidence";
+
+  return {
+    evalName: input.evalName,
+    artifactVersion: "0.1",
+    runId: input.input.runId,
+    repo: input.sticky.scorecard.repo,
+    pullNumber: input.sticky.scorecard.pullNumber,
+    headSha: input.sticky.scorecard.headSha,
+    suite: input.sticky.scorecard.suite,
+    decision,
+    ok,
+    publicConfidence: "uncalibrated",
+    generatedAt: input.now.toISOString(),
+    ...(input.input.scenarioSource ? { scenarioSource: redactUnknown(input.input.scenarioSource) } : {}),
+    packets: {
+      cold: {
+        outputDir: input.cold.outputDir,
+        ok: input.cold.ok,
+        scorecard: input.cold.scorecard
+      },
+      sticky: {
+        outputDir: input.sticky.outputDir,
+        ok: input.sticky.ok,
+        scorecard: input.sticky.scorecard
+      }
+    },
+    deltas,
+    context: {
+      ...(input.input.coldRuntime ? { coldRuntime: redactUnknown(input.input.coldRuntime) } : {}),
+      ...(input.input.stickyRuntime ? { stickyRuntime: redactUnknown(input.input.stickyRuntime) } : {})
+    },
+    evidenceCounts,
+    thresholds: input.thresholds,
+    gates,
+    artifactInventory: [],
+    proofBoundary: "offline paired sticky-vs-cold eval packet only; no GitHub posting, launchd mutation, repo mutation, or calibrated public confidence claim"
+  };
+}
+
+function buildStickyVsColdDeltas(input: {
+  cold: EvalScorecard;
+  sticky: EvalScorecard;
+  coldRuntime?: StickyVsColdRuntimeMetrics;
+  stickyRuntime?: StickyVsColdRuntimeMetrics;
+}): StickyVsColdSummary["deltas"] {
+  return {
+    precision: roundMetric(input.sticky.metrics.precision - input.cold.metrics.precision),
+    recall: roundMetric(input.sticky.metrics.recall - input.cold.metrics.recall),
+    seededRecall: roundMetric(input.sticky.metrics.seededRecall - input.cold.metrics.seededRecall),
+    truePositive: input.sticky.counts.truePositive - input.cold.counts.truePositive,
+    falsePositive: input.sticky.counts.falsePositive - input.cold.counts.falsePositive,
+    falseNegative: input.sticky.counts.falseNegative - input.cold.counts.falseNegative,
+    botFindings: input.sticky.counts.botFindings - input.cold.counts.botFindings,
+    secretFindings: input.sticky.counts.secretFindings - input.cold.counts.secretFindings,
+    duplicateFindings: input.sticky.counts.duplicateFindings - input.cold.counts.duplicateFindings,
+    droppedFromSchema: input.sticky.counts.droppedFromSchema - input.cold.counts.droppedFromSchema,
+    ...optionalNumberDelta("providerAttempts", input.coldRuntime?.providerAttempts, input.stickyRuntime?.providerAttempts),
+    ...optionalNumberDelta("latencyMs", input.coldRuntime?.latencyMs, input.stickyRuntime?.latencyMs),
+    ...optionalNumberDelta("promptTokens", input.coldRuntime?.promptTokens, input.stickyRuntime?.promptTokens),
+    ...optionalNumberDelta("outputTokens", input.coldRuntime?.outputTokens, input.stickyRuntime?.outputTokens),
+    ...optionalNumberDelta("totalTokens", input.coldRuntime?.totalTokens, input.stickyRuntime?.totalTokens),
+    ...optionalNumberDelta("providerCooldowns", input.coldRuntime?.providerCooldowns, input.stickyRuntime?.providerCooldowns)
+  };
+}
+
+function buildStickyVsColdGates(input: {
+  cold: EvalRunResult;
+  sticky: EvalRunResult;
+  deltas: StickyVsColdSummary["deltas"];
+  thresholds: StickyVsColdThresholds;
+  coldRuntime?: StickyVsColdRuntimeMetrics;
+  stickyRuntime?: StickyVsColdRuntimeMetrics;
+}): StickyVsColdSummary["gates"] {
+  const providerAttemptsComparable =
+    typeof input.coldRuntime?.providerAttempts === "number" &&
+    typeof input.stickyRuntime?.providerAttempts === "number";
+  return [
+    {
+      name: "sticky_packet_ok",
+      ok: input.sticky.ok,
+      detail: input.sticky.ok ? "sticky packet gates passed" : "sticky packet gates failed"
+    },
+    {
+      name: "no_secret_regression",
+      ok: input.deltas.secretFindings <= input.thresholds.maxSecretFindingDelta,
+      detail: `${input.deltas.secretFindings} <= ${input.thresholds.maxSecretFindingDelta}`
+    },
+    {
+      name: "no_duplicate_regression",
+      ok: input.deltas.duplicateFindings <= input.thresholds.maxDuplicateFindingDelta,
+      detail: `${input.deltas.duplicateFindings} <= ${input.thresholds.maxDuplicateFindingDelta}`
+    },
+    {
+      name: "no_schema_drop_regression",
+      ok: input.deltas.droppedFromSchema <= input.thresholds.maxSchemaDropDelta,
+      detail: `${input.deltas.droppedFromSchema} <= ${input.thresholds.maxSchemaDropDelta}`
+    },
+    {
+      name: "no_false_positive_regression",
+      ok: input.deltas.falsePositive <= input.thresholds.maxFalsePositiveDelta,
+      detail: `${input.deltas.falsePositive} <= ${input.thresholds.maxFalsePositiveDelta}`
+    },
+    {
+      name: "provider_attempts_not_higher",
+      ok: !input.thresholds.requireProviderAttemptsNotHigher ||
+        !providerAttemptsComparable ||
+        (input.stickyRuntime?.providerAttempts ?? 0) <= (input.coldRuntime?.providerAttempts ?? 0),
+      detail: providerAttemptsComparable
+        ? `${input.stickyRuntime!.providerAttempts} <= ${input.coldRuntime!.providerAttempts}`
+        : "provider attempt counts not supplied; gate is informational"
+    },
+    {
+      name: "cold_packet_observed",
+      ok: true,
+      detail: input.cold.ok ? "cold packet gates passed" : "cold packet gates failed but remains usable as baseline evidence"
+    }
+  ];
+}
+
+function buildStickyVsColdReport(summary: StickyVsColdSummary): string {
+  return [
+    "# Sticky vs Cold Eval Report",
+    "",
+    `Decision: ${summary.decision}`,
+    `Public confidence: ${summary.publicConfidence}`,
+    `Scenario: ${summary.repo}#${summary.pullNumber} @ ${summary.headSha}`,
+    `Suite: ${summary.suite}`,
+    "",
+    "## Packets",
+    "",
+    `- Cold: ${summary.packets.cold.ok ? "ok" : "failed"} (${summary.packets.cold.outputDir})`,
+    `- Sticky: ${summary.packets.sticky.ok ? "ok" : "failed"} (${summary.packets.sticky.outputDir})`,
+    "",
+    "## Scorecard Deltas",
+    "",
+    "| Metric | Sticky - cold |",
+    "| --- | ---: |",
+    `| Precision | ${summary.deltas.precision} |`,
+    `| Recall | ${summary.deltas.recall} |`,
+    `| Seeded recall | ${summary.deltas.seededRecall} |`,
+    `| True positives | ${summary.deltas.truePositive} |`,
+    `| False positives | ${summary.deltas.falsePositive} |`,
+    `| False negatives | ${summary.deltas.falseNegative} |`,
+    `| Bot findings | ${summary.deltas.botFindings} |`,
+    `| Secret findings | ${summary.deltas.secretFindings} |`,
+    `| Duplicate findings | ${summary.deltas.duplicateFindings} |`,
+    `| Schema drops | ${summary.deltas.droppedFromSchema} |`,
+    ...optionalDeltaRows(summary.deltas),
+    "",
+    "## Gates",
+    "",
+    ...summary.gates.map((gate) => `- ${gate.ok ? "PASS" : "FAIL"} ${gate.name}: ${gate.detail}`),
+    "",
+    "## Evidence Counts",
+    "",
+    `- Paired scenarios: ${summary.evidenceCounts.pairedScenarios} / ${summary.thresholds.minRuntimeSafeScenarios}`,
+    `- Labeled findings: ${summary.evidenceCounts.labeledFindings} / ${summary.thresholds.minRuntimeSafeLabeledFindings}`,
+    `- P0/P1 labels: ${summary.evidenceCounts.p0p1Labels} / ${summary.thresholds.minRuntimeSafeP0P1Labels}`,
+    `- Negative-control scenarios: ${summary.evidenceCounts.negativeControlScenarios} / ${summary.thresholds.minRuntimeSafeNegativeControls}`,
+    "",
+    "## Proof Boundary",
+    "",
+    summary.proofBoundary,
+    ""
+  ].join("\n");
+}
+
+function optionalDeltaRows(deltas: StickyVsColdSummary["deltas"]): string[] {
+  const rows: string[] = [];
+  for (const key of ["providerAttempts", "latencyMs", "promptTokens", "outputTokens", "totalTokens", "providerCooldowns"] as const) {
+    if (typeof deltas[key] === "number") rows.push(`| ${key} | ${deltas[key]} |`);
+  }
+  return rows;
+}
+
+function optionalNumberDelta<K extends keyof StickyVsColdSummary["deltas"]>(
+  key: K,
+  cold: number | undefined,
+  sticky: number | undefined
+): Partial<Pick<StickyVsColdSummary["deltas"], K>> {
+  if (typeof cold !== "number" || typeof sticky !== "number") return {};
+  return { [key]: sticky - cold } as Partial<Pick<StickyVsColdSummary["deltas"], K>>;
 }
 
 function buildScorecard(input: {
@@ -937,6 +1333,76 @@ function csvCell(value: string): string {
 
 function roundMetric(value: number): number {
   return Math.round(value * 1000) / 1000;
+}
+
+function defaultStickyVsColdOutputRoot(input: Pick<StickyVsColdScenarioInput, "runId">, now: Date): string {
+  const date = now.toISOString().slice(0, 10);
+  return join("/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review", date, sanitizePathSegment(input.runId));
+}
+
+function validateStickyVsColdInput(input: StickyVsColdScenarioInput): void {
+  validateNonEmpty(input.runId, "runId");
+  if (!input.cold || typeof input.cold !== "object") throw new Error("cold scenario is required");
+  if (!input.sticky || typeof input.sticky !== "object") throw new Error("sticky scenario is required");
+  validateEvalInput(input.cold);
+  validateEvalInput(input.sticky);
+  if (input.scenarioSource !== undefined) validateScenarioSource(input.scenarioSource);
+  if (input.coldRuntime !== undefined) validateStickyRuntimeMetrics(input.coldRuntime, "coldRuntime");
+  if (input.stickyRuntime !== undefined) validateStickyRuntimeMetrics(input.stickyRuntime, "stickyRuntime");
+  if (input.thresholds !== undefined) validateStickyVsColdThresholds({ ...DEFAULT_STICKY_VS_COLD_THRESHOLDS, ...input.thresholds });
+
+  for (const field of ["repo", "pullNumber", "headSha", "suite"] as const) {
+    if (input.cold[field] !== input.sticky[field]) {
+      throw new Error(`cold.${field} must match sticky.${field}`);
+    }
+  }
+}
+
+function validateStickyRuntimeMetrics(metrics: StickyVsColdRuntimeMetrics, labelPath: string): void {
+  for (const field of [
+    "providerAttempts",
+    "latencyMs",
+    "promptTokens",
+    "outputTokens",
+    "totalTokens",
+    "providerCooldowns",
+    "repoMemoryAgeSeconds"
+  ] as const) {
+    if (metrics[field] !== undefined && (!Number.isFinite(metrics[field]) || metrics[field] < 0)) {
+      throw new Error(`${labelPath}.${field} must be a non-negative number`);
+    }
+  }
+  for (const field of ["memoryPacketSha", "gitnexusPacketSha"] as const) {
+    if (metrics[field] !== undefined && !/^[a-f0-9]{64}$/i.test(metrics[field])) {
+      throw new Error(`${labelPath}.${field} must be a sha256 hex digest`);
+    }
+  }
+  if (metrics.stickySessionId !== undefined && typeof metrics.stickySessionId !== "string") {
+    throw new Error(`${labelPath}.stickySessionId must be a string`);
+  }
+  if (metrics.staleContext !== undefined && typeof metrics.staleContext !== "boolean") {
+    throw new Error(`${labelPath}.staleContext must be a boolean`);
+  }
+  if (metrics.notes !== undefined && (!Array.isArray(metrics.notes) || metrics.notes.some((note) => typeof note !== "string"))) {
+    throw new Error(`${labelPath}.notes must be an array of strings`);
+  }
+}
+
+function validateStickyVsColdThresholds(thresholds: StickyVsColdThresholds): void {
+  for (const key of ["maxFalsePositiveDelta", "maxSecretFindingDelta", "maxDuplicateFindingDelta", "maxSchemaDropDelta"] as const) {
+    if (!Number.isInteger(thresholds[key]) || thresholds[key] < 0) throw new Error(`${key} must be a non-negative integer`);
+  }
+  if (typeof thresholds.requireProviderAttemptsNotHigher !== "boolean") {
+    throw new Error("requireProviderAttemptsNotHigher must be a boolean");
+  }
+  for (const key of [
+    "minRuntimeSafeScenarios",
+    "minRuntimeSafeLabeledFindings",
+    "minRuntimeSafeP0P1Labels",
+    "minRuntimeSafeNegativeControls"
+  ] as const) {
+    if (!Number.isInteger(thresholds[key]) || thresholds[key] < 0) throw new Error(`${key} must be a non-negative integer`);
+  }
 }
 
 function validateEvalInput(input: EvalScenarioInput): void {

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { parseFindings } from "./findings.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
@@ -235,6 +235,7 @@ export interface EvalScorecard {
     seededRecall: number;
     maxWilsonLowerBound: number;
   };
+  matchedLabelKeys: string[];
   thresholds: EvalThresholds;
   gates: Array<{ name: string; ok: boolean; detail: string }>;
 }
@@ -444,6 +445,7 @@ export function runStickyVsColdEval(
   validateStickyVsColdThresholds(thresholds);
   const outputRoot = options.outputRoot ?? defaultStickyVsColdOutputRoot(input, now);
   guardOutputDir(outputRoot);
+  guardEmptyOutputRoot(outputRoot);
   mkdirSync(outputRoot, { recursive: true });
 
   const cold = runOfflineEval(input.cold, {
@@ -619,12 +621,21 @@ function buildStickyVsColdGates(input: {
   const stickyRepoMemoryAgeFresh =
     typeof stickyRepoMemoryAge === "number" && stickyRepoMemoryAge <= input.thresholds.maxRepoMemoryAgeSeconds;
   const coldComparable = input.cold.ok;
+  const stickyMatchedLabelSet = new Set(input.sticky.scorecard.matchedLabelKeys);
+  const missingColdMatchesInSticky = input.cold.scorecard.matchedLabelKeys
+    .filter((labelKey) => !stickyMatchedLabelSet.has(labelKey));
   return [
     {
       name: "sticky_packet_ok",
       ok: input.sticky.ok,
       status: input.sticky.ok ? "pass" : "fail",
       detail: input.sticky.ok ? "sticky packet gates passed" : "sticky packet gates failed"
+    },
+    {
+      name: "sticky_has_no_secrets",
+      ok: input.sticky.scorecard.counts.secretFindings === 0,
+      status: input.sticky.scorecard.counts.secretFindings === 0 ? "pass" : "fail",
+      detail: `${input.sticky.scorecard.counts.secretFindings} sticky secret-like finding(s)`
     },
     {
       name: "no_secret_regression",
@@ -693,6 +704,18 @@ function buildStickyVsColdGates(input: {
         : "SKIPPED: cold packet failed; comparative seeded-recall delta is not meaningful"
     },
     {
+      name: "sticky_preserves_cold_matches",
+      ok: !coldComparable || missingColdMatchesInSticky.length === 0,
+      status: !coldComparable
+        ? "skip"
+        : missingColdMatchesInSticky.length === 0
+          ? "pass"
+          : "fail",
+      detail: coldComparable
+        ? `${missingColdMatchesInSticky.length} cold-matched label(s) missing from sticky`
+        : "SKIPPED: cold packet failed; matched-label comparison is not meaningful"
+    },
+    {
       name: "provider_attempts_not_higher",
       ok: !input.thresholds.requireProviderAttemptsNotHigher ||
         !providerAttemptsComparable ||
@@ -736,7 +759,7 @@ function buildStickyVsColdGates(input: {
       name: "cold_packet_ok",
       ok: input.cold.ok,
       status: input.cold.ok ? "pass" : "fail",
-      detail: input.cold.ok ? "cold packet gates passed" : "cold packet gates failed; paired comparison cannot be advisory"
+      detail: input.cold.ok ? "cold packet gates passed" : "cold packet gates failed; paired comparison cannot pass"
     }
   ];
 }
@@ -825,6 +848,12 @@ function buildScorecard(input: {
   const truePositive = matchedBotIds.size;
   const falsePositive = input.botFindings.length - truePositive;
   const falseNegative = input.labels.length - matchedLabelIds.size;
+  const labelById = new Map(input.labels.map((label) => [label.id, label]));
+  const matchedLabelKeys = [...matchedLabelIds]
+    .map((labelId) => labelById.get(labelId))
+    .filter((label): label is NormalizedEvalFinding => label !== undefined)
+    .map(normalizedExpectedLabelKey)
+    .sort();
   const seededLabels = input.labels.filter((label) => label.source === "seeded_defect");
   const matchedSeeded = seededLabels.filter((label) => matchedLabelIds.has(label.id)).length;
   const precision = input.botFindings.length === 0 ? (input.labels.length === 0 ? 1 : 0) : truePositive / input.botFindings.length;
@@ -873,6 +902,7 @@ function buildScorecard(input: {
       seededRecall: roundMetric(seededRecall),
       maxWilsonLowerBound
     },
+    matchedLabelKeys,
     thresholds: input.thresholds,
     gates: [
       {
@@ -1379,6 +1409,17 @@ function guardOutputDir(outputDir: string): void {
   assertEvalOutputDirSafe(outputDir);
 }
 
+function guardEmptyOutputRoot(outputRoot: string): void {
+  if (!existsSync(outputRoot)) return;
+  const stat = statSync(outputRoot);
+  if (!stat.isDirectory()) {
+    throw new Error("outputRoot must be a directory when it already exists");
+  }
+  if (readdirSync(outputRoot).length > 0) {
+    throw new Error("outputRoot must be empty before running sticky-vs-cold eval; choose a fresh output root to avoid stale artifacts");
+  }
+}
+
 function resolveRealPathForPotentialOutput(path: string): string {
   const resolved = resolve(path);
   if (existsSync(resolved)) return realpathSync(resolved);
@@ -1564,6 +1605,24 @@ function expectedLabelKeys(labels: EvalLabelInput[]): string[] {
       label.diffSummary ?? ""
     ].join("\u001f"))
     .sort();
+}
+
+function normalizedExpectedLabelKey(label: NormalizedEvalFinding): string {
+  const evidence = label.evidence ?? {};
+  return [
+    label.source,
+    label.severity,
+    label.path,
+    label.line,
+    label.title.trim(),
+    label.body.trim(),
+    evidence.sourceId ?? "",
+    evidence.sourceUrl ?? "",
+    evidence.author ?? "",
+    evidence.checkName ?? "",
+    evidence.mergeSha ?? "",
+    evidence.diffSummary ?? ""
+  ].join("\u001f");
 }
 
 function validateEvalInput(input: EvalScenarioInput): void {

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -117,9 +117,12 @@ export interface StickyVsColdRuntimeMetrics {
 
 export interface StickyVsColdThresholds {
   maxFalsePositiveDelta: number;
+  maxFalseNegativeDelta: number;
   maxSecretFindingDelta: number;
   maxDuplicateFindingDelta: number;
   maxSchemaDropDelta: number;
+  minRecallDelta: number;
+  minSeededRecallDelta: number;
   requireProviderAttemptsNotHigher: boolean;
   minRuntimeSafeScenarios: number;
   minRuntimeSafeLabeledFindings: number;
@@ -195,7 +198,7 @@ export interface StickyVsColdSummary {
     negativeControlScenarios: number;
   };
   thresholds: StickyVsColdThresholds;
-  gates: Array<{ name: string; ok: boolean; detail: string }>;
+  gates: Array<{ name: string; ok: boolean; status: "pass" | "fail" | "skip"; detail: string }>;
   artifactInventory: Array<{ name: string; sha256: string }>;
   proofBoundary: string;
 }
@@ -315,9 +318,12 @@ export const REQUIRED_SUITES: EvalSuiteName[] = [
 
 const DEFAULT_STICKY_VS_COLD_THRESHOLDS: StickyVsColdThresholds = {
   maxFalsePositiveDelta: 0,
+  maxFalseNegativeDelta: 0,
   maxSecretFindingDelta: 0,
   maxDuplicateFindingDelta: 0,
   maxSchemaDropDelta: 0,
+  minRecallDelta: 0,
+  minSeededRecallDelta: 0,
   requireProviderAttemptsNotHigher: true,
   minRuntimeSafeScenarios: 30,
   minRuntimeSafeLabeledFindings: PUBLIC_CONFIDENCE_POLICY.minLabeledFindings,
@@ -604,41 +610,70 @@ function buildStickyVsColdGates(input: {
     {
       name: "sticky_packet_ok",
       ok: input.sticky.ok,
+      status: input.sticky.ok ? "pass" : "fail",
       detail: input.sticky.ok ? "sticky packet gates passed" : "sticky packet gates failed"
     },
     {
       name: "no_secret_regression",
       ok: input.deltas.secretFindings <= input.thresholds.maxSecretFindingDelta,
+      status: input.deltas.secretFindings <= input.thresholds.maxSecretFindingDelta ? "pass" : "fail",
       detail: `${input.deltas.secretFindings} <= ${input.thresholds.maxSecretFindingDelta}`
     },
     {
       name: "no_duplicate_regression",
       ok: input.deltas.duplicateFindings <= input.thresholds.maxDuplicateFindingDelta,
+      status: input.deltas.duplicateFindings <= input.thresholds.maxDuplicateFindingDelta ? "pass" : "fail",
       detail: `${input.deltas.duplicateFindings} <= ${input.thresholds.maxDuplicateFindingDelta}`
     },
     {
       name: "no_schema_drop_regression",
       ok: input.deltas.droppedFromSchema <= input.thresholds.maxSchemaDropDelta,
+      status: input.deltas.droppedFromSchema <= input.thresholds.maxSchemaDropDelta ? "pass" : "fail",
       detail: `${input.deltas.droppedFromSchema} <= ${input.thresholds.maxSchemaDropDelta}`
     },
     {
       name: "no_false_positive_regression",
       ok: input.deltas.falsePositive <= input.thresholds.maxFalsePositiveDelta,
+      status: input.deltas.falsePositive <= input.thresholds.maxFalsePositiveDelta ? "pass" : "fail",
       detail: `${input.deltas.falsePositive} <= ${input.thresholds.maxFalsePositiveDelta}`
+    },
+    {
+      name: "no_false_negative_regression",
+      ok: input.deltas.falseNegative <= input.thresholds.maxFalseNegativeDelta,
+      status: input.deltas.falseNegative <= input.thresholds.maxFalseNegativeDelta ? "pass" : "fail",
+      detail: `${input.deltas.falseNegative} <= ${input.thresholds.maxFalseNegativeDelta}`
+    },
+    {
+      name: "recall_not_lower",
+      ok: input.deltas.recall >= input.thresholds.minRecallDelta,
+      status: input.deltas.recall >= input.thresholds.minRecallDelta ? "pass" : "fail",
+      detail: `${input.deltas.recall} >= ${input.thresholds.minRecallDelta}`
+    },
+    {
+      name: "seeded_recall_not_lower",
+      ok: input.deltas.seededRecall >= input.thresholds.minSeededRecallDelta,
+      status: input.deltas.seededRecall >= input.thresholds.minSeededRecallDelta ? "pass" : "fail",
+      detail: `${input.deltas.seededRecall} >= ${input.thresholds.minSeededRecallDelta}`
     },
     {
       name: "provider_attempts_not_higher",
       ok: !input.thresholds.requireProviderAttemptsNotHigher ||
         !providerAttemptsComparable ||
         (input.stickyRuntime?.providerAttempts ?? 0) <= (input.coldRuntime?.providerAttempts ?? 0),
+      status: providerAttemptsComparable
+        ? (input.stickyRuntime?.providerAttempts ?? 0) <= (input.coldRuntime?.providerAttempts ?? 0)
+          ? "pass"
+          : "fail"
+        : "skip",
       detail: providerAttemptsComparable
         ? `${input.stickyRuntime!.providerAttempts} <= ${input.coldRuntime!.providerAttempts}`
-        : "provider attempt counts not supplied; gate is informational"
+        : "SKIPPED: provider attempt counts not supplied; runtime_safe_candidate remains disabled"
     },
     {
-      name: "cold_packet_observed",
-      ok: true,
-      detail: input.cold.ok ? "cold packet gates passed" : "cold packet gates failed but remains usable as baseline evidence"
+      name: "cold_packet_ok",
+      ok: input.cold.ok,
+      status: input.cold.ok ? "pass" : "fail",
+      detail: input.cold.ok ? "cold packet gates passed" : "cold packet gates failed; paired comparison cannot be advisory"
     }
   ];
 }
@@ -675,7 +710,7 @@ function buildStickyVsColdReport(summary: StickyVsColdSummary): string {
     "",
     "## Gates",
     "",
-    ...summary.gates.map((gate) => `- ${gate.ok ? "PASS" : "FAIL"} ${gate.name}: ${gate.detail}`),
+    ...summary.gates.map((gate) => `- ${gate.status.toUpperCase()} ${gate.name}: ${gate.detail}`),
     "",
     "## Evidence Counts",
     "",
@@ -1356,6 +1391,7 @@ function validateStickyVsColdInput(input: StickyVsColdScenarioInput): void {
       throw new Error(`cold.${field} must match sticky.${field}`);
     }
   }
+  validateEquivalentExpectedLabels(input.cold.labels, input.sticky.labels);
 }
 
 function validateStickyRuntimeMetrics(metrics: StickyVsColdRuntimeMetrics, labelPath: string): void {
@@ -1389,11 +1425,25 @@ function validateStickyRuntimeMetrics(metrics: StickyVsColdRuntimeMetrics, label
 }
 
 function validateStickyVsColdThresholds(thresholds: StickyVsColdThresholds): void {
-  for (const key of ["maxFalsePositiveDelta", "maxSecretFindingDelta", "maxDuplicateFindingDelta", "maxSchemaDropDelta"] as const) {
+  for (const key of ["maxFalsePositiveDelta", "maxFalseNegativeDelta", "maxSecretFindingDelta", "maxDuplicateFindingDelta", "maxSchemaDropDelta"] as const) {
     if (!Number.isInteger(thresholds[key]) || thresholds[key] < 0) throw new Error(`${key} must be a non-negative integer`);
+    if (thresholds[key] > DEFAULT_STICKY_VS_COLD_THRESHOLDS[key]) {
+      throw new Error(`${key} cannot be loosened below the default sticky-vs-cold safety policy`);
+    }
+  }
+  for (const key of ["minRecallDelta", "minSeededRecallDelta"] as const) {
+    if (typeof thresholds[key] !== "number" || thresholds[key] < -1 || thresholds[key] > 1) {
+      throw new Error(`${key} must be between -1 and 1`);
+    }
+    if (thresholds[key] < DEFAULT_STICKY_VS_COLD_THRESHOLDS[key]) {
+      throw new Error(`${key} cannot be loosened below the default sticky-vs-cold quality policy`);
+    }
   }
   if (typeof thresholds.requireProviderAttemptsNotHigher !== "boolean") {
     throw new Error("requireProviderAttemptsNotHigher must be a boolean");
+  }
+  if (thresholds.requireProviderAttemptsNotHigher !== DEFAULT_STICKY_VS_COLD_THRESHOLDS.requireProviderAttemptsNotHigher) {
+    throw new Error("requireProviderAttemptsNotHigher cannot be disabled for sticky-vs-cold promotion");
   }
   for (const key of [
     "minRuntimeSafeScenarios",
@@ -1402,7 +1452,43 @@ function validateStickyVsColdThresholds(thresholds: StickyVsColdThresholds): voi
     "minRuntimeSafeNegativeControls"
   ] as const) {
     if (!Number.isInteger(thresholds[key]) || thresholds[key] < 0) throw new Error(`${key} must be a non-negative integer`);
+    if (thresholds[key] < DEFAULT_STICKY_VS_COLD_THRESHOLDS[key]) {
+      throw new Error(`${key} cannot be loosened below the default sticky-vs-cold promotion policy`);
+    }
   }
+}
+
+function validateEquivalentExpectedLabels(coldLabels: EvalLabelInput[], stickyLabels: EvalLabelInput[]): void {
+  const cold = expectedLabelKeys(coldLabels);
+  const sticky = expectedLabelKeys(stickyLabels);
+  if (cold.length !== sticky.length) {
+    throw new Error(`cold and sticky expected labels must match (${cold.length} != ${sticky.length})`);
+  }
+  for (let index = 0; index < cold.length; index += 1) {
+    if (cold[index] !== sticky[index]) {
+      throw new Error("cold and sticky expected labels must match");
+    }
+  }
+}
+
+function expectedLabelKeys(labels: EvalLabelInput[]): string[] {
+  return labels
+    .filter((label) => label.expected !== false)
+    .map((label) => [
+      label.source,
+      label.severity,
+      label.path,
+      label.line,
+      label.title.trim(),
+      label.body.trim(),
+      label.sourceId ?? "",
+      label.sourceUrl ?? "",
+      label.author ?? "",
+      label.checkName ?? "",
+      label.mergeSha ?? "",
+      label.diffSummary ?? ""
+    ].join("\u001f"))
+    .sort();
 }
 
 function validateEvalInput(input: EvalScenarioInput): void {

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -134,6 +134,7 @@ export interface StickyVsColdScenarioInput {
   evalName?: string;
   runId: string;
   scenarioSource?: EvalScenarioSourceInput;
+  negativeControl?: boolean;
   cold: EvalScenarioInput;
   sticky: EvalScenarioInput;
   coldRuntime?: StickyVsColdRuntimeMetrics;
@@ -504,7 +505,7 @@ function buildStickyVsColdSummary(input: {
     pairedScenarios: 1,
     labeledFindings: input.sticky.scorecard.counts.labels,
     p0p1Labels: input.sticky.scorecard.counts.p0p1Labels,
-    negativeControlScenarios: input.sticky.scorecard.counts.labels === 0 ? 1 : 0
+    negativeControlScenarios: input.input.negativeControl === true ? 1 : 0
   };
   const gates = buildStickyVsColdGates({
     cold: input.cold,
@@ -608,6 +609,7 @@ function buildStickyVsColdGates(input: {
   const providerAttemptsComparable =
     typeof input.coldRuntime?.providerAttempts === "number" &&
     typeof input.stickyRuntime?.providerAttempts === "number";
+  const coldComparable = input.cold.ok;
   return [
     {
       name: "sticky_packet_ok",
@@ -635,27 +637,51 @@ function buildStickyVsColdGates(input: {
     },
     {
       name: "no_false_positive_regression",
-      ok: input.deltas.falsePositive <= input.thresholds.maxFalsePositiveDelta,
-      status: input.deltas.falsePositive <= input.thresholds.maxFalsePositiveDelta ? "pass" : "fail",
-      detail: `${input.deltas.falsePositive} <= ${input.thresholds.maxFalsePositiveDelta}`
+      ok: !coldComparable || input.deltas.falsePositive <= input.thresholds.maxFalsePositiveDelta,
+      status: !coldComparable
+        ? "skip"
+        : input.deltas.falsePositive <= input.thresholds.maxFalsePositiveDelta
+          ? "pass"
+          : "fail",
+      detail: coldComparable
+        ? `${input.deltas.falsePositive} <= ${input.thresholds.maxFalsePositiveDelta}`
+        : "SKIPPED: cold packet failed; comparative false-positive delta is not meaningful"
     },
     {
       name: "no_false_negative_regression",
-      ok: input.deltas.falseNegative <= input.thresholds.maxFalseNegativeDelta,
-      status: input.deltas.falseNegative <= input.thresholds.maxFalseNegativeDelta ? "pass" : "fail",
-      detail: `${input.deltas.falseNegative} <= ${input.thresholds.maxFalseNegativeDelta}`
+      ok: !coldComparable || input.deltas.falseNegative <= input.thresholds.maxFalseNegativeDelta,
+      status: !coldComparable
+        ? "skip"
+        : input.deltas.falseNegative <= input.thresholds.maxFalseNegativeDelta
+          ? "pass"
+          : "fail",
+      detail: coldComparable
+        ? `${input.deltas.falseNegative} <= ${input.thresholds.maxFalseNegativeDelta}`
+        : "SKIPPED: cold packet failed; comparative false-negative delta is not meaningful"
     },
     {
       name: "recall_not_lower",
-      ok: input.deltas.recall >= input.thresholds.minRecallDelta,
-      status: input.deltas.recall >= input.thresholds.minRecallDelta ? "pass" : "fail",
-      detail: `${input.deltas.recall} >= ${input.thresholds.minRecallDelta}`
+      ok: !coldComparable || input.deltas.recall >= input.thresholds.minRecallDelta,
+      status: !coldComparable
+        ? "skip"
+        : input.deltas.recall >= input.thresholds.minRecallDelta
+          ? "pass"
+          : "fail",
+      detail: coldComparable
+        ? `${input.deltas.recall} >= ${input.thresholds.minRecallDelta}`
+        : "SKIPPED: cold packet failed; comparative recall delta is not meaningful"
     },
     {
       name: "seeded_recall_not_lower",
-      ok: input.deltas.seededRecall >= input.thresholds.minSeededRecallDelta,
-      status: input.deltas.seededRecall >= input.thresholds.minSeededRecallDelta ? "pass" : "fail",
-      detail: `${input.deltas.seededRecall} >= ${input.thresholds.minSeededRecallDelta}`
+      ok: !coldComparable || input.deltas.seededRecall >= input.thresholds.minSeededRecallDelta,
+      status: !coldComparable
+        ? "skip"
+        : input.deltas.seededRecall >= input.thresholds.minSeededRecallDelta
+          ? "pass"
+          : "fail",
+      detail: coldComparable
+        ? `${input.deltas.seededRecall} >= ${input.thresholds.minSeededRecallDelta}`
+        : "SKIPPED: cold packet failed; comparative seeded-recall delta is not meaningful"
     },
     {
       name: "provider_attempts_not_higher",
@@ -1401,6 +1427,9 @@ function validateStickyVsColdInput(input: StickyVsColdScenarioInput): void {
   if (input.coldRuntime !== undefined) validateStickyRuntimeMetrics(input.coldRuntime, "coldRuntime");
   if (input.stickyRuntime !== undefined) validateStickyRuntimeMetrics(input.stickyRuntime, "stickyRuntime");
   if (input.thresholds !== undefined) validateStickyVsColdThresholds({ ...DEFAULT_STICKY_VS_COLD_THRESHOLDS, ...input.thresholds });
+  if (input.negativeControl !== undefined && typeof input.negativeControl !== "boolean") {
+    throw new Error("negativeControl must be a boolean");
+  }
 
   for (const field of ["repo", "pullNumber", "headSha", "suite"] as const) {
     if (input.cold[field] !== input.sticky[field]) {
@@ -1408,6 +1437,9 @@ function validateStickyVsColdInput(input: StickyVsColdScenarioInput): void {
     }
   }
   validateEquivalentExpectedLabels(input.cold.labels, input.sticky.labels);
+  if (input.negativeControl === true && expectedLabelKeys(input.sticky.labels).length > 0) {
+    throw new Error("negativeControl sticky-vs-cold scenarios must not include expected labels");
+  }
 }
 
 function validateStickyRuntimeMetrics(metrics: StickyVsColdRuntimeMetrics, labelPath: string): void {

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -518,9 +518,11 @@ function buildStickyVsColdSummary(input: {
   const providerAttemptsComparable =
     typeof input.input.coldRuntime?.providerAttempts === "number" &&
     typeof input.input.stickyRuntime?.providerAttempts === "number";
+  const stickyContextFreshForPromotion = input.input.stickyRuntime?.staleContext === false;
   const runtimeSafeEvidence =
     ok &&
     providerAttemptsComparable &&
+    stickyContextFreshForPromotion &&
     evidenceCounts.pairedScenarios >= input.thresholds.minRuntimeSafeScenarios &&
     evidenceCounts.labeledFindings >= input.thresholds.minRuntimeSafeLabeledFindings &&
     evidenceCounts.p0p1Labels >= input.thresholds.minRuntimeSafeP0P1Labels &&
@@ -668,6 +670,20 @@ function buildStickyVsColdGates(input: {
       detail: providerAttemptsComparable
         ? `${input.stickyRuntime!.providerAttempts} <= ${input.coldRuntime!.providerAttempts}`
         : "SKIPPED: provider attempt counts not supplied; runtime_safe_candidate remains disabled"
+    },
+    {
+      name: "sticky_context_fresh",
+      ok: input.stickyRuntime?.staleContext !== true,
+      status: input.stickyRuntime?.staleContext === true
+        ? "fail"
+        : input.stickyRuntime?.staleContext === false
+          ? "pass"
+          : "skip",
+      detail: input.stickyRuntime?.staleContext === true
+        ? "sticky runtime marked context stale"
+        : input.stickyRuntime?.staleContext === false
+          ? "sticky runtime marked context fresh"
+          : "SKIPPED: sticky context freshness not supplied; runtime_safe_candidate remains disabled"
     },
     {
       name: "cold_packet_ok",

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -124,6 +124,7 @@ export interface StickyVsColdThresholds {
   minRecallDelta: number;
   minSeededRecallDelta: number;
   requireProviderAttemptsNotHigher: boolean;
+  maxRepoMemoryAgeSeconds: number;
   minRuntimeSafeScenarios: number;
   minRuntimeSafeLabeledFindings: number;
   minRuntimeSafeP0P1Labels: number;
@@ -326,6 +327,7 @@ const DEFAULT_STICKY_VS_COLD_THRESHOLDS: StickyVsColdThresholds = {
   minRecallDelta: 0,
   minSeededRecallDelta: 0,
   requireProviderAttemptsNotHigher: true,
+  maxRepoMemoryAgeSeconds: 86400,
   minRuntimeSafeScenarios: 30,
   minRuntimeSafeLabeledFindings: PUBLIC_CONFIDENCE_POLICY.minLabeledFindings,
   minRuntimeSafeP0P1Labels: PUBLIC_CONFIDENCE_POLICY.minP0P1Labels,
@@ -520,10 +522,14 @@ function buildStickyVsColdSummary(input: {
     typeof input.input.coldRuntime?.providerAttempts === "number" &&
     typeof input.input.stickyRuntime?.providerAttempts === "number";
   const stickyContextFreshForPromotion = input.input.stickyRuntime?.staleContext === false;
+  const stickyRepoMemoryFreshForPromotion =
+    typeof input.input.stickyRuntime?.repoMemoryAgeSeconds === "number" &&
+    input.input.stickyRuntime.repoMemoryAgeSeconds <= input.thresholds.maxRepoMemoryAgeSeconds;
   const runtimeSafeEvidence =
     ok &&
     providerAttemptsComparable &&
     stickyContextFreshForPromotion &&
+    stickyRepoMemoryFreshForPromotion &&
     evidenceCounts.pairedScenarios >= input.thresholds.minRuntimeSafeScenarios &&
     evidenceCounts.labeledFindings >= input.thresholds.minRuntimeSafeLabeledFindings &&
     evidenceCounts.p0p1Labels >= input.thresholds.minRuntimeSafeP0P1Labels &&
@@ -609,6 +615,9 @@ function buildStickyVsColdGates(input: {
   const providerAttemptsComparable =
     typeof input.coldRuntime?.providerAttempts === "number" &&
     typeof input.stickyRuntime?.providerAttempts === "number";
+  const stickyRepoMemoryAge = input.stickyRuntime?.repoMemoryAgeSeconds;
+  const stickyRepoMemoryAgeFresh =
+    typeof stickyRepoMemoryAge === "number" && stickyRepoMemoryAge <= input.thresholds.maxRepoMemoryAgeSeconds;
   const coldComparable = input.cold.ok;
   return [
     {
@@ -710,6 +719,18 @@ function buildStickyVsColdGates(input: {
         : input.stickyRuntime?.staleContext === false
           ? "sticky runtime marked context fresh"
           : "SKIPPED: sticky context freshness not supplied; runtime_safe_candidate remains disabled"
+    },
+    {
+      name: "sticky_repo_memory_fresh",
+      ok: typeof stickyRepoMemoryAge !== "number" || stickyRepoMemoryAgeFresh,
+      status: typeof stickyRepoMemoryAge === "number"
+        ? stickyRepoMemoryAgeFresh
+          ? "pass"
+          : "fail"
+        : "skip",
+      detail: typeof stickyRepoMemoryAge === "number"
+        ? `${stickyRepoMemoryAge} <= ${input.thresholds.maxRepoMemoryAgeSeconds}`
+        : "SKIPPED: sticky repo-memory age not supplied; runtime_safe_candidate remains disabled"
     },
     {
       name: "cold_packet_ok",
@@ -1492,6 +1513,12 @@ function validateStickyVsColdThresholds(thresholds: StickyVsColdThresholds): voi
   }
   if (thresholds.requireProviderAttemptsNotHigher !== DEFAULT_STICKY_VS_COLD_THRESHOLDS.requireProviderAttemptsNotHigher) {
     throw new Error("requireProviderAttemptsNotHigher cannot be disabled for sticky-vs-cold promotion");
+  }
+  if (!Number.isFinite(thresholds.maxRepoMemoryAgeSeconds) || thresholds.maxRepoMemoryAgeSeconds < 0) {
+    throw new Error("maxRepoMemoryAgeSeconds must be a non-negative number");
+  }
+  if (thresholds.maxRepoMemoryAgeSeconds > DEFAULT_STICKY_VS_COLD_THRESHOLDS.maxRepoMemoryAgeSeconds) {
+    throw new Error("maxRepoMemoryAgeSeconds cannot be loosened below the default sticky-vs-cold freshness policy");
   }
   for (const key of [
     "minRuntimeSafeScenarios",

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -639,21 +639,39 @@ function buildStickyVsColdGates(input: {
     },
     {
       name: "no_secret_regression",
-      ok: input.deltas.secretFindings <= input.thresholds.maxSecretFindingDelta,
-      status: input.deltas.secretFindings <= input.thresholds.maxSecretFindingDelta ? "pass" : "fail",
-      detail: `${input.deltas.secretFindings} <= ${input.thresholds.maxSecretFindingDelta}`
+      ok: !coldComparable || input.deltas.secretFindings <= input.thresholds.maxSecretFindingDelta,
+      status: !coldComparable
+        ? "skip"
+        : input.deltas.secretFindings <= input.thresholds.maxSecretFindingDelta
+          ? "pass"
+          : "fail",
+      detail: coldComparable
+        ? `${input.deltas.secretFindings} <= ${input.thresholds.maxSecretFindingDelta}`
+        : "SKIPPED: cold packet failed; comparative secret delta is not meaningful"
     },
     {
       name: "no_duplicate_regression",
-      ok: input.deltas.duplicateFindings <= input.thresholds.maxDuplicateFindingDelta,
-      status: input.deltas.duplicateFindings <= input.thresholds.maxDuplicateFindingDelta ? "pass" : "fail",
-      detail: `${input.deltas.duplicateFindings} <= ${input.thresholds.maxDuplicateFindingDelta}`
+      ok: !coldComparable || input.deltas.duplicateFindings <= input.thresholds.maxDuplicateFindingDelta,
+      status: !coldComparable
+        ? "skip"
+        : input.deltas.duplicateFindings <= input.thresholds.maxDuplicateFindingDelta
+          ? "pass"
+          : "fail",
+      detail: coldComparable
+        ? `${input.deltas.duplicateFindings} <= ${input.thresholds.maxDuplicateFindingDelta}`
+        : "SKIPPED: cold packet failed; comparative duplicate delta is not meaningful"
     },
     {
       name: "no_schema_drop_regression",
-      ok: input.deltas.droppedFromSchema <= input.thresholds.maxSchemaDropDelta,
-      status: input.deltas.droppedFromSchema <= input.thresholds.maxSchemaDropDelta ? "pass" : "fail",
-      detail: `${input.deltas.droppedFromSchema} <= ${input.thresholds.maxSchemaDropDelta}`
+      ok: !coldComparable || input.deltas.droppedFromSchema <= input.thresholds.maxSchemaDropDelta,
+      status: !coldComparable
+        ? "skip"
+        : input.deltas.droppedFromSchema <= input.thresholds.maxSchemaDropDelta
+          ? "pass"
+          : "fail",
+      detail: coldComparable
+        ? `${input.deltas.droppedFromSchema} <= ${input.thresholds.maxSchemaDropDelta}`
+        : "SKIPPED: cold packet failed; comparative schema-drop delta is not meaningful"
     },
     {
       name: "no_false_positive_regression",

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1345,7 +1345,7 @@ function updateReviewerSessionJobAfterReviewStatus(input: {
         return;
       }
       const sessionState = reviewerSessionJobStateForProcessedStatus(processed?.status);
-      updateReviewerSessionJobFromQueueStatus(input, sessionState, processed?.status ?? (input.dryRun ? "dry_run" : "posted"));
+      updateReviewerSessionJobFromQueueStatus(input, sessionState, processed?.status);
       return;
     }
     case "skipped_provider_cooldown":
@@ -1543,7 +1543,7 @@ function reviewerSessionJobStateForProcessedStatus(status: ProcessedStatus | und
     case "skipped":
       return "skipped";
     case undefined:
-      return "completed";
+      return "assigned";
     default:
       return assertNever(status);
   }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1194,7 +1194,7 @@ function readinessStateForProcessedStatus(
     case "skipped":
       return "skipped";
     case undefined:
-      return "ready_for_human";
+      return "queued";
     default:
       return assertNever(status);
   }
@@ -1510,7 +1510,7 @@ function reviewStatusCommentStateForProcessedStatus(
     case "skipped":
       return "skipped";
     case undefined:
-      return "completed";
+      return "queued";
     default:
       return assertNever(status);
   }
@@ -1527,7 +1527,7 @@ function reviewQueueJobStateForProcessedStatus(status: ProcessedStatus | undefin
     case "skipped":
       return "stale_retired";
     case undefined:
-      return dryRun ? "queued" : "posted";
+      return "queued";
     default:
       return assertNever(status);
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -576,7 +576,10 @@ function updateRetryQueueJobsAfterRetry(input: {
       states: ["queued", "leased", "running", "provider_deferred"]
     })
     .filter((job) => job.headSha === input.headSha);
-  if (activeJobs.length === 0) return;
+  const targetJobs = isRetryCommandRecordedStatus(input.status)
+    ? activeJobs.filter((job) => job.source === "manual_command")
+    : activeJobs;
+  if (targetJobs.length === 0) return;
 
   const processed = input.state.getProcessedReview(input.repo, input.pullNumber, input.headSha);
   const providerCooldown = parseProviderCooldownError(processed?.error);
@@ -588,7 +591,7 @@ function updateRetryQueueJobsAfterRetry(input: {
     providerCooldownUntil: providerCooldown?.cooldownUntil,
     processedError: processed?.error
   });
-  for (const job of activeJobs) {
+  for (const job of targetJobs) {
     input.state.updateReviewQueueJobState({
       jobId: job.jobId,
       state: patch.state,
@@ -741,10 +744,21 @@ function reviewerSessionJobStateForProcessedStatus(status: ProcessedStatus | und
     case "skipped":
       return "skipped";
     case undefined:
-      return "completed";
+      return "assigned";
     default:
       return assertNever(status);
   }
+}
+
+function isRetryCommandRecordedStatus(
+  status: RetryFailedHeadResult["status"]
+): status is Extract<
+  RetryFailedHeadResult["status"],
+  "skipped_command_stop" | "skipped_command_explain" | "skipped_finishing_touch_draft"
+> {
+  return status === "skipped_command_stop" ||
+    status === "skipped_command_explain" ||
+    status === "skipped_finishing_touch_draft";
 }
 
 function retryQueueCommandRecordedReason(status: Extract<

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -46,6 +46,7 @@ import {
   isActivationBaselineProcessedReview,
   parseProviderCooldownError,
   ReviewStateStore,
+  type ReviewQueueJobState,
   type ReviewRunLease,
   type StoredProcessedReviewRecord
 } from "./state.js";
@@ -422,6 +423,14 @@ export async function retryFailedHeadWithDeps(input: {
   const pull = await github.getPull(options.repo, options.pullNumber);
   if (isClosedPull(pull)) {
     recordClosedRetrySkip({ state, repo: options.repo, pull, headSha: options.headSha });
+    updateRetryQueueJobsAfterRetry({
+      state,
+      repo: options.repo,
+      pullNumber: options.pullNumber,
+      headSha: options.headSha,
+      status: "skipped_closed",
+      dryRun: options.dryRun
+    });
     return {
       repo: options.repo,
       pullNumber: options.pullNumber,
@@ -440,6 +449,14 @@ export async function retryFailedHeadWithDeps(input: {
       state,
       retryTarget,
       reason: "retry_did_not_review=skipped_stale_head"
+    });
+    updateRetryQueueJobsAfterRetry({
+      state,
+      repo: options.repo,
+      pullNumber: options.pullNumber,
+      headSha: options.headSha,
+      status: "skipped_stale_head",
+      dryRun: options.dryRun
     });
     return {
       repo: options.repo,
@@ -481,6 +498,14 @@ export async function retryFailedHeadWithDeps(input: {
       retryTarget,
       reason: retryStatus === "dry_run" ? "retry_dry_run" : `retry_did_not_review=${retryStatus}`
     });
+    updateRetryQueueJobsAfterRetry({
+      state,
+      repo: options.repo,
+      pullNumber: options.pullNumber,
+      headSha: options.headSha,
+      status: retryStatus,
+      dryRun: options.dryRun
+    });
     return {
       repo: options.repo,
       pullNumber: options.pullNumber,
@@ -495,6 +520,14 @@ export async function retryFailedHeadWithDeps(input: {
       pull,
       error: retryFailureError(retryTarget.previousError, error)
     })) {
+      updateRetryQueueJobsAfterRetry({
+        state,
+        repo: options.repo,
+        pullNumber: options.pullNumber,
+        headSha: options.headSha,
+        status: "skipped_provider_cooldown",
+        dryRun: options.dryRun
+      });
       return {
         repo: options.repo,
         pullNumber: options.pullNumber,
@@ -509,12 +542,131 @@ export async function retryFailedHeadWithDeps(input: {
       pull,
       error: retryFailureError(retryTarget.previousError, error)
     });
+    updateRetryQueueJobsAfterRetry({
+      state,
+      repo: options.repo,
+      pullNumber: options.pullNumber,
+      headSha: options.headSha,
+      status: "failed",
+      dryRun: options.dryRun
+    });
     return {
       repo: options.repo,
       pullNumber: options.pullNumber,
       headSha: options.headSha,
       status: "failed"
     };
+  }
+}
+
+function updateRetryQueueJobsAfterRetry(input: {
+  state: ReviewStateStore;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  status: RetryFailedHeadResult["status"];
+  dryRun: boolean;
+}): void {
+  const activeJobs = input.state
+    .listReviewQueueJobsForPull({
+      repo: input.repo,
+      pullNumber: input.pullNumber,
+      states: ["queued", "leased", "running", "provider_deferred"]
+    })
+    .filter((job) => job.headSha === input.headSha);
+  if (activeJobs.length === 0) return;
+
+  const processed = input.state.getProcessedReview(input.repo, input.pullNumber, input.headSha);
+  const providerCooldown = parseProviderCooldownError(processed?.error);
+  const patch = retryQueuePatchForStatus({
+    status: input.status,
+    dryRun: input.dryRun,
+    processedReviewUrl: processed?.reviewUrl,
+    providerCooldownUntil: providerCooldown?.cooldownUntil,
+    processedError: processed?.error
+  });
+  for (const job of activeJobs) {
+    input.state.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: patch.state,
+      ...(patch.nextEligibleAt ? { nextEligibleAt: patch.nextEligibleAt } : {}),
+      ...(patch.reviewUrl ? { reviewUrl: patch.reviewUrl } : {}),
+      lastError: patch.lastError
+    });
+  }
+}
+
+function retryQueuePatchForStatus(input: {
+  status: RetryFailedHeadResult["status"];
+  dryRun: boolean;
+  processedReviewUrl?: string;
+  providerCooldownUntil?: string;
+  processedError?: string;
+}): { state: ReviewQueueJobState; nextEligibleAt?: string; reviewUrl?: string; lastError: string } {
+  switch (input.status) {
+    case "reviewed":
+    case "reviewed_command":
+      return input.dryRun
+        ? {
+            state: "provider_deferred",
+            lastError: "retry_dry_run_completed_not_posted"
+          }
+        : {
+            state: "posted",
+            ...(input.processedReviewUrl ? { reviewUrl: input.processedReviewUrl } : {}),
+            lastError: input.status
+          };
+    case "dry_run":
+      return {
+        state: "provider_deferred",
+        lastError: "retry_dry_run_completed_not_posted"
+      };
+    case "skipped_provider_cooldown":
+      return {
+        state: "provider_deferred",
+        ...(input.providerCooldownUntil ? { nextEligibleAt: input.providerCooldownUntil } : {}),
+        lastError: input.processedError ?? "provider_deferred_without_cooldown"
+      };
+    case "skipped_stale_head":
+      return {
+        state: "stale_retired",
+        lastError: "retry_did_not_review=skipped_stale_head"
+      };
+    case "skipped_closed":
+      return {
+        state: "closed_retired",
+        lastError: "retry_did_not_review=skipped_closed"
+      };
+    case "skipped_capacity":
+      return {
+        state: "queued",
+        lastError: "retry_did_not_review=skipped_capacity"
+      };
+    case "skipped_processed":
+      return input.processedError && parseProviderCooldownError(input.processedError)
+        ? {
+            state: "provider_deferred",
+            ...(input.providerCooldownUntil ? { nextEligibleAt: input.providerCooldownUntil } : {}),
+            lastError: input.processedError
+          }
+        : {
+            state: "posted",
+            ...(input.processedReviewUrl ? { reviewUrl: input.processedReviewUrl } : {}),
+            lastError: "retry_did_not_review=skipped_processed"
+          };
+    case "failed":
+    case "skipped_draft":
+    case "skipped_canary":
+    case "skipped_policy":
+    case "skipped_command_stop":
+    case "skipped_command_explain":
+    case "skipped_finishing_touch_draft":
+      return {
+        state: "failed",
+        lastError: `retry_did_not_review=${input.status}`
+      };
+    default:
+      return assertNever(input.status);
   }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -46,7 +46,9 @@ import {
   isActivationBaselineProcessedReview,
   parseProviderCooldownError,
   ReviewStateStore,
+  type ProcessedStatus,
   type ReviewQueueJobState,
+  type ReviewerSessionJobState,
   type ReviewRunLease,
   type StoredProcessedReviewRecord
 } from "./state.js";
@@ -493,11 +495,6 @@ export async function retryFailedHeadWithDeps(input: {
     });
     const retryStatus = options.dryRun && (status === "reviewed" || status === "reviewed_command") ? "dry_run" : status;
     // A retry dry-run is a successful inspection, but the original row must remain retryable for the later live run.
-    restoreFailedRetryRowIfNeeded({
-      state,
-      retryTarget,
-      reason: retryStatus === "dry_run" ? "retry_dry_run" : `retry_did_not_review=${retryStatus}`
-    });
     updateRetryQueueJobsAfterRetry({
       state,
       repo: options.repo,
@@ -505,6 +502,11 @@ export async function retryFailedHeadWithDeps(input: {
       headSha: options.headSha,
       status: retryStatus,
       dryRun: options.dryRun
+    });
+    restoreFailedRetryRowIfNeeded({
+      state,
+      retryTarget,
+      reason: retryStatus === "dry_run" ? "retry_dry_run" : `retry_did_not_review=${retryStatus}`
     });
     return {
       repo: options.repo,
@@ -581,6 +583,7 @@ function updateRetryQueueJobsAfterRetry(input: {
   const patch = retryQueuePatchForStatus({
     status: input.status,
     dryRun: input.dryRun,
+    processedStatus: processed?.status,
     processedReviewUrl: processed?.reviewUrl,
     providerCooldownUntil: providerCooldown?.cooldownUntil,
     processedError: processed?.error
@@ -593,80 +596,170 @@ function updateRetryQueueJobsAfterRetry(input: {
       ...(patch.reviewUrl ? { reviewUrl: patch.reviewUrl } : {}),
       lastError: patch.lastError
     });
+    if (job.sessionId && patch.sessionJobState) {
+      input.state.updateReviewerSessionJobState({
+        repo: job.repo,
+        pullNumber: job.pullNumber,
+        headSha: job.headSha,
+        jobState: patch.sessionJobState,
+        ...(patch.sessionProcessedStatus ? { processedReviewStatus: patch.sessionProcessedStatus } : {})
+      });
+    }
   }
 }
 
 function retryQueuePatchForStatus(input: {
   status: RetryFailedHeadResult["status"];
   dryRun: boolean;
+  processedStatus?: ProcessedStatus;
   processedReviewUrl?: string;
   providerCooldownUntil?: string;
   processedError?: string;
-}): { state: ReviewQueueJobState; nextEligibleAt?: string; reviewUrl?: string; lastError: string } {
+}): {
+  state: ReviewQueueJobState;
+  nextEligibleAt?: string;
+  reviewUrl?: string;
+  lastError: string;
+  sessionJobState?: ReviewerSessionJobState;
+  sessionProcessedStatus?: ProcessedStatus;
+} {
   switch (input.status) {
     case "reviewed":
     case "reviewed_command":
       return input.dryRun
         ? {
-            state: "provider_deferred",
-            lastError: "retry_dry_run_completed_not_posted"
+            state: "queued",
+            lastError: "retry_dry_run_completed_not_posted",
+            sessionJobState: "completed",
+            sessionProcessedStatus: "dry_run"
           }
         : {
             state: "posted",
             ...(input.processedReviewUrl ? { reviewUrl: input.processedReviewUrl } : {}),
-            lastError: input.status
+            lastError: input.status,
+            sessionJobState: "completed",
+            sessionProcessedStatus: "posted"
           };
     case "dry_run":
       return {
-        state: "provider_deferred",
-        lastError: "retry_dry_run_completed_not_posted"
+        state: "queued",
+        lastError: "retry_dry_run_completed_not_posted",
+        sessionJobState: "completed",
+        sessionProcessedStatus: "dry_run"
       };
     case "skipped_provider_cooldown":
       return {
         state: "provider_deferred",
         ...(input.providerCooldownUntil ? { nextEligibleAt: input.providerCooldownUntil } : {}),
-        lastError: input.processedError ?? "provider_deferred_without_cooldown"
+        lastError: input.processedError ?? "provider_deferred_without_cooldown",
+        sessionJobState: "assigned"
       };
     case "skipped_stale_head":
       return {
         state: "stale_retired",
-        lastError: "retry_did_not_review=skipped_stale_head"
+        lastError: "retry_did_not_review=skipped_stale_head",
+        sessionJobState: "skipped",
+        sessionProcessedStatus: "skipped"
       };
     case "skipped_closed":
       return {
         state: "closed_retired",
-        lastError: "retry_did_not_review=skipped_closed"
+        lastError: "retry_did_not_review=skipped_closed",
+        sessionJobState: "skipped",
+        sessionProcessedStatus: "skipped"
       };
     case "skipped_capacity":
       return {
         state: "queued",
-        lastError: "retry_did_not_review=skipped_capacity"
+        lastError: "retry_did_not_review=skipped_capacity",
+        sessionJobState: "assigned"
       };
     case "skipped_processed":
       return input.processedError && parseProviderCooldownError(input.processedError)
         ? {
             state: "provider_deferred",
             ...(input.providerCooldownUntil ? { nextEligibleAt: input.providerCooldownUntil } : {}),
-            lastError: input.processedError
+            lastError: input.processedError,
+            sessionJobState: "assigned",
+            ...(input.processedStatus ? { sessionProcessedStatus: input.processedStatus } : {})
           }
         : {
-            state: "posted",
+            state: retryQueueJobStateForProcessedStatus(input.processedStatus, input.dryRun),
             ...(input.processedReviewUrl ? { reviewUrl: input.processedReviewUrl } : {}),
-            lastError: "retry_did_not_review=skipped_processed"
+            lastError: `retry_did_not_review=skipped_processed:${input.processedStatus ?? "unknown"}`,
+            sessionJobState: reviewerSessionJobStateForProcessedStatus(input.processedStatus),
+            ...(input.processedStatus ? { sessionProcessedStatus: input.processedStatus } : {})
           };
-    case "failed":
-    case "skipped_draft":
-    case "skipped_canary":
-    case "skipped_policy":
     case "skipped_command_stop":
     case "skipped_command_explain":
     case "skipped_finishing_touch_draft":
       return {
+        state: "command_recorded",
+        lastError: retryQueueCommandRecordedReason(input.status),
+        sessionJobState: "skipped",
+        sessionProcessedStatus: "skipped"
+      };
+    case "failed":
+    case "skipped_draft":
+    case "skipped_canary":
+    case "skipped_policy":
+      return {
         state: "failed",
-        lastError: `retry_did_not_review=${input.status}`
+        lastError: `retry_did_not_review=${input.status}`,
+        sessionJobState: "failed",
+        sessionProcessedStatus: "failed"
       };
     default:
       return assertNever(input.status);
+  }
+}
+
+function retryQueueJobStateForProcessedStatus(status: ProcessedStatus | undefined, dryRun: boolean): ReviewQueueJobState {
+  switch (status) {
+    case "posted":
+      return "posted";
+    case "dry_run":
+      return "queued";
+    case "failed":
+      return "failed";
+    case "skipped":
+      return "stale_retired";
+    case undefined:
+      return dryRun ? "queued" : "posted";
+    default:
+      return assertNever(status);
+  }
+}
+
+function reviewerSessionJobStateForProcessedStatus(status: ProcessedStatus | undefined): ReviewerSessionJobState {
+  switch (status) {
+    case "posted":
+    case "dry_run":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "skipped":
+      return "skipped";
+    case undefined:
+      return "completed";
+    default:
+      return assertNever(status);
+  }
+}
+
+function retryQueueCommandRecordedReason(status: Extract<
+  RetryFailedHeadResult["status"],
+  "skipped_command_stop" | "skipped_command_explain" | "skipped_finishing_touch_draft"
+>): string {
+  switch (status) {
+    case "skipped_command_stop":
+      return "manual_command_stop_recorded";
+    case "skipped_command_explain":
+      return "manual_command_explain_recorded";
+    case "skipped_finishing_touch_draft":
+      return "manual_command_finishing_touch_draft_recorded";
+    default:
+      return assertNever(status);
   }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -725,7 +725,7 @@ function retryQueueJobStateForProcessedStatus(status: ProcessedStatus | undefine
     case "skipped":
       return "stale_retired";
     case undefined:
-      return dryRun ? "queued" : "posted";
+      return "queued";
     default:
       return assertNever(status);
   }

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -958,11 +958,182 @@ describe("offline eval harness", () => {
     expect(readFileSync(join(outputRoot, "sticky", "normalized-findings.json"), "utf8")).not.toContain(token);
   });
 
+  it("fails sticky-vs-cold closed when the cold baseline packet fails", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-cold-fail-"));
+    roots.push(outputRoot);
+    const label = {
+      source: "seeded_defect" as const,
+      severity: "P1" as const,
+      path: "src/worker.ts",
+      line: 44,
+      title: "Provider timeout kills the review loop",
+      body: "A provider timeout escaping the per-PR boundary can stop the worker from scanning later repos."
+    };
+
+    const result = runStickyVsColdEval({
+      runId: "sticky-vs-cold-cold-fail",
+      cold: {
+        runId: "cold-missed-seed",
+        repo: "electricsheephq/evaos-code-review-bot",
+        pullNumber: 85,
+        headSha: "abc",
+        suite: "seeded_defect_recall",
+        botFindings: { findings: [] },
+        labels: [label]
+      },
+      sticky: {
+        runId: "sticky-found-seed",
+        repo: "electricsheephq/evaos-code-review-bot",
+        pullNumber: 85,
+        headSha: "abc",
+        suite: "seeded_defect_recall",
+        botFindings: {
+          findings: [{
+            severity: "P1",
+            path: "src/worker.ts",
+            line: 44,
+            title: "Provider timeout kills the review loop",
+            body: "The provider timeout escapes the per-PR review boundary and can stop later repos from being scanned.",
+            confidence: 0.93
+          }]
+        },
+        labels: [label]
+      },
+      coldRuntime: { providerAttempts: 1 },
+      stickyRuntime: { providerAttempts: 1 }
+    }, { outputRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.decision).toBe("not_enough_evidence");
+    expect(result.summary.gates.find((gate) => gate.name === "cold_packet_ok")).toMatchObject({ ok: false, status: "fail" });
+  });
+
+  it("fails sticky-vs-cold when sticky regresses recall against the same labels", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-recall-regression-"));
+    roots.push(outputRoot);
+    const labels = [{
+      source: "seeded_defect" as const,
+      severity: "P1" as const,
+      path: "src/worker.ts",
+      line: 44,
+      title: "Provider timeout kills the review loop",
+      body: "A provider timeout escaping the per-PR boundary can stop the worker from scanning later repos."
+    }];
+
+    const result = runStickyVsColdEval({
+      runId: "sticky-vs-cold-recall-regression",
+      cold: {
+        runId: "cold-found-seed",
+        repo: "electricsheephq/evaos-code-review-bot",
+        pullNumber: 85,
+        headSha: "abc",
+        suite: "seeded_defect_recall",
+        botFindings: {
+          findings: [{
+            severity: "P1",
+            path: "src/worker.ts",
+            line: 44,
+            title: "Provider timeout kills the review loop",
+            body: "The provider timeout escapes the per-PR review boundary and can stop later repos from being scanned.",
+            confidence: 0.93
+          }]
+        },
+        labels
+      },
+      sticky: {
+        runId: "sticky-missed-seed",
+        repo: "electricsheephq/evaos-code-review-bot",
+        pullNumber: 85,
+        headSha: "abc",
+        suite: "seeded_defect_recall",
+        mode: "exploratory",
+        botFindings: { findings: [] },
+        labels,
+        thresholds: {
+          minPrecision: 0,
+          minRecall: 0,
+          minSeededRecall: 0
+        }
+      },
+      coldRuntime: { providerAttempts: 1 },
+      stickyRuntime: { providerAttempts: 1 }
+    }, { outputRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.decision).toBe("not_enough_evidence");
+    expect(result.summary.gates.find((gate) => gate.name === "no_false_negative_regression")).toMatchObject({ ok: false, status: "fail" });
+    expect(result.summary.gates.find((gate) => gate.name === "recall_not_lower")).toMatchObject({ ok: false, status: "fail" });
+    expect(result.summary.gates.find((gate) => gate.name === "seeded_recall_not_lower")).toMatchObject({ ok: false, status: "fail" });
+  });
+
+  it("rejects sticky-vs-cold scenarios with different expected labels", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-label-mismatch-"));
+    roots.push(outputRoot);
+    const scenario = JSON.parse(
+      readFileSync(join(process.cwd(), "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"), "utf8")
+    ) as StickyVsColdScenarioInput;
+
+    expect(() => runStickyVsColdEval({
+      ...scenario,
+      sticky: {
+        ...scenario.sticky,
+        labels: []
+      }
+    }, { outputRoot })).toThrow("cold and sticky expected labels must match");
+  });
+
+  it("rejects loosened sticky-vs-cold promotion thresholds", () => {
+    const scenario = JSON.parse(
+      readFileSync(join(process.cwd(), "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"), "utf8")
+    ) as StickyVsColdScenarioInput;
+    const minRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-loosen-min-"));
+    const deltaRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-loosen-delta-"));
+    const providerRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-loosen-provider-"));
+    roots.push(minRoot, deltaRoot, providerRoot);
+
+    expect(() => runStickyVsColdEval({
+      ...scenario,
+      thresholds: { minRuntimeSafeScenarios: 0 }
+    }, { outputRoot: minRoot }))
+      .toThrow("minRuntimeSafeScenarios cannot be loosened");
+    expect(() => runStickyVsColdEval({
+      ...scenario,
+      thresholds: { maxFalsePositiveDelta: 1 }
+    }, { outputRoot: deltaRoot }))
+      .toThrow("maxFalsePositiveDelta cannot be loosened");
+    expect(() => runStickyVsColdEval({
+      ...scenario,
+      thresholds: { minRecallDelta: -1 }
+    }, { outputRoot: deltaRoot }))
+      .toThrow("minRecallDelta cannot be loosened");
+    expect(() => runStickyVsColdEval({
+      ...scenario,
+      thresholds: { requireProviderAttemptsNotHigher: false }
+    }, { outputRoot: providerRoot }))
+      .toThrow("requireProviderAttemptsNotHigher cannot be disabled");
+  });
+
+  it("rejects paired scenarios for different heads", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-head-mismatch-"));
+    roots.push(outputRoot);
+    const scenario = JSON.parse(
+      readFileSync(join(process.cwd(), "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"), "utf8")
+    ) as StickyVsColdScenarioInput;
+
+    expect(() => runStickyVsColdEval({
+      ...scenario,
+      sticky: {
+        ...scenario.sticky,
+        headSha: "different-head"
+      }
+    }, { outputRoot })).toThrow("cold.headSha must match sticky.headSha");
+  });
+
   it("runs sticky-vs-cold eval through the CLI", () => {
     const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-cli-"));
     roots.push(outputRoot);
-    const output = execFileSync("npx", [
-      "tsx",
+    const output = execFileSync(process.execPath, [
+      join(process.cwd(), "node_modules", "tsx", "dist", "cli.mjs"),
       "src/cli.ts",
       "eval-sticky-vs-cold",
       "--input",

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSy
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { runOfflineEval, type EvalScenarioInput } from "../src/eval-harness.js";
+import { runOfflineEval, runStickyVsColdEval, type EvalScenarioInput, type StickyVsColdScenarioInput } from "../src/eval-harness.js";
 
 describe("offline eval harness", () => {
   const roots: string[] = [];
@@ -856,5 +856,141 @@ describe("offline eval harness", () => {
       "safety_redaction",
       "duplicate_suppression"
     ]);
+  });
+
+  it("writes paired sticky-vs-cold packets and an advisory report", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-output-"));
+    roots.push(outputRoot);
+    const scenario = JSON.parse(
+      readFileSync(join(process.cwd(), "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"), "utf8")
+    ) as StickyVsColdScenarioInput;
+
+    const result = runStickyVsColdEval(scenario, {
+      outputRoot,
+      now: new Date("2026-07-03T08:00:00Z")
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.summary).toMatchObject({
+      decision: "advisory",
+      publicConfidence: "uncalibrated",
+      deltas: {
+        falsePositive: -1,
+        providerAttempts: -1,
+        latencyMs: -5000
+      },
+      evidenceCounts: {
+        pairedScenarios: 1,
+        labeledFindings: 1,
+        p0p1Labels: 1,
+        negativeControlScenarios: 0
+      }
+    });
+    expect(existsSync(join(outputRoot, "cold", "scorecard.json"))).toBe(true);
+    expect(existsSync(join(outputRoot, "sticky", "scorecard.json"))).toBe(true);
+    expect(existsSync(join(outputRoot, "sticky-vs-cold-summary.json"))).toBe(true);
+    expect(existsSync(join(outputRoot, "sticky-vs-cold-report.md"))).toBe(true);
+    expect(readFileSync(join(outputRoot, "sticky-vs-cold-report.md"), "utf8")).toContain("Decision: advisory");
+    expect(result.summary.artifactInventory.map((artifact) => artifact.name)).toEqual([
+      "sticky-vs-cold-report.md",
+      "cold/scorecard.json",
+      "sticky/scorecard.json",
+      "cold/manifest.json",
+      "sticky/manifest.json"
+    ]);
+  });
+
+  it("fails sticky-vs-cold when sticky introduces a safety regression", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-regression-"));
+    roots.push(outputRoot);
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+    const scenario: StickyVsColdScenarioInput = {
+      runId: "sticky-vs-cold-safety-regression",
+      cold: {
+        runId: "cold-safe",
+        repo: "electricsheephq/evaos-code-review-bot",
+        pullNumber: 85,
+        headSha: "abc",
+        suite: "safety_redaction",
+        mode: "exploratory",
+        botFindings: { findings: [] },
+        labels: [],
+        thresholds: {
+          minPrecision: 0,
+          minRecall: 0
+        }
+      },
+      sticky: {
+        runId: "sticky-secret",
+        repo: "electricsheephq/evaos-code-review-bot",
+        pullNumber: 85,
+        headSha: "abc",
+        suite: "safety_redaction",
+        mode: "exploratory",
+        botFindings: {
+          findings: [
+            {
+              severity: "P1",
+              path: "src/worker.ts",
+              line: 1,
+              title: "Leaked token",
+              body: `The sticky run repeated ${token}.`,
+              confidence: 0.9
+            }
+          ]
+        },
+        labels: [],
+        thresholds: {
+          minPrecision: 0,
+          minRecall: 0
+        }
+      },
+      coldRuntime: { providerAttempts: 1 },
+      stickyRuntime: { providerAttempts: 1 }
+    };
+
+    const result = runStickyVsColdEval(scenario, { outputRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.decision).toBe("not_enough_evidence");
+    expect(result.summary.gates.find((gate) => gate.name === "sticky_packet_ok")).toMatchObject({ ok: false });
+    expect(result.summary.gates.find((gate) => gate.name === "no_secret_regression")).toMatchObject({ ok: false });
+    expect(readFileSync(join(outputRoot, "sticky", "normalized-findings.json"), "utf8")).not.toContain(token);
+  });
+
+  it("runs sticky-vs-cold eval through the CLI", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-cli-"));
+    roots.push(outputRoot);
+    const output = execFileSync("npx", [
+      "tsx",
+      "src/cli.ts",
+      "eval-sticky-vs-cold",
+      "--input",
+      join(process.cwd(), "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"),
+      "--output-root",
+      outputRoot
+    ], { cwd: process.cwd(), encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+
+    const summary = JSON.parse(output);
+    expect(summary).toMatchObject({
+      ok: true,
+      decision: "advisory",
+      publicConfidence: "uncalibrated"
+    });
+    expect(existsSync(join(outputRoot, "sticky-vs-cold-summary.json"))).toBe(true);
+    expect(existsSync(join(outputRoot, "sticky-vs-cold-report.md"))).toBe(true);
+  });
+
+  it("rejects sticky-vs-cold output roots inside the checkout", () => {
+    const outputRoot = join(process.cwd(), ".tmp-sticky-vs-cold-output-inside-checkout");
+    roots.push(outputRoot);
+    rmSync(outputRoot, { recursive: true, force: true });
+    const scenario = JSON.parse(
+      readFileSync(join(process.cwd(), "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"), "utf8")
+    ) as StickyVsColdScenarioInput;
+
+    expect(() => runStickyVsColdEval(scenario, { outputRoot }))
+      .toThrow("outputDir must not be inside the current git checkout");
+    expect(existsSync(join(outputRoot, "sticky-vs-cold-summary.json"))).toBe(false);
   });
 });

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -955,7 +955,14 @@ describe("offline eval harness", () => {
     expect(result.summary.decision).toBe("not_enough_evidence");
     expect(result.summary.gates.find((gate) => gate.name === "sticky_packet_ok")).toMatchObject({ ok: false });
     expect(result.summary.gates.find((gate) => gate.name === "no_secret_regression")).toMatchObject({ ok: false });
-    expect(readFileSync(join(outputRoot, "sticky", "normalized-findings.json"), "utf8")).not.toContain(token);
+    for (const artifact of [
+      join(outputRoot, "sticky", "normalized-findings.json"),
+      join(outputRoot, "sticky", "scorecard.json"),
+      join(outputRoot, "sticky", "manifest.json"),
+      join(outputRoot, "sticky-vs-cold-summary.json")
+    ]) {
+      expect(readFileSync(artifact, "utf8"), artifact).not.toContain(token);
+    }
   });
 
   it("fails sticky-vs-cold closed when the cold baseline packet fails", () => {
@@ -1006,6 +1013,7 @@ describe("offline eval harness", () => {
     expect(result.ok).toBe(false);
     expect(result.summary.decision).toBe("not_enough_evidence");
     expect(result.summary.gates.find((gate) => gate.name === "cold_packet_ok")).toMatchObject({ ok: false, status: "fail" });
+    expect(result.summary.gates.find((gate) => gate.name === "recall_not_lower")).toMatchObject({ ok: true, status: "skip" });
   });
 
   it("fails sticky-vs-cold when sticky regresses recall against the same labels", () => {
@@ -1080,6 +1088,51 @@ describe("offline eval harness", () => {
         labels: []
       }
     }, { outputRoot })).toThrow("cold and sticky expected labels must match");
+  });
+
+  it("counts negative-control evidence only when explicitly declared", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-negative-control-"));
+    roots.push(outputRoot);
+    const base = {
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 85,
+      headSha: "abc",
+      suite: "canary_shadow" as const,
+      botFindings: { findings: [] },
+      labels: []
+    };
+
+    const implicit = runStickyVsColdEval({
+      runId: "sticky-vs-cold-implicit-empty-labels",
+      cold: { ...base, runId: "cold-empty" },
+      sticky: { ...base, runId: "sticky-empty" },
+      coldRuntime: { providerAttempts: 1 },
+      stickyRuntime: { providerAttempts: 1, staleContext: false }
+    }, { outputRoot: join(outputRoot, "implicit") });
+    const explicit = runStickyVsColdEval({
+      runId: "sticky-vs-cold-explicit-negative-control",
+      negativeControl: true,
+      cold: { ...base, runId: "cold-negative" },
+      sticky: { ...base, runId: "sticky-negative" },
+      coldRuntime: { providerAttempts: 1 },
+      stickyRuntime: { providerAttempts: 1, staleContext: false }
+    }, { outputRoot: join(outputRoot, "explicit") });
+
+    expect(implicit.summary.evidenceCounts.negativeControlScenarios).toBe(0);
+    expect(explicit.summary.evidenceCounts.negativeControlScenarios).toBe(1);
+  });
+
+  it("rejects declared negative-control scenarios with expected labels", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-negative-labels-"));
+    roots.push(outputRoot);
+    const scenario = JSON.parse(
+      readFileSync(join(process.cwd(), "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"), "utf8")
+    ) as StickyVsColdScenarioInput;
+
+    expect(() => runStickyVsColdEval({
+      ...scenario,
+      negativeControl: true
+    }, { outputRoot })).toThrow("negativeControl sticky-vs-cold scenarios must not include expected labels");
   });
 
   it("fails sticky-vs-cold when sticky runtime reports stale context", () => {

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -916,6 +916,28 @@ describe("offline eval harness", () => {
     expect(readFileSync(join(outputRoot, "stale-artifact.json"), "utf8")).toBe("{}\n");
   });
 
+  it("preflights both sticky-vs-cold packet threshold policies before writing artifacts", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-preflight-policies-"));
+    roots.push(outputRoot);
+    const scenario = JSON.parse(
+      readFileSync(join(process.cwd(), "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"), "utf8")
+    ) as StickyVsColdScenarioInput;
+
+    expect(() => runStickyVsColdEval({
+      ...scenario,
+      sticky: {
+        ...scenario.sticky,
+        mode: "gating",
+        thresholds: {
+          ...scenario.sticky.thresholds,
+          minPrecision: 0
+        }
+      }
+    }, { outputRoot })).toThrow('sticky.minPrecision below the default requires mode="exploratory"');
+    expect(existsSync(join(outputRoot, "cold"))).toBe(false);
+    expect(existsSync(join(outputRoot, "sticky"))).toBe(false);
+  });
+
   it("fails sticky-vs-cold when sticky introduces a safety regression", () => {
     const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-regression-"));
     roots.push(outputRoot);

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { runOfflineEval, runStickyVsColdEval, type EvalScenarioInput, type StickyVsColdScenarioInput } from "../src/eval-harness.js";
 
 const nodeRequire = createRequire(import.meta.url);
+const tsxCli = nodeRequire.resolve("tsx/cli");
 
 describe("offline eval harness", () => {
   const roots: string[] = [];
@@ -737,8 +738,8 @@ describe("offline eval harness", () => {
     const outputRoot = mkdtempSync(join(tmpdir(), "evaos-eval-suite-success-output-"));
     roots.push(outputRoot);
 
-    const output = execFileSync("npx", [
-      "tsx",
+    const output = execFileSync(process.execPath, [
+      tsxCli,
       "src/cli.ts",
       "eval-suite",
       "--input-dir",
@@ -765,8 +766,8 @@ describe("offline eval harness", () => {
 
     let stderr = "";
     try {
-      execFileSync("npx", [
-        "tsx",
+      execFileSync(process.execPath, [
+        tsxCli,
         "src/cli.ts",
         "eval-suite",
         "--input-dir",
@@ -801,8 +802,8 @@ describe("offline eval harness", () => {
 
     let output = "";
     try {
-      execFileSync("npx", [
-        "tsx",
+      execFileSync(process.execPath, [
+        tsxCli,
         "src/cli.ts",
         "eval-suite",
         "--input-dir",
@@ -838,8 +839,8 @@ describe("offline eval harness", () => {
 
     let output = "";
     try {
-      execFileSync("npx", [
-        "tsx",
+      execFileSync(process.execPath, [
+        tsxCli,
         "src/cli.ts",
         "eval-suite",
         "--input-dir",
@@ -903,6 +904,18 @@ describe("offline eval harness", () => {
     ]);
   });
 
+  it("rejects non-empty sticky-vs-cold output roots to avoid stale artifacts", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-stale-root-"));
+    roots.push(outputRoot);
+    writeFileSync(join(outputRoot, "stale-artifact.json"), "{}\n");
+    const scenario = JSON.parse(
+      readFileSync(join(process.cwd(), "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"), "utf8")
+    ) as StickyVsColdScenarioInput;
+
+    expect(() => runStickyVsColdEval(scenario, { outputRoot })).toThrow("outputRoot must be empty");
+    expect(readFileSync(join(outputRoot, "stale-artifact.json"), "utf8")).toBe("{}\n");
+  });
+
   it("fails sticky-vs-cold when sticky introduces a safety regression", () => {
     const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-regression-"));
     roots.push(outputRoot);
@@ -957,6 +970,7 @@ describe("offline eval harness", () => {
     expect(result.ok).toBe(false);
     expect(result.summary.decision).toBe("not_enough_evidence");
     expect(result.summary.gates.find((gate) => gate.name === "sticky_packet_ok")).toMatchObject({ ok: false });
+    expect(result.summary.gates.find((gate) => gate.name === "sticky_has_no_secrets")).toMatchObject({ ok: false });
     expect(result.summary.gates.find((gate) => gate.name === "no_secret_regression")).toMatchObject({ ok: false });
     for (const artifact of [
       join(outputRoot, "sticky", "normalized-findings.json"),
@@ -966,6 +980,50 @@ describe("offline eval harness", () => {
     ]) {
       expect(readFileSync(artifact, "utf8"), artifact).not.toContain(token);
     }
+  });
+
+  it("fails sticky-vs-cold when sticky has secret-like findings even without a secret-count delta", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-secret-same-count-"));
+    roots.push(outputRoot);
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+    const secretFinding = {
+      severity: "P1" as const,
+      path: "src/worker.ts",
+      line: 1,
+      title: "Leaked token",
+      body: `The packet repeated ${token}.`,
+      confidence: 0.9
+    };
+    const packet = {
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 85,
+      headSha: "abc",
+      suite: "canary_shadow" as const,
+      mode: "exploratory" as const,
+      botFindings: { findings: [secretFinding] },
+      labels: [],
+      thresholds: {
+        minPrecision: 0,
+        minRecall: 0,
+        maxSecretFindings: 1
+      }
+    };
+
+    const result = runStickyVsColdEval({
+      runId: "sticky-vs-cold-secret-same-count",
+      cold: { ...packet, runId: "cold-secret" },
+      sticky: { ...packet, runId: "sticky-secret" },
+      coldRuntime: { providerAttempts: 1 },
+      stickyRuntime: { providerAttempts: 1, staleContext: false, repoMemoryAgeSeconds: 60 }
+    }, { outputRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.decision).toBe("not_enough_evidence");
+    expect(result.summary.deltas.secretFindings).toBe(0);
+    expect(result.summary.gates.find((gate) => gate.name === "sticky_has_no_secrets")).toMatchObject({
+      ok: false,
+      status: "fail"
+    });
   });
 
   it("fails sticky-vs-cold closed when the cold baseline packet fails", () => {
@@ -1017,6 +1075,84 @@ describe("offline eval harness", () => {
     expect(result.summary.decision).toBe("not_enough_evidence");
     expect(result.summary.gates.find((gate) => gate.name === "cold_packet_ok")).toMatchObject({ ok: false, status: "fail" });
     expect(result.summary.gates.find((gate) => gate.name === "recall_not_lower")).toMatchObject({ ok: true, status: "skip" });
+  });
+
+  it("fails sticky-vs-cold when sticky misses a label matched by cold", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-matched-label-regression-"));
+    roots.push(outputRoot);
+    const labelA = {
+      source: "seeded_defect" as const,
+      severity: "P1" as const,
+      path: "src/worker.ts",
+      line: 44,
+      title: "Provider timeout kills the review loop",
+      body: "A provider timeout escaping the per-PR boundary can stop the worker from scanning later repos.",
+      sourceId: "seed-provider-timeout-loop"
+    };
+    const labelB = {
+      source: "seeded_defect" as const,
+      severity: "P1" as const,
+      path: "src/state.ts",
+      line: 88,
+      title: "Duplicate head state is overwritten",
+      body: "A duplicate head row overwrite can hide a pending review lease from the scheduler.",
+      sourceId: "seed-duplicate-head-state"
+    };
+    const packetBase = {
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 85,
+      headSha: "abc",
+      suite: "seeded_defect_recall" as const,
+      mode: "exploratory" as const,
+      labels: [labelA, labelB],
+      thresholds: {
+        minPrecision: 0.5,
+        minRecall: 0.5,
+        minSeededRecall: 0.5
+      }
+    };
+
+    const result = runStickyVsColdEval({
+      runId: "sticky-vs-cold-matched-label-regression",
+      cold: {
+        ...packetBase,
+        runId: "cold-label-a",
+        botFindings: {
+          findings: [{
+            severity: "P1",
+            path: labelA.path,
+            line: labelA.line,
+            title: labelA.title,
+            body: labelA.body,
+            confidence: 0.9
+          }]
+        }
+      },
+      sticky: {
+        ...packetBase,
+        runId: "sticky-label-b",
+        botFindings: {
+          findings: [{
+            severity: "P1",
+            path: labelB.path,
+            line: labelB.line,
+            title: labelB.title,
+            body: labelB.body,
+            confidence: 0.9
+          }]
+        }
+      },
+      coldRuntime: { providerAttempts: 1 },
+      stickyRuntime: { providerAttempts: 1, staleContext: false, repoMemoryAgeSeconds: 60 }
+    }, { outputRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.decision).toBe("not_enough_evidence");
+    expect(result.summary.deltas.recall).toBe(0);
+    expect(result.summary.gates.find((gate) => gate.name === "sticky_preserves_cold_matches")).toMatchObject({
+      ok: false,
+      status: "fail"
+    });
   });
 
   it("fails sticky-vs-cold when sticky regresses recall against the same labels", () => {
@@ -1241,7 +1377,6 @@ describe("offline eval harness", () => {
   it("runs sticky-vs-cold eval through the CLI", () => {
     const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-cli-"));
     roots.push(outputRoot);
-    const tsxCli = nodeRequire.resolve("tsx/cli");
     const output = execFileSync(process.execPath, [
       tsxCli,
       "src/cli.ts",
@@ -1260,6 +1395,31 @@ describe("offline eval harness", () => {
     });
     expect(existsSync(join(outputRoot, "sticky-vs-cold-summary.json"))).toBe(true);
     expect(existsSync(join(outputRoot, "sticky-vs-cold-report.md"))).toBe(true);
+  });
+
+  it("reports malformed sticky-vs-cold CLI input with path context", () => {
+    const inputDir = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-bad-input-"));
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-bad-output-"));
+    roots.push(inputDir, outputRoot);
+    const inputPath = join(inputDir, "bad.json");
+    writeFileSync(inputPath, "{ bad json\n");
+
+    let stderr = "";
+    try {
+      execFileSync(process.execPath, [
+        tsxCli,
+        "src/cli.ts",
+        "eval-sticky-vs-cold",
+        "--input",
+        inputPath,
+        "--output-root",
+        outputRoot
+      ], { cwd: process.cwd(), encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    } catch (error) {
+      stderr = String((error as { stderr?: string }).stderr ?? "");
+    }
+
+    expect(stderr).toContain(`failed to parse --input ${inputPath}`);
   });
 
   it("rejects sticky-vs-cold output roots inside the checkout", () => {

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -1082,6 +1082,29 @@ describe("offline eval harness", () => {
     }, { outputRoot })).toThrow("cold and sticky expected labels must match");
   });
 
+  it("fails sticky-vs-cold when sticky runtime reports stale context", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-stale-context-"));
+    roots.push(outputRoot);
+    const scenario = JSON.parse(
+      readFileSync(join(process.cwd(), "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"), "utf8")
+    ) as StickyVsColdScenarioInput;
+
+    const result = runStickyVsColdEval({
+      ...scenario,
+      stickyRuntime: {
+        ...scenario.stickyRuntime,
+        staleContext: true
+      }
+    }, { outputRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.decision).toBe("not_enough_evidence");
+    expect(result.summary.gates.find((gate) => gate.name === "sticky_context_fresh")).toMatchObject({
+      ok: false,
+      status: "fail"
+    });
+  });
+
   it("rejects loosened sticky-vs-cold promotion thresholds", () => {
     const scenario = JSON.parse(
       readFileSync(join(process.cwd(), "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"), "utf8")

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -1074,6 +1074,9 @@ describe("offline eval harness", () => {
     expect(result.ok).toBe(false);
     expect(result.summary.decision).toBe("not_enough_evidence");
     expect(result.summary.gates.find((gate) => gate.name === "cold_packet_ok")).toMatchObject({ ok: false, status: "fail" });
+    expect(result.summary.gates.find((gate) => gate.name === "no_secret_regression")).toMatchObject({ ok: true, status: "skip" });
+    expect(result.summary.gates.find((gate) => gate.name === "no_duplicate_regression")).toMatchObject({ ok: true, status: "skip" });
+    expect(result.summary.gates.find((gate) => gate.name === "no_schema_drop_regression")).toMatchObject({ ok: true, status: "skip" });
     expect(result.summary.gates.find((gate) => gate.name === "recall_not_lower")).toMatchObject({ ok: true, status: "skip" });
   });
 

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -1,9 +1,12 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { runOfflineEval, runStickyVsColdEval, type EvalScenarioInput, type StickyVsColdScenarioInput } from "../src/eval-harness.js";
+
+const nodeRequire = createRequire(import.meta.url);
 
 describe("offline eval harness", () => {
   const roots: string[] = [];
@@ -1158,6 +1161,30 @@ describe("offline eval harness", () => {
     });
   });
 
+  it("fails sticky-vs-cold when sticky repo memory is older than the freshness threshold", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-stale-memory-"));
+    roots.push(outputRoot);
+    const scenario = JSON.parse(
+      readFileSync(join(process.cwd(), "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"), "utf8")
+    ) as StickyVsColdScenarioInput;
+
+    const result = runStickyVsColdEval({
+      ...scenario,
+      stickyRuntime: {
+        ...scenario.stickyRuntime,
+        repoMemoryAgeSeconds: 90000,
+        staleContext: false
+      }
+    }, { outputRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.decision).toBe("not_enough_evidence");
+    expect(result.summary.gates.find((gate) => gate.name === "sticky_repo_memory_fresh")).toMatchObject({
+      ok: false,
+      status: "fail"
+    });
+  });
+
   it("rejects loosened sticky-vs-cold promotion thresholds", () => {
     const scenario = JSON.parse(
       readFileSync(join(process.cwd(), "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"), "utf8")
@@ -1165,7 +1192,8 @@ describe("offline eval harness", () => {
     const minRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-loosen-min-"));
     const deltaRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-loosen-delta-"));
     const providerRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-loosen-provider-"));
-    roots.push(minRoot, deltaRoot, providerRoot);
+    const memoryRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-loosen-memory-"));
+    roots.push(minRoot, deltaRoot, providerRoot, memoryRoot);
 
     expect(() => runStickyVsColdEval({
       ...scenario,
@@ -1187,6 +1215,11 @@ describe("offline eval harness", () => {
       thresholds: { requireProviderAttemptsNotHigher: false }
     }, { outputRoot: providerRoot }))
       .toThrow("requireProviderAttemptsNotHigher cannot be disabled");
+    expect(() => runStickyVsColdEval({
+      ...scenario,
+      thresholds: { maxRepoMemoryAgeSeconds: 172800 }
+    }, { outputRoot: memoryRoot }))
+      .toThrow("maxRepoMemoryAgeSeconds cannot be loosened");
   });
 
   it("rejects paired scenarios for different heads", () => {
@@ -1208,8 +1241,9 @@ describe("offline eval harness", () => {
   it("runs sticky-vs-cold eval through the CLI", () => {
     const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-cli-"));
     roots.push(outputRoot);
+    const tsxCli = nodeRequire.resolve("tsx/cli");
     const output = execFileSync(process.execPath, [
-      join(process.cwd(), "node_modules", "tsx", "dist", "cli.mjs"),
+      tsxCli,
       "src/cli.ts",
       "eval-sticky-vs-cold",
       "--input",

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -1264,6 +1264,49 @@ describe("offline eval harness", () => {
     expect(explicit.summary.evidenceCounts.negativeControlScenarios).toBe(1);
   });
 
+  it("fails declared negative-control evidence when either packet emits findings", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-dirty-negative-control-"));
+    roots.push(outputRoot);
+    const finding = {
+      severity: "P3" as const,
+      path: "src/worker.ts",
+      line: 12,
+      title: "Noisy advisory",
+      body: "A clean negative-control packet should not produce findings.",
+      confidence: 0.4
+    };
+    const packet = {
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 85,
+      headSha: "abc",
+      suite: "canary_shadow" as const,
+      mode: "exploratory" as const,
+      botFindings: { findings: [finding] },
+      labels: [],
+      thresholds: {
+        minPrecision: 0,
+        minRecall: 0
+      }
+    };
+
+    const result = runStickyVsColdEval({
+      runId: "sticky-vs-cold-dirty-negative-control",
+      negativeControl: true,
+      cold: { ...packet, runId: "cold-noisy" },
+      sticky: { ...packet, runId: "sticky-noisy" },
+      coldRuntime: { providerAttempts: 1 },
+      stickyRuntime: { providerAttempts: 1, staleContext: false, repoMemoryAgeSeconds: 60 }
+    }, { outputRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.decision).toBe("not_enough_evidence");
+    expect(result.summary.evidenceCounts.negativeControlScenarios).toBe(0);
+    expect(result.summary.gates.find((gate) => gate.name === "negative_control_clean")).toMatchObject({
+      ok: false,
+      status: "fail"
+    });
+  });
+
   it("rejects declared negative-control scenarios with expected labels", () => {
     const outputRoot = mkdtempSync(join(tmpdir(), "evaos-sticky-vs-cold-negative-labels-"));
     roots.push(outputRoot);

--- a/tests/fixtures/sticky-vs-cold/seeded_quality_packet.json
+++ b/tests/fixtures/sticky-vs-cold/seeded_quality_packet.json
@@ -1,0 +1,100 @@
+{
+  "evalName": "evaos-zcode-review-bot-sticky-vs-cold-v0.1",
+  "runId": "sticky-vs-cold-seeded-quality",
+  "scenarioSource": {
+    "path": "tests/fixtures/sticky-vs-cold/seeded_quality_packet.json"
+  },
+  "cold": {
+    "evalName": "evaos-zcode-review-bot-comparison-v0.1",
+    "runId": "sticky-vs-cold-seeded-quality-cold",
+    "repo": "electricsheephq/evaos-code-review-bot",
+    "pullNumber": 85,
+    "headSha": "abc123sticky",
+    "suite": "seeded_defect_recall",
+    "mode": "exploratory",
+    "botFindings": {
+      "findings": [
+        {
+          "severity": "P1",
+          "path": "src/worker.ts",
+          "line": 44,
+          "title": "Provider timeout kills the review loop",
+          "body": "The provider timeout escapes the per-PR review boundary and can stop later repos from being scanned.",
+          "confidence": 0.91
+        },
+        {
+          "severity": "P3",
+          "path": "src/docs.ts",
+          "line": 12,
+          "title": "Doc wording could be clearer",
+          "body": "The wording around beta releases could use another sentence.",
+          "confidence": 0.54
+        }
+      ]
+    },
+    "labels": [
+      {
+        "source": "seeded_defect",
+        "severity": "P1",
+        "path": "src/worker.ts",
+        "line": 44,
+        "title": "Provider timeout kills the review loop",
+        "body": "A provider timeout escaping the per-PR boundary can stop the worker from scanning later repos.",
+        "sourceId": "seed-provider-timeout-loop"
+      }
+    ],
+    "thresholds": {
+      "minPrecision": 0.5,
+      "minRecall": 1,
+      "minSeededRecall": 1
+    }
+  },
+  "sticky": {
+    "evalName": "evaos-zcode-review-bot-comparison-v0.1",
+    "runId": "sticky-vs-cold-seeded-quality-sticky",
+    "repo": "electricsheephq/evaos-code-review-bot",
+    "pullNumber": 85,
+    "headSha": "abc123sticky",
+    "suite": "seeded_defect_recall",
+    "botFindings": {
+      "findings": [
+        {
+          "severity": "P1",
+          "path": "src/worker.ts",
+          "line": 44,
+          "title": "Provider timeout kills the review loop",
+          "body": "The provider timeout escapes the per-PR review boundary and can stop later repos from being scanned.",
+          "confidence": 0.93
+        }
+      ]
+    },
+    "labels": [
+      {
+        "source": "seeded_defect",
+        "severity": "P1",
+        "path": "src/worker.ts",
+        "line": 44,
+        "title": "Provider timeout kills the review loop",
+        "body": "A provider timeout escaping the per-PR boundary can stop the worker from scanning later repos.",
+        "sourceId": "seed-provider-timeout-loop"
+      }
+    ]
+  },
+  "coldRuntime": {
+    "providerAttempts": 2,
+    "latencyMs": 14000,
+    "promptTokens": 12000,
+    "outputTokens": 800,
+    "totalTokens": 12800
+  },
+  "stickyRuntime": {
+    "providerAttempts": 1,
+    "latencyMs": 9000,
+    "promptTokens": 9000,
+    "outputTokens": 650,
+    "totalTokens": 9650,
+    "memoryPacketSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "gitnexusPacketSha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "stickySessionId": "repo-sticky-eval-fixture"
+  }
+}

--- a/tests/fixtures/sticky-vs-cold/seeded_quality_packet.json
+++ b/tests/fixtures/sticky-vs-cold/seeded_quality_packet.json
@@ -95,6 +95,7 @@
     "totalTokens": 9650,
     "memoryPacketSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "gitnexusPacketSha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    "stickySessionId": "repo-sticky-eval-fixture"
+    "stickySessionId": "repo-sticky-eval-fixture",
+    "staleContext": false
   }
 }

--- a/tests/fixtures/sticky-vs-cold/seeded_quality_packet.json
+++ b/tests/fixtures/sticky-vs-cold/seeded_quality_packet.json
@@ -96,6 +96,7 @@
     "memoryPacketSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "gitnexusPacketSha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
     "stickySessionId": "repo-sticky-eval-fixture",
+    "repoMemoryAgeSeconds": 120,
     "staleContext": false
   }
 }

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -720,6 +720,58 @@ describe("provider-aware review scheduler", () => {
     }
   });
 
+  it("keeps RepoSticky session jobs assigned when processed-head status is missing", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-processed-missing-session-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    config.reviewerSessions = {
+      enabled: true,
+      ttlMs: 8 * 60 * 60_000,
+      headCountLimit: 10
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const assignment = state.assignReviewerSessionJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      ttlMs: 8 * 60 * 60_000,
+      headCountLimit: 10,
+      allowProcessed: true,
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+    if (!assignment.session) throw new Error("expected session assignment");
+    const job = state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      baseSha: "base",
+      sessionId: assignment.session.sessionId
+    }).job;
+    const statusCalls: StatusCommentCall[] = [];
+
+    await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => "skipped_processed",
+      now: new Date("2026-07-02T00:01:00.000Z")
+    });
+
+    expect(statusCalls.map(statusFromBody)).toEqual(["in_progress", "queued"]);
+    expect(state.getReviewQueueJob(job.jobId)).toMatchObject({
+      state: "queued",
+      lastError: "processed_head_already_unknown"
+    });
+    const sessionJob = state.getReviewerSessionJob("org/repo-a", 1, HEAD_A);
+    expect(sessionJob).toMatchObject({ jobState: "assigned" });
+    expect(sessionJob?.processedReviewStatus).toBeUndefined();
+    state.close();
+  });
+
   it("reconciles historical failed queue rows for already-skipped processed heads", async () => {
     const cooldownError = "provider_rate_limit_cooldown_until=2026-07-02T00:10:00.000Z; reason=provider_overloaded";
     const scenarios = [

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -667,6 +667,12 @@ describe("provider-aware review scheduler", () => {
         expectedStatus: "provider_deferred",
         expectedQueueState: "provider_deferred",
         expectedLastError: cooldownError
+      },
+      {
+        processedStatus: undefined,
+        expectedStatus: "queued",
+        expectedQueueState: "queued",
+        expectedLastError: "processed_head_already_unknown"
       }
     ] as const;
 
@@ -676,16 +682,18 @@ describe("provider-aware review scheduler", () => {
       const config = schedulerConfig(root, ["org/repo-a"]);
       config.reviewStatusComment!.enabled = true;
       const state = new ReviewStateStore(config.statePath);
-      state.recordProcessed({
-        repo: "org/repo-a",
-        pullNumber: 1,
-        headSha: HEAD_A,
-        status: scenario.processedStatus,
-        ...("error" in scenario ? { error: scenario.error } : {}),
-        ...(scenario.processedStatus === "posted"
-          ? { event: "COMMENT" as const, reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-existing" }
-          : {})
-      });
+      if (scenario.processedStatus) {
+        state.recordProcessed({
+          repo: "org/repo-a",
+          pullNumber: 1,
+          headSha: HEAD_A,
+          status: scenario.processedStatus,
+          ...("error" in scenario ? { error: scenario.error } : {}),
+          ...(scenario.processedStatus === "posted"
+            ? { event: "COMMENT" as const, reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-existing" }
+            : {})
+        });
+      }
       const job = state.enqueueReviewQueueJob({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, baseSha: "base" }).job;
       const statusCalls: StatusCommentCall[] = [];
 

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -981,6 +981,18 @@ describe("worker review failures", () => {
       status: "skipped",
       error: "provider_rate_limit_cooldown_until=2000-01-01T00:00:00.000Z; reason=provider_rate_limit"
     });
+    const queueJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      baseSha: pull.base.sha
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "running",
+      clearLease: false,
+      lastError: "retry_started"
+    });
 
     const result = await retryProviderCooldownsWithDeps({
       config,
@@ -1007,6 +1019,11 @@ describe("worker review failures", () => {
     expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
       status: "skipped",
       error: expect.stringContaining("provider_rate_limit_cooldown_until=")
+    });
+    expect(state.getReviewQueueJob(queueJob.jobId)).toMatchObject({
+      state: "provider_deferred",
+      nextEligibleAt: expect.stringMatching(/T/),
+      lastError: expect.stringContaining("provider_rate_limit_cooldown_until=")
     });
     state.close();
   });

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -1590,6 +1590,9 @@ describe("worker review failures", () => {
       pullNumber: pull.number,
       headSha: pull.head.sha,
       baseSha: pull.base.sha,
+      source: "manual_command",
+      lane: "manual",
+      commentId: 12345,
       sessionId: assignment.session.sessionId
     }).job;
     state.updateReviewQueueJobState({
@@ -1623,6 +1626,74 @@ describe("worker review failures", () => {
     expect(state.getReviewerSessionJob("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
       jobState: "skipped",
       processedReviewStatus: "skipped"
+    });
+    state.close();
+  });
+
+  it("does not retire automatic retry work when a provider retry only records a command", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-command-auto-isolation-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1236, "head-retry-command-isolated");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "failed",
+      error: "original provider cooldown"
+    });
+    const automaticJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      baseSha: pull.base.sha
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: automaticJob.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-01T00:01:00.000Z",
+      lastError: "provider cooldown"
+    });
+    const manualJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      baseSha: pull.base.sha,
+      source: "manual_command",
+      lane: "manual",
+      commentId: 98765
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: manualJob.jobId,
+      state: "running",
+      clearLease: false,
+      lastError: "manual_retry_started"
+    });
+
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async () => "skipped_command_explain"
+    });
+
+    expect(result.status).toBe("skipped_command_explain");
+    expect(state.getReviewQueueJob(manualJob.jobId)).toMatchObject({
+      state: "command_recorded",
+      lastError: "manual_command_explain_recorded"
+    });
+    expect(state.getReviewQueueJob(automaticJob.jobId)).toMatchObject({
+      state: "provider_deferred",
+      lastError: "provider cooldown"
     });
     state.close();
   });

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -1503,6 +1503,130 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("keeps dry-run processed retry rows queued instead of marking them posted", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-race-dry-run-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1234, "head-retry-dry-run");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "failed",
+      error: "original timeout"
+    });
+    const queueJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      baseSha: pull.base.sha
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "running",
+      clearLease: false,
+      lastError: "retry_started"
+    });
+
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async (input) => {
+        state.recordProcessed({
+          repo: "electricsheephq/WorldOS",
+          pullNumber: pull.number,
+          headSha: pull.head.sha,
+          status: "dry_run",
+          event: "COMMENT"
+        });
+        return reviewPull(input);
+      }
+    });
+
+    expect(result.status).toBe("skipped_processed");
+    const updatedQueueJob = state.getReviewQueueJob(queueJob.jobId);
+    expect(updatedQueueJob).toMatchObject({
+      state: "queued",
+      lastError: "retry_did_not_review=skipped_processed:dry_run"
+    });
+    expect(updatedQueueJob?.reviewUrl).toBeUndefined();
+    state.close();
+  });
+
+  it("settles retry-owned RepoSticky session rows for command-recorded outcomes", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-command-session-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1235, "head-retry-command");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "failed",
+      error: "original timeout"
+    });
+    const assignment = state.assignReviewerSessionJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      ttlMs: 60_000,
+      headCountLimit: 5,
+      allowProcessed: true
+    });
+    if (!assignment.session) throw new Error("expected session assignment");
+    const queueJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      baseSha: pull.base.sha,
+      sessionId: assignment.session.sessionId
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "running",
+      sessionId: assignment.session.sessionId,
+      clearLease: false,
+      lastError: "retry_started"
+    });
+
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async () => "skipped_command_explain"
+    });
+
+    expect(result.status).toBe("skipped_command_explain");
+    expect(state.getReviewQueueJob(queueJob.jobId)).toMatchObject({
+      state: "command_recorded",
+      lastError: "manual_command_explain_recorded"
+    });
+    expect(state.getReviewerSessionJob("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      jobState: "skipped",
+      processedReviewStatus: "skipped"
+    });
+    state.close();
+  });
+
   it("keeps retry CLI success status mapping explicit", () => {
     expect(isSuccessfulRetryStatus("reviewed")).toBe(true);
     expect(isSuccessfulRetryStatus("reviewed_command")).toBe(true);


### PR DESCRIPTION
## Summary
- adds an offline `eval-sticky-vs-cold` runner that executes paired cold/sticky eval packets for the same PR head
- writes `sticky-vs-cold-summary.json` and `sticky-vs-cold-report.md` with quality/safety/provider deltas
- keeps public confidence `uncalibrated`; clean small packets are `advisory`, while safety regressions fail closed as `not_enough_evidence`

Closes #85.

## Evidence
- Focused tests: `npm test -- tests/eval-harness.test.ts --pool=forks --maxWorkers=1` (27 passed)
- Build: `npm run build`
- Whitespace: `git diff --check`
- Local packet: `/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-03/issue-85-sticky-vs-cold-local/`

## Proof Boundary
This is offline eval plumbing only. It does not post GitHub comments, mutate repos, change launchd, expand issue enrichment allowlists, or enable public calibrated confidence percentages.