### PR TITLE
Fix retire-failed dry-run safety

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -140,8 +140,14 @@ npx tsx src/cli.ts retire-failed \
   --repo owner/repo \
   --pr 123 \
   --head-sha <failed-head-sha> \
-  --reason closed_or_stale_after_coverage_audit
+  --reason closed_or_stale_after_coverage_audit \
+  --dry-run true
 ```
+
+Inspect the dry-run output first. To perform the retirement against the current
+SQLite state, rerun the same command with `--dry-run false`; the live command
+re-checks state and may refuse or retire a different queue-job set if the row
+changed after the preview.
 
 Do not retire an active failed current head. Use `retry-failed` or disable the
 repo through the tracked allowlist/policy lane when the provider is repeatedly

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -363,11 +363,17 @@ Mutating commands remain explicit:
 
 - `retry-provider-cooldowns --dry-run false`
 - `retry-failed --dry-run false`
-- `retire-failed`
+- `retire-failed --dry-run false`
 - `build-memory-packet --record-build true`
 - `run-once --dry-run false`
 - `daemon --dry-run false`
 - `daemon start|stop --dry-run false --confirm true`
+
+`retire-failed` defaults to dry-run and prints the normalized retirement reason
+plus any failed queue jobs that a live run would reconcile. If the processed row
+is already a retired failed head, dry-run returns `alreadyRetired`; rerunning
+with `--dry-run false` is idempotent for the processed row and can still retire
+matching failed queue jobs.
 
 `build-skill-pack` and `build-enrichment-comment` are dry-run/evidence builders.
 They remain read-only. Live `run-once` and `daemon` can consume skill-pack

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,7 +51,14 @@ import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./
 import { runOnceCliCommand } from "./run-once-cli.js";
 import { redactSecrets } from "./secrets.js";
 import { buildSkillPackContextPacket } from "./skill-packs.js";
-import { listRepoMemoryNotesReadOnly, ReviewStateStore, type ReviewQueueJobRecord, type ReviewQueueJobState } from "./state.js";
+import {
+  buildRetiredFailedHeadError,
+  listRepoMemoryNotesReadOnly,
+  normalizeRetirementReason,
+  ReviewStateStore,
+  type ReviewQueueJobRecord,
+  type ReviewQueueJobState
+} from "./state.js";
 import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "./validation-selector.js";
 import { isSuccessfulRetryStatus, retryFailedHead, retryProviderCooldowns } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
@@ -1319,16 +1326,41 @@ async function main(): Promise<void> {
     if (!args.pr) throw new Error("--pr is required for retire-failed");
     if (!args["head-sha"]) throw new Error("--head-sha is required for retire-failed");
     if (!args.reason) throw new Error("--reason is required for retire-failed");
+    const pullNumber = Number(args.pr);
+    const headSha = args["head-sha"];
+    const reason = normalizeRetirementReason(args.reason);
+    const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
     const config = loadConfig(args.config);
     const state = new ReviewStateStore(args["state-path"] ?? config.statePath);
     try {
+      if (dryRun) {
+        const current = state.getProcessedReview(args.repo, pullNumber, headSha);
+        if (!current) {
+          throw new Error(`Refusing to retire missing review row for ${args.repo}#${pullNumber}@${headSha}`);
+        }
+        const queueJobsToRetire = state
+          .listReviewQueueJobsForPull({ repo: args.repo, pullNumber, state: "failed" })
+          .filter((job) => job.headSha === headSha);
+        if (current.status !== "failed") {
+          if (current.status === "skipped" && current.error?.startsWith("retired_failed_head:")) {
+            console.log(stringifyRedactedJson({ ok: true, dryRun, alreadyRetired: current, queueJobsToRetire }));
+            return;
+          }
+          throw new Error(
+            `Refusing to retire ${args.repo}#${pullNumber}@${headSha}: status is ${current.status}, not failed`
+          );
+        }
+        const retiredErrorPreview = buildRetiredFailedHeadError({ reason, previousError: current.error });
+        console.log(stringifyRedactedJson({ ok: true, dryRun, wouldRetire: current, queueJobsToRetire, reason, retiredErrorPreview }));
+        return;
+      }
       const retired = state.retireFailedReview({
         repo: args.repo,
-        pullNumber: Number(args.pr),
-        headSha: args["head-sha"],
-        reason: args.reason
+        pullNumber,
+        headSha,
+        reason
       });
-      console.log(JSON.stringify({ ok: true, retired }, null, 2));
+      console.log(stringifyRedactedJson({ ok: true, dryRun, retired }));
     } finally {
       state.close();
     }
@@ -2254,6 +2286,21 @@ function validateScenarioRunId(input: unknown, scenarioPath: string): string {
     throw new Error(`${scenarioPath}: runId must be a safe path segment`);
   }
   return trimmed;
+}
+
+function stringifyRedactedJson(input: unknown): string {
+  return JSON.stringify(redactJsonValue(input), null, 2);
+}
+
+function redactJsonValue(input: unknown): unknown {
+  if (typeof input === "string") return redactSecrets(input);
+  if (Array.isArray(input)) return input.map((item) => redactJsonValue(item));
+  if (input && typeof input === "object") {
+    const output: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input)) output[key] = redactJsonValue(value);
+    return output;
+  }
+  return input;
 }
 
 interface ParsedArgs {

--- a/src/state.ts
+++ b/src/state.ts
@@ -982,8 +982,7 @@ export class ReviewStateStore {
     }
 
     const reason = normalizeRetirementReason(input.reason);
-    const previousError = existing.error ? `; previous_error=${redactSecrets(existing.error)}` : "";
-    const retiredError = `retired_failed_head:${reason}${previousError}`;
+    const retiredError = buildRetiredFailedHeadError({ reason, previousError: existing.error });
     this.recordProcessed({
       repo: input.repo,
       pullNumber: input.pullNumber,
@@ -2505,7 +2504,7 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-function normalizeRetirementReason(reason: string): string {
+export function normalizeRetirementReason(reason: string): string {
   const normalized = reason
     .trim()
     .toLowerCase()
@@ -2513,6 +2512,12 @@ function normalizeRetirementReason(reason: string): string {
     .replaceAll(/^_+|_+$/g, "")
     .slice(0, 80);
   return normalized || "operator_acknowledged";
+}
+
+export function buildRetiredFailedHeadError(input: { reason: string; previousError?: string }): string {
+  const reason = normalizeRetirementReason(input.reason);
+  const previousError = input.previousError ? `; previous_error=${redactSecrets(input.previousError)}` : "";
+  return `retired_failed_head:${reason}${previousError}`;
 }
 
 function validateReviewerSessionInput(ttlMs: number, headCountLimit: number, workerPid?: number): void {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -39,6 +39,11 @@ import {
 import { applyDeterministicReviewGate } from "./review-gate.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown, type RepoMemoryPacket } from "./repo-memory.js";
 import { ReviewRunBudget } from "./review-budget.js";
+import {
+  postReviewStatusComment,
+  type ReviewStatusCommentGithub,
+  type ReviewStatusCommentState
+} from "./review-status-comment.js";
 import { redactSecrets } from "./secrets.js";
 import { buildSkillPackContextPacket, type SkillPackContextPacket } from "./skill-packs.js";
 import {
@@ -455,11 +460,48 @@ export async function retryFailedHeadWithDeps(input: {
       status: "skipped_closed",
       dryRun: options.dryRun
     });
+    await syncRetryReviewStatusComment({
+      config,
+      github,
+      state,
+      repo: options.repo,
+      pull,
+      headSha: options.headSha,
+      status: "skipped_closed",
+      dryRun: options.dryRun
+    });
     return {
       repo: options.repo,
       pullNumber: options.pullNumber,
       headSha: options.headSha,
       status: "skipped_closed"
+    };
+  }
+  const processed = state.getProcessedReview(options.repo, options.pullNumber, options.headSha);
+  if (processed && processed.status !== "failed" && !isProviderCooldownProcessedReview(processed)) {
+    updateRetryQueueJobsAfterRetry({
+      state,
+      repo: options.repo,
+      pullNumber: options.pullNumber,
+      headSha: options.headSha,
+      status: "skipped_processed",
+      dryRun: options.dryRun
+    });
+    await syncRetryReviewStatusComment({
+      config,
+      github,
+      state,
+      repo: options.repo,
+      pull,
+      headSha: options.headSha,
+      status: "skipped_processed",
+      dryRun: options.dryRun
+    });
+    return {
+      repo: options.repo,
+      pullNumber: options.pullNumber,
+      headSha: options.headSha,
+      status: "skipped_processed"
     };
   }
   if (pull.head.sha !== options.headSha) {
@@ -478,6 +520,16 @@ export async function retryFailedHeadWithDeps(input: {
       state,
       repo: options.repo,
       pullNumber: options.pullNumber,
+      headSha: options.headSha,
+      status: "skipped_stale_head",
+      dryRun: options.dryRun
+    });
+    await syncRetryReviewStatusComment({
+      config,
+      github,
+      state,
+      repo: options.repo,
+      pull,
       headSha: options.headSha,
       status: "skipped_stale_head",
       dryRun: options.dryRun
@@ -525,6 +577,16 @@ export async function retryFailedHeadWithDeps(input: {
       status: retryStatus,
       dryRun: options.dryRun
     });
+    await syncRetryReviewStatusComment({
+      config,
+      github,
+      state,
+      repo: options.repo,
+      pull,
+      headSha: options.headSha,
+      status: retryStatus,
+      dryRun: options.dryRun
+    });
     restoreFailedRetryRowIfNeeded({
       state,
       retryTarget,
@@ -552,6 +614,16 @@ export async function retryFailedHeadWithDeps(input: {
         status: "skipped_provider_cooldown",
         dryRun: options.dryRun
       });
+      await syncRetryReviewStatusComment({
+        config,
+        github,
+        state,
+        repo: options.repo,
+        pull,
+        headSha: options.headSha,
+        status: "skipped_provider_cooldown",
+        dryRun: options.dryRun
+      });
       return {
         repo: options.repo,
         pullNumber: options.pullNumber,
@@ -574,12 +646,96 @@ export async function retryFailedHeadWithDeps(input: {
       status: "failed",
       dryRun: options.dryRun
     });
+    await syncRetryReviewStatusComment({
+      config,
+      github,
+      state,
+      repo: options.repo,
+      pull,
+      headSha: options.headSha,
+      status: "failed",
+      dryRun: options.dryRun
+    });
     return {
       repo: options.repo,
       pullNumber: options.pullNumber,
       headSha: options.headSha,
       status: "failed"
     };
+  }
+}
+
+async function syncRetryReviewStatusComment(input: {
+  config: BotConfig;
+  github: GitHubApi;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  headSha: string;
+  status: RetryFailedHeadResult["status"];
+  dryRun: boolean;
+}): Promise<void> {
+  if (!isReviewStatusCommentGithub(input.github)) return;
+  const processed = input.state.getProcessedReview(input.repo, input.pull.number, input.headSha);
+  const state = retryStatusCommentState(input.status, processed?.status, processed?.error);
+  if (!state) return;
+  await postReviewStatusComment({
+    enabled: input.config.reviewStatusComment?.enabled ?? false,
+    dryRun: input.dryRun,
+    github: input.github,
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.headSha,
+    state,
+    pullTitle: input.pull.title,
+    pullUrl: input.pull.html_url,
+    ...(processed?.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
+    ...(state === "failed" ? { details: "Review failed; see bot evidence for operator-only details." } : {})
+  });
+}
+
+function isReviewStatusCommentGithub(github: GitHubApi): github is GitHubApi & ReviewStatusCommentGithub {
+  const candidate = github as Partial<ReviewStatusCommentGithub>;
+  return typeof candidate.canPostAsApp === "function" && typeof candidate.upsertIssueComment === "function";
+}
+
+function retryStatusCommentState(
+  status: RetryFailedHeadResult["status"],
+  processedStatus?: ProcessedStatus,
+  processedError?: string
+): ReviewStatusCommentState | undefined {
+  switch (status) {
+    case "reviewed":
+    case "reviewed_command":
+      return "completed";
+    case "dry_run":
+      return undefined;
+    case "skipped_processed":
+      if (processedStatus === "posted") return "completed";
+      if (processedStatus === "skipped" && processedError && parseProviderCooldownError(processedError)) {
+        return "provider_deferred";
+      }
+      if (processedStatus === "skipped") return "skipped";
+      return undefined;
+    case "skipped_provider_cooldown":
+      return "provider_deferred";
+    case "skipped_stale_head":
+      return "stale_head";
+    case "skipped_closed":
+      return "closed_or_merged_before_review";
+    case "failed":
+      return "failed";
+    case "skipped_capacity":
+      return "provider_deferred";
+    case "skipped_draft":
+    case "skipped_canary":
+    case "skipped_policy":
+    case "skipped_command_stop":
+    case "skipped_command_explain":
+    case "skipped_finishing_touch_draft":
+      return undefined;
+    default:
+      return assertNever(status);
   }
 }
 
@@ -591,11 +747,13 @@ function updateRetryQueueJobsAfterRetry(input: {
   status: RetryFailedHeadResult["status"];
   dryRun: boolean;
 }): void {
+  const retryStates: ReviewQueueJobState[] = ["queued", "leased", "running", "provider_deferred"];
+  if (!input.dryRun) retryStates.push("failed");
   const activeJobs = input.state
     .listReviewQueueJobsForPull({
       repo: input.repo,
       pullNumber: input.pullNumber,
-      states: ["queued", "leased", "running", "provider_deferred"]
+      states: retryStates
     })
     .filter((job) => job.headSha === input.headSha);
   const targetJobs = isRetryCommandRecordedStatus(input.status)

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -120,6 +120,410 @@ describe("public NeonDiff CLI surface", () => {
     expect(readFileSync(output.backupPath, "utf8")).toBe("{}\n");
   });
 
+  it("does not mutate failed review rows when retire-failed runs in dry-run mode", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-retire-failed-dry-run-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const repo = "electricsheephq/evaos-code-review-bot";
+    const pullNumber = 176;
+    const headSha = "dry-run-failed-head";
+    const previousError = "ZCode failed before completion: spawnSync node ETIMEDOUT";
+    let store = new ReviewStateStore(statePath);
+
+    store.recordProcessed({
+      repo,
+      pullNumber,
+      headSha,
+      status: "failed",
+      error: previousError
+    });
+    const queueJob = store.enqueueReviewQueueJob({
+      repo,
+      pullNumber,
+      headSha,
+      baseSha: "base-head",
+      now: new Date("2026-07-03T00:00:00.000Z")
+    }).job;
+    store.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "failed",
+      lastError: previousError,
+      now: new Date("2026-07-03T00:01:00.000Z")
+    });
+    const beforeProcessed = store.getProcessedReview(repo, pullNumber, headSha);
+    const beforeQueueJob = store.getReviewQueueJob(queueJob.jobId);
+    store.close();
+
+    const { stdout } = await runCli([
+      "retire-failed",
+      "--state-path",
+      statePath,
+      "--repo",
+      repo,
+      "--pr",
+      String(pullNumber),
+      "--head-sha",
+      headSha,
+      "--reason",
+      "Closed Or Merged Before Review!",
+      "--dry-run",
+      "true"
+    ]);
+    const output = JSON.parse(stdout);
+
+    expect(output).toMatchObject({
+      ok: true,
+      dryRun: true,
+      wouldRetire: {
+        repo,
+        pullNumber,
+        headSha,
+        status: "failed",
+        error: previousError
+      },
+      reason: "closed_or_merged_before_review",
+      retiredErrorPreview: `retired_failed_head:closed_or_merged_before_review; previous_error=${previousError}`
+    });
+    store = new ReviewStateStore(statePath);
+    expect(store.getProcessedReview(repo, pullNumber, headSha)).toEqual(beforeProcessed);
+    expect(store.getReviewQueueJob(queueJob.jobId)).toEqual(beforeQueueJob);
+    store.close();
+  });
+
+  it("refuses retire-failed dry-runs for missing or non-failed rows", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-retire-failed-refuse-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const repo = "electricsheephq/evaos-code-review-bot";
+    const pullNumber = 176;
+    const store = new ReviewStateStore(statePath);
+
+    store.recordProcessed({
+      repo,
+      pullNumber,
+      headSha: "posted-head",
+      status: "posted",
+      event: "COMMENT"
+    });
+    store.close();
+
+    await expect(runCli([
+      "retire-failed",
+      "--state-path",
+      statePath,
+      "--repo",
+      repo,
+      "--pr",
+      String(pullNumber),
+      "--head-sha",
+      "missing-head",
+      "--reason",
+      "operator_request",
+      "--dry-run",
+      "true"
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining(`Refusing to retire missing review row for ${repo}#${pullNumber}@missing-head`)
+    });
+
+    await expect(runCli([
+      "retire-failed",
+      "--state-path",
+      statePath,
+      "--repo",
+      repo,
+      "--pr",
+      String(pullNumber),
+      "--head-sha",
+      "posted-head",
+      "--reason",
+      "operator_request",
+      "--dry-run",
+      "true"
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining(`Refusing to retire ${repo}#${pullNumber}@posted-head: status is posted, not failed`)
+    });
+  });
+
+  it("redacts retire-failed dry-run output before operators copy evidence", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-retire-failed-redact-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const repo = "electricsheephq/evaos-code-review-bot";
+    const pullNumber = 176;
+    const headSha = "secret-failed-head";
+    const ghToken = "ghp_abcdefghijklmnopqrstuvwx";
+    const bearerToken = "Bearer abcdefghijklmnopqrstuvwxyz";
+    let store = new ReviewStateStore(statePath);
+
+    store.recordProcessed({
+      repo,
+      pullNumber,
+      headSha,
+      status: "failed",
+      error: `provider failed with ${ghToken} at https://user@example.com`
+    });
+    const queueJob = store.enqueueReviewQueueJob({
+      repo,
+      pullNumber,
+      headSha,
+      baseSha: "base-head",
+      now: new Date("2026-07-03T00:00:00.000Z")
+    }).job;
+    store.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "failed",
+      lastError: `retry failed with ${bearerToken}`,
+      now: new Date("2026-07-03T00:01:00.000Z")
+    });
+    store.close();
+
+    const { stdout } = await runCli([
+      "retire-failed",
+      "--state-path",
+      statePath,
+      "--repo",
+      repo,
+      "--pr",
+      String(pullNumber),
+      "--head-sha",
+      headSha,
+      "--reason",
+      "closed_or_merged_before_review",
+      "--dry-run",
+      "true"
+    ]);
+    const output = JSON.parse(stdout);
+
+    expect(stdout).not.toContain(ghToken);
+    expect(stdout).not.toContain(bearerToken);
+    expect(stdout).not.toContain("https://user@example.com");
+    expect(output.wouldRetire.error).toContain("[redacted-secret]");
+    expect(output.retiredErrorPreview).toContain("[redacted-secret]");
+    expect(output.queueJobsToRetire[0].lastError).toContain("[redacted-secret]");
+  });
+
+  it("retires failed review rows only when retire-failed is explicit non-dry-run", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-retire-failed-live-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const repo = "electricsheephq/evaos-code-review-bot";
+    const pullNumber = 176;
+    const headSha = "live-failed-head";
+    const previousError = "ZCode failed before completion: spawnSync node ETIMEDOUT";
+    let store = new ReviewStateStore(statePath);
+
+    store.recordProcessed({
+      repo,
+      pullNumber,
+      headSha,
+      status: "failed",
+      error: previousError
+    });
+    const queueJob = store.enqueueReviewQueueJob({
+      repo,
+      pullNumber,
+      headSha,
+      baseSha: "base-head",
+      now: new Date("2026-07-03T00:00:00.000Z")
+    }).job;
+    store.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "failed",
+      lastError: previousError,
+      now: new Date("2026-07-03T00:01:00.000Z")
+    });
+    store.close();
+
+    const { stdout } = await runCli([
+      "retire-failed",
+      "--state-path",
+      statePath,
+      "--repo",
+      repo,
+      "--pr",
+      String(pullNumber),
+      "--head-sha",
+      headSha,
+      "--reason",
+      "closed_or_merged_before_review",
+      "--dry-run",
+      "false"
+    ]);
+    const output = JSON.parse(stdout);
+
+    expect(output).toMatchObject({
+      ok: true,
+      dryRun: false,
+      retired: {
+        repo,
+        pullNumber,
+        headSha,
+        status: "skipped",
+        error: "retired_failed_head:closed_or_merged_before_review; previous_error=ZCode failed before completion: spawnSync node ETIMEDOUT"
+      }
+    });
+    store = new ReviewStateStore(statePath);
+    expect(store.getProcessedReview(repo, pullNumber, headSha)).toMatchObject({
+      status: "skipped",
+      error: "retired_failed_head:closed_or_merged_before_review; previous_error=ZCode failed before completion: spawnSync node ETIMEDOUT"
+    });
+    expect(store.getReviewQueueJob(queueJob.jobId)).toMatchObject({
+      state: "stale_retired",
+      lastError: "retired_failed_head:closed_or_merged_before_review; previous_error=ZCode failed before completion: spawnSync node ETIMEDOUT"
+    });
+    store.close();
+  });
+
+  it("previews failed queue reconciliation for already retired heads without mutation", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-retire-failed-already-dry-run-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const repo = "electricsheephq/evaos-code-review-bot";
+    const pullNumber = 176;
+    const headSha = "already-retired-head";
+    const retiredError = "retired_failed_head:old_operator_run; previous_error=ENOENT";
+    let store = new ReviewStateStore(statePath);
+
+    store.recordProcessed({
+      repo,
+      pullNumber,
+      headSha,
+      status: "skipped",
+      error: retiredError
+    });
+    const queueJob = store.enqueueReviewQueueJob({
+      repo,
+      pullNumber,
+      headSha,
+      baseSha: "base-head",
+      now: new Date("2026-07-03T00:00:00.000Z")
+    }).job;
+    store.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "failed",
+      lastError: "ENOENT",
+      now: new Date("2026-07-03T00:01:00.000Z")
+    });
+    const beforeProcessed = store.getProcessedReview(repo, pullNumber, headSha);
+    const beforeQueueJob = store.getReviewQueueJob(queueJob.jobId);
+    store.close();
+
+    const { stdout } = await runCli([
+      "retire-failed",
+      "--state-path",
+      statePath,
+      "--repo",
+      repo,
+      "--pr",
+      String(pullNumber),
+      "--head-sha",
+      headSha,
+      "--reason",
+      "closed_or_merged_before_review",
+      "--dry-run",
+      "true"
+    ]);
+    const output = JSON.parse(stdout);
+
+    expect(output).toMatchObject({
+      ok: true,
+      dryRun: true,
+      alreadyRetired: {
+        repo,
+        pullNumber,
+        headSha,
+        status: "skipped",
+        error: retiredError
+      },
+      queueJobsToRetire: [
+        {
+          jobId: queueJob.jobId,
+          repo,
+          pullNumber,
+          headSha,
+          state: "failed",
+          lastError: "ENOENT"
+        }
+      ]
+    });
+    store = new ReviewStateStore(statePath);
+    expect(store.getProcessedReview(repo, pullNumber, headSha)).toEqual(beforeProcessed);
+    expect(store.getReviewQueueJob(queueJob.jobId)).toEqual(beforeQueueJob);
+    store.close();
+  });
+
+  it("reconciles failed queue jobs for already retired heads only when explicit non-dry-run", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-retire-failed-already-live-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const repo = "electricsheephq/evaos-code-review-bot";
+    const pullNumber = 176;
+    const headSha = "already-retired-live-head";
+    const retiredError = "retired_failed_head:old_operator_run; previous_error=ENOENT";
+    let store = new ReviewStateStore(statePath);
+
+    store.recordProcessed({
+      repo,
+      pullNumber,
+      headSha,
+      status: "skipped",
+      error: retiredError
+    });
+    const queueJob = store.enqueueReviewQueueJob({
+      repo,
+      pullNumber,
+      headSha,
+      baseSha: "base-head",
+      now: new Date("2026-07-03T00:00:00.000Z")
+    }).job;
+    store.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "failed",
+      lastError: "ENOENT",
+      now: new Date("2026-07-03T00:01:00.000Z")
+    });
+    store.close();
+
+    const { stdout } = await runCli([
+      "retire-failed",
+      "--state-path",
+      statePath,
+      "--repo",
+      repo,
+      "--pr",
+      String(pullNumber),
+      "--head-sha",
+      headSha,
+      "--reason",
+      "closed_or_merged_before_review",
+      "--dry-run",
+      "false"
+    ]);
+    const output = JSON.parse(stdout);
+
+    expect(output).toMatchObject({
+      ok: true,
+      dryRun: false,
+      retired: {
+        repo,
+        pullNumber,
+        headSha,
+        status: "skipped",
+        error: retiredError
+      }
+    });
+    store = new ReviewStateStore(statePath);
+    expect(store.getProcessedReview(repo, pullNumber, headSha)).toMatchObject({
+      status: "skipped",
+      error: retiredError
+    });
+    expect(store.getReviewQueueJob(queueJob.jobId)).toMatchObject({
+      state: "stale_retired",
+      lastError: retiredError
+    });
+    store.close();
+  });
+
   it("requires review-pr repos to be configured and enabled", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-review-pr-"));
     roots.push(root);

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -1556,6 +1556,270 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("clears failed durable queue jobs when a live retry posts the review", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-failed-queue-posted-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1234, "head-retry-posted");
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "failed",
+      error: "ZCode failed before completion: spawnSync node ETIMEDOUT"
+    });
+    const queueJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      baseSha: pull.base.sha
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "failed",
+      lastError: "ZCode failed before completion: spawnSync node ETIMEDOUT"
+    });
+
+    const reviewUrl = "https://github.com/electricsheephq/WorldOS/pull/1234#pullrequestreview-1";
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async () => {
+        state.recordProcessed({
+          repo: "electricsheephq/WorldOS",
+          pullNumber: pull.number,
+          headSha: pull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl
+        });
+        return "reviewed";
+      }
+    });
+
+    expect(result.status).toBe("reviewed");
+    expect(state.getReviewQueueJob(queueJob.jobId)).toMatchObject({
+      state: "posted",
+      reviewUrl,
+      lastError: "reviewed"
+    });
+    state.close();
+  });
+
+  it("repairs failed durable queue jobs when the processed row is already posted", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-posted-queue-repair-"));
+    roots.push(root);
+    const config = {
+      ...minimalConfig(root),
+      reviewStatusComment: { enabled: true }
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const headSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const pull = pullSummary(1234, headSha);
+    const reviewUrl = "https://github.com/electricsheephq/WorldOS/pull/1234#pullrequestreview-2";
+    const statusCalls: Array<{ marker: string; body: string }> = [];
+    const github = {
+      getPull: async () => pull,
+      canPostAsApp: () => true,
+      upsertIssueComment: async (input: { marker: string; body: string }) => {
+        statusCalls.push(input);
+        return { action: "updated" as const, id: 12345, html_url: "https://github.test/status-comment" };
+      }
+    } as unknown as GitHubApi;
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl
+    });
+    const queueJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      baseSha: pull.base.sha
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "failed",
+      lastError: "ZCode failed before completion: spawnSync node ETIMEDOUT"
+    });
+
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github,
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async () => {
+        throw new Error("already posted retry repair should not rerun review");
+      }
+    });
+
+    expect(result.status).toBe("skipped_processed");
+    expect(state.getReviewQueueJob(queueJob.jobId)).toMatchObject({
+      state: "posted",
+      reviewUrl,
+      lastError: "retry_did_not_review=skipped_processed:posted"
+    });
+    expect(statusCalls).toHaveLength(1);
+    expect(statusCalls[0]?.marker).toBe(
+      `<!-- evaos-code-review-bot:review-status repo=electricsheephq/WorldOS pr=1234 sha=${headSha} -->`
+    );
+    expect(statusCalls[0]?.body).toContain("review-status-state status=completed");
+    expect(statusCalls[0]?.body).toContain(reviewUrl);
+    state.close();
+  });
+
+  it("posts retry status comments against the requested stale failed head", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-stale-status-"));
+    roots.push(root);
+    const config = {
+      ...minimalConfig(root),
+      reviewStatusComment: { enabled: true }
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const staleHeadSha = "1111111111111111111111111111111111111111";
+    const currentHeadSha = "2222222222222222222222222222222222222222";
+    const pull = pullSummary(1234, currentHeadSha);
+    const statusCalls: Array<{ marker: string; body: string }> = [];
+    const github = {
+      getPull: async () => pull,
+      canPostAsApp: () => true,
+      upsertIssueComment: async (input: { marker: string; body: string }) => {
+        statusCalls.push(input);
+        return { action: "updated" as const, id: 12345, html_url: "https://github.test/status-comment" };
+      }
+    } as unknown as GitHubApi;
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: staleHeadSha,
+      status: "failed",
+      error: "original timeout"
+    });
+    const queueJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: staleHeadSha,
+      baseSha: pull.base.sha
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "failed",
+      lastError: "ZCode failed before completion: spawnSync node ETIMEDOUT"
+    });
+
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github,
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: staleHeadSha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async () => {
+        throw new Error("stale retry must not rerun review");
+      }
+    });
+
+    expect(result.status).toBe("skipped_stale_head");
+    expect(statusCalls).toHaveLength(1);
+    expect(statusCalls[0]?.marker).toBe(
+      `<!-- evaos-code-review-bot:review-status repo=electricsheephq/WorldOS pr=1234 sha=${staleHeadSha} -->`
+    );
+    expect(statusCalls[0]?.marker).not.toContain(currentHeadSha);
+    expect(statusCalls[0]?.body).toContain("review-status-state status=stale_head");
+    state.close();
+  });
+
+  it("updates retry status comments to provider_deferred when capacity blocks a retry", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-capacity-status-"));
+    roots.push(root);
+    const config = {
+      ...minimalConfig(root),
+      reviewStatusComment: { enabled: true }
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const headSha = "3333333333333333333333333333333333333333";
+    const pull = pullSummary(1234, headSha);
+    const statusCalls: Array<{ marker: string; body: string }> = [];
+    const github = {
+      getPull: async () => pull,
+      canPostAsApp: () => true,
+      upsertIssueComment: async (input: { marker: string; body: string }) => {
+        statusCalls.push(input);
+        return { action: "updated" as const, id: 12345, html_url: "https://github.test/status-comment" };
+      }
+    } as unknown as GitHubApi;
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha,
+      status: "failed",
+      error: "original timeout"
+    });
+    const queueJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha,
+      baseSha: pull.base.sha
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "failed",
+      lastError: "ZCode failed before completion: spawnSync node ETIMEDOUT"
+    });
+
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github,
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async () => "skipped_capacity"
+    });
+
+    expect(result.status).toBe("skipped_capacity");
+    expect(state.getReviewQueueJob(queueJob.jobId)).toMatchObject({
+      state: "queued",
+      lastError: "retry_did_not_review=skipped_capacity"
+    });
+    expect(statusCalls).toHaveLength(1);
+    expect(statusCalls[0]?.marker).toBe(
+      `<!-- evaos-code-review-bot:review-status repo=electricsheephq/WorldOS pr=1234 sha=${headSha} -->`
+    );
+    expect(statusCalls[0]?.body).toContain("review-status-state status=provider_deferred");
+    state.close();
+  });
+
   it("keeps dry-run processed retry rows queued instead of marking them posted", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-race-dry-run-"));
     roots.push(root);


### PR DESCRIPTION
## Summary

Closes #177.

- Make `retire-failed` default to dry-run unless `--dry-run false` is explicit.
- In dry-run mode, preview the failed processed row without mutating `processed_reviews` or `review_queue_jobs`.
- Preserve explicit non-dry-run retirement behavior and include `dryRun:false` in the JSON response.
- Update operator docs and the beta release runbook to document dry-run-first retirement.

## Sibling command audit

- `retry-failed` and `retry-provider-cooldowns` already require explicit `--dry-run true|false`.
- `clear-issue-enrichment-leases` and `clear-review-queue-leases` default to dry-run and require `--confirm true` for mutation.
- `daemon start|stop` defaults to dry-run and requires `--confirm true` for mutation.
- `issue-enrichment-scan` is dry-run-only.

## Validation

- Red test first: `npx vitest run tests/public-cli.test.ts -t "does not mutate failed review rows" --pool=forks --poolOptions.forks.maxForks=1` failed before the fix because the command returned a live `retired` result.
- `npx vitest run tests/public-cli.test.ts -t "retire-failed" --pool=forks --poolOptions.forks.maxForks=1`
- `npx vitest run tests/state.test.ts -t "retire" --pool=forks --poolOptions.forks.maxForks=1`
- `npx vitest run tests/public-cli.test.ts tests/state.test.ts --pool=forks --poolOptions.forks.maxForks=1`
- `npm run build`

Evidence: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-03/issue-177-retire-failed-dry-run/summary.md`