### PR TITLE
Fix provider overload backoff and scheduler throttle

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,8 @@ export interface BotConfig {
     requestRateLimitDurationMs: number;
     overloadDurationMs: number;
     quotaDurationMs: number;
+    overloadBackoffMaxDurationMs: number;
+    overloadBackoffJitterMs: number;
     transientRetryAttempts: number;
     transientRetryBaseDelayMs: number;
     transientRetryMaxDelayMs: number;
@@ -193,6 +195,8 @@ const DEFAULT_CONFIG: BotConfig = {
     requestRateLimitDurationMs: 90_000,
     overloadDurationMs: 2 * 60_000,
     quotaDurationMs: 30 * 60_000,
+    overloadBackoffMaxDurationMs: 10 * 60_000,
+    overloadBackoffJitterMs: 30_000,
     transientRetryAttempts: 4,
     transientRetryBaseDelayMs: 2_000,
     transientRetryMaxDelayMs: 20_000
@@ -328,6 +332,8 @@ function validateConfig(config: BotConfig): void {
   validatePositiveInteger(config.providerCooldown.requestRateLimitDurationMs, "config.providerCooldown.requestRateLimitDurationMs");
   validatePositiveInteger(config.providerCooldown.overloadDurationMs, "config.providerCooldown.overloadDurationMs");
   validatePositiveInteger(config.providerCooldown.quotaDurationMs, "config.providerCooldown.quotaDurationMs");
+  validatePositiveInteger(config.providerCooldown.overloadBackoffMaxDurationMs, "config.providerCooldown.overloadBackoffMaxDurationMs");
+  validateNonNegativeInteger(config.providerCooldown.overloadBackoffJitterMs, "config.providerCooldown.overloadBackoffJitterMs");
   validateNonNegativeInteger(config.providerCooldown.transientRetryAttempts, "config.providerCooldown.transientRetryAttempts");
   validatePositiveInteger(config.providerCooldown.transientRetryBaseDelayMs, "config.providerCooldown.transientRetryBaseDelayMs");
   validatePositiveInteger(config.providerCooldown.transientRetryMaxDelayMs, "config.providerCooldown.transientRetryMaxDelayMs");

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -188,7 +188,7 @@ export async function runScheduledCycleWithDeps(input: {
   result.queue.leased = leased.length;
 
   const budget = new ReviewRunBudget(Math.max(1, scheduler.maxProviderActive));
-  for (const job of leased) {
+  for (const [index, job] of leased.entries()) {
     const status = await runLeasedQueueJob({
       config,
       github: input.github,
@@ -205,6 +205,16 @@ export async function runScheduledCycleWithDeps(input: {
       clock: eventClock
     });
     applyReviewStatus(result, status);
+    if (status === "skipped_provider_cooldown") {
+      result.queue.providerDeferred += deferUnstartedLeasedJobsForProviderThrottle({
+        config,
+        state: input.state,
+        triggerJob: job,
+        jobs: leased.slice(index + 1),
+        now: eventClock()
+      });
+      break;
+    }
   }
 
   result.queue.remainingQueued = input.state.listReviewQueueJobs({ states: ["queued", "provider_deferred"] }).length;
@@ -449,11 +459,17 @@ function enqueueReviewJob(input: {
     source,
     lane: source === "manual_command" ? "manual" : "background",
     providerId: input.providerId,
-    priority: source === "manual_command" ? undefined : input.config.reviewScheduler?.backgroundPriority,
+    priority: source === "manual_command" ? undefined : automaticQueuePriority(input.config, input.repo),
     ...(commandDecision ? { commentId: commandDecision.commandId } : {}),
     ...(sessionId ? { sessionId } : {}),
     now: input.now
   });
+}
+
+function automaticQueuePriority(config: BotConfig, repo: string): number | undefined {
+  const backgroundPriority = config.reviewScheduler?.backgroundPriority;
+  if (repo.toLowerCase() !== "electricsheephq/evaos-code-review-bot") return backgroundPriority;
+  return Math.min(backgroundPriority ?? 50, 1);
 }
 
 function recordReadinessForEnqueue(input: {
@@ -1117,6 +1133,42 @@ function shouldMarkJobReviewing(state: ReviewStateStore, job: ReviewQueueJobReco
   return existing?.commandAction ? isReviewCommandAction(existing.commandAction) : true;
 }
 
+function deferUnstartedLeasedJobsForProviderThrottle(input: {
+  config: BotConfig;
+  state: ReviewStateStore;
+  triggerJob: ReviewQueueJobRecord;
+  jobs: ReviewQueueJobRecord[];
+  now: Date;
+}): number {
+  const cooldown = providerThrottleCooldownFromTriggerJob(input);
+  for (const job of input.jobs) {
+    input.state.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: cooldown.cooldownUntil,
+      lastError: `provider_throttle_cycle_deferred_until=${cooldown.cooldownUntil}; reason=${cooldown.reason}; trigger_repo=${input.triggerJob.repo}`,
+      now: input.now
+    });
+  }
+  return input.jobs.length;
+}
+
+function providerThrottleCooldownFromTriggerJob(input: {
+  config: BotConfig;
+  state: ReviewStateStore;
+  triggerJob: ReviewQueueJobRecord;
+  now: Date;
+}): { cooldownUntil: string; reason: string } {
+  const processed = input.state.getProcessedReview(input.triggerJob.repo, input.triggerJob.pullNumber, input.triggerJob.headSha);
+  const parsed = parseProviderCooldownError(processed?.error);
+  const repoCooldown = input.state.getActiveRepoProviderCooldown(input.triggerJob.repo, input.now);
+  const fallbackCooldownUntil = new Date(input.now.getTime() + input.config.providerCooldown.durationMs).toISOString();
+  return {
+    cooldownUntil: parsed?.cooldownUntil ?? repoCooldown?.cooldownUntil ?? fallbackCooldownUntil,
+    reason: parsed?.reason ?? repoCooldown?.reason ?? "provider_cooldown"
+  };
+}
+
 function readinessStateForReviewResult(
   status: ReviewPullResult,
   processed?: { status: ProcessedStatus; event?: ReviewEvent; error?: string }
@@ -1563,8 +1615,8 @@ function markQueueJobProviderDeferredFromProcessed(input: {
     : undefined;
   const parsed = parseProviderCooldownError(processed?.error);
   const repoCooldown = input.state.getActiveRepoProviderCooldown(input.job.repo, input.now);
-  const cooldownUntil = directCooldown?.cooldownUntil ?? parsed?.cooldownUntil ?? repoCooldown?.cooldownUntil;
-  const reason = directCooldown?.reason ?? parsed?.reason ?? repoCooldown?.reason;
+  const cooldownUntil = parsed?.cooldownUntil ?? repoCooldown?.cooldownUntil ?? directCooldown?.cooldownUntil;
+  const reason = parsed?.reason ?? repoCooldown?.reason ?? directCooldown?.reason;
   input.state.updateReviewQueueJobState({
     jobId: input.job.jobId,
     state: "provider_deferred",

--- a/src/state.ts
+++ b/src/state.ts
@@ -216,6 +216,9 @@ export const PROVIDER_COOLDOWN_ERROR_PREFIX = "provider_rate_limit_cooldown_unti
 export interface ParsedProviderCooldownError {
   cooldownUntil: string;
   reason?: string;
+  retryAttempt?: number;
+  providerCode?: string;
+  retryAfterMs?: number;
 }
 
 export interface ProviderCooldownReviewRecord extends StoredProcessedReviewRecord {
@@ -2506,10 +2509,25 @@ export function parseProviderCooldownError(error?: string): ParsedProviderCooldo
   if (!cooldownUntil) return undefined;
   const reasonPart = rest.map((part) => part.trim()).find((part) => part.startsWith("reason="));
   const reason = reasonPart?.slice("reason=".length).trim();
+  const retryAttemptPart = rest.map((part) => part.trim()).find((part) => part.startsWith("retry_attempt="));
+  const retryAttempt = parsePositiveInt(retryAttemptPart?.slice("retry_attempt=".length));
+  const providerCodePart = rest.map((part) => part.trim()).find((part) => part.startsWith("provider_code="));
+  const providerCode = providerCodePart?.slice("provider_code=".length).trim();
+  const retryAfterPart = rest.map((part) => part.trim()).find((part) => part.startsWith("retry_after_ms="));
+  const retryAfterMs = parsePositiveInt(retryAfterPart?.slice("retry_after_ms=".length));
   return {
     cooldownUntil,
-    ...(reason ? { reason } : {})
+    ...(reason ? { reason } : {}),
+    ...(retryAttempt ? { retryAttempt } : {}),
+    ...(providerCode ? { providerCode } : {}),
+    ...(retryAfterMs ? { retryAfterMs } : {})
   };
+}
+
+function parsePositiveInt(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 interface ProcessedReviewRow {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1649,7 +1649,11 @@ export function recordProviderRateLimitCooldownIfNeeded(input: {
   if (!classification.cooldown) return false;
 
   const now = input.now ?? new Date();
-  const cooldownUntil = new Date(now.getTime() + providerCooldownDurationMs(input.config, classification));
+  const previous = input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha);
+  const retryAttempt = nextProviderCooldownRetryAttempt(previous?.error, classification);
+  const jitterMs = providerCooldownJitterMs(input.config, classification, retryAttempt);
+  const durationMs = providerCooldownDurationMs(input.config, classification, retryAttempt, jitterMs);
+  const cooldownUntil = new Date(now.getTime() + durationMs);
   input.state.recordRepoProviderCooldown({
     repo: input.repo,
     cooldownUntil,
@@ -1660,7 +1664,10 @@ export function recordProviderRateLimitCooldownIfNeeded(input: {
     repo: input.repo,
     pull: input.pull,
     cooldownUntil: cooldownUntil.toISOString(),
-    reason: classification.reason
+    reason: classification.reason,
+    ...(classification.category === "overloaded" ? { retryAttempt } : {}),
+    ...(classification.category === "overloaded" && classification.providerCode ? { providerCode: classification.providerCode } : {}),
+    ...(classification.category === "overloaded" && classification.retryAfterMs ? { retryAfterMs: classification.retryAfterMs } : {})
   });
   return true;
 }
@@ -1713,11 +1720,46 @@ export function classifyProviderError(error: unknown): ProviderErrorClassificati
   };
 }
 
-export function providerCooldownDurationMs(config: BotConfig, classification: ProviderErrorClassification): number {
+export function providerCooldownDurationMs(
+  config: BotConfig,
+  classification: ProviderErrorClassification,
+  retryAttempt = 1,
+  jitterMs = 0
+): number {
   if (classification.category === "request_rate_limit") return config.providerCooldown.requestRateLimitDurationMs;
-  if (classification.category === "overloaded") return config.providerCooldown.overloadDurationMs;
+  if (classification.category === "overloaded") {
+    const attempt = Math.max(1, Math.floor(retryAttempt));
+    const exponential = config.providerCooldown.overloadDurationMs * 2 ** Math.max(0, attempt - 1);
+    const boundedJitter = Math.min(
+      Math.max(0, Math.floor(jitterMs)),
+      config.providerCooldown.overloadBackoffJitterMs
+    );
+    return Math.min(config.providerCooldown.overloadBackoffMaxDurationMs, exponential + boundedJitter);
+  }
   if (classification.category === "quota_exhausted") return config.providerCooldown.quotaDurationMs;
   return config.providerCooldown.durationMs;
+}
+
+function nextProviderCooldownRetryAttempt(
+  previousError: string | undefined,
+  classification: ProviderErrorClassification
+): number {
+  if (classification.category !== "overloaded") return 1;
+  const previous = parseProviderCooldownError(previousError);
+  if (previous?.reason !== classification.reason) return 1;
+  return Math.min(99, (previous.retryAttempt ?? 1) + 1);
+}
+
+function providerCooldownJitterMs(
+  config: BotConfig,
+  classification: ProviderErrorClassification,
+  retryAttempt: number
+): number {
+  if (classification.category !== "overloaded") return 0;
+  if (retryAttempt <= 1) return 0;
+  const max = config.providerCooldown.overloadBackoffJitterMs;
+  if (max <= 0) return 0;
+  return Math.floor(Math.random() * (max + 1));
 }
 
 async function runZCodeReviewWithProviderRetry(input: {
@@ -1854,13 +1896,22 @@ function recordProviderCooldownSkip(input: {
   pull: PullRequestSummary;
   cooldownUntil: string;
   reason: string;
+  retryAttempt?: number;
+  providerCode?: string;
+  retryAfterMs?: number;
 }): void {
+  const metadata = [
+    `reason=${redactSecrets(input.reason)}`,
+    ...(input.retryAttempt ? [`retry_attempt=${input.retryAttempt}`] : []),
+    ...(input.providerCode ? [`provider_code=${redactSecrets(input.providerCode)}`] : []),
+    ...(input.retryAfterMs ? [`retry_after_ms=${input.retryAfterMs}`] : [])
+  ];
   input.state.recordProcessed({
     repo: input.repo,
     pullNumber: input.pull.number,
     headSha: input.pull.head.sha,
     status: "skipped",
-    error: `provider_rate_limit_cooldown_until=${input.cooldownUntil}; reason=${redactSecrets(input.reason)}`
+    error: `provider_rate_limit_cooldown_until=${input.cooldownUntil}; ${metadata.join("; ")}`
   });
 }
 

--- a/tests/coverage-audit.test.ts
+++ b/tests/coverage-audit.test.ts
@@ -1116,6 +1116,8 @@ function minimalConfig(root: string): BotConfig {
       requestRateLimitDurationMs: 5 * 60_000,
       overloadDurationMs: 2 * 60_000,
       quotaDurationMs: 30 * 60_000,
+      overloadBackoffMaxDurationMs: 10 * 60_000,
+      overloadBackoffJitterMs: 0,
       transientRetryAttempts: 2,
       transientRetryBaseDelayMs: 1,
       transientRetryMaxDelayMs: 1

--- a/tests/review-budget.test.ts
+++ b/tests/review-budget.test.ts
@@ -341,6 +341,8 @@ function minimalConfig(root: string): BotConfig {
       requestRateLimitDurationMs: 5 * 60_000,
       overloadDurationMs: 2 * 60_000,
       quotaDurationMs: 30 * 60_000,
+      overloadBackoffMaxDurationMs: 10 * 60_000,
+      overloadBackoffJitterMs: 0,
       transientRetryAttempts: 2,
       transientRetryBaseDelayMs: 1,
       transientRetryMaxDelayMs: 1

--- a/tests/review-scheduler-config.test.ts
+++ b/tests/review-scheduler-config.test.ts
@@ -23,6 +23,10 @@ describe("review scheduler config", () => {
       manualCommandReserve: 1,
       backgroundPriority: 50
     });
+    expect(config.providerCooldown).toMatchObject({
+      overloadBackoffMaxDurationMs: 10 * 60_000,
+      overloadBackoffJitterMs: 30_000
+    });
   });
 
   it("rejects scheduler settings that cannot preserve manual reserve capacity", () => {
@@ -32,6 +36,19 @@ describe("review scheduler config", () => {
         manualCommandReserve: 2
       }
     }))).toThrow("config.reviewScheduler.manualCommandReserve must be <= config.reviewScheduler.maxProviderActive");
+  });
+
+  it("validates provider overload backoff settings", () => {
+    expect(() => loadConfig(writeConfig({
+      providerCooldown: {
+        overloadBackoffMaxDurationMs: 0
+      }
+    }))).toThrow("config.providerCooldown.overloadBackoffMaxDurationMs must be a positive integer");
+    expect(() => loadConfig(writeConfig({
+      providerCooldown: {
+        overloadBackoffJitterMs: -1
+      }
+    }))).toThrow("config.providerCooldown.overloadBackoffJitterMs must be a non-negative integer");
   });
 
   it("validates optional GitHub API client settings", () => {

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -476,6 +476,156 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("stops the current provider batch after an overload and requeues unstarted leased jobs", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-provider-overload-stop-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    config.reviewScheduler!.maxProviderActive = 2;
+    config.reviewScheduler!.maxOrgActive = 2;
+    config.reviewScheduler!.maxRepoActive = 1;
+    const state = new ReviewStateStore(config.statePath);
+    const first = state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      baseSha: "base",
+      priority: 10,
+      providerId: "zai-coding-plan",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    }).job;
+    const second = state.enqueueReviewQueueJob({
+      repo: "org/repo-b",
+      pullNumber: 2,
+      headSha: HEAD_B,
+      baseSha: "base",
+      priority: 20,
+      providerId: "zai-coding-plan",
+      now: new Date("2026-07-02T00:00:01.000Z")
+    }).job;
+    const attempted: string[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]],
+        ["org/repo-b", [pull("org/repo-b", 2, HEAD_B)]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: true },
+      reviewPullImpl: async ({ repo }) => {
+        attempted.push(repo);
+        throw new Error("ProviderBusinessError: [1305][The service may be temporarily overloaded]");
+      },
+      now: new Date("2026-07-02T00:05:00.000Z")
+    });
+
+    expect(attempted).toEqual(["org/repo-a"]);
+    expect(result.skippedProviderCooldown).toBe(1);
+    expect(result.queue.providerDeferred).toBe(2);
+    expect(state.getReviewQueueJob(first.jobId)).toMatchObject({
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-02T00:07:00.000Z",
+      lastError: expect.stringContaining("reason=provider_overloaded")
+    });
+    expect(state.getReviewQueueJob(second.jobId)).toMatchObject({
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-02T00:07:00.000Z",
+      lastError: expect.stringContaining("provider_throttle_cycle_deferred_until=2026-07-02T00:07:00.000Z")
+    });
+    state.close();
+  });
+
+  it("prioritizes self-repo release PR heads ahead of ordinary background queue work", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-self-repo-priority-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a", "electricsheephq/evaos-code-review-bot"]);
+    config.reviewScheduler!.maxProviderActive = 1;
+    const state = new ReviewStateStore(config.statePath);
+    const reviewed: string[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]],
+        ["electricsheephq/evaos-code-review-bot", [pull("electricsheephq/evaos-code-review-bot", 165, HEAD_B)]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewed.push(`${repo}#${reviewPull.number}`);
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.queue.enqueued).toBe(2);
+    expect(result.reviewed).toBe(1);
+    expect(reviewed).toEqual(["electricsheephq/evaos-code-review-bot#165"]);
+    expect(state.listReviewQueueJobs({ repo: "electricsheephq/evaos-code-review-bot" })).toEqual([
+      expect.objectContaining({ pullNumber: 165, priority: 1, lastError: "reviewed" })
+    ]);
+    expect(state.listReviewQueueJobs({ repo: "org/repo-a", state: "queued" })).toEqual([
+      expect.objectContaining({ pullNumber: 1, priority: 50 })
+    ]);
+    state.close();
+  });
+
+  it("retires self-repo provider-deferred jobs when the PR closes before retry", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-self-repo-provider-deferred-closed-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    const state = new ReviewStateStore(config.statePath);
+    const job = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 165,
+      headSha: HEAD_A,
+      baseSha: "base",
+      priority: 1,
+      providerId: "zai-coding-plan",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-02T00:04:00.000Z",
+      lastError: "provider_rate_limit_cooldown_until=2026-07-02T00:04:00.000Z; reason=provider_overloaded",
+      now: new Date("2026-07-02T00:00:01.000Z")
+    });
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["electricsheephq/evaos-code-review-bot", [
+          pull("electricsheephq/evaos-code-review-bot", 165, HEAD_A, "base", { state: "closed", mergedAt: "2026-07-02T00:03:00Z" })
+        ]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: true },
+      reviewPullImpl: async () => {
+        throw new Error("closed provider-deferred self-repo PR must not run review work");
+      },
+      now: new Date("2026-07-02T00:05:00.000Z")
+    });
+
+    expect(result.queue.closedRetired).toBe(1);
+    expect(state.getReviewQueueJob(job.jobId)).toMatchObject({
+      state: "closed_retired",
+      lastError: "closed_or_merged_before_review state=closed"
+    });
+    expect(state.getReviewReadiness("electricsheephq/evaos-code-review-bot", 165, HEAD_A)).toMatchObject({
+      state: "closed",
+      reason: "closed_or_merged_before_review state=closed"
+    });
+    state.close();
+  });
+
   it("marks a queued status failed when refetching the leased pull fails", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-refetch-failed-"));
     roots.push(root);
@@ -1258,7 +1408,7 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
-  it("records provider throttle on one repo without blocking an unrelated leased repo", async () => {
+  it("records provider throttle and stops the current leased provider batch", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-provider-throttle-"));
     roots.push(root);
     const config = schedulerConfig(root, ["org/repo-a", "org/repo-b", "org/repo-c"]);
@@ -1291,15 +1441,16 @@ describe("provider-aware review scheduler", () => {
       now: new Date("2026-07-01T00:00:00.000Z")
     });
 
-    expect(result.reviewed).toBe(1);
+    expect(result.reviewed).toBe(0);
     expect(result.skippedProviderCooldown).toBe(1);
     expect(state.getActiveRepoProviderCooldown("org/repo-a", new Date("2026-07-01T00:00:01.000Z"))).toBeDefined();
     expect(state.getActiveRepoProviderCooldown("org/repo-b", new Date("2026-07-01T00:00:01.000Z"))).toBeUndefined();
     expect(state.listReviewQueueJobs({ state: "provider_deferred" })).toEqual([
-      expect.objectContaining({ repo: "org/repo-a", pullNumber: 1, nextEligibleAt: "2026-07-01T00:01:30.000Z" })
+      expect.objectContaining({ repo: "org/repo-a", pullNumber: 1, nextEligibleAt: "2026-07-01T00:01:30.000Z" }),
+      expect.objectContaining({ repo: "org/repo-b", pullNumber: 1, nextEligibleAt: "2026-07-01T00:01:30.000Z", lastError: expect.stringContaining("trigger_repo=org/repo-a") })
     ]);
-    expect(state.listReviewQueueJobs({ state: "posted" })).toEqual([
-      expect.objectContaining({ repo: "org/repo-b", pullNumber: 1 })
+    expect(state.listReviewQueueJobs({ state: "queued" })).toEqual([
+      expect.objectContaining({ repo: "org/repo-c", pullNumber: 1 })
     ]);
     state.close();
   });
@@ -2680,6 +2831,8 @@ function schedulerConfig(root: string, repos: string[]): BotConfig {
       requestRateLimitDurationMs: 90_000,
       overloadDurationMs: 2 * 60_000,
       quotaDurationMs: 30 * 60_000,
+      overloadBackoffMaxDurationMs: 10 * 60_000,
+      overloadBackoffJitterMs: 0,
       transientRetryAttempts: 0,
       transientRetryBaseDelayMs: 1,
       transientRetryMaxDelayMs: 1

--- a/tests/stale-head.test.ts
+++ b/tests/stale-head.test.ts
@@ -391,6 +391,8 @@ function minimalConfig(root: string): BotConfig {
       requestRateLimitDurationMs: 5 * 60_000,
       overloadDurationMs: 2 * 60_000,
       quotaDurationMs: 30 * 60_000,
+      overloadBackoffMaxDurationMs: 10 * 60_000,
+      overloadBackoffJitterMs: 0,
       transientRetryAttempts: 2,
       transientRetryBaseDelayMs: 1,
       transientRetryMaxDelayMs: 1

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1114,6 +1114,15 @@ describe("review state store", () => {
       cooldownUntil: "2026-07-01T00:15:00.000Z",
       reason: "provider_rate_limit"
     });
+    expect(parseProviderCooldownError(
+      "provider_rate_limit_cooldown_until=2026-07-01T00:15:00.000Z; reason=provider_overloaded; retry_attempt=3; provider_code=1305; retry_after_ms=45000"
+    )).toEqual({
+      cooldownUntil: "2026-07-01T00:15:00.000Z",
+      reason: "provider_overloaded",
+      retryAttempt: 3,
+      providerCode: "1305",
+      retryAfterMs: 45000
+    });
     expect(store.listProviderCooldownReviews({
       repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
       now: new Date("2026-07-01T00:30:00.000Z")

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -525,7 +525,60 @@ describe("worker review failures", () => {
     });
     expect(providerCooldownDurationMs(config, rateLimit)).toBe(90_000);
     expect(providerCooldownDurationMs(config, overload)).toBe(2 * 60_000);
+    expect(providerCooldownDurationMs(config, overload, 2)).toBe(4 * 60_000);
+    expect(providerCooldownDurationMs({
+      ...config,
+      providerCooldown: {
+        ...config.providerCooldown,
+        overloadBackoffJitterMs: 30_000
+      }
+    }, overload, 3, 5_000)).toBe(8 * 60_000 + 5_000);
+    expect(providerCooldownDurationMs(config, overload, 99, 60_000)).toBe(10 * 60_000);
     expect(providerCooldownDurationMs(config, quota)).toBe(30 * 60_000);
+  });
+
+  it("backs off repeated provider overload cooldowns for the same head", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-overload-backoff-"));
+    roots.push(root);
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = minimalConfig(root);
+    const pull = pullSummary(1330, "head-overload");
+
+    const first = recordProviderRateLimitCooldownIfNeeded({
+      config,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      error: new Error("ProviderBusinessError: [1305][The service may be temporarily overloaded] providerRequestId: 'req-1'"),
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+    const firstRecord = state.getProcessedReview("electricsheephq/WorldOS", 1330, "head-overload");
+
+    const second = recordProviderRateLimitCooldownIfNeeded({
+      config,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      error: new Error("ProviderBusinessError: [1305][The service may be temporarily overloaded] providerRequestId: 'req-2'"),
+      now: new Date("2026-07-01T00:02:00.000Z")
+    });
+    const secondRecord = state.getProcessedReview("electricsheephq/WorldOS", 1330, "head-overload");
+
+    expect(first).toBe(true);
+    expect(firstRecord).toMatchObject({
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2026-07-01T00:02:00.000Z; reason=provider_overloaded; retry_attempt=1; provider_code=1305"
+    });
+    expect(second).toBe(true);
+    expect(secondRecord).toMatchObject({
+      status: "skipped",
+      error: "provider_rate_limit_cooldown_until=2026-07-01T00:06:00.000Z; reason=provider_overloaded; retry_attempt=2; provider_code=1305"
+    });
+    expect(state.getActiveRepoProviderCooldown("electricsheephq/WorldOS", new Date("2026-07-01T00:05:59.000Z"))).toMatchObject({
+      reason: "provider_overloaded",
+      cooldownUntil: "2026-07-01T00:06:00.000Z"
+    });
+    state.close();
   });
 
   it("retries transient provider throttles before surfacing failure", async () => {
@@ -1732,6 +1785,8 @@ function minimalConfig(root: string): BotConfig {
       requestRateLimitDurationMs: 90_000,
       overloadDurationMs: 2 * 60_000,
       quotaDurationMs: 30 * 60_000,
+      overloadBackoffMaxDurationMs: 10 * 60_000,
+      overloadBackoffJitterMs: 0,
       transientRetryAttempts: 4,
       transientRetryBaseDelayMs: 1,
       transientRetryMaxDelayMs: 1


### PR DESCRIPTION
## Summary

Fixes the provider overload retry loop that kept the live bot red during peak/provider-throttle windows.

## Changes

- Add bounded exponential cooldown backoff for repeated `provider_overloaded` / `1305` responses on the same PR head.
- Persist provider overload retry metadata (`retry_attempt`, provider code, retry-after) in the skipped processed row so operators can see why the next retry moved.
- Stop the current scheduler provider batch after a provider cooldown and defer unstarted leased jobs with the same cooldown instead of immediately requeueing them.
- Prefer the durable processed/repo cooldown when setting queue `nextEligibleAt`, so the queue matches recorded evidence.
- Escalate automatic self-repo `electricsheephq/evaos-code-review-bot` jobs to priority `1` while preserving stale/closed-head guards.
- Add focused scheduler/config/worker/state tests for the overload loop and self-repo release lane.

## Validation

- `npm test -- tests/scheduler.test.ts tests/review-scheduler-config.test.ts tests/worker-failure.test.ts tests/state.test.ts tests/release-status.test.ts tests/operator-cli.test.ts --pool=forks --maxWorkers=1` — 197 passed.
- `npm run build` — passed.
- `git diff --check` — passed.
- Read-only spec/safety review — approved.
- Read-only code-quality review — found two issues; both fixed before PR publication.

## Scope Boundary

This intentionally does not close the broader operator-surface consistency work in #168 or telemetry/reporting work in #170.

Closes #166.
Closes #169.
