### PR TITLE
Fix self-repo exact-head review gate

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -93,6 +93,21 @@ banner to stdout.
 
 - GitHub PR merged to `main` with checks green and no current-head actionable
   review threads.
+- For self-repo or release-critical PRs, run the exact-head evaOS gate before
+  merge. It must pass for the current PR head:
+
+```bash
+CURRENT_HEAD="$(gh pr view <pr-number> --repo electricsheephq/evaos-code-review-bot --json headRefOid --jq .headRefOid)"
+npx tsx src/cli.ts review-head-gate \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --repo electricsheephq/evaos-code-review-bot \
+  --pr <pr-number> \
+  --head-sha "$CURRENT_HEAD"
+```
+
+  A green `coverage-audit` does not replace this gate: coverage only checks
+  currently open eligible heads, so a final head pushed and merged between
+  daemon cycles can otherwise leave no terminal evaOS marker for agents.
 - Release checkout is clean and exactly at the intended source SHA.
 - `npm test` and `npm run build` pass from the release checkout.
 - `release:status` records exact source SHA, branch, config path, launchd job,

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -99,7 +99,7 @@ banner to stdout.
 ```bash
 CURRENT_HEAD="$(gh pr view <pr-number> --repo electricsheephq/evaos-code-review-bot --json headRefOid --jq .headRefOid)"
 npx tsx src/cli.ts review-head-gate \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config <path-to-active-installed-live.json> \
   --repo electricsheephq/evaos-code-review-bot \
   --pr <pr-number> \
   --head-sha "$CURRENT_HEAD"
@@ -108,6 +108,9 @@ npx tsx src/cli.ts review-head-gate \
   A green `coverage-audit` does not replace this gate: coverage only checks
   currently open eligible heads, so a final head pushed and merged between
   daemon cycles can otherwise leave no terminal evaOS marker for agents.
+  This exact-head gate checks the bot's recorded review state for the current
+  head; it does not independently prove GitHub App authorship. Pair it with
+  `release-status`, which verifies the live App-backed launchd configuration.
 - Release checkout is clean and exactly at the intended source SHA.
 - `npm test` and `npm run build` pass from the release checkout.
 - `release:status` records exact source SHA, branch, config path, launchd job,

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -59,8 +59,10 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
   read-only pre-merge guard for self-repo and release-critical PRs. It checks
   the exact `{repo, pr, head_sha}` against processed reviews, durable queue
   state, and readiness state. It exits zero only when the exact head has a live
-  posted evaOS review; missing, queued, provider-deferred, skipped, failed,
-  stale, closed, or dry-run-only heads exit nonzero with a next action.
+  recorded, non-blocking evaOS review; missing, queued, provider-deferred,
+  skipped, failed, stale, closed, or dry-run-only heads exit nonzero with a next
+  action. The gate does not independently prove GitHub App authorship; pair it
+  with `release-status` to verify the live App-backed launchd configuration.
 - `coverage`: raw coverage-audit report with the shorter operator command name.
 - `cooldowns`: provider cooldown review rows plus repo/global cooldown rows.
 - `clear-review-queue-leases`: dry-run-first recovery command for stale

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -55,6 +55,12 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
   `repo_capacity`, `manual_reserve`, and `lease_limit`. Broad status commands
   include only compact budget counts and reason histograms; use this command for
   capped row-level details.
+- `review-head-gate --repo <owner/name> --pr <number> --head-sha <sha>`:
+  read-only pre-merge guard for self-repo and release-critical PRs. It checks
+  the exact `{repo, pr, head_sha}` against processed reviews, durable queue
+  state, and readiness state. It exits zero only when the exact head has a live
+  posted evaOS review; missing, queued, provider-deferred, skipped, failed,
+  stale, closed, or dry-run-only heads exit nonzero with a next action.
 - `coverage`: raw coverage-audit report with the shorter operator command name.
 - `cooldowns`: provider cooldown review rows plus repo/global cooldown rows.
 - `clear-review-queue-leases`: dry-run-first recovery command for stale

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,7 @@ import {
   type OperatorQueueSnapshot
 } from "./operator-cli.js";
 import { collectReleaseStatus, type ReleaseStatus } from "./release-status.js";
+import { buildReviewHeadGate } from "./review-head-gate.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown } from "./repo-memory.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
 import { runOnceCliCommand } from "./run-once-cli.js";
@@ -196,6 +197,28 @@ async function main(): Promise<void> {
       failedGates: failedGates(status.gates)
     }, null, 2));
     if (!status.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "review-head-gate") {
+    if (!args.repo) throw new Error("--repo is required for review-head-gate");
+    if (!args.pr) throw new Error("--pr is required for review-head-gate");
+    const headSha = args["head-sha"] ?? args["current-head"];
+    if (!headSha) throw new Error("--head-sha is required for review-head-gate");
+    const config = loadConfig(args.config);
+    const state = new ReviewStateStore(args["state-path"] ?? config.statePath);
+    try {
+      const result = buildReviewHeadGate({
+        state,
+        repo: args.repo,
+        pullNumber: parsePositiveInteger(args.pr, "--pr"),
+        headSha: parseSingleArg(headSha, "--head-sha")
+      });
+      console.log(stringifyRedactedJson(result));
+      if (!result.ok) process.exitCode = 1;
+    } finally {
+      state.close();
+    }
     return;
   }
 
@@ -2042,6 +2065,7 @@ function buildHelp(command?: string) {
         "queue",
         "dashboard",
         "budget-status",
+        "review-head-gate",
         "coverage",
         "cooldowns",
         "why"
@@ -2049,6 +2073,7 @@ function buildHelp(command?: string) {
       existing: [
         "doctor",
         "release-status",
+        "review-head-gate",
         "coverage-audit",
         "build-memory-packet",
         "build-gitnexus-context-packet",
@@ -2083,6 +2108,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts status --config /path/to/live.json --launchd-label com.electricsheephq.evaos-code-review-bot",
       "npx tsx src/cli.ts runtime-inventory --config /path/to/live.json --launchd-label com.electricsheephq.evaos-code-review-bot",
       "npx tsx src/cli.ts runtime-inventory --config /path/to/live.json --human",
+      "npx tsx src/cli.ts review-head-gate --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD",
       "npx tsx src/cli.ts agents --config /path/to/live.json",
       "npx tsx src/cli.ts queue --config /path/to/live.json",
       "npx tsx src/cli.ts queue --config /path/to/live.json --state provider_deferred",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2108,7 +2108,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts status --config /path/to/live.json --launchd-label com.electricsheephq.evaos-code-review-bot",
       "npx tsx src/cli.ts runtime-inventory --config /path/to/live.json --launchd-label com.electricsheephq.evaos-code-review-bot",
       "npx tsx src/cli.ts runtime-inventory --config /path/to/live.json --human",
-      "npx tsx src/cli.ts review-head-gate --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD",
+      "npx tsx src/cli.ts review-head-gate --config /path/to/live.json --repo owner/repo --pr 123 --head-sha \"$(gh pr view 123 --repo owner/repo --json headRefOid --jq .headRefOid)\"",
       "npx tsx src/cli.ts agents --config /path/to/live.json",
       "npx tsx src/cli.ts queue --config /path/to/live.json",
       "npx tsx src/cli.ts queue --config /path/to/live.json --state provider_deferred",

--- a/src/review-head-gate.ts
+++ b/src/review-head-gate.ts
@@ -1,5 +1,4 @@
 import type {
-  ProcessedStatus,
   ReviewQueueJobRecord,
   ReviewReadinessRecord,
   ReviewStateStore,
@@ -82,10 +81,12 @@ function decideReviewHeadGate(input: {
   readiness?: ReviewReadinessRecord;
   queueJobs: ReviewQueueJobRecord[];
 }): ReviewHeadGateDecision {
+  const activeJob = input.queueJobs.find(isActiveQueueJob);
+  if (activeJob) return decisionFromQueueJob(activeJob);
   if (input.processed) return decisionFromProcessed(input.processed);
-  const activeJob = input.queueJobs.find((job) => ["queued", "leased", "running", "provider_deferred"].includes(job.state));
-  if (activeJob) return decisionFromQueueState(activeJob.state);
-  if (input.readiness) return decisionFromReadinessState(input.readiness.state);
+  const terminalJob = input.queueJobs.find(isTerminalQueueJob);
+  if (terminalJob) return decisionFromQueueJob(terminalJob);
+  if (input.readiness) return decisionFromReadiness(input.readiness);
   return "missing";
 }
 
@@ -106,8 +107,8 @@ function decisionFromProcessed(processed: StoredProcessedReviewRecord): ReviewHe
   }
 }
 
-function decisionFromQueueState(state: ReviewQueueJobRecord["state"]): ReviewHeadGateDecision {
-  switch (state) {
+function decisionFromQueueJob(job: ReviewQueueJobRecord): ReviewHeadGateDecision {
+  switch (job.state) {
     case "queued":
       return "queued";
     case "leased":
@@ -124,16 +125,16 @@ function decisionFromQueueState(state: ReviewQueueJobRecord["state"]): ReviewHea
     case "command_recorded":
       return "blocked";
     case "posted":
-      return "passed";
+      return job.reviewUrl ? "passed" : "blocked";
     default:
-      return assertNever(state);
+      return assertNever(job.state);
   }
 }
 
-function decisionFromReadinessState(state: ReviewReadinessRecord["state"]): ReviewHeadGateDecision {
-  switch (state) {
+function decisionFromReadiness(readiness: ReviewReadinessRecord): ReviewHeadGateDecision {
+  switch (readiness.state) {
     case "ready_for_human":
-      return "passed";
+      return readiness.reviewUrl ? "passed" : "blocked";
     case "needs_fix":
       return "needs_fix";
     case "queued":
@@ -156,8 +157,16 @@ function decisionFromReadinessState(state: ReviewReadinessRecord["state"]): Revi
     case "blocked_on_proof":
       return "blocked";
     default:
-      return assertNever(state);
+      return assertNever(readiness.state);
   }
+}
+
+function isActiveQueueJob(job: ReviewQueueJobRecord): boolean {
+  return job.state === "queued" || job.state === "leased" || job.state === "running" || job.state === "provider_deferred";
+}
+
+function isTerminalQueueJob(job: ReviewQueueJobRecord): boolean {
+  return job.state === "posted" || job.state === "failed" || job.state === "stale_retired" || job.state === "closed_retired" || job.state === "command_recorded";
 }
 
 function gateDetail(
@@ -169,14 +178,18 @@ function gateDetail(
   if (decision === "passed" && processed) {
     return `processed_reviews status=${processed.status} event=${processed.event ?? "unknown"} reviewUrl=${processed.reviewUrl ?? "none"}`;
   }
+  const activeJob = queueJobs.find(isActiveQueueJob);
+  if (activeJob) {
+    return `queue_job state=${activeJob.state} priority=${activeJob.priority} lastError=${activeJob.lastError ?? "none"}`;
+  }
+  const terminalJob = queueJobs.find(isTerminalQueueJob);
+  if (terminalJob) {
+    return `queue_job state=${terminalJob.state} priority=${terminalJob.priority} reviewUrl=${terminalJob.reviewUrl ?? "none"} lastError=${terminalJob.lastError ?? "none"}`;
+  }
   if (decision === "passed" && readiness) {
     return `review_readiness state=${readiness.state} reviewUrl=${readiness.reviewUrl ?? "none"}`;
   }
   if (processed) return `processed_reviews status=${processed.status} error=${processed.error ?? "none"}`;
-  const activeJob = queueJobs.find((job) => ["queued", "leased", "running", "provider_deferred"].includes(job.state));
-  if (activeJob) {
-    return `queue_job state=${activeJob.state} priority=${activeJob.priority} lastError=${activeJob.lastError ?? "none"}`;
-  }
   if (readiness) return `review_readiness state=${readiness.state} reason=${readiness.reason ?? "none"}`;
   return "no processed review, active queue job, or readiness row for exact head";
 }

--- a/src/review-head-gate.ts
+++ b/src/review-head-gate.ts
@@ -93,6 +93,7 @@ function decisionFromProcessed(processed: StoredProcessedReviewRecord): ReviewHe
   switch (processed.status) {
     case "posted":
       if (processed.event === "REQUEST_CHANGES") return "needs_fix";
+      // This gate proves exact-head review state. App authorship is verified by live release-status config.
       return "passed";
     case "dry_run":
       return "dry_run";

--- a/src/review-head-gate.ts
+++ b/src/review-head-gate.ts
@@ -1,0 +1,227 @@
+import type {
+  ProcessedStatus,
+  ReviewQueueJobRecord,
+  ReviewReadinessRecord,
+  ReviewStateStore,
+  StoredProcessedReviewRecord
+} from "./state.js";
+
+export type ReviewHeadGateDecision =
+  | "passed"
+  | "missing"
+  | "queued"
+  | "reviewing"
+  | "provider_deferred"
+  | "failed"
+  | "needs_fix"
+  | "skipped"
+  | "dry_run"
+  | "stale"
+  | "closed"
+  | "blocked";
+
+export interface ReviewHeadGateResult {
+  ok: boolean;
+  healthState: "review_head_gate_ok" | "review_head_gate_blocked";
+  checkedAt: string;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  decision: ReviewHeadGateDecision;
+  processed?: StoredProcessedReviewRecord;
+  readiness?: ReviewReadinessRecord;
+  queueJobs: ReviewQueueJobRecord[];
+  gates: { name: string; ok: boolean; detail: string }[];
+  nextAction: string;
+}
+
+export function buildReviewHeadGate(input: {
+  state: Pick<ReviewStateStore, "getProcessedReview" | "getReviewReadiness" | "listReviewQueueJobsForPull">;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  now?: Date;
+}): ReviewHeadGateResult {
+  validateRepoSlug(input.repo);
+  validatePullNumber(input.pullNumber);
+  validateHeadSha(input.headSha);
+
+  const processed = input.state.getProcessedReview(input.repo, input.pullNumber, input.headSha);
+  const readiness = input.state.getReviewReadiness(input.repo, input.pullNumber, input.headSha);
+  const queueJobs = input.state
+    .listReviewQueueJobsForPull({ repo: input.repo, pullNumber: input.pullNumber })
+    .filter((job) => job.headSha === input.headSha);
+  const decision = decideReviewHeadGate({ processed, readiness, queueJobs });
+  const ok = decision === "passed";
+  const gates = [
+    {
+      name: "exact_head_has_terminal_evaos_review",
+      ok,
+      detail: gateDetail(decision, processed, readiness, queueJobs)
+    }
+  ];
+
+  return {
+    ok,
+    healthState: ok ? "review_head_gate_ok" : "review_head_gate_blocked",
+    checkedAt: (input.now ?? new Date()).toISOString(),
+    repo: input.repo,
+    pullNumber: input.pullNumber,
+    headSha: input.headSha,
+    decision,
+    ...(processed ? { processed } : {}),
+    ...(readiness ? { readiness } : {}),
+    queueJobs,
+    gates,
+    nextAction: nextAction(decision)
+  };
+}
+
+function decideReviewHeadGate(input: {
+  processed?: StoredProcessedReviewRecord;
+  readiness?: ReviewReadinessRecord;
+  queueJobs: ReviewQueueJobRecord[];
+}): ReviewHeadGateDecision {
+  if (input.processed) return decisionFromProcessed(input.processed);
+  const activeJob = input.queueJobs.find((job) => ["queued", "leased", "running", "provider_deferred"].includes(job.state));
+  if (activeJob) return decisionFromQueueState(activeJob.state);
+  if (input.readiness) return decisionFromReadinessState(input.readiness.state);
+  return "missing";
+}
+
+function decisionFromProcessed(processed: StoredProcessedReviewRecord): ReviewHeadGateDecision {
+  switch (processed.status) {
+    case "posted":
+      if (processed.event === "REQUEST_CHANGES") return "needs_fix";
+      return "passed";
+    case "dry_run":
+      return "dry_run";
+    case "skipped":
+      return "skipped";
+    case "failed":
+      return "failed";
+    default:
+      return assertNever(processed.status);
+  }
+}
+
+function decisionFromQueueState(state: ReviewQueueJobRecord["state"]): ReviewHeadGateDecision {
+  switch (state) {
+    case "queued":
+      return "queued";
+    case "leased":
+    case "running":
+      return "reviewing";
+    case "provider_deferred":
+      return "provider_deferred";
+    case "failed":
+      return "failed";
+    case "stale_retired":
+      return "stale";
+    case "closed_retired":
+      return "closed";
+    case "command_recorded":
+      return "blocked";
+    case "posted":
+      return "passed";
+    default:
+      return assertNever(state);
+  }
+}
+
+function decisionFromReadinessState(state: ReviewReadinessRecord["state"]): ReviewHeadGateDecision {
+  switch (state) {
+    case "ready_for_human":
+      return "passed";
+    case "needs_fix":
+      return "needs_fix";
+    case "queued":
+      return "queued";
+    case "reviewing":
+      return "reviewing";
+    case "provider_deferred":
+      return "provider_deferred";
+    case "failed":
+      return "failed";
+    case "skipped":
+    case "command_recorded":
+      return "skipped";
+    case "stale":
+    case "awaiting_re_review":
+      return "stale";
+    case "closed":
+      return "closed";
+    case "blocked_on_checks":
+    case "blocked_on_proof":
+      return "blocked";
+    default:
+      return assertNever(state);
+  }
+}
+
+function gateDetail(
+  decision: ReviewHeadGateDecision,
+  processed: StoredProcessedReviewRecord | undefined,
+  readiness: ReviewReadinessRecord | undefined,
+  queueJobs: ReviewQueueJobRecord[]
+): string {
+  if (decision === "passed" && processed) {
+    return `processed_reviews status=${processed.status} event=${processed.event ?? "unknown"} reviewUrl=${processed.reviewUrl ?? "none"}`;
+  }
+  if (decision === "passed" && readiness) {
+    return `review_readiness state=${readiness.state} reviewUrl=${readiness.reviewUrl ?? "none"}`;
+  }
+  if (processed) return `processed_reviews status=${processed.status} error=${processed.error ?? "none"}`;
+  const activeJob = queueJobs.find((job) => ["queued", "leased", "running", "provider_deferred"].includes(job.state));
+  if (activeJob) {
+    return `queue_job state=${activeJob.state} priority=${activeJob.priority} lastError=${activeJob.lastError ?? "none"}`;
+  }
+  if (readiness) return `review_readiness state=${readiness.state} reason=${readiness.reason ?? "none"}`;
+  return "no processed review, active queue job, or readiness row for exact head";
+}
+
+function nextAction(decision: ReviewHeadGateDecision): string {
+  switch (decision) {
+    case "passed":
+      return "merge gate passed for exact head";
+    case "queued":
+    case "reviewing":
+      return "wait for evaOS review status to reach completed before merging";
+    case "provider_deferred":
+      return "wait for provider cooldown or retry according to provider-cooldown policy before merging";
+    case "missing":
+      return "do not merge; wait for the daemon to observe this head or run an explicit review-pr/re-review command";
+    case "dry_run":
+      return "do not merge from dry-run proof; require a live App-authored review or explicit waiver";
+    case "skipped":
+      return "do not merge without confirming the skip reason is an approved waiver";
+    case "failed":
+      return "inspect failure evidence and retry or fix before merging";
+    case "needs_fix":
+      return "do not merge; address evaOS requested changes or explicitly override with human approval";
+    case "stale":
+      return "refresh the current PR head and run the gate for the latest SHA";
+    case "closed":
+      return "PR is already closed or merged; record this as incident evidence if the final head needed review";
+    case "blocked":
+      return "resolve the blocked readiness state before merging";
+    default:
+      return assertNever(decision);
+  }
+}
+
+function validateRepoSlug(repo: string): void {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) throw new Error(`Invalid repo slug: ${repo}`);
+}
+
+function validatePullNumber(pullNumber: number): void {
+  if (!Number.isInteger(pullNumber) || pullNumber < 1) throw new Error(`Invalid PR number: ${pullNumber}`);
+}
+
+function validateHeadSha(headSha: string): void {
+  if (!/^[0-9a-f]{40}$/i.test(headSha)) throw new Error(`Invalid head SHA: ${headSha}`);
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled review-head-gate value: ${String(value)}`);
+}

--- a/src/review-head-gate.ts
+++ b/src/review-head-gate.ts
@@ -55,7 +55,7 @@ export function buildReviewHeadGate(input: {
   const ok = decision === "passed";
   const gates = [
     {
-      name: "exact_head_has_terminal_evaos_review",
+      name: "exact_head_has_recorded_nonblocking_evaos_review",
       ok,
       detail: gateDetail(decision, processed, readiness, queueJobs)
     }

--- a/src/review-head-gate.ts
+++ b/src/review-head-gate.ts
@@ -82,7 +82,9 @@ function decideReviewHeadGate(input: {
   queueJobs: ReviewQueueJobRecord[];
 }): ReviewHeadGateDecision {
   const activeJob = input.queueJobs.find(isActiveQueueJob);
-  if (activeJob) return decisionFromQueueJob(activeJob);
+  if (activeJob && (!input.processed || isQueueJobNewerThanProcessed(activeJob, input.processed))) {
+    return decisionFromQueueJob(activeJob);
+  }
   if (input.processed) return decisionFromProcessed(input.processed);
   const terminalJob = input.queueJobs.find(isTerminalQueueJob);
   if (terminalJob) return decisionFromQueueJob(terminalJob);
@@ -167,6 +169,20 @@ function isActiveQueueJob(job: ReviewQueueJobRecord): boolean {
 
 function isTerminalQueueJob(job: ReviewQueueJobRecord): boolean {
   return job.state === "posted" || job.state === "failed" || job.state === "stale_retired" || job.state === "closed_retired" || job.state === "command_recorded";
+}
+
+function isQueueJobNewerThanProcessed(job: ReviewQueueJobRecord, processed: StoredProcessedReviewRecord): boolean {
+  const jobMs = parseStoreTimestamp(job.updatedAt);
+  const processedMs = parseStoreTimestamp(processed.createdAt);
+  if (!Number.isFinite(jobMs) || !Number.isFinite(processedMs)) return true;
+  return jobMs > processedMs;
+}
+
+function parseStoreTimestamp(value: string): number {
+  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(value)) {
+    return Date.parse(`${value.replace(" ", "T")}Z`);
+  }
+  return Date.parse(value);
 }
 
 function gateDetail(

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -50,6 +50,12 @@ describe("public NeonDiff CLI surface", () => {
     ]);
     expect(output.examples).toContain("neondiff init --config config.local.json");
     expect(output.examples).toContain("npx tsx src/cli.ts daemon --config /path/to/live.json --dry-run true --once true");
+    expect(output.examples).toContain(
+      "npx tsx src/cli.ts review-head-gate --config /path/to/live.json --repo owner/repo --pr 123 --head-sha \"$(gh pr view 123 --repo owner/repo --json headRefOid --jq .headRefOid)\""
+    );
+    expect(output.examples).not.toContain(
+      "npx tsx src/cli.ts review-head-gate --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD"
+    );
   });
 
   it("prints command help without executing run-once, review-pr, or daemon paths", async () => {
@@ -630,7 +636,7 @@ describe("public NeonDiff CLI surface", () => {
         nextAction: expect.stringContaining("do not merge")
       });
       expect(output.gates[0]).toMatchObject({
-        name: "exact_head_has_terminal_evaos_review",
+        name: "exact_head_has_recorded_nonblocking_evaos_review",
         ok: false
       });
     }

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -694,6 +694,171 @@ describe("public NeonDiff CLI surface", () => {
     }
   });
 
+  it("blocks review-head-gate when an exact-head re-review job is still active", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-head-gate-rereview-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const configPath = join(root, "config.json");
+    const repo = "electricsheephq/evaos-code-review-bot";
+    const pullNumber = 181;
+    const headSha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: [repo],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+    const store = new ReviewStateStore(statePath);
+    store.recordProcessed({
+      repo,
+      pullNumber,
+      headSha,
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: `https://github.com/${repo}/pull/${pullNumber}#pullrequestreview-3`
+    });
+    store.enqueueReviewQueueJob({
+      repo,
+      pullNumber,
+      headSha,
+      baseSha: "base",
+      source: "manual_command",
+      priority: 0
+    });
+    store.close();
+
+    try {
+      await runCli([
+        "review-head-gate",
+        "--config",
+        configPath,
+        "--repo",
+        repo,
+        "--pr",
+        String(pullNumber),
+        "--head-sha",
+        headSha
+      ]);
+      throw new Error("review-head-gate unexpectedly passed");
+    } catch (error) {
+      const output = JSON.parse((error as { stdout: string }).stdout);
+      expect(output).toMatchObject({
+        ok: false,
+        decision: "queued",
+        processed: {
+          status: "posted",
+          event: "COMMENT"
+        },
+        nextAction: expect.stringContaining("wait for evaOS review")
+      });
+    }
+  });
+
+  it("passes review-head-gate from terminal posted queue evidence when processed rows are absent", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-head-gate-queue-posted-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const configPath = join(root, "config.json");
+    const repo = "electricsheephq/evaos-code-review-bot";
+    const pullNumber = 181;
+    const headSha = "cccccccccccccccccccccccccccccccccccccccc";
+    const reviewUrl = `https://github.com/${repo}/pull/${pullNumber}#pullrequestreview-4`;
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: [repo],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+    const store = new ReviewStateStore(statePath);
+    const queueJob = store.enqueueReviewQueueJob({
+      repo,
+      pullNumber,
+      headSha,
+      baseSha: "base"
+    }).job;
+    store.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "posted",
+      reviewUrl,
+      lastError: "reviewed"
+    });
+    store.close();
+
+    const { stdout } = await runCli([
+      "review-head-gate",
+      "--config",
+      configPath,
+      "--repo",
+      repo,
+      "--pr",
+      String(pullNumber),
+      "--head-sha",
+      headSha
+    ]);
+    const output = JSON.parse(stdout);
+
+    expect(output).toMatchObject({
+      ok: true,
+      decision: "passed",
+      queueJobs: [
+        {
+          state: "posted",
+          reviewUrl
+        }
+      ]
+    });
+  });
+
+  it("blocks review-head-gate for readiness-only passes without review proof", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-head-gate-readiness-proof-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const configPath = join(root, "config.json");
+    const repo = "electricsheephq/evaos-code-review-bot";
+    const pullNumber = 181;
+    const headSha = "dddddddddddddddddddddddddddddddddddddddd";
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: [repo],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+    const store = new ReviewStateStore(statePath);
+    store.recordReviewReadiness({
+      repo,
+      pullNumber,
+      headSha,
+      state: "ready_for_human",
+      reason: "dry-run-ready"
+    });
+    store.close();
+
+    try {
+      await runCli([
+        "review-head-gate",
+        "--config",
+        configPath,
+        "--repo",
+        repo,
+        "--pr",
+        String(pullNumber),
+        "--head-sha",
+        headSha
+      ]);
+      throw new Error("review-head-gate unexpectedly passed");
+    } catch (error) {
+      const output = JSON.parse((error as { stdout: string }).stdout);
+      expect(output).toMatchObject({
+        ok: false,
+        decision: "blocked",
+        readiness: {
+          state: "ready_for_human"
+        },
+        nextAction: expect.stringContaining("resolve the blocked")
+      });
+    }
+  });
+
   it("requires review-pr repos to be configured and enabled", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-review-pr-"));
     roots.push(root);

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -526,6 +526,168 @@ describe("public NeonDiff CLI surface", () => {
     store.close();
   });
 
+  it("passes review-head-gate only for an exact head with a posted evaOS review", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-head-gate-pass-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const configPath = join(root, "config.json");
+    const repo = "electricsheephq/evaos-code-review-bot";
+    const pullNumber = 181;
+    const headSha = "fb40fd1d340bb9896b2988b7913395df0b983c3d";
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: [repo],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+    const store = new ReviewStateStore(statePath);
+    store.recordProcessed({
+      repo,
+      pullNumber,
+      headSha,
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: `https://github.com/${repo}/pull/${pullNumber}#pullrequestreview-1`
+    });
+    store.close();
+
+    const { stdout } = await runCli([
+      "review-head-gate",
+      "--config",
+      configPath,
+      "--repo",
+      repo,
+      "--pr",
+      String(pullNumber),
+      "--head-sha",
+      headSha
+    ]);
+    const output = JSON.parse(stdout);
+
+    expect(output).toMatchObject({
+      ok: true,
+      healthState: "review_head_gate_ok",
+      decision: "passed",
+      repo,
+      pullNumber,
+      headSha,
+      processed: {
+        status: "posted",
+        event: "COMMENT"
+      }
+    });
+  });
+
+  it("fails review-head-gate for a final head the daemon never observed", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-head-gate-missing-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const configPath = join(root, "config.json");
+    const repo = "electricsheephq/evaos-code-review-bot";
+    const pullNumber = 181;
+    const previousHead = "8fef8d6abd0924d42b1d37d11911aed2587619cc";
+    const finalHead = "fb40fd1d340bb9896b2988b7913395df0b983c3d";
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: [repo],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+    const store = new ReviewStateStore(statePath);
+    store.recordProcessed({
+      repo,
+      pullNumber,
+      headSha: previousHead,
+      status: "posted",
+      event: "COMMENT"
+    });
+    store.close();
+
+    try {
+      await runCli([
+        "review-head-gate",
+        "--config",
+        configPath,
+        "--repo",
+        repo,
+        "--pr",
+        String(pullNumber),
+        "--head-sha",
+        finalHead
+      ]);
+      throw new Error("review-head-gate unexpectedly passed");
+    } catch (error) {
+      const stdout = (error as { stdout: string }).stdout;
+      const output = JSON.parse(stdout);
+      expect(output).toMatchObject({
+        ok: false,
+        healthState: "review_head_gate_blocked",
+        decision: "missing",
+        repo,
+        pullNumber,
+        headSha: finalHead,
+        queueJobs: [],
+        nextAction: expect.stringContaining("do not merge")
+      });
+      expect(output.gates[0]).toMatchObject({
+        name: "exact_head_has_terminal_evaos_review",
+        ok: false
+      });
+    }
+  });
+
+  it("fails review-head-gate for exact heads with evaOS requested changes", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-head-gate-needs-fix-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const configPath = join(root, "config.json");
+    const repo = "electricsheephq/evaos-code-review-bot";
+    const pullNumber = 181;
+    const headSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: [repo],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+    const store = new ReviewStateStore(statePath);
+    store.recordProcessed({
+      repo,
+      pullNumber,
+      headSha,
+      status: "posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl: `https://github.com/${repo}/pull/${pullNumber}#pullrequestreview-2`
+    });
+    store.close();
+
+    try {
+      await runCli([
+        "review-head-gate",
+        "--config",
+        configPath,
+        "--repo",
+        repo,
+        "--pr",
+        String(pullNumber),
+        "--head-sha",
+        headSha
+      ]);
+      throw new Error("review-head-gate unexpectedly passed");
+    } catch (error) {
+      const output = JSON.parse((error as { stdout: string }).stdout);
+      expect(output).toMatchObject({
+        ok: false,
+        decision: "needs_fix",
+        processed: {
+          status: "posted",
+          event: "REQUEST_CHANGES"
+        },
+        nextAction: expect.stringContaining("do not merge")
+      });
+    }
+  });
+
   it("requires review-pr repos to be configured and enabled", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-review-pr-"));
     roots.push(root);

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -723,7 +723,8 @@ describe("public NeonDiff CLI surface", () => {
       headSha,
       baseSha: "base",
       source: "manual_command",
-      priority: 0
+      priority: 0,
+      now: new Date("2099-01-01T00:00:00.000Z")
     });
     store.close();
 
@@ -752,6 +753,68 @@ describe("public NeonDiff CLI surface", () => {
         nextAction: expect.stringContaining("wait for evaOS review")
       });
     }
+  });
+
+  it("does not let older active queue residue block a newer posted exact-head review", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-head-gate-zombie-active-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const configPath = join(root, "config.json");
+    const repo = "electricsheephq/evaos-code-review-bot";
+    const pullNumber = 181;
+    const headSha = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: [repo],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+    const store = new ReviewStateStore(statePath);
+    store.enqueueReviewQueueJob({
+      repo,
+      pullNumber,
+      headSha,
+      baseSha: "base",
+      source: "manual_command",
+      priority: 0,
+      now: new Date("2020-01-01T00:00:00.000Z")
+    });
+    store.recordProcessed({
+      repo,
+      pullNumber,
+      headSha,
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: `https://github.com/${repo}/pull/${pullNumber}#pullrequestreview-5`
+    });
+    store.close();
+
+    const { stdout } = await runCli([
+      "review-head-gate",
+      "--config",
+      configPath,
+      "--repo",
+      repo,
+      "--pr",
+      String(pullNumber),
+      "--head-sha",
+      headSha
+    ]);
+    const output = JSON.parse(stdout);
+
+    expect(output).toMatchObject({
+      ok: true,
+      decision: "passed",
+      processed: {
+        status: "posted",
+        event: "COMMENT"
+      },
+      queueJobs: [
+        {
+          state: "queued"
+        }
+      ]
+    });
   });
 
   it("passes review-head-gate from terminal posted queue evidence when processed rows are absent", async () => {


### PR DESCRIPTION
## Summary

Closes #182. Adds a deterministic `review-head-gate` operator command so self-repo/release PRs fail pre-merge when the exact current head lacks a terminal evaOS review row. This catches the PR #181 incident shape: earlier heads were reviewed, but final head `fb40fd1d340bb9896b2988b7913395df0b983c3d` was pushed and merged before the poller observed it.

## Changes

- Add `src/review-head-gate.ts` to evaluate exact `{repo, pr, head_sha}` state across processed reviews, durable queue jobs, and readiness rows.
- Add CLI command `review-head-gate`.
- Document the new self-repo/release-critical pre-merge gate in the beta release runbook and operator CLI docs.
- Add public CLI regression tests for reviewed heads, missing final heads, and `REQUEST_CHANGES` heads.

## Validation

- `npx vitest run tests/public-cli.test.ts --pool=forks --poolOptions.forks.maxForks=1`
- `npm run build`
- `git diff --check`
- Live incident proof: `review-head-gate` fails for #181 final head `fb40fd1d340bb9896b2988b7913395df0b983c3d`.
- Live positive proof: `review-head-gate` passes for #180 reviewed head `595172f60f28091bae87772492bcf97212887027`.

## Runtime Scope

Read-only operator guard only. No provider concurrency change, no monitored repo widening, no issue-enrichment activation, no launchd config mutation.
