### PR TITLE
Add NeonDiff pricing contract

### DIFF
--- a/.github/ISSUE_TEMPLATE/license_setup_confusion.yml
+++ b/.github/ISSUE_TEMPLATE/license_setup_confusion.yml
@@ -14,7 +14,7 @@ body:
     id: doc
     attributes:
       label: Current doc or page
-      placeholder: README.md, docs/SETUP.md, docs/license-boundary.md, https://www.neondiff.com/...
+      placeholder: README.md, docs/SETUP.md, docs/license-boundary.md, docs/pricing.md, https://www.neondiff.com/...
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ with your GitHub installation, your provider keys, your repo policy, and
 public-safe evidence for every live posting decision.
 
 Public open-source repos are free. Private and commercial repos require a paid
-NeonDiff license. NeonDiff is a source-available beta, not an open-source or
-GA release.
+NeonDiff support license: $1/month, $10/year, or $100 lifetime. NeonDiff is a
+source-available beta, not an open-source or GA release.
 
 [Website](https://www.neondiff.com) · [Setup](docs/SETUP.md) ·
 [Contributing](CONTRIBUTING.md) · [Agent Instructions](AGENTS.md) ·
 [Security](SECURITY.md) · [Code of Conduct](CODE_OF_CONDUCT.md) ·
 [License](LICENSE.md) · [License Boundary](docs/license-boundary.md) ·
+[Pricing](docs/pricing.md) ·
 [Roadmap](https://github.com/electricsheephq/evaos-code-review-bot/issues/103)
 
 ## Why It Matters
@@ -123,6 +124,7 @@ Useful public-product issues:
 
 - [#103 NeonDiff public product roadmap](https://github.com/electricsheephq/evaos-code-review-bot/issues/103)
 - [#104 license and commercial boundary](https://github.com/electricsheephq/evaos-code-review-bot/issues/104)
+- [#105 pricing implementation](https://github.com/electricsheephq/evaos-code-review-bot/issues/105)
 - [#107 CLI package and local daemon public install flow](https://github.com/electricsheephq/evaos-code-review-bot/issues/107)
 - [#113 agent-first CLI and API documentation contract](https://github.com/electricsheephq/evaos-code-review-bot/issues/113)
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -3,7 +3,8 @@
 This guide is the first-run path for the current source-available beta. After
 `npm run build`, the source checkout exposes the beta `neondiff` binary. See
 [LICENSE.md](../LICENSE.md) and [docs/license-boundary.md](license-boundary.md)
-for the public/private repo license boundary.
+for the public/private repo license boundary, and [docs/pricing.md](pricing.md)
+for the support-tier pricing contract.
 
 ## Requirements
 
@@ -14,7 +15,11 @@ for the public/private repo license boundary.
 - optional NeonDiff license key for private or commercial repo use
 
 Public open-source repos are free. Private and commercial repos require a paid
-license.
+support license: $1/month, $10/year, or $100 lifetime. Paid support includes
+private repo review, commercial usage, and auto-updates. Provider/model costs
+remain external through your own provider key or local model; NeonDiff does not
+include hosted model credits, unlimited SaaS inference, or bundled provider
+tokens.
 
 ## 1. Install From Source
 
@@ -95,6 +100,12 @@ Check entitlement cache state:
 
 ```bash
 neondiff license status --config config.local.json --json
+```
+
+Inspect the canonical support-tier pricing without making a network call:
+
+```bash
+neondiff pricing --json
 ```
 
 Remove the local key and cache:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -105,7 +105,7 @@ neondiff license status --config config.local.json --json
 Inspect the canonical support-tier pricing without making a network call:
 
 ```bash
-neondiff pricing --json
+neondiff pricing
 ```
 
 Remove the local key and cache:

--- a/docs/license-boundary.md
+++ b/docs/license-boundary.md
@@ -8,8 +8,8 @@ CLI help, package metadata, and release notes instead of inventing new wording.
 
 NeonDiff is source-available beta software, not open-source software. Public
 open-source repository review is free. Private, internal, commercial,
-proprietary, hosted, marketplace, binary redistribution, and access to auto-updates
-requires an active paid NeonDiff license.
+proprietary, hosted, marketplace, binary redistribution, and auto-updates require
+an active paid NeonDiff license.
 
 Public open-source repositories are free. Private and commercial repository
 review requires a paid NeonDiff support license: $1/month, $10/year, or $100
@@ -30,7 +30,7 @@ SaaS inference, or bundled provider tokens.
 - Using NeonDiff in a company, agency, consulting, or paid-support workflow.
 - Shipping NeonDiff binaries, installers, update channels, marketplace
   packages, or hosted services.
-- Enabling private-repo entitlement or access to auto-updates.
+- Enabling private-repo entitlement or auto-updates.
 
 ## Public Repo Grant
 

--- a/docs/license-boundary.md
+++ b/docs/license-boundary.md
@@ -8,11 +8,13 @@ CLI help, package metadata, and release notes instead of inventing new wording.
 
 NeonDiff is source-available beta software, not open-source software. Public
 open-source repository review is free. Private, internal, commercial,
-proprietary, hosted, marketplace, binary redistribution, and auto-update use
+proprietary, hosted, marketplace, binary redistribution, and access to auto-updates
 requires an active paid NeonDiff license.
 
 Public open-source repositories are free. Private and commercial repository
-review requires a paid NeonDiff license.
+review requires a paid NeonDiff support license: $1/month, $10/year, or $100
+lifetime. NeonDiff support tiers do not include hosted model credits, unlimited
+SaaS inference, or bundled provider tokens.
 
 ## Allowed Without A Paid License
 
@@ -28,7 +30,7 @@ review requires a paid NeonDiff license.
 - Using NeonDiff in a company, agency, consulting, or paid-support workflow.
 - Shipping NeonDiff binaries, installers, update channels, marketplace
   packages, or hosted services.
-- Enabling private-repo entitlement or auto-update capabilities.
+- Enabling private-repo entitlement or access to auto-updates.
 
 ## Public Repo Grant
 
@@ -50,6 +52,7 @@ Use:
 - "source-available beta"
 - "free for public open-source repositories"
 - "private and commercial repository review requires a paid NeonDiff license"
+- "$1/month, $10/year, or $100 lifetime support license"
 - "bring your own provider key or local model"
 - "local worker; current-head, secret-redacted review evidence"
 
@@ -82,7 +85,9 @@ CLI setup/help copy should say:
 
 > NeonDiff is source-available beta software. Public open-source repository
 > review is free. Private, internal, and commercial repository review requires
-> an active paid NeonDiff license.
+> an active paid NeonDiff license. Support tiers are $1/month, $10/year, or
+> $100 lifetime; provider/model costs stay external through BYOK or local
+> providers.
 
 Private-repo failure copy should say:
 

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -23,10 +23,10 @@ Use the CLI to inspect the canonical pricing and entitlement shape that docs,
 license copy, and website copy should follow:
 
 ```bash
-neondiff pricing --json
+neondiff pricing
 ```
 
-The pricing command is deterministic and does not call the network. It reports:
+The pricing command emits JSON by default and does not call the network. It reports:
 
 - public open-source repositories are free
 - paid support tiers are `$1/mo`, `$10/yr`, and `$100 lifetime`

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -44,9 +44,9 @@ usage, and auto-updates:
 - `yearly_support`
 - `lifetime_support`
 
-Private-repo review should fail closed before worktree prep, provider calls, or
-GitHub review posting when license enforcement is enabled and no active paid
-entitlement covers private repositories.
+Runtime license enforcement is outside this pricing command. This document only
+defines the pricing and entitlement vocabulary that enforcement code and setup
+docs should use.
 
 ## Tracking
 

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -1,0 +1,55 @@
+# NeonDiff Pricing
+
+NeonDiff is a local-first, source-available beta. Public open-source repository
+review is free. Private repo review, commercial usage, and auto-updates require
+a paid NeonDiff support license.
+
+NeonDiff pricing is for the software/support entitlement only. Users bring
+their own provider key or local model. NeonDiff does not include hosted model
+credits, unlimited SaaS inference, or bundled provider tokens.
+
+## Support Tiers
+
+| Tier | Price | Best For | Private Repos | Commercial Use | Auto-Updates | Provider Credits |
+| --- | ---: | --- | --- | --- | --- | --- |
+| Free OSS | $0 | Public open-source projects | No | No | No | Not included |
+| Monthly Support | $1/mo | Low-friction private or commercial use | Yes | Yes | Yes | Not included |
+| Yearly Support | $10/yr | Annual support license | Yes | Yes | Yes | Not included |
+| Lifetime Support | $100 lifetime | One-time support license | Yes | Yes | Yes | Not included |
+
+## CLI Contract
+
+Use the CLI to inspect the canonical pricing and entitlement shape that docs,
+license copy, and website copy should follow:
+
+```bash
+neondiff pricing --json
+```
+
+The pricing command is deterministic and does not call the network. It reports:
+
+- public open-source repositories are free
+- paid support tiers are `$1/mo`, `$10/yr`, and `$100 lifetime`
+- paid support includes private repo review, commercial usage, and auto-updates
+- provider/model costs stay external through BYOK or local providers
+- hosted model credits and unlimited SaaS inference are not included
+
+## Entitlement Shape
+
+Free OSS mode is scoped to public open-source repository review. Paid support
+licenses map to entitlement plans for private repository review, commercial
+usage, and auto-updates:
+
+- `monthly_support`
+- `yearly_support`
+- `lifetime_support`
+
+Private-repo review should fail closed before worktree prep, provider calls, or
+GitHub review posting when license enforcement is enabled and no active paid
+entitlement covers private repositories.
+
+## Tracking
+
+- Public product roadmap: https://github.com/electricsheephq/evaos-code-review-bot/issues/103
+- License/commercial boundary gate: https://github.com/electricsheephq/evaos-code-review-bot/issues/104
+- Pricing implementation: https://github.com/electricsheephq/evaos-code-review-bot/issues/105

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,7 @@ import {
   type OperatorDurableQueueSnapshot,
   type OperatorQueueSnapshot
 } from "./operator-cli.js";
+import { buildPricingOutput } from "./pricing.js";
 import { collectReleaseStatus, type ReleaseStatus } from "./release-status.js";
 import { buildReviewHeadGate } from "./review-head-gate.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown } from "./repo-memory.js";
@@ -113,6 +114,11 @@ async function main(): Promise<void> {
       return;
     }
     throw new Error("config subcommand must be one of: inspect, patch");
+  }
+
+  if (command === "pricing") {
+    console.log(stringifyRedactedJson(buildPricingOutput()));
+    return;
   }
 
   if (command === "license") {
@@ -2108,6 +2114,7 @@ function buildHelp(command?: string) {
         "init",
         "config inspect",
         "config patch",
+        "pricing",
         "doctor",
         "daemon start",
         "daemon stop",
@@ -2161,6 +2168,7 @@ function buildHelp(command?: string) {
       "neondiff config inspect --config config.local.json",
       "neondiff config patch --config config.local.json --input desktop-patch.json --dry-run true",
       "desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}",
+      "neondiff pricing --json",
       "neondiff license activate --config config.local.json --license-key-env NEONDIFF_LICENSE_KEY --json",
       "neondiff license status --config config.local.json --json",
       "neondiff license deactivate --config config.local.json --json",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2168,7 +2168,7 @@ function buildHelp(command?: string) {
       "neondiff config inspect --config config.local.json",
       "neondiff config patch --config config.local.json --input desktop-patch.json --dry-run true",
       "desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}",
-      "neondiff pricing --json",
+      "neondiff pricing",
       "neondiff license activate --config config.local.json --license-key-env NEONDIFF_LICENSE_KEY --json",
       "neondiff license status --config config.local.json --json",
       "neondiff license deactivate --config config.local.json --json",

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,0 +1,123 @@
+export type NeonDiffPricingPlanId = "free_oss" | "monthly_support" | "yearly_support" | "lifetime_support";
+
+export interface NeonDiffPricingPlan {
+  id: NeonDiffPricingPlanId;
+  name: string;
+  priceUsd: number;
+  displayPrice: string;
+  cadence: "public open-source repositories" | "month" | "year" | "lifetime";
+  summary: string;
+  requiresPaidLicense: boolean;
+  repoVisibilityScope: "public" | "private";
+  commercialUse: boolean;
+  autoUpdates: boolean;
+  providerCreditsIncluded: false;
+  entitlementPlan?: "monthly_support" | "yearly_support" | "lifetime_support";
+}
+
+export const NEONDIFF_PRICING_PLANS: readonly NeonDiffPricingPlan[] = [
+  {
+    id: "free_oss",
+    name: "Free OSS",
+    priceUsd: 0,
+    displayPrice: "$0",
+    cadence: "public open-source repositories",
+    summary: "Free local review for public open-source projects.",
+    requiresPaidLicense: false,
+    repoVisibilityScope: "public",
+    commercialUse: false,
+    autoUpdates: false,
+    providerCreditsIncluded: false
+  },
+  {
+    id: "monthly_support",
+    name: "Monthly Support",
+    priceUsd: 1,
+    displayPrice: "$1/mo",
+    cadence: "month",
+    summary: "Paid support tier for private repo review, commercial use, and auto-updates.",
+    requiresPaidLicense: true,
+    repoVisibilityScope: "private",
+    commercialUse: true,
+    autoUpdates: true,
+    providerCreditsIncluded: false,
+    entitlementPlan: "monthly_support"
+  },
+  {
+    id: "yearly_support",
+    name: "Yearly Support",
+    priceUsd: 10,
+    displayPrice: "$10/yr",
+    cadence: "year",
+    summary: "Annual paid support tier for private repo review, commercial use, and auto-updates.",
+    requiresPaidLicense: true,
+    repoVisibilityScope: "private",
+    commercialUse: true,
+    autoUpdates: true,
+    providerCreditsIncluded: false,
+    entitlementPlan: "yearly_support"
+  },
+  {
+    id: "lifetime_support",
+    name: "Lifetime Support",
+    priceUsd: 100,
+    displayPrice: "$100 lifetime",
+    cadence: "lifetime",
+    summary: "Lifetime paid support tier for private repo review, commercial use, and auto-updates.",
+    requiresPaidLicense: true,
+    repoVisibilityScope: "private",
+    commercialUse: true,
+    autoUpdates: true,
+    providerCreditsIncluded: false,
+    entitlementPlan: "lifetime_support"
+  }
+] as const;
+
+export function buildPricingOutput() {
+  return {
+    ok: true,
+    command: "pricing",
+    product: "NeonDiff",
+    currency: "USD",
+    billingModel: "local-first support tiers",
+    sourceAvailableBeta: true,
+    publicOpenSourceReposFree: true,
+    paidTierIncludes: [
+      "private repo review",
+      "commercial usage",
+      "auto-updates"
+    ],
+    providerCosts: {
+      model: "BYOK or local provider",
+      includedHostedModelCredits: false,
+      detail: "NeonDiff pricing does not include hosted model credits, unlimited SaaS inference, or bundled provider tokens."
+    },
+    plans: NEONDIFF_PRICING_PLANS,
+    entitlementShape: {
+      freeOss: {
+        repoVisibilityScope: "public",
+        requiresPaidLicense: false,
+        commercialUse: false,
+        autoUpdates: false
+      },
+      paidSupport: {
+        repoVisibilityScope: "private",
+        requiresPaidLicense: true,
+        commercialUse: true,
+        autoUpdates: true,
+        acceptedPlanIds: ["monthly_support", "yearly_support", "lifetime_support"]
+      }
+    },
+    sourceOfTruth: {
+      roadmap: "https://github.com/electricsheephq/evaos-code-review-bot/issues/103",
+      licenseBoundary: "https://github.com/electricsheephq/evaos-code-review-bot/issues/104",
+      pricingImplementation: "https://github.com/electricsheephq/evaos-code-review-bot/issues/105"
+    },
+    forbiddenClaims: [
+      "hosted model credits included",
+      "unlimited SaaS inference included",
+      "free private repo review",
+      "OSI open-source license"
+    ]
+  };
+}

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -131,7 +131,7 @@ describe("public NeonDiff CLI surface", () => {
       })
     ]);
     expect(stdout).toContain("does not include hosted model credits");
-    expect(stdout).not.toMatch(/includedHostedModelCredits\"\\s*:\\s*true|bundled provider tokens included/i);
+    expect(stdout).not.toMatch(/"includedHostedModelCredits":\s*true|bundled provider tokens included/i);
   });
 
   it("rejects non-boolean public rollback ref verification values", async () => {
@@ -1433,35 +1433,36 @@ describe("public NeonDiff CLI surface", () => {
       }
     })}\n`);
     const store = new ReviewStateStore(statePath);
+    const fixtureNow = new Date();
     try {
       store.enqueueReviewQueueJob({
         repo: "other/repo",
         pullNumber: 1,
         headSha: "active-head",
         providerId: "GLM-5.2",
-        now: new Date("2026-07-03T00:00:00.000Z")
+        now: new Date(fixtureNow.getTime() - 2_000)
       });
       store.leaseNextReviewQueueJobs({
         maxProviderActive: 1,
         maxOrgActive: 1,
         maxRepoActive: 1,
-        // Keep the synthetic active provider lease alive regardless of wall-clock test date.
-        leaseTtlMs: 14 * 24 * 60 * 60_000,
-        now: new Date("2026-07-03T00:00:01.000Z")
+        // Issue #195: keep the synthetic active provider lease relative to the process clock.
+        leaseTtlMs: 60 * 60_000,
+        now: new Date(fixtureNow.getTime() - 1_000)
       });
       const deferred = store.enqueueReviewQueueJob({
         repo: "owner/repo",
         pullNumber: 123,
         headSha: "head-provider-deferred",
         providerId: "GLM-5.2",
-        now: new Date("2026-07-03T00:00:02.000Z")
+        now: new Date(fixtureNow.getTime() - 500)
       }).job;
       store.updateReviewQueueJobState({
         jobId: deferred.jobId,
         state: "provider_deferred",
-        nextEligibleAt: "2026-07-03T00:00:03.000Z",
+        nextEligibleAt: new Date(fixtureNow.getTime() - 250).toISOString(),
         lastError: "provider_overloaded",
-        now: new Date("2026-07-03T00:00:04.000Z")
+        now: fixtureNow
       });
     } finally {
       store.close();

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1445,6 +1445,7 @@ describe("public NeonDiff CLI surface", () => {
         maxProviderActive: 1,
         maxOrgActive: 1,
         maxRepoActive: 1,
+        // Keep the synthetic active provider lease alive regardless of wall-clock test date.
         leaseTtlMs: 14 * 24 * 60 * 60_000,
         now: new Date("2026-07-03T00:00:01.000Z")
       });

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -54,7 +54,7 @@ describe("public NeonDiff CLI surface", () => {
       "review-pr"
     ]);
     expect(output.examples).toContain("neondiff init --config config.local.json");
-    expect(output.examples).toContain("neondiff pricing --json");
+    expect(output.examples).toContain("neondiff pricing");
     expect(output.examples).toContain("neondiff license status --config config.local.json --json");
     expect(output.examples).toContain("npx tsx src/cli.ts daemon --config /path/to/live.json --dry-run true --once true");
     expect(output.commands.existing).toContain("provider-throttle-report");
@@ -71,7 +71,7 @@ describe("public NeonDiff CLI surface", () => {
   });
 
   it("prints canonical pricing tiers without hosted model credit claims", async () => {
-    const { stdout } = await runCli(["pricing", "--json"]);
+    const { stdout } = await runCli(["pricing"]);
     const output = JSON.parse(stdout);
 
     expect(output).toMatchObject({

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -42,6 +42,7 @@ describe("public NeonDiff CLI surface", () => {
       "init",
       "config inspect",
       "config patch",
+      "pricing",
       "doctor",
       "daemon start",
       "daemon stop",
@@ -53,6 +54,7 @@ describe("public NeonDiff CLI surface", () => {
       "review-pr"
     ]);
     expect(output.examples).toContain("neondiff init --config config.local.json");
+    expect(output.examples).toContain("neondiff pricing --json");
     expect(output.examples).toContain("neondiff license status --config config.local.json --json");
     expect(output.examples).toContain("npx tsx src/cli.ts daemon --config /path/to/live.json --dry-run true --once true");
     expect(output.commands.existing).toContain("provider-throttle-report");
@@ -66,6 +68,70 @@ describe("public NeonDiff CLI surface", () => {
       "npx tsx src/cli.ts review-head-gate --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD"
     );
     expect(output.examples).toContain("desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}");
+  });
+
+  it("prints canonical pricing tiers without hosted model credit claims", async () => {
+    const { stdout } = await runCli(["pricing", "--json"]);
+    const output = JSON.parse(stdout);
+
+    expect(output).toMatchObject({
+      ok: true,
+      command: "pricing",
+      product: "NeonDiff",
+      currency: "USD",
+      publicOpenSourceReposFree: true,
+      providerCosts: {
+        model: "BYOK or local provider",
+        includedHostedModelCredits: false
+      },
+      entitlementShape: {
+        freeOss: {
+          repoVisibilityScope: "public",
+          requiresPaidLicense: false
+        },
+        paidSupport: {
+          repoVisibilityScope: "private",
+          requiresPaidLicense: true,
+          commercialUse: true,
+          autoUpdates: true,
+          acceptedPlanIds: ["monthly_support", "yearly_support", "lifetime_support"]
+        }
+      }
+    });
+    expect(output.plans).toEqual([
+      expect.objectContaining({
+        id: "free_oss",
+        displayPrice: "$0",
+        requiresPaidLicense: false,
+        providerCreditsIncluded: false
+      }),
+      expect.objectContaining({
+        id: "monthly_support",
+        displayPrice: "$1/mo",
+        requiresPaidLicense: true,
+        commercialUse: true,
+        autoUpdates: true,
+        providerCreditsIncluded: false
+      }),
+      expect.objectContaining({
+        id: "yearly_support",
+        displayPrice: "$10/yr",
+        requiresPaidLicense: true,
+        commercialUse: true,
+        autoUpdates: true,
+        providerCreditsIncluded: false
+      }),
+      expect.objectContaining({
+        id: "lifetime_support",
+        displayPrice: "$100 lifetime",
+        requiresPaidLicense: true,
+        commercialUse: true,
+        autoUpdates: true,
+        providerCreditsIncluded: false
+      })
+    ]);
+    expect(stdout).toContain("does not include hosted model credits");
+    expect(stdout).not.toMatch(/includedHostedModelCredits\"\\s*:\\s*true|bundled provider tokens included/i);
   });
 
   it("rejects non-boolean public rollback ref verification values", async () => {
@@ -1379,7 +1445,7 @@ describe("public NeonDiff CLI surface", () => {
         maxProviderActive: 1,
         maxOrgActive: 1,
         maxRepoActive: 1,
-        leaseTtlMs: 24 * 60 * 60_000,
+        leaseTtlMs: 14 * 24 * 60 * 60_000,
         now: new Date("2026-07-03T00:00:01.000Z")
       });
       const deferred = store.enqueueReviewQueueJob({

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -20,13 +20,18 @@ describe("NeonDiff public community funnel", () => {
       /CODE_OF_CONDUCT\.md/i,
       /LICENSE\.md/i,
       /docs\/license-boundary\.md/i,
+      /docs\/pricing\.md/i,
       /public open-source repos.*free/i,
+      /\$1\/month/i,
+      /\$10\/year/i,
+      /\$100 lifetime/i,
       /private.*commercial.*paid/i,
       /source-available beta/i,
       /GitHub App/i,
       /dry-run review/i,
       /electricsheephq\/evaos-code-review-bot\/issues\/103/i,
       /electricsheephq\/evaos-code-review-bot\/issues\/104/i,
+      /electricsheephq\/evaos-code-review-bot\/issues\/105/i,
       /electricsheephq\/evaos-code-review-bot\/issues\/107/i,
       /electricsheephq\/evaos-code-review-bot\/issues\/113/i
     ]) {
@@ -67,6 +72,32 @@ describe("NeonDiff public community funnel", () => {
 
     expect(boundary).toMatch(/copy these claims/i);
     expect(boundary).toMatch(/Do not describe NeonDiff as \"open source\"|Avoid:\n\n- \"open source\"/i);
+  });
+
+  it("pricing doc records support tiers, BYOK costs, and no hosted model credit bundle", () => {
+    const pricing = read("docs/pricing.md");
+    const setup = read("docs/SETUP.md");
+    const boundary = read("docs/license-boundary.md");
+    const issueTemplate = read(".github/ISSUE_TEMPLATE/license_setup_confusion.yml");
+
+    for (const text of [pricing, setup, boundary]) {
+      expect(text).toMatch(/public open-source/i);
+      expect(text).toMatch(/\$1\/mo|\$1\/month/i);
+      expect(text).toMatch(/\$10\/yr|\$10\/year/i);
+      expect(text).toMatch(/\$100 lifetime/i);
+      expect(text).toMatch(/private repo review|private.*repo/i);
+      expect(text).toMatch(/commercial/i);
+      expect(text).toMatch(/auto-updates/i);
+      expect(text).toMatch(/BYOK|provider key|local model/i);
+      expect(text).toMatch(/does not\s+include hosted model\s+credits|do not\s+include hosted model\s+credits/i);
+      expect(text).not.toMatch(/unlimited SaaS inference included|bundled provider tokens included/i);
+    }
+
+    expect(pricing).toMatch(/neondiff pricing --json/i);
+    expect(pricing).toMatch(/monthly_support/i);
+    expect(pricing).toMatch(/yearly_support/i);
+    expect(pricing).toMatch(/lifetime_support/i);
+    expect(issueTemplate).toMatch(/docs\/pricing\.md/i);
   });
 
   it("setup guide gives a first-run path without hiding safety prerequisites in operator runbooks", () => {

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -93,7 +93,7 @@ describe("NeonDiff public community funnel", () => {
       expect(text).not.toMatch(/unlimited SaaS inference included|bundled provider tokens included/i);
     }
 
-    expect(pricing).toMatch(/neondiff pricing --json/i);
+    expect(pricing).toMatch(/neondiff pricing/i);
     expect(pricing).toMatch(/monthly_support/i);
     expect(pricing).toMatch(/yearly_support/i);
     expect(pricing).toMatch(/lifetime_support/i);

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -89,7 +89,9 @@ describe("NeonDiff public community funnel", () => {
       expect(text).toMatch(/commercial/i);
       expect(text).toMatch(/auto-updates/i);
       expect(text).toMatch(/BYOK|provider key|local model/i);
-      expect(text).toMatch(/does not\s+include hosted model\s+credits|do not\s+include hosted model\s+credits/i);
+      const normalized = text.replace(/\s+/g, " ");
+      expect(normalized).toMatch(/hosted model credits/i);
+      expect(normalized).toMatch(/does not include|do not include|not included|no bundled/i);
       expect(text).not.toMatch(/unlimited SaaS inference included|bundled provider tokens included/i);
     }
 


### PR DESCRIPTION
## Summary
- add a deterministic `neondiff pricing` JSON contract for Free OSS, Monthly Support, Yearly Support, and Lifetime Support
- document $1/month, $10/year, and $100 lifetime support tiers across README/setup/license/pricing surfaces
- assert BYOK/local-provider cost boundaries and no bundled hosted model credits in public tests
- fix and trace the public CLI queue fixture calendar flake from #195

## Validation
- NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/public-cli.test.ts tests/public-community-funnel.test.ts
- NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/public-community-funnel.test.ts
- NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/public-cli.test.ts
- NODE_OPTIONS=--experimental-sqlite npm run build
- git diff --check
- npx tsx src/cli.ts pricing
- scoped claim scan for hosted model credit, unlimited SaaS, free private repo, OSI/open-source, MIT, and Apache wording

## Safety Boundary
- no live daemon config changes
- no launchd restart or live promotion in this PR
- no payment processor or license API billing implementation
- no hosted model credits or unlimited SaaS inference claim
- release-status remains a post-merge/promotion gate if this CLI behavior is tagged as a beta release

Closes #105
Closes #195