### PR TITLE
Add provider family registry catalog

### DIFF
--- a/docs/provider-registry.md
+++ b/docs/provider-registry.md
@@ -1,0 +1,55 @@
+# Provider Registry Catalog
+
+NeonDiff keeps provider choice local-first and BYOK-oriented. The provider
+registry catalog lists supported provider families and the metadata operators
+need before wiring a provider into config validation or runtime adapters.
+
+This catalog is not a claim that every provider family can run live reviews
+today. The current runtime surface is still limited by the adapters and proof
+gates documented in `docs/providers.md`. A provider family should be promoted to
+runtime support only after fixture review proof, redaction proof, bounded retry
+behavior, cooldown behavior, and release-status evidence are available.
+
+## Provider Families
+
+- `glm`: GLM / Z.ai through the existing ZCode path. Auth is delegated to the
+  local ZCode configuration; do not publish key values in GitHub comments,
+  config examples, logs, or evidence packets.
+- `openai-compatible`: OpenAI-compatible APIs such as internal gateways,
+  OpenRouter-style gateways, vLLM, LM Studio, or other `/v1` endpoints. Local
+  endpoints may need no key; hosted endpoints should use an environment
+  variable such as `NEONDIFF_PROVIDER_API_KEY`.
+- `ollama`: Local Ollama through its OpenAI-compatible API surface. This is the
+  preferred no-egress family when the endpoint is loopback and the model is
+  local.
+- `anthropic`: Anthropic Messages API. Use `ANTHROPIC_API_KEY` from the
+  operator environment.
+- `openai`: OpenAI Responses or Chat Completions API. Use `OPENAI_API_KEY` from
+  the operator environment.
+- `gemini`: Gemini / Google AI or Vertex AI surfaces. Use `GEMINI_API_KEY` or
+  `GOOGLE_APPLICATION_CREDENTIALS` from the operator environment.
+
+## Public Metadata
+
+Public registry output is safe to include in docs or evidence because it
+contains environment variable names, not secret values. If a secret-like value
+is accidentally added to auth hints or risk notes, callers should use the public
+catalog helper so the value is redacted before serialization.
+
+The catalog metadata includes:
+
+- provider id and aliases
+- display name
+- transport and API shape
+- auth environment hints without secret values
+- local or remote posture
+- JSON-mode and tool-use support when known
+- risk notes
+- BYOK posture
+
+## Implementation Boundary
+
+`src/provider-registry.ts` is a typed catalog and lookup helper layer. It is
+intended for config validation, UI copy, and evidence-safe provider summaries.
+It does not replace the existing runtime provider doctor or implement live
+adapter execution for every listed family.

--- a/src/provider-registry.ts
+++ b/src/provider-registry.ts
@@ -41,7 +41,10 @@ export interface ProviderFamily {
   };
 }
 
+const publicProviderFamilyBrand: unique symbol = Symbol("PublicProviderFamily");
+
 export interface PublicProviderFamily extends Omit<ProviderFamily, "authHints" | "riskNotes" | "byok"> {
+  readonly [publicProviderFamilyBrand]: true;
   authHints: readonly ProviderAuthHint[];
   riskNotes: readonly string[];
   byok: {
@@ -259,6 +262,7 @@ export function toPublicProviderFamilies(
 
 export function toPublicProviderFamily(provider: ProviderFamily): PublicProviderFamily {
   return {
+    [publicProviderFamilyBrand]: true,
     id: provider.id,
     displayName: redactProviderPublicText(provider.displayName),
     aliases: provider.aliases.map((alias) => redactProviderPublicText(alias)),

--- a/src/provider-registry.ts
+++ b/src/provider-registry.ts
@@ -263,7 +263,7 @@ export function toPublicProviderFamilies(
 export function toPublicProviderFamily(provider: ProviderFamily): PublicProviderFamily {
   return {
     [publicProviderFamilyBrand]: true,
-    id: provider.id,
+    id: redactProviderPublicText(provider.id),
     displayName: redactProviderPublicText(provider.displayName),
     aliases: provider.aliases.map((alias) => redactProviderPublicText(alias)),
     transport: provider.transport,

--- a/src/provider-registry.ts
+++ b/src/provider-registry.ts
@@ -1,0 +1,302 @@
+import { redactSecrets } from "./secrets.js";
+
+export type ProviderFamilyId =
+  | "glm"
+  | "openai-compatible"
+  | "ollama"
+  | "anthropic"
+  | "openai"
+  | "gemini";
+
+export type ProviderTransport =
+  | "zai-chat-completions"
+  | "openai-compatible-chat-completions"
+  | "anthropic-messages"
+  | "openai-responses-or-chat-completions"
+  | "gemini-generate-content";
+
+export type ProviderLocality = "local" | "remote" | "local-or-remote";
+export type ProviderSupport = boolean | "unknown";
+export type ProviderByokPosture = "required" | "optional" | "not-required" | "delegated";
+
+export interface ProviderAuthHint {
+  envVar?: string;
+  description: string;
+}
+
+export interface ProviderFamily {
+  id: ProviderFamilyId | string;
+  displayName: string;
+  aliases: readonly string[];
+  transport: ProviderTransport;
+  apiShape: string;
+  authHints: readonly ProviderAuthHint[];
+  locality: ProviderLocality;
+  supportsJsonMode: ProviderSupport;
+  supportsToolUse: ProviderSupport;
+  riskNotes: readonly string[];
+  byok: {
+    posture: ProviderByokPosture;
+    notes: string;
+  };
+}
+
+export interface PublicProviderFamily extends Omit<ProviderFamily, "authHints" | "riskNotes" | "byok"> {
+  authHints: readonly ProviderAuthHint[];
+  riskNotes: readonly string[];
+  byok: {
+    posture: ProviderByokPosture;
+    notes: string;
+  };
+}
+
+export interface ProviderCatalogDuplicate {
+  value: string;
+  firstProviderId: string;
+  duplicateProviderId: string;
+}
+
+export interface ProviderCatalogValidation {
+  ok: boolean;
+  duplicates: ProviderCatalogDuplicate[];
+}
+
+export const PROVIDER_FAMILY_CATALOG = [
+  {
+    id: "glm",
+    displayName: "GLM / Z.ai",
+    aliases: ["z.ai", "zai", "zcode", "glm-5", "glm-5.2"],
+    transport: "zai-chat-completions",
+    apiShape: "Z.ai GLM chat-completions style API, currently reached through the local ZCode path.",
+    authHints: [
+      {
+        envVar: "ZCODE_API_KEY",
+        description: "Used by the local ZCode runtime; do not place the value in tracked config."
+      }
+    ],
+    locality: "remote",
+    supportsJsonMode: true,
+    supportsToolUse: "unknown",
+    riskNotes: [
+      "Hosted provider; review prompts and repository excerpts can leave the local machine.",
+      "Existing live execution is ZCode-backed; direct GLM adapter parity still needs fixture proof."
+    ],
+    byok: {
+      posture: "delegated",
+      notes: "Credentials are delegated to the existing local ZCode app configuration."
+    }
+  },
+  {
+    id: "openai-compatible",
+    displayName: "OpenAI-Compatible API",
+    aliases: ["openai-compatible-api", "openai-compatible-endpoint", "openrouter", "vllm", "lm-studio", "internal-gateway"],
+    transport: "openai-compatible-chat-completions",
+    apiShape: "OpenAI-style /v1/chat/completions and /v1/models endpoints.",
+    authHints: [
+      {
+        envVar: "NEONDIFF_PROVIDER_API_KEY",
+        description: "Optional bearer token environment variable for hosted or internal gateways."
+      }
+    ],
+    locality: "local-or-remote",
+    supportsJsonMode: "unknown",
+    supportsToolUse: "unknown",
+    riskNotes: [
+      "Compatibility varies by gateway and model; validate JSON output and context behavior before promotion.",
+      "Hosted gateways can receive repository excerpts; local gateways depend on operator network binding."
+    ],
+    byok: {
+      posture: "optional",
+      notes: "Local endpoints may use no key; hosted and internal gateways should use env-var backed BYOK."
+    }
+  },
+  {
+    id: "ollama",
+    displayName: "Ollama / Local",
+    aliases: ["ollama-local", "local-ollama", "local-model"],
+    transport: "openai-compatible-chat-completions",
+    apiShape: "Ollama OpenAI-compatible /v1 API when enabled by the local runtime.",
+    authHints: [
+      {
+        description: "No API key is normally required for loopback Ollama."
+      }
+    ],
+    locality: "local",
+    supportsJsonMode: "unknown",
+    supportsToolUse: "unknown",
+    riskNotes: [
+      "No-egress posture depends on using a loopback endpoint and a local model.",
+      "Model quality, context limits, and JSON reliability vary by downloaded model."
+    ],
+    byok: {
+      posture: "not-required",
+      notes: "Uses a locally running Ollama service rather than a hosted API key."
+    }
+  },
+  {
+    id: "anthropic",
+    displayName: "Anthropic",
+    aliases: ["claude", "anthropic-claude"],
+    transport: "anthropic-messages",
+    apiShape: "Anthropic Messages API.",
+    authHints: [
+      {
+        envVar: "ANTHROPIC_API_KEY",
+        description: "Anthropic API key environment variable."
+      }
+    ],
+    locality: "remote",
+    supportsJsonMode: false,
+    supportsToolUse: true,
+    riskNotes: [
+      "Hosted provider; review prompts and repository excerpts can leave the local machine.",
+      "Schema-constrained output should be validated through adapter fixtures before runtime promotion."
+    ],
+    byok: {
+      posture: "required",
+      notes: "Operator supplies an Anthropic key through the environment."
+    }
+  },
+  {
+    id: "openai",
+    displayName: "OpenAI",
+    aliases: ["openai-native", "gpt", "chatgpt"],
+    transport: "openai-responses-or-chat-completions",
+    apiShape: "OpenAI Responses API or Chat Completions API.",
+    authHints: [
+      {
+        envVar: "OPENAI_API_KEY",
+        description: "OpenAI API key environment variable."
+      }
+    ],
+    locality: "remote",
+    supportsJsonMode: true,
+    supportsToolUse: true,
+    riskNotes: [
+      "Hosted provider; review prompts and repository excerpts can leave the local machine.",
+      "Choose project and data controls appropriate to the repository sensitivity."
+    ],
+    byok: {
+      posture: "required",
+      notes: "Operator supplies an OpenAI key through the environment."
+    }
+  },
+  {
+    id: "gemini",
+    displayName: "Gemini / Google AI",
+    aliases: ["google-ai", "google-gemini", "vertex-gemini", "vertex-ai"],
+    transport: "gemini-generate-content",
+    apiShape: "Gemini generateContent API or compatible Vertex AI surface.",
+    authHints: [
+      {
+        envVar: "GEMINI_API_KEY",
+        description: "Google AI Studio API key environment variable."
+      },
+      {
+        envVar: "GOOGLE_APPLICATION_CREDENTIALS",
+        description: "Optional Vertex AI application credentials file path."
+      }
+    ],
+    locality: "remote",
+    supportsJsonMode: true,
+    supportsToolUse: true,
+    riskNotes: [
+      "Hosted provider; review prompts and repository excerpts can leave the local machine.",
+      "Google AI Studio and Vertex AI have different auth and data-governance postures."
+    ],
+    byok: {
+      posture: "required",
+      notes: "Operator supplies Google credentials through environment-backed configuration."
+    }
+  }
+] satisfies readonly ProviderFamily[];
+
+export function listProviderFamilies(catalog: readonly ProviderFamily[] = PROVIDER_FAMILY_CATALOG): ProviderFamily[] {
+  return catalog.map((provider) => cloneProviderFamily(provider));
+}
+
+export function findProviderFamily(
+  idOrAlias: string,
+  catalog: readonly ProviderFamily[] = PROVIDER_FAMILY_CATALOG
+): ProviderFamily | undefined {
+  const normalizedNeedle = normalizeProviderKey(idOrAlias);
+  const provider = catalog.find((entry) => providerLookupKeys(entry).some((key) => key === normalizedNeedle));
+  return provider ? cloneProviderFamily(provider) : undefined;
+}
+
+export function validateProviderFamilyCatalog(
+  catalog: readonly ProviderFamily[] = PROVIDER_FAMILY_CATALOG
+): ProviderCatalogValidation {
+  const seen = new Map<string, string>();
+  const duplicates: ProviderCatalogDuplicate[] = [];
+
+  for (const provider of catalog) {
+    for (const key of providerLookupKeys(provider)) {
+      const firstProviderId = seen.get(key);
+      if (firstProviderId && firstProviderId !== provider.id) {
+        duplicates.push({
+          value: key,
+          firstProviderId,
+          duplicateProviderId: provider.id
+        });
+        continue;
+      }
+      seen.set(key, provider.id);
+    }
+  }
+
+  return {
+    ok: duplicates.length === 0,
+    duplicates
+  };
+}
+
+export function toPublicProviderFamilies(
+  catalog: readonly ProviderFamily[] = PROVIDER_FAMILY_CATALOG
+): PublicProviderFamily[] {
+  return catalog.map((provider) => toPublicProviderFamily(provider));
+}
+
+export function toPublicProviderFamily(provider: ProviderFamily): PublicProviderFamily {
+  return {
+    id: provider.id,
+    displayName: redactProviderPublicText(provider.displayName),
+    aliases: provider.aliases.map((alias) => redactProviderPublicText(alias)),
+    transport: provider.transport,
+    apiShape: redactProviderPublicText(provider.apiShape),
+    authHints: provider.authHints.map((hint) => ({
+      ...(hint.envVar ? { envVar: redactProviderPublicText(hint.envVar) } : {}),
+      description: redactProviderPublicText(hint.description)
+    })),
+    locality: provider.locality,
+    supportsJsonMode: provider.supportsJsonMode,
+    supportsToolUse: provider.supportsToolUse,
+    riskNotes: provider.riskNotes.map((note) => redactProviderPublicText(note)),
+    byok: {
+      posture: provider.byok.posture,
+      notes: redactProviderPublicText(provider.byok.notes)
+    }
+  };
+}
+
+function providerLookupKeys(provider: ProviderFamily): string[] {
+  return [provider.id, ...provider.aliases].map((key) => normalizeProviderKey(key));
+}
+
+function normalizeProviderKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function redactProviderPublicText(value: string): string {
+  return redactSecrets(value).replace(/\bsk-[A-Za-z0-9._-]{8,}\b/g, "[redacted-secret]");
+}
+
+function cloneProviderFamily(provider: ProviderFamily): ProviderFamily {
+  return {
+    ...provider,
+    aliases: [...provider.aliases],
+    authHints: provider.authHints.map((hint) => ({ ...hint })),
+    riskNotes: [...provider.riskNotes],
+    byok: { ...provider.byok }
+  };
+}

--- a/src/provider-registry.ts
+++ b/src/provider-registry.ts
@@ -65,7 +65,7 @@ export const PROVIDER_FAMILY_CATALOG = [
   {
     id: "glm",
     displayName: "GLM / Z.ai",
-    aliases: ["z.ai", "zai", "zcode", "glm-5", "glm-5.2"],
+    aliases: ["z.ai", "zai", "zcode", "zcode-glm", "glm-5", "glm-5.2"],
     transport: "zai-chat-completions",
     apiShape: "Z.ai GLM chat-completions style API, currently reached through the local ZCode path.",
     authHints: [
@@ -227,21 +227,21 @@ export function findProviderFamily(
 export function validateProviderFamilyCatalog(
   catalog: readonly ProviderFamily[] = PROVIDER_FAMILY_CATALOG
 ): ProviderCatalogValidation {
-  const seen = new Map<string, string>();
+  const seen = new Map<string, { providerId: string; entryIndex: number }>();
   const duplicates: ProviderCatalogDuplicate[] = [];
 
-  for (const provider of catalog) {
+  for (const [entryIndex, provider] of catalog.entries()) {
     for (const key of providerLookupKeys(provider)) {
-      const firstProviderId = seen.get(key);
-      if (firstProviderId && firstProviderId !== provider.id) {
+      const first = seen.get(key);
+      if (first && first.entryIndex !== entryIndex) {
         duplicates.push({
           value: key,
-          firstProviderId,
+          firstProviderId: first.providerId,
           duplicateProviderId: provider.id
         });
         continue;
       }
-      seen.set(key, provider.id);
+      seen.set(key, { providerId: provider.id, entryIndex });
     }
   }
 
@@ -288,7 +288,9 @@ function normalizeProviderKey(value: string): string {
 }
 
 function redactProviderPublicText(value: string): string {
-  return redactSecrets(value).replace(/\bsk-[A-Za-z0-9._-]{8,}\b/g, "[redacted-secret]");
+  return redactSecrets(value)
+    .replace(/\bsk-[A-Za-z0-9._-]{8,}\b/g, "[redacted-secret]")
+    .replace(/\bAIza[0-9A-Za-z_-]{20,}\b/g, "[redacted-secret]");
 }
 
 function cloneProviderFamily(provider: ProviderFamily): ProviderFamily {

--- a/tests/provider-registry-catalog.test.ts
+++ b/tests/provider-registry-catalog.test.ts
@@ -22,6 +22,7 @@ describe("provider family catalog", () => {
 
   it("finds providers by id and alias without case-sensitive caller coupling", () => {
     expect(findProviderFamily("glm")?.displayName).toBe("GLM / Z.ai");
+    expect(findProviderFamily("zcode-glm")?.id).toBe("glm");
     expect(findProviderFamily("z.ai")?.id).toBe("glm");
     expect(findProviderFamily("ZCODE")?.id).toBe("glm");
     expect(findProviderFamily("openai-compatible-api")?.id).toBe("openai-compatible");
@@ -32,7 +33,7 @@ describe("provider family catalog", () => {
   });
 
   it("validates duplicate provider ids and aliases across custom catalogs", () => {
-    const validation = validateProviderFamilyCatalog([
+    const aliasValidation = validateProviderFamilyCatalog([
       ...PROVIDER_FAMILY_CATALOG,
       {
         ...PROVIDER_FAMILY_CATALOG[0],
@@ -41,10 +42,24 @@ describe("provider family catalog", () => {
       }
     ]);
 
-    expect(validation.ok).toBe(false);
-    expect(validation.duplicates).toEqual([
+    expect(aliasValidation.ok).toBe(false);
+    expect(aliasValidation.duplicates).toEqual([
       { value: "z.ai", firstProviderId: "glm", duplicateProviderId: "glm-canary" }
     ]);
+
+    const idValidation = validateProviderFamilyCatalog([
+      ...PROVIDER_FAMILY_CATALOG,
+      {
+        ...PROVIDER_FAMILY_CATALOG[0],
+        aliases: ["glm-canary"]
+      }
+    ]);
+    expect(idValidation.ok).toBe(false);
+    expect(idValidation.duplicates).toContainEqual({
+      value: "glm",
+      firstProviderId: "glm",
+      duplicateProviderId: "glm"
+    });
   });
 
   it("keeps public metadata free of secret-looking auth values", () => {
@@ -70,5 +85,15 @@ describe("provider family catalog", () => {
     expect(serialized).toContain("OPENAI_API_KEY");
     expect(serialized).not.toContain("sk-live-accidental-secret");
     expect(serialized).toContain("[redacted-secret]");
+
+    const geminiProvider = {
+      ...PROVIDER_FAMILY_CATALOG.find((provider) => provider.id === "gemini")!,
+      riskNotes: [
+        "Accidental Google key AIzaSyDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx must not leak."
+      ]
+    };
+    const geminiSerialized = JSON.stringify(toPublicProviderFamily(geminiProvider));
+    expect(geminiSerialized).not.toContain("AIzaSyDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+    expect(geminiSerialized).toContain("[redacted-secret]");
   });
 });

--- a/tests/provider-registry-catalog.test.ts
+++ b/tests/provider-registry-catalog.test.ts
@@ -33,6 +33,11 @@ describe("provider family catalog", () => {
   });
 
   it("validates duplicate provider ids and aliases across custom catalogs", () => {
+    expect(validateProviderFamilyCatalog(PROVIDER_FAMILY_CATALOG)).toEqual({
+      ok: true,
+      duplicates: []
+    });
+
     const aliasValidation = validateProviderFamilyCatalog([
       ...PROVIDER_FAMILY_CATALOG,
       {
@@ -68,7 +73,7 @@ describe("provider family catalog", () => {
       authHints: [
         {
           envVar: "OPENAI_API_KEY",
-          description: "OpenAI API key",
+          description: "OpenAI API key sk-live-accidental-secret",
           secretValue: "sk-live-accidental-secret"
         }
       ],

--- a/tests/provider-registry-catalog.test.ts
+++ b/tests/provider-registry-catalog.test.ts
@@ -70,6 +70,7 @@ describe("provider family catalog", () => {
   it("keeps public metadata free of secret-looking auth values", () => {
     const providerWithAccidentalSecret = {
       ...PROVIDER_FAMILY_CATALOG.find((provider) => provider.id === "openai")!,
+      id: "custom-sk-live-accidental-secret",
       authHints: [
         {
           envVar: "OPENAI_API_KEY",

--- a/tests/provider-registry-catalog.test.ts
+++ b/tests/provider-registry-catalog.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  PROVIDER_FAMILY_CATALOG,
+  findProviderFamily,
+  listProviderFamilies,
+  toPublicProviderFamily,
+  toPublicProviderFamilies,
+  validateProviderFamilyCatalog
+} from "../src/provider-registry.js";
+
+describe("provider family catalog", () => {
+  it("lists supported provider families in deterministic registry order", () => {
+    expect(listProviderFamilies().map((provider) => provider.id)).toEqual([
+      "glm",
+      "openai-compatible",
+      "ollama",
+      "anthropic",
+      "openai",
+      "gemini"
+    ]);
+  });
+
+  it("finds providers by id and alias without case-sensitive caller coupling", () => {
+    expect(findProviderFamily("glm")?.displayName).toBe("GLM / Z.ai");
+    expect(findProviderFamily("z.ai")?.id).toBe("glm");
+    expect(findProviderFamily("ZCODE")?.id).toBe("glm");
+    expect(findProviderFamily("openai-compatible-api")?.id).toBe("openai-compatible");
+    expect(findProviderFamily("ollama-local")?.id).toBe("ollama");
+    expect(findProviderFamily("claude")?.id).toBe("anthropic");
+    expect(findProviderFamily("google-ai")?.id).toBe("gemini");
+    expect(findProviderFamily("missing-provider")).toBeUndefined();
+  });
+
+  it("validates duplicate provider ids and aliases across custom catalogs", () => {
+    const validation = validateProviderFamilyCatalog([
+      ...PROVIDER_FAMILY_CATALOG,
+      {
+        ...PROVIDER_FAMILY_CATALOG[0],
+        id: "glm-canary",
+        aliases: ["z.ai", "glm-canary"]
+      }
+    ]);
+
+    expect(validation.ok).toBe(false);
+    expect(validation.duplicates).toEqual([
+      { value: "z.ai", firstProviderId: "glm", duplicateProviderId: "glm-canary" }
+    ]);
+  });
+
+  it("keeps public metadata free of secret-looking auth values", () => {
+    const providerWithAccidentalSecret = {
+      ...PROVIDER_FAMILY_CATALOG.find((provider) => provider.id === "openai")!,
+      authHints: [
+        {
+          envVar: "OPENAI_API_KEY",
+          description: "OpenAI API key",
+          secretValue: "sk-live-accidental-secret"
+        }
+      ],
+      riskNotes: [
+        "Hosted API; repository excerpts leave the local machine.",
+        "Accidental token sk-live-accidental-secret must not leak."
+      ]
+    };
+
+    const publicProvider = toPublicProviderFamily(providerWithAccidentalSecret);
+    const publicCatalog = toPublicProviderFamilies([providerWithAccidentalSecret]);
+    const serialized = JSON.stringify({ publicProvider, publicCatalog });
+
+    expect(serialized).toContain("OPENAI_API_KEY");
+    expect(serialized).not.toContain("sk-live-accidental-secret");
+    expect(serialized).toContain("[redacted-secret]");
+  });
+});


### PR DESCRIPTION
## Summary
- add a typed provider-family registry catalog for GLM/Z.ai, OpenAI-compatible APIs, Ollama/local, Anthropic, OpenAI, and Gemini
- add deterministic helpers for listing, id/alias lookup, duplicate alias validation, and evidence-safe public metadata redaction
- document the local-first BYOK catalog boundary without claiming every provider family has live runtime adapter parity yet

## Proof Boundary
This is the low-collision #108 MVP catalog slice. It does not claim full provider execution parity, fixture review support for every family, or daemon cooldown/fallback completion. Runtime promotion still needs adapter-level fixture proof, retry/cooldown proof, and release-status evidence.

Related #108

## Validation
- `NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/provider-registry-catalog.test.ts --pool forks`
- `NODE_OPTIONS=--experimental-sqlite npm run build`
- `git diff --check`
