### PR TITLE
Add provider-throttle telemetry report

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { loadConfig } from "./config.js";
 import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
+import { collectProviderThrottleReport } from "./provider-throttle-report.js";
 import { runDaemonCycle } from "./daemon.js";
 import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, extname, join, parse as parsePath, resolve, sep } from "node:path";
@@ -1351,6 +1352,19 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "provider-throttle-report") {
+    const config = loadConfig(args.config);
+    const report = collectProviderThrottleReport({
+      statePath: args["state-path"] ?? config.statePath,
+      since: args.since ? parseSingleArg(args.since, "--since") : undefined,
+      timezone: args.timezone ? parseSingleArg(args.timezone, "--timezone") : undefined,
+      peakStartHour: args["peak-start-hour"] ? parseHourArg(args["peak-start-hour"], "--peak-start-hour") : undefined,
+      peakEndHour: args["peak-end-hour"] ? parseHourArg(args["peak-end-hour"], "--peak-end-hour") : undefined
+    });
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
   if (command === "retry-provider-cooldowns") {
     if (args["dry-run"] !== "true" && args["dry-run"] !== "false") {
       throw new Error("retry-provider-cooldowns requires explicit --dry-run true or --dry-run false");
@@ -2085,6 +2099,7 @@ function buildHelp(command?: string) {
         "clear-review-queue-leases",
         "finishing-touch-dry-run",
         "provider-cooldowns",
+        "provider-throttle-report",
         "retry-provider-cooldowns",
         "retry-failed",
         "retire-failed",
@@ -2116,6 +2131,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts dashboard --config /path/to/live.json --status blocked_on_proof",
       "npx tsx src/cli.ts dashboard --config /path/to/live.json --human",
       "npx tsx src/cli.ts budget-status --config /path/to/live.json",
+      "npx tsx src/cli.ts provider-throttle-report --config /path/to/live.json --since 7d --timezone Asia/Singapore",
       "npx tsx src/cli.ts why --config /path/to/live.json --repo owner/repo --pr 123",
       "npx tsx src/cli.ts build-memory-packet --config /path/to/live.json --repo owner/repo --output-dir /path/to/evidence",
       "npx tsx src/cli.ts build-gitnexus-context-packet --config /path/to/live.json --repo owner/repo --pr 123 --output-dir /path/to/evidence",
@@ -2166,6 +2182,12 @@ function setParsedArg(parsed: ParsedArgs, key: string, value: string): void {
 function parseNonNegativeInteger(value: string, label: string): number {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 0) throw new Error(`${label} must be a non-negative integer`);
+  return parsed;
+}
+
+function parseHourArg(value: string | string[], label: string): number {
+  const parsed = Number(parseSingleArg(value, label));
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 23) throw new Error(`${label} must be an hour from 0 to 23`);
   return parsed;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2132,6 +2132,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts dashboard --config /path/to/live.json --human",
       "npx tsx src/cli.ts budget-status --config /path/to/live.json",
       "npx tsx src/cli.ts provider-throttle-report --config /path/to/live.json --since 7d --timezone Asia/Singapore",
+      "provider-throttle-report peak-window flags use inclusive local-hour buckets, e.g. --peak-start-hour 14 --peak-end-hour 18 includes 14:00 through 18:00",
       "npx tsx src/cli.ts why --config /path/to/live.json --repo owner/repo --pr 123",
       "npx tsx src/cli.ts build-memory-packet --config /path/to/live.json --repo owner/repo --output-dir /path/to/evidence",
       "npx tsx src/cli.ts build-gitnexus-context-packet --config /path/to/live.json --repo owner/repo --pr 123 --output-dir /path/to/evidence",

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -113,6 +113,7 @@ interface ReviewQueueErrorRow {
   updated_at: string;
   started_at?: string | null;
   finished_at?: string | null;
+  event_timestamp: string;
 }
 
 const EXPLICIT_PROVIDER_CODES = /(?:\bprovider_code=|\bprevious_provider_code=|\bproviderCode:\s*["']?)(\d{4})\b/g;
@@ -269,7 +270,8 @@ function collectProviderThrottleEvents(db: DatabaseSync, sinceStart: Date, now: 
                 ${hasProviderId ? "provider_id" : "null as provider_id"},
                 created_at, updated_at,
                 ${hasStartedAt ? "started_at" : "null as started_at"},
-                ${hasFinishedAt ? "finished_at" : "null as finished_at"}
+                ${hasFinishedAt ? "finished_at" : "null as finished_at"},
+                ${timestampExpr} as event_timestamp
          from review_queue_jobs
          where last_error is not null
            and state not in ('queued', 'leased', 'running')
@@ -286,7 +288,7 @@ function collectProviderThrottleEvents(db: DatabaseSync, sinceStart: Date, now: 
         headSha: row.head_sha,
         status: row.state,
         error: row.last_error,
-        timestamp: row.finished_at ?? row.updated_at ?? row.started_at ?? row.created_at,
+        timestamp: row.event_timestamp,
         providerId: normalizeProviderId(row.provider_id),
         source: "review_queue_jobs"
       });
@@ -506,7 +508,6 @@ function isNetworkOrGithubDependencySignal(normalizedError: string): boolean {
       normalizedError.includes("fetch failed") &&
       (
         normalizedError.includes("github") ||
-        normalizedError.includes("provider") ||
         normalizedError.includes("api.github.com")
       )
     );

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -29,6 +29,7 @@ export interface ProviderThrottleReport {
   codes: Array<{ code: string; count: number }>;
   hourly: ProviderThrottleHourlyBucket[];
   repos: ProviderThrottleRepoBucket[];
+  knownLimitations: string[];
 }
 
 export interface ProviderThrottleSummary extends ProviderThrottleCounts {
@@ -109,6 +110,7 @@ const DEFAULT_SINCE = "24h";
 const DEFAULT_TIMEZONE = "Asia/Singapore";
 const DEFAULT_PEAK_START_HOUR = 14;
 const DEFAULT_PEAK_END_HOUR = 18;
+const KNOWN_PROVIDER_CODES = new Set(["1302", "1305", "1308", "1309", "1310", "1316", "1317"]);
 
 export function collectProviderThrottleReport(input: ProviderThrottleReportOptions): ProviderThrottleReport {
   const now = input.now ?? new Date();
@@ -188,7 +190,10 @@ function emptyReport(input: {
     },
     codes: [],
     hourly: [],
-    repos: []
+    repos: [],
+    knownLimitations: [
+      "processed_reviews is a current-state table keyed by repo/pull/head; provider throttles that were overwritten before queue retry metadata was preserved may be undercounted."
+    ]
   };
 }
 
@@ -405,7 +410,7 @@ function addRetryOutcome(report: ProviderThrottleReport, event: ProviderThrottle
 function extractProviderCodes(error: string): string[] {
   const codes = new Set<string>();
   for (const match of error.matchAll(PROVIDER_CODES)) {
-    if (match[1]) codes.add(match[1]);
+    if (match[1] && KNOWN_PROVIDER_CODES.has(match[1])) codes.add(match[1]);
   }
   return [...codes];
 }

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -213,7 +213,7 @@ function emptyReport(input: {
       "processed_reviews is a current-state table keyed by repo/pull/head; provider throttles that were overwritten before queue retry metadata was preserved may be undercounted.",
       "processed_reviews events are bucketed by created_at; review_queue_jobs events are bucketed by coalesce(finished_at, updated_at, started_at, created_at), so deduped queue incidents may reflect retry/update time instead of first-observed throttle time.",
       "processed_reviews does not store provider_id, so provider context for those rows is reported as unknown.",
-      "retryOutcomes is sourced from review_queue_jobs current state only; stale queue rows can skew retry outcome telemetry until the worker repairs them."
+      "retryOutcomes is sourced from review_queue_jobs current state only; processed_reviews-only incidents are excluded from retry outcomes, and stale queue rows can skew retry outcome telemetry until the worker repairs them."
     ]
   };
 }
@@ -471,10 +471,10 @@ function addRetryOutcome(report: ProviderThrottleReport, event: ProviderThrottle
 function extractProviderCodes(error: string): string[] {
   const codes = new Set<string>();
   for (const match of error.matchAll(EXPLICIT_PROVIDER_CODES)) {
-    if (match[1] && KNOWN_PROVIDER_CODES.has(match[1])) codes.add(match[1]);
+    if (match[1]) codes.add(match[1]);
   }
   for (const match of error.matchAll(PROVIDER_BUSINESS_ERROR_CODES)) {
-    if (match[1] && KNOWN_PROVIDER_CODES.has(match[1])) codes.add(match[1]);
+    if (match[1]) codes.add(match[1]);
   }
   return [...codes];
 }

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -415,16 +415,7 @@ function classifyProviderThrottle(error: string): ProviderThrottleCategory | und
   ) {
     return "requestRateLimit";
   }
-  if (
-    normalized.includes("github api fetch failed") ||
-    normalized.includes("enotfound") ||
-    normalized.includes("econnreset") ||
-    normalized.includes("eaddrnotavail") ||
-    normalized.includes("nghttp2") ||
-    normalized.includes("connect timeout") ||
-    normalized.includes("unable to verify first certificate") ||
-    normalized.includes("fetch failed")
-  ) {
+  if (isNetworkOrGithubDependencySignal(normalized)) {
     return "networkOrGithubDependency";
   }
   if (
@@ -500,6 +491,25 @@ function extractProviderCodes(error: string): string[] {
     if (match[1]) codes.add(match[1]);
   }
   return [...codes];
+}
+
+function isNetworkOrGithubDependencySignal(normalizedError: string): boolean {
+  return normalizedError.includes("github api fetch failed") ||
+    normalizedError.includes("api.github.com") ||
+    normalizedError.includes("enotfound") ||
+    normalizedError.includes("econnreset") ||
+    normalizedError.includes("eaddrnotavail") ||
+    normalizedError.includes("nghttp2") ||
+    normalizedError.includes("connect timeout") ||
+    normalizedError.includes("unable to verify first certificate") ||
+    (
+      normalizedError.includes("fetch failed") &&
+      (
+        normalizedError.includes("github") ||
+        normalizedError.includes("provider") ||
+        normalizedError.includes("api.github.com")
+      )
+    );
 }
 
 function hasRetryAttemptTrail(error: string): boolean {

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -121,6 +121,7 @@ const SQLITE_UTC_TEXT_TIMESTAMP = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
 const ISO_TIMESTAMP_WITHOUT_OFFSET = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$/;
 const PROVIDER_ID_SECRET_LIKE =
   /(-----BEGIN\b|github_pat_|gh[opurs]_[A-Za-z0-9_]+|xox[abprs]-|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|\bBearer\s+\S+|\bsk-[A-Za-z0-9_-]{16,}|[A-Za-z0-9_-]{80,})/i;
+const OPAQUE_PROVIDER_ID = /^[A-Za-z0-9_-]{32,79}$/;
 const REVIEW_QUEUE_JOBS_TABLE = "review_queue_jobs";
 const DEFAULT_SINCE = "24h";
 const DEFAULT_TIMEZONE = "Asia/Singapore";
@@ -388,8 +389,7 @@ function classifyProviderThrottle(error: string): ProviderThrottleCategory | und
 
   if (
     normalized.includes("provider_overloaded") ||
-    normalized.includes("temporarily overloaded") ||
-    normalized.includes("overloaded") ||
+    (normalized.includes("providerbusinesserror") && normalized.includes("temporarily overloaded")) ||
     codes.includes("1305")
   ) {
     return "overloaded";
@@ -554,7 +554,7 @@ function assertValidHour(name: string, hour: number): void {
 function normalizeProviderId(value?: string | null): string {
   const trimmed = value?.trim();
   if (!trimmed) return "unknown";
-  if (PROVIDER_ID_SECRET_LIKE.test(trimmed)) return "[redacted-provider-id]";
+  if (PROVIDER_ID_SECRET_LIKE.test(trimmed) || OPAQUE_PROVIDER_ID.test(trimmed)) return "[redacted-provider-id]";
   const singleLine = trimmed.replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim();
   if (!singleLine) return "unknown";
   return singleLine.length > 96 ? `${singleLine.slice(0, 93)}...` : singleLine;

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
+import { redactSecrets } from "./secrets.js";
 
 export interface ProviderThrottleReportOptions {
   statePath: string;
@@ -29,6 +30,7 @@ export interface ProviderThrottleReport {
   codes: Array<{ code: string; count: number }>;
   hourly: ProviderThrottleHourlyBucket[];
   repos: ProviderThrottleRepoBucket[];
+  providers: ProviderThrottleProviderBucket[];
   knownLimitations: string[];
 }
 
@@ -61,6 +63,11 @@ export interface ProviderThrottleRepoBucket extends ProviderThrottleCounts {
   total: number;
 }
 
+export interface ProviderThrottleProviderBucket extends ProviderThrottleCounts {
+  providerId: string;
+  total: number;
+}
+
 interface ProviderThrottleCounts {
   requestRateLimit: number;
   overloaded: number;
@@ -83,6 +90,7 @@ interface ProviderThrottleEvent {
   status: string;
   error: string;
   timestamp: string;
+  providerId: string;
   source: "processed_reviews" | "review_queue_jobs";
 }
 
@@ -101,6 +109,7 @@ interface ReviewQueueErrorRow {
   head_sha: string;
   state: string;
   last_error: string | null;
+  provider_id?: string | null;
   created_at: string;
   updated_at: string;
   started_at?: string | null;
@@ -121,6 +130,8 @@ export function collectProviderThrottleReport(input: ProviderThrottleReportOptio
   assertValidTimezone(timezone);
   const peakStartHour = input.peakStartHour ?? DEFAULT_PEAK_START_HOUR;
   const peakEndHour = input.peakEndHour ?? DEFAULT_PEAK_END_HOUR;
+  assertValidHour("--peak-start-hour", peakStartHour);
+  assertValidHour("--peak-end-hour", peakEndHour);
   const sinceRaw = input.since ?? DEFAULT_SINCE;
   const sinceStart = resolveSinceStart(sinceRaw, now);
   const report = emptyReport({
@@ -147,6 +158,7 @@ export function collectProviderThrottleReport(input: ProviderThrottleReportOptio
   report.codes.sort((left, right) => right.count - left.count || left.code.localeCompare(right.code));
   report.hourly.sort((left, right) => left.localHour.localeCompare(right.localHour));
   report.repos.sort((left, right) => right.total - left.total || left.repo.localeCompare(right.repo));
+  report.providers.sort((left, right) => right.total - left.total || left.providerId.localeCompare(right.providerId));
   report.summary.worstLocalHour = findWorstLocalHour(report.hourly);
   return report;
 }
@@ -196,9 +208,12 @@ function emptyReport(input: {
     codes: [],
     hourly: [],
     repos: [],
+    providers: [],
     knownLimitations: [
       "processed_reviews is a current-state table keyed by repo/pull/head; provider throttles that were overwritten before queue retry metadata was preserved may be undercounted.",
-      "processed_reviews events are bucketed by created_at; review_queue_jobs events are bucketed by coalesce(finished_at, updated_at, started_at, created_at), so deduped queue incidents may reflect retry/update time instead of first-observed throttle time."
+      "processed_reviews events are bucketed by created_at; review_queue_jobs events are bucketed by coalesce(finished_at, updated_at, started_at, created_at), so deduped queue incidents may reflect retry/update time instead of first-observed throttle time.",
+      "processed_reviews does not store provider_id, so provider context for those rows is reported as unknown.",
+      "retryOutcomes is sourced from review_queue_jobs current state only; stale queue rows can skew retry outcome telemetry until the worker repairs them."
     ]
   };
 }
@@ -227,6 +242,7 @@ function collectProviderThrottleEvents(db: DatabaseSync, sinceStart: Date, now: 
         status: row.status,
         error: row.error,
         timestamp: row.created_at,
+        providerId: "unknown",
         source: "processed_reviews"
       });
     }
@@ -236,13 +252,17 @@ function collectProviderThrottleEvents(db: DatabaseSync, sinceStart: Date, now: 
     const timestampExpr = queueTimestampExpression(db);
     const rows = db
       .prepare(
-        `select repo, pull_number, head_sha, state, last_error, created_at, updated_at,
+        `select repo, pull_number, head_sha, state, last_error,
+                ${hasColumn(db, "review_queue_jobs", "provider_id") ? "provider_id" : "null as provider_id"},
+                created_at, updated_at,
                 ${hasColumn(db, "review_queue_jobs", "started_at") ? "started_at" : "null as started_at"},
                 ${hasColumn(db, "review_queue_jobs", "finished_at") ? "finished_at" : "null as finished_at"}
          from review_queue_jobs
          where last_error is not null
+           and state not in ('queued', 'leased', 'running')
            and datetime(${timestampExpr}) >= datetime(?)
-           and datetime(${timestampExpr}) <= datetime(?)`
+           and datetime(${timestampExpr}) <= datetime(?)
+         order by datetime(${timestampExpr}) asc`
       )
       .all(start, end) as unknown as ReviewQueueErrorRow[];
     for (const row of rows) {
@@ -254,6 +274,7 @@ function collectProviderThrottleEvents(db: DatabaseSync, sinceStart: Date, now: 
         status: row.state,
         error: row.last_error,
         timestamp: row.finished_at ?? row.updated_at ?? row.started_at ?? row.created_at,
+        providerId: normalizeProviderId(row.provider_id),
         source: "review_queue_jobs"
       });
     }
@@ -280,6 +301,7 @@ function addEventToReport(
   const peakWindow = isPeakHour(hour, peakStartHour, peakEndHour);
   const hourly = getHourlyBucket(report, hour, peakWindow);
   const repo = getRepoBucket(report, event.repo);
+  const provider = getProviderBucket(report, event.providerId);
 
   report.summary.providerErrors += 1;
   report.summary[category] += 1;
@@ -287,6 +309,8 @@ function addEventToReport(
   hourly[category] += 1;
   repo.total += 1;
   repo[category] += 1;
+  provider.total += 1;
+  provider[category] += 1;
   if (peakWindow) report.summary.peakWindowErrors += 1;
   else report.summary.offPeakErrors += 1;
 
@@ -321,6 +345,18 @@ function getRepoBucket(report: ProviderThrottleReport, repo: string): ProviderTh
     ...emptyCounts()
   };
   report.repos.push(created);
+  return created;
+}
+
+function getProviderBucket(report: ProviderThrottleReport, providerId: string): ProviderThrottleProviderBucket {
+  const existing = report.providers.find((row) => row.providerId === providerId);
+  if (existing) return existing;
+  const created: ProviderThrottleProviderBucket = {
+    providerId,
+    total: 0,
+    ...emptyCounts()
+  };
+  report.providers.push(created);
   return created;
 }
 
@@ -396,11 +432,22 @@ function dedupeProviderThrottleEvents(events: ProviderThrottleEvent[]): Provider
       extractProviderCodes(event.error).sort().join(",")
     ].join("\0");
     const existing = byIncident.get(key);
-    if (!existing || event.source === "review_queue_jobs") {
+    if (!existing || shouldReplaceProviderThrottleIncident(existing, event)) {
       byIncident.set(key, event);
     }
   }
   return [...byIncident.values()];
+}
+
+function shouldReplaceProviderThrottleIncident(existing: ProviderThrottleEvent, candidate: ProviderThrottleEvent): boolean {
+  if (existing.source === "processed_reviews" && candidate.source === "review_queue_jobs") return true;
+  if (existing.source === "review_queue_jobs" && candidate.source === "processed_reviews") return false;
+  return eventTimestampMs(candidate) >= eventTimestampMs(existing);
+}
+
+function eventTimestampMs(event: ProviderThrottleEvent): number {
+  const date = parseSqliteUtcTimestamp(event.timestamp);
+  return Number.isFinite(date.getTime()) ? date.getTime() : Number.NEGATIVE_INFINITY;
 }
 
 function addRetryOutcome(report: ProviderThrottleReport, event: ProviderThrottleEvent): void {
@@ -456,6 +503,17 @@ function assertValidTimezone(timezone: string): void {
   } catch {
     throw new Error(`Invalid --timezone value: ${timezone}`);
   }
+}
+
+function assertValidHour(name: string, hour: number): void {
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
+    throw new Error(`Invalid ${name} value: ${hour}; expected an integer from 0 to 23`);
+  }
+}
+
+function normalizeProviderId(value?: string | null): string {
+  const redacted = redactSecrets(value?.trim() || "unknown");
+  return redacted || "unknown";
 }
 
 function isPeakHour(localHour: string, peakStartHour: number, peakEndHour: number): boolean {

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
-import { redactSecrets } from "./secrets.js";
 
 export interface ProviderThrottleReportOptions {
   statePath: string;
@@ -118,6 +117,11 @@ interface ReviewQueueErrorRow {
 
 const EXPLICIT_PROVIDER_CODES = /(?:\bprovider_code=|\bprevious_provider_code=|\bproviderCode:\s*["']?)(\d{4})\b/g;
 const PROVIDER_BUSINESS_ERROR_CODES = /\bproviderbusinesserror\b[^\[]*\[(\d{4})\]/gi;
+const SQLITE_UTC_TEXT_TIMESTAMP = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+const ISO_TIMESTAMP_WITHOUT_OFFSET = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$/;
+const PROVIDER_ID_SECRET_LIKE =
+  /(-----BEGIN\b|github_pat_|gh[opurs]_[A-Za-z0-9_]+|xox[abprs]-|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|\bBearer\s+\S+|\bsk-[A-Za-z0-9_-]{16,}|[A-Za-z0-9_-]{80,})/i;
+const REVIEW_QUEUE_JOBS_TABLE = "review_queue_jobs";
 const DEFAULT_SINCE = "24h";
 const DEFAULT_TIMEZONE = "Asia/Singapore";
 const DEFAULT_PEAK_START_HOUR = 14;
@@ -147,8 +151,13 @@ export function collectProviderThrottleReport(input: ProviderThrottleReportOptio
   const db = new DatabaseSync(input.statePath, { readOnly: true });
   try {
     const events = collectProviderThrottleEvents(db, sinceStart, now);
+    const hourFormatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      hour: "2-digit",
+      hourCycle: "h23"
+    });
     for (const event of events) {
-      addEventToReport(report, event, timezone, peakStartHour, peakEndHour);
+      addEventToReport(report, event, hourFormatter, peakStartHour, peakEndHour);
     }
   } finally {
     db.close();
@@ -212,7 +221,7 @@ function emptyReport(input: {
       "processed_reviews is a current-state table keyed by repo/pull/head; provider throttles that were overwritten before queue retry metadata was preserved may be undercounted.",
       "processed_reviews events are bucketed by created_at; review_queue_jobs events are bucketed by coalesce(finished_at, updated_at, started_at, created_at), so deduped queue incidents may reflect retry/update time instead of first-observed throttle time.",
       "processed_reviews does not store provider_id, so provider context for those rows is reported as unknown.",
-      "retryOutcomes is sourced from review_queue_jobs current state only; processed_reviews-only incidents are excluded from retry outcomes, and stale queue rows can skew retry outcome telemetry until the worker repairs them.",
+      "retryOutcomes is sourced from review_queue_jobs current state only; processed_reviews-only incidents are excluded from retry outcomes, and still-deferred rows only count as retriedProviderDeferred when their error trail includes retry metadata.",
       "Each incident is assigned to the first matching category by precedence; mixed-cause provider errors are collapsed into one summary category while all extracted provider codes remain visible."
     ]
   };
@@ -248,15 +257,18 @@ function collectProviderThrottleEvents(db: DatabaseSync, sinceStart: Date, now: 
     }
   }
 
-  if (hasTable(db, "review_queue_jobs")) {
+  if (hasTable(db, REVIEW_QUEUE_JOBS_TABLE)) {
     const timestampExpr = queueTimestampExpression(db);
+    const hasProviderId = hasColumn(db, REVIEW_QUEUE_JOBS_TABLE, "provider_id");
+    const hasStartedAt = hasColumn(db, REVIEW_QUEUE_JOBS_TABLE, "started_at");
+    const hasFinishedAt = hasColumn(db, REVIEW_QUEUE_JOBS_TABLE, "finished_at");
     const rows = db
       .prepare(
         `select repo, pull_number, head_sha, state, last_error,
-                ${hasColumn(db, "review_queue_jobs", "provider_id") ? "provider_id" : "null as provider_id"},
+                ${hasProviderId ? "provider_id" : "null as provider_id"},
                 created_at, updated_at,
-                ${hasColumn(db, "review_queue_jobs", "started_at") ? "started_at" : "null as started_at"},
-                ${hasColumn(db, "review_queue_jobs", "finished_at") ? "finished_at" : "null as finished_at"}
+                ${hasStartedAt ? "started_at" : "null as started_at"},
+                ${hasFinishedAt ? "finished_at" : "null as finished_at"}
          from review_queue_jobs
          where last_error is not null
            and state not in ('queued', 'leased', 'running')
@@ -286,13 +298,13 @@ function collectProviderThrottleEvents(db: DatabaseSync, sinceStart: Date, now: 
 function addEventToReport(
   report: ProviderThrottleReport,
   event: ProviderThrottleEvent,
-  timezone: string,
+  hourFormatter: Intl.DateTimeFormat,
   peakStartHour: number,
   peakEndHour: number
 ): void {
   const category = classifyProviderThrottle(event.error);
   if (!category) return;
-  const hour = localHour(event.timestamp, timezone);
+  const hour = localHour(event.timestamp, hourFormatter);
   if (!hour) {
     report.summary.droppedEvents += 1;
     report.summary.malformedTimestamps += 1;
@@ -464,7 +476,9 @@ function addRetryOutcome(report: ProviderThrottleReport, event: ProviderThrottle
   const status = event.status.toLowerCase();
   if (status === "posted" || status === "reviewed" || status === "reviewed_command") {
     report.retryOutcomes.retriedPosted += 1;
-  } else if (status === "provider_deferred" || status === "skipped_provider_cooldown") {
+  } else if (status === "provider_deferred" && hasRetryAttemptTrail(event.error)) {
+    report.retryOutcomes.retriedProviderDeferred += 1;
+  } else if (status === "skipped_provider_cooldown") {
     report.retryOutcomes.retriedProviderDeferred += 1;
   } else if (status === "stale_retired" || status === "skipped_stale_head") {
     report.retryOutcomes.retriedStaleHead += 1;
@@ -488,22 +502,29 @@ function extractProviderCodes(error: string): string[] {
   return [...codes];
 }
 
-function localHour(timestamp: string, timezone: string): string | undefined {
+function hasRetryAttemptTrail(error: string): boolean {
+  return /\bretry_attempt=\d+\b/.test(error) ||
+    /\bretry_after_ms=\d+\b/.test(error) ||
+    error.includes("_after_provider_deferred") ||
+    error.includes("previous_reason=");
+}
+
+function localHour(timestamp: string, hourFormatter: Intl.DateTimeFormat): string | undefined {
   const date = parseSqliteUtcTimestamp(timestamp);
   if (!Number.isFinite(date.getTime())) return undefined;
-  const hour = new Intl.DateTimeFormat("en-US", {
-    timeZone: timezone,
-    hour: "2-digit",
-    hourCycle: "h23"
-  }).format(date);
+  const hour = hourFormatter.format(date);
   return `${hour}:00`;
 }
 
 function parseSqliteUtcTimestamp(timestamp: string): Date {
-  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(timestamp)) {
-    return new Date(`${timestamp.replace(" ", "T")}Z`);
+  const trimmed = timestamp.trim();
+  if (SQLITE_UTC_TEXT_TIMESTAMP.test(trimmed)) {
+    return new Date(`${trimmed.replace(" ", "T")}Z`);
   }
-  return new Date(timestamp);
+  if (ISO_TIMESTAMP_WITHOUT_OFFSET.test(trimmed)) {
+    return new Date(`${trimmed}Z`);
+  }
+  return new Date(trimmed);
 }
 
 function assertValidTimezone(timezone: string): void {
@@ -521,8 +542,12 @@ function assertValidHour(name: string, hour: number): void {
 }
 
 function normalizeProviderId(value?: string | null): string {
-  const redacted = redactSecrets(value?.trim() || "unknown");
-  return redacted || "unknown";
+  const trimmed = value?.trim();
+  if (!trimmed) return "unknown";
+  if (PROVIDER_ID_SECRET_LIKE.test(trimmed)) return "[redacted-provider-id]";
+  const singleLine = trimmed.replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim();
+  if (!singleLine) return "unknown";
+  return singleLine.length > 96 ? `${singleLine.slice(0, 93)}...` : singleLine;
 }
 
 function isPeakHour(localHour: string, peakStartHour: number, peakEndHour: number): boolean {
@@ -548,9 +573,9 @@ function findWorstLocalHour(rows: ProviderThrottleHourlyBucket[]): string | unde
 
 function queueTimestampExpression(db: DatabaseSync): string {
   const columns = [
-    hasColumn(db, "review_queue_jobs", "finished_at") ? "finished_at" : undefined,
-    hasColumn(db, "review_queue_jobs", "updated_at") ? "updated_at" : undefined,
-    hasColumn(db, "review_queue_jobs", "started_at") ? "started_at" : undefined,
+    hasColumn(db, REVIEW_QUEUE_JOBS_TABLE, "finished_at") ? "finished_at" : undefined,
+    hasColumn(db, REVIEW_QUEUE_JOBS_TABLE, "updated_at") ? "updated_at" : undefined,
+    hasColumn(db, REVIEW_QUEUE_JOBS_TABLE, "started_at") ? "started_at" : undefined,
     "created_at"
   ].filter(Boolean);
   return `coalesce(${columns.join(", ")})`;
@@ -578,6 +603,9 @@ function hasTable(db: DatabaseSync, tableName: string): boolean {
 }
 
 function hasColumn(db: DatabaseSync, tableName: string, columnName: string): boolean {
-  const rows = db.prepare(`pragma table_info(${tableName})`).all() as unknown as Array<{ name: string }>;
+  if (tableName !== REVIEW_QUEUE_JOBS_TABLE) {
+    throw new Error(`Unsupported table for column introspection: ${tableName}`);
+  }
+  const rows = db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>;
   return rows.some((row) => row.name === columnName);
 }

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -1,0 +1,442 @@
+import { existsSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+
+export interface ProviderThrottleReportOptions {
+  statePath: string;
+  now?: Date;
+  since?: string;
+  timezone?: string;
+  peakStartHour?: number;
+  peakEndHour?: number;
+}
+
+export interface ProviderThrottleReport {
+  ok: true;
+  checkedAt: string;
+  since: {
+    raw: string;
+    start: string;
+    end: string;
+  };
+  timezone: string;
+  peakWindow: {
+    startHour: number;
+    endHour: number;
+  };
+  recommendedPolicy: "measure_only";
+  summary: ProviderThrottleSummary;
+  retryOutcomes: ProviderThrottleRetryOutcomes;
+  codes: Array<{ code: string; count: number }>;
+  hourly: ProviderThrottleHourlyBucket[];
+  repos: ProviderThrottleRepoBucket[];
+}
+
+export interface ProviderThrottleSummary extends ProviderThrottleCounts {
+  providerErrors: number;
+  peakWindowErrors: number;
+  offPeakErrors: number;
+  worstLocalHour?: string;
+}
+
+export interface ProviderThrottleRetryOutcomes {
+  retriedPosted: number;
+  retriedProviderDeferred: number;
+  retriedStaleHead: number;
+  retriedClosed: number;
+  skippedCapacity: number;
+  gaveUpAfterBackoff: number;
+}
+
+export interface ProviderThrottleHourlyBucket extends ProviderThrottleCounts {
+  localHour: string;
+  total: number;
+  peakWindow: boolean;
+}
+
+export interface ProviderThrottleRepoBucket extends ProviderThrottleCounts {
+  repo: string;
+  total: number;
+}
+
+interface ProviderThrottleCounts {
+  requestRateLimit: number;
+  overloaded: number;
+  quotaExhausted: number;
+  networkOrGithubDependency: number;
+  unknownProviderError: number;
+}
+
+type ProviderThrottleCategory =
+  | "requestRateLimit"
+  | "overloaded"
+  | "quotaExhausted"
+  | "networkOrGithubDependency"
+  | "unknownProviderError";
+
+interface ProviderThrottleEvent {
+  repo: string;
+  status: string;
+  error: string;
+  timestamp: string;
+}
+
+interface ProcessedReviewErrorRow {
+  repo: string;
+  status: string;
+  error: string | null;
+  created_at: string;
+}
+
+interface ReviewQueueErrorRow {
+  repo: string;
+  state: string;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+  started_at?: string | null;
+  finished_at?: string | null;
+}
+
+const PROVIDER_CODES = /(?:\bprovider_code=|\bproviderCode:\s*["']?|\[)(\d{4})\b/g;
+const DEFAULT_SINCE = "24h";
+const DEFAULT_TIMEZONE = "Asia/Singapore";
+const DEFAULT_PEAK_START_HOUR = 14;
+const DEFAULT_PEAK_END_HOUR = 18;
+
+export function collectProviderThrottleReport(input: ProviderThrottleReportOptions): ProviderThrottleReport {
+  const now = input.now ?? new Date();
+  const timezone = input.timezone ?? DEFAULT_TIMEZONE;
+  const peakStartHour = input.peakStartHour ?? DEFAULT_PEAK_START_HOUR;
+  const peakEndHour = input.peakEndHour ?? DEFAULT_PEAK_END_HOUR;
+  const sinceRaw = input.since ?? DEFAULT_SINCE;
+  const sinceStart = resolveSinceStart(sinceRaw, now);
+  const report = emptyReport({
+    now,
+    sinceRaw,
+    sinceStart,
+    timezone,
+    peakStartHour,
+    peakEndHour
+  });
+
+  if (!existsSync(input.statePath)) return report;
+
+  const db = new DatabaseSync(input.statePath, { readOnly: true });
+  try {
+    const events = collectProviderThrottleEvents(db, sinceStart, now);
+    for (const event of events) {
+      addEventToReport(report, event, timezone, peakStartHour, peakEndHour);
+    }
+  } finally {
+    db.close();
+  }
+
+  report.codes.sort((left, right) => right.count - left.count || left.code.localeCompare(right.code));
+  report.hourly.sort((left, right) => left.localHour.localeCompare(right.localHour));
+  report.repos.sort((left, right) => right.total - left.total || left.repo.localeCompare(right.repo));
+  report.summary.worstLocalHour = findWorstLocalHour(report.hourly);
+  return report;
+}
+
+function emptyReport(input: {
+  now: Date;
+  sinceRaw: string;
+  sinceStart: Date;
+  timezone: string;
+  peakStartHour: number;
+  peakEndHour: number;
+}): ProviderThrottleReport {
+  return {
+    ok: true,
+    checkedAt: input.now.toISOString(),
+    since: {
+      raw: input.sinceRaw,
+      start: input.sinceStart.toISOString(),
+      end: input.now.toISOString()
+    },
+    timezone: input.timezone,
+    peakWindow: {
+      startHour: input.peakStartHour,
+      endHour: input.peakEndHour
+    },
+    recommendedPolicy: "measure_only",
+    summary: {
+      providerErrors: 0,
+      requestRateLimit: 0,
+      overloaded: 0,
+      quotaExhausted: 0,
+      networkOrGithubDependency: 0,
+      unknownProviderError: 0,
+      peakWindowErrors: 0,
+      offPeakErrors: 0
+    },
+    retryOutcomes: {
+      retriedPosted: 0,
+      retriedProviderDeferred: 0,
+      retriedStaleHead: 0,
+      retriedClosed: 0,
+      skippedCapacity: 0,
+      gaveUpAfterBackoff: 0
+    },
+    codes: [],
+    hourly: [],
+    repos: []
+  };
+}
+
+function collectProviderThrottleEvents(db: DatabaseSync, sinceStart: Date, now: Date): ProviderThrottleEvent[] {
+  const events: ProviderThrottleEvent[] = [];
+  const start = sinceStart.toISOString();
+  const end = now.toISOString();
+
+  if (hasTable(db, "processed_reviews")) {
+    const rows = db
+      .prepare(
+        `select repo, status, error, created_at
+         from processed_reviews
+         where error is not null
+           and datetime(created_at) >= datetime(?)
+           and datetime(created_at) <= datetime(?)`
+      )
+      .all(start, end) as unknown as ProcessedReviewErrorRow[];
+    for (const row of rows) {
+      if (!row.error || !classifyProviderThrottle(row.error)) continue;
+      events.push({
+        repo: row.repo,
+        status: row.status,
+        error: row.error,
+        timestamp: row.created_at
+      });
+    }
+  }
+
+  if (hasTable(db, "review_queue_jobs")) {
+    const timestampExpr = queueTimestampExpression(db);
+    const rows = db
+      .prepare(
+        `select repo, state, last_error, created_at, updated_at,
+                ${hasColumn(db, "review_queue_jobs", "started_at") ? "started_at" : "null as started_at"},
+                ${hasColumn(db, "review_queue_jobs", "finished_at") ? "finished_at" : "null as finished_at"}
+         from review_queue_jobs
+         where last_error is not null
+           and datetime(${timestampExpr}) >= datetime(?)
+           and datetime(${timestampExpr}) <= datetime(?)`
+      )
+      .all(start, end) as unknown as ReviewQueueErrorRow[];
+    for (const row of rows) {
+      if (!row.last_error || !classifyProviderThrottle(row.last_error)) continue;
+      events.push({
+        repo: row.repo,
+        status: row.state,
+        error: row.last_error,
+        timestamp: row.finished_at ?? row.updated_at ?? row.started_at ?? row.created_at
+      });
+    }
+  }
+
+  return events;
+}
+
+function addEventToReport(
+  report: ProviderThrottleReport,
+  event: ProviderThrottleEvent,
+  timezone: string,
+  peakStartHour: number,
+  peakEndHour: number
+): void {
+  const category = classifyProviderThrottle(event.error);
+  if (!category) return;
+  const hour = localHour(event.timestamp, timezone);
+  const peakWindow = isPeakHour(hour, peakStartHour, peakEndHour);
+  const hourly = getHourlyBucket(report, hour, peakWindow);
+  const repo = getRepoBucket(report, event.repo);
+
+  report.summary.providerErrors += 1;
+  report.summary[category] += 1;
+  hourly.total += 1;
+  hourly[category] += 1;
+  repo.total += 1;
+  repo[category] += 1;
+  if (peakWindow) report.summary.peakWindowErrors += 1;
+  else report.summary.offPeakErrors += 1;
+
+  for (const code of extractProviderCodes(event.error)) {
+    const row = report.codes.find((candidate) => candidate.code === code);
+    if (row) row.count += 1;
+    else report.codes.push({ code, count: 1 });
+  }
+
+  addRetryOutcome(report, event);
+}
+
+function getHourlyBucket(report: ProviderThrottleReport, localHour: string, peakWindow: boolean): ProviderThrottleHourlyBucket {
+  const existing = report.hourly.find((row) => row.localHour === localHour);
+  if (existing) return existing;
+  const created: ProviderThrottleHourlyBucket = {
+    localHour,
+    total: 0,
+    peakWindow,
+    ...emptyCounts()
+  };
+  report.hourly.push(created);
+  return created;
+}
+
+function getRepoBucket(report: ProviderThrottleReport, repo: string): ProviderThrottleRepoBucket {
+  const existing = report.repos.find((row) => row.repo === repo);
+  if (existing) return existing;
+  const created: ProviderThrottleRepoBucket = {
+    repo,
+    total: 0,
+    ...emptyCounts()
+  };
+  report.repos.push(created);
+  return created;
+}
+
+function emptyCounts(): ProviderThrottleCounts {
+  return {
+    requestRateLimit: 0,
+    overloaded: 0,
+    quotaExhausted: 0,
+    networkOrGithubDependency: 0,
+    unknownProviderError: 0
+  };
+}
+
+function classifyProviderThrottle(error: string): ProviderThrottleCategory | undefined {
+  const normalized = error.toLowerCase();
+  const codes = extractProviderCodes(error);
+
+  if (
+    normalized.includes("provider_overloaded") ||
+    normalized.includes("temporarily overloaded") ||
+    normalized.includes("overloaded") ||
+    codes.includes("1305")
+  ) {
+    return "overloaded";
+  }
+  if (
+    normalized.includes("provider_quota_exhausted") ||
+    normalized.includes("weekly/monthly limit exhausted") ||
+    normalized.includes("limit exhausted") ||
+    normalized.includes("quota exhausted") ||
+    codes.some((code) => ["1308", "1309", "1310", "1316", "1317"].includes(code))
+  ) {
+    return "quotaExhausted";
+  }
+  if (
+    normalized.includes("reason=provider_request_rate_limit") ||
+    normalized.includes("reason=provider_rate_limit") ||
+    normalized.includes("provider_request_rate_limit") ||
+    codes.includes("1302")
+  ) {
+    return "requestRateLimit";
+  }
+  if (
+    normalized.includes("github api fetch failed") ||
+    normalized.includes("enotfound") ||
+    normalized.includes("econnreset") ||
+    normalized.includes("eaddrnotavail") ||
+    normalized.includes("nghttp2") ||
+    normalized.includes("connect timeout") ||
+    normalized.includes("unable to verify first certificate") ||
+    normalized.includes("fetch failed")
+  ) {
+    return "networkOrGithubDependency";
+  }
+  if (normalized.includes("provider") || codes.length > 0) return "unknownProviderError";
+  return undefined;
+}
+
+function addRetryOutcome(report: ProviderThrottleReport, event: ProviderThrottleEvent): void {
+  const status = event.status.toLowerCase();
+  if (status === "posted" || status === "reviewed" || status === "reviewed_command") {
+    report.retryOutcomes.retriedPosted += 1;
+  } else if (status === "provider_deferred" || status === "skipped_provider_cooldown") {
+    report.retryOutcomes.retriedProviderDeferred += 1;
+  } else if (status === "stale_retired" || status === "skipped_stale_head") {
+    report.retryOutcomes.retriedStaleHead += 1;
+  } else if (status === "closed_retired" || status === "skipped_closed") {
+    report.retryOutcomes.retriedClosed += 1;
+  } else if (status === "skipped_capacity") {
+    report.retryOutcomes.skippedCapacity += 1;
+  } else if (status === "failed") {
+    report.retryOutcomes.gaveUpAfterBackoff += 1;
+  }
+}
+
+function extractProviderCodes(error: string): string[] {
+  const codes = new Set<string>();
+  for (const match of error.matchAll(PROVIDER_CODES)) {
+    if (match[1]) codes.add(match[1]);
+  }
+  return [...codes];
+}
+
+function localHour(timestamp: string, timezone: string): string {
+  const date = new Date(timestamp);
+  const hour = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hour: "2-digit",
+    hourCycle: "h23"
+  }).format(date);
+  return `${hour}:00`;
+}
+
+function isPeakHour(localHour: string, peakStartHour: number, peakEndHour: number): boolean {
+  const hour = Number(localHour.slice(0, 2));
+  if (!Number.isFinite(hour)) return false;
+  if (peakStartHour <= peakEndHour) return hour >= peakStartHour && hour <= peakEndHour;
+  return hour >= peakStartHour || hour <= peakEndHour;
+}
+
+function findWorstLocalHour(rows: ProviderThrottleHourlyBucket[]): string | undefined {
+  const [worst] = [...rows].sort((left, right) => {
+    return (
+      right.total - left.total ||
+      right.requestRateLimit - left.requestRateLimit ||
+      right.overloaded - left.overloaded ||
+      right.quotaExhausted - left.quotaExhausted ||
+      right.networkOrGithubDependency - left.networkOrGithubDependency ||
+      left.localHour.localeCompare(right.localHour)
+    );
+  });
+  return worst?.localHour;
+}
+
+function queueTimestampExpression(db: DatabaseSync): string {
+  const columns = [
+    hasColumn(db, "review_queue_jobs", "finished_at") ? "finished_at" : undefined,
+    hasColumn(db, "review_queue_jobs", "updated_at") ? "updated_at" : undefined,
+    hasColumn(db, "review_queue_jobs", "started_at") ? "started_at" : undefined,
+    "created_at"
+  ].filter(Boolean);
+  return `coalesce(${columns.join(", ")})`;
+}
+
+function resolveSinceStart(raw: string, now: Date): Date {
+  const trimmed = raw.trim();
+  const relative = /^(\d+)([hd])$/i.exec(trimmed);
+  if (relative) {
+    const amount = Number(relative[1]);
+    const unit = relative[2].toLowerCase();
+    const milliseconds = unit === "h" ? amount * 60 * 60 * 1000 : amount * 24 * 60 * 60 * 1000;
+    return new Date(now.getTime() - milliseconds);
+  }
+  const parsed = Date.parse(trimmed);
+  if (Number.isNaN(parsed)) throw new Error(`Invalid --since value: ${raw}`);
+  return new Date(parsed);
+}
+
+function hasTable(db: DatabaseSync, tableName: string): boolean {
+  const row = db
+    .prepare("select 1 as ok from sqlite_master where type = 'table' and name = ? limit 1")
+    .get(tableName) as { ok: number } | undefined;
+  return Boolean(row);
+}
+
+function hasColumn(db: DatabaseSync, tableName: string, columnName: string): boolean {
+  const rows = db.prepare(`pragma table_info(${tableName})`).all() as unknown as Array<{ name: string }>;
+  return rows.some((row) => row.name === columnName);
+}

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -107,7 +107,8 @@ interface ReviewQueueErrorRow {
   finished_at?: string | null;
 }
 
-const PROVIDER_CODES = /(?:\bprovider_code=|\bprevious_provider_code=|\bproviderCode:\s*["']?|\[)(\d{4})\b/g;
+const EXPLICIT_PROVIDER_CODES = /(?:\bprovider_code=|\bprevious_provider_code=|\bproviderCode:\s*["']?)(\d{4})\b/g;
+const PROVIDER_BUSINESS_ERROR_CODES = /\bproviderbusinesserror\b[^\[]*\[(\d{4})\]/gi;
 const DEFAULT_SINCE = "24h";
 const DEFAULT_TIMEZONE = "Asia/Singapore";
 const DEFAULT_PEAK_START_HOUR = 14;
@@ -196,7 +197,8 @@ function emptyReport(input: {
     hourly: [],
     repos: [],
     knownLimitations: [
-      "processed_reviews is a current-state table keyed by repo/pull/head; provider throttles that were overwritten before queue retry metadata was preserved may be undercounted."
+      "processed_reviews is a current-state table keyed by repo/pull/head; provider throttles that were overwritten before queue retry metadata was preserved may be undercounted.",
+      "processed_reviews events are bucketed by created_at; review_queue_jobs events are bucketed by coalesce(finished_at, updated_at, started_at, created_at), so deduped queue incidents may reflect retry/update time instead of first-observed throttle time."
     ]
   };
 }
@@ -358,6 +360,8 @@ function classifyProviderThrottle(error: string): ProviderThrottleCategory | und
   if (
     normalized.includes("reason=provider_request_rate_limit") ||
     normalized.includes("reason=provider_rate_limit") ||
+    normalized.includes("previous_reason=provider_request_rate_limit") ||
+    normalized.includes("previous_reason=provider_rate_limit") ||
     normalized.includes("provider_request_rate_limit") ||
     codes.includes("1302")
   ) {
@@ -400,6 +404,7 @@ function dedupeProviderThrottleEvents(events: ProviderThrottleEvent[]): Provider
 }
 
 function addRetryOutcome(report: ProviderThrottleReport, event: ProviderThrottleEvent): void {
+  if (event.source !== "review_queue_jobs") return;
   const status = event.status.toLowerCase();
   if (status === "posted" || status === "reviewed" || status === "reviewed_command") {
     report.retryOutcomes.retriedPosted += 1;
@@ -418,7 +423,10 @@ function addRetryOutcome(report: ProviderThrottleReport, event: ProviderThrottle
 
 function extractProviderCodes(error: string): string[] {
   const codes = new Set<string>();
-  for (const match of error.matchAll(PROVIDER_CODES)) {
+  for (const match of error.matchAll(EXPLICIT_PROVIDER_CODES)) {
+    if (match[1] && KNOWN_PROVIDER_CODES.has(match[1])) codes.add(match[1]);
+  }
+  for (const match of error.matchAll(PROVIDER_BUSINESS_ERROR_CODES)) {
     if (match[1] && KNOWN_PROVIDER_CODES.has(match[1])) codes.add(match[1]);
   }
   return [...codes];

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -106,6 +106,7 @@ const DEFAULT_PEAK_END_HOUR = 18;
 export function collectProviderThrottleReport(input: ProviderThrottleReportOptions): ProviderThrottleReport {
   const now = input.now ?? new Date();
   const timezone = input.timezone ?? DEFAULT_TIMEZONE;
+  assertValidTimezone(timezone);
   const peakStartHour = input.peakStartHour ?? DEFAULT_PEAK_START_HOUR;
   const peakEndHour = input.peakEndHour ?? DEFAULT_PEAK_END_HOUR;
   const sinceRaw = input.since ?? DEFAULT_SINCE;
@@ -375,13 +376,28 @@ function extractProviderCodes(error: string): string[] {
 }
 
 function localHour(timestamp: string, timezone: string): string {
-  const date = new Date(timestamp);
+  const date = parseSqliteUtcTimestamp(timestamp);
   const hour = new Intl.DateTimeFormat("en-US", {
     timeZone: timezone,
     hour: "2-digit",
     hourCycle: "h23"
   }).format(date);
   return `${hour}:00`;
+}
+
+function parseSqliteUtcTimestamp(timestamp: string): Date {
+  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(timestamp)) {
+    return new Date(`${timestamp.replace(" ", "T")}Z`);
+  }
+  return new Date(timestamp);
+}
+
+function assertValidTimezone(timezone: string): void {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date(0));
+  } catch {
+    throw new Error(`Invalid --timezone value: ${timezone}`);
+  }
 }
 
 function isPeakHour(localHour: string, peakStartHour: number, peakEndHour: number): boolean {

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -36,6 +36,8 @@ export interface ProviderThrottleSummary extends ProviderThrottleCounts {
   providerErrors: number;
   peakWindowErrors: number;
   offPeakErrors: number;
+  droppedEvents: number;
+  malformedTimestamps: number;
   worstLocalHour?: string;
 }
 
@@ -178,7 +180,9 @@ function emptyReport(input: {
       networkOrGithubDependency: 0,
       unknownProviderError: 0,
       peakWindowErrors: 0,
-      offPeakErrors: 0
+      offPeakErrors: 0,
+      droppedEvents: 0,
+      malformedTimestamps: 0
     },
     retryOutcomes: {
       retriedPosted: 0,
@@ -266,6 +270,11 @@ function addEventToReport(
   const category = classifyProviderThrottle(event.error);
   if (!category) return;
   const hour = localHour(event.timestamp, timezone);
+  if (!hour) {
+    report.summary.droppedEvents += 1;
+    report.summary.malformedTimestamps += 1;
+    return;
+  }
   const peakWindow = isPeakHour(hour, peakStartHour, peakEndHour);
   const hourly = getHourlyBucket(report, hour, peakWindow);
   const repo = getRepoBucket(report, event.repo);
@@ -415,8 +424,9 @@ function extractProviderCodes(error: string): string[] {
   return [...codes];
 }
 
-function localHour(timestamp: string, timezone: string): string {
+function localHour(timestamp: string, timezone: string): string | undefined {
   const date = parseSqliteUtcTimestamp(timestamp);
+  if (!Number.isFinite(date.getTime())) return undefined;
   const hour = new Intl.DateTimeFormat("en-US", {
     timeZone: timezone,
     hour: "2-digit",

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -122,7 +122,6 @@ const DEFAULT_SINCE = "24h";
 const DEFAULT_TIMEZONE = "Asia/Singapore";
 const DEFAULT_PEAK_START_HOUR = 14;
 const DEFAULT_PEAK_END_HOUR = 18;
-const KNOWN_PROVIDER_CODES = new Set(["1302", "1305", "1308", "1309", "1310", "1316", "1317"]);
 
 export function collectProviderThrottleReport(input: ProviderThrottleReportOptions): ProviderThrottleReport {
   const now = input.now ?? new Date();
@@ -213,7 +212,8 @@ function emptyReport(input: {
       "processed_reviews is a current-state table keyed by repo/pull/head; provider throttles that were overwritten before queue retry metadata was preserved may be undercounted.",
       "processed_reviews events are bucketed by created_at; review_queue_jobs events are bucketed by coalesce(finished_at, updated_at, started_at, created_at), so deduped queue incidents may reflect retry/update time instead of first-observed throttle time.",
       "processed_reviews does not store provider_id, so provider context for those rows is reported as unknown.",
-      "retryOutcomes is sourced from review_queue_jobs current state only; processed_reviews-only incidents are excluded from retry outcomes, and stale queue rows can skew retry outcome telemetry until the worker repairs them."
+      "retryOutcomes is sourced from review_queue_jobs current state only; processed_reviews-only incidents are excluded from retry outcomes, and stale queue rows can skew retry outcome telemetry until the worker repairs them.",
+      "Each incident is assigned to the first matching category by precedence; mixed-cause provider errors are collapsed into one summary category while all extracted provider codes remain visible."
     ]
   };
 }
@@ -415,7 +415,16 @@ function classifyProviderThrottle(error: string): ProviderThrottleCategory | und
   ) {
     return "networkOrGithubDependency";
   }
-  if (normalized.includes("provider") || codes.length > 0) return "unknownProviderError";
+  if (
+    normalized.includes("providerbusinesserror") ||
+    normalized.includes("provider throttle") ||
+    normalized.includes("provider cooldown") ||
+    normalized.includes("provider_throttle") ||
+    normalized.includes("provider_cooldown") ||
+    codes.length > 0
+  ) {
+    return "unknownProviderError";
+  }
   return undefined;
 }
 

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -75,13 +75,18 @@ type ProviderThrottleCategory =
 
 interface ProviderThrottleEvent {
   repo: string;
+  pullNumber: number;
+  headSha: string;
   status: string;
   error: string;
   timestamp: string;
+  source: "processed_reviews" | "review_queue_jobs";
 }
 
 interface ProcessedReviewErrorRow {
   repo: string;
+  pull_number: number;
+  head_sha: string;
   status: string;
   error: string | null;
   created_at: string;
@@ -89,6 +94,8 @@ interface ProcessedReviewErrorRow {
 
 interface ReviewQueueErrorRow {
   repo: string;
+  pull_number: number;
+  head_sha: string;
   state: string;
   last_error: string | null;
   created_at: string;
@@ -97,7 +104,7 @@ interface ReviewQueueErrorRow {
   finished_at?: string | null;
 }
 
-const PROVIDER_CODES = /(?:\bprovider_code=|\bproviderCode:\s*["']?|\[)(\d{4})\b/g;
+const PROVIDER_CODES = /(?:\bprovider_code=|\bprevious_provider_code=|\bproviderCode:\s*["']?|\[)(\d{4})\b/g;
 const DEFAULT_SINCE = "24h";
 const DEFAULT_TIMEZONE = "Asia/Singapore";
 const DEFAULT_PEAK_START_HOUR = 14;
@@ -193,7 +200,7 @@ function collectProviderThrottleEvents(db: DatabaseSync, sinceStart: Date, now: 
   if (hasTable(db, "processed_reviews")) {
     const rows = db
       .prepare(
-        `select repo, status, error, created_at
+        `select repo, pull_number, head_sha, status, error, created_at
          from processed_reviews
          where error is not null
            and datetime(created_at) >= datetime(?)
@@ -204,9 +211,12 @@ function collectProviderThrottleEvents(db: DatabaseSync, sinceStart: Date, now: 
       if (!row.error || !classifyProviderThrottle(row.error)) continue;
       events.push({
         repo: row.repo,
+        pullNumber: row.pull_number,
+        headSha: row.head_sha,
         status: row.status,
         error: row.error,
-        timestamp: row.created_at
+        timestamp: row.created_at,
+        source: "processed_reviews"
       });
     }
   }
@@ -215,7 +225,7 @@ function collectProviderThrottleEvents(db: DatabaseSync, sinceStart: Date, now: 
     const timestampExpr = queueTimestampExpression(db);
     const rows = db
       .prepare(
-        `select repo, state, last_error, created_at, updated_at,
+        `select repo, pull_number, head_sha, state, last_error, created_at, updated_at,
                 ${hasColumn(db, "review_queue_jobs", "started_at") ? "started_at" : "null as started_at"},
                 ${hasColumn(db, "review_queue_jobs", "finished_at") ? "finished_at" : "null as finished_at"}
          from review_queue_jobs
@@ -228,14 +238,17 @@ function collectProviderThrottleEvents(db: DatabaseSync, sinceStart: Date, now: 
       if (!row.last_error || !classifyProviderThrottle(row.last_error)) continue;
       events.push({
         repo: row.repo,
+        pullNumber: row.pull_number,
+        headSha: row.head_sha,
         status: row.state,
         error: row.last_error,
-        timestamp: row.finished_at ?? row.updated_at ?? row.started_at ?? row.created_at
+        timestamp: row.finished_at ?? row.updated_at ?? row.started_at ?? row.created_at,
+        source: "review_queue_jobs"
       });
     }
   }
 
-  return events;
+  return dedupeProviderThrottleEvents(events);
 }
 
 function addEventToReport(
@@ -319,9 +332,11 @@ function classifyProviderThrottle(error: string): ProviderThrottleCategory | und
   }
   if (
     normalized.includes("provider_quota_exhausted") ||
+    normalized.includes("usage limit reached") ||
     normalized.includes("weekly/monthly limit exhausted") ||
     normalized.includes("limit exhausted") ||
     normalized.includes("quota exhausted") ||
+    normalized.includes("package has expired") ||
     codes.some((code) => ["1308", "1309", "1310", "1316", "1317"].includes(code))
   ) {
     return "quotaExhausted";
@@ -348,6 +363,26 @@ function classifyProviderThrottle(error: string): ProviderThrottleCategory | und
   }
   if (normalized.includes("provider") || codes.length > 0) return "unknownProviderError";
   return undefined;
+}
+
+function dedupeProviderThrottleEvents(events: ProviderThrottleEvent[]): ProviderThrottleEvent[] {
+  const byIncident = new Map<string, ProviderThrottleEvent>();
+  for (const event of events) {
+    const category = classifyProviderThrottle(event.error);
+    if (!category) continue;
+    const key = [
+      event.repo,
+      event.pullNumber,
+      event.headSha,
+      category,
+      extractProviderCodes(event.error).sort().join(",")
+    ].join("\0");
+    const existing = byIncident.get(key);
+    if (!existing || event.source === "review_queue_jobs") {
+      byIncident.set(key, event);
+    }
+  }
+  return [...byIncident.values()];
 }
 
 function addRetryOutcome(report: ProviderThrottleReport, event: ProviderThrottleEvent): void {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -575,7 +575,8 @@ export async function retryFailedHeadWithDeps(input: {
       pullNumber: options.pullNumber,
       headSha: options.headSha,
       status: retryStatus,
-      dryRun: options.dryRun
+      dryRun: options.dryRun,
+      providerCooldownError: retryTarget.previousError
     });
     await syncRetryReviewStatusComment({
       config,
@@ -746,6 +747,7 @@ function updateRetryQueueJobsAfterRetry(input: {
   headSha: string;
   status: RetryFailedHeadResult["status"];
   dryRun: boolean;
+  providerCooldownError?: string;
 }): void {
   const retryStates: ReviewQueueJobState[] = ["queued", "leased", "running", "provider_deferred"];
   if (!input.dryRun) retryStates.push("failed");
@@ -762,7 +764,7 @@ function updateRetryQueueJobsAfterRetry(input: {
   if (targetJobs.length === 0) return;
 
   const processed = input.state.getProcessedReview(input.repo, input.pullNumber, input.headSha);
-  const providerCooldown = parseProviderCooldownError(processed?.error);
+  const providerCooldown = parseProviderCooldownError(processed?.error) ?? parseProviderCooldownError(input.providerCooldownError);
   const patch = retryQueuePatchForStatus({
     status: input.status,
     dryRun: input.dryRun,
@@ -772,7 +774,12 @@ function updateRetryQueueJobsAfterRetry(input: {
     processedError: processed?.error
   });
   for (const job of targetJobs) {
-    const lastError = buildRetryQueueLastError({ jobLastError: job.lastError, patchLastError: patch.lastError, patchState: patch.state });
+    const lastError = buildRetryQueueLastError({
+      jobLastError: job.lastError,
+      patchLastError: patch.lastError,
+      patchState: patch.state,
+      fallbackProviderCooldown: providerCooldown
+    });
     input.state.updateReviewQueueJobState({
       jobId: job.jobId,
       state: patch.state,
@@ -796,9 +803,10 @@ function buildRetryQueueLastError(input: {
   jobLastError?: string;
   patchLastError: string;
   patchState: ReviewQueueJobState;
+  fallbackProviderCooldown?: ReturnType<typeof parseProviderCooldownError>;
 }): string {
   if (input.patchState !== "posted") return input.patchLastError;
-  const providerCooldown = parseProviderCooldownError(input.jobLastError);
+  const providerCooldown = parseProviderCooldownError(input.jobLastError) ?? input.fallbackProviderCooldown;
   if (!providerCooldown) return input.patchLastError;
   const previousReason = redactSecrets(providerCooldown.reason ?? "provider_cooldown");
   const previousProviderCode = providerCooldown.providerCode ? redactSecrets(providerCooldown.providerCode) : undefined;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -772,12 +772,13 @@ function updateRetryQueueJobsAfterRetry(input: {
     processedError: processed?.error
   });
   for (const job of targetJobs) {
+    const lastError = buildRetryQueueLastError({ jobLastError: job.lastError, patchLastError: patch.lastError, patchState: patch.state });
     input.state.updateReviewQueueJobState({
       jobId: job.jobId,
       state: patch.state,
       ...(patch.nextEligibleAt ? { nextEligibleAt: patch.nextEligibleAt } : {}),
       ...(patch.reviewUrl ? { reviewUrl: patch.reviewUrl } : {}),
-      lastError: patch.lastError
+      lastError
     });
     if (job.sessionId && patch.sessionJobState) {
       input.state.updateReviewerSessionJobState({
@@ -789,6 +790,21 @@ function updateRetryQueueJobsAfterRetry(input: {
       });
     }
   }
+}
+
+function buildRetryQueueLastError(input: {
+  jobLastError?: string;
+  patchLastError: string;
+  patchState: ReviewQueueJobState;
+}): string {
+  if (input.patchState !== "posted") return input.patchLastError;
+  const providerCooldown = parseProviderCooldownError(input.jobLastError);
+  if (!providerCooldown) return input.patchLastError;
+  return [
+    `${input.patchLastError}_after_provider_deferred`,
+    `previous_reason=${providerCooldown.reason ?? "provider_cooldown"}`,
+    ...(providerCooldown.providerCode ? [`previous_provider_code=${providerCooldown.providerCode}`] : [])
+  ].join("; ");
 }
 
 function retryQueuePatchForStatus(input: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -800,10 +800,12 @@ function buildRetryQueueLastError(input: {
   if (input.patchState !== "posted") return input.patchLastError;
   const providerCooldown = parseProviderCooldownError(input.jobLastError);
   if (!providerCooldown) return input.patchLastError;
+  const previousReason = redactSecrets(providerCooldown.reason ?? "provider_cooldown");
+  const previousProviderCode = providerCooldown.providerCode ? redactSecrets(providerCooldown.providerCode) : undefined;
   return [
     `${input.patchLastError}_after_provider_deferred`,
-    `previous_reason=${providerCooldown.reason ?? "provider_cooldown"}`,
-    ...(providerCooldown.providerCode ? [`previous_provider_code=${providerCooldown.providerCode}`] : [])
+    `previous_reason=${previousReason}`,
+    ...(previousProviderCode ? [`previous_provider_code=${previousProviderCode}`] : [])
   ].join("; ");
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -806,14 +806,16 @@ function buildRetryQueueLastError(input: {
   fallbackProviderCooldown?: ReturnType<typeof parseProviderCooldownError>;
 }): string {
   if (input.patchState !== "posted") return input.patchLastError;
-  const providerCooldown = parseProviderCooldownError(input.jobLastError) ?? input.fallbackProviderCooldown;
+  const jobProviderCooldown = parseProviderCooldownError(input.jobLastError);
+  const providerCooldown = jobProviderCooldown ?? input.fallbackProviderCooldown;
   if (!providerCooldown) return input.patchLastError;
   const previousReason = redactSecrets(providerCooldown.reason ?? "provider_cooldown");
-  const previousProviderCode = providerCooldown.providerCode ? redactSecrets(providerCooldown.providerCode) : undefined;
+  const previousProviderCode = providerCooldown.providerCode ?? input.fallbackProviderCooldown?.providerCode;
+  const redactedProviderCode = previousProviderCode ? redactSecrets(previousProviderCode) : undefined;
   return [
     `${input.patchLastError}_after_provider_deferred`,
     `previous_reason=${previousReason}`,
-    ...(previousProviderCode ? [`previous_provider_code=${previousProviderCode}`] : [])
+    ...(redactedProviderCode ? [`previous_provider_code=${redactedProviderCode}`] : [])
   ].join("; ");
 }
 

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -67,7 +67,7 @@ describe("provider throttle report", () => {
         pullNumber: 6,
         headSha: "posted-head",
         state: "posted",
-        lastError: "provider_rate_limit_cooldown_until=2026-07-01T12:00:00.000Z; reason=provider_request_rate_limit; provider_code=1302",
+        lastError: "reviewed_after_provider_deferred; previous_reason=provider_request_rate_limit; previous_provider_code=1302",
         createdAt: "2026-07-01T12:00:00.000Z",
         updatedAt: "2026-07-01T12:01:00.000Z"
       });
@@ -128,6 +128,86 @@ describe("provider throttle report", () => {
       statePath,
       timezone: "Foo/Bar"
     })).toThrow("Invalid --timezone value: Foo/Bar");
+  });
+
+  it("deduplicates processed and queued rows for the same provider incident", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-dedupe-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    new ReviewStateStore(statePath).close();
+    const db = new DatabaseSync(statePath);
+    try {
+      insertProcessed(db, {
+        repo: "owner/repo",
+        pullNumber: 7,
+        headSha: "same-provider-head",
+        status: "skipped",
+        error: "provider_rate_limit_cooldown_until=2026-07-01T08:05:00.000Z; reason=provider_request_rate_limit; provider_code=1302",
+        createdAt: "2026-07-01 08:00:00"
+      });
+      insertQueueJob(db, {
+        repo: "owner/repo",
+        pullNumber: 7,
+        headSha: "same-provider-head",
+        state: "provider_deferred",
+        lastError: "provider_rate_limit_cooldown_until=2026-07-01T08:05:00.000Z; reason=provider_request_rate_limit; provider_code=1302",
+        createdAt: "2026-07-01T08:00:00.000Z",
+        updatedAt: "2026-07-01T08:01:00.000Z"
+      });
+    } finally {
+      db.close();
+    }
+
+    const report = collectProviderThrottleReport({
+      statePath,
+      now: new Date("2026-07-08T00:00:00.000Z"),
+      since: "7d",
+      timezone: "Asia/Singapore"
+    });
+
+    expect(report.summary.providerErrors).toBe(1);
+    expect(report.summary.requestRateLimit).toBe(1);
+    expect(report.retryOutcomes.retriedProviderDeferred).toBe(1);
+    expect(report.codes).toContainEqual({ code: "1302", count: 1 });
+  });
+
+  it("matches quota exhaustion text forms used by provider classification", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-quota-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    new ReviewStateStore(statePath).close();
+    const db = new DatabaseSync(statePath);
+    try {
+      insertProcessed(db, {
+        repo: "owner/repo",
+        pullNumber: 8,
+        headSha: "usage-limit-head",
+        status: "failed",
+        error: "ProviderBusinessError: usage limit reached",
+        createdAt: "2026-07-01 08:00:00"
+      });
+      insertProcessed(db, {
+        repo: "owner/repo",
+        pullNumber: 9,
+        headSha: "expired-package-head",
+        status: "failed",
+        error: "ProviderBusinessError: package has expired",
+        createdAt: "2026-07-01 09:00:00"
+      });
+    } finally {
+      db.close();
+    }
+
+    const report = collectProviderThrottleReport({
+      statePath,
+      now: new Date("2026-07-08T00:00:00.000Z"),
+      since: "7d",
+      timezone: "Asia/Singapore"
+    });
+
+    expect(report.summary.providerErrors).toBe(2);
+    expect(report.summary.quotaExhausted).toBe(2);
+    expect(report.summary.unknownProviderError).toBe(0);
   });
 });
 

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -50,7 +50,7 @@ describe("provider throttle report", () => {
         headSha: "queue-deferred",
         providerId: "GLM-5.2",
         state: "provider_deferred",
-        lastError: "ProviderBusinessError: [1305][temporarily overloaded]",
+        lastError: "ProviderBusinessError: [1305][temporarily overloaded]; retry_attempt=2",
         createdAt: "2026-07-01T10:00:00.000Z",
         updatedAt: "2026-07-01T10:01:00.000Z"
       });
@@ -357,6 +357,198 @@ describe("provider throttle report", () => {
     });
     expect(report.hourly).toEqual([]);
     expect(report.repos).toEqual([]);
+  });
+
+  it("treats offsetless ISO queue timestamps as UTC for local-hour buckets", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-offsetless-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    new ReviewStateStore(statePath).close();
+    const db = new DatabaseSync(statePath);
+    try {
+      insertQueueJob(db, {
+        repo: "owner/repo",
+        pullNumber: 12,
+        headSha: "offsetless-head",
+        providerId: "z.ai/GLM-5.2@beta",
+        state: "failed",
+        lastError: "provider_rate_limit_cooldown_until=2026-07-01T10:05:00.000Z; reason=provider_request_rate_limit; provider_code=1302",
+        createdAt: "2026-07-01T10:00:00.000",
+        updatedAt: "2026-07-01T10:00:00.000"
+      });
+    } finally {
+      db.close();
+    }
+
+    const report = collectProviderThrottleReport({
+      statePath,
+      now: new Date("2026-07-08T00:00:00.000Z"),
+      since: "7d",
+      timezone: "Asia/Singapore",
+      peakStartHour: 14,
+      peakEndHour: 18
+    });
+
+    expect(report.summary).toMatchObject({
+      providerErrors: 1,
+      requestRateLimit: 1,
+      peakWindowErrors: 1,
+      offPeakErrors: 0,
+      worstLocalHour: "18:00"
+    });
+    expect(report.providers).toEqual([
+      expect.objectContaining({ providerId: "z.ai/GLM-5.2@beta", total: 1 })
+    ]);
+  });
+
+  it("preserves normal provider IDs while redacting obvious credential-shaped values", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-provider-id-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    new ReviewStateStore(statePath).close();
+    const db = new DatabaseSync(statePath);
+    try {
+      insertQueueJob(db, {
+        repo: "owner/repo",
+        pullNumber: 13,
+        headSha: "provider-id-head",
+        providerId: "z.ai/GLM-5.2@beta",
+        state: "failed",
+        lastError: "ProviderBusinessError: [1305][temporarily overloaded]",
+        createdAt: "2026-07-01T10:00:00.000Z",
+        updatedAt: "2026-07-01T10:00:00.000Z"
+      });
+      insertQueueJob(db, {
+        repo: "owner/repo",
+        pullNumber: 14,
+        headSha: "secret-provider-id-head",
+        providerId: "ghp_123456789012345678901234567890123456",
+        state: "failed",
+        lastError: "ProviderBusinessError: [1305][temporarily overloaded]",
+        createdAt: "2026-07-01T11:00:00.000Z",
+        updatedAt: "2026-07-01T11:00:00.000Z"
+      });
+    } finally {
+      db.close();
+    }
+
+    const report = collectProviderThrottleReport({
+      statePath,
+      now: new Date("2026-07-08T00:00:00.000Z"),
+      since: "7d",
+      timezone: "Asia/Singapore"
+    });
+
+    expect(report.providers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ providerId: "z.ai/GLM-5.2@beta", total: 1 }),
+      expect.objectContaining({ providerId: "[redacted-provider-id]", total: 1 })
+    ]));
+    expect(JSON.stringify(report)).not.toContain("ghp_123456789012345678901234567890123456");
+  });
+
+  it("does not count never-retried provider-deferred rows as retry outcomes", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-deferred-outcome-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    new ReviewStateStore(statePath).close();
+    const db = new DatabaseSync(statePath);
+    try {
+      insertQueueJob(db, {
+        repo: "owner/repo",
+        pullNumber: 15,
+        headSha: "first-deferred-head",
+        providerId: "GLM-5.2",
+        state: "provider_deferred",
+        lastError: "provider_rate_limit_cooldown_until=2026-07-01T08:05:00.000Z; reason=provider_request_rate_limit; provider_code=1302",
+        createdAt: "2026-07-01T08:00:00.000Z",
+        updatedAt: "2026-07-01T08:01:00.000Z"
+      });
+      insertQueueJob(db, {
+        repo: "owner/repo",
+        pullNumber: 16,
+        headSha: "retry-deferred-head",
+        providerId: "GLM-5.2",
+        state: "provider_deferred",
+        lastError: "provider_rate_limit_cooldown_until=2026-07-01T09:05:00.000Z; reason=provider_request_rate_limit; retry_attempt=2; provider_code=1302",
+        createdAt: "2026-07-01T09:00:00.000Z",
+        updatedAt: "2026-07-01T09:01:00.000Z"
+      });
+    } finally {
+      db.close();
+    }
+
+    const report = collectProviderThrottleReport({
+      statePath,
+      now: new Date("2026-07-08T00:00:00.000Z"),
+      since: "7d",
+      timezone: "Asia/Singapore"
+    });
+
+    expect(report.summary.providerErrors).toBe(2);
+    expect(report.retryOutcomes.retriedProviderDeferred).toBe(1);
+  });
+
+  it("aggregates legacy review_queue_jobs rows without provider_id or lifecycle timestamp columns", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-legacy-queue-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    const db = new DatabaseSync(statePath);
+    try {
+      db.exec(`
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          priority integer not null,
+          state text not null,
+          last_error text,
+          created_at text not null,
+          updated_at text not null
+        )
+      `);
+      db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, last_error, created_at, updated_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, ?, ?, ?, ?)`
+      ).run(
+        "legacy-job",
+        "legacy:owner/repo#17@legacy-head",
+        "owner/repo",
+        "owner",
+        17,
+        "legacy-head",
+        "failed",
+        "ProviderBusinessError: [1305][temporarily overloaded]",
+        "2026-07-01T10:00:00.000Z",
+        "2026-07-01T10:01:00.000Z"
+      );
+    } finally {
+      db.close();
+    }
+
+    const report = collectProviderThrottleReport({
+      statePath,
+      now: new Date("2026-07-08T00:00:00.000Z"),
+      since: "7d",
+      timezone: "Asia/Singapore"
+    });
+
+    expect(report.summary).toMatchObject({
+      providerErrors: 1,
+      overloaded: 1
+    });
+    expect(report.providers).toEqual([
+      expect.objectContaining({ providerId: "unknown", total: 1 })
+    ]);
+    expect(report.hourly).toEqual([
+      expect.objectContaining({ localHour: "18:00", total: 1 })
+    ]);
   });
 });
 

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -309,6 +309,14 @@ describe("provider throttle report", () => {
         error: "reviewer provider not configured",
         createdAt: "2026-07-01 10:00:00"
       });
+      insertProcessed(db, {
+        repo: "owner/repo",
+        pullNumber: 13,
+        headSha: "generic-fetch-head",
+        status: "failed",
+        error: "Tool failed while fetching a project URL: fetch failed",
+        createdAt: "2026-07-01 11:00:00"
+      });
     } finally {
       db.close();
     }

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -317,6 +317,14 @@ describe("provider throttle report", () => {
         error: "Tool failed while fetching a project URL: fetch failed",
         createdAt: "2026-07-01 11:00:00"
       });
+      insertProcessed(db, {
+        repo: "owner/repo",
+        pullNumber: 14,
+        headSha: "generic-overloaded-head",
+        status: "failed",
+        error: "Local review worker overloaded while opening the worktree",
+        createdAt: "2026-07-01 12:00:00"
+      });
     } finally {
       db.close();
     }
@@ -436,6 +444,16 @@ describe("provider throttle report", () => {
         createdAt: "2026-07-01T11:00:00.000Z",
         updatedAt: "2026-07-01T11:00:00.000Z"
       });
+      insertQueueJob(db, {
+        repo: "owner/repo",
+        pullNumber: 15,
+        headSha: "opaque-provider-id-head",
+        providerId: "0123456789abcdefghijklmnopqrstuvwxyzAB",
+        state: "failed",
+        lastError: "ProviderBusinessError: [1305][temporarily overloaded]",
+        createdAt: "2026-07-01T12:00:00.000Z",
+        updatedAt: "2026-07-01T12:00:00.000Z"
+      });
     } finally {
       db.close();
     }
@@ -449,9 +467,10 @@ describe("provider throttle report", () => {
 
     expect(report.providers).toEqual(expect.arrayContaining([
       expect.objectContaining({ providerId: "z.ai/GLM-5.2@beta", total: 1 }),
-      expect.objectContaining({ providerId: "[redacted-provider-id]", total: 1 })
+      expect.objectContaining({ providerId: "[redacted-provider-id]", total: 2 })
     ]));
     expect(JSON.stringify(report)).not.toContain("ghp_123456789012345678901234567890123456");
+    expect(JSON.stringify(report)).not.toContain("0123456789abcdefghijklmnopqrstuvwxyzAB");
   });
 
   it("does not count never-retried provider-deferred rows as retry outcomes", () => {

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -247,6 +247,37 @@ describe("provider throttle report", () => {
     expect(report.summary.unknownProviderError).toBe(0);
   });
 
+  it("surfaces unknown provider business-error codes for measurement", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-unknown-code-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    new ReviewStateStore(statePath).close();
+    const db = new DatabaseSync(statePath);
+    try {
+      insertProcessed(db, {
+        repo: "owner/repo",
+        pullNumber: 10,
+        headSha: "unknown-provider-code-head",
+        status: "failed",
+        error: "ProviderBusinessError: [1399][new provider throttle shape]",
+        createdAt: "2026-07-01 08:00:00"
+      });
+    } finally {
+      db.close();
+    }
+
+    const report = collectProviderThrottleReport({
+      statePath,
+      now: new Date("2026-07-08T00:00:00.000Z"),
+      since: "7d",
+      timezone: "Asia/Singapore"
+    });
+
+    expect(report.summary.providerErrors).toBe(1);
+    expect(report.summary.unknownProviderError).toBe(1);
+    expect(report.codes).toContainEqual({ code: "1399", count: 1 });
+  });
+
   it("does not treat unrelated bracketed numbers as provider codes", () => {
     const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-codes-"));
     roots.push(root);

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -242,6 +242,41 @@ describe("provider throttle report", () => {
     expect(report.summary.providerErrors).toBe(0);
     expect(report.codes).toEqual([]);
   });
+
+  it("drops provider events whose SQLite timestamp cannot be bucketed by JavaScript", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-malformed-timestamp-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    new ReviewStateStore(statePath).close();
+    const db = new DatabaseSync(statePath);
+    try {
+      insertProcessed(db, {
+        repo: "owner/repo",
+        pullNumber: 11,
+        headSha: "julian-date-head",
+        status: "skipped",
+        error: "provider_rate_limit_cooldown_until=2000-01-01T12:05:00.000Z; reason=provider_request_rate_limit; provider_code=1302",
+        createdAt: "2451545.0"
+      });
+    } finally {
+      db.close();
+    }
+
+    const report = collectProviderThrottleReport({
+      statePath,
+      now: new Date("2000-01-02T00:00:00.000Z"),
+      since: "1999-12-31T00:00:00.000Z",
+      timezone: "Asia/Singapore"
+    });
+
+    expect(report.summary).toMatchObject({
+      providerErrors: 0,
+      droppedEvents: 1,
+      malformedTimestamps: 1
+    });
+    expect(report.hourly).toEqual([]);
+    expect(report.repos).toEqual([]);
+  });
 });
 
 function insertProcessed(

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -301,6 +301,14 @@ describe("provider throttle report", () => {
         error: "Tool failed with internal marker [1302]",
         createdAt: "2026-07-01 09:00:00"
       });
+      insertProcessed(db, {
+        repo: "owner/repo",
+        pullNumber: 12,
+        headSha: "provider-wording-head",
+        status: "failed",
+        error: "reviewer provider not configured",
+        createdAt: "2026-07-01 10:00:00"
+      });
     } finally {
       db.close();
     }

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -48,6 +48,7 @@ describe("provider throttle report", () => {
         repo: "owner/repo",
         pullNumber: 4,
         headSha: "queue-deferred",
+        providerId: "GLM-5.2",
         state: "provider_deferred",
         lastError: "ProviderBusinessError: [1305][temporarily overloaded]",
         createdAt: "2026-07-01T10:00:00.000Z",
@@ -57,8 +58,9 @@ describe("provider throttle report", () => {
         repo: "owner/other",
         pullNumber: 5,
         headSha: "network-head",
+        providerId: "GLM-5.2",
         state: "failed",
-        lastError: "GitHub API fetch failed for /app/installations/access_tokens: fetch failed; cause=Error: getaddrinfo ENOTFOUND api.github.com",
+        lastError: "GitHub API fetch failed for /app/installations/access_tokens: fetch failed; providerRequestId: 'secret-request-id'; cause=Error: getaddrinfo ENOTFOUND api.github.com",
         createdAt: "2026-07-01T11:00:00.000Z",
         updatedAt: "2026-07-01T11:01:00.000Z"
       });
@@ -66,6 +68,7 @@ describe("provider throttle report", () => {
         repo: "owner/repo",
         pullNumber: 6,
         headSha: "posted-head",
+        providerId: "GLM-5.2",
         state: "posted",
         lastError: "reviewed_after_provider_deferred; previous_reason=provider_request_rate_limit; previous_provider_code=1302",
         createdAt: "2026-07-01T12:00:00.000Z",
@@ -116,6 +119,10 @@ describe("provider throttle report", () => {
       repo: "owner/repo",
       total: 4
     });
+    expect(report.providers).toEqual([
+      expect.objectContaining({ providerId: "GLM-5.2", total: 3 }),
+      expect.objectContaining({ providerId: "unknown", total: 3 })
+    ]);
     expect(report.knownLimitations).toContain(
       "processed_reviews is a current-state table keyed by repo/pull/head; provider throttles that were overwritten before queue retry metadata was preserved may be undercounted."
     );
@@ -131,6 +138,21 @@ describe("provider throttle report", () => {
       statePath,
       timezone: "Foo/Bar"
     })).toThrow("Invalid --timezone value: Foo/Bar");
+  });
+
+  it("rejects invalid peak-window hour values before aggregating", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-peak-hour-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+
+    expect(() => collectProviderThrottleReport({
+      statePath,
+      peakStartHour: 24
+    })).toThrow("Invalid --peak-start-hour value: 24; expected an integer from 0 to 23");
+    expect(() => collectProviderThrottleReport({
+      statePath,
+      peakEndHour: 14.5
+    })).toThrow("Invalid --peak-end-hour value: 14.5; expected an integer from 0 to 23");
   });
 
   it("deduplicates processed and queued rows for the same provider incident", () => {
@@ -152,10 +174,21 @@ describe("provider throttle report", () => {
         repo: "owner/repo",
         pullNumber: 7,
         headSha: "same-provider-head",
+        providerId: "GLM-5.2",
         state: "provider_deferred",
         lastError: "provider_rate_limit_cooldown_until=2026-07-01T08:05:00.000Z; reason=provider_request_rate_limit; provider_code=1302",
         createdAt: "2026-07-01T08:00:00.000Z",
         updatedAt: "2026-07-01T08:01:00.000Z"
+      });
+      insertQueueJob(db, {
+        repo: "owner/repo",
+        pullNumber: 7,
+        headSha: "same-provider-head",
+        providerId: "GLM-5.2",
+        state: "posted",
+        lastError: "reviewed_after_provider_deferred; previous_reason=provider_request_rate_limit; previous_provider_code=1302",
+        createdAt: "2026-07-01T08:00:00.000Z",
+        updatedAt: "2026-07-01T09:01:00.000Z"
       });
     } finally {
       db.close();
@@ -170,7 +203,8 @@ describe("provider throttle report", () => {
 
     expect(report.summary.providerErrors).toBe(1);
     expect(report.summary.requestRateLimit).toBe(1);
-    expect(report.retryOutcomes.retriedProviderDeferred).toBe(1);
+    expect(report.retryOutcomes.retriedProviderDeferred).toBe(0);
+    expect(report.retryOutcomes.retriedPosted).toBe(1);
     expect(report.codes).toContainEqual({ code: "1302", count: 1 });
   });
 
@@ -314,13 +348,14 @@ function insertQueueJob(
     lastError: string;
     createdAt: string;
     updatedAt: string;
+    providerId?: string;
   }
 ): void {
   db.prepare(
     `insert into review_queue_jobs
       (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
-       priority, state, last_error, created_at, updated_at)
-     values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, ?, ?, ?, ?)`
+       provider_id, priority, state, last_error, created_at, updated_at)
+     values (?, ?, 'automatic', 'background', ?, ?, ?, ?, ?, 50, ?, ?, ?, ?)`
   ).run(
     `${input.state}-${input.headSha}`,
     `${input.state}:${input.repo}#${input.pullNumber}@${input.headSha}`,
@@ -328,6 +363,7 @@ function insertQueueJob(
     input.repo.split("/")[0],
     input.pullNumber,
     input.headSha,
+    input.providerId ?? null,
     input.state,
     input.lastError,
     input.createdAt,

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -116,6 +116,9 @@ describe("provider throttle report", () => {
       repo: "owner/repo",
       total: 4
     });
+    expect(report.knownLimitations).toContain(
+      "processed_reviews is a current-state table keyed by repo/pull/head; provider throttles that were overwritten before queue retry metadata was preserved may be undercounted."
+    );
     expect(JSON.stringify(report)).not.toMatch(/secret-request-id|PRIVATE KEY|ghp_/);
   });
 
@@ -208,6 +211,36 @@ describe("provider throttle report", () => {
     expect(report.summary.providerErrors).toBe(2);
     expect(report.summary.quotaExhausted).toBe(2);
     expect(report.summary.unknownProviderError).toBe(0);
+  });
+
+  it("does not treat unrelated bracketed numbers as provider codes", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-codes-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    new ReviewStateStore(statePath).close();
+    const db = new DatabaseSync(statePath);
+    try {
+      insertProcessed(db, {
+        repo: "owner/repo",
+        pullNumber: 10,
+        headSha: "unrelated-code-head",
+        status: "failed",
+        error: "Tool failed with internal marker [1234]",
+        createdAt: "2026-07-01 08:00:00"
+      });
+    } finally {
+      db.close();
+    }
+
+    const report = collectProviderThrottleReport({
+      statePath,
+      now: new Date("2026-07-08T00:00:00.000Z"),
+      since: "7d",
+      timezone: "Asia/Singapore"
+    });
+
+    expect(report.summary.providerErrors).toBe(0);
+    expect(report.codes).toEqual([]);
   });
 });
 

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -320,10 +320,18 @@ describe("provider throttle report", () => {
       insertProcessed(db, {
         repo: "owner/repo",
         pullNumber: 14,
+        headSha: "generic-provider-fetch-head",
+        status: "failed",
+        error: "Local provider metadata refresh failed: fetch failed",
+        createdAt: "2026-07-01 12:00:00"
+      });
+      insertProcessed(db, {
+        repo: "owner/repo",
+        pullNumber: 15,
         headSha: "generic-overloaded-head",
         status: "failed",
         error: "Local review worker overloaded while opening the worktree",
-        createdAt: "2026-07-01 12:00:00"
+        createdAt: "2026-07-01 13:00:00"
       });
     } finally {
       db.close();

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -102,7 +102,7 @@ describe("provider throttle report", () => {
       retryOutcomes: {
         retriedPosted: 1,
         retriedProviderDeferred: 1,
-        gaveUpAfterBackoff: 2
+        gaveUpAfterBackoff: 1
       }
     });
     expect(report.codes).toContainEqual({ code: "1302", count: 2 });
@@ -227,6 +227,14 @@ describe("provider throttle report", () => {
         status: "failed",
         error: "Tool failed with internal marker [1234]",
         createdAt: "2026-07-01 08:00:00"
+      });
+      insertProcessed(db, {
+        repo: "owner/repo",
+        pullNumber: 11,
+        headSha: "unrelated-known-code-head",
+        status: "failed",
+        error: "Tool failed with internal marker [1302]",
+        createdAt: "2026-07-01 09:00:00"
       });
     } finally {
       db.close();

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -26,7 +26,7 @@ describe("provider throttle report", () => {
         headSha: "rate-head",
         status: "skipped",
         error: "provider_rate_limit_cooldown_until=2026-07-01T08:05:00.000Z; reason=provider_request_rate_limit; provider_code=1302; providerRequestId: 'secret-request-id'",
-        createdAt: "2026-07-01T08:00:00.000Z"
+        createdAt: "2026-07-01 08:00:00"
       });
       insertProcessed(db, {
         repo: "owner/repo",
@@ -34,7 +34,7 @@ describe("provider throttle report", () => {
         headSha: "overload-head",
         status: "skipped",
         error: "provider_rate_limit_cooldown_until=2026-07-01T09:05:00.000Z; reason=provider_overloaded; retry_attempt=2; provider_code=1305",
-        createdAt: "2026-07-01T09:00:00.000Z"
+        createdAt: "2026-07-01 09:00:00"
       });
       insertProcessed(db, {
         repo: "owner/other",
@@ -42,7 +42,7 @@ describe("provider throttle report", () => {
         headSha: "quota-head",
         status: "failed",
         error: "ProviderBusinessError: [1310][Weekly/Monthly Limit Exhausted]",
-        createdAt: "2026-07-01T20:00:00.000Z"
+        createdAt: "2026-07-01 20:00:00"
       });
       insertQueueJob(db, {
         repo: "owner/repo",
@@ -117,6 +117,17 @@ describe("provider throttle report", () => {
       total: 4
     });
     expect(JSON.stringify(report)).not.toMatch(/secret-request-id|PRIVATE KEY|ghp_/);
+  });
+
+  it("rejects invalid timezone values before formatting buckets", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-timezone-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+
+    expect(() => collectProviderThrottleReport({
+      statePath,
+      timezone: "Foo/Bar"
+    })).toThrow("Invalid --timezone value: Foo/Bar");
   });
 });
 

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -1,0 +1,169 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { collectProviderThrottleReport } from "../src/provider-throttle-report.js";
+import { ReviewStateStore } from "../src/state.js";
+
+describe("provider throttle report", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("classifies provider throttle categories, retry outcomes, and local-hour buckets without raw payloads", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    new ReviewStateStore(statePath).close();
+    const db = new DatabaseSync(statePath);
+    try {
+      insertProcessed(db, {
+        repo: "owner/repo",
+        pullNumber: 1,
+        headSha: "rate-head",
+        status: "skipped",
+        error: "provider_rate_limit_cooldown_until=2026-07-01T08:05:00.000Z; reason=provider_request_rate_limit; provider_code=1302; providerRequestId: 'secret-request-id'",
+        createdAt: "2026-07-01T08:00:00.000Z"
+      });
+      insertProcessed(db, {
+        repo: "owner/repo",
+        pullNumber: 2,
+        headSha: "overload-head",
+        status: "skipped",
+        error: "provider_rate_limit_cooldown_until=2026-07-01T09:05:00.000Z; reason=provider_overloaded; retry_attempt=2; provider_code=1305",
+        createdAt: "2026-07-01T09:00:00.000Z"
+      });
+      insertProcessed(db, {
+        repo: "owner/other",
+        pullNumber: 3,
+        headSha: "quota-head",
+        status: "failed",
+        error: "ProviderBusinessError: [1310][Weekly/Monthly Limit Exhausted]",
+        createdAt: "2026-07-01T20:00:00.000Z"
+      });
+      insertQueueJob(db, {
+        repo: "owner/repo",
+        pullNumber: 4,
+        headSha: "queue-deferred",
+        state: "provider_deferred",
+        lastError: "ProviderBusinessError: [1305][temporarily overloaded]",
+        createdAt: "2026-07-01T10:00:00.000Z",
+        updatedAt: "2026-07-01T10:01:00.000Z"
+      });
+      insertQueueJob(db, {
+        repo: "owner/other",
+        pullNumber: 5,
+        headSha: "network-head",
+        state: "failed",
+        lastError: "GitHub API fetch failed for /app/installations/access_tokens: fetch failed; cause=Error: getaddrinfo ENOTFOUND api.github.com",
+        createdAt: "2026-07-01T11:00:00.000Z",
+        updatedAt: "2026-07-01T11:01:00.000Z"
+      });
+      insertQueueJob(db, {
+        repo: "owner/repo",
+        pullNumber: 6,
+        headSha: "posted-head",
+        state: "posted",
+        lastError: "provider_rate_limit_cooldown_until=2026-07-01T12:00:00.000Z; reason=provider_request_rate_limit; provider_code=1302",
+        createdAt: "2026-07-01T12:00:00.000Z",
+        updatedAt: "2026-07-01T12:01:00.000Z"
+      });
+    } finally {
+      db.close();
+    }
+
+    const report = collectProviderThrottleReport({
+      statePath,
+      now: new Date("2026-07-08T00:00:00.000Z"),
+      since: "7d",
+      timezone: "Asia/Singapore",
+      peakStartHour: 14,
+      peakEndHour: 18
+    });
+
+    expect(report).toMatchObject({
+      ok: true,
+      timezone: "Asia/Singapore",
+      recommendedPolicy: "measure_only",
+      summary: {
+        providerErrors: 6,
+        requestRateLimit: 2,
+        overloaded: 2,
+        quotaExhausted: 1,
+        networkOrGithubDependency: 1,
+        unknownProviderError: 0,
+        peakWindowErrors: 3,
+        offPeakErrors: 3,
+        worstLocalHour: "16:00"
+      },
+      retryOutcomes: {
+        retriedPosted: 1,
+        retriedProviderDeferred: 1,
+        gaveUpAfterBackoff: 2
+      }
+    });
+    expect(report.codes).toContainEqual({ code: "1302", count: 2 });
+    expect(report.codes).toContainEqual({ code: "1305", count: 2 });
+    expect(report.codes).toContainEqual({ code: "1310", count: 1 });
+    expect(report.hourly.find((row) => row.localHour === "16:00")).toMatchObject({
+      total: 1,
+      requestRateLimit: 1
+    });
+    expect(report.repos[0]).toMatchObject({
+      repo: "owner/repo",
+      total: 4
+    });
+    expect(JSON.stringify(report)).not.toMatch(/secret-request-id|PRIVATE KEY|ghp_/);
+  });
+});
+
+function insertProcessed(
+  db: DatabaseSync,
+  input: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    status: string;
+    error: string;
+    createdAt: string;
+  }
+): void {
+  db.prepare(
+    `insert into processed_reviews (repo, pull_number, head_sha, status, error, created_at)
+     values (?, ?, ?, ?, ?, ?)`
+  ).run(input.repo, input.pullNumber, input.headSha, input.status, input.error, input.createdAt);
+}
+
+function insertQueueJob(
+  db: DatabaseSync,
+  input: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    state: string;
+    lastError: string;
+    createdAt: string;
+    updatedAt: string;
+  }
+): void {
+  db.prepare(
+    `insert into review_queue_jobs
+      (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+       priority, state, last_error, created_at, updated_at)
+     values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, ?, ?, ?, ?)`
+  ).run(
+    `${input.state}-${input.headSha}`,
+    `${input.state}:${input.repo}#${input.pullNumber}@${input.headSha}`,
+    input.repo,
+    input.repo.split("/")[0],
+    input.pullNumber,
+    input.headSha,
+    input.state,
+    input.lastError,
+    input.createdAt,
+    input.updatedAt
+  );
+}

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1734,10 +1734,14 @@ describe("public NeonDiff CLI surface", () => {
     new ReviewStateStore(statePath).close();
     const db = new DatabaseSync(statePath);
     try {
+      const recentTimestamp = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .replace("T", " ")
+        .replace(/\.\d+Z$/, "");
       db.prepare(
         `insert into processed_reviews (repo, pull_number, head_sha, status, error, created_at)
-         values ('owner/repo', 1, 'head-provider-overload', 'failed', ?, '2026-07-01 08:00:00')`
-      ).run("ProviderBusinessError: [1305][temporarily overloaded] providerRequestId: 'secret-request-id'");
+         values ('owner/repo', 1, 'head-provider-overload', 'failed', ?, ?)`
+      ).run("ProviderBusinessError: [1305][temporarily overloaded] providerRequestId: 'secret-request-id'", recentTimestamp);
     } finally {
       db.close();
     }
@@ -1767,6 +1771,9 @@ describe("public NeonDiff CLI surface", () => {
       codes: [{ code: "1305", count: 1 }]
     });
     expect(stdout).not.toContain("secret-request-id");
+    expect(stdout).not.toContain("ProviderBusinessError");
+    expect(stdout).not.toContain("[1305]");
+    expect(stdout).not.toContain("temporarily overloaded");
   });
 
   it("prints launchd daemon control plans in dry-run mode by default", async () => {

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileS
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import { ReviewStateStore } from "../src/state.js";
@@ -50,6 +51,10 @@ describe("public NeonDiff CLI surface", () => {
     ]);
     expect(output.examples).toContain("neondiff init --config config.local.json");
     expect(output.examples).toContain("npx tsx src/cli.ts daemon --config /path/to/live.json --dry-run true --once true");
+    expect(output.commands.existing).toContain("provider-throttle-report");
+    expect(output.examples).toContain(
+      "npx tsx src/cli.ts provider-throttle-report --config /path/to/live.json --since 7d --timezone Asia/Singapore"
+    );
     expect(output.examples).toContain(
       "npx tsx src/cli.ts review-head-gate --config /path/to/live.json --repo owner/repo --pr 123 --head-sha \"$(gh pr view 123 --repo owner/repo --json headRefOid --jq .headRefOid)\""
     );
@@ -1713,6 +1718,55 @@ describe("public NeonDiff CLI surface", () => {
       );
       expect(output.recommendedActions.some((action: string) => action.includes("retry-provider-cooldowns"))).toBe(false);
     }
+  });
+
+  it("prints provider throttle telemetry without raw provider payloads", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-provider-throttle-report-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    const statePath = join(root, "state.sqlite");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath,
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+    new ReviewStateStore(statePath).close();
+    const db = new DatabaseSync(statePath);
+    try {
+      db.prepare(
+        `insert into processed_reviews (repo, pull_number, head_sha, status, error, created_at)
+         values ('owner/repo', 1, 'head-provider-overload', 'failed', ?, '2026-07-01T08:00:00.000Z')`
+      ).run("ProviderBusinessError: [1305][temporarily overloaded] providerRequestId: 'secret-request-id'");
+    } finally {
+      db.close();
+    }
+
+    const { stdout } = await runCli([
+      "provider-throttle-report",
+      "--config",
+      configPath,
+      "--since",
+      "7d",
+      "--timezone",
+      "Asia/Singapore",
+      "--peak-start-hour",
+      "14",
+      "--peak-end-hour",
+      "18"
+    ]);
+    const output = JSON.parse(stdout);
+
+    expect(output).toMatchObject({
+      ok: true,
+      recommendedPolicy: "measure_only",
+      summary: {
+        providerErrors: 1,
+        overloaded: 1
+      },
+      codes: [{ code: "1305", count: 1 }]
+    });
+    expect(stdout).not.toContain("secret-request-id");
   });
 
   it("prints launchd daemon control plans in dry-run mode by default", async () => {

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1736,7 +1736,7 @@ describe("public NeonDiff CLI surface", () => {
     try {
       db.prepare(
         `insert into processed_reviews (repo, pull_number, head_sha, status, error, created_at)
-         values ('owner/repo', 1, 'head-provider-overload', 'failed', ?, '2026-07-01T08:00:00.000Z')`
+         values ('owner/repo', 1, 'head-provider-overload', 'failed', ?, '2026-07-01 08:00:00')`
       ).run("ProviderBusinessError: [1305][temporarily overloaded] providerRequestId: 'secret-request-id'");
     } finally {
       db.close();

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -1679,6 +1679,69 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("preserves provider-deferred retry signal from processed rows when queue lastError was overwritten", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-provider-processed-fallback-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1234, "head-provider-retry-fallback");
+    const providerCooldownError =
+      "provider_rate_limit_cooldown_until=2026-07-01T00:05:00.000Z; reason=provider_request_rate_limit; provider_code=1302";
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      error: providerCooldownError
+    });
+    const queueJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      baseSha: pull.base.sha
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-01T00:05:00.000Z",
+      lastError: "manual_retry_started"
+    });
+
+    const reviewUrl = "https://github.com/electricsheephq/WorldOS/pull/1234#pullrequestreview-3";
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async () => {
+        state.recordProcessed({
+          repo: "electricsheephq/WorldOS",
+          pullNumber: pull.number,
+          headSha: pull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl
+        });
+        return "reviewed";
+      }
+    });
+
+    expect(result.status).toBe("reviewed");
+    expect(state.getReviewQueueJob(queueJob.jobId)).toMatchObject({
+      state: "posted",
+      reviewUrl,
+      lastError: "reviewed_after_provider_deferred; previous_reason=provider_request_rate_limit; previous_provider_code=1302"
+    });
+    state.close();
+  });
+
   it("does not append provider-deferred retry signal when the retry remains non-posted", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-provider-queue-capacity-"));
     roots.push(root);

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -1742,6 +1742,69 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("fills missing retry provider code from processed fallback when queue lastError only has reason", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-provider-merged-fallback-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1234, "head-provider-retry-merged-fallback");
+    const providerCooldownError =
+      "provider_rate_limit_cooldown_until=2026-07-01T00:05:00.000Z; reason=provider_request_rate_limit; provider_code=1302";
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      error: providerCooldownError
+    });
+    const queueJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      baseSha: pull.base.sha
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-01T00:05:00.000Z",
+      lastError: "provider_rate_limit_cooldown_until=2026-07-01T00:05:00.000Z; reason=provider_request_rate_limit"
+    });
+
+    const reviewUrl = "https://github.com/electricsheephq/WorldOS/pull/1234#pullrequestreview-4";
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async () => {
+        state.recordProcessed({
+          repo: "electricsheephq/WorldOS",
+          pullNumber: pull.number,
+          headSha: pull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl
+        });
+        return "reviewed";
+      }
+    });
+
+    expect(result.status).toBe("reviewed");
+    expect(state.getReviewQueueJob(queueJob.jobId)).toMatchObject({
+      state: "posted",
+      reviewUrl,
+      lastError: "reviewed_after_provider_deferred; previous_reason=provider_request_rate_limit; previous_provider_code=1302"
+    });
+    state.close();
+  });
+
   it("does not append provider-deferred retry signal when the retry remains non-posted", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-provider-queue-capacity-"));
     roots.push(root);

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -1616,6 +1616,69 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("preserves provider-deferred retry signal when a live retry posts the review", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-provider-queue-posted-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1234, "head-provider-retry-posted");
+    const providerCooldownError =
+      "provider_rate_limit_cooldown_until=2026-07-01T00:05:00.000Z; reason=provider_request_rate_limit; provider_code=1302";
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      error: providerCooldownError
+    });
+    const queueJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      baseSha: pull.base.sha
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-01T00:05:00.000Z",
+      lastError: providerCooldownError
+    });
+
+    const reviewUrl = "https://github.com/electricsheephq/WorldOS/pull/1234#pullrequestreview-2";
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async () => {
+        state.recordProcessed({
+          repo: "electricsheephq/WorldOS",
+          pullNumber: pull.number,
+          headSha: pull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl
+        });
+        return "reviewed";
+      }
+    });
+
+    expect(result.status).toBe("reviewed");
+    expect(state.getReviewQueueJob(queueJob.jobId)).toMatchObject({
+      state: "posted",
+      reviewUrl,
+      lastError: "reviewed_after_provider_deferred; previous_reason=provider_request_rate_limit; previous_provider_code=1302"
+    });
+    state.close();
+  });
+
   it("repairs failed durable queue jobs when the processed row is already posted", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-posted-queue-repair-"));
     roots.push(root);

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -1679,6 +1679,57 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("does not append provider-deferred retry signal when the retry remains non-posted", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-provider-queue-capacity-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1234, "head-provider-retry-capacity");
+    const providerCooldownError =
+      "provider_rate_limit_cooldown_until=2026-07-01T00:05:00.000Z; reason=provider_request_rate_limit; provider_code=1302";
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "skipped",
+      error: providerCooldownError
+    });
+    const queueJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      baseSha: pull.base.sha
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-01T00:05:00.000Z",
+      lastError: providerCooldownError
+    });
+
+    const result = await retryFailedHeadWithDeps({
+      config,
+      github: retryGithub(pull),
+      state,
+      budget: new ReviewRunBudget(1),
+      options: {
+        repo: "electricsheephq/WorldOS",
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        dryRun: false,
+        useZCode: false
+      },
+      reviewPullImpl: async () => "skipped_capacity"
+    });
+
+    expect(result.status).toBe("skipped_capacity");
+    expect(state.getReviewQueueJob(queueJob.jobId)).toMatchObject({
+      state: "queued",
+      lastError: "retry_did_not_review=skipped_capacity"
+    });
+    state.close();
+  });
+
   it("repairs failed durable queue jobs when the processed row is already posted", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-retry-posted-queue-repair-"));
     roots.push(root);


### PR DESCRIPTION
Closes #170.

## Summary
- Adds a measure-only `provider-throttle-report` operator command for provider rate-limit, overload, quota, and GitHub/network dependency telemetry.
- Aggregates by provider code, local hour, repo, peak/off-peak window, and retry outcome without exposing raw provider error payloads.
- Adds focused module and CLI coverage for classification, retry outcomes, help wiring, and redaction.

## Evidence
- Live report: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-03/issue-170-provider-throttle/provider-throttle-report-live.json`
- Current 7d live summary: 87 provider-throttle-related events; 55 request-rate-limit, 30 overloaded, 0 quota-exhausted, 2 GitHub/network dependency; top repos were LCO and evaos-code-review-bot.

## Validation
- `npm test -- tests/provider-throttle-report.test.ts tests/public-cli.test.ts`
- `npm run build`
- `git diff --check`

## Proof boundary
This is telemetry only. It does not change scheduler behavior, cooldown policy, retry timing, live config, launchd, or provider backoff decisions.