### PR TITLE
Add repo wiki packet export model

### DIFF
--- a/docs/repo-wiki-packet.md
+++ b/docs/repo-wiki-packet.md
@@ -57,6 +57,11 @@ multi-byte character. It then drops lower-priority sections until the rendered
 packet fits the byte and token-ish budgets. Budgets smaller than the fixed
 packet header fail closed instead of returning an over-budget packet.
 
+`maxBytes` and `maxTokens` bind the Markdown emitter because that is the prompt
+context form. JSON output is an evidence-safe machine payload, but callers that
+persist or transmit JSON must measure `formatRepoWikiPacketJson(packet)` against
+their own storage or transport limits.
+
 Secret-like text is passed through the repository's shared redaction helper
 before packet emission, including remote URLs and section provenance strings.
 Generated markdown and JSON must not contain raw tokens, API keys,

--- a/docs/repo-wiki-packet.md
+++ b/docs/repo-wiki-packet.md
@@ -1,0 +1,75 @@
+# Repo Wiki Packet
+
+Repo wiki packets are deterministic, evidence-safe context bundles for future
+codebase-map and repo-wiki review prompts. The MVP is library-only and dry-run:
+it does not change live worker behavior, prompt construction, GitHub comments,
+checks, queueing, or runtime state.
+
+This context is advisory. GitHub diff, current checkout files, current review
+evidence, and configured repo policy remain truth. A stale or missing wiki
+packet must degrade to a low-confidence context hint, not override the code
+under review.
+
+## Packet Model
+
+`src/repo-wiki-packet.ts` builds a packet with:
+
+- repo identity: `owner/repo`, optional default branch, optional remote URL
+- source freshness: ref, head SHA, checked-at timestamp, and `fresh`, `stale`,
+  or `missing` status
+- included sections: normalized codebase-map sections with source files, byte
+  length, token-ish estimate, truncation state, and redaction state
+- included files: stable file-to-section provenance
+- budget: max and used byte budget plus token-ish budget
+- redaction result: `passed` or `redacted` with replacement count
+- degraded mode: true when the source is stale or missing
+- generated timestamp
+- deterministic `packetSha`
+
+The packet SHA is derived from canonical JSON with sorted object keys. Markdown
+and JSON emitters are evidence-safe presentation formats over that packet.
+
+## Section Inputs
+
+Sections should be small, review-useful summaries such as:
+
+- architecture overview
+- key entrypoints
+- domain map
+- test commands
+- review rules
+- known risky areas
+
+Inputs are normalized deterministically:
+
+- IDs are trimmed, lowercased, and slugged.
+- CRLF text becomes LF text.
+- empty sections are excluded with reason `empty`.
+- source file lists are trimmed, de-duplicated, and sorted.
+- sections sort by `order`, then `id`.
+
+## Budgets And Redaction
+
+The builder caps section bodies by UTF-8 byte length without splitting a
+multi-byte character. It then drops lower-priority sections until the rendered
+packet fits the byte and token-ish budgets.
+
+Secret-like text is passed through the repository's shared redaction helper
+before packet emission. Generated markdown and JSON must not contain raw tokens,
+API keys, cookie/session values, private keys, email addresses, or customer data
+matched by that helper.
+
+## Degraded Mode
+
+Use `source.status = "stale"` when the packet was generated from an older ref or
+checkout. Use `source.status = "missing"` when no repo wiki/codebase map exists
+yet. Both statuses set `degraded: true` and should be treated as context hints
+only. Missing source with no sections records an excluded `packet:sections`
+entry with reason `missing_source`.
+
+## Runtime Boundary
+
+This MVP intentionally does not wire packets into `src/worker.ts`,
+`src/walkthrough.ts`, `src/config.ts`, `src/cli.ts`, or `src/state.ts`.
+Future integration should add a separate feature flag, evidence files, and
+review-prompt caps before any live prompt use.

--- a/docs/repo-wiki-packet.md
+++ b/docs/repo-wiki-packet.md
@@ -14,7 +14,8 @@ under review.
 
 `src/repo-wiki-packet.ts` builds a packet with:
 
-- repo identity: `owner/repo`, optional default branch, optional remote URL
+- repo identity: `owner/repo`, optional default branch, optional redacted
+  remote URL
 - source freshness: ref, head SHA, checked-at timestamp, and `fresh`, `stale`,
   or `missing` status
 - included sections: normalized codebase-map sections with source files, byte
@@ -42,7 +43,8 @@ Sections should be small, review-useful summaries such as:
 
 Inputs are normalized deterministically:
 
-- IDs are trimmed, lowercased, and slugged.
+- IDs are trimmed, lowercased, slugged, and made unique with deterministic
+  suffixes when normalized IDs collide.
 - CRLF text becomes LF text.
 - empty sections are excluded with reason `empty`.
 - source file lists are trimmed, de-duplicated, and sorted.
@@ -52,12 +54,14 @@ Inputs are normalized deterministically:
 
 The builder caps section bodies by UTF-8 byte length without splitting a
 multi-byte character. It then drops lower-priority sections until the rendered
-packet fits the byte and token-ish budgets.
+packet fits the byte and token-ish budgets. Budgets smaller than the fixed
+packet header fail closed instead of returning an over-budget packet.
 
 Secret-like text is passed through the repository's shared redaction helper
-before packet emission. Generated markdown and JSON must not contain raw tokens,
-API keys, cookie/session values, private keys, email addresses, or customer data
-matched by that helper.
+before packet emission, including remote URLs and section provenance strings.
+Generated markdown and JSON must not contain raw tokens, API keys,
+cookie/session values, private keys, email addresses, or customer data matched
+by that helper.
 
 ## Degraded Mode
 

--- a/src/repo-wiki-packet.ts
+++ b/src/repo-wiki-packet.ts
@@ -279,11 +279,14 @@ export function formatRepoWikiPacketJson(packet: RepoWikiPacket): string {
 }
 
 export function redactRepoWikiText(input: string): { text: string; replacementCount: number } {
-  const text = redactSecrets(input);
-  const replacementCount = countNeedles(text, "[redacted-secret]") - countNeedles(input, "[redacted-secret]");
+  const marker = "[redacted-secret]";
+  const sentinel = chooseRedactionSentinel(input);
+  const shieldedInput = input.split(marker).join(sentinel);
+  const shieldedText = redactSecrets(shieldedInput);
+  const replacementCount = Math.max(0, countNeedles(shieldedText, marker) - countNeedles(shieldedInput, marker));
   return {
-    text,
-    replacementCount: Math.max(0, replacementCount)
+    text: shieldedText.split(sentinel).join(marker),
+    replacementCount
   };
 }
 
@@ -326,13 +329,13 @@ function finalizePacket(
     };
     const nextSha = sha256(canonicalStringify(nextWithoutSha));
     if (usedBytes === withoutSha.byteBudget.usedBytes && usedTokens === withoutSha.tokenBudget.usedTokens) {
-      return { ...nextWithoutSha, packetSha: nextSha };
+      return assertFinalPacketSize({ ...nextWithoutSha, packetSha: nextSha });
     }
     withoutSha = nextWithoutSha;
     packetSha = nextSha;
   }
 
-  return { ...withoutSha, packetSha };
+  return assertFinalPacketSize({ ...withoutSha, packetSha });
 }
 
 function buildIncludedFiles(sections: RepoWikiIncludedSection[]): RepoWikiIncludedFile[] {
@@ -345,8 +348,8 @@ function buildIncludedFiles(sections: RepoWikiIncludedSection[]): RepoWikiInclud
     }
   }
   return [...byPath.entries()]
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([path, sectionIds]) => ({ path, sections: [...sectionIds].sort() }));
+    .sort(([left], [right]) => codeUnitCompare(left, right))
+    .map(([path, sectionIds]) => ({ path, sections: [...sectionIds].sort(codeUnitCompare) }));
 }
 
 function normalizeRepo(repo: RepoWikiIdentity, counter: { count: number }): RepoWikiIdentity {
@@ -394,15 +397,15 @@ function normalizeSourceFiles(files: string[]): string[] {
 
 function compareSections(left: RepoWikiNormalizedSection, right: RepoWikiNormalizedSection): number {
   if (left.order !== right.order) return left.order - right.order;
-  const id = left.id.localeCompare(right.id);
+  const id = codeUnitCompare(left.id, right.id);
   if (id !== 0) return id;
-  const title = left.title.localeCompare(right.title);
+  const title = codeUnitCompare(left.title, right.title);
   if (title !== 0) return title;
-  const body = left.body.localeCompare(right.body);
+  const body = codeUnitCompare(left.body, right.body);
   if (body !== 0) return body;
-  const sourceFiles = left.sourceFiles.join("\0").localeCompare(right.sourceFiles.join("\0"));
+  const sourceFiles = codeUnitCompare(left.sourceFiles.join("\0"), right.sourceFiles.join("\0"));
   if (sourceFiles !== 0) return sourceFiles;
-  return (left.sourceSha ?? "").localeCompare(right.sourceSha ?? "");
+  return codeUnitCompare(left.sourceSha ?? "", right.sourceSha ?? "");
 }
 
 function makeSectionIdsUnique(sections: RepoWikiNormalizedSection[]): RepoWikiNormalizedSection[] {
@@ -416,8 +419,8 @@ function makeSectionIdsUnique(sections: RepoWikiNormalizedSection[]): RepoWikiNo
 }
 
 function compareExcluded(left: RepoWikiExcludedSection, right: RepoWikiExcludedSection): number {
-  const id = left.id.localeCompare(right.id);
-  return id !== 0 ? id : left.reason.localeCompare(right.reason);
+  const id = codeUnitCompare(left.id, right.id);
+  return id !== 0 ? id : codeUnitCompare(left.reason, right.reason);
 }
 
 function assertRepoName(repo: string): void {
@@ -451,6 +454,12 @@ function tokenEstimateForBytes(bytes: number): number {
   return Math.max(1, Math.ceil(bytes / 4));
 }
 
+function chooseRedactionSentinel(input: string): string {
+  let sentinel = "__repo_wiki_existing_redaction_marker__";
+  while (input.includes(sentinel)) sentinel = `_${sentinel}`;
+  return sentinel;
+}
+
 function countNeedles(input: string, needle: string): number {
   return input.split(needle).length - 1;
 }
@@ -468,9 +477,26 @@ function sortJson(input: unknown): unknown {
   if (input && typeof input === "object") {
     return Object.fromEntries(
       Object.entries(input)
-        .sort(([left], [right]) => left.localeCompare(right))
+        .sort(([left], [right]) => codeUnitCompare(left, right))
         .map(([key, value]) => [key, sortJson(value)])
     );
   }
   return input;
+}
+
+function assertFinalPacketSize(packet: RepoWikiPacket): RepoWikiPacket {
+  const usedBytes = Buffer.byteLength(formatRepoWikiPacketMarkdown(packet), "utf8");
+  const usedTokens = tokenEstimateForBytes(usedBytes);
+  if (usedBytes !== packet.byteBudget.usedBytes || usedTokens !== packet.tokenBudget.usedTokens) {
+    throw new Error(
+      `repo wiki packet size invariant failed (${usedBytes}/${packet.byteBudget.usedBytes} bytes, ${usedTokens}/${packet.tokenBudget.usedTokens} token-ish)`
+    );
+  }
+  return packet;
+}
+
+function codeUnitCompare(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
 }

--- a/src/repo-wiki-packet.ts
+++ b/src/repo-wiki-packet.ts
@@ -317,6 +317,7 @@ function finalizePacket(
     includedFiles
   };
   let packetSha = sha256(canonicalStringify(withoutSha));
+  assertPacketSha(packetSha);
 
   for (let attempt = 0; attempt < 10; attempt += 1) {
     const packet: RepoWikiPacket = { ...withoutSha, packetSha };
@@ -328,6 +329,7 @@ function finalizePacket(
       tokenBudget: { ...withoutSha.tokenBudget, usedTokens }
     };
     const nextSha = sha256(canonicalStringify(nextWithoutSha));
+    assertPacketSha(nextSha);
     if (usedBytes === withoutSha.byteBudget.usedBytes && usedTokens === withoutSha.tokenBudget.usedTokens) {
       return assertFinalPacketSize({ ...nextWithoutSha, packetSha: nextSha });
     }
@@ -466,6 +468,12 @@ function countNeedles(input: string, needle: string): number {
 
 function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex");
+}
+
+function assertPacketSha(packetSha: string): void {
+  if (!/^[a-f0-9]{64}$/.test(packetSha)) {
+    throw new Error("repo wiki packet SHA must be a fixed 64-character hex digest");
+  }
 }
 
 function canonicalStringify(input: unknown): string {

--- a/src/repo-wiki-packet.ts
+++ b/src/repo-wiki-packet.ts
@@ -355,10 +355,11 @@ function buildIncludedFiles(sections: RepoWikiIncludedSection[]): RepoWikiInclud
 }
 
 function normalizeRepo(repo: RepoWikiIdentity, counter: { count: number }): RepoWikiIdentity {
+  const fullName = redactAndCount(repo.fullName, counter).text;
   const defaultBranch = repo.defaultBranch ? redactAndCount(repo.defaultBranch, counter).text : undefined;
   const remoteUrl = repo.remoteUrl ? redactAndCount(repo.remoteUrl, counter).text : undefined;
   return {
-    fullName: repo.fullName,
+    fullName,
     ...(defaultBranch ? { defaultBranch } : {}),
     ...(remoteUrl ? { remoteUrl } : {})
   };
@@ -368,11 +369,14 @@ function normalizeSource(
   source: RepoWikiSourceFreshness,
   counter: { count: number }
 ): RepoWikiSourceFreshness {
+  const ref = redactAndCount(source.ref, counter).text;
+  const headSha = source.headSha ? redactAndCount(source.headSha, counter).text : undefined;
+  const checkedAt = source.checkedAt ? redactAndCount(source.checkedAt, counter).text : undefined;
   const staleReason = source.staleReason ? redactAndCount(source.staleReason, counter).text : undefined;
   return {
-    ref: source.ref,
-    ...(source.headSha ? { headSha: source.headSha } : {}),
-    ...(source.checkedAt ? { checkedAt: source.checkedAt } : {}),
+    ref,
+    ...(headSha ? { headSha } : {}),
+    ...(checkedAt ? { checkedAt } : {}),
     status: source.status,
     ...(staleReason ? { staleReason } : {})
   };

--- a/src/repo-wiki-packet.ts
+++ b/src/repo-wiki-packet.ts
@@ -118,17 +118,17 @@ export function normalizeRepoWikiSections(input: RepoWikiSectionInput[]): {
   excluded: RepoWikiExcludedSection[];
 } {
   const excluded: RepoWikiExcludedSection[] = [];
-  const sections = input
+  const sortedSections = input
     .map((section) => {
-      const id = normalizeSectionId(section.id);
+      const baseId = normalizeSectionId(section.id);
       const body = normalizeText(section.body);
       if (!body) {
-        excluded.push({ id, reason: "empty" });
+        excluded.push({ id: baseId, reason: "empty" });
         return undefined;
       }
       return {
-        id,
-        title: normalizeText(section.title) || id,
+        id: baseId,
+        title: normalizeText(section.title) || baseId,
         body,
         order: Number.isFinite(section.order) ? Number(section.order) : 0,
         sourceFiles: normalizeSourceFiles(section.sourceFiles ?? []),
@@ -138,7 +138,7 @@ export function normalizeRepoWikiSections(input: RepoWikiSectionInput[]): {
     .filter((section): section is RepoWikiNormalizedSection => section !== undefined)
     .sort(compareSections);
 
-  return { sections, excluded };
+  return { sections: makeSectionIdsUnique(sortedSections), excluded };
 }
 
 export function buildRepoWikiPacket(input: BuildRepoWikiPacketInput): RepoWikiPacket {
@@ -162,25 +162,32 @@ export function buildRepoWikiPacket(input: BuildRepoWikiPacketInput): RepoWikiPa
   for (const section of normalized.sections) {
     const redactedTitle = redactAndCount(section.title, redactionCounter);
     const redactedBody = redactAndCount(section.body, redactionCounter);
+    const redactedSourceFileResults = section.sourceFiles.map((file) => redactAndCount(file, redactionCounter));
+    const redactedSourceFiles = normalizeSourceFiles(redactedSourceFileResults.map((file) => file.text));
+    const redactedSourceShaResult = section.sourceSha ? redactAndCount(section.sourceSha, redactionCounter) : undefined;
+    const redactedSourceSha = redactedSourceShaResult?.text;
     const cappedBody = truncateUtf8Bytes(redactedBody.text, maxSectionBytes);
+    const provenanceReplacementCount =
+      redactedSourceFileResults.reduce((count, file) => count + file.replacementCount, 0) +
+      (redactedSourceShaResult?.replacementCount ?? 0);
     const included: RepoWikiIncludedSection = {
       id: section.id,
       title: redactedTitle.text,
       body: cappedBody,
       order: section.order,
-      sourceFiles: section.sourceFiles,
-      ...(section.sourceSha ? { sourceSha: section.sourceSha } : {}),
+      sourceFiles: redactedSourceFiles,
+      ...(redactedSourceSha ? { sourceSha: redactedSourceSha } : {}),
       byteLength: Buffer.byteLength(cappedBody, "utf8"),
       tokenEstimate: tokenEstimateForBytes(Buffer.byteLength(cappedBody, "utf8")),
       truncated: cappedBody !== redactedBody.text,
-      redacted: redactedTitle.replacementCount + redactedBody.replacementCount > 0
+      redacted: redactedTitle.replacementCount + redactedBody.replacementCount + provenanceReplacementCount > 0
     };
     includedSections.push(included);
   }
 
   const packetBase = {
     packetVersion: input.packetVersion ?? REPO_WIKI_PACKET_VERSION,
-    repo: normalizeRepo(input.repo),
+    repo: normalizeRepo(input.repo, redactionCounter),
     source: normalizeSource(input.source, redactionCounter),
     generatedAt,
     advisory: REPO_WIKI_ADVISORY_LINE,
@@ -204,7 +211,13 @@ export function buildRepoWikiPacket(input: BuildRepoWikiPacketInput): RepoWikiPa
     if (dropped) acceptedExcluded = [{ id: dropped.id, reason: "packet_budget_exceeded" }, ...acceptedExcluded];
   }
 
-  return finalizePacket(packetBase, acceptedSections, acceptedExcluded);
+  const emptyPacket = finalizePacket(packetBase, acceptedSections, acceptedExcluded);
+  if (emptyPacket.byteBudget.usedBytes > maxBytes || emptyPacket.tokenBudget.usedTokens > maxTokens) {
+    throw new Error(
+      `fixed packet header exceeds budget (${emptyPacket.byteBudget.usedBytes}/${maxBytes} bytes, ${emptyPacket.tokenBudget.usedTokens}/${maxTokens} token-ish)`
+    );
+  }
+  return emptyPacket;
 }
 
 export function formatRepoWikiPacketMarkdown(packet: RepoWikiPacket): string {
@@ -294,25 +307,32 @@ function finalizePacket(
   excludedSections: RepoWikiExcludedSection[]
 ): RepoWikiPacket {
   const includedFiles = buildIncludedFiles(includedSections);
-  const withoutSha: Omit<RepoWikiPacket, "packetSha"> = {
+  let withoutSha: Omit<RepoWikiPacket, "packetSha"> = {
     ...base,
     includedSections,
     excludedSections: [...excludedSections].sort(compareExcluded),
     includedFiles
   };
-  const packetSha = sha256(canonicalStringify(withoutSha));
-  const packet: RepoWikiPacket = { ...withoutSha, packetSha };
-  const usedBytes = Buffer.byteLength(formatRepoWikiPacketMarkdown(packet), "utf8");
-  const usedTokens = tokenEstimateForBytes(usedBytes);
-  const measuredWithoutSha: Omit<RepoWikiPacket, "packetSha"> = {
-    ...withoutSha,
-    byteBudget: { ...withoutSha.byteBudget, usedBytes },
-    tokenBudget: { ...withoutSha.tokenBudget, usedTokens }
-  };
-  return {
-    ...measuredWithoutSha,
-    packetSha: sha256(canonicalStringify(measuredWithoutSha))
-  };
+  let packetSha = sha256(canonicalStringify(withoutSha));
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const packet: RepoWikiPacket = { ...withoutSha, packetSha };
+    const usedBytes = Buffer.byteLength(formatRepoWikiPacketMarkdown(packet), "utf8");
+    const usedTokens = tokenEstimateForBytes(usedBytes);
+    const nextWithoutSha: Omit<RepoWikiPacket, "packetSha"> = {
+      ...withoutSha,
+      byteBudget: { ...withoutSha.byteBudget, usedBytes },
+      tokenBudget: { ...withoutSha.tokenBudget, usedTokens }
+    };
+    const nextSha = sha256(canonicalStringify(nextWithoutSha));
+    if (usedBytes === withoutSha.byteBudget.usedBytes && usedTokens === withoutSha.tokenBudget.usedTokens) {
+      return { ...nextWithoutSha, packetSha: nextSha };
+    }
+    withoutSha = nextWithoutSha;
+    packetSha = nextSha;
+  }
+
+  return { ...withoutSha, packetSha };
 }
 
 function buildIncludedFiles(sections: RepoWikiIncludedSection[]): RepoWikiIncludedFile[] {
@@ -329,11 +349,13 @@ function buildIncludedFiles(sections: RepoWikiIncludedSection[]): RepoWikiInclud
     .map(([path, sectionIds]) => ({ path, sections: [...sectionIds].sort() }));
 }
 
-function normalizeRepo(repo: RepoWikiIdentity): RepoWikiIdentity {
+function normalizeRepo(repo: RepoWikiIdentity, counter: { count: number }): RepoWikiIdentity {
+  const defaultBranch = repo.defaultBranch ? redactAndCount(repo.defaultBranch, counter).text : undefined;
+  const remoteUrl = repo.remoteUrl ? redactAndCount(repo.remoteUrl, counter).text : undefined;
   return {
     fullName: repo.fullName,
-    ...(repo.defaultBranch ? { defaultBranch: repo.defaultBranch } : {}),
-    ...(repo.remoteUrl ? { remoteUrl: repo.remoteUrl } : {})
+    ...(defaultBranch ? { defaultBranch } : {}),
+    ...(remoteUrl ? { remoteUrl } : {})
   };
 }
 
@@ -358,7 +380,7 @@ function redactAndCount(input: string, counter: { count: number }): { text: stri
 }
 
 function normalizeSectionId(id: string): string {
-  const normalized = id.trim().toLowerCase().replace(/[^a-z0-9_.-]+/g, "-").replace(/^-+|-+$/g, "");
+  const normalized = id.trim().toLowerCase().replace(/[^a-z0-9.-]+/g, "-").replace(/^-+|-+$/g, "");
   return normalized || "section";
 }
 
@@ -372,7 +394,25 @@ function normalizeSourceFiles(files: string[]): string[] {
 
 function compareSections(left: RepoWikiNormalizedSection, right: RepoWikiNormalizedSection): number {
   if (left.order !== right.order) return left.order - right.order;
-  return left.id.localeCompare(right.id);
+  const id = left.id.localeCompare(right.id);
+  if (id !== 0) return id;
+  const title = left.title.localeCompare(right.title);
+  if (title !== 0) return title;
+  const body = left.body.localeCompare(right.body);
+  if (body !== 0) return body;
+  const sourceFiles = left.sourceFiles.join("\0").localeCompare(right.sourceFiles.join("\0"));
+  if (sourceFiles !== 0) return sourceFiles;
+  return (left.sourceSha ?? "").localeCompare(right.sourceSha ?? "");
+}
+
+function makeSectionIdsUnique(sections: RepoWikiNormalizedSection[]): RepoWikiNormalizedSection[] {
+  const seen = new Map<string, number>();
+  return sections.map((section) => {
+    const count = (seen.get(section.id) ?? 0) + 1;
+    seen.set(section.id, count);
+    if (count === 1) return section;
+    return { ...section, id: `${section.id}-${count}` };
+  });
 }
 
 function compareExcluded(left: RepoWikiExcludedSection, right: RepoWikiExcludedSection): number {

--- a/src/repo-wiki-packet.ts
+++ b/src/repo-wiki-packet.ts
@@ -1,0 +1,436 @@
+import { createHash } from "node:crypto";
+import { redactSecrets } from "./secrets.js";
+
+export const REPO_WIKI_PACKET_VERSION = "repo-wiki-packet-v0.1";
+export const REPO_WIKI_ADVISORY_LINE =
+  "Repo wiki packet context is advisory. GitHub diff and checkout remain truth.";
+
+export type RepoWikiSourceStatus = "fresh" | "stale" | "missing";
+
+export interface RepoWikiIdentity {
+  fullName: string;
+  defaultBranch?: string;
+  remoteUrl?: string;
+}
+
+export interface RepoWikiSourceFreshness {
+  ref: string;
+  headSha?: string;
+  checkedAt?: string;
+  status: RepoWikiSourceStatus;
+  staleReason?: string;
+}
+
+export interface RepoWikiSectionInput {
+  id: string;
+  title: string;
+  body: string;
+  order?: number;
+  sourceFiles?: string[];
+  sourceSha?: string;
+}
+
+export interface RepoWikiNormalizedSection {
+  id: string;
+  title: string;
+  body: string;
+  order: number;
+  sourceFiles: string[];
+  sourceSha?: string;
+}
+
+export type RepoWikiExcludedSectionReason =
+  | "empty"
+  | "missing_source"
+  | "packet_budget_exceeded";
+
+export interface RepoWikiExcludedSection {
+  id: string;
+  reason: RepoWikiExcludedSectionReason;
+}
+
+export interface RepoWikiIncludedSection {
+  id: string;
+  title: string;
+  body: string;
+  order: number;
+  sourceFiles: string[];
+  sourceSha?: string;
+  byteLength: number;
+  tokenEstimate: number;
+  truncated: boolean;
+  redacted: boolean;
+}
+
+export interface RepoWikiIncludedFile {
+  path: string;
+  sections: string[];
+}
+
+export interface RepoWikiPacketBudgetInput {
+  maxBytes: number;
+  maxTokens?: number;
+  maxSectionBytes?: number;
+}
+
+export interface RepoWikiPacketBudget {
+  maxBytes: number;
+  usedBytes: number;
+}
+
+export interface RepoWikiTokenBudget {
+  maxTokens: number;
+  usedTokens: number;
+}
+
+export interface RepoWikiRedactionResult {
+  status: "passed" | "redacted";
+  replacementCount: number;
+}
+
+export interface RepoWikiPacket {
+  packetVersion: string;
+  repo: RepoWikiIdentity;
+  source: RepoWikiSourceFreshness;
+  generatedAt: string;
+  advisory: string;
+  degraded: boolean;
+  byteBudget: RepoWikiPacketBudget;
+  tokenBudget: RepoWikiTokenBudget;
+  redaction: RepoWikiRedactionResult;
+  includedSections: RepoWikiIncludedSection[];
+  excludedSections: RepoWikiExcludedSection[];
+  includedFiles: RepoWikiIncludedFile[];
+  packetSha: string;
+}
+
+export interface BuildRepoWikiPacketInput {
+  repo: RepoWikiIdentity;
+  source: RepoWikiSourceFreshness;
+  sections: RepoWikiSectionInput[];
+  budget: RepoWikiPacketBudgetInput;
+  generatedAt?: string;
+  packetVersion?: string;
+}
+
+export function normalizeRepoWikiSections(input: RepoWikiSectionInput[]): {
+  sections: RepoWikiNormalizedSection[];
+  excluded: RepoWikiExcludedSection[];
+} {
+  const excluded: RepoWikiExcludedSection[] = [];
+  const sections = input
+    .map((section) => {
+      const id = normalizeSectionId(section.id);
+      const body = normalizeText(section.body);
+      if (!body) {
+        excluded.push({ id, reason: "empty" });
+        return undefined;
+      }
+      return {
+        id,
+        title: normalizeText(section.title) || id,
+        body,
+        order: Number.isFinite(section.order) ? Number(section.order) : 0,
+        sourceFiles: normalizeSourceFiles(section.sourceFiles ?? []),
+        ...(section.sourceSha ? { sourceSha: section.sourceSha } : {})
+      } satisfies RepoWikiNormalizedSection;
+    })
+    .filter((section): section is RepoWikiNormalizedSection => section !== undefined)
+    .sort(compareSections);
+
+  return { sections, excluded };
+}
+
+export function buildRepoWikiPacket(input: BuildRepoWikiPacketInput): RepoWikiPacket {
+  assertRepoName(input.repo.fullName);
+  assertBudget(input.budget);
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+  assertIsoTimestamp(generatedAt, "generatedAt");
+  if (input.source.checkedAt) assertIsoTimestamp(input.source.checkedAt, "source.checkedAt");
+
+  const maxBytes = input.budget.maxBytes;
+  const maxTokens = input.budget.maxTokens ?? tokenEstimateForBytes(maxBytes);
+  const maxSectionBytes = input.budget.maxSectionBytes ?? maxBytes;
+  const normalized = normalizeRepoWikiSections(input.sections);
+  const excluded = [...normalized.excluded];
+  if (input.source.status === "missing" && normalized.sections.length === 0) {
+    excluded.push({ id: "packet:sections", reason: "missing_source" });
+  }
+
+  const redactionCounter = { count: 0 };
+  const includedSections: RepoWikiIncludedSection[] = [];
+  for (const section of normalized.sections) {
+    const redactedTitle = redactAndCount(section.title, redactionCounter);
+    const redactedBody = redactAndCount(section.body, redactionCounter);
+    const cappedBody = truncateUtf8Bytes(redactedBody.text, maxSectionBytes);
+    const included: RepoWikiIncludedSection = {
+      id: section.id,
+      title: redactedTitle.text,
+      body: cappedBody,
+      order: section.order,
+      sourceFiles: section.sourceFiles,
+      ...(section.sourceSha ? { sourceSha: section.sourceSha } : {}),
+      byteLength: Buffer.byteLength(cappedBody, "utf8"),
+      tokenEstimate: tokenEstimateForBytes(Buffer.byteLength(cappedBody, "utf8")),
+      truncated: cappedBody !== redactedBody.text,
+      redacted: redactedTitle.replacementCount + redactedBody.replacementCount > 0
+    };
+    includedSections.push(included);
+  }
+
+  const packetBase = {
+    packetVersion: input.packetVersion ?? REPO_WIKI_PACKET_VERSION,
+    repo: normalizeRepo(input.repo),
+    source: normalizeSource(input.source, redactionCounter),
+    generatedAt,
+    advisory: REPO_WIKI_ADVISORY_LINE,
+    degraded: input.source.status !== "fresh",
+    byteBudget: { maxBytes, usedBytes: 0 },
+    tokenBudget: { maxTokens, usedTokens: 0 },
+    redaction: {
+      status: redactionCounter.count > 0 ? "redacted" : "passed",
+      replacementCount: redactionCounter.count
+    } satisfies RepoWikiRedactionResult
+  };
+
+  let acceptedSections = [...includedSections];
+  let acceptedExcluded = [...excluded];
+  while (acceptedSections.length > 0) {
+    const tentative = finalizePacket(packetBase, acceptedSections, acceptedExcluded);
+    if (tentative.byteBudget.usedBytes <= maxBytes && tentative.tokenBudget.usedTokens <= maxTokens) {
+      return tentative;
+    }
+    const dropped = acceptedSections.pop();
+    if (dropped) acceptedExcluded = [{ id: dropped.id, reason: "packet_budget_exceeded" }, ...acceptedExcluded];
+  }
+
+  return finalizePacket(packetBase, acceptedSections, acceptedExcluded);
+}
+
+export function formatRepoWikiPacketMarkdown(packet: RepoWikiPacket): string {
+  const lines = [
+    "# Repo Wiki Packet",
+    "",
+    `Repository: ${packet.repo.fullName}`,
+    packet.repo.defaultBranch ? `Default branch: ${packet.repo.defaultBranch}` : undefined,
+    `Source ref: ${packet.source.ref}`,
+    packet.source.headSha ? `Source head: ${packet.source.headSha}` : undefined,
+    `Source status: ${packet.source.status}`,
+    packet.source.staleReason ? `Source note: ${packet.source.staleReason}` : undefined,
+    `Generated at: ${packet.generatedAt}`,
+    `Packet SHA: ${packet.packetSha}`,
+    `Budget: ${packet.byteBudget.usedBytes}/${packet.byteBudget.maxBytes} bytes; ${packet.tokenBudget.usedTokens}/${packet.tokenBudget.maxTokens} token-ish`,
+    `Redaction: ${packet.redaction.status} (${packet.redaction.replacementCount} replacements)`,
+    packet.degraded ? "Degraded: true" : "Degraded: false",
+    "",
+    packet.advisory,
+    ""
+  ].filter((line): line is string => line !== undefined);
+
+  if (packet.includedSections.length === 0) {
+    lines.push("## Sections", "", "No repo wiki sections were included.");
+  } else {
+    lines.push("## Sections");
+    for (const section of packet.includedSections) {
+      lines.push(
+        "",
+        `### ${section.title}`,
+        "",
+        [
+          `id=${section.id}`,
+          `bytes=${section.byteLength}`,
+          `tokens=${section.tokenEstimate}`,
+          section.truncated ? "truncated=true" : "truncated=false",
+          section.redacted ? "redacted=true" : "redacted=false",
+          section.sourceSha ? `source_sha=${section.sourceSha}` : undefined,
+          section.sourceFiles.length ? `files=${section.sourceFiles.join(", ")}` : undefined
+        ].filter(Boolean).join("; "),
+        "",
+        section.body
+      );
+    }
+  }
+
+  if (packet.excludedSections.length) {
+    lines.push("", "## Excluded Sections");
+    for (const section of packet.excludedSections) {
+      lines.push("", `- ${section.id}: ${section.reason}`);
+    }
+  }
+
+  return `${lines.join("\n").trim()}\n`;
+}
+
+export function formatRepoWikiPacketJson(packet: RepoWikiPacket): string {
+  return `${canonicalStringify(packet)}\n`;
+}
+
+export function redactRepoWikiText(input: string): { text: string; replacementCount: number } {
+  const text = redactSecrets(input);
+  const replacementCount = countNeedles(text, "[redacted-secret]") - countNeedles(input, "[redacted-secret]");
+  return {
+    text,
+    replacementCount: Math.max(0, replacementCount)
+  };
+}
+
+export function truncateUtf8Bytes(input: string, maxBytes: number): string {
+  if (!Number.isInteger(maxBytes) || maxBytes < 0) throw new Error("maxBytes must be a non-negative integer");
+  if (Buffer.byteLength(input, "utf8") <= maxBytes) return input;
+  let output = "";
+  let used = 0;
+  for (const char of input) {
+    const size = Buffer.byteLength(char, "utf8");
+    if (used + size > maxBytes) break;
+    output += char;
+    used += size;
+  }
+  return output;
+}
+
+function finalizePacket(
+  base: Omit<RepoWikiPacket, "includedSections" | "excludedSections" | "includedFiles" | "packetSha">,
+  includedSections: RepoWikiIncludedSection[],
+  excludedSections: RepoWikiExcludedSection[]
+): RepoWikiPacket {
+  const includedFiles = buildIncludedFiles(includedSections);
+  const withoutSha: Omit<RepoWikiPacket, "packetSha"> = {
+    ...base,
+    includedSections,
+    excludedSections: [...excludedSections].sort(compareExcluded),
+    includedFiles
+  };
+  const packetSha = sha256(canonicalStringify(withoutSha));
+  const packet: RepoWikiPacket = { ...withoutSha, packetSha };
+  const usedBytes = Buffer.byteLength(formatRepoWikiPacketMarkdown(packet), "utf8");
+  const usedTokens = tokenEstimateForBytes(usedBytes);
+  const measuredWithoutSha: Omit<RepoWikiPacket, "packetSha"> = {
+    ...withoutSha,
+    byteBudget: { ...withoutSha.byteBudget, usedBytes },
+    tokenBudget: { ...withoutSha.tokenBudget, usedTokens }
+  };
+  return {
+    ...measuredWithoutSha,
+    packetSha: sha256(canonicalStringify(measuredWithoutSha))
+  };
+}
+
+function buildIncludedFiles(sections: RepoWikiIncludedSection[]): RepoWikiIncludedFile[] {
+  const byPath = new Map<string, Set<string>>();
+  for (const section of sections) {
+    for (const path of section.sourceFiles) {
+      const ids = byPath.get(path) ?? new Set<string>();
+      ids.add(section.id);
+      byPath.set(path, ids);
+    }
+  }
+  return [...byPath.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([path, sectionIds]) => ({ path, sections: [...sectionIds].sort() }));
+}
+
+function normalizeRepo(repo: RepoWikiIdentity): RepoWikiIdentity {
+  return {
+    fullName: repo.fullName,
+    ...(repo.defaultBranch ? { defaultBranch: repo.defaultBranch } : {}),
+    ...(repo.remoteUrl ? { remoteUrl: repo.remoteUrl } : {})
+  };
+}
+
+function normalizeSource(
+  source: RepoWikiSourceFreshness,
+  counter: { count: number }
+): RepoWikiSourceFreshness {
+  const staleReason = source.staleReason ? redactAndCount(source.staleReason, counter).text : undefined;
+  return {
+    ref: source.ref,
+    ...(source.headSha ? { headSha: source.headSha } : {}),
+    ...(source.checkedAt ? { checkedAt: source.checkedAt } : {}),
+    status: source.status,
+    ...(staleReason ? { staleReason } : {})
+  };
+}
+
+function redactAndCount(input: string, counter: { count: number }): { text: string; replacementCount: number } {
+  const result = redactRepoWikiText(input);
+  counter.count += result.replacementCount;
+  return result;
+}
+
+function normalizeSectionId(id: string): string {
+  const normalized = id.trim().toLowerCase().replace(/[^a-z0-9_.-]+/g, "-").replace(/^-+|-+$/g, "");
+  return normalized || "section";
+}
+
+function normalizeText(value: string): string {
+  return value.replace(/\r\n?/g, "\n").trim();
+}
+
+function normalizeSourceFiles(files: string[]): string[] {
+  return [...new Set(files.map((file) => file.trim()).filter(Boolean))].sort();
+}
+
+function compareSections(left: RepoWikiNormalizedSection, right: RepoWikiNormalizedSection): number {
+  if (left.order !== right.order) return left.order - right.order;
+  return left.id.localeCompare(right.id);
+}
+
+function compareExcluded(left: RepoWikiExcludedSection, right: RepoWikiExcludedSection): number {
+  const id = left.id.localeCompare(right.id);
+  return id !== 0 ? id : left.reason.localeCompare(right.reason);
+}
+
+function assertRepoName(repo: string): void {
+  const [owner, name, extra] = repo.split("/");
+  if (extra !== undefined || !owner || !name) throw new Error("repo.fullName must be an owner/repo name");
+  if (!/^[A-Za-z0-9_.-]+$/.test(owner) || !/^[A-Za-z0-9_.-]+$/.test(name)) {
+    throw new Error("repo.fullName must be an owner/repo name");
+  }
+}
+
+function assertBudget(budget: RepoWikiPacketBudgetInput): void {
+  if (!Number.isInteger(budget.maxBytes) || budget.maxBytes < 1) {
+    throw new Error("budget.maxBytes must be a positive integer");
+  }
+  if (budget.maxTokens !== undefined && (!Number.isInteger(budget.maxTokens) || budget.maxTokens < 1)) {
+    throw new Error("budget.maxTokens must be a positive integer");
+  }
+  if (budget.maxSectionBytes !== undefined && (!Number.isInteger(budget.maxSectionBytes) || budget.maxSectionBytes < 1)) {
+    throw new Error("budget.maxSectionBytes must be a positive integer");
+  }
+}
+
+function assertIsoTimestamp(value: string, fieldName: string): void {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed) || new Date(parsed).toISOString() !== value) {
+    throw new Error(`${fieldName} must be a canonical ISO timestamp`);
+  }
+}
+
+function tokenEstimateForBytes(bytes: number): number {
+  return Math.max(1, Math.ceil(bytes / 4));
+}
+
+function countNeedles(input: string, needle: string): number {
+  return input.split(needle).length - 1;
+}
+
+function sha256(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function canonicalStringify(input: unknown): string {
+  return JSON.stringify(sortJson(input));
+}
+
+function sortJson(input: unknown): unknown {
+  if (Array.isArray(input)) return input.map((item) => sortJson(item));
+  if (input && typeof input === "object") {
+    return Object.fromEntries(
+      Object.entries(input)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, value]) => [key, sortJson(value)])
+    );
+  }
+  return input;
+}

--- a/tests/repo-wiki-packet.test.ts
+++ b/tests/repo-wiki-packet.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRepoWikiPacket,
+  formatRepoWikiPacketJson,
+  formatRepoWikiPacketMarkdown,
+  normalizeRepoWikiSections,
+  redactRepoWikiText,
+  truncateUtf8Bytes
+} from "../src/repo-wiki-packet.js";
+
+const generatedAt = "2026-07-04T08:00:00.000Z";
+
+describe("repo wiki packets", () => {
+  it("builds deterministic packet hashes from normalized section order", () => {
+    const common = {
+      repo: {
+        fullName: "electricsheephq/evaos-code-review-bot",
+        defaultBranch: "main",
+        remoteUrl: "https://github.com/electricsheephq/evaos-code-review-bot"
+      },
+      source: {
+        ref: "main",
+        headSha: "02c388056e6b04405bce2e6fe2de74db34db6ba7",
+        checkedAt: generatedAt,
+        status: "fresh" as const
+      },
+      generatedAt,
+      budget: { maxBytes: 12_000, maxTokens: 3_000, maxSectionBytes: 2_000 }
+    };
+    const sections = [
+      section({ id: "tests", title: "Test commands", order: 30, body: "npm run build; npm test" }),
+      section({ id: "architecture", title: "Architecture overview", order: 10, body: "Local-first GitHub App worker." }),
+      section({ id: "entrypoints", title: "Key entrypoints", order: 20, body: "src/cli.ts and src/worker.ts." })
+    ];
+
+    const first = buildRepoWikiPacket({ ...common, sections });
+    const second = buildRepoWikiPacket({ ...common, sections: [...sections].reverse() });
+
+    expect(first.packetSha).toMatch(/^[a-f0-9]{64}$/);
+    expect(second.packetSha).toBe(first.packetSha);
+    expect(first.includedSections.map((included) => included.id)).toEqual([
+      "architecture",
+      "entrypoints",
+      "tests"
+    ]);
+    expect(first.includedFiles.map((file) => file.path)).toEqual([
+      "AGENTS.md",
+      "README.md",
+      "src/cli.ts",
+      "src/worker.ts",
+      "tests/repo-wiki-packet.test.ts"
+    ]);
+  });
+
+  it("caps section text and packet budget deterministically", () => {
+    const packet = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "feature/wiki", status: "fresh" },
+      generatedAt,
+      budget: { maxBytes: 700, maxTokens: 300, maxSectionBytes: 48 },
+      sections: [
+        section({
+          id: "long",
+          title: "Long architecture notes",
+          order: 1,
+          body: "A".repeat(200)
+        }),
+        section({
+          id: "later",
+          title: "Later notes",
+          order: 2,
+          body: "This lower-priority section may be excluded if the packet budget is tight."
+        })
+      ]
+    });
+
+    expect(packet.byteBudget.usedBytes).toBeLessThanOrEqual(packet.byteBudget.maxBytes);
+    expect(packet.tokenBudget.usedTokens).toBeLessThanOrEqual(packet.tokenBudget.maxTokens);
+    expect(packet.includedSections[0]).toMatchObject({
+      id: "long",
+      byteLength: 48,
+      truncated: true
+    });
+    expect(packet.excludedSections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "later", reason: "packet_budget_exceeded" })
+      ])
+    );
+  });
+
+  it("redacts token-like strings from markdown and JSON payloads", () => {
+    const token = "ghp_123456789012345678901234";
+    const packet = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "main", status: "fresh" },
+      generatedAt,
+      budget: { maxBytes: 12_000, maxTokens: 3_000 },
+      sections: [
+        section({
+          id: "security",
+          title: "Security notes",
+          body: `Never paste ${token} into repo wiki context.`
+        })
+      ]
+    });
+    const markdown = formatRepoWikiPacketMarkdown(packet);
+    const json = formatRepoWikiPacketJson(packet);
+
+    expect(packet.redaction.status).toBe("redacted");
+    expect(packet.redaction.replacementCount).toBe(1);
+    expect(markdown).not.toContain(token);
+    expect(json).not.toContain(token);
+    expect(markdown).toContain("[redacted-secret]");
+    expect(JSON.parse(json).packetSha).toBe(packet.packetSha);
+  });
+
+  it("normalizes sections with stable ids, source files, and empty exclusions", () => {
+    const normalized = normalizeRepoWikiSections([
+      section({
+        id: " Zeta ",
+        title: " Zeta ",
+        body: "Uses CRLF\r\nand surrounding whitespace. ",
+        order: 20,
+        sourceFiles: ["src/worker.ts", "src/worker.ts", " README.md "]
+      }),
+      section({ id: "empty", title: "Empty", body: "   ", order: 10 }),
+      section({ id: "alpha", title: "Alpha", body: "Alpha body.", order: 20 })
+    ]);
+
+    expect(normalized.sections.map((section) => section.id)).toEqual(["alpha", "zeta"]);
+    expect(normalized.sections[1]).toMatchObject({
+      title: "Zeta",
+      body: "Uses CRLF\nand surrounding whitespace.",
+      sourceFiles: ["README.md", "src/worker.ts"]
+    });
+    expect(normalized.excluded).toEqual([{ id: "empty", reason: "empty" }]);
+  });
+
+  it("marks stale and missing source context as degraded advisory packets", () => {
+    const stale = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: {
+        ref: "main",
+        headSha: "02c388056e6b04405bce2e6fe2de74db34db6ba7",
+        checkedAt: "2026-07-01T00:00:00.000Z",
+        status: "stale",
+        staleReason: "source generated before current checkout"
+      },
+      generatedAt,
+      budget: { maxBytes: 12_000, maxTokens: 3_000 },
+      sections: [section({ id: "arch", title: "Architecture", body: "Old but useful map." })]
+    });
+    const missing = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "main", status: "missing", staleReason: "repo-memory.md not generated yet" },
+      generatedAt,
+      budget: { maxBytes: 12_000, maxTokens: 3_000 },
+      sections: []
+    });
+
+    expect(stale.degraded).toBe(true);
+    expect(stale.source.status).toBe("stale");
+    expect(formatRepoWikiPacketMarkdown(stale)).toContain("GitHub diff and checkout remain truth");
+    expect(missing.degraded).toBe(true);
+    expect(missing.excludedSections).toContainEqual({ id: "packet:sections", reason: "missing_source" });
+    expect(missing.includedSections).toEqual([]);
+  });
+
+  it("exposes evidence-safe text helpers", () => {
+    expect(truncateUtf8Bytes("ééabc", 3)).toBe("é");
+    expect(redactRepoWikiText("token=abcdefghijklmnop")).toEqual({
+      text: "[redacted-secret]",
+      replacementCount: 1
+    });
+  });
+});
+
+function section(input: {
+  id: string;
+  title: string;
+  body: string;
+  order?: number;
+  sourceFiles?: string[];
+}) {
+  return {
+    id: input.id,
+    title: input.title,
+    body: input.body,
+    order: input.order,
+    sourceFiles: input.sourceFiles ?? ["README.md", "AGENTS.md", "src/worker.ts", "src/cli.ts", "tests/repo-wiki-packet.test.ts"]
+  };
+}

--- a/tests/repo-wiki-packet.test.ts
+++ b/tests/repo-wiki-packet.test.ts
@@ -91,7 +91,10 @@ describe("repo wiki packets", () => {
   it("redacts token-like strings from markdown and JSON payloads", () => {
     const token = "ghp_123456789012345678901234";
     const packet = buildRepoWikiPacket({
-      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      repo: {
+        fullName: "electricsheephq/evaos-code-review-bot",
+        remoteUrl: `https://${token}@github.com/electricsheephq/evaos-code-review-bot.git`
+      },
       source: { ref: "main", status: "fresh" },
       generatedAt,
       budget: { maxBytes: 12_000, maxTokens: 3_000 },
@@ -99,7 +102,8 @@ describe("repo wiki packets", () => {
         section({
           id: "security",
           title: "Security notes",
-          body: `Never paste ${token} into repo wiki context.`
+          body: `Never paste ${token} into repo wiki context.`,
+          sourceFiles: [`docs/person@example.com/${token}.md`, "README.md"]
         })
       ]
     });
@@ -107,11 +111,46 @@ describe("repo wiki packets", () => {
     const json = formatRepoWikiPacketJson(packet);
 
     expect(packet.redaction.status).toBe("redacted");
-    expect(packet.redaction.replacementCount).toBe(1);
+    expect(packet.redaction.replacementCount).toBeGreaterThanOrEqual(4);
+    expect(packet.repo.remoteUrl).toContain("[redacted-secret]");
+    expect(packet.repo.remoteUrl).not.toContain(token);
+    expect(packet.includedSections[0]?.sourceFiles).toContain("README.md");
+    expect(packet.includedSections[0]?.sourceFiles.join("\n")).toContain("[redacted-secret]");
+    expect(packet.includedFiles.map((file) => file.path)).toContain("README.md");
+    expect(packet.includedFiles.map((file) => file.path).join("\n")).toContain("[redacted-secret]");
     expect(markdown).not.toContain(token);
     expect(json).not.toContain(token);
+    expect(markdown).not.toContain("person@example.com");
+    expect(json).not.toContain("person@example.com");
     expect(markdown).toContain("[redacted-secret]");
     expect(JSON.parse(json).packetSha).toBe(packet.packetSha);
+  });
+
+  it("rejects budgets that cannot fit the fixed packet header", () => {
+    expect(() =>
+      buildRepoWikiPacket({
+        repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+        source: { ref: "main", status: "fresh" },
+        generatedAt,
+        budget: { maxBytes: 10, maxTokens: 3 },
+        sections: []
+      })
+    ).toThrow(/fixed packet header exceeds budget/);
+  });
+
+  it("measures final packet size after budget fields stabilize", () => {
+    const packet = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "main", status: "fresh" },
+      generatedAt,
+      budget: { maxBytes: 520, maxTokens: 130 },
+      sections: [section({ id: "tight", title: "Tight", body: "This section must be dropped near the header budget." })]
+    });
+    const markdown = formatRepoWikiPacketMarkdown(packet);
+
+    expect(Buffer.byteLength(markdown, "utf8")).toBe(packet.byteBudget.usedBytes);
+    expect(packet.byteBudget.usedBytes).toBeLessThanOrEqual(packet.byteBudget.maxBytes);
+    expect(packet.tokenBudget.usedTokens).toBeLessThanOrEqual(packet.tokenBudget.maxTokens);
   });
 
   it("normalizes sections with stable ids, source files, and empty exclusions", () => {
@@ -134,6 +173,31 @@ describe("repo wiki packets", () => {
       sourceFiles: ["README.md", "src/worker.ts"]
     });
     expect(normalized.excluded).toEqual([{ id: "empty", reason: "empty" }]);
+  });
+
+  it("makes normalized section ID collisions deterministic across input order", () => {
+    const colliding = [
+      section({ id: "API Docs", title: "Second title", body: "Second body.", order: 10 }),
+      section({ id: "api_docs", title: "First title", body: "First body.", order: 10 })
+    ];
+
+    const first = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "main", status: "fresh" },
+      generatedAt,
+      budget: { maxBytes: 12_000, maxTokens: 3_000 },
+      sections: colliding
+    });
+    const second = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "main", status: "fresh" },
+      generatedAt,
+      budget: { maxBytes: 12_000, maxTokens: 3_000 },
+      sections: [...colliding].reverse()
+    });
+
+    expect(first.packetSha).toBe(second.packetSha);
+    expect(first.includedSections.map((included) => included.id)).toEqual(["api-docs", "api-docs-2"]);
   });
 
   it("marks stale and missing source context as degraded advisory packets", () => {

--- a/tests/repo-wiki-packet.test.ts
+++ b/tests/repo-wiki-packet.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   buildRepoWikiPacket,
@@ -126,6 +127,28 @@ describe("repo wiki packets", () => {
     expect(JSON.parse(json).packetSha).toBe(packet.packetSha);
   });
 
+  it("counts real replacements when input already contains the literal redaction marker", () => {
+    const token = "ghp_123456789012345678901234";
+    const packet = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "main", status: "fresh" },
+      generatedAt,
+      budget: { maxBytes: 12_000, maxTokens: 3_000 },
+      sections: [
+        section({
+          id: "marker",
+          title: "Marker",
+          body: `Document literal [redacted-secret] while scrubbing https://${token}@github.com/[redacted-secret]/repo.git.`
+        })
+      ]
+    });
+
+    expect(packet.redaction.status).toBe("redacted");
+    expect(packet.redaction.replacementCount).toBeGreaterThan(0);
+    expect(packet.includedSections[0]).toMatchObject({ redacted: true });
+    expect(formatRepoWikiPacketMarkdown(packet)).not.toContain(token);
+  });
+
   it("rejects budgets that cannot fit the fixed packet header", () => {
     expect(() =>
       buildRepoWikiPacket({
@@ -151,6 +174,23 @@ describe("repo wiki packets", () => {
     expect(Buffer.byteLength(markdown, "utf8")).toBe(packet.byteBudget.usedBytes);
     expect(packet.byteBudget.usedBytes).toBeLessThanOrEqual(packet.byteBudget.maxBytes);
     expect(packet.tokenBudget.usedTokens).toBeLessThanOrEqual(packet.tokenBudget.maxTokens);
+  });
+
+  it("binds packet byte and token budgets to the markdown emitter only", () => {
+    const packet = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "main", status: "fresh" },
+      generatedAt,
+      budget: { maxBytes: 620, maxTokens: 155 },
+      sections: [section({ id: "json-budget", title: "JSON budget", body: "JSON callers must re-check serialized size." })]
+    });
+    const markdownBytes = Buffer.byteLength(formatRepoWikiPacketMarkdown(packet), "utf8");
+    const jsonBytes = Buffer.byteLength(formatRepoWikiPacketJson(packet), "utf8");
+
+    expect(packet.byteBudget.usedBytes).toBe(markdownBytes);
+    expect(packet.tokenBudget.usedTokens).toBe(Math.ceil(markdownBytes / 4));
+    expect(markdownBytes).toBeLessThanOrEqual(packet.byteBudget.maxBytes);
+    expect(jsonBytes).toBeGreaterThan(packet.byteBudget.maxBytes);
   });
 
   it("normalizes sections with stable ids, source files, and empty exclusions", () => {
@@ -200,6 +240,49 @@ describe("repo wiki packets", () => {
     expect(first.includedSections.map((included) => included.id)).toEqual(["api-docs", "api-docs-2"]);
   });
 
+  it("uses locale-independent code-unit ordering for packet hash inputs", () => {
+    const packet = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "main", status: "fresh" },
+      generatedAt,
+      budget: { maxBytes: 12_000, maxTokens: 3_000 },
+      sections: [
+        section({ id: "same", title: "alpha", body: "lower title", order: 1, sourceFiles: ["a.md"] }),
+        section({ id: "same", title: "Zed", body: "upper title", order: 1, sourceFiles: ["Z.md"] })
+      ]
+    });
+
+    expect(packet.includedSections.map((included) => included.title)).toEqual(["Zed", "alpha"]);
+    expect(packet.includedFiles.map((file) => file.path)).toEqual(["Z.md", "a.md"]);
+  });
+
+  it("hashes canonical packet content without self-referential packetSha", () => {
+    const common = {
+      source: { status: "fresh" as const, ref: "main", checkedAt: generatedAt },
+      generatedAt,
+      budget: { maxBytes: 12_000, maxTokens: 3_000 },
+      sections: [section({ id: "hash", title: "Hash", body: "Stable hash input." })]
+    };
+    const first = buildRepoWikiPacket({
+      ...common,
+      repo: { remoteUrl: "https://github.com/electricsheephq/evaos-code-review-bot", fullName: "electricsheephq/evaos-code-review-bot" }
+    });
+    const second = buildRepoWikiPacket({
+      ...common,
+      repo: { fullName: "electricsheephq/evaos-code-review-bot", remoteUrl: "https://github.com/electricsheephq/evaos-code-review-bot" }
+    });
+    const parsed = JSON.parse(formatRepoWikiPacketJson(first)) as Record<string, unknown>;
+    const packetSha = parsed.packetSha;
+    delete parsed.packetSha;
+
+    expect(first.packetSha).toBe(second.packetSha);
+    expect(packetSha).toBe(first.packetSha);
+    expect(sha256(canonicalStringifyForTest(parsed))).toBe(first.packetSha);
+    expect(Object.keys(JSON.parse(formatRepoWikiPacketJson(first)))).toEqual([...Object.keys(JSON.parse(formatRepoWikiPacketJson(first)))].sort(codeUnitCompare));
+    expect(Object.keys((JSON.parse(formatRepoWikiPacketJson(first)) as { byteBudget: Record<string, unknown> }).byteBudget)).toEqual(["maxBytes", "usedBytes"]);
+    expect(Object.keys((JSON.parse(formatRepoWikiPacketJson(first)) as { tokenBudget: Record<string, unknown> }).tokenBudget)).toEqual(["maxTokens", "usedTokens"]);
+  });
+
   it("marks stale and missing source context as degraded advisory packets", () => {
     const stale = buildRepoWikiPacket({
       repo: { fullName: "electricsheephq/evaos-code-review-bot" },
@@ -236,6 +319,10 @@ describe("repo wiki packets", () => {
       text: "[redacted-secret]",
       replacementCount: 1
     });
+    expect(redactRepoWikiText("-----BEGIN PRIVATE KEY-----\n[redacted-secret]\nabc\n-----END PRIVATE KEY-----")).toEqual({
+      text: "[redacted-secret]",
+      replacementCount: 1
+    });
   });
 });
 
@@ -253,4 +340,30 @@ function section(input: {
     order: input.order,
     sourceFiles: input.sourceFiles ?? ["README.md", "AGENTS.md", "src/worker.ts", "src/cli.ts", "tests/repo-wiki-packet.test.ts"]
   };
+}
+
+function sha256(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function canonicalStringifyForTest(input: unknown): string {
+  return JSON.stringify(sortJsonForTest(input));
+}
+
+function sortJsonForTest(input: unknown): unknown {
+  if (Array.isArray(input)) return input.map((item) => sortJsonForTest(item));
+  if (input && typeof input === "object") {
+    return Object.fromEntries(
+      Object.entries(input)
+        .sort(([left], [right]) => codeUnitCompare(left, right))
+        .map(([key, value]) => [key, sortJsonForTest(value)])
+    );
+  }
+  return input;
+}
+
+function codeUnitCompare(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
 }

--- a/tests/repo-wiki-packet.test.ts
+++ b/tests/repo-wiki-packet.test.ts
@@ -161,6 +161,32 @@ describe("repo wiki packets", () => {
     ).toThrow(/fixed packet header exceeds budget/);
   });
 
+  it("rejects invalid repo names, budgets, timestamps, and byte caps", () => {
+    const validInput = {
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "main", status: "fresh" as const },
+      generatedAt,
+      budget: { maxBytes: 12_000, maxTokens: 3_000, maxSectionBytes: 2_000 },
+      sections: [section({ id: "valid", title: "Valid", body: "Valid packet content." })]
+    };
+
+    expect(() => buildRepoWikiPacket({ ...validInput, repo: { fullName: "owner/repo/extra" } })).toThrow(/repo.fullName/);
+    expect(() => buildRepoWikiPacket({ ...validInput, repo: { fullName: "/repo" } })).toThrow(/repo.fullName/);
+    expect(() => buildRepoWikiPacket({ ...validInput, repo: { fullName: "owner/re_po!" } })).toThrow(/repo.fullName/);
+    expect(() => buildRepoWikiPacket({ ...validInput, budget: { maxBytes: 0 } })).toThrow(/budget.maxBytes/);
+    expect(() => buildRepoWikiPacket({ ...validInput, budget: { maxBytes: 12_000, maxTokens: -1 } })).toThrow(/budget.maxTokens/);
+    expect(() => buildRepoWikiPacket({ ...validInput, budget: { maxBytes: 12_000, maxSectionBytes: 1.5 } })).toThrow(/budget.maxSectionBytes/);
+    expect(() => buildRepoWikiPacket({ ...validInput, generatedAt: "2026-07-04T08:00:00Z" })).toThrow(/generatedAt/);
+    expect(() =>
+      buildRepoWikiPacket({
+        ...validInput,
+        source: { ref: "main", status: "fresh", checkedAt: "2026-07-04T08:00:00Z" }
+      })
+    ).toThrow(/source.checkedAt/);
+    expect(() => truncateUtf8Bytes("abc", -1)).toThrow(/maxBytes/);
+    expect(() => truncateUtf8Bytes("abc", 1.5)).toThrow(/maxBytes/);
+  });
+
   it("measures final packet size after budget fields stabilize", () => {
     const packet = buildRepoWikiPacket({
       repo: { fullName: "electricsheephq/evaos-code-review-bot" },
@@ -277,6 +303,7 @@ describe("repo wiki packets", () => {
 
     expect(first.packetSha).toBe(second.packetSha);
     expect(packetSha).toBe(first.packetSha);
+    expect(packetSha).toMatch(/^[a-f0-9]{64}$/);
     expect(sha256(canonicalStringifyForTest(parsed))).toBe(first.packetSha);
     expect(Object.keys(JSON.parse(formatRepoWikiPacketJson(first)))).toEqual([...Object.keys(JSON.parse(formatRepoWikiPacketJson(first)))].sort(codeUnitCompare));
     expect(Object.keys((JSON.parse(formatRepoWikiPacketJson(first)) as { byteBudget: Record<string, unknown> }).byteBudget)).toEqual(["maxBytes", "usedBytes"]);

--- a/tests/repo-wiki-packet.test.ts
+++ b/tests/repo-wiki-packet.test.ts
@@ -93,10 +93,17 @@ describe("repo wiki packets", () => {
     const token = "ghp_123456789012345678901234";
     const packet = buildRepoWikiPacket({
       repo: {
-        fullName: "electricsheephq/evaos-code-review-bot",
+        fullName: `electricsheephq/${token}`,
+        defaultBranch: `release-${token}`,
         remoteUrl: `https://${token}@github.com/electricsheephq/evaos-code-review-bot.git`
       },
-      source: { ref: "main", status: "fresh" },
+      source: {
+        ref: `refs/heads/${token}`,
+        headSha: token,
+        checkedAt: generatedAt,
+        status: "fresh",
+        staleReason: `stale source mentions ${token}`
+      },
       generatedAt,
       budget: { maxBytes: 12_000, maxTokens: 3_000 },
       sections: [
@@ -112,9 +119,17 @@ describe("repo wiki packets", () => {
     const json = formatRepoWikiPacketJson(packet);
 
     expect(packet.redaction.status).toBe("redacted");
-    expect(packet.redaction.replacementCount).toBeGreaterThanOrEqual(4);
+    expect(packet.redaction.replacementCount).toBeGreaterThanOrEqual(9);
+    expect(packet.repo.fullName).toContain("[redacted-secret]");
+    expect(packet.repo.fullName).not.toContain(token);
+    expect(packet.repo.defaultBranch).toContain("[redacted-secret]");
+    expect(packet.repo.defaultBranch).not.toContain(token);
     expect(packet.repo.remoteUrl).toContain("[redacted-secret]");
     expect(packet.repo.remoteUrl).not.toContain(token);
+    expect(packet.source.ref).toContain("[redacted-secret]");
+    expect(packet.source.ref).not.toContain(token);
+    expect(packet.source.headSha).toBe("[redacted-secret]");
+    expect(packet.source.staleReason).toContain("[redacted-secret]");
     expect(packet.includedSections[0]?.sourceFiles).toContain("README.md");
     expect(packet.includedSections[0]?.sourceFiles.join("\n")).toContain("[redacted-secret]");
     expect(packet.includedFiles.map((file) => file.path)).toContain("README.md");
@@ -125,6 +140,29 @@ describe("repo wiki packets", () => {
     expect(json).not.toContain("person@example.com");
     expect(markdown).toContain("[redacted-secret]");
     expect(JSON.parse(json).packetSha).toBe(packet.packetSha);
+  });
+
+  it("dedupes included files when redaction collapses distinct source paths", () => {
+    const token = "ghp_123456789012345678901234";
+    const packet = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "main", status: "fresh" },
+      generatedAt,
+      budget: { maxBytes: 12_000, maxTokens: 3_000 },
+      sections: [
+        section({ id: "one", title: "One", body: "First body.", sourceFiles: [token] }),
+        section({ id: "two", title: "Two", body: "Second body.", sourceFiles: ["person@example.com"] })
+      ]
+    });
+
+    expect(packet.includedFiles).toContainEqual({
+      path: "[redacted-secret]",
+      sections: ["one", "two"]
+    });
+    expect(packet.includedSections.map((included) => included.sourceFiles)).toEqual([
+      ["[redacted-secret]"],
+      ["[redacted-secret]"]
+    ]);
   });
 
   it("counts real replacements when input already contains the literal redaction marker", () => {
@@ -200,6 +238,24 @@ describe("repo wiki packets", () => {
     expect(Buffer.byteLength(markdown, "utf8")).toBe(packet.byteBudget.usedBytes);
     expect(packet.byteBudget.usedBytes).toBeLessThanOrEqual(packet.byteBudget.maxBytes);
     expect(packet.tokenBudget.usedTokens).toBeLessThanOrEqual(packet.tokenBudget.maxTokens);
+  });
+
+  it("converges packet size at decimal digit boundaries", () => {
+    const base = {
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "main", status: "fresh" as const },
+      generatedAt,
+      sections: [section({ id: "digit-boundary", title: "Digit boundary", body: "x".repeat(80) })]
+    };
+
+    for (let maxBytes = 510; maxBytes <= 620; maxBytes += 1) {
+      const packet = buildRepoWikiPacket({
+        ...base,
+        budget: { maxBytes, maxTokens: 200, maxSectionBytes: 80 }
+      });
+      expect(Buffer.byteLength(formatRepoWikiPacketMarkdown(packet), "utf8")).toBe(packet.byteBudget.usedBytes);
+      expect(packet.byteBudget.usedBytes).toBeLessThanOrEqual(maxBytes);
+    }
   });
 
   it("binds packet byte and token budgets to the markdown emitter only", () => {


### PR DESCRIPTION
## Summary
- add a dry-run/library-only repo wiki packet builder for codebase-map context
- include deterministic packet SHA, repo/source freshness metadata, included sections/files, budgets, redaction result, and degraded stale/missing source mode
- document the advisory/runtime boundary for future review-prompt integration

Closes #122

## Validation
- NODE_OPTIONS=--experimental-sqlite npm test -- tests/repo-wiki-packet.test.ts
- npm run build

## Runtime boundary
- No live worker, CLI, config, walkthrough, or state integration in this MVP.
- GitHub diff/current checkout remain truth; wiki packets are advisory context only.