### PR TITLE
Add public release manifest gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,11 @@ proof gates close.
 For live beta operation, use [docs/beta-release-runbook.md](docs/beta-release-runbook.md)
 and [docs/release-governance.md](docs/release-governance.md). Documentation-only
 changes do not restart launchd or promote a release by themselves.
+
+For public source-beta release readiness, use
+[docs/public-release-manifest.json](docs/public-release-manifest.json) with
+`neondiff release-status --public-release-manifest docs/public-release-manifest.json --expected-public-version <public-beta-tag>`.
+Replace `<public-beta-tag>` with the actual semver prerelease tag, such as
+`v1.0.0-beta.1`; the CLI rejects literal placeholders. The manifest is the
+compact version/alignment surface for setup docs, release notes, license API
+state, and update-channel readiness.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -151,6 +151,13 @@ Launchd and live beta promotion are advanced operator tasks. Use
 [docs/beta-release-runbook.md](beta-release-runbook.md) only after dry-run proof
 passes.
 
+Public source-beta promotion additionally uses
+[docs/public-release-manifest.json](public-release-manifest.json). The manifest
+declares the current public beta version, setup/release-notes alignment, license
+API state, and update-channel readiness. A local source beta may explicitly
+defer license API, website, or desktop channels only when the manifest marks
+that channel as `requiredForThisRelease: false`.
+
 ## Troubleshooting
 
 - `doctor` cannot read repos: verify GitHub App installation, app ID, private

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -89,16 +89,16 @@ npm run release:status -- \
 For public source-beta releases, run the same gate with manifest checks:
 
 ```bash
+PUBLIC_BETA_TAG=v1.0.0-beta.1
 npx tsx src/cli.ts release-status \
   --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
   --expected-head "$(git rev-parse HEAD)" \
   --public-release-manifest docs/public-release-manifest.json \
-  --expected-public-version <tag> \
+  --expected-public-version "$PUBLIC_BETA_TAG" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
-Replace `<tag>` with the actual public beta tag before running the command; do
-not copy the placeholder literally.
+Set `PUBLIC_BETA_TAG` to the actual public beta tag before running the command.
 
 By default this public manifest gate validates rollback command shape only, so
 fresh or shallow checkouts are not blocked by missing local tags. After
@@ -106,6 +106,20 @@ fresh or shallow checkouts are not blocked by missing local tags. After
 `--verify-public-rollback-refs true` for the stricter local ref-existence check;
 that failure is reported as a missing rollback target rather than a malformed
 rollback command.
+
+Public promotion evidence should include the strict variant after tags are
+fetched:
+
+```bash
+git fetch origin --tags
+npx tsx src/cli.ts release-status \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --public-release-manifest docs/public-release-manifest.json \
+  --expected-public-version "$PUBLIC_BETA_TAG" \
+  --verify-public-rollback-refs true \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
 
 If the first `release:status` fails only because launchd is still on the
 previous head before restart, record that as pre-promotion state. The

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -100,6 +100,13 @@ npx tsx src/cli.ts release-status \
 Replace `<tag>` with the actual public beta tag before running the command; do
 not copy the placeholder literally.
 
+By default this public manifest gate validates rollback command shape only, so
+fresh or shallow checkouts are not blocked by missing local tags. After
+`git fetch origin --tags`, operators can add
+`--verify-public-rollback-refs true` for the stricter local ref-existence check;
+that failure is reported as a missing rollback target rather than a malformed
+rollback command.
+
 If the first `release:status` fails only because launchd is still on the
 previous head before restart, record that as pre-promotion state. The
 post-restart `release:status` must pass before calling the beta promoted.

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -21,6 +21,11 @@ The beta release unit does not include expanding monitored repos, GitHub App
 permissions, ZCode tools, auto-merge, approvals, or repair behavior. Those need
 their own tracked issue, PR, dry-run evidence, and explicit promotion gate.
 
+Public source-beta releases also include a compact manifest at
+`docs/public-release-manifest.json`. That manifest is the release-status input
+for docs version alignment, license API readiness or explicit deferral, and
+update-channel readiness for CLI, daemon, website, and desktop surfaces.
+
 ## Cadence
 
 - Cut at most one normal beta promotion per focused sprint lane unless a safety
@@ -81,6 +86,20 @@ npm run release:status -- \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
+For public source-beta releases, run the same gate with manifest checks:
+
+```bash
+npx tsx src/cli.ts release-status \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --public-release-manifest docs/public-release-manifest.json \
+  --expected-public-version <tag> \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+Replace `<tag>` with the actual public beta tag before running the command; do
+not copy the placeholder literally.
+
 If the first `release:status` fails only because launchd is still on the
 previous head before restart, record that as pre-promotion state. The
 post-restart `release:status` must pass before calling the beta promoted.
@@ -118,6 +137,12 @@ npx tsx src/cli.ts review-head-gate \
 - `release:status` verifies the loaded LaunchAgent includes
   `NODE_OPTIONS=--use-system-ca` so Node uses the macOS system trust store for
   GitHub App installation fetches.
+- Public source-beta promotions pass `release:status` with
+  `--public-release-manifest docs/public-release-manifest.json` and the release
+  tag as `--expected-public-version`.
+- Public release manifests may mark license API, website, or desktop channels
+  as pending only when `requiredForThisRelease` is `false`; required channels
+  must not be pending.
 - launchd emits a fresh heartbeat after restart.
 - live DB has no unexpected error rows.
 - active provider cooldown rows are allowed only when they are explicit
@@ -245,7 +270,12 @@ For each beta promotion, record:
 - live DB row/error count.
 - provider cooldown rows, if any, with affected repo, PR, head SHA, cooldown
   expiry, active/expired count, retry command, and retry result.
+- public release manifest state for docs, license API, CLI update channel,
+  daemon update channel, website/download channel, and desktop update channel.
 - rollback SHA and command.
+- rollback note for provider config, GitHub App settings, website deploy, and
+  desktop update channel when those surfaces are in scope; otherwise record the
+  tracking issue or `not in this release`.
 - next monitoring action or heartbeat.
 
 Keep raw evidence under `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
@@ -269,6 +299,7 @@ when a docs file is not warranted:
 - Live config:
 - State DB:
 - Evidence path:
+- Public manifest:
 - Monitor owner/window:
 - Rollback SHA:
 - Rollback command:
@@ -283,6 +314,7 @@ when a docs file is not warranted:
 - heartbeat:
 - DB state:
 - provider cooldown rows:
+- public manifest:
 
 ## Notes
 

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,0 +1,39 @@
+{
+  "version": "v1.0.0-beta.1",
+  "releaseLevel": "source-beta",
+  "docs": {
+    "version": "v1.0.0-beta.1",
+    "setupPath": "docs/SETUP.md",
+    "releaseNotesPath": "docs/releases/v1.0.0-beta.1.md",
+    "websiteRepo": "electricsheephq/neon-diff-agent"
+  },
+  "licenseApi": {
+    "requiredForThisRelease": false,
+    "state": "pending",
+    "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot/issues/111"
+  },
+  "updateChannels": {
+    "cli": {
+      "requiredForThisRelease": true,
+      "state": "source_checkout",
+      "version": "v1.0.0-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
+    },
+    "daemon": {
+      "requiredForThisRelease": true,
+      "state": "launchd_prerelease",
+      "version": "v1.0.0-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
+    },
+    "website": {
+      "requiredForThisRelease": false,
+      "state": "pending-site-sync",
+      "trackingIssue": "https://github.com/electricsheephq/neon-diff-agent/issues/1"
+    },
+    "desktop": {
+      "requiredForThisRelease": false,
+      "state": "post_1_0",
+      "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot/issues/116"
+    }
+  }
+}

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -130,17 +130,17 @@ npm run release:status -- \
 For public source-beta or public beta releases, include the public manifest gate:
 
 ```bash
+SOURCE_SHA=replace-with-release-source-sha
+PUBLIC_BETA_TAG=vX.Y.Z-beta.N
 npx tsx src/cli.ts release-status \
   --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
-  --expected-head <source-sha> \
+  --expected-head "$SOURCE_SHA" \
   --public-release-manifest docs/public-release-manifest.json \
-  --expected-public-version <tag> \
+  --expected-public-version "$PUBLIC_BETA_TAG" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
-Replace `<source-sha>` and `<tag>` with the actual release source SHA and
-public beta tag before running the command; the placeholders are not valid gate
-inputs.
+Set `SOURCE_SHA` and `PUBLIC_BETA_TAG` before running the command.
 
 The public manifest gate validates rollback command syntax by default. Use
 `git fetch origin --tags` and append `--verify-public-rollback-refs true` only

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -142,6 +142,11 @@ Replace `<source-sha>` and `<tag>` with the actual release source SHA and
 public beta tag before running the command; the placeholders are not valid gate
 inputs.
 
+The public manifest gate validates rollback command syntax by default. Use
+`git fetch origin --tags` and append `--verify-public-rollback-refs true` only
+when you want the operator machine to prove that rollback refs are present in
+that checkout; absent refs are reported as a missing rollback target.
+
 Also run:
 
 ```bash

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -8,6 +8,10 @@ and a rollback path.
 
 - `beta`: local launchd worker on the operator Mac, posting as the GitHub App
   on the active allowlist. Beta releases are prereleases.
+- `source-beta`: public source-checkout release. The CLI and daemon are
+  installable from git and npm-linkable locally, but package publishing,
+  license activation, website download/version sync, and desktop auto-update may
+  still be explicitly deferred in `docs/public-release-manifest.json`.
 - `stable`: future multi-operator or production rollout. Stable releases are
   blocked until beta evidence proves low-noise behavior over labeled PRs.
 
@@ -19,6 +23,7 @@ Use semver prerelease tags for live beta promotions:
 v0.2.5-beta.1
 v0.2.5-beta.2
 v0.3.0-beta.1
+v1.0.0-beta.1
 ```
 
 Patch beta tags are for runtime/reliability fixes. Minor beta tags are for new
@@ -49,7 +54,22 @@ Before tagging:
    - live config path
    - rollback command
    - known provider cooldown or runtime caveats
-6. `git status --short` is clean in the live checkout.
+6. For public source-beta or public beta releases,
+   `docs/public-release-manifest.json` exists and declares:
+   - docs version and release-notes path
+   - license API state and whether it is required for this release
+   - CLI, daemon, website, and desktop update-channel state
+   - rollback command or tracking issue for each required channel
+   - required-channel rollback fields with one source revert command such as
+     `git reset --hard refs/tags/<tag>` or `git revert <sha>`
+7. `git status --short` is clean in the live checkout.
+
+The manifest `rollback` field is intentionally only the source-revert step.
+Full operator rollback runbooks may restart launchd after that source revert,
+but restart commands live outside the manifest rollback field. `launchctl
+kickstart` alone is a restart, not a rollback. `git checkout` detaches HEAD or
+resets the working tree; it is not accepted as a release rollback for this
+manifest gate.
 
 ## Tag And Release
 
@@ -107,6 +127,21 @@ npm run release:status -- \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
+For public source-beta or public beta releases, include the public manifest gate:
+
+```bash
+npx tsx src/cli.ts release-status \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head <source-sha> \
+  --public-release-manifest docs/public-release-manifest.json \
+  --expected-public-version <tag> \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+Replace `<source-sha>` and `<tag>` with the actual release source SHA and
+public beta tag before running the command; the placeholders are not valid gate
+inputs.
+
 Also run:
 
 ```bash
@@ -124,6 +159,9 @@ The release is green only when:
 - launchd is running with the active live config
 - daemon heartbeat is fresh
 - no blocking DB error rows exist
+- public docs, license API state, and update channels are either healthy or
+  explicitly deferred as non-required for the release in
+  `docs/public-release-manifest.json`
 - coverage audit has zero unprocessed eligible heads
 - provider cooldowns are either absent or active and named in release notes
 - durable queue jobs have zero failed rows and zero retryable provider-deferred

--- a/docs/releases/v0.4.10-beta.1.md
+++ b/docs/releases/v0.4.10-beta.1.md
@@ -53,6 +53,9 @@ separate public source-beta packet version checked by the new manifest gate.
   docs paths, license API state, and update-channel state.
 - Requires explicit `--expected-public-version` when checking a public release
   manifest.
+- Keeps the default rollback gate hermetic by validating rollback command shape
+  without requiring local tags to be fetched; operators can opt into strict
+  local ref checks with `--verify-public-rollback-refs true`.
 - Fails closed when required public update channels, currently `cli` and
   `daemon`, are omitted from the manifest.
 

--- a/docs/releases/v0.4.10-beta.1.md
+++ b/docs/releases/v0.4.10-beta.1.md
@@ -1,0 +1,91 @@
+# v0.4.10-beta.1
+
+- Release type: public release governance gate and source-beta manifest packet
+- Release source SHA: to be set by the `v0.4.10-beta.1` tag
+- Previous prerelease: `v0.4.9-beta.1`
+- Implementation PR targeted for promotion: `#189`
+- Tracking issues: `#112`, `#103`
+- Public source-beta packet: `docs/releases/v1.0.0-beta.1.md`
+- Public manifest: `docs/public-release-manifest.json`
+- Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- launchd label: `com.electricsheephq.evaos-code-review-bot`
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+- State DB: `/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews-live.sqlite`
+- Evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-04/v0.4.10-beta.1/`
+- Monitor owner/window: implementing agent, post-promotion release-status and coverage watch
+- Rollback SHA: `v0.4.9-beta.1`
+- Rollback command:
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v0.4.9-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npx tsx src/cli.ts release-status \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+This rollback proof intentionally omits `--public-release-manifest`: the target
+rollback tag is `v0.4.9-beta.1`, before the public manifest exists. Public
+manifest gates apply to the public `v1.0.0-beta.1` packet and forward public
+promotions, not to proving a rollback onto an older internal v0.x tag.
+
+## Purpose
+
+Add a machine-readable public release manifest gate to the existing local beta
+release-status flow, so public source-beta promotion cannot drift away from
+setup docs, release notes, license API state, or update-channel readiness.
+
+The `v0.4.10-beta.1` tag is the internal live beta release for this bot change;
+the `v1.0.0-beta.1` value in `docs/public-release-manifest.json` is the
+separate public source-beta packet version checked by the new manifest gate.
+
+## Included Changes
+
+- Adds `docs/public-release-manifest.json` as the compact source of truth for
+  public source-beta release readiness.
+- Adds `docs/releases/v1.0.0-beta.1.md` as the first public source-beta dry-run
+  packet and keeps it separate from internal v0.x live beta releases.
+- Extends `release-status` with public manifest gates for docs version, required
+  docs paths, license API state, and update-channel state.
+- Requires explicit `--expected-public-version` when checking a public release
+  manifest.
+- Fails closed when required public update channels, currently `cli` and
+  `daemon`, are omitted from the manifest.
+
+## Required Gates
+
+- Before promotion, PR `#189` must be merged from exact head with checks green, current-head actionable
+  review threads resolved or explicitly dispositioned, and evaOS App review
+  posted for the merged head.
+- `npm test -- tests/release-status.test.ts --pool=forks --maxWorkers=1` passes.
+- `npm run build` passes.
+- `release-status` passes after launchd restart on the merged source SHA.
+- `release-status` passes when invoked with:
+  - `--public-release-manifest docs/public-release-manifest.json`
+  - `--expected-public-version v1.0.0-beta.1`
+- `coverage-audit` reports zero unprocessed eligible heads, or every exception
+  is named in the evidence packet.
+- `provider-cooldowns --expired-only true` reports zero expired actionable
+  cooldowns.
+
+## Caveats
+
+- This release does not publish npm packages, a public download portal, a
+  signed desktop app, or a license activation API.
+- `v1.0.0-beta.1` remains a public source-beta governance packet until a later
+  promotion explicitly tags and publishes it.
+- The live default remains one active review run.
+- Calibrated review accuracy, CodeRabbit parity, and autonomous maintainer
+  behavior are not claimed.
+
+## Runtime Notes
+
+- This release does not widen monitored repos, issue enrichment allowlists, live
+  concurrency, posting policy, ZCode tools, GitHub App permissions, or
+  finishing-touch mutation behavior.
+- Public release manifest checks are release gates only; they do not change
+  daemon review scheduling or PR posting behavior.

--- a/docs/releases/v0.4.10-beta.1.md
+++ b/docs/releases/v0.4.10-beta.1.md
@@ -70,6 +70,7 @@ separate public source-beta packet version checked by the new manifest gate.
 - `release-status` passes when invoked with:
   - `--public-release-manifest docs/public-release-manifest.json`
   - `--expected-public-version v1.0.0-beta.1`
+  - `--verify-public-rollback-refs true` after `git fetch origin --tags`
 - `coverage-audit` reports zero unprocessed eligible heads, or every exception
   is named in the evidence packet.
 - `provider-cooldowns --expired-only true` reports zero expired actionable

--- a/docs/releases/v1.0.0-beta.1.md
+++ b/docs/releases/v1.0.0-beta.1.md
@@ -50,6 +50,9 @@ non-goals. It does not by itself publish a public beta.
   - `--expected-head <tag-target-sha>`
   - `--public-release-manifest docs/public-release-manifest.json`
   - `--expected-public-version v1.0.0-beta.1`
+- The default rollback gate validates command shape only; after `git fetch
+  origin --tags`, operators may add `--verify-public-rollback-refs true` to
+  prove the referenced rollback tag exists locally.
 - `coverage-audit` reports zero unprocessed eligible heads, or every exception
   is named in this packet.
 - `provider-cooldowns --expired-only true` reports zero expired actionable

--- a/docs/releases/v1.0.0-beta.1.md
+++ b/docs/releases/v1.0.0-beta.1.md
@@ -50,9 +50,10 @@ non-goals. It does not by itself publish a public beta.
   - `--expected-head <tag-target-sha>`
   - `--public-release-manifest docs/public-release-manifest.json`
   - `--expected-public-version v1.0.0-beta.1`
-- The default rollback gate validates command shape only; after `git fetch
-  origin --tags`, operators may add `--verify-public-rollback-refs true` to
-  prove the referenced rollback tag exists locally.
+  - `--verify-public-rollback-refs true` after `git fetch origin --tags`
+- The default rollback gate validates command shape only for contributor and
+  smoke-test checkouts; public promotion evidence must include the strict
+  rollback-ref check above.
 - `coverage-audit` reports zero unprocessed eligible heads, or every exception
   is named in this packet.
 - `provider-cooldowns --expired-only true` reports zero expired actionable

--- a/docs/releases/v1.0.0-beta.1.md
+++ b/docs/releases/v1.0.0-beta.1.md
@@ -1,0 +1,92 @@
+# v1.0.0-beta.1
+
+- Release type: public source beta dry-run packet
+- Release source SHA: to be set by the `v1.0.0-beta.1` tag
+- Public manifest: `docs/public-release-manifest.json`
+- Tracking issue: `#112`
+- Parent roadmap: `#103`
+- Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- launchd label: `com.electricsheephq.evaos-code-review-bot`
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+- Evidence path: `/Volumes/LEXAR/Codex/evidence/neondiff-public-product/<date>/v1.0.0-beta.1/`
+- Rollback SHA/tag: `v0.4.9-beta.1`
+- Rollback command:
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v0.4.9-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npx tsx src/cli.ts release-status \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+## Purpose
+
+Define the public source-beta release packet shape before the first public
+`v1.0.0-beta.1` promotion. This packet is a dry-run governance artifact: it
+documents the gates that must pass, the rollback shape, and the current
+non-goals. It does not by itself publish a public beta.
+
+## Included Scope
+
+- Source-checkout CLI and local launchd daemon release path.
+- Public release manifest version alignment for setup docs and release notes.
+- `release-status` public manifest gate for docs, license API state, and update
+  channel state.
+- Explicit deferral of website download/version sync, license API activation,
+  and desktop signed update channel until their own issues close.
+
+## Required Gates For Promotion
+
+- GitHub PR merged to `main` with checks green and current-head actionable review
+  threads resolved or explicitly dispositioned.
+- `npm test` and `npm run build` pass.
+- GitHub prerelease exists for the exact tag target SHA.
+- `release-status` passes with:
+  - `--expected-head <tag-target-sha>`
+  - `--public-release-manifest docs/public-release-manifest.json`
+  - `--expected-public-version v1.0.0-beta.1`
+- `coverage-audit` reports zero unprocessed eligible heads, or every exception
+  is named in this packet.
+- `provider-cooldowns --expired-only true` reports zero expired actionable
+  cooldowns.
+- `doctor --json` proves GitHub App read mode and provider readiness without
+  printing secrets.
+
+## Known Deferrals
+
+- Public npm/package publishing is not claimed by this packet.
+- Website/download portal synchronization is tracked in
+  `electricsheephq/neon-diff-agent#1` through `#3`.
+- License activation API and entitlement cache are tracked in `#111`; source
+  beta docs may describe license boundaries, but private/commercial enforcement
+  is not considered complete until that issue closes.
+- Desktop signing, notarization, Sparkle/appcast, and auto-update entitlement
+  are tracked in `#116`.
+- Calibrated review accuracy and CodeRabbit parity are not claimed.
+
+## Validation Commands
+
+```bash
+npm test -- tests/release-status.test.ts --pool=forks --maxWorkers=1
+npm run build
+npx tsx src/cli.ts release-status \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --public-release-manifest docs/public-release-manifest.json \
+  --expected-public-version v1.0.0-beta.1 \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+## Notes
+
+- This packet keeps public release governance separate from the internal v0.x
+  operator packets.
+- `docs/public-release-manifest.json` is the compact machine-readable surface
+  for docs version, license API state, and update-channel readiness.
+- A passing source-beta manifest may explicitly mark the license API as
+  `pending` only when `requiredForThisRelease` is `false`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -187,7 +187,9 @@ async function main(): Promise<void> {
       expectedHead: args["expected-head"],
       publicReleaseManifestPath: args["public-release-manifest"],
       expectedPublicVersion: args["expected-public-version"],
-      verifyPublicRollbackRefs: args["verify-public-rollback-refs"] === "true",
+      verifyPublicRollbackRefs: args["verify-public-rollback-refs"] === undefined
+        ? false
+        : parseBooleanArg(args["verify-public-rollback-refs"], "--verify-public-rollback-refs"),
       launchdLabel: args["launchd-label"],
       statePath: args["state-path"],
       budgetDetails: args["budget-details"] === "true",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -187,6 +187,7 @@ async function main(): Promise<void> {
       expectedHead: args["expected-head"],
       publicReleaseManifestPath: args["public-release-manifest"],
       expectedPublicVersion: args["expected-public-version"],
+      verifyPublicRollbackRefs: args["verify-public-rollback-refs"] === "true",
       launchdLabel: args["launchd-label"],
       statePath: args["state-path"],
       budgetDetails: args["budget-details"] === "true",
@@ -2378,6 +2379,7 @@ interface ParsedArgs {
   "expected-head"?: string;
   "public-release-manifest"?: string;
   "expected-public-version"?: string;
+  "verify-public-rollback-refs"?: string;
   "launchd-label"?: string;
   "state-path"?: string;
   "dry-run"?: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ import { buildReviewHeadGate } from "./review-head-gate.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown } from "./repo-memory.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
 import { runOnceCliCommand } from "./run-once-cli.js";
-import { redactSecrets } from "./secrets.js";
+import { redactSecrets, stringifyRedactedJson } from "./secrets.js";
 import { buildSkillPackContextPacket } from "./skill-packs.js";
 import {
   buildRetiredFailedHeadError,
@@ -185,18 +185,20 @@ async function main(): Promise<void> {
       cwd: process.cwd(),
       configPath: args.config,
       expectedHead: args["expected-head"],
+      publicReleaseManifestPath: args["public-release-manifest"],
+      expectedPublicVersion: args["expected-public-version"],
       launchdLabel: args["launchd-label"],
       statePath: args["state-path"],
       budgetDetails: args["budget-details"] === "true",
       ...(budgetDetailLimit !== undefined ? { budgetDetailLimit } : {}),
       ...(budgetJobLimit !== undefined ? { budgetJobLimit } : {})
     });
-    console.log(JSON.stringify({
+    console.log(stringifyRedactedJson({
       ...status,
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok,
       failedGates: failedGates(status.gates)
-    }, null, 2));
+    }));
     if (!status.ok) process.exitCode = 1;
     return;
   }
@@ -2122,6 +2124,7 @@ function buildHelp(command?: string) {
       "neondiff daemon stop --launchd-label com.example.neondiff --dry-run true",
       "npx tsx src/cli.ts daemon --config /path/to/live.json --dry-run true --once true",
       "npx tsx src/cli.ts status --config /path/to/live.json --launchd-label com.electricsheephq.evaos-code-review-bot",
+      "npx tsx src/cli.ts release-status --config /path/to/live.json --expected-head \"$(git rev-parse HEAD)\" --public-release-manifest docs/public-release-manifest.json --expected-public-version vX.Y.Z-beta.N --launchd-label com.electricsheephq.evaos-code-review-bot",
       "npx tsx src/cli.ts runtime-inventory --config /path/to/live.json --launchd-label com.electricsheephq.evaos-code-review-bot",
       "npx tsx src/cli.ts runtime-inventory --config /path/to/live.json --human",
       "npx tsx src/cli.ts review-head-gate --config /path/to/live.json --repo owner/repo --pr 123 --head-sha \"$(gh pr view 123 --repo owner/repo --json headRefOid --jq .headRefOid)\"",
@@ -2366,21 +2369,6 @@ function validateScenarioRunId(input: unknown, scenarioPath: string): string {
   return trimmed;
 }
 
-function stringifyRedactedJson(input: unknown): string {
-  return JSON.stringify(redactJsonValue(input), null, 2);
-}
-
-function redactJsonValue(input: unknown): unknown {
-  if (typeof input === "string") return redactSecrets(input);
-  if (Array.isArray(input)) return input.map((item) => redactJsonValue(item));
-  if (input && typeof input === "object") {
-    const output: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(input)) output[key] = redactJsonValue(value);
-    return output;
-  }
-  return input;
-}
-
 interface ParsedArgs {
   _: string[];
   config?: string;
@@ -2388,6 +2376,8 @@ interface ParsedArgs {
   pr?: string;
   reason?: string;
   "expected-head"?: string;
+  "public-release-manifest"?: string;
+  "expected-public-version"?: string;
   "launchd-label"?: string;
   "state-path"?: string;
   "dry-run"?: string;

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -176,7 +176,8 @@ export interface ReleaseStatus {
 
 const REQUIRED_PUBLIC_UPDATE_CHANNELS = ["cli", "daemon"] as const;
 const PUBLIC_RELEASE_LEVELS = new Set(["beta", "source-beta", "stable"]);
-const PUBLIC_VERSION_PATTERN = /^v\d+\.\d+\.\d+-[0-9A-Za-z.-]+(?:\+[0-9A-Za-z.-]+)?$/;
+const PUBLIC_VERSION_PATTERN =
+  /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES = new Set(["source_checkout", "launchd_prerelease", "healthy", "published"]);
 const GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES = new Set([
   ...REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES,
@@ -492,9 +493,18 @@ export function readPublicReleaseManifestStatus(input: {
     const missingDocsPaths = docsPathChecks.filter((pathCheck) => !pathCheck.exists);
     const manifestVersionOk = expectedVersionOk && version === expectedVersion;
     const docsVersionOk = expectedVersionOk && docsVersion === expectedVersion;
-    const docsOk = expectedVersionOk && manifestVersionOk && docsVersionOk && missingDocsPaths.length === 0;
+    const expectedReleaseNotesPath = expectedVersionOk ? `docs/releases/${expectedVersion}.md` : undefined;
+    const releaseNotesPathOk = expectedReleaseNotesPath !== undefined && releaseNotesPath === expectedReleaseNotesPath;
+    const docsOk =
+      expectedVersionOk &&
+      manifestVersionOk &&
+      docsVersionOk &&
+      releaseNotesPathOk &&
+      missingDocsPaths.length === 0;
     const licenseState = readString(licenseApi.state) ?? "missing";
-    const licenseRequired = readBoolean(licenseApi.requiredForThisRelease) ?? true;
+    const licenseRequired = releaseLevel === "source-beta"
+      ? (readBoolean(licenseApi.requiredForThisRelease) ?? true)
+      : true;
     const licenseOk = isLicenseApiStateAcceptable(licenseState, licenseRequired);
     const declaredChannelNames = Object.keys(updateChannels);
     const channelNames = [
@@ -502,7 +512,10 @@ export function readPublicReleaseManifestStatus(input: {
       ...declaredChannelNames.filter((name) => !isRequiredPublicUpdateChannel(name))
     ];
     const channels = channelNames.map((name) =>
-      buildPublicReleaseChannelStatus(name, asRecord(updateChannels[name]))
+      buildPublicReleaseChannelStatus(name, asRecord(updateChannels[name]), {
+        cwd: input.cwd,
+        releaseLevel
+      })
     );
     const channelsOk = channels.every((channel) => channel.ok);
     return {
@@ -540,6 +553,9 @@ export function readPublicReleaseManifestStatus(input: {
                       ? `docs version ${docsVersion} matches ${expectedVersion}`
                       : `docs version ${docsVersion} does not match ${expectedVersion}`
                   ]
+                : []),
+              ...(releaseNotesPath && expectedReleaseNotesPath && !releaseNotesPathOk
+                ? [`release notes path ${releaseNotesPath} does not match ${expectedReleaseNotesPath}`]
                 : []),
               ...missingDocsPaths.map((pathCheck) => `${pathCheck.label} missing at ${pathCheck.path}`)
             ].join("; ")
@@ -591,15 +607,19 @@ export function readPublicReleaseManifestStatus(input: {
 
 function buildPublicReleaseChannelStatus(
   name: string,
-  channel: Record<string, unknown>
+  channel: Record<string, unknown>,
+  options: { cwd?: string; releaseLevel: string }
 ): PublicReleaseChannelStatus {
   const state = readString(channel.state) ?? "missing";
-  const requiredForThisRelease = isRequiredPublicUpdateChannel(name) || (readBoolean(channel.requiredForThisRelease) ?? true);
+  const requiredForThisRelease =
+    isRequiredPublicUpdateChannel(name) ||
+    options.releaseLevel !== "source-beta" ||
+    (readBoolean(channel.requiredForThisRelease) ?? true);
   const version = readString(channel.version);
   const rollback = readString(channel.rollback);
   const trackingIssue = readString(channel.trackingIssue);
   const stateOk = isUpdateChannelStateAcceptable(name, state, requiredForThisRelease);
-  const rollbackOk = rollback ? isRollbackCommandLike(rollback) : false;
+  const rollbackOk = rollback ? isRollbackCommandLike(rollback, options.cwd) : false;
   const missingRequiredMetadata = [
     ...(requiredForThisRelease && !version ? ["version"] : []),
     ...(requiredForThisRelease && !rollbackOk ? ["rollback command"] : [])
@@ -635,22 +655,51 @@ function isRequiredPublicUpdateChannel(name: string): boolean {
   return REQUIRED_PUBLIC_UPDATE_CHANNELS.includes(name as typeof REQUIRED_PUBLIC_UPDATE_CHANNELS[number]);
 }
 
-function isRollbackCommandLike(rollback: string): boolean {
+function isRollbackCommandLike(rollback: string, cwd?: string): boolean {
   if (/\s*(?:&&|\|\||;)\s*/.test(rollback)) return false;
   const command = rollback.trim();
   const resetTarget = command.match(/^git\s+reset\s+--hard\s+([^\s;&|]+)$/)?.[1];
-  if (resetTarget) return isRollbackTarget(resetTarget);
+  if (resetTarget) return isRollbackTarget(resetTarget, cwd);
   const revertTarget = command.match(/^git\s+revert\s+(?:--no-edit\s+)?([^\s;&|]+)$/)?.[1];
-  if (revertTarget) return isRollbackTarget(revertTarget);
+  if (revertTarget) return isRollbackTarget(revertTarget, cwd);
   return false;
 }
 
-function isRollbackTarget(target: string): boolean {
-  return /^refs\/tags\/v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(target) || /^[0-9a-f]{40}$/i.test(target);
+function isRollbackTarget(target: string, cwd?: string): boolean {
+  const targetFormatOk =
+    /^refs\/tags\/v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(target) ||
+    /^[0-9a-f]{40}$/i.test(target);
+  if (!targetFormatOk) return false;
+  if (!cwd || !isGitWorktree(cwd)) return true;
+  return gitCommitishExists(cwd, target);
 }
 
 function isPublicVersionTag(version: string): boolean {
   return PUBLIC_VERSION_PATTERN.test(version);
+}
+
+function isGitWorktree(cwd: string): boolean {
+  try {
+    return execFileSync("git", ["rev-parse", "--is-inside-work-tree"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    }).trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
+function gitCommitishExists(cwd: string, target: string): boolean {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", `${target}^{commit}`], {
+      cwd,
+      stdio: "ignore"
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function isLicenseApiStateAcceptable(state: string, requiredForThisRelease: boolean): boolean {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -1,5 +1,6 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { loadConfig } from "./config.js";
 import { buildReviewBudgetStatus, type ReviewBudgetStatus } from "./review-budget.js";
@@ -92,7 +93,51 @@ export interface ReleaseStatusInput {
   database: ReleaseDatabaseStatus;
   heartbeat: ReleaseHeartbeatStatus;
   budget?: ReviewBudgetStatus;
+  publicRelease?: PublicReleaseStatus;
   now?: Date;
+}
+
+export interface PublicReleaseStatus {
+  manifestPath: string;
+  ok: boolean;
+  version: string;
+  releaseLevel: string;
+  releaseLevelGate: PublicReleaseGateStatus & {
+    state: string;
+  };
+  docs: PublicReleaseGateStatus & {
+    setupPath?: string;
+    releaseNotesPath?: string;
+    websiteRepo?: string;
+  };
+  licenseApi: PublicReleaseGateStatus & {
+    requiredForThisRelease: boolean;
+    state: string;
+    trackingIssue?: string;
+    healthUrl?: string;
+  };
+  updateChannels: {
+    ok: boolean;
+    channels: PublicReleaseChannelStatus[];
+  };
+}
+
+export interface PublicReleaseGateStatus {
+  ok: boolean;
+  expectedVersion?: string;
+  actualVersion?: string;
+  detail: string;
+}
+
+export interface PublicReleaseChannelStatus {
+  name: string;
+  ok: boolean;
+  state: string;
+  requiredForThisRelease: boolean;
+  version?: string;
+  rollback?: string;
+  trackingIssue?: string;
+  detail: string;
 }
 
 export interface ReleaseStatus {
@@ -120,6 +165,7 @@ export interface ReleaseStatus {
   database: ReleaseDatabaseStatus;
   heartbeat: ReleaseHeartbeatStatus;
   budget?: ReviewBudgetStatus;
+  publicRelease?: PublicReleaseStatus;
   recommendedActions: string[];
   gates: Array<{ name: string; ok: boolean; detail: string }>;
   rollback: {
@@ -127,6 +173,22 @@ export interface ReleaseStatus {
     unloadCommand: string;
   };
 }
+
+const REQUIRED_PUBLIC_UPDATE_CHANNELS = ["cli", "daemon"] as const;
+const PUBLIC_RELEASE_LEVELS = new Set(["beta", "source-beta", "stable"]);
+const PUBLIC_VERSION_PATTERN = /^v\d+\.\d+\.\d+-[0-9A-Za-z.-]+(?:\+[0-9A-Za-z.-]+)?$/;
+const REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES = new Set(["source_checkout", "launchd_prerelease", "healthy", "published"]);
+const GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES = new Set([
+  ...REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES,
+  "deferred",
+  "disabled",
+  "not_applicable",
+  "pending"
+]);
+const OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATE_OVERRIDES = new Map([
+  ["website", new Set([...GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES, "pending-site-sync"])],
+  ["desktop", new Set([...GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES, "post_1_0"])]
+]);
 
 export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const expectedHeadOk = !input.expectedHead || input.repo.head === input.expectedHead;
@@ -156,7 +218,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const retryProviderCooldownCommand =
     `npx tsx src/cli.ts retry-provider-cooldowns --config ${input.configPath} ` +
     "--expired-only true --dry-run false --zcode true";
-  const gates = [
+  const runtimeGates = [
     {
       name: "expected_head",
       ok: expectedHeadOk,
@@ -228,6 +290,34 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       detail: describeHeartbeat(input.heartbeat)
     }
   ];
+  const publicReleaseGates = input.publicRelease
+    ? [
+        {
+          name: "public_release_level",
+          ok: input.publicRelease.releaseLevelGate.ok,
+          detail: input.publicRelease.releaseLevelGate.detail
+        },
+        {
+          name: "public_docs_version",
+          ok: input.publicRelease.docs.ok,
+          detail: input.publicRelease.docs.detail
+        },
+        {
+          name: "public_license_api_state",
+          ok: input.publicRelease.licenseApi.ok,
+          detail: input.publicRelease.licenseApi.detail
+        },
+        {
+          name: "public_update_channels",
+          ok: input.publicRelease.updateChannels.ok,
+          detail: describePublicUpdateChannels(input.publicRelease.updateChannels.channels)
+        }
+      ]
+    : [];
+  const gates = [
+    ...runtimeGates,
+    ...publicReleaseGates
+  ];
 
   return {
     ok: gates.every((gate) => gate.ok),
@@ -254,7 +344,11 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     database: input.database,
     heartbeat: input.heartbeat,
     ...(input.budget ? { budget: input.budget } : {}),
+    ...(input.publicRelease ? { publicRelease: input.publicRelease } : {}),
     recommendedActions: [
+      ...(input.publicRelease && !input.publicRelease.ok
+        ? [`inspect public release manifest ${input.publicRelease.manifestPath}`]
+        : []),
       ...(expiredProviderCooldownOk
         ? retryableDeferredQueueJobsOk
           ? []
@@ -279,6 +373,8 @@ export function collectReleaseStatus(input: {
   cwd: string;
   configPath?: string;
   expectedHead?: string;
+  publicReleaseManifestPath?: string;
+  expectedPublicVersion?: string;
   launchdLabel?: string;
   statePath?: string;
   budgetDetails?: boolean;
@@ -286,6 +382,7 @@ export function collectReleaseStatus(input: {
   budgetJobLimit?: number;
   now?: Date;
 }): ReleaseStatus {
+  validatePublicReleaseManifestInputs(input);
   const config = loadConfig(input.configPath);
   const configPath = input.configPath ?? "(default config)";
   const now = input.now ?? new Date();
@@ -307,8 +404,278 @@ export function collectReleaseStatus(input: {
       detailLimit: input.budgetDetailLimit,
       jobLimit: input.budgetJobLimit ?? 1_000
     }),
+    ...(input.publicReleaseManifestPath
+      ? {
+          publicRelease: readPublicReleaseManifestStatus({
+            cwd: input.cwd,
+            manifestPath: input.publicReleaseManifestPath,
+            expectedVersion: input.expectedPublicVersion
+          })
+        }
+      : {}),
     now
   });
+}
+
+export function validatePublicReleaseManifestInputs(input: {
+  publicReleaseManifestPath?: string;
+  expectedPublicVersion?: string;
+}): void {
+  if (input.publicReleaseManifestPath && !input.expectedPublicVersion) {
+    throw new Error("--expected-public-version is required when --public-release-manifest is provided");
+  }
+  if (input.expectedPublicVersion && !input.publicReleaseManifestPath) {
+    throw new Error("--public-release-manifest is required when --expected-public-version is provided");
+  }
+  if (input.expectedPublicVersion && !isPublicVersionTag(input.expectedPublicVersion)) {
+    throw new Error("--expected-public-version must be a semver prerelease tag like v1.0.0-beta.1");
+  }
+}
+
+export function readPublicReleaseManifestStatus(input: {
+  cwd: string;
+  manifestPath: string;
+  expectedVersion?: string;
+}): PublicReleaseStatus {
+  const absolutePath = resolve(input.cwd, input.manifestPath);
+  if (!existsSync(absolutePath)) {
+    return {
+      manifestPath: input.manifestPath,
+      ok: false,
+      version: "(missing)",
+      releaseLevel: "unknown",
+      releaseLevelGate: {
+        ok: false,
+        state: "missing",
+        detail: "release level missing because manifest is absent"
+      },
+      docs: {
+        ok: false,
+        expectedVersion: input.expectedVersion,
+        detail: `public release manifest missing at ${input.manifestPath}`
+      },
+      licenseApi: {
+        ok: false,
+        requiredForThisRelease: true,
+        state: "missing",
+        detail: "license API state missing because manifest is absent"
+      },
+      updateChannels: {
+        ok: false,
+        channels: []
+      }
+    };
+  }
+
+  try {
+    const manifest = JSON.parse(readFileSync(absolutePath, "utf8")) as unknown;
+    const root = asRecord(manifest);
+    const docs = asRecord(root.docs);
+    const licenseApi = asRecord(root.licenseApi);
+    const updateChannels = asRecord(root.updateChannels);
+    const version = readString(root.version) ?? "(missing)";
+    const expectedVersion = input.expectedVersion;
+    const releaseLevel = readString(root.releaseLevel) ?? "unknown";
+    const expectedVersionOk = expectedVersion !== undefined && isPublicVersionTag(expectedVersion);
+    const releaseLevelOk = PUBLIC_RELEASE_LEVELS.has(releaseLevel);
+    const docsVersion = readString(docs.version) ?? "(missing)";
+    const setupPath = readString(docs.setupPath);
+    const releaseNotesPath = readString(docs.releaseNotesPath);
+    const docsPathChecks = [
+      setupPath
+        ? { label: "setup", path: setupPath, exists: existsSync(resolve(input.cwd, setupPath)) }
+        : { label: "setupPath", path: "(missing)", exists: false },
+      releaseNotesPath
+        ? { label: "release notes", path: releaseNotesPath, exists: existsSync(resolve(input.cwd, releaseNotesPath)) }
+        : { label: "releaseNotesPath", path: "(missing)", exists: false }
+    ];
+    const missingDocsPaths = docsPathChecks.filter((pathCheck) => !pathCheck.exists);
+    const manifestVersionOk = expectedVersionOk && version === expectedVersion;
+    const docsVersionOk = expectedVersionOk && docsVersion === expectedVersion;
+    const docsOk = expectedVersionOk && manifestVersionOk && docsVersionOk && missingDocsPaths.length === 0;
+    const licenseState = readString(licenseApi.state) ?? "missing";
+    const licenseRequired = readBoolean(licenseApi.requiredForThisRelease) ?? true;
+    const licenseOk = isLicenseApiStateAcceptable(licenseState, licenseRequired);
+    const declaredChannelNames = Object.keys(updateChannels);
+    const channelNames = [
+      ...REQUIRED_PUBLIC_UPDATE_CHANNELS,
+      ...declaredChannelNames.filter((name) => !isRequiredPublicUpdateChannel(name))
+    ];
+    const channels = channelNames.map((name) =>
+      buildPublicReleaseChannelStatus(name, asRecord(updateChannels[name]))
+    );
+    const channelsOk = channels.every((channel) => channel.ok);
+    return {
+      manifestPath: input.manifestPath,
+      ok: releaseLevelOk && docsOk && licenseOk && channelsOk,
+      version,
+      releaseLevel,
+      releaseLevelGate: {
+        ok: releaseLevelOk,
+        state: releaseLevel,
+        detail: releaseLevelOk
+          ? `release level ${releaseLevel}`
+          : `release level ${releaseLevel} is not one of beta, source-beta, stable`
+      },
+      docs: {
+        ok: docsOk,
+        expectedVersion,
+        actualVersion: docsVersion,
+        setupPath,
+        releaseNotesPath,
+        websiteRepo: readString(docs.websiteRepo),
+        detail: docsOk
+          ? `manifest version ${version} and docs version ${docsVersion} match ${expectedVersion}; checked setup and release notes paths`
+          : [
+              expectedVersion
+                ? manifestVersionOk
+                  ? `manifest version ${version} matches ${expectedVersion}`
+                  : expectedVersionOk
+                    ? `manifest version ${version} does not match ${expectedVersion}`
+                    : "--expected-public-version must be a semver prerelease tag like v1.0.0-beta.1"
+                : "--expected-public-version is required",
+              ...(expectedVersion
+                ? [
+                    docsVersionOk
+                      ? `docs version ${docsVersion} matches ${expectedVersion}`
+                      : `docs version ${docsVersion} does not match ${expectedVersion}`
+                  ]
+                : []),
+              ...missingDocsPaths.map((pathCheck) => `${pathCheck.label} missing at ${pathCheck.path}`)
+            ].join("; ")
+      },
+      licenseApi: {
+        ok: licenseOk,
+        requiredForThisRelease: licenseRequired,
+        state: licenseState,
+        trackingIssue: readString(licenseApi.trackingIssue),
+        healthUrl: readString(licenseApi.healthUrl),
+        detail: licenseOk
+          ? `license API state ${licenseState}; requiredForThisRelease=${licenseRequired}`
+          : `license API state ${licenseState} blocks this release; requiredForThisRelease=${licenseRequired}`
+      },
+      updateChannels: {
+        ok: channelsOk,
+        channels
+      }
+    };
+  } catch (error) {
+    return {
+      manifestPath: input.manifestPath,
+      ok: false,
+      version: "(invalid)",
+      releaseLevel: "unknown",
+      releaseLevelGate: {
+        ok: false,
+        state: "invalid",
+        detail: "release level unavailable because manifest is invalid"
+      },
+      docs: {
+        ok: false,
+        expectedVersion: input.expectedVersion,
+        detail: `public release manifest is invalid JSON: ${error instanceof Error ? error.message : String(error)}`
+      },
+      licenseApi: {
+        ok: false,
+        requiredForThisRelease: true,
+        state: "invalid",
+        detail: "license API state unavailable because manifest is invalid"
+      },
+      updateChannels: {
+        ok: false,
+        channels: []
+      }
+    };
+  }
+}
+
+function buildPublicReleaseChannelStatus(
+  name: string,
+  channel: Record<string, unknown>
+): PublicReleaseChannelStatus {
+  const state = readString(channel.state) ?? "missing";
+  const requiredForThisRelease = readBoolean(channel.requiredForThisRelease) ?? true;
+  const version = readString(channel.version);
+  const rollback = readString(channel.rollback);
+  const trackingIssue = readString(channel.trackingIssue);
+  const stateOk = isUpdateChannelStateAcceptable(name, state, requiredForThisRelease);
+  const rollbackOk = rollback ? isRollbackCommandLike(rollback) : false;
+  const missingRequiredMetadata = [
+    ...(requiredForThisRelease && !version ? ["version"] : []),
+    ...(requiredForThisRelease && !rollbackOk ? ["rollback command"] : [])
+  ];
+  const metadataOk = missingRequiredMetadata.length === 0;
+  const ok = stateOk && metadataOk;
+  return {
+    name,
+    ok,
+    state,
+    requiredForThisRelease,
+    version,
+    rollback,
+    trackingIssue,
+    detail: ok
+      ? `${name} state ${state}; requiredForThisRelease=${requiredForThisRelease}`
+      : `${name} state ${state} blocks this release; requiredForThisRelease=${requiredForThisRelease}${
+          missingRequiredMetadata.length ? `; missing ${missingRequiredMetadata.join(", ")}` : ""
+        }`
+  };
+}
+
+function describePublicUpdateChannels(channels: PublicReleaseChannelStatus[]): string {
+  if (channels.length === 0) return "no public update channels declared";
+  return channels
+    .map((channel) =>
+      `${channel.name}=${channel.state}${channel.ok ? "" : " [BLOCKED]"}${channel.requiredForThisRelease ? "" : " (not required)"}`
+    )
+    .join("; ");
+}
+
+function isRequiredPublicUpdateChannel(name: string): boolean {
+  return REQUIRED_PUBLIC_UPDATE_CHANNELS.includes(name as typeof REQUIRED_PUBLIC_UPDATE_CHANNELS[number]);
+}
+
+function isRollbackCommandLike(rollback: string): boolean {
+  if (/\s*(?:&&|\|\||;)\s*/.test(rollback)) return false;
+  const command = rollback.trim();
+  const resetTarget = command.match(/^git\s+reset\s+--hard\s+([^\s;&|]+)/)?.[1];
+  if (resetTarget) return isRollbackTarget(resetTarget);
+  const revertTarget = command.match(/^git\s+revert\s+(?:--no-edit\s+)?([^\s;&|]+)/)?.[1];
+  if (revertTarget) return isRollbackTarget(revertTarget);
+  return false;
+}
+
+function isRollbackTarget(target: string): boolean {
+  return /^refs\/tags\/v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(target) || /^[0-9a-f]{40}$/i.test(target);
+}
+
+function isPublicVersionTag(version: string): boolean {
+  return PUBLIC_VERSION_PATTERN.test(version);
+}
+
+function isLicenseApiStateAcceptable(state: string, requiredForThisRelease: boolean): boolean {
+  if (requiredForThisRelease) return state === "healthy";
+  return state === "healthy" || state === "not_applicable" || state === "disabled" || state === "pending";
+}
+
+function isUpdateChannelStateAcceptable(name: string, state: string, requiredForThisRelease: boolean): boolean {
+  return requiredForThisRelease
+    ? REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES.has(state)
+    : (OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATE_OVERRIDES.get(name) ?? GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES).has(state);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
 }
 
 function readRepoStatus(cwd: string): ReleaseRepoStatus {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -594,7 +594,7 @@ function buildPublicReleaseChannelStatus(
   channel: Record<string, unknown>
 ): PublicReleaseChannelStatus {
   const state = readString(channel.state) ?? "missing";
-  const requiredForThisRelease = readBoolean(channel.requiredForThisRelease) ?? true;
+  const requiredForThisRelease = isRequiredPublicUpdateChannel(name) || (readBoolean(channel.requiredForThisRelease) ?? true);
   const version = readString(channel.version);
   const rollback = readString(channel.rollback);
   const trackingIssue = readString(channel.trackingIssue);

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -177,7 +177,7 @@ export interface ReleaseStatus {
 const REQUIRED_PUBLIC_UPDATE_CHANNELS = ["cli", "daemon"] as const;
 const PUBLIC_RELEASE_LEVELS = new Set(["beta", "source-beta", "stable"]);
 const PUBLIC_VERSION_PATTERN =
-  /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+  /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES = new Set(["source_checkout", "launchd_prerelease", "healthy", "published"]);
 const GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES = new Set([
   ...REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES,
@@ -376,6 +376,7 @@ export function collectReleaseStatus(input: {
   expectedHead?: string;
   publicReleaseManifestPath?: string;
   expectedPublicVersion?: string;
+  verifyPublicRollbackRefs?: boolean;
   launchdLabel?: string;
   statePath?: string;
   budgetDetails?: boolean;
@@ -410,7 +411,8 @@ export function collectReleaseStatus(input: {
           publicRelease: readPublicReleaseManifestStatus({
             cwd: input.cwd,
             manifestPath: input.publicReleaseManifestPath,
-            expectedVersion: input.expectedPublicVersion
+            expectedVersion: input.expectedPublicVersion,
+            verifyRollbackRefs: input.verifyPublicRollbackRefs === true
           })
         }
       : {}),
@@ -429,7 +431,7 @@ export function validatePublicReleaseManifestInputs(input: {
     throw new Error("--public-release-manifest is required when --expected-public-version is provided");
   }
   if (input.expectedPublicVersion && !isPublicVersionTag(input.expectedPublicVersion)) {
-    throw new Error("--expected-public-version must be a semver prerelease tag like v1.0.0-beta.1");
+    throw new Error("--expected-public-version must be a semver tag like v1.0.0 or v1.0.0-beta.1");
   }
 }
 
@@ -437,6 +439,7 @@ export function readPublicReleaseManifestStatus(input: {
   cwd: string;
   manifestPath: string;
   expectedVersion?: string;
+  verifyRollbackRefs?: boolean;
 }): PublicReleaseStatus {
   const absolutePath = resolve(input.cwd, input.manifestPath);
   if (!existsSync(absolutePath)) {
@@ -514,7 +517,8 @@ export function readPublicReleaseManifestStatus(input: {
     const channels = channelNames.map((name) =>
       buildPublicReleaseChannelStatus(name, asRecord(updateChannels[name]), {
         cwd: input.cwd,
-        releaseLevel
+        releaseLevel,
+        verifyRollbackRefs: input.verifyRollbackRefs === true
       })
     );
     const channelsOk = channels.every((channel) => channel.ok);
@@ -545,7 +549,7 @@ export function readPublicReleaseManifestStatus(input: {
                   ? `manifest version ${version} matches ${expectedVersion}`
                   : expectedVersionOk
                     ? `manifest version ${version} does not match ${expectedVersion}`
-                    : "--expected-public-version must be a semver prerelease tag like v1.0.0-beta.1"
+                    : "--expected-public-version must be a semver tag like v1.0.0 or v1.0.0-beta.1"
                 : "--expected-public-version is required",
               ...(expectedVersion
                 ? [
@@ -608,7 +612,7 @@ export function readPublicReleaseManifestStatus(input: {
 function buildPublicReleaseChannelStatus(
   name: string,
   channel: Record<string, unknown>,
-  options: { cwd?: string; releaseLevel: string }
+  options: { cwd?: string; releaseLevel: string; verifyRollbackRefs?: boolean }
 ): PublicReleaseChannelStatus {
   const state = readString(channel.state) ?? "missing";
   const requiredForThisRelease =
@@ -619,10 +623,10 @@ function buildPublicReleaseChannelStatus(
   const rollback = readString(channel.rollback);
   const trackingIssue = readString(channel.trackingIssue);
   const stateOk = isUpdateChannelStateAcceptable(name, state, requiredForThisRelease);
-  const rollbackOk = rollback ? isRollbackCommandLike(rollback, options.cwd) : false;
+  const rollbackCheck = rollback ? checkRollbackCommand(rollback, options) : { ok: false, missingMetadata: "rollback command" };
   const missingRequiredMetadata = [
     ...(requiredForThisRelease && !version ? ["version"] : []),
-    ...(requiredForThisRelease && !rollbackOk ? ["rollback command"] : [])
+    ...(requiredForThisRelease && !rollbackCheck.ok ? [rollbackCheck.missingMetadata] : [])
   ];
   const metadataOk = missingRequiredMetadata.length === 0;
   const ok = stateOk && metadataOk;
@@ -655,27 +659,39 @@ function isRequiredPublicUpdateChannel(name: string): boolean {
   return REQUIRED_PUBLIC_UPDATE_CHANNELS.includes(name as typeof REQUIRED_PUBLIC_UPDATE_CHANNELS[number]);
 }
 
-function isRollbackCommandLike(rollback: string, cwd?: string): boolean {
-  if (/\s*(?:&&|\|\||;)\s*/.test(rollback)) return false;
+function checkRollbackCommand(
+  rollback: string,
+  options: { cwd?: string; verifyRollbackRefs?: boolean }
+): { ok: boolean; missingMetadata: "rollback command" | "rollback target" } {
+  if (/\s*(?:&&|\|\||;)\s*/.test(rollback)) return { ok: false, missingMetadata: "rollback command" };
   const command = rollback.trim();
   const resetTarget = command.match(/^git\s+reset\s+--hard\s+([^\s;&|]+)$/)?.[1];
-  if (resetTarget) return isRollbackTarget(resetTarget, cwd);
+  if (resetTarget) return checkRollbackTarget(resetTarget, options);
   const revertTarget = command.match(/^git\s+revert\s+(?:--no-edit\s+)?([^\s;&|]+)$/)?.[1];
-  if (revertTarget) return isRollbackTarget(revertTarget, cwd);
-  return false;
+  if (revertTarget) return checkRollbackTarget(revertTarget, options);
+  return { ok: false, missingMetadata: "rollback command" };
 }
 
-function isRollbackTarget(target: string, cwd?: string): boolean {
-  const targetFormatOk =
-    /^refs\/tags\/v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(target) ||
-    /^[0-9a-f]{40}$/i.test(target);
-  if (!targetFormatOk) return false;
-  if (!cwd || !isGitWorktree(cwd)) return true;
-  return gitCommitishExists(cwd, target);
+function checkRollbackTarget(
+  target: string,
+  options: { cwd?: string; verifyRollbackRefs?: boolean }
+): { ok: boolean; missingMetadata: "rollback command" | "rollback target" } {
+  const targetFormatOk = isRollbackVersionTagRef(target) || /^[0-9a-f]{40}$/i.test(target);
+  if (!targetFormatOk) return { ok: false, missingMetadata: "rollback command" };
+  if (options.verifyRollbackRefs !== true) return { ok: true, missingMetadata: "rollback command" };
+  if (!options.cwd || !isGitWorktree(options.cwd)) return { ok: false, missingMetadata: "rollback target" };
+  return gitCommitishExists(options.cwd, target)
+    ? { ok: true, missingMetadata: "rollback command" }
+    : { ok: false, missingMetadata: "rollback target" };
 }
 
 function isPublicVersionTag(version: string): boolean {
   return PUBLIC_VERSION_PATTERN.test(version);
+}
+
+function isRollbackVersionTagRef(target: string): boolean {
+  const prefix = "refs/tags/";
+  return target.startsWith(prefix) && isPublicVersionTag(target.slice(prefix.length));
 }
 
 function isGitWorktree(cwd: string): boolean {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -638,9 +638,9 @@ function isRequiredPublicUpdateChannel(name: string): boolean {
 function isRollbackCommandLike(rollback: string): boolean {
   if (/\s*(?:&&|\|\||;)\s*/.test(rollback)) return false;
   const command = rollback.trim();
-  const resetTarget = command.match(/^git\s+reset\s+--hard\s+([^\s;&|]+)/)?.[1];
+  const resetTarget = command.match(/^git\s+reset\s+--hard\s+([^\s;&|]+)$/)?.[1];
   if (resetTarget) return isRollbackTarget(resetTarget);
-  const revertTarget = command.match(/^git\s+revert\s+(?:--no-edit\s+)?([^\s;&|]+)/)?.[1];
+  const revertTarget = command.match(/^git\s+revert\s+(?:--no-edit\s+)?([^\s;&|]+)$/)?.[1];
   if (revertTarget) return isRollbackTarget(revertTarget);
   return false;
 }

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -35,6 +35,7 @@ export function stringifyRedactedJson(input: unknown): string {
 
 function redactJsonValue(input: unknown): unknown {
   if (typeof input === "string") return redactSecrets(input);
+  if (input instanceof Date) return input.toISOString();
   if (Array.isArray(input)) return input.map((item) => redactJsonValue(item));
   if (input && typeof input === "object") {
     const output: Record<string, unknown> = {};

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -28,3 +28,18 @@ export function containsSecretLikeText(input: string): boolean {
 export function redactSecrets(input: string): string {
   return SECRET_PATTERNS.reduce((text, pattern) => text.replace(pattern, "[redacted-secret]"), input);
 }
+
+export function stringifyRedactedJson(input: unknown): string {
+  return JSON.stringify(redactJsonValue(input), null, 2);
+}
+
+function redactJsonValue(input: unknown): unknown {
+  if (typeof input === "string") return redactSecrets(input);
+  if (Array.isArray(input)) return input.map((item) => redactJsonValue(item));
+  if (input && typeof input === "object") {
+    const output: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input)) output[key] = redactJsonValue(value);
+    return output;
+  }
+  return input;
+}

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -64,6 +64,29 @@ describe("public NeonDiff CLI surface", () => {
     expect(output.examples).toContain("desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}");
   });
 
+  it("rejects non-boolean public rollback ref verification values", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-release-status-bool-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: [],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      pollIntervalMs: 60_000
+    })}\n`);
+
+    await expect(runCli([
+      "release-status",
+      "--config",
+      configPath,
+      "--verify-public-rollback-refs",
+      "yes"
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining("--verify-public-rollback-refs must be true or false")
+    });
+  });
+
   it("prints command help without executing run-once, review-pr, or daemon paths", async () => {
     for (const args of [["run-once", "--help"], ["review-pr", "help"], ["daemon", "start", "-h"]]) {
       const { stdout } = await runCli(args);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1,15 +1,24 @@
-import { mkdirSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
-import { buildReleaseStatus, collectReleaseStatus, parseLaunchdPrintStatus } from "../src/release-status.js";
+import {
+  buildReleaseStatus,
+  collectReleaseStatus,
+  parseLaunchdPrintStatus,
+  readPublicReleaseManifestStatus,
+  validatePublicReleaseManifestInputs
+} from "../src/release-status.js";
 import type { ReviewBudgetStatus } from "../src/review-budget.js";
+import { stringifyRedactedJson } from "../src/secrets.js";
 import { ReviewStateStore } from "../src/state.js";
 
 describe("beta release status", () => {
   const roots: string[] = [];
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
   afterEach(() => {
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
@@ -81,6 +90,986 @@ describe("beta release status", () => {
       staleReviewLeases: 0
     });
     expect(JSON.stringify(status)).not.toMatch(/PRIVATE KEY|ghp_|BEGIN RSA|BEGIN OPENSSH/);
+  });
+
+  it("adds public release manifest gates while allowing an explicit source beta license API deferral", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-green-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md",
+        websiteRepo: "electricsheephq/neon-diff-agent"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending",
+        trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot/issues/111"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        desktop: {
+          requiredForThisRelease: false,
+          state: "post_1_0",
+          trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot/issues/116"
+        }
+      }
+    }));
+
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
+      },
+      database: { rowCount: 2, errorCount: 0 },
+      heartbeat: freshHeartbeat(),
+      publicRelease: readPublicReleaseManifestStatus({
+        cwd: root,
+        manifestPath: "public-release.json",
+        expectedVersion: "v1.0.0-beta.1"
+      }),
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(true);
+    expect(status.publicRelease).toMatchObject({
+      ok: true,
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      licenseApi: {
+        ok: true,
+        state: "pending",
+        requiredForThisRelease: false
+      }
+    });
+    expect(status.gates).toContainEqual({
+      name: "public_docs_version",
+      ok: true,
+      detail: "manifest version v1.0.0-beta.1 and docs version v1.0.0-beta.1 match v1.0.0-beta.1; checked setup and release notes paths"
+    });
+    expect(status.gates).toContainEqual({
+      name: "public_license_api_state",
+      ok: true,
+      detail: "license API state pending; requiredForThisRelease=false"
+    });
+    expect(status.gates).toContainEqual({
+      name: "public_update_channels",
+      ok: true,
+      detail: "cli=source_checkout; daemon=launchd_prerelease; desktop=post_1_0 (not required)"
+    });
+  });
+
+  it("validates the shipped public release manifest against the shipped release notes", () => {
+    // Intentional shipped-manifest smoke: keep assertions scoped to publicRelease fields.
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: repoRoot,
+      manifestPath: "docs/public-release-manifest.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest).toMatchObject({
+      ok: true,
+      version: "v1.0.0-beta.1",
+      docs: {
+        ok: true,
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      updateChannels: {
+        ok: true
+      }
+    });
+    expect(manifest.updateChannels.channels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "cli",
+          requiredForThisRelease: true,
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }),
+        expect.objectContaining({
+          name: "daemon",
+          requiredForThisRelease: true,
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        })
+      ])
+    );
+  });
+
+  it("fails closed when public release manifest flags are not paired", () => {
+    expect(() =>
+      validatePublicReleaseManifestInputs({
+        publicReleaseManifestPath: "docs/public-release-manifest.json"
+      })
+    ).toThrow("--expected-public-version is required when --public-release-manifest is provided");
+    expect(() =>
+      validatePublicReleaseManifestInputs({
+        expectedPublicVersion: "v1.0.0-beta.1"
+      })
+    ).toThrow("--public-release-manifest is required when --expected-public-version is provided");
+    expect(() =>
+      validatePublicReleaseManifestInputs({
+        publicReleaseManifestPath: "docs/public-release-manifest.json",
+        expectedPublicVersion: "<tag>"
+      })
+    ).toThrow("--expected-public-version must be a semver prerelease tag like v1.0.0-beta.1");
+    expect(() =>
+      validatePublicReleaseManifestInputs({
+        publicReleaseManifestPath: "docs/public-release-manifest.json",
+        expectedPublicVersion: "v1.0.0"
+      })
+    ).toThrow("--expected-public-version must be a semver prerelease tag like v1.0.0-beta.1");
+  });
+
+  it("collects public release manifest gates through release-status wiring", () => {
+    // Intentional shipped-manifest smoke: surrounding repo/live-path status is machine-local.
+    const root = mkdtempSync(join(tmpdir(), "release-status-public-manifest-"));
+    roots.push(root);
+
+    const status = collectReleaseStatus({
+      cwd: repoRoot,
+      statePath: join(root, "missing-live-state.sqlite"),
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      publicReleaseManifestPath: "docs/public-release-manifest.json",
+      expectedPublicVersion: "v1.0.0-beta.1",
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot"
+    });
+
+    expect(status.publicRelease).toMatchObject({
+      ok: true,
+      version: "v1.0.0-beta.1"
+    });
+    expect(status.gates).toContainEqual({
+      name: "public_update_channels",
+      ok: true,
+      detail: "cli=source_checkout; daemon=launchd_prerelease; website=pending-site-sync (not required); desktop=post_1_0 (not required)"
+    });
+    const redactedOutput = stringifyRedactedJson({
+      ...status,
+      healthState: status.ok ? "runtime_ok" : "runtime_blocked",
+      runtimeOk: status.ok
+    });
+    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.9-beta.1");
+    expect(redactedOutput).toContain("cli=source_checkout; daemon=launchd_prerelease");
+    expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot/issues/111");
+  });
+
+  it("fails closed without throwing when collectReleaseStatus receives a missing public manifest path", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-missing-public-manifest-"));
+    roots.push(root);
+
+    const status = collectReleaseStatus({
+      cwd: repoRoot,
+      statePath: join(root, "missing-live-state.sqlite"),
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      publicReleaseManifestPath: "docs/not-a-public-release-manifest.json",
+      expectedPublicVersion: "v1.0.0-beta.1",
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot"
+    });
+
+    expect(status.publicRelease).toMatchObject({
+      ok: false,
+      version: "(missing)",
+      docs: {
+        ok: false,
+        detail: "public release manifest missing at docs/not-a-public-release-manifest.json"
+      }
+    });
+    expect(status.gates).toContainEqual({
+      name: "public_docs_version",
+      ok: false,
+      detail: "public release manifest missing at docs/not-a-public-release-manifest.json"
+    });
+  });
+
+  it("fails closed without throwing when the public manifest is invalid JSON", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-invalid-json-"));
+    roots.push(root);
+    writeFileSync(join(root, "public-release.json"), "{ not valid json");
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest).toMatchObject({
+      ok: false,
+      version: "(invalid)",
+      docs: {
+        ok: false
+      },
+      licenseApi: {
+        ok: false,
+        state: "invalid"
+      },
+      updateChannels: {
+        ok: false,
+        channels: []
+      }
+    });
+    expect(manifest.docs.detail).toContain("public release manifest is invalid JSON");
+  });
+
+  it("redacts secret-like public manifest strings before release-status JSON output", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-redaction-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending",
+        healthUrl: "https://license.example/status?access_token=abcdefghijklmnopqrstuvwxyz"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+    const redactedOutput = stringifyRedactedJson({
+      publicRelease: manifest,
+      healthState: manifest.ok ? "runtime_ok" : "runtime_blocked"
+    });
+
+    expect(manifest.licenseApi.healthUrl).toContain("abcdefghijklmnopqrstuvwxyz");
+    expect(redactedOutput).not.toContain("abcdefghijklmnopqrstuvwxyz");
+    expect(redactedOutput).toContain("[redacted-secret]");
+  });
+
+  it("fails public docs gate when the expected public version is omitted", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-no-version-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json"
+    });
+
+    expect(manifest.ok).toBe(false);
+    expect(manifest.docs).toMatchObject({
+      ok: false,
+      detail: "--expected-public-version is required"
+    });
+  });
+
+  it("fails public docs gate when required docs paths are omitted", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-no-doc-paths-"));
+    roots.push(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.ok).toBe(false);
+    expect(manifest.docs.detail).toBe(
+      "manifest version v1.0.0-beta.1 matches v1.0.0-beta.1; docs version v1.0.0-beta.1 matches v1.0.0-beta.1; setupPath missing at (missing); releaseNotesPath missing at (missing)"
+    );
+  });
+
+  it("fails public update channel gates when required channels are omitted", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-missing-channels-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        desktop: {
+          requiredForThisRelease: false,
+          state: "post_1_0",
+          trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot/issues/116"
+        }
+      }
+    }));
+
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
+      },
+      database: { rowCount: 2, errorCount: 0 },
+      heartbeat: freshHeartbeat(),
+      publicRelease: readPublicReleaseManifestStatus({
+        cwd: root,
+        manifestPath: "public-release.json",
+        expectedVersion: "v1.0.0-beta.1"
+      }),
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.publicRelease?.updateChannels).toMatchObject({
+      ok: false,
+      channels: [
+        { name: "cli", ok: false, state: "missing", requiredForThisRelease: true },
+        { name: "daemon", ok: false, state: "missing", requiredForThisRelease: true },
+        { name: "desktop", ok: true, state: "post_1_0", requiredForThisRelease: false }
+      ]
+    });
+    expect(status.gates).toContainEqual({
+      name: "public_update_channels",
+      ok: false,
+      detail: "cli=missing [BLOCKED]; daemon=missing [BLOCKED]; desktop=post_1_0 (not required)"
+    });
+  });
+
+  it("fails public release gates for unknown required license and update-channel states", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-unknown-states-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "unknown"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source-chekout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
+      },
+      database: { rowCount: 2, errorCount: 0 },
+      heartbeat: freshHeartbeat(),
+      publicRelease: readPublicReleaseManifestStatus({
+        cwd: root,
+        manifestPath: "public-release.json",
+        expectedVersion: "v1.0.0-beta.1"
+      }),
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.gates).toContainEqual({
+      name: "public_license_api_state",
+      ok: false,
+      detail: "license API state unknown blocks this release; requiredForThisRelease=true"
+    });
+    expect(status.gates).toContainEqual({
+      name: "public_update_channels",
+      ok: false,
+      detail: "cli=source-chekout [BLOCKED]; daemon=launchd_prerelease"
+    });
+  });
+
+  it("fails required public update channels without version and rollback or tracking evidence", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-missing-channel-metadata-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot/issues/112"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.updateChannels.channels).toEqual([
+      expect.objectContaining({
+        name: "cli",
+        ok: false,
+        detail: "cli state source_checkout blocks this release; requiredForThisRelease=true; missing version, rollback command"
+      }),
+      expect.objectContaining({
+        name: "daemon",
+        ok: false,
+        detail: "daemon state launchd_prerelease blocks this release; requiredForThisRelease=true; missing rollback command"
+      })
+    ]);
+    expect(manifest.updateChannels.ok).toBe(false);
+  });
+
+  it("fails required public update channels with restart-only rollback commands", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-restart-rollback-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.updateChannels.channels[0]).toMatchObject({
+      name: "cli",
+      ok: false,
+      detail: "cli state source_checkout blocks this release; requiredForThisRelease=true; missing rollback command"
+    });
+    expect(manifest.updateChannels.ok).toBe(false);
+  });
+
+  it("fails required public update channels with chained rollback commands", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-chained-rollback-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1 && launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.updateChannels.channels[0]).toMatchObject({
+      name: "cli",
+      ok: false,
+      detail: "cli state source_checkout blocks this release; requiredForThisRelease=true; missing rollback command"
+    });
+    expect(manifest.updateChannels.ok).toBe(false);
+  });
+
+  it("fails optional public update channels with another channel's specific state", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-cross-channel-state-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        website: {
+          requiredForThisRelease: false,
+          state: "post_1_0"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.updateChannels.channels.find((channel) => channel.name === "website")).toMatchObject({
+      ok: false,
+      detail: "website state post_1_0 blocks this release; requiredForThisRelease=false"
+    });
+    expect(manifest.updateChannels.ok).toBe(false);
+  });
+
+  it("fails required public update channels when rollback-like text is not the command", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-embedded-rollback-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "echo git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.updateChannels.channels[0]).toMatchObject({
+      name: "cli",
+      ok: false,
+      detail: "cli state source_checkout blocks this release; requiredForThisRelease=true; missing rollback command"
+    });
+    expect(manifest.updateChannels.ok).toBe(false);
+  });
+
+  it("fails required public update channels when checkout only resets the worktree", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-checkout-worktree-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git checkout ."
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.updateChannels.channels[0]).toMatchObject({
+      name: "cli",
+      ok: false,
+      detail: "cli state source_checkout blocks this release; requiredForThisRelease=true; missing rollback command"
+    });
+    expect(manifest.updateChannels.ok).toBe(false);
+  });
+
+  it("fails required public update channels when rollback uses an ambiguous plain tag target", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-plain-tag-rollback-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.updateChannels.channels[0]).toMatchObject({
+      name: "cli",
+      ok: false,
+      detail: "cli state source_checkout blocks this release; requiredForThisRelease=true; missing rollback command"
+    });
+    expect(manifest.updateChannels.ok).toBe(false);
+  });
+
+  it("fails required public update channels when rollback uses an abbreviated SHA", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-short-sha-rollback-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git revert abc1234"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.updateChannels.channels[0]).toMatchObject({
+      name: "cli",
+      ok: false,
+      detail: "cli state source_checkout blocks this release; requiredForThisRelease=true; missing rollback command"
+    });
+    expect(manifest.updateChannels.ok).toBe(false);
+  });
+
+  it("fails public release gates for stale docs, required pending license API, and blocked channels", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-red-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "public-beta",
+      docs: {
+        version: "v0.9.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "pending"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease"
+        }
+      }
+    }));
+
+    const status = buildReleaseStatus({
+      repo: {
+        branch: "main",
+        head: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+        dirtyFiles: []
+      },
+      expectedHead: "fcb9484b904a5e4225dc0446b50d5dd83972bb5d",
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchd: {
+        label: "com.electricsheephq.evaos-code-review-bot",
+        state: "running",
+        configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+        dryRun: false,
+        nodeOptions: "--use-system-ca",
+        usesSystemCa: true
+      },
+      database: { rowCount: 2, errorCount: 0 },
+      heartbeat: freshHeartbeat(),
+      publicRelease: readPublicReleaseManifestStatus({
+        cwd: root,
+        manifestPath: "public-release.json",
+        expectedVersion: "v1.0.0-beta.1"
+      }),
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.gates).toContainEqual({
+      name: "public_release_level",
+      ok: false,
+      detail: "release level public-beta is not one of beta, source-beta, stable"
+    });
+    expect(status.gates).toContainEqual({
+      name: "public_docs_version",
+      ok: false,
+      detail: "manifest version v1.0.0-beta.1 matches v1.0.0-beta.1; docs version v0.9.0-beta.1 does not match v1.0.0-beta.1; release notes missing at docs/releases/v1.0.0-beta.1.md"
+    });
+    expect(status.gates).toContainEqual({
+      name: "public_license_api_state",
+      ok: false,
+      detail: "license API state pending blocks this release; requiredForThisRelease=true"
+    });
+    expect(status.gates).toContainEqual({
+      name: "public_update_channels",
+      ok: false,
+      detail: "cli=pending [BLOCKED]; daemon=launchd_prerelease [BLOCKED]"
+    });
+    expect(status.recommendedActions).toContain("inspect public release manifest public-release.json");
   });
 
   it("fails closed when launchd config path cannot be verified", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -993,6 +993,59 @@ describe("beta release status", () => {
     expect(manifest.updateChannels.ok).toBe(false);
   });
 
+  it("fails required public update channels when rollback includes trailing operands", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-trailing-rollback-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1 extra"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git revert 0123456789abcdef0123456789abcdef01234567 unexpected"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.updateChannels.channels[0]).toMatchObject({
+      name: "cli",
+      ok: false,
+      detail: "cli state source_checkout blocks this release; requiredForThisRelease=true; missing rollback command"
+    });
+    expect(manifest.updateChannels.channels[1]).toMatchObject({
+      name: "daemon",
+      ok: false,
+      detail: "daemon state launchd_prerelease blocks this release; requiredForThisRelease=true; missing rollback command"
+    });
+    expect(manifest.updateChannels.ok).toBe(false);
+  });
+
   it("fails public release gates for stale docs, required pending license API, and blocked channels", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-red-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -240,13 +240,16 @@ describe("beta release status", () => {
         publicReleaseManifestPath: "docs/public-release-manifest.json",
         expectedPublicVersion: "<tag>"
       })
-    ).toThrow("--expected-public-version must be a semver prerelease tag like v1.0.0-beta.1");
+    ).toThrow("--expected-public-version must be a semver tag like v1.0.0 or v1.0.0-beta.1");
+  });
+
+  it("accepts stable public release versions for future stable manifests", () => {
     expect(() =>
       validatePublicReleaseManifestInputs({
         publicReleaseManifestPath: "docs/public-release-manifest.json",
         expectedPublicVersion: "v1.0.0"
       })
-    ).toThrow("--expected-public-version must be a semver prerelease tag like v1.0.0-beta.1");
+    ).not.toThrow();
   });
 
   it("collects public release manifest gates through release-status wiring", () => {
@@ -559,7 +562,7 @@ describe("beta release status", () => {
     });
 
     expect(manifest.docs.ok).toBe(false);
-    expect(manifest.docs.detail).toContain("--expected-public-version must be a semver prerelease tag like v1.0.0-beta.1");
+    expect(manifest.docs.detail).toContain("--expected-public-version must be a semver tag like v1.0.0 or v1.0.0-beta.1");
     expect(manifest.ok).toBe(false);
   });
 
@@ -1157,7 +1160,7 @@ describe("beta release status", () => {
     expect(manifest.updateChannels.ok).toBe(false);
   });
 
-  it("fails required public update channels when rollback target is absent in a git checkout", () => {
+  it("accepts format-valid rollback targets without requiring local refs by default", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-missing-rollback-ref-"));
     roots.push(root);
     execFileSync("git", ["init"], { cwd: root, stdio: "ignore" });
@@ -1201,13 +1204,70 @@ describe("beta release status", () => {
     expect(manifest.updateChannels.channels).toEqual([
       expect.objectContaining({
         name: "cli",
+        ok: true,
+        detail: "cli state source_checkout; requiredForThisRelease=true"
+      }),
+      expect.objectContaining({
+        name: "daemon",
+        ok: true,
+        detail: "daemon state launchd_prerelease; requiredForThisRelease=true"
+      })
+    ]);
+    expect(manifest.updateChannels.ok).toBe(true);
+  });
+
+  it("can fail required public update channels when rollback target verification is enabled", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-missing-rollback-ref-"));
+    roots.push(root);
+    execFileSync("git", ["init"], { cwd: root, stdio: "ignore" });
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v9.9.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git revert 0123456789abcdef0123456789abcdef01234567"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1",
+      verifyRollbackRefs: true
+    });
+
+    expect(manifest.updateChannels.channels).toEqual([
+      expect.objectContaining({
+        name: "cli",
         ok: false,
-        detail: "cli state source_checkout blocks this release; requiredForThisRelease=true; missing rollback command"
+        detail: "cli state source_checkout blocks this release; requiredForThisRelease=true; missing rollback target"
       }),
       expect.objectContaining({
         name: "daemon",
         ok: false,
-        detail: "daemon state launchd_prerelease blocks this release; requiredForThisRelease=true; missing rollback command"
+        detail: "daemon state launchd_prerelease blocks this release; requiredForThisRelease=true; missing rollback target"
       })
     ]);
     expect(manifest.updateChannels.ok).toBe(false);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1273,6 +1273,69 @@ describe("beta release status", () => {
     expect(manifest.updateChannels.ok).toBe(false);
   });
 
+  it("passes required public update channels when strict rollback targets exist in a git checkout", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-existing-rollback-ref-"));
+    roots.push(root);
+    execFileSync("git", ["init"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["-c", "user.name=evaOS Bot", "-c", "user.email=bot@example.invalid", "commit", "--allow-empty", "-m", "seed"], {
+      cwd: root,
+      stdio: "ignore"
+    });
+    execFileSync("git", ["tag", "v0.4.9-beta.1"], { cwd: root, stdio: "ignore" });
+    const headSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: `git revert ${headSha}`
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1",
+      verifyRollbackRefs: true
+    });
+
+    expect(manifest.updateChannels.channels).toEqual([
+      expect.objectContaining({
+        name: "cli",
+        ok: true,
+        detail: "cli state source_checkout; requiredForThisRelease=true"
+      }),
+      expect.objectContaining({
+        name: "daemon",
+        ok: true,
+        detail: "daemon state launchd_prerelease; requiredForThisRelease=true"
+      })
+    ]);
+    expect(manifest.updateChannels.ok).toBe(true);
+  });
+
   it("fails required public update channels when rollback uses an ambiguous plain tag target", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-plain-tag-rollback-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -472,6 +473,96 @@ describe("beta release status", () => {
     );
   });
 
+  it("fails public docs gate when release notes path does not match the expected version", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-wrong-release-notes-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v0.9.0-beta.1.md"), "# v0.9.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v0.9.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.docs.ok).toBe(false);
+    expect(manifest.docs.detail).toContain("release notes path docs/releases/v0.9.0-beta.1.md does not match docs/releases/v1.0.0-beta.1.md");
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("fails public docs gate when the expected version has malformed prerelease identifiers", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-malformed-prerelease-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta..1.md"), "# v1.0.0-beta..1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta..1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta..1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta..1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta..1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta..1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta..1"
+    });
+
+    expect(manifest.docs.ok).toBe(false);
+    expect(manifest.docs.detail).toContain("--expected-public-version must be a semver prerelease tag like v1.0.0-beta.1");
+    expect(manifest.ok).toBe(false);
+  });
+
   it("fails public update channel gates when required channels are omitted", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-missing-channels-"));
     roots.push(root);
@@ -539,6 +630,109 @@ describe("beta release status", () => {
       ok: false,
       detail: "cli=missing [BLOCKED]; daemon=missing [BLOCKED]; desktop=post_1_0 (not required)"
     });
+  });
+
+  it("blocks license API deferrals outside source-beta releases", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stable-license-deferral-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "stable",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi).toMatchObject({
+      ok: false,
+      requiredForThisRelease: true,
+      state: "pending",
+      detail: "license API state pending blocks this release; requiredForThisRelease=true"
+    });
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("blocks optional channel deferrals outside source-beta releases", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stable-channel-deferral-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "stable",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        website: {
+          requiredForThisRelease: false,
+          state: "pending-site-sync"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.updateChannels.channels).toContainEqual(expect.objectContaining({
+      name: "website",
+      requiredForThisRelease: true,
+      ok: false,
+      detail: "website state pending-site-sync blocks this release; requiredForThisRelease=true; missing version, rollback command"
+    }));
+    expect(manifest.updateChannels.ok).toBe(false);
+    expect(manifest.ok).toBe(false);
   });
 
   it("fails public release gates for unknown required license and update-channel states", () => {
@@ -960,6 +1154,62 @@ describe("beta release status", () => {
       ok: false,
       detail: "cli state source_checkout blocks this release; requiredForThisRelease=true; missing rollback command"
     });
+    expect(manifest.updateChannels.ok).toBe(false);
+  });
+
+  it("fails required public update channels when rollback target is absent in a git checkout", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-missing-rollback-ref-"));
+    roots.push(root);
+    execFileSync("git", ["init"], { cwd: root, stdio: "ignore" });
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v9.9.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git revert 0123456789abcdef0123456789abcdef01234567"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.updateChannels.channels).toEqual([
+      expect.objectContaining({
+        name: "cli",
+        ok: false,
+        detail: "cli state source_checkout blocks this release; requiredForThisRelease=true; missing rollback command"
+      }),
+      expect.objectContaining({
+        name: "daemon",
+        ok: false,
+        detail: "daemon state launchd_prerelease blocks this release; requiredForThisRelease=true; missing rollback command"
+      })
+    ]);
     expect(manifest.updateChannels.ok).toBe(false);
   });
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -388,6 +388,19 @@ describe("beta release status", () => {
     expect(redactedOutput).toContain("[redacted-secret]");
   });
 
+  it("preserves Date values when redacting JSON output", () => {
+    const redactedOutput = stringifyRedactedJson({
+      checkedAt: new Date("2026-07-04T00:00:00.000Z"),
+      nested: {
+        generatedAt: new Date("2026-07-04T00:01:00.000Z")
+      }
+    });
+
+    expect(redactedOutput).toContain("\"checkedAt\": \"2026-07-04T00:00:00.000Z\"");
+    expect(redactedOutput).toContain("\"generatedAt\": \"2026-07-04T00:01:00.000Z\"");
+    expect(redactedOutput).not.toContain("\"checkedAt\": {}");
+  });
+
   it("fails public docs gate when the expected public version is omitted", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-no-version-"));
     roots.push(root);
@@ -649,6 +662,59 @@ describe("beta release status", () => {
         name: "daemon",
         ok: false,
         detail: "daemon state launchd_prerelease blocks this release; requiredForThisRelease=true; missing rollback command"
+      })
+    ]);
+    expect(manifest.updateChannels.ok).toBe(false);
+  });
+
+  it("forces policy-mandatory public update channels to remain required", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-mandatory-channel-opt-out-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: false,
+          state: "pending"
+        },
+        daemon: {
+          requiredForThisRelease: false,
+          state: "pending"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.updateChannels.channels).toEqual([
+      expect.objectContaining({
+        name: "cli",
+        requiredForThisRelease: true,
+        ok: false,
+        detail: "cli state pending blocks this release; requiredForThisRelease=true; missing version, rollback command"
+      }),
+      expect.objectContaining({
+        name: "daemon",
+        requiredForThisRelease: true,
+        ok: false,
+        detail: "daemon state pending blocks this release; requiredForThisRelease=true; missing version, rollback command"
       })
     ]);
     expect(manifest.updateChannels.ok).toBe(false);


### PR DESCRIPTION
## Summary
- add `docs/public-release-manifest.json` as the compact public source-beta release status surface
- teach `release-status` to validate public docs version, license API state, and update-channel readiness when a manifest is provided
- add a `v1.0-beta.1` dry-run release packet plus runbook/README/setup guidance

## Validation
- `npm test -- tests/release-status.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`

## Evidence
- `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-04/issue-112-public-release-governance/validation-summary.txt`

Related: #112
