### PR TITLE
feat(cli): expose NeonDiff source-checkout commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,16 @@ git clone https://github.com/electricsheephq/evaos-code-review-bot.git neondiff
 cd neondiff
 npm install
 npm run build
+npm link
 ```
 
-The public CLI package and final binary name are tracked in
-[issue #107](https://github.com/electricsheephq/evaos-code-review-bot/issues/107).
-Until that closes, use the repo scripts shown in [docs/SETUP.md](docs/SETUP.md)
-and [docs/operator-cli.md](docs/operator-cli.md).
+The source checkout exposes the beta `neondiff` binary through `npm link`.
+If you intentionally skip linking, substitute `./dist/src/cli.js` anywhere this
+guide calls `neondiff`. Public npm/package distribution stays blocked until the license gate in
+[issue #104](https://github.com/electricsheephq/evaos-code-review-bot/issues/104)
+and the distribution work in
+[issue #107](https://github.com/electricsheephq/evaos-code-review-bot/issues/107)
+are both resolved.
 
 ## Set Up
 
@@ -77,10 +81,10 @@ Follow [docs/SETUP.md](docs/SETUP.md) for the full first-run path. The short
 version is:
 
 ```bash
-cp config.example.json config.local.json
+neondiff init --config config.local.json
 export EVAOS_REVIEW_BOT_APP_ID="<github-app-id>"
 export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
-npm run doctor -- --config config.local.json
+neondiff doctor --config config.local.json --json
 ```
 
 Do not store the GitHub App private key, provider API key, license key, tokens,
@@ -92,7 +96,7 @@ evidence outside git.
 Run a dry-run review before any live posting:
 
 ```bash
-npm run run-once -- \
+neondiff review-pr \
   --config config.local.json \
   --repo owner/name \
   --pr 123 \

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,8 +1,9 @@
 # NeonDiff Setup
 
-This guide is the first-run path for the current source-available beta. It uses
-the checked-out repository scripts until the public CLI package and final
-`neondiff` binary are completed in issue #107.
+This guide is the first-run path for the current source-available beta. After
+`npm run build`, the source checkout exposes the beta `neondiff` binary. Public
+npm/package publishing stays blocked until the license gate in issue #104 and
+the distribution work in issue #107 are both resolved.
 
 ## Requirements
 
@@ -22,7 +23,12 @@ git clone https://github.com/electricsheephq/evaos-code-review-bot.git neondiff
 cd neondiff
 npm install
 npm run build
+npm link
 ```
+
+`npm link` installs the local source-checkout shim so the examples below can use
+`neondiff`. If you intentionally skip linking, substitute `./dist/src/cli.js`
+for `neondiff`.
 
 ## 2. Create A GitHub App
 
@@ -52,11 +58,11 @@ export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key
 
 ## 3. Configure Provider And License
 
-Copy the example config and edit it for your local repo allowlist, provider
-path, state path, and evidence path:
+Create a local config from the example, then edit it for your local repo
+allowlist, provider path, state path, and evidence path:
 
 ```bash
-cp config.example.json config.local.json
+neondiff init --config config.local.json
 ```
 
 For the current internal provider path, the worker derives transient ZCode/GLM
@@ -72,7 +78,7 @@ Do not paste license keys into tracked config.
 Run doctor with the config you intend to use:
 
 ```bash
-npm run doctor -- --config config.local.json
+neondiff doctor --config config.local.json --json
 ```
 
 The doctor output is JSON. Check:
@@ -89,7 +95,7 @@ Use a known repo, PR number, and current head. A dry-run review should produce
 structured output and evidence without posting comments:
 
 ```bash
-npm run run-once -- \
+neondiff review-pr \
   --config config.local.json \
   --repo owner/name \
   --pr 123 \
@@ -106,16 +112,39 @@ path.
 Before touching launchd, use JSON status commands:
 
 ```bash
-npm run cli -- status --json --config config.local.json
-npm run cli -- queue --config config.local.json
-npm run cli -- dashboard --config config.local.json --limit 10
+neondiff status --json --config config.local.json
+neondiff queue --config config.local.json
+neondiff dashboard --config config.local.json --limit 10
 ```
 
-After `npm run build`, the local package also exposes the current beta binary:
+Launchd controls are explicit and JSON-first. Dry-run them before changing a
+loaded LaunchAgent:
 
 ```bash
-./dist/src/cli.js status --config config.local.json
+neondiff daemon status --config config.local.json --launchd-label com.example.neondiff
+neondiff daemon start --launchd-label com.example.neondiff --dry-run true
+neondiff daemon stop --launchd-label com.example.neondiff --dry-run true
 ```
+
+`daemon start` and `daemon stop` default to dry-run planning. Live launchd
+mutation requires both `--dry-run false` and `--confirm true`.
+`daemon start` without `--plist` restarts an already loaded LaunchAgent with
+`kickstart`; first-time LaunchAgent installation must pass the plist path so the
+dry-run plan includes `bootstrap`. If a live `bootstrap` fails because the
+LaunchAgent is already loaded, rerun `daemon start` without `--plist` to perform
+the kickstart-only restart path.
+Use only operator-owned plist paths. The CLI validates the plist `Label` against
+`--launchd-label` and warns when the plist lives outside the NeonDiff package
+root. Live mutation with an external plist also requires
+`--allow-external-plist true`; keep the default off unless the release issue
+names the exact operator-owned plist path. The external-plist check is a lexical
+path warning, not a realpath/symlink containment proof, so do not rely on it as
+a filesystem security boundary.
+
+Live `review-pr` posting is intentionally harder than dry-run inspection. Use
+`--dry-run true` for normal local checks. A live scoped PR review requires
+`--dry-run false --confirm true` after the target repo, PR, head SHA, and config
+path are approved by the relevant issue.
 
 Launchd and live beta promotion are advanced operator tasks. Use
 [docs/launchd.md](launchd.md), [docs/operator-cli.md](operator-cli.md), and

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -10,9 +10,11 @@ Run commands from the repository checkout:
 npx tsx src/cli.ts status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
-After `npm run build`, the package also exposes:
+After `npm run build` and `npm link`, the package exposes both the public beta
+binary and the legacy internal binary:
 
 ```bash
+neondiff status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
 evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
 ```
 
@@ -104,6 +106,30 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
   the default live posture for repos with large historic issue backlogs.
 - `doctor`: auth/config readiness. Use this for GitHub App/ZCode readiness, not
   runtime health.
+- `init --config <path>`: copy `config.example.json` to a local config path
+  without embedding credentials. Refuses to overwrite unless `--force true` is
+  supplied.
+- `review-pr --repo <owner/name> --pr <number> --dry-run true`: public alias for
+  the existing scoped `run-once` review command. Live posting through this
+  public alias requires `--dry-run false --confirm true` after the exact repo,
+  PR, head SHA, and config path are approved.
+- `daemon start|stop|status`: JSON-first launchd controls. All daemon
+  subcommands require `--launchd-label`; `start` and `stop` default to dry-run planning; live mutation
+  requires both `--dry-run false` and `--confirm true`.
+  When `start` uses `--plist <path>`, `stop` can either pass the same `--plist`
+  to boot out by domain/plist or omit `--plist` to boot out by service label.
+  `start` without `--plist` restarts an already loaded LaunchAgent; first-time
+  installation must pass `--plist`. Use only operator-owned plist paths. Live
+  mutation with a `--plist` outside the NeonDiff package root requires
+  `--allow-external-plist true`; dry-run still reports the warning and planned
+  commands without mutating launchd. The external-plist warning is a lexical
+  path check, not a realpath/symlink containment proof.
+  If a live `bootstrap` fails because the LaunchAgent is already loaded, rerun
+  `daemon start` without `--plist` to use the kickstart-only restart path.
+- `daemon --config <config.json> --dry-run true --once true`: runs one legacy
+  daemon cycle and exits. This is intended for deterministic local smoke tests
+  and operator diagnostics; omit `--once true` for the normal long-running
+  worker loop.
 
 ## Common Operator Flows
 
@@ -307,6 +333,7 @@ Mutating commands remain explicit:
 - `build-memory-packet --record-build true`
 - `run-once --dry-run false`
 - `daemon --dry-run false`
+- `daemon start|stop --dry-run false --confirm true`
 
 `build-skill-pack` and `build-enrichment-comment` are dry-run/evidence builders.
 They remain read-only. Live `run-once` and `daemon` can consume skill-pack

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "evaos-code-review-bot",
       "version": "0.1.0",
       "bin": {
+        "neondiff": "dist/src/cli.js",
         "evaos-review-bot": "dist/src/cli.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "bin": {
+    "neondiff": "dist/src/cli.js",
     "evaos-review-bot": "dist/src/cli.js"
   },
   "description": "Local ZCode-backed GitHub PR review bot pilot for evaOS repos.",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { loadConfig } from "./config.js";
 import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
 import { runDaemonCycle } from "./daemon.js";
 import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
-import { basename, dirname, join, parse as parsePath, resolve, sep } from "node:path";
+import { basename, dirname, extname, join, parse as parsePath, resolve, sep } from "node:path";
 import {
   assertEvalOutputDirSafe,
   buildEvalPromotionDecisionMarkdown,
@@ -52,12 +54,22 @@ import { isSuccessfulRetryStatus, retryFailedHead, retryProviderCooldowns } from
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
 import { parsePositiveInteger } from "./cli-args.js";
 
+const LAUNCHCTL_TIMEOUT_MS = 15_000;
+const PLUTIL_TIMEOUT_MS = 5_000;
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const command = args._[0];
 
   if (!command || command === "help" || command === "--help" || command === "-h") {
     console.log(JSON.stringify(buildHelp(), null, 2));
+    return;
+  }
+
+  if (command === "init") {
+    const result = runInitCommand(args);
+    console.log(JSON.stringify(result, null, 2));
+    if (!result.ok) process.exitCode = 1;
     return;
   }
 
@@ -922,18 +934,114 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "run-once") {
+  if (command === "run-once" || command === "review-pr") {
+    if (command === "review-pr" && (!args.repo || !args.pr)) {
+      console.log(JSON.stringify({
+        ok: false,
+        command: "review-pr",
+        error: "review-pr requires --repo and --pr so the public alias cannot scan every configured repository"
+      }, null, 2));
+      process.exitCode = 1;
+      return;
+    }
+    const repo = args.repo ? parseSingleArg(args.repo, "--repo") : undefined;
     const dryRun = args["dry-run"] !== "false";
+    if (command === "review-pr" && !dryRun && args.confirm !== "true") {
+      console.log(JSON.stringify({
+        ok: false,
+        command: "review-pr",
+        ...(repo ? { repo } : {}),
+        error: "review-pr requires --confirm true when --dry-run false is used"
+      }, null, 2));
+      process.exitCode = 1;
+      return;
+    }
+    let reviewPrExpectedHeadSha: string | undefined;
+    if (command === "review-pr" && !dryRun) {
+      const configPath = args.config ? parseSingleArg(args.config, "--config") : undefined;
+      if (!configPath) {
+        console.log(JSON.stringify({
+          ok: false,
+          command: "review-pr",
+          ...(repo ? { repo } : {}),
+          error: "review-pr requires --config when --dry-run false is used"
+        }, null, 2));
+        process.exitCode = 1;
+        return;
+      }
+      if (!existsSync(configPath) || !statSync(configPath).isFile()) {
+        console.log(JSON.stringify({
+          ok: false,
+          command: "review-pr",
+          ...(repo ? { repo } : {}),
+          error: "review-pr --config must point to an existing config file when --dry-run false is used"
+        }, null, 2));
+        process.exitCode = 1;
+        return;
+      }
+      if (args["head-sha"] && args["expected-head"] && args["head-sha"] !== args["expected-head"]) {
+        console.log(JSON.stringify({
+          ok: false,
+          command: "review-pr",
+          ...(repo ? { repo } : {}),
+          error: "review-pr --head-sha and --expected-head must match when both are provided"
+        }, null, 2));
+        process.exitCode = 1;
+        return;
+      }
+      reviewPrExpectedHeadSha = args["head-sha"] ?? args["expected-head"];
+      if (!reviewPrExpectedHeadSha) {
+        console.log(JSON.stringify({
+          ok: false,
+          command: "review-pr",
+          ...(repo ? { repo } : {}),
+          error: "review-pr requires --head-sha when --dry-run false is used"
+        }, null, 2));
+        process.exitCode = 1;
+        return;
+      }
+    }
+    if (command === "review-pr") {
+      const config = loadConfig(args.config);
+      const allowedRepoError = validateReviewPrRepoAllowed(config, repo!);
+      if (allowedRepoError) {
+        console.log(JSON.stringify({
+          ok: false,
+          command: "review-pr",
+          repo: repo!,
+          error: allowedRepoError
+        }, null, 2));
+        process.exitCode = 1;
+        return;
+      }
+    }
     const useZCode = args.zcode !== "false";
-    const pullNumber = args.pr ? parsePositiveInteger(args.pr, "--pr") : undefined;
+    let pullNumber: number | undefined;
+    try {
+      pullNumber = args.pr ? parsePositiveInteger(parseSingleArg(args.pr, "--pr"), "--pr") : undefined;
+    } catch (error) {
+      if (command === "review-pr") {
+        console.log(JSON.stringify({
+          ok: false,
+          command: "review-pr",
+          ...(repo ? { repo } : {}),
+          error: error instanceof Error ? error.message : String(error)
+        }, null, 2));
+        process.exitCode = 1;
+        return;
+      }
+      throw error;
+    }
     const result = await runOnceCliCommand({
       options: {
         configPath: args.config,
         dryRun,
-        repo: args.repo,
+        repo,
         pullNumber,
-        useZCode
-      }
+        useZCode,
+        expectedHeadSha: reviewPrExpectedHeadSha
+      },
+      commandName: command
     });
     console.log(result.output);
     if (result.exitCode !== 0) process.exitCode = result.exitCode;
@@ -1025,9 +1133,20 @@ async function main(): Promise<void> {
   }
 
   if (command === "daemon") {
+    const daemonAction = args._[1];
+    if (daemonAction === "start" || daemonAction === "stop" || daemonAction === "status") {
+      const result = runDaemonControlCommandSafely(daemonAction, args);
+      console.log(JSON.stringify(result, null, 2));
+      if (!result.ok) process.exitCode = 1;
+      return;
+    }
+    if (daemonAction) {
+      throw new Error("daemon subcommand must be one of: start, stop, status");
+    }
     const config = loadConfig(args.config);
     const monitoredRepos = listReposToScan(config);
     let cycle = 0;
+    const runOnce = args.once === "true";
     for (;;) {
       cycle += 1;
       const dryRun = args["dry-run"] !== "false";
@@ -1042,6 +1161,7 @@ async function main(): Promise<void> {
         issueEnrichmentEnabled: config.issueEnrichment?.enabled === true,
         configPath: args.config
       });
+      if (runOnce) return;
       await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs));
     }
   }
@@ -1064,6 +1184,421 @@ async function collectCoverageReport(args: ParsedArgs, config = loadConfig(args.
   } finally {
     state.close();
   }
+}
+
+function runInitCommand(args: ParsedArgs): {
+  ok: boolean;
+  command: "init";
+  configPath: string;
+  created: boolean;
+  examplePath: string;
+  recommendedCommands: string[];
+  backupPath?: string;
+  error?: string;
+} {
+  const configPath = resolve(parseSingleArg(args.config ?? "config.local.json", "--config"));
+  const examplePath = join(resolvePackageRoot(), "config.example.json");
+  const force = args.force === "true";
+  if (!existsSync(examplePath)) {
+    return {
+      ok: false,
+      command: "init",
+      configPath,
+      created: false,
+      examplePath,
+      recommendedCommands: [],
+      error: "config.example.json not found in the current checkout"
+    };
+  }
+  if (existsSync(configPath) && !force) {
+    return {
+      ok: false,
+      command: "init",
+      configPath,
+      created: false,
+      examplePath,
+      recommendedCommands: [`neondiff doctor --config ${configPath} --json`],
+      error: "config already exists; rerun with --force true to overwrite"
+    };
+  }
+  const forceTargetError = force ? validateInitForceTarget(configPath) : undefined;
+  if (forceTargetError) {
+    return {
+      ok: false,
+      command: "init",
+      configPath,
+      created: false,
+      examplePath,
+      recommendedCommands: [`neondiff init --config ${configPath}`],
+      error: forceTargetError
+    };
+  }
+  const backupPath = force && existsSync(configPath) ? backupInitForceTarget(configPath) : undefined;
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, readFileSync(examplePath, "utf8"));
+  return {
+    ok: true,
+    command: "init",
+    configPath,
+    created: true,
+    examplePath,
+    ...(backupPath ? { backupPath } : {}),
+    recommendedCommands: [
+      `neondiff doctor --config ${configPath} --json`,
+      `neondiff review-pr --config ${configPath} --repo owner/name --pr 123 --dry-run true --zcode false`,
+      `neondiff status --config ${configPath} --json`
+    ]
+  };
+}
+
+function resolvePackageRoot(): string {
+  for (const start of [dirname(fileURLToPath(import.meta.url)), process.cwd()]) {
+    let cursor = resolve(start);
+    while (true) {
+      if (isNeonDiffPackageRoot(cursor)) {
+        return cursor;
+      }
+      const parent = dirname(cursor);
+      if (parent === cursor) break;
+      cursor = parent;
+    }
+  }
+  return process.cwd();
+}
+
+function isNeonDiffPackageRoot(candidate: string): boolean {
+  if (!existsSync(join(candidate, "package.json")) || !existsSync(join(candidate, "config.example.json"))) {
+    return false;
+  }
+  try {
+    const packageJson = JSON.parse(readFileSync(join(candidate, "package.json"), "utf8"));
+    return packageJson.name === "evaos-code-review-bot"
+      && packageJson.bin?.neondiff === "dist/src/cli.js";
+  } catch {
+    return false;
+  }
+}
+
+function validateReviewPrRepoAllowed(config: ReturnType<typeof loadConfig>, repo: string): string | undefined {
+  const configuredRepos = listReposToScan(config);
+  if (!configuredRepos.map(canonicalRepoNameForCli).includes(canonicalRepoNameForCli(repo))) {
+    return `review-pr repo must be present in configured repos: ${configuredRepos.join(", ") || "(none)"}`;
+  }
+  const policy = resolveRepoProfile(config, repo);
+  if (!policy.allowed) {
+    return `review-pr repo is blocked by repo policy: ${policy.reason}`;
+  }
+  return undefined;
+}
+
+function canonicalRepoNameForCli(repo: string): string {
+  const [owner, name] = repo.split("/");
+  return `${owner?.toLowerCase() ?? ""}/${name?.toLowerCase() ?? ""}`;
+}
+
+function validateInitForceTarget(configPath: string): string | undefined {
+  if (!existsSync(configPath)) return undefined;
+  if (extname(configPath) !== ".json") {
+    return "--force true only overwrites existing JSON config files";
+  }
+  const stat = statSync(configPath);
+  if (!stat.isFile()) {
+    return "--force true only overwrites existing JSON config files";
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return "--force true only overwrites existing JSON config object files";
+    }
+  } catch {
+    return "--force true only overwrites existing JSON config files";
+  }
+  return undefined;
+}
+
+function backupInitForceTarget(configPath: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const backupPath = `${configPath}.${timestamp}.bak`;
+  writeFileSync(backupPath, readFileSync(configPath, "utf8"));
+  return backupPath;
+}
+
+type DaemonControlResult = {
+  ok: boolean;
+  command: "daemon start" | "daemon stop" | "daemon status";
+  dryRun?: boolean;
+  launchdLabel?: string;
+  launchdTarget?: string;
+  operation?: "bootstrap_then_kickstart" | "kickstart_existing" | "bootout_plist" | "bootout_service" | "status";
+  plistPath?: string;
+  warning?: string;
+  plannedCommands?: string[][];
+  results?: Array<{ command: string[]; exitCode: number; stdout?: string; stderr?: string; error?: string; signal?: string }>;
+  status?: ReleaseStatus;
+  error?: string;
+};
+
+function runDaemonControlCommandSafely(
+  action: "start" | "stop" | "status",
+  args: ParsedArgs
+): DaemonControlResult {
+  try {
+    return runDaemonControlCommand(action, args);
+  } catch (error) {
+    return {
+      ok: false,
+      command: `daemon ${action}`,
+      error: redactSecrets(error instanceof Error ? error.message : String(error))
+    };
+  }
+}
+
+function runDaemonControlCommand(
+  action: "start" | "stop" | "status",
+  args: ParsedArgs
+): DaemonControlResult {
+  if (action === "status") {
+    if (!args["launchd-label"]) {
+      return {
+        ok: false,
+        command: "daemon status",
+        error: "--launchd-label is required for daemon status"
+      };
+    }
+    if (!args.config) {
+      return {
+        ok: false,
+        command: "daemon status",
+        error: "--config is required for daemon status"
+      };
+    }
+    const launchdLabel = parseLaunchdLabelArg(args["launchd-label"], "--launchd-label");
+    const launchdTarget = launchdServiceTarget(launchdLabel);
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      configPath: parseSingleArg(args.config, "--config"),
+      expectedHead: args["expected-head"],
+      launchdLabel,
+      statePath: args["state-path"]
+    });
+    return {
+      ok: status.ok,
+      command: "daemon status",
+      launchdLabel,
+      launchdTarget,
+      operation: "status",
+      status
+    };
+  }
+
+  if (!args["launchd-label"]) {
+    return {
+      ok: false,
+      command: `daemon ${action}`,
+      error: `--launchd-label is required for daemon ${action}`
+    };
+  }
+  const dryRun = args["dry-run"] !== "false";
+  const confirm = args.confirm === "true";
+  const allowExternalPlist = args["allow-external-plist"] === "true";
+  const launchdLabel = parseLaunchdLabelArg(args["launchd-label"], "--launchd-label");
+  const plistPath = args.plist ? resolve(parseSingleArg(args.plist, "--plist")) : undefined;
+  if (plistPath) assertPlistLabelMatches(plistPath, launchdLabel);
+  const launchdTarget = launchdServiceTarget(launchdLabel);
+  const commands = buildDaemonLaunchctlCommands({
+    action,
+    launchdLabel,
+    ...(plistPath ? { plistPath } : {})
+  });
+  const operation = daemonControlOperation(action, plistPath);
+  const warning = plistPath ? daemonPlistWarning(plistPath) : undefined;
+  if (dryRun) {
+    return {
+      ok: true,
+      command: `daemon ${action}`,
+      dryRun,
+      launchdLabel,
+      launchdTarget,
+      operation,
+      ...(plistPath ? { plistPath } : {}),
+      ...(warning ? { warning } : {}),
+      plannedCommands: commands
+    };
+  }
+  const launchdSessionError = launchdUserSessionError();
+  if (launchdSessionError) {
+    return {
+      ok: false,
+      command: `daemon ${action}`,
+      dryRun,
+      launchdLabel,
+      launchdTarget,
+      operation,
+      ...(plistPath ? { plistPath } : {}),
+      ...(warning ? { warning } : {}),
+      plannedCommands: commands,
+      error: launchdSessionError
+    };
+  }
+  if (warning && !allowExternalPlist) {
+    return {
+      ok: false,
+      command: `daemon ${action}`,
+      dryRun,
+      launchdLabel,
+      launchdTarget,
+      operation,
+      ...(plistPath ? { plistPath } : {}),
+      warning,
+      plannedCommands: commands,
+      error: `daemon ${action} requires --allow-external-plist true when --dry-run false uses a --plist outside the NeonDiff package root`
+    };
+  }
+  if (!confirm) {
+    return {
+      ok: false,
+      command: `daemon ${action}`,
+      dryRun,
+      launchdLabel,
+      launchdTarget,
+      operation,
+      ...(plistPath ? { plistPath } : {}),
+      ...(warning ? { warning } : {}),
+      plannedCommands: commands,
+      error: `daemon ${action} requires --confirm true when --dry-run false is used`
+    };
+  }
+  const results = runLaunchctlPlan(commands);
+  return {
+    ok: results.every((result) => result.exitCode === 0),
+    command: `daemon ${action}`,
+    dryRun,
+    launchdLabel,
+    launchdTarget,
+    operation,
+    ...(plistPath ? { plistPath } : {}),
+    ...(warning ? { warning } : {}),
+    results
+  };
+}
+
+function buildDaemonLaunchctlCommands(input: {
+  action: "start" | "stop";
+  launchdLabel: string;
+  plistPath?: string;
+}): string[][] {
+  const domain = launchdDomainTarget();
+  const service = launchdServiceTarget(input.launchdLabel);
+  if (input.action === "start") {
+    return [
+      ...(input.plistPath ? [["launchctl", "bootstrap", domain, input.plistPath]] : []),
+      ["launchctl", "kickstart", "-k", service]
+    ];
+  }
+  return input.plistPath
+    ? [["launchctl", "bootout", domain, input.plistPath]]
+    : [["launchctl", "bootout", service]];
+}
+
+function daemonControlOperation(
+  action: "start" | "stop",
+  plistPath?: string
+): "bootstrap_then_kickstart" | "kickstart_existing" | "bootout_plist" | "bootout_service" {
+  if (action === "start") return plistPath ? "bootstrap_then_kickstart" : "kickstart_existing";
+  return plistPath ? "bootout_plist" : "bootout_service";
+}
+
+function daemonPlistWarning(plistPath: string): string | undefined {
+  const packageRoot = resolvePackageRoot();
+  const normalizedRoot = `${packageRoot.replace(/\/+$/, "")}/`;
+  const normalizedPlist = resolve(plistPath);
+  if (normalizedPlist === packageRoot || normalizedPlist.startsWith(normalizedRoot)) return undefined;
+  return "--plist is outside the NeonDiff package root; use only operator-owned plist paths";
+}
+
+function runLaunchctlPlan(commands: string[][]): Array<{
+  command: string[];
+  exitCode: number;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+  signal?: string;
+}> {
+  const results = [];
+  for (const command of commands) {
+    const result = runLaunchctl(command);
+    results.push(result);
+    if (result.exitCode !== 0) break;
+  }
+  return results;
+}
+
+function runLaunchctl(command: string[]): {
+  command: string[];
+  exitCode: number;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+  signal?: string;
+} {
+  const [binary, ...args] = command;
+  if (binary !== "launchctl") throw new Error(`unsupported daemon control command: ${command.join(" ")}`);
+  const result = spawnSync(binary, args, {
+    encoding: "utf8",
+    timeout: LAUNCHCTL_TIMEOUT_MS
+  });
+  return {
+    command,
+    exitCode: result.status ?? 1,
+    ...(result.stdout ? { stdout: redactSecrets(result.stdout.trim()) } : {}),
+    ...(result.stderr ? { stderr: redactSecrets(result.stderr.trim()) } : {}),
+    ...(result.error ? { error: redactSecrets(result.error.message) } : {}),
+    ...(result.signal ? { signal: result.signal } : {})
+  };
+}
+
+function parseLaunchdLabelArg(value: string | string[] | undefined, label: string): string {
+  if (value === undefined) throw new Error(`${label} is required`);
+  const parsed = parseSingleArg(value, label);
+  if (!/^[A-Za-z0-9][A-Za-z0-9_.-]{0,255}$/.test(parsed)) {
+    throw new Error(`${label} must be a launchd label using only letters, digits, dots, underscores, and hyphens`);
+  }
+  return parsed;
+}
+
+function assertPlistLabelMatches(plistPath: string, launchdLabel: string): void {
+  if (!existsSync(plistPath)) throw new Error(`--plist does not exist: ${plistPath}`);
+  const result = spawnSync("plutil", ["-extract", "Label", "raw", plistPath], {
+    encoding: "utf8",
+    timeout: PLUTIL_TIMEOUT_MS
+  });
+  if (result.error) {
+    throw new Error(`failed to read --plist Label: ${redactSecrets(result.error.message)}`);
+  }
+  if (result.status !== 0) {
+    const detail = redactSecrets((result.stderr || result.stdout || "").trim());
+    throw new Error(`failed to read --plist Label${detail ? `: ${detail}` : ""}`);
+  }
+  const plistLabel = result.stdout.trim();
+  if (plistLabel !== launchdLabel) {
+    throw new Error(`--plist Label (${redactSecrets(plistLabel)}) must match --launchd-label (${redactSecrets(launchdLabel)})`);
+  }
+}
+
+function launchdDomainTarget(): string {
+  const uid = process.getuid?.();
+  if (uid === undefined) return "gui/<uid-unavailable>";
+  return `gui/${uid}`;
+}
+
+function launchdServiceTarget(label: string): string {
+  return `${launchdDomainTarget()}/${label}`;
+}
+
+function launchdUserSessionError(): string | undefined {
+  return process.getuid?.() === undefined
+    ? "launchd daemon controls require a user session with process.getuid()"
+    : undefined;
 }
 
 function collectQueueBudget(args: ParsedArgs): {
@@ -1091,6 +1626,15 @@ function buildHelp() {
   return {
     ok: true,
     commands: {
+      public: [
+        "init",
+        "doctor",
+        "daemon start",
+        "daemon stop",
+        "daemon status",
+        "status",
+        "review-pr"
+      ],
       operator: [
         "status",
         "runtime-inventory",
@@ -1126,6 +1670,13 @@ function buildHelp() {
       ]
     },
     examples: [
+      "neondiff init --config config.local.json",
+      "neondiff doctor --config config.local.json --json",
+      "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 --dry-run true --zcode false",
+      "neondiff daemon status --config config.local.json --launchd-label com.example.neondiff",
+      "neondiff daemon start --launchd-label com.example.neondiff --dry-run true",
+      "neondiff daemon stop --launchd-label com.example.neondiff --dry-run true",
+      "npx tsx src/cli.ts daemon --config /path/to/live.json --dry-run true --once true",
       "npx tsx src/cli.ts status --config /path/to/live.json --launchd-label com.electricsheephq.evaos-code-review-bot",
       "npx tsx src/cli.ts runtime-inventory --config /path/to/live.json --launchd-label com.electricsheephq.evaos-code-review-bot",
       "npx tsx src/cli.ts runtime-inventory --config /path/to/live.json --human",
@@ -1162,13 +1713,18 @@ function parseArgs(argv: string[]): ParsedArgs {
     const key = arg.slice(2);
     const next = argv[index + 1];
     if (next && !next.startsWith("--")) {
-      parsed[key] = next;
+      setParsedArg(parsed, key, next);
       index += 1;
     } else {
-      parsed[key] = "true";
+      setParsedArg(parsed, key, "true");
     }
   }
   return parsed;
+}
+
+function setParsedArg(parsed: ParsedArgs, key: string, value: string): void {
+  if (parsed[key] !== undefined) throw new Error(`--${key} must be provided once`);
+  parsed[key] = value;
 }
 
 function parseNonNegativeInteger(value: string, label: string): number {

--- a/src/run-once-cli.ts
+++ b/src/run-once-cli.ts
@@ -6,7 +6,7 @@ const STRUCTURED_SECRET_VALUE_PATTERN =
 
 export interface RunOnceCliReportBase {
   ok: boolean;
-  command: "run-once";
+  command: "run-once" | "review-pr";
   dryRun: boolean;
   useZCode: boolean;
   scope: {
@@ -44,10 +44,11 @@ export function buildRunOnceCliReport(input: {
   useZCode: boolean;
   repo?: string;
   pullNumber?: number;
+  commandName?: "run-once" | "review-pr";
 }): RunOnceCliReport {
   return {
     ok: runOnceCliExitCode(input.result) === 0,
-    command: "run-once",
+    command: input.commandName ?? "run-once",
     dryRun: input.dryRun,
     useZCode: input.useZCode,
     scope: {
@@ -71,6 +72,7 @@ export function serializeRunOnceCliReport(report: RunOnceCliReport): string {
 export async function runOnceCliCommand(input: {
   options: RunOnceOptions;
   runOnceImpl?: (options: RunOnceOptions) => Promise<RunOnceResult>;
+  commandName?: "run-once" | "review-pr";
 }): Promise<RunOnceCliCommandResult> {
   let result: RunOnceResult;
   try {
@@ -81,7 +83,8 @@ export async function runOnceCliCommand(input: {
       dryRun: input.options.dryRun,
       useZCode: input.options.useZCode ?? true,
       repo: input.options.repo,
-      pullNumber: input.options.pullNumber
+      pullNumber: input.options.pullNumber,
+      commandName: input.commandName
     });
     return {
       report,
@@ -94,7 +97,8 @@ export async function runOnceCliCommand(input: {
     dryRun: input.options.dryRun,
     useZCode: input.options.useZCode ?? true,
     repo: input.options.repo,
-    pullNumber: input.options.pullNumber
+    pullNumber: input.options.pullNumber,
+    commandName: input.commandName
   });
   return {
     report,
@@ -109,10 +113,11 @@ function buildRunOnceCliErrorReport(input: {
   useZCode: boolean;
   repo?: string;
   pullNumber?: number;
+  commandName?: "run-once" | "review-pr";
 }): RunOnceCliErrorReport {
   return {
     ok: false,
-    command: "run-once",
+    command: input.commandName ?? "run-once",
     dryRun: input.dryRun,
     useZCode: input.useZCode,
     scope: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -63,6 +63,7 @@ export interface RunOnceOptions {
   dryRun: boolean;
   repo?: string;
   pullNumber?: number;
+  expectedHeadSha?: string;
   useZCode?: boolean;
 }
 
@@ -181,6 +182,19 @@ export function isSuccessfulRetryStatus(status: RetryFailedHeadResult["status"])
   }
 }
 
+export function assertExpectedReviewPrHead(input: {
+  repo: string;
+  pullNumber: number;
+  expectedHeadSha?: string;
+  currentHeadSha?: string;
+}): void {
+  if (!input.expectedHeadSha) return;
+  if (input.currentHeadSha === input.expectedHeadSha) return;
+  throw new Error(
+    `review-pr expected head mismatch for ${input.repo}#${input.pullNumber}: expected=${input.expectedHeadSha} current=${input.currentHeadSha ?? "unknown"}`
+  );
+}
+
 export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
   const config = loadConfig(options.configPath);
   const github = new GitHubApi(config.github);
@@ -218,6 +232,14 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
       const pulls = options.pullNumber
         ? [await github.getPull(repo, options.pullNumber)]
         : await github.listOpenPulls(repo);
+      if (options.pullNumber) {
+        assertExpectedReviewPrHead({
+          repo,
+          pullNumber: options.pullNumber,
+          expectedHeadSha: options.expectedHeadSha,
+          currentHeadSha: pulls[0]?.head.sha
+        });
+      }
       if (options.pullNumber && pulls[0]) {
         result.scopedPull = {
           repo,

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1,0 +1,590 @@
+import { execFile } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
+const tsxCliPath = require.resolve("tsx/cli");
+const repoRoot = process.cwd();
+
+describe("public NeonDiff CLI surface", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("declares the neondiff source-checkout binary", () => {
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+    const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
+
+    expect(packageJson.bin).toMatchObject({
+      neondiff: "dist/src/cli.js",
+      "evaos-review-bot": "dist/src/cli.js"
+    });
+    expect(packageLock.packages[""].bin).toMatchObject({
+      neondiff: "dist/src/cli.js",
+      "evaos-review-bot": "dist/src/cli.js"
+    });
+  });
+
+  it("shows public commands in help output", async () => {
+    const { stdout } = await runCli(["help"]);
+    const output = JSON.parse(stdout);
+
+    expect(output.commands.public).toEqual([
+      "init",
+      "doctor",
+      "daemon start",
+      "daemon stop",
+      "daemon status",
+      "status",
+      "review-pr"
+    ]);
+    expect(output.examples).toContain("neondiff init --config config.local.json");
+    expect(output.examples).toContain("npx tsx src/cli.ts daemon --config /path/to/live.json --dry-run true --once true");
+  });
+
+  it("initializes a local config from the packaged example outside the repo cwd", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-init-"));
+    roots.push(root);
+    const configPath = join(root, "config.local.json");
+
+    const { stdout } = await runCli(["init", "--config", "config.local.json"], {
+      cwd: root
+    });
+    const output = JSON.parse(stdout);
+    const example = readFileSync(join(repoRoot, "config.example.json"), "utf8");
+
+    expect(output).toMatchObject({
+      ok: true,
+      command: "init",
+      created: true
+    });
+    expect(realpathSync(output.configPath)).toBe(realpathSync(configPath));
+    expect(existsSync(configPath)).toBe(true);
+    const config = readFileSync(configPath, "utf8");
+    expect(config).toBe(example);
+    expect(example).toContain("\"pilotRepos\"");
+    expect(example).not.toMatch(/ghp_|BEGIN PRIVATE KEY|api[_-]?key["']?\s*[:=]\s*["'][A-Za-z0-9._~+/=-]{16,}/i);
+  });
+
+  it("refuses to overwrite an existing config without force", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-init-existing-"));
+    roots.push(root);
+    const configPath = join(root, "config.local.json");
+    writeFileSync(configPath, "{}\n");
+
+    await expect(runCli(["init", "--config", configPath])).rejects.toMatchObject({
+      stdout: expect.stringContaining("config already exists")
+    });
+  });
+
+  it("only force-overwrites existing JSON config-looking files", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-init-force-"));
+    roots.push(root);
+    const textPath = join(root, "notes.txt");
+    const configPath = join(root, "config.local.json");
+    writeFileSync(textPath, "do not replace me\n");
+    writeFileSync(configPath, "{}\n");
+
+    await expect(runCli(["init", "--config", textPath, "--force", "true"])).rejects.toMatchObject({
+      stdout: expect.stringContaining("only overwrites existing JSON config files")
+    });
+
+    const { stdout } = await runCli(["init", "--config", configPath, "--force", "true"]);
+    const output = JSON.parse(stdout);
+
+    expect(output.ok).toBe(true);
+    expect(output.backupPath).toEqual(expect.stringContaining("config.local.json."));
+    expect(existsSync(output.backupPath)).toBe(true);
+    expect(readFileSync(output.backupPath, "utf8")).toBe("{}\n");
+  });
+
+  it("requires review-pr repos to be configured and enabled", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-pr-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/skipped"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      repoProfiles: {
+        repos: {
+          "owner/skipped": { enabled: false }
+        }
+      }
+    })}\n`);
+
+    await expect(runCli([
+      "review-pr",
+      "--config",
+      configPath,
+      "--repo",
+      "owner/skipped",
+      "--pr",
+      "123",
+      "--dry-run",
+      "true",
+      "--zcode",
+      "false"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("repo is blocked by repo policy")
+    });
+
+    await expect(runCli([
+      "review-pr",
+      "--config",
+      configPath,
+      "--repo",
+      "owner/unconfigured",
+      "--pr",
+      "123",
+      "--dry-run",
+      "true",
+      "--zcode",
+      "false"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("repo must be present in configured repos")
+    });
+  });
+
+  it("requires explicit confirmation before review-pr live posting", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-pr-live-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+
+    await expect(runCli([
+      "review-pr",
+      "--config",
+      configPath,
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "123",
+      "--dry-run",
+      "false",
+      "--zcode",
+      "false"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("requires --confirm true")
+    });
+  });
+
+  it("requires an explicit config file before review-pr live posting", async () => {
+    await expect(runCli([
+      "review-pr",
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "123",
+      "--dry-run",
+      "false",
+      "--confirm",
+      "true",
+      "--head-sha",
+      "abc123",
+      "--zcode",
+      "false"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("requires --config")
+    });
+  });
+
+  it("requires review-pr live config paths to exist", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-pr-missing-config-"));
+    roots.push(root);
+    const configPath = join(root, "missing.json");
+
+    await expect(runCli([
+      "review-pr",
+      "--config",
+      configPath,
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "123",
+      "--dry-run",
+      "false",
+      "--confirm",
+      "true",
+      "--head-sha",
+      "abc123",
+      "--zcode",
+      "false"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("config file")
+    });
+  });
+
+  it("requires an approved head before review-pr live posting", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-pr-head-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+
+    await expect(runCli([
+      "review-pr",
+      "--config",
+      configPath,
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "123",
+      "--dry-run",
+      "false",
+      "--confirm",
+      "true",
+      "--zcode",
+      "false"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("requires --head-sha")
+    });
+  });
+
+  it("rejects conflicting review-pr live head aliases before posting", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-pr-head-mismatch-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+
+    await expect(runCli([
+      "review-pr",
+      "--config",
+      configPath,
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "123",
+      "--dry-run",
+      "false",
+      "--confirm",
+      "true",
+      "--head-sha",
+      "abc123",
+      "--expected-head",
+      "def456",
+      "--zcode",
+      "false"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("must match")
+    });
+  });
+
+  it("rejects duplicated review-pr repo flags before policy and execution can diverge", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-pr-duplicate-repo-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+
+    await expect(runCli([
+      "review-pr",
+      "--config",
+      configPath,
+      "--repo",
+      "owner/repo",
+      "--repo",
+      "other/repo",
+      "--pr",
+      "123",
+      "--dry-run",
+      "true",
+      "--zcode",
+      "false"
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining("--repo must be provided once")
+    });
+  });
+
+  it("rejects duplicated review-pr PR flags before execution", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-pr-duplicate-pr-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+
+    await expect(runCli([
+      "review-pr",
+      "--config",
+      configPath,
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "123",
+      "--pr",
+      "456",
+      "--dry-run",
+      "true",
+      "--zcode",
+      "false"
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining("--pr must be provided once")
+    });
+  });
+
+  it("returns structured JSON for malformed review-pr PR values", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-pr-bad-pr-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+
+    await expect(runCli([
+      "review-pr",
+      "--config",
+      configPath,
+      "--repo",
+      "owner/repo",
+      "--pr",
+      "abc",
+      "--dry-run",
+      "true",
+      "--zcode",
+      "false"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("\"command\": \"review-pr\"")
+    });
+  });
+
+  it("requires review-pr to be scoped to one repo and PR", async () => {
+    await expect(runCli([
+      "review-pr",
+      "--dry-run",
+      "true",
+      "--zcode",
+      "false"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("requires --repo and --pr")
+    });
+  });
+
+  it("prints launchd daemon control plans in dry-run mode by default", async () => {
+    const { stdout: startStdout } = await runCli([
+      "daemon",
+      "start",
+      "--launchd-label",
+      "com.example.neondiff"
+    ]);
+    const { stdout: stopStdout } = await runCli([
+      "daemon",
+      "stop",
+      "--launchd-label",
+      "com.example.neondiff"
+    ]);
+
+    expect(JSON.parse(startStdout)).toMatchObject({
+      ok: true,
+      command: "daemon start",
+      dryRun: true,
+      launchdLabel: "com.example.neondiff",
+      operation: "kickstart_existing",
+      plannedCommands: [["launchctl", "kickstart", "-k", expect.stringMatching(/gui\/\d+\/com\.example\.neondiff/)]]
+    });
+    expect(JSON.parse(stopStdout)).toMatchObject({
+      ok: true,
+      command: "daemon stop",
+      dryRun: true,
+      launchdLabel: "com.example.neondiff",
+      operation: "bootout_service",
+      plannedCommands: [["launchctl", "bootout", expect.stringMatching(/gui\/\d+\/com\.example\.neondiff/)]]
+    });
+  });
+
+  it("requires config for daemon status", async () => {
+    await expect(runCli([
+      "daemon",
+      "status",
+      "--launchd-label",
+      "com.example.neondiff"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("--config is required for daemon status")
+    });
+  });
+
+  it("validates launchd labels and plist labels before planning daemon commands", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-launchd-plist-"));
+    roots.push(root);
+    const plistPath = join(root, "com.example.neondiff.plist");
+    writeLaunchdPlist(plistPath, "com.example.neondiff");
+
+    const { stdout } = await runCli([
+      "daemon",
+      "start",
+      "--launchd-label",
+      "com.example.neondiff",
+      "--plist",
+      plistPath
+    ]);
+
+    expect(JSON.parse(stdout)).toMatchObject({
+      ok: true,
+      command: "daemon start",
+      dryRun: true,
+      operation: "bootstrap_then_kickstart",
+      warning: expect.stringContaining("operator-owned plist paths"),
+      plannedCommands: [
+        ["launchctl", "bootstrap", expect.stringMatching(/^gui\/\d+$/), plistPath],
+        ["launchctl", "kickstart", "-k", expect.stringMatching(/gui\/\d+\/com\.example\.neondiff/)]
+      ]
+    });
+
+    await expect(runCli([
+      "daemon",
+      "start",
+      "--launchd-label",
+      "bad label",
+      "--plist",
+      plistPath
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("must be a launchd label")
+    });
+  });
+
+  it("rejects daemon plist files whose Label differs from --launchd-label", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-launchd-mismatch-"));
+    roots.push(root);
+    const plistPath = join(root, "wrong.plist");
+    writeLaunchdPlist(plistPath, "com.example.other");
+
+    await expect(runCli([
+      "daemon",
+      "start",
+      "--launchd-label",
+      "com.example.neondiff",
+      "--plist",
+      plistPath
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("must match --launchd-label")
+    });
+  });
+
+  it("requires explicit confirmation before launchd daemon mutation", async () => {
+    await expect(runCli([
+      "daemon",
+      "start",
+      "--launchd-label",
+      "com.example.neondiff",
+      "--dry-run",
+      "false"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("requires --confirm true")
+    });
+  });
+
+  it("requires an explicit override for live daemon mutation with an external plist", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-launchd-external-"));
+    roots.push(root);
+    const plistPath = join(root, "com.example.neondiff.plist");
+    writeLaunchdPlist(plistPath, "com.example.neondiff");
+
+    await expect(runCli([
+      "daemon",
+      "start",
+      "--launchd-label",
+      "com.example.neondiff",
+      "--plist",
+      plistPath,
+      "--dry-run",
+      "false",
+      "--confirm",
+      "true"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("requires --allow-external-plist true")
+    });
+  });
+
+  it("keeps daemon subcommands separate from the legacy cycle loop", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-daemon-loop-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: [],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      pollIntervalMs: 60_000
+    })}\n`);
+
+    await expect(runCli(["daemon", "bad-subcommand"])).rejects.toMatchObject({
+      stderr: expect.stringContaining("daemon subcommand must be one of")
+    });
+    // Empty temp repo config keeps runDaemonCycle local-only while proving dispatch.
+    await expect(runCli([
+      "daemon",
+      "--config",
+      configPath,
+      "--dry-run",
+      "true",
+      "--once",
+      "true"
+    ])).resolves.toMatchObject({
+      stdout: expect.stringContaining("daemon_cycle_start")
+    });
+  });
+});
+
+async function runCli(args: string[], options: { cwd?: string; timeout?: number } = {}) {
+  return execFileAsync(process.execPath, [tsxCliPath, join(repoRoot, "src/cli.ts"), ...args], {
+    cwd: options.cwd ?? repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      EVAOS_REVIEW_BOT_APP_ID: "",
+      EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: "",
+      GITHUB_TOKEN: ""
+    },
+    timeout: options.timeout ?? 15_000,
+    killSignal: "SIGTERM",
+    maxBuffer: 1024 * 1024
+  });
+}
+
+function writeLaunchdPlist(path: string, label: string): void {
+  writeFileSync(path, `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${label}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/true</string>
+  </array>
+</dict>
+</plist>
+`);
+}

--- a/tests/run-once-cli.test.ts
+++ b/tests/run-once-cli.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parsePositiveInteger } from "../src/cli-args.js";
 import { buildRunOnceCliReport, runOnceCliCommand, runOnceCliExitCode, serializeRunOnceCliReport } from "../src/run-once-cli.js";
-import type { RunOnceResult } from "../src/worker.js";
+import { assertExpectedReviewPrHead, type RunOnceResult } from "../src/worker.js";
 
 describe("run-once CLI reporting", () => {
   it("prints invocation metadata with the structured runOnce result", () => {
@@ -41,6 +41,57 @@ describe("run-once CLI reporting", () => {
       },
       result
     });
+  });
+
+  it("prints review-pr as the command on successful review-pr invocations", async () => {
+    let forwardedExpectedHeadSha: string | undefined;
+    const command = await runOnceCliCommand({
+      options: {
+        dryRun: true,
+        repo: "owner/repo",
+        pullNumber: 123,
+        expectedHeadSha: "head-123",
+        useZCode: false
+      },
+      commandName: "review-pr",
+      runOnceImpl: async (options) => {
+        forwardedExpectedHeadSha = options.expectedHeadSha;
+        return runOnceResult({
+          reposScanned: 1,
+          pullsSeen: 1,
+          reviewed: 1,
+          scopedPull: {
+            repo: "owner/repo",
+            pullNumber: 123,
+            headSha: "head-123",
+            title: "reviewed",
+            url: "https://github.com/owner/repo/pull/123"
+          }
+        });
+      }
+    });
+
+    expect(command.exitCode).toBe(0);
+    expect(forwardedExpectedHeadSha).toBe("head-123");
+    expect(command.report.command).toBe("review-pr");
+    expect(JSON.parse(command.output)).toMatchObject({
+      ok: true,
+      command: "review-pr",
+      scope: {
+        repo: "owner/repo",
+        pullNumber: 123,
+        headSha: "head-123"
+      }
+    });
+  });
+
+  it("rejects review-pr execution when the fetched PR head differs from the approved head", () => {
+    expect(() => assertExpectedReviewPrHead({
+      repo: "owner/repo",
+      pullNumber: 123,
+      expectedHeadSha: "approved-head",
+      currentHeadSha: "advanced-head"
+    })).toThrow("review-pr expected head mismatch for owner/repo#123: expected=approved-head current=advanced-head");
   });
 
   it("marks failed reviews as non-ok and requests a nonzero exit code", () => {
@@ -114,6 +165,37 @@ describe("run-once CLI reporting", () => {
     expect(JSON.parse(command.output)).toMatchObject({
       ok: false,
       command: "run-once",
+      dryRun: true,
+      useZCode: false,
+      scope: {
+        repo: "owner/repo",
+        pullNumber: 123
+      },
+      error: {
+        message: "GitHub API fetch failed for /repos/owner/repo/pulls/123"
+      }
+    });
+  });
+
+  it("prints review-pr as the command when review-pr execution throws", async () => {
+    const command = await runOnceCliCommand({
+      options: {
+        dryRun: true,
+        repo: "owner/repo",
+        pullNumber: 123,
+        useZCode: false
+      },
+      commandName: "review-pr",
+      runOnceImpl: async () => {
+        throw new Error("GitHub API fetch failed for /repos/owner/repo/pulls/123");
+      }
+    });
+
+    expect(command.exitCode).toBe(1);
+    expect(command.report.ok).toBe(false);
+    expect(JSON.parse(command.output)).toMatchObject({
+      ok: false,
+      command: "review-pr",
       dryRun: true,
       useZCode: false,
       scope: {


### PR DESCRIPTION
## Summary
- adds the beta `neondiff` bin alias while preserving `evaos-review-bot`
- adds public-safe `init`, scoped `review-pr`, and JSON-first daemon start/stop/status commands
- updates setup/operator docs for source-checkout install while keeping public npm publishing blocked by #104/#107

## Safety boundaries
- `review-pr` now requires both `--repo` and `--pr` so the public alias cannot scan all configured repos
- `daemon start` and `daemon stop` default to dry-run planning; live launchd mutation requires `--dry-run false --confirm true`
- package remains `private: true`; this is source-checkout beta CLI exposure only
- no live config, launchd plist, runtime state, or issue-enrichment allowlist changes

## Validation
- `npm test -- tests/public-cli.test.ts tests/run-once-cli.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- built CLI smoke: unscoped `review-pr` exits 1; default daemon start returns dry-run plan; unconfirmed `--dry-run false` exits 1
- subagent spec re-review: PASS
- subagent code-quality re-review: PASS

Related: #107
Blocked-public-package-boundary: #104
