### PR TITLE
[codex] Gate launchd system CA in release status

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -97,6 +97,9 @@ banner to stdout.
 - `npm test` and `npm run build` pass from the release checkout.
 - `release:status` records exact source SHA, branch, config path, launchd job,
   launchd dry-run mode, state DB row count, and error count.
+- `release:status` verifies the loaded LaunchAgent includes
+  `NODE_OPTIONS=--use-system-ca` so Node uses the macOS system trust store for
+  GitHub App installation fetches.
 - launchd emits a fresh heartbeat after restart.
 - live DB has no unexpected error rows.
 - active provider cooldown rows are allowed only when they are explicit

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -21,6 +21,26 @@ npm run daemon -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/can
 
 When installed as a LaunchAgent, write stdout/stderr to `~/Library/Logs/evaos-code-review-bot/`. On this Mac, launchd failed with `EX_CONFIG` when those paths pointed directly at the Lexar volume; copy the local launch logs into the Lexar evidence packet after each proof window.
 
+Set `NODE_OPTIONS=--use-system-ca` in the LaunchAgent environment. Without this
+flag, launchd-started Node processes may fail GitHub App installation reads with
+`unable to verify the first certificate` even while the same CLI commands work
+from an interactive shell. `release:status` reports the loaded launchd
+environment and fails when launchd explicitly omits this option.
+
+Minimum LaunchAgent environment block:
+
+```xml
+<key>EnvironmentVariables</key>
+<dict>
+  <key>EVAOS_REVIEW_BOT_APP_ID</key>
+  <string>&lt;github-app-id&gt;</string>
+  <key>EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH</key>
+  <string>/absolute/path/to/evaos-code-review-bot.private-key.pem</string>
+  <key>NODE_OPTIONS</key>
+  <string>--use-system-ca</string>
+</dict>
+```
+
 Only switch to `--dry-run false` after:
 
 - current-head duplicate reruns post nothing,

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -19,6 +19,8 @@ export interface ReleaseLaunchdStatus {
   pid?: number;
   configPath?: string;
   dryRun?: boolean;
+  nodeOptions?: string;
+  usesSystemCa?: boolean;
 }
 
 export interface ReleaseDatabaseStatus {
@@ -132,6 +134,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const cleanOk = input.repo.dirtyFiles.length === 0;
   const launchdRunningOk = input.launchd.state === "running";
   const launchdConfigOk = input.launchd.configPath === input.configPath;
+  const launchdSystemCaOk = input.launchd.usesSystemCa === true;
   const dbOk = input.database.errorCount === 0;
   const providerThrottleState = input.database.providerThrottleState ?? inferProviderThrottleState(input.database);
   const retryableExpiredProviderCooldownCount =
@@ -178,6 +181,15 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       name: "launchd_config",
       ok: launchdConfigOk,
       detail: input.launchd.configPath ?? "not detected"
+    },
+    {
+      name: "launchd_node_system_ca",
+      ok: launchdSystemCaOk,
+      detail: input.launchd.usesSystemCa === undefined
+        ? "NODE_OPTIONS not detected"
+        : input.launchd.usesSystemCa
+          ? "NODE_OPTIONS includes --use-system-ca"
+          : "NODE_OPTIONS missing --use-system-ca"
     },
     {
       name: "live_db_no_errors",
@@ -315,19 +327,74 @@ function readLaunchdStatus(label: string): ReleaseLaunchdStatus {
   const target = uid === undefined ? label : `gui/${uid}/${label}`;
   const result = spawnSync("launchctl", ["print", target], { encoding: "utf8" });
   if (result.status !== 0) return { label, state: "unknown" };
-  const stdout = result.stdout;
+  return parseLaunchdPrintStatus(label, result.stdout);
+}
+
+export function parseLaunchdPrintStatus(label: string, stdout: string): ReleaseLaunchdStatus {
   const state = stdout.match(/\bstate = (\w+)/)?.[1] === "running" ? "running" : "not_running";
   const pidText = stdout.match(/\bpid = (\d+)/)?.[1];
-  const args = stdout.match(/arguments = \{([\s\S]*?)\n\t\}/)?.[1] ?? "";
+  const args = extractLaunchdSection(stdout, "arguments") ?? "";
   const configMatch = args.match(/--config\s*\n\s*([^\n]+)/);
   const dryRunMatch = args.match(/--dry-run\s*\n\s*([^\n]+)/);
+  const environment = extractLaunchdSection(stdout, "environment");
+  const nodeOptions = normalizeLaunchdValue(readLaunchdEnvironmentValue(environment, "NODE_OPTIONS"));
+  const hasLaunchdEnvironment = environment !== undefined;
   return {
     label,
     state,
     ...(pidText ? { pid: Number(pidText) } : {}),
     ...(configMatch?.[1] ? { configPath: configMatch[1].trim() } : {}),
-    ...(dryRunMatch?.[1] ? { dryRun: dryRunMatch[1].trim() !== "false" } : {})
+    ...(dryRunMatch?.[1] ? { dryRun: dryRunMatch[1].trim() !== "false" } : {}),
+    ...(nodeOptions ? { nodeOptions } : {}),
+    ...(hasLaunchdEnvironment ? { usesSystemCa: splitNodeOptions(nodeOptions).includes("--use-system-ca") } : {})
   };
+}
+
+function extractLaunchdSection(stdout: string, sectionName: string): string | undefined {
+  const lines = stdout.split(/\r?\n/);
+  const sectionStart = lines.findIndex((line) => line.trim() === `${sectionName} = {`);
+  if (sectionStart === -1) return undefined;
+
+  const sectionIndent = leadingWhitespace(lines[sectionStart]).length;
+  const body: string[] = [];
+  for (const line of lines.slice(sectionStart + 1)) {
+    if (line.trim() === "}" && leadingWhitespace(line).length <= sectionIndent) {
+      return body.join("\n");
+    }
+    body.push(line);
+  }
+  return body.join("\n");
+}
+
+function leadingWhitespace(value: string): string {
+  return value.match(/^\s*/)?.[0] ?? "";
+}
+
+function readLaunchdEnvironmentValue(environment: string | undefined, key: string): string | undefined {
+  if (!environment) return undefined;
+  for (const line of environment.split(/\r?\n/)) {
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=>\s*(.*?)\s*$/);
+    if (match?.[1] === key) return match[2];
+  }
+  return undefined;
+}
+
+function normalizeLaunchdValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  const first = trimmed[0];
+  const last = trimmed[trimmed.length - 1];
+  if ((first === "\"" && last === "\"") || (first === "'" && last === "'")) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function splitNodeOptions(nodeOptions: string | undefined): string[] {
+  return (nodeOptions ?? "")
+    .split(/\s+/)
+    .map((option) => option.trim())
+    .filter(Boolean);
 }
 
 function readReviewBudgetStatus(

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
-import { buildReleaseStatus, collectReleaseStatus } from "../src/release-status.js";
+import { buildReleaseStatus, collectReleaseStatus, parseLaunchdPrintStatus } from "../src/release-status.js";
 import type { ReviewBudgetStatus } from "../src/review-budget.js";
 import { ReviewStateStore } from "../src/state.js";
 
@@ -60,7 +60,9 @@ describe("beta release status", () => {
         state: "running",
         pid: 456,
         configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-live.json",
-        dryRun: false
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
       },
       database: { rowCount: 2, errorCount: 0 },
       heartbeat: freshHeartbeat(),
@@ -103,6 +105,213 @@ describe("beta release status", () => {
     expect(status.gates).toContainEqual({ name: "launchd_config", ok: false, detail: "not detected" });
   });
 
+  it("fails closed when launchd reports Node without the macOS system CA option", () => {
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false,
+        nodeOptions: "--trace-warnings",
+        usesSystemCa: false
+      },
+      database: { rowCount: 2, errorCount: 0 },
+      heartbeat: freshHeartbeat(),
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.gates).toContainEqual({
+      name: "launchd_node_system_ca",
+      ok: false,
+      detail: "NODE_OPTIONS missing --use-system-ca"
+    });
+  });
+
+  it("fails closed when launchd NODE_OPTIONS cannot be verified", () => {
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false
+      },
+      database: { rowCount: 2, errorCount: 0 },
+      heartbeat: freshHeartbeat(),
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.gates).toContainEqual({
+      name: "launchd_node_system_ca",
+      ok: false,
+      detail: "NODE_OPTIONS not detected"
+    });
+  });
+
+  it("parses launchd NODE_OPTIONS from the loaded service environment", () => {
+    const status = parseLaunchdPrintStatus("com.electricsheephq.evaos-code-review-bot", `
+gui/502/com.electricsheephq.evaos-code-review-bot = {
+\tstate = running
+\tpid = 57466
+\targuments = {
+\t\t/opt/homebrew/bin/node
+\t\tsrc/cli.ts
+\t\tdaemon
+\t\t--config
+\t\t/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+\t\t--dry-run
+\t\tfalse
+\t}
+\tenvironment = {
+\t\tNODE_OPTIONS => --use-system-ca --trace-warnings
+\t}
+}
+`);
+
+    expect(status).toMatchObject({
+      state: "running",
+      pid: 57466,
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      dryRun: false,
+      nodeOptions: "--use-system-ca --trace-warnings",
+      usesSystemCa: true
+    });
+  });
+
+  it("normalizes quoted launchd NODE_OPTIONS and requires the exact system CA flag", () => {
+    const status = parseLaunchdPrintStatus("com.electricsheephq.evaos-code-review-bot", `
+gui/502/com.electricsheephq.evaos-code-review-bot = {
+\tstate = running
+\tenvironment = {
+\t\tNODE_OPTIONS => "\t--use-system-ca   --trace-warnings\t"
+\t}
+}
+`);
+
+    expect(status.nodeOptions).toBe("--use-system-ca   --trace-warnings");
+    expect(status.usesSystemCa).toBe(true);
+
+    const substringOnly = parseLaunchdPrintStatus("com.electricsheephq.evaos-code-review-bot", `
+gui/502/com.electricsheephq.evaos-code-review-bot = {
+\tstate = running
+\tenvironment = {
+\t\tNODE_OPTIONS => "--use-system-ca-proxy"
+\t}
+}
+`);
+
+    expect(substringOnly.nodeOptions).toBe("--use-system-ca-proxy");
+    expect(substringOnly.usesSystemCa).toBe(false);
+  });
+
+  it("leaves launchd system CA undetected when the loaded service environment block is absent", () => {
+    const status = parseLaunchdPrintStatus("com.electricsheephq.evaos-code-review-bot", `
+gui/502/com.electricsheephq.evaos-code-review-bot = {
+\tstate = running
+\targuments = {
+\t\t/opt/homebrew/bin/node
+\t\tsrc/cli.ts
+\t\tdaemon
+\t\t--config
+\t\t/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+\t}
+}
+`);
+
+    expect(status.usesSystemCa).toBeUndefined();
+    expect(status.nodeOptions).toBeUndefined();
+  });
+
+  it("parses NODE_OPTIONS from a launchctl print excerpt with adjacent environment sections", () => {
+    const status = parseLaunchdPrintStatus("com.electricsheephq.evaos-code-review-bot", `
+gui/502/com.electricsheephq.evaos-code-review-bot = {
+\tstate = running
+\tpid = 57466
+\targuments = {
+\t\t/opt/homebrew/bin/node
+\t\t/Volumes/LEXAR/repos/evaos-code-review-bot/node_modules/tsx/dist/cli.mjs
+\t\tsrc/cli.ts
+\t\tdaemon
+\t\t--config
+\t\t/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+\t\t--dry-run
+\t\tfalse
+\t}
+\tinherited environment = {
+\t\tSSH_AUTH_SOCK => /var/run/com.apple.launchd.example/Listeners
+\t}
+\tdefault environment = {
+\t\tPATH => /usr/bin:/bin:/usr/sbin:/sbin
+\t}
+\tenvironment = {
+\t\tOSLogRateLimit => 64
+\t\tPATH => /opt/homebrew/bin:/usr/bin:/bin
+\t\tNODE_OPTIONS => --use-system-ca
+\t\tSHELL => /bin/zsh
+\t}
+}
+`);
+
+    expect(status).toMatchObject({
+      state: "running",
+      pid: 57466,
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      dryRun: false,
+      nodeOptions: "--use-system-ca",
+      usesSystemCa: true
+    });
+  });
+
+  it("marks launchd system CA as disabled when the loaded service environment omits it", () => {
+    const status = parseLaunchdPrintStatus("com.electricsheephq.evaos-code-review-bot", `
+gui/502/com.electricsheephq.evaos-code-review-bot = {
+\tstate = running
+\targuments = {
+\t\t/opt/homebrew/bin/node
+\t\tsrc/cli.ts
+\t\tdaemon
+\t\t--config
+\t\t/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+\t}
+\tenvironment = {
+\t\tPATH => /usr/bin:/bin
+\t}
+}
+`);
+
+    expect(status.usesSystemCa).toBe(false);
+    expect(status.nodeOptions).toBeUndefined();
+  });
+
+  it("does not match NODE_OPTIONS text embedded inside another environment value", () => {
+    const status = parseLaunchdPrintStatus("com.electricsheephq.evaos-code-review-bot", `
+gui/502/com.electricsheephq.evaos-code-review-bot = {
+\tstate = running
+\tenvironment = {
+\t\tPATH => /usr/bin:/bin NODE_OPTIONS => --use-system-ca
+\t}
+}
+`);
+
+    expect(status.usesSystemCa).toBe(false);
+    expect(status.nodeOptions).toBeUndefined();
+  });
+
   it("fails closed when promotion is attempted from a non-main branch", () => {
     const status = buildReleaseStatus({
       repo: {
@@ -116,7 +325,9 @@ describe("beta release status", () => {
         label: "com.electricsheephq.evaos-code-review-bot",
         state: "running",
         configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
-        dryRun: false
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
       },
       database: { rowCount: 2, errorCount: 0 },
       heartbeat: freshHeartbeat(),
@@ -140,7 +351,9 @@ describe("beta release status", () => {
         label: "com.electricsheephq.evaos-code-review-bot",
         state: "running",
         configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
-        dryRun: false
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
       },
       database: { rowCount: 21, errorCount: 0, skippedCount: 16 },
       heartbeat: freshHeartbeat(),
@@ -170,7 +383,9 @@ describe("beta release status", () => {
         label: "com.electricsheephq.evaos-code-review-bot",
         state: "running",
         configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
-        dryRun: false
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
       },
       database: {
         rowCount: 21,
@@ -211,7 +426,9 @@ describe("beta release status", () => {
         label: "com.electricsheephq.evaos-code-review-bot",
         state: "running",
         configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
-        dryRun: false
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
       },
       database: {
         rowCount: 21,
@@ -249,7 +466,9 @@ describe("beta release status", () => {
         label: "com.electricsheephq.evaos-code-review-bot",
         state: "running",
         configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
-        dryRun: false
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
       },
       database: {
         rowCount: 21,
@@ -1004,7 +1223,9 @@ describe("beta release status", () => {
         label: "com.electricsheephq.evaos-code-review-bot",
         state: "running",
         configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
-        dryRun: false
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
       },
       database: {
         rowCount: 21,
@@ -1482,7 +1703,9 @@ describe("beta release status", () => {
         label: "com.electricsheephq.evaos-code-review-bot",
         state: "running",
         configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
-        dryRun: false
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
       },
       database: { rowCount: 21, errorCount: 0, skippedCount: 16 },
       heartbeat: { status: "missing", maxAgeMs: 120_000 },
@@ -1510,7 +1733,9 @@ describe("beta release status", () => {
         label: "com.electricsheephq.evaos-code-review-bot",
         state: "running",
         configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
-        dryRun: false
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
       },
       database: { rowCount: 21, errorCount: 0, skippedCount: 16 },
       heartbeat: {
@@ -1546,7 +1771,9 @@ describe("beta release status", () => {
         label: "com.electricsheephq.evaos-code-review-bot",
         state: "running",
         configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
-        dryRun: false
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
       },
       database: { rowCount: 21, errorCount: 0, skippedCount: 16 },
       heartbeat: {


### PR DESCRIPTION
## Summary

- Adds launchd `NODE_OPTIONS=--use-system-ca` visibility to `release:status`.
- Fails the release gate when launchd explicitly reports a loaded environment that omits `--use-system-ca`.
- Documents the LaunchAgent system-CA requirement in the launchd and beta release runbooks.

Fixes #178.

## Why

During the `v0.4.6-beta.5` live recovery, the daemon was launchd-running but
repeatedly failed GitHub App installation reads with:

```text
unable to verify the first certificate; if the root CA is installed locally, try running Node.js with --use-system-ca
```

The live operator plist has already been patched and reloaded. This PR codifies
the invariant so future plist regeneration or release promotion catches the
same drift before the bot silently stops scanning.

## Test Plan

- [x] `npx vitest run tests/release-status.test.ts --pool forks --poolOptions.forks.maxForks=1`
- [x] `npm run build`
- [x] `git diff --check`

## Evidence

- Live containment evidence: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-03/v0.4.6-beta.5/`
- Post-containment status: `release-status-post-node-options.json` is `ok=true`, `healthState=runtime_ok`.
