### PR TITLE
Add review settings preview evidence

### DIFF
--- a/docs/repo-profiles.md
+++ b/docs/repo-profiles.md
@@ -90,6 +90,34 @@ evidence are recorded.
 - `suggestedLabels` / `suggestedReviewers`: reserved for later enrichment; they
   do not auto-apply labels or reviewers.
 
+## Review Settings Preview
+
+Each review now records a `review-settings-preview.json` evidence file and, when
+walkthroughs are enabled, renders a `Review Settings Preview` section in the
+walkthrough body. This is the first narrow settings-parity slice for users who
+expect CodeRabbit-style knobs to be visible before live posting.
+
+The preview maps current config into user-facing review behavior:
+
+- `reviewProfile` becomes the visible profile, currently `chill` or
+  `assertive`.
+- `walkthrough.enabled` and `walkthrough.postIssueComment` decide whether the
+  walkthrough-related sections are inline review content or a sticky issue
+  comment.
+- changed-file table, effort estimate, related issues/PRs, suggested labels,
+  and suggested reviewers are reported as enabled sections when the configured
+  review output can render them.
+- `reviewStatusComment.enabled` is shown as a sticky-status section when on.
+- `pathInstructions` are listed with their glob and instructions so maintainers
+  can confirm path-specific guidance before enabling broader review coverage.
+- label and reviewer settings remain suggestions only. Auto-applying labels or
+  requesting reviewers is explicitly roadmap-only until permissions and eval
+  gates justify it.
+
+The preview is descriptive evidence only. It does not change repo eligibility,
+provider selection, App permissions, live allowlists, labels, reviewers, status
+checks, or release state.
+
 ## Changed-Surface Validation
 
 For every review, the worker now writes deterministic validation and proof
@@ -102,6 +130,9 @@ evidence beside the review plan:
 - `deterministic-gate.json`: final inline comment, drop-reason, category, and
   `REQUEST_CHANGES` decisions after schema, diff-line, secret, cap, and taxonomy
   gates.
+- `review-settings-preview.json`: mapped review-output settings, path
+  instructions, suggestion-only labels/reviewers, and roadmap-only unsafe
+  settings.
 
 These selectors do not run tests, builds, project scripts, Unity, or arbitrary
 PR code. They only decide which proof a reviewer should expect and whether that

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -208,13 +208,15 @@ export function buildRepoPolicySnapshot(config: BotConfig, repo: string): RepoPo
 
 export function buildReviewSettingsPreview(config: BotConfig, profile: ResolvedRepoProfile): ReviewSettingsPreview {
   const walkthroughEnabled = config.walkthrough.enabled;
-  const walkthroughMode = config.walkthrough.postIssueComment ? "issue_comment" : "inline_review";
+  const walkthroughPostsSeparately = config.walkthrough.postIssueComment;
+  const walkthroughMode = walkthroughPostsSeparately ? "issue_comment" : "inline_review";
+  const highLevelSummaryVisibleInReview = !walkthroughEnabled || walkthroughPostsSeparately;
   const labels = profile.suggestedLabels ?? [];
   const reviewers = profile.suggestedReviewers ?? [];
   return {
     profile: profile.reviewProfile ?? "assertive",
     sections: [
-      { key: "highLevelSummary", label: "High-level summary", enabled: true, mode: "inline_review" },
+      { key: "highLevelSummary", label: "High-level summary", enabled: highLevelSummaryVisibleInReview, mode: "inline_review" },
       { key: "walkthrough", label: "Walkthrough", enabled: walkthroughEnabled, mode: walkthroughMode },
       { key: "changedFiles", label: "Changed-files table", enabled: walkthroughEnabled, mode: "walkthrough" },
       { key: "effortEstimate", label: "Effort estimate", enabled: walkthroughEnabled, mode: "walkthrough" },

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -31,7 +31,7 @@ export interface RepoPolicySnapshot {
 }
 
 export type ReviewSettingsSectionKey =
-  | "highLevelSummary"
+  | "reviewSummary"
   | "walkthrough"
   | "changedFiles"
   | "effortEstimate"
@@ -210,13 +210,12 @@ export function buildReviewSettingsPreview(config: BotConfig, profile: ResolvedR
   const walkthroughEnabled = config.walkthrough.enabled;
   const walkthroughPostsSeparately = config.walkthrough.postIssueComment;
   const walkthroughMode = walkthroughPostsSeparately ? "issue_comment" : "inline_review";
-  const highLevelSummaryVisibleInReview = !walkthroughEnabled || walkthroughPostsSeparately;
   const labels = profile.suggestedLabels ?? [];
   const reviewers = profile.suggestedReviewers ?? [];
   return {
     profile: profile.reviewProfile ?? "assertive",
     sections: [
-      { key: "highLevelSummary", label: "High-level summary", enabled: highLevelSummaryVisibleInReview, mode: "inline_review" },
+      { key: "reviewSummary", label: "Review summary", enabled: true, mode: "inline_review" },
       { key: "walkthrough", label: "Walkthrough", enabled: walkthroughEnabled, mode: walkthroughMode },
       { key: "changedFiles", label: "Changed-files table", enabled: walkthroughEnabled, mode: "walkthrough" },
       { key: "effortEstimate", label: "Effort estimate", enabled: walkthroughEnabled, mode: "walkthrough" },

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -30,6 +30,40 @@ export interface RepoPolicySnapshot {
   skippedByPolicy?: RepoProfileSkipReason;
 }
 
+export type ReviewSettingsSectionKey =
+  | "highLevelSummary"
+  | "walkthrough"
+  | "changedFiles"
+  | "effortEstimate"
+  | "relatedContext"
+  | "suggestedLabels"
+  | "suggestedReviewers"
+  | "statusComment";
+
+export interface ReviewSettingsPreviewSection {
+  key: ReviewSettingsSectionKey;
+  label: string;
+  enabled: boolean;
+  mode: "inline_review" | "issue_comment" | "walkthrough" | "sticky_status" | "suggestion_only";
+}
+
+export interface ReviewSettingsPathInstruction {
+  pattern: string;
+  instructions: string[];
+}
+
+export interface ReviewSettingsPreview {
+  profile: "chill" | "assertive";
+  sections: ReviewSettingsPreviewSection[];
+  pathInstructions: ReviewSettingsPathInstruction[];
+  suggestions: {
+    labels: string[];
+    reviewers: string[];
+    autoApply: false;
+  };
+  roadmapOnly: string[];
+}
+
 export type PullFileFilterReason =
   | "no_profile_filters"
   | "matched_profile_include"
@@ -169,6 +203,36 @@ export function buildRepoPolicySnapshot(config: BotConfig, repo: string): RepoPo
     finishingTouches: profile.finishingTouches,
     suggestedLabels: profile.suggestedLabels,
     suggestedReviewers: profile.suggestedReviewers
+  };
+}
+
+export function buildReviewSettingsPreview(config: BotConfig, profile: ResolvedRepoProfile): ReviewSettingsPreview {
+  const walkthroughEnabled = config.walkthrough.enabled;
+  const walkthroughMode = config.walkthrough.postIssueComment ? "issue_comment" : "inline_review";
+  const labels = profile.suggestedLabels ?? [];
+  const reviewers = profile.suggestedReviewers ?? [];
+  return {
+    profile: profile.reviewProfile ?? "assertive",
+    sections: [
+      { key: "highLevelSummary", label: "High-level summary", enabled: true, mode: "inline_review" },
+      { key: "walkthrough", label: "Walkthrough", enabled: walkthroughEnabled, mode: walkthroughMode },
+      { key: "changedFiles", label: "Changed-files table", enabled: walkthroughEnabled, mode: "walkthrough" },
+      { key: "effortEstimate", label: "Effort estimate", enabled: walkthroughEnabled, mode: "walkthrough" },
+      { key: "relatedContext", label: "Related issues/PRs", enabled: walkthroughEnabled, mode: "walkthrough" },
+      { key: "suggestedLabels", label: "Suggested labels", enabled: labels.length > 0, mode: "suggestion_only" },
+      { key: "suggestedReviewers", label: "Suggested reviewers", enabled: reviewers.length > 0, mode: "suggestion_only" },
+      { key: "statusComment", label: "Review status comment", enabled: config.reviewStatusComment?.enabled === true, mode: "sticky_status" }
+    ],
+    pathInstructions: Object.entries(profile.pathInstructions ?? {}).map(([pattern, instructions]) => ({
+      pattern,
+      instructions
+    })),
+    suggestions: {
+      labels,
+      reviewers,
+      autoApply: false
+    },
+    roadmapOnly: ["auto-apply labels", "auto-request reviewers"]
   };
 }
 

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -141,7 +141,7 @@ function formatSettingsPreviewSection(settings: ReviewSettingsPreview | undefine
 function formatSettingsPathInstructions(settings: ReviewSettingsPreview): string[] {
   if (settings.pathInstructions.length === 0) return ["- Path instructions: none"];
   return settings.pathInstructions.map((entry) =>
-    `- Path instructions: \`${formatInlinePublicText(entry.pattern)}\` - ${entry.instructions.map(formatInlinePublicText).join("; ")}`
+    `- Path instructions: \`${formatInlineCodePublicText(entry.pattern)}\` - ${entry.instructions.map(formatInlinePublicText).join("; ")}`
   );
 }
 
@@ -181,6 +181,10 @@ function formatInlinePublicText(value: string | undefined): string {
     .trim()
     .replace(/^#{1,6}\s+/, "")
     .slice(0, 200);
+}
+
+function formatInlineCodePublicText(value: string | undefined): string {
+  return formatInlinePublicText(value).replace(/`/g, "\\`");
 }
 
 function summarizeFile(file: PullFilePatch, comments: ReviewComment[]): {

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -54,6 +54,7 @@ export function buildWalkthroughComment(input: {
   const severityCounts = countSeverities(input.comments);
   const highSeverity = severityCounts.P0 + severityCounts.P1;
   const requestChangesEligible = input.comments.filter(isRequestChangesEligible).length;
+  const settingsPreviewSection = formatSettingsPreviewSection(input.settingsPreview);
 
   const visibleBody = [
     "## Walkthrough",
@@ -90,9 +91,7 @@ export function buildWalkthroughComment(input: {
     `Related issues/PRs: ${relatedRefs.length > 0 ? relatedRefs.join(", ") : "none detected from PR metadata"}.`,
     `Suggested labels: ${suggestedLabels.length > 0 ? suggestedLabels.join(", ") : "none"}.`,
     `Suggested reviewers: ${suggestedReviewers.length > 0 ? suggestedReviewers.join(", ") : "none from current metadata"}.`,
-    "",
-    ...formatSettingsPreviewSection(input.settingsPreview),
-    "",
+    ...(settingsPreviewSection.length > 0 ? ["", ...settingsPreviewSection, ""] : [""]),
     "### Pre-merge checklist",
     "",
     checklistItem(input.comments.every((comment) => comment.side === "RIGHT"), "Inline comments target current RIGHT-side diff lines."),

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 import { categoryLabel, isRequestChangesEligible } from "./regression-taxonomy.js";
+import type { ReviewSettingsPreview } from "./repo-policy.js";
 import type {
   ChangedSurfaceValidationReport,
   DroppedFinding,
@@ -38,6 +39,7 @@ export function buildWalkthroughComment(input: {
   event: ReviewEvent;
   validation?: ChangedSurfaceValidationReport;
   proof?: ProofRequirementReport;
+  settingsPreview?: ReviewSettingsPreview;
   postIssueComment?: boolean;
 }): WalkthroughComment {
   validateWalkthroughIdentity({ repo: input.repo, pullNumber: input.pull.number, headSha: input.pull.head.sha });
@@ -89,6 +91,8 @@ export function buildWalkthroughComment(input: {
     `Suggested labels: ${suggestedLabels.length > 0 ? suggestedLabels.join(", ") : "none"}.`,
     `Suggested reviewers: ${suggestedReviewers.length > 0 ? suggestedReviewers.join(", ") : "none from current metadata"}.`,
     "",
+    ...formatSettingsPreviewSection(input.settingsPreview),
+    "",
     "### Pre-merge checklist",
     "",
     checklistItem(input.comments.every((comment) => comment.side === "RIGHT"), "Inline comments target current RIGHT-side diff lines."),
@@ -115,6 +119,31 @@ export function buildWalkthroughComment(input: {
     body: [marker, stateMarker, redactedBody].join("\n"),
     postIssueComment: input.postIssueComment ?? false
   };
+}
+
+function formatSettingsPreviewSection(settings: ReviewSettingsPreview | undefined): string[] {
+  if (!settings) return [];
+  const enabledSections = settings.sections
+    .filter((section) => section.enabled)
+    .map((section) => `${formatInlinePublicText(section.label)} (${section.mode})`);
+  return [
+    "### Review Settings Preview",
+    "",
+    `- Profile: ${settings.profile}`,
+    `- Enabled sections: ${enabledSections.length > 0 ? enabledSections.join("; ") : "none"}`,
+    ...formatSettingsPathInstructions(settings),
+    `- Label suggestions: ${settings.suggestions.labels.length > 0 ? settings.suggestions.labels.map(formatInlinePublicText).join(", ") : "none"}`,
+    `- Reviewer suggestions: ${settings.suggestions.reviewers.length > 0 ? settings.suggestions.reviewers.map(formatInlinePublicText).join(", ") : "none"}`,
+    `- Suggestion behavior: ${settings.suggestions.autoApply ? "auto-apply enabled" : "suggestions only; labels and reviewers are not auto-applied."}`,
+    `- Roadmap-only settings: ${settings.roadmapOnly.length > 0 ? settings.roadmapOnly.map(formatInlinePublicText).join("; ") : "none"}`
+  ];
+}
+
+function formatSettingsPathInstructions(settings: ReviewSettingsPreview): string[] {
+  if (settings.pathInstructions.length === 0) return ["- Path instructions: none"];
+  return settings.pathInstructions.map((entry) =>
+    `- Path instructions: \`${formatInlinePublicText(entry.pattern)}\` - ${entry.instructions.map(formatInlinePublicText).join("; ")}`
+  );
 }
 
 function buildWalkthroughStateMarker(input: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1387,7 +1387,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     writeFileSync(join(evidenceDir, "repo-profile.json"), `${JSON.stringify(repoPolicy.profile, null, 2)}\n`);
     writeFileSync(join(evidenceDir, "filter-impact.json"), `${JSON.stringify(filterImpact, null, 2)}\n`);
     const settingsPreview = buildReviewSettingsPreview(config, repoPolicy.profile);
-    writeFileSync(join(evidenceDir, "review-settings-preview.json"), `${JSON.stringify(settingsPreview, null, 2)}\n`);
+    writeRedactedJson(join(evidenceDir, "review-settings-preview.json"), settingsPreview);
     if (commandDecision.action !== "none") {
       writeFileSync(join(evidenceDir, "command.json"), `${JSON.stringify(commandDecision.command, null, 2)}\n`);
     }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -33,6 +33,7 @@ import { getProtectedCheckoutRoots } from "./path-safety.js";
 import { evaluateLicenseReviewGate, type LicenseReviewGateResult } from "./license.js";
 import {
   buildPullFileFilterImpact,
+  buildReviewSettingsPreview,
   filterPullFilesForProfile,
   listReposToScan,
   resolveRepoProfile
@@ -1385,6 +1386,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     });
     writeFileSync(join(evidenceDir, "repo-profile.json"), `${JSON.stringify(repoPolicy.profile, null, 2)}\n`);
     writeFileSync(join(evidenceDir, "filter-impact.json"), `${JSON.stringify(filterImpact, null, 2)}\n`);
+    const settingsPreview = buildReviewSettingsPreview(config, repoPolicy.profile);
+    writeFileSync(join(evidenceDir, "review-settings-preview.json"), `${JSON.stringify(settingsPreview, null, 2)}\n`);
     if (commandDecision.action !== "none") {
       writeFileSync(join(evidenceDir, "command.json"), `${JSON.stringify(commandDecision.command, null, 2)}\n`);
     }
@@ -1439,6 +1442,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
           event,
           validation,
           proof,
+          settingsPreview,
           postIssueComment: config.walkthrough.postIssueComment
         })
       : undefined;

--- a/tests/repo-policy.test.ts
+++ b/tests/repo-policy.test.ts
@@ -432,6 +432,40 @@ describe("repo profile registry", () => {
     });
   });
 
+  it("marks high-level summary disabled when inline walkthrough replaces the review body", () => {
+    const config = loadConfig(
+      writeConfig({
+        walkthrough: {
+          enabled: true,
+          postIssueComment: false
+        },
+        repoProfiles: {
+          repos: {
+            "electricsheephq/evaos-code-review-bot": {
+              displayName: "Review bot"
+            }
+          }
+        }
+      })
+    );
+    const profile = expectAllowed(resolveRepoProfile(config, "electricsheephq/evaos-code-review-bot"));
+
+    const preview = buildReviewSettingsPreview(config, profile);
+
+    expect(preview.sections).toContainEqual({
+      key: "highLevelSummary",
+      label: "High-level summary",
+      enabled: false,
+      mode: "inline_review"
+    });
+    expect(preview.sections).toContainEqual({
+      key: "walkthrough",
+      label: "Walkthrough",
+      enabled: true,
+      mode: "inline_review"
+    });
+  });
+
   it("keeps the active monitor profile template explicit and non-executing", () => {
     const template = JSON.parse(readFileSync(new URL("../config.active-profiles.example.json", import.meta.url), "utf8"));
     const config = loadConfig(writeConfig(template));

--- a/tests/repo-policy.test.ts
+++ b/tests/repo-policy.test.ts
@@ -466,6 +466,36 @@ describe("repo profile registry", () => {
     });
   });
 
+  it("preserves chill profile and disabled status comment defaults in settings preview", () => {
+    const config = loadConfig(
+      writeConfig({
+        walkthrough: {
+          enabled: true,
+          postIssueComment: true
+        },
+        repoProfiles: {
+          repos: {
+            "electricsheephq/evaos-code-review-bot": {
+              displayName: "Review bot",
+              reviewProfile: "chill"
+            }
+          }
+        }
+      })
+    );
+    const profile = expectAllowed(resolveRepoProfile(config, "electricsheephq/evaos-code-review-bot"));
+
+    const preview = buildReviewSettingsPreview(config, profile);
+
+    expect(preview.profile).toBe("chill");
+    expect(preview.sections).toContainEqual({
+      key: "statusComment",
+      label: "Review status comment",
+      enabled: false,
+      mode: "sticky_status"
+    });
+  });
+
   it("keeps the active monitor profile template explicit and non-executing", () => {
     const template = JSON.parse(readFileSync(new URL("../config.active-profiles.example.json", import.meta.url), "utf8"));
     const config = loadConfig(writeConfig(template));

--- a/tests/repo-policy.test.ts
+++ b/tests/repo-policy.test.ts
@@ -7,6 +7,7 @@ import {
   buildPullFileFilterImpact,
   buildRepoPolicySnapshot,
   buildRepoProfilePromptSection,
+  buildReviewSettingsPreview,
   filterPullFilesForProfile,
   listReposToScan,
   resolveRepoProfile
@@ -377,6 +378,57 @@ describe("repo profile registry", () => {
       canonicalRepo: "electricsheephq/unknown",
       allowed: false,
       skippedByPolicy: "repo_profile_missing"
+    });
+  });
+
+  it("maps CodeRabbit-style repo settings into a preview without enabling auto-apply behavior", () => {
+    const config = loadConfig(
+      writeConfig({
+        walkthrough: {
+          enabled: true,
+          postIssueComment: true
+        },
+        reviewStatusComment: {
+          enabled: true
+        },
+        repoProfiles: {
+          repos: {
+            "electricsheephq/evaos-code-review-bot": {
+              displayName: "Review bot",
+              reviewProfile: "assertive",
+              pathInstructions: {
+                "src/**": ["Prioritize runtime correctness and duplicate-posting regressions."]
+              },
+              suggestedLabels: ["review-settings"],
+              suggestedReviewers: ["maintainer-one"]
+            }
+          }
+        }
+      })
+    );
+    const profile = expectAllowed(resolveRepoProfile(config, "electricsheephq/evaos-code-review-bot"));
+
+    expect(buildReviewSettingsPreview(config, profile)).toEqual({
+      profile: "assertive",
+      sections: [
+        { key: "highLevelSummary", label: "High-level summary", enabled: true, mode: "inline_review" },
+        { key: "walkthrough", label: "Walkthrough", enabled: true, mode: "issue_comment" },
+        { key: "changedFiles", label: "Changed-files table", enabled: true, mode: "walkthrough" },
+        { key: "effortEstimate", label: "Effort estimate", enabled: true, mode: "walkthrough" },
+        { key: "relatedContext", label: "Related issues/PRs", enabled: true, mode: "walkthrough" },
+        { key: "suggestedLabels", label: "Suggested labels", enabled: true, mode: "suggestion_only" },
+        { key: "suggestedReviewers", label: "Suggested reviewers", enabled: true, mode: "suggestion_only" },
+        { key: "statusComment", label: "Review status comment", enabled: true, mode: "sticky_status" }
+      ],
+      pathInstructions: [
+        { pattern: "src/**", instructions: ["Prioritize runtime correctness and duplicate-posting regressions."] }
+      ],
+      suggestions: {
+        labels: ["review-settings"],
+        reviewers: ["maintainer-one"],
+        autoApply: false
+      },
+      roadmapOnly: ["auto-apply labels", "auto-request reviewers"]
     });
   });
 

--- a/tests/repo-policy.test.ts
+++ b/tests/repo-policy.test.ts
@@ -411,7 +411,7 @@ describe("repo profile registry", () => {
     expect(buildReviewSettingsPreview(config, profile)).toEqual({
       profile: "assertive",
       sections: [
-        { key: "highLevelSummary", label: "High-level summary", enabled: true, mode: "inline_review" },
+        { key: "reviewSummary", label: "Review summary", enabled: true, mode: "inline_review" },
         { key: "walkthrough", label: "Walkthrough", enabled: true, mode: "issue_comment" },
         { key: "changedFiles", label: "Changed-files table", enabled: true, mode: "walkthrough" },
         { key: "effortEstimate", label: "Effort estimate", enabled: true, mode: "walkthrough" },
@@ -432,7 +432,7 @@ describe("repo profile registry", () => {
     });
   });
 
-  it("marks high-level summary disabled when inline walkthrough replaces the review body", () => {
+  it("keeps review summary enabled when inline walkthrough carries the review body", () => {
     const config = loadConfig(
       writeConfig({
         walkthrough: {
@@ -453,9 +453,9 @@ describe("repo profile registry", () => {
     const preview = buildReviewSettingsPreview(config, profile);
 
     expect(preview.sections).toContainEqual({
-      key: "highLevelSummary",
-      label: "High-level summary",
-      enabled: false,
+      key: "reviewSummary",
+      label: "Review summary",
+      enabled: true,
       mode: "inline_review"
     });
     expect(preview.sections).toContainEqual({

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -151,7 +151,7 @@ describe("walkthrough comment rendering", () => {
     const settingsPreview: ReviewSettingsPreview = {
       profile: "assertive",
       sections: [
-        { key: "highLevelSummary", label: "High-level summary", enabled: true, mode: "inline_review" },
+        { key: "reviewSummary", label: "Review summary", enabled: true, mode: "inline_review" },
         { key: "walkthrough", label: "Walkthrough", enabled: true, mode: "issue_comment" },
         { key: "changedFiles", label: "Changed-files table", enabled: true, mode: "walkthrough" },
         { key: "effortEstimate", label: "Effort estimate", enabled: true, mode: "walkthrough" },
@@ -190,7 +190,7 @@ describe("walkthrough comment rendering", () => {
 
     expect(walkthrough.body).toContain("### Review Settings Preview");
     expect(walkthrough.body).toContain("- Profile: assertive");
-    expect(walkthrough.body).toContain("- Enabled sections: High-level summary (inline_review); Walkthrough (issue_comment); Changed-files table (walkthrough); Effort estimate (walkthrough); Review status comment (sticky_status)");
+    expect(walkthrough.body).toContain("- Enabled sections: Review summary (inline_review); Walkthrough (issue_comment); Changed-files table (walkthrough); Effort estimate (walkthrough); Review status comment (sticky_status)");
     expect(walkthrough.body).toContain("- Path instructions: `src/**` - Prioritize runtime correctness and duplicate-posting regressions.");
     expect(walkthrough.body).toContain("- Label suggestions: review-settings");
     expect(walkthrough.body).toContain("- Reviewer suggestions: maintainer-one");
@@ -199,6 +199,52 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).not.toContain("auto-apply enabled");
     expect(walkthrough.body).not.toContain("auto-request reviewers enabled");
     expect(walkthrough.body).not.toContain("labels were auto-applied");
+  });
+
+  it("redacts secrets and escapes markdown backticks in settings preview metadata", () => {
+    const secretLikeToken = "ghp_123456789012345678901234567890123456";
+    const settingsPreview: ReviewSettingsPreview = {
+      profile: "assertive",
+      sections: [
+        { key: "reviewSummary", label: "Review summary", enabled: true, mode: "inline_review" }
+      ],
+      pathInstructions: [
+        {
+          pattern: "src/`templates`/**",
+          instructions: [`Never quote ${secretLikeToken} in review output.`]
+        }
+      ],
+      suggestions: {
+        labels: [`token-${secretLikeToken}`],
+        reviewers: ["maintainer-one"],
+        autoApply: false
+      },
+      roadmapOnly: []
+    };
+
+    const walkthrough = buildWalkthroughComment({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pull: {
+        ...pull,
+        head: {
+          ...pull.head,
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        },
+        base: {
+          ...pull.base,
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        }
+      },
+      files: [{ filename: "src/walkthrough.ts", status: "modified", additions: 2, deletions: 1, changes: 3 }],
+      comments: [],
+      dropped: [],
+      event: "COMMENT",
+      settingsPreview
+    });
+
+    expect(walkthrough.body).toContain("- Path instructions: `src/\\`templates\\`/**`");
+    expect(walkthrough.body).not.toContain(secretLikeToken);
+    expect(walkthrough.body).toContain("[redacted-secret]");
   });
 
   it("omits settings preview cleanly when no settings metadata is provided", () => {

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -6,6 +6,7 @@ import {
   WALKTHROUGH_SCHEMA_VERSION,
   WALKTHROUGH_STATE_MARKER_PREFIX
 } from "../src/walkthrough.js";
+import type { ReviewSettingsPreview } from "../src/repo-policy.js";
 import type { PullFilePatch, PullRequestSummary, ReviewComment } from "../src/types.js";
 
 const HEAD_A = "a".repeat(40);
@@ -144,6 +145,57 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("Proof status: missing");
     expect(walkthrough.body).toContain("Pre-merge checklist");
     expect(walkthrough.body).toContain("REQUEST_CHANGES");
+  });
+
+  it("renders CodeRabbit-style settings parity as preview-only walkthrough metadata", () => {
+    const settingsPreview: ReviewSettingsPreview = {
+      profile: "assertive",
+      sections: [
+        { key: "highLevelSummary", label: "High-level summary", enabled: true, mode: "inline_review" },
+        { key: "walkthrough", label: "Walkthrough", enabled: true, mode: "issue_comment" },
+        { key: "changedFiles", label: "Changed-files table", enabled: true, mode: "walkthrough" },
+        { key: "effortEstimate", label: "Effort estimate", enabled: true, mode: "walkthrough" },
+        { key: "statusComment", label: "Review status comment", enabled: true, mode: "sticky_status" }
+      ],
+      pathInstructions: [
+        { pattern: "src/**", instructions: ["Prioritize runtime correctness and duplicate-posting regressions."] }
+      ],
+      suggestions: {
+        labels: ["review-settings"],
+        reviewers: ["maintainer-one"],
+        autoApply: false
+      },
+      roadmapOnly: ["auto-apply labels", "auto-request reviewers"]
+    };
+
+    const walkthrough = buildWalkthroughComment({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pull: {
+        ...pull,
+        head: {
+          ...pull.head,
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        },
+        base: {
+          ...pull.base,
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        }
+      },
+      files: [{ filename: "src/worker.ts", status: "modified", additions: 5, deletions: 1, changes: 6 }],
+      comments: [],
+      dropped: [],
+      event: "COMMENT",
+      settingsPreview
+    });
+
+    expect(walkthrough.body).toContain("### Review Settings Preview");
+    expect(walkthrough.body).toContain("- Profile: assertive");
+    expect(walkthrough.body).toContain("- Enabled sections: High-level summary (inline_review); Walkthrough (issue_comment); Changed-files table (walkthrough); Effort estimate (walkthrough); Review status comment (sticky_status)");
+    expect(walkthrough.body).toContain("- Path instructions: `src/**` - Prioritize runtime correctness and duplicate-posting regressions.");
+    expect(walkthrough.body).toContain("- Label suggestions: review-settings");
+    expect(walkthrough.body).toContain("- Reviewer suggestions: maintainer-one");
+    expect(walkthrough.body).toContain("- Suggestion behavior: suggestions only; labels and reviewers are not auto-applied.");
+    expect(walkthrough.body).toContain("- Roadmap-only settings: auto-apply labels; auto-request reviewers");
   });
 
   it("uses one sticky walkthrough marker per PR while updating head-specific state metadata", () => {

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -196,6 +196,9 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("- Reviewer suggestions: maintainer-one");
     expect(walkthrough.body).toContain("- Suggestion behavior: suggestions only; labels and reviewers are not auto-applied.");
     expect(walkthrough.body).toContain("- Roadmap-only settings: auto-apply labels; auto-request reviewers");
+    expect(walkthrough.body).not.toContain("auto-apply enabled");
+    expect(walkthrough.body).not.toContain("auto-request reviewers enabled");
+    expect(walkthrough.body).not.toContain("labels were auto-applied");
   });
 
   it("uses one sticky walkthrough marker per PR while updating head-specific state metadata", () => {

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -201,6 +201,31 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).not.toContain("labels were auto-applied");
   });
 
+  it("omits settings preview cleanly when no settings metadata is provided", () => {
+    const walkthrough = buildWalkthroughComment({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pull: {
+        ...pull,
+        head: {
+          ...pull.head,
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        },
+        base: {
+          ...pull.base,
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        }
+      },
+      files: [{ filename: "src/walkthrough.ts", status: "modified", additions: 2, deletions: 1, changes: 3 }],
+      comments: [],
+      dropped: [],
+      event: "COMMENT"
+    });
+
+    expect(walkthrough.body).not.toContain("### Review Settings Preview");
+    expect(walkthrough.body).toContain("Suggested reviewers: reviewer-one.\n\n### Pre-merge checklist");
+    expect(walkthrough.body).not.toMatch(/Suggested reviewers:[^\n]*\n\n\n### Pre-merge checklist/);
+  });
+
   it("uses one sticky walkthrough marker per PR while updating head-specific state metadata", () => {
     const first = buildWalkthroughComment({
       repo: "electricsheephq/WorldOS",

--- a/tests/worker-settings-preview.test.ts
+++ b/tests/worker-settings-preview.test.ts
@@ -1,0 +1,167 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BotConfig } from "../src/config.js";
+import type { GitHubApi } from "../src/github.js";
+import { ReviewStateStore } from "../src/state.js";
+import type { PullRequestSummary } from "../src/types.js";
+
+vi.mock("../src/git.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/git.js")>();
+  return {
+    ...actual,
+    preparePullWorktree: vi.fn((input: { workRoot: string; expectedHeadSha: string }) => {
+      const path = join(input.workRoot, "mock-worktree");
+      mkdirSync(path, { recursive: true });
+      return { path, headSha: input.expectedHeadSha };
+    }),
+    assertGitClean: vi.fn()
+  };
+});
+
+const { localDateFolder, reviewPull } = await import("../src/worker.js");
+
+describe("worker review settings preview evidence", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("writes review settings preview evidence and threads it into walkthrough output", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-settings-preview-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1410, "a".repeat(40));
+    const secretLikeToken = "ghp_123456789012345678901234567890123456";
+    const github = {
+      getPull: async () => pull,
+      listPullFiles: async () => [
+        {
+          filename: "src/walkthrough.ts",
+          status: "modified",
+          additions: 4,
+          deletions: 1,
+          changes: 5
+        }
+      ],
+      canPostAsApp: () => false
+    } as unknown as GitHubApi;
+
+    const result = await reviewPull({
+      config,
+      github,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: false
+    });
+
+    expect(result).toBe("reviewed");
+    const evidenceDir = join(
+      root,
+      "evidence",
+      localDateFolder(),
+      "electricsheephq__WorldOS",
+      "pr-1410",
+      pull.head.sha
+    );
+    const preview = JSON.parse(readFileSync(join(evidenceDir, "review-settings-preview.json"), "utf8"));
+    const walkthrough = readFileSync(join(evidenceDir, "walkthrough.md"), "utf8");
+
+    expect(preview.sections).toContainEqual({
+      key: "reviewSummary",
+      label: "Review summary",
+      enabled: true,
+      mode: "inline_review"
+    });
+    expect(walkthrough).toContain("### Review Settings Preview");
+    expect(walkthrough).toContain("- Enabled sections: Review summary (inline_review); Walkthrough (inline_review)");
+    expect(walkthrough).toContain("- Path instructions: `src/\\`templates\\`/**`");
+    expect(walkthrough).not.toContain(secretLikeToken);
+    state.close();
+  });
+});
+
+function minimalConfig(root: string): BotConfig {
+  return {
+    pilotRepos: ["electricsheephq/WorldOS"],
+    pollIntervalMs: 60_000,
+    skipDrafts: true,
+    workRoot: join(root, "work"),
+    statePath: join(root, "state.sqlite"),
+    evidenceDir: join(root, "evidence"),
+    activation: {
+      reviewExistingOpenPrsOnActivation: false
+    },
+    reviewConcurrency: {
+      maxActiveRuns: 1,
+      leaseTtlMs: 60_000
+    },
+    providerCooldown: {
+      enabled: false,
+      durationMs: 15 * 60_000,
+      requestRateLimitDurationMs: 90_000,
+      overloadDurationMs: 2 * 60_000,
+      quotaDurationMs: 30 * 60_000,
+      overloadBackoffMaxDurationMs: 10 * 60_000,
+      overloadBackoffJitterMs: 0,
+      transientRetryAttempts: 1,
+      transientRetryBaseDelayMs: 1,
+      transientRetryMaxDelayMs: 1
+    },
+    walkthrough: {
+      enabled: true,
+      postIssueComment: false
+    },
+    commands: {
+      enabled: false,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: [],
+      acknowledge: false
+    },
+    repoProfiles: {
+      repos: {
+        "electricsheephq/WorldOS": {
+          reviewProfile: "assertive",
+          pathInstructions: {
+            "src/`templates`/**": [`Do not quote ghp_123456789012345678901234567890123456 in public comments.`]
+          },
+          suggestedLabels: ["review-settings"],
+          suggestedReviewers: ["maintainer-one"]
+        }
+      }
+    },
+    zcode: {
+      cliPath: "/unused/zcode.cjs",
+      appConfigPath: "/unused/config.json",
+      model: "GLM-5.2",
+      timeoutMs: 1,
+      maxPatchBytes: 1,
+      retryMaxRetries: 0
+    },
+    github: {}
+  };
+}
+
+function pullSummary(number: number, headSha: string): PullRequestSummary {
+  return {
+    number,
+    title: `PR ${number}`,
+    draft: false,
+    head: {
+      sha: headSha,
+      ref: `pr-${number}`,
+      repo: { full_name: "electricsheephq/WorldOS" }
+    },
+    base: {
+      sha: "b".repeat(40),
+      ref: "main",
+      repo: { full_name: "electricsheephq/WorldOS" }
+    },
+    html_url: `https://github.com/electricsheephq/WorldOS/pull/${number}`
+  };
+}


### PR DESCRIPTION
## Summary
- add a review settings preview model for existing repo-profile, walkthrough, suggestion, and status-comment knobs
- write `review-settings-preview.json` evidence for each review plan
- render a `Review Settings Preview` walkthrough section when walkthroughs are enabled
- document the preview-only behavior and roadmap-only auto-apply settings

## Scope
- Refs #117
- Narrow slice only; does not claim full CodeRabbit parity
- Does not touch provider registry, live release surfaces, launchd/config/tags/releases, or config.example provider blocks
- Keeps labels/reviewers suggestion-only by default

## Validation
- `npm test -- tests/walkthrough.test.ts tests/repo-policy.test.ts`
- `npm run build`