### PR TITLE
Harden NeonDiff desktop config cleanup

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
@@ -106,45 +106,50 @@ public final class NeonDiffCLIClient: NeonDiffCLIClienting {
 private func resolveExecutablePath(_ executablePath: String, workingDirectory: URL?) -> URL? {
     let fileManager = FileManager.default
     if executablePath.contains("/") {
-        return fileManager.isExecutableFile(atPath: executablePath) ? URL(fileURLWithPath: executablePath) : nil
+        return isExecutableFilePath(executablePath, fileManager: fileManager) ? URL(fileURLWithPath: executablePath) : nil
     }
 
-    let home = fileManager.homeDirectoryForCurrentUser.path
-    let candidates = [
-        "/opt/homebrew/bin/\(executablePath)",
-        "/usr/local/bin/\(executablePath)",
-        "\(home)/.local/bin/\(executablePath)",
-        "\(home)/.bun/bin/\(executablePath)",
-        "\(home)/.npm-global/bin/\(executablePath)",
-        workingDirectory?.appendingPathComponent("node_modules/.bin/\(executablePath)").path
-    ].compactMap { $0 }
+    var candidates = guiSafeUserBinDirectories(fileManager: fileManager).map { "\($0)/\(executablePath)" }
+    if let localBin = workingDirectory?.appendingPathComponent("node_modules/.bin/\(executablePath)").path {
+        candidates.append(localBin)
+    }
 
-    return candidates.first(where: fileManager.isExecutableFile).map(URL.init(fileURLWithPath:))
+    return candidates.first { isExecutableFilePath($0, fileManager: fileManager) }.map(URL.init(fileURLWithPath:))
 }
 
-private func guiSafeSearchPath() -> String {
-    let home = FileManager.default.homeDirectoryForCurrentUser.path
+private func isExecutableFilePath(_ path: String, fileManager: FileManager) -> Bool {
+    var isDirectory: ObjCBool = false
+    guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory), !isDirectory.boolValue else {
+        return false
+    }
+    return fileManager.isExecutableFile(atPath: path)
+}
+
+private func guiSafeUserBinDirectories(fileManager: FileManager = .default) -> [String] {
+    let home = fileManager.homeDirectoryForCurrentUser.path
     return [
         "/opt/homebrew/bin",
-        "/opt/homebrew/sbin",
         "/usr/local/bin",
-        "/usr/bin",
-        "/bin",
-        "/usr/sbin",
-        "/sbin",
         "\(home)/.local/bin",
         "\(home)/.bun/bin",
         "\(home)/.npm-global/bin"
-    ].joined(separator: ":")
+    ]
+}
+
+private func guiSafeSearchPath() -> String {
+    (
+        guiSafeUserBinDirectories()
+            + ["/opt/homebrew/sbin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+    ).joined(separator: ":")
 }
 
 private func guiSafeEnvironment() -> [String: String] {
-    var environment = ProcessInfo.processInfo.environment
-    let safePath = guiSafeSearchPath()
-    if let existingPath = environment["PATH"], !existingPath.isEmpty {
-        environment["PATH"] = "\(safePath):\(existingPath)"
-    } else {
-        environment["PATH"] = safePath
+    let inherited = ProcessInfo.processInfo.environment
+    var environment = ["PATH": guiSafeSearchPath()]
+    for key in ["HOME", "USER", "LOGNAME", "TMPDIR", "LANG", "LC_ALL", "LC_CTYPE"] {
+        if let value = inherited[key], !value.isEmpty {
+            environment[key] = value
+        }
     }
     return environment
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
@@ -36,13 +36,14 @@ public final class NeonDiffCLIClient: NeonDiffCLIClienting {
 
     public func run(arguments: [String], timeout: TimeInterval = 15) throws -> CLIRunResult {
         let process = Process()
-        if executablePath.contains("/") {
-            process.executableURL = URL(fileURLWithPath: executablePath)
+        if let resolvedExecutable = resolveExecutablePath(executablePath, workingDirectory: workingDirectory) {
+            process.executableURL = resolvedExecutable
             process.arguments = arguments
         } else {
             process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
             process.arguments = [executablePath] + arguments
         }
+        process.environment = guiSafeEnvironment()
         if let workingDirectory {
             process.currentDirectoryURL = workingDirectory
         }
@@ -100,4 +101,50 @@ public final class NeonDiffCLIClient: NeonDiffCLIClienting {
         let stderrText = String(data: stderrSnapshot, encoding: .utf8) ?? ""
         return CLIRunResult(exitCode: process.terminationStatus, stdout: stdoutText, stderr: stderrText)
     }
+}
+
+private func resolveExecutablePath(_ executablePath: String, workingDirectory: URL?) -> URL? {
+    let fileManager = FileManager.default
+    if executablePath.contains("/") {
+        return fileManager.isExecutableFile(atPath: executablePath) ? URL(fileURLWithPath: executablePath) : nil
+    }
+
+    let home = fileManager.homeDirectoryForCurrentUser.path
+    let candidates = [
+        "/opt/homebrew/bin/\(executablePath)",
+        "/usr/local/bin/\(executablePath)",
+        "\(home)/.local/bin/\(executablePath)",
+        "\(home)/.bun/bin/\(executablePath)",
+        "\(home)/.npm-global/bin/\(executablePath)",
+        workingDirectory?.appendingPathComponent("node_modules/.bin/\(executablePath)").path
+    ].compactMap { $0 }
+
+    return candidates.first(where: fileManager.isExecutableFile).map(URL.init(fileURLWithPath:))
+}
+
+private func guiSafeSearchPath() -> String {
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+    return [
+        "/opt/homebrew/bin",
+        "/opt/homebrew/sbin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",
+        "/sbin",
+        "\(home)/.local/bin",
+        "\(home)/.bun/bin",
+        "\(home)/.npm-global/bin"
+    ].joined(separator: ":")
+}
+
+private func guiSafeEnvironment() -> [String: String] {
+    var environment = ProcessInfo.processInfo.environment
+    let safePath = guiSafeSearchPath()
+    if let existingPath = environment["PATH"], !existingPath.isEmpty {
+        environment["PATH"] = "\(safePath):\(existingPath)"
+    } else {
+        environment["PATH"] = safePath
+    }
+    return environment
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/Redactor.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/Redactor.swift
@@ -9,7 +9,7 @@ public enum NeonDiffRedactor {
         (#"[?&](?:access[_-]?token|auth[_-]?token|api[_-]?key|token|secret|session|cookie)=[A-Za-z0-9._~+/=-]{16,}"#, [.caseInsensitive]),
         (#"\b(?:api[_-]?key|license[_-]?key|licenseKey|license|token|secret|password|cookie|session)\b\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{12,}"#, [.caseInsensitive]),
         (#""(?:api[_-]?key|license[_-]?key|licenseKey|license|token|secret|password|cookie|session)"\s*:\s*"[^"]{8,}""#, [.caseInsensitive]),
-        (#"\b(?:LIC|NDL|NEONDIFF)-[A-Za-z0-9-]{12,}\b"#, [.caseInsensitive]),
+        (#"\b(?:LIC|NDL|NEONDIFF)[_-][A-Za-z0-9][A-Za-z0-9_-]{11,}\b"#, [.caseInsensitive]),
         (#"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z ]*PRIVATE KEY-----)?"#, [])
     ]
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
@@ -108,9 +108,10 @@ do {
     }
 
     let fakeProductLicense = "NEONDIFF-1234567890-ABCDE"
+    let fakeUnderscoreLicense = "NDL_PRIVATE_1234567890"
     let jsonLicense = "fixture-license-secret-1234567890"
-    let redacted = NeonDiffRedactor.redact("token=\(fakeProviderKey)\nlicenseKey=\(fakeProductLicense)\n{\"licenseKey\":\"\(jsonLicense)\"}")
-    guard !redacted.contains(fakeProviderKey), !redacted.contains(fakeProductLicense), !redacted.contains(jsonLicense) else {
+    let redacted = NeonDiffRedactor.redact("token=\(fakeProviderKey)\nlicenseKey=\(fakeProductLicense)\nlicense=\(fakeUnderscoreLicense)\n{\"licenseKey\":\"\(jsonLicense)\"}")
+    guard !redacted.contains(fakeProviderKey), !redacted.contains(fakeProductLicense), !redacted.contains(fakeUnderscoreLicense), !redacted.contains(jsonLicense) else {
         throw NSError(domain: "NeonDiffDesktopSmoke", code: 9, userInfo: [NSLocalizedDescriptionKey: "redaction failed"])
     }
 

--- a/config.example.json
+++ b/config.example.json
@@ -177,6 +177,7 @@
     }
   },
   "zcode": {
+    "_desktopPathComment": "Developer-machine defaults. Override cliPath and appConfigPath for any non-author workstation or packaged desktop install.",
     "cliPath": "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
     "appConfigPath": "/Volumes/LEXAR/zcode/.zcode/v2/config.json",
     "model": "GLM-5.2",

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -33,5 +33,6 @@ neondiff daemon stop --config config.local.json --launchd-label com.example.neon
 ```
 
 `config patch` writes only whitelisted non-secret fields, defaults to dry-run, and requires `--confirm true` for live writes.
+Patch inputs use nested JSON object shape for editable paths. For example, the advertised `zcode.cliPath` path is supplied as `{ "zcode": { "cliPath": "/path/to/neondiff" } }`; flat dotted keys such as `{ "zcode.cliPath": "/path/to/neondiff" }` are rejected to avoid ambiguous profile keys.
 
 The ZCode defaults in `config.example.json` are developer-machine paths. On any non-author workstation or packaged desktop install, set explicit local values for `zcode.cliPath`, `zcode.appConfigPath`, and `zcode.model` before relying on daemon controls.

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -33,3 +33,5 @@ neondiff daemon stop --config config.local.json --launchd-label com.example.neon
 ```
 
 `config patch` writes only whitelisted non-secret fields, defaults to dry-run, and requires `--confirm true` for live writes.
+
+The ZCode defaults in `config.example.json` are developer-machine paths. On any non-author workstation or packaged desktop install, set explicit local values for `zcode.cliPath`, `zcode.appConfigPath`, and `zcode.model` before relying on daemon controls.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2099,6 +2099,7 @@ function buildHelp(command?: string) {
       "neondiff init --config config.local.json",
       "neondiff config inspect --config config.local.json",
       "neondiff config patch --config config.local.json --input desktop-patch.json --dry-run true",
+      "desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}",
       "neondiff doctor --config config.local.json --json",
       "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 --dry-run true --zcode false",
       "neondiff daemon status --config config.local.json --launchd-label com.example.neondiff",

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -32,6 +32,7 @@ const REPO_PROFILE_DESKTOP_SAFE_FIELDS = [
 ] as const satisfies readonly (keyof RepoProfileConfig)[];
 
 const REPO_PROFILE_DESKTOP_SAFE_FIELD_PATTERN = REPO_PROFILE_DESKTOP_SAFE_FIELDS.join("|");
+const CONFIG_NAME_SEGMENT_PATTERN = "[A-Za-z0-9_.-]+";
 
 const EXACT_PATCH_PATHS = new Set([
   "pilotRepos",
@@ -50,10 +51,10 @@ const EXACT_PATCH_PATHS = new Set([
 ]);
 
 const REPO_PROFILE_FIELD_PATTERN =
-  new RegExp(`^repoProfiles\\.(?:repos\\.[A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+|orgFallbacks\\.[A-Za-z0-9_.-]+)\\.(?:${REPO_PROFILE_DESKTOP_SAFE_FIELD_PATTERN})$`);
+  new RegExp(`^repoProfiles\\.(?:repos\\.(${CONFIG_NAME_SEGMENT_PATTERN}\\/${CONFIG_NAME_SEGMENT_PATTERN})|orgFallbacks\\.(${CONFIG_NAME_SEGMENT_PATTERN}))\\.(?:${REPO_PROFILE_DESKTOP_SAFE_FIELD_PATTERN})$`);
 
 const REPO_PROFILE_NESTED_PATTERN =
-  /^repoProfiles\.repos\.[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\.(?:autoReview\.(?:baseBranches|labels)|preMergeChecks\.(?:title|description|linkedIssue|testEvidence|docs|docstrings)\.(?:mode|instructions|threshold)|finishingTouches\.(?:docs|docstrings|unitTests|simplifySuggestion|changelogDraft|riskExplanation|reviewReady|stackedPr)\.(?:enabled|instructions))$/;
+  new RegExp(`^repoProfiles\\.repos\\.(${CONFIG_NAME_SEGMENT_PATTERN}\\/${CONFIG_NAME_SEGMENT_PATTERN})\\.(?:autoReview\\.(?:baseBranches|labels)|preMergeChecks\\.(?:title|description|linkedIssue|testEvidence|docs|docstrings)\\.(?:mode|instructions|threshold)|finishingTouches\\.(?:docs|docstrings|unitTests|simplifySuggestion|changelogDraft|riskExplanation|reviewReady|stackedPr)\\.(?:enabled|instructions))$`);
 
 export interface ConfigInspectResult {
   ok: true;
@@ -129,6 +130,10 @@ export function patchConfigForDesktop(input: {
   if (!isRecord(patch)) {
     return failedPatch(input, configPath, inputPath, "patch input must contain a JSON object");
   }
+  const unsupportedKey = findUnsupportedDottedPatchKey(patch);
+  if (unsupportedKey) {
+    return failedPatch(input, configPath, inputPath, unsupportedDottedKeyError(unsupportedKey));
+  }
   const patchText = JSON.stringify(patch);
   if (containsSecretLikeText(patchText)) {
     return failedPatch(input, configPath, inputPath, "patch input contains secret-like text; store provider and license keys in Keychain instead");
@@ -138,9 +143,9 @@ export function patchConfigForDesktop(input: {
   if (flattened.length === 0) {
     return failedPatch(input, configPath, inputPath, "patch input did not contain any leaf settings");
   }
-  const disallowed = flattened.map((entry) => entry.path.join(".")).filter((path) => !isPatchPathAllowed(path));
+  const disallowed = flattened.map((entry) => entry.path).filter((path) => !isPatchPathAllowed(path.join(".")));
   if (disallowed.length > 0) {
-    return failedPatch(input, configPath, inputPath, `patch contains non-desktop-safe path(s): ${disallowed.join(", ")}`);
+    return failedPatch(input, configPath, inputPath, disallowedPatchPathError(disallowed));
   }
 
   const next = structuredClone(current) as Record<string, unknown>;
@@ -211,6 +216,7 @@ function failedPatch(input: { dryRun: boolean }, configPath: string, inputPath: 
 }
 
 function flattenPatch(value: unknown, prefix: string[] = []): FlattenedPatch[] {
+  if (prefix.length === 0 && !isRecord(value)) return [];
   if (!isRecord(value)) return [{ path: prefix, value }];
   const entries: FlattenedPatch[] = [];
   for (const [key, entry] of Object.entries(value)) {
@@ -224,7 +230,15 @@ function flattenPatch(value: unknown, prefix: string[] = []): FlattenedPatch[] {
 }
 
 function isPatchPathAllowed(path: string): boolean {
-  return EXACT_PATCH_PATHS.has(path) || REPO_PROFILE_FIELD_PATTERN.test(path) || REPO_PROFILE_NESTED_PATTERN.test(path);
+  if (EXACT_PATCH_PATHS.has(path)) return true;
+  const fieldMatch = path.match(REPO_PROFILE_FIELD_PATTERN);
+  if (fieldMatch) {
+    const repo = fieldMatch[1];
+    const owner = fieldMatch[2];
+    return repo ? isConfigRepoName(repo) : Boolean(owner && isConfigNameSegment(owner));
+  }
+  const nestedMatch = path.match(REPO_PROFILE_NESTED_PATTERN);
+  return Boolean(nestedMatch?.[1] && isConfigRepoName(nestedMatch[1]));
 }
 
 function setNestedValue(target: Record<string, unknown>, path: string[], value: unknown): void {
@@ -300,13 +314,56 @@ function writeConfigAtomic(configPath: string, value: unknown): void {
 
 function redactSecretValue(value: unknown): unknown {
   if (value === undefined || value === null || value === "") return value;
-  if (Array.isArray(value)) return value.map((entry) => redactSecretValue(entry));
-  if (isRecord(value)) {
-    return Object.fromEntries(Object.keys(value).map((key) => [key, "[redacted-secret]"]));
-  }
+  if (Array.isArray(value) || isRecord(value)) return "[redacted-secret]";
   return "[redacted-secret]";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function findUnsupportedDottedPatchKey(value: unknown, prefix: string[] = []): string[] | undefined {
+  if (!isRecord(value)) return undefined;
+  for (const [key, entry] of Object.entries(value)) {
+    const keyPath = [...prefix, key];
+    if (key.includes(".") && !isProfileIdentifierSegment(prefix)) {
+      return keyPath;
+    }
+    const nested = findUnsupportedDottedPatchKey(entry, keyPath);
+    if (nested) return nested;
+  }
+  return undefined;
+}
+
+function isProfileIdentifierSegment(prefix: string[]): boolean {
+  return prefix.length === 2 && prefix[0] === "repoProfiles" && (prefix[1] === "repos" || prefix[1] === "orgFallbacks");
+}
+
+function unsupportedDottedKeyError(path: string[]): string {
+  const rendered = renderPatchPath(path);
+  if (containsSecretLikeText(rendered)) {
+    return "patch contains unsupported dotted key segment; one or more path names looked sensitive";
+  }
+  return `patch contains unsupported dotted key segment: ${redactSecrets(rendered)}`;
+}
+
+function disallowedPatchPathError(paths: string[][]): string {
+  const rendered = paths.map(renderPatchPath);
+  if (rendered.some((path) => containsSecretLikeText(path))) {
+    return "patch contains non-desktop-safe path(s); one or more path names looked sensitive";
+  }
+  return `patch contains non-desktop-safe path(s): ${rendered.map(redactSecrets).join(", ")}`;
+}
+
+function renderPatchPath(path: string[]): string {
+  return path.length === 0 ? "<root>" : path.join(".");
+}
+
+function isConfigRepoName(value: string): boolean {
+  const [owner, repo, extra] = value.split("/");
+  return extra === undefined && Boolean(owner && repo && isConfigNameSegment(owner) && isConfigNameSegment(repo));
+}
+
+function isConfigNameSegment(value: string): boolean {
+  return value !== "." && value !== ".." && /^[A-Za-z0-9_.-]+$/.test(value);
 }

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -84,6 +84,32 @@ interface FlattenedPatch {
   value: unknown;
 }
 
+type ConfigFileOps = {
+  chmodSync: typeof chmodSync;
+  closeSync: typeof closeSync;
+  existsSync: typeof existsSync;
+  fsyncSync: typeof fsyncSync;
+  mkdirSync: typeof mkdirSync;
+  openSync: typeof openSync;
+  renameSync: typeof renameSync;
+  statSync: typeof statSync;
+  unlinkSync: typeof unlinkSync;
+  writeFileSync: typeof writeFileSync;
+};
+
+const defaultConfigFileOps: ConfigFileOps = {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync
+};
+
 export function inspectConfigForDesktop(configPath?: string): ConfigInspectResult {
   const resolvedConfigPath = configPath ? resolve(configPath) : undefined;
   const config = loadConfig(resolvedConfigPath);
@@ -103,6 +129,7 @@ export function patchConfigForDesktop(input: {
   inputPath: string;
   dryRun: boolean;
   confirm: boolean;
+  fileOps?: Partial<ConfigFileOps>;
 }): ConfigPatchResult {
   const configPath = resolve(input.configPath);
   const inputPath = resolve(input.inputPath);
@@ -165,7 +192,11 @@ export function patchConfigForDesktop(input: {
   if (validationError) return failedPatch(input, configPath, inputPath, validationError);
 
   if (!input.dryRun && changedPaths.length > 0) {
-    writeConfigAtomic(configPath, next);
+    try {
+      writeConfigAtomic(configPath, next, input.fileOps);
+    } catch (error) {
+      return failedPatch(input, configPath, inputPath, `failed to write config atomically: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 
   return {
@@ -291,30 +322,36 @@ function validateCandidateConfig(candidate: unknown): string | undefined {
   }
 }
 
-function writeConfigAtomic(configPath: string, value: unknown): void {
-  mkdirSync(dirname(configPath), { recursive: true });
-  const mode = existsSync(configPath) ? statSync(configPath).mode & 0o777 : 0o600;
+function writeConfigAtomic(configPath: string, value: unknown, fileOps?: Partial<ConfigFileOps>): void {
+  const ops = { ...defaultConfigFileOps, ...fileOps };
+  ops.mkdirSync(dirname(configPath), { recursive: true });
+  const mode = ops.existsSync(configPath) ? ops.statSync(configPath).mode & 0o777 : 0o600;
   const tempPath = `${configPath}.${process.pid}.${Date.now()}.tmp`;
   const data = `${JSON.stringify(value, null, 2)}\n`;
   let fd: number | undefined;
   try {
-    fd = openSync(tempPath, "w", mode);
-    writeFileSync(fd, data);
-    fsyncSync(fd);
-    closeSync(fd);
+    fd = ops.openSync(tempPath, "w", mode);
+    ops.writeFileSync(fd, data);
+    ops.fsyncSync(fd);
+    ops.closeSync(fd);
     fd = undefined;
-    chmodSync(tempPath, mode);
-    renameSync(tempPath, configPath);
+    ops.chmodSync(tempPath, mode);
+    ops.renameSync(tempPath, configPath);
   } catch (error) {
-    if (fd !== undefined) closeSync(fd);
-    if (existsSync(tempPath)) unlinkSync(tempPath);
+    if (fd !== undefined) {
+      try {
+        ops.closeSync(fd);
+      } catch {
+        // Continue cleanup; preserving no temp config is more important here.
+      }
+    }
+    if (ops.existsSync(tempPath)) ops.unlinkSync(tempPath);
     throw error;
   }
 }
 
 function redactSecretValue(value: unknown): unknown {
-  if (value === undefined || value === null || value === "") return value;
-  if (Array.isArray(value) || isRecord(value)) return "[redacted-secret]";
+  if (value === undefined || value === null) return value;
   return "[redacted-secret]";
 }
 

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -29,6 +29,12 @@ describe("desktop config CLI", () => {
         appId: "123",
         privateKeyPath: join(root, "private-key.pem"),
         token: "ghp_123456789012345678901234567890123456"
+      },
+      notes: {
+        customProviderHeader: "Bearer custom-provider-token-1234567890"
+      },
+      customSecret: {
+        nestedKeyName: "not-secret-shaped-but-container-is"
       }
     });
 
@@ -57,6 +63,8 @@ describe("desktop config CLI", () => {
       privateKeyPath: "[redacted-secret]",
       token: "[redacted-secret]"
     });
+    expect(output.config.notes.customProviderHeader).toBe("[redacted-secret]");
+    expect(output.config.customSecret).toBe("[redacted-secret]");
   });
 
   it("dry-runs whitelisted non-secret patches without writing", async () => {
@@ -213,12 +221,45 @@ describe("desktop config CLI", () => {
     expect(readFileSync(configPath, "utf8")).toBe(before);
   });
 
+  it("keeps default patch mode dry-run even when confirm is true", async () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    const patchPath = join(root, "patch.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      desktop: {
+        updateChannel: "dev"
+      }
+    });
+    writeConfig(patchPath, {
+      desktop: {
+        updateChannel: "beta"
+      }
+    });
+    const before = readFileSync(configPath, "utf8");
+
+    const output = await runConfig(["config", "patch", "--config", configPath, "--input", patchPath, "--confirm", "true"]);
+
+    expect(output).toMatchObject({
+      ok: true,
+      dryRun: true,
+      wrote: false,
+      changedPaths: ["desktop.updateChannel"]
+    });
+    expect(readFileSync(configPath, "utf8")).toBe(before);
+  });
+
   it("rejects secrets and non-desktop-safe patch paths", async () => {
     const root = mkRoot();
     const configPath = join(root, "config.json");
     const secretPatchPath = join(root, "secret-patch.json");
     const licensePatchPath = join(root, "license-patch.json");
     const blockedPatchPath = join(root, "blocked-patch.json");
+    const sensitivePathPatchPath = join(root, "sensitive-path-patch.json");
+    const flatDottedPatchPath = join(root, "flat-dotted-patch.json");
     writeConfig(configPath, {
       pilotRepos: ["owner/repo"],
       workRoot: join(root, "runtime"),
@@ -233,6 +274,12 @@ describe("desktop config CLI", () => {
     });
     writeConfig(blockedPatchPath, {
       pollIntervalMs: 120_000
+    });
+    writeConfig(sensitivePathPatchPath, {
+      "NDL_SECRETLIKEPATH12345": "not-a-secret-value"
+    });
+    writeConfig(flatDottedPatchPath, {
+      "zcode.cliPath": "/new/bin/neondiff"
     });
 
     expect(await runConfig(["config", "patch", "--config", configPath, "--input", secretPatchPath])).toMatchObject({
@@ -249,6 +296,18 @@ describe("desktop config CLI", () => {
       ok: false,
       error: expect.stringContaining("non-desktop-safe path")
     });
+    const sensitivePathRejected = await runConfig(["config", "patch", "--config", configPath, "--input", sensitivePathPatchPath]);
+    expect(sensitivePathRejected).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("secret-like text")
+    });
+    expect(JSON.stringify(sensitivePathRejected)).not.toContain("NDL_SECRETLIKEPATH12345");
+    const flatDottedRejected = await runConfig(["config", "patch", "--config", configPath, "--input", flatDottedPatchPath]);
+    expect(flatDottedRejected).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("unsupported dotted key segment")
+    });
+    expect(JSON.stringify(flatDottedRejected)).not.toContain("/new/bin/neondiff");
   });
 
   it("keeps GitHub API base URL out of desktop-safe patches", async () => {
@@ -297,6 +356,68 @@ describe("desktop config CLI", () => {
     expect(output).toMatchObject({
       ok: false,
       error: expect.stringContaining("config.zcode.cliPath must be a non-empty string")
+    });
+  });
+
+  it("does not leave temp config files after candidate validation rejects a live patch", async () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    const patchPath = join(root, "patch.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      zcode: {
+        cliPath: "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
+        appConfigPath: "/Volumes/LEXAR/zcode/.zcode/v2/config.json",
+        model: "GLM-5.2"
+      }
+    });
+    writeConfig(patchPath, {
+      zcode: {
+        cliPath: "",
+        appConfigPath: "/Volumes/LEXAR/zcode/.zcode/v2/config.json",
+        model: "GLM-5.2"
+      }
+    });
+
+    const output = await runConfig([
+      "config",
+      "patch",
+      "--config",
+      configPath,
+      "--input",
+      patchPath,
+      "--dry-run",
+      "false",
+      "--confirm",
+      "true"
+    ]);
+
+    expect(output).toMatchObject({
+      ok: false,
+      wrote: false,
+      error: expect.stringContaining("config.zcode.cliPath must be a non-empty string")
+    });
+    expect(readdirSync(root).filter((name) => name.includes(".tmp"))).toEqual([]);
+  });
+
+  it("rejects empty object patches with a clear message", async () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    const patchPath = join(root, "patch.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    });
+    writeConfig(patchPath, {});
+
+    await expect(runConfig(["config", "patch", "--config", configPath, "--input", patchPath])).resolves.toMatchObject({
+      ok: false,
+      error: "patch input did not contain any leaf settings"
     });
   });
 

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
+import { patchConfigForDesktop } from "../src/config-cli.js";
 
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
@@ -65,6 +66,28 @@ describe("desktop config CLI", () => {
     });
     expect(output.config.notes.customProviderHeader).toBe("[redacted-secret]");
     expect(output.config.customSecret).toBe("[redacted-secret]");
+  });
+
+  it("redacts empty secret values consistently", async () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      github: {
+        token: "",
+        privateKeyPath: null
+      }
+    });
+
+    const output = await runConfig(["config", "inspect", "--config", configPath]);
+
+    expect(output.config.github).toMatchObject({
+      token: "[redacted-secret]",
+      privateKeyPath: null
+    });
   });
 
   it("dry-runs whitelisted non-secret patches without writing", async () => {
@@ -359,7 +382,7 @@ describe("desktop config CLI", () => {
     });
   });
 
-  it("does not leave temp config files after candidate validation rejects a live patch", async () => {
+  it("rejects invalid live patches before creating temp config files", async () => {
     const root = mkRoot();
     const configPath = join(root, "config.json");
     const patchPath = join(root, "patch.json");
@@ -400,6 +423,47 @@ describe("desktop config CLI", () => {
       wrote: false,
       error: expect.stringContaining("config.zcode.cliPath must be a non-empty string")
     });
+    expect(readdirSync(root).filter((name) => name.includes(".tmp"))).toEqual([]);
+  });
+
+  it("removes temp config files when an atomic live write fails", () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    const patchPath = join(root, "patch.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      desktop: {
+        updateChannel: "dev"
+      }
+    });
+    const before = readFileSync(configPath, "utf8");
+    writeConfig(patchPath, {
+      desktop: {
+        updateChannel: "beta"
+      }
+    });
+
+    const output = patchConfigForDesktop({
+      configPath,
+      inputPath: patchPath,
+      dryRun: false,
+      confirm: true,
+      fileOps: {
+        renameSync: () => {
+          throw new Error("forced rename failure");
+        }
+      }
+    });
+
+    expect(output).toMatchObject({
+      ok: false,
+      wrote: false,
+      error: expect.stringContaining("failed to write config atomically")
+    });
+    expect(readFileSync(configPath, "utf8")).toBe(before);
     expect(readdirSync(root).filter((name) => name.includes(".tmp"))).toEqual([]);
   });
 

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -56,6 +56,7 @@ describe("public NeonDiff CLI surface", () => {
     expect(output.examples).not.toContain(
       "npx tsx src/cli.ts review-head-gate --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD"
     );
+    expect(output.examples).toContain("desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}");
   });
 
   it("prints command help without executing run-once, review-pr, or daemon paths", async () => {


### PR DESCRIPTION
## Summary\n- harden the NeonDiff desktop config patch contract after post-merge PR #180 review\n- add redaction coverage for sensitive patch paths, arbitrary Bearer values, secret-named containers, and underscore-form license keys\n- reject ambiguous flat dotted patch keys, clarify dev-machine ZCode defaults, and resolve common GUI-safe neondiff CLI paths\n\nCloses #184\n\n## Test Plan\n- npm test -- tests/config-cli.test.ts tests/public-cli.test.ts\n- npm run build\n- cd apps/neondiff-desktop && swift build\n- cd apps/neondiff-desktop && swift run NeonDiffDesktopCoreSmoke\n- npm test\n- git diff --check\n\n## Evidence\n/Volumes/LEXAR/Codex/evidence/neondiff-desktop/2026-07-03/post-180-cleanup-and-brand/cleanup-184-validation.md\n\n## Deferred\n- Provider key handoff from Keychain to review runtime remains deferred to #108/#111; this PR intentionally does not add a UI-only live review credential path.