### PR TITLE
Add provider registry operator surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ source-available beta, not an open-source or GA release.
 [Agent Instructions](AGENTS.md) · [Security](SECURITY.md) ·
 [Code of Conduct](CODE_OF_CONDUCT.md) · [License](LICENSE.md) ·
 [License Boundary](docs/license-boundary.md) · [Pricing](docs/pricing.md) ·
+[Providers](docs/providers.md) ·
 [Roadmap](https://github.com/electricsheephq/evaos-code-review-bot/issues/103)
 
 ## Why It Matters
@@ -86,6 +87,8 @@ neondiff init --config config.local.json
 export EVAOS_REVIEW_BOT_APP_ID="<github-app-id>"
 export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 neondiff doctor github --config config.local.json --json
+neondiff providers list --config config.local.json --json
+neondiff providers doctor --config config.local.json --json
 neondiff doctor --config config.local.json --json
 ```
 

--- a/config.example.json
+++ b/config.example.json
@@ -60,6 +60,63 @@
     "openAICompatibleEndpoint": "http://localhost:8000/v1",
     "updateChannel": "dev"
   },
+  "providers": {
+    "_comment": "Provider registry metadata for operator/desktop setup. API keys stay in environment variables or provider app config, never in this JSON file.",
+    "defaultProviderId": "zcode-glm",
+    "providers": {
+      "zcode-glm": {
+        "enabled": true,
+        "adapter": "zcode",
+        "displayName": "GLM/Z.ai through ZCode",
+        "model": "GLM-5.2",
+        "authMode": "zcode-app-config",
+        "contextWindowTokens": 128000,
+        "timeoutMs": 180000,
+        "retryMaxRetries": 0,
+        "capabilities": {
+          "review": true,
+          "jsonOutput": true,
+          "local": false,
+          "streaming": false
+        }
+      },
+      "ollama-local": {
+        "enabled": false,
+        "adapter": "openai-compatible",
+        "displayName": "Ollama local OpenAI-compatible endpoint",
+        "baseUrl": "http://localhost:11434/v1",
+        "model": "qwen2.5-coder:7b",
+        "authMode": "none",
+        "contextWindowTokens": 32000,
+        "timeoutMs": 180000,
+        "retryMaxRetries": 1,
+        "capabilities": {
+          "review": true,
+          "jsonOutput": true,
+          "local": true,
+          "streaming": false
+        }
+      },
+      "openai-compatible": {
+        "enabled": false,
+        "adapter": "openai-compatible",
+        "displayName": "OpenAI-compatible BYOK or gateway endpoint",
+        "baseUrl": "https://example.invalid/v1",
+        "model": "model-id",
+        "authMode": "api-key-env",
+        "apiKeyEnv": "NEONDIFF_PROVIDER_API_KEY",
+        "contextWindowTokens": 128000,
+        "timeoutMs": 180000,
+        "retryMaxRetries": 1,
+        "capabilities": {
+          "review": true,
+          "jsonOutput": true,
+          "local": false,
+          "streaming": false
+        }
+      }
+    }
+  },
   "commands": {
     "enabled": false,
     "botMentions": ["@evaos-code-review-bot"],

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -79,6 +79,11 @@ For the current internal provider path, the worker derives transient ZCode/GLM
 environment from the local app config referenced by `config.local.json`. Do not
 copy provider API keys into this repository.
 
+Use [docs/providers.md](providers.md) for GLM/Z.ai, Ollama, and
+OpenAI-compatible endpoint examples. The provider registry stores metadata such
+as provider id, base URL, model id, timeout, retry policy, and an API-key
+environment variable name; it must not store the API key itself.
+
 If you are reviewing private or commercial repos, set your license key through
 the configured local secret path or environment used by your operator wrapper.
 Do not paste license keys into tracked config.
@@ -155,6 +160,8 @@ Check:
 Then run full doctor with the config you intend to use:
 
 ```bash
+neondiff providers list --config config.local.json --json
+neondiff providers doctor --config config.local.json --json
 neondiff doctor --config config.local.json --json
 ```
 
@@ -164,6 +171,7 @@ The full doctor output is JSON. Check:
 - `github.readMode`
 - each `github.readChecks[]`
 - provider readiness
+- provider registry readiness from `providers doctor`
 - repo policy allow/skip state
 
 ## 5. Run A Dry-Run Review

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -33,6 +33,10 @@ neondiff providers doctor \
   --json
 ```
 
+The example `ollama-local` provider is disabled by default. Enable it in
+`config.local.json` or with a dry-run-verified config patch before running the
+smoke command; otherwise the doctor exits before calling `/models`.
+
 ## GLM/Z.ai Through ZCode
 
 The default beta provider is `zcode-glm`. It delegates auth and endpoint

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -94,8 +94,8 @@ does not need an API key:
 }
 ```
 
-For BYOK gateways, store only the environment variable name in config. This
-field must not store the API key:
+For BYOK gateways, store only an uppercase environment variable name in config.
+This field must not store the API key:
 
 ```json
 {

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,9 +1,11 @@
 # NeonDiff Provider Registry
 
-NeonDiff is local-first: repository data stays on the worker machine and model
-credentials stay in local app config, environment variables, Keychain-backed
-wrappers, or a local model runtime. Do not paste provider API keys into tracked
-config, GitHub comments, release notes, or evidence packets.
+NeonDiff is local-first for checkout state, evidence, credentials, and operator
+control. Repository prompts and diffs can still leave the worker when you choose
+a hosted model provider such as ZCode-backed GLM/Z.ai or a hosted
+OpenAI-compatible gateway. For no-egress review, use a local model runtime. Do
+not paste provider API keys into tracked config, GitHub comments, release notes,
+or evidence packets.
 
 The current live review engine remains ZCode-backed. The provider registry is
 the public setup and operator surface for declaring available providers before
@@ -36,8 +38,8 @@ neondiff providers doctor \
 The example `ollama-local` provider is disabled by default. Enable it in
 `config.local.json` or with a dry-run-verified config patch before running the
 smoke command; otherwise the doctor exits before calling `/models`. Smoke checks
-must include `--provider` so a single command cannot fan out authenticated
-requests to every enabled provider.
+are local-loopback only in this beta and must include `--provider` so a single
+command cannot fan out authenticated requests to every enabled provider.
 
 ## GLM/Z.ai Through ZCode
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,146 @@
+# NeonDiff Provider Registry
+
+NeonDiff is local-first: repository data stays on the worker machine and model
+credentials stay in local app config, environment variables, Keychain-backed
+wrappers, or a local model runtime. Do not paste provider API keys into tracked
+config, GitHub comments, release notes, or evidence packets.
+
+The current live review engine remains ZCode-backed. The provider registry is
+the public setup and operator surface for declaring available providers before
+alternate adapter execution is promoted.
+
+## Commands
+
+List configured providers without printing secrets:
+
+```bash
+neondiff providers list --config config.local.json --json
+```
+
+Check enabled provider metadata:
+
+```bash
+neondiff providers doctor --config config.local.json --json
+```
+
+Smoke an OpenAI-compatible `/models` endpoint:
+
+```bash
+neondiff providers doctor \
+  --config config.local.json \
+  --provider ollama-local \
+  --smoke true \
+  --json
+```
+
+## GLM/Z.ai Through ZCode
+
+The default beta provider is `zcode-glm`. It delegates auth and endpoint
+resolution to the local ZCode app config referenced by `zcode.appConfigPath`.
+NeonDiff derives a transient runtime environment for the ZCode child process and
+writes only redacted provider metadata into evidence.
+
+```json
+{
+  "providers": {
+    "defaultProviderId": "zcode-glm",
+    "providers": {
+      "zcode-glm": {
+        "enabled": true,
+        "adapter": "zcode",
+        "model": "GLM-5.2",
+        "authMode": "zcode-app-config",
+        "capabilities": {
+          "review": true,
+          "jsonOutput": true,
+          "local": false,
+          "streaming": false
+        }
+      }
+    }
+  }
+}
+```
+
+## Ollama Or OpenAI-Compatible Endpoint
+
+Ollama, LM Studio, vLLM, local gateways, and hosted gateways can be described as
+`openai-compatible` when they expose an OpenAI-style API. Local Ollama normally
+does not need an API key:
+
+```json
+{
+  "providers": {
+    "providers": {
+      "ollama-local": {
+        "enabled": true,
+        "adapter": "openai-compatible",
+        "baseUrl": "http://localhost:11434/v1",
+        "model": "qwen2.5-coder:7b",
+        "authMode": "none",
+        "capabilities": {
+          "review": true,
+          "jsonOutput": true,
+          "local": true,
+          "streaming": false
+        }
+      }
+    }
+  }
+}
+```
+
+For BYOK gateways, store only the environment variable name in config. This
+field must not store the API key:
+
+```json
+{
+  "providers": {
+    "providers": {
+      "openai-compatible": {
+        "enabled": true,
+        "adapter": "openai-compatible",
+        "baseUrl": "https://gateway.example.com/v1",
+        "model": "model-id",
+        "authMode": "api-key-env",
+        "apiKeyEnv": "NEONDIFF_PROVIDER_API_KEY",
+        "capabilities": {
+          "review": true,
+          "jsonOutput": true,
+          "local": false,
+          "streaming": false
+        }
+      }
+    }
+  }
+}
+```
+
+Then export the key in the operator wrapper, not in JSON:
+
+```bash
+export NEONDIFF_PROVIDER_API_KEY="..."
+neondiff providers doctor --config config.local.json --provider openai-compatible --smoke true --json
+```
+
+## Error Categories
+
+Provider checks normalize common failures into these categories:
+
+- `auth`
+- `quota_or_rate_limit`
+- `transient`
+- `timeout`
+- `context_limit`
+- `model_output_schema`
+- `unknown`
+
+Retries and cooldowns must stay bounded and observable. A transient provider
+error should not kill the daemon or globally pause unrelated providers.
+
+## Proof Boundary
+
+This registry does not claim CodeRabbit parity, calibrated review accuracy, or
+that all listed providers can execute live reviews. A provider should be promoted
+to live review only after mocked adapter tests, fixture review proof, redaction
+proof, duplicate-suppression proof, and release-status evidence pass.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -35,7 +35,9 @@ neondiff providers doctor \
 
 The example `ollama-local` provider is disabled by default. Enable it in
 `config.local.json` or with a dry-run-verified config patch before running the
-smoke command; otherwise the doctor exits before calling `/models`.
+smoke command; otherwise the doctor exits before calling `/models`. Smoke checks
+must include `--provider` so a single command cannot fan out authenticated
+requests to every enabled provider.
 
 ## GLM/Z.ai Through ZCode
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,6 +49,7 @@ import {
   type OperatorQueueSnapshot
 } from "./operator-cli.js";
 import { buildPricingOutput } from "./pricing.js";
+import { buildProviderRegistrySummary, doctorProviderRegistry } from "./providers.js";
 import { collectReleaseStatus, type ReleaseStatus } from "./release-status.js";
 import { buildReviewHeadGate } from "./review-head-gate.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown } from "./repo-memory.js";
@@ -119,6 +120,40 @@ async function main(): Promise<void> {
   if (command === "pricing") {
     console.log(stringifyRedactedJson(buildPricingOutput()));
     return;
+  }
+
+  if (command === "providers") {
+    const action = args._[1];
+    const config = loadConfig(args.config);
+    if (action === "list") {
+      console.log(stringifyProviderOutput({
+        ok: true,
+        command: "providers list",
+        proofBoundary: "Provider registry visibility only; live review execution remains ZCode-backed until adapter rollout evidence passes.",
+        ...buildProviderRegistrySummary({
+          registry: config.providers!,
+          currentZCode: {
+            providerId: config.zcode.providerId,
+            model: config.zcode.model
+          }
+        })
+      }));
+      return;
+    }
+    if (action === "doctor") {
+      const result = await doctorProviderRegistry({
+        registry: config.providers!,
+        ...(args.provider ? { providerId: parseSingleArg(args.provider, "--provider") } : {}),
+        smoke: args.smoke === undefined ? false : parseBooleanArg(args.smoke, "--smoke")
+      });
+      console.log(stringifyProviderOutput({
+        ...result,
+        proofBoundary: "Provider readiness check only; alternate providers are not selected for live review execution by this command."
+      }));
+      if (!result.ok) process.exitCode = 1;
+      return;
+    }
+    throw new Error("providers subcommand must be one of: list, doctor");
   }
 
   if (command === "license") {
@@ -2205,6 +2240,8 @@ function buildHelp(command?: string) {
         "config inspect",
         "config patch",
         "pricing",
+        "providers list",
+        "providers doctor",
         "doctor",
         "doctor github",
         "daemon start",
@@ -2260,6 +2297,9 @@ function buildHelp(command?: string) {
       "neondiff config patch --config config.local.json --input desktop-patch.json --dry-run true",
       "desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}",
       "neondiff pricing",
+      "neondiff providers list --config config.local.json --json",
+      "neondiff providers doctor --config config.local.json --json",
+      "neondiff providers doctor --config config.local.json --provider ollama-local --smoke true --json",
       "neondiff license activate --config config.local.json --license-key-env NEONDIFF_LICENSE_KEY --json",
       "neondiff license status --config config.local.json --json",
       "neondiff license deactivate --config config.local.json --json",
@@ -2298,6 +2338,22 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ]
   };
+}
+
+function stringifyProviderOutput(input: unknown): string {
+  return JSON.stringify(redactProviderOutput(input), null, 2);
+}
+
+function redactProviderOutput(input: unknown, key?: string): unknown {
+  if (typeof input === "string") return key === "apiKeyEnv" ? input : redactSecrets(input);
+  if (input instanceof Date) return input.toISOString();
+  if (Array.isArray(input)) return input.map((item) => redactProviderOutput(item));
+  if (input && typeof input === "object") {
+    const output: Record<string, unknown> = {};
+    for (const [entryKey, value] of Object.entries(input)) output[entryKey] = redactProviderOutput(value, entryKey);
+    return output;
+  }
+  return input;
 }
 
 function isHelpRequested(args: ParsedArgs): boolean {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,7 @@ import {
   type OperatorQueueSnapshot
 } from "./operator-cli.js";
 import { buildPricingOutput } from "./pricing.js";
-import { buildProviderRegistrySummary, doctorProviderRegistry } from "./providers.js";
+import { buildProviderRegistrySummary, doctorProviderRegistry, isProviderId } from "./providers.js";
 import { collectReleaseStatus, type ReleaseStatus } from "./release-status.js";
 import { buildReviewHeadGate } from "./review-head-gate.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown } from "./repo-memory.js";
@@ -141,9 +141,19 @@ async function main(): Promise<void> {
       return;
     }
     if (action === "doctor") {
+      const providerId = args.provider ? parseSingleArg(args.provider, "--provider") : undefined;
+      if (providerId && !isProviderId(providerId)) {
+        console.log(stringifyProviderOutput({
+          ok: false,
+          command: "providers doctor",
+          error: "--provider must be a stable provider identifier"
+        }));
+        process.exitCode = 1;
+        return;
+      }
       const result = await doctorProviderRegistry({
         registry: config.providers!,
-        ...(args.provider ? { providerId: parseSingleArg(args.provider, "--provider") } : {}),
+        ...(providerId ? { providerId } : {}),
         smoke: args.smoke === undefined ? false : parseBooleanArg(args.smoke, "--smoke")
       });
       console.log(stringifyProviderOutput({

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -375,9 +375,15 @@ function maskAllowedSecretPointerFields(value: unknown): unknown {
   if (!isRecord(value)) return value;
   const output: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
-    output[key] = key === "apiKeyEnv" && typeof entry === "string" ? "[env-var-name]" : maskAllowedSecretPointerFields(entry);
+    output[key] = key === "apiKeyEnv" && typeof entry === "string" && isEnvVarName(entry)
+      ? "[env-var-name]"
+      : maskAllowedSecretPointerFields(entry);
   }
   return output;
+}
+
+function isEnvVarName(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -15,7 +15,7 @@ import { dirname, resolve } from "node:path";
 import { loadConfig, loadConfigFromObject, type RepoProfileConfig } from "./config.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
-const SECRET_KEY_PATTERN = /(?:token|secret|password|cookie|license|api[_-]?key|privateKey)/i;
+const SECRET_KEY_PATTERN = /(?:token|secret|password|cookie|license|api[_-]?key(?!env)|privateKey)/i;
 const REPO_PROFILE_DESKTOP_SAFE_FIELDS = [
   "enabled",
   "displayName",
@@ -47,7 +47,8 @@ const EXACT_PATCH_PATHS = new Set([
   "github.botLogin",
   "github.requestTimeoutMs",
   "desktop.openAICompatibleEndpoint",
-  "desktop.updateChannel"
+  "desktop.updateChannel",
+  "providers.defaultProviderId"
 ]);
 
 const REPO_PROFILE_FIELD_PATTERN =
@@ -55,6 +56,12 @@ const REPO_PROFILE_FIELD_PATTERN =
 
 const REPO_PROFILE_NESTED_PATTERN =
   new RegExp(`^repoProfiles\\.repos\\.(${CONFIG_NAME_SEGMENT_PATTERN}\\/${CONFIG_NAME_SEGMENT_PATTERN})\\.(?:autoReview\\.(?:baseBranches|labels)|preMergeChecks\\.(?:title|description|linkedIssue|testEvidence|docs|docstrings)\\.(?:mode|instructions|threshold)|finishingTouches\\.(?:docs|docstrings|unitTests|simplifySuggestion|changelogDraft|riskExplanation|reviewReady|stackedPr)\\.(?:enabled|instructions))$`);
+
+const PROVIDER_SAFE_FIELD_PATTERN =
+  new RegExp(`^providers\\.providers\\.(${CONFIG_NAME_SEGMENT_PATTERN})\\.(?:enabled|adapter|displayName|baseUrl|model|authMode|apiKeyEnv|contextWindowTokens|timeoutMs|retryMaxRetries)$`);
+
+const PROVIDER_CAPABILITY_PATTERN =
+  new RegExp(`^providers\\.providers\\.(${CONFIG_NAME_SEGMENT_PATTERN})\\.capabilities\\.(?:review|jsonOutput|local|streaming)$`);
 
 export interface ConfigInspectResult {
   ok: true;
@@ -161,7 +168,7 @@ export function patchConfigForDesktop(input: {
   if (unsupportedKey) {
     return failedPatch(input, configPath, inputPath, unsupportedDottedKeyError(unsupportedKey));
   }
-  const patchText = JSON.stringify(patch);
+  const patchText = JSON.stringify(maskAllowedSecretPointerFields(patch));
   if (containsSecretLikeText(patchText)) {
     return failedPatch(input, configPath, inputPath, "patch input contains secret-like text; store provider and license keys in Keychain instead");
   }
@@ -219,7 +226,9 @@ export function redactConfigObject(value: unknown): unknown {
   }
   const output: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
-    output[key] = SECRET_KEY_PATTERN.test(key) ? redactSecretValue(entry) : redactConfigObject(entry);
+    output[key] = key === "apiKeyEnv" && typeof entry === "string"
+      ? entry
+      : SECRET_KEY_PATTERN.test(key) ? redactSecretValue(entry) : redactConfigObject(entry);
   }
   return output;
 }
@@ -227,6 +236,8 @@ export function redactConfigObject(value: unknown): unknown {
 export function editablePatchPaths(): string[] {
   return [
     ...EXACT_PATCH_PATHS,
+    "providers.providers.<provider-id>.<desktop-safe-provider-field>",
+    "providers.providers.<provider-id>.capabilities.<capability>",
     "repoProfiles.repos.<owner/repo>.<desktop-safe-field>",
     "repoProfiles.orgFallbacks.<owner>.<desktop-safe-field>"
   ].sort();
@@ -269,7 +280,11 @@ function isPatchPathAllowed(path: string): boolean {
     return repo ? isConfigRepoName(repo) : Boolean(owner && isConfigNameSegment(owner));
   }
   const nestedMatch = path.match(REPO_PROFILE_NESTED_PATTERN);
-  return Boolean(nestedMatch?.[1] && isConfigRepoName(nestedMatch[1]));
+  if (nestedMatch?.[1] && isConfigRepoName(nestedMatch[1])) return true;
+  const providerFieldMatch = path.match(PROVIDER_SAFE_FIELD_PATTERN);
+  if (providerFieldMatch?.[1] && isConfigNameSegment(providerFieldMatch[1])) return true;
+  const providerCapabilityMatch = path.match(PROVIDER_CAPABILITY_PATTERN);
+  return Boolean(providerCapabilityMatch?.[1] && isConfigNameSegment(providerCapabilityMatch[1]));
 }
 
 function setNestedValue(target: Record<string, unknown>, path: string[], value: unknown): void {
@@ -353,6 +368,16 @@ function writeConfigAtomic(configPath: string, value: unknown, fileOps?: Partial
 function redactSecretValue(value: unknown): unknown {
   if (value === undefined || value === null) return value;
   return "[redacted-secret]";
+}
+
+function maskAllowedSecretPointerFields(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((entry) => maskAllowedSecretPointerFields(entry));
+  if (!isRecord(value)) return value;
+  const output: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    output[key] = key === "apiKeyEnv" && typeof entry === "string" ? "[env-var-name]" : maskAllowedSecretPointerFields(entry);
+  }
+  return output;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -13,6 +13,7 @@ import {
 } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { loadConfig, loadConfigFromObject, type RepoProfileConfig } from "./config.js";
+import { isApiKeyEnvName } from "./providers.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 const SECRET_KEY_PATTERN = /(?:token|secret|password|cookie|license|api[_-]?key(?!env)|privateKey)/i;
@@ -375,15 +376,11 @@ function maskAllowedSecretPointerFields(value: unknown): unknown {
   if (!isRecord(value)) return value;
   const output: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
-    output[key] = key === "apiKeyEnv" && typeof entry === "string" && isEnvVarName(entry)
+    output[key] = key === "apiKeyEnv" && typeof entry === "string" && isApiKeyEnvName(entry)
       ? "[env-var-name]"
       : maskAllowedSecretPointerFields(entry);
   }
   return output;
-}
-
-function isEnvVarName(value: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ import { DEFAULT_ISSUE_ENRICHMENT_CONFIG, type IssueEnrichmentConfig } from "./i
 import type { LicenseConfig } from "./license.js";
 import { assertPathOutsideProtectedRoot, getProtectedCheckoutRoots } from "./path-safety.js";
 import { isApiKeyEnvName, isProviderId, type ProviderRegistryConfig } from "./providers.js";
+import { containsSecretLikeText } from "./secrets.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
 
 const MAX_LICENSE_OFFLINE_GRACE_MS = 15 * 60_000;
@@ -914,6 +915,9 @@ function validateProviderBaseUrl(value: string, label: string): void {
   }
   if (parsed.protocol !== "https:" && parsed.protocol !== "http:") throw new Error(`${label} must use http or https`);
   if (parsed.username || parsed.password) throw new Error(`${label} must not include username or password credentials`);
+  if (containsSecretLikeText(decodeURIComponent(`${parsed.pathname}${parsed.hash}`))) {
+    throw new Error(`${label} must not include secret-like path or fragment values`);
+  }
   for (const key of parsed.searchParams.keys()) {
     if (/(key|token|secret|password|session|cookie)/i.test(key)) {
       throw new Error(`${label} must not include credential query parameters`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ import type { GitHubRelatedContextConfig } from "./github-related-context.js";
 import { DEFAULT_ISSUE_ENRICHMENT_CONFIG, type IssueEnrichmentConfig } from "./issue-enrichment.js";
 import type { LicenseConfig } from "./license.js";
 import { assertPathOutsideProtectedRoot, getProtectedCheckoutRoots } from "./path-safety.js";
-import type { ProviderRegistryConfig } from "./providers.js";
+import { isProviderId, type ProviderRegistryConfig } from "./providers.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
 
 const MAX_LICENSE_OFFLINE_GRACE_MS = 15 * 60_000;
@@ -814,7 +814,9 @@ function validateProviderRegistryConfig(value: unknown, label: string): void {
 function validateProviderRegistryEntry(value: unknown, label: string): void {
   if (!isRecord(value)) throw new Error(`${label} must be an object`);
   validateBoolean(value.enabled, `${label}.enabled`);
-  if (!["zcode", "openai-compatible", "anthropic", "openai", "gemini"].includes(String(value.adapter))) {
+  const adapter = String(value.adapter);
+  const authMode = String(value.authMode);
+  if (!["zcode", "openai-compatible", "anthropic", "openai", "gemini"].includes(adapter)) {
     throw new Error(`${label}.adapter must be zcode, openai-compatible, anthropic, openai, or gemini`);
   }
   validateOptionalString(value.displayName, `${label}.displayName`);
@@ -822,9 +824,10 @@ function validateProviderRegistryEntry(value: unknown, label: string): void {
   if (typeof value.baseUrl === "string") validateProviderBaseUrl(value.baseUrl, `${label}.baseUrl`);
   validateOptionalString(value.model, `${label}.model`);
   if (typeof value.model !== "string" || value.model.trim().length === 0) throw new Error(`${label}.model must be a non-empty string`);
-  if (!["zcode-app-config", "api-key-env", "none"].includes(String(value.authMode))) {
+  if (!["zcode-app-config", "api-key-env", "none"].includes(authMode)) {
     throw new Error(`${label}.authMode must be zcode-app-config, api-key-env, or none`);
   }
+  validateProviderAdapterAuthMode(adapter, authMode, label);
   validateOptionalString(value.apiKeyEnv, `${label}.apiKeyEnv`);
   if (typeof value.apiKeyEnv === "string" && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(value.apiKeyEnv)) {
     throw new Error(`${label}.apiKeyEnv must be an environment variable name`);
@@ -836,16 +839,29 @@ function validateProviderRegistryEntry(value: unknown, label: string): void {
   for (const capability of ["review", "jsonOutput", "local", "streaming"] as const) {
     validateBoolean(value.capabilities[capability], `${label}.capabilities.${capability}`);
   }
-  if (value.adapter === "openai-compatible" && value.enabled === true && typeof value.baseUrl !== "string") {
+  if (adapter === "openai-compatible" && value.enabled === true && typeof value.baseUrl !== "string") {
     throw new Error(`${label}.baseUrl is required when enabled openai-compatible provider`);
   }
-  if (value.authMode === "api-key-env" && value.enabled === true && typeof value.apiKeyEnv !== "string") {
+  if (authMode === "api-key-env" && value.enabled === true && typeof value.apiKeyEnv !== "string") {
     throw new Error(`${label}.apiKeyEnv is required when enabled provider uses api-key-env`);
   }
 }
 
+function validateProviderAdapterAuthMode(adapter: string, authMode: string, label: string): void {
+  const allowedByAdapter: Record<string, string[]> = {
+    zcode: ["zcode-app-config"],
+    "openai-compatible": ["api-key-env", "none"],
+    anthropic: ["api-key-env"],
+    openai: ["api-key-env"],
+    gemini: ["api-key-env"]
+  };
+  if (!allowedByAdapter[adapter]?.includes(authMode)) {
+    throw new Error(`${label}.authMode ${authMode} is not supported for ${adapter} provider`);
+  }
+}
+
 function validateProviderId(value: string, label: string): void {
-  if (!/^[A-Za-z0-9_.:-]+$/.test(value) || value === "." || value === "..") {
+  if (!isProviderId(value)) {
     throw new Error(`${label} keys must be stable provider identifiers`);
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ import type { GitHubRelatedContextConfig } from "./github-related-context.js";
 import { DEFAULT_ISSUE_ENRICHMENT_CONFIG, type IssueEnrichmentConfig } from "./issue-enrichment.js";
 import type { LicenseConfig } from "./license.js";
 import { assertPathOutsideProtectedRoot, getProtectedCheckoutRoots } from "./path-safety.js";
-import { isProviderId, type ProviderRegistryConfig } from "./providers.js";
+import { isApiKeyEnvName, isProviderId, type ProviderRegistryConfig } from "./providers.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
 
 const MAX_LICENSE_OFFLINE_GRACE_MS = 15 * 60_000;
@@ -829,8 +829,8 @@ function validateProviderRegistryEntry(value: unknown, label: string): void {
   }
   validateProviderAdapterAuthMode(adapter, authMode, label);
   validateOptionalString(value.apiKeyEnv, `${label}.apiKeyEnv`);
-  if (typeof value.apiKeyEnv === "string" && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(value.apiKeyEnv)) {
-    throw new Error(`${label}.apiKeyEnv must be an environment variable name`);
+  if (typeof value.apiKeyEnv === "string" && !isApiKeyEnvName(value.apiKeyEnv)) {
+    throw new Error(`${label}.apiKeyEnv must be an uppercase environment variable name, not a provider key`);
   }
   if (value.contextWindowTokens !== undefined) validatePositiveInteger(value.contextWindowTokens, `${label}.contextWindowTokens`);
   if (value.timeoutMs !== undefined) validatePositiveInteger(value.timeoutMs, `${label}.timeoutMs`);
@@ -874,6 +874,12 @@ function validateProviderBaseUrl(value: string, label: string): void {
     throw new Error(`${label} must be a valid URL`);
   }
   if (parsed.protocol !== "https:" && parsed.protocol !== "http:") throw new Error(`${label} must use http or https`);
+  if (parsed.username || parsed.password) throw new Error(`${label} must not include username or password credentials`);
+  for (const key of parsed.searchParams.keys()) {
+    if (/(key|token|secret|password|session|cookie)/i.test(key)) {
+      throw new Error(`${label} must not include credential query parameters`);
+    }
+  }
   if (parsed.protocol === "http:" && !isLoopbackHost(parsed.hostname)) {
     throw new Error(`${label} must use https unless it points to localhost/loopback`);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import type { GitHubRelatedContextConfig } from "./github-related-context.js";
 import { DEFAULT_ISSUE_ENRICHMENT_CONFIG, type IssueEnrichmentConfig } from "./issue-enrichment.js";
 import type { LicenseConfig } from "./license.js";
 import { assertPathOutsideProtectedRoot, getProtectedCheckoutRoots } from "./path-safety.js";
+import type { ProviderRegistryConfig } from "./providers.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
 
 const MAX_LICENSE_OFFLINE_GRACE_MS = 15 * 60_000;
@@ -58,6 +59,7 @@ export interface BotConfig {
   issueEnrichment?: IssueEnrichmentConfig;
   license?: LicenseConfig;
   desktop?: DesktopConfig;
+  providers?: ProviderRegistryConfig;
   repoProfiles?: RepoProfilesConfig;
   commands: CommandConfig;
   zcode: {
@@ -292,6 +294,113 @@ const DEFAULT_CONFIG: BotConfig = {
     openAICompatibleEndpoint: "http://localhost:8000/v1",
     updateChannel: "dev"
   },
+  providers: {
+    defaultProviderId: "zcode-glm",
+    providers: {
+      "zcode-glm": {
+        enabled: true,
+        adapter: "zcode",
+        displayName: "GLM/Z.ai through ZCode",
+        model: "GLM-5.2",
+        authMode: "zcode-app-config",
+        contextWindowTokens: 128_000,
+        timeoutMs: 180_000,
+        retryMaxRetries: 0,
+        capabilities: {
+          review: true,
+          jsonOutput: true,
+          local: false,
+          streaming: false
+        }
+      },
+      "ollama-local": {
+        enabled: false,
+        adapter: "openai-compatible",
+        displayName: "Ollama local OpenAI-compatible endpoint",
+        baseUrl: "http://localhost:11434/v1",
+        model: "qwen2.5-coder:7b",
+        authMode: "none",
+        contextWindowTokens: 32_000,
+        timeoutMs: 180_000,
+        retryMaxRetries: 1,
+        capabilities: {
+          review: true,
+          jsonOutput: true,
+          local: true,
+          streaming: false
+        }
+      },
+      "openai-compatible": {
+        enabled: false,
+        adapter: "openai-compatible",
+        displayName: "OpenAI-compatible BYOK or gateway endpoint",
+        baseUrl: "https://example.invalid/v1",
+        model: "model-id",
+        authMode: "api-key-env",
+        apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+        contextWindowTokens: 128_000,
+        timeoutMs: 180_000,
+        retryMaxRetries: 1,
+        capabilities: {
+          review: true,
+          jsonOutput: true,
+          local: false,
+          streaming: false
+        }
+      },
+      anthropic: {
+        enabled: false,
+        adapter: "anthropic",
+        displayName: "Anthropic native adapter placeholder",
+        model: "claude-sonnet-4",
+        authMode: "api-key-env",
+        apiKeyEnv: "ANTHROPIC_API_KEY",
+        contextWindowTokens: 200_000,
+        timeoutMs: 180_000,
+        retryMaxRetries: 1,
+        capabilities: {
+          review: false,
+          jsonOutput: true,
+          local: false,
+          streaming: false
+        }
+      },
+      openai: {
+        enabled: false,
+        adapter: "openai",
+        displayName: "OpenAI native adapter placeholder",
+        model: "gpt-4.1",
+        authMode: "api-key-env",
+        apiKeyEnv: "OPENAI_API_KEY",
+        contextWindowTokens: 128_000,
+        timeoutMs: 180_000,
+        retryMaxRetries: 1,
+        capabilities: {
+          review: false,
+          jsonOutput: true,
+          local: false,
+          streaming: false
+        }
+      },
+      gemini: {
+        enabled: false,
+        adapter: "gemini",
+        displayName: "Gemini native adapter placeholder",
+        model: "gemini-2.5-pro",
+        authMode: "api-key-env",
+        apiKeyEnv: "GEMINI_API_KEY",
+        contextWindowTokens: 1_000_000,
+        timeoutMs: 180_000,
+        retryMaxRetries: 1,
+        capabilities: {
+          review: false,
+          jsonOutput: true,
+          local: false,
+          streaming: false
+        }
+      }
+    }
+  },
   commands: {
     enabled: false,
     botMentions: ["@evaos-code-review-bot"],
@@ -403,6 +512,9 @@ function validateConfig(config: BotConfig): void {
   const desktop = config.desktop ?? DEFAULT_CONFIG.desktop!;
   config.desktop = desktop;
   validateDesktopConfig(desktop, "config.desktop");
+  const providers = config.providers ?? DEFAULT_CONFIG.providers!;
+  config.providers = providers;
+  validateProviderRegistryConfig(providers, "config.providers");
   validateBoolean(config.commands.enabled, "config.commands.enabled");
   validateStringArray(config.commands.botMentions, "config.commands.botMentions");
   validateStringArray(config.commands.trustedAuthors, "config.commands.trustedAuthors");
@@ -680,6 +792,74 @@ function validateDesktopConfig(value: unknown, label: string): void {
   }
   if (typeof value.updateChannel === "string" && value.updateChannel.trim().length === 0) {
     throw new Error(`${label}.updateChannel must not be empty`);
+  }
+}
+
+function validateProviderRegistryConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  validateOptionalString(value.defaultProviderId, `${label}.defaultProviderId`);
+  if (typeof value.defaultProviderId !== "string" || value.defaultProviderId.trim().length === 0) {
+    throw new Error(`${label}.defaultProviderId must be a non-empty string`);
+  }
+  if (!isRecord(value.providers)) throw new Error(`${label}.providers must be an object`);
+  if (!Object.prototype.hasOwnProperty.call(value.providers, value.defaultProviderId)) {
+    throw new Error(`${label}.defaultProviderId must reference a configured provider`);
+  }
+  for (const [providerId, provider] of Object.entries(value.providers)) {
+    validateProviderId(providerId, `${label}.providers`);
+    validateProviderRegistryEntry(provider, `${label}.providers.${providerId}`);
+  }
+}
+
+function validateProviderRegistryEntry(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  validateBoolean(value.enabled, `${label}.enabled`);
+  if (!["zcode", "openai-compatible", "anthropic", "openai", "gemini"].includes(String(value.adapter))) {
+    throw new Error(`${label}.adapter must be zcode, openai-compatible, anthropic, openai, or gemini`);
+  }
+  validateOptionalString(value.displayName, `${label}.displayName`);
+  validateOptionalString(value.baseUrl, `${label}.baseUrl`);
+  if (typeof value.baseUrl === "string") validateProviderBaseUrl(value.baseUrl, `${label}.baseUrl`);
+  validateOptionalString(value.model, `${label}.model`);
+  if (typeof value.model !== "string" || value.model.trim().length === 0) throw new Error(`${label}.model must be a non-empty string`);
+  if (!["zcode-app-config", "api-key-env", "none"].includes(String(value.authMode))) {
+    throw new Error(`${label}.authMode must be zcode-app-config, api-key-env, or none`);
+  }
+  validateOptionalString(value.apiKeyEnv, `${label}.apiKeyEnv`);
+  if (typeof value.apiKeyEnv === "string" && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(value.apiKeyEnv)) {
+    throw new Error(`${label}.apiKeyEnv must be an environment variable name`);
+  }
+  if (value.contextWindowTokens !== undefined) validatePositiveInteger(value.contextWindowTokens, `${label}.contextWindowTokens`);
+  if (value.timeoutMs !== undefined) validatePositiveInteger(value.timeoutMs, `${label}.timeoutMs`);
+  if (value.retryMaxRetries !== undefined) validateNonNegativeInteger(value.retryMaxRetries, `${label}.retryMaxRetries`);
+  if (!isRecord(value.capabilities)) throw new Error(`${label}.capabilities must be an object`);
+  for (const capability of ["review", "jsonOutput", "local", "streaming"] as const) {
+    validateBoolean(value.capabilities[capability], `${label}.capabilities.${capability}`);
+  }
+  if (value.adapter === "openai-compatible" && value.enabled === true && typeof value.baseUrl !== "string") {
+    throw new Error(`${label}.baseUrl is required when enabled openai-compatible provider`);
+  }
+  if (value.authMode === "api-key-env" && value.enabled === true && typeof value.apiKeyEnv !== "string") {
+    throw new Error(`${label}.apiKeyEnv is required when enabled provider uses api-key-env`);
+  }
+}
+
+function validateProviderId(value: string, label: string): void {
+  if (!/^[A-Za-z0-9_.:-]+$/.test(value) || value === "." || value === "..") {
+    throw new Error(`${label} keys must be stable provider identifiers`);
+  }
+}
+
+function validateProviderBaseUrl(value: string, label: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${label} must be a valid URL`);
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") throw new Error(`${label} must use http or https`);
+  if (parsed.protocol === "http:" && !isLoopbackHost(parsed.hostname)) {
+    throw new Error(`${label} must use https unless it points to localhost/loopback`);
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { isIP } from "node:net";
 import { dirname, join } from "node:path";
 import type { EnrichmentConfig } from "./enrichment.js";
 import type { GitNexusContextConfig } from "./gitnexus-context.js";
@@ -783,6 +784,42 @@ function isLoopbackHost(hostname: string): boolean {
   return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1" || normalized === "[::1]";
 }
 
+function isUnsafeProviderHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+  if (isLoopbackHost(hostname)) return false;
+  if (
+    normalized === "metadata" ||
+    normalized === "metadata.google.internal" ||
+    normalized === "metadata.azure.internal" ||
+    normalized === "169.254.169.254" ||
+    normalized === "100.100.100.200"
+  ) {
+    return true;
+  }
+  const ipVersion = isIP(normalized);
+  if (ipVersion === 4) return isPrivateOrLinkLocalIpv4(normalized);
+  if (ipVersion === 6) return isPrivateOrLinkLocalIpv6(normalized);
+  return false;
+}
+
+function isPrivateOrLinkLocalIpv4(value: string): boolean {
+  const parts = value.split(".").map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+  const [a, b] = parts;
+  return a === 10 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254) ||
+    (a === 100 && b >= 64 && b <= 127);
+}
+
+function isPrivateOrLinkLocalIpv6(value: string): boolean {
+  return value === "::" ||
+    value.startsWith("fc") ||
+    value.startsWith("fd") ||
+    value.startsWith("fe80:");
+}
+
 function validateDesktopConfig(value: unknown, label: string): void {
   if (!isRecord(value)) throw new Error(`${label} must be an object`);
   validateOptionalString(value.openAICompatibleEndpoint, `${label}.openAICompatibleEndpoint`);
@@ -814,8 +851,10 @@ function validateProviderRegistryConfig(value: unknown, label: string): void {
 function validateProviderRegistryEntry(value: unknown, label: string): void {
   if (!isRecord(value)) throw new Error(`${label} must be an object`);
   validateBoolean(value.enabled, `${label}.enabled`);
-  const adapter = String(value.adapter);
-  const authMode = String(value.authMode);
+  if (typeof value.adapter !== "string") throw new Error(`${label}.adapter must be a string`);
+  if (typeof value.authMode !== "string") throw new Error(`${label}.authMode must be a string`);
+  const adapter = value.adapter;
+  const authMode = value.authMode;
   if (!["zcode", "openai-compatible", "anthropic", "openai", "gemini"].includes(adapter)) {
     throw new Error(`${label}.adapter must be zcode, openai-compatible, anthropic, openai, or gemini`);
   }
@@ -882,6 +921,9 @@ function validateProviderBaseUrl(value: string, label: string): void {
   }
   if (parsed.protocol === "http:" && !isLoopbackHost(parsed.hostname)) {
     throw new Error(`${label} must use https unless it points to localhost/loopback`);
+  }
+  if (isUnsafeProviderHost(parsed.hostname)) {
+    throw new Error(`${label} must not point to private, link-local, or cloud metadata hosts`);
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -781,8 +781,11 @@ function validateLicenseApiBaseUrl(value: unknown, label: string): void {
 }
 
 function isLoopbackHost(hostname: string): boolean {
-  const normalized = hostname.toLowerCase();
-  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1" || normalized === "[::1]";
+  const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+  if (normalized === "localhost" || normalized === "::1") return true;
+  if (isIP(normalized) === 4) return normalized.split(".")[0] === "127";
+  const mappedIpv4 = ipv4MappedIpv6Address(normalized);
+  return mappedIpv4 ? isLoopbackHost(mappedIpv4) : false;
 }
 
 function isUnsafeProviderHost(hostname: string): boolean {

--- a/src/config.ts
+++ b/src/config.ts
@@ -792,6 +792,7 @@ function isUnsafeProviderHost(hostname: string): boolean {
     normalized === "metadata" ||
     normalized === "metadata.google.internal" ||
     normalized === "metadata.azure.internal" ||
+    normalized === "0.0.0.0" ||
     normalized === "169.254.169.254" ||
     normalized === "100.100.100.200"
   ) {
@@ -815,10 +816,25 @@ function isPrivateOrLinkLocalIpv4(value: string): boolean {
 }
 
 function isPrivateOrLinkLocalIpv6(value: string): boolean {
+  const mappedIpv4 = ipv4MappedIpv6Address(value);
+  if (mappedIpv4) return isPrivateOrLinkLocalIpv4(mappedIpv4);
   return value === "::" ||
     value.startsWith("fc") ||
     value.startsWith("fd") ||
     value.startsWith("fe80:");
+}
+
+function ipv4MappedIpv6Address(value: string): string | undefined {
+  const normalized = value.toLowerCase();
+  if (!normalized.startsWith("::ffff:")) return undefined;
+  const suffix = normalized.slice("::ffff:".length);
+  if (isIP(suffix) === 4) return suffix;
+  const parts = suffix.split(":");
+  if (parts.length !== 2) return undefined;
+  const high = Number.parseInt(parts[0], 16);
+  const low = Number.parseInt(parts[1], 16);
+  if ([high, low].some((part) => !Number.isInteger(part) || part < 0 || part > 0xffff)) return undefined;
+  return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
 }
 
 function validateDesktopConfig(value: unknown, label: string): void {
@@ -879,6 +895,9 @@ function validateProviderRegistryEntry(value: unknown, label: string): void {
   for (const capability of ["review", "jsonOutput", "local", "streaming"] as const) {
     validateBoolean(value.capabilities[capability], `${label}.capabilities.${capability}`);
   }
+  if (typeof value.baseUrl === "string" && isLoopbackProviderBaseUrl(value.baseUrl) && value.capabilities.local !== true) {
+    throw new Error(`${label}.capabilities.local must be true for loopback provider baseUrl`);
+  }
   if (adapter === "openai-compatible" && value.enabled === true && typeof value.baseUrl !== "string") {
     throw new Error(`${label}.baseUrl is required when enabled openai-compatible provider`);
   }
@@ -928,6 +947,14 @@ function validateProviderBaseUrl(value: string, label: string): void {
   }
   if (isUnsafeProviderHost(parsed.hostname)) {
     throw new Error(`${label} must not point to private, link-local, or cloud metadata hosts`);
+  }
+}
+
+function isLoopbackProviderBaseUrl(value: string): boolean {
+  try {
+    return isLoopbackHost(new URL(value).hostname);
+  } catch {
+    return false;
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -821,10 +821,11 @@ function isPrivateOrLinkLocalIpv4(value: string): boolean {
 function isPrivateOrLinkLocalIpv6(value: string): boolean {
   const mappedIpv4 = ipv4MappedIpv6Address(value);
   if (mappedIpv4) return isPrivateOrLinkLocalIpv4(mappedIpv4);
+  const firstHextet = Number.parseInt(value.split(":")[0] ?? "", 16);
   return value === "::" ||
     value.startsWith("fc") ||
     value.startsWith("fd") ||
-    value.startsWith("fe80:");
+    (Number.isInteger(firstHextet) && firstHextet >= 0xfe80 && firstHextet <= 0xfebf);
 }
 
 function ipv4MappedIpv6Address(value: string): string | undefined {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -227,7 +227,8 @@ async function smokeOpenAICompatibleProvider(input: {
     });
     const text = await response.text();
     if (!response.ok) {
-      const error = `OpenAI-compatible models endpoint returned ${response.status}: ${redactSecrets(text).slice(0, 300)}`;
+      const redactedText = redactProviderSmokeText(text, input.provider, input.env);
+      const error = `OpenAI-compatible models endpoint returned ${response.status}: ${redactedText.slice(0, 300)}`;
       return {
         ...baseCheck,
         ok: false,
@@ -254,11 +255,12 @@ async function smokeOpenAICompatibleProvider(input: {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const errorCategory = classifyProviderError(message);
+    const redactedMessage = redactProviderSmokeText(message, input.provider, input.env);
     return {
       ...baseCheck,
       ok: false,
       errorCategory,
-      error: `${errorCategory}: ${redactSecrets(message)}`
+      error: `${errorCategory}: ${redactedMessage}`
     };
   }
 }
@@ -276,6 +278,19 @@ function providerReadinessCapabilityError(provider: ProviderRegistryEntry): stri
 function providerAuthMetadataError(provider: ProviderRegistryEntry): string | undefined {
   if (provider.authMode === "api-key-env" && !provider.apiKeyEnv) return "Provider requires apiKeyEnv for api-key-env auth.";
   return undefined;
+}
+
+function redactProviderSmokeText(
+  value: string,
+  provider: ProviderRegistryEntry,
+  env: Record<string, string | undefined>
+): string {
+  let redacted = redactSecrets(value);
+  const providerKey = provider.authMode === "api-key-env" && provider.apiKeyEnv
+    ? env[provider.apiKeyEnv]
+    : undefined;
+  if (providerKey) redacted = redacted.split(providerKey).join("[redacted-provider-key]");
+  return redacted;
 }
 
 function extractModelIds(data: unknown[]): string[] {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 const DEFAULT_PROVIDER_SMOKE_TIMEOUT_MS = 30_000;
@@ -86,6 +87,8 @@ export function buildProviderRegistrySummary(input: {
   registry: ProviderRegistryConfig;
   currentZCode?: { providerId?: string; model?: string };
 }): { defaultProviderId: string; providers: ProviderRegistrySummaryEntry[] } {
+  const currentZCodeProviderId = input.currentZCode?.providerId;
+  const currentZCodeModel = input.currentZCode?.model;
   return {
     defaultProviderId: input.registry.defaultProviderId,
     providers: Object.entries(input.registry.providers).map(([id, provider]) => ({
@@ -102,8 +105,11 @@ export function buildProviderRegistrySummary(input: {
       ...(provider.timeoutMs ? { timeoutMs: provider.timeoutMs } : {}),
       ...(provider.retryMaxRetries !== undefined ? { retryMaxRetries: provider.retryMaxRetries } : {}),
       capabilities: provider.capabilities,
-      currentRuntime: provider.adapter === "zcode" &&
-        id === (input.currentZCode?.providerId ?? input.registry.defaultProviderId)
+      currentRuntime: provider.adapter === "zcode" && (
+        currentZCodeProviderId
+          ? id === currentZCodeProviderId
+          : Boolean(provider.enabled && currentZCodeModel && provider.model === currentZCodeModel)
+      )
     }))
   };
 }
@@ -212,6 +218,8 @@ async function smokeOpenAICompatibleProvider(input: {
   const authError = providerAuthMetadataError(input.provider);
   if (authError) return { ...baseCheck, ok: false, error: authError };
   if (!input.provider.baseUrl) return { ...baseCheck, ok: false, error: "OpenAI-compatible provider requires baseUrl for smoke checks." };
+  const targetError = providerSmokeTargetError(input.provider.baseUrl, input.provider);
+  if (targetError) return { ...baseCheck, ok: false, error: targetError };
   if (input.provider.authMode === "api-key-env" && input.provider.apiKeyEnv && !input.env[input.provider.apiKeyEnv]) {
     return { ...baseCheck, ok: false, error: `Missing API key environment variable ${input.provider.apiKeyEnv}.` };
   }
@@ -296,6 +304,62 @@ function redactProviderSmokeText(
 
 function safeProviderIdForOutput(value: string): string {
   return isProviderId(value) ? value : "[invalid-provider-id]";
+}
+
+function providerSmokeTargetError(baseUrl: string, provider: ProviderRegistryEntry): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    return "OpenAI-compatible provider baseUrl must be a valid URL for smoke checks.";
+  }
+  const loopback = isLoopbackHost(parsed.hostname);
+  if (loopback && provider.capabilities.local) return undefined;
+  if (isUnsafeSmokeHost(parsed.hostname)) {
+    return "OpenAI-compatible smoke target must not point to private, link-local, loopback, or cloud metadata hosts.";
+  }
+  return undefined;
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1" || normalized === "[::1]";
+}
+
+function isUnsafeSmokeHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+  if (
+    isLoopbackHost(hostname) ||
+    normalized === "metadata" ||
+    normalized === "metadata.google.internal" ||
+    normalized === "metadata.azure.internal" ||
+    normalized === "169.254.169.254" ||
+    normalized === "100.100.100.200"
+  ) {
+    return true;
+  }
+  const ipVersion = isIP(normalized);
+  if (ipVersion === 4) return isPrivateOrLinkLocalIpv4(normalized);
+  if (ipVersion === 6) return isPrivateOrLinkLocalIpv6(normalized);
+  return false;
+}
+
+function isPrivateOrLinkLocalIpv4(value: string): boolean {
+  const parts = value.split(".").map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+  const [a, b] = parts;
+  return a === 10 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254) ||
+    (a === 100 && b >= 64 && b <= 127);
+}
+
+function isPrivateOrLinkLocalIpv6(value: string): boolean {
+  return value === "::" ||
+    value.startsWith("fc") ||
+    value.startsWith("fd") ||
+    value.startsWith("fe80:");
 }
 
 function extractModelIds(data: unknown[]): string[] {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,0 +1,258 @@
+import { redactSecrets } from "./secrets.js";
+
+export type ProviderAdapter = "zcode" | "openai-compatible" | "anthropic" | "openai" | "gemini";
+export type ProviderAuthMode = "zcode-app-config" | "api-key-env" | "none";
+
+export interface ProviderCapabilityFlags {
+  review: boolean;
+  jsonOutput: boolean;
+  local: boolean;
+  streaming: boolean;
+}
+
+export interface ProviderRegistryEntry {
+  enabled: boolean;
+  adapter: ProviderAdapter;
+  displayName?: string;
+  baseUrl?: string;
+  model: string;
+  authMode: ProviderAuthMode;
+  apiKeyEnv?: string;
+  contextWindowTokens?: number;
+  timeoutMs?: number;
+  retryMaxRetries?: number;
+  capabilities: ProviderCapabilityFlags;
+}
+
+export interface ProviderRegistryConfig {
+  defaultProviderId: string;
+  providers: Record<string, ProviderRegistryEntry>;
+}
+
+export type ProviderErrorCategory =
+  | "auth"
+  | "quota_or_rate_limit"
+  | "transient"
+  | "timeout"
+  | "context_limit"
+  | "model_output_schema"
+  | "unknown";
+
+export interface ProviderRegistrySummaryEntry {
+  id: string;
+  enabled: boolean;
+  adapter: ProviderAdapter;
+  displayName?: string;
+  model: string;
+  authMode: ProviderAuthMode;
+  apiKeyEnv?: string;
+  hasBaseUrl: boolean;
+  baseUrl?: string;
+  contextWindowTokens?: number;
+  timeoutMs?: number;
+  retryMaxRetries?: number;
+  capabilities: ProviderCapabilityFlags;
+  currentRuntime?: boolean;
+}
+
+export interface ProviderDoctorResult {
+  ok: boolean;
+  command: "providers doctor";
+  providerId?: string;
+  defaultProviderId: string;
+  checks: ProviderDoctorCheck[];
+  troubleshooting: string[];
+}
+
+export interface ProviderDoctorCheck {
+  providerId: string;
+  ok: boolean;
+  adapter: ProviderAdapter;
+  enabled: boolean;
+  model: string;
+  authMode: ProviderAuthMode;
+  smokeAttempted: boolean;
+  readMode: "metadata_only" | "openai_compatible_models";
+  baseUrl?: string;
+  apiKeyEnv?: string;
+  error?: string;
+  modelCount?: number;
+}
+
+export function buildProviderRegistrySummary(input: {
+  registry: ProviderRegistryConfig;
+  currentZCode?: { providerId?: string; model?: string };
+}): { defaultProviderId: string; providers: ProviderRegistrySummaryEntry[] } {
+  return {
+    defaultProviderId: input.registry.defaultProviderId,
+    providers: Object.entries(input.registry.providers).map(([id, provider]) => ({
+      id,
+      enabled: provider.enabled,
+      adapter: provider.adapter,
+      ...(provider.displayName ? { displayName: provider.displayName } : {}),
+      model: provider.model,
+      authMode: provider.authMode,
+      ...(provider.apiKeyEnv ? { apiKeyEnv: provider.apiKeyEnv } : {}),
+      hasBaseUrl: Boolean(provider.baseUrl),
+      ...(provider.baseUrl ? { baseUrl: redactProviderUrl(provider.baseUrl) } : {}),
+      ...(provider.contextWindowTokens ? { contextWindowTokens: provider.contextWindowTokens } : {}),
+      ...(provider.timeoutMs ? { timeoutMs: provider.timeoutMs } : {}),
+      ...(provider.retryMaxRetries !== undefined ? { retryMaxRetries: provider.retryMaxRetries } : {}),
+      capabilities: provider.capabilities,
+      currentRuntime: provider.adapter === "zcode" &&
+        (id === input.registry.defaultProviderId || id === input.currentZCode?.providerId || provider.model === input.currentZCode?.model)
+    }))
+  };
+}
+
+export async function doctorProviderRegistry(input: {
+  registry: ProviderRegistryConfig;
+  providerId?: string;
+  smoke?: boolean;
+  fetchImpl?: typeof fetch;
+  env?: Record<string, string | undefined>;
+}): Promise<ProviderDoctorResult> {
+  const providerIds = input.providerId
+    ? [input.providerId]
+    : Object.entries(input.registry.providers)
+      .filter(([id, provider]) => provider.enabled || id === input.registry.defaultProviderId)
+      .map(([id]) => id);
+  const checks: ProviderDoctorCheck[] = [];
+  const troubleshooting: string[] = [];
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const env = input.env ?? process.env;
+
+  for (const providerId of providerIds) {
+    const provider = input.registry.providers[providerId];
+    if (!provider) {
+      checks.push({
+        providerId,
+        ok: false,
+        adapter: "openai-compatible",
+        enabled: false,
+        model: "",
+        authMode: "none",
+        smokeAttempted: false,
+        readMode: "metadata_only",
+        error: `Provider ${providerId} is not configured.`
+      });
+      troubleshooting.push(`Add provider ${providerId} to providers.providers or choose an existing provider id.`);
+      continue;
+    }
+
+    if (provider.adapter !== "openai-compatible" || !input.smoke) {
+      checks.push({
+        providerId,
+        ok: provider.enabled,
+        adapter: provider.adapter,
+        enabled: provider.enabled,
+        model: provider.model,
+        authMode: provider.authMode,
+        smokeAttempted: false,
+        readMode: "metadata_only",
+        ...(provider.baseUrl ? { baseUrl: redactProviderUrl(provider.baseUrl) } : {}),
+        ...(provider.apiKeyEnv ? { apiKeyEnv: provider.apiKeyEnv } : {}),
+        ...(provider.enabled ? {} : { error: "Provider is disabled." })
+      });
+      if (!provider.enabled) troubleshooting.push(`Enable provider ${providerId} before selecting it for review.`);
+      continue;
+    }
+
+    checks.push(await smokeOpenAICompatibleProvider({ providerId, provider, fetchImpl, env }));
+  }
+
+  return {
+    ok: checks.every((check) => check.ok),
+    command: "providers doctor",
+    ...(input.providerId ? { providerId: input.providerId } : {}),
+    defaultProviderId: input.registry.defaultProviderId,
+    checks,
+    troubleshooting
+  };
+}
+
+async function smokeOpenAICompatibleProvider(input: {
+  providerId: string;
+  provider: ProviderRegistryEntry;
+  fetchImpl: typeof fetch;
+  env: Record<string, string | undefined>;
+}): Promise<ProviderDoctorCheck> {
+  const baseCheck = {
+    providerId: input.providerId,
+    adapter: input.provider.adapter,
+    enabled: input.provider.enabled,
+    model: input.provider.model,
+    authMode: input.provider.authMode,
+    smokeAttempted: true,
+    readMode: "openai_compatible_models" as const,
+    ...(input.provider.baseUrl ? { baseUrl: redactProviderUrl(input.provider.baseUrl) } : {}),
+    ...(input.provider.apiKeyEnv ? { apiKeyEnv: input.provider.apiKeyEnv } : {})
+  };
+  if (!input.provider.enabled) return { ...baseCheck, ok: false, error: "Provider is disabled." };
+  if (!input.provider.baseUrl) return { ...baseCheck, ok: false, error: "OpenAI-compatible provider requires baseUrl for smoke checks." };
+  if (input.provider.authMode === "api-key-env" && input.provider.apiKeyEnv && !input.env[input.provider.apiKeyEnv]) {
+    return { ...baseCheck, ok: false, error: `Missing API key environment variable ${input.provider.apiKeyEnv}.` };
+  }
+
+  try {
+    const response = await input.fetchImpl(buildOpenAIModelsUrl(input.provider.baseUrl), {
+      headers: {
+        Accept: "application/json",
+        ...(input.provider.authMode === "api-key-env" && input.provider.apiKeyEnv
+          ? { Authorization: `Bearer ${input.env[input.provider.apiKeyEnv]}` }
+          : {})
+      }
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      return {
+        ...baseCheck,
+        ok: false,
+        error: `OpenAI-compatible models endpoint returned ${response.status}: ${redactSecrets(text).slice(0, 300)}`
+      };
+    }
+    const parsed = JSON.parse(text) as { data?: unknown[] };
+    return {
+      ...baseCheck,
+      ok: Array.isArray(parsed.data),
+      ...(Array.isArray(parsed.data) ? { modelCount: parsed.data.length } : { error: "Models response did not contain a data array." })
+    };
+  } catch (error) {
+    return {
+      ...baseCheck,
+      ok: false,
+      error: classifyProviderError(error instanceof Error ? error.message : String(error))
+    };
+  }
+}
+
+export function buildOpenAIModelsUrl(baseUrl: string): string {
+  const parsed = new URL(baseUrl);
+  parsed.pathname = `${parsed.pathname.replace(/\/+$/, "")}/models`;
+  return parsed.toString();
+}
+
+export function classifyProviderError(message: string): ProviderErrorCategory {
+  const normalized = message.toLowerCase();
+  if (/\b(unauthorized|forbidden|invalid api key|401|403)\b/.test(normalized)) return "auth";
+  if (/\b(rate limit|quota|too many requests|429|insufficient_quota)\b/.test(normalized)) return "quota_or_rate_limit";
+  if (/\b(timeout|timed out|etimedout|abort)\b/.test(normalized)) return "timeout";
+  if (/\b(context length|context window|maximum context|token limit|too many tokens)\b/.test(normalized)) return "context_limit";
+  if (/\b(json|schema|parseable|malformed output|invalid response)\b/.test(normalized)) return "model_output_schema";
+  if (/\b(econnreset|econnrefused|refused|5\d\d|temporarily|unavailable|overload)\b/.test(normalized)) return "transient";
+  return "unknown";
+}
+
+export function redactProviderUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    for (const key of [...url.searchParams.keys()]) {
+      if (/(key|token|secret|password|session)/i.test(key)) url.searchParams.set(key, "[redacted-secret]");
+    }
+    if (url.username) url.username = "[redacted]";
+    if (url.password) url.password = "[redacted-secret]";
+    return url.toString();
+  } catch {
+    return redactSecrets(value);
+  }
+}

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -354,8 +354,11 @@ function providerSmokeTargetError(baseUrl: string, provider: ProviderRegistryEnt
 }
 
 function isLoopbackHost(hostname: string): boolean {
-  const normalized = hostname.toLowerCase();
-  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1" || normalized === "[::1]";
+  const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+  if (normalized === "localhost" || normalized === "::1") return true;
+  if (isIP(normalized) === 4) return normalized.split(".")[0] === "127";
+  const mappedIpv4 = ipv4MappedIpv6Address(normalized);
+  return mappedIpv4 ? isLoopbackHost(mappedIpv4) : false;
 }
 
 function isUnsafeSmokeHost(hostname: string): boolean {
@@ -422,7 +425,8 @@ function extractModelIds(data: unknown[]): string[] {
 
 export function buildOpenAIModelsUrl(baseUrl: string): string {
   const parsed = new URL(baseUrl);
-  parsed.pathname = `${parsed.pathname.replace(/\/+$/, "")}/models`;
+  const pathname = parsed.pathname.replace(/\/+$/, "");
+  parsed.pathname = pathname.endsWith("/models") ? pathname : `${pathname}/models`;
   return parsed.toString();
 }
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -178,9 +178,9 @@ export async function doctorProviderRegistry(input: {
         ...(provider.apiKeyEnv ? { apiKeyEnv: provider.apiKeyEnv } : {}),
         ...(error ? { error } : {})
       });
-      if (!provider.enabled) troubleshooting.push(`Enable provider ${providerId} before selecting it for review.`);
-      if (capabilityError) troubleshooting.push(`Provider ${providerId} must support review and JSON output before it can be selected for review.`);
-      if (authError) troubleshooting.push(`Provider ${providerId} must declare an API key environment variable before it can be selected for review.`);
+      if (!provider.enabled) troubleshooting.push(`Enable provider ${safeProviderId} before selecting it for review.`);
+      if (capabilityError) troubleshooting.push(`Provider ${safeProviderId} must support review and JSON output before it can be selected for review.`);
+      if (authError) troubleshooting.push(`Provider ${safeProviderId} must declare an API key environment variable before it can be selected for review.`);
       continue;
     }
 
@@ -287,7 +287,11 @@ async function smokeOpenAICompatibleProvider(input: {
 }
 
 function signalWithTimeout(timeoutMs: number | undefined): AbortSignal | undefined {
-  return AbortSignal.timeout(timeoutMs && timeoutMs > 0 ? timeoutMs : DEFAULT_PROVIDER_SMOKE_TIMEOUT_MS);
+  const timeout = timeoutMs && timeoutMs > 0 ? timeoutMs : DEFAULT_PROVIDER_SMOKE_TIMEOUT_MS;
+  if (typeof AbortSignal.timeout === "function") return AbortSignal.timeout(timeout);
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), timeout);
+  return controller.signal;
 }
 
 function providerReadinessCapabilityError(provider: ProviderRegistryEntry): string | undefined {
@@ -345,6 +349,7 @@ function isUnsafeSmokeHost(hostname: string): boolean {
     normalized === "metadata" ||
     normalized === "metadata.google.internal" ||
     normalized === "metadata.azure.internal" ||
+    normalized === "0.0.0.0" ||
     normalized === "169.254.169.254" ||
     normalized === "100.100.100.200"
   ) {
@@ -368,10 +373,25 @@ function isPrivateOrLinkLocalIpv4(value: string): boolean {
 }
 
 function isPrivateOrLinkLocalIpv6(value: string): boolean {
+  const mappedIpv4 = ipv4MappedIpv6Address(value);
+  if (mappedIpv4) return isPrivateOrLinkLocalIpv4(mappedIpv4);
   return value === "::" ||
     value.startsWith("fc") ||
     value.startsWith("fd") ||
     value.startsWith("fe80:");
+}
+
+function ipv4MappedIpv6Address(value: string): string | undefined {
+  const normalized = value.toLowerCase();
+  if (!normalized.startsWith("::ffff:")) return undefined;
+  const suffix = normalized.slice("::ffff:".length);
+  if (isIP(suffix) === 4) return suffix;
+  const parts = suffix.split(":");
+  if (parts.length !== 2) return undefined;
+  const high = Number.parseInt(parts[0], 16);
+  const low = Number.parseInt(parts[1], 16);
+  if ([high, low].some((part) => !Number.isInteger(part) || part < 0 || part > 0xffff)) return undefined;
+  return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
 }
 
 function extractModelIds(data: unknown[]): string[] {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,4 +1,4 @@
-import { redactSecrets } from "./secrets.js";
+import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 export type ProviderAdapter = "zcode" | "openai-compatible" | "anthropic" | "openai" | "gemini";
 export type ProviderAuthMode = "zcode-app-config" | "api-key-env" | "none";
@@ -75,6 +75,7 @@ export interface ProviderDoctorCheck {
   readMode: "metadata_only" | "openai_compatible_models";
   baseUrl?: string;
   apiKeyEnv?: string;
+  errorCategory?: ProviderErrorCategory;
   error?: string;
   modelCount?: number;
 }
@@ -100,7 +101,7 @@ export function buildProviderRegistrySummary(input: {
       ...(provider.retryMaxRetries !== undefined ? { retryMaxRetries: provider.retryMaxRetries } : {}),
       capabilities: provider.capabilities,
       currentRuntime: provider.adapter === "zcode" &&
-        (id === input.registry.defaultProviderId || id === input.currentZCode?.providerId || provider.model === input.currentZCode?.model)
+        id === (input.currentZCode?.providerId ?? input.registry.defaultProviderId)
     }))
   };
 }
@@ -196,6 +197,7 @@ async function smokeOpenAICompatibleProvider(input: {
 
   try {
     const response = await input.fetchImpl(buildOpenAIModelsUrl(input.provider.baseUrl), {
+      signal: signalWithTimeout(input.provider.timeoutMs),
       headers: {
         Accept: "application/json",
         ...(input.provider.authMode === "api-key-env" && input.provider.apiKeyEnv
@@ -205,10 +207,12 @@ async function smokeOpenAICompatibleProvider(input: {
     });
     const text = await response.text();
     if (!response.ok) {
+      const error = `OpenAI-compatible models endpoint returned ${response.status}: ${redactSecrets(text).slice(0, 300)}`;
       return {
         ...baseCheck,
         ok: false,
-        error: `OpenAI-compatible models endpoint returned ${response.status}: ${redactSecrets(text).slice(0, 300)}`
+        errorCategory: classifyProviderError(`${response.status} ${text}`),
+        error
       };
     }
     const parsed = JSON.parse(text) as { data?: unknown[] };
@@ -218,12 +222,20 @@ async function smokeOpenAICompatibleProvider(input: {
       ...(Array.isArray(parsed.data) ? { modelCount: parsed.data.length } : { error: "Models response did not contain a data array." })
     };
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const errorCategory = classifyProviderError(message);
     return {
       ...baseCheck,
       ok: false,
-      error: classifyProviderError(error instanceof Error ? error.message : String(error))
+      errorCategory,
+      error: `${errorCategory}: ${redactSecrets(message)}`
     };
   }
+}
+
+function signalWithTimeout(timeoutMs: number | undefined): AbortSignal | undefined {
+  if (!timeoutMs || timeoutMs <= 0) return undefined;
+  return AbortSignal.timeout(timeoutMs);
 }
 
 export function buildOpenAIModelsUrl(baseUrl: string): string {
@@ -236,11 +248,15 @@ export function classifyProviderError(message: string): ProviderErrorCategory {
   const normalized = message.toLowerCase();
   if (/\b(unauthorized|forbidden|invalid api key|401|403)\b/.test(normalized)) return "auth";
   if (/\b(rate limit|quota|too many requests|429|insufficient_quota)\b/.test(normalized)) return "quota_or_rate_limit";
-  if (/\b(timeout|timed out|etimedout|abort)\b/.test(normalized)) return "timeout";
+  if (/\b(timeout|timed out|etimedout|abort(?:ed)?)\b/.test(normalized)) return "timeout";
   if (/\b(context length|context window|maximum context|token limit|too many tokens)\b/.test(normalized)) return "context_limit";
   if (/\b(json|schema|parseable|malformed output|invalid response)\b/.test(normalized)) return "model_output_schema";
   if (/\b(econnreset|econnrefused|refused|5\d\d|temporarily|unavailable|overload)\b/.test(normalized)) return "transient";
   return "unknown";
+}
+
+export function isProviderId(value: string): boolean {
+  return /^[A-Za-z0-9_.:-]+$/.test(value) && value !== "." && value !== ".." && !containsSecretLikeText(value);
 }
 
 export function redactProviderUrl(value: string): string {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,5 +1,7 @@
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
+const DEFAULT_PROVIDER_SMOKE_TIMEOUT_MS = 30_000;
+
 export type ProviderAdapter = "zcode" | "openai-compatible" | "anthropic" | "openai" | "gemini";
 export type ProviderAuthMode = "zcode-app-config" | "api-key-env" | "none";
 
@@ -152,9 +154,10 @@ export async function doctorProviderRegistry(input: {
 
     if (provider.adapter !== "openai-compatible" || !input.smoke) {
       const capabilityError = providerReadinessCapabilityError(provider);
+      const authError = providerAuthMetadataError(provider);
       checks.push({
         providerId,
-        ok: provider.enabled && !capabilityError,
+        ok: provider.enabled && !capabilityError && !authError,
         adapter: provider.adapter,
         enabled: provider.enabled,
         model: provider.model,
@@ -164,10 +167,11 @@ export async function doctorProviderRegistry(input: {
         ...(provider.baseUrl ? { baseUrl: redactProviderUrl(provider.baseUrl) } : {}),
         ...(provider.apiKeyEnv ? { apiKeyEnv: provider.apiKeyEnv } : {}),
         ...(provider.enabled ? {} : { error: "Provider is disabled." }),
-        ...(capabilityError ? { error: capabilityError } : {})
+        ...(capabilityError || authError ? { error: capabilityError ?? authError } : {})
       });
       if (!provider.enabled) troubleshooting.push(`Enable provider ${providerId} before selecting it for review.`);
       if (capabilityError) troubleshooting.push(`Provider ${providerId} must support review and JSON output before it can be selected for review.`);
+      if (authError) troubleshooting.push(`Provider ${providerId} must declare an API key environment variable before it can be selected for review.`);
       continue;
     }
 
@@ -204,6 +208,8 @@ async function smokeOpenAICompatibleProvider(input: {
   if (!input.provider.enabled) return { ...baseCheck, ok: false, error: "Provider is disabled." };
   const capabilityError = providerReadinessCapabilityError(input.provider);
   if (capabilityError) return { ...baseCheck, ok: false, error: capabilityError };
+  const authError = providerAuthMetadataError(input.provider);
+  if (authError) return { ...baseCheck, ok: false, error: authError };
   if (!input.provider.baseUrl) return { ...baseCheck, ok: false, error: "OpenAI-compatible provider requires baseUrl for smoke checks." };
   if (input.provider.authMode === "api-key-env" && input.provider.apiKeyEnv && !input.env[input.provider.apiKeyEnv]) {
     return { ...baseCheck, ok: false, error: `Missing API key environment variable ${input.provider.apiKeyEnv}.` };
@@ -231,6 +237,9 @@ async function smokeOpenAICompatibleProvider(input: {
     }
     const parsed = JSON.parse(text) as { data?: unknown[] };
     const modelIds = Array.isArray(parsed.data) ? extractModelIds(parsed.data) : [];
+    const missingModelError = modelIds.length === 0
+      ? "Models response did not advertise any usable model ids."
+      : `Models response did not advertise configured model ${input.provider.model}.`;
     return {
       ...baseCheck,
       ok: Array.isArray(parsed.data) && modelIds.includes(input.provider.model),
@@ -238,7 +247,7 @@ async function smokeOpenAICompatibleProvider(input: {
       ...(Array.isArray(parsed.data) && !modelIds.includes(input.provider.model)
         ? {
             errorCategory: "model_output_schema" as const,
-            error: `Models response did not advertise configured model ${input.provider.model}.`
+            error: missingModelError
           }
         : {})
     };
@@ -255,13 +264,17 @@ async function smokeOpenAICompatibleProvider(input: {
 }
 
 function signalWithTimeout(timeoutMs: number | undefined): AbortSignal | undefined {
-  if (!timeoutMs || timeoutMs <= 0) return undefined;
-  return AbortSignal.timeout(timeoutMs);
+  return AbortSignal.timeout(timeoutMs && timeoutMs > 0 ? timeoutMs : DEFAULT_PROVIDER_SMOKE_TIMEOUT_MS);
 }
 
 function providerReadinessCapabilityError(provider: ProviderRegistryEntry): string | undefined {
   if (!provider.capabilities.review) return "Provider is not review-capable.";
   if (!provider.capabilities.jsonOutput) return "Provider does not declare JSON output support.";
+  return undefined;
+}
+
+function providerAuthMetadataError(provider: ProviderRegistryEntry): string | undefined {
+  if (provider.authMode === "api-key-env" && !provider.apiKeyEnv) return "Provider requires apiKeyEnv for api-key-env auth.";
   return undefined;
 }
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -359,6 +359,9 @@ async function providerSmokeTargetError(
   if (isUnsafeSmokeHost(parsed.hostname)) {
     return "OpenAI-compatible smoke target must not point to private, link-local, loopback, or cloud metadata hosts.";
   }
+  if (!loopback) {
+    return "Remote OpenAI-compatible smoke checks are disabled until the transport can pin the validated DNS result.";
+  }
   if (!isIP(parsed.hostname)) {
     const resolvedAddresses = await safeLookupProviderHost(parsed.hostname, lookupImpl);
     if (resolvedAddresses.some((address) => isUnsafeSmokeHost(address))) {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -113,6 +113,15 @@ export async function doctorProviderRegistry(input: {
   fetchImpl?: typeof fetch;
   env?: Record<string, string | undefined>;
 }): Promise<ProviderDoctorResult> {
+  if (input.smoke && !input.providerId) {
+    return {
+      ok: false,
+      command: "providers doctor",
+      defaultProviderId: input.registry.defaultProviderId,
+      checks: [],
+      troubleshooting: ["--smoke true requires --provider to avoid unscoped provider network fan-out."]
+    };
+  }
   const providerIds = input.providerId
     ? [input.providerId]
     : Object.entries(input.registry.providers)
@@ -225,7 +234,7 @@ async function smokeOpenAICompatibleProvider(input: {
     return {
       ...baseCheck,
       ok: Array.isArray(parsed.data) && modelIds.includes(input.provider.model),
-      ...(Array.isArray(parsed.data) ? { modelCount: parsed.data.length } : { errorCategory: "model_output_schema" as const, error: "Models response did not contain a data array." }),
+      ...(Array.isArray(parsed.data) ? { modelCount: modelIds.length } : { errorCategory: "model_output_schema" as const, error: "Models response did not contain a data array." }),
       ...(Array.isArray(parsed.data) && !modelIds.includes(input.provider.model)
         ? {
             errorCategory: "model_output_schema" as const,

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,5 +1,4 @@
 import { isIP } from "node:net";
-import { lookup } from "node:dns/promises";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 const DEFAULT_PROVIDER_SMOKE_TIMEOUT_MS = 30_000;
@@ -32,8 +31,6 @@ export interface ProviderRegistryConfig {
   defaultProviderId: string;
   providers: Record<string, ProviderRegistryEntry>;
 }
-
-type ProviderDnsLookup = (hostname: string) => Promise<{ address: string }[]>;
 
 export type ProviderErrorCategory =
   | "auth"
@@ -122,7 +119,6 @@ export async function doctorProviderRegistry(input: {
   providerId?: string;
   smoke?: boolean;
   fetchImpl?: typeof fetch;
-  lookupImpl?: ProviderDnsLookup;
   env?: Record<string, string | undefined>;
 }): Promise<ProviderDoctorResult> {
   if (input.smoke && !input.providerId) {
@@ -191,7 +187,7 @@ export async function doctorProviderRegistry(input: {
       continue;
     }
 
-    checks.push(await smokeOpenAICompatibleProvider({ providerId, provider, fetchImpl, lookupImpl: input.lookupImpl ?? lookupProviderHost, env }));
+    checks.push(await smokeOpenAICompatibleProvider({ providerId, provider, fetchImpl, env }));
   }
 
   return {
@@ -208,7 +204,6 @@ async function smokeOpenAICompatibleProvider(input: {
   providerId: string;
   provider: ProviderRegistryEntry;
   fetchImpl: typeof fetch;
-  lookupImpl: ProviderDnsLookup;
   env: Record<string, string | undefined>;
 }): Promise<ProviderDoctorCheck> {
   const safeProviderId = safeProviderIdForOutput(input.providerId);
@@ -229,7 +224,7 @@ async function smokeOpenAICompatibleProvider(input: {
   const authError = providerAuthMetadataError(input.provider);
   if (authError) return { ...baseCheck, ok: false, error: authError };
   if (!input.provider.baseUrl) return { ...baseCheck, ok: false, error: "OpenAI-compatible provider requires baseUrl for smoke checks." };
-  const targetError = await providerSmokeTargetError(input.provider.baseUrl, input.provider, input.lookupImpl);
+  const targetError = providerSmokeTargetError(input.provider.baseUrl, input.provider);
   if (targetError) return { ...baseCheck, ok: false, error: targetError };
   if (input.provider.authMode === "api-key-env" && input.provider.apiKeyEnv && !input.env[input.provider.apiKeyEnv]) {
     return { ...baseCheck, ok: false, error: `Missing API key environment variable ${input.provider.apiKeyEnv}.` };
@@ -332,11 +327,7 @@ function safeProviderIdForOutput(value: string): string {
   return isProviderId(value) ? value : "[invalid-provider-id]";
 }
 
-async function providerSmokeTargetError(
-  baseUrl: string,
-  provider: ProviderRegistryEntry,
-  lookupImpl: ProviderDnsLookup
-): Promise<string | undefined> {
+function providerSmokeTargetError(baseUrl: string, provider: ProviderRegistryEntry): string | undefined {
   let parsed: URL;
   try {
     parsed = new URL(baseUrl);
@@ -362,25 +353,7 @@ async function providerSmokeTargetError(
   if (!loopback) {
     return "Remote OpenAI-compatible smoke checks are disabled until the transport can pin the validated DNS result.";
   }
-  if (!isIP(parsed.hostname)) {
-    const resolvedAddresses = await safeLookupProviderHost(parsed.hostname, lookupImpl);
-    if (resolvedAddresses.some((address) => isUnsafeSmokeHost(address))) {
-      return "OpenAI-compatible smoke target resolved to a private, link-local, loopback, or cloud metadata address.";
-    }
-  }
   return undefined;
-}
-
-async function lookupProviderHost(hostname: string): Promise<{ address: string }[]> {
-  return lookup(hostname, { all: true, verbatim: true });
-}
-
-async function safeLookupProviderHost(hostname: string, lookupImpl: ProviderDnsLookup): Promise<string[]> {
-  try {
-    return (await lookupImpl(hostname)).map((entry) => entry.address);
-  } catch {
-    return [];
-  }
 }
 
 function isLoopbackHost(hostname: string): boolean {
@@ -424,10 +397,11 @@ function isPrivateOrLinkLocalIpv4(value: string): boolean {
 function isPrivateOrLinkLocalIpv6(value: string): boolean {
   const mappedIpv4 = ipv4MappedIpv6Address(value);
   if (mappedIpv4) return isPrivateOrLinkLocalIpv4(mappedIpv4);
+  const firstHextet = Number.parseInt(value.split(":")[0] ?? "", 16);
   return value === "::" ||
     value.startsWith("fc") ||
     value.startsWith("fd") ||
-    value.startsWith("fe80:");
+    (Number.isInteger(firstHextet) && firstHextet >= 0xfe80 && firstHextet <= 0xfebf);
 }
 
 function ipv4MappedIpv6Address(value: string): string | undefined {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -142,9 +142,10 @@ export async function doctorProviderRegistry(input: {
     }
 
     if (provider.adapter !== "openai-compatible" || !input.smoke) {
+      const capabilityError = providerReadinessCapabilityError(provider);
       checks.push({
         providerId,
-        ok: provider.enabled,
+        ok: provider.enabled && !capabilityError,
         adapter: provider.adapter,
         enabled: provider.enabled,
         model: provider.model,
@@ -153,9 +154,11 @@ export async function doctorProviderRegistry(input: {
         readMode: "metadata_only",
         ...(provider.baseUrl ? { baseUrl: redactProviderUrl(provider.baseUrl) } : {}),
         ...(provider.apiKeyEnv ? { apiKeyEnv: provider.apiKeyEnv } : {}),
-        ...(provider.enabled ? {} : { error: "Provider is disabled." })
+        ...(provider.enabled ? {} : { error: "Provider is disabled." }),
+        ...(capabilityError ? { error: capabilityError } : {})
       });
       if (!provider.enabled) troubleshooting.push(`Enable provider ${providerId} before selecting it for review.`);
+      if (capabilityError) troubleshooting.push(`Provider ${providerId} must support review and JSON output before it can be selected for review.`);
       continue;
     }
 
@@ -190,6 +193,8 @@ async function smokeOpenAICompatibleProvider(input: {
     ...(input.provider.apiKeyEnv ? { apiKeyEnv: input.provider.apiKeyEnv } : {})
   };
   if (!input.provider.enabled) return { ...baseCheck, ok: false, error: "Provider is disabled." };
+  const capabilityError = providerReadinessCapabilityError(input.provider);
+  if (capabilityError) return { ...baseCheck, ok: false, error: capabilityError };
   if (!input.provider.baseUrl) return { ...baseCheck, ok: false, error: "OpenAI-compatible provider requires baseUrl for smoke checks." };
   if (input.provider.authMode === "api-key-env" && input.provider.apiKeyEnv && !input.env[input.provider.apiKeyEnv]) {
     return { ...baseCheck, ok: false, error: `Missing API key environment variable ${input.provider.apiKeyEnv}.` };
@@ -216,10 +221,17 @@ async function smokeOpenAICompatibleProvider(input: {
       };
     }
     const parsed = JSON.parse(text) as { data?: unknown[] };
+    const modelIds = Array.isArray(parsed.data) ? extractModelIds(parsed.data) : [];
     return {
       ...baseCheck,
-      ok: Array.isArray(parsed.data),
-      ...(Array.isArray(parsed.data) ? { modelCount: parsed.data.length } : { error: "Models response did not contain a data array." })
+      ok: Array.isArray(parsed.data) && modelIds.includes(input.provider.model),
+      ...(Array.isArray(parsed.data) ? { modelCount: parsed.data.length } : { errorCategory: "model_output_schema" as const, error: "Models response did not contain a data array." }),
+      ...(Array.isArray(parsed.data) && !modelIds.includes(input.provider.model)
+        ? {
+            errorCategory: "model_output_schema" as const,
+            error: `Models response did not advertise configured model ${input.provider.model}.`
+          }
+        : {})
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -236,6 +248,22 @@ async function smokeOpenAICompatibleProvider(input: {
 function signalWithTimeout(timeoutMs: number | undefined): AbortSignal | undefined {
   if (!timeoutMs || timeoutMs <= 0) return undefined;
   return AbortSignal.timeout(timeoutMs);
+}
+
+function providerReadinessCapabilityError(provider: ProviderRegistryEntry): string | undefined {
+  if (!provider.capabilities.review) return "Provider is not review-capable.";
+  if (!provider.capabilities.jsonOutput) return "Provider does not declare JSON output support.";
+  return undefined;
+}
+
+function extractModelIds(data: unknown[]): string[] {
+  return data.flatMap((entry) => {
+    if (typeof entry === "string") return [entry];
+    if (entry && typeof entry === "object" && typeof (entry as { id?: unknown }).id === "string") {
+      return [(entry as { id: string }).id];
+    }
+    return [];
+  });
 }
 
 export function buildOpenAIModelsUrl(baseUrl: string): string {
@@ -257,6 +285,10 @@ export function classifyProviderError(message: string): ProviderErrorCategory {
 
 export function isProviderId(value: string): boolean {
   return /^[A-Za-z0-9_.:-]+$/.test(value) && value !== "." && value !== ".." && !containsSecretLikeText(value);
+}
+
+export function isApiKeyEnvName(value: string): boolean {
+  return /^[A-Z_][A-Z0-9_]*$/.test(value) && !/^(?:gh[pousr]_|github_pat_|sk-|xox[baprs]-)/i.test(value);
 }
 
 export function redactProviderUrl(value: string): string {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -162,9 +162,12 @@ export async function doctorProviderRegistry(input: {
     if (provider.adapter !== "openai-compatible" || !input.smoke) {
       const capabilityError = providerReadinessCapabilityError(provider);
       const authError = providerAuthMetadataError(provider);
+      const error = provider.enabled
+        ? capabilityError ?? authError
+        : "Provider is disabled.";
       checks.push({
         providerId,
-        ok: provider.enabled && !capabilityError && !authError,
+        ok: !error,
         adapter: provider.adapter,
         enabled: provider.enabled,
         model: provider.model,
@@ -173,8 +176,7 @@ export async function doctorProviderRegistry(input: {
         readMode: "metadata_only",
         ...(provider.baseUrl ? { baseUrl: redactProviderUrl(provider.baseUrl) } : {}),
         ...(provider.apiKeyEnv ? { apiKeyEnv: provider.apiKeyEnv } : {}),
-        ...(provider.enabled ? {} : { error: "Provider is disabled." }),
-        ...(capabilityError || authError ? { error: capabilityError ?? authError } : {})
+        ...(error ? { error } : {})
       });
       if (!provider.enabled) troubleshooting.push(`Enable provider ${providerId} before selecting it for review.`);
       if (capabilityError) troubleshooting.push(`Provider ${providerId} must support review and JSON output before it can be selected for review.`);
@@ -245,7 +247,17 @@ async function smokeOpenAICompatibleProvider(input: {
         error
       };
     }
-    const parsed = JSON.parse(text) as { data?: unknown[] };
+    let parsed: { data?: unknown[] };
+    try {
+      parsed = JSON.parse(text) as { data?: unknown[] };
+    } catch {
+      return {
+        ...baseCheck,
+        ok: false,
+        errorCategory: "model_output_schema",
+        error: "Models response was not valid JSON."
+      };
+    }
     const modelIds = Array.isArray(parsed.data) ? extractModelIds(parsed.data) : [];
     const missingModelError = modelIds.length === 0
       ? "Models response did not advertise any usable model ids."

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,4 +1,5 @@
 import { isIP } from "node:net";
+import { lookup } from "node:dns/promises";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 const DEFAULT_PROVIDER_SMOKE_TIMEOUT_MS = 30_000;
@@ -31,6 +32,8 @@ export interface ProviderRegistryConfig {
   defaultProviderId: string;
   providers: Record<string, ProviderRegistryEntry>;
 }
+
+type ProviderDnsLookup = (hostname: string) => Promise<{ address: string }[]>;
 
 export type ProviderErrorCategory =
   | "auth"
@@ -119,6 +122,7 @@ export async function doctorProviderRegistry(input: {
   providerId?: string;
   smoke?: boolean;
   fetchImpl?: typeof fetch;
+  lookupImpl?: ProviderDnsLookup;
   env?: Record<string, string | undefined>;
 }): Promise<ProviderDoctorResult> {
   if (input.smoke && !input.providerId) {
@@ -187,7 +191,7 @@ export async function doctorProviderRegistry(input: {
       continue;
     }
 
-    checks.push(await smokeOpenAICompatibleProvider({ providerId, provider, fetchImpl, env }));
+    checks.push(await smokeOpenAICompatibleProvider({ providerId, provider, fetchImpl, lookupImpl: input.lookupImpl ?? lookupProviderHost, env }));
   }
 
   return {
@@ -204,10 +208,12 @@ async function smokeOpenAICompatibleProvider(input: {
   providerId: string;
   provider: ProviderRegistryEntry;
   fetchImpl: typeof fetch;
+  lookupImpl: ProviderDnsLookup;
   env: Record<string, string | undefined>;
 }): Promise<ProviderDoctorCheck> {
+  const safeProviderId = safeProviderIdForOutput(input.providerId);
   const baseCheck = {
-    providerId: input.providerId,
+    providerId: safeProviderId,
     adapter: input.provider.adapter,
     enabled: input.provider.enabled,
     model: input.provider.model,
@@ -223,7 +229,7 @@ async function smokeOpenAICompatibleProvider(input: {
   const authError = providerAuthMetadataError(input.provider);
   if (authError) return { ...baseCheck, ok: false, error: authError };
   if (!input.provider.baseUrl) return { ...baseCheck, ok: false, error: "OpenAI-compatible provider requires baseUrl for smoke checks." };
-  const targetError = providerSmokeTargetError(input.provider.baseUrl, input.provider);
+  const targetError = await providerSmokeTargetError(input.provider.baseUrl, input.provider, input.lookupImpl);
   if (targetError) return { ...baseCheck, ok: false, error: targetError };
   if (input.provider.authMode === "api-key-env" && input.provider.apiKeyEnv && !input.env[input.provider.apiKeyEnv]) {
     return { ...baseCheck, ok: false, error: `Missing API key environment variable ${input.provider.apiKeyEnv}.` };
@@ -291,7 +297,6 @@ async function smokeOpenAICompatibleProvider(input: {
 
 function signalWithTimeout(timeoutMs: number | undefined): AbortSignal | undefined {
   const timeout = timeoutMs && timeoutMs > 0 ? timeoutMs : DEFAULT_PROVIDER_SMOKE_TIMEOUT_MS;
-  if (typeof AbortSignal.timeout === "function") return AbortSignal.timeout(timeout);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeout);
   const maybeUnref = timer as { unref?: () => void };
@@ -327,7 +332,11 @@ function safeProviderIdForOutput(value: string): string {
   return isProviderId(value) ? value : "[invalid-provider-id]";
 }
 
-function providerSmokeTargetError(baseUrl: string, provider: ProviderRegistryEntry): string | undefined {
+async function providerSmokeTargetError(
+  baseUrl: string,
+  provider: ProviderRegistryEntry,
+  lookupImpl: ProviderDnsLookup
+): Promise<string | undefined> {
   let parsed: URL;
   try {
     parsed = new URL(baseUrl);
@@ -350,7 +359,25 @@ function providerSmokeTargetError(baseUrl: string, provider: ProviderRegistryEnt
   if (isUnsafeSmokeHost(parsed.hostname)) {
     return "OpenAI-compatible smoke target must not point to private, link-local, loopback, or cloud metadata hosts.";
   }
+  if (!isIP(parsed.hostname)) {
+    const resolvedAddresses = await safeLookupProviderHost(parsed.hostname, lookupImpl);
+    if (resolvedAddresses.some((address) => isUnsafeSmokeHost(address))) {
+      return "OpenAI-compatible smoke target resolved to a private, link-local, loopback, or cloud metadata address.";
+    }
+  }
   return undefined;
+}
+
+async function lookupProviderHost(hostname: string): Promise<{ address: string }[]> {
+  return lookup(hostname, { all: true, verbatim: true });
+}
+
+async function safeLookupProviderHost(hostname: string, lookupImpl: ProviderDnsLookup): Promise<string[]> {
+  try {
+    return (await lookupImpl(hostname)).map((entry) => entry.address);
+  } catch {
+    return [];
+  }
 }
 
 function isLoopbackHost(hostname: string): boolean {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -162,8 +162,11 @@ export async function doctorProviderRegistry(input: {
     if (provider.adapter !== "openai-compatible" || !input.smoke) {
       const capabilityError = providerReadinessCapabilityError(provider);
       const authError = providerAuthMetadataError(provider);
+      const smokeUnsupportedError = input.smoke && provider.adapter !== "openai-compatible"
+        ? `Smoke checks are not implemented for ${provider.adapter} providers.`
+        : undefined;
       const error = provider.enabled
-        ? capabilityError ?? authError
+        ? smokeUnsupportedError ?? capabilityError ?? authError
         : "Provider is disabled.";
       checks.push({
         providerId,
@@ -290,7 +293,9 @@ function signalWithTimeout(timeoutMs: number | undefined): AbortSignal | undefin
   const timeout = timeoutMs && timeoutMs > 0 ? timeoutMs : DEFAULT_PROVIDER_SMOKE_TIMEOUT_MS;
   if (typeof AbortSignal.timeout === "function") return AbortSignal.timeout(timeout);
   const controller = new AbortController();
-  setTimeout(() => controller.abort(), timeout);
+  const timer = setTimeout(() => controller.abort(), timeout);
+  const maybeUnref = timer as { unref?: () => void };
+  if (typeof maybeUnref.unref === "function") maybeUnref.unref();
   return controller.signal;
 }
 
@@ -328,6 +333,17 @@ function providerSmokeTargetError(baseUrl: string, provider: ProviderRegistryEnt
     parsed = new URL(baseUrl);
   } catch {
     return "OpenAI-compatible provider baseUrl must be a valid URL for smoke checks.";
+  }
+  if (parsed.username || parsed.password) {
+    return "OpenAI-compatible smoke target must not include username or password credentials.";
+  }
+  if (containsSecretLikeText(decodeURIComponent(`${parsed.pathname}${parsed.hash}`))) {
+    return "OpenAI-compatible smoke target must not include secret-like path or fragment values.";
+  }
+  for (const key of parsed.searchParams.keys()) {
+    if (/(key|token|secret|password|session|cookie)/i.test(key)) {
+      return "OpenAI-compatible smoke target must not include credential query parameters.";
+    }
   }
   const loopback = isLoopbackHost(parsed.hostname);
   if (loopback && provider.capabilities.local) return undefined;

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -136,9 +136,10 @@ export async function doctorProviderRegistry(input: {
 
   for (const providerId of providerIds) {
     const provider = input.registry.providers[providerId];
+    const safeProviderId = safeProviderIdForOutput(providerId);
     if (!provider) {
       checks.push({
-        providerId,
+        providerId: safeProviderId,
         ok: false,
         adapter: "openai-compatible",
         enabled: false,
@@ -146,9 +147,9 @@ export async function doctorProviderRegistry(input: {
         authMode: "none",
         smokeAttempted: false,
         readMode: "metadata_only",
-        error: `Provider ${providerId} is not configured.`
+        error: `Provider ${safeProviderId} is not configured.`
       });
-      troubleshooting.push(`Add provider ${providerId} to providers.providers or choose an existing provider id.`);
+      troubleshooting.push(`Add provider ${safeProviderId} to providers.providers or choose an existing provider id.`);
       continue;
     }
 
@@ -181,7 +182,7 @@ export async function doctorProviderRegistry(input: {
   return {
     ok: checks.every((check) => check.ok),
     command: "providers doctor",
-    ...(input.providerId ? { providerId: input.providerId } : {}),
+    ...(input.providerId ? { providerId: safeProviderIdForOutput(input.providerId) } : {}),
     defaultProviderId: input.registry.defaultProviderId,
     checks,
     troubleshooting
@@ -232,7 +233,7 @@ async function smokeOpenAICompatibleProvider(input: {
       return {
         ...baseCheck,
         ok: false,
-        errorCategory: classifyProviderError(`${response.status} ${text}`),
+        errorCategory: classifyProviderError(`${response.status} ${redactedText}`),
         error
       };
     }
@@ -291,6 +292,10 @@ function redactProviderSmokeText(
     : undefined;
   if (providerKey) redacted = redacted.split(providerKey).join("[redacted-provider-key]");
   return redacted;
+}
+
+function safeProviderIdForOutput(value: string): string {
+  return isProviderId(value) ? value : "[invalid-provider-id]";
 }
 
 function extractModelIds(data: unknown[]): string[] {

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -50,6 +50,8 @@ describe("desktop config CLI", () => {
     expect(output.editablePaths).toContain("zcode.model");
     expect(output.editablePaths).toContain("desktop.openAICompatibleEndpoint");
     expect(output.editablePaths).toContain("github.appId");
+    expect(output.editablePaths).toContain("providers.defaultProviderId");
+    expect(output.editablePaths).toContain("providers.providers.<provider-id>.<desktop-safe-provider-field>");
     expect(output.editablePaths).not.toContain("github.apiBaseUrl");
     expect(output.editablePaths).not.toContain("github.privateKeyPath");
     expect(output.editablePaths).not.toContain("workRoot");
@@ -137,6 +139,75 @@ describe("desktop config CLI", () => {
     expect(readFileSync(configPath, "utf8")).toBe(before);
     expect(output.config.zcode.model).toBe("GLM-5.2-Air");
     expect(output.config.desktop.openAICompatibleEndpoint).toBe("http://localhost:8001/v1");
+  });
+
+  it("dry-runs provider metadata patches without allowing provider secrets", async () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    const patchPath = join(root, "patch.json");
+    const secretPatchPath = join(root, "secret-provider-patch.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    });
+    writeConfig(patchPath, {
+      providers: {
+        defaultProviderId: "ollama-local",
+        providers: {
+          "ollama-local": {
+            enabled: true,
+            baseUrl: "http://localhost:11434/v1",
+            model: "qwen2.5-coder:14b",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true
+            }
+          },
+          "openai-compatible": {
+            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY"
+          }
+        }
+      }
+    });
+    writeConfig(secretPatchPath, {
+      providers: {
+        providers: {
+          "openai-compatible": {
+            baseUrl: "https://gateway.example.test/v1?api_key=sk-live-secret-secret-secret-secret"
+          }
+        }
+      }
+    });
+
+    const output = await runConfig(["config", "patch", "--config", configPath, "--input", patchPath]);
+
+    expect(output).toMatchObject({
+      ok: true,
+      dryRun: true,
+      wrote: false,
+      changedPaths: [
+        "providers.defaultProviderId",
+        "providers.providers.ollama-local.enabled",
+        "providers.providers.ollama-local.baseUrl",
+        "providers.providers.ollama-local.model",
+        "providers.providers.ollama-local.authMode",
+        "providers.providers.ollama-local.capabilities.review",
+        "providers.providers.ollama-local.capabilities.jsonOutput",
+        "providers.providers.openai-compatible.apiKeyEnv"
+      ]
+    });
+    expect(output.config.providers.defaultProviderId).toBe("ollama-local");
+    expect(output.config.providers.providers["openai-compatible"].apiKeyEnv).toBe("NEONDIFF_PROVIDER_API_KEY");
+
+    const rejected = await runConfig(["config", "patch", "--config", configPath, "--input", secretPatchPath]);
+    expect(rejected).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("secret-like text")
+    });
+    expect(JSON.stringify(rejected)).not.toContain("sk-live-secret");
   });
 
   it("requires confirm for live writes, then writes atomically while preserving unknown fields", async () => {

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -146,6 +146,7 @@ describe("desktop config CLI", () => {
     const configPath = join(root, "config.json");
     const patchPath = join(root, "patch.json");
     const secretPatchPath = join(root, "secret-provider-patch.json");
+    const secretApiKeyEnvPatchPath = join(root, "secret-provider-env-patch.json");
     writeConfig(configPath, {
       pilotRepos: ["owner/repo"],
       workRoot: join(root, "runtime"),
@@ -181,6 +182,15 @@ describe("desktop config CLI", () => {
         }
       }
     });
+    writeConfig(secretApiKeyEnvPatchPath, {
+      providers: {
+        providers: {
+          "openai-compatible": {
+            apiKeyEnv: "sk-live-secret-secret-secret-secret"
+          }
+        }
+      }
+    });
 
     const output = await runConfig(["config", "patch", "--config", configPath, "--input", patchPath]);
 
@@ -208,6 +218,12 @@ describe("desktop config CLI", () => {
       error: expect.stringContaining("secret-like text")
     });
     expect(JSON.stringify(rejected)).not.toContain("sk-live-secret");
+    const rejectedApiKeyEnv = await runConfig(["config", "patch", "--config", configPath, "--input", secretApiKeyEnvPatchPath]);
+    expect(rejectedApiKeyEnv).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("secret-like text")
+    });
+    expect(JSON.stringify(rejectedApiKeyEnv)).not.toContain("sk-live-secret");
   });
 
   it("requires confirm for live writes, then writes atomically while preserving unknown fields", async () => {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { loadConfigFromObject } from "../src/config.js";
+import {
+  buildProviderRegistrySummary,
+  classifyProviderError,
+  doctorProviderRegistry,
+  redactProviderUrl
+} from "../src/providers.js";
+
+describe("provider registry", () => {
+  it("loads safe default providers and doctors only enabled/default entries by default", async () => {
+    const config = loadConfigFromObject({});
+    const summary = buildProviderRegistrySummary({
+      registry: config.providers!,
+      currentZCode: {
+        providerId: config.zcode.providerId,
+        model: config.zcode.model
+      }
+    });
+
+    expect(summary.defaultProviderId).toBe("zcode-glm");
+    expect(summary.providers.map((provider) => provider.id)).toEqual(
+      expect.arrayContaining(["zcode-glm", "ollama-local", "openai-compatible", "anthropic", "openai", "gemini"])
+    );
+    expect(summary.providers.find((provider) => provider.id === "zcode-glm")).toMatchObject({
+      enabled: true,
+      adapter: "zcode",
+      authMode: "zcode-app-config",
+      currentRuntime: true
+    });
+    expect(summary.providers.find((provider) => provider.id === "openai-compatible")).toMatchObject({
+      authMode: "api-key-env",
+      apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY"
+    });
+
+    const doctor = await doctorProviderRegistry({ registry: config.providers! });
+    expect(doctor).toMatchObject({
+      ok: true,
+      command: "providers doctor",
+      defaultProviderId: "zcode-glm"
+    });
+    expect(doctor.checks).toHaveLength(1);
+    expect(doctor.checks[0]).toMatchObject({
+      providerId: "zcode-glm",
+      ok: true,
+      smokeAttempted: false,
+      readMode: "metadata_only"
+    });
+  });
+
+  it("smokes an OpenAI-compatible provider with an environment-backed bearer token", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            baseUrl: "https://gateway.example.test/v1?token=do-not-leak",
+            model: "review-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY"
+          }
+        }
+      }
+    });
+    const fetchImpl: typeof fetch = async (url, init) => {
+      expect(String(url)).toBe("https://gateway.example.test/v1/models?token=do-not-leak");
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer provider-secret");
+      return new Response(JSON.stringify({ data: [{ id: "review-model" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    };
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "openai-compatible",
+      smoke: true,
+      fetchImpl,
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: "provider-secret"
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.checks[0]).toMatchObject({
+      providerId: "openai-compatible",
+      ok: true,
+      smokeAttempted: true,
+      readMode: "openai_compatible_models",
+      baseUrl: "https://gateway.example.test/v1?token=%5Bredacted-secret%5D",
+      apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+      modelCount: 1
+    });
+    expect(JSON.stringify(result)).not.toContain("provider-secret");
+    expect(JSON.stringify(result)).not.toContain("do-not-leak");
+  });
+
+  it("classifies provider failures and redacts provider URLs", () => {
+    expect(classifyProviderError("401 invalid api key")).toBe("auth");
+    expect(classifyProviderError("429 too many requests")).toBe("quota_or_rate_limit");
+    expect(classifyProviderError("spawnSync ETIMEDOUT")).toBe("timeout");
+    expect(classifyProviderError("maximum context length exceeded")).toBe("context_limit");
+    expect(classifyProviderError("malformed JSON schema output")).toBe("model_output_schema");
+    expect(classifyProviderError("503 service unavailable")).toBe("transient");
+    expect(classifyProviderError("something else")).toBe("unknown");
+
+    expect(redactProviderUrl("https://user:pass@example.test/v1?api_key=secret&safe=1")).toBe(
+      "https://%5Bredacted%5D:%5Bredacted-secret%5D@example.test/v1?api_key=%5Bredacted-secret%5D&safe=1"
+    );
+  });
+
+  it("rejects unsafe enabled provider config", () => {
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "remote-http",
+        providers: {
+          "remote-http": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "http://example.test/v1",
+            model: "review-model",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/must use https unless it points to localhost\/loopback/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "needs-key",
+        providers: {
+          "needs-key": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model",
+            authMode: "api-key-env",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/apiKeyEnv is required/);
+  });
+});

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -483,6 +483,68 @@ describe("provider registry", () => {
     });
   });
 
+  it("keeps disabled provider metadata errors focused on disabled state", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: false,
+            model: "review-model",
+            authMode: "api-key-env",
+            capabilities: {
+              review: false,
+              jsonOutput: false
+            }
+          }
+        }
+      }
+    });
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "openai-compatible"
+    });
+
+    expect(result.checks[0]).toMatchObject({
+      ok: false,
+      enabled: false,
+      error: "Provider is disabled."
+    });
+  });
+
+  it("classifies non-JSON successful models responses as output schema failures", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            model: "review-model",
+            authMode: "none",
+            baseUrl: "https://gateway.example.test/v1"
+          }
+        }
+      }
+    });
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "openai-compatible",
+      smoke: true,
+      fetchImpl: async () => new Response("<html>ok</html>", {
+        status: 200,
+        headers: { "Content-Type": "text/html" }
+      })
+    });
+
+    expect(result.checks[0]).toMatchObject({
+      ok: false,
+      errorCategory: "model_output_schema",
+      error: "Models response was not valid JSON."
+    });
+  });
+
   it("aborts OpenAI-compatible smoke checks using provider timeoutMs", async () => {
     const config = loadConfigFromObject({
       providers: {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { loadConfigFromObject } from "../src/config.js";
 import {
+  buildOpenAIModelsUrl,
   buildProviderRegistrySummary,
   classifyProviderError,
   doctorProviderRegistry,
@@ -355,6 +356,8 @@ describe("provider registry", () => {
     for (const unsafeBaseUrl of [
       "https://[::ffff:169.254.169.254]/latest",
       "https://[::ffff:10.0.0.1]/v1",
+      "https://127.0.0.2/v1",
+      "https://[::ffff:127.0.0.2]/v1",
       "https://0.0.0.0/v1"
     ]) {
       const unsafeResult = await doctorProviderRegistry({
@@ -460,6 +463,13 @@ describe("provider registry", () => {
       errorCategory: "model_output_schema",
       error: "Models response did not advertise any usable model ids."
     });
+  });
+
+  it("builds OpenAI-compatible models URLs without duplicating existing models suffix", () => {
+    expect(buildOpenAIModelsUrl("https://gateway.example.test/v1")).toBe("https://gateway.example.test/v1/models");
+    expect(buildOpenAIModelsUrl("https://gateway.example.test/v1/")).toBe("https://gateway.example.test/v1/models");
+    expect(buildOpenAIModelsUrl("https://gateway.example.test/v1/models")).toBe("https://gateway.example.test/v1/models");
+    expect(buildOpenAIModelsUrl("https://gateway.example.test/v1/models/")).toBe("https://gateway.example.test/v1/models");
   });
 
   it("fails provider doctor for providers that cannot review JSON", async () => {
@@ -916,6 +926,48 @@ describe("provider registry", () => {
         }
       }
     })).toThrow(/must not point to private, link-local, or cloud metadata hosts/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "loopback-range",
+        providers: {
+          "loopback-range": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "http://127.0.0.2/v1",
+            model: "review-model",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/capabilities\.local must be true for loopback provider baseUrl/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "mapped-loopback",
+        providers: {
+          "mapped-loopback": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "http://[::ffff:127.0.0.2]/v1",
+            model: "review-model",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/capabilities\.local must be true for loopback provider baseUrl/);
 
     expect(() => loadConfigFromObject({
       providers: {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -172,6 +172,38 @@ describe("provider registry", () => {
     expect(JSON.stringify(thrownResult)).not.toContain("token-secret");
   });
 
+  it("doctors multiple enabled providers in metadata mode without smoking network endpoints", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "zcode-glm",
+        providers: {
+          "zcode-glm": {
+            enabled: true
+          },
+          "openai-compatible": {
+            enabled: true,
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    });
+
+    const result = await doctorProviderRegistry({ registry: config.providers! });
+
+    expect(result.ok).toBe(true);
+    expect(result.checks.map((check) => check.providerId)).toEqual(["zcode-glm", "openai-compatible"]);
+    expect(result.checks.every((check) => check.readMode === "metadata_only" && !check.smokeAttempted)).toBe(true);
+  });
+
   it("requires --provider for smoke to avoid unscoped provider fan-out", async () => {
     const config = loadConfigFromObject({
       providers: {
@@ -243,6 +275,22 @@ describe("provider registry", () => {
       errorCategory: "model_output_schema",
       error: "Models response did not advertise configured model wanted-model."
     });
+
+    const emptyResult = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "openai-compatible",
+      smoke: true,
+      fetchImpl: async () => new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      })
+    });
+    expect(emptyResult.checks[0]).toMatchObject({
+      ok: false,
+      modelCount: 0,
+      errorCategory: "model_output_schema",
+      error: "Models response did not advertise any usable model ids."
+    });
   });
 
   it("fails provider doctor for providers that cannot review JSON", async () => {
@@ -280,6 +328,52 @@ describe("provider registry", () => {
     });
   });
 
+  it("requires api-key-env providers to declare apiKeyEnv before metadata readiness passes", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: false,
+            model: "review-model",
+            authMode: "api-key-env",
+            apiKeyEnv: undefined
+          }
+        }
+      }
+    });
+
+    const providerWithoutKey = {
+      ...config.providers!.providers["openai-compatible"],
+      enabled: true
+    };
+    delete providerWithoutKey.apiKeyEnv;
+    const result = await doctorProviderRegistry({
+      registry: {
+        ...config.providers!,
+        providers: {
+          ...config.providers!.providers,
+          "openai-compatible": providerWithoutKey
+        }
+      },
+      providerId: "openai-compatible"
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      checks: [
+        expect.objectContaining({
+          providerId: "openai-compatible",
+          ok: false,
+          error: "Provider requires apiKeyEnv for api-key-env auth."
+        })
+      ],
+      troubleshooting: [
+        "Provider openai-compatible must declare an API key environment variable before it can be selected for review."
+      ]
+    });
+  });
+
   it("aborts OpenAI-compatible smoke checks using provider timeoutMs", async () => {
     const config = loadConfigFromObject({
       providers: {
@@ -307,6 +401,37 @@ describe("provider registry", () => {
       ok: false,
       errorCategory: "timeout",
       error: expect.stringContaining("timeout:")
+    });
+  });
+
+  it("always binds OpenAI-compatible smoke requests to an abort signal", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "ollama-local",
+        providers: {
+          "ollama-local": {
+            enabled: true
+          }
+        }
+      }
+    });
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "ollama-local",
+      smoke: true,
+      fetchImpl: async (_url, init) => {
+        expect(init?.signal).toBeInstanceOf(AbortSignal);
+        return new Response(JSON.stringify({ data: [{ id: config.providers!.providers["ollama-local"].model }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        });
+      }
+    });
+
+    expect(result.checks[0]).toMatchObject({
+      ok: true,
+      modelCount: 1
     });
   });
 

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -351,6 +351,39 @@ describe("provider registry", () => {
       error: "OpenAI-compatible smoke target must not point to private, link-local, loopback, or cloud metadata hosts."
     });
     expect(fetchCalls).toBe(0);
+
+    for (const unsafeBaseUrl of [
+      "https://[::ffff:169.254.169.254]/latest",
+      "https://[::ffff:10.0.0.1]/v1",
+      "https://0.0.0.0/v1"
+    ]) {
+      const unsafeResult = await doctorProviderRegistry({
+        registry: {
+          ...config.providers!,
+          providers: {
+            ...config.providers!.providers,
+            "openai-compatible": {
+              ...config.providers!.providers["openai-compatible"],
+              baseUrl: unsafeBaseUrl
+            }
+          }
+        },
+        providerId: "openai-compatible",
+        smoke: true,
+        fetchImpl: async () => {
+          fetchCalls += 1;
+          return new Response(JSON.stringify({ data: [] }));
+        },
+        env: {
+          NEONDIFF_PROVIDER_API_KEY: "short-provider-key"
+        }
+      });
+      expect(unsafeResult.checks[0]).toMatchObject({
+        ok: false,
+        error: "OpenAI-compatible smoke target must not point to private, link-local, loopback, or cloud metadata hosts."
+      });
+    }
+    expect(fetchCalls).toBe(0);
   });
 
   it("fails smoke when the configured model is not advertised", async () => {
@@ -753,6 +786,69 @@ describe("provider registry", () => {
         }
       }
     })).toThrow(/must not point to private, link-local, or cloud metadata hosts/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "ipv4-mapped-metadata",
+        providers: {
+          "ipv4-mapped-metadata": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://[::ffff:169.254.169.254]/latest",
+            model: "review-model",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/must not point to private, link-local, or cloud metadata hosts/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "wildcard-host",
+        providers: {
+          "wildcard-host": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://0.0.0.0/v1",
+            model: "review-model",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/must not point to private, link-local, or cloud metadata hosts/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "loopback-not-local",
+        providers: {
+          "loopback-not-local": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "http://localhost:11434/v1",
+            model: "review-model",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/capabilities\.local must be true for loopback provider baseUrl/);
 
     expect(() => loadConfigFromObject({
       providers: {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -73,7 +73,7 @@ describe("provider registry", () => {
         providers: {
           "openai-compatible": {
             enabled: true,
-            baseUrl: "https://gateway.example.test/v1?token=do-not-leak",
+            baseUrl: "https://gateway.example.test/v1",
             model: "review-model",
             authMode: "api-key-env",
             apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY"
@@ -82,7 +82,7 @@ describe("provider registry", () => {
       }
     });
     const fetchImpl: typeof fetch = async (url, init) => {
-      expect(String(url)).toBe("https://gateway.example.test/v1/models?token=do-not-leak");
+      expect(String(url)).toBe("https://gateway.example.test/v1/models");
       expect(new Headers(init?.headers).get("authorization")).toBe("Bearer provider-secret");
       return new Response(JSON.stringify({ data: [{ id: "review-model" }] }), {
         status: 200,
@@ -106,12 +106,11 @@ describe("provider registry", () => {
       ok: true,
       smokeAttempted: true,
       readMode: "openai_compatible_models",
-      baseUrl: "https://gateway.example.test/v1?token=%5Bredacted-secret%5D",
+      baseUrl: "https://gateway.example.test/v1",
       apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
       modelCount: 1
     });
     expect(JSON.stringify(result)).not.toContain("provider-secret");
-    expect(JSON.stringify(result)).not.toContain("do-not-leak");
   });
 
   it("classifies provider failures and redacts provider URLs", () => {
@@ -171,6 +170,74 @@ describe("provider registry", () => {
       error: expect.stringContaining("transient:")
     });
     expect(JSON.stringify(thrownResult)).not.toContain("token-secret");
+  });
+
+  it("fails smoke when the configured model is not advertised", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            model: "wanted-model",
+            authMode: "none",
+            baseUrl: "https://gateway.example.test/v1"
+          }
+        }
+      }
+    });
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "openai-compatible",
+      smoke: true,
+      fetchImpl: async () => new Response(JSON.stringify({ data: [{ id: "other-model" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      })
+    });
+
+    expect(result.checks[0]).toMatchObject({
+      ok: false,
+      modelCount: 1,
+      errorCategory: "model_output_schema",
+      error: "Models response did not advertise configured model wanted-model."
+    });
+  });
+
+  it("fails provider doctor for providers that cannot review JSON", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "anthropic",
+        providers: {
+          anthropic: {
+            enabled: true,
+            capabilities: {
+              review: false
+            }
+          }
+        }
+      }
+    });
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "anthropic"
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      checks: [
+        expect.objectContaining({
+          providerId: "anthropic",
+          ok: false,
+          error: "Provider is not review-capable."
+        })
+      ],
+      troubleshooting: [
+        "Provider anthropic must support review and JSON output before it can be selected for review."
+      ]
+    });
   });
 
   it("aborts OpenAI-compatible smoke checks using provider timeoutMs", async () => {
@@ -245,6 +312,70 @@ describe("provider registry", () => {
         }
       }
     })).toThrow(/apiKeyEnv is required/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "leaky-url",
+        providers: {
+          "leaky-url": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://user:password@gateway.example.test/v1",
+            model: "review-model",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/must not include username or password credentials/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "leaky-query",
+        providers: {
+          "leaky-query": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://gateway.example.test/v1?api_key=short",
+            model: "review-model",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/must not include credential query parameters/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "secret-env",
+        providers: {
+          "secret-env": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "ghp_123456789012345678901234567890123456",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/apiKeyEnv must be an uppercase environment variable name, not a provider key/);
 
     expect(() => loadConfigFromObject({
       providers: {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -370,6 +370,7 @@ describe("provider registry", () => {
       "https://[::ffff:10.0.0.1]/v1",
       "https://127.0.0.2/v1",
       "https://[::ffff:127.0.0.2]/v1",
+      "https://[fe90::1]/v1",
       "https://0.0.0.0/v1"
     ]) {
       const unsafeResult = await doctorProviderRegistry({
@@ -427,7 +428,7 @@ describe("provider registry", () => {
     });
     expect(fetchCalls).toBe(0);
 
-    const resolvedPrivateResult = await doctorProviderRegistry({
+    const remoteResult = await doctorProviderRegistry({
       registry: {
         ...config.providers!,
         providers: {
@@ -444,12 +445,11 @@ describe("provider registry", () => {
         fetchCalls += 1;
         return new Response(JSON.stringify({ data: [] }));
       },
-      lookupImpl: async () => [{ address: "169.254.169.254" }],
       env: {
         NEONDIFF_PROVIDER_API_KEY: "short-provider-key"
       }
     });
-    expect(resolvedPrivateResult.checks[0]).toMatchObject({
+    expect(remoteResult.checks[0]).toMatchObject({
       ok: false,
       error: "Remote OpenAI-compatible smoke checks are disabled until the transport can pin the validated DNS result."
     });
@@ -966,6 +966,27 @@ describe("provider registry", () => {
             enabled: true,
             adapter: "openai-compatible",
             baseUrl: "https://0.0.0.0/v1",
+            model: "review-model",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/must not point to private, link-local, or cloud metadata hosts/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "ipv6-link-local",
+        providers: {
+          "ipv6-link-local": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://[fe90::1]/v1",
             model: "review-model",
             authMode: "none",
             capabilities: {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -137,7 +137,8 @@ describe("provider registry", () => {
           "openai-compatible": {
             enabled: true,
             model: "review-model",
-            authMode: "none",
+            authMode: "api-key-env",
+            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
             baseUrl: "https://gateway.example.test/v1"
           }
         }
@@ -148,7 +149,10 @@ describe("provider registry", () => {
       registry: config.providers!,
       providerId: "openai-compatible",
       smoke: true,
-      fetchImpl: async () => new Response("temporary provider overload", { status: 503 })
+      fetchImpl: async () => new Response("temporary provider overload for short-provider-key", { status: 503 }),
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: "short-provider-key"
+      }
     });
     expect(httpResult.checks[0]).toMatchObject({
       ok: false,
@@ -162,6 +166,9 @@ describe("provider registry", () => {
       smoke: true,
       fetchImpl: async () => {
         throw new Error("ECONNREFUSED http://token-secret@example.test");
+      },
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: "short-provider-key"
       }
     });
     expect(thrownResult.checks[0]).toMatchObject({
@@ -169,6 +176,8 @@ describe("provider registry", () => {
       errorCategory: "transient",
       error: expect.stringContaining("transient:")
     });
+    expect(JSON.stringify(httpResult)).not.toContain("short-provider-key");
+    expect(JSON.stringify(httpResult)).toContain("[redacted-provider-key]");
     expect(JSON.stringify(thrownResult)).not.toContain("token-secret");
   });
 

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -85,16 +85,22 @@ describe("provider registry", () => {
         providers: {
           "openai-compatible": {
             enabled: true,
-            baseUrl: "https://gateway.example.test/v1",
+            baseUrl: "http://127.0.0.1:8080/v1",
             model: "review-model",
             authMode: "api-key-env",
-            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY"
+            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: true,
+              streaming: false
+            }
           }
         }
       }
     });
     const fetchImpl: typeof fetch = async (url, init) => {
-      expect(String(url)).toBe("https://gateway.example.test/v1/models");
+      expect(String(url)).toBe("http://127.0.0.1:8080/v1/models");
       expect(new Headers(init?.headers).get("authorization")).toBe("Bearer provider-secret");
       return new Response(JSON.stringify({ data: [{ id: "review-model" }] }), {
         status: 200,
@@ -118,7 +124,7 @@ describe("provider registry", () => {
       ok: true,
       smokeAttempted: true,
       readMode: "openai_compatible_models",
-      baseUrl: "https://gateway.example.test/v1",
+      baseUrl: "http://127.0.0.1:8080/v1",
       apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
       modelCount: 1
     });
@@ -151,7 +157,13 @@ describe("provider registry", () => {
             model: "review-model",
             authMode: "api-key-env",
             apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
-            baseUrl: "https://gateway.example.test/v1"
+            baseUrl: "http://127.0.0.1:8080/v1",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: true,
+              streaming: false
+            }
           }
         }
       }
@@ -439,7 +451,7 @@ describe("provider registry", () => {
     });
     expect(resolvedPrivateResult.checks[0]).toMatchObject({
       ok: false,
-      error: "OpenAI-compatible smoke target resolved to a private, link-local, loopback, or cloud metadata address."
+      error: "Remote OpenAI-compatible smoke checks are disabled until the transport can pin the validated DNS result."
     });
     expect(fetchCalls).toBe(0);
   });
@@ -453,7 +465,13 @@ describe("provider registry", () => {
             enabled: true,
             model: "wanted-model",
             authMode: "none",
-            baseUrl: "https://gateway.example.test/v1"
+            baseUrl: "http://127.0.0.1:8080/v1",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: true,
+              streaming: false
+            }
           }
         }
       }
@@ -637,7 +655,13 @@ describe("provider registry", () => {
             enabled: true,
             model: "review-model",
             authMode: "none",
-            baseUrl: "https://gateway.example.test/v1"
+            baseUrl: "http://127.0.0.1:8080/v1",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: true,
+              streaming: false
+            }
           }
         }
       }

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -179,6 +179,21 @@ describe("provider registry", () => {
     expect(JSON.stringify(httpResult)).not.toContain("short-provider-key");
     expect(JSON.stringify(httpResult)).toContain("[redacted-provider-key]");
     expect(JSON.stringify(thrownResult)).not.toContain("token-secret");
+
+    const categoryResult = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "openai-compatible",
+      smoke: true,
+      fetchImpl: async () => new Response("gateway echoed overload", { status: 400 }),
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: "overload"
+      }
+    });
+    expect(categoryResult.checks[0]).toMatchObject({
+      ok: false,
+      errorCategory: "unknown"
+    });
+    expect(JSON.stringify(categoryResult)).not.toContain("overload");
   });
 
   it("doctors multiple enabled providers in metadata mode without smoking network endpoints", async () => {
@@ -251,6 +266,28 @@ describe("provider registry", () => {
       troubleshooting: ["--smoke true requires --provider to avoid unscoped provider network fan-out."]
     });
     expect(fetchCalls).toBe(0);
+  });
+
+  it("does not reflect unsafe unknown provider ids into doctor output", async () => {
+    const config = loadConfigFromObject({});
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "sk-live-secret-secret"
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      providerId: "[invalid-provider-id]",
+      checks: [
+        expect.objectContaining({
+          providerId: "[invalid-provider-id]",
+          error: "Provider [invalid-provider-id] is not configured."
+        })
+      ],
+      troubleshooting: ["Add provider [invalid-provider-id] to providers.providers or choose an existing provider id."]
+    });
+    expect(JSON.stringify(result)).not.toContain("sk-live-secret-secret");
   });
 
   it("fails smoke when the configured model is not advertised", async () => {
@@ -528,6 +565,90 @@ describe("provider registry", () => {
         }
       }
     })).toThrow(/must not include credential query parameters/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "metadata-host",
+        providers: {
+          "metadata-host": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://169.254.169.254/latest",
+            model: "review-model",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/must not point to private, link-local, or cloud metadata hosts/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "metadata-name",
+        providers: {
+          "metadata-name": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://metadata.google.internal/computeMetadata/v1",
+            model: "review-model",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/must not point to private, link-local, or cloud metadata hosts/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "bad-adapter-type",
+        providers: {
+          "bad-adapter-type": {
+            enabled: true,
+            adapter: { toString: () => "openai-compatible" },
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/adapter must be a string/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "bad-auth-type",
+        providers: {
+          "bad-auth-type": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model",
+            authMode: { toString: () => "none" },
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/authMode must be a string/);
 
     expect(() => loadConfigFromObject({
       providers: {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -414,6 +414,34 @@ describe("provider registry", () => {
       error: "OpenAI-compatible smoke target must not include credential query parameters."
     });
     expect(fetchCalls).toBe(0);
+
+    const resolvedPrivateResult = await doctorProviderRegistry({
+      registry: {
+        ...config.providers!,
+        providers: {
+          ...config.providers!.providers,
+          "openai-compatible": {
+            ...config.providers!.providers["openai-compatible"],
+            baseUrl: "https://metadata-proxy.example.test/v1"
+          }
+        }
+      },
+      providerId: "openai-compatible",
+      smoke: true,
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ data: [] }));
+      },
+      lookupImpl: async () => [{ address: "169.254.169.254" }],
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: "short-provider-key"
+      }
+    });
+    expect(resolvedPrivateResult.checks[0]).toMatchObject({
+      ok: false,
+      error: "OpenAI-compatible smoke target resolved to a private, link-local, loopback, or cloud metadata address."
+    });
+    expect(fetchCalls).toBe(0);
   });
 
   it("fails smoke when the configured model is not advertised", async () => {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -4,6 +4,7 @@ import {
   buildProviderRegistrySummary,
   classifyProviderError,
   doctorProviderRegistry,
+  isProviderId,
   redactProviderUrl
 } from "../src/providers.js";
 
@@ -32,6 +33,23 @@ describe("provider registry", () => {
       authMode: "api-key-env",
       apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY"
     });
+    const secondZCode = buildProviderRegistrySummary({
+      registry: {
+        ...config.providers!,
+        providers: {
+          ...config.providers!.providers,
+          "zcode-glm-canary": {
+            ...config.providers!.providers["zcode-glm"],
+            enabled: false
+          }
+        }
+      },
+      currentZCode: {
+        model: "GLM-5.2"
+      }
+    });
+    expect(secondZCode.providers.find((provider) => provider.id === "zcode-glm")).toMatchObject({ currentRuntime: true });
+    expect(secondZCode.providers.find((provider) => provider.id === "zcode-glm-canary")).toMatchObject({ currentRuntime: false });
 
     const doctor = await doctorProviderRegistry({ registry: config.providers! });
     expect(doctor).toMatchObject({
@@ -108,6 +126,81 @@ describe("provider registry", () => {
     expect(redactProviderUrl("https://user:pass@example.test/v1?api_key=secret&safe=1")).toBe(
       "https://%5Bredacted%5D:%5Bredacted-secret%5D@example.test/v1?api_key=%5Bredacted-secret%5D&safe=1"
     );
+    expect(isProviderId("openai-compatible")).toBe(true);
+    expect(isProviderId("sk-live-secret-secret")).toBe(false);
+  });
+
+  it("reports HTTP and thrown smoke failures with category and redacted detail", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            model: "review-model",
+            authMode: "none",
+            baseUrl: "https://gateway.example.test/v1"
+          }
+        }
+      }
+    });
+
+    const httpResult = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "openai-compatible",
+      smoke: true,
+      fetchImpl: async () => new Response("temporary provider overload", { status: 503 })
+    });
+    expect(httpResult.checks[0]).toMatchObject({
+      ok: false,
+      errorCategory: "transient",
+      error: expect.stringContaining("OpenAI-compatible models endpoint returned 503")
+    });
+
+    const thrownResult = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "openai-compatible",
+      smoke: true,
+      fetchImpl: async () => {
+        throw new Error("ECONNREFUSED http://token-secret@example.test");
+      }
+    });
+    expect(thrownResult.checks[0]).toMatchObject({
+      ok: false,
+      errorCategory: "transient",
+      error: expect.stringContaining("transient:")
+    });
+    expect(JSON.stringify(thrownResult)).not.toContain("token-secret");
+  });
+
+  it("aborts OpenAI-compatible smoke checks using provider timeoutMs", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "ollama-local",
+        providers: {
+          "ollama-local": {
+            enabled: true,
+            timeoutMs: 1
+          }
+        }
+      }
+    });
+    const fetchImpl: typeof fetch = async (_url, init) => new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(new Error("The operation was aborted.")), { once: true });
+    });
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "ollama-local",
+      smoke: true,
+      fetchImpl
+    });
+
+    expect(result.checks[0]).toMatchObject({
+      ok: false,
+      errorCategory: "timeout",
+      error: expect.stringContaining("timeout:")
+    });
   });
 
   it("rejects unsafe enabled provider config", () => {
@@ -152,5 +245,25 @@ describe("provider registry", () => {
         }
       }
     })).toThrow(/apiKeyEnv is required/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "zcode-bad",
+        providers: {
+          "zcode-bad": {
+            enabled: true,
+            adapter: "zcode",
+            model: "GLM-5.2",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/authMode none is not supported for zcode provider/);
   });
 });

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -172,6 +172,46 @@ describe("provider registry", () => {
     expect(JSON.stringify(thrownResult)).not.toContain("token-secret");
   });
 
+  it("requires --provider for smoke to avoid unscoped provider fan-out", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "ollama-local",
+        providers: {
+          "ollama-local": {
+            enabled: true
+          },
+          "openai-compatible": {
+            enabled: true,
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY"
+          }
+        }
+      }
+    });
+    let fetchCalls = 0;
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      smoke: true,
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ data: [] }));
+      },
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: "provider-secret"
+      }
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      checks: [],
+      troubleshooting: ["--smoke true requires --provider to avoid unscoped provider network fan-out."]
+    });
+    expect(fetchCalls).toBe(0);
+  });
+
   it("fails smoke when the configured model is not advertised", async () => {
     const config = loadConfigFromObject({
       providers: {
@@ -191,7 +231,7 @@ describe("provider registry", () => {
       registry: config.providers!,
       providerId: "openai-compatible",
       smoke: true,
-      fetchImpl: async () => new Response(JSON.stringify({ data: [{ id: "other-model" }] }), {
+      fetchImpl: async () => new Response(JSON.stringify({ data: [{ id: "other-model" }, null, 123, { name: "missing-id" }] }), {
         status: 200,
         headers: { "Content-Type": "application/json" }
       })

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { loadConfigFromObject } from "../src/config.js";
 import {
   buildProviderRegistrySummary,
@@ -384,6 +384,33 @@ describe("provider registry", () => {
       });
     }
     expect(fetchCalls).toBe(0);
+
+    const credentialResult = await doctorProviderRegistry({
+      registry: {
+        ...config.providers!,
+        providers: {
+          ...config.providers!.providers,
+          "openai-compatible": {
+            ...config.providers!.providers["openai-compatible"],
+            baseUrl: "https://gateway.example.test/v1?api_key=short-provider-key"
+          }
+        }
+      },
+      providerId: "openai-compatible",
+      smoke: true,
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ data: [] }));
+      },
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: "short-provider-key"
+      }
+    });
+    expect(credentialResult.checks[0]).toMatchObject({
+      ok: false,
+      error: "OpenAI-compatible smoke target must not include credential query parameters."
+    });
+    expect(fetchCalls).toBe(0);
   });
 
   it("fails smoke when the configured model is not advertised", async () => {
@@ -546,6 +573,23 @@ describe("provider registry", () => {
     });
   });
 
+  it("reports unsupported smoke requests for non-OpenAI-compatible adapters", async () => {
+    const config = loadConfigFromObject({});
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "zcode-glm",
+      smoke: true
+    });
+
+    expect(result.checks[0]).toMatchObject({
+      providerId: "zcode-glm",
+      ok: false,
+      smokeAttempted: false,
+      error: "Smoke checks are not implemented for zcode providers."
+    });
+  });
+
   it("classifies non-JSON successful models responses as output schema failures", async () => {
     const config = loadConfigFromObject({
       providers: {
@@ -637,6 +681,50 @@ describe("provider registry", () => {
       ok: true,
       modelCount: 1
     });
+  });
+
+  it("unrefs fallback smoke timeout timers on runtimes without AbortSignal.timeout", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "ollama-local",
+        providers: {
+          "ollama-local": {
+            enabled: true
+          }
+        }
+      }
+    });
+    const originalAbortTimeout = AbortSignal.timeout;
+    const unref = vi.fn();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((() => ({ unref })) as unknown as typeof setTimeout);
+    Object.defineProperty(AbortSignal, "timeout", {
+      configurable: true,
+      value: undefined
+    });
+
+    try {
+      const result = await doctorProviderRegistry({
+        registry: config.providers!,
+        providerId: "ollama-local",
+        smoke: true,
+        fetchImpl: async (_url, init) => {
+          expect(init?.signal).toBeInstanceOf(AbortSignal);
+          return new Response(JSON.stringify({ data: [{ id: config.providers!.providers["ollama-local"].model }] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" }
+          });
+        }
+      });
+
+      expect(result.checks[0]).toMatchObject({ ok: true });
+      expect(unref).toHaveBeenCalledTimes(1);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      Object.defineProperty(AbortSignal, "timeout", {
+        configurable: true,
+        value: originalAbortTimeout
+      });
+    }
   });
 
   it("rejects unsafe enabled provider config", () => {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -50,6 +50,17 @@ describe("provider registry", () => {
     });
     expect(secondZCode.providers.find((provider) => provider.id === "zcode-glm")).toMatchObject({ currentRuntime: true });
     expect(secondZCode.providers.find((provider) => provider.id === "zcode-glm-canary")).toMatchObject({ currentRuntime: false });
+    const zcodeRuntimeWithAlternateDefault = buildProviderRegistrySummary({
+      registry: {
+        ...config.providers!,
+        defaultProviderId: "ollama-local"
+      },
+      currentZCode: {
+        model: config.zcode.model
+      }
+    });
+    expect(zcodeRuntimeWithAlternateDefault.providers.find((provider) => provider.id === "zcode-glm")).toMatchObject({ currentRuntime: true });
+    expect(zcodeRuntimeWithAlternateDefault.providers.find((provider) => provider.id === "ollama-local")).toMatchObject({ currentRuntime: false });
 
     const doctor = await doctorProviderRegistry({ registry: config.providers! });
     expect(doctor).toMatchObject({
@@ -288,6 +299,58 @@ describe("provider registry", () => {
       troubleshooting: ["Add provider [invalid-provider-id] to providers.providers or choose an existing provider id."]
     });
     expect(JSON.stringify(result)).not.toContain("sk-live-secret-secret");
+  });
+
+  it("fails smoke checks for unsafe provider targets even when config validation was bypassed", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    });
+    let fetchCalls = 0;
+
+    const result = await doctorProviderRegistry({
+      registry: {
+        ...config.providers!,
+        providers: {
+          ...config.providers!.providers,
+          "openai-compatible": {
+            ...config.providers!.providers["openai-compatible"],
+            baseUrl: "https://169.254.169.254/latest"
+          }
+        }
+      },
+      providerId: "openai-compatible",
+      smoke: true,
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ data: [] }));
+      },
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: "short-provider-key"
+      }
+    });
+
+    expect(result.checks[0]).toMatchObject({
+      ok: false,
+      error: "OpenAI-compatible smoke target must not point to private, link-local, loopback, or cloud metadata hosts."
+    });
+    expect(fetchCalls).toBe(0);
   });
 
   it("fails smoke when the configured model is not advertised", async () => {
@@ -565,6 +628,27 @@ describe("provider registry", () => {
         }
       }
     })).toThrow(/must not include credential query parameters/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "leaky-path",
+        providers: {
+          "leaky-path": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://gateway.example.test/proxy/sk-live-secret-secret-secret/v1#github_pat_secretsecretsecretsecretsecretsecretsecretsecret",
+            model: "review-model",
+            authMode: "none",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/must not include secret-like path or fragment values/);
 
     expect(() => loadConfigFromObject({
       providers: {

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -180,6 +180,77 @@ describe("public NeonDiff CLI surface", () => {
     });
   });
 
+  it("runs providers doctor smoke through the public CLI against a local OpenAI-compatible endpoint", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-provider-cli-"));
+    roots.push(root);
+    const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      response.setHeader("Content-Type", "application/json");
+      if (request.method === "GET" && url.pathname === "/v1/models") {
+        response.end(JSON.stringify({ data: [{ id: "local-review-model" }] }));
+        return;
+      }
+      response.statusCode = 404;
+      response.end(JSON.stringify({ message: `unexpected ${request.method} ${url.pathname}` }));
+    });
+    await listen(server);
+    try {
+      const address = server.address() as AddressInfo;
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        pilotRepos: ["acme/demo"],
+        workRoot: join(root, "runtime"),
+        statePath: join(root, "state.sqlite"),
+        evidenceDir: join(root, "evidence"),
+        providers: {
+          defaultProviderId: "ollama-local",
+          providers: {
+            "ollama-local": {
+              enabled: true,
+              baseUrl: `http://127.0.0.1:${address.port}/v1`,
+              model: "local-review-model",
+              authMode: "none"
+            }
+          }
+        }
+      })}\n`);
+
+      const output = JSON.parse((await runCli([
+        "providers",
+        "doctor",
+        "--config",
+        configPath,
+        "--provider",
+        "ollama-local",
+        "--smoke",
+        "true"
+      ])).stdout);
+
+      expect(output).toMatchObject({
+        ok: true,
+        command: "providers doctor",
+        providerId: "ollama-local",
+        checks: [
+          expect.objectContaining({
+            providerId: "ollama-local",
+            ok: true,
+            smokeAttempted: true,
+            readMode: "openai_compatible_models",
+            modelCount: 1
+          })
+        ]
+      });
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("rejects malformed provider ids before reflecting them", async () => {
+    await expect(runCli(["providers", "doctor", "--provider", "sk-live-secret-secret-secret-secret"])).rejects.toMatchObject({
+      stdout: expect.stringContaining("--provider must be a stable provider identifier")
+    });
+  });
+
   it("doctor github proves App installation reads without printing secrets", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-doctor-github-"));
     roots.push(root);

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -46,6 +46,8 @@ describe("public NeonDiff CLI surface", () => {
       "config inspect",
       "config patch",
       "pricing",
+      "providers list",
+      "providers doctor",
       "doctor",
       "doctor github",
       "daemon start",
@@ -59,6 +61,9 @@ describe("public NeonDiff CLI surface", () => {
     ]);
     expect(output.examples).toContain("neondiff init --config config.local.json");
     expect(output.examples).toContain("neondiff pricing");
+    expect(output.examples).toContain("neondiff providers list --config config.local.json --json");
+    expect(output.examples).toContain("neondiff providers doctor --config config.local.json --json");
+    expect(output.examples).toContain("neondiff providers doctor --config config.local.json --provider ollama-local --smoke true --json");
     expect(output.examples).toContain("neondiff doctor github --config config.local.json --json");
     expect(output.examples).toContain("neondiff license status --config config.local.json --json");
     expect(output.examples).toContain("npx tsx src/cli.ts daemon --config /path/to/live.json --dry-run true --once true");
@@ -137,6 +142,42 @@ describe("public NeonDiff CLI surface", () => {
     ]);
     expect(stdout).toContain("does not include hosted model credits");
     expect(stdout).not.toMatch(/"includedHostedModelCredits":\s*true|bundled provider tokens included/i);
+  });
+
+  it("lists and doctors providers without hiding env-var names or printing keys", async () => {
+    const list = JSON.parse((await runCli(["providers", "list"])).stdout);
+    const doctor = JSON.parse((await runCli(["providers", "doctor"])).stdout);
+
+    expect(list).toMatchObject({
+      ok: true,
+      command: "providers list",
+      defaultProviderId: "zcode-glm"
+    });
+    expect(list.providers).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: "openai-compatible",
+        authMode: "api-key-env",
+        apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY"
+      }),
+      expect.objectContaining({
+        id: "ollama-local",
+        adapter: "openai-compatible"
+      })
+    ]));
+    expect(JSON.stringify(list)).not.toMatch(/sk-[A-Za-z0-9]|provider-secret/i);
+
+    expect(doctor).toMatchObject({
+      ok: true,
+      command: "providers doctor",
+      defaultProviderId: "zcode-glm",
+      checks: [
+        expect.objectContaining({
+          providerId: "zcode-glm",
+          ok: true,
+          readMode: "metadata_only"
+        })
+      ]
+    });
   });
 
   it("doctor github proves App installation reads without printing secrets", async () => {

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -22,6 +22,7 @@ describe("NeonDiff public community funnel", () => {
       /LICENSE\.md/i,
       /docs\/license-boundary\.md/i,
       /docs\/pricing\.md/i,
+      /docs\/providers\.md/i,
       /public open-source repos.*free/i,
       /\$1\/month/i,
       /\$10\/year/i,
@@ -106,6 +107,7 @@ describe("NeonDiff public community funnel", () => {
   it("setup guide gives a first-run path without hiding safety prerequisites in operator runbooks", () => {
     const setup = read("docs/SETUP.md");
     const githubApp = read("docs/github-app-setup.md");
+    const providers = read("docs/providers.md");
 
     for (const required of [
       /^# NeonDiff Setup/m,
@@ -115,6 +117,8 @@ describe("NeonDiff public community funnel", () => {
       /Contents: read/i,
       /Pull requests: read\/write/i,
       /doctor github/i,
+      /providers list/i,
+      /providers doctor/i,
       /app_installation/i,
       /provider/i,
       /license/i,
@@ -130,6 +134,14 @@ describe("NeonDiff public community funnel", () => {
 
     expect(setup).not.toMatch(/BEGIN (RSA|OPENSSH|PRIVATE) KEY|ghp_|github_pat_|sk-[A-Za-z0-9]/);
     expect(githubApp).toMatch(/^# GitHub App Install And Onboarding/m);
+    expect(providers).toMatch(/^# NeonDiff Provider Registry/m);
+    expect(providers).toMatch(/GLM\/Z\.ai/i);
+    expect(providers).toMatch(/Ollama/i);
+    expect(providers).toMatch(/OpenAI-compatible/i);
+    expect(providers).toMatch(/apiKeyEnv/i);
+    expect(providers).toMatch(/must not store the API key/i);
+    expect(providers).toMatch(/proof boundary/i);
+    expect(providers).not.toMatch(/BEGIN (RSA|OPENSSH|PRIVATE) KEY|ghp_|github_pat_|sk-[A-Za-z0-9]/);
     for (const required of [
       /Install URL/i,
       /Selected-Repo Install Path/i,


### PR DESCRIPTION
## Summary
- add a provider registry config/default surface for GLM/ZCode, Ollama local, OpenAI-compatible, and native-provider placeholders
- add `neondiff providers list` and `neondiff providers doctor` with optional OpenAI-compatible `/models` smoke checks
- document GLM/Z.ai and Ollama/OpenAI-compatible setup while keeping provider keys out of config/comments/evidence

## Proof Boundary
This is a first #108 slice, not full provider execution parity. Live review execution remains ZCode-backed until a later adapter rollout proves fixture review execution, provider-scoped cooldown semantics, and release-status evidence for alternate providers.

Related #108

## Validation
- `NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/provider-registry.test.ts tests/config-cli.test.ts tests/public-cli.test.ts tests/public-community-funnel.test.ts --pool forks`
- `NODE_OPTIONS=--experimental-sqlite npm run build`
- `git diff --check`
- `neondiff providers list --config config.example.json`
- `neondiff providers doctor --config config.example.json`