### PR TITLE
Include LCO plugin skill eval profile surfaces

### DIFF
--- a/config.active-profiles.example.json
+++ b/config.active-profiles.example.json
@@ -528,7 +528,7 @@
           "baseBranches": ["main"],
           "labels": ["!wip", "!do-not-review"]
         },
-        "pathFilters": ["packages/**", "src/**", "scripts/**", "tests/**", "docs/**", "package.json", "package-lock.json"],
+        "pathFilters": ["openclaw.plugin.json", "skills/**", "evals/**", "packages/**", "src/**", "scripts/**", "tests/**", "docs/**", "package.json", "package-lock.json"],
         "riskyPaths": ["src/**", "scripts/**"],
         "proofExpectations": ["Look for focused sanitizer, signature, orchestration, or fixture proof."],
         "validationHints": ["Call out evidence leakage, replay/collision risks, duplicate side effects, and brittle sanitizer logic."],

--- a/tests/repo-policy.test.ts
+++ b/tests/repo-policy.test.ts
@@ -425,6 +425,10 @@ describe("repo profile registry", () => {
       {
         repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
         files: [
+          "openclaw.plugin.json",
+          "skills/lossless-openclaw-orchestrator/SKILL.md",
+          "evals/scenarios/v1/codex-collaboration-cockpit.json",
+          "evals/scorecards/v1.0/local-agent-usability-review.json",
           "packages/runtime/src/review-runner.ts",
           "packages/runtime/tests/review-runner.test.ts",
           "src/index.ts"


### PR DESCRIPTION
## Summary
- add LCO root `openclaw.plugin.json`, `skills/**`, and `evals/**` to the tracked active-profile template path filters
- extend the active-profile visibility regression with representative LCO plugin manifest, skill, eval scenario, and eval scorecard paths

Closes #139.

## Evidence
- Representative LCO PRs inspected: 100yenadmin/Lossless-Codex-Orchestrator-LCO#317, #320, #327
- Current pre-patch behavior classified `openclaw.plugin.json`, `skills/**`, and `evals/**` as `no_matching_include` under the LCO profile
- This PR changes only tracked template config and tests; it does not mutate live active config, launchd, release docs, provider queue, tags, or unrelated repo profiles

## Validation
- `npm test -- tests/repo-policy.test.ts --pool=forks --maxWorkers=1`
- `npm run build`

## Notes
- Scratch notes: `/Volumes/LEXAR/Codex/session-notes/2026-07-04/issue-139-lco-profile-scope/implementation-notes.html`