### PR TITLE
[codex] Harden operator queue health surfaces

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -35,7 +35,9 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
 - `queue`: open PR-head coverage grouped into processed, provider-deferred,
   pending review, skipped, stale-head, and read-failure buckets. Also includes
   durable `review_queue_jobs` rows and budget delay reasons when the state DB
-  has the scheduler table.
+  has the scheduler table. The command reports both `coverageOk` and
+  `runtimeOk`; `coverageOk: true` can still pair with `runtimeOk: false` when
+  every PR head is covered but a durable queue row is failed or ready to retry.
 - `dashboard`: read-only PR review dashboard over coverage, durable queue,
   readiness lifecycle rows, GitHub PR links, and local evidence-path hints.
   Filter with `--repo`, `--status`, `--priority`, `--stale-head-reason`, and
@@ -55,6 +57,11 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
   capped row-level details.
 - `coverage`: raw coverage-audit report with the shorter operator command name.
 - `cooldowns`: provider cooldown review rows plus repo/global cooldown rows.
+- `clear-review-queue-leases`: dry-run-first recovery command for stale
+  review-run leases and leased/running durable PR review queue rows. Use it
+  instead of manual SQLite edits after launchd restarts leave orphaned review
+  work. Mutation requires `--dry-run false --confirm true`; active/non-expired
+  rows additionally require `--expired-only false --force-active true`.
 - `why --repo <owner/name> --pr <number>`: scoped explanation for why one PR
   head is processed, pending, provider-deferred, skipped, blocked by a read
   failure, or unknown.
@@ -184,6 +191,11 @@ Inspect only durable provider-deferred jobs:
 npx tsx src/cli.ts queue --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --state provider_deferred
 ```
 
+If `queue` returns `coverageOk: true` and `runtimeOk: false`, coverage has found
+every eligible head but the durable queue still has actionable runtime debt.
+Inspect `failedGates`, `recommendedActions`, and `actionableRows` before
+restarting launchd or retrying provider work.
+
 Show the review dashboard:
 
 ```bash
@@ -228,6 +240,18 @@ Inspect provider cooldowns:
 
 ```bash
 npx tsx src/cli.ts cooldowns --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expired-only true
+```
+
+Dry-run stale review queue lease cleanup:
+
+```bash
+npx tsx src/cli.ts clear-review-queue-leases --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --dry-run true --expired-only true
+```
+
+Apply expired-only cleanup after inspecting the dry-run output:
+
+```bash
+npx tsx src/cli.ts clear-review-queue-leases --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --dry-run false --confirm true --expired-only true
 ```
 
 Build a repo-memory packet for dry-run evidence:

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -239,8 +239,14 @@ npx tsx src/cli.ts why --config /Volumes/LEXAR/Codex/evaos-code-review-bot/confi
 Inspect provider cooldowns:
 
 ```bash
-npx tsx src/cli.ts cooldowns --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expired-only true
+npx tsx src/cli.ts provider-cooldowns --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expired-only true
 ```
+
+The provider-cooldown output includes `runtimeOk`, `healthState`, `failedGates`,
+and a compact summary of expired cooldown rows plus durable queue provider
+backpressure. `provider_cooldowns_backpressured` means retryable
+provider-deferred jobs exist, but provider capacity is currently occupied by an
+active run; wait for that run to finish before retrying.
 
 Dry-run stale review queue lease cleanup:
 
@@ -253,6 +259,10 @@ Apply expired-only cleanup after inspecting the dry-run output:
 ```bash
 npx tsx src/cli.ts clear-review-queue-leases --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --dry-run false --confirm true --expired-only true
 ```
+
+`--force-active true` only applies to queue jobs matched by the explicit filters.
+It does not clear healthy global run leases; stale/dead run leases are removed
+only when they are independently expired or owned by a dead worker.
 
 Build a repo-memory packet for dry-run evidence:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -410,7 +410,7 @@ async function main(): Promise<void> {
 	      repo: args.repo,
 	      state: queueState
 	    });
-	    const budgetOutput = collectQueueBudget(config, budgetQueue.jobs);
+	    const budgetOutput = collectQueueBudget(config, collectBudgetJobsForSelection(statePath, budgetQueue.jobs));
     const gates = queueHealthGates(queue, durableQueue, budgetOutput.budget);
     const ok = gates.every((gate) => gate.ok);
     const output = {
@@ -1218,16 +1218,18 @@ async function main(): Promise<void> {
         repo: args.repo,
         now: checkedAt
       });
+      const activeProviderCooldowns = state.listRepoProviderCooldowns({ activeOnly: true, now: checkedAt });
       const budget = buildReviewBudgetStatus({
         config,
-        jobs: durableQueue.jobs,
+        jobs: collectBudgetJobsForSelection(statePath, durableQueue.jobs, checkedAt),
         now: checkedAt,
         includeDetails: false,
-        inputJobLimit: durableQueue.jobs.length
+        inputJobLimit: durableQueue.jobs.length + activeProviderCooldowns.length
       });
       const failedQueueJobs = durableQueue.summary.failed;
       const retryableProviderDeferred = durableQueue.summary.retryableProviderDeferred;
       const readyToRetry = budget.providerDeferred.readyToRetry;
+      const activeProviderCooldownCount = activeProviderCooldowns.length;
       const gates = [
         {
           name: "provider_cooldowns_no_expired_rows",
@@ -1252,7 +1254,7 @@ async function main(): Promise<void> {
         ok,
         healthState: ok
           ? "provider_cooldowns_ok"
-          : retryableProviderDeferred > 0 && readyToRetry === 0
+          : retryableProviderDeferred > 0 && (readyToRetry === 0 || activeProviderCooldownCount > 0)
             ? "provider_cooldowns_backpressured"
             : "provider_cooldowns_actionable",
         runtimeOk: ok,
@@ -1266,6 +1268,7 @@ async function main(): Promise<void> {
           providerDeferredJobs: durableQueue.summary.providerDeferred,
           retryableProviderDeferredJobs: retryableProviderDeferred,
           readyToRetryProviderDeferredJobs: readyToRetry,
+          activeProviderCooldowns: activeProviderCooldownCount,
           waitingProviderCapacity: budget.providerDeferred.waitingProviderCapacity,
           waitingCooldown: budget.providerDeferred.waitingCooldown
         },
@@ -1277,6 +1280,7 @@ async function main(): Promise<void> {
           failedQueueJobs,
           retryableProviderDeferred,
           readyToRetry,
+          activeProviderCooldownCount,
           waitingProviderCapacity: budget.providerDeferred.waitingProviderCapacity
         }),
         gates,
@@ -1820,6 +1824,21 @@ function collectQueueBudget(config: ReturnType<typeof loadConfig>, jobs: ReviewQ
   }
 }
 
+function collectBudgetJobsForSelection(
+  statePath: string,
+  selectedJobs: ReviewQueueJobRecord[],
+  now?: Date
+): ReviewQueueJobRecord[] {
+  const jobsById = new Map<string, ReviewQueueJobRecord>();
+  for (const job of collectOperatorReviewQueue(statePath, { now }).jobs) {
+    if (job.state === "leased" || job.state === "running") jobsById.set(job.jobId, job);
+  }
+  for (const job of selectedJobs) {
+    jobsById.set(job.jobId, job);
+  }
+  return [...jobsById.values()];
+}
+
 function failedGates(gates: Array<{ name: string; ok: boolean; detail: string }>): Array<{ name: string; ok: boolean; detail: string }> {
   return gates.filter((gate) => !gate.ok);
 }
@@ -1858,6 +1877,7 @@ function queueHealthGates(
   budget?: ReleaseStatus["budget"]
 ): Array<{ name: string; ok: boolean; detail: string }> {
   const readyToRetry = budget?.providerDeferred.readyToRetry ?? durableQueue.summary.retryableProviderDeferred;
+  const retryableProviderDeferred = budget?.providerDeferred.retryable ?? durableQueue.summary.retryableProviderDeferred;
   return [
     {
       name: "queue_coverage_ok",
@@ -1873,10 +1893,13 @@ function queueHealthGates(
     },
     {
       name: "queue_no_ready_provider_deferred_jobs",
-      ok: readyToRetry === 0,
+      ok: retryableProviderDeferred === 0,
       detail:
         `${readyToRetry} ready-to-retry provider-deferred job(s); ` +
-        `provider_deferred total=${budget?.providerDeferred.total ?? durableQueue.summary.providerDeferred}`
+        `provider_deferred total=${budget?.providerDeferred.total ?? durableQueue.summary.providerDeferred} ` +
+        `retryable=${retryableProviderDeferred} ` +
+        `waiting_capacity=${budget?.providerDeferred.waitingProviderCapacity ?? 0} ` +
+        `waiting_cooldown=${budget?.providerDeferred.waitingCooldown ?? 0}`
     }
   ];
 }
@@ -1899,6 +1922,7 @@ function providerCooldownRecommendedActions(input: {
   failedQueueJobs: number;
   retryableProviderDeferred: number;
   readyToRetry: number;
+  activeProviderCooldownCount: number;
   waitingProviderCapacity: number;
 }): string[] {
   const retryCommand =
@@ -1906,7 +1930,10 @@ function providerCooldownRecommendedActions(input: {
     `--expired-only true --dry-run false --zcode true${input.repo ? ` --repo ${input.repo}` : ""}`;
   return [
     ...(input.failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
-    ...(input.expiredCount > 0 || input.readyToRetry > 0 ? [retryCommand] : []),
+    ...(input.activeProviderCooldownCount > 0
+      ? ["wait for active provider cooldown to expire before retrying provider-deferred work"]
+      : []),
+    ...(input.activeProviderCooldownCount === 0 && (input.expiredCount > 0 || input.readyToRetry > 0) ? [retryCommand] : []),
     ...(input.retryableProviderDeferred > 0 && input.readyToRetry === 0 && input.waitingProviderCapacity > 0
       ? ["wait for active provider run to finish; retryable provider-deferred jobs are blocked by provider capacity"]
       : []),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1945,14 +1945,22 @@ function providerCooldownRecommendedActions(input: {
 
 function queueActionableRows(
   durableQueue: OperatorDurableQueueSnapshot,
-  budget?: ReleaseStatus["budget"]
+  budget?: ReleaseStatus["budget"],
+  now = new Date()
 ): ReviewQueueJobRecord[] {
   const readyToRetry = budget?.providerDeferred.readyToRetry ?? durableQueue.summary.retryableProviderDeferred;
   const failed = durableQueue.jobs.filter((job) => job.state === "failed");
   const providerDeferred = readyToRetry > 0
-    ? durableQueue.jobs.filter((job) => job.state === "provider_deferred")
+    ? durableQueue.jobs.filter((job) => job.state === "provider_deferred" && isProviderDeferredQueueJobEligible(job, now))
     : [];
   return [...failed, ...providerDeferred];
+}
+
+function isProviderDeferredQueueJobEligible(job: ReviewQueueJobRecord, now: Date): boolean {
+  if (job.state !== "provider_deferred") return false;
+  if (!job.nextEligibleAt) return true;
+  const eligibleAtMs = Date.parse(job.nextEligibleAt);
+  return !Number.isFinite(eligibleAtMs) || eligibleAtMs <= now.getTime();
 }
 
 function buildHelp(command?: string) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -244,19 +244,21 @@ async function main(): Promise<void> {
         repo: args.repo,
         pullNumber: args.pr ? Number(args.pr) : undefined,
         verifyCurrentHeads: args["verify-current-heads"] !== "false"
-      });
-      const gates = coverageAuditGates(audit);
-      console.log(JSON.stringify({
-        ...audit,
-        healthScope: "coverage",
-        healthState: audit.ok ? "coverage_ok" : "coverage_blocked",
-        coverageOk: audit.ok,
-        runtimeOk: null,
-        failedGates: failedGates(gates),
-        recommendedActions: coverageAuditRecommendedActions(audit),
-        gates
-      }, null, 2));
-      if (!audit.ok) process.exitCode = 1;
+	      });
+	      const gates = coverageAuditGates(audit);
+	      const coverageOk = gates.every((gate) => gate.ok);
+	      console.log(JSON.stringify({
+	        ...audit,
+	        ok: coverageOk,
+	        healthScope: "coverage",
+	        healthState: coverageOk ? "coverage_ok" : "coverage_blocked",
+	        coverageOk,
+	        runtimeOk: null,
+	        failedGates: failedGates(gates),
+	        recommendedActions: coverageAuditRecommendedActions(audit),
+	        gates
+	      }, null, 2));
+	      if (!coverageOk) process.exitCode = 1;
     } finally {
       state.close();
     }
@@ -393,16 +395,22 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "queue") {
-    const config = loadConfig(args.config);
-    const report = await collectCoverageReport(args, config);
-    const queue = buildOperatorQueue(report);
-    const durableQueue = collectOperatorReviewQueue(args["state-path"] ?? config.statePath, {
-      repo: args.repo,
-      state: parseReviewQueueJobState(args.state),
-      limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
-    });
-    const budgetOutput = collectQueueBudget(args);
+	  if (command === "queue") {
+	    const config = loadConfig(args.config);
+	    const report = await collectCoverageReport(args, config);
+	    const queue = buildOperatorQueue(report);
+	    const statePath = args["state-path"] ?? config.statePath;
+	    const queueState = parseReviewQueueJobState(args.state);
+	    const durableQueue = collectOperatorReviewQueue(statePath, {
+	      repo: args.repo,
+	      state: queueState,
+	      limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
+	    });
+	    const budgetQueue = collectOperatorReviewQueue(statePath, {
+	      repo: args.repo,
+	      state: queueState
+	    });
+	    const budgetOutput = collectQueueBudget(config, budgetQueue.jobs);
     const gates = queueHealthGates(queue, durableQueue, budgetOutput.budget);
     const ok = gates.every((gate) => gate.ok);
     const output = {
@@ -1792,19 +1800,18 @@ function launchdUserSessionError(): string | undefined {
     : undefined;
 }
 
-function collectQueueBudget(args: ParsedArgs): {
+function collectQueueBudget(config: ReturnType<typeof loadConfig>, jobs: ReviewQueueJobRecord[]): {
   budget?: ReleaseStatus["budget"];
   budgetError?: string;
 } {
   try {
     return {
-      budget: collectReleaseStatus({
-        cwd: process.cwd(),
-        configPath: args.config,
-        expectedHead: args["expected-head"],
-        launchdLabel: args["launchd-label"],
-        statePath: args["state-path"]
-      }).budget
+      budget: buildReviewBudgetStatus({
+        config,
+        jobs,
+        includeDetails: false,
+        inputJobLimit: jobs.length
+      })
     };
   } catch (error) {
     return {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import { GitHubApi } from "./github.js";
 import { buildGitNexusContextPacket } from "./gitnexus-context.js";
 import { buildGitHubRelatedContextPacket } from "./github-related-context.js";
 import { buildIssueEnrichmentStatus, collectIssueEnrichmentScan } from "./issue-enrichment.js";
+import { buildReviewBudgetStatus } from "./review-budget.js";
 import {
   buildOperatorDashboard,
   buildRuntimeInventory,
@@ -869,6 +870,7 @@ async function main(): Promise<void> {
         dryRun,
         expiredOnly,
         forceActive,
+        leaseTtlMs: config.reviewConcurrency.leaseTtlMs,
         ...(args.repo ? { repo: parseSingleArg(args.repo, "--repo") } : {}),
         ...(args.pr ? { pullNumber: parsePositiveInteger(parseSingleArg(args.pr, "--pr"), "--pr") } : {}),
         ...(args["job-id"] ? { jobId: parseSingleArg(args["job-id"], "--job-id") } : {})
@@ -1192,8 +1194,10 @@ async function main(): Promise<void> {
 
   if (command === "provider-cooldowns") {
     const config = loadConfig(args.config);
-    const state = new ReviewStateStore(args["state-path"] ?? config.statePath);
+    const statePath = args["state-path"] ?? config.statePath;
+    const state = new ReviewStateStore(statePath);
     try {
+      const checkedAt = new Date();
       const expiredOnly = args["expired-only"] === "true";
       const limit = args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined;
       const rows = state.listProviderCooldownReviews({
@@ -1202,32 +1206,76 @@ async function main(): Promise<void> {
         limit
       });
       const expiredCount = rows.filter((row) => row.expired).length;
+      const durableQueue = collectOperatorReviewQueue(statePath, {
+        repo: args.repo,
+        now: checkedAt
+      });
+      const budget = buildReviewBudgetStatus({
+        config,
+        jobs: durableQueue.jobs,
+        now: checkedAt,
+        includeDetails: false,
+        inputJobLimit: durableQueue.jobs.length
+      });
+      const failedQueueJobs = durableQueue.summary.failed;
+      const retryableProviderDeferred = durableQueue.summary.retryableProviderDeferred;
+      const readyToRetry = budget.providerDeferred.readyToRetry;
       const gates = [
         {
           name: "provider_cooldowns_no_expired_rows",
           ok: expiredCount === 0,
           detail: `${expiredCount} expired provider cooldown row(s)`
+        },
+        {
+          name: "provider_cooldowns_no_failed_queue_jobs",
+          ok: failedQueueJobs === 0,
+          detail: `${failedQueueJobs} failed durable queue job(s)`
+        },
+        {
+          name: "provider_cooldowns_no_retryable_provider_deferred_jobs",
+          ok: retryableProviderDeferred === 0,
+          detail:
+            `${retryableProviderDeferred} retryable provider-deferred job(s); ` +
+            `${readyToRetry} ready now; ${budget.providerDeferred.waitingProviderCapacity} waiting provider capacity`
         }
       ];
       const ok = gates.every((gate) => gate.ok);
       console.log(JSON.stringify({
         ok,
-        healthState: ok ? "provider_cooldowns_ok" : "provider_cooldowns_actionable",
+        healthState: ok
+          ? "provider_cooldowns_ok"
+          : retryableProviderDeferred > 0 && readyToRetry === 0
+            ? "provider_cooldowns_backpressured"
+            : "provider_cooldowns_actionable",
         runtimeOk: ok,
-        checkedAt: new Date().toISOString(),
+        checkedAt: checkedAt.toISOString(),
         expiredOnly,
         ...(args.repo ? { repo: args.repo } : {}),
         summary: {
           total: rows.length,
-          expired: expiredCount
+          expired: expiredCount,
+          failedQueueJobs,
+          providerDeferredJobs: durableQueue.summary.providerDeferred,
+          retryableProviderDeferredJobs: retryableProviderDeferred,
+          readyToRetryProviderDeferredJobs: readyToRetry,
+          waitingProviderCapacity: budget.providerDeferred.waitingProviderCapacity,
+          waitingCooldown: budget.providerDeferred.waitingCooldown
         },
         failedGates: failedGates(gates),
-        recommendedActions: expiredCount > 0
-          ? [`npx tsx src/cli.ts retry-provider-cooldowns --config ${args.config ?? "(default config)"} --expired-only true --dry-run false --zcode true${args.repo ? ` --repo ${args.repo}` : ""}`]
-          : [],
+        recommendedActions: providerCooldownRecommendedActions({
+          configPath: args.config ?? "(default config)",
+          repo: args.repo,
+          expiredCount,
+          failedQueueJobs,
+          retryableProviderDeferred,
+          readyToRetry,
+          waitingProviderCapacity: budget.providerDeferred.waitingProviderCapacity
+        }),
         gates,
         count: rows.length,
         expiredCount,
+        durableQueue,
+        budget,
         rows
       }, null, 2));
       if (!ok) process.exitCode = 1;
@@ -1833,6 +1881,30 @@ function queueRecommendedActions(gates: Array<{ name: string; ok: boolean; detai
     ...(failed.has("queue_no_failed_jobs") ? ["inspect operator queue failed jobs before promotion"] : []),
     ...(failed.has("queue_no_ready_provider_deferred_jobs")
       ? ["wait for the next scheduler cycle or inspect provider-deferred jobs marked ready_to_retry"]
+      : [])
+  ];
+}
+
+function providerCooldownRecommendedActions(input: {
+  configPath: string;
+  repo?: string;
+  expiredCount: number;
+  failedQueueJobs: number;
+  retryableProviderDeferred: number;
+  readyToRetry: number;
+  waitingProviderCapacity: number;
+}): string[] {
+  const retryCommand =
+    `npx tsx src/cli.ts retry-provider-cooldowns --config ${input.configPath} ` +
+    `--expired-only true --dry-run false --zcode true${input.repo ? ` --repo ${input.repo}` : ""}`;
+  return [
+    ...(input.failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(input.expiredCount > 0 || input.readyToRetry > 0 ? [retryCommand] : []),
+    ...(input.retryableProviderDeferred > 0 && input.readyToRetry === 0 && input.waitingProviderCapacity > 0
+      ? ["wait for active provider run to finish; retryable provider-deferred jobs are blocked by provider capacity"]
+      : []),
+    ...(input.retryableProviderDeferred > 0 && input.readyToRetry === 0 && input.waitingProviderCapacity === 0
+      ? ["inspect provider-deferred queue rows; retryable jobs are blocked by a non-cooldown budget gate"]
       : [])
   ];
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,7 +40,9 @@ import {
   explainPullStatus,
   formatOperatorDashboardHuman,
   formatRuntimeInventoryHuman,
-  summarizeAgentInventory
+  summarizeAgentInventory,
+  type OperatorDurableQueueSnapshot,
+  type OperatorQueueSnapshot
 } from "./operator-cli.js";
 import { collectReleaseStatus, type ReleaseStatus } from "./release-status.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown } from "./repo-memory.js";
@@ -48,7 +50,7 @@ import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./
 import { runOnceCliCommand } from "./run-once-cli.js";
 import { redactSecrets } from "./secrets.js";
 import { buildSkillPackContextPacket } from "./skill-packs.js";
-import { listRepoMemoryNotesReadOnly, ReviewStateStore, type ReviewQueueJobState } from "./state.js";
+import { listRepoMemoryNotesReadOnly, ReviewStateStore, type ReviewQueueJobRecord, type ReviewQueueJobState } from "./state.js";
 import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "./validation-selector.js";
 import { isSuccessfulRetryStatus, retryFailedHead, retryProviderCooldowns } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
@@ -63,6 +65,11 @@ async function main(): Promise<void> {
 
   if (!command || command === "help" || command === "--help" || command === "-h") {
     console.log(JSON.stringify(buildHelp(), null, 2));
+    return;
+  }
+
+  if (isHelpRequested(args)) {
+    console.log(JSON.stringify(buildHelp(command), null, 2));
     return;
   }
 
@@ -150,7 +157,12 @@ async function main(): Promise<void> {
       ...(budgetDetailLimit !== undefined ? { budgetDetailLimit } : {}),
       ...(budgetJobLimit !== undefined ? { budgetJobLimit } : {})
     });
-    console.log(JSON.stringify(status, null, 2));
+    console.log(JSON.stringify({
+      ...status,
+      healthState: status.ok ? "runtime_ok" : "runtime_blocked",
+      runtimeOk: status.ok,
+      failedGates: failedGates(status.gates)
+    }, null, 2));
     if (!status.ok) process.exitCode = 1;
     return;
   }
@@ -168,10 +180,51 @@ async function main(): Promise<void> {
       budgetDetailLimit,
       budgetJobLimit
     });
-    const ok = status.budget?.enabled === true && status.budget.details.inputJobsTruncated !== true;
+    const readyToRetry = status.budget?.providerDeferred.readyToRetry ?? 0;
+    const failed = status.database.failedReviewQueueJobCount ?? 0;
+    const ok = status.budget?.enabled === true &&
+      status.budget.details.inputJobsTruncated !== true &&
+      readyToRetry === 0 &&
+      failed === 0;
+    const gates = [
+      {
+        name: "budget_available",
+        ok: status.budget?.enabled === true,
+        detail: status.budget?.enabled === true ? "enabled" : "not available"
+      },
+      {
+        name: "budget_input_not_truncated",
+        ok: status.budget?.details.inputJobsTruncated !== true,
+        detail: status.budget?.details.inputJobsTruncated === true ? "input jobs truncated" : "input jobs complete"
+      },
+      {
+        name: "budget_no_ready_provider_deferred_jobs",
+        ok: readyToRetry === 0,
+        detail: `${readyToRetry} ready-to-retry provider-deferred job(s)`
+      },
+      {
+        name: "budget_no_failed_queue_jobs",
+        ok: failed === 0,
+        detail: `${failed} failed durable queue job(s)`
+      }
+    ];
     console.log(JSON.stringify({
       ok,
+      healthState: ok ? "runtime_ok" : "runtime_blocked",
+      runtimeOk: ok,
       checkedAt: status.checkedAt,
+      summary: {
+        readyToRetryProviderDeferredJobs: readyToRetry,
+        failedQueueJobs: failed,
+        wouldLeaseCount: status.budget?.wouldLeaseCount ?? 0,
+        delayedCount: status.budget?.delayedCount ?? 0
+      },
+      failedGates: failedGates(gates),
+      recommendedActions: ok ? [] : [
+        ...(readyToRetry > 0 ? ["wait for the next scheduler cycle or inspect provider-deferred jobs marked ready_to_retry"] : []),
+        ...(failed > 0 ? ["inspect operator queue failed jobs before promotion"] : [])
+      ],
+      gates,
       budget: status.budget
     }, null, 2));
     if (!ok) process.exitCode = 1;
@@ -191,7 +244,17 @@ async function main(): Promise<void> {
         pullNumber: args.pr ? Number(args.pr) : undefined,
         verifyCurrentHeads: args["verify-current-heads"] !== "false"
       });
-      console.log(JSON.stringify(audit, null, 2));
+      const gates = coverageAuditGates(audit);
+      console.log(JSON.stringify({
+        ...audit,
+        healthScope: "coverage",
+        healthState: audit.ok ? "coverage_ok" : "coverage_blocked",
+        coverageOk: audit.ok,
+        runtimeOk: null,
+        failedGates: failedGates(gates),
+        recommendedActions: coverageAuditRecommendedActions(audit),
+        gates
+      }, null, 2));
       if (!audit.ok) process.exitCode = 1;
     } finally {
       state.close();
@@ -338,7 +401,23 @@ async function main(): Promise<void> {
       state: parseReviewQueueJobState(args.state),
       limit: args.limit ? parsePositiveInteger(args.limit, "--limit") : undefined
     });
-    const output = { ...queue, ok: queue.ok, coverage: queue, durableQueue, ...collectQueueBudget(args) };
+    const budgetOutput = collectQueueBudget(args);
+    const gates = queueHealthGates(queue, durableQueue, budgetOutput.budget);
+    const ok = gates.every((gate) => gate.ok);
+    const output = {
+      ...queue,
+      ok,
+      healthState: ok ? "runtime_ok" : "runtime_blocked",
+      coverageOk: queue.ok,
+      runtimeOk: ok,
+      failedGates: failedGates(gates),
+      recommendedActions: queueRecommendedActions(gates),
+      actionableRows: queueActionableRows(durableQueue, budgetOutput.budget),
+      gates,
+      coverage: queue,
+      durableQueue,
+      ...budgetOutput
+    };
     console.log(JSON.stringify(output, null, 2));
     if (!output.ok) process.exitCode = 1;
     return;
@@ -771,6 +850,49 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "clear-review-queue-leases") {
+    const config = loadConfig(args.config);
+    const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
+    const confirm = args.confirm === undefined ? false : parseBooleanArg(args.confirm, "--confirm");
+    const expiredOnly = args["expired-only"] === undefined ? true : parseBooleanArg(args["expired-only"], "--expired-only");
+    const forceActive = args["force-active"] === undefined ? false : parseBooleanArg(args["force-active"], "--force-active");
+    if (!dryRun && !confirm) {
+      throw new Error("clear-review-queue-leases requires --confirm true when --dry-run false");
+    }
+    if (!dryRun && !expiredOnly && !forceActive) {
+      throw new Error("clearing active review queue leases requires --force-active true; use --expired-only true for expired-only cleanup");
+    }
+    const statePath = args["state-path"] ?? config.statePath;
+    const state = new ReviewStateStore(statePath);
+    try {
+      const result = state.clearReviewQueueLeases({
+        dryRun,
+        expiredOnly,
+        forceActive,
+        ...(args.repo ? { repo: parseSingleArg(args.repo, "--repo") } : {}),
+        ...(args.pr ? { pullNumber: parsePositiveInteger(parseSingleArg(args.pr, "--pr"), "--pr") } : {}),
+        ...(args["job-id"] ? { jobId: parseSingleArg(args["job-id"], "--job-id") } : {})
+      });
+      const recommendedActions = buildReviewQueueLeaseClearRecommendations({
+        dryRun,
+        expiredOnly,
+        forceActive,
+        expiredMatched: result.expiredMatched,
+        activeMatched: result.activeMatched
+      });
+      console.log(redactSecrets(JSON.stringify({
+        ok: true,
+        statePath,
+        forceActive,
+        ...result,
+        recommendedActions
+      }, null, 2)));
+    } finally {
+      state.close();
+    }
+    return;
+  }
+
   if (command === "finishing-touch-dry-run") {
     if (!args.repo) throw new Error("--repo is required for finishing-touch-dry-run");
     if (!args.pr) throw new Error("--pr is required for finishing-touch-dry-run");
@@ -1079,15 +1201,36 @@ async function main(): Promise<void> {
         expiredOnly,
         limit
       });
+      const expiredCount = rows.filter((row) => row.expired).length;
+      const gates = [
+        {
+          name: "provider_cooldowns_no_expired_rows",
+          ok: expiredCount === 0,
+          detail: `${expiredCount} expired provider cooldown row(s)`
+        }
+      ];
+      const ok = gates.every((gate) => gate.ok);
       console.log(JSON.stringify({
-        ok: true,
+        ok,
+        healthState: ok ? "provider_cooldowns_ok" : "provider_cooldowns_actionable",
+        runtimeOk: ok,
         checkedAt: new Date().toISOString(),
         expiredOnly,
         ...(args.repo ? { repo: args.repo } : {}),
+        summary: {
+          total: rows.length,
+          expired: expiredCount
+        },
+        failedGates: failedGates(gates),
+        recommendedActions: expiredCount > 0
+          ? [`npx tsx src/cli.ts retry-provider-cooldowns --config ${args.config ?? "(default config)"} --expired-only true --dry-run false --zcode true${args.repo ? ` --repo ${args.repo}` : ""}`]
+          : [],
+        gates,
         count: rows.length,
-        expiredCount: rows.filter((row) => row.expired).length,
+        expiredCount,
         rows
       }, null, 2));
+      if (!ok) process.exitCode = 1;
     } finally {
       state.close();
     }
@@ -1622,9 +1765,94 @@ function collectQueueBudget(args: ParsedArgs): {
   }
 }
 
-function buildHelp() {
+function failedGates(gates: Array<{ name: string; ok: boolean; detail: string }>): Array<{ name: string; ok: boolean; detail: string }> {
+  return gates.filter((gate) => !gate.ok);
+}
+
+function coverageAuditGates(report: Awaited<ReturnType<typeof collectCoverageAudit>>): Array<{ name: string; ok: boolean; detail: string }> {
+  return [
+    {
+      name: "coverage_no_unprocessed_heads",
+      ok: report.summary.unprocessed === 0,
+      detail: `${report.summary.unprocessed} unprocessed eligible head(s)`
+    },
+    {
+      name: "coverage_no_read_failures",
+      ok: report.summary.readFailures === 0,
+      detail: `${report.summary.readFailures} read failure(s)`
+    },
+    {
+      name: "coverage_no_stale_heads",
+      ok: report.summary.staleHeads === 0,
+      detail: `${report.summary.staleHeads} stale head(s)`
+    }
+  ];
+}
+
+function coverageAuditRecommendedActions(report: Awaited<ReturnType<typeof collectCoverageAudit>>): string[] {
+  return [
+    ...(report.summary.unprocessed > 0 ? ["wait for daemon cycle or run scoped run-once for unprocessed heads"] : []),
+    ...(report.summary.readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
+    ...(report.summary.staleHeads > 0 ? ["wait for next daemon cycle or run scoped coverage audit"] : [])
+  ];
+}
+
+function queueHealthGates(
+  coverage: OperatorQueueSnapshot,
+  durableQueue: OperatorDurableQueueSnapshot,
+  budget?: ReleaseStatus["budget"]
+): Array<{ name: string; ok: boolean; detail: string }> {
+  const readyToRetry = budget?.providerDeferred.readyToRetry ?? durableQueue.summary.retryableProviderDeferred;
+  return [
+    {
+      name: "queue_coverage_ok",
+      ok: coverage.ok,
+      detail:
+        `${coverage.summary.pending} pending, ${coverage.summary.readFailures} read failure(s), ` +
+        `${coverage.summary.staleHeads} stale head(s)`
+    },
+    {
+      name: "queue_no_failed_jobs",
+      ok: durableQueue.summary.failed === 0,
+      detail: `${durableQueue.summary.failed} failed durable queue job(s)`
+    },
+    {
+      name: "queue_no_ready_provider_deferred_jobs",
+      ok: readyToRetry === 0,
+      detail:
+        `${readyToRetry} ready-to-retry provider-deferred job(s); ` +
+        `provider_deferred total=${budget?.providerDeferred.total ?? durableQueue.summary.providerDeferred}`
+    }
+  ];
+}
+
+function queueRecommendedActions(gates: Array<{ name: string; ok: boolean; detail: string }>): string[] {
+  const failed = new Set(failedGates(gates).map((gate) => gate.name));
+  return [
+    ...(failed.has("queue_coverage_ok") ? ["inspect coverage queues, read failures, and stale heads before promotion"] : []),
+    ...(failed.has("queue_no_failed_jobs") ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(failed.has("queue_no_ready_provider_deferred_jobs")
+      ? ["wait for the next scheduler cycle or inspect provider-deferred jobs marked ready_to_retry"]
+      : [])
+  ];
+}
+
+function queueActionableRows(
+  durableQueue: OperatorDurableQueueSnapshot,
+  budget?: ReleaseStatus["budget"]
+): ReviewQueueJobRecord[] {
+  const readyToRetry = budget?.providerDeferred.readyToRetry ?? durableQueue.summary.retryableProviderDeferred;
+  const failed = durableQueue.jobs.filter((job) => job.state === "failed");
+  const providerDeferred = readyToRetry > 0
+    ? durableQueue.jobs.filter((job) => job.state === "provider_deferred")
+    : [];
+  return [...failed, ...providerDeferred];
+}
+
+function buildHelp(command?: string) {
   return {
     ok: true,
+    ...(command ? { command } : {}),
     commands: {
       public: [
         "init",
@@ -1657,6 +1885,7 @@ function buildHelp() {
         "build-enrichment-comment",
         "issue-enrichment-scan",
         "clear-issue-enrichment-leases",
+        "clear-review-queue-leases",
         "finishing-touch-dry-run",
         "provider-cooldowns",
         "retry-provider-cooldowns",
@@ -1695,11 +1924,17 @@ function buildHelp() {
       "npx tsx src/cli.ts build-enrichment-comment --config /path/to/live.json --repo owner/repo --issue 456 --output-dir /path/to/evidence",
       "npx tsx src/cli.ts issue-enrichment-scan --config /path/to/live.json --dry-run true --output-dir /path/to/evidence",
       "npx tsx src/cli.ts clear-issue-enrichment-leases --config /path/to/live.json --dry-run true --expired-only true",
+      "npx tsx src/cli.ts clear-review-queue-leases --config /path/to/live.json --dry-run true --expired-only true",
       "npx tsx src/cli.ts eval-sticky-vs-cold --input /path/to/sticky-vs-cold.json --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold",
       "npx tsx src/cli.ts finishing-touch-dry-run --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD --current-head HEAD --comment-id 456 --author maintainer --trusted-authors maintainer --body '@evaos-code-review-bot explain risk'",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ]
   };
+}
+
+function isHelpRequested(args: ParsedArgs): boolean {
+  if (args.help === "true") return true;
+  return args._.slice(1).some((arg) => arg === "help" || arg === "-h" || arg === "--help");
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -1766,6 +2001,24 @@ function buildIssueEnrichmentLeaseClearRecommendations(input: {
   }
   if (input.activeMatched > 0 && !input.expiredOnly) {
     recommendations.push("active issue-enrichment lease(s) matched; verify no worker is running before rerunning with --dry-run false --confirm true --expired-only false --force-active true");
+  }
+  return recommendations;
+}
+
+function buildReviewQueueLeaseClearRecommendations(input: {
+  dryRun: boolean;
+  expiredOnly: boolean;
+  forceActive: boolean;
+  activeMatched: number;
+  expiredMatched: number;
+}): string[] {
+  if (!input.dryRun) return [];
+  const recommendations: string[] = [];
+  if (input.expiredMatched > 0) {
+    recommendations.push("rerun with --dry-run false --confirm true --expired-only true to requeue expired review queue lease(s) and delete stale review run lease(s)");
+  }
+  if (input.activeMatched > 0 && !input.expiredOnly && !input.forceActive) {
+    recommendations.push("active review queue lease(s) matched; verify no worker is running before rerunning with --dry-run false --confirm true --expired-only false --force-active true");
   }
   return recommendations;
 }

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -54,6 +54,7 @@ export interface OperatorStatus {
     issueEnrichmentRuntimeState?: OperatorIssueEnrichmentRuntimeState;
   };
   gates: Array<{ name: string; ok: boolean; detail: string }>;
+  failedGates: Array<{ name: string; ok: boolean; detail: string }>;
   recommendedActions: string[];
   release: ReleaseStatus;
   budget?: ReviewBudgetStatus;
@@ -100,6 +101,7 @@ export interface RuntimeInventory {
     issueEnrichmentRuntimeState?: OperatorIssueEnrichmentRuntimeState;
   };
   gates: Array<{ name: string; ok: boolean; detail: string }>;
+  failedGates: Array<{ name: string; ok: boolean; detail: string }>;
   recommendedActions: string[];
   activeWork: ReviewQueueJobRecord[];
   uncoveredPendingHeads: OperatorQueueEntry[];
@@ -467,6 +469,7 @@ export function buildOperatorStatus(input: {
       ...(issueEnrichmentRuntimeState ? { issueEnrichmentRuntimeState } : {})
     },
     gates,
+    failedGates: gates.filter((gate) => !gate.ok),
     recommendedActions,
     release: input.release,
     ...(budget ? { budget } : {}),
@@ -664,6 +667,7 @@ export function buildRuntimeInventory(input: {
       ...(issueEnrichmentRuntimeState ? { issueEnrichmentRuntimeState } : {})
     },
     gates,
+    failedGates: gates.filter((gate) => !gate.ok),
     recommendedActions,
     activeWork,
     uncoveredPendingHeads,

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -639,11 +639,11 @@ function readStaleActiveReviewQueueJobCount(db: DatabaseSync, now: Date, leaseTt
       .prepare(
         `select count(*) as count
          from review_queue_jobs
-         where state in ('leased', 'running')
-           and (
-             (lease_expires_at is not null and datetime(lease_expires_at) <= datetime(?))
-             or (lease_expires_at is null and datetime(updated_at) <= datetime(?))
-           )`
+	         where state in ('leased', 'running')
+	           and (
+	             (lease_expires_at is not null and (datetime(lease_expires_at) is null or datetime(lease_expires_at) <= datetime(?)))
+	             or (lease_expires_at is null and datetime(updated_at) <= datetime(?))
+	           )`
       )
       .get(now.toISOString(), legacyLeaseCutoffIso) as { count?: number };
     return row.count ?? 0;

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -44,6 +44,9 @@ export interface ReleaseDatabaseStatus {
   providerDeferredReviewQueueJobCount?: number;
   retryableProviderDeferredReviewQueueJobCount?: number;
   failedReviewQueueJobCount?: number;
+  reviewRunLeaseCount?: number;
+  staleReviewRunLeaseCount?: number;
+  staleActiveReviewQueueJobCount?: number;
   reviewQueueJobsByRepo?: ReviewQueueRepoStatus[];
 }
 
@@ -128,6 +131,9 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     );
   const expiredProviderCooldownOk = retryableExpiredProviderCooldownCount === 0;
   const failedQueueJobsOk = (input.database.failedReviewQueueJobCount ?? 0) === 0;
+  const staleReviewLeaseCount = (input.database.staleReviewRunLeaseCount ?? 0) +
+    (input.database.staleActiveReviewQueueJobCount ?? 0);
+  const staleReviewLeasesOk = staleReviewLeaseCount === 0;
   const actionableProviderDeferredQueueJobs =
     input.budget?.providerDeferred.readyToRetry ??
     (input.database.retryableProviderDeferredReviewQueueJobCount ?? 0);
@@ -182,6 +188,13 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       detail: `${input.database.failedReviewQueueJobCount ?? 0} failed durable queue job(s)`
     },
     {
+      name: "queue_no_stale_review_leases",
+      ok: staleReviewLeasesOk,
+      detail:
+        `${input.database.staleReviewRunLeaseCount ?? 0} stale review run lease(s); ` +
+        `${input.database.staleActiveReviewQueueJobCount ?? 0} stale active queue job(s)`
+    },
+    {
       name: "queue_no_retryable_provider_deferred_jobs",
       ok: retryableDeferredQueueJobsOk,
       detail: describeProviderDeferredQueueStatus(input.database, input.budget)
@@ -207,14 +220,19 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     database: input.database,
     heartbeat: input.heartbeat,
     ...(input.budget ? { budget: input.budget } : {}),
-    recommendedActions: expiredProviderCooldownOk
-      ? retryableDeferredQueueJobsOk
-        ? []
-        : ["wait for the next scheduler cycle or inspect provider-deferred jobs marked ready_to_retry"]
-      : [
-          retryProviderCooldownCommand,
-          `npx tsx src/cli.ts provider-cooldowns --config ${input.configPath} --expired-only true`
-        ],
+    recommendedActions: [
+      ...(expiredProviderCooldownOk
+        ? retryableDeferredQueueJobsOk
+          ? []
+          : ["wait for the next scheduler cycle or inspect provider-deferred jobs marked ready_to_retry"]
+        : [
+            retryProviderCooldownCommand,
+            `npx tsx src/cli.ts provider-cooldowns --config ${input.configPath} --expired-only true`
+          ]),
+      ...(!staleReviewLeasesOk
+        ? [`npx tsx src/cli.ts clear-review-queue-leases --config ${input.configPath} --dry-run true --expired-only true`]
+        : [])
+    ],
     gates,
     rollback: {
       restartCommand: `launchctl kickstart -k gui/$(id -u)/${input.launchd.label}`,
@@ -456,6 +474,8 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
         : "none";
     const reviewerSessions = readReviewerSessionCounts(db, now);
     const reviewQueue = readReviewQueueCounts(db, now);
+    const reviewRunLeases = readReviewRunLeaseCounts(db, now);
+    const staleActiveReviewQueueJobCount = readStaleActiveReviewQueueJobCount(db, now, leaseTtlMs);
     return {
       rowCount: row.rowCount ?? 0,
       skippedCount: row.skippedCount ?? 0,
@@ -478,6 +498,9 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       providerDeferredReviewQueueJobCount: reviewQueue.providerDeferred,
       retryableProviderDeferredReviewQueueJobCount: reviewQueue.retryableProviderDeferred,
       failedReviewQueueJobCount: reviewQueue.failed,
+      reviewRunLeaseCount: reviewRunLeases.total,
+      staleReviewRunLeaseCount: reviewRunLeases.stale,
+      staleActiveReviewQueueJobCount,
       reviewQueueJobsByRepo: reviewQueue.byRepo,
       errorCount: row.errorCount ?? 0
     };
@@ -554,6 +577,64 @@ function readReviewQueueCounts(
       failed: repoRow.failed ?? 0
     }))
   };
+}
+
+function readReviewRunLeaseCounts(db: DatabaseSync, now: Date): { total: number; stale: number } {
+  const hasLeaseTable = db
+    .prepare("select 1 from sqlite_master where type = 'table' and name = 'review_run_leases' limit 1")
+    .get();
+  if (!hasLeaseTable) return { total: 0, stale: 0 };
+  const columns = new Set(
+    (db.prepare("pragma table_info(review_run_leases)").all() as unknown as Array<{ name: string }>)
+      .map((column) => column.name)
+  );
+  const ownerPidColumn = columns.has("owner_pid") ? "owner_pid" : "null as owner_pid";
+  const rows = db
+    .prepare(`select lease_id, expires_at, ${ownerPidColumn} from review_run_leases`)
+    .all() as unknown as Array<{ lease_id: string; expires_at: string; owner_pid: number | null }>;
+  return {
+    total: rows.length,
+    stale: rows.filter((row) => {
+      const expiresAtMs = Date.parse(row.expires_at);
+      if (!Number.isFinite(expiresAtMs) || expiresAtMs <= now.getTime()) return true;
+      return row.owner_pid !== null && !isProcessAlive(row.owner_pid);
+    }).length
+  };
+}
+
+function readStaleActiveReviewQueueJobCount(db: DatabaseSync, now: Date, leaseTtlMs: number): number {
+  const hasQueueTable = db
+    .prepare("select 1 from sqlite_master where type = 'table' and name = 'review_queue_jobs' limit 1")
+    .get();
+  if (!hasQueueTable) return 0;
+  const columns = new Set(
+    (db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>)
+      .map((column) => column.name)
+  );
+  if (columns.has("lease_expires_at")) {
+    const row = db
+      .prepare(
+        `select count(*) as count
+         from review_queue_jobs
+         where state in ('leased', 'running')
+           and (
+             lease_expires_at is null
+             or datetime(lease_expires_at) <= datetime(?)
+           )`
+      )
+      .get(now.toISOString()) as { count?: number };
+    return row.count ?? 0;
+  }
+  const legacyLeaseCutoffIso = new Date(now.getTime() - leaseTtlMs).toISOString();
+  const row = db
+    .prepare(
+      `select count(*) as count
+       from review_queue_jobs
+       where state in ('leased', 'running')
+         and datetime(updated_at) <= datetime(?)`
+    )
+    .get(legacyLeaseCutoffIso) as { count?: number };
+  return row.count ?? 0;
 }
 
 function readReviewerSessionCounts(

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -96,6 +96,17 @@ export interface ReleaseStatusInput {
 export interface ReleaseStatus {
   ok: boolean;
   checkedAt: string;
+  summary: {
+    blockingErrorRows: number;
+    failedQueueJobs: number;
+    staleReviewLeases: number;
+    providerDeferredQueueJobs: number;
+    retryableProviderDeferredQueueJobs: number;
+    readyToRetryProviderDeferredJobs: number;
+    expiredProviderCooldowns: number;
+    retryableExpiredProviderCooldowns: number;
+    activeProviderCooldowns: number;
+  };
   releaseUnit: {
     channel: "local-beta";
     sourceHead: string;
@@ -209,6 +220,17 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   return {
     ok: gates.every((gate) => gate.ok),
     checkedAt: (input.now ?? new Date()).toISOString(),
+    summary: {
+      blockingErrorRows: input.database.errorCount,
+      failedQueueJobs: input.database.failedReviewQueueJobCount ?? 0,
+      staleReviewLeases: staleReviewLeaseCount,
+      providerDeferredQueueJobs: input.database.providerDeferredReviewQueueJobCount ?? 0,
+      retryableProviderDeferredQueueJobs: input.database.retryableProviderDeferredReviewQueueJobCount ?? 0,
+      readyToRetryProviderDeferredJobs: actionableProviderDeferredQueueJobs,
+      expiredProviderCooldowns: input.database.expiredProviderCooldownCount ?? 0,
+      retryableExpiredProviderCooldowns: retryableExpiredProviderCooldownCount,
+      activeProviderCooldowns: input.database.activeProviderCooldownCount ?? 0
+    },
     releaseUnit: {
       channel: "local-beta",
       sourceHead: input.repo.head,
@@ -612,17 +634,18 @@ function readStaleActiveReviewQueueJobCount(db: DatabaseSync, now: Date, leaseTt
       .map((column) => column.name)
   );
   if (columns.has("lease_expires_at")) {
+    const legacyLeaseCutoffIso = new Date(now.getTime() - leaseTtlMs).toISOString();
     const row = db
       .prepare(
         `select count(*) as count
          from review_queue_jobs
          where state in ('leased', 'running')
            and (
-             lease_expires_at is null
-             or datetime(lease_expires_at) <= datetime(?)
+             (lease_expires_at is not null and datetime(lease_expires_at) <= datetime(?))
+             or (lease_expires_at is null and datetime(updated_at) <= datetime(?))
            )`
       )
-      .get(now.toISOString()) as { count?: number };
+      .get(now.toISOString(), legacyLeaseCutoffIso) as { count?: number };
     return row.count ?? 0;
   }
   const legacyLeaseCutoffIso = new Date(now.getTime() - leaseTtlMs).toISOString();

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -619,7 +619,7 @@ function readReviewRunLeaseCounts(db: DatabaseSync, now: Date): { total: number;
     stale: rows.filter((row) => {
       const expiresAtMs = Date.parse(row.expires_at);
       if (!Number.isFinite(expiresAtMs) || expiresAtMs <= now.getTime()) return true;
-      return row.owner_pid !== null && !isProcessAlive(row.owner_pid);
+      return row.owner_pid === null || !isProcessAlive(row.owner_pid);
     }).length
   };
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1160,6 +1160,7 @@ export class ReviewStateStore {
 
   clearReviewQueueLeases(input: {
     now?: Date;
+    leaseTtlMs?: number;
     expiredOnly?: boolean;
     dryRun?: boolean;
     repo?: string;
@@ -1171,16 +1172,19 @@ export class ReviewStateStore {
     const expiredOnly = input.expiredOnly ?? true;
     const dryRun = input.dryRun ?? true;
     const forceActive = input.forceActive ?? false;
+    const leaseTtlMs = input.leaseTtlMs ?? 15 * 60_000;
+    validatePositiveQueueLimit(leaseTtlMs, "leaseTtlMs");
     const checkedAtMs = Date.parse(checkedAt);
 
     this.db.exec("begin immediate");
     try {
       const runLeases = this.listReviewRunLeaseClearCandidates(checkedAt)
-        .filter((lease) => !expiredOnly || lease.staleReason);
+        .filter((lease) => lease.staleReason);
       const staleRunLeaseIds = new Set(runLeases.filter((lease) => lease.staleReason).map((lease) => lease.leaseId));
       const jobs = this.listReviewQueueLeaseClearCandidates({
         checkedAt,
         checkedAtMs,
+        leaseTtlMs,
         expiredOnly,
         forceActive,
         staleRunLeaseIds,
@@ -1190,7 +1194,7 @@ export class ReviewStateStore {
       });
       const matched = jobs.length + runLeases.length;
       const expiredMatched =
-        jobs.filter((job) => job.expired || job.staleReason === "missing_lease_expiry").length +
+        jobs.filter((job) => job.expired).length +
         runLeases.filter((lease) => lease.staleReason).length;
       const activeMatched = matched - expiredMatched;
       let requeued = 0;
@@ -1217,7 +1221,6 @@ export class ReviewStateStore {
           requeued += Number(result.changes);
         }
         for (const lease of runLeases) {
-          if (!lease.staleReason && !forceActive) continue;
           deletedRunLeases += Number(
             this.db.prepare("delete from review_run_leases where lease_id = ?").run(lease.leaseId).changes
           );
@@ -1907,6 +1910,7 @@ export class ReviewStateStore {
   private listReviewQueueLeaseClearCandidates(input: {
     checkedAt: string;
     checkedAtMs: number;
+    leaseTtlMs: number;
     expiredOnly: boolean;
     forceActive: boolean;
     staleRunLeaseIds: Set<string>;
@@ -1920,12 +1924,18 @@ export class ReviewStateStore {
       .filter((job) => !input.jobId || job.jobId === input.jobId)
       .map((job) => {
         const leaseExpiresAtMs = job.leaseExpiresAt ? Date.parse(job.leaseExpiresAt) : Number.NaN;
+        const updatedAtMs = Date.parse(job.updatedAt);
+        const legacyLeaseCutoffMs = input.checkedAtMs - input.leaseTtlMs;
+        const expiredByLeaseExpiry = job.leaseExpiresAt
+          ? !Number.isFinite(leaseExpiresAtMs) ||
+            (Number.isFinite(input.checkedAtMs) && leaseExpiresAtMs <= input.checkedAtMs)
+          : !Number.isFinite(updatedAtMs) ||
+            (Number.isFinite(input.checkedAtMs) && updatedAtMs <= legacyLeaseCutoffMs);
+        const expiredByStaleRunLease = Boolean(job.leaseId && input.staleRunLeaseIds.has(job.leaseId));
         const expired =
-          !job.leaseExpiresAt ||
-          !Number.isFinite(leaseExpiresAtMs) ||
-          (Number.isFinite(input.checkedAtMs) && leaseExpiresAtMs <= input.checkedAtMs) ||
-          Boolean(job.leaseId && input.staleRunLeaseIds.has(job.leaseId));
-        const staleReason: ReviewQueueLeaseClearCandidate["staleReason"] = !job.leaseExpiresAt
+          expiredByLeaseExpiry ||
+          expiredByStaleRunLease;
+        const staleReason: ReviewQueueLeaseClearCandidate["staleReason"] = !job.leaseExpiresAt && expiredByLeaseExpiry
           ? "missing_lease_expiry"
           : expired
             ? "expired"

--- a/src/state.ts
+++ b/src/state.ts
@@ -1178,24 +1178,29 @@ export class ReviewStateStore {
 
     this.db.exec("begin immediate");
     try {
-      const runLeases = this.listReviewRunLeaseClearCandidates(checkedAt)
-        .filter((lease) => lease.staleReason);
-      const staleRunLeaseIds = new Set(runLeases.filter((lease) => lease.staleReason).map((lease) => lease.leaseId));
-      const jobs = this.listReviewQueueLeaseClearCandidates({
-        checkedAt,
-        checkedAtMs,
+	      const staleRunLeases = this.listReviewRunLeaseClearCandidates(checkedAt)
+	        .filter((lease) => lease.staleReason);
+	      const staleRunLeaseIds = new Set(staleRunLeases.map((lease) => lease.leaseId));
+	      const jobs = this.listReviewQueueLeaseClearCandidates({
+	        checkedAt,
+	        checkedAtMs,
         leaseTtlMs,
         expiredOnly,
         forceActive,
         staleRunLeaseIds,
         repo: input.repo,
-        pullNumber: input.pullNumber,
-        jobId: input.jobId
-      });
-      const matched = jobs.length + runLeases.length;
-      const expiredMatched =
-        jobs.filter((job) => job.expired).length +
-        runLeases.filter((lease) => lease.staleReason).length;
+	        pullNumber: input.pullNumber,
+	        jobId: input.jobId
+	      });
+	      const hasQueueFilters = Boolean(input.repo || input.pullNumber !== undefined || input.jobId);
+	      const scopedJobLeaseIds = new Set(jobs.map((job) => job.leaseId).filter((leaseId): leaseId is string => Boolean(leaseId)));
+	      const runLeases = hasQueueFilters
+	        ? staleRunLeases.filter((lease) => scopedJobLeaseIds.has(lease.leaseId))
+	        : staleRunLeases;
+	      const matched = jobs.length + runLeases.length;
+	      const expiredMatched =
+	        jobs.filter((job) => job.expired).length +
+	        runLeases.length;
       const activeMatched = matched - expiredMatched;
       let requeued = 0;
       let deletedRunLeases = 0;

--- a/src/state.ts
+++ b/src/state.ts
@@ -114,6 +114,36 @@ export interface ClearIssueEnrichmentRunLeasesResult {
   leases: IssueEnrichmentRunLeaseClearCandidate[];
 }
 
+export interface ReviewRunLeaseClearCandidate extends ReviewRunLease {
+  expired: boolean;
+  ownerAlive: boolean;
+  staleReason?: "expired" | "owner_not_running";
+}
+
+export interface ReviewQueueLeaseClearCandidate extends ReviewQueueJobRecord {
+  expired: boolean;
+  active: boolean;
+  staleReason?: "expired" | "missing_lease_expiry" | "forced_active";
+}
+
+export interface ClearReviewQueueLeasesResult {
+  checkedAt: string;
+  expiredOnly: boolean;
+  dryRun: boolean;
+  filters: {
+    repo?: string;
+    pullNumber?: number;
+    jobId?: string;
+  };
+  matched: number;
+  expiredMatched: number;
+  activeMatched: number;
+  requeued: number;
+  deletedRunLeases: number;
+  jobs: ReviewQueueLeaseClearCandidate[];
+  runLeases: ReviewRunLeaseClearCandidate[];
+}
+
 export interface ReviewerSessionRecord {
   sessionId: string;
   repo: string;
@@ -1128,6 +1158,96 @@ export class ReviewStateStore {
     }
   }
 
+  clearReviewQueueLeases(input: {
+    now?: Date;
+    expiredOnly?: boolean;
+    dryRun?: boolean;
+    repo?: string;
+    pullNumber?: number;
+    jobId?: string;
+    forceActive?: boolean;
+  } = {}): ClearReviewQueueLeasesResult {
+    const checkedAt = (input.now ?? new Date()).toISOString();
+    const expiredOnly = input.expiredOnly ?? true;
+    const dryRun = input.dryRun ?? true;
+    const forceActive = input.forceActive ?? false;
+    const checkedAtMs = Date.parse(checkedAt);
+
+    this.db.exec("begin immediate");
+    try {
+      const runLeases = this.listReviewRunLeaseClearCandidates(checkedAt)
+        .filter((lease) => !expiredOnly || lease.staleReason);
+      const staleRunLeaseIds = new Set(runLeases.filter((lease) => lease.staleReason).map((lease) => lease.leaseId));
+      const jobs = this.listReviewQueueLeaseClearCandidates({
+        checkedAt,
+        checkedAtMs,
+        expiredOnly,
+        forceActive,
+        staleRunLeaseIds,
+        repo: input.repo,
+        pullNumber: input.pullNumber,
+        jobId: input.jobId
+      });
+      const matched = jobs.length + runLeases.length;
+      const expiredMatched =
+        jobs.filter((job) => job.expired || job.staleReason === "missing_lease_expiry").length +
+        runLeases.filter((lease) => lease.staleReason).length;
+      const activeMatched = matched - expiredMatched;
+      let requeued = 0;
+      let deletedRunLeases = 0;
+
+      if (!dryRun) {
+        for (const job of jobs) {
+          const result = this.db
+            .prepare(
+              `update review_queue_jobs
+               set state = 'queued',
+                   lease_id = null,
+                   lease_expires_at = null,
+                   last_error = ?,
+                   updated_at = ?
+               where job_id = ?
+                 and state in ('leased', 'running')`
+            )
+            .run(
+              `queue_lease_operator_requeued:${job.staleReason ?? "matched"}`,
+              checkedAt,
+              job.jobId
+            );
+          requeued += Number(result.changes);
+        }
+        for (const lease of runLeases) {
+          if (!lease.staleReason && !forceActive) continue;
+          deletedRunLeases += Number(
+            this.db.prepare("delete from review_run_leases where lease_id = ?").run(lease.leaseId).changes
+          );
+        }
+      }
+
+      this.db.exec("commit");
+      return {
+        checkedAt,
+        expiredOnly,
+        dryRun,
+        filters: {
+          ...(input.repo ? { repo: input.repo } : {}),
+          ...(input.pullNumber !== undefined ? { pullNumber: input.pullNumber } : {}),
+          ...(input.jobId ? { jobId: input.jobId } : {})
+        },
+        matched,
+        expiredMatched,
+        activeMatched,
+        requeued,
+        deletedRunLeases,
+        jobs,
+        runLeases
+      };
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
   assignReviewerSessionJob(input: {
     repo: string;
     pullNumber: number;
@@ -1753,6 +1873,73 @@ export class ReviewStateStore {
         this.db.prepare("delete from review_run_leases where lease_id = ?").run(row.lease_id);
       }
     }
+  }
+
+  private listReviewRunLeaseClearCandidates(checkedAt: string): ReviewRunLeaseClearCandidate[] {
+    const rows = this.db
+      .prepare("select lease_id, started_at, expires_at, owner_pid from review_run_leases order by datetime(expires_at) asc")
+      .all() as unknown as Array<{
+        lease_id: string;
+        expires_at: string;
+        owner_pid: number | null;
+      }>;
+    const checkedAtMs = Date.parse(checkedAt);
+    return rows.map((row) => {
+      const expiresAtMs = Date.parse(row.expires_at);
+      const expired = !Number.isFinite(expiresAtMs) || (Number.isFinite(checkedAtMs) && expiresAtMs <= checkedAtMs);
+      const ownerAlive = row.owner_pid === null ? false : isProcessAlive(row.owner_pid);
+      const staleReason = ownerAlive === false
+        ? "owner_not_running"
+        : expired
+          ? "expired"
+          : undefined;
+      return {
+        leaseId: row.lease_id,
+        expiresAt: row.expires_at,
+        ownerPid: row.owner_pid ?? 0,
+        expired,
+        ownerAlive,
+        ...(staleReason ? { staleReason } : {})
+      };
+    });
+  }
+
+  private listReviewQueueLeaseClearCandidates(input: {
+    checkedAt: string;
+    checkedAtMs: number;
+    expiredOnly: boolean;
+    forceActive: boolean;
+    staleRunLeaseIds: Set<string>;
+    repo?: string;
+    pullNumber?: number;
+    jobId?: string;
+  }): ReviewQueueLeaseClearCandidate[] {
+    return this.listReviewQueueJobs({ states: ["leased", "running"] })
+      .filter((job) => !input.repo || job.repo === input.repo)
+      .filter((job) => input.pullNumber === undefined || job.pullNumber === input.pullNumber)
+      .filter((job) => !input.jobId || job.jobId === input.jobId)
+      .map((job) => {
+        const leaseExpiresAtMs = job.leaseExpiresAt ? Date.parse(job.leaseExpiresAt) : Number.NaN;
+        const expired =
+          !job.leaseExpiresAt ||
+          !Number.isFinite(leaseExpiresAtMs) ||
+          (Number.isFinite(input.checkedAtMs) && leaseExpiresAtMs <= input.checkedAtMs) ||
+          Boolean(job.leaseId && input.staleRunLeaseIds.has(job.leaseId));
+        const staleReason: ReviewQueueLeaseClearCandidate["staleReason"] = !job.leaseExpiresAt
+          ? "missing_lease_expiry"
+          : expired
+            ? "expired"
+            : input.forceActive && !input.expiredOnly
+              ? "forced_active"
+              : undefined;
+        return {
+          ...job,
+          expired,
+          active: !expired,
+          ...(staleReason ? { staleReason } : {})
+        };
+      })
+      .filter((job) => job.expired || (!input.expiredOnly && input.forceActive));
   }
 
   private createReviewerSession(input: {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1432,10 +1432,23 @@ function releaseStatus(input: {
       sourceHead: "head",
       branch: "main",
       configPath: "/config/live.json"
-    },
-    repo: { branch: "main", head: "head", dirtyFiles: [] },
-    launchd: { label: "com.electricsheephq.evaos-code-review-bot", state: "running", pid: 1234, dryRun: false },
-    database: {
+	    },
+	    repo: { branch: "main", head: "head", dirtyFiles: [] },
+	    launchd: { label: "com.electricsheephq.evaos-code-review-bot", state: "running", pid: 1234, dryRun: false },
+	    summary: {
+	      blockingErrorRows: input.database?.errorCount ?? 0,
+	      failedQueueJobs: input.database?.failedReviewQueueJobCount ?? 0,
+	      staleReviewLeases:
+	        (input.database?.staleReviewRunLeaseCount ?? 0) +
+	        (input.database?.staleActiveReviewQueueJobCount ?? 0),
+	      providerDeferredQueueJobs: input.database?.providerDeferredReviewQueueJobCount ?? 0,
+	      retryableProviderDeferredQueueJobs: input.database?.retryableProviderDeferredReviewQueueJobCount ?? 0,
+	      readyToRetryProviderDeferredJobs: input.budget?.providerDeferred.readyToRetry ?? 0,
+	      expiredProviderCooldowns: expiredProviderCooldownCount,
+	      retryableExpiredProviderCooldowns: input.database?.retryableExpiredProviderCooldownCount ?? expiredProviderCooldownCount,
+	      activeProviderCooldowns: input.database?.activeProviderCooldownCount ?? 0
+	    },
+	    database: {
       rowCount: 10,
       errorCount: 0,
       providerCooldownCount,

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -452,6 +452,20 @@ describe("public NeonDiff CLI surface", () => {
         lastError: "provider_overloaded",
         now: new Date("2026-07-03T00:00:02.000Z")
       });
+      const coolingDown = store.enqueueReviewQueueJob({
+        repo: "owner/repo",
+        pullNumber: 124,
+        headSha: "head-cooling-down",
+        providerId: "GLM-5.2",
+        now: new Date("2026-07-03T00:00:00.000Z")
+      }).job;
+      store.updateReviewQueueJobState({
+        jobId: coolingDown.jobId,
+        state: "provider_deferred",
+        nextEligibleAt: "2999-01-01T00:00:00.000Z",
+        lastError: "provider_overloaded",
+        now: new Date("2026-07-03T00:00:02.000Z")
+      });
     } finally {
       store.close();
     }
@@ -471,19 +485,20 @@ describe("public NeonDiff CLI surface", () => {
         coverageOk: true,
         runtimeOk: false,
         healthState: "runtime_blocked",
-        durableQueue: {
-          summary: {
-            providerDeferred: 1,
-            retryableProviderDeferred: 1
-          }
-        }
+	        durableQueue: {
+	          summary: {
+	            providerDeferred: 2,
+	            retryableProviderDeferred: 1
+	          }
+	        }
       });
       expect(output.failedGates).toEqual([
         expect.objectContaining({ name: "queue_no_ready_provider_deferred_jobs" })
       ]);
-      expect(output.actionableRows).toEqual([
-        expect.objectContaining({ repo: "owner/repo", pullNumber: 123, state: "provider_deferred" })
-      ]);
+	      expect(output.actionableRows).toEqual([
+	        expect.objectContaining({ repo: "owner/repo", pullNumber: 123, state: "provider_deferred" })
+	      ]);
+	      expect(output.actionableRows.some((row: { pullNumber: number }) => row.pullNumber === 124)).toBe(false);
     }
   });
 

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -487,6 +487,101 @@ describe("public NeonDiff CLI surface", () => {
     }
   });
 
+  it("keeps queue --state provider_deferred blocked by global active provider capacity", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-queue-provider-deferred-capacity-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    const statePath = join(root, "state.sqlite");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence"),
+      reviewConcurrency: {
+        maxActiveRuns: 1,
+        leaseTtlMs: 24 * 60 * 60_000
+      },
+      reviewScheduler: {
+        enabled: true,
+        maxProviderActive: 1,
+        maxOrgActive: 1,
+        maxRepoActive: 1,
+        maxQueuedPerRepo: 10,
+        manualCommandReserve: 0,
+        backgroundPriority: 50
+      },
+      repoProfiles: {
+        repos: {
+          "owner/repo": { enabled: false }
+        }
+      }
+    })}\n`);
+    const store = new ReviewStateStore(statePath);
+    try {
+      store.enqueueReviewQueueJob({
+        repo: "other/repo",
+        pullNumber: 1,
+        headSha: "active-head",
+        providerId: "GLM-5.2",
+        now: new Date("2026-07-03T00:00:00.000Z")
+      });
+      store.leaseNextReviewQueueJobs({
+        maxProviderActive: 1,
+        maxOrgActive: 1,
+        maxRepoActive: 1,
+        leaseTtlMs: 24 * 60 * 60_000,
+        now: new Date("2026-07-03T00:00:01.000Z")
+      });
+      const deferred = store.enqueueReviewQueueJob({
+        repo: "owner/repo",
+        pullNumber: 123,
+        headSha: "head-provider-deferred",
+        providerId: "GLM-5.2",
+        now: new Date("2026-07-03T00:00:02.000Z")
+      }).job;
+      store.updateReviewQueueJobState({
+        jobId: deferred.jobId,
+        state: "provider_deferred",
+        nextEligibleAt: "2026-07-03T00:00:03.000Z",
+        lastError: "provider_overloaded",
+        now: new Date("2026-07-03T00:00:04.000Z")
+      });
+    } finally {
+      store.close();
+    }
+
+    try {
+      await runCli(["queue", "--config", configPath, "--state", "provider_deferred"]);
+      throw new Error("queue command unexpectedly passed");
+    } catch (error) {
+      const output = JSON.parse((error as { stdout: string }).stdout);
+      expect(output).toMatchObject({
+        ok: false,
+        runtimeOk: false,
+        durableQueue: {
+          summary: {
+            providerDeferred: 1,
+            retryableProviderDeferred: 1
+          }
+        },
+        budget: {
+          active: {
+            total: 1
+          },
+          providerDeferred: {
+            total: 1,
+            readyToRetry: 0,
+            waitingProviderCapacity: 1
+          }
+        }
+      });
+      expect(output.actionableRows).toEqual([]);
+      expect(output.failedGates).toEqual([
+        expect.objectContaining({ name: "queue_no_ready_provider_deferred_jobs" })
+      ]);
+    }
+  });
+
   it("keeps queue --repo health scoped to the requested repo", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-queue-health-scoped-"));
     roots.push(root);
@@ -612,7 +707,7 @@ describe("public NeonDiff CLI surface", () => {
     }
 
     try {
-      await runCli(["provider-cooldowns", "--config", configPath, "--expired-only", "true"]);
+      await runCli(["provider-cooldowns", "--config", configPath, "--expired-only", "true", "--repo", "owner/repo"]);
       throw new Error("provider-cooldowns command unexpectedly passed");
     } catch (error) {
       const stdout = (error as { stdout: string }).stdout;
@@ -701,7 +796,7 @@ describe("public NeonDiff CLI surface", () => {
     }
 
     try {
-      await runCli(["provider-cooldowns", "--config", configPath, "--expired-only", "true"]);
+      await runCli(["provider-cooldowns", "--config", configPath, "--expired-only", "true", "--repo", "owner/repo"]);
       throw new Error("provider-cooldowns command unexpectedly passed");
     } catch (error) {
       const stdout = (error as { stdout: string }).stdout;
@@ -710,6 +805,7 @@ describe("public NeonDiff CLI surface", () => {
         ok: false,
         runtimeOk: false,
         healthState: "provider_cooldowns_backpressured",
+        repo: "owner/repo",
         summary: {
           expired: 0,
           providerDeferredJobs: 1,
@@ -721,6 +817,83 @@ describe("public NeonDiff CLI surface", () => {
       expect(output.recommendedActions).toContain(
         "wait for active provider run to finish; retryable provider-deferred jobs are blocked by provider capacity"
       );
+    }
+  });
+
+  it("keeps provider-cooldowns backpressured under an active provider cooldown", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-provider-cooldown-active-window-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    const statePath = join(root, "state.sqlite");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence"),
+      reviewConcurrency: {
+        maxActiveRuns: 1,
+        leaseTtlMs: 24 * 60 * 60_000
+      },
+      reviewScheduler: {
+        enabled: true,
+        maxProviderActive: 1,
+        maxOrgActive: 1,
+        maxRepoActive: 1,
+        maxQueuedPerRepo: 10,
+        manualCommandReserve: 0,
+        backgroundPriority: 50
+      },
+      repoProfiles: {
+        repos: {
+          "owner/repo": { enabled: false }
+        }
+      }
+    })}\n`);
+    const store = new ReviewStateStore(statePath);
+    try {
+      store.recordRepoProviderCooldown({
+        repo: "other/repo",
+        cooldownUntil: new Date("2999-01-01T00:00:00.000Z"),
+        reason: "provider_overloaded"
+      });
+      const deferred = store.enqueueReviewQueueJob({
+        repo: "owner/repo",
+        pullNumber: 126,
+        headSha: "head-active-provider-cooldown",
+        providerId: "GLM-5.2",
+        now: new Date("2026-07-03T00:00:00.000Z")
+      }).job;
+      store.updateReviewQueueJobState({
+        jobId: deferred.jobId,
+        state: "provider_deferred",
+        nextEligibleAt: "2026-07-03T00:00:01.000Z",
+        lastError: "provider_overloaded",
+        now: new Date("2026-07-03T00:00:02.000Z")
+      });
+    } finally {
+      store.close();
+    }
+
+    try {
+      await runCli(["provider-cooldowns", "--config", configPath, "--expired-only", "true", "--repo", "owner/repo"]);
+      throw new Error("provider-cooldowns command unexpectedly passed");
+    } catch (error) {
+      const output = JSON.parse((error as { stdout: string }).stdout);
+      expect(output).toMatchObject({
+        ok: false,
+        runtimeOk: false,
+        healthState: "provider_cooldowns_backpressured",
+        summary: {
+          activeProviderCooldowns: 1,
+          providerDeferredJobs: 1,
+          retryableProviderDeferredJobs: 1,
+          readyToRetryProviderDeferredJobs: 1
+        }
+      });
+      expect(output.recommendedActions).toContain(
+        "wait for active provider cooldown to expire before retrying provider-deferred work"
+      );
+      expect(output.recommendedActions.some((action: string) => action.includes("retry-provider-cooldowns"))).toBe(false);
     }
   });
 

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -417,6 +417,19 @@ describe("public NeonDiff CLI surface", () => {
       workRoot: join(root, "runtime"),
       statePath,
       evidenceDir: join(root, "evidence"),
+      reviewConcurrency: {
+        maxActiveRuns: 1,
+        leaseTtlMs: 24 * 60 * 60_000
+      },
+      reviewScheduler: {
+        enabled: true,
+        maxProviderActive: 1,
+        maxOrgActive: 1,
+        maxRepoActive: 1,
+        maxQueuedPerRepo: 10,
+        manualCommandReserve: 0,
+        backgroundPriority: 50
+      },
       repoProfiles: {
         repos: {
           "owner/repo": { enabled: false }
@@ -471,6 +484,168 @@ describe("public NeonDiff CLI surface", () => {
       expect(output.actionableRows).toEqual([
         expect.objectContaining({ repo: "owner/repo", pullNumber: 123, state: "provider_deferred" })
       ]);
+    }
+  });
+
+  it("marks provider-cooldowns blocked when retryable durable provider-deferred work exists", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-provider-cooldown-health-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    const statePath = join(root, "state.sqlite");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence"),
+      reviewConcurrency: {
+        maxActiveRuns: 1,
+        leaseTtlMs: 24 * 60 * 60_000
+      },
+      reviewScheduler: {
+        enabled: true,
+        maxProviderActive: 1,
+        maxOrgActive: 1,
+        maxRepoActive: 1,
+        maxQueuedPerRepo: 10,
+        manualCommandReserve: 0,
+        backgroundPriority: 50
+      },
+      repoProfiles: {
+        repos: {
+          "owner/repo": { enabled: false }
+        }
+      }
+    })}\n`);
+    const store = new ReviewStateStore(statePath);
+    try {
+      const job = store.enqueueReviewQueueJob({
+        repo: "owner/repo",
+        pullNumber: 124,
+        headSha: "head-provider-deferred",
+        providerId: "GLM-5.2",
+        now: new Date("2026-07-03T00:00:00.000Z")
+      }).job;
+      store.updateReviewQueueJobState({
+        jobId: job.jobId,
+        state: "provider_deferred",
+        nextEligibleAt: "2026-07-03T00:00:01.000Z",
+        lastError: "provider_overloaded",
+        now: new Date("2026-07-03T00:00:02.000Z")
+      });
+    } finally {
+      store.close();
+    }
+
+    try {
+      await runCli(["provider-cooldowns", "--config", configPath, "--expired-only", "true"]);
+      throw new Error("provider-cooldowns command unexpectedly passed");
+    } catch (error) {
+      const stdout = (error as { stdout: string }).stdout;
+      const output = JSON.parse(stdout);
+      expect(output).toMatchObject({
+        ok: false,
+        runtimeOk: false,
+        healthState: "provider_cooldowns_actionable",
+        summary: {
+          expired: 0,
+          providerDeferredJobs: 1,
+          retryableProviderDeferredJobs: 1,
+          readyToRetryProviderDeferredJobs: 1
+        }
+      });
+      expect(output.failedGates).toEqual([
+        expect.objectContaining({ name: "provider_cooldowns_no_retryable_provider_deferred_jobs" })
+      ]);
+      expect(output.recommendedActions).toEqual([
+        expect.stringContaining("retry-provider-cooldowns")
+      ]);
+    }
+  });
+
+  it("reports provider-cooldowns backpressured when retryable work waits on active provider capacity", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-provider-cooldown-backpressure-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    const statePath = join(root, "state.sqlite");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence"),
+      reviewConcurrency: {
+        maxActiveRuns: 1,
+        leaseTtlMs: 24 * 60 * 60_000
+      },
+      reviewScheduler: {
+        enabled: true,
+        maxProviderActive: 1,
+        maxOrgActive: 1,
+        maxRepoActive: 1,
+        maxQueuedPerRepo: 10,
+        manualCommandReserve: 0,
+        backgroundPriority: 50
+      },
+      repoProfiles: {
+        repos: {
+          "owner/repo": { enabled: false }
+        }
+      }
+    })}\n`);
+    const store = new ReviewStateStore(statePath);
+    try {
+      store.enqueueReviewQueueJob({
+        repo: "other/repo",
+        pullNumber: 1,
+        headSha: "active-head",
+        providerId: "GLM-5.2",
+        now: new Date("2026-07-03T00:00:00.000Z")
+      });
+      store.leaseNextReviewQueueJobs({
+        maxProviderActive: 1,
+        maxOrgActive: 1,
+        maxRepoActive: 1,
+        leaseTtlMs: 24 * 60 * 60_000,
+        now: new Date("2026-07-03T00:00:01.000Z")
+      });
+      const deferred = store.enqueueReviewQueueJob({
+        repo: "owner/repo",
+        pullNumber: 125,
+        headSha: "head-provider-backpressured",
+        providerId: "GLM-5.2",
+        now: new Date("2026-07-03T00:00:02.000Z")
+      }).job;
+      store.updateReviewQueueJobState({
+        jobId: deferred.jobId,
+        state: "provider_deferred",
+        nextEligibleAt: "2026-07-03T00:00:03.000Z",
+        lastError: "provider_overloaded",
+        now: new Date("2026-07-03T00:00:04.000Z")
+      });
+    } finally {
+      store.close();
+    }
+
+    try {
+      await runCli(["provider-cooldowns", "--config", configPath, "--expired-only", "true"]);
+      throw new Error("provider-cooldowns command unexpectedly passed");
+    } catch (error) {
+      const stdout = (error as { stdout: string }).stdout;
+      const output = JSON.parse(stdout);
+      expect(output).toMatchObject({
+        ok: false,
+        runtimeOk: false,
+        healthState: "provider_cooldowns_backpressured",
+        summary: {
+          expired: 0,
+          providerDeferredJobs: 1,
+          retryableProviderDeferredJobs: 1,
+          readyToRetryProviderDeferredJobs: 0,
+          waitingProviderCapacity: 1
+        }
+      });
+      expect(output.recommendedActions).toContain(
+        "wait for active provider run to finish; retryable provider-deferred jobs are blocked by provider capacity"
+      );
     }
   });
 

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -487,6 +487,81 @@ describe("public NeonDiff CLI surface", () => {
     }
   });
 
+  it("keeps queue --repo health scoped to the requested repo", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-queue-health-scoped-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    const statePath = join(root, "state.sqlite");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence"),
+      reviewScheduler: {
+        enabled: true,
+        maxProviderActive: 1,
+        maxOrgActive: 1,
+        maxRepoActive: 1,
+        maxQueuedPerRepo: 10,
+        manualCommandReserve: 0,
+        backgroundPriority: 50
+      },
+      repoProfiles: {
+        repos: {
+          "owner/repo": { enabled: false }
+        }
+      }
+    })}\n`);
+    const store = new ReviewStateStore(statePath);
+    try {
+      const job = store.enqueueReviewQueueJob({
+        repo: "other/repo",
+        pullNumber: 999,
+        headSha: "other-head-ready",
+        providerId: "GLM-5.2",
+        now: new Date("2026-07-03T00:00:00.000Z")
+      }).job;
+      store.updateReviewQueueJobState({
+        jobId: job.jobId,
+        state: "provider_deferred",
+        nextEligibleAt: "2026-07-03T00:00:01.000Z",
+        lastError: "provider_overloaded",
+        now: new Date("2026-07-03T00:00:02.000Z")
+      });
+    } finally {
+      store.close();
+    }
+
+    let output: Record<string, any>;
+    try {
+      await runCli(["queue", "--config", configPath, "--repo", "owner/repo"]);
+      throw new Error("queue command unexpectedly passed");
+    } catch (error) {
+      output = JSON.parse((error as { stdout: string }).stdout);
+    }
+    expect(output).toMatchObject({
+      ok: false,
+      coverageOk: false,
+      runtimeOk: false,
+      durableQueue: {
+        summary: {
+          total: 0,
+          providerDeferred: 0,
+          retryableProviderDeferred: 0
+        }
+      },
+      budget: {
+        providerDeferred: {
+          total: 0,
+          readyToRetry: 0
+        }
+      }
+    });
+    expect(output.failedGates).toEqual([
+      expect.objectContaining({ name: "queue_coverage_ok" })
+    ]);
+  });
+
   it("marks provider-cooldowns blocked when retryable durable provider-deferred work exists", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-provider-cooldown-health-"));
     roots.push(root);

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
+import { ReviewStateStore } from "../src/state.js";
 
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
@@ -47,6 +48,20 @@ describe("public NeonDiff CLI surface", () => {
     ]);
     expect(output.examples).toContain("neondiff init --config config.local.json");
     expect(output.examples).toContain("npx tsx src/cli.ts daemon --config /path/to/live.json --dry-run true --once true");
+  });
+
+  it("prints command help without executing run-once, review-pr, or daemon paths", async () => {
+    for (const args of [["run-once", "--help"], ["review-pr", "help"], ["daemon", "start", "-h"]]) {
+      const { stdout } = await runCli(args);
+      const output = JSON.parse(stdout);
+
+      expect(output.ok).toBe(true);
+      expect(output.command).toBe(args[0]);
+      expect(output.commands.existing).toContain("run-once");
+      expect(output.commands.public).toContain("review-pr");
+      expect(stdout).not.toContain("\"dryRun\"");
+      expect(stdout).not.toContain("\"reposScanned\"");
+    }
   });
 
   it("initializes a local config from the packaged example outside the repo cwd", async () => {
@@ -390,6 +405,73 @@ describe("public NeonDiff CLI surface", () => {
     ])).rejects.toMatchObject({
       stdout: expect.stringContaining("requires --repo and --pr")
     });
+  });
+
+  it("marks queue output blocked when durable provider-deferred work is ready even if coverage is scoped-ok", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-queue-health-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    const statePath = join(root, "state.sqlite");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence"),
+      repoProfiles: {
+        repos: {
+          "owner/repo": { enabled: false }
+        }
+      }
+    })}\n`);
+    const store = new ReviewStateStore(statePath);
+    try {
+      const job = store.enqueueReviewQueueJob({
+        repo: "owner/repo",
+        pullNumber: 123,
+        headSha: "head-ready",
+        providerId: "GLM-5.2",
+        now: new Date("2026-07-03T00:00:00.000Z")
+      }).job;
+      store.updateReviewQueueJobState({
+        jobId: job.jobId,
+        state: "provider_deferred",
+        nextEligibleAt: "2026-07-03T00:00:01.000Z",
+        lastError: "provider_overloaded",
+        now: new Date("2026-07-03T00:00:02.000Z")
+      });
+    } finally {
+      store.close();
+    }
+
+    await expect(runCli(["queue", "--config", configPath, "--state", "provider_deferred"])).rejects.toMatchObject({
+      stdout: expect.stringContaining("\"runtimeOk\": false")
+    });
+
+    try {
+      await runCli(["queue", "--config", configPath, "--state", "provider_deferred"]);
+      throw new Error("queue command unexpectedly passed");
+    } catch (error) {
+      const stdout = (error as { stdout: string }).stdout;
+      const output = JSON.parse(stdout);
+      expect(output).toMatchObject({
+        ok: false,
+        coverageOk: true,
+        runtimeOk: false,
+        healthState: "runtime_blocked",
+        durableQueue: {
+          summary: {
+            providerDeferred: 1,
+            retryableProviderDeferred: 1
+          }
+        }
+      });
+      expect(output.failedGates).toEqual([
+        expect.objectContaining({ name: "queue_no_ready_provider_deferred_jobs" })
+      ]);
+      expect(output.actionableRows).toEqual([
+        expect.objectContaining({ repo: "owner/repo", pullNumber: 123, state: "provider_deferred" })
+      ]);
+    }
   });
 
   it("prints launchd daemon control plans in dry-run mode by default", async () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1229,6 +1229,89 @@ describe("beta release status", () => {
     });
   });
 
+  it("flags malformed active review queue lease expiries as stale", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-malformed-review-lease-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          lease_expires_at text,
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, lease_id, lease_expires_at, created_at, updated_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, 'running', ?, ?, ?, ?)`
+      ).run(
+        "malformed-running",
+        "automatic:electricsheephq/evaos-code-review-bot#176@head-malformed",
+        "electricsheephq/evaos-code-review-bot",
+        "electricsheephq",
+        176,
+        "head-malformed",
+        "queue-lease-malformed",
+        "not-a-date",
+        "2026-07-03T08:00:00.000Z",
+        "2026-07-03T08:00:59.000Z"
+      );
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-03T08:01:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.database.staleActiveReviewQueueJobCount).toBe(1);
+    expect(status.gates).toContainEqual({
+      name: "queue_no_stale_review_leases",
+      ok: false,
+      detail: "0 stale review run lease(s); 1 stale active queue job(s)"
+    });
+  });
+
   it("filters terminal queue rows and preserves active jobs before applying the budget row cap", () => {
     const root = mkdtempSync(join(tmpdir(), "release-status-budget-cap-terminal-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -72,6 +72,11 @@ describe("beta release status", () => {
       sourceHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-live.json"
     });
+    expect(status.summary).toMatchObject({
+      blockingErrorRows: 0,
+      failedQueueJobs: 0,
+      staleReviewLeases: 0
+    });
     expect(JSON.stringify(status)).not.toMatch(/PRIVATE KEY|ghp_|BEGIN RSA|BEGIN OPENSSH/);
   });
 
@@ -1141,6 +1146,87 @@ describe("beta release status", () => {
     expect(status.recommendedActions).toContain(
       "npx tsx src/cli.ts clear-review-queue-leases --config (default config) --dry-run true --expired-only true"
     );
+  });
+
+  it("does not flag fresh legacy null review queue leases before the TTL expires", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-fresh-null-review-lease-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          lease_expires_at text,
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, lease_id, lease_expires_at, created_at, updated_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, 'running', ?, null, ?, ?)`
+      ).run(
+        "fresh-null-running",
+        "automatic:electricsheephq/evaos-code-review-bot#176@head-null",
+        "electricsheephq/evaos-code-review-bot",
+        "electricsheephq",
+        176,
+        "head-null",
+        "queue-lease-fresh-null",
+        "2026-07-03T08:00:00.000Z",
+        "2026-07-03T08:00:59.000Z"
+      );
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-03T08:01:00.000Z")
+    });
+
+    expect(status.database.staleActiveReviewQueueJobCount).toBe(0);
+    expect(status.gates).toContainEqual({
+      name: "queue_no_stale_review_leases",
+      ok: true,
+      detail: "0 stale review run lease(s); 0 stale active queue job(s)"
+    });
   });
 
   it("filters terminal queue rows and preserves active jobs before applying the budget row cap", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1044,6 +1044,105 @@ describe("beta release status", () => {
     expect(status.recommendedActions).not.toContain("wait for the next scheduler cycle or inspect provider-deferred jobs marked ready_to_retry");
   });
 
+  it("recommends review queue lease cleanup when stale run leases or active queue leases exist", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-stale-review-leases-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_run_leases (
+          lease_id text primary key,
+          started_at text not null,
+          expires_at text not null,
+          owner_pid integer
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          lease_expires_at text,
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      db.prepare("insert into review_run_leases (lease_id, started_at, expires_at, owner_pid) values (?, ?, ?, ?)")
+        .run("dead-owner", "2026-07-03T08:00:00.000Z", "2026-07-03T09:00:00.000Z", 999_999_999);
+      db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, lease_id, lease_expires_at, created_at, updated_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, 'running', ?, ?, ?, ?)`
+      ).run(
+        "stale-running",
+        "automatic:electricsheephq/evaos-code-review-bot#174@head-a",
+        "electricsheephq/evaos-code-review-bot",
+        "electricsheephq",
+        174,
+        "head-a",
+        "queue-lease-expired",
+        "2026-07-03T08:00:10.000Z",
+        "2026-07-03T08:00:00.000Z",
+        "2026-07-03T08:00:00.000Z"
+      );
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-03T08:01:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.database).toMatchObject({
+      reviewRunLeaseCount: 1,
+      staleReviewRunLeaseCount: 1,
+      staleActiveReviewQueueJobCount: 1
+    });
+    expect(status.gates).toContainEqual({
+      name: "queue_no_stale_review_leases",
+      ok: false,
+      detail: "1 stale review run lease(s); 1 stale active queue job(s)"
+    });
+    expect(status.recommendedActions).toContain(
+      "npx tsx src/cli.ts clear-review-queue-leases --config (default config) --dry-run true --expired-only true"
+    );
+  });
+
   it("filters terminal queue rows and preserves active jobs before applying the budget row cap", () => {
     const root = mkdtempSync(join(tmpdir(), "release-status-budget-cap-terminal-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -6,6 +6,7 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { buildReleaseStatus, collectReleaseStatus } from "../src/release-status.js";
 import type { ReviewBudgetStatus } from "../src/review-budget.js";
+import { ReviewStateStore } from "../src/state.js";
 
 describe("beta release status", () => {
   const roots: string[] = [];
@@ -1146,6 +1147,39 @@ describe("beta release status", () => {
     expect(status.recommendedActions).toContain(
       "npx tsx src/cli.ts clear-review-queue-leases --config (default config) --dry-run true --expired-only true"
     );
+  });
+
+  it("counts fresh null-owner review run leases as stale", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-null-owner-run-lease-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const store = new ReviewStateStore(dbPath);
+    store.close();
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.prepare("insert into review_run_leases (lease_id, started_at, expires_at, owner_pid) values (?, ?, ?, ?)")
+        .run("null-owner", "2026-07-03T08:00:00.000Z", "2026-07-03T09:00:00.000Z", null);
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-03T08:01:00.000Z")
+    });
+
+    expect(status.database).toMatchObject({
+      reviewRunLeaseCount: 1,
+      staleReviewRunLeaseCount: 1
+    });
+    expect(status.gates).toContainEqual({
+      name: "queue_no_stale_review_leases",
+      ok: false,
+      detail: "1 stale review run lease(s); 0 stale active queue job(s)"
+    });
   });
 
   it("does not flag fresh legacy null review queue leases before the TTL expires", () => {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -988,6 +988,167 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("dry-runs and clears expired review queue leases without manual SQL", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-lease-clear-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const job = store.enqueueReviewQueueJob({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 174,
+      headSha: "head-a",
+      providerId: "zai",
+      now: new Date("2026-07-03T08:00:00.000Z")
+    }).job;
+    const leased = store.leaseNextReviewQueueJobs({
+      maxProviderActive: 1,
+      maxOrgActive: 1,
+      maxRepoActive: 1,
+      leaseTtlMs: 1_000,
+      now: new Date("2026-07-03T08:00:01.000Z")
+    })[0]!;
+
+    const dryRun = store.clearReviewQueueLeases({
+      dryRun: true,
+      expiredOnly: true,
+      now: new Date("2026-07-03T08:00:02.001Z")
+    });
+    expect(dryRun).toMatchObject({
+      dryRun: true,
+      expiredOnly: true,
+      matched: 1,
+      expiredMatched: 1,
+      activeMatched: 0,
+      requeued: 0,
+      jobs: [
+        expect.objectContaining({
+          jobId: job.jobId,
+          state: "leased",
+          staleReason: "expired"
+        })
+      ]
+    });
+    expect(store.getReviewQueueJob(job.jobId)).toMatchObject({ state: "leased", leaseId: leased.leaseId });
+
+    const cleared = store.clearReviewQueueLeases({
+      dryRun: false,
+      expiredOnly: true,
+      now: new Date("2026-07-03T08:00:02.002Z")
+    });
+    expect(cleared).toMatchObject({ dryRun: false, matched: 1, expiredMatched: 1, requeued: 1 });
+    expect(store.getReviewQueueJob(job.jobId)).toMatchObject({
+      state: "queued",
+      lastError: "queue_lease_operator_requeued:expired"
+    });
+    expect(store.getReviewQueueJob(job.jobId)?.leaseId).toBeUndefined();
+    store.close();
+  });
+
+  it("requires force-active semantics before requeueing active review queue leases", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-force-active-clear-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const job = store.enqueueReviewQueueJob({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 175,
+      headSha: "head-active",
+      providerId: "zai",
+      now: new Date("2026-07-03T08:10:00.000Z")
+    }).job;
+    const leased = store.leaseNextReviewQueueJobs({
+      maxProviderActive: 1,
+      maxOrgActive: 1,
+      maxRepoActive: 1,
+      leaseTtlMs: 60_000,
+      now: new Date("2026-07-03T08:10:01.000Z")
+    })[0]!;
+
+    expect(store.clearReviewQueueLeases({
+      dryRun: true,
+      expiredOnly: true,
+      now: new Date("2026-07-03T08:10:02.000Z")
+    })).toMatchObject({ matched: 0, activeMatched: 0 });
+
+    const forcedDryRun = store.clearReviewQueueLeases({
+      dryRun: true,
+      expiredOnly: false,
+      forceActive: true,
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 175,
+      now: new Date("2026-07-03T08:10:02.000Z")
+    });
+    expect(forcedDryRun).toMatchObject({
+      matched: 1,
+      expiredMatched: 0,
+      activeMatched: 1,
+      requeued: 0,
+      filters: {
+        repo: "electricsheephq/evaos-code-review-bot",
+        pullNumber: 175
+      },
+      jobs: [
+        expect.objectContaining({
+          jobId: job.jobId,
+          active: true,
+          staleReason: "forced_active"
+        })
+      ]
+    });
+    expect(store.getReviewQueueJob(job.jobId)).toMatchObject({ state: "leased", leaseId: leased.leaseId });
+
+    const cleared = store.clearReviewQueueLeases({
+      dryRun: false,
+      expiredOnly: false,
+      forceActive: true,
+      jobId: job.jobId,
+      now: new Date("2026-07-03T08:10:03.000Z")
+    });
+    expect(cleared).toMatchObject({ matched: 1, activeMatched: 1, requeued: 1 });
+    expect(store.getReviewQueueJob(job.jobId)).toMatchObject({
+      state: "queued",
+      lastError: "queue_lease_operator_requeued:forced_active"
+    });
+    store.close();
+  });
+
+  it("deletes stale review run leases owned by dead workers", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-run-lease-clear-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const lease = store.tryAcquireReviewRunLease(
+      1,
+      60_000,
+      new Date("2026-07-03T08:20:00.000Z"),
+      999_999_999
+    );
+
+    const dryRun = store.clearReviewQueueLeases({
+      dryRun: true,
+      expiredOnly: true,
+      now: new Date("2026-07-03T08:20:01.000Z")
+    });
+    expect(dryRun).toMatchObject({
+      matched: 1,
+      expiredMatched: 1,
+      deletedRunLeases: 0,
+      runLeases: [
+        expect.objectContaining({
+          leaseId: lease!.leaseId,
+          ownerAlive: false,
+          staleReason: "owner_not_running"
+        })
+      ]
+    });
+
+    const cleared = store.clearReviewQueueLeases({
+      dryRun: false,
+      expiredOnly: true,
+      now: new Date("2026-07-03T08:20:02.000Z")
+    });
+    expect(cleared).toMatchObject({ matched: 1, deletedRunLeases: 1 });
+    expect(store.tryAcquireReviewRunLease(1, 60_000, new Date("2026-07-03T08:20:03.000Z"), process.pid)).toBeDefined();
+    store.close();
+  });
+
   it("defers and later leases provider-deferred queue jobs after next eligible time", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-deferred-"));
     roots.push(root);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1047,6 +1047,13 @@ describe("review state store", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-force-active-clear-"));
     roots.push(root);
     const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const runLease = store.tryAcquireReviewRunLease(
+      1,
+      60_000,
+      new Date("2026-07-03T08:10:00.000Z"),
+      process.pid
+    );
+    expect(runLease).toBeDefined();
     const job = store.enqueueReviewQueueJob({
       repo: "electricsheephq/evaos-code-review-bot",
       pullNumber: 175,
@@ -1101,11 +1108,65 @@ describe("review state store", () => {
       forceActive: true,
       jobId: job.jobId,
       now: new Date("2026-07-03T08:10:03.000Z")
+	    });
+	    expect(cleared).toMatchObject({ matched: 1, activeMatched: 1, requeued: 1, deletedRunLeases: 0, runLeases: [] });
+	    expect(store.getReviewQueueJob(job.jobId)).toMatchObject({
+	      state: "queued",
+	      lastError: "queue_lease_operator_requeued:forced_active"
+	    });
+	    expect(store.tryAcquireReviewRunLease(1, 60_000, new Date("2026-07-03T08:10:04.000Z"), process.pid)).toBeUndefined();
+	    store.close();
+	  });
+
+  it("uses the queue lease TTL fallback for fresh legacy null lease expiries", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-null-lease-fallback-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const store = new ReviewStateStore(dbPath);
+    const job = store.enqueueReviewQueueJob({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 176,
+      headSha: "head-null-expiry",
+      providerId: "zai",
+      now: new Date("2026-07-03T08:30:00.000Z")
+    }).job;
+    store.leaseNextReviewQueueJobs({
+      maxProviderActive: 1,
+      maxOrgActive: 1,
+      maxRepoActive: 1,
+      leaseTtlMs: 60_000,
+      now: new Date("2026-07-03T08:30:01.000Z")
     });
-    expect(cleared).toMatchObject({ matched: 1, activeMatched: 1, requeued: 1 });
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.prepare("update review_queue_jobs set lease_expires_at = null, updated_at = ? where job_id = ?")
+        .run("2026-07-03T08:30:01.000Z", job.jobId);
+    } finally {
+      db.close();
+    }
+
+    expect(store.clearReviewQueueLeases({
+      dryRun: true,
+      expiredOnly: true,
+      leaseTtlMs: 60_000,
+      now: new Date("2026-07-03T08:30:30.000Z")
+    })).toMatchObject({ matched: 0, expiredMatched: 0 });
+
+    const expired = store.clearReviewQueueLeases({
+      dryRun: false,
+      expiredOnly: true,
+      leaseTtlMs: 60_000,
+      now: new Date("2026-07-03T08:31:01.001Z")
+    });
+    expect(expired).toMatchObject({
+      matched: 1,
+      expiredMatched: 1,
+      requeued: 1,
+      jobs: [expect.objectContaining({ jobId: job.jobId, staleReason: "missing_lease_expiry" })]
+    });
     expect(store.getReviewQueueJob(job.jobId)).toMatchObject({
       state: "queued",
-      lastError: "queue_lease_operator_requeued:forced_active"
+      lastError: "queue_lease_operator_requeued:missing_lease_expiry"
     });
     store.close();
   });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1210,6 +1210,46 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("does not delete unrelated stale run leases during scoped queue cleanup", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-run-lease-scoped-clear-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const lease = store.tryAcquireReviewRunLease(
+      1,
+      60_000,
+      new Date("2026-07-03T08:25:00.000Z"),
+      999_999_999
+    );
+    expect(lease).toBeDefined();
+    store.enqueueReviewQueueJob({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 176,
+      headSha: "head-scoped",
+      providerId: "zai",
+      now: new Date("2026-07-03T08:25:00.000Z")
+    });
+
+    const scoped = store.clearReviewQueueLeases({
+      dryRun: false,
+      expiredOnly: true,
+      repo: "electricsheephq/evaos-code-review-bot",
+      now: new Date("2026-07-03T08:25:01.000Z")
+    });
+    expect(scoped).toMatchObject({ matched: 0, deletedRunLeases: 0, runLeases: [] });
+
+    const unscoped = store.clearReviewQueueLeases({
+      dryRun: false,
+      expiredOnly: true,
+      now: new Date("2026-07-03T08:25:02.000Z")
+    });
+    expect(unscoped).toMatchObject({
+      matched: 1,
+      deletedRunLeases: 1,
+      runLeases: [expect.objectContaining({ leaseId: lease!.leaseId, staleReason: "owner_not_running" })]
+    });
+    store.close();
+  });
+
   it("defers and later leases provider-deferred queue jobs after next eligible time", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-deferred-"));
     roots.push(root);


### PR DESCRIPTION
## Summary

- Fix command-specific help so `run-once --help`, `review-pr help`, and daemon help print CLI usage without loading config or executing worker paths.
- Make queue/provider/operator health surfaces agree on provider-deferred and stale-lease runtime blockers, with explicit `runtimeOk`, `failedGates`, `recommendedActions`, and actionable queue rows.
- Add `clear-review-queue-leases` as a dry-run-first operator cleanup command for stale run leases and orphaned active PR review queue leases after launchd restarts.

## Root Cause

Provider-deferred and stale queue lease state was represented differently across `coverage-audit`, `queue`, `budget-status`, `provider-cooldowns`, and `release-status`, so one surface could look green while another correctly blocked runtime. Separately, nested command help was parsed too late, after command execution branches were already selected.

## Validation

- `npm test -- tests/public-cli.test.ts tests/state.test.ts tests/release-status.test.ts tests/operator-cli.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- `node /Volumes/LEXAR/repos/evaos-code-review-bot/node_modules/tsx/dist/cli.mjs src/cli.ts run-once --help`
- `node /Volumes/LEXAR/repos/evaos-code-review-bot/node_modules/tsx/dist/cli.mjs src/cli.ts clear-review-queue-leases --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --dry-run true --expired-only true`

Closes #168.
Closes #173.
Closes #175.
