### PR TITLE
Add GitHub App onboarding doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ NeonDiff support license: $1/month, $10/year, or $100 lifetime. NeonDiff is a
 source-available beta, not an open-source or GA release.
 
 [Website](https://www.neondiff.com) · [Setup](docs/SETUP.md) ·
-[Contributing](CONTRIBUTING.md) · [Agent Instructions](AGENTS.md) ·
-[Security](SECURITY.md) · [Code of Conduct](CODE_OF_CONDUCT.md) ·
-[License](LICENSE.md) · [License Boundary](docs/license-boundary.md) ·
-[Pricing](docs/pricing.md) ·
+[GitHub App Install](docs/github-app-setup.md) · [Contributing](CONTRIBUTING.md) ·
+[Agent Instructions](AGENTS.md) · [Security](SECURITY.md) ·
+[Code of Conduct](CODE_OF_CONDUCT.md) · [License](LICENSE.md) ·
+[License Boundary](docs/license-boundary.md) · [Pricing](docs/pricing.md) ·
 [Roadmap](https://github.com/electricsheephq/evaos-code-review-bot/issues/103)
 
 ## Why It Matters
@@ -85,6 +85,7 @@ version is:
 neondiff init --config config.local.json
 export EVAOS_REVIEW_BOT_APP_ID="<github-app-id>"
 export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
+neondiff doctor github --config config.local.json --json
 neondiff doctor --config config.local.json --json
 ```
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -35,10 +35,15 @@ npm link
 `neondiff`. If you intentionally skip linking, substitute `./dist/src/cli.js`
 for `neondiff`.
 
-## 2. Create A GitHub App
+## 2. Create Or Install A GitHub App
 
-Create a GitHub App for NeonDiff and install it only on repos you intend to
-review.
+Use the public NeonDiff GitHub App install URL for the beta you are testing, or
+create an equivalent App while the public registration is being finalized. See
+[docs/github-app-setup.md](github-app-setup.md) for the selected-repo install
+path, uninstall path, evidence packet, and troubleshooting details.
+
+Install the App only on repos you intend to review, then put the same repos in
+your local `pilotRepos` allowlist.
 
 Required repository permissions:
 
@@ -131,13 +136,29 @@ primitive.
 
 ## 4. Check Readiness
 
-Run doctor with the config you intend to use:
+Run the GitHub-only doctor first. It verifies App installation visibility and
+repo read access without running ZCode, calling a provider, posting comments, or
+printing secrets:
+
+```bash
+neondiff doctor github --config config.local.json --json
+```
+
+Check:
+
+- `ok`
+- `github.readMode` is `app_installation`
+- `github.canPostAsApp`
+- each enabled repo in `github.readChecks[]`
+- `activeRepoChecks` is greater than zero
+
+Then run full doctor with the config you intend to use:
 
 ```bash
 neondiff doctor --config config.local.json --json
 ```
 
-The doctor output is JSON. Check:
+The full doctor output is JSON. Check:
 
 - `ok`
 - `github.readMode`
@@ -216,8 +237,15 @@ that channel as `requiredForThisRelease: false`.
 
 ## Troubleshooting
 
-- `doctor` cannot read repos: verify GitHub App installation, app ID, private
-  key path, and repo permissions.
+- `doctor github` cannot read repos: verify GitHub App installation, selected
+  repo access, app ID, private key configuration, and repo permissions.
+- `doctor github` reports `fallback_token`: token reads may work, but this does
+  not prove App-authored review posting.
+- `doctor github` reports `activeRepoChecks: 0`: enable at least one selected
+  installed repo in local config before using the output as install proof.
+- Uninstall path: remove the GitHub App installation from GitHub settings, stop
+  the local worker, remove the repo from `pilotRepos`, and then delete local App
+  keys only after confirming no worker still needs them.
 - Provider calls fail: verify local provider config outside this repository and
   inspect redacted provider errors only.
 - Review says stale head: re-fetch the PR head and rerun against the current

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -1,18 +1,40 @@
-# GitHub App Setup
+# GitHub App Install And Onboarding
 
-Create a GitHub App named `evaOS Code Review Bot` with slug `evaos-code-review-bot`.
+NeonDiff reviews pull requests through a GitHub App, while the reviewer worker
+runs on your own machine or server. The App identity is what authors review
+comments in GitHub; your local worker holds the App ID, private key, provider
+configuration, state database, and evidence files.
 
-GitHub does not provide a direct noninteractive `gh app create` command for this. Use the GitHub App manifest handshake or the GitHub web UI. The manifest flow requires a signed-in user to open the organization app-registration URL, approve the manifest, then exchange GitHub's temporary `code` for the app ID and PEM within one hour.
+## Install URL
 
-Required repository permissions:
+Use the public NeonDiff GitHub App install URL from the release notes or website
+for the beta you are testing. Until the public App registration is finalized,
+operators can create an equivalent App with the permission set below and record
+the generated install URL in the issue or release evidence packet.
 
+Install only on selected repositories. NeonDiff does not need organization-wide
+discovery for the v1.0 MVP, and the worker only reviews repos present in your
+local config allowlist.
+
+## Repository Permissions
+
+Required repository permissions for pull-request review:
+
+- Metadata: read
 - Contents: read
 - Pull requests: read/write
 - Checks: read
 - Actions: read
-- Metadata: read
 
-Optional issue-enrichment permissions, gated by `issueEnrichment`:
+Why these permissions are needed:
+
+- `Metadata: read` lets the App identify installed repositories.
+- `Contents: read` lets the worker fetch and inspect the target head.
+- `Pull requests: read/write` lets the App read PR metadata and submit reviews.
+- `Checks: read` and `Actions: read` let review summaries include CI context
+  without creating or modifying workflow runs.
+
+Optional issue-enrichment permissions are separate from PR review:
 
 - Issues: read, only for dry-run/operator issue enrichment reads.
 - Issues: write, only after a tracked rollout explicitly enables App-authored
@@ -22,18 +44,118 @@ Do not add Issues permissions merely because a repository is in the PR review
 monitor list. Issue enrichment has a separate allowlist and per-repo throttles
 because milestone or planning days can create large issue bursts.
 
-Install the app only on:
+## Selected-Repo Install Path
 
-- `electricsheephq/WorldOS`
-- `100yenadmin/evaOS-GUI`
+1. Open the NeonDiff GitHub App install URL.
+2. Choose the user or organization that owns the repositories.
+3. Select `Only select repositories`.
+4. Pick the repos you want NeonDiff to review.
+5. Confirm the permissions above.
+6. Save the generated private key outside this repository.
+7. Add the same repos to `pilotRepos` in your local `config.local.json`.
 
-After installation, save the generated private key outside the repository and launch the worker with:
+Keep the private key and local config out of git. A typical shell setup is:
 
 ```bash
-export EVAOS_REVIEW_BOT_APP_ID=...
-export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH=/absolute/path/to/evaos-code-review-bot.private-key.pem
-npm run doctor
-npm run run-once -- --dry-run true
+export EVAOS_REVIEW_BOT_APP_ID="<github-app-id>"
+export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 ```
 
-Do not run with `--dry-run false` until dry-run evidence exists for both pilot repos and `npm test` plus `npm run build` pass.
+## Verify Installation
+
+Run the GitHub-only doctor before provider or daemon checks:
+
+```bash
+neondiff doctor github --config config.local.json --json
+```
+
+The command verifies App credential presence, App installation visibility, and
+repo read access for the enabled repos in your local config. It does not run
+ZCode, call a model provider, post comments, print tokens, or print the private
+key path.
+
+Expected signs of a usable install:
+
+- `ok: true`
+- `github.readMode: "app_installation"`
+- `github.canPostAsApp: true`
+- each enabled repo has `ok: true`
+- `activeRepoChecks` is greater than zero
+
+If a repo is disabled by repo policy, the doctor reports it as
+`skippedByPolicy`; that is useful config evidence, but it is not proof that the
+App can read or review that repo.
+
+## First Review Path
+
+Start with a dry run on a known PR:
+
+```bash
+neondiff review-pr \
+  --config config.local.json \
+  --repo owner/name \
+  --pr 123 \
+  --dry-run true \
+  --zcode false
+```
+
+Only move to live review after the dry-run output and evidence are inspected and
+the exact repo, PR, head SHA, config path, and posting intent are recorded in
+the relevant issue.
+
+When live posting is approved, the review author in GitHub must be the NeonDiff
+GitHub App bot, not the human user token. If the author is a user account, stop
+and fix App credentials before continuing.
+
+## License Boundary
+
+Public open-source repositories are free when `license.publicReposFree` is true.
+Private and commercial repositories require a paid NeonDiff support license when
+`license.privateReposRequireEntitlement` is true.
+
+Private repo data stays local to the worker and GitHub App installation. Do not
+send private repository names, diffs, logs, private keys, provider keys, license
+keys, or customer data to a website form or public issue.
+
+## Uninstall
+
+To remove NeonDiff from a user or organization:
+
+1. Open GitHub Settings for the user or organization.
+2. Go to `GitHub Apps` or `Installed GitHub Apps`.
+3. Select the NeonDiff App installation.
+4. Remove individual repositories or uninstall the App entirely.
+5. Stop the local worker and remove the repo from `pilotRepos`.
+6. Delete local App private keys only after confirming no worker still needs
+   them.
+
+## Troubleshooting
+
+- `doctor github` reports `readMode: "unconfigured"`: set
+  `EVAOS_REVIEW_BOT_APP_ID` and `EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH`, or set
+  `github.appId` and `github.privateKeyPath` in an untracked local config.
+- `doctor github` reports `fallback_token`: the worker can use a token for
+  local reads, but it cannot prove App-authored review posting.
+- A repo read fails with 404 or "Resource not accessible by integration":
+  confirm the App is installed on that selected repo and has the permissions
+  listed above.
+- `activeRepoChecks` is zero: the config has no enabled repo to prove; add a
+  selected installed repo to `pilotRepos`.
+- Private repo review fails before provider calls: check license status before
+  widening GitHub permissions or changing provider settings.
+- App-authored comments do not appear: verify the live command used App
+  credentials, not only `GITHUB_TOKEN`.
+
+## Evidence To Save
+
+For public App install acceptance, save a redacted evidence packet containing:
+
+- the App permissions snapshot
+- `neondiff doctor github --json` output
+- public test-repo dry-run output
+- private repo missing-license fail-closed output when applicable
+- the first App-authored review URL and target head SHA
+
+This setup guide proves the local onboarding path only. It does not by itself
+prove Marketplace readiness, package publishing, calibrated review accuracy, or
+all-org rollout safety.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { loadConfig, validateLicenseConfigOverride } from "./config.js";
+import { loadConfig, validateLicenseConfigOverride, type BotConfig } from "./config.js";
 import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
 import { collectProviderThrottleReport } from "./provider-throttle-report.js";
 import { runDaemonCycle } from "./daemon.js";
@@ -160,6 +160,12 @@ async function main(): Promise<void> {
 
   if (command === "doctor") {
     const config = loadConfig(args.config);
+    if (args._[1] === "github") {
+      const result = await buildDoctorGithubReport(config);
+      console.log(stringifyRedactedJson(result));
+      if (!result.ok) process.exitCode = 1;
+      return;
+    }
     const zcode = resolveZCodeProviderEnv({
       appConfigPath: config.zcode.appConfigPath,
       model: config.zcode.model,
@@ -2105,6 +2111,90 @@ function isProviderDeferredQueueJobEligible(job: ReviewQueueJobRecord, now: Date
   return !Number.isFinite(eligibleAtMs) || eligibleAtMs <= now.getTime();
 }
 
+async function buildDoctorGithubReport(config: BotConfig) {
+  const github = new GitHubApi(config.github);
+  const monitoredRepos = listReposToScan(config);
+  const readChecks = [];
+  let activeRepoChecks = 0;
+  const appCredentialsConfigured = github.canPostAsApp();
+  const hasFallbackReadToken = Boolean(config.github.token);
+
+  for (const repo of monitoredRepos) {
+    const repoPolicy = resolveRepoProfile(config, repo);
+    const policy = buildRepoPolicySnapshot(config, repo);
+    if (!repoPolicy.allowed) {
+      readChecks.push({ repo, ok: true, policy, skippedByPolicy: repoPolicy.reason });
+      continue;
+    }
+    activeRepoChecks += 1;
+    if (!appCredentialsConfigured && !hasFallbackReadToken) {
+      readChecks.push({
+        repo,
+        ok: false,
+        policy,
+        error: "GitHub App credentials or fallback read token are required before checking repository access."
+      });
+      continue;
+    }
+    try {
+      const pulls = await github.listOpenPulls(repo);
+      readChecks.push({ repo, ok: true, policy, openPullCount: pulls.length });
+    } catch (error) {
+      readChecks.push({
+        repo,
+        ok: false,
+        policy,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  const ok = appCredentialsConfigured && activeRepoChecks > 0 && readChecks.every((check) => check.ok);
+  return {
+    ok,
+    command: "doctor github",
+    purpose: "Verify GitHub App installation visibility and repo read access without provider or ZCode checks.",
+    monitoredRepos,
+    activeRepoChecks,
+    appCredentials: {
+      appIdConfigured: Boolean(config.github.appId),
+      privateKeyConfigured: Boolean(config.github.privateKeyPath),
+      fallbackTokenConfigured: Boolean(config.github.token)
+    },
+    github: {
+      canPostAsApp: appCredentialsConfigured,
+      readMode: appCredentialsConfigured ? "app_installation" : hasFallbackReadToken ? "fallback_token" : "unconfigured",
+      botLogin: config.github.botLogin ?? "evaos-code-review-bot[bot]",
+      apiBaseUrl: config.github.apiBaseUrl ?? "https://api.github.com",
+      readChecks
+    },
+    requiredRepositoryPermissions: [
+      "Metadata: read",
+      "Contents: read",
+      "Pull requests: read/write",
+      "Checks: read",
+      "Actions: read"
+    ],
+    optionalPermissions: [
+      "Issues: read/write only for separately allowlisted issue-enrichment repos"
+    ],
+    licenseBoundary: {
+      publicReposFree: config.license?.publicReposFree ?? true,
+      privateReposRequireEntitlement: config.license?.privateReposRequireEntitlement ?? true,
+      privateRepoDataStaysLocal: true
+    },
+    nextCommands: [
+      "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 --dry-run true --zcode false",
+      "neondiff daemon status --config config.local.json --launchd-label com.example.neondiff"
+    ],
+    troubleshooting: [
+      ...(appCredentialsConfigured ? [] : ["Set EVAOS_REVIEW_BOT_APP_ID and EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH, or configure github.appId/privateKeyPath outside git."]),
+      ...(activeRepoChecks > 0 ? [] : ["Add at least one enabled repo to pilotRepos or repoProfiles before using this as an install proof."]),
+      ...(readChecks.some((check) => !check.ok) ? ["Confirm the GitHub App is installed on selected repositories with the required repository permissions."] : [])
+    ]
+  };
+}
+
 function buildHelp(command?: string) {
   return {
     ok: true,
@@ -2116,6 +2206,7 @@ function buildHelp(command?: string) {
         "config patch",
         "pricing",
         "doctor",
+        "doctor github",
         "daemon start",
         "daemon stop",
         "daemon status",
@@ -2173,6 +2264,7 @@ function buildHelp(command?: string) {
       "neondiff license status --config config.local.json --json",
       "neondiff license deactivate --config config.local.json --json",
       "neondiff doctor --config config.local.json --json",
+      "neondiff doctor github --config config.local.json --json",
       "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 --dry-run true --zcode false",
       "neondiff daemon status --config config.local.json --launchd-label com.example.neondiff",
       "neondiff daemon start --launchd-label com.example.neondiff --dry-run true",

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1,6 +1,9 @@
 import { execFile } from "node:child_process";
+import { generateKeyPairSync } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { createRequire } from "node:module";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -44,6 +47,7 @@ describe("public NeonDiff CLI surface", () => {
       "config patch",
       "pricing",
       "doctor",
+      "doctor github",
       "daemon start",
       "daemon stop",
       "daemon status",
@@ -55,6 +59,7 @@ describe("public NeonDiff CLI surface", () => {
     ]);
     expect(output.examples).toContain("neondiff init --config config.local.json");
     expect(output.examples).toContain("neondiff pricing");
+    expect(output.examples).toContain("neondiff doctor github --config config.local.json --json");
     expect(output.examples).toContain("neondiff license status --config config.local.json --json");
     expect(output.examples).toContain("npx tsx src/cli.ts daemon --config /path/to/live.json --dry-run true --once true");
     expect(output.commands.existing).toContain("provider-throttle-report");
@@ -132,6 +137,99 @@ describe("public NeonDiff CLI surface", () => {
     ]);
     expect(stdout).toContain("does not include hosted model credits");
     expect(stdout).not.toMatch(/"includedHostedModelCredits":\s*true|bundled provider tokens included/i);
+  });
+
+  it("doctor github proves App installation reads without printing secrets", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-doctor-github-"));
+    roots.push(root);
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+    const privateKeyPath = join(root, "neondiff.private-key.pem");
+    const installationToken = "installation-token-secret";
+    writeFileSync(privateKeyPath, privateKeyPem);
+
+    const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      response.setHeader("Content-Type", "application/json");
+      if (request.method === "GET" && url.pathname === "/repos/acme/demo/installation") {
+        response.end(JSON.stringify({ id: 42 }));
+        return;
+      }
+      if (request.method === "POST" && url.pathname === "/app/installations/42/access_tokens") {
+        response.end(JSON.stringify({ token: installationToken, expires_at: "2099-01-01T00:00:00Z" }));
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/repos/acme/demo/pulls") {
+        expect(request.headers.authorization).toBe(`Bearer ${installationToken}`);
+        response.end(JSON.stringify([]));
+        return;
+      }
+      response.statusCode = 404;
+      response.end(JSON.stringify({ message: `unexpected ${request.method} ${url.pathname}` }));
+    });
+
+    await listen(server);
+    try {
+      const address = server.address() as AddressInfo;
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        pilotRepos: ["acme/demo"],
+        workRoot: join(root, "runtime"),
+        statePath: join(root, "state.sqlite"),
+        evidenceDir: join(root, "evidence"),
+        github: {
+          appId: "12345",
+          privateKeyPath,
+          apiBaseUrl: `http://127.0.0.1:${address.port}`
+        },
+        zcode: {
+          cliPath: "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
+          appConfigPath: join(root, "zcode-config.json"),
+          model: "GLM-5.2",
+          timeoutMs: 1000,
+          maxPatchBytes: 1000,
+          retryMaxRetries: 0
+        }
+      })}\n`);
+
+      const { stdout } = await runCli(["doctor", "github", "--config", configPath], {
+        env: {
+          EVAOS_REVIEW_BOT_APP_ID: "12345",
+          EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: privateKeyPath
+        }
+      });
+      const output = JSON.parse(stdout);
+
+      expect(output).toMatchObject({
+        ok: true,
+        command: "doctor github",
+        activeRepoChecks: 1,
+        appCredentials: {
+          appIdConfigured: true,
+          privateKeyConfigured: true,
+          fallbackTokenConfigured: false
+        },
+        github: {
+          canPostAsApp: true,
+          readMode: "app_installation",
+          readChecks: [
+            {
+              repo: "acme/demo",
+              ok: true,
+              openPullCount: 0
+            }
+          ]
+        }
+      });
+      expect(output.requiredRepositoryPermissions).toContain("Pull requests: read/write");
+      expect(output.optionalPermissions.join(" ")).toMatch(/issue-enrichment/i);
+      expect(output.licenseBoundary.privateRepoDataStaysLocal).toBe(true);
+      expect(stdout).not.toContain(privateKeyPem);
+      expect(stdout).not.toContain(privateKeyPath);
+      expect(stdout).not.toContain(installationToken);
+    } finally {
+      await closeServer(server);
+    }
   });
 
   it("rejects non-boolean public rollback ref verification values", async () => {
@@ -2036,7 +2134,7 @@ describe("public NeonDiff CLI surface", () => {
   });
 });
 
-async function runCli(args: string[], options: { cwd?: string; timeout?: number } = {}) {
+async function runCli(args: string[], options: { cwd?: string; timeout?: number; env?: NodeJS.ProcessEnv } = {}) {
   return execFileAsync(process.execPath, [tsxCliPath, join(repoRoot, "src/cli.ts"), ...args], {
     cwd: options.cwd ?? repoRoot,
     encoding: "utf8",
@@ -2044,11 +2142,31 @@ async function runCli(args: string[], options: { cwd?: string; timeout?: number 
       ...process.env,
       EVAOS_REVIEW_BOT_APP_ID: "",
       EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: "",
-      GITHUB_TOKEN: ""
+      GITHUB_TOKEN: "",
+      ...options.env
     },
     timeout: options.timeout ?? 15_000,
     killSignal: "SIGTERM",
     maxBuffer: 1024 * 1024
+  });
+}
+
+function listen(server: ReturnType<typeof createServer>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
   });
 }
 

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -14,6 +14,7 @@ describe("NeonDiff public community funnel", () => {
       /local-first AI PR reviewer/i,
       /https:\/\/www\.neondiff\.com/i,
       /docs\/SETUP\.md/i,
+      /docs\/github-app-setup\.md/i,
       /CONTRIBUTING\.md/i,
       /AGENTS\.md/i,
       /SECURITY\.md/i,
@@ -104,13 +105,17 @@ describe("NeonDiff public community funnel", () => {
 
   it("setup guide gives a first-run path without hiding safety prerequisites in operator runbooks", () => {
     const setup = read("docs/SETUP.md");
+    const githubApp = read("docs/github-app-setup.md");
 
     for (const required of [
       /^# NeonDiff Setup/m,
       /Requirements/i,
       /GitHub App/i,
+      /github-app-setup\.md/i,
       /Contents: read/i,
       /Pull requests: read\/write/i,
+      /doctor github/i,
+      /app_installation/i,
       /provider/i,
       /license/i,
       /config/i,
@@ -124,6 +129,35 @@ describe("NeonDiff public community funnel", () => {
     }
 
     expect(setup).not.toMatch(/BEGIN (RSA|OPENSSH|PRIVATE) KEY|ghp_|github_pat_|sk-[A-Za-z0-9]/);
+    expect(githubApp).toMatch(/^# GitHub App Install And Onboarding/m);
+    for (const required of [
+      /Install URL/i,
+      /Selected-Repo Install Path/i,
+      /Only select repositories/i,
+      /Repository Permissions/i,
+      /Metadata: read/i,
+      /Contents: read/i,
+      /Pull requests: read\/write/i,
+      /Checks: read/i,
+      /Actions: read/i,
+      /issue-enrichment permissions are separate from PR review/i,
+      /issueEnrichment\.allowlist/i,
+      /neondiff doctor github --config config\.local\.json --json/i,
+      /activeRepoChecks/i,
+      /First Review Path/i,
+      /dry-run true/i,
+      /App bot, not the human user token/i,
+      /License Boundary/i,
+      /Public open-source repositories are free/i,
+      /Private and commercial repositories require/i,
+      /Private repo data stays local/i,
+      /Uninstall/i,
+      /Troubleshooting/i,
+      /Evidence To Save/i
+    ]) {
+      expect(githubApp).toMatch(required);
+    }
+    expect(githubApp).not.toMatch(/BEGIN (RSA|OPENSSH|PRIVATE) KEY|ghp_|github_pat_|sk-[A-Za-z0-9]/);
   });
 
   it("CONTRIBUTING and AGENTS are useful to humans and coding agents", () => {


### PR DESCRIPTION
## Summary
- add `neondiff doctor github` for GitHub App install/readiness checks without provider or ZCode calls
- rewrite the GitHub App setup page into public selected-repo onboarding, uninstall, troubleshooting, license-boundary, and evidence guidance
- link the onboarding path from README/SETUP and cover it with public CLI/docs tests

## Validation
- `NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/public-cli.test.ts tests/public-community-funnel.test.ts --pool forks`
- `NODE_OPTIONS=--experimental-sqlite npm run build`
- `git diff --check`
- no-credential `./dist/src/cli.js doctor github --config <tmp-config> --json` smoke fails locally with setup guidance

## Operational Proof
- evaOS App review posted for exact head `6eb4556e9ebfeec13a4dd284215139a9c3fa2a83`: https://github.com/electricsheephq/evaos-code-review-bot/pull/196#pullrequestreview-4628684576
- `why` after reconciliation: processed=1, queued=0, providerDeferred=0, staleHeads=0
- `release:status` after reconciliation: ok, launchd running, no failed queue jobs, no provider cooldown backlog, no stale review leases

Related #106

## Proof Boundary
This implements the local CLI/docs onboarding slice for #106. It does not close #106 by itself because the issue still requires a fresh external App install smoke, private-repo missing-license smoke, permissions snapshot, and first App-authored review URL.