### PR TITLE
Add NeonDiff license boundary

### DIFF
--- a/.github/ISSUE_TEMPLATE/license_setup_confusion.yml
+++ b/.github/ISSUE_TEMPLATE/license_setup_confusion.yml
@@ -14,7 +14,7 @@ body:
     id: doc
     attributes:
       label: Current doc or page
-      placeholder: README.md, docs/SETUP.md, https://www.neondiff.com/...
+      placeholder: README.md, docs/SETUP.md, docs/license-boundary.md, https://www.neondiff.com/...
     validations:
       required: true
   - type: textarea

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,64 @@
+# NeonDiff Source-Available Beta License
+
+Copyright (c) Electric Sheep. All rights reserved.
+
+NeonDiff is source-available beta software. The source is available for
+inspection, contribution, and self-hosted evaluation, but this repository is not
+published under an open-source license.
+
+Public open-source repositories are free. Private and commercial repository
+review requires a paid NeonDiff license.
+
+## Free Public-Repository Grant
+
+You may use, copy, modify, and run NeonDiff without a paid NeonDiff license when
+all reviewed repositories are public open-source repositories.
+
+This free grant covers local review of public open-source pull requests with
+your own GitHub App installation, your own provider keys, and your own local
+worker.
+
+## Paid Private And Commercial Use
+
+You need an active paid NeonDiff license for:
+
+- reviewing private, internal, or otherwise non-public repositories;
+- reviewing commercial or proprietary code;
+- using NeonDiff in a company, client, agency, or consulting workflow;
+- distributing NeonDiff binaries, installers, hosted services, marketplace
+  packages, or managed update channels; and
+- enabling paid-support, private-repo entitlement, or auto-update features.
+
+Private-repository entitlement checks are implemented separately from pricing.
+Exact prices, support tiers, and marketplace terms live in the product/pricing
+trackers and public purchase surfaces.
+
+## Redistribution And Public Claims
+
+You may fork this repository and submit contributions through GitHub pull
+requests. You may not sell, sublicense, host, repackage, or redistribute
+NeonDiff as a product or service without written permission from Electric Sheep.
+
+Do not describe NeonDiff as "open source", "MIT", "Apache", "free for private
+repos", "production-ready", or "enterprise-ready" unless a later license file
+or release explicitly says so.
+
+## Contributions
+
+By submitting a contribution, you agree that Electric Sheep may use,
+redistribute, and relicense that contribution as part of NeonDiff, including in
+paid, source-available, commercial, or future open-source distributions.
+
+## Third-Party Software
+
+Third-party dependencies, generated artifacts, and bundled notices remain under
+their own licenses. This license does not replace or revoke those terms.
+
+Historical third-party license grants remain governed by their original
+license text unless counsel-approved public wording says otherwise.
+
+## No Warranty
+
+NeonDiff is provided as-is, without warranty of any kind. You are responsible
+for validating generated reviews, protecting secrets, configuring repository
+permissions, and complying with your own legal and security requirements.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ GA release.
 [Website](https://www.neondiff.com) · [Setup](docs/SETUP.md) ·
 [Contributing](CONTRIBUTING.md) · [Agent Instructions](AGENTS.md) ·
 [Security](SECURITY.md) · [Code of Conduct](CODE_OF_CONDUCT.md) ·
-[Roadmap](https://github.com/electricsheephq/evaos-code-review-bot/issues/103) ·
-[License Boundary](https://github.com/electricsheephq/evaos-code-review-bot/issues/104)
+[License](LICENSE.md) · [License Boundary](docs/license-boundary.md) ·
+[Roadmap](https://github.com/electricsheephq/evaos-code-review-bot/issues/103)
 
 ## Why It Matters
 
@@ -160,6 +160,10 @@ Provider registry, `.neondiff.yml`, public CLI packaging, license activation,
 desktop client, wiki exports, marketplace packaging, and confidence calibration
 each have separate issues and must not be treated as shipped until their PRs and
 proof gates close.
+
+Use [LICENSE.md](LICENSE.md) and [docs/license-boundary.md](docs/license-boundary.md)
+as the canonical public-beta license language. Do not copy older issue comments
+or release notes into public product surfaces when these files are more recent.
 
 For live beta operation, use [docs/beta-release-runbook.md](docs/beta-release-runbook.md)
 and [docs/release-governance.md](docs/release-governance.md). Documentation-only

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,9 +1,9 @@
 # NeonDiff Setup
 
 This guide is the first-run path for the current source-available beta. After
-`npm run build`, the source checkout exposes the beta `neondiff` binary. Public
-npm/package publishing stays blocked until the license gate in issue #104 and
-the distribution work in issue #107 are both resolved.
+`npm run build`, the source checkout exposes the beta `neondiff` binary. See
+[LICENSE.md](../LICENSE.md) and [docs/license-boundary.md](license-boundary.md)
+for the public/private repo license boundary.
 
 ## Requirements
 
@@ -14,7 +14,7 @@ the distribution work in issue #107 are both resolved.
 - optional NeonDiff license key for private or commercial repo use
 
 Public open-source repos are free. Private and commercial repos require a paid
-license. Final license wording is tracked in issue #104.
+license.
 
 ## 1. Install From Source
 

--- a/docs/license-boundary.md
+++ b/docs/license-boundary.md
@@ -1,0 +1,97 @@
+# NeonDiff License Boundary
+
+This document is the canonical public-beta wording for NeonDiff licensing and
+commercial boundaries. Copy these claims into README, setup docs, website copy,
+CLI help, package metadata, and release notes instead of inventing new wording.
+
+## Short Copy
+
+NeonDiff is source-available beta software, not open-source software. Public
+open-source repository review is free. Private, internal, commercial,
+proprietary, hosted, marketplace, binary redistribution, and auto-update use
+requires an active paid NeonDiff license.
+
+Public open-source repositories are free. Private and commercial repository
+review requires a paid NeonDiff license.
+
+## Allowed Without A Paid License
+
+- Inspecting the source.
+- Forking the repository to evaluate NeonDiff or propose changes.
+- Running NeonDiff locally to review public open-source repositories.
+- Submitting GitHub issues and pull requests.
+
+## Requires A Paid License
+
+- Reviewing private repositories.
+- Reviewing internal, proprietary, client, or commercial code.
+- Using NeonDiff in a company, agency, consulting, or paid-support workflow.
+- Shipping NeonDiff binaries, installers, update channels, marketplace
+  packages, or hosted services.
+- Enabling private-repo entitlement or auto-update capabilities.
+
+## Public Repo Grant
+
+The public-repository grant is based on repository visibility and use case:
+
+- Public open-source repos: free.
+- Private, internal, or non-public repos: paid license required.
+- Public repos used primarily for proprietary or commercial distribution:
+  paid license required unless Electric Sheep grants an explicit exception.
+
+The default config may keep license enforcement disabled for internal beta
+workers. Public/private product installs should enable license enforcement and
+keep `license.publicReposFree` true when the public free path is intended.
+
+## Product Surface Wording
+
+Use:
+
+- "source-available beta"
+- "free for public open-source repositories"
+- "private and commercial repository review requires a paid NeonDiff license"
+- "bring your own provider key or local model"
+- "local worker; current-head, secret-redacted review evidence"
+
+Avoid:
+
+- "open source"
+- "MIT licensed"
+- "Apache licensed"
+- "free for private repositories"
+- "free for all commercial use"
+- "hosted review SaaS"
+- "enterprise-ready"
+- "production-ready"
+- "CodeRabbit parity" unless the eval gate for that exact claim passes
+
+## Attribution And Provenance
+
+- Keep Electric Sheep copyright and NeonDiff license notices in source,
+  packages, and generated release artifacts.
+- Keep third-party notices with bundled third-party code and assets; third-party
+  dependencies remain under their own licenses.
+- Do not describe historical third-party license grants as revoked unless
+  counsel-approved wording explicitly says so.
+- Optional GitNexus, repo-wiki, OpenWiki-compatible, desktop, and marketplace
+  work must keep their own provenance and license packets.
+
+## CLI And Docs Copy
+
+CLI setup/help copy should say:
+
+> NeonDiff is source-available beta software. Public open-source repository
+> review is free. Private, internal, and commercial repository review requires
+> an active paid NeonDiff license.
+
+Private-repo failure copy should say:
+
+> Review blocked: this repo requires an active NeonDiff entitlement before
+> worktree prep, provider calls, or GitHub review posting.
+
+## Tracking
+
+- Public product roadmap: https://github.com/electricsheephq/evaos-code-review-bot/issues/103
+- License/commercial boundary gate: https://github.com/electricsheephq/evaos-code-review-bot/issues/104
+- Pricing implementation: https://github.com/electricsheephq/evaos-code-review-bot/issues/105
+- License activation implementation: https://github.com/electricsheephq/evaos-code-review-bot/issues/111

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "evaos-code-review-bot",
       "version": "0.1.0",
+      "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "neondiff": "dist/src/cli.js",
         "evaos-review-bot": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "license": "SEE LICENSE IN LICENSE.md",
   "bin": {
     "neondiff": "dist/src/cli.js",
     "evaos-review-bot": "dist/src/cli.js"

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -18,6 +18,8 @@ describe("NeonDiff public community funnel", () => {
       /AGENTS\.md/i,
       /SECURITY\.md/i,
       /CODE_OF_CONDUCT\.md/i,
+      /LICENSE\.md/i,
+      /docs\/license-boundary\.md/i,
       /public open-source repos.*free/i,
       /private.*commercial.*paid/i,
       /source-available beta/i,
@@ -41,6 +43,30 @@ describe("NeonDiff public community funnel", () => {
     ]) {
       expect(readme).not.toMatch(forbidden);
     }
+  });
+
+  it("license boundary surfaces are canonical and avoid open-source claims", () => {
+    const license = read("LICENSE.md");
+    const boundary = read("docs/license-boundary.md");
+    const pkg = JSON.parse(read("package.json")) as { license?: string };
+
+    expect(pkg.license).toBe("SEE LICENSE IN LICENSE.md");
+
+    for (const text of [license, boundary]) {
+      expect(text).toMatch(/source-available beta/i);
+      expect(text).toMatch(/Public open-source repositor(?:y|ies).*free/i);
+      expect(text).toMatch(/private/i);
+      expect(text).toMatch(/commercial/i);
+      expect(text).toMatch(/paid NeonDiff license/i);
+      expect(text).toMatch(/Third-party/i);
+      expect(text).toMatch(/own licenses/i);
+      expect(text).not.toMatch(/^# MIT License/im);
+      expect(text).not.toMatch(/^# Apache License/im);
+      expect(text).not.toMatch(/OSI-approved/i);
+    }
+
+    expect(boundary).toMatch(/copy these claims/i);
+    expect(boundary).toMatch(/Do not describe NeonDiff as \"open source\"|Avoid:\n\n- \"open source\"/i);
   });
 
   it("setup guide gives a first-run path without hiding safety prerequisites in operator runbooks", () => {


### PR DESCRIPTION
Closes #104.

## Summary
- Add `LICENSE.md` with the source-available beta license boundary.
- Add `docs/license-boundary.md` as the canonical copy surface for README, setup, website, CLI, package metadata, and release notes.
- Align README, setup docs, package metadata, and license confusion template with the canonical boundary.
- Extend the public-community funnel test to enforce source-available wording and avoid accidental MIT/Apache/OSI claims.

## Validation
- `NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/public-community-funnel.test.ts`
- `NODE_OPTIONS=--experimental-sqlite npm run build`
- `git diff --check`
- scoped claim scan for MIT/Apache/OSI/open-source wording

## Safety Boundary
- No live worker restart or launchd mutation.
- No package publish, GitHub Release, repo visibility change, or App permission expansion.
- No pricing implementation; #105 remains separate.