### PR TITLE
Fix provider-deferred release status readiness

### DIFF
--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -358,8 +358,11 @@ export function buildOperatorStatus(input: {
   const staleHeads = queue?.summary.staleHeads ?? 0;
   const failedRows = input.release.database.errorCount;
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
-  const retryableProviderDeferredJobs = durableQueue?.summary.retryableProviderDeferred ?? 0;
   const budget = input.release.budget;
+  const retryableProviderDeferredJobs = actionableProviderDeferredJobs(
+    budget,
+    durableQueue?.summary.retryableProviderDeferred ?? 0
+  );
   const issueEnrichment = input.issueEnrichment;
   const issueEnrichmentRuntime = input.issueEnrichmentRuntime;
   const issueEnrichmentRuntimeState = displayIssueEnrichmentRuntimeState(issueEnrichment, issueEnrichmentRuntime);
@@ -398,7 +401,7 @@ export function buildOperatorStatus(input: {
     {
       name: "durable_queue_no_retryable_provider_deferred_jobs",
       ok: retryableProviderDeferredJobs === 0,
-      detail: `${retryableProviderDeferredJobs} retryable provider-deferred durable queue job(s)`
+      detail: describeActionableProviderDeferredJobs(budget, retryableProviderDeferredJobs)
     },
     ...(issueEnrichment
       ? [{
@@ -514,12 +517,15 @@ export function buildRuntimeInventory(input: {
     input.release.database.retryableExpiredProviderCooldownCount ??
     Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
-  const retryableProviderDeferredJobs = durableQueue?.summary.retryableProviderDeferred ?? 0;
   const providerDeferredJobs = durableQueue?.summary.providerDeferred ?? 0;
   const readFailures = queue?.summary.readFailures ?? 0;
   const staleHeads = queue?.summary.staleHeads ?? 0;
   const providerDeferredHeads = queue?.summary.providerDeferred ?? 0;
   const budget = input.release.budget;
+  const retryableProviderDeferredJobs = actionableProviderDeferredJobs(
+    budget,
+    durableQueue?.summary.retryableProviderDeferred ?? 0
+  );
   const issueEnrichment = input.issueEnrichment;
   const issueEnrichmentRuntime = input.issueEnrichmentRuntime;
   const issueEnrichmentRuntimeState = displayIssueEnrichmentRuntimeState(issueEnrichment, issueEnrichmentRuntime);
@@ -541,7 +547,7 @@ export function buildRuntimeInventory(input: {
     {
       name: "runtime_no_retryable_provider_deferred_jobs",
       ok: retryableProviderDeferredJobs === 0,
-      detail: `${retryableProviderDeferredJobs} retryable provider-deferred durable queue job(s)`
+      detail: describeActionableProviderDeferredJobs(budget, retryableProviderDeferredJobs)
     },
     {
       name: "runtime_pending_heads_covered",
@@ -1549,6 +1555,33 @@ function isRetryableQueueJob(job: ReviewQueueJobRecord, now: Date): boolean {
   if (!job.nextEligibleAt) return true;
   const nextEligibleAtMs = Date.parse(job.nextEligibleAt);
   return !Number.isFinite(nextEligibleAtMs) || nextEligibleAtMs <= now.getTime();
+}
+
+function actionableProviderDeferredJobs(
+  budget: ReviewBudgetStatus | undefined,
+  fallbackRetryableProviderDeferred: number
+): number {
+  return budget?.providerDeferred.readyToRetry ?? fallbackRetryableProviderDeferred;
+}
+
+function describeActionableProviderDeferredJobs(
+  budget: ReviewBudgetStatus | undefined,
+  actionableCount: number
+): string {
+  if (!budget) return `${actionableCount} retryable provider-deferred durable queue job(s)`;
+  const waitingCapacity =
+    budget.providerDeferred.waitingProviderCapacity +
+    budget.providerDeferred.waitingOrgCapacity +
+    budget.providerDeferred.waitingRepoCapacity +
+    budget.providerDeferred.waitingManualReserve +
+    budget.providerDeferred.waitingLeaseLimit;
+  return (
+    `${actionableCount} ready-to-retry provider-deferred durable queue job(s)` +
+    `; provider_deferred total=${budget.providerDeferred.total}` +
+    ` retryable=${budget.providerDeferred.retryable}` +
+    ` waiting_cooldown=${budget.providerDeferred.waitingCooldown}` +
+    ` waiting_capacity=${waitingCapacity}`
+  );
 }
 
 function emptyIssueEnrichmentRuntime(checkedAt: string): OperatorIssueEnrichmentRuntime {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -128,7 +128,10 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     );
   const expiredProviderCooldownOk = retryableExpiredProviderCooldownCount === 0;
   const failedQueueJobsOk = (input.database.failedReviewQueueJobCount ?? 0) === 0;
-  const retryableDeferredQueueJobsOk = (input.database.retryableProviderDeferredReviewQueueJobCount ?? 0) === 0;
+  const actionableProviderDeferredQueueJobs =
+    input.budget?.providerDeferred.readyToRetry ??
+    (input.database.retryableProviderDeferredReviewQueueJobCount ?? 0);
+  const retryableDeferredQueueJobsOk = actionableProviderDeferredQueueJobs === 0;
   const heartbeatOk = input.heartbeat.status === "fresh" || input.heartbeat.status === "active";
   const retryProviderCooldownCommand =
     `npx tsx src/cli.ts retry-provider-cooldowns --config ${input.configPath} ` +
@@ -181,9 +184,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     {
       name: "queue_no_retryable_provider_deferred_jobs",
       ok: retryableDeferredQueueJobsOk,
-      detail:
-        `${input.database.retryableProviderDeferredReviewQueueJobCount ?? 0} retryable provider-deferred queue job(s)` +
-        describeReviewQueueCounts(input.database)
+      detail: describeProviderDeferredQueueStatus(input.database, input.budget)
     },
     {
       name: "daemon_heartbeat_recent",
@@ -209,7 +210,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     recommendedActions: expiredProviderCooldownOk
       ? retryableDeferredQueueJobsOk
         ? []
-        : ["inspect operator queue and retry provider-deferred jobs whose nextEligibleAt has expired"]
+        : ["wait for the next scheduler cycle or inspect provider-deferred jobs marked ready_to_retry"]
       : [
           retryProviderCooldownCommand,
           `npx tsx src/cli.ts provider-cooldowns --config ${input.configPath} --expired-only true`
@@ -727,6 +728,32 @@ function describeReviewQueueCounts(database: ReleaseDatabaseStatus): string {
     ` running=${database.runningReviewQueueJobCount ?? 0}` +
     ` provider_deferred=${database.providerDeferredReviewQueueJobCount ?? 0}` +
     ` failed=${database.failedReviewQueueJobCount ?? 0}`
+  );
+}
+
+function describeProviderDeferredQueueStatus(
+  database: ReleaseDatabaseStatus,
+  budget?: ReviewBudgetStatus
+): string {
+  if (!budget) {
+    return (
+      `${database.retryableProviderDeferredReviewQueueJobCount ?? 0} retryable provider-deferred queue job(s)` +
+      describeReviewQueueCounts(database)
+    );
+  }
+  const waitingCapacity =
+    budget.providerDeferred.waitingProviderCapacity +
+    budget.providerDeferred.waitingOrgCapacity +
+    budget.providerDeferred.waitingRepoCapacity +
+    budget.providerDeferred.waitingManualReserve +
+    budget.providerDeferred.waitingLeaseLimit;
+  return (
+    `${budget.providerDeferred.readyToRetry} ready-to-retry provider-deferred queue job(s)` +
+    `; provider_deferred total=${budget.providerDeferred.total}` +
+    ` retryable=${budget.providerDeferred.retryable}` +
+    ` waiting_cooldown=${budget.providerDeferred.waitingCooldown}` +
+    ` waiting_capacity=${waitingCapacity}` +
+    describeReviewQueueCounts(database)
   );
 }
 

--- a/src/review-budget.ts
+++ b/src/review-budget.ts
@@ -34,6 +34,8 @@ export interface ReviewBudgetCandidate {
   headSha: string;
   providerId: string;
   priority: number;
+  state: ReviewQueueJobRecord["state"];
+  nextEligibleAt?: string;
 }
 
 export interface ReviewBudgetCapacity {
@@ -77,6 +79,17 @@ export interface ReviewBudgetStatus {
     background: number;
     providerDeferred: number;
     retryableProviderDeferred: number;
+  };
+  providerDeferred: {
+    total: number;
+    retryable: number;
+    readyToRetry: number;
+    waitingCooldown: number;
+    waitingProviderCapacity: number;
+    waitingOrgCapacity: number;
+    waitingRepoCapacity: number;
+    waitingManualReserve: number;
+    waitingLeaseLimit: number;
   };
   manualReserve: {
     configured: number;
@@ -206,6 +219,9 @@ export function buildReviewBudgetStatus(input: {
   for (const entry of delayed) {
     delayedByReason[entry.reason] = (delayedByReason[entry.reason] ?? 0) + 1;
   }
+  const providerDeferredJobs = queued.filter((job) => job.state === "provider_deferred");
+  const providerDeferredDelayed = delayed.filter((job) => job.state === "provider_deferred");
+  const providerDeferredByReason = countBy(providerDeferredDelayed, (job) => job.reason);
   const returnedWouldLease = includeDetails ? applyDetailLimit(wouldLease, detailLimit) : [];
   const returnedDelayed = includeDetails ? applyDetailLimit(delayed, detailLimit) : [];
   const detailsTruncated =
@@ -245,10 +261,19 @@ export function buildReviewBudgetStatus(input: {
       total: queued.length,
       manual: manualQueued,
       background: queued.filter((job) => job.lane === "background").length,
-      providerDeferred: queued.filter((job) => job.state === "provider_deferred").length,
-      retryableProviderDeferred: queued.filter((job) =>
-        job.state === "provider_deferred" && isProviderDeferredEligible(job, now)
-      ).length
+      providerDeferred: providerDeferredJobs.length,
+      retryableProviderDeferred: providerDeferredJobs.filter((job) => isProviderDeferredEligible(job, now)).length
+    },
+    providerDeferred: {
+      total: providerDeferredJobs.length,
+      retryable: providerDeferredJobs.filter((job) => isProviderDeferredEligible(job, now)).length,
+      readyToRetry: wouldLease.filter((job) => job.state === "provider_deferred").length,
+      waitingCooldown: providerDeferredByReason.get("provider_cooldown") ?? 0,
+      waitingProviderCapacity: providerDeferredByReason.get("provider_capacity") ?? 0,
+      waitingOrgCapacity: providerDeferredByReason.get("org_capacity") ?? 0,
+      waitingRepoCapacity: providerDeferredByReason.get("repo_capacity") ?? 0,
+      waitingManualReserve: providerDeferredByReason.get("manual_reserve") ?? 0,
+      waitingLeaseLimit: providerDeferredByReason.get("lease_limit") ?? 0
     },
     manualReserve: {
       configured: scheduler.manualCommandReserve,
@@ -367,7 +392,9 @@ function candidate(job: ReviewQueueJobRecord): ReviewBudgetCandidate {
     pullNumber: job.pullNumber,
     headSha: job.headSha,
     providerId: providerKey(job),
-    priority: job.priority
+    priority: job.priority,
+    state: job.state,
+    ...(job.nextEligibleAt ? { nextEligibleAt: job.nextEligibleAt } : {})
   };
 }
 

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -98,6 +98,73 @@ describe("operator CLI summaries", () => {
     expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
   });
 
+  it("uses review budget readiness instead of raw provider-deferred retry counts for gates", () => {
+    const budget: ReviewBudgetStatus = {
+      ...reviewBudgetStatus(),
+      queued: {
+        total: 1,
+        manual: 0,
+        background: 1,
+        providerDeferred: 1,
+        retryableProviderDeferred: 1
+      },
+      providerDeferred: {
+        total: 1,
+        retryable: 1,
+        readyToRetry: 0,
+        waitingCooldown: 0,
+        waitingProviderCapacity: 1,
+        waitingOrgCapacity: 0,
+        waitingRepoCapacity: 0,
+        waitingManualReserve: 0,
+        waitingLeaseLimit: 0
+      }
+    };
+    const durableQueue = durableQueueSnapshot({
+      ok: false,
+      summary: {
+        total: 2,
+        queued: 0,
+        running: 1,
+        providerDeferred: 1,
+        retryableProviderDeferred: 1,
+        failed: 0
+      }
+    });
+
+    const status = buildOperatorStatus({
+      release: releaseStatus({ ok: true, budget }),
+      coverage: coverageReport({ ok: true }),
+      agents: agentInventory({ ok: true }),
+      providerCooldowns: [],
+      durableQueue,
+      checkedAt: "2026-07-01T00:30:00.000Z"
+    });
+
+    expect(status.gates).toContainEqual({
+      name: "durable_queue_no_retryable_provider_deferred_jobs",
+      ok: true,
+      detail: "0 ready-to-retry provider-deferred durable queue job(s); provider_deferred total=1 retryable=1 waiting_cooldown=0 waiting_capacity=1"
+    });
+    expect(status.recommendedActions).not.toContain("retry or requeue provider-deferred jobs whose nextEligibleAt has expired");
+
+    const inventory = buildRuntimeInventory({
+      release: releaseStatus({ ok: true, budget }),
+      coverage: coverageReport({ ok: true }),
+      agents: agentInventory({ ok: true }),
+      providerCooldowns: [],
+      durableQueue,
+      checkedAt: "2026-07-01T00:30:00.000Z"
+    });
+
+    expect(inventory.gates).toContainEqual({
+      name: "runtime_no_retryable_provider_deferred_jobs",
+      ok: true,
+      detail: "0 ready-to-retry provider-deferred durable queue job(s); provider_deferred total=1 retryable=1 waiting_cooldown=0 waiting_capacity=1"
+    });
+    expect(inventory.recommendedActions).not.toContain("retry or requeue provider-deferred jobs whose nextEligibleAt has expired");
+  });
+
   it("surfaces issue enrichment live-post blockers in operator status", () => {
     const issueEnrichment: IssueEnrichmentStatus = {
       ok: false,
@@ -1439,6 +1506,17 @@ function reviewBudgetStatus(): ReviewBudgetStatus {
       providerDeferred: 0,
       retryableProviderDeferred: 0
     },
+    providerDeferred: {
+      total: 0,
+      retryable: 0,
+      readyToRetry: 0,
+      waitingCooldown: 0,
+      waitingProviderCapacity: 0,
+      waitingOrgCapacity: 0,
+      waitingRepoCapacity: 0,
+      waitingManualReserve: 0,
+      waitingLeaseLimit: 0
+    },
     manualReserve: {
       configured: 1,
       activeManual: 0,
@@ -1467,7 +1545,8 @@ function reviewBudgetStatus(): ReviewBudgetStatus {
       pullNumber: 7,
       headSha: "head-manual",
       providerId: "zai",
-      priority: 40
+      priority: 40,
+      state: "queued"
     }],
     delayed: [{
       reason: "manual_reserve",

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { buildReleaseStatus, collectReleaseStatus } from "../src/release-status.js";
+import type { ReviewBudgetStatus } from "../src/review-budget.js";
 
 describe("beta release status", () => {
   const roots: string[] = [];
@@ -898,6 +899,12 @@ describe("beta release status", () => {
         providerDeferred: 2,
         retryableProviderDeferred: 1
       },
+      providerDeferred: {
+        total: 2,
+        retryable: 1,
+        readyToRetry: 1,
+        waitingCooldown: 1
+      },
       delayedByReason: {
         repo_capacity: 1,
         provider_cooldown: 1
@@ -953,9 +960,9 @@ describe("beta release status", () => {
     expect(status.gates).toContainEqual({
       name: "queue_no_retryable_provider_deferred_jobs",
       ok: false,
-      detail: "1 retryable provider-deferred queue job(s); queue total=5 queued=1 leased=0 running=1 provider_deferred=2 failed=1"
+      detail: "1 ready-to-retry provider-deferred queue job(s); provider_deferred total=2 retryable=1 waiting_cooldown=1 waiting_capacity=0; queue total=5 queued=1 leased=0 running=1 provider_deferred=2 failed=1"
     });
-    expect(status.recommendedActions).toContain("inspect operator queue and retry provider-deferred jobs whose nextEligibleAt has expired");
+    expect(status.recommendedActions).toContain("wait for the next scheduler cycle or inspect provider-deferred jobs marked ready_to_retry");
 
     const detailedStatus = collectReleaseStatus({
       cwd: process.cwd(),
@@ -976,6 +983,65 @@ describe("beta release status", () => {
     });
     expect(detailedStatus.budget?.wouldLease.length).toBeLessThanOrEqual(1);
     expect(detailedStatus.budget?.delayed.length).toBeLessThanOrEqual(1);
+  });
+
+  it("does not fail the provider-deferred gate when retryable jobs are waiting on capacity", () => {
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false
+      },
+      database: {
+        rowCount: 21,
+        errorCount: 0,
+        reviewQueueJobCount: 2,
+        queuedReviewQueueJobCount: 0,
+        leasedReviewQueueJobCount: 0,
+        runningReviewQueueJobCount: 1,
+        providerDeferredReviewQueueJobCount: 1,
+        retryableProviderDeferredReviewQueueJobCount: 1,
+        failedReviewQueueJobCount: 0
+      },
+      budget: releaseBudgetStatus({
+        queued: {
+          total: 1,
+          manual: 0,
+          background: 1,
+          providerDeferred: 1,
+          retryableProviderDeferred: 1
+        },
+        providerDeferred: {
+          total: 1,
+          retryable: 1,
+          readyToRetry: 0,
+          waitingCooldown: 0,
+          waitingProviderCapacity: 1,
+          waitingOrgCapacity: 0,
+          waitingRepoCapacity: 0,
+          waitingManualReserve: 0,
+          waitingLeaseLimit: 0
+        }
+      }),
+      heartbeat: freshHeartbeat(),
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(true);
+    expect(status.gates).toContainEqual({
+      name: "queue_no_retryable_provider_deferred_jobs",
+      ok: true,
+      detail: "0 ready-to-retry provider-deferred queue job(s); provider_deferred total=1 retryable=1 waiting_cooldown=0 waiting_capacity=1; queue total=2 queued=0 leased=0 running=1 provider_deferred=1 failed=0"
+    });
+    expect(status.recommendedActions).not.toContain("wait for the next scheduler cycle or inspect provider-deferred jobs marked ready_to_retry");
   });
 
   it("filters terminal queue rows and preserves active jobs before applying the budget row cap", () => {
@@ -1215,6 +1281,76 @@ function freshHeartbeat() {
     cycle: 5,
     event: "daemon_cycle_complete",
     dryRun: false
+  };
+}
+
+function releaseBudgetStatus(overrides: Partial<ReviewBudgetStatus> = {}): ReviewBudgetStatus {
+  return {
+    enabled: true,
+    checkedAt: "2026-07-01T00:00:00.000Z",
+    config: {
+      reviewConcurrency: {
+        maxActiveRuns: 1,
+        leaseTtlMs: 60_000
+      },
+      scheduler: {
+        enabled: true,
+        maxProviderActive: 1,
+        maxOrgActive: 1,
+        maxRepoActive: 1,
+        maxQueuedPerRepo: 10,
+        manualCommandReserve: 0,
+        backgroundPriority: 50
+      }
+    },
+    active: {
+      total: 1,
+      leased: 0,
+      running: 1,
+      manual: 0,
+      background: 1,
+      byProvider: [],
+      byOrg: [],
+      byRepo: []
+    },
+    queued: {
+      total: 0,
+      manual: 0,
+      background: 0,
+      providerDeferred: 0,
+      retryableProviderDeferred: 0
+    },
+    providerDeferred: {
+      total: 0,
+      retryable: 0,
+      readyToRetry: 0,
+      waitingCooldown: 0,
+      waitingProviderCapacity: 0,
+      waitingOrgCapacity: 0,
+      waitingRepoCapacity: 0,
+      waitingManualReserve: 0,
+      waitingLeaseLimit: 0
+    },
+    manualReserve: {
+      configured: 0,
+      activeManual: 0,
+      queuedManual: 0,
+      reservedSlotsOpen: 0,
+      backgroundSlotsAvailableBeforeReserve: 1
+    },
+    wouldLeaseCount: 0,
+    delayedCount: 0,
+    details: {
+      included: false,
+      wouldLeaseReturned: 0,
+      delayedReturned: 0,
+      detailsTruncated: false,
+      inputJobs: 0
+    },
+    wouldLease: [],
+    delayed: [],
+    delayedByReason: {},
+    ...overrides
   };
 }
 

--- a/tests/review-budget.test.ts
+++ b/tests/review-budget.test.ts
@@ -127,6 +127,17 @@ describe("review run budget", () => {
       providerDeferred: 1,
       retryableProviderDeferred: 0
     });
+    expect(status.providerDeferred).toMatchObject({
+      total: 1,
+      retryable: 0,
+      readyToRetry: 0,
+      waitingCooldown: 1,
+      waitingProviderCapacity: 0,
+      waitingOrgCapacity: 0,
+      waitingRepoCapacity: 0,
+      waitingManualReserve: 0,
+      waitingLeaseLimit: 0
+    });
     expect(status.wouldLease.map((entry) => entry.jobId)).toEqual(["manual-slot"]);
     expect(status.delayedByReason).toMatchObject({
       repo_capacity: 1,
@@ -140,6 +151,84 @@ describe("review run budget", () => {
       reservedSlotsOpen: 1,
       backgroundSlotsAvailableBeforeReserve: 0
     });
+  });
+
+  it("separates retryable provider-deferred jobs from actionable ready-to-retry jobs", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-budget-provider-deferred-"));
+    roots.push(root);
+    const config = {
+      ...minimalConfig(root),
+      reviewScheduler: {
+        enabled: true,
+        maxProviderActive: 1,
+        maxOrgActive: 10,
+        maxRepoActive: 10,
+        maxQueuedPerRepo: 10,
+        manualCommandReserve: 0,
+        backgroundPriority: 50
+      }
+    };
+    const now = new Date("2026-07-01T00:05:00.000Z");
+
+    const capacityBlocked = buildReviewBudgetStatus({
+      config,
+      now,
+      jobs: [
+        queueJob("active", { repo: "owner/active", state: "running", priority: 1 }),
+        queueJob("retryable", {
+          repo: "owner/retryable",
+          state: "provider_deferred",
+          priority: 2,
+          nextEligibleAt: "2026-07-01T00:01:00.000Z"
+        }),
+        queueJob("cooldown", {
+          repo: "owner/cooldown",
+          state: "provider_deferred",
+          priority: 3,
+          nextEligibleAt: "2026-07-01T00:10:00.000Z"
+        })
+      ]
+    });
+
+    expect(capacityBlocked.queued).toMatchObject({
+      providerDeferred: 2,
+      retryableProviderDeferred: 1
+    });
+    expect(capacityBlocked.providerDeferred).toMatchObject({
+      total: 2,
+      retryable: 1,
+      readyToRetry: 0,
+      waitingCooldown: 1,
+      waitingProviderCapacity: 1
+    });
+
+    const ready = buildReviewBudgetStatus({
+      config,
+      now,
+      jobs: [
+        queueJob("retryable", {
+          repo: "owner/retryable",
+          state: "provider_deferred",
+          priority: 2,
+          nextEligibleAt: "2026-07-01T00:01:00.000Z"
+        })
+      ]
+    });
+
+    expect(ready.providerDeferred).toMatchObject({
+      total: 1,
+      retryable: 1,
+      readyToRetry: 1,
+      waitingCooldown: 0,
+      waitingProviderCapacity: 0
+    });
+    expect(ready.wouldLease).toEqual([
+      expect.objectContaining({
+        jobId: "retryable",
+        state: "provider_deferred",
+        nextEligibleAt: "2026-07-01T00:01:00.000Z"
+      })
+    ]);
   });
 
   it("does not count expired leased or running jobs against active capacity", () => {


### PR DESCRIPTION
## Summary
- Treat provider-deferred queue jobs as release-blocking only when the review budget says they are actually ready to retry.
- Add provider-deferred readiness counts to budget status and operator/release gate details.
- Keep raw retryable counts visible while separating capacity/cooldown waits from actionable retry debt.

Closes #167

## Validation
- `npm test -- tests/review-budget.test.ts tests/release-status.test.ts tests/operator-cli.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`

## Proof Boundary
This fixes release/operator status semantics for provider-deferred queue rows. It does not expand scheduler concurrency, live config, or provider retry behavior.
