### PR TITLE
Apply NeonDiff Desktop Saiba theme

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -27,8 +27,14 @@ struct NeonDiffDesktopApp: App {
         }
 
         Settings {
-            SettingsPane(model: model)
-                .frame(width: 560)
+            ZStack {
+                OperatorBackdrop()
+                SettingsPane(model: model)
+            }
+            .buttonStyle(OperatorButtonStyle())
+            .tint(NeonDiffTheme.accent)
+            .preferredColorScheme(.dark)
+            .frame(width: 560)
         }
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
@@ -5,11 +5,23 @@ struct ContentView: View {
     @ObservedObject var model: NeonDiffDesktopModel
 
     var body: some View {
-        NavigationSplitView {
-            SidebarView(selection: $model.selectedSection)
-        } detail: {
-            DetailView(model: model)
+        ZStack {
+            OperatorBackdrop()
+            HStack(spacing: 0) {
+                SidebarView(selection: $model.selectedSection)
+                    .frame(width: 230)
+
+                Rectangle()
+                    .fill(NeonDiffTheme.stroke.opacity(0.55))
+                    .frame(width: 1)
+
+                DetailView(model: model)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
         }
+        .tint(NeonDiffTheme.accent)
+        .buttonStyle(OperatorButtonStyle())
+        .preferredColorScheme(.dark)
     }
 }
 
@@ -17,17 +29,26 @@ private struct DetailView: View {
     @ObservedObject var model: NeonDiffDesktopModel
 
     var body: some View {
-        Group {
-            switch model.selectedSection {
-            case .overview: OverviewView(model: model)
-            case .repos: ReposView(model: model)
-            case .providers: ProviderSettingsView(model: model)
-            case .license: LicenseView(model: model)
-            case .logs: LogsView(model: model)
-            case .policy: PolicyView(model: model)
-            case .settings: SettingsPane(model: model)
+        ZStack {
+            OperatorBackdrop()
+            VStack(spacing: 0) {
+                OperatorSectionHeader(title: model.selectedSection.title, status: model.status.healthState)
+                    .padding(.horizontal, 22)
+                    .padding(.top, 20)
+                    .padding(.bottom, 8)
+
+                Group {
+                    switch model.selectedSection {
+                    case .overview: OverviewView(model: model)
+                    case .repos: ReposView(model: model)
+                    case .providers: ProviderSettingsView(model: model)
+                    case .license: LicenseView(model: model)
+                    case .logs: LogsView(model: model)
+                    case .policy: PolicyView(model: model)
+                    case .settings: SettingsPane(model: model)
+                    }
+                }
             }
         }
-        .navigationTitle(model.selectedSection.title)
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LicenseView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LicenseView.swift
@@ -4,24 +4,34 @@ struct LicenseView: View {
     @ObservedObject var model: NeonDiffDesktopModel
 
     var body: some View {
-        Form {
-            Section("License") {
-                SecureField("License Key", text: $model.pendingLicenseKey)
-                HStack {
-                    Button("Store License") { model.storeLicenseKey() }
-                    Label(model.license.keyStored ? "Stored locally" : "No key stored", systemImage: model.license.keyStored ? "checkmark.seal" : "key")
-                        .foregroundStyle(model.license.keyStored ? .green : .secondary)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                OperatorSection("License") {
+                    OperatorTextField(title: "License Key", text: $model.pendingLicenseKey, secure: true)
+                    HStack(spacing: 10) {
+                        Button { model.storeLicenseKey() } label: {
+                            Label("Store License", systemImage: "key.fill")
+                        }
+                        OperatorBadge(
+                            text: model.license.keyStored ? "Stored Locally" : "No Key Stored",
+                            color: model.license.keyStored ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary
+                        )
+                    }
+                    Divider()
+                        .overlay(NeonDiffTheme.stroke.opacity(0.6))
+                    LabeledContent("Entitlement", value: model.license.entitlement)
+                        .foregroundStyle(NeonDiffTheme.textPrimary)
+                    LabeledContent("Update Channel", value: model.license.updateChannel)
+                        .foregroundStyle(NeonDiffTheme.textPrimary)
                 }
-                LabeledContent("Entitlement", value: model.license.entitlement)
-                LabeledContent("Update Channel", value: model.license.updateChannel)
-            }
 
-            Section("Boundary") {
-                Text("This MVP stores a fake/local license key only. Activation, signed updater behavior, and downloadable app readiness remain separate release work.")
-                    .foregroundStyle(.secondary)
+                OperatorSection("Boundary") {
+                    Text("This MVP stores a fake/local license key only. Activation, signed updater behavior, and downloadable app readiness remain separate release work.")
+                        .operatorBodyText()
+                }
             }
+            .padding(24)
         }
-        .formStyle(.grouped)
-        .padding(20)
+        .scrollContentBackground(.hidden)
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LogsView.swift
@@ -4,24 +4,42 @@ struct LogsView: View {
     @ObservedObject var model: NeonDiffDesktopModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Button("Refresh Status Logs") { model.refreshStatus() }
-                Button("Copy Last Command") { model.copyCommand(model.statusCommand) }
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 10) {
+                Button { model.refreshStatus() } label: {
+                    Label("Refresh Status Logs", systemImage: "arrow.clockwise")
+                }
+                Button { model.copyCommand(model.statusCommand) } label: {
+                    Label("Copy Last Command", systemImage: "doc.on.doc")
+                }
             }
 
-            TextEditor(text: $model.logText)
-                .font(.system(.body, design: .monospaced))
-                .textSelection(.enabled)
-                .frame(minHeight: 420)
-                .overlay {
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(.quaternary)
-                }
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Redacted Output")
+                    .font(NeonDiffTheme.headlineFont)
+                    .foregroundStyle(NeonDiffTheme.accentSoft)
 
-            Text("Output is redacted before display. Raw provider keys, license keys, tokens, private keys, and credential URLs must not appear here.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
+                TextEditor(text: $model.logText)
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+                    .scrollContentBackground(.hidden)
+                    .textSelection(.enabled)
+                    .frame(minHeight: 420)
+                    .padding(8)
+                    .background(Color.black.opacity(0.42))
+                    .overlay {
+                        AngularRectangle(corner: 10)
+                            .stroke(NeonDiffTheme.stroke.opacity(0.7), lineWidth: 0.8)
+                    }
+                    .clipShape(AngularRectangle(corner: 10))
+            }
+            .operatorPanel()
+
+            OperatorSection("Display Safety") {
+                Text("Output is redacted before display. Raw provider keys, license keys, tokens, private keys, and credential URLs must not appear here.")
+                    .operatorBodyText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .padding(24)
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/NeonDiffTheme.swift
@@ -1,0 +1,299 @@
+import SwiftUI
+
+enum NeonDiffTheme {
+    static let shell = Color(red: 0.015, green: 0.018, blue: 0.016)
+    static let sidebar = Color(red: 0.025, green: 0.032, blue: 0.028)
+    static let panel = Color(red: 0.035, green: 0.052, blue: 0.043)
+    static let panelActive = Color(red: 0.05, green: 0.095, blue: 0.065)
+    static let panelRaised = Color(red: 0.055, green: 0.071, blue: 0.061)
+    static let accent = Color(red: 0.22, green: 1.0, blue: 0.12)
+    static let accentSoft = Color(red: 0.50, green: 1.0, blue: 0.42)
+    static let textPrimary = Color(red: 0.91, green: 0.98, blue: 0.91)
+    static let textSecondary = Color(red: 0.56, green: 0.70, blue: 0.57)
+    static let stroke = Color(red: 0.16, green: 0.55, blue: 0.18)
+    static let warning = Color(red: 1.0, green: 0.34, blue: 0.30)
+
+    static let logoFont = Font.system(size: 24, weight: .black, design: .monospaced)
+    static let headlineFont = Font.system(.headline, design: .monospaced).weight(.bold)
+    static let badgeFont = Font.system(.caption, design: .monospaced).weight(.bold)
+    static let commandFont = Font.system(.caption, design: .monospaced)
+
+    static func statusColor(_ value: String) -> Color {
+        let normalized = value.lowercased()
+        if normalized.contains("ok") || normalized.contains("stored") || normalized.contains("ready") || normalized.contains("active") {
+            return accent
+        }
+        if normalized.contains("missing") || normalized.contains("blocked") || normalized.contains("error") || normalized.contains("unknown") {
+            return warning
+        }
+        return accentSoft
+    }
+}
+
+struct AngularRectangle: Shape {
+    var corner: CGFloat = 14
+
+    func path(in rect: CGRect) -> Path {
+        let cut = min(corner, rect.width / 3, rect.height / 3)
+        var path = Path()
+        path.move(to: CGPoint(x: rect.minX + cut, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX - cut, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY + cut))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - cut))
+        path.addLine(to: CGPoint(x: rect.maxX - cut, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX + cut, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY - cut))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + cut))
+        path.closeSubpath()
+        return path
+    }
+}
+
+struct OperatorBackdrop: View {
+    var body: some View {
+        ZStack {
+            NeonDiffTheme.shell
+
+            Canvas { context, size in
+                var grid = Path()
+                let spacing: CGFloat = 36
+                var x: CGFloat = 0
+                while x <= size.width {
+                    grid.move(to: CGPoint(x: x, y: 0))
+                    grid.addLine(to: CGPoint(x: x, y: size.height))
+                    x += spacing
+                }
+                var y: CGFloat = 0
+                while y <= size.height {
+                    grid.move(to: CGPoint(x: 0, y: y))
+                    grid.addLine(to: CGPoint(x: size.width, y: y))
+                    y += spacing
+                }
+                context.stroke(grid, with: .color(NeonDiffTheme.accent.opacity(0.055)), lineWidth: 0.6)
+
+                var scanlines = Path()
+                y = 0
+                while y <= size.height {
+                    scanlines.move(to: CGPoint(x: 0, y: y))
+                    scanlines.addLine(to: CGPoint(x: size.width, y: y))
+                    y += 7
+                }
+                context.stroke(scanlines, with: .color(NeonDiffTheme.accent.opacity(0.032)), lineWidth: 0.35)
+
+                var diagonal = Path()
+                diagonal.move(to: CGPoint(x: size.width * 0.70, y: 0))
+                diagonal.addLine(to: CGPoint(x: size.width, y: size.height * 0.26))
+                diagonal.move(to: CGPoint(x: size.width * 0.77, y: size.height))
+                diagonal.addLine(to: CGPoint(x: size.width, y: size.height * 0.76))
+                context.stroke(diagonal, with: .color(NeonDiffTheme.accent.opacity(0.18)), lineWidth: 0.8)
+            }
+        }
+        .ignoresSafeArea()
+    }
+}
+
+struct OperatorSectionHeader: View {
+    var title: String
+    var status: String
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("NEONDIFF")
+                    .font(NeonDiffTheme.logoFont)
+                    .foregroundStyle(NeonDiffTheme.accent)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                Text(title)
+                    .font(NeonDiffTheme.headlineFont)
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+            }
+
+            Spacer(minLength: 16)
+
+            HStack(spacing: 8) {
+                OperatorBadge(text: "DEV MVP")
+                OperatorBadge(text: status, color: NeonDiffTheme.statusColor(status))
+            }
+        }
+        .operatorPanel(padding: 16, active: true)
+    }
+}
+
+struct OperatorBadge: View {
+    var text: String
+    var color: Color = NeonDiffTheme.accent
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(NeonDiffTheme.badgeFont)
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+            .foregroundStyle(color)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(
+                AngularRectangle(corner: 6)
+                    .fill(color.opacity(0.10))
+            )
+            .overlay {
+                AngularRectangle(corner: 6)
+                    .stroke(color.opacity(0.72), lineWidth: 0.8)
+            }
+    }
+}
+
+struct OperatorSection<Content: View>: View {
+    var title: String
+    private let content: Content
+
+    init(_ title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(NeonDiffTheme.headlineFont)
+                .foregroundStyle(NeonDiffTheme.accentSoft)
+            content
+        }
+        .operatorPanel()
+    }
+}
+
+struct OperatorTextField: View {
+    var title: String
+    @Binding var text: String
+    var secure = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(NeonDiffTheme.textSecondary)
+            field
+                .textFieldStyle(.plain)
+                .font(.body)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(
+                    AngularRectangle(corner: 7)
+                        .fill(Color.black.opacity(0.38))
+                )
+                .overlay {
+                    AngularRectangle(corner: 7)
+                        .stroke(NeonDiffTheme.stroke.opacity(0.72), lineWidth: 0.7)
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var field: some View {
+        if secure {
+            SecureField(title, text: $text)
+        } else {
+            TextField(title, text: $text)
+        }
+    }
+}
+
+struct OperatorCommandText: View {
+    var text: String
+    var lineLimit: Int? = 3
+
+    var body: some View {
+        Text(text)
+            .font(NeonDiffTheme.commandFont)
+            .foregroundStyle(NeonDiffTheme.textSecondary)
+            .textSelection(.enabled)
+            .lineLimit(lineLimit)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct OperatorButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.callout.weight(.semibold))
+            .lineLimit(1)
+            .minimumScaleFactor(0.82)
+            .foregroundStyle(configuration.isPressed ? NeonDiffTheme.shell : NeonDiffTheme.accent)
+            .padding(.horizontal, 11)
+            .padding(.vertical, 7)
+            .background(
+                AngularRectangle(corner: 7)
+                    .fill(configuration.isPressed ? NeonDiffTheme.accent : NeonDiffTheme.accent.opacity(0.08))
+            )
+            .overlay {
+                AngularRectangle(corner: 7)
+                    .stroke(NeonDiffTheme.accent.opacity(configuration.isPressed ? 0.95 : 0.68), lineWidth: 0.8)
+            }
+    }
+}
+
+private struct CornerTicks: View {
+    var color: Color
+
+    var body: some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            let height = proxy.size.height
+            let length: CGFloat = 18
+
+            Path { path in
+                path.move(to: CGPoint(x: 0, y: length))
+                path.addLine(to: .zero)
+                path.addLine(to: CGPoint(x: length, y: 0))
+
+                path.move(to: CGPoint(x: width - length, y: 0))
+                path.addLine(to: CGPoint(x: width, y: 0))
+                path.addLine(to: CGPoint(x: width, y: length))
+
+                path.move(to: CGPoint(x: width, y: height - length))
+                path.addLine(to: CGPoint(x: width, y: height))
+                path.addLine(to: CGPoint(x: width - length, y: height))
+
+                path.move(to: CGPoint(x: length, y: height))
+                path.addLine(to: CGPoint(x: 0, y: height))
+                path.addLine(to: CGPoint(x: 0, y: height - length))
+            }
+            .stroke(color, lineWidth: 1.1)
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+private struct OperatorPanelModifier: ViewModifier {
+    var padding: CGFloat
+    var active: Bool
+
+    func body(content: Content) -> some View {
+        let shape = AngularRectangle(corner: active ? 18 : 12)
+        content
+            .padding(padding)
+            .background {
+                shape
+                    .fill(active ? NeonDiffTheme.panelActive.opacity(0.88) : NeonDiffTheme.panel.opacity(0.88))
+            }
+            .overlay {
+                shape
+                    .stroke(active ? NeonDiffTheme.accent.opacity(0.74) : NeonDiffTheme.stroke.opacity(0.72), lineWidth: active ? 1.1 : 0.8)
+            }
+            .overlay {
+                CornerTicks(color: (active ? NeonDiffTheme.accent : NeonDiffTheme.stroke).opacity(active ? 0.82 : 0.58))
+            }
+    }
+}
+
+extension View {
+    func operatorPanel(padding: CGFloat = 16, active: Bool = false) -> some View {
+        modifier(OperatorPanelModifier(padding: padding, active: active))
+    }
+
+    func operatorBodyText() -> some View {
+        foregroundStyle(NeonDiffTheme.textSecondary)
+            .font(.body)
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -3,11 +3,12 @@ import NeonDiffDesktopCore
 
 struct OverviewView: View {
     @ObservedObject var model: NeonDiffDesktopModel
+    private let statusColumns = [GridItem(.adaptive(minimum: 160), spacing: 12)]
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
-                HStack(alignment: .top, spacing: 12) {
+                LazyVGrid(columns: statusColumns, alignment: .leading, spacing: 12) {
                     StatusTile(title: "Runtime", value: model.status.healthState, systemImage: "bolt.horizontal.circle")
                     StatusTile(title: "Repos", value: "\(model.status.monitoredRepos.count)", systemImage: "folder")
                     StatusTile(title: "Keys", value: model.providers.providerKeyStored ? "stored" : "missing", systemImage: "key")
@@ -20,30 +21,35 @@ struct OverviewView: View {
                     model.configInspectCommand
                 ], copy: model.copyCommand)
 
-                HStack {
-                    Button("Refresh") { model.refreshStatus() }
-                    Button("Load Config") { model.inspectConfig() }
-                    Button("Preview Start") { model.previewStartDaemon() }
-                    Button("Preview Stop") { model.previewStopDaemon() }
+                HStack(spacing: 10) {
+                    Button { model.refreshStatus() } label: {
+                        Label("Refresh", systemImage: "arrow.clockwise")
+                    }
+                    Button { model.inspectConfig() } label: {
+                        Label("Load Config", systemImage: "doc.text.magnifyingglass")
+                    }
+                    Button { model.previewStartDaemon() } label: {
+                        Label("Preview Start", systemImage: "play.circle")
+                    }
+                    Button { model.previewStopDaemon() } label: {
+                        Label("Preview Stop", systemImage: "stop.circle")
+                    }
                 }
 
                 if let lastError = model.lastError, !lastError.isEmpty {
                     Text(lastError)
-                        .foregroundStyle(.red)
+                        .foregroundStyle(NeonDiffTheme.warning)
                         .font(.callout)
+                        .operatorPanel()
                 }
 
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Last Command")
-                        .font(.headline)
-                    Text(model.lastCommandLine)
-                        .font(.system(.callout, design: .monospaced))
-                        .textSelection(.enabled)
-                        .foregroundStyle(.secondary)
+                OperatorSection("Last Command") {
+                    OperatorCommandText(text: model.lastCommandLine, lineLimit: 4)
                 }
             }
             .padding(24)
         }
+        .scrollContentBackground(.hidden)
     }
 }
 
@@ -55,15 +61,15 @@ private struct StatusTile: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Label(title, systemImage: systemImage)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                .font(NeonDiffTheme.badgeFont)
+                .foregroundStyle(NeonDiffTheme.textSecondary)
             Text(value)
-                .font(.title3.weight(.semibold))
+                .font(.system(.title3, design: .monospaced).weight(.black))
+                .foregroundStyle(NeonDiffTheme.statusColor(value))
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(14)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+        .operatorPanel(active: true)
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/PolicyView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/PolicyView.swift
@@ -7,15 +7,17 @@ struct PolicyView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
-                Text("Review Policy Defaults")
-                    .font(.title2.weight(.semibold))
-
-                VStack(alignment: .leading, spacing: 8) {
+                OperatorSection("Review Policy Defaults") {
                     Label("No direct review posting from desktop UI", systemImage: "checkmark.shield")
                     Label("Daemon duplicate, stale-head, secret, and inline-coordinate gates stay authoritative", systemImage: "checkmark.shield")
                     Label("Config writes use `config patch` with dry-run preview first", systemImage: "checkmark.shield")
                 }
-                .foregroundStyle(.secondary)
+                .foregroundStyle(NeonDiffTheme.textSecondary)
+
+                OperatorSection("Proof Boundary") {
+                    Text("This desktop shell previews and copies operator-safe commands. Runtime gates, live review posting, signing, updater, and release claims remain outside this MVP.")
+                        .operatorBodyText()
+                }
 
                 CommandPanel(commands: [
                     model.configInspectCommand,
@@ -24,6 +26,7 @@ struct PolicyView: View {
             }
             .padding(24)
         }
+        .scrollContentBackground(.hidden)
     }
 }
 
@@ -34,17 +37,15 @@ struct CommandPanel: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("CLI Equivalents")
-                .font(.headline)
+                .font(NeonDiffTheme.headlineFont)
+                .foregroundStyle(NeonDiffTheme.accentSoft)
             ForEach(commands) { command in
                 HStack(alignment: .firstTextBaseline) {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(command.title)
                             .font(.subheadline.weight(.semibold))
-                        Text(command.commandLine)
-                            .font(.system(.caption, design: .monospaced))
-                            .textSelection(.enabled)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(3)
+                            .foregroundStyle(NeonDiffTheme.textPrimary)
+                        OperatorCommandText(text: command.commandLine)
                     }
                     Spacer()
                     Button {
@@ -54,8 +55,7 @@ struct CommandPanel: View {
                     }
                     .help("Copy command")
                 }
-                .padding(10)
-                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+                .operatorPanel(padding: 10)
             }
         }
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
@@ -5,35 +5,45 @@ struct ProviderSettingsView: View {
     @ObservedObject var model: NeonDiffDesktopModel
 
     var body: some View {
-        Form {
-            Section("ZCode / GLM") {
-                TextField("Model", text: $model.providers.zcodeModel)
-                TextField("CLI Path", text: $model.providers.zcodeCliPath)
-                TextField("App Config Path", text: $model.providers.zcodeAppConfigPath)
-            }
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                OperatorSection("ZCode / GLM") {
+                    OperatorTextField(title: "Model", text: $model.providers.zcodeModel)
+                    OperatorTextField(title: "CLI Path", text: $model.providers.zcodeCliPath)
+                    OperatorTextField(title: "App Config Path", text: $model.providers.zcodeAppConfigPath)
+                }
 
-            Section("OpenAI-Compatible Endpoint") {
-                TextField("Endpoint", text: $model.providers.openAICompatibleEndpoint)
-                SecureField("Provider API Key", text: $model.pendingProviderKey)
-                HStack {
-                    Button("Store Key") { model.storeProviderKey() }
-                    Label(model.providers.providerKeyStored ? "Stored in Keychain" : "Not stored", systemImage: model.providers.providerKeyStored ? "checkmark.seal" : "key")
-                        .foregroundStyle(model.providers.providerKeyStored ? .green : .secondary)
+                OperatorSection("OpenAI-Compatible Endpoint") {
+                    OperatorTextField(title: "Endpoint", text: $model.providers.openAICompatibleEndpoint)
+                    OperatorTextField(title: "Provider API Key", text: $model.pendingProviderKey, secure: true)
+                    HStack(spacing: 10) {
+                        Button { model.storeProviderKey() } label: {
+                            Label("Store Key", systemImage: "key.fill")
+                        }
+                        OperatorBadge(
+                            text: model.providers.providerKeyStored ? "Stored in Keychain" : "Not Stored",
+                            color: model.providers.providerKeyStored ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary
+                        )
+                    }
+                }
+
+                OperatorSection("CLI Equivalent") {
+                    OperatorCommandText(text: model.providerPatchPreviewCommand.commandLine, lineLimit: 5)
+                    HStack(spacing: 10) {
+                        Button { model.previewProviderConfigPatch() } label: {
+                            Label("Preview Patch", systemImage: "eye")
+                        }
+                        Button { model.applyProviderConfigPatch() } label: {
+                            Label("Apply Patch", systemImage: "checkmark.square")
+                        }
+                        Button { model.copyCommand(model.providerPatchPreviewCommand) } label: {
+                            Label("Copy Patch Command", systemImage: "doc.on.doc")
+                        }
+                    }
                 }
             }
-
-            Section("CLI Equivalent") {
-                Text(model.providerPatchPreviewCommand.commandLine)
-                    .font(.system(.callout, design: .monospaced))
-                    .textSelection(.enabled)
-                HStack {
-                    Button("Preview Patch") { model.previewProviderConfigPatch() }
-                    Button("Apply Patch") { model.applyProviderConfigPatch() }
-                    Button("Copy Patch Command") { model.copyCommand(model.providerPatchPreviewCommand) }
-                }
-            }
+            .padding(24)
         }
-        .formStyle(.grouped)
-        .padding(20)
+        .scrollContentBackground(.hidden)
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -6,27 +6,41 @@ struct ReposView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            HStack {
-                Button("Load From Config") { model.inspectConfig() }
-                Button("Refresh Runtime") { model.refreshStatus() }
+            HStack(spacing: 10) {
+                Button { model.inspectConfig() } label: {
+                    Label("Load From Config", systemImage: "doc.text.magnifyingglass")
+                }
+                Button { model.refreshStatus() } label: {
+                    Label("Refresh Runtime", systemImage: "arrow.clockwise")
+                }
             }
 
-            Table(model.repos) {
-                TableColumn("Repository") { repo in
-                    Text(repo.name)
-                        .textSelection(.enabled)
-                }
-                TableColumn("Enabled") { repo in
-                    Image(systemName: repo.enabled ? "checkmark.circle.fill" : "pause.circle")
-                        .foregroundStyle(repo.enabled ? .green : .secondary)
-                }
-                TableColumn("Profile", value: \.profile)
-                TableColumn("Last Review", value: \.lastReview)
-            }
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Monitored Repositories")
+                    .font(NeonDiffTheme.headlineFont)
+                    .foregroundStyle(NeonDiffTheme.accentSoft)
 
-            Text("Repo changes are written through `config patch` only; the desktop does not post reviews or bypass daemon gates.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
+                Table(model.repos) {
+                    TableColumn("Repository") { repo in
+                        Text(repo.name)
+                            .textSelection(.enabled)
+                    }
+                    TableColumn("Enabled") { repo in
+                        Image(systemName: repo.enabled ? "checkmark.circle.fill" : "pause.circle")
+                            .foregroundStyle(repo.enabled ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary)
+                    }
+                    TableColumn("Profile", value: \.profile)
+                    TableColumn("Last Review", value: \.lastReview)
+                }
+                .scrollContentBackground(.hidden)
+                .frame(minHeight: 360)
+            }
+            .operatorPanel()
+
+            OperatorSection("Boundary") {
+                Text("Repo changes are written through `config patch` only; the desktop does not post reviews or bypass daemon gates.")
+                    .operatorBodyText()
+            }
         }
         .padding(24)
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
@@ -4,22 +4,26 @@ struct SettingsPane: View {
     @ObservedObject var model: NeonDiffDesktopModel
 
     var body: some View {
-        Form {
-            Section("Local Paths") {
-                TextField("NeonDiff CLI", text: $model.cliPath)
-                TextField("Config", text: $model.configPath)
-                TextField("Launchd Label", text: $model.launchdLabel)
-                Button("Save Local Settings") { model.persistLocalSettings() }
-            }
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                OperatorSection("Local Paths") {
+                    OperatorTextField(title: "NeonDiff CLI", text: $model.cliPath)
+                    OperatorTextField(title: "Config", text: $model.configPath)
+                    OperatorTextField(title: "Launchd Label", text: $model.launchdLabel)
+                    Button { model.persistLocalSettings() } label: {
+                        Label("Save Local Settings", systemImage: "externaldrive.badge.checkmark")
+                    }
+                }
 
-            Section("Commands") {
-                Text(model.statusCommand.commandLine)
-                    .font(.system(.callout, design: .monospaced))
-                    .textSelection(.enabled)
-                Button("Copy Status Command") { model.copyCommand(model.statusCommand) }
+                OperatorSection("Commands") {
+                    OperatorCommandText(text: model.statusCommand.commandLine, lineLimit: 5)
+                    Button { model.copyCommand(model.statusCommand) } label: {
+                        Label("Copy Status Command", systemImage: "doc.on.doc")
+                    }
+                }
             }
+            .padding(24)
         }
-        .formStyle(.grouped)
-        .padding(20)
+        .scrollContentBackground(.hidden)
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SidebarView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SidebarView.swift
@@ -5,11 +5,63 @@ struct SidebarView: View {
     @Binding var selection: DesktopSection
 
     var body: some View {
-        List(DesktopSection.allCases, selection: $selection) { section in
-            Label(section.title, systemImage: section.systemImage)
-                .tag(section)
+        ZStack {
+            NeonDiffTheme.sidebar
+
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("ND")
+                        .font(.system(size: 34, weight: .black, design: .monospaced))
+                        .foregroundStyle(NeonDiffTheme.accent)
+                    Text("Operator Console")
+                        .font(NeonDiffTheme.badgeFont)
+                        .foregroundStyle(NeonDiffTheme.textSecondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .operatorPanel(padding: 12, active: true)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(DesktopSection.allCases) { section in
+                        Button {
+                            selection = section
+                        } label: {
+                            HStack(spacing: 10) {
+                                Image(systemName: section.systemImage)
+                                    .frame(width: 18)
+                                Text(section.title)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .font(.callout.weight(selection == section ? .semibold : .regular))
+                            .foregroundStyle(selection == section ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 9)
+                            .background {
+                                AngularRectangle(corner: 8)
+                                    .fill(selection == section ? NeonDiffTheme.panelActive.opacity(0.92) : Color.clear)
+                            }
+                            .overlay {
+                                AngularRectangle(corner: 8)
+                                    .stroke(selection == section ? NeonDiffTheme.accent.opacity(0.78) : NeonDiffTheme.stroke.opacity(0.18), lineWidth: 0.7)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+
+                Spacer(minLength: 12)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    OperatorBadge(text: "NO LIVE POSTING")
+                    Text("Dry-run-first desktop shell.")
+                        .font(.caption)
+                        .foregroundStyle(NeonDiffTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .operatorPanel(padding: 12)
+            }
+            .padding(.horizontal, 14)
+            .padding(.top, 18)
+            .padding(.bottom, 14)
         }
-        .listStyle(.sidebar)
-        .navigationSplitViewColumnWidth(min: 190, ideal: 220)
     }
 }


### PR DESCRIPTION
## Summary
- Applies a Saiba-inspired black/neon-green operator theme to the NeonDiff Desktop SwiftUI dev MVP.
- Adds shared theme tokens, angular operator panels, grid/scanline backdrop, status badges, and themed sidebar/detail surfaces.
- Keeps the supplied Saiba assets as visual reference only; no font file is bundled in this PR.

## Scope Boundary
- No signing, notarization, Sparkle/appcast, downloadable artifact, live review posting, or license activation readiness is claimed.
- The desktop remains a thin UI over existing CLI/daemon contracts.
- Font bundling remains deferred until official upstream license/notice handling is added.

## Validation
- `cd apps/neondiff-desktop && swift build`
- `cd apps/neondiff-desktop && swift run NeonDiffDesktopCoreSmoke`
- `cd apps/neondiff-desktop && ./script/build_and_run.sh --verify`
- `git diff --check`

Evidence: `/Volumes/LEXAR/Codex/evidence/neondiff-desktop/2026-07-03/post-180-cleanup-and-brand/theme-185-validation.md`
Screenshot: `/Volumes/LEXAR/Codex/evidence/neondiff-desktop/2026-07-03/post-180-cleanup-and-brand/neondiff-saiba-theme-final-cgwindow.png`

Closes #185.