### PR TITLE
Add public confidence display guard

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -906,7 +906,8 @@ async function main(): Promise<void> {
         suggestedOwners: repoPolicy.allowed ? repoPolicy.profile.suggestedReviewers : undefined,
         validationSuggestions: ["Confirm owner, acceptance criteria, and validation evidence before implementation."],
         maxRelatedRefs: enrichmentConfig.maxRelatedRefs,
-        maxSuggestions: enrichmentConfig.maxSuggestions
+        maxSuggestions: enrichmentConfig.maxSuggestions,
+        publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
       });
       if (args["output-dir"]) {
         const safeOutputDir = assertMemoryPacketOutputDirSafe(args["output-dir"], config.evidenceDir);
@@ -941,7 +942,8 @@ async function main(): Promise<void> {
       ],
       maxRelatedRefs: enrichmentConfig.maxRelatedRefs,
       maxSuggestions: enrichmentConfig.maxSuggestions,
-      postIssueComment: false
+      postIssueComment: false,
+      publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
     });
     const output = {
       ok: true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -503,6 +503,12 @@ function validateConfig(config: BotConfig): void {
   config.reviewStatusComment = reviewStatusComment;
   validateBoolean(reviewStatusComment.enabled, "config.reviewStatusComment.enabled");
   const confidenceCalibration = config.confidenceCalibration ?? DEFAULT_CONFIG.confidenceCalibration!;
+  if (!isRecord(confidenceCalibration)) {
+    throw new Error("config.confidenceCalibration must be an object");
+  }
+  if (confidenceCalibration.publicDisplay !== undefined && !isRecord(confidenceCalibration.publicDisplay)) {
+    throw new Error("config.confidenceCalibration.publicDisplay must be an object");
+  }
   validatePublicConfidenceDisplayFloorOverrides(confidenceCalibration.publicDisplay, "config.confidenceCalibration.publicDisplay");
   confidenceCalibration.publicDisplay = buildPublicConfidencePolicy(confidenceCalibration.publicDisplay);
   validatePublicConfidenceDisplayConfig(confidenceCalibration.publicDisplay, "config.confidenceCalibration.publicDisplay");

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,10 @@ import {
   buildPublicConfidencePolicy,
   isPublicConfidenceDisplayAllowed,
   isUsablePublicConfidenceEvidenceUrl,
+  PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS,
+  PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS,
+  PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS,
+  PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND,
   type PublicConfidenceDisplayPolicy
 } from "./public-confidence.js";
 import { isApiKeyEnvName, isProviderId, type ProviderRegistryConfig } from "./providers.js";
@@ -566,10 +570,18 @@ function validatePublicConfidenceDisplayConfig(value: unknown, label: string): v
   validatePositiveInteger(value.minP0P1Labels, `${label}.minP0P1Labels`);
   validatePositiveInteger(value.minNegativeControlScenarios, `${label}.minNegativeControlScenarios`);
   validateProbability(value.minWilsonLowerBound, `${label}.minWilsonLowerBound`);
-  if ((value.minLabeledFindings as number) < 100) throw new Error(`${label}.minLabeledFindings must be >= 100`);
-  if ((value.minP0P1Labels as number) < 30) throw new Error(`${label}.minP0P1Labels must be >= 30`);
-  if ((value.minNegativeControlScenarios as number) < 10) throw new Error(`${label}.minNegativeControlScenarios must be >= 10`);
-  if ((value.minWilsonLowerBound as number) < 0.95) throw new Error(`${label}.minWilsonLowerBound must be >= 0.95`);
+  if ((value.minLabeledFindings as number) < PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS) {
+    throw new Error(`${label}.minLabeledFindings must be >= ${PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS}`);
+  }
+  if ((value.minP0P1Labels as number) < PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS) {
+    throw new Error(`${label}.minP0P1Labels must be >= ${PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS}`);
+  }
+  if ((value.minNegativeControlScenarios as number) < PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS) {
+    throw new Error(`${label}.minNegativeControlScenarios must be >= ${PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS}`);
+  }
+  if ((value.minWilsonLowerBound as number) < PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND) {
+    throw new Error(`${label}.minWilsonLowerBound must be >= ${PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND}`);
+  }
   if (value.labeledFindings !== undefined) validateNonNegativeInteger(value.labeledFindings, `${label}.labeledFindings`);
   if (value.p0p1Labels !== undefined) validateNonNegativeInteger(value.p0p1Labels, `${label}.p0p1Labels`);
   if (value.negativeControlScenarios !== undefined) validateNonNegativeInteger(value.negativeControlScenarios, `${label}.negativeControlScenarios`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -558,8 +558,12 @@ function validatePublicConfidenceDisplayConfig(value: unknown, label: string): v
     throw new Error(`${label}.mode must be uncalibrated or calibrated`);
   }
   validatePositiveInteger(value.minLabeledFindings, `${label}.minLabeledFindings`);
+  validatePositiveInteger(value.minP0P1Labels, `${label}.minP0P1Labels`);
+  validatePositiveInteger(value.minNegativeControlScenarios, `${label}.minNegativeControlScenarios`);
   validateProbability(value.minWilsonLowerBound, `${label}.minWilsonLowerBound`);
   if (value.labeledFindings !== undefined) validateNonNegativeInteger(value.labeledFindings, `${label}.labeledFindings`);
+  if (value.p0p1Labels !== undefined) validateNonNegativeInteger(value.p0p1Labels, `${label}.p0p1Labels`);
+  if (value.negativeControlScenarios !== undefined) validateNonNegativeInteger(value.negativeControlScenarios, `${label}.negativeControlScenarios`);
   if (value.wilsonLowerBound !== undefined) validateProbability(value.wilsonLowerBound, `${label}.wilsonLowerBound`);
   validateOptionalString(value.evidenceUrl, `${label}.evidenceUrl`);
   validateOptionalString(value.datasetId, `${label}.datasetId`);
@@ -573,6 +577,15 @@ function validatePublicConfidenceDisplayConfig(value: unknown, label: string): v
     }
     if (typeof value.labeledFindings !== "number" || value.labeledFindings < (value.minLabeledFindings as number)) {
       throw new Error(`${label}.labeledFindings must be >= minLabeledFindings before public confidence display is calibrated`);
+    }
+    if (typeof value.p0p1Labels !== "number" || value.p0p1Labels < (value.minP0P1Labels as number)) {
+      throw new Error(`${label}.p0p1Labels must be >= minP0P1Labels before public confidence display is calibrated`);
+    }
+    if (
+      typeof value.negativeControlScenarios !== "number" ||
+      value.negativeControlScenarios < (value.minNegativeControlScenarios as number)
+    ) {
+      throw new Error(`${label}.negativeControlScenarios must be >= minNegativeControlScenarios before public confidence display is calibrated`);
     }
     if (typeof value.wilsonLowerBound !== "number" || value.wilsonLowerBound < (value.minWilsonLowerBound as number)) {
       throw new Error(`${label}.wilsonLowerBound must be >= minWilsonLowerBound before public confidence display is calibrated`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -571,18 +571,6 @@ function validatePublicConfidenceDisplayConfig(value: unknown, label: string): v
   validatePositiveInteger(value.minP0P1Labels, `${label}.minP0P1Labels`);
   validatePositiveInteger(value.minNegativeControlScenarios, `${label}.minNegativeControlScenarios`);
   validateProbability(value.minWilsonLowerBound, `${label}.minWilsonLowerBound`);
-  if ((value.minLabeledFindings as number) < PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS) {
-    throw new Error(`${label}.minLabeledFindings must be >= ${PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS}`);
-  }
-  if ((value.minP0P1Labels as number) < PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS) {
-    throw new Error(`${label}.minP0P1Labels must be >= ${PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS}`);
-  }
-  if ((value.minNegativeControlScenarios as number) < PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS) {
-    throw new Error(`${label}.minNegativeControlScenarios must be >= ${PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS}`);
-  }
-  if ((value.minWilsonLowerBound as number) < PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND) {
-    throw new Error(`${label}.minWilsonLowerBound must be >= ${PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND}`);
-  }
   if (value.labeledFindings !== undefined) validateNonNegativeInteger(value.labeledFindings, `${label}.labeledFindings`);
   if (value.p0p1Labels !== undefined) validateNonNegativeInteger(value.p0p1Labels, `${label}.p0p1Labels`);
   if (value.negativeControlScenarios !== undefined) validateNonNegativeInteger(value.negativeControlScenarios, `${label}.negativeControlScenarios`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -503,8 +503,9 @@ function validateConfig(config: BotConfig): void {
   config.reviewStatusComment = reviewStatusComment;
   validateBoolean(reviewStatusComment.enabled, "config.reviewStatusComment.enabled");
   const confidenceCalibration = config.confidenceCalibration ?? DEFAULT_CONFIG.confidenceCalibration!;
-  validatePublicConfidenceDisplayConfig(confidenceCalibration.publicDisplay, "config.confidenceCalibration.publicDisplay");
+  validatePublicConfidenceDisplayFloorOverrides(confidenceCalibration.publicDisplay, "config.confidenceCalibration.publicDisplay");
   confidenceCalibration.publicDisplay = buildPublicConfidencePolicy(confidenceCalibration.publicDisplay);
+  validatePublicConfidenceDisplayConfig(confidenceCalibration.publicDisplay, "config.confidenceCalibration.publicDisplay");
   config.confidenceCalibration = confidenceCalibration;
   const repoMemory = config.repoMemory ?? DEFAULT_CONFIG.repoMemory!;
   config.repoMemory = repoMemory;
@@ -611,6 +612,25 @@ function validatePublicConfidenceDisplayConfig(value: unknown, label: string): v
     if (typeof value.wilsonLowerBound !== "number" || value.wilsonLowerBound < (value.minWilsonLowerBound as number)) {
       throw new Error(`${label}.wilsonLowerBound must be >= minWilsonLowerBound before public confidence display is calibrated`);
     }
+  }
+}
+
+function validatePublicConfidenceDisplayFloorOverrides(value: unknown, label: string): void {
+  if (!isRecord(value)) return;
+  if (value.minLabeledFindings !== undefined && (value.minLabeledFindings as number) < PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS) {
+    throw new Error(`${label}.minLabeledFindings must be >= ${PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS}`);
+  }
+  if (value.minP0P1Labels !== undefined && (value.minP0P1Labels as number) < PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS) {
+    throw new Error(`${label}.minP0P1Labels must be >= ${PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS}`);
+  }
+  if (
+    value.minNegativeControlScenarios !== undefined &&
+    (value.minNegativeControlScenarios as number) < PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS
+  ) {
+    throw new Error(`${label}.minNegativeControlScenarios must be >= ${PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS}`);
+  }
+  if (value.minWilsonLowerBound !== undefined && (value.minWilsonLowerBound as number) < PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND) {
+    throw new Error(`${label}.minWilsonLowerBound must be >= ${PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND}`);
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ import type { GitHubRelatedContextConfig } from "./github-related-context.js";
 import { DEFAULT_ISSUE_ENRICHMENT_CONFIG, type IssueEnrichmentConfig } from "./issue-enrichment.js";
 import type { LicenseConfig } from "./license.js";
 import { assertPathOutsideProtectedRoot, getProtectedCheckoutRoots } from "./path-safety.js";
+import { buildPublicConfidencePolicy, isPublicConfidenceDisplayAllowed, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import { isApiKeyEnvName, isProviderId, type ProviderRegistryConfig } from "./providers.js";
 import { containsSecretLikeText } from "./secrets.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
@@ -52,6 +53,9 @@ export interface BotConfig {
   };
   reviewStatusComment?: {
     enabled: boolean;
+  };
+  confidenceCalibration?: {
+    publicDisplay: PublicConfidenceDisplayPolicy;
   };
   repoMemory?: RepoMemoryConfig;
   gitnexusContext?: GitNexusContextConfig;
@@ -222,6 +226,9 @@ const DEFAULT_CONFIG: BotConfig = {
   },
   reviewStatusComment: {
     enabled: false
+  },
+  confidenceCalibration: {
+    publicDisplay: buildPublicConfidencePolicy()
   },
   repoMemory: {
     enabled: false,
@@ -486,6 +493,10 @@ function validateConfig(config: BotConfig): void {
   const reviewStatusComment = config.reviewStatusComment ?? DEFAULT_CONFIG.reviewStatusComment!;
   config.reviewStatusComment = reviewStatusComment;
   validateBoolean(reviewStatusComment.enabled, "config.reviewStatusComment.enabled");
+  const confidenceCalibration = config.confidenceCalibration ?? DEFAULT_CONFIG.confidenceCalibration!;
+  confidenceCalibration.publicDisplay = buildPublicConfidencePolicy(confidenceCalibration.publicDisplay);
+  config.confidenceCalibration = confidenceCalibration;
+  validatePublicConfidenceDisplayConfig(confidenceCalibration.publicDisplay, "config.confidenceCalibration.publicDisplay");
   const repoMemory = config.repoMemory ?? DEFAULT_CONFIG.repoMemory!;
   config.repoMemory = repoMemory;
   validateRepoMemoryConfig(repoMemory, "config.repoMemory");
@@ -539,6 +550,34 @@ function validateConfig(config: BotConfig): void {
   }
   validateProfileRecord(config.repoProfiles.repos, "repoProfiles.repos");
   validateProfileRecord(config.repoProfiles.orgFallbacks, "repoProfiles.orgFallbacks");
+}
+
+function validatePublicConfidenceDisplayConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  if (value.mode !== "uncalibrated" && value.mode !== "calibrated") {
+    throw new Error(`${label}.mode must be uncalibrated or calibrated`);
+  }
+  validatePositiveInteger(value.minLabeledFindings, `${label}.minLabeledFindings`);
+  validateProbability(value.minWilsonLowerBound, `${label}.minWilsonLowerBound`);
+  if (value.labeledFindings !== undefined) validateNonNegativeInteger(value.labeledFindings, `${label}.labeledFindings`);
+  if (value.wilsonLowerBound !== undefined) validateProbability(value.wilsonLowerBound, `${label}.wilsonLowerBound`);
+  validateOptionalString(value.evidenceUrl, `${label}.evidenceUrl`);
+  validateOptionalString(value.datasetId, `${label}.datasetId`);
+  const policy = value as unknown as PublicConfidenceDisplayPolicy;
+  if (value.mode === "calibrated" && !isPublicConfidenceDisplayAllowed(policy)) {
+    if (typeof value.evidenceUrl !== "string" || value.evidenceUrl.trim().length === 0) {
+      throw new Error(`${label}.evidenceUrl is required when mode=calibrated`);
+    }
+    if (typeof value.datasetId !== "string" || value.datasetId.trim().length === 0) {
+      throw new Error(`${label}.datasetId is required when mode=calibrated`);
+    }
+    if (typeof value.labeledFindings !== "number" || value.labeledFindings < (value.minLabeledFindings as number)) {
+      throw new Error(`${label}.labeledFindings must be >= minLabeledFindings before public confidence display is calibrated`);
+    }
+    if (typeof value.wilsonLowerBound !== "number" || value.wilsonLowerBound < (value.minWilsonLowerBound as number)) {
+      throw new Error(`${label}.wilsonLowerBound must be >= minWilsonLowerBound before public confidence display is calibrated`);
+    }
+  }
 }
 
 function validateRepoMemoryConfig(value: unknown, label: string): void {
@@ -1106,6 +1145,12 @@ function validatePositiveInteger(value: unknown, label: string): void {
 
 function validateNonNegativeInteger(value: unknown, label: string): void {
   if (!Number.isInteger(value) || Number(value) < 0) throw new Error(`${label} must be a non-negative integer`);
+}
+
+function validateProbability(value: unknown, label: string): void {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw new Error(`${label} must be a number from 0 to 1`);
+  }
 }
 
 function validatePercentage(value: unknown, label: string): void {

--- a/src/config.ts
+++ b/src/config.ts
@@ -579,7 +579,7 @@ function validatePublicConfidenceDisplayConfig(value: unknown, label: string): v
   const policy = value as unknown as PublicConfidenceDisplayPolicy;
   if (value.mode === "calibrated" && !isPublicConfidenceDisplayAllowed(policy)) {
     if (!isUsablePublicConfidenceEvidenceUrl(typeof value.evidenceUrl === "string" ? value.evidenceUrl : undefined)) {
-      throw new Error(`${label}.evidenceUrl must be an http(s) URL when mode=calibrated`);
+      throw new Error(`${label}.evidenceUrl must be an https URL when mode=calibrated`);
     }
     if (typeof value.datasetId !== "string" || value.datasetId.trim().length === 0) {
       throw new Error(`${label}.datasetId is required when mode=calibrated`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,12 @@ import type { GitHubRelatedContextConfig } from "./github-related-context.js";
 import { DEFAULT_ISSUE_ENRICHMENT_CONFIG, type IssueEnrichmentConfig } from "./issue-enrichment.js";
 import type { LicenseConfig } from "./license.js";
 import { assertPathOutsideProtectedRoot, getProtectedCheckoutRoots } from "./path-safety.js";
-import { buildPublicConfidencePolicy, isPublicConfidenceDisplayAllowed, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
+import {
+  buildPublicConfidencePolicy,
+  isPublicConfidenceDisplayAllowed,
+  isUsablePublicConfidenceEvidenceUrl,
+  type PublicConfidenceDisplayPolicy
+} from "./public-confidence.js";
 import { isApiKeyEnvName, isProviderId, type ProviderRegistryConfig } from "./providers.js";
 import { containsSecretLikeText } from "./secrets.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
@@ -494,9 +499,9 @@ function validateConfig(config: BotConfig): void {
   config.reviewStatusComment = reviewStatusComment;
   validateBoolean(reviewStatusComment.enabled, "config.reviewStatusComment.enabled");
   const confidenceCalibration = config.confidenceCalibration ?? DEFAULT_CONFIG.confidenceCalibration!;
+  validatePublicConfidenceDisplayConfig(confidenceCalibration.publicDisplay, "config.confidenceCalibration.publicDisplay");
   confidenceCalibration.publicDisplay = buildPublicConfidencePolicy(confidenceCalibration.publicDisplay);
   config.confidenceCalibration = confidenceCalibration;
-  validatePublicConfidenceDisplayConfig(confidenceCalibration.publicDisplay, "config.confidenceCalibration.publicDisplay");
   const repoMemory = config.repoMemory ?? DEFAULT_CONFIG.repoMemory!;
   config.repoMemory = repoMemory;
   validateRepoMemoryConfig(repoMemory, "config.repoMemory");
@@ -561,6 +566,10 @@ function validatePublicConfidenceDisplayConfig(value: unknown, label: string): v
   validatePositiveInteger(value.minP0P1Labels, `${label}.minP0P1Labels`);
   validatePositiveInteger(value.minNegativeControlScenarios, `${label}.minNegativeControlScenarios`);
   validateProbability(value.minWilsonLowerBound, `${label}.minWilsonLowerBound`);
+  if ((value.minLabeledFindings as number) < 100) throw new Error(`${label}.minLabeledFindings must be >= 100`);
+  if ((value.minP0P1Labels as number) < 30) throw new Error(`${label}.minP0P1Labels must be >= 30`);
+  if ((value.minNegativeControlScenarios as number) < 10) throw new Error(`${label}.minNegativeControlScenarios must be >= 10`);
+  if ((value.minWilsonLowerBound as number) < 0.95) throw new Error(`${label}.minWilsonLowerBound must be >= 0.95`);
   if (value.labeledFindings !== undefined) validateNonNegativeInteger(value.labeledFindings, `${label}.labeledFindings`);
   if (value.p0p1Labels !== undefined) validateNonNegativeInteger(value.p0p1Labels, `${label}.p0p1Labels`);
   if (value.negativeControlScenarios !== undefined) validateNonNegativeInteger(value.negativeControlScenarios, `${label}.negativeControlScenarios`);
@@ -569,8 +578,8 @@ function validatePublicConfidenceDisplayConfig(value: unknown, label: string): v
   validateOptionalString(value.datasetId, `${label}.datasetId`);
   const policy = value as unknown as PublicConfidenceDisplayPolicy;
   if (value.mode === "calibrated" && !isPublicConfidenceDisplayAllowed(policy)) {
-    if (typeof value.evidenceUrl !== "string" || value.evidenceUrl.trim().length === 0) {
-      throw new Error(`${label}.evidenceUrl is required when mode=calibrated`);
+    if (!isUsablePublicConfidenceEvidenceUrl(typeof value.evidenceUrl === "string" ? value.evidenceUrl : undefined)) {
+      throw new Error(`${label}.evidenceUrl must be an http(s) URL when mode=calibrated`);
     }
     if (typeof value.datasetId !== "string" || value.datasetId.trim().length === 0) {
       throw new Error(`${label}.datasetId is required when mode=calibrated`);

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -383,7 +383,12 @@ function inferIssueAcceptanceGaps(issue: GitHubRelatedIssueOrPull): string[] {
 }
 
 function formatInlinePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
-  return formatPublicText(value, publicConfidencePolicy).replace(/\s+/g, " ").replace(/^#{1,6}\s+/, "").slice(0, 200);
+  const boundedText = redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]"))
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^#{1,6}\s+/, "")
+    .slice(0, 200);
+  return sanitizePublicConfidenceText(boundedText, publicConfidencePolicy);
 }
 
 function formatPublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { sanitizePublicConfidenceText, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import { redactSecrets } from "./secrets.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
 import type {
@@ -81,6 +82,7 @@ export function buildEnrichmentComment(input: {
   maxRelatedRefs?: number;
   maxSuggestions?: number;
   postIssueComment?: boolean;
+  publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
 }): EnrichmentComment {
   validateIdentity({ repo: input.repo, pullNumber: input.pull.number, headSha: input.pull.head.sha });
   const marker = buildEnrichmentMarker({ repo: input.repo, pullNumber: input.pull.number });
@@ -99,7 +101,7 @@ export function buildEnrichmentComment(input: {
   const visibleBody = [
     "## evaOS enrichment",
     "",
-    `PR: ${input.repo}#${input.pull.number} - ${formatInlinePublicText(input.pull.title)}`,
+    `PR: ${input.repo}#${input.pull.number} - ${formatInlinePublicText(input.pull.title, input.publicConfidencePolicy)}`,
     `Head: \`${input.pull.head.sha}\` into \`${input.pull.base.ref}\``,
     "",
     `Related issues/PRs: ${relatedRefs.length ? relatedRefs.join(", ") : "none detected from PR metadata"}.`,
@@ -108,7 +110,7 @@ export function buildEnrichmentComment(input: {
     "",
     "### Validation suggestions",
     "",
-    ...(validationSuggestions.length ? validationSuggestions.map((item) => `- ${formatPublicText(item)}`) : ["- No extra validation suggestions."]),
+    ...(validationSuggestions.length ? validationSuggestions.map((item) => `- ${formatPublicText(item, input.publicConfidencePolicy)}`) : ["- No extra validation suggestions."]),
     "",
     "### Triage gaps",
     "",
@@ -140,6 +142,7 @@ export function buildIssueEnrichmentComment(input: {
   maxRelatedRefs?: number;
   maxSuggestions?: number;
   postIssueComment?: boolean;
+  publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
 }): EnrichmentComment {
   validateRepoIssue({ repo: input.repo, issueNumber: input.issue.number });
   const eligibility = getIssueEnrichmentEligibility(input.issue);
@@ -159,8 +162,8 @@ export function buildIssueEnrichmentComment(input: {
   const visibleBody = [
     "## evaOS issue enrichment",
     "",
-    `Issue: ${input.repo}#${input.issue.number} - ${formatInlinePublicText(input.issue.title ?? "(untitled)")}`,
-    `State: \`${state}\`${input.issue.milestone?.title ? `; milestone: \`${formatInlinePublicText(input.issue.milestone.title)}\`` : ""}`,
+    `Issue: ${input.repo}#${input.issue.number} - ${formatInlinePublicText(input.issue.title ?? "(untitled)", input.publicConfidencePolicy)}`,
+    `State: \`${state}\`${input.issue.milestone?.title ? `; milestone: \`${formatInlinePublicText(input.issue.milestone.title, input.publicConfidencePolicy)}\`` : ""}`,
     "",
     `Related issues/PRs: ${relatedRefs.length ? relatedRefs.join(", ") : "none detected from issue metadata"}.`,
     `Existing labels: ${existingLabels.length ? existingLabels.join(", ") : "none"}.`,
@@ -169,7 +172,7 @@ export function buildIssueEnrichmentComment(input: {
     "",
     "### Validation suggestions",
     "",
-    ...(validationSuggestions.length ? validationSuggestions.map((item) => `- ${formatPublicText(item)}`) : ["- Confirm owner, acceptance criteria, and validation evidence before implementation."]),
+    ...(validationSuggestions.length ? validationSuggestions.map((item) => `- ${formatPublicText(item, input.publicConfidencePolicy)}`) : ["- Confirm owner, acceptance criteria, and validation evidence before implementation."]),
     "",
     "### Triage gaps",
     "",
@@ -200,6 +203,7 @@ export function buildIssueEnrichmentDryRunOutput(input: {
   validationSuggestions?: string[];
   maxRelatedRefs?: number;
   maxSuggestions?: number;
+  publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
 }): IssueEnrichmentDryRunOutput {
   validateRepoIssue({ repo: input.repo, issueNumber: input.issue.number });
   const eligibility = getIssueEnrichmentEligibility(input.issue);
@@ -224,6 +228,7 @@ export function buildIssueEnrichmentDryRunOutput(input: {
     validationSuggestions: input.validationSuggestions,
     maxRelatedRefs: input.maxRelatedRefs,
     maxSuggestions: input.maxSuggestions,
+    publicConfidencePolicy: input.publicConfidencePolicy,
     postIssueComment: false
   });
   return {
@@ -360,12 +365,15 @@ function inferIssueAcceptanceGaps(issue: GitHubRelatedIssueOrPull): string[] {
   return gaps;
 }
 
-function formatInlinePublicText(value: string | undefined): string {
-  return formatPublicText(value).replace(/\s+/g, " ").replace(/^#{1,6}\s+/, "").slice(0, 200);
+function formatInlinePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
+  return formatPublicText(value, publicConfidencePolicy).replace(/\s+/g, " ").replace(/^#{1,6}\s+/, "").slice(0, 200);
 }
 
-function formatPublicText(value: string | undefined): string {
-  return redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]")).trim();
+function formatPublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
+  return sanitizePublicConfidenceText(
+    redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]")),
+    publicConfidencePolicy
+  ).trim();
 }
 
 function unique(values: string[]): string[] {

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -383,12 +383,15 @@ function inferIssueAcceptanceGaps(issue: GitHubRelatedIssueOrPull): string[] {
 }
 
 function formatInlinePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
-  const boundedText = redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]"))
+  const normalizedText = redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]"))
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^#{1,6}\s+/, "");
+  return sanitizePublicConfidenceText(normalizedText, publicConfidencePolicy)
     .replace(/\s+/g, " ")
     .trim()
     .replace(/^#{1,6}\s+/, "")
     .slice(0, 200);
-  return sanitizePublicConfidenceText(boundedText, publicConfidencePolicy);
 }
 
 function formatPublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {

--- a/src/findings.ts
+++ b/src/findings.ts
@@ -80,7 +80,7 @@ export function normalizeFindingsForReview(
 
   for (const finding of findings) {
     if (containsSecretLikeText(`${finding.title}\n${finding.body}\n${finding.why_this_matters ?? ""}`)) {
-      dropped.push({ ...redactFinding(finding), reason: "secret_detected" });
+      dropped.push({ ...sanitizeDroppedFindingPublicText(redactFinding(finding), options.publicConfidencePolicy), reason: "secret_detected" });
       continue;
     }
     accepted.push(finding);
@@ -96,7 +96,7 @@ export function normalizeFindingsForReview(
 
   const kept = accepted.slice(0, maxInlineComments);
   for (const finding of accepted.slice(maxInlineComments)) {
-    dropped.push({ ...finding, reason: "comment_cap_exceeded" });
+    dropped.push({ ...sanitizeDroppedFindingPublicText(finding, options.publicConfidencePolicy), reason: "comment_cap_exceeded" });
   }
 
   return {
@@ -131,6 +131,17 @@ function redactFinding<T extends Finding>(finding: T): T {
     title: redactSecrets(finding.title),
     body: redactSecrets(finding.body),
     ...(finding.why_this_matters ? { why_this_matters: redactSecrets(finding.why_this_matters) } : {})
+  };
+}
+
+function sanitizeDroppedFindingPublicText<T extends Partial<Finding>>(finding: T, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): T {
+  return {
+    ...finding,
+    ...(typeof finding.title === "string" ? { title: sanitizePublicConfidenceText(finding.title, publicConfidencePolicy) } : {}),
+    ...(typeof finding.body === "string" ? { body: sanitizePublicConfidenceText(finding.body, publicConfidencePolicy) } : {}),
+    ...(typeof finding.why_this_matters === "string"
+      ? { why_this_matters: sanitizePublicConfidenceText(finding.why_this_matters, publicConfidencePolicy) }
+      : {})
   };
 }
 

--- a/src/findings.ts
+++ b/src/findings.ts
@@ -1,5 +1,6 @@
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 import { categoryLabel, isRegressionCategory, isRequestChangesEligible, normalizeFindingCategory } from "./regression-taxonomy.js";
+import { sanitizePublicConfidenceText, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import type { DroppedFinding, Finding, ReviewComment, ReviewEvent, Severity } from "./types.js";
 
 const SEVERITY_RANK: Record<Severity, number> = {
@@ -71,7 +72,7 @@ export function parseFindings(value: unknown): { findings: Finding[]; dropped: D
 
 export function normalizeFindingsForReview(
   findings: Finding[],
-  options: { maxInlineComments?: number } = {}
+  options: { maxInlineComments?: number; publicConfidencePolicy?: PublicConfidenceDisplayPolicy } = {}
 ): { comments: ReviewComment[]; dropped: DroppedFinding[] } {
   const maxInlineComments = options.maxInlineComments ?? 25;
   const accepted: Finding[] = [];
@@ -108,7 +109,7 @@ export function normalizeFindingsForReview(
         severity: finding.severity,
         category,
         title: finding.title,
-        body: formatReviewComment({ ...finding, category })
+        body: formatReviewComment({ ...finding, category }, options.publicConfidencePolicy)
       };
     }),
     dropped
@@ -128,10 +129,12 @@ export function decideReviewEvent(findings: Pick<ReviewComment, "severity" | "ca
   return findings.some((finding) => isRequestChangesEligible(finding)) ? "REQUEST_CHANGES" : "COMMENT";
 }
 
-export function formatReviewComment(finding: Finding): string {
+export function formatReviewComment(finding: Finding, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
+  const title = sanitizePublicConfidenceText(finding.title, publicConfidencePolicy);
+  const body = sanitizePublicConfidenceText(finding.body, publicConfidencePolicy);
   const category = finding.category ? `\n\nCategory: ${categoryLabel(finding.category)}` : "";
-  const why = finding.why_this_matters ? `\n\nWhy this matters: ${finding.why_this_matters}` : "";
-  return `**${finding.severity}: ${finding.title}**\n\n${finding.body}${category}${why}`;
+  const why = finding.why_this_matters ? `\n\nWhy this matters: ${sanitizePublicConfidenceText(finding.why_this_matters, publicConfidencePolicy)}` : "";
+  return `**${finding.severity}: ${title}**\n\n${body}${category}${why}`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/findings.ts
+++ b/src/findings.ts
@@ -102,14 +102,15 @@ export function normalizeFindingsForReview(
   return {
     comments: kept.map((finding) => {
       const category = normalizeFindingCategory(finding);
+      const publicTitle = sanitizePublicConfidenceText(finding.title, options.publicConfidencePolicy);
       return {
         path: finding.path,
         line: finding.line,
         side: "RIGHT",
         severity: finding.severity,
         category,
-        title: sanitizePublicConfidenceText(finding.title, options.publicConfidencePolicy),
-        body: formatReviewComment({ ...finding, category }, options.publicConfidencePolicy)
+        title: publicTitle,
+        body: formatReviewComment({ ...finding, category, title: publicTitle }, options.publicConfidencePolicy, { titleAlreadySanitized: true })
       };
     }),
     dropped
@@ -129,8 +130,12 @@ export function decideReviewEvent(findings: Pick<ReviewComment, "severity" | "ca
   return findings.some((finding) => isRequestChangesEligible(finding)) ? "REQUEST_CHANGES" : "COMMENT";
 }
 
-export function formatReviewComment(finding: Finding, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
-  const title = sanitizePublicConfidenceText(finding.title, publicConfidencePolicy);
+export function formatReviewComment(
+  finding: Finding,
+  publicConfidencePolicy?: PublicConfidenceDisplayPolicy,
+  options: { titleAlreadySanitized?: boolean } = {}
+): string {
+  const title = options.titleAlreadySanitized ? finding.title : sanitizePublicConfidenceText(finding.title, publicConfidencePolicy);
   const body = sanitizePublicConfidenceText(finding.body, publicConfidencePolicy);
   const category = finding.category ? `\n\nCategory: ${categoryLabel(finding.category)}` : "";
   const why = finding.why_this_matters ? `\n\nWhy this matters: ${sanitizePublicConfidenceText(finding.why_this_matters, publicConfidencePolicy)}` : "";

--- a/src/findings.ts
+++ b/src/findings.ts
@@ -103,6 +103,10 @@ export function normalizeFindingsForReview(
     comments: kept.map((finding) => {
       const category = normalizeFindingCategory(finding);
       const publicTitle = sanitizePublicConfidenceText(finding.title, options.publicConfidencePolicy);
+      const publicBody = sanitizePublicConfidenceText(finding.body, options.publicConfidencePolicy);
+      const publicWhy = finding.why_this_matters
+        ? sanitizePublicConfidenceText(finding.why_this_matters, options.publicConfidencePolicy)
+        : undefined;
       return {
         path: finding.path,
         line: finding.line,
@@ -110,7 +114,11 @@ export function normalizeFindingsForReview(
         severity: finding.severity,
         category,
         title: publicTitle,
-        body: formatReviewComment({ ...finding, category, title: publicTitle }, options.publicConfidencePolicy, { titleAlreadySanitized: true })
+        body: formatReviewComment(
+          { ...finding, category, title: publicTitle, body: publicBody, ...(publicWhy ? { why_this_matters: publicWhy } : {}) },
+          options.publicConfidencePolicy,
+          { textAlreadySanitized: true }
+        )
       };
     }),
     dropped
@@ -133,12 +141,14 @@ export function decideReviewEvent(findings: Pick<ReviewComment, "severity" | "ca
 export function formatReviewComment(
   finding: Finding,
   publicConfidencePolicy?: PublicConfidenceDisplayPolicy,
-  options: { titleAlreadySanitized?: boolean } = {}
+  options: { textAlreadySanitized?: boolean } = {}
 ): string {
-  const title = options.titleAlreadySanitized ? finding.title : sanitizePublicConfidenceText(finding.title, publicConfidencePolicy);
-  const body = sanitizePublicConfidenceText(finding.body, publicConfidencePolicy);
+  const title = options.textAlreadySanitized ? finding.title : sanitizePublicConfidenceText(finding.title, publicConfidencePolicy);
+  const body = options.textAlreadySanitized ? finding.body : sanitizePublicConfidenceText(finding.body, publicConfidencePolicy);
   const category = finding.category ? `\n\nCategory: ${categoryLabel(finding.category)}` : "";
-  const why = finding.why_this_matters ? `\n\nWhy this matters: ${sanitizePublicConfidenceText(finding.why_this_matters, publicConfidencePolicy)}` : "";
+  const why = finding.why_this_matters
+    ? `\n\nWhy this matters: ${options.textAlreadySanitized ? finding.why_this_matters : sanitizePublicConfidenceText(finding.why_this_matters, publicConfidencePolicy)}`
+    : "";
   return `**${finding.severity}: ${title}**\n\n${body}${category}${why}`;
 }
 

--- a/src/findings.ts
+++ b/src/findings.ts
@@ -108,7 +108,7 @@ export function normalizeFindingsForReview(
         side: "RIGHT",
         severity: finding.severity,
         category,
-        title: finding.title,
+        title: sanitizePublicConfidenceText(finding.title, options.publicConfidencePolicy),
         body: formatReviewComment({ ...finding, category }, options.publicConfidencePolicy)
       };
     }),

--- a/src/findings.ts
+++ b/src/findings.ts
@@ -143,13 +143,14 @@ export function formatReviewComment(
   publicConfidencePolicy?: PublicConfidenceDisplayPolicy,
   options: { textAlreadySanitized?: boolean } = {}
 ): string {
+  const severity = SEVERITIES.has(finding.severity as Severity) ? finding.severity : "P3";
   const title = options.textAlreadySanitized ? finding.title : sanitizePublicConfidenceText(finding.title, publicConfidencePolicy);
   const body = options.textAlreadySanitized ? finding.body : sanitizePublicConfidenceText(finding.body, publicConfidencePolicy);
   const category = finding.category ? `\n\nCategory: ${categoryLabel(finding.category)}` : "";
   const why = finding.why_this_matters
     ? `\n\nWhy this matters: ${options.textAlreadySanitized ? finding.why_this_matters : sanitizePublicConfidenceText(finding.why_this_matters, publicConfidencePolicy)}`
     : "";
-  return `**${finding.severity}: ${title}**\n\n${body}${category}${why}`;
+  return `**${severity}: ${title}**\n\n${body}${category}${why}`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/findings.ts
+++ b/src/findings.ts
@@ -154,6 +154,7 @@ export function formatReviewComment(
   publicConfidencePolicy?: PublicConfidenceDisplayPolicy,
   options: { textAlreadySanitized?: boolean } = {}
 ): string {
+  // textAlreadySanitized means title, body, and why_this_matters have all crossed the same public-text boundary.
   const severity = SEVERITIES.has(finding.severity as Severity) ? finding.severity : "P3";
   const title = options.textAlreadySanitized ? finding.title : sanitizePublicConfidenceText(finding.title, publicConfidencePolicy);
   const body = options.textAlreadySanitized ? finding.body : sanitizePublicConfidenceText(finding.body, publicConfidencePolicy);

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -83,20 +83,40 @@ export function buildPublicConfidencePolicy(input?: Partial<PublicConfidenceDisp
 export function isPublicConfidenceDisplayAllowed(policy?: PublicConfidenceDisplayPolicy): boolean {
   if (!policy || policy.mode !== "calibrated") return false;
   if (!isUsablePublicConfidenceEvidenceUrl(policy.evidenceUrl) || !policy.datasetId?.trim()) return false;
-  if (policy.labeledFindings === undefined || policy.labeledFindings < Math.max(policy.minLabeledFindings, PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS)) {
+  if (
+    !isPositiveInteger(policy.minLabeledFindings) ||
+    !isPositiveInteger(policy.minP0P1Labels) ||
+    !isPositiveInteger(policy.minNegativeControlScenarios) ||
+    !isProbability(policy.minWilsonLowerBound)
+  ) {
     return false;
   }
-  if (policy.p0p1Labels === undefined || policy.p0p1Labels < Math.max(policy.minP0P1Labels, PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS)) return false;
+  if (!isNonNegativeInteger(policy.labeledFindings) || policy.labeledFindings < Math.max(policy.minLabeledFindings, PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS)) {
+    return false;
+  }
+  if (!isNonNegativeInteger(policy.p0p1Labels) || policy.p0p1Labels < Math.max(policy.minP0P1Labels, PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS)) return false;
   if (
-    policy.negativeControlScenarios === undefined ||
+    !isNonNegativeInteger(policy.negativeControlScenarios) ||
     policy.negativeControlScenarios < Math.max(policy.minNegativeControlScenarios, PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS)
   ) {
     return false;
   }
-  if (policy.wilsonLowerBound === undefined || policy.wilsonLowerBound < Math.max(policy.minWilsonLowerBound, PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND)) {
+  if (!isProbability(policy.wilsonLowerBound) || policy.wilsonLowerBound < Math.max(policy.minWilsonLowerBound, PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND)) {
     return false;
   }
   return true;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) >= 0;
+}
+
+function isProbability(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
 }
 
 export function isUsablePublicConfidenceEvidenceUrl(value: string | undefined): boolean {

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -1,0 +1,49 @@
+export interface PublicConfidenceDisplayPolicy {
+  mode: "uncalibrated" | "calibrated";
+  evidenceUrl?: string;
+  datasetId?: string;
+  minLabeledFindings: number;
+  labeledFindings?: number;
+  minWilsonLowerBound: number;
+  wilsonLowerBound?: number;
+}
+
+const DEFAULT_MIN_LABELED_FINDINGS = 100;
+const DEFAULT_MIN_WILSON_LOWER_BOUND = 0.95;
+const CONFIDENCE_PERCENT_PATTERN = /\b(confidence\s*[:=]\s*)\d+(?:\.\d+)?\s*%/gi;
+const CONFIDENCE_DECIMAL_PATTERN = /\b(confidence\s*[:=]\s*)(?:0?\.\d+|1(?:\.0+)?)\b/gi;
+const PERCENT_CONFIDENT_PATTERN = /\b\d+(?:\.\d+)?\s*%\s*(confident|confidence)\b/gi;
+const DECIMAL_CONFIDENT_PATTERN = /\b(?:0?\.\d+|1(?:\.0+)?)\s*(confident|confidence)\b/gi;
+const CONFIDENCE_NOUN_PERCENT_PATTERN = /\b(confidence)\s+\d+(?:\.\d+)?\s*%/gi;
+const CONFIDENCE_QUERY_PERCENT_PATTERN = /\b(confidence=)\d+(?:\.\d+)?\s*%/gi;
+
+export function buildPublicConfidencePolicy(input?: Partial<PublicConfidenceDisplayPolicy>): PublicConfidenceDisplayPolicy {
+  return {
+    mode: input?.mode ?? "uncalibrated",
+    minLabeledFindings: input?.minLabeledFindings ?? DEFAULT_MIN_LABELED_FINDINGS,
+    minWilsonLowerBound: input?.minWilsonLowerBound ?? DEFAULT_MIN_WILSON_LOWER_BOUND,
+    ...(input?.evidenceUrl ? { evidenceUrl: input.evidenceUrl } : {}),
+    ...(input?.datasetId ? { datasetId: input.datasetId } : {}),
+    ...(input?.labeledFindings !== undefined ? { labeledFindings: input.labeledFindings } : {}),
+    ...(input?.wilsonLowerBound !== undefined ? { wilsonLowerBound: input.wilsonLowerBound } : {})
+  };
+}
+
+export function isPublicConfidenceDisplayAllowed(policy?: PublicConfidenceDisplayPolicy): boolean {
+  if (!policy || policy.mode !== "calibrated") return false;
+  if (!policy.evidenceUrl || !policy.datasetId) return false;
+  if (policy.labeledFindings === undefined || policy.labeledFindings < policy.minLabeledFindings) return false;
+  if (policy.wilsonLowerBound === undefined || policy.wilsonLowerBound < policy.minWilsonLowerBound) return false;
+  return true;
+}
+
+export function sanitizePublicConfidenceText(value: string, policy?: PublicConfidenceDisplayPolicy): string {
+  if (isPublicConfidenceDisplayAllowed(policy)) return value;
+  return value
+    .replace(CONFIDENCE_PERCENT_PATTERN, "$1uncalibrated")
+    .replace(CONFIDENCE_DECIMAL_PATTERN, "$1uncalibrated")
+    .replace(PERCENT_CONFIDENT_PATTERN, "uncalibrated $1")
+    .replace(DECIMAL_CONFIDENT_PATTERN, "uncalibrated $1")
+    .replace(CONFIDENCE_NOUN_PERCENT_PATTERN, "$1 uncalibrated")
+    .replace(CONFIDENCE_QUERY_PERCENT_PATTERN, "$1uncalibrated");
+}

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -19,7 +19,10 @@ const DEFAULT_MIN_WILSON_LOWER_BOUND = 0.95;
 const PUBLIC_CONFIDENCE_REPLACEMENT = "confidence not calibrated";
 const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1(?:\.0+)?)\b)`;
 const CONFIDENCE_LABEL_PATTERN = new RegExp(String.raw`\b((?:confidence|certainty)\s*[:=]\s*)${CONFIDENCE_VALUE_PATTERN}`, "gi");
-const CONFIDENCE_NOUN_VALUE_PATTERN = new RegExp(String.raw`\bconfidence(?:\s+score)?(?:\s+of)?\s*${CONFIDENCE_VALUE_PATTERN}`, "gi");
+const CONFIDENCE_NOUN_VALUE_PATTERN = new RegExp(
+  String.raw`\bconfidence(?:\s+score(?:\s*(?::|=)\s*|\s+of\s+|\s+)|\s+of\s+|\s+)${CONFIDENCE_VALUE_PATTERN}`,
+  "gi"
+);
 const VALUE_CONFIDENCE_PATTERN = new RegExp(String.raw`\b${CONFIDENCE_VALUE_PATTERN}\s*(?:confident|confidence)\b`, "gi");
 const QUALIFIED_CONFIDENCE_DECIMAL_PATTERN = /\b(?:high|medium|low)\s+confidence\s*\(\s*(?:0?\.\d+|1(?:\.0+)?)\s*\)/gi;
 
@@ -28,10 +31,13 @@ export function buildPublicConfidencePolicy(input?: Partial<PublicConfidenceDisp
   const datasetId = input?.datasetId?.trim();
   return {
     mode: input?.mode ?? "uncalibrated",
-    minLabeledFindings: input?.minLabeledFindings ?? DEFAULT_MIN_LABELED_FINDINGS,
-    minP0P1Labels: input?.minP0P1Labels ?? DEFAULT_MIN_P0_P1_LABELS,
-    minNegativeControlScenarios: input?.minNegativeControlScenarios ?? DEFAULT_MIN_NEGATIVE_CONTROL_SCENARIOS,
-    minWilsonLowerBound: input?.minWilsonLowerBound ?? DEFAULT_MIN_WILSON_LOWER_BOUND,
+    minLabeledFindings: Math.max(input?.minLabeledFindings ?? DEFAULT_MIN_LABELED_FINDINGS, DEFAULT_MIN_LABELED_FINDINGS),
+    minP0P1Labels: Math.max(input?.minP0P1Labels ?? DEFAULT_MIN_P0_P1_LABELS, DEFAULT_MIN_P0_P1_LABELS),
+    minNegativeControlScenarios: Math.max(
+      input?.minNegativeControlScenarios ?? DEFAULT_MIN_NEGATIVE_CONTROL_SCENARIOS,
+      DEFAULT_MIN_NEGATIVE_CONTROL_SCENARIOS
+    ),
+    minWilsonLowerBound: Math.max(input?.minWilsonLowerBound ?? DEFAULT_MIN_WILSON_LOWER_BOUND, DEFAULT_MIN_WILSON_LOWER_BOUND),
     ...(evidenceUrl ? { evidenceUrl } : {}),
     ...(datasetId ? { datasetId } : {}),
     ...(input?.labeledFindings !== undefined ? { labeledFindings: input.labeledFindings } : {}),
@@ -43,17 +49,31 @@ export function buildPublicConfidencePolicy(input?: Partial<PublicConfidenceDisp
 
 export function isPublicConfidenceDisplayAllowed(policy?: PublicConfidenceDisplayPolicy): boolean {
   if (!policy || policy.mode !== "calibrated") return false;
-  if (!policy.evidenceUrl?.trim() || !policy.datasetId?.trim()) return false;
-  if (policy.labeledFindings === undefined || policy.labeledFindings < policy.minLabeledFindings) return false;
-  if (policy.p0p1Labels === undefined || policy.p0p1Labels < policy.minP0P1Labels) return false;
+  if (!isUsablePublicConfidenceEvidenceUrl(policy.evidenceUrl) || !policy.datasetId?.trim()) return false;
+  if (policy.labeledFindings === undefined || policy.labeledFindings < Math.max(policy.minLabeledFindings, DEFAULT_MIN_LABELED_FINDINGS)) {
+    return false;
+  }
+  if (policy.p0p1Labels === undefined || policy.p0p1Labels < Math.max(policy.minP0P1Labels, DEFAULT_MIN_P0_P1_LABELS)) return false;
   if (
     policy.negativeControlScenarios === undefined ||
-    policy.negativeControlScenarios < policy.minNegativeControlScenarios
+    policy.negativeControlScenarios < Math.max(policy.minNegativeControlScenarios, DEFAULT_MIN_NEGATIVE_CONTROL_SCENARIOS)
   ) {
     return false;
   }
-  if (policy.wilsonLowerBound === undefined || policy.wilsonLowerBound < policy.minWilsonLowerBound) return false;
+  if (policy.wilsonLowerBound === undefined || policy.wilsonLowerBound < Math.max(policy.minWilsonLowerBound, DEFAULT_MIN_WILSON_LOWER_BOUND)) {
+    return false;
+  }
   return true;
+}
+
+export function isUsablePublicConfidenceEvidenceUrl(value: string | undefined): boolean {
+  if (!value?.trim()) return false;
+  try {
+    const url = new URL(value.trim());
+    return (url.protocol === "https:" || url.protocol === "http:") && url.hostname.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 export function sanitizePublicConfidenceText(value: string, policy?: PublicConfidenceDisplayPolicy): string {

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -20,10 +20,13 @@ const PUBLIC_CONFIDENCE_REPLACEMENT = "confidence not calibrated";
 const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1(?:\.0+)?)\b)`;
 const CONFIDENCE_LABEL_PATTERN = new RegExp(String.raw`\b((?:confidence|certainty)\s*[:=]\s*)${CONFIDENCE_VALUE_PATTERN}`, "gi");
 const CONFIDENCE_NOUN_VALUE_PATTERN = new RegExp(
-  String.raw`\bconfidence(?:\s+score(?:\s*(?::|=)\s*|\s+of\s+|\s+)|\s+of\s+|\s+)${CONFIDENCE_VALUE_PATTERN}`,
+  String.raw`\bconfidence(?:\s+score(?:\s*(?::|=)\s*|\s+of\s+|\s+(?:is|was|at)\s+|\s+)|\s+of\s+|\s+(?:is|was|at|in)\s+|\s+)${CONFIDENCE_VALUE_PATTERN}`,
   "gi"
 );
-const VALUE_CONFIDENCE_PATTERN = new RegExp(String.raw`\b${CONFIDENCE_VALUE_PATTERN}\s*(?:confident|confidence)\b`, "gi");
+const VALUE_CONFIDENCE_PATTERN = new RegExp(
+  String.raw`\b${CONFIDENCE_VALUE_PATTERN}\s*(?:confident|confidence(?:\s+in\b)?)`,
+  "gi"
+);
 const QUALIFIED_CONFIDENCE_DECIMAL_PATTERN = /\b(?:high|medium|low)\s+confidence\s*\(\s*(?:0?\.\d+|1(?:\.0+)?)\s*\)/gi;
 
 export function buildPublicConfidencePolicy(input?: Partial<PublicConfidenceDisplayPolicy>): PublicConfidenceDisplayPolicy {

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -148,11 +148,9 @@ export function sanitizePublicConfidenceText(value: string, policy?: PublicConfi
 function boundPublicConfidenceText(value: string): string {
   if (value.length <= MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH) return value;
   const truncated = value.slice(0, MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH);
-  const boundaryWindowStart = Math.max(0, truncated.length - 128);
-  const boundaryWindow = truncated.slice(boundaryWindowStart);
-  const danglingConfidenceTokenStart = findDanglingConfidenceTokenStart(boundaryWindow);
+  const danglingConfidenceTokenStart = findDanglingConfidenceTokenStart(truncated);
   if (danglingConfidenceTokenStart !== -1) {
-    return `${truncated.slice(0, boundaryWindowStart + danglingConfidenceTokenStart).trimEnd()}${PUBLIC_CONFIDENCE_TRUNCATION_NOTICE}`;
+    return `${truncated.slice(0, danglingConfidenceTokenStart).trimEnd()}${PUBLIC_CONFIDENCE_TRUNCATION_NOTICE}`;
   }
   const lastTokenBoundary = Math.max(
     truncated.lastIndexOf(" "),
@@ -160,9 +158,7 @@ function boundPublicConfidenceText(value: string): string {
     truncated.lastIndexOf("\r"),
     truncated.lastIndexOf("\t")
   );
-  const safeTruncated = lastTokenBoundary >= MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH - 128
-    ? truncated.slice(0, lastTokenBoundary).trimEnd()
-    : truncated;
+  const safeTruncated = lastTokenBoundary === -1 ? truncated : truncated.slice(0, lastTokenBoundary).trimEnd();
   return `${safeTruncated}${PUBLIC_CONFIDENCE_TRUNCATION_NOTICE}`;
 }
 

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -4,35 +4,54 @@ export interface PublicConfidenceDisplayPolicy {
   datasetId?: string;
   minLabeledFindings: number;
   labeledFindings?: number;
+  minP0P1Labels: number;
+  p0p1Labels?: number;
+  minNegativeControlScenarios: number;
+  negativeControlScenarios?: number;
   minWilsonLowerBound: number;
   wilsonLowerBound?: number;
 }
 
 const DEFAULT_MIN_LABELED_FINDINGS = 100;
+const DEFAULT_MIN_P0_P1_LABELS = 30;
+const DEFAULT_MIN_NEGATIVE_CONTROL_SCENARIOS = 10;
 const DEFAULT_MIN_WILSON_LOWER_BOUND = 0.95;
-const CONFIDENCE_PERCENT_PATTERN = /\b(confidence\s*[:=]\s*)\d+(?:\.\d+)?\s*%/gi;
-const CONFIDENCE_DECIMAL_PATTERN = /\b(confidence\s*[:=]\s*)(?:0?\.\d+|1(?:\.0+)?)\b/gi;
-const PERCENT_CONFIDENT_PATTERN = /\b\d+(?:\.\d+)?\s*%\s*(confident|confidence)\b/gi;
-const DECIMAL_CONFIDENT_PATTERN = /\b(?:0?\.\d+|1(?:\.0+)?)\s*(confident|confidence)\b/gi;
-const CONFIDENCE_NOUN_PERCENT_PATTERN = /\b(confidence)\s+\d+(?:\.\d+)?\s*%/gi;
-const CONFIDENCE_QUERY_PERCENT_PATTERN = /\b(confidence=)\d+(?:\.\d+)?\s*%/gi;
+const PUBLIC_CONFIDENCE_REPLACEMENT = "confidence not calibrated";
+const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1(?:\.0+)?)\b)`;
+const CONFIDENCE_LABEL_PATTERN = new RegExp(String.raw`\b((?:confidence|certainty)\s*[:=]\s*)${CONFIDENCE_VALUE_PATTERN}`, "gi");
+const CONFIDENCE_NOUN_VALUE_PATTERN = new RegExp(String.raw`\bconfidence(?:\s+score)?(?:\s+of)?\s*${CONFIDENCE_VALUE_PATTERN}`, "gi");
+const VALUE_CONFIDENCE_PATTERN = new RegExp(String.raw`\b${CONFIDENCE_VALUE_PATTERN}\s*(?:confident|confidence)\b`, "gi");
+const QUALIFIED_CONFIDENCE_DECIMAL_PATTERN = /\b(?:high|medium|low)\s+confidence\s*\(\s*(?:0?\.\d+|1(?:\.0+)?)\s*\)/gi;
 
 export function buildPublicConfidencePolicy(input?: Partial<PublicConfidenceDisplayPolicy>): PublicConfidenceDisplayPolicy {
+  const evidenceUrl = input?.evidenceUrl?.trim();
+  const datasetId = input?.datasetId?.trim();
   return {
     mode: input?.mode ?? "uncalibrated",
     minLabeledFindings: input?.minLabeledFindings ?? DEFAULT_MIN_LABELED_FINDINGS,
+    minP0P1Labels: input?.minP0P1Labels ?? DEFAULT_MIN_P0_P1_LABELS,
+    minNegativeControlScenarios: input?.minNegativeControlScenarios ?? DEFAULT_MIN_NEGATIVE_CONTROL_SCENARIOS,
     minWilsonLowerBound: input?.minWilsonLowerBound ?? DEFAULT_MIN_WILSON_LOWER_BOUND,
-    ...(input?.evidenceUrl ? { evidenceUrl: input.evidenceUrl } : {}),
-    ...(input?.datasetId ? { datasetId: input.datasetId } : {}),
+    ...(evidenceUrl ? { evidenceUrl } : {}),
+    ...(datasetId ? { datasetId } : {}),
     ...(input?.labeledFindings !== undefined ? { labeledFindings: input.labeledFindings } : {}),
+    ...(input?.p0p1Labels !== undefined ? { p0p1Labels: input.p0p1Labels } : {}),
+    ...(input?.negativeControlScenarios !== undefined ? { negativeControlScenarios: input.negativeControlScenarios } : {}),
     ...(input?.wilsonLowerBound !== undefined ? { wilsonLowerBound: input.wilsonLowerBound } : {})
   };
 }
 
 export function isPublicConfidenceDisplayAllowed(policy?: PublicConfidenceDisplayPolicy): boolean {
   if (!policy || policy.mode !== "calibrated") return false;
-  if (!policy.evidenceUrl || !policy.datasetId) return false;
+  if (!policy.evidenceUrl?.trim() || !policy.datasetId?.trim()) return false;
   if (policy.labeledFindings === undefined || policy.labeledFindings < policy.minLabeledFindings) return false;
+  if (policy.p0p1Labels === undefined || policy.p0p1Labels < policy.minP0P1Labels) return false;
+  if (
+    policy.negativeControlScenarios === undefined ||
+    policy.negativeControlScenarios < policy.minNegativeControlScenarios
+  ) {
+    return false;
+  }
   if (policy.wilsonLowerBound === undefined || policy.wilsonLowerBound < policy.minWilsonLowerBound) return false;
   return true;
 }
@@ -40,10 +59,8 @@ export function isPublicConfidenceDisplayAllowed(policy?: PublicConfidenceDispla
 export function sanitizePublicConfidenceText(value: string, policy?: PublicConfidenceDisplayPolicy): string {
   if (isPublicConfidenceDisplayAllowed(policy)) return value;
   return value
-    .replace(CONFIDENCE_PERCENT_PATTERN, "$1uncalibrated")
-    .replace(CONFIDENCE_DECIMAL_PATTERN, "$1uncalibrated")
-    .replace(PERCENT_CONFIDENT_PATTERN, "uncalibrated $1")
-    .replace(DECIMAL_CONFIDENT_PATTERN, "uncalibrated $1")
-    .replace(CONFIDENCE_NOUN_PERCENT_PATTERN, "$1 uncalibrated")
-    .replace(CONFIDENCE_QUERY_PERCENT_PATTERN, "$1uncalibrated");
+    .replace(QUALIFIED_CONFIDENCE_DECIMAL_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
+    .replace(CONFIDENCE_LABEL_PATTERN, `$1${PUBLIC_CONFIDENCE_REPLACEMENT}`)
+    .replace(CONFIDENCE_NOUN_VALUE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
+    .replace(VALUE_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT);
 }

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -17,15 +17,16 @@ const DEFAULT_MIN_P0_P1_LABELS = 30;
 const DEFAULT_MIN_NEGATIVE_CONTROL_SCENARIOS = 10;
 const DEFAULT_MIN_WILSON_LOWER_BOUND = 0.95;
 const PUBLIC_CONFIDENCE_REPLACEMENT = "confidence not calibrated";
-const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1\.0+)\b)`;
+const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1\.0+)(?=\b|[-_]))`;
 const CONFIDENCE_NOUN_PATTERN = String.raw`(?:confidence|certainty|reliability|accuracy|likelihood|sure(?:ness)?)`;
+const CONFIDENCE_SEPARATOR_PATTERN = String.raw`(?:\s+|[-_]+)`;
 const CONFIDENCE_LABEL_PATTERN = new RegExp(String.raw`\b((${CONFIDENCE_NOUN_PATTERN})\s*[:=]\s*)${CONFIDENCE_VALUE_PATTERN}`, "gi");
 const CONFIDENCE_NOUN_VALUE_PATTERN = new RegExp(
-  String.raw`\b${CONFIDENCE_NOUN_PATTERN}(?:\s+score(?:\s*(?::|=)\s*|\s+of\s+|\s+(?:is|was|at)\s+|\s+)|\s+of\s+|\s+(?:is|was|at|in)\s+|\s+)${CONFIDENCE_VALUE_PATTERN}`,
+  String.raw`\b${CONFIDENCE_NOUN_PATTERN}(?:${CONFIDENCE_SEPARATOR_PATTERN}score(?:\s*(?::|=)\s*|\s+of\s+|\s+(?:is|was|at)\s+|${CONFIDENCE_SEPARATOR_PATTERN})|\s+of\s+|\s+(?:is|was|at|in)\s+|${CONFIDENCE_SEPARATOR_PATTERN})${CONFIDENCE_VALUE_PATTERN}`,
   "gi"
 );
 const VALUE_CONFIDENCE_PATTERN = new RegExp(
-  String.raw`\b${CONFIDENCE_VALUE_PATTERN}\s*(?:confident|confidence(?:\s+in\b)?|reliable|reliability|accurate|accuracy|likely|likelihood|sure)\b`,
+  String.raw`\b${CONFIDENCE_VALUE_PATTERN}(?:\s*|[-_]+)(?:confident|confidence(?:\s+in\b)?|reliable|reliability|accurate|accuracy|likely|likelihood|sure)\b`,
   "gi"
 );
 const QUALIFIED_CONFIDENCE_DECIMAL_PATTERN = /\b(?:high|medium|low)\s+confidence\s*\(\s*(?:0?\.\d+|1(?:\.0+)?)\s*\)/gi;

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -45,6 +45,10 @@ const VALUE_CONFIDENCE_PATTERN = new RegExp(
   String.raw`\b${CONFIDENCE_VALUE_PATTERN}(?:\s*|[-_]+)(?:confident|confidence(?:\s+in\b)?|reliable|reliability|sure)\b`,
   "gi"
 );
+const CONCATENATED_VALUE_CONFIDENCE_PATTERN = new RegExp(
+  String.raw`${MARKDOWN_VALUE_START_PATTERN}${MARKDOWN_WRAPPER_PATTERN}(?:0?\.\d+|1\.0+)${MARKDOWN_WRAPPER_PATTERN}(?:confident|confidence(?:\s+in\b)?|reliable|reliability|sure)${MARKDOWN_WRAPPER_PATTERN}\b`,
+  "gi"
+);
 const MARKDOWN_VALUE_CONFIDENCE_PATTERN = new RegExp(
   String.raw`${MARKDOWN_VALUE_START_PATTERN}${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}(?:\s*|[-_]+)${MARKDOWN_WRAPPER_PATTERN}(?:confident|confidence(?:\s+in\b)?|reliable|reliability|sure)${MARKDOWN_WRAPPER_PATTERN}\b`,
   "gi"
@@ -103,18 +107,40 @@ export function isUsablePublicConfidenceEvidenceUrl(value: string | undefined): 
 
 export function sanitizePublicConfidenceText(value: string, policy?: PublicConfidenceDisplayPolicy): string {
   if (isPublicConfidenceDisplayAllowed(policy)) return value;
-  const boundedValue = value.length > MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH
-    ? `${value.slice(0, MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH)}${PUBLIC_CONFIDENCE_TRUNCATION_NOTICE}`
-    : value;
+  const boundedValue = boundPublicConfidenceText(value);
   return boundedValue
     .replace(QUALIFIED_CONFIDENCE_DECIMAL_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(CONFIDENCE_LABEL_CONTINUATION_PATTERN, (_match, noun: string, continuation: string) => formatConfidenceLabelContinuation(noun, continuation))
     .replace(MARKDOWN_CONFIDENCE_LABEL_CONTINUATION_PATTERN, (_match, noun: string, continuation: string) => formatConfidenceLabelContinuation(noun, continuation))
     .replace(MARKDOWN_CONFIDENCE_LABEL_PATTERN, (_match, noun: string) => `${noun}: ${PUBLIC_CONFIDENCE_REPLACEMENT}`)
+    .replace(CONCATENATED_VALUE_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(MARKDOWN_VALUE_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(CONFIDENCE_LABEL_PATTERN, (_match, prefix: string) => `${prefix}${PUBLIC_CONFIDENCE_REPLACEMENT}`)
     .replace(CONFIDENCE_NOUN_VALUE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(VALUE_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT);
+}
+
+function boundPublicConfidenceText(value: string): string {
+  if (value.length <= MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH) return value;
+  const truncated = value.slice(0, MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH);
+  const boundaryWindowStart = Math.max(0, truncated.length - 128);
+  const boundaryWindow = truncated.slice(boundaryWindowStart);
+  const danglingConfidenceValue = boundaryWindow.match(
+    /(?:^|\s)(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1\.0+))(?:\s+[A-Za-z]*)?$/i
+  );
+  if (danglingConfidenceValue?.index !== undefined) {
+    return `${truncated.slice(0, boundaryWindowStart + danglingConfidenceValue.index).trimEnd()}${PUBLIC_CONFIDENCE_TRUNCATION_NOTICE}`;
+  }
+  const lastTokenBoundary = Math.max(
+    truncated.lastIndexOf(" "),
+    truncated.lastIndexOf("\n"),
+    truncated.lastIndexOf("\r"),
+    truncated.lastIndexOf("\t")
+  );
+  const safeTruncated = lastTokenBoundary >= MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH - 128
+    ? truncated.slice(0, lastTokenBoundary).trimEnd()
+    : truncated;
+  return `${safeTruncated}${PUBLIC_CONFIDENCE_TRUNCATION_NOTICE}`;
 }
 
 function formatConfidenceLabelContinuation(_noun: string, continuation: string): string {

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -117,8 +117,7 @@ export function sanitizePublicConfidenceText(value: string, policy?: PublicConfi
     .replace(VALUE_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT);
 }
 
-function formatConfidenceLabelContinuation(noun: string, continuation: string): string {
-  const normalizedNoun = noun.toLowerCase() === "confidence" ? "confidence" : noun;
-  if (continuation.toLowerCase() === "that") return `${normalizedNoun} is not calibrated;`;
-  return `${normalizedNoun} is not calibrated; it ${continuation}`;
+function formatConfidenceLabelContinuation(_noun: string, continuation: string): string {
+  if (continuation.toLowerCase() === "that") return "confidence is not calibrated;";
+  return `confidence is not calibrated; it ${continuation}`;
 }

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -18,13 +18,14 @@ const DEFAULT_MIN_NEGATIVE_CONTROL_SCENARIOS = 10;
 const DEFAULT_MIN_WILSON_LOWER_BOUND = 0.95;
 const PUBLIC_CONFIDENCE_REPLACEMENT = "confidence not calibrated";
 const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1(?:\.0+)?)\b)`;
-const CONFIDENCE_LABEL_PATTERN = new RegExp(String.raw`\b((?:confidence|certainty)\s*[:=]\s*)${CONFIDENCE_VALUE_PATTERN}`, "gi");
+const CONFIDENCE_NOUN_PATTERN = String.raw`(?:confidence|certainty|reliability|accuracy|likelihood|sure(?:ness)?)`;
+const CONFIDENCE_LABEL_PATTERN = new RegExp(String.raw`\b((${CONFIDENCE_NOUN_PATTERN})\s*[:=]\s*)${CONFIDENCE_VALUE_PATTERN}`, "gi");
 const CONFIDENCE_NOUN_VALUE_PATTERN = new RegExp(
-  String.raw`\bconfidence(?:\s+score(?:\s*(?::|=)\s*|\s+of\s+|\s+(?:is|was|at)\s+|\s+)|\s+of\s+|\s+(?:is|was|at|in)\s+|\s+)${CONFIDENCE_VALUE_PATTERN}`,
+  String.raw`\b${CONFIDENCE_NOUN_PATTERN}(?:\s+score(?:\s*(?::|=)\s*|\s+of\s+|\s+(?:is|was|at)\s+|\s+)|\s+of\s+|\s+(?:is|was|at|in)\s+|\s+)${CONFIDENCE_VALUE_PATTERN}`,
   "gi"
 );
 const VALUE_CONFIDENCE_PATTERN = new RegExp(
-  String.raw`\b${CONFIDENCE_VALUE_PATTERN}\s*(?:confident|confidence(?:\s+in\b)?)`,
+  String.raw`\b${CONFIDENCE_VALUE_PATTERN}\s*(?:confident|confidence(?:\s+in\b)?|reliable|reliability|accurate|accuracy|likely|likelihood|sure)\b`,
   "gi"
 );
 const QUALIFIED_CONFIDENCE_DECIMAL_PATTERN = /\b(?:high|medium|low)\s+confidence\s*\(\s*(?:0?\.\d+|1(?:\.0+)?)\s*\)/gi;
@@ -73,7 +74,7 @@ export function isUsablePublicConfidenceEvidenceUrl(value: string | undefined): 
   if (!value?.trim()) return false;
   try {
     const url = new URL(value.trim());
-    return (url.protocol === "https:" || url.protocol === "http:") && url.hostname.length > 0;
+    return url.protocol === "https:" && url.hostname.length > 0;
   } catch {
     return false;
   }

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -38,11 +38,15 @@ const MARKDOWN_CONFIDENCE_LABEL_CONTINUATION_PATTERN = new RegExp(
   "gi"
 );
 const CONFIDENCE_NOUN_VALUE_PATTERN = new RegExp(
-  String.raw`\b${CONFIDENCE_NOUN_PATTERN}(?:${CONFIDENCE_SEPARATOR_PATTERN}score(?:\s*(?::|=)\s*|\s+of\s+|\s+(?:is|was|at)\s+|${CONFIDENCE_SEPARATOR_PATTERN})|\s+of\s+|\s+(?:is|was|at|in)\s+|${CONFIDENCE_SEPARATOR_PATTERN})${CONFIDENCE_VALUE_PATTERN}`,
+  String.raw`\b${CONFIDENCE_NOUN_PATTERN}(?:${CONFIDENCE_SEPARATOR_PATTERN}score(?:\s*(?::|=)\s*|\s+of\s+|\s+(?:is|was|at)\s+|${CONFIDENCE_SEPARATOR_PATTERN})|\s+of\s+|\s+(?:is|was|at|in)\s+|${CONFIDENCE_SEPARATOR_PATTERN}|(?=\d))${CONFIDENCE_VALUE_PATTERN}`,
   "gi"
 );
 const VALUE_CONFIDENCE_PATTERN = new RegExp(
   String.raw`\b${CONFIDENCE_VALUE_PATTERN}(?:\s*|[-_]+)(?:confident|confidence(?:\s+in\b)?|reliable|reliability|sure)\b`,
+  "gi"
+);
+const VALUE_IN_CONFIDENCE_PATTERN = new RegExp(
+  String.raw`\b${CONFIDENCE_VALUE_PATTERN}\s+in\s+${CONFIDENCE_NOUN_PATTERN}\b`,
   "gi"
 );
 const CONCATENATED_VALUE_CONFIDENCE_PATTERN = new RegExp(
@@ -113,6 +117,7 @@ export function sanitizePublicConfidenceText(value: string, policy?: PublicConfi
     .replace(CONFIDENCE_LABEL_CONTINUATION_PATTERN, (_match, noun: string, continuation: string) => formatConfidenceLabelContinuation(noun, continuation))
     .replace(MARKDOWN_CONFIDENCE_LABEL_CONTINUATION_PATTERN, (_match, noun: string, continuation: string) => formatConfidenceLabelContinuation(noun, continuation))
     .replace(MARKDOWN_CONFIDENCE_LABEL_PATTERN, (_match, noun: string) => `${noun}: ${PUBLIC_CONFIDENCE_REPLACEMENT}`)
+    .replace(VALUE_IN_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(CONCATENATED_VALUE_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(MARKDOWN_VALUE_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(CONFIDENCE_LABEL_PATTERN, (_match, prefix: string) => `${prefix}${PUBLIC_CONFIDENCE_REPLACEMENT}`)

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -130,11 +130,9 @@ function boundPublicConfidenceText(value: string): string {
   const truncated = value.slice(0, MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH);
   const boundaryWindowStart = Math.max(0, truncated.length - 128);
   const boundaryWindow = truncated.slice(boundaryWindowStart);
-  const danglingConfidenceValue = boundaryWindow.match(
-    /(?:^|\s)(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1\.0+))(?:\s+[A-Za-z]*)?$/i
-  );
-  if (danglingConfidenceValue?.index !== undefined) {
-    return `${truncated.slice(0, boundaryWindowStart + danglingConfidenceValue.index).trimEnd()}${PUBLIC_CONFIDENCE_TRUNCATION_NOTICE}`;
+  const danglingConfidenceTokenStart = findDanglingConfidenceTokenStart(boundaryWindow);
+  if (danglingConfidenceTokenStart !== -1) {
+    return `${truncated.slice(0, boundaryWindowStart + danglingConfidenceTokenStart).trimEnd()}${PUBLIC_CONFIDENCE_TRUNCATION_NOTICE}`;
   }
   const lastTokenBoundary = Math.max(
     truncated.lastIndexOf(" "),
@@ -146,6 +144,15 @@ function boundPublicConfidenceText(value: string): string {
     ? truncated.slice(0, lastTokenBoundary).trimEnd()
     : truncated;
   return `${safeTruncated}${PUBLIC_CONFIDENCE_TRUNCATION_NOTICE}`;
+}
+
+function findDanglingConfidenceTokenStart(value: string): number {
+  const confidenceFragment = /confidence|certainty|reliability|sure(?:ness)?|\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1\.0+)/gi;
+  let lastMatchIndex = -1;
+  for (const match of value.matchAll(confidenceFragment)) {
+    lastMatchIndex = match.index;
+  }
+  return lastMatchIndex;
 }
 
 function formatConfidenceLabelContinuation(_noun: string, continuation: string): string {

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -16,37 +16,42 @@ export const PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS = 100;
 export const PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS = 30;
 export const PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS = 10;
 export const PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND = 0.95;
-const PUBLIC_CONFIDENCE_REPLACEMENT = "confidence not calibrated";
+const PUBLIC_CONFIDENCE_REPLACEMENT = "[confidence not calibrated]";
 const MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH = 128_000;
+const PUBLIC_CONFIDENCE_BOUNDARY_SCAN_LENGTH = 4_096;
 const PUBLIC_CONFIDENCE_TRUNCATION_NOTICE = "\n\n[truncated before public confidence sanitization]";
-const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1\.0+)(?=\b|[-_]))`;
+const HORIZONTAL_WHITESPACE_PATTERN = String.raw`[^\S\r\n]`;
+const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?${HORIZONTAL_WHITESPACE_PATTERN}*(?:%|percent\b)|(?:0?\.\d+|1\.0+)(?=\b|[-_]))`;
 const CONFIDENCE_NOUN_PATTERN = String.raw`(?:confidence|certainty|reliability|sure(?:ness)?)`;
-const CONFIDENCE_SEPARATOR_PATTERN = String.raw`(?:\s+|[-_]+)`;
+const CONFIDENCE_SEPARATOR_PATTERN = String.raw`(?:${HORIZONTAL_WHITESPACE_PATTERN}+|[-_]+)`;
 const MARKDOWN_WRAPPER_PATTERN = "(?:[*_~`]+)?";
 const MARKDOWN_VALUE_START_PATTERN = "(?:\\b|(?<=[*_~`]))";
-const CONFIDENCE_LABEL_PATTERN = new RegExp(String.raw`\b((${CONFIDENCE_NOUN_PATTERN})\s*[:=]\s*)${CONFIDENCE_VALUE_PATTERN}(?=\s*(?:[.,;:!?)]|$))`, "gi");
+const CONFIDENCE_LABEL_PATTERN = new RegExp(
+  String.raw`\b((${CONFIDENCE_NOUN_PATTERN})${HORIZONTAL_WHITESPACE_PATTERN}*[:=]${HORIZONTAL_WHITESPACE_PATTERN}*)${CONFIDENCE_VALUE_PATTERN}(?=${HORIZONTAL_WHITESPACE_PATTERN}*(?:[.,;:!?)]|$|\r?\n))`,
+  "gi"
+);
 const CONFIDENCE_LABEL_CONTINUATION_PATTERN = new RegExp(
-  String.raw`\b(${CONFIDENCE_NOUN_PATTERN})\s*[:=]\s*${CONFIDENCE_VALUE_PATTERN}\s+(is|was|are|were|that)\b`,
+  String.raw`\b(${CONFIDENCE_NOUN_PATTERN})${HORIZONTAL_WHITESPACE_PATTERN}*[:=]${HORIZONTAL_WHITESPACE_PATTERN}*${CONFIDENCE_VALUE_PATTERN}${HORIZONTAL_WHITESPACE_PATTERN}+(is|was|are|were|that)\b`,
   "gi"
 );
 const MARKDOWN_CONFIDENCE_LABEL_PATTERN = new RegExp(
-  String.raw`\b${MARKDOWN_WRAPPER_PATTERN}(${CONFIDENCE_NOUN_PATTERN})${MARKDOWN_WRAPPER_PATTERN}\s*[:=]\s*${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}(?=\s*(?:[.,;:!?)]|$))`,
+  String.raw`\b${MARKDOWN_WRAPPER_PATTERN}(${CONFIDENCE_NOUN_PATTERN})${MARKDOWN_WRAPPER_PATTERN}${HORIZONTAL_WHITESPACE_PATTERN}*[:=]${HORIZONTAL_WHITESPACE_PATTERN}*${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}(?=${HORIZONTAL_WHITESPACE_PATTERN}*(?:[.,;:!?)]|$|\r?\n))`,
   "gi"
 );
 const MARKDOWN_CONFIDENCE_LABEL_CONTINUATION_PATTERN = new RegExp(
-  String.raw`\b${MARKDOWN_WRAPPER_PATTERN}(${CONFIDENCE_NOUN_PATTERN})${MARKDOWN_WRAPPER_PATTERN}\s*[:=]\s*${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}\s+(is|was|are|were|that)\b`,
+  String.raw`\b${MARKDOWN_WRAPPER_PATTERN}(${CONFIDENCE_NOUN_PATTERN})${MARKDOWN_WRAPPER_PATTERN}${HORIZONTAL_WHITESPACE_PATTERN}*[:=]${HORIZONTAL_WHITESPACE_PATTERN}*${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}${HORIZONTAL_WHITESPACE_PATTERN}+(is|was|are|were|that)\b`,
   "gi"
 );
 const CONFIDENCE_NOUN_VALUE_PATTERN = new RegExp(
-  String.raw`\b${CONFIDENCE_NOUN_PATTERN}(?:${CONFIDENCE_SEPARATOR_PATTERN}score(?:\s*(?::|=)\s*|\s+of\s+|\s+(?:is|was|at)\s+|${CONFIDENCE_SEPARATOR_PATTERN})|\s+of\s+|\s+(?:is|was|at|in)\s+|${CONFIDENCE_SEPARATOR_PATTERN}|(?=\d))${CONFIDENCE_VALUE_PATTERN}`,
+  String.raw`\b${CONFIDENCE_NOUN_PATTERN}(?:${CONFIDENCE_SEPARATOR_PATTERN}score(?:${HORIZONTAL_WHITESPACE_PATTERN}*(?::|=)${HORIZONTAL_WHITESPACE_PATTERN}*|${HORIZONTAL_WHITESPACE_PATTERN}+of${HORIZONTAL_WHITESPACE_PATTERN}+|${HORIZONTAL_WHITESPACE_PATTERN}+(?:is|was|at)${HORIZONTAL_WHITESPACE_PATTERN}+|${CONFIDENCE_SEPARATOR_PATTERN})|${HORIZONTAL_WHITESPACE_PATTERN}+of${HORIZONTAL_WHITESPACE_PATTERN}+|${HORIZONTAL_WHITESPACE_PATTERN}+(?:is|was|at|in)${HORIZONTAL_WHITESPACE_PATTERN}+|${CONFIDENCE_SEPARATOR_PATTERN}|(?=\d))${CONFIDENCE_VALUE_PATTERN}`,
   "gi"
 );
 const VALUE_CONFIDENCE_PATTERN = new RegExp(
-  String.raw`\b${CONFIDENCE_VALUE_PATTERN}(?:\s*|[-_]+)(?:confident|confidence(?:\s+in\b)?|reliable|reliability|sure)\b`,
+  String.raw`\b${CONFIDENCE_VALUE_PATTERN}(?:${HORIZONTAL_WHITESPACE_PATTERN}*|[-_]+)(?:confident|confidence(?:${HORIZONTAL_WHITESPACE_PATTERN}+in\b)?|reliable|reliability|sure)\b`,
   "gi"
 );
 const VALUE_IN_CONFIDENCE_PATTERN = new RegExp(
-  String.raw`\b${CONFIDENCE_VALUE_PATTERN}\s+in\s+${CONFIDENCE_NOUN_PATTERN}\b`,
+  String.raw`\b${CONFIDENCE_VALUE_PATTERN}${HORIZONTAL_WHITESPACE_PATTERN}+in${HORIZONTAL_WHITESPACE_PATTERN}+${CONFIDENCE_NOUN_PATTERN}\b`,
   "gi"
 );
 const CONCATENATED_VALUE_CONFIDENCE_PATTERN = new RegExp(
@@ -54,10 +59,15 @@ const CONCATENATED_VALUE_CONFIDENCE_PATTERN = new RegExp(
   "gi"
 );
 const MARKDOWN_VALUE_CONFIDENCE_PATTERN = new RegExp(
-  String.raw`${MARKDOWN_VALUE_START_PATTERN}${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}(?:\s*|[-_]+)${MARKDOWN_WRAPPER_PATTERN}(?:confident|confidence(?:\s+in\b)?|reliable|reliability|sure)${MARKDOWN_WRAPPER_PATTERN}\b`,
+  String.raw`${MARKDOWN_VALUE_START_PATTERN}${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}(?:${HORIZONTAL_WHITESPACE_PATTERN}*|[-_]+)${MARKDOWN_WRAPPER_PATTERN}(?:confident|confidence(?:${HORIZONTAL_WHITESPACE_PATTERN}+in\b)?|reliable|reliability|sure)${MARKDOWN_WRAPPER_PATTERN}\b`,
   "gi"
 );
-const QUALIFIED_CONFIDENCE_DECIMAL_PATTERN = /\b(?:high|medium|low)\s+confidence\s*\(\s*(?:0?\.\d+|1(?:\.0+)?)\s*\)/gi;
+const QUALIFIED_CONFIDENCE_DECIMAL_PATTERN = new RegExp(
+  String.raw`\b(?:high|medium|low)${HORIZONTAL_WHITESPACE_PATTERN}+confidence${HORIZONTAL_WHITESPACE_PATTERN}*\(${HORIZONTAL_WHITESPACE_PATTERN}*(?:0?\.\d+|1(?:\.0+)?)${HORIZONTAL_WHITESPACE_PATTERN}*\)`,
+  "gi"
+);
+const CONFIDENCE_SANITIZER_CONTEXT_PREFILTER = /confidence|certainty|reliability|sure|confident|reliable/i;
+const CONFIDENCE_SANITIZER_VALUE_PREFILTER = /\d/;
 
 export function buildPublicConfidencePolicy(input?: Partial<PublicConfidenceDisplayPolicy>): PublicConfidenceDisplayPolicy {
   const evidenceUrl = input?.evidenceUrl?.trim();
@@ -132,6 +142,9 @@ export function isUsablePublicConfidenceEvidenceUrl(value: string | undefined): 
 export function sanitizePublicConfidenceText(value: string, policy?: PublicConfidenceDisplayPolicy): string {
   if (isPublicConfidenceDisplayAllowed(policy)) return value;
   const boundedValue = boundPublicConfidenceText(value);
+  if (!CONFIDENCE_SANITIZER_CONTEXT_PREFILTER.test(boundedValue) || !CONFIDENCE_SANITIZER_VALUE_PREFILTER.test(boundedValue)) {
+    return boundedValue;
+  }
   return boundedValue
     .replace(QUALIFIED_CONFIDENCE_DECIMAL_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(CONFIDENCE_LABEL_CONTINUATION_PATTERN, (_match, noun: string, continuation: string) => formatConfidenceLabelContinuation(noun, continuation))
@@ -148,17 +161,20 @@ export function sanitizePublicConfidenceText(value: string, policy?: PublicConfi
 function boundPublicConfidenceText(value: string): string {
   if (value.length <= MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH) return value;
   const truncated = value.slice(0, MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH);
-  const danglingConfidenceTokenStart = findDanglingConfidenceTokenStart(truncated);
+  const boundaryWindowStart = Math.max(0, truncated.length - PUBLIC_CONFIDENCE_BOUNDARY_SCAN_LENGTH);
+  const boundaryWindow = truncated.slice(boundaryWindowStart);
+  const danglingConfidenceTokenStart = findDanglingConfidenceTokenStart(boundaryWindow);
   if (danglingConfidenceTokenStart !== -1) {
-    return `${truncated.slice(0, danglingConfidenceTokenStart).trimEnd()}${PUBLIC_CONFIDENCE_TRUNCATION_NOTICE}`;
+    return `${truncated.slice(0, boundaryWindowStart + danglingConfidenceTokenStart).trimEnd()}${PUBLIC_CONFIDENCE_TRUNCATION_NOTICE}`;
   }
-  const lastTokenBoundary = Math.max(
-    truncated.lastIndexOf(" "),
-    truncated.lastIndexOf("\n"),
-    truncated.lastIndexOf("\r"),
-    truncated.lastIndexOf("\t")
+  const lastTokenBoundaryInWindow = Math.max(
+    boundaryWindow.lastIndexOf(" "),
+    boundaryWindow.lastIndexOf("\n"),
+    boundaryWindow.lastIndexOf("\r"),
+    boundaryWindow.lastIndexOf("\t")
   );
-  const safeTruncated = lastTokenBoundary === -1 ? truncated : truncated.slice(0, lastTokenBoundary).trimEnd();
+  const safeTruncated =
+    lastTokenBoundaryInWindow === -1 ? truncated : truncated.slice(0, boundaryWindowStart + lastTokenBoundaryInWindow).trimEnd();
   return `${safeTruncated}${PUBLIC_CONFIDENCE_TRUNCATION_NOTICE}`;
 }
 
@@ -172,6 +188,6 @@ function findDanglingConfidenceTokenStart(value: string): number {
 }
 
 function formatConfidenceLabelContinuation(_noun: string, continuation: string): string {
-  if (continuation.toLowerCase() === "that") return "confidence is not calibrated;";
-  return `confidence is not calibrated; it ${continuation}`;
+  if (continuation.toLowerCase() === "that") return `${PUBLIC_CONFIDENCE_REPLACEMENT};`;
+  return `${PUBLIC_CONFIDENCE_REPLACEMENT}; it ${continuation}`;
 }

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -17,13 +17,23 @@ export const PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS = 30;
 export const PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS = 10;
 export const PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND = 0.95;
 const PUBLIC_CONFIDENCE_REPLACEMENT = "confidence not calibrated";
+const MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH = 128_000;
+const PUBLIC_CONFIDENCE_TRUNCATION_NOTICE = "\n\n[truncated before public confidence sanitization]";
 const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1\.0+)(?=\b|[-_]))`;
-const CONFIDENCE_NOUN_PATTERN = String.raw`(?:confidence|certainty|reliability|accuracy|likelihood|sure(?:ness)?)`;
+const CONFIDENCE_NOUN_PATTERN = String.raw`(?:confidence|certainty|reliability|sure(?:ness)?)`;
 const CONFIDENCE_SEPARATOR_PATTERN = String.raw`(?:\s+|[-_]+)`;
 const MARKDOWN_WRAPPER_PATTERN = "(?:[*_~`]+)?";
-const CONFIDENCE_LABEL_PATTERN = new RegExp(String.raw`\b((${CONFIDENCE_NOUN_PATTERN})\s*[:=]\s*)${CONFIDENCE_VALUE_PATTERN}`, "gi");
+const CONFIDENCE_LABEL_PATTERN = new RegExp(String.raw`\b((${CONFIDENCE_NOUN_PATTERN})\s*[:=]\s*)${CONFIDENCE_VALUE_PATTERN}(?=\s*(?:[.,;:!?)]|$))`, "gi");
+const CONFIDENCE_LABEL_CONTINUATION_PATTERN = new RegExp(
+  String.raw`\b(${CONFIDENCE_NOUN_PATTERN})\s*[:=]\s*${CONFIDENCE_VALUE_PATTERN}\s+(is|was|are|were|that)\b`,
+  "gi"
+);
 const MARKDOWN_CONFIDENCE_LABEL_PATTERN = new RegExp(
-  String.raw`\b${MARKDOWN_WRAPPER_PATTERN}(${CONFIDENCE_NOUN_PATTERN})${MARKDOWN_WRAPPER_PATTERN}\s*[:=]\s*${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}`,
+  String.raw`\b${MARKDOWN_WRAPPER_PATTERN}(${CONFIDENCE_NOUN_PATTERN})${MARKDOWN_WRAPPER_PATTERN}\s*[:=]\s*${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}(?=\s*(?:[.,;:!?)]|$))`,
+  "gi"
+);
+const MARKDOWN_CONFIDENCE_LABEL_CONTINUATION_PATTERN = new RegExp(
+  String.raw`\b${MARKDOWN_WRAPPER_PATTERN}(${CONFIDENCE_NOUN_PATTERN})${MARKDOWN_WRAPPER_PATTERN}\s*[:=]\s*${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}\s+(is|was|are|were|that)\b`,
   "gi"
 );
 const CONFIDENCE_NOUN_VALUE_PATTERN = new RegExp(
@@ -31,11 +41,11 @@ const CONFIDENCE_NOUN_VALUE_PATTERN = new RegExp(
   "gi"
 );
 const VALUE_CONFIDENCE_PATTERN = new RegExp(
-  String.raw`\b${CONFIDENCE_VALUE_PATTERN}(?:\s*|[-_]+)(?:confident|confidence(?:\s+in\b)?|reliable|reliability|accurate|accuracy|likely|likelihood|sure)\b`,
+  String.raw`\b${CONFIDENCE_VALUE_PATTERN}(?:\s*|[-_]+)(?:confident|confidence(?:\s+in\b)?|reliable|reliability|sure)\b`,
   "gi"
 );
 const MARKDOWN_VALUE_CONFIDENCE_PATTERN = new RegExp(
-  String.raw`\b${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}(?:\s*|[-_]+)${MARKDOWN_WRAPPER_PATTERN}(?:confident|confidence(?:\s+in\b)?|reliable|reliability|accurate|accuracy|likely|likelihood|sure)${MARKDOWN_WRAPPER_PATTERN}\b`,
+  String.raw`\b${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}(?:\s*|[-_]+)${MARKDOWN_WRAPPER_PATTERN}(?:confident|confidence(?:\s+in\b)?|reliable|reliability|sure)${MARKDOWN_WRAPPER_PATTERN}\b`,
   "gi"
 );
 const QUALIFIED_CONFIDENCE_DECIMAL_PATTERN = /\b(?:high|medium|low)\s+confidence\s*\(\s*(?:0?\.\d+|1(?:\.0+)?)\s*\)/gi;
@@ -92,11 +102,22 @@ export function isUsablePublicConfidenceEvidenceUrl(value: string | undefined): 
 
 export function sanitizePublicConfidenceText(value: string, policy?: PublicConfidenceDisplayPolicy): string {
   if (isPublicConfidenceDisplayAllowed(policy)) return value;
-  return value
+  const boundedValue = value.length > MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH
+    ? `${value.slice(0, MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH)}${PUBLIC_CONFIDENCE_TRUNCATION_NOTICE}`
+    : value;
+  return boundedValue
     .replace(QUALIFIED_CONFIDENCE_DECIMAL_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
+    .replace(CONFIDENCE_LABEL_CONTINUATION_PATTERN, (_match, noun: string, continuation: string) => formatConfidenceLabelContinuation(noun, continuation))
+    .replace(MARKDOWN_CONFIDENCE_LABEL_CONTINUATION_PATTERN, (_match, noun: string, continuation: string) => formatConfidenceLabelContinuation(noun, continuation))
     .replace(MARKDOWN_CONFIDENCE_LABEL_PATTERN, (_match, noun: string) => `${noun}: ${PUBLIC_CONFIDENCE_REPLACEMENT}`)
     .replace(MARKDOWN_VALUE_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(CONFIDENCE_LABEL_PATTERN, (_match, prefix: string) => `${prefix}${PUBLIC_CONFIDENCE_REPLACEMENT}`)
     .replace(CONFIDENCE_NOUN_VALUE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(VALUE_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT);
+}
+
+function formatConfidenceLabelContinuation(noun: string, continuation: string): string {
+  const normalizedNoun = noun.toLowerCase() === "confidence" ? "confidence" : noun;
+  if (continuation.toLowerCase() === "that") return `${normalizedNoun} is not calibrated;`;
+  return `${normalizedNoun} is not calibrated; it ${continuation}`;
 }

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -19,6 +19,8 @@ export const PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND = 0.95;
 const PUBLIC_CONFIDENCE_REPLACEMENT = "[confidence not calibrated]";
 const MAX_PUBLIC_CONFIDENCE_TEXT_LENGTH = 128_000;
 const PUBLIC_CONFIDENCE_BOUNDARY_SCAN_LENGTH = 4_096;
+const DANGLING_CONFIDENCE_FRAGMENT_MAX_TRAILING_CHARS = 64;
+const DANGLING_CONFIDENCE_VALUE_CONTEXT_CHARS = 256;
 const PUBLIC_CONFIDENCE_TRUNCATION_NOTICE = "\n\n[truncated before public confidence sanitization]";
 const HORIZONTAL_WHITESPACE_PATTERN = String.raw`[^\S\r\n]`;
 const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?${HORIZONTAL_WHITESPACE_PATTERN}*(?:%|percent\b)|(?:0?\.\d+|1\.0+)(?=\b|[-_]))`;
@@ -66,8 +68,14 @@ const QUALIFIED_CONFIDENCE_DECIMAL_PATTERN = new RegExp(
   String.raw`\b(?:high|medium|low)${HORIZONTAL_WHITESPACE_PATTERN}+confidence${HORIZONTAL_WHITESPACE_PATTERN}*\(${HORIZONTAL_WHITESPACE_PATTERN}*(?:0?\.\d+|1(?:\.0+)?)${HORIZONTAL_WHITESPACE_PATTERN}*\)`,
   "gi"
 );
+const RESIDUAL_CONFIDENCE_VALUE_PATTERN = new RegExp(CONFIDENCE_VALUE_PATTERN, "gi");
 const CONFIDENCE_SANITIZER_CONTEXT_PREFILTER = /confidence|certainty|reliability|sure|confident|reliable/i;
 const CONFIDENCE_SANITIZER_VALUE_PREFILTER = /\d/;
+const RESIDUAL_CONFIDENCE_CONTEXT_PATTERN = /confidence|certainty|reliability/i;
+// Keep this carve-out deliberately narrow: until calibrated evidence is present,
+// review-confidence redaction wins over ambiguous statistical phrasing.
+const PRESERVED_TECHNICAL_CONFIDENCE_CONTEXT_PATTERN = /\bconfidence\s+(?:interval|threshold|calibration)\b|\b(?:precision|recall|accuracy|coverage|pass rate|success rate|uptime)\b/i;
+const RESIDUAL_CONFIDENCE_CONTEXT_WINDOW = 80;
 
 export function buildPublicConfidencePolicy(input?: Partial<PublicConfidenceDisplayPolicy>): PublicConfidenceDisplayPolicy {
   const evidenceUrl = input?.evidenceUrl?.trim();
@@ -140,12 +148,12 @@ export function isUsablePublicConfidenceEvidenceUrl(value: string | undefined): 
 }
 
 export function sanitizePublicConfidenceText(value: string, policy?: PublicConfidenceDisplayPolicy): string {
-  if (isPublicConfidenceDisplayAllowed(policy)) return value;
   const boundedValue = boundPublicConfidenceText(value);
+  if (isPublicConfidenceDisplayAllowed(policy)) return boundedValue;
   if (!CONFIDENCE_SANITIZER_CONTEXT_PREFILTER.test(boundedValue) || !CONFIDENCE_SANITIZER_VALUE_PREFILTER.test(boundedValue)) {
     return boundedValue;
   }
-  return boundedValue
+  const sanitized = boundedValue
     .replace(QUALIFIED_CONFIDENCE_DECIMAL_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(CONFIDENCE_LABEL_CONTINUATION_PATTERN, (_match, noun: string, continuation: string) => formatConfidenceLabelContinuation(noun, continuation))
     .replace(MARKDOWN_CONFIDENCE_LABEL_CONTINUATION_PATTERN, (_match, noun: string, continuation: string) => formatConfidenceLabelContinuation(noun, continuation))
@@ -156,6 +164,46 @@ export function sanitizePublicConfidenceText(value: string, policy?: PublicConfi
     .replace(CONFIDENCE_LABEL_PATTERN, (_match, prefix: string) => `${prefix}${PUBLIC_CONFIDENCE_REPLACEMENT}`)
     .replace(CONFIDENCE_NOUN_VALUE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(VALUE_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT);
+  return redactResidualPublicConfidenceValues(sanitized);
+}
+
+function redactResidualPublicConfidenceValues(value: string): string {
+  let output = "";
+  let cursor = 0;
+  for (const match of value.matchAll(RESIDUAL_CONFIDENCE_VALUE_PATTERN)) {
+    const token = match[0];
+    const offset = match.index;
+    if (offset === undefined) continue;
+    const lineStart = value.lastIndexOf("\n", offset - 1) + 1;
+    const nextLineBreak = value.indexOf("\n", offset + token.length);
+    const lineEnd = nextLineBreak === -1 ? value.length : nextLineBreak;
+    const context = value.slice(
+      Math.max(lineStart, offset - RESIDUAL_CONFIDENCE_CONTEXT_WINDOW),
+      Math.min(lineEnd, offset + token.length + RESIDUAL_CONFIDENCE_CONTEXT_WINDOW)
+    );
+    const replacement =
+      !isVersionLikeDecimalFragment(value, offset, token) &&
+      RESIDUAL_CONFIDENCE_CONTEXT_PATTERN.test(context) &&
+      !PRESERVED_TECHNICAL_CONFIDENCE_CONTEXT_PATTERN.test(context)
+        ? PUBLIC_CONFIDENCE_REPLACEMENT
+        : token;
+    output += value.slice(cursor, offset) + replacement;
+    cursor = offset + token.length;
+  }
+  return `${output}${value.slice(cursor)}`;
+}
+
+function isVersionLikeDecimalFragment(value: string, offset: number, token: string): boolean {
+  if (!token.includes(".")) return false;
+  const previous = value[offset - 1];
+  const previousPrevious = value[offset - 2];
+  const next = value[offset + token.length];
+  const nextNext = value[offset + token.length + 1];
+  return (
+    (token.startsWith(".") && /\d/.test(previous ?? "")) ||
+    (previous === "." && /\d/.test(previousPrevious ?? "")) ||
+    (next === "." && /\d/.test(nextNext ?? ""))
+  );
 }
 
 function boundPublicConfidenceText(value: string): string {
@@ -180,9 +228,23 @@ function boundPublicConfidenceText(value: string): string {
 
 function findDanglingConfidenceTokenStart(value: string): number {
   const confidenceFragment = /confidence|certainty|reliability|sure(?:ness)?|\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1\.0+)/gi;
+  let lastConfidenceWordIndex = -1;
   let lastMatchIndex = -1;
   for (const match of value.matchAll(confidenceFragment)) {
-    lastMatchIndex = match.index;
+    const token = match[0];
+    const isConfidenceWord = /^(?:confidence|certainty|reliability|sure)/i.test(token);
+    if (isConfidenceWord) lastConfidenceWordIndex = match.index;
+    const matchEnd = match.index + match[0].length;
+    const trailingChars = value.length - matchEnd;
+    if (isConfidenceWord && trailingChars <= DANGLING_CONFIDENCE_VALUE_CONTEXT_CHARS) {
+      lastMatchIndex = match.index;
+    } else if (trailingChars <= DANGLING_CONFIDENCE_FRAGMENT_MAX_TRAILING_CHARS) {
+      const shouldIncludeConfidenceWord =
+        !isConfidenceWord &&
+        lastConfidenceWordIndex !== -1 &&
+        match.index - lastConfidenceWordIndex <= DANGLING_CONFIDENCE_VALUE_CONTEXT_CHARS;
+      lastMatchIndex = shouldIncludeConfidenceWord ? lastConfidenceWordIndex : match.index;
+    }
   }
   return lastMatchIndex;
 }

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -12,21 +12,30 @@ export interface PublicConfidenceDisplayPolicy {
   wilsonLowerBound?: number;
 }
 
-const DEFAULT_MIN_LABELED_FINDINGS = 100;
-const DEFAULT_MIN_P0_P1_LABELS = 30;
-const DEFAULT_MIN_NEGATIVE_CONTROL_SCENARIOS = 10;
-const DEFAULT_MIN_WILSON_LOWER_BOUND = 0.95;
+export const PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS = 100;
+export const PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS = 30;
+export const PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS = 10;
+export const PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND = 0.95;
 const PUBLIC_CONFIDENCE_REPLACEMENT = "confidence not calibrated";
 const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1\.0+)(?=\b|[-_]))`;
 const CONFIDENCE_NOUN_PATTERN = String.raw`(?:confidence|certainty|reliability|accuracy|likelihood|sure(?:ness)?)`;
 const CONFIDENCE_SEPARATOR_PATTERN = String.raw`(?:\s+|[-_]+)`;
+const MARKDOWN_WRAPPER_PATTERN = "(?:[*_~`]+)?";
 const CONFIDENCE_LABEL_PATTERN = new RegExp(String.raw`\b((${CONFIDENCE_NOUN_PATTERN})\s*[:=]\s*)${CONFIDENCE_VALUE_PATTERN}`, "gi");
+const MARKDOWN_CONFIDENCE_LABEL_PATTERN = new RegExp(
+  String.raw`\b${MARKDOWN_WRAPPER_PATTERN}(${CONFIDENCE_NOUN_PATTERN})${MARKDOWN_WRAPPER_PATTERN}\s*[:=]\s*${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}`,
+  "gi"
+);
 const CONFIDENCE_NOUN_VALUE_PATTERN = new RegExp(
   String.raw`\b${CONFIDENCE_NOUN_PATTERN}(?:${CONFIDENCE_SEPARATOR_PATTERN}score(?:\s*(?::|=)\s*|\s+of\s+|\s+(?:is|was|at)\s+|${CONFIDENCE_SEPARATOR_PATTERN})|\s+of\s+|\s+(?:is|was|at|in)\s+|${CONFIDENCE_SEPARATOR_PATTERN})${CONFIDENCE_VALUE_PATTERN}`,
   "gi"
 );
 const VALUE_CONFIDENCE_PATTERN = new RegExp(
   String.raw`\b${CONFIDENCE_VALUE_PATTERN}(?:\s*|[-_]+)(?:confident|confidence(?:\s+in\b)?|reliable|reliability|accurate|accuracy|likely|likelihood|sure)\b`,
+  "gi"
+);
+const MARKDOWN_VALUE_CONFIDENCE_PATTERN = new RegExp(
+  String.raw`\b${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}(?:\s*|[-_]+)${MARKDOWN_WRAPPER_PATTERN}(?:confident|confidence(?:\s+in\b)?|reliable|reliability|accurate|accuracy|likely|likelihood|sure)${MARKDOWN_WRAPPER_PATTERN}\b`,
   "gi"
 );
 const QUALIFIED_CONFIDENCE_DECIMAL_PATTERN = /\b(?:high|medium|low)\s+confidence\s*\(\s*(?:0?\.\d+|1(?:\.0+)?)\s*\)/gi;
@@ -36,13 +45,13 @@ export function buildPublicConfidencePolicy(input?: Partial<PublicConfidenceDisp
   const datasetId = input?.datasetId?.trim();
   return {
     mode: input?.mode ?? "uncalibrated",
-    minLabeledFindings: Math.max(input?.minLabeledFindings ?? DEFAULT_MIN_LABELED_FINDINGS, DEFAULT_MIN_LABELED_FINDINGS),
-    minP0P1Labels: Math.max(input?.minP0P1Labels ?? DEFAULT_MIN_P0_P1_LABELS, DEFAULT_MIN_P0_P1_LABELS),
+    minLabeledFindings: Math.max(input?.minLabeledFindings ?? PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS, PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS),
+    minP0P1Labels: Math.max(input?.minP0P1Labels ?? PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS, PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS),
     minNegativeControlScenarios: Math.max(
-      input?.minNegativeControlScenarios ?? DEFAULT_MIN_NEGATIVE_CONTROL_SCENARIOS,
-      DEFAULT_MIN_NEGATIVE_CONTROL_SCENARIOS
+      input?.minNegativeControlScenarios ?? PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS,
+      PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS
     ),
-    minWilsonLowerBound: Math.max(input?.minWilsonLowerBound ?? DEFAULT_MIN_WILSON_LOWER_BOUND, DEFAULT_MIN_WILSON_LOWER_BOUND),
+    minWilsonLowerBound: Math.max(input?.minWilsonLowerBound ?? PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND, PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND),
     ...(evidenceUrl ? { evidenceUrl } : {}),
     ...(datasetId ? { datasetId } : {}),
     ...(input?.labeledFindings !== undefined ? { labeledFindings: input.labeledFindings } : {}),
@@ -55,17 +64,17 @@ export function buildPublicConfidencePolicy(input?: Partial<PublicConfidenceDisp
 export function isPublicConfidenceDisplayAllowed(policy?: PublicConfidenceDisplayPolicy): boolean {
   if (!policy || policy.mode !== "calibrated") return false;
   if (!isUsablePublicConfidenceEvidenceUrl(policy.evidenceUrl) || !policy.datasetId?.trim()) return false;
-  if (policy.labeledFindings === undefined || policy.labeledFindings < Math.max(policy.minLabeledFindings, DEFAULT_MIN_LABELED_FINDINGS)) {
+  if (policy.labeledFindings === undefined || policy.labeledFindings < Math.max(policy.minLabeledFindings, PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS)) {
     return false;
   }
-  if (policy.p0p1Labels === undefined || policy.p0p1Labels < Math.max(policy.minP0P1Labels, DEFAULT_MIN_P0_P1_LABELS)) return false;
+  if (policy.p0p1Labels === undefined || policy.p0p1Labels < Math.max(policy.minP0P1Labels, PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS)) return false;
   if (
     policy.negativeControlScenarios === undefined ||
-    policy.negativeControlScenarios < Math.max(policy.minNegativeControlScenarios, DEFAULT_MIN_NEGATIVE_CONTROL_SCENARIOS)
+    policy.negativeControlScenarios < Math.max(policy.minNegativeControlScenarios, PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS)
   ) {
     return false;
   }
-  if (policy.wilsonLowerBound === undefined || policy.wilsonLowerBound < Math.max(policy.minWilsonLowerBound, DEFAULT_MIN_WILSON_LOWER_BOUND)) {
+  if (policy.wilsonLowerBound === undefined || policy.wilsonLowerBound < Math.max(policy.minWilsonLowerBound, PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND)) {
     return false;
   }
   return true;
@@ -85,6 +94,8 @@ export function sanitizePublicConfidenceText(value: string, policy?: PublicConfi
   if (isPublicConfidenceDisplayAllowed(policy)) return value;
   return value
     .replace(QUALIFIED_CONFIDENCE_DECIMAL_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
+    .replace(MARKDOWN_CONFIDENCE_LABEL_PATTERN, (_match, noun: string) => `${noun}: ${PUBLIC_CONFIDENCE_REPLACEMENT}`)
+    .replace(MARKDOWN_VALUE_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(CONFIDENCE_LABEL_PATTERN, (_match, prefix: string) => `${prefix}${PUBLIC_CONFIDENCE_REPLACEMENT}`)
     .replace(CONFIDENCE_NOUN_VALUE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(VALUE_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT);

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -23,6 +23,7 @@ const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(
 const CONFIDENCE_NOUN_PATTERN = String.raw`(?:confidence|certainty|reliability|sure(?:ness)?)`;
 const CONFIDENCE_SEPARATOR_PATTERN = String.raw`(?:\s+|[-_]+)`;
 const MARKDOWN_WRAPPER_PATTERN = "(?:[*_~`]+)?";
+const MARKDOWN_VALUE_START_PATTERN = "(?:\\b|(?<=[*_~`]))";
 const CONFIDENCE_LABEL_PATTERN = new RegExp(String.raw`\b((${CONFIDENCE_NOUN_PATTERN})\s*[:=]\s*)${CONFIDENCE_VALUE_PATTERN}(?=\s*(?:[.,;:!?)]|$))`, "gi");
 const CONFIDENCE_LABEL_CONTINUATION_PATTERN = new RegExp(
   String.raw`\b(${CONFIDENCE_NOUN_PATTERN})\s*[:=]\s*${CONFIDENCE_VALUE_PATTERN}\s+(is|was|are|were|that)\b`,
@@ -45,7 +46,7 @@ const VALUE_CONFIDENCE_PATTERN = new RegExp(
   "gi"
 );
 const MARKDOWN_VALUE_CONFIDENCE_PATTERN = new RegExp(
-  String.raw`\b${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}(?:\s*|[-_]+)${MARKDOWN_WRAPPER_PATTERN}(?:confident|confidence(?:\s+in\b)?|reliable|reliability|sure)${MARKDOWN_WRAPPER_PATTERN}\b`,
+  String.raw`${MARKDOWN_VALUE_START_PATTERN}${MARKDOWN_WRAPPER_PATTERN}${CONFIDENCE_VALUE_PATTERN}${MARKDOWN_WRAPPER_PATTERN}(?:\s*|[-_]+)${MARKDOWN_WRAPPER_PATTERN}(?:confident|confidence(?:\s+in\b)?|reliable|reliability|sure)${MARKDOWN_WRAPPER_PATTERN}\b`,
   "gi"
 );
 const QUALIFIED_CONFIDENCE_DECIMAL_PATTERN = /\b(?:high|medium|low)\s+confidence\s*\(\s*(?:0?\.\d+|1(?:\.0+)?)\s*\)/gi;

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -17,7 +17,7 @@ const DEFAULT_MIN_P0_P1_LABELS = 30;
 const DEFAULT_MIN_NEGATIVE_CONTROL_SCENARIOS = 10;
 const DEFAULT_MIN_WILSON_LOWER_BOUND = 0.95;
 const PUBLIC_CONFIDENCE_REPLACEMENT = "confidence not calibrated";
-const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1(?:\.0+)?)\b)`;
+const CONFIDENCE_VALUE_PATTERN = String.raw`(?:\d+(?:\.\d+)?\s*(?:%|percent\b)|(?:0?\.\d+|1\.0+)\b)`;
 const CONFIDENCE_NOUN_PATTERN = String.raw`(?:confidence|certainty|reliability|accuracy|likelihood|sure(?:ness)?)`;
 const CONFIDENCE_LABEL_PATTERN = new RegExp(String.raw`\b((${CONFIDENCE_NOUN_PATTERN})\s*[:=]\s*)${CONFIDENCE_VALUE_PATTERN}`, "gi");
 const CONFIDENCE_NOUN_VALUE_PATTERN = new RegExp(
@@ -84,7 +84,7 @@ export function sanitizePublicConfidenceText(value: string, policy?: PublicConfi
   if (isPublicConfidenceDisplayAllowed(policy)) return value;
   return value
     .replace(QUALIFIED_CONFIDENCE_DECIMAL_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
-    .replace(CONFIDENCE_LABEL_PATTERN, `$1${PUBLIC_CONFIDENCE_REPLACEMENT}`)
+    .replace(CONFIDENCE_LABEL_PATTERN, (_match, prefix: string) => `${prefix}${PUBLIC_CONFIDENCE_REPLACEMENT}`)
     .replace(CONFIDENCE_NOUN_VALUE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT)
     .replace(VALUE_CONFIDENCE_PATTERN, PUBLIC_CONFIDENCE_REPLACEMENT);
 }

--- a/src/review-gate.ts
+++ b/src/review-gate.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { validateFindingLocations } from "./diff.js";
 import { decideReviewEvent, normalizeFindingsForReview } from "./findings.js";
+import type { PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import { countCategories, isRequestChangesEligible } from "./regression-taxonomy.js";
 import type {
   DeterministicReviewGateSummary,
@@ -24,6 +25,7 @@ export function applyDeterministicReviewGate(input: {
   droppedFromSchema?: DroppedFinding[];
   maxInlineComments?: number;
   repoMemoryFalsePositiveFingerprints?: string[];
+  publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
 }): DeterministicReviewGateResult {
   const located = validateFindingLocations(input.findings, input.files);
   // Memory suppression intentionally precedes normalization; dropReasonCounts reflects that ordering.
@@ -31,7 +33,10 @@ export function applyDeterministicReviewGate(input: {
     located.valid,
     input.repoMemoryFalsePositiveFingerprints ?? []
   );
-  const normalized = normalizeFindingsForReview(repoMemoryFiltered.findings, { maxInlineComments: input.maxInlineComments });
+  const normalized = normalizeFindingsForReview(repoMemoryFiltered.findings, {
+    maxInlineComments: input.maxInlineComments,
+    publicConfidencePolicy: input.publicConfidencePolicy
+  });
   const dropped = [
     ...(input.droppedFromSchema ?? []),
     ...located.dropped,

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -162,11 +162,12 @@ function sanitizePublicUrlText(value: string | undefined): string {
 }
 
 function formatInlinePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
-  return sanitizePublicText(value, publicConfidencePolicy)
+  const boundedText = redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]"))
     .replace(/\s+/g, " ")
     .trim()
     .replace(/^#{1,6}\s+/, "")
     .slice(0, 200);
+  return sanitizePublicConfidenceText(boundedText, publicConfidencePolicy);
 }
 
 function statusMessage(input: BuildReviewStatusCommentInput): string {

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -1,4 +1,5 @@
 import { redactSecrets } from "./secrets.js";
+import { sanitizePublicConfidenceText, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 
 export type ReviewStatusCommentState =
   | "queued"
@@ -34,6 +35,7 @@ export interface BuildReviewStatusCommentInput {
   reviewUrl?: string;
   details?: string;
   now?: Date;
+  publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
 }
 
 export const REVIEW_STATUS_MARKER_PREFIX = "<!-- evaos-code-review-bot:review-status";
@@ -57,10 +59,10 @@ export function buildReviewStatusComment(input: BuildReviewStatusCommentInput): 
 } {
   const marker = buildReviewStatusMarker(input);
   const updatedAt = (input.now ?? new Date()).toISOString();
-  const title = formatInlinePublicText(input.pullTitle);
-  const details = sanitizePublicText(input.details);
-  const pullUrl = sanitizePublicText(input.pullUrl);
-  const reviewUrl = sanitizePublicText(input.reviewUrl);
+  const title = formatInlinePublicText(input.pullTitle, input.publicConfidencePolicy);
+  const details = sanitizePublicText(input.details, input.publicConfidencePolicy);
+  const pullUrl = sanitizePublicText(input.pullUrl, input.publicConfidencePolicy);
+  const reviewUrl = sanitizePublicText(input.reviewUrl, input.publicConfidencePolicy);
   const lines = [
     marker,
     `${REVIEW_STATUS_STATE_MARKER_PREFIX} status=${input.state} updated_at=${updatedAt} -->`,
@@ -98,6 +100,7 @@ export async function postReviewStatusComment(input: {
   reviewUrl?: string;
   details?: string;
   now?: Date;
+  publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
 }): Promise<ReviewStatusCommentPostResult> {
   if (!input.enabled) return { posted: false, reason: "disabled", state: input.state };
   if (input.dryRun) return { posted: false, reason: "dry_run", state: input.state };
@@ -145,13 +148,16 @@ function validateMarkerIdentity(input: { repo: string; pullNumber: number; headS
   if (!HEAD_SHA_PATTERN.test(input.headSha)) throw new Error(`Invalid review status head SHA: ${input.headSha}`);
 }
 
-function sanitizePublicText(value: string | undefined): string {
+function sanitizePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
   if (!value) return "";
-  return redactSecrets(value.replace(HTML_COMMENT_PATTERN, "[hidden comment removed]")).trim();
+  return sanitizePublicConfidenceText(
+    redactSecrets(value.replace(HTML_COMMENT_PATTERN, "[hidden comment removed]")),
+    publicConfidencePolicy
+  ).trim();
 }
 
-function formatInlinePublicText(value: string | undefined): string {
-  return sanitizePublicText(value)
+function formatInlinePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
+  return sanitizePublicText(value, publicConfidencePolicy)
     .replace(/\s+/g, " ")
     .trim()
     .replace(/^#{1,6}\s+/, "")

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -158,6 +158,7 @@ function sanitizePublicText(value: string | undefined, publicConfidencePolicy?: 
 
 function sanitizePublicUrlText(value: string | undefined): string {
   if (!value) return "";
+  // URLs skip confidence sanitization so query strings stay intact.
   return redactSecrets(value.replace(HTML_COMMENT_PATTERN, "[hidden comment removed]")).trim();
 }
 

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -61,8 +61,8 @@ export function buildReviewStatusComment(input: BuildReviewStatusCommentInput): 
   const updatedAt = (input.now ?? new Date()).toISOString();
   const title = formatInlinePublicText(input.pullTitle, input.publicConfidencePolicy);
   const details = sanitizePublicText(input.details, input.publicConfidencePolicy);
-  const pullUrl = sanitizePublicText(input.pullUrl, input.publicConfidencePolicy);
-  const reviewUrl = sanitizePublicText(input.reviewUrl, input.publicConfidencePolicy);
+  const pullUrl = sanitizePublicUrlText(input.pullUrl);
+  const reviewUrl = sanitizePublicUrlText(input.reviewUrl);
   const lines = [
     marker,
     `${REVIEW_STATUS_STATE_MARKER_PREFIX} status=${input.state} updated_at=${updatedAt} -->`,
@@ -154,6 +154,11 @@ function sanitizePublicText(value: string | undefined, publicConfidencePolicy?: 
     redactSecrets(value.replace(HTML_COMMENT_PATTERN, "[hidden comment removed]")),
     publicConfidencePolicy
   ).trim();
+}
+
+function sanitizePublicUrlText(value: string | undefined): string {
+  if (!value) return "";
+  return redactSecrets(value.replace(HTML_COMMENT_PATTERN, "[hidden comment removed]")).trim();
 }
 
 function formatInlinePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -162,12 +162,15 @@ function sanitizePublicUrlText(value: string | undefined): string {
 }
 
 function formatInlinePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
-  const boundedText = redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]"))
+  const normalizedText = redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]"))
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^#{1,6}\s+/, "");
+  return sanitizePublicConfidenceText(normalizedText, publicConfidencePolicy)
     .replace(/\s+/g, " ")
     .trim()
     .replace(/^#{1,6}\s+/, "")
     .slice(0, 200);
-  return sanitizePublicConfidenceText(boundedText, publicConfidencePolicy);
 }
 
 function statusMessage(input: BuildReviewStatusCommentInput): string {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1017,7 +1017,8 @@ async function syncReviewStatusComment(input: {
     pullUrl: input.pull.html_url,
     ...(input.reviewUrl ? { reviewUrl: input.reviewUrl } : {}),
     ...(input.details ? { details: input.details } : {}),
-    now: input.now
+    now: input.now,
+    publicConfidencePolicy: input.config.confidenceCalibration?.publicDisplay
   });
   if (isStatusCommentFailure(result)) input.onStatusCommentFailure?.();
 }

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -47,16 +47,16 @@ export function buildWalkthroughComment(input: {
   validateWalkthroughIdentity({ repo: input.repo, pullNumber: input.pull.number, headSha: input.pull.head.sha });
   const marker = buildWalkthroughMarker({ repo: input.repo, pullNumber: input.pull.number });
   const publicComments = input.comments.map((comment) => sanitizeReviewCommentPublicText(comment, input.publicConfidencePolicy));
-  const files = input.files.map((file) => summarizeFile(file, publicComments));
+  const files = input.files.map((file) => summarizeFile(file, input.comments));
   const visibleFiles = files.slice(0, MAX_CHANGED_FILE_ROWS);
   const omittedFileCount = Math.max(0, files.length - visibleFiles.length);
-  const effort = estimateReviewEffort(input.files, publicComments);
+  const effort = estimateReviewEffort(input.files, input.comments);
   const relatedRefs = extractRelatedRefs(`${input.pull.title}\n${input.pull.body ?? ""}`);
-  const suggestedLabels = suggestLabels(input.files, publicComments);
+  const suggestedLabels = suggestLabels(input.files, input.comments);
   const suggestedReviewers = input.pull.requested_reviewers?.map((reviewer) => reviewer.login).filter(Boolean) ?? [];
-  const severityCounts = countSeverities(publicComments);
+  const severityCounts = countSeverities(input.comments);
   const highSeverity = severityCounts.P0 + severityCounts.P1;
-  const requestChangesEligible = publicComments.filter(isRequestChangesEligible).length;
+  const requestChangesEligible = input.comments.filter(isRequestChangesEligible).length;
   const settingsPreviewSection = formatSettingsPreviewSection(input.settingsPreview, input.publicConfidencePolicy);
 
   const visibleBody = [
@@ -76,14 +76,14 @@ export function buildWalkthroughComment(input: {
     "",
     "### Review Signal",
     "",
-    publicComments.length === 0
+    input.comments.length === 0
       ? "No validated inline findings."
-      : `Validated inline findings: ${publicComments.length} (${formatSeverityCounts(severityCounts)}).`,
+      : `Validated inline findings: ${input.comments.length} (${formatSeverityCounts(severityCounts)}).`,
     `Dropped findings before posting: ${input.dropped.length}. High-severity findings: ${highSeverity}.`,
     "",
     "### Risk Taxonomy",
     "",
-    formatCategoryBreakdown(publicComments),
+    formatCategoryBreakdown(input.comments),
     "",
     "### Validation and Proof",
     "",
@@ -97,7 +97,7 @@ export function buildWalkthroughComment(input: {
     ...(settingsPreviewSection.length > 0 ? ["", ...settingsPreviewSection, ""] : [""]),
     "### Pre-merge checklist",
     "",
-    checklistItem(publicComments.every((comment) => comment.side === "RIGHT"), "Inline comments target current RIGHT-side diff lines."),
+    checklistItem(input.comments.every((comment) => comment.side === "RIGHT"), "Inline comments target current RIGHT-side diff lines."),
     checklistItem(!commentsContainSecretLikeText(publicComments), "No secret-like content survived into posted inline comments."),
     checklistItem(
       input.event !== "REQUEST_CHANGES" || requestChangesEligible > 0,

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 import { categoryLabel, isRequestChangesEligible } from "./regression-taxonomy.js";
+import { sanitizePublicConfidenceText, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import type {
   ChangedSurfaceValidationReport,
   DroppedFinding,
@@ -39,6 +40,7 @@ export function buildWalkthroughComment(input: {
   validation?: ChangedSurfaceValidationReport;
   proof?: ProofRequirementReport;
   postIssueComment?: boolean;
+  publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
 }): WalkthroughComment {
   validateWalkthroughIdentity({ repo: input.repo, pullNumber: input.pull.number, headSha: input.pull.head.sha });
   const marker = buildWalkthroughMarker({ repo: input.repo, pullNumber: input.pull.number });
@@ -56,7 +58,7 @@ export function buildWalkthroughComment(input: {
   const visibleBody = [
     "## Walkthrough",
     "",
-    `PR: ${input.repo}#${input.pull.number} - ${formatInlinePublicText(input.pull.title)}`,
+    `PR: ${input.repo}#${input.pull.number} - ${formatInlinePublicText(input.pull.title, input.publicConfidencePolicy)}`,
     `Head: \`${input.pull.head.sha}\` into \`${input.pull.base.ref}\`. Review event: \`${input.event}\`.`,
     "",
     `Estimated review effort: ${effort.score}/5 (~${effort.minutes} min)`,
@@ -81,7 +83,7 @@ export function buildWalkthroughComment(input: {
     "",
     "### Validation and Proof",
     "",
-    ...formatValidationSection(input.validation, input.proof),
+    ...formatValidationSection(input.validation, input.proof, input.publicConfidencePolicy),
     "",
     "### Related Context",
     "",
@@ -147,8 +149,11 @@ function hashWalkthrough(body: string): string {
   return createHash("sha256").update(body, "utf8").digest("hex");
 }
 
-function formatInlinePublicText(value: string | undefined): string {
-  return redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]"))
+function formatInlinePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
+  return sanitizePublicConfidenceText(
+    redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]")),
+    publicConfidencePolicy
+  )
     .replace(/\s+/g, " ")
     .trim()
     .replace(/^#{1,6}\s+/, "")
@@ -239,22 +244,23 @@ function formatCategoryBreakdown(comments: ReviewComment[]): string {
 
 function formatValidationSection(
   validation: ChangedSurfaceValidationReport | undefined,
-  proof: ProofRequirementReport | undefined
+  proof: ProofRequirementReport | undefined,
+  publicConfidencePolicy?: PublicConfidenceDisplayPolicy
 ): string[] {
   if (!validation) return ["Validation selector did not run."];
-  const lines = [validation.summary];
+  const lines = [sanitizePublicConfidenceText(validation.summary, publicConfidencePolicy)];
   for (const recommendation of validation.recommendations) {
     lines.push(
-      `- ${recommendation.status}: ${recommendation.title} - ${recommendation.reason}` +
-        (recommendation.proofTypes.length > 0 ? ` Proof: ${recommendation.proofTypes.join("; ")}.` : "")
+      `- ${recommendation.status}: ${sanitizePublicConfidenceText(recommendation.title, publicConfidencePolicy)} - ${sanitizePublicConfidenceText(recommendation.reason, publicConfidencePolicy)}` +
+        (recommendation.proofTypes.length > 0 ? ` Proof: ${sanitizePublicConfidenceText(recommendation.proofTypes.join("; "), publicConfidencePolicy)}.` : "")
     );
   }
-  if (proof) lines.push(`Proof status: ${proof.status} - ${proof.summary}`);
+  if (proof) lines.push(`Proof status: ${proof.status} - ${sanitizePublicConfidenceText(proof.summary, publicConfidencePolicy)}`);
   if (validation.profileHints.validationHints.length > 0) {
-    lines.push(`Profile validation hints: ${validation.profileHints.validationHints.join("; ")}`);
+    lines.push(`Profile validation hints: ${sanitizePublicConfidenceText(validation.profileHints.validationHints.join("; "), publicConfidencePolicy)}`);
   }
   if (validation.profileHints.proofExpectations.length > 0) {
-    lines.push(`Profile proof expectations: ${validation.profileHints.proofExpectations.join("; ")}`);
+    lines.push(`Profile proof expectations: ${sanitizePublicConfidenceText(validation.profileHints.proofExpectations.join("; "), publicConfidencePolicy)}`);
   }
   return lines;
 }

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -46,6 +46,7 @@ export function buildWalkthroughComment(input: {
 }): WalkthroughComment {
   validateWalkthroughIdentity({ repo: input.repo, pullNumber: input.pull.number, headSha: input.pull.head.sha });
   const marker = buildWalkthroughMarker({ repo: input.repo, pullNumber: input.pull.number });
+  // Keep gate/count signal on original comments; use publicComments only for public-text safety checks.
   const publicComments = input.comments.map((comment) => sanitizeReviewCommentPublicText(comment, input.publicConfidencePolicy));
   const files = input.files.map((file) => summarizeFile(file, input.comments));
   const visibleFiles = files.slice(0, MAX_CHANGED_FILE_ROWS);

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -46,16 +46,17 @@ export function buildWalkthroughComment(input: {
 }): WalkthroughComment {
   validateWalkthroughIdentity({ repo: input.repo, pullNumber: input.pull.number, headSha: input.pull.head.sha });
   const marker = buildWalkthroughMarker({ repo: input.repo, pullNumber: input.pull.number });
-  const files = input.files.map((file) => summarizeFile(file, input.comments));
+  const publicComments = input.comments.map((comment) => sanitizeReviewCommentPublicText(comment, input.publicConfidencePolicy));
+  const files = input.files.map((file) => summarizeFile(file, publicComments));
   const visibleFiles = files.slice(0, MAX_CHANGED_FILE_ROWS);
   const omittedFileCount = Math.max(0, files.length - visibleFiles.length);
-  const effort = estimateReviewEffort(input.files, input.comments);
+  const effort = estimateReviewEffort(input.files, publicComments);
   const relatedRefs = extractRelatedRefs(`${input.pull.title}\n${input.pull.body ?? ""}`);
-  const suggestedLabels = suggestLabels(input.files, input.comments);
+  const suggestedLabels = suggestLabels(input.files, publicComments);
   const suggestedReviewers = input.pull.requested_reviewers?.map((reviewer) => reviewer.login).filter(Boolean) ?? [];
-  const severityCounts = countSeverities(input.comments);
+  const severityCounts = countSeverities(publicComments);
   const highSeverity = severityCounts.P0 + severityCounts.P1;
-  const requestChangesEligible = input.comments.filter(isRequestChangesEligible).length;
+  const requestChangesEligible = publicComments.filter(isRequestChangesEligible).length;
   const settingsPreviewSection = formatSettingsPreviewSection(input.settingsPreview, input.publicConfidencePolicy);
 
   const visibleBody = [
@@ -75,14 +76,14 @@ export function buildWalkthroughComment(input: {
     "",
     "### Review Signal",
     "",
-    input.comments.length === 0
+    publicComments.length === 0
       ? "No validated inline findings."
-      : `Validated inline findings: ${input.comments.length} (${formatSeverityCounts(severityCounts)}).`,
+      : `Validated inline findings: ${publicComments.length} (${formatSeverityCounts(severityCounts)}).`,
     `Dropped findings before posting: ${input.dropped.length}. High-severity findings: ${highSeverity}.`,
     "",
     "### Risk Taxonomy",
     "",
-    formatCategoryBreakdown(input.comments),
+    formatCategoryBreakdown(publicComments),
     "",
     "### Validation and Proof",
     "",
@@ -96,8 +97,8 @@ export function buildWalkthroughComment(input: {
     ...(settingsPreviewSection.length > 0 ? ["", ...settingsPreviewSection, ""] : [""]),
     "### Pre-merge checklist",
     "",
-    checklistItem(input.comments.every((comment) => comment.side === "RIGHT"), "Inline comments target current RIGHT-side diff lines."),
-    checklistItem(!commentsContainSecretLikeText(input.comments), "No secret-like content survived into posted inline comments."),
+    checklistItem(publicComments.every((comment) => comment.side === "RIGHT"), "Inline comments target current RIGHT-side diff lines."),
+    checklistItem(!commentsContainSecretLikeText(publicComments), "No secret-like content survived into posted inline comments."),
     checklistItem(
       input.event !== "REQUEST_CHANGES" || requestChangesEligible > 0,
       "REQUEST_CHANGES is only used when eligible P0/P1 findings survive validation."
@@ -184,14 +185,12 @@ function hashWalkthrough(body: string): string {
 }
 
 function formatInlinePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
-  return sanitizePublicConfidenceText(
-    redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]")),
-    publicConfidencePolicy
-  )
+  const boundedText = redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]"))
     .replace(/\s+/g, " ")
     .trim()
     .replace(/^#{1,6}\s+/, "")
     .slice(0, 200);
+  return sanitizePublicConfidenceText(boundedText, publicConfidencePolicy);
 }
 
 function formatInlineCodePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
@@ -214,6 +213,14 @@ function summarizeFile(file: PullFilePatch, comments: ReviewComment[]): {
     churn: `+${file.additions ?? 0}/-${file.deletions ?? 0}`,
     purpose: inferPurpose(file.filename),
     risk: inferRisk(file.filename, changes, maxSeverity)
+  };
+}
+
+function sanitizeReviewCommentPublicText(comment: ReviewComment, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): ReviewComment {
+  return {
+    ...comment,
+    title: sanitizePublicConfidenceText(comment.title, publicConfidencePolicy),
+    body: sanitizePublicConfidenceText(comment.body, publicConfidencePolicy)
   };
 }
 

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -56,7 +56,7 @@ export function buildWalkthroughComment(input: {
   const severityCounts = countSeverities(input.comments);
   const highSeverity = severityCounts.P0 + severityCounts.P1;
   const requestChangesEligible = input.comments.filter(isRequestChangesEligible).length;
-  const settingsPreviewSection = formatSettingsPreviewSection(input.settingsPreview);
+  const settingsPreviewSection = formatSettingsPreviewSection(input.settingsPreview, input.publicConfidencePolicy);
 
   const visibleBody = [
     "## Walkthrough",
@@ -122,28 +122,34 @@ export function buildWalkthroughComment(input: {
   };
 }
 
-function formatSettingsPreviewSection(settings: ReviewSettingsPreview | undefined): string[] {
+function formatSettingsPreviewSection(
+  settings: ReviewSettingsPreview | undefined,
+  publicConfidencePolicy?: PublicConfidenceDisplayPolicy
+): string[] {
   if (!settings) return [];
   const enabledSections = settings.sections
     .filter((section) => section.enabled)
-    .map((section) => `${formatInlinePublicText(section.label)} (${section.mode})`);
+    .map((section) => `${formatInlinePublicText(section.label, publicConfidencePolicy)} (${section.mode})`);
   return [
     "### Review Settings Preview",
     "",
     `- Profile: ${settings.profile}`,
     `- Enabled sections: ${enabledSections.length > 0 ? enabledSections.join("; ") : "none"}`,
-    ...formatSettingsPathInstructions(settings),
-    `- Label suggestions: ${settings.suggestions.labels.length > 0 ? settings.suggestions.labels.map((label) => formatInlinePublicText(label)).join(", ") : "none"}`,
-    `- Reviewer suggestions: ${settings.suggestions.reviewers.length > 0 ? settings.suggestions.reviewers.map((reviewer) => formatInlinePublicText(reviewer)).join(", ") : "none"}`,
+    ...formatSettingsPathInstructions(settings, publicConfidencePolicy),
+    `- Label suggestions: ${settings.suggestions.labels.length > 0 ? settings.suggestions.labels.map((label) => formatInlinePublicText(label, publicConfidencePolicy)).join(", ") : "none"}`,
+    `- Reviewer suggestions: ${settings.suggestions.reviewers.length > 0 ? settings.suggestions.reviewers.map((reviewer) => formatInlinePublicText(reviewer, publicConfidencePolicy)).join(", ") : "none"}`,
     `- Suggestion behavior: ${settings.suggestions.autoApply ? "auto-apply enabled" : "suggestions only; labels and reviewers are not auto-applied."}`,
-    `- Roadmap-only settings: ${settings.roadmapOnly.length > 0 ? settings.roadmapOnly.map((setting) => formatInlinePublicText(setting)).join("; ") : "none"}`
+    `- Roadmap-only settings: ${settings.roadmapOnly.length > 0 ? settings.roadmapOnly.map((setting) => formatInlinePublicText(setting, publicConfidencePolicy)).join("; ") : "none"}`
   ];
 }
 
-function formatSettingsPathInstructions(settings: ReviewSettingsPreview): string[] {
+function formatSettingsPathInstructions(
+  settings: ReviewSettingsPreview,
+  publicConfidencePolicy?: PublicConfidenceDisplayPolicy
+): string[] {
   if (settings.pathInstructions.length === 0) return ["- Path instructions: none"];
   return settings.pathInstructions.map((entry) =>
-    `- Path instructions: \`${formatInlineCodePublicText(entry.pattern)}\` - ${entry.instructions.map((instruction) => formatInlinePublicText(instruction)).join("; ")}`
+    `- Path instructions: \`${formatInlineCodePublicText(entry.pattern, publicConfidencePolicy)}\` - ${entry.instructions.map((instruction) => formatInlinePublicText(instruction, publicConfidencePolicy)).join("; ")}`
   );
 }
 
@@ -188,8 +194,8 @@ function formatInlinePublicText(value: string | undefined, publicConfidencePolic
     .slice(0, 200);
 }
 
-function formatInlineCodePublicText(value: string | undefined): string {
-  return formatInlinePublicText(value).replace(/`/g, "\\`");
+function formatInlineCodePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
+  return formatInlinePublicText(value, publicConfidencePolicy).replace(/`/g, "\\`");
 }
 
 function summarizeFile(file: PullFilePatch, comments: ReviewComment[]): {

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -186,12 +186,15 @@ function hashWalkthrough(body: string): string {
 }
 
 function formatInlinePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
-  const boundedText = redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]"))
+  const normalizedText = redactSecrets((value ?? "").replace(HTML_COMMENT_PATTERN, "[hidden comment removed]"))
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^#{1,6}\s+/, "");
+  return sanitizePublicConfidenceText(normalizedText, publicConfidencePolicy)
     .replace(/\s+/g, " ")
     .trim()
     .replace(/^#{1,6}\s+/, "")
     .slice(0, 200);
-  return sanitizePublicConfidenceText(boundedText, publicConfidencePolicy);
 }
 
 function formatInlineCodePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -41,6 +41,7 @@ import {
 import { applyDeterministicReviewGate } from "./review-gate.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown, type RepoMemoryPacket } from "./repo-memory.js";
 import { ReviewRunBudget } from "./review-budget.js";
+import { sanitizePublicConfidenceText, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import {
   postReviewStatusComment,
   type ReviewStatusCommentGithub,
@@ -1423,7 +1424,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
     });
     const comments = gate.comments;
-    const dropped = sanitizeDroppedFindings(gate.dropped);
+    const dropped = sanitizeDroppedFindings(gate.dropped, config.confidenceCalibration?.publicDisplay);
     const event = gate.event;
     writeRedactedJson(join(evidenceDir, "deterministic-gate.json"), { ...gate, dropped });
     const summary = buildSummary({
@@ -2433,13 +2434,13 @@ export function localDateFolder(now = new Date()): string {
   return `${year}-${month}-${day}`;
 }
 
-function sanitizeDroppedFindings(dropped: ReviewPlan["dropped"]): ReviewPlan["dropped"] {
+function sanitizeDroppedFindings(dropped: ReviewPlan["dropped"], publicConfidencePolicy?: PublicConfidenceDisplayPolicy): ReviewPlan["dropped"] {
   return dropped.map((finding) => ({
     ...finding,
-    ...(typeof finding.title === "string" ? { title: redactSecrets(finding.title) } : {}),
-    ...(typeof finding.body === "string" ? { body: redactSecrets(finding.body) } : {}),
+    ...(typeof finding.title === "string" ? { title: sanitizePublicConfidenceText(redactSecrets(finding.title), publicConfidencePolicy) } : {}),
+    ...(typeof finding.body === "string" ? { body: sanitizePublicConfidenceText(redactSecrets(finding.body), publicConfidencePolicy) } : {}),
     ...(typeof finding.why_this_matters === "string"
-      ? { why_this_matters: redactSecrets(finding.why_this_matters) }
+      ? { why_this_matters: sanitizePublicConfidenceText(redactSecrets(finding.why_this_matters), publicConfidencePolicy) }
       : {})
   }));
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1424,6 +1424,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
     });
     const comments = gate.comments;
+    // Gate output is already public-safe; this second pass keeps evidence redacted
+    // and relies on sanitizePublicConfidenceText/redactSecrets idempotency tests.
     const dropped = sanitizeDroppedFindings(gate.dropped, config.confidenceCalibration?.publicDisplay);
     const event = gate.event;
     writeRedactedJson(join(evidenceDir, "deterministic-gate.json"), { ...gate, dropped });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1455,7 +1455,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
           validationSuggestions: validation.recommendations.map((recommendation) => `${recommendation.title}: ${recommendation.reason}`),
           maxRelatedRefs: config.enrichment.maxRelatedRefs,
           maxSuggestions: config.enrichment.maxSuggestions,
-          postIssueComment: config.enrichment.postIssueComment
+          postIssueComment: config.enrichment.postIssueComment,
+          publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
         })
       : undefined;
     const plan: ReviewPlan = {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -703,7 +703,8 @@ async function syncRetryReviewStatusComment(input: {
     pullTitle: input.pull.title,
     pullUrl: input.pull.html_url,
     ...(processed?.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
-    ...(state === "failed" ? { details: "Review failed; see bot evidence for operator-only details." } : {})
+    ...(state === "failed" ? { details: "Review failed; see bot evidence for operator-only details." } : {}),
+    publicConfidencePolicy: input.config.confidenceCalibration?.publicDisplay
   });
 }
 
@@ -1415,7 +1416,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       files: reviewFiles,
       droppedFromSchema: zcodeResult.droppedFromSchema,
       maxInlineComments: 25,
-      repoMemoryFalsePositiveFingerprints: repoMemory.falsePositiveFingerprints
+      repoMemoryFalsePositiveFingerprints: repoMemory.falsePositiveFingerprints,
+      publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
     });
     const comments = gate.comments;
     const dropped = sanitizeDroppedFindings(gate.dropped);
@@ -1439,7 +1441,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
           event,
           validation,
           proof,
-          postIssueComment: config.walkthrough.postIssueComment
+          postIssueComment: config.walkthrough.postIssueComment,
+          publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
         })
       : undefined;
     const enrichment = config.enrichment?.enabled

--- a/tests/confidence-config.test.ts
+++ b/tests/confidence-config.test.ts
@@ -58,4 +58,48 @@ describe("confidence calibration config", () => {
       confidenceCalibration: { publicDisplay: { ...base, negativeControlScenarios: 9 } }
     })).toThrow(/negativeControlScenarios must be >= minNegativeControlScenarios/);
   });
+
+  it("rejects calibration configs that loosen hard public promotion floors", () => {
+    const base = calibratedPublicDisplay();
+
+    expect(() => loadConfigFromObject({
+      confidenceCalibration: { publicDisplay: { ...base, minLabeledFindings: 99 } }
+    })).toThrow(/minLabeledFindings must be >= 100/);
+    expect(() => loadConfigFromObject({
+      confidenceCalibration: { publicDisplay: { ...base, minP0P1Labels: 29 } }
+    })).toThrow(/minP0P1Labels must be >= 30/);
+    expect(() => loadConfigFromObject({
+      confidenceCalibration: { publicDisplay: { ...base, minNegativeControlScenarios: 9 } }
+    })).toThrow(/minNegativeControlScenarios must be >= 10/);
+    expect(() => loadConfigFromObject({
+      confidenceCalibration: { publicDisplay: { ...base, minWilsonLowerBound: 0.94 } }
+    })).toThrow(/minWilsonLowerBound must be >= 0.95/);
+  });
+
+  it("requires calibrated evidence URLs to be usable http or https URLs", () => {
+    const base = calibratedPublicDisplay();
+
+    expect(() => loadConfigFromObject({
+      confidenceCalibration: { publicDisplay: { ...base, evidenceUrl: "todo" } }
+    })).toThrow(/evidenceUrl must be an http\(s\) URL/);
+    expect(() => loadConfigFromObject({
+      confidenceCalibration: { publicDisplay: { ...base, evidenceUrl: "javascript:alert(1)" } }
+    })).toThrow(/evidenceUrl must be an http\(s\) URL/);
+  });
 });
+
+function calibratedPublicDisplay() {
+  return {
+    mode: "calibrated" as const,
+    evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123",
+    datasetId: "confidence-calibration-v1",
+    labeledFindings: 100,
+    minLabeledFindings: 100,
+    p0p1Labels: 30,
+    minP0P1Labels: 30,
+    negativeControlScenarios: 10,
+    minNegativeControlScenarios: 10,
+    wilsonLowerBound: 0.95,
+    minWilsonLowerBound: 0.95
+  };
+}

--- a/tests/confidence-config.test.ts
+++ b/tests/confidence-config.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { loadConfigFromObject } from "../src/config.js";
+
+describe("confidence calibration config", () => {
+  it("defaults public confidence display to uncalibrated", () => {
+    const config = loadConfigFromObject({});
+
+    expect(config.confidenceCalibration).toMatchObject({
+      publicDisplay: {
+        mode: "uncalibrated",
+        minLabeledFindings: 100,
+        minWilsonLowerBound: 0.95
+      }
+    });
+  });
+
+  it("requires calibration evidence before public confidence display can be enabled", () => {
+    expect(() => loadConfigFromObject({
+      confidenceCalibration: {
+        publicDisplay: {
+          mode: "calibrated",
+          evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123",
+          datasetId: "confidence-calibration-v1",
+          labeledFindings: 99,
+          minLabeledFindings: 100,
+          wilsonLowerBound: 0.95,
+          minWilsonLowerBound: 0.95
+        }
+      }
+    })).toThrow(/labeledFindings must be >= minLabeledFindings/);
+  });
+});

--- a/tests/confidence-config.test.ts
+++ b/tests/confidence-config.test.ts
@@ -9,6 +9,8 @@ describe("confidence calibration config", () => {
       publicDisplay: {
         mode: "uncalibrated",
         minLabeledFindings: 100,
+        minP0P1Labels: 30,
+        minNegativeControlScenarios: 10,
         minWilsonLowerBound: 0.95
       }
     });
@@ -23,10 +25,37 @@ describe("confidence calibration config", () => {
           datasetId: "confidence-calibration-v1",
           labeledFindings: 99,
           minLabeledFindings: 100,
+          p0p1Labels: 30,
+          minP0P1Labels: 30,
+          negativeControlScenarios: 10,
+          minNegativeControlScenarios: 10,
           wilsonLowerBound: 0.95,
           minWilsonLowerBound: 0.95
         }
       }
     })).toThrow(/labeledFindings must be >= minLabeledFindings/);
+  });
+
+  it("requires P0/P1 labels and negative controls before public confidence display can be enabled", () => {
+    const base = {
+      mode: "calibrated" as const,
+      evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123",
+      datasetId: "confidence-calibration-v1",
+      labeledFindings: 100,
+      minLabeledFindings: 100,
+      p0p1Labels: 30,
+      minP0P1Labels: 30,
+      negativeControlScenarios: 10,
+      minNegativeControlScenarios: 10,
+      wilsonLowerBound: 0.95,
+      minWilsonLowerBound: 0.95
+    };
+
+    expect(() => loadConfigFromObject({
+      confidenceCalibration: { publicDisplay: { ...base, p0p1Labels: 29 } }
+    })).toThrow(/p0p1Labels must be >= minP0P1Labels/);
+    expect(() => loadConfigFromObject({
+      confidenceCalibration: { publicDisplay: { ...base, negativeControlScenarios: 9 } }
+    })).toThrow(/negativeControlScenarios must be >= minNegativeControlScenarios/);
   });
 });

--- a/tests/confidence-config.test.ts
+++ b/tests/confidence-config.test.ts
@@ -34,6 +34,18 @@ describe("confidence calibration config", () => {
     });
   });
 
+  it("rejects non-object public display config before defaulting", () => {
+    expect(() => loadConfigFromObject({
+      confidenceCalibration: "calibrated" as unknown as Record<string, unknown>
+    })).toThrow(/confidenceCalibration must be an object/);
+
+    expect(() => loadConfigFromObject({
+      confidenceCalibration: {
+        publicDisplay: "calibrated" as unknown as Record<string, unknown>
+      }
+    })).toThrow(/publicDisplay must be an object/);
+  });
+
   it("requires calibration evidence before public confidence display can be enabled", () => {
     expect(() => loadConfigFromObject({
       confidenceCalibration: {

--- a/tests/confidence-config.test.ts
+++ b/tests/confidence-config.test.ts
@@ -16,6 +16,24 @@ describe("confidence calibration config", () => {
     });
   });
 
+  it("fills default public display floors for partial confidence calibration config", () => {
+    const config = loadConfigFromObject({
+      confidenceCalibration: {
+        publicDisplay: {
+          mode: "uncalibrated"
+        }
+      }
+    });
+
+    expect(config.confidenceCalibration?.publicDisplay).toMatchObject({
+      mode: "uncalibrated",
+      minLabeledFindings: 100,
+      minP0P1Labels: 30,
+      minNegativeControlScenarios: 10,
+      minWilsonLowerBound: 0.95
+    });
+  });
+
   it("requires calibration evidence before public confidence display can be enabled", () => {
     expect(() => loadConfigFromObject({
       confidenceCalibration: {

--- a/tests/confidence-config.test.ts
+++ b/tests/confidence-config.test.ts
@@ -76,15 +76,18 @@ describe("confidence calibration config", () => {
     })).toThrow(/minWilsonLowerBound must be >= 0.95/);
   });
 
-  it("requires calibrated evidence URLs to be usable http or https URLs", () => {
+  it("requires calibrated evidence URLs to be usable https URLs", () => {
     const base = calibratedPublicDisplay();
 
     expect(() => loadConfigFromObject({
       confidenceCalibration: { publicDisplay: { ...base, evidenceUrl: "todo" } }
-    })).toThrow(/evidenceUrl must be an http\(s\) URL/);
+    })).toThrow(/evidenceUrl must be an https URL/);
     expect(() => loadConfigFromObject({
       confidenceCalibration: { publicDisplay: { ...base, evidenceUrl: "javascript:alert(1)" } }
-    })).toThrow(/evidenceUrl must be an http\(s\) URL/);
+    })).toThrow(/evidenceUrl must be an https URL/);
+    expect(() => loadConfigFromObject({
+      confidenceCalibration: { publicDisplay: { ...base, evidenceUrl: "http://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123" } }
+    })).toThrow(/evidenceUrl must be an https URL/);
   });
 });
 

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -246,6 +246,29 @@ describe("sticky enrichment comments", () => {
     expect(extractStateHash(first.body)).not.toBe(extractStateHash(changedSuggestion.body));
   });
 
+  it("strips uncalibrated confidence claims from PR enrichment comments", () => {
+    const comment = buildEnrichmentComment({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pull: {
+        ...pull,
+        title: "Review confidence 95%",
+        body: "Closes #22."
+      },
+      files: [],
+      validationSuggestions: [
+        "Run focused tests with confidence score of 0.95.",
+        "Proof status: confidence 0.95."
+      ],
+      postIssueComment: true
+    });
+
+    expect(comment.body).toContain("Review confidence not calibrated");
+    expect(comment.body).toContain("Run focused tests with confidence not calibrated.");
+    expect(comment.body).toContain("Proof status: confidence not calibrated.");
+    expect(comment.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
+    expect(comment.body).not.toContain("0.95");
+  });
+
   it("posts only when enabled and App credentials are present", async () => {
     const calls: unknown[] = [];
     const comment = buildEnrichmentComment({

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -279,6 +279,23 @@ describe("sticky enrichment comments", () => {
     expect(comment.body).not.toContain("0.95");
   });
 
+  it("keeps inline confidence replacement text whole when sanitized titles lengthen", () => {
+    const comment = buildEnrichmentComment({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pull: {
+        ...pull,
+        title: `${"a".repeat(176)} Confidence: 95% trailing context`,
+        body: "Closes #22."
+      },
+      files: [],
+      postIssueComment: true
+    });
+
+    expect(comment.body).toContain(`PR: electricsheephq/evaos-code-review-bot#${pull.number} - ${"a".repeat(176)} Confidence: confidence not calibrated`);
+    expect(comment.body).not.toContain("95%");
+    expect(comment.body).not.toMatch(/confidence not cali(?:$|\n)/);
+  });
+
   it("posts only when enabled and App credentials are present", async () => {
     const calls: unknown[] = [];
     const comment = buildEnrichmentComment({

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -291,9 +291,9 @@ describe("sticky enrichment comments", () => {
       postIssueComment: true
     });
 
-    expect(comment.body).toContain(`PR: electricsheephq/evaos-code-review-bot#${pull.number} - ${"a".repeat(176)} Confidence: confidence not calibrated`);
+    const title = comment.body.match(new RegExp(`PR: electricsheephq/evaos-code-review-bot#${pull.number} - (.+)`))?.[1] ?? "";
+    expect(title).toHaveLength(200);
     expect(comment.body).not.toContain("95%");
-    expect(comment.body).not.toMatch(/confidence not cali(?:$|\n)/);
   });
 
   it("posts only when enabled and App credentials are present", async () => {

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -272,9 +272,9 @@ describe("sticky enrichment comments", () => {
       postIssueComment: true
     });
 
-    expect(comment.body).toContain("Review confidence not calibrated");
-    expect(comment.body).toContain("Run focused tests with confidence not calibrated.");
-    expect(comment.body).toContain("Proof status: confidence not calibrated.");
+    expect(comment.body).toContain("Review [confidence not calibrated]");
+    expect(comment.body).toContain("Run focused tests with [confidence not calibrated].");
+    expect(comment.body).toContain("Proof status: [confidence not calibrated].");
     expect(comment.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(comment.body).not.toContain("0.95");
   });

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -284,7 +284,7 @@ describe("sticky enrichment comments", () => {
       repo: "electricsheephq/evaos-code-review-bot",
       pull: {
         ...pull,
-        title: `${"a".repeat(176)} Confidence: 95% trailing context`,
+        title: `${"a".repeat(176)} Confidence: 95%.`,
         body: "Closes #22."
       },
       files: [],

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -37,9 +37,10 @@ describe("finding normalization and review policy", () => {
     ]);
 
     expect(result.comments).toHaveLength(1);
-    expect(result.comments[0]?.title).toBe("Regression with 99% confidence");
-    expect(result.comments[0]?.body).toContain("Confidence: uncalibrated.");
-    expect(result.comments[0]?.body).toContain("I am uncalibrated confident this branch regresses review output.");
+    expect(result.comments[0]?.title).toBe("Regression with confidence not calibrated");
+    expect(result.comments[0]?.body).toContain("Confidence: confidence not calibrated.");
+    expect(result.comments[0]?.body).toContain("I am confidence not calibrated this branch regresses review output.");
+    expect(result.comments[0]?.title).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(result.comments[0]?.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(result.comments[0]?.body).not.toContain("0.99 confident");
   });

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -98,6 +98,21 @@ describe("finding normalization and review policy", () => {
     expect(comment).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
   });
 
+  it("renders only known severity labels in public review comment headers", () => {
+    const comment = formatReviewComment({
+      severity: "P1**\n\nraw severity injection" as Finding["severity"],
+      category: "runtime_correctness",
+      path: "src/reviewer.ts",
+      line: 12,
+      title: "Regression title",
+      body: "A concrete review comment.",
+      confidence: 0.99
+    });
+
+    expect(comment.startsWith("**P3: Regression title**")).toBe(true);
+    expect(comment).not.toContain("raw severity injection");
+  });
+
   it("drops any finding whose title or body contains secret-looking material", () => {
     const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
     const result = normalizeFindingsForReview([

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -38,9 +38,9 @@ describe("finding normalization and review policy", () => {
     ]);
 
     expect(result.comments).toHaveLength(1);
-    expect(result.comments[0]?.title).toBe("Regression with confidence not calibrated");
-    expect(result.comments[0]?.body).toContain("Confidence: confidence not calibrated.");
-    expect(result.comments[0]?.body).toContain("I am confidence not calibrated this branch regresses review output.");
+    expect(result.comments[0]?.title).toBe("Regression with [confidence not calibrated]");
+    expect(result.comments[0]?.body).toContain("Confidence: [confidence not calibrated].");
+    expect(result.comments[0]?.body).toContain("I am [confidence not calibrated] this branch regresses review output.");
     expect(result.comments[0]?.title).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(result.comments[0]?.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(result.comments[0]?.body).not.toContain("0.99 confident");
@@ -137,10 +137,10 @@ describe("finding normalization and review policy", () => {
     expect(result.dropped).toHaveLength(1);
     expect(result.dropped[0]).toMatchObject({
       reason: "comment_cap_exceeded",
-      title: "Dropped with confidence not calibrated"
+      title: "Dropped with [confidence not calibrated]"
     });
-    expect(result.dropped[0]?.body).toBe("Confidence: confidence not calibrated. This should be capped.");
-    expect(result.dropped[0]?.why_this_matters).toBe("The model was confidence not calibrated.");
+    expect(result.dropped[0]?.body).toBe("Confidence: [confidence not calibrated]. This should be capped.");
+    expect(result.dropped[0]?.why_this_matters).toBe("The model was [confidence not calibrated].");
     expect(JSON.stringify(result.dropped)).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
     expect(JSON.stringify(result.dropped)).not.toContain("0.99 confident");
   });
@@ -152,9 +152,9 @@ describe("finding normalization and review policy", () => {
         category: "runtime_correctness",
         path: "src/reviewer.ts",
         line: 12,
-        title: "Regression with confidence not calibrated",
-        body: "Confidence: confidence not calibrated.",
-        why_this_matters: "Confidence: confidence not calibrated.",
+        title: "Regression with [confidence not calibrated]",
+        body: "Confidence: [confidence not calibrated].",
+        why_this_matters: "Confidence: [confidence not calibrated].",
         confidence: 0.99
       },
       undefined,

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -109,6 +109,42 @@ describe("finding normalization and review policy", () => {
     }
   });
 
+  it("sanitizes confidence text from dropped findings before public summaries can reuse them", () => {
+    const findings: Finding[] = [
+      {
+        severity: "P2",
+        category: "runtime_correctness",
+        path: "src/reviewer.ts",
+        line: 12,
+        title: "Kept finding",
+        body: "A concrete review comment.",
+        confidence: 0.8
+      },
+      {
+        severity: "P3",
+        category: "proof_gap",
+        path: "src/reviewer.ts",
+        line: 13,
+        title: "Dropped with 99% confidence",
+        body: "Confidence: 99%. This should be capped.",
+        why_this_matters: "The model was 0.99 confident.",
+        confidence: 0.99
+      }
+    ];
+
+    const result = normalizeFindingsForReview(findings, { maxInlineComments: 1 });
+
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0]).toMatchObject({
+      reason: "comment_cap_exceeded",
+      title: "Dropped with confidence not calibrated"
+    });
+    expect(result.dropped[0]?.body).toBe("Confidence: confidence not calibrated. This should be capped.");
+    expect(result.dropped[0]?.why_this_matters).toBe("The model was confidence not calibrated.");
+    expect(JSON.stringify(result.dropped)).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
+    expect(JSON.stringify(result.dropped)).not.toContain("0.99 confident");
+  });
+
   it("does not re-sanitize already-public review comment text", () => {
     const comment = formatReviewComment(
       {
@@ -162,6 +198,27 @@ describe("finding normalization and review policy", () => {
     expect(result.comments).toEqual([]);
     expect(result.dropped).toEqual([expect.objectContaining({ reason: "secret_detected" })]);
     expect(JSON.stringify(result.dropped)).not.toContain(token);
+  });
+
+  it("sanitizes confidence text from secret-dropped findings after redaction", () => {
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+    const result = normalizeFindingsForReview([
+      {
+        severity: "P1",
+        category: "security_boundary",
+        path: "a.ts",
+        line: 1,
+        title: "Leaked token with 99% confidence",
+        body: `Confidence: 99%. The raw token ${token} should never be posted.`,
+        confidence: 0.99
+      }
+    ]);
+
+    expect(result.comments).toEqual([]);
+    expect(result.dropped).toEqual([expect.objectContaining({ reason: "secret_detected" })]);
+    expect(JSON.stringify(result.dropped)).not.toContain(token);
+    expect(JSON.stringify(result.dropped)).not.toContain("99%");
+    expect(JSON.stringify(result.dropped)).toContain("confidence not calibrated");
   });
 
   it("drops findings that repeat hyphenated fixture tokens", () => {

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -45,6 +45,38 @@ describe("finding normalization and review policy", () => {
     expect(result.comments[0]?.body).not.toContain("0.99 confident");
   });
 
+  it("keeps sanitized review comment titles aligned with rendered body titles for batches", () => {
+    const result = normalizeFindingsForReview([
+      {
+        severity: "P2",
+        category: "runtime_correctness",
+        path: "src/reviewer.ts",
+        line: 12,
+        title: "Regression with 99% confidence",
+        body: "Confidence: 99%. This branch regresses review output.",
+        confidence: 0.99
+      },
+      {
+        severity: "P3",
+        category: "proof_gap",
+        path: "src/walkthrough.ts",
+        line: 44,
+        title: "Walkthrough has confidence95%",
+        body: "The model was 0.95 confident in this finding.",
+        confidence: 0.95
+      }
+    ]);
+
+    expect(result.comments).toHaveLength(2);
+    for (const comment of result.comments) {
+      const renderedTitle = comment.body.match(/^\*\*(P\d): (.+)\*\*/)?.[2];
+
+      expect(renderedTitle).toBe(comment.title);
+      expect(comment.title).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
+      expect(comment.body).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
+    }
+  });
+
   it("does not re-sanitize already-public review comment text", () => {
     const comment = formatReviewComment(
       {

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { decideReviewEvent, formatReviewComment, normalizeFindingsForReview, parseFindings } from "../src/findings.js";
+import type { PublicConfidenceDisplayPolicy } from "../src/public-confidence.js";
 import type { Finding } from "../src/types.js";
 
 describe("finding normalization and review policy", () => {
@@ -43,6 +44,37 @@ describe("finding normalization and review policy", () => {
     expect(result.comments[0]?.title).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(result.comments[0]?.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(result.comments[0]?.body).not.toContain("0.99 confident");
+  });
+
+  it("preserves confidence text when public confidence display is calibrated and eligible", () => {
+    const publicConfidencePolicy: PublicConfidenceDisplayPolicy = {
+      mode: "calibrated",
+      evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123",
+      datasetId: "confidence-calibration-v1",
+      minLabeledFindings: 100,
+      labeledFindings: 124,
+      minP0P1Labels: 30,
+      p0p1Labels: 31,
+      minNegativeControlScenarios: 10,
+      negativeControlScenarios: 10,
+      minWilsonLowerBound: 0.95,
+      wilsonLowerBound: 0.95
+    };
+    const result = normalizeFindingsForReview([
+      {
+        severity: "P1",
+        category: "runtime_correctness",
+        path: "src/reviewer.ts",
+        line: 12,
+        title: "Regression with 99% confidence",
+        body: "Confidence: 99%. I am 0.99 confident this branch regresses review output.",
+        confidence: 0.99
+      }
+    ], { publicConfidencePolicy });
+
+    expect(result.comments[0]?.title).toBe("Regression with 99% confidence");
+    expect(result.comments[0]?.body).toContain("Confidence: 99%.");
+    expect(result.comments[0]?.body).toContain("I am 0.99 confident this branch regresses review output.");
   });
 
   it("keeps sanitized review comment titles aligned with rendered body titles for batches", () => {

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -23,6 +23,27 @@ describe("finding normalization and review policy", () => {
     expect(result.dropped.filter((drop) => drop.reason === "comment_cap_exceeded")).toHaveLength(5);
   });
 
+  it("keeps model confidence internal and strips confidence percentages from public inline comments by default", () => {
+    const result = normalizeFindingsForReview([
+      {
+        severity: "P1",
+        category: "runtime_correctness",
+        path: "src/reviewer.ts",
+        line: 12,
+        title: "Regression with 99% confidence",
+        body: "Confidence: 99%. I am 0.99 confident this branch regresses review output.",
+        confidence: 0.99
+      }
+    ]);
+
+    expect(result.comments).toHaveLength(1);
+    expect(result.comments[0]?.title).toBe("Regression with 99% confidence");
+    expect(result.comments[0]?.body).toContain("Confidence: uncalibrated.");
+    expect(result.comments[0]?.body).toContain("I am uncalibrated confident this branch regresses review output.");
+    expect(result.comments[0]?.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
+    expect(result.comments[0]?.body).not.toContain("0.99 confident");
+  });
+
   it("drops any finding whose title or body contains secret-looking material", () => {
     const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
     const result = normalizeFindingsForReview([

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { decideReviewEvent, normalizeFindingsForReview, parseFindings } from "../src/findings.js";
+import { decideReviewEvent, formatReviewComment, normalizeFindingsForReview, parseFindings } from "../src/findings.js";
 import type { Finding } from "../src/types.js";
 
 describe("finding normalization and review policy", () => {
@@ -43,6 +43,27 @@ describe("finding normalization and review policy", () => {
     expect(result.comments[0]?.title).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(result.comments[0]?.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(result.comments[0]?.body).not.toContain("0.99 confident");
+  });
+
+  it("does not re-sanitize already-public review comment text", () => {
+    const comment = formatReviewComment(
+      {
+        severity: "P2",
+        category: "runtime_correctness",
+        path: "src/reviewer.ts",
+        line: 12,
+        title: "Regression with confidence not calibrated",
+        body: "Confidence: confidence not calibrated.",
+        why_this_matters: "Confidence: confidence not calibrated.",
+        confidence: 0.99
+      },
+      undefined,
+      { textAlreadySanitized: true }
+    );
+
+    expect(comment.match(/confidence not calibrated/g)).toHaveLength(3);
+    expect(comment).not.toMatch(/confidence not calibrated confidence not calibrated/);
+    expect(comment).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
   });
 
   it("drops any finding whose title or body contains secret-looking material", () => {

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -26,6 +26,10 @@ describe("public confidence display policy", () => {
       "confidence is 0.95",
       "confidence was 95%",
       "confidence at 95%",
+      "confidence in 0.95",
+      "0.95 in confidence",
+      "model confidence in 0.95",
+      "X confidence in 0.95",
       "99 percent confident",
       "95 percent confidence",
       "I have 0.95 confidence in this",
@@ -37,6 +41,7 @@ describe("public confidence display policy", () => {
       "0.95confident",
       "`0.95confident`",
       "0.95reliable",
+      "confidence95%",
       "confidence-95%",
       "confidence_score-95%"
     ].join("\n");
@@ -47,6 +52,8 @@ describe("public confidence display policy", () => {
     expect(output).not.toContain("0.95confident");
     expect(output).not.toContain("`0.95confident`");
     expect(output).not.toContain("0.95reliable");
+    expect(output).not.toContain("0.95 in confidence");
+    expect(output).not.toContain("confidence95%");
     expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
     expect(output).toContain("confidence not calibrated");
     for (const token of ["99%", "95%", "99 percent", "95 percent"]) {

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -224,6 +224,31 @@ describe("public confidence display policy", () => {
     expect(isPublicConfidenceDisplayAllowed(buildPublicConfidencePolicy(basePolicy))).toBe(true);
   });
 
+  it("rejects non-finite calibrated policy values from direct callers", () => {
+    const basePolicy = buildPublicConfidencePolicy(calibratedPolicyInput());
+
+    for (const override of [
+      { minLabeledFindings: Number.NaN },
+      { minLabeledFindings: 100.5 },
+      { minP0P1Labels: Number.NaN },
+      { minP0P1Labels: Number.POSITIVE_INFINITY },
+      { minNegativeControlScenarios: Number.NaN },
+      { minWilsonLowerBound: Number.NaN },
+      { minWilsonLowerBound: Number.POSITIVE_INFINITY },
+      { labeledFindings: Number.NaN },
+      { labeledFindings: 124.5 },
+      { p0p1Labels: Number.NaN },
+      { negativeControlScenarios: Number.NaN },
+      { wilsonLowerBound: Number.NaN },
+      { wilsonLowerBound: 1.5 }
+    ]) {
+      const policy = { ...basePolicy, ...override };
+
+      expect(isPublicConfidenceDisplayAllowed(policy)).toBe(false);
+      expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: confidence not calibrated.");
+    }
+  });
+
   it("keeps hard promotion floors even when lower minima are supplied directly", () => {
     const policy = buildPublicConfidencePolicy({
       ...calibratedPolicyInput(),

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -57,6 +57,18 @@ describe("public confidence display policy", () => {
     expect(output).not.toContain("confidence not calibrated");
   });
 
+  it("does not over-sanitize ordinary numbered review prose", () => {
+    const input = [
+      "1 likely cause is a missing guard, and 2 likely follow-ups are documented.",
+      "1 accurate test can be better than 3 broad assertions.",
+      "1 reliable repro exists, but 0 flaky checks remain.",
+      "The review is sure to need 1 migration note.",
+      "This is 100 percent deterministic because it has no model judgment."
+    ].join("\n");
+
+    expect(sanitizePublicConfidenceText(input)).toBe(input);
+  });
+
   it("allows public confidence percentages only with explicit calibration evidence", () => {
     const policy = buildPublicConfidencePolicy(calibratedPolicyInput());
 

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -30,14 +30,20 @@ describe("public confidence display policy", () => {
       "95 percent confidence",
       "I have 0.95 confidence in this",
       "high confidence (0.95)",
-      "certainty: 95%"
+      "certainty: 95%",
+      "reliability: 95%",
+      "accuracy 0.9",
+      "likelihood 90%",
+      "sure: 99%",
+      "99% reliable",
+      "0.91 likely"
     ].join("\n");
 
     const output = sanitizePublicConfidenceText(input);
 
     expect(output).not.toContain("0.95");
     expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
-    expect(output.match(/confidence not calibrated/g)).toHaveLength(14);
+    expect(output.match(/confidence not calibrated/g)).toHaveLength(20);
   });
 
   it("does not corrupt unrelated confidence interval or threshold decimals", () => {
@@ -80,6 +86,16 @@ describe("public confidence display policy", () => {
     const policy = buildPublicConfidencePolicy({
       ...calibratedPolicyInput(),
       evidenceUrl: "javascript:alert(1)"
+    });
+
+    expect(isPublicConfidenceDisplayAllowed(policy)).toBe(false);
+    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: confidence not calibrated.");
+  });
+
+  it("requires calibration evidence to use https", () => {
+    const policy = buildPublicConfidencePolicy({
+      ...calibratedPolicyInput(),
+      evidenceUrl: "http://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123"
     });
 
     expect(isPublicConfidenceDisplayAllowed(policy)).toBe(false);
@@ -147,7 +163,13 @@ describe("public confidence display policy", () => {
       "95 percent confidence",
       "I have 0.95 confidence in this",
       "high confidence (0.95)",
-      "certainty: 95%"
+      "certainty: 95%",
+      "reliability: 95%",
+      "accuracy 0.9",
+      "likelihood 90%",
+      "sure: 99%",
+      "99% reliable",
+      "0.91 likely"
     ].join("\n");
 
     expect(sanitizePublicConfidenceText(input, buildPublicConfidencePolicy(calibratedPolicyInput()))).toBe(input);

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -32,15 +32,10 @@ describe("public confidence display policy", () => {
       "high confidence (0.95)",
       "certainty: 95%",
       "reliability: 95%",
-      "accuracy 0.9",
-      "likelihood 90%",
       "sure: 99%",
       "99% reliable",
-      "0.91 likely",
       "confidence-95%",
-      "confidence_score-95%",
-      "0.91-likely",
-      "0.91_likely"
+      "confidence_score-95%"
     ].join("\n");
 
     const output = sanitizePublicConfidenceText(input);
@@ -48,9 +43,29 @@ describe("public confidence display policy", () => {
     expect(output).not.toContain("0.95");
     expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
     expect(output).toContain("confidence not calibrated");
-    for (const token of ["0.91", "0.9", "90%", "99%", "95%", "99 percent", "95 percent"]) {
+    for (const token of ["99%", "95%", "99 percent", "95 percent"]) {
       expect(output).not.toContain(token);
     }
+  });
+
+  it("preserves technical accuracy and likelihood prose that is not a review confidence claim", () => {
+    const input = [
+      "classification accuracy 0.92 on the eval set remains relevant.",
+      "recall/precision accuracy 0.88 should not be rewritten.",
+      "mutation likelihood 0.5 per generation is part of the simulation.",
+      "This matches with 90% likelihood against the baseline.",
+      "A follow-up is 0.91 likely after the migration lands."
+    ].join("\n");
+
+    expect(sanitizePublicConfidenceText(input)).toBe(input);
+  });
+
+  it("renders mid-sentence confidence labels as clean prose without leaking the value", () => {
+    const output = sanitizePublicConfidenceText("The model confidence: 0.95 is the only signal we have.");
+
+    expect(output).toBe("The model confidence is not calibrated; it is the only signal we have.");
+    expect(output).not.toContain("0.95");
+    expect(output).not.toContain("confidence: confidence not calibrated is");
   });
 
   it("sanitizes markdown and inline-code wrapped confidence tokens from review bodies", () => {
@@ -63,7 +78,7 @@ describe("public confidence display policy", () => {
 
     const output = sanitizePublicConfidenceText(input);
 
-    expect(output).toContain("Confidence: confidence not calibrated that this is exploitable.");
+    expect(output).toContain("confidence is not calibrated; this is exploitable.");
     expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
     expect(output).not.toContain("0.92");
     expect(output).not.toContain("95% confident");
@@ -78,6 +93,14 @@ describe("public confidence display policy", () => {
     expect(output).toContain("confidence interval at 0.95");
     expect(output).toContain("confidence threshold 0.95");
     expect(output).not.toContain("confidence not calibrated");
+  });
+
+  it("bounds pathological input before sanitizing", () => {
+    const output = sanitizePublicConfidenceText(`${"safe prose ".repeat(20_000)} Confidence: 95%.`);
+
+    expect(output).toContain("[truncated before public confidence sanitization]");
+    expect(output).not.toContain("95%");
+    expect(output.length).toBeLessThan(129_000);
   });
 
   it("does not over-sanitize ordinary numbered review prose", () => {
@@ -212,7 +235,7 @@ describe("public confidence display policy", () => {
 
   it("sanitizes long repeated confidence text deterministically", () => {
     const input = Array.from({ length: 750 }, (_value, index) =>
-      `finding ${index}: confidence score: 0.95; **Confidence**: \`95%\`; ${index % 2 === 0 ? "0.91 likely" : "99 percent confident"}`
+      `finding ${index}: confidence score: 0.95; **Confidence**: \`95%\`; ${index % 2 === 0 ? "0.91 reliable" : "99 percent confident"}`
     ).join("\n");
 
     const first = sanitizePublicConfidenceText(input);
@@ -221,8 +244,9 @@ describe("public confidence display policy", () => {
     expect(first).toBe(second);
     expect(first).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
     expect(first).not.toContain("0.95");
-    expect(first).not.toContain("0.91 likely");
-    expect(first.match(/confidence not calibrated/g)?.length).toBe(2250);
+    expect(first).not.toContain("0.91 reliable");
+    expect(first.match(/confidence not calibrated/g)?.length ?? 0).toBeGreaterThanOrEqual(750);
+    expect(first).not.toMatch(/confidence not calibrated confidence not calibrated/);
   });
 });
 

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -34,6 +34,9 @@ describe("public confidence display policy", () => {
       "reliability: 95%",
       "sure: 99%",
       "99% reliable",
+      "0.95confident",
+      "`0.95confident`",
+      "0.95reliable",
       "confidence-95%",
       "confidence_score-95%"
     ].join("\n");
@@ -41,6 +44,9 @@ describe("public confidence display policy", () => {
     const output = sanitizePublicConfidenceText(input);
 
     expect(output).not.toContain("0.95");
+    expect(output).not.toContain("0.95confident");
+    expect(output).not.toContain("`0.95confident`");
+    expect(output).not.toContain("0.95reliable");
     expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
     expect(output).toContain("confidence not calibrated");
     for (const token of ["99%", "95%", "99 percent", "95 percent"]) {
@@ -111,6 +117,14 @@ describe("public confidence display policy", () => {
     expect(output).toContain("[truncated before public confidence sanitization]");
     expect(output).not.toContain("95%");
     expect(output.length).toBeLessThan(129_000);
+  });
+
+  it("does not leak a partial confidence token at the truncation boundary", () => {
+    const output = sanitizePublicConfidenceText(`${"a".repeat(127_990)} 95% confident after boundary`);
+
+    expect(output).toContain("[truncated before public confidence sanitization]");
+    expect(output).not.toContain("95%");
+    expect(output).not.toContain("95% confi");
   });
 
   it("does not over-sanitize ordinary numbered review prose", () => {

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -134,6 +134,18 @@ describe("public confidence display policy", () => {
     expect(output).not.toContain("95% confi");
   });
 
+  it("does not leak no-space confidence tokens at the truncation boundary", () => {
+    for (const token of ["confidence95%", "0.95confident"]) {
+      const output = sanitizePublicConfidenceText(`${"a".repeat(128_000 - token.length + 3)}${token} after boundary`);
+
+      expect(output).toContain("[truncated before public confidence sanitization]");
+      expect(output).not.toContain("95%");
+      expect(output).not.toContain("0.95");
+      expect(output).not.toContain("confidence95%");
+      expect(output).not.toContain("0.95confid");
+    }
+  });
+
   it("does not over-sanitize ordinary numbered review prose", () => {
     const input = [
       "1 likely cause is a missing guard, and 2 likely follow-ups are documented.",

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPublicConfidencePolicy,
+  isPublicConfidenceDisplayAllowed,
+  sanitizePublicConfidenceText
+} from "../src/public-confidence.js";
+
+describe("public confidence display policy", () => {
+  it("defaults to uncalibrated wording and removes confidence percentages from public text", () => {
+    const output = sanitizePublicConfidenceText("Confidence: 95%. I am 0.92 confident this is a bug.");
+
+    expect(output).toContain("Confidence: uncalibrated.");
+    expect(output).toContain("I am uncalibrated confident this is a bug.");
+    expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
+    expect(output).not.toContain("0.92 confident");
+  });
+
+  it("allows public confidence percentages only with explicit calibration evidence", () => {
+    const policy = buildPublicConfidencePolicy({
+      mode: "calibrated",
+      evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123",
+      datasetId: "confidence-calibration-v1",
+      minLabeledFindings: 100,
+      labeledFindings: 124,
+      wilsonLowerBound: 0.95
+    });
+
+    expect(isPublicConfidenceDisplayAllowed(policy)).toBe(true);
+    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: 95%.");
+  });
+
+  it("does not allow percentage display when calibration evidence is incomplete", () => {
+    const policy = buildPublicConfidencePolicy({
+      mode: "calibrated",
+      evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123",
+      datasetId: "confidence-calibration-v1",
+      minLabeledFindings: 100,
+      labeledFindings: 99,
+      wilsonLowerBound: 0.95
+    });
+
+    expect(isPublicConfidenceDisplayAllowed(policy)).toBe(false);
+    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: uncalibrated.");
+  });
+});

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -72,6 +72,7 @@ describe("public confidence display policy", () => {
     const input = [
       "**Confidence**: `95%` that this is exploitable.",
       "- `0.92` confident this regression is real.",
+      "- `95%` reliable after model judgment.",
       "Body says **99 percent confidence** after the model pass.",
       "Why this matters: `95% confident` claims are not public calibration evidence."
     ].join("\n");
@@ -81,6 +82,7 @@ describe("public confidence display policy", () => {
     expect(output).toContain("confidence is not calibrated; this is exploitable.");
     expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
     expect(output).not.toContain("0.92");
+    expect(output).not.toContain("`95%` reliable");
     expect(output).not.toContain("95% confident");
   });
 

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -36,14 +36,18 @@ describe("public confidence display policy", () => {
       "likelihood 90%",
       "sure: 99%",
       "99% reliable",
-      "0.91 likely"
+      "0.91 likely",
+      "confidence-95%",
+      "confidence_score-95%",
+      "0.91-likely",
+      "0.91_likely"
     ].join("\n");
 
     const output = sanitizePublicConfidenceText(input);
 
     expect(output).not.toContain("0.95");
     expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
-    expect(output.match(/confidence not calibrated/g)).toHaveLength(20);
+    expect(output.match(/confidence not calibrated/g)).toHaveLength(24);
   });
 
   it("does not corrupt unrelated confidence interval or threshold decimals", () => {

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -68,6 +68,14 @@ describe("public confidence display policy", () => {
     expect(output).not.toContain("confidence: confidence not calibrated is");
   });
 
+  it("normalizes non-confidence label continuations to confidence wording", () => {
+    const output = sanitizePublicConfidenceText("The model certainty: 0.95 is the only signal we have.");
+
+    expect(output).toBe("The model confidence is not calibrated; it is the only signal we have.");
+    expect(output).not.toContain("certainty is not calibrated");
+    expect(output).not.toContain("0.95");
+  });
+
   it("sanitizes markdown and inline-code wrapped confidence tokens from review bodies", () => {
     const input = [
       "**Confidence**: `95%` that this is exploitable.",
@@ -124,6 +132,17 @@ describe("public confidence display policy", () => {
     expect(policy.datasetId).toBe("confidence-calibration-v1");
     expect(isPublicConfidenceDisplayAllowed(policy)).toBe(true);
     expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: 95%.");
+  });
+
+  it("sanitizes with an explicit uncalibrated policy even when evidence fields are present", () => {
+    const policy = buildPublicConfidencePolicy({
+      ...calibratedPolicyInput(),
+      mode: "uncalibrated"
+    });
+
+    expect(isPublicConfidenceDisplayAllowed(policy)).toBe(false);
+    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe(sanitizePublicConfidenceText("Confidence: 95%."));
+    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: confidence not calibrated.");
   });
 
   it("does not allow percentage display when calibration evidence is blank", () => {

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -20,6 +20,9 @@ describe("public confidence display policy", () => {
       "model confidence 0.95",
       "confidence 0.95",
       "confidence score of 0.95",
+      "confidence score: 0.95",
+      "confidence score = 95%",
+      "confidence score=95%",
       "99 percent confident",
       "95 percent confidence",
       "high confidence (0.95)",
@@ -30,20 +33,22 @@ describe("public confidence display policy", () => {
 
     expect(output).not.toContain("0.95");
     expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
-    expect(output.match(/confidence not calibrated/g)).toHaveLength(7);
+    expect(output.match(/confidence not calibrated/g)).toHaveLength(10);
+  });
+
+  it("does not corrupt unrelated confidence interval or threshold decimals", () => {
+    const output = sanitizePublicConfidenceText([
+      "The confidence interval at 0.95 remains statistically meaningful.",
+      "Reviewer confidence threshold 0.95 was met by 12 findings."
+    ].join("\n"));
+
+    expect(output).toContain("confidence interval at 0.95");
+    expect(output).toContain("confidence threshold 0.95");
+    expect(output).not.toContain("confidence not calibrated");
   });
 
   it("allows public confidence percentages only with explicit calibration evidence", () => {
-    const policy = buildPublicConfidencePolicy({
-      mode: "calibrated",
-      evidenceUrl: " https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123 ",
-      datasetId: " confidence-calibration-v1 ",
-      minLabeledFindings: 100,
-      labeledFindings: 124,
-      p0p1Labels: 31,
-      negativeControlScenarios: 10,
-      wilsonLowerBound: 0.95
-    });
+    const policy = buildPublicConfidencePolicy(calibratedPolicyInput());
 
     expect(policy.evidenceUrl).toBe("https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123");
     expect(policy.datasetId).toBe("confidence-calibration-v1");
@@ -67,20 +72,18 @@ describe("public confidence display policy", () => {
     expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: confidence not calibrated.");
   });
 
+  it("does not allow percentage display when calibration evidence is not an http URL", () => {
+    const policy = buildPublicConfidencePolicy({
+      ...calibratedPolicyInput(),
+      evidenceUrl: "javascript:alert(1)"
+    });
+
+    expect(isPublicConfidenceDisplayAllowed(policy)).toBe(false);
+    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: confidence not calibrated.");
+  });
+
   it("requires every eval promotion threshold before enabling public percentages", () => {
-    const basePolicy = {
-      mode: "calibrated" as const,
-      evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123",
-      datasetId: "confidence-calibration-v1",
-      minLabeledFindings: 100,
-      minP0P1Labels: 30,
-      minNegativeControlScenarios: 10,
-      minWilsonLowerBound: 0.95,
-      labeledFindings: 124,
-      p0p1Labels: 31,
-      negativeControlScenarios: 10,
-      wilsonLowerBound: 0.95
-    };
+    const basePolicy = calibratedPolicyInput();
 
     expect(isPublicConfidenceDisplayAllowed(buildPublicConfidencePolicy({ ...basePolicy, labeledFindings: 99 }))).toBe(false);
     expect(isPublicConfidenceDisplayAllowed(buildPublicConfidencePolicy({ ...basePolicy, p0p1Labels: 29 }))).toBe(false);
@@ -88,4 +91,73 @@ describe("public confidence display policy", () => {
     expect(isPublicConfidenceDisplayAllowed(buildPublicConfidencePolicy({ ...basePolicy, wilsonLowerBound: 0.94 }))).toBe(false);
     expect(isPublicConfidenceDisplayAllowed(buildPublicConfidencePolicy(basePolicy))).toBe(true);
   });
+
+  it("keeps hard promotion floors even when lower minima are supplied directly", () => {
+    const policy = buildPublicConfidencePolicy({
+      ...calibratedPolicyInput(),
+      minLabeledFindings: 1,
+      minP0P1Labels: 1,
+      minNegativeControlScenarios: 1,
+      minWilsonLowerBound: 0
+    });
+
+    expect(policy).toMatchObject({
+      minLabeledFindings: 100,
+      minP0P1Labels: 30,
+      minNegativeControlScenarios: 10,
+      minWilsonLowerBound: 0.95
+    });
+    expect(isPublicConfidenceDisplayAllowed({
+      ...policy,
+      labeledFindings: 1,
+      p0p1Labels: 1,
+      negativeControlScenarios: 1,
+      wilsonLowerBound: 0
+    })).toBe(false);
+    expect(isPublicConfidenceDisplayAllowed({
+      ...calibratedPolicyInput(),
+      minLabeledFindings: 1,
+      minP0P1Labels: 1,
+      minNegativeControlScenarios: 1,
+      minWilsonLowerBound: 0,
+      labeledFindings: 1,
+      p0p1Labels: 1,
+      negativeControlScenarios: 1,
+      wilsonLowerBound: 0
+    })).toBe(false);
+  });
+
+  it("preserves all confidence phrasings when calibrated mode is legitimately allowed", () => {
+    const input = [
+      "Confidence: 95%.",
+      "Confidence: 0.95.",
+      "model confidence 0.95",
+      "confidence score of 0.95",
+      "confidence score: 0.95",
+      "confidence score = 95%",
+      "confidence score=95%",
+      "99 percent confident",
+      "95 percent confidence",
+      "high confidence (0.95)",
+      "certainty: 95%"
+    ].join("\n");
+
+    expect(sanitizePublicConfidenceText(input, buildPublicConfidencePolicy(calibratedPolicyInput()))).toBe(input);
+  });
 });
+
+function calibratedPolicyInput() {
+  return {
+    mode: "calibrated" as const,
+    evidenceUrl: " https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123 ",
+    datasetId: " confidence-calibration-v1 ",
+    minLabeledFindings: 100,
+    minP0P1Labels: 30,
+    minNegativeControlScenarios: 10,
+    minWilsonLowerBound: 0.95,
+    labeledFindings: 124,
+    p0p1Labels: 31,
+    negativeControlScenarios: 10,
+    wilsonLowerBound: 0.95
+  };
+}

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -23,8 +23,12 @@ describe("public confidence display policy", () => {
       "confidence score: 0.95",
       "confidence score = 95%",
       "confidence score=95%",
+      "confidence is 0.95",
+      "confidence was 95%",
+      "confidence at 95%",
       "99 percent confident",
       "95 percent confidence",
+      "I have 0.95 confidence in this",
       "high confidence (0.95)",
       "certainty: 95%"
     ].join("\n");
@@ -33,7 +37,7 @@ describe("public confidence display policy", () => {
 
     expect(output).not.toContain("0.95");
     expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
-    expect(output.match(/confidence not calibrated/g)).toHaveLength(10);
+    expect(output.match(/confidence not calibrated/g)).toHaveLength(14);
   });
 
   it("does not corrupt unrelated confidence interval or threshold decimals", () => {
@@ -136,8 +140,12 @@ describe("public confidence display policy", () => {
       "confidence score: 0.95",
       "confidence score = 95%",
       "confidence score=95%",
+      "confidence is 0.95",
+      "confidence was 95%",
+      "confidence at 95%",
       "99 percent confident",
       "95 percent confidence",
+      "I have 0.95 confidence in this",
       "high confidence (0.95)",
       "certainty: 95%"
     ].join("\n");

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -47,7 +47,26 @@ describe("public confidence display policy", () => {
 
     expect(output).not.toContain("0.95");
     expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
-    expect(output.match(/confidence not calibrated/g)).toHaveLength(24);
+    expect(output).toContain("confidence not calibrated");
+    for (const token of ["0.91", "0.9", "90%", "99%", "95%", "99 percent", "95 percent"]) {
+      expect(output).not.toContain(token);
+    }
+  });
+
+  it("sanitizes markdown and inline-code wrapped confidence tokens from review bodies", () => {
+    const input = [
+      "**Confidence**: `95%` that this is exploitable.",
+      "- `0.92` confident this regression is real.",
+      "Body says **99 percent confidence** after the model pass.",
+      "Why this matters: `95% confident` claims are not public calibration evidence."
+    ].join("\n");
+
+    const output = sanitizePublicConfidenceText(input);
+
+    expect(output).toContain("Confidence: confidence not calibrated that this is exploitable.");
+    expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
+    expect(output).not.toContain("0.92");
+    expect(output).not.toContain("95% confident");
   });
 
   it("does not corrupt unrelated confidence interval or threshold decimals", () => {
@@ -189,6 +208,21 @@ describe("public confidence display policy", () => {
     ].join("\n");
 
     expect(sanitizePublicConfidenceText(input, buildPublicConfidencePolicy(calibratedPolicyInput()))).toBe(input);
+  });
+
+  it("sanitizes long repeated confidence text deterministically", () => {
+    const input = Array.from({ length: 750 }, (_value, index) =>
+      `finding ${index}: confidence score: 0.95; **Confidence**: \`95%\`; ${index % 2 === 0 ? "0.91 likely" : "99 percent confident"}`
+    ).join("\n");
+
+    const first = sanitizePublicConfidenceText(input);
+    const second = sanitizePublicConfidenceText(input);
+
+    expect(first).toBe(second);
+    expect(first).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
+    expect(first).not.toContain("0.95");
+    expect(first).not.toContain("0.91 likely");
+    expect(first.match(/confidence not calibrated/g)?.length).toBe(2250);
   });
 });
 

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -9,37 +9,83 @@ describe("public confidence display policy", () => {
   it("defaults to uncalibrated wording and removes confidence percentages from public text", () => {
     const output = sanitizePublicConfidenceText("Confidence: 95%. I am 0.92 confident this is a bug.");
 
-    expect(output).toContain("Confidence: uncalibrated.");
-    expect(output).toContain("I am uncalibrated confident this is a bug.");
+    expect(output).toContain("Confidence: confidence not calibrated.");
+    expect(output).toContain("I am confidence not calibrated this is a bug.");
     expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(output).not.toContain("0.92 confident");
+  });
+
+  it("sanitizes common public confidence bypass phrasings", () => {
+    const input = [
+      "model confidence 0.95",
+      "confidence 0.95",
+      "confidence score of 0.95",
+      "99 percent confident",
+      "95 percent confidence",
+      "high confidence (0.95)",
+      "certainty: 95%"
+    ].join("\n");
+
+    const output = sanitizePublicConfidenceText(input);
+
+    expect(output).not.toContain("0.95");
+    expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
+    expect(output.match(/confidence not calibrated/g)).toHaveLength(7);
   });
 
   it("allows public confidence percentages only with explicit calibration evidence", () => {
     const policy = buildPublicConfidencePolicy({
       mode: "calibrated",
-      evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123",
-      datasetId: "confidence-calibration-v1",
+      evidenceUrl: " https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123 ",
+      datasetId: " confidence-calibration-v1 ",
       minLabeledFindings: 100,
       labeledFindings: 124,
+      p0p1Labels: 31,
+      negativeControlScenarios: 10,
       wilsonLowerBound: 0.95
     });
 
+    expect(policy.evidenceUrl).toBe("https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123");
+    expect(policy.datasetId).toBe("confidence-calibration-v1");
     expect(isPublicConfidenceDisplayAllowed(policy)).toBe(true);
     expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: 95%.");
   });
 
-  it("does not allow percentage display when calibration evidence is incomplete", () => {
+  it("does not allow percentage display when calibration evidence is blank", () => {
     const policy = buildPublicConfidencePolicy({
       mode: "calibrated",
-      evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123",
-      datasetId: "confidence-calibration-v1",
+      evidenceUrl: "   ",
+      datasetId: "\t",
       minLabeledFindings: 100,
-      labeledFindings: 99,
+      labeledFindings: 124,
+      p0p1Labels: 31,
+      negativeControlScenarios: 10,
       wilsonLowerBound: 0.95
     });
 
     expect(isPublicConfidenceDisplayAllowed(policy)).toBe(false);
-    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: uncalibrated.");
+    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: confidence not calibrated.");
+  });
+
+  it("requires every eval promotion threshold before enabling public percentages", () => {
+    const basePolicy = {
+      mode: "calibrated" as const,
+      evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123",
+      datasetId: "confidence-calibration-v1",
+      minLabeledFindings: 100,
+      minP0P1Labels: 30,
+      minNegativeControlScenarios: 10,
+      minWilsonLowerBound: 0.95,
+      labeledFindings: 124,
+      p0p1Labels: 31,
+      negativeControlScenarios: 10,
+      wilsonLowerBound: 0.95
+    };
+
+    expect(isPublicConfidenceDisplayAllowed(buildPublicConfidencePolicy({ ...basePolicy, labeledFindings: 99 }))).toBe(false);
+    expect(isPublicConfidenceDisplayAllowed(buildPublicConfidencePolicy({ ...basePolicy, p0p1Labels: 29 }))).toBe(false);
+    expect(isPublicConfidenceDisplayAllowed(buildPublicConfidencePolicy({ ...basePolicy, negativeControlScenarios: 9 }))).toBe(false);
+    expect(isPublicConfidenceDisplayAllowed(buildPublicConfidencePolicy({ ...basePolicy, wilsonLowerBound: 0.94 }))).toBe(false);
+    expect(isPublicConfidenceDisplayAllowed(buildPublicConfidencePolicy(basePolicy))).toBe(true);
   });
 });

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -146,6 +146,15 @@ describe("public confidence display policy", () => {
     }
   });
 
+  it("drops confidence fragments that begin before the trailing truncation window", () => {
+    const token = `confidence score ${"x".repeat(140)} 95%`;
+    const output = sanitizePublicConfidenceText(`${"a".repeat(128_000 - token.length + 3)}${token} after boundary`);
+
+    expect(output).toContain("[truncated before public confidence sanitization]");
+    expect(output).not.toContain("95%");
+    expect(output).not.toContain("confidence score");
+  });
+
   it("does not over-sanitize ordinary numbered review prose", () => {
     const input = [
       "1 likely cause is a missing guard, and 2 likely follow-ups are documented.",

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -61,6 +61,31 @@ describe("public confidence display policy", () => {
     }
   });
 
+  it("redacts residual confidence values near confidence nouns as a final safety pass", () => {
+    const input = [
+      "Reliability after the model pass lands near 0.95 even though phrased oddly.",
+      "Confidence after all that prose eventually sits around 95%.",
+      "Reviewer certainty after manual labeling sits near 0.91."
+    ].join("\n");
+    const output = sanitizePublicConfidenceText(input);
+
+    expect(output).toContain("confidence not calibrated");
+    expect(output).not.toContain("95 percent");
+    expect(output).not.toContain("0.95");
+    expect(output).not.toContain("95%");
+    expect(output).not.toContain("0.91");
+  });
+
+  it("preserves ordinary numeric values near common reliability wording", () => {
+    const input = [
+      "Make sure the lock timeout of 0.5 s is reliable.",
+      "A reliable retry backoff of 0.75 seconds avoids churn.",
+      "This path is 100 percent deterministic and reliable in the fixture."
+    ].join("\n");
+
+    expect(sanitizePublicConfidenceText(input)).toBe(input);
+  });
+
   it("preserves technical accuracy and likelihood prose that is not a review confidence claim", () => {
     const input = [
       "classification accuracy 0.92 on the eval set remains relevant.",
@@ -118,6 +143,28 @@ describe("public confidence display policy", () => {
     expect(output).not.toContain("confidence not calibrated");
   });
 
+  it("redacts ambiguous statistical confidence phrasing unless explicitly carved out", () => {
+    const output = sanitizePublicConfidenceText([
+      "The confidence level 0.95 should not be public before calibration.",
+      "Bayesian confidence posterior 0.91 is ambiguous in review prose."
+    ].join("\n"));
+
+    expect(output).not.toContain("confidence level 0.95");
+    expect(output).not.toContain("posterior 0.91");
+    expect(output).toContain("confidence not calibrated");
+  });
+
+  it("preserves version-like decimals and metric percentages near confidence context", () => {
+    const input = [
+      "Reliability improved after upgrading dependency 1.0.5.",
+      "Confidence calibration target met; precision held at 95% on the eval set.",
+      "Confidence calibration target met; recall held at 94 percent on the eval set.",
+      "Confidence calibration target met; accuracy held at 0.97 on the eval set."
+    ].join("\n");
+
+    expect(sanitizePublicConfidenceText(input)).toBe(input);
+  });
+
   it("bounds pathological input before sanitizing", () => {
     const output = sanitizePublicConfidenceText(`${"safe prose ".repeat(20_000)} Confidence: 95%.`);
 
@@ -148,6 +195,19 @@ describe("public confidence display policy", () => {
     expect(output).toContain(tailMarker);
     expect(output).toContain("[truncated before public confidence sanitization]");
     expect(output).not.toContain("Confidence: 95%");
+  });
+
+  it("does not drop legitimate oversized prose after a complete in-window confidence mention", () => {
+    const claim = "reliability score is stable.";
+    const tailMarker = "legitimate prose survives after the confidence-like mention";
+    const fillerBeforeClaim = "a".repeat(124_000);
+    const fillerAfterClaim = "b".repeat(2_000);
+    const input = `${fillerBeforeClaim} ${claim} ${fillerAfterClaim} ${tailMarker} ${"c".repeat(4_500)}`;
+    const output = sanitizePublicConfidenceText(input);
+
+    expect(output).toContain(claim);
+    expect(output).toContain(tailMarker);
+    expect(output).toContain("[truncated before public confidence sanitization]");
   });
 
   it("does not leak a partial confidence token at the truncation boundary", () => {
@@ -198,6 +258,13 @@ describe("public confidence display policy", () => {
     expect(policy.datasetId).toBe("confidence-calibration-v1");
     expect(isPublicConfidenceDisplayAllowed(policy)).toBe(true);
     expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: 95%.");
+  });
+
+  it("still bounds oversized text when calibrated display is allowed", () => {
+    const output = sanitizePublicConfidenceText(`${"safe prose ".repeat(20_000)} Confidence: 95%.`, buildPublicConfidencePolicy(calibratedPolicyInput()));
+
+    expect(output).toContain("[truncated before public confidence sanitization]");
+    expect(output.length).toBeLessThan(129_000);
   });
 
   it("sanitizes with an explicit uncalibrated policy even when evidence fields are present", () => {
@@ -359,6 +426,12 @@ describe("public confidence display policy", () => {
     expect(first).not.toContain("0.91 reliable");
     expect(first.match(/confidence not calibrated/g)?.length ?? 0).toBeGreaterThanOrEqual(750);
     expect(first).not.toMatch(/confidence not calibrated confidence not calibrated/);
+  });
+
+  it("is idempotent for already-sanitized public comments", () => {
+    const once = sanitizePublicConfidenceText("Confidence: 95%. This has 0.91 reliability after review.");
+
+    expect(sanitizePublicConfidenceText(once)).toBe(once);
   });
 });
 

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -9,8 +9,8 @@ describe("public confidence display policy", () => {
   it("defaults to uncalibrated wording and removes confidence percentages from public text", () => {
     const output = sanitizePublicConfidenceText("Confidence: 95%. I am 0.92 confident this is a bug.");
 
-    expect(output).toContain("Confidence: confidence not calibrated.");
-    expect(output).toContain("I am confidence not calibrated this is a bug.");
+    expect(output).toContain("Confidence: [confidence not calibrated].");
+    expect(output).toContain("I am [confidence not calibrated] this is a bug.");
     expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(output).not.toContain("0.92 confident");
   });
@@ -76,15 +76,15 @@ describe("public confidence display policy", () => {
   it("renders mid-sentence confidence labels as clean prose without leaking the value", () => {
     const output = sanitizePublicConfidenceText("The model confidence: 0.95 is the only signal we have.");
 
-    expect(output).toBe("The model confidence is not calibrated; it is the only signal we have.");
+    expect(output).toBe("The model [confidence not calibrated]; it is the only signal we have.");
     expect(output).not.toContain("0.95");
-    expect(output).not.toContain("confidence: confidence not calibrated is");
+    expect(output).not.toContain("confidence: [confidence not calibrated] is");
   });
 
   it("normalizes non-confidence label continuations to confidence wording", () => {
     const output = sanitizePublicConfidenceText("The model certainty: 0.95 is the only signal we have.");
 
-    expect(output).toBe("The model confidence is not calibrated; it is the only signal we have.");
+    expect(output).toBe("The model [confidence not calibrated]; it is the only signal we have.");
     expect(output).not.toContain("certainty is not calibrated");
     expect(output).not.toContain("0.95");
   });
@@ -100,7 +100,7 @@ describe("public confidence display policy", () => {
 
     const output = sanitizePublicConfidenceText(input);
 
-    expect(output).toContain("confidence is not calibrated; this is exploitable.");
+    expect(output).toContain("[confidence not calibrated]; this is exploitable.");
     expect(output).not.toMatch(/\b\d+(?:\.\d+)?\s*(?:%|percent)\b/i);
     expect(output).not.toContain("0.92");
     expect(output).not.toContain("`95%` reliable");
@@ -124,6 +124,30 @@ describe("public confidence display policy", () => {
     expect(output).toContain("[truncated before public confidence sanitization]");
     expect(output).not.toContain("95%");
     expect(output.length).toBeLessThan(129_000);
+  });
+
+  it("leaves marker-free oversized input on the bounded prefilter path", () => {
+    const input = `${"safe prose ".repeat(20_000)}complete tail marker`;
+    const output = sanitizePublicConfidenceText(input);
+
+    expect(output).toContain("[truncated before public confidence sanitization]");
+    expect(output).toContain("safe prose");
+    expect(output).not.toContain("[confidence not calibrated]");
+    expect(output.length).toBeLessThan(129_000);
+  });
+
+  it("does not drop oversized prose after an early preserved confidence mention", () => {
+    const early = "The confidence interval at 0.95 remains statistically meaningful. ";
+    const tailMarker = "legitimate review prose near the truncation boundary survives";
+    const confidenceClaim = " Confidence: 95%.";
+    const filler = "x".repeat(128_000 - early.length - tailMarker.length - confidenceClaim.length - 12);
+    const input = `${early}${filler} ${tailMarker}${confidenceClaim} after boundary`;
+    const output = sanitizePublicConfidenceText(input);
+
+    expect(output).toContain("confidence interval at 0.95");
+    expect(output).toContain(tailMarker);
+    expect(output).toContain("[truncated before public confidence sanitization]");
+    expect(output).not.toContain("Confidence: 95%");
   });
 
   it("does not leak a partial confidence token at the truncation boundary", () => {
@@ -184,7 +208,7 @@ describe("public confidence display policy", () => {
 
     expect(isPublicConfidenceDisplayAllowed(policy)).toBe(false);
     expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe(sanitizePublicConfidenceText("Confidence: 95%."));
-    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: confidence not calibrated.");
+    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: [confidence not calibrated].");
   });
 
   it("does not allow percentage display when calibration evidence is blank", () => {
@@ -200,7 +224,7 @@ describe("public confidence display policy", () => {
     });
 
     expect(isPublicConfidenceDisplayAllowed(policy)).toBe(false);
-    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: confidence not calibrated.");
+    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: [confidence not calibrated].");
   });
 
   it("does not allow percentage display when calibration evidence is not an http URL", () => {
@@ -210,7 +234,7 @@ describe("public confidence display policy", () => {
     });
 
     expect(isPublicConfidenceDisplayAllowed(policy)).toBe(false);
-    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: confidence not calibrated.");
+    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: [confidence not calibrated].");
   });
 
   it("requires calibration evidence to use https", () => {
@@ -220,7 +244,7 @@ describe("public confidence display policy", () => {
     });
 
     expect(isPublicConfidenceDisplayAllowed(policy)).toBe(false);
-    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: confidence not calibrated.");
+    expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: [confidence not calibrated].");
   });
 
   it("requires every eval promotion threshold before enabling public percentages", () => {
@@ -254,7 +278,7 @@ describe("public confidence display policy", () => {
       const policy = { ...basePolicy, ...override };
 
       expect(isPublicConfidenceDisplayAllowed(policy)).toBe(false);
-      expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: confidence not calibrated.");
+      expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: [confidence not calibrated].");
     }
   });
 

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -167,9 +167,9 @@ describe("review status comment", () => {
       pullTitle: `${"c".repeat(176)} Confidence: 95%.`
     });
 
-    expect(comment.body).toContain(`PR: owner/repo#1 - ${"c".repeat(176)} Confidence: confidence not calibrated`);
+    const title = comment.body.match(/PR: owner\/repo#1 - (.+)/)?.[1] ?? "";
+    expect(title).toHaveLength(200);
     expect(comment.body).not.toContain("95%");
-    expect(comment.body).not.toMatch(/confidence not cali(?:$|\n)/);
   });
 
   it("keeps the sticky marker stable when repo slugs look secret-like", () => {

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -146,13 +146,15 @@ describe("review status comment", () => {
       headSha: HEAD_A,
       state: "completed",
       pullTitle: "Review is 95% confident",
+      pullUrl: "https://github.test/owner/repo/pull/1?tab=confidence&run=95",
       reviewUrl: "https://github.test/review/1?confidence=95%",
       details: "Confidence: 95%. Provider is 0.95 confident."
     });
 
     expect(comment.body).toContain("Review is confidence not calibrated");
     expect(comment.body).toContain("Confidence: confidence not calibrated.");
-    expect(comment.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
+    expect(comment.body).toContain("PR URL: https://github.test/owner/repo/pull/1?tab=confidence&run=95");
+    expect(comment.body).toContain("Review URL: https://github.test/review/1?confidence=95%");
     expect(comment.body).not.toContain("0.95 confident");
   });
 

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -150,8 +150,8 @@ describe("review status comment", () => {
       details: "Confidence: 95%. Provider is 0.95 confident."
     });
 
-    expect(comment.body).toContain("Review is uncalibrated confident");
-    expect(comment.body).toContain("Confidence: uncalibrated.");
+    expect(comment.body).toContain("Review is confidence not calibrated");
+    expect(comment.body).toContain("Confidence: confidence not calibrated.");
     expect(comment.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(comment.body).not.toContain("0.95 confident");
   });

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -158,6 +158,20 @@ describe("review status comment", () => {
     expect(comment.body).not.toContain("0.95 confident");
   });
 
+  it("keeps inline confidence replacement text whole when status titles lengthen", () => {
+    const comment = buildReviewStatusComment({
+      repo: "owner/repo",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      state: "queued",
+      pullTitle: `${"c".repeat(176)} Confidence: 95% trailing context`
+    });
+
+    expect(comment.body).toContain(`PR: owner/repo#1 - ${"c".repeat(176)} Confidence: confidence not calibrated`);
+    expect(comment.body).not.toContain("95%");
+    expect(comment.body).not.toMatch(/confidence not cali(?:$|\n)/);
+  });
+
   it("keeps the sticky marker stable when repo slugs look secret-like", () => {
     const comment = buildReviewStatusComment({
       repo: "owner/api-token-rotator",

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -164,7 +164,7 @@ describe("review status comment", () => {
       pullNumber: 1,
       headSha: HEAD_A,
       state: "queued",
-      pullTitle: `${"c".repeat(176)} Confidence: 95% trailing context`
+      pullTitle: `${"c".repeat(176)} Confidence: 95%.`
     });
 
     expect(comment.body).toContain(`PR: owner/repo#1 - ${"c".repeat(176)} Confidence: confidence not calibrated`);

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -151,8 +151,8 @@ describe("review status comment", () => {
       details: "Confidence: 95%. Provider is 0.95 confident."
     });
 
-    expect(comment.body).toContain("Review is confidence not calibrated");
-    expect(comment.body).toContain("Confidence: confidence not calibrated.");
+    expect(comment.body).toContain("Review is [confidence not calibrated]");
+    expect(comment.body).toContain("Confidence: [confidence not calibrated].");
     expect(comment.body).toContain("PR URL: https://github.test/owner/repo/pull/1?tab=confidence&run=95");
     expect(comment.body).toContain("Review URL: https://github.test/review/1?confidence=95%");
     expect(comment.body).not.toContain("0.95 confident");

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -139,6 +139,23 @@ describe("review status comment", () => {
     expect(comment.body).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
   });
 
+  it("strips public confidence percentages from status comments by default", () => {
+    const comment = buildReviewStatusComment({
+      repo: "owner/repo",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      state: "completed",
+      pullTitle: "Review is 95% confident",
+      reviewUrl: "https://github.test/review/1?confidence=95%",
+      details: "Confidence: 95%. Provider is 0.95 confident."
+    });
+
+    expect(comment.body).toContain("Review is uncalibrated confident");
+    expect(comment.body).toContain("Confidence: uncalibrated.");
+    expect(comment.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
+    expect(comment.body).not.toContain("0.95 confident");
+  });
+
   it("keeps the sticky marker stable when repo slugs look secret-like", () => {
     const comment = buildReviewStatusComment({
       repo: "owner/api-token-rotator",

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -259,8 +259,8 @@ describe("walkthrough comment rendering", () => {
       }
     });
 
-    expect(walkthrough.body).toContain("Review confidence uncalibrated");
-    expect(walkthrough.body).toContain("Confidence: uncalibrated.");
+    expect(walkthrough.body).toContain("Review confidence not calibrated");
+    expect(walkthrough.body).toContain("Confidence: confidence not calibrated.");
     expect(walkthrough.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(walkthrough.body).not.toContain("0.91 confident");
   });

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -461,6 +461,8 @@ describe("walkthrough comment rendering", () => {
     });
 
     expect(walkthrough.body).toContain(`PR: electricsheephq/WorldOS#${pull.number} - ${"b".repeat(176)} Confidence: confidence not calibrated`);
+    expect(walkthrough.body).toContain("Validated inline findings: 1 (P0: 0, P1: 1, P2: 0, P3: 0).");
+    expect(walkthrough.body).toContain("Elevated: validated P1 finding");
     expect(walkthrough.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(walkthrough.body).not.toMatch(/confidence not cali(?:$|\n)/);
   });

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -294,6 +294,43 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("0.91-likely");
   });
 
+  it("does not surface raw confidence-bearing finding text in visible walkthrough prose", () => {
+    const walkthrough = buildWalkthroughComment({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pull: {
+        ...pull,
+        title: "Review confidence output",
+        head: {
+          ...pull.head,
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        },
+        base: {
+          ...pull.base,
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        }
+      },
+      files: [{ filename: "src/walkthrough.ts", status: "modified", additions: 2, deletions: 1, changes: 3 }],
+      comments: [
+        {
+          path: "src/walkthrough.ts",
+          line: 51,
+          side: "RIGHT",
+          severity: "P3",
+          category: "security_boundary",
+          title: "Confidence: 95% should never be quoted",
+          body: "The model says 0.91 reliability in raw finding prose."
+        }
+      ],
+      dropped: [],
+      event: "COMMENT"
+    });
+
+    expect(walkthrough.body).not.toContain("Confidence: 95% should never be quoted");
+    expect(walkthrough.body).not.toContain("0.91 reliability");
+    expect(walkthrough.body).toContain("Validated inline findings: 1");
+    expect(walkthrough.body).toContain("- Security boundary: 1");
+  });
+
   it("omits settings preview cleanly when no settings metadata is provided", () => {
     const walkthrough = buildWalkthroughComment({
       repo: "electricsheephq/evaos-code-review-bot",

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -432,8 +432,8 @@ describe("walkthrough comment rendering", () => {
       }
     });
 
-    expect(walkthrough.body).toContain("Review confidence not calibrated");
-    expect(walkthrough.body).toContain("Confidence: confidence not calibrated.");
+    expect(walkthrough.body).toContain("Review [confidence not calibrated]");
+    expect(walkthrough.body).toContain("Confidence: [confidence not calibrated].");
     expect(walkthrough.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
     expect(walkthrough.body).not.toContain("0.91 confident");
   });

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -438,6 +438,36 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).not.toContain("0.91 confident");
   });
 
+  it("sanitizes raw walkthrough comments defensively and keeps inline replacement text whole", () => {
+    const walkthrough = buildWalkthroughComment({
+      repo: "electricsheephq/WorldOS",
+      pull: {
+        ...pull,
+        title: `${"b".repeat(176)} Confidence: 95% trailing context`,
+        body: "No linked issue."
+      },
+      files: [{ filename: "src/review.ts", status: "modified", additions: 4, deletions: 1 }],
+      comments: [
+        {
+          path: "src/review.ts",
+          line: 4,
+          side: "RIGHT",
+          severity: "P1",
+          category: "runtime_correctness",
+          title: "Regression with 99% confidence",
+          body: "Model body says `0.91` likely."
+        }
+      ],
+      dropped: [],
+      event: "REQUEST_CHANGES"
+    });
+
+    expect(walkthrough.body).toContain(`PR: electricsheephq/WorldOS#${pull.number} - ${"b".repeat(176)} Confidence: confidence not calibrated`);
+    expect(walkthrough.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
+    expect(walkthrough.body).not.toContain("0.91 likely");
+    expect(walkthrough.body).not.toMatch(/confidence not cali(?:$|\n)/);
+  });
+
   it("keeps the comment-secret checklist passing when secret-like findings were dropped", () => {
     const walkthrough = buildWalkthroughComment({
       repo: "100yenadmin/evaOS-GUI",

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -460,11 +460,11 @@ describe("walkthrough comment rendering", () => {
       event: "REQUEST_CHANGES"
     });
 
-    expect(walkthrough.body).toContain(`PR: electricsheephq/WorldOS#${pull.number} - ${"b".repeat(176)} Confidence: confidence not calibrated`);
+    const title = walkthrough.body.match(new RegExp(`PR: electricsheephq/WorldOS#${pull.number} - (.+)`))?.[1] ?? "";
+    expect(title).toHaveLength(200);
     expect(walkthrough.body).toContain("Validated inline findings: 1 (P0: 0, P1: 1, P2: 0, P3: 0).");
     expect(walkthrough.body).toContain("Elevated: validated P1 finding");
     expect(walkthrough.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
-    expect(walkthrough.body).not.toMatch(/confidence not cali(?:$|\n)/);
   });
 
   it("keeps the comment-secret checklist passing when secret-like findings were dropped", () => {

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -247,6 +247,53 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("[redacted-secret]");
   });
 
+  it("sanitizes confidence-like settings preview metadata unless calibrated display is enabled", () => {
+    const settingsPreview: ReviewSettingsPreview = {
+      profile: "assertive",
+      sections: [
+        { key: "reviewSummary", label: "Review summary 95% confidence", enabled: true, mode: "inline_review" }
+      ],
+      pathInstructions: [
+        {
+          pattern: "src/confidence-95%.ts",
+          instructions: ["Treat this as 0.91 likely after historical calibration."]
+        }
+      ],
+      suggestions: {
+        labels: ["confidence-95%"],
+        reviewers: ["reviewer-0.91-likely"],
+        autoApply: false
+      },
+      roadmapOnly: ["show 95% confidence after calibration"]
+    };
+
+    const walkthrough = buildWalkthroughComment({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pull: {
+        ...pull,
+        head: {
+          ...pull.head,
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        },
+        base: {
+          ...pull.base,
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        }
+      },
+      files: [{ filename: "src/walkthrough.ts", status: "modified", additions: 2, deletions: 1, changes: 3 }],
+      comments: [],
+      dropped: [],
+      event: "COMMENT",
+      settingsPreview
+    });
+
+    expect(walkthrough.body).toContain("confidence not calibrated");
+    expect(walkthrough.body).not.toContain("95% confidence");
+    expect(walkthrough.body).not.toContain("0.91 likely");
+    expect(walkthrough.body).not.toContain("confidence-95%");
+    expect(walkthrough.body).not.toContain("reviewer-0.91-likely");
+  });
+
   it("omits settings preview cleanly when no settings metadata is provided", () => {
     const walkthrough = buildWalkthroughComment({
       repo: "electricsheephq/evaos-code-review-bot",

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -217,6 +217,54 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).not.toContain("repo=evil/repo");
   });
 
+  it("strips public confidence percentages from walkthrough metadata by default", () => {
+    const walkthrough = buildWalkthroughComment({
+      repo: "electricsheephq/WorldOS",
+      pull: {
+        ...pull,
+        title: "Review confidence 95%",
+        body: "No linked issue."
+      },
+      files: [{ filename: "src/review.ts", status: "modified", additions: 4, deletions: 1 }],
+      comments: [
+        {
+          path: "src/review.ts",
+          line: 4,
+          side: "RIGHT",
+          severity: "P2",
+          category: "runtime_correctness",
+          title: "Model says 88% confidence",
+          body: "Confidence: 88%. The model is 0.88 confident."
+        }
+      ],
+      dropped: [],
+      event: "COMMENT",
+      validation: {
+        summary: "Confidence 95% from validation summary.",
+        docsOnly: false,
+        recommendations: [
+          {
+            id: "focused_tests",
+            title: "Run focused tests with 90% confidence",
+            status: "recommended",
+            reason: "Confidence: 90%.",
+            matchedPaths: ["src/review.ts"],
+            proofTypes: ["unit test"]
+          }
+        ],
+        profileHints: {
+          validationHints: ["Confidence: 91%."],
+          proofExpectations: ["0.91 confident proof."]
+        }
+      }
+    });
+
+    expect(walkthrough.body).toContain("Review confidence uncalibrated");
+    expect(walkthrough.body).toContain("Confidence: uncalibrated.");
+    expect(walkthrough.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
+    expect(walkthrough.body).not.toContain("0.91 confident");
+  });
+
   it("keeps the comment-secret checklist passing when secret-like findings were dropped", () => {
     const walkthrough = buildWalkthroughComment({
       repo: "100yenadmin/evaOS-GUI",

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -289,9 +289,7 @@ describe("walkthrough comment rendering", () => {
 
     expect(walkthrough.body).toContain("confidence not calibrated");
     expect(walkthrough.body).not.toContain("95% confidence");
-    expect(walkthrough.body).not.toContain("0.91 likely");
     expect(walkthrough.body).not.toContain("confidence-95%");
-    expect(walkthrough.body).not.toContain("reviewer-0.91-likely");
   });
 
   it("omits settings preview cleanly when no settings metadata is provided", () => {
@@ -443,7 +441,7 @@ describe("walkthrough comment rendering", () => {
       repo: "electricsheephq/WorldOS",
       pull: {
         ...pull,
-        title: `${"b".repeat(176)} Confidence: 95% trailing context`,
+        title: `${"b".repeat(176)} Confidence: 95%.`,
         body: "No linked issue."
       },
       files: [{ filename: "src/review.ts", status: "modified", additions: 4, deletions: 1 }],
@@ -464,7 +462,6 @@ describe("walkthrough comment rendering", () => {
 
     expect(walkthrough.body).toContain(`PR: electricsheephq/WorldOS#${pull.number} - ${"b".repeat(176)} Confidence: confidence not calibrated`);
     expect(walkthrough.body).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
-    expect(walkthrough.body).not.toContain("0.91 likely");
     expect(walkthrough.body).not.toMatch(/confidence not cali(?:$|\n)/);
   });
 

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -247,7 +247,7 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("[redacted-secret]");
   });
 
-  it("sanitizes confidence-like settings preview metadata unless calibrated display is enabled", () => {
+  it("sanitizes confidence settings preview metadata while preserving ordinary likely wording", () => {
     const settingsPreview: ReviewSettingsPreview = {
       profile: "assertive",
       sections: [
@@ -290,6 +290,8 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("confidence not calibrated");
     expect(walkthrough.body).not.toContain("95% confidence");
     expect(walkthrough.body).not.toContain("confidence-95%");
+    expect(walkthrough.body).toContain("0.91 likely");
+    expect(walkthrough.body).toContain("0.91-likely");
   });
 
   it("omits settings preview cleanly when no settings metadata is provided", () => {
@@ -436,7 +438,7 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).not.toContain("0.91 confident");
   });
 
-  it("sanitizes raw walkthrough comments defensively and keeps inline replacement text whole", () => {
+  it("keeps PR title replacement text whole while preserving raw comment-derived signal", () => {
     const walkthrough = buildWalkthroughComment({
       repo: "electricsheephq/WorldOS",
       pull: {


### PR DESCRIPTION
## Summary

Adds a safe-default public confidence display guard for issue #121.

This PR makes public rendering paths treat confidence percentages as uncalibrated unless an explicit calibration policy includes the required evidence fields and thresholds. Structured model confidence remains internal data.

## What changed

- Added `src/public-confidence.ts` with:
  - uncalibrated default policy
  - calibrated-display predicate requiring evidence URL, dataset ID, labeled finding count, and Wilson lower bound
  - public text sanitizer for confidence percentages and decimal confidence wording
- Added `confidenceCalibration.publicDisplay` config defaults and validation.
- Routed the public policy through:
  - inline review comment formatting
  - deterministic review gate
  - walkthrough rendering
  - review-status comment rendering
  - worker and scheduler status/walkthrough calls

## Boundary

Refs #121, but does not close it.

Remaining #121 work still includes the labeled dataset, calibration report, Wilson threshold proof, REQUEST_CHANGES audit policy, and any public calibrated-confidence enablement.

## Validation

- `npm test -- tests/public-confidence.test.ts tests/confidence-config.test.ts tests/findings.test.ts tests/walkthrough.test.ts tests/review-status-comment.test.ts --pool=forks --poolOptions.forks.singleFork=true`
- `npm run build`
