### PR TITLE
Fix existing self-repo queue priority

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -166,6 +166,11 @@ export async function runScheduledCycleWithDeps(input: {
   const reconciled = reconcileProcessedSkippedFailedQueueJobs(input.state, now);
   result.queue.providerDeferred += reconciled.providerDeferred;
   result.queue.staleRetired += reconciled.staleRetired;
+  reprioritizeExistingSelfRepoQueueJobs({
+    config,
+    state: input.state,
+    now
+  });
 
   result.queue.budget = buildReviewBudgetStatus({
     config,
@@ -468,8 +473,32 @@ function enqueueReviewJob(input: {
 
 function automaticQueuePriority(config: BotConfig, repo: string): number | undefined {
   const backgroundPriority = config.reviewScheduler?.backgroundPriority;
-  if (repo.toLowerCase() !== "electricsheephq/evaos-code-review-bot") return backgroundPriority;
+  if (repo.toLowerCase() !== SELF_REPO) return backgroundPriority;
   return Math.min(backgroundPriority ?? 50, 1);
+}
+
+const SELF_REPO = "electricsheephq/evaos-code-review-bot";
+
+function reprioritizeExistingSelfRepoQueueJobs(input: {
+  config: BotConfig;
+  state: ReviewStateStore;
+  now: Date;
+}): number {
+  const targetPriority = automaticQueuePriority(input.config, SELF_REPO);
+  if (targetPriority === undefined) return 0;
+  let updated = 0;
+  for (const job of input.state.listReviewQueueJobs({ states: ["queued", "provider_deferred"] })) {
+    if (job.repo.toLowerCase() !== SELF_REPO) continue;
+    if (job.source !== "automatic" || job.lane !== "background") continue;
+    if (job.priority <= targetPriority) continue;
+    input.state.updateReviewQueueJobPriority({
+      jobId: job.jobId,
+      priority: targetPriority,
+      now: input.now
+    });
+    updated += 1;
+  }
+  return updated;
 }
 
 function recordReadinessForEnqueue(input: {

--- a/src/state.ts
+++ b/src/state.ts
@@ -1551,6 +1551,26 @@ export class ReviewStateStore {
     return this.getReviewQueueJob(input.jobId)!;
   }
 
+  updateReviewQueueJobPriority(input: {
+    jobId: string;
+    priority: number;
+    now?: Date;
+  }): ReviewQueueJobRecord {
+    const existing = this.getReviewQueueJob(input.jobId);
+    if (!existing) throw new Error(`No review queue job for jobId ${input.jobId}`);
+    validateReviewQueueInput(existing.repo, existing.pullNumber, existing.headSha, input.priority, existing.commentId);
+    const nowIso = (input.now ?? new Date()).toISOString();
+    this.db
+      .prepare(
+        `update review_queue_jobs
+         set priority = ?,
+             updated_at = ?
+         where job_id = ?`
+      )
+      .run(input.priority, nowIso, input.jobId);
+    return this.getReviewQueueJob(input.jobId)!;
+  }
+
   getReviewQueueJob(jobId: string): ReviewQueueJobRecord | undefined {
     const row = this.db
       .prepare(

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -577,6 +577,66 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("reprioritizes existing queued self-repo jobs before ordinary backlog", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-self-repo-existing-priority-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a", "electricsheephq/evaos-code-review-bot"]);
+    config.reviewScheduler!.maxProviderActive = 1;
+    config.reviewScheduler!.maxOrgActive = 1;
+    config.reviewScheduler!.manualCommandReserve = 0;
+    const state = new ReviewStateStore(config.statePath);
+    const selfRepoJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 172,
+      headSha: HEAD_A,
+      baseSha: "base",
+      providerId: "zai-coding-plan",
+      priority: 50,
+      now: new Date("2026-07-03T00:00:00.000Z")
+    }).job;
+    const ordinaryJob = state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_B,
+      baseSha: "base",
+      providerId: "zai-coding-plan",
+      priority: 10,
+      now: new Date("2026-07-03T00:00:01.000Z")
+    }).job;
+    const reviewed: string[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_B)]],
+        ["electricsheephq/evaos-code-review-bot", [
+          pull("electricsheephq/evaos-code-review-bot", 172, HEAD_A, "base", { state: "closed", mergedAt: "2026-07-03T00:00:30Z" })
+        ]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ repo, pull: reviewPull }) => {
+        reviewed.push(`${repo}#${reviewPull.number}`);
+        return "reviewed";
+      },
+      now: new Date("2026-07-03T00:01:00.000Z")
+    });
+
+    expect(result.queue.leased).toBe(1);
+    expect(result.queue.closedRetired).toBe(1);
+    expect(reviewed).toEqual([]);
+    expect(state.getReviewQueueJob(selfRepoJob.jobId)).toMatchObject({
+      priority: 1,
+      state: "closed_retired",
+      lastError: "closed_or_merged_before_review state=closed"
+    });
+    expect(state.getReviewQueueJob(ordinaryJob.jobId)).toMatchObject({
+      priority: 10,
+      state: "queued"
+    });
+    state.close();
+  });
+
   it("retires self-repo provider-deferred jobs when the PR closes before retry", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-self-repo-provider-deferred-closed-"));
     roots.push(root);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -844,6 +844,45 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("updates queued job priority without losing provider deferral metadata", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-priority-update-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const job = store.enqueueReviewQueueJob({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 172,
+      headSha: "head-a",
+      baseSha: "base-a",
+      priority: 50,
+      now: new Date("2026-07-03T00:00:00.000Z")
+    }).job;
+    store.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-03T00:05:00.000Z",
+      lastError: "provider_rate_limit_cooldown_until=2026-07-03T00:05:00.000Z; reason=provider_overloaded",
+      now: new Date("2026-07-03T00:00:01.000Z")
+    });
+
+    const updated = store.updateReviewQueueJobPriority({
+      jobId: job.jobId,
+      priority: 1,
+      now: new Date("2026-07-03T00:00:02.000Z")
+    });
+
+    expect(updated).toMatchObject({
+      priority: 1,
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-03T00:05:00.000Z",
+      lastError: "provider_rate_limit_cooldown_until=2026-07-03T00:05:00.000Z; reason=provider_overloaded",
+      updatedAt: "2026-07-03T00:00:02.000Z"
+    });
+    expect(() => store.updateReviewQueueJobPriority({ jobId: job.jobId, priority: -1 })).toThrow(
+      "priority must be a non-negative integer"
+    );
+    store.close();
+  });
+
   it("leases bounded queue jobs by provider org repo and manual reserve", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-lease-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- Reprioritizes existing queued/provider-deferred automatic self-repo jobs before budget and lease selection.
- Adds a narrow state-store priority update that preserves cooldown, lease, and terminal metadata.
- Covers the live regression where an already-queued release PR row stayed at background priority 50 and sat behind ordinary backlog.

Closes #169.

## Validation
- npm test -- tests/scheduler.test.ts tests/state.test.ts --pool=forks --maxWorkers=1
- npm run build
- git diff --check