### PR TITLE
Add finishing-touch dry-run contract

### DIFF
--- a/docs/maintainer-commands.md
+++ b/docs/maintainer-commands.md
@@ -75,10 +75,13 @@ npx tsx src/cli.ts finishing-touch-dry-run \
 ```
 
 The dry-run JSON includes a `contract` object with the target repo/PR/head,
-trusted-author status, stale-head check, clean-worktree flag, secret-scan
-result, and explicit mutation booleans. All mutation booleans remain `false`;
-the command is `defaultOff: true` and `mode: "draft_only"` even when validation
-passes.
+trusted-author status, stale-head check, clean-worktree state
+(`verified_clean`, `dirty`, or `assumed_clean`), secret-scan state (`passed`,
+`failed`, or `not_scanned`), and explicit mutation booleans. All mutation
+booleans remain `false`; the command is `defaultOff: true` and
+`mode: "draft_only"` even when validation passes. When `--worktree-clean` is
+omitted, the dry-run contract reports `assumed_clean` rather than claiming an
+explicit Git clean check was performed.
 
 ## Trust Boundary
 

--- a/docs/maintainer-commands.md
+++ b/docs/maintainer-commands.md
@@ -74,6 +74,12 @@ npx tsx src/cli.ts finishing-touch-dry-run \
   --body '@evaos-code-review-bot explain risk'
 ```
 
+The dry-run JSON includes a `contract` object with the target repo/PR/head,
+trusted-author status, stale-head check, clean-worktree flag, secret-scan
+result, and explicit mutation booleans. All mutation booleans remain `false`;
+the command is `defaultOff: true` and `mode: "draft_only"` even when validation
+passes.
+
 ## Trust Boundary
 
 Only authors listed in `commands.trustedAuthors` are executable in this MVP.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1087,9 +1087,14 @@ async function main(): Promise<void> {
     const pullNumber = parsePositiveInteger(parseSingleArg(args.pr, "--pr"), "--pr");
     const commentId = parsePositiveInteger(parseSingleArg(args["comment-id"], "--comment-id"), "--comment-id");
     const trustedAuthors = parseCsv(args["trusted-authors"]);
-    const worktreeClean = args["worktree-clean"] === undefined
-      ? true
-      : parseBooleanArg(args["worktree-clean"], "--worktree-clean");
+    const worktreeCleanArg = args["worktree-clean"];
+    const worktreeCleanExplicit = worktreeCleanArg !== undefined;
+    const worktreeClean = worktreeCleanExplicit
+      ? parseBooleanArg(worktreeCleanArg, "--worktree-clean")
+      : true;
+    const worktreeCleanState = worktreeCleanExplicit
+      ? worktreeClean ? "verified_clean" : "dirty"
+      : "assumed_clean";
     const trigger = parseSingleArg(args.body ?? args.action ?? action, "--body");
     const draft = buildFinishingTouchDraft({
       repo,
@@ -1119,6 +1124,7 @@ async function main(): Promise<void> {
       draft,
       currentHeadSha,
       worktreeClean,
+      worktreeCleanState,
       trustedAuthors,
       validation
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import {
 import { inspectConfigForDesktop, patchConfigForDesktop } from "./config-cli.js";
 import { buildEnrichmentComment, buildIssueEnrichmentDryRunOutput } from "./enrichment.js";
 import {
+  buildFinishingTouchDryRunContract,
   buildFinishingTouchDraft,
   FINISHING_TOUCH_ACTIONS,
   parseFinishingTouchCommand,
@@ -1076,6 +1077,7 @@ async function main(): Promise<void> {
     if (dryRun && record) throw new Error("--record true requires --dry-run false");
     const repo = parseSingleArg(args.repo, "--repo");
     const headSha = parseSingleArg(args["head-sha"], "--head-sha");
+    const currentHeadSha = parseSingleArg(args["current-head"], "--current-head");
     const author = parseSingleArg(args.author, "--author");
     const action = resolveFinishingTouchAction({
       action: args.action,
@@ -1103,7 +1105,7 @@ async function main(): Promise<void> {
       repo,
       pullNumber,
       headSha,
-      currentHeadSha: parseSingleArg(args["current-head"], "--current-head"),
+      currentHeadSha,
       commentId,
       author,
       trustedAuthors,
@@ -1111,8 +1113,17 @@ async function main(): Promise<void> {
       action,
       proposedOutput: draft
     });
+    const contract = buildFinishingTouchDryRunContract({
+      dryRun,
+      recorded: false,
+      draft,
+      currentHeadSha,
+      worktreeClean,
+      trustedAuthors,
+      validation
+    });
     if (!validation.ok) {
-      console.log(redactSecrets(JSON.stringify({ ok: false, dryRun, validation }, null, 2)));
+      console.log(redactSecrets(JSON.stringify({ ok: false, dryRun, validation, contract }, null, 2)));
       process.exitCode = 1;
       return;
     }
@@ -1140,6 +1151,7 @@ async function main(): Promise<void> {
       ok: true,
       dryRun,
       recorded: Boolean(stored),
+      contract: stored ? { ...contract, recorded: true } : contract,
       draft,
       ...(stored ? { stored } : {})
     }, null, 2)));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1118,17 +1118,17 @@ async function main(): Promise<void> {
       action,
       proposedOutput: draft
     });
-    const contract = buildFinishingTouchDryRunContract({
-      dryRun,
-      recorded: false,
-      draft,
-      currentHeadSha,
-      worktreeClean,
-      worktreeCleanState,
-      trustedAuthors,
-      validation
-    });
     if (!validation.ok) {
+      const contract = buildFinishingTouchDryRunContract({
+        dryRun,
+        recorded: false,
+        draft,
+        currentHeadSha,
+        worktreeClean,
+        worktreeCleanState,
+        trustedAuthors,
+        validation
+      });
       console.log(redactSecrets(JSON.stringify({ ok: false, dryRun, validation, contract }, null, 2)));
       process.exitCode = 1;
       return;
@@ -1153,11 +1153,21 @@ async function main(): Promise<void> {
         state.close();
       }
     }
+    const contract = buildFinishingTouchDryRunContract({
+      dryRun,
+      recorded: Boolean(stored),
+      draft,
+      currentHeadSha,
+      worktreeClean,
+      worktreeCleanState,
+      trustedAuthors,
+      validation
+    });
     console.log(redactSecrets(JSON.stringify({
       ok: true,
       dryRun,
       recorded: Boolean(stored),
-      contract: stored ? { ...contract, recorded: true } : contract,
+      contract,
       draft,
       ...(stored ? { stored } : {})
     }, null, 2)));

--- a/src/finishing-touches.ts
+++ b/src/finishing-touches.ts
@@ -77,6 +77,51 @@ export interface FinishingTouchDraft {
   markdown: string;
 }
 
+export interface BuildFinishingTouchDryRunContractInput {
+  dryRun: boolean;
+  recorded: boolean;
+  draft: FinishingTouchDraft;
+  currentHeadSha: string;
+  worktreeClean: boolean;
+  trustedAuthors: string[];
+  validation: FinishingTouchRequestValidationResult;
+}
+
+export interface FinishingTouchDryRunContract {
+  ok: boolean;
+  mode: "draft_only";
+  defaultOff: true;
+  dryRun: boolean;
+  recorded: boolean;
+  target: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    currentHeadSha: string;
+    staleHead: boolean;
+  };
+  command: {
+    action: FinishingTouchAction;
+    author: string;
+    commentId: number;
+    trigger: string;
+  };
+  safety: {
+    trustedAuthor: boolean;
+    currentHeadMatches: boolean;
+    worktreeClean: boolean;
+    secretScan: "passed" | "failed";
+    mutation: {
+      canPush: false;
+      canCommit: false;
+      canApprove: false;
+      directProtectedBranchCommit: false;
+    };
+  };
+  validation: FinishingTouchRequestValidationResult;
+  draft?: FinishingTouchDraft;
+}
+
 const COMMAND_PHRASES: Array<[FinishingTouchAction, string[]]> = [
   ["generate_tests", ["generate tests", "generate unit tests"]],
   ["generate_docs", ["generate docs", "generate documentation", "docs draft"]],
@@ -202,6 +247,48 @@ export function buildFinishingTouchDraft(input: BuildFinishingTouchDraftInput): 
     canCommit: false,
     canApprove: false,
     markdown
+  };
+}
+
+export function buildFinishingTouchDryRunContract(
+  input: BuildFinishingTouchDryRunContractInput
+): FinishingTouchDryRunContract {
+  const currentHeadMatches = input.currentHeadSha === input.draft.headSha;
+  const trustedAuthor = input.trustedAuthors.includes("*") || input.trustedAuthors.includes(input.draft.author);
+  const secretScan = input.validation.ok || input.validation.reason !== "secret_detected" ? "passed" : "failed";
+  return {
+    ok: input.validation.ok,
+    mode: "draft_only",
+    defaultOff: true,
+    dryRun: input.dryRun,
+    recorded: input.recorded,
+    target: {
+      repo: input.draft.repo,
+      pullNumber: input.draft.pullNumber,
+      headSha: input.draft.headSha,
+      currentHeadSha: input.currentHeadSha,
+      staleHead: !currentHeadMatches
+    },
+    command: {
+      action: input.draft.action,
+      author: input.draft.author,
+      commentId: input.draft.commandCommentId,
+      trigger: input.draft.trigger
+    },
+    safety: {
+      trustedAuthor,
+      currentHeadMatches,
+      worktreeClean: input.worktreeClean,
+      secretScan,
+      mutation: {
+        canPush: false,
+        canCommit: false,
+        canApprove: false,
+        directProtectedBranchCommit: false
+      }
+    },
+    validation: input.validation,
+    ...(input.validation.ok ? { draft: input.draft } : {})
   };
 }
 

--- a/src/finishing-touches.ts
+++ b/src/finishing-touches.ts
@@ -268,7 +268,7 @@ export function buildFinishingTouchDryRunContract(
   const currentHeadSha = input.currentHeadSha.trim();
   const draftHeadSha = input.draft.headSha.trim();
   const currentHeadMatches =
-    currentHeadSha.length > 0 && draftHeadSha.length > 0 && currentHeadSha === draftHeadSha;
+    isFullGitSha(currentHeadSha) && isFullGitSha(draftHeadSha) && currentHeadSha === draftHeadSha;
   const trustedAuthor = input.trustedAuthors.includes("*") || input.trustedAuthors.includes(input.draft.author);
   const secretScan = input.validation.secretScan;
   const worktreeCleanState = input.worktreeCleanState ?? (input.worktreeClean ? "verified_clean" : "dirty");
@@ -306,6 +306,10 @@ export function buildFinishingTouchDryRunContract(
     validation: input.validation,
     ...(input.validation.ok ? { draft: input.draft } : {})
   };
+}
+
+function isFullGitSha(value: string): boolean {
+  return /^[0-9a-f]{40}$/i.test(value);
 }
 
 function titleForAction(action: FinishingTouchAction): string {

--- a/src/finishing-touches.ts
+++ b/src/finishing-touches.ts
@@ -39,7 +39,7 @@ export interface FinishingTouchRequestValidationInput {
 }
 
 export type FinishingTouchRequestValidationResult =
-  | { ok: true }
+  | { ok: true; secretScan: "passed" }
   | {
       ok: false;
       reason:
@@ -48,6 +48,7 @@ export type FinishingTouchRequestValidationResult =
         | "dirty_worktree"
         | "secret_detected";
       detail: string;
+      secretScan: FinishingTouchSecretScanState;
     };
 
 export interface BuildFinishingTouchDraftInput {
@@ -169,31 +170,35 @@ export function validateFinishingTouchRequest(
     return {
       ok: false,
       reason: "untrusted_author",
-      detail: `Author ${input.author} is not trusted for finishing-touch commands.`
+      detail: `Author ${input.author} is not trusted for finishing-touch commands.`,
+      secretScan: "not_scanned"
     };
   }
   if (input.currentHeadSha && input.currentHeadSha !== input.headSha) {
     return {
       ok: false,
       reason: "stale_head",
-      detail: `Command targeted ${input.headSha}, but current head is ${input.currentHeadSha}.`
+      detail: `Command targeted ${input.headSha}, but current head is ${input.currentHeadSha}.`,
+      secretScan: "not_scanned"
     };
   }
   if (!input.worktreeClean) {
     return {
       ok: false,
       reason: "dirty_worktree",
-      detail: "Refusing finishing-touch draft while the worktree is dirty."
+      detail: "Refusing finishing-touch draft while the worktree is dirty.",
+      secretScan: "not_scanned"
     };
   }
   if (input.proposedOutput !== undefined && containsSecretLikeText(stringifyOutput(input.proposedOutput))) {
     return {
       ok: false,
       reason: "secret_detected",
-      detail: "Refusing finishing-touch draft because proposed output contains secret-like text."
+      detail: "Refusing finishing-touch draft because proposed output contains secret-like text.",
+      secretScan: "failed"
     };
   }
-  return { ok: true };
+  return { ok: true, secretScan: "passed" };
 }
 
 export function isFinishingTouchActionEnabled(
@@ -259,11 +264,7 @@ export function buildFinishingTouchDryRunContract(
 ): FinishingTouchDryRunContract {
   const currentHeadMatches = input.currentHeadSha === input.draft.headSha;
   const trustedAuthor = input.trustedAuthors.includes("*") || input.trustedAuthors.includes(input.draft.author);
-  const secretScan: FinishingTouchSecretScanState = input.validation.ok
-    ? "passed"
-    : input.validation.reason === "secret_detected"
-      ? "failed"
-      : "not_scanned";
+  const secretScan = input.validation.secretScan;
   const worktreeCleanState = input.worktreeCleanState ?? (input.worktreeClean ? "verified_clean" : "dirty");
   return {
     ok: input.validation.ok,

--- a/src/finishing-touches.ts
+++ b/src/finishing-touches.ts
@@ -83,9 +83,13 @@ export interface BuildFinishingTouchDryRunContractInput {
   draft: FinishingTouchDraft;
   currentHeadSha: string;
   worktreeClean: boolean;
+  worktreeCleanState?: FinishingTouchWorktreeCleanState;
   trustedAuthors: string[];
   validation: FinishingTouchRequestValidationResult;
 }
+
+export type FinishingTouchSecretScanState = "passed" | "failed" | "not_scanned";
+export type FinishingTouchWorktreeCleanState = "verified_clean" | "dirty" | "assumed_clean";
 
 export interface FinishingTouchDryRunContract {
   ok: boolean;
@@ -104,13 +108,13 @@ export interface FinishingTouchDryRunContract {
     action: FinishingTouchAction;
     author: string;
     commentId: number;
-    trigger: string;
+    trigger?: string;
   };
   safety: {
     trustedAuthor: boolean;
     currentHeadMatches: boolean;
-    worktreeClean: boolean;
-    secretScan: "passed" | "failed";
+    worktreeClean: FinishingTouchWorktreeCleanState;
+    secretScan: FinishingTouchSecretScanState;
     mutation: {
       canPush: false;
       canCommit: false;
@@ -255,7 +259,12 @@ export function buildFinishingTouchDryRunContract(
 ): FinishingTouchDryRunContract {
   const currentHeadMatches = input.currentHeadSha === input.draft.headSha;
   const trustedAuthor = input.trustedAuthors.includes("*") || input.trustedAuthors.includes(input.draft.author);
-  const secretScan = input.validation.ok || input.validation.reason !== "secret_detected" ? "passed" : "failed";
+  const secretScan: FinishingTouchSecretScanState = input.validation.ok
+    ? "passed"
+    : input.validation.reason === "secret_detected"
+      ? "failed"
+      : "not_scanned";
+  const worktreeCleanState = input.worktreeCleanState ?? (input.worktreeClean ? "verified_clean" : "dirty");
   return {
     ok: input.validation.ok,
     mode: "draft_only",
@@ -273,12 +282,12 @@ export function buildFinishingTouchDryRunContract(
       action: input.draft.action,
       author: input.draft.author,
       commentId: input.draft.commandCommentId,
-      trigger: input.draft.trigger
+      ...(input.validation.ok ? { trigger: input.draft.trigger } : {})
     },
     safety: {
       trustedAuthor,
       currentHeadMatches,
-      worktreeClean: input.worktreeClean,
+      worktreeClean: worktreeCleanState,
       secretScan,
       mutation: {
         canPush: false,

--- a/src/finishing-touches.ts
+++ b/src/finishing-touches.ts
@@ -39,7 +39,7 @@ export interface FinishingTouchRequestValidationInput {
 }
 
 export type FinishingTouchRequestValidationResult =
-  | { ok: true; secretScan: "passed" }
+  | { ok: true; secretScan: "passed" | "not_scanned" }
   | {
       ok: false;
       reason:
@@ -190,15 +190,18 @@ export function validateFinishingTouchRequest(
       secretScan: "not_scanned"
     };
   }
-  if (input.proposedOutput !== undefined && containsSecretLikeText(stringifyOutput(input.proposedOutput))) {
-    return {
-      ok: false,
-      reason: "secret_detected",
-      detail: "Refusing finishing-touch draft because proposed output contains secret-like text.",
-      secretScan: "failed"
-    };
+  if (input.proposedOutput !== undefined) {
+    if (containsSecretLikeText(stringifyOutput(input.proposedOutput))) {
+      return {
+        ok: false,
+        reason: "secret_detected",
+        detail: "Refusing finishing-touch draft because proposed output contains secret-like text.",
+        secretScan: "failed"
+      };
+    }
+    return { ok: true, secretScan: "passed" };
   }
-  return { ok: true, secretScan: "passed" };
+  return { ok: true, secretScan: "not_scanned" };
 }
 
 export function isFinishingTouchActionEnabled(
@@ -262,7 +265,10 @@ export function buildFinishingTouchDraft(input: BuildFinishingTouchDraftInput): 
 export function buildFinishingTouchDryRunContract(
   input: BuildFinishingTouchDryRunContractInput
 ): FinishingTouchDryRunContract {
-  const currentHeadMatches = input.currentHeadSha === input.draft.headSha;
+  const currentHeadSha = input.currentHeadSha.trim();
+  const draftHeadSha = input.draft.headSha.trim();
+  const currentHeadMatches =
+    currentHeadSha.length > 0 && draftHeadSha.length > 0 && currentHeadSha === draftHeadSha;
   const trustedAuthor = input.trustedAuthors.includes("*") || input.trustedAuthors.includes(input.draft.author);
   const secretScan = input.validation.secretScan;
   const worktreeCleanState = input.worktreeCleanState ?? (input.worktreeClean ? "verified_clean" : "dirty");

--- a/tests/finishing-touches.test.ts
+++ b/tests/finishing-touches.test.ts
@@ -146,7 +146,7 @@ describe("finishing-touch draft commands", () => {
       safety: {
         trustedAuthor: true,
         currentHeadMatches: true,
-        worktreeClean: true,
+        worktreeClean: "verified_clean",
         secretScan: "passed",
         mutation: {
           canPush: false,
@@ -157,5 +157,99 @@ describe("finishing-touch draft commands", () => {
       }
     });
     expect(contract.draft).toBe(draft);
+  });
+
+  it("renders validation failures without drafts, skipped scan claims, or raw triggers", () => {
+    const baseDraft = buildFinishingTouchDraft({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 157,
+      headSha: "head-a",
+      action: "generate_tests",
+      author: "100yenadmin",
+      commentId: 789,
+      trigger: "@evaos-code-review-bot generate tests ghp_123456789012345678901234567890123456",
+      generatedAt: "2026-07-03T00:00:00.000Z"
+    });
+    const failureCases = [
+      {
+        name: "untrusted_author",
+        validation: { ok: false, reason: "untrusted_author", detail: "Author stranger is not trusted." } as const,
+        trustedAuthors: ["maintainer"],
+        currentHeadSha: "head-a",
+        worktreeClean: true,
+        expectedSafety: {
+          trustedAuthor: false,
+          currentHeadMatches: true,
+          worktreeClean: "verified_clean",
+          secretScan: "not_scanned"
+        }
+      },
+      {
+        name: "stale_head",
+        validation: { ok: false, reason: "stale_head", detail: "Command targeted head-a, but current head is head-b." } as const,
+        trustedAuthors: ["100yenadmin"],
+        currentHeadSha: "head-b",
+        worktreeClean: true,
+        expectedSafety: {
+          trustedAuthor: true,
+          currentHeadMatches: false,
+          worktreeClean: "verified_clean",
+          secretScan: "not_scanned"
+        }
+      },
+      {
+        name: "dirty_worktree",
+        validation: { ok: false, reason: "dirty_worktree", detail: "Refusing finishing-touch draft while the worktree is dirty." } as const,
+        trustedAuthors: ["100yenadmin"],
+        currentHeadSha: "head-a",
+        worktreeClean: false,
+        expectedSafety: {
+          trustedAuthor: true,
+          currentHeadMatches: true,
+          worktreeClean: "dirty",
+          secretScan: "not_scanned"
+        }
+      },
+      {
+        name: "secret_detected",
+        validation: { ok: false, reason: "secret_detected", detail: "Refusing finishing-touch draft because proposed output contains secret-like text." } as const,
+        trustedAuthors: ["100yenadmin"],
+        currentHeadSha: "head-a",
+        worktreeClean: true,
+        expectedSafety: {
+          trustedAuthor: true,
+          currentHeadMatches: true,
+          worktreeClean: "verified_clean",
+          secretScan: "failed"
+        }
+      }
+    ];
+
+    for (const failureCase of failureCases) {
+      const contract = buildFinishingTouchDryRunContract({
+        dryRun: true,
+        recorded: false,
+        draft: {
+          ...baseDraft,
+          author: failureCase.name === "untrusted_author" ? "stranger" : baseDraft.author
+        },
+        currentHeadSha: failureCase.currentHeadSha,
+        worktreeClean: failureCase.worktreeClean,
+        trustedAuthors: failureCase.trustedAuthors,
+        validation: failureCase.validation
+      });
+
+      expect(contract, failureCase.name).toMatchObject({
+        ok: false,
+        target: {
+          staleHead: failureCase.name === "stale_head"
+        },
+        safety: failureCase.expectedSafety,
+        validation: failureCase.validation
+      });
+      expect(contract, failureCase.name).not.toHaveProperty("draft");
+      expect(contract, failureCase.name).not.toHaveProperty("command.trigger");
+      expect(JSON.stringify(contract), failureCase.name).not.toContain("ghp_123456789012345678901234567890123456");
+    }
   });
 });

--- a/tests/finishing-touches.test.ts
+++ b/tests/finishing-touches.test.ts
@@ -7,6 +7,9 @@ import {
 } from "../src/finishing-touches.js";
 
 describe("finishing-touch draft commands", () => {
+  const fullHeadSha = "0123456789abcdef0123456789abcdef01234567";
+  const otherFullHeadSha = "89abcdef0123456789abcdef0123456789abcdef";
+
   it("parses trusted bot-mentioned finishing-touch commands", () => {
     expect(parseFinishingTouchCommand({
       body: "@evaos-code-review-bot generate tests",
@@ -44,8 +47,8 @@ describe("finishing-touch draft commands", () => {
     const base = {
       repo: "electricsheephq/evaos-code-review-bot",
       pullNumber: 157,
-      headSha: "head-a",
-      currentHeadSha: "head-a",
+      headSha: fullHeadSha,
+      currentHeadSha: fullHeadSha,
       commentId: 123,
       author: "100yenadmin",
       trustedAuthors: ["100yenadmin"],
@@ -63,7 +66,7 @@ describe("finishing-touch draft commands", () => {
       reason: "untrusted_author",
       secretScan: "not_scanned"
     });
-    expect(validateFinishingTouchRequest({ ...base, currentHeadSha: "head-b" })).toMatchObject({
+    expect(validateFinishingTouchRequest({ ...base, currentHeadSha: otherFullHeadSha })).toMatchObject({
       ok: false,
       reason: "stale_head",
       secretScan: "not_scanned"
@@ -87,7 +90,7 @@ describe("finishing-touch draft commands", () => {
     const draft = buildFinishingTouchDraft({
       repo: "electricsheephq/evaos-code-review-bot",
       pullNumber: 157,
-      headSha: "head-a",
+      headSha: fullHeadSha,
       action: "explain_risk",
       author: "100yenadmin",
       commentId: 456,
@@ -99,7 +102,7 @@ describe("finishing-touch draft commands", () => {
       mode: "draft_only",
       repo: "electricsheephq/evaos-code-review-bot",
       pullNumber: 157,
-      headSha: "head-a",
+      headSha: fullHeadSha,
       action: "explain_risk",
       author: "100yenadmin",
       commandCommentId: 456,
@@ -115,7 +118,7 @@ describe("finishing-touch draft commands", () => {
     const draft = buildFinishingTouchDraft({
       repo: "electricsheephq/evaos-code-review-bot",
       pullNumber: 157,
-      headSha: "head-a",
+      headSha: fullHeadSha,
       action: "changelog_draft",
       author: "100yenadmin",
       commentId: 789,
@@ -127,7 +130,7 @@ describe("finishing-touch draft commands", () => {
       dryRun: true,
       recorded: false,
       draft,
-      currentHeadSha: "head-a",
+      currentHeadSha: fullHeadSha,
       worktreeClean: true,
       trustedAuthors: ["100yenadmin"],
       validation: { ok: true, secretScan: "passed" }
@@ -142,8 +145,8 @@ describe("finishing-touch draft commands", () => {
       target: {
         repo: "electricsheephq/evaos-code-review-bot",
         pullNumber: 157,
-        headSha: "head-a",
-        currentHeadSha: "head-a",
+        headSha: fullHeadSha,
+        currentHeadSha: fullHeadSha,
         staleHead: false
       },
       command: {
@@ -171,7 +174,7 @@ describe("finishing-touch draft commands", () => {
     const draft = buildFinishingTouchDraft({
       repo: "electricsheephq/evaos-code-review-bot",
       pullNumber: 157,
-      headSha: "head-a",
+      headSha: fullHeadSha,
       action: "changelog_draft",
       author: "100yenadmin",
       commentId: 789,
@@ -202,11 +205,44 @@ describe("finishing-touch draft commands", () => {
     });
   });
 
+  it("treats placeholder head values as stale instead of current-head evidence", () => {
+    const draft = buildFinishingTouchDraft({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 157,
+      headSha: "HEAD",
+      action: "changelog_draft",
+      author: "100yenadmin",
+      commentId: 789,
+      trigger: "@evaos-code-review-bot changelog draft",
+      generatedAt: "2026-07-03T00:00:00.000Z"
+    });
+
+    const contract = buildFinishingTouchDryRunContract({
+      dryRun: true,
+      recorded: false,
+      draft,
+      currentHeadSha: "HEAD",
+      worktreeClean: true,
+      trustedAuthors: ["100yenadmin"],
+      validation: { ok: true, secretScan: "not_scanned" }
+    });
+
+    expect(contract).toMatchObject({
+      target: {
+        currentHeadSha: "HEAD",
+        staleHead: true
+      },
+      safety: {
+        currentHeadMatches: false
+      }
+    });
+  });
+
   it("renders validation failures without drafts, skipped scan claims, or raw triggers", () => {
     const baseDraft = buildFinishingTouchDraft({
       repo: "electricsheephq/evaos-code-review-bot",
       pullNumber: 157,
-      headSha: "head-a",
+      headSha: fullHeadSha,
       action: "generate_tests",
       author: "100yenadmin",
       commentId: 789,
@@ -223,7 +259,7 @@ describe("finishing-touch draft commands", () => {
           secretScan: "not_scanned"
         } as const,
         trustedAuthors: ["maintainer"],
-        currentHeadSha: "head-a",
+        currentHeadSha: fullHeadSha,
         worktreeClean: true,
         expectedSafety: {
           trustedAuthor: false,
@@ -237,11 +273,11 @@ describe("finishing-touch draft commands", () => {
         validation: {
           ok: false,
           reason: "stale_head",
-          detail: "Command targeted head-a, but current head is head-b.",
+          detail: `Command targeted ${fullHeadSha}, but current head is ${otherFullHeadSha}.`,
           secretScan: "not_scanned"
         } as const,
         trustedAuthors: ["100yenadmin"],
-        currentHeadSha: "head-b",
+        currentHeadSha: otherFullHeadSha,
         worktreeClean: true,
         expectedSafety: {
           trustedAuthor: true,
@@ -259,7 +295,7 @@ describe("finishing-touch draft commands", () => {
           secretScan: "not_scanned"
         } as const,
         trustedAuthors: ["100yenadmin"],
-        currentHeadSha: "head-a",
+        currentHeadSha: fullHeadSha,
         worktreeClean: false,
         expectedSafety: {
           trustedAuthor: true,
@@ -277,7 +313,7 @@ describe("finishing-touch draft commands", () => {
           secretScan: "failed"
         } as const,
         trustedAuthors: ["100yenadmin"],
-        currentHeadSha: "head-a",
+        currentHeadSha: fullHeadSha,
         worktreeClean: true,
         expectedSafety: {
           trustedAuthor: true,

--- a/tests/finishing-touches.test.ts
+++ b/tests/finishing-touches.test.ts
@@ -53,25 +53,29 @@ describe("finishing-touch draft commands", () => {
       action: "generate_tests" as const
     };
 
-    expect(validateFinishingTouchRequest(base)).toEqual({ ok: true });
+    expect(validateFinishingTouchRequest(base)).toEqual({ ok: true, secretScan: "passed" });
     expect(validateFinishingTouchRequest({ ...base, author: "stranger" })).toMatchObject({
       ok: false,
-      reason: "untrusted_author"
+      reason: "untrusted_author",
+      secretScan: "not_scanned"
     });
     expect(validateFinishingTouchRequest({ ...base, currentHeadSha: "head-b" })).toMatchObject({
       ok: false,
-      reason: "stale_head"
+      reason: "stale_head",
+      secretScan: "not_scanned"
     });
     expect(validateFinishingTouchRequest({ ...base, worktreeClean: false })).toMatchObject({
       ok: false,
-      reason: "dirty_worktree"
+      reason: "dirty_worktree",
+      secretScan: "not_scanned"
     });
     expect(validateFinishingTouchRequest({
       ...base,
       proposedOutput: "token ghp_123456789012345678901234567890123456"
     })).toMatchObject({
       ok: false,
-      reason: "secret_detected"
+      reason: "secret_detected",
+      secretScan: "failed"
     });
   });
 
@@ -122,7 +126,7 @@ describe("finishing-touch draft commands", () => {
       currentHeadSha: "head-a",
       worktreeClean: true,
       trustedAuthors: ["100yenadmin"],
-      validation: { ok: true }
+      validation: { ok: true, secretScan: "passed" }
     });
 
     expect(contract).toMatchObject({
@@ -173,7 +177,12 @@ describe("finishing-touch draft commands", () => {
     const failureCases = [
       {
         name: "untrusted_author",
-        validation: { ok: false, reason: "untrusted_author", detail: "Author stranger is not trusted." } as const,
+        validation: {
+          ok: false,
+          reason: "untrusted_author",
+          detail: "Author stranger is not trusted.",
+          secretScan: "not_scanned"
+        } as const,
         trustedAuthors: ["maintainer"],
         currentHeadSha: "head-a",
         worktreeClean: true,
@@ -186,7 +195,12 @@ describe("finishing-touch draft commands", () => {
       },
       {
         name: "stale_head",
-        validation: { ok: false, reason: "stale_head", detail: "Command targeted head-a, but current head is head-b." } as const,
+        validation: {
+          ok: false,
+          reason: "stale_head",
+          detail: "Command targeted head-a, but current head is head-b.",
+          secretScan: "not_scanned"
+        } as const,
         trustedAuthors: ["100yenadmin"],
         currentHeadSha: "head-b",
         worktreeClean: true,
@@ -199,7 +213,12 @@ describe("finishing-touch draft commands", () => {
       },
       {
         name: "dirty_worktree",
-        validation: { ok: false, reason: "dirty_worktree", detail: "Refusing finishing-touch draft while the worktree is dirty." } as const,
+        validation: {
+          ok: false,
+          reason: "dirty_worktree",
+          detail: "Refusing finishing-touch draft while the worktree is dirty.",
+          secretScan: "not_scanned"
+        } as const,
         trustedAuthors: ["100yenadmin"],
         currentHeadSha: "head-a",
         worktreeClean: false,
@@ -212,7 +231,12 @@ describe("finishing-touch draft commands", () => {
       },
       {
         name: "secret_detected",
-        validation: { ok: false, reason: "secret_detected", detail: "Refusing finishing-touch draft because proposed output contains secret-like text." } as const,
+        validation: {
+          ok: false,
+          reason: "secret_detected",
+          detail: "Refusing finishing-touch draft because proposed output contains secret-like text.",
+          secretScan: "failed"
+        } as const,
         trustedAuthors: ["100yenadmin"],
         currentHeadSha: "head-a",
         worktreeClean: true,

--- a/tests/finishing-touches.test.ts
+++ b/tests/finishing-touches.test.ts
@@ -53,7 +53,11 @@ describe("finishing-touch draft commands", () => {
       action: "generate_tests" as const
     };
 
-    expect(validateFinishingTouchRequest(base)).toEqual({ ok: true, secretScan: "passed" });
+    expect(validateFinishingTouchRequest(base)).toEqual({ ok: true, secretScan: "not_scanned" });
+    expect(validateFinishingTouchRequest({
+      ...base,
+      proposedOutput: "Draft output with no credential material."
+    })).toEqual({ ok: true, secretScan: "passed" });
     expect(validateFinishingTouchRequest({ ...base, author: "stranger" })).toMatchObject({
       ok: false,
       reason: "untrusted_author",
@@ -161,6 +165,41 @@ describe("finishing-touch draft commands", () => {
       }
     });
     expect(contract.draft).toBe(draft);
+  });
+
+  it("treats missing current head evidence as stale instead of a match", () => {
+    const draft = buildFinishingTouchDraft({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 157,
+      headSha: "head-a",
+      action: "changelog_draft",
+      author: "100yenadmin",
+      commentId: 789,
+      trigger: "@evaos-code-review-bot changelog draft",
+      generatedAt: "2026-07-03T00:00:00.000Z"
+    });
+
+    const contract = buildFinishingTouchDryRunContract({
+      dryRun: true,
+      recorded: false,
+      draft,
+      currentHeadSha: "",
+      worktreeClean: true,
+      trustedAuthors: ["100yenadmin"],
+      validation: { ok: true, secretScan: "not_scanned" }
+    });
+
+    expect(contract).toMatchObject({
+      ok: true,
+      target: {
+        currentHeadSha: "",
+        staleHead: true
+      },
+      safety: {
+        currentHeadMatches: false,
+        secretScan: "not_scanned"
+      }
+    });
   });
 
   it("renders validation failures without drafts, skipped scan claims, or raw triggers", () => {

--- a/tests/finishing-touches.test.ts
+++ b/tests/finishing-touches.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildFinishingTouchDryRunContract,
   buildFinishingTouchDraft,
   parseFinishingTouchCommand,
   validateFinishingTouchRequest
@@ -100,5 +101,61 @@ describe("finishing-touch draft commands", () => {
     });
     expect(draft.markdown).toContain("Draft only");
     expect(draft.markdown).toContain("No branch was pushed");
+  });
+
+  it("renders a dry-run contract with explicit default-off mutation guards", () => {
+    const draft = buildFinishingTouchDraft({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 157,
+      headSha: "head-a",
+      action: "changelog_draft",
+      author: "100yenadmin",
+      commentId: 789,
+      trigger: "@evaos-code-review-bot changelog draft",
+      generatedAt: "2026-07-03T00:00:00.000Z"
+    });
+
+    const contract = buildFinishingTouchDryRunContract({
+      dryRun: true,
+      recorded: false,
+      draft,
+      currentHeadSha: "head-a",
+      worktreeClean: true,
+      trustedAuthors: ["100yenadmin"],
+      validation: { ok: true }
+    });
+
+    expect(contract).toMatchObject({
+      ok: true,
+      mode: "draft_only",
+      defaultOff: true,
+      dryRun: true,
+      recorded: false,
+      target: {
+        repo: "electricsheephq/evaos-code-review-bot",
+        pullNumber: 157,
+        headSha: "head-a",
+        currentHeadSha: "head-a",
+        staleHead: false
+      },
+      command: {
+        action: "changelog_draft",
+        author: "100yenadmin",
+        commentId: 789
+      },
+      safety: {
+        trustedAuthor: true,
+        currentHeadMatches: true,
+        worktreeClean: true,
+        secretScan: "passed",
+        mutation: {
+          canPush: false,
+          canCommit: false,
+          canApprove: false,
+          directProtectedBranchCommit: false
+        }
+      }
+    });
+    expect(contract.draft).toBe(draft);
   });
 });

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -80,6 +80,70 @@ describe("public NeonDiff CLI surface", () => {
     expect(output.examples).toContain("desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}");
   });
 
+  it("prints finishing-touch dry-run output as a default-off draft-only contract", async () => {
+    const { stdout } = await runCli([
+      "finishing-touch-dry-run",
+      "--repo",
+      "electricsheephq/evaos-code-review-bot",
+      "--pr",
+      "120",
+      "--head-sha",
+      "head-a",
+      "--current-head",
+      "head-a",
+      "--comment-id",
+      "789",
+      "--author",
+      "100yenadmin",
+      "--trusted-authors",
+      "100yenadmin",
+      "--body",
+      "@evaos-code-review-bot changelog draft",
+      "--generated-at",
+      "2026-07-03T00:00:00.000Z"
+    ]);
+    const output = JSON.parse(stdout);
+
+    expect(output).toMatchObject({
+      ok: true,
+      dryRun: true,
+      recorded: false,
+      contract: {
+        ok: true,
+        mode: "draft_only",
+        defaultOff: true,
+        dryRun: true,
+        recorded: false,
+        target: {
+          repo: "electricsheephq/evaos-code-review-bot",
+          pullNumber: 120,
+          headSha: "head-a",
+          currentHeadSha: "head-a",
+          staleHead: false
+        },
+        safety: {
+          trustedAuthor: true,
+          currentHeadMatches: true,
+          worktreeClean: true,
+          secretScan: "passed",
+          mutation: {
+            canPush: false,
+            canCommit: false,
+            canApprove: false,
+            directProtectedBranchCommit: false
+          }
+        }
+      }
+    });
+    expect(output.contract.draft).toMatchObject({
+      mode: "draft_only",
+      action: "changelog_draft",
+      canPush: false,
+      canCommit: false,
+      canApprove: false
+    });
+  });
+
   it("prints canonical pricing tiers without hosted model credit claims", async () => {
     const { stdout } = await runCli(["pricing"]);
     const output = JSON.parse(stdout);

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -88,9 +88,9 @@ describe("public NeonDiff CLI surface", () => {
       "--pr",
       "120",
       "--head-sha",
-      "head-a",
+      "0123456789abcdef0123456789abcdef01234567",
       "--current-head",
-      "head-a",
+      "0123456789abcdef0123456789abcdef01234567",
       "--comment-id",
       "789",
       "--author",
@@ -117,8 +117,8 @@ describe("public NeonDiff CLI surface", () => {
         target: {
           repo: "electricsheephq/evaos-code-review-bot",
           pullNumber: 120,
-          headSha: "head-a",
-          currentHeadSha: "head-a",
+          headSha: "0123456789abcdef0123456789abcdef01234567",
+          currentHeadSha: "0123456789abcdef0123456789abcdef01234567",
           staleHead: false
         },
         safety: {

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -124,7 +124,7 @@ describe("public NeonDiff CLI surface", () => {
         safety: {
           trustedAuthor: true,
           currentHeadMatches: true,
-          worktreeClean: true,
+          worktreeClean: "assumed_clean",
           secretScan: "passed",
           mutation: {
             canPush: false,
@@ -142,6 +142,65 @@ describe("public NeonDiff CLI surface", () => {
       canCommit: false,
       canApprove: false
     });
+  });
+
+  it("omits failed finishing-touch drafts and secret-bearing triggers from CLI stdout", async () => {
+    const secretLikeToken = "ghp_123456789012345678901234567890123456";
+    let failure: unknown;
+    try {
+      await runCli([
+        "finishing-touch-dry-run",
+        "--repo",
+        "electricsheephq/evaos-code-review-bot",
+        "--pr",
+        "120",
+        "--head-sha",
+        "head-a",
+        "--current-head",
+        "head-a",
+        "--comment-id",
+        "789",
+        "--author",
+        "100yenadmin",
+        "--trusted-authors",
+        "100yenadmin",
+        "--action",
+        "changelog_draft",
+        "--body",
+        `@evaos-code-review-bot changelog draft ${secretLikeToken}`,
+        "--generated-at",
+        "2026-07-03T00:00:00.000Z"
+      ]);
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toMatchObject({ stdout: expect.any(String) });
+    const stdout = (failure as { stdout: string }).stdout;
+    const output = JSON.parse(stdout);
+
+    expect(output).toMatchObject({
+      ok: false,
+      dryRun: true,
+      validation: {
+        ok: false,
+        reason: "secret_detected"
+      },
+      contract: {
+        ok: false,
+        command: {
+          action: "changelog_draft",
+          author: "100yenadmin",
+          commentId: 789
+        },
+        safety: {
+          worktreeClean: "assumed_clean",
+          secretScan: "failed"
+        }
+      }
+    });
+    expect(output.contract).not.toHaveProperty("draft");
+    expect(output.contract).not.toHaveProperty("command.trigger");
+    expect(stdout).not.toContain(secretLikeToken);
   });
 
   it("prints canonical pricing tiers without hosted model credit claims", async () => {


### PR DESCRIPTION
## Summary
- add a structured finishing-touch dry-run `contract` that is default-off and draft-only
- expose target head, trusted-author, stale-head, clean-worktree, secret-scan, and all-false mutation guards in CLI output
- document the operator-facing contract shape and cover it with focused unit/CLI tests

## Validation
- `npm test -- tests/finishing-touches.test.ts tests/public-cli.test.ts -t "finishing-touch|public NeonDiff CLI surface > prints finishing-touch dry-run output" --pool=forks --maxWorkers=1`
- `npm run build`

Refs #120. Narrow slice only; this does not claim the full finishing-touch command roadmap is complete.

Avoided PR #197 provider-registry files by design.