### PR TITLE
Add deterministic pre-merge checks module

### DIFF
--- a/docs/pre-merge-checks.md
+++ b/docs/pre-merge-checks.md
@@ -1,0 +1,122 @@
+# Pre-Merge Checks
+
+Pre-merge checks are deterministic PR metadata gates that complement model
+findings. They do not inspect code semantically, do not call a model, and do
+not turn uncertainty into `REQUEST_CHANGES`.
+
+The module lives in `src/pre-merge-checks.ts` and is intentionally pure: callers
+pass PR metadata plus a policy object and receive check results, evidence,
+warnings, blocking errors, and the recommended review event.
+
+## Modes
+
+Every check uses one mode:
+
+| Mode | Behavior |
+| --- | --- |
+| `off` | Emits a skipped check and never warns or blocks. |
+| `warning` | Emits a warning on failure and never blocks merge by itself. |
+| `error` | Emits a blocking error on deterministic failure. |
+
+Warning and error results are separate arrays in the evaluation output:
+
+- `warnings`: failed warning-mode checks only.
+- `blockingErrors`: failed error-mode checks and policy validation failures.
+
+Callers should map `blockingErrors.length > 0` to `REQUEST_CHANGES`. Warning
+checks should render as status/walkthrough guidance only.
+
+## Built-In Checks
+
+Built-in checks are enabled only when present in policy:
+
+```ts
+const policy = {
+  title: { mode: "warning", minLength: 8 },
+  description: { mode: "warning", minLength: 20 },
+  linkedIssue: { mode: "error" }
+};
+```
+
+`title` checks for a non-placeholder title with a minimum length and no draft/WIP
+prefix by default.
+
+`description` checks for a non-placeholder PR body with a minimum length.
+
+`linkedIssue` checks structured linked issues, explicit linked issue refs, and
+PR title/body text such as `Closes #118` or `Related: owner/repo#118`.
+
+Each check returns evidence entries with a `key`, `value`, `passed`, and
+optional `detail` field so status rendering can show why a result passed or
+failed.
+
+## Custom Checks
+
+Custom checks use a stable name, deterministic instructions, a mode, and a
+structured matcher:
+
+```ts
+const policy = {
+  customChecks: [
+    {
+      name: "release-notes",
+      mode: "warning",
+      instructions: "Require a Release notes section in the PR description.",
+      match: { source: "description", includes: "Release notes:" }
+    },
+    {
+      name: "focused-test-file",
+      mode: "error",
+      instructions: "Require a focused test file in the changed files.",
+      match: { source: "changed_files", matches: "^tests/.+\\.test\\.ts$" }
+    }
+  ]
+};
+```
+
+Supported matcher sources:
+
+| Source | Values searched |
+| --- | --- |
+| `title` | PR title |
+| `description` | PR body |
+| `title_or_description` | PR title and body |
+| `changed_files` | Changed file paths |
+| `linked_issue_refs` | Normalized linked issue refs |
+
+Supported matcher operators:
+
+- `includes`: case-insensitive substring check.
+- `matches`: JavaScript regular expression.
+
+Custom instructions are descriptive only. The pass/fail decision comes from the
+matcher, not from model judgment or a human-style interpretation of the prose.
+
+## Policy Validation
+
+Use `validatePreMergeCheckPolicy(policy)` before accepting user or repo config.
+Validation rejects:
+
+- custom names outside `^[a-z][a-z0-9-]{1,63}$`
+- duplicate custom names
+- modes outside `off`, `warning`, and `error`
+- empty or invalid matchers
+- invalid regular expressions
+- custom instructions shorter than 12 or longer than 500 characters
+- instructions that delegate pass/fail judgment to a model or vague judgment
+
+`evaluatePreMergeChecks` also validates policy. Invalid policy returns blocking
+`policy_validation:*` results so live integrations fail closed instead of
+silently skipping a broken deterministic gate.
+
+## Integration Hooks
+
+The captain still needs to wire this module into the shared surfaces:
+
+- config/profile parsing for pre-merge check policy
+- walkthrough/status rendering without duplicate status-comment spam
+- worker/review flow mapping of `blockingErrors` to `REQUEST_CHANGES`
+- dry-run evidence output for fixture PRs covering pass, warning, and error
+
+This PR does not touch `src/cli.ts`, `src/config.ts`, `src/worker.ts`, or
+`src/walkthrough.ts`.

--- a/docs/pre-merge-checks.md
+++ b/docs/pre-merge-checks.md
@@ -89,6 +89,10 @@ Supported matcher operators:
 - `includes`: case-insensitive substring check.
 - `matches`: JavaScript regular expression.
 
+Set exactly one matcher operator. A custom check with both `includes` and
+`matches` is rejected during policy validation so operators do not accidentally
+believe both rules are enforced.
+
 Custom instructions are descriptive only. The pass/fail decision comes from the
 matcher, not from model judgment or a human-style interpretation of the prose.
 

--- a/src/pre-merge-checks.ts
+++ b/src/pre-merge-checks.ts
@@ -161,7 +161,7 @@ function evaluateTitleCheck(pull: PreMergePullInput, config: PreMergeTitleCheckC
   const minLength = config.minLength ?? 8;
   const rejectDraftPrefixes = config.rejectDraftPrefixes ?? true;
   const lengthPassed = title.length >= minLength;
-  const draftPassed = !rejectDraftPrefixes || !/^\s*(?:\[?\s*)?(?:wip|draft|tmp|test)(?:\s*\]?|[:\-\s]|$)/i.test(title);
+  const draftPassed = !rejectDraftPrefixes || !isExplicitDraftTitle(title);
   const passed = lengthPassed && draftPassed;
 
   return checkFromOutcome({
@@ -203,8 +203,10 @@ function evaluateDescriptionCheck(pull: PreMergePullInput, config: PreMergeDescr
 function evaluateLinkedIssueCheck(pull: PreMergePullInput, config: PreMergeLinkedIssueCheckConfig): PreMergeCheckResult {
   if (config.mode === "off") return skippedCheck("linked_issue", "Linked issue", config.mode, "Linked issue check is disabled.");
   const refs = collectLinkedIssueRefs(pull);
+  const linkedIssues = collectLinkedIssues(pull);
   const hasRefs = refs.length > 0;
-  const openStatePassed = !config.requireOpen || collectLinkedIssues(pull).every((issue) => !issue.state || issue.state === "OPEN" || issue.state === "open");
+  const openState = evaluateOpenLinkedIssueState(linkedIssues, config.requireOpen === true);
+  const openStatePassed = openState.passed;
   const passed = hasRefs && openStatePassed;
 
   return checkFromOutcome({
@@ -222,9 +224,9 @@ function evaluateLinkedIssueCheck(pull: PreMergePullInput, config: PreMergeLinke
       },
       {
         key: "linked_issue.open_state",
-        value: String(openStatePassed),
+        value: openState.value,
         passed: openStatePassed,
-        detail: config.requireOpen ? "open issue required" : "not required"
+        detail: openState.detail
       }
     ]
   });
@@ -260,8 +262,8 @@ function evaluateMatcher(pull: PreMergePullInput, matcher: PreMergeCustomMatcher
     const passed = values.some((value) => value.toLowerCase().includes(needle));
     return {
       passed,
-      value: passed ? matcher.includes : "not found",
-      detail: `required substring in ${matcher.source}`
+      value: passed ? "matched" : "not_matched",
+      detail: `operator=includes; source=${matcher.source}`
     };
   }
   if (matcher.matches !== undefined) {
@@ -269,11 +271,42 @@ function evaluateMatcher(pull: PreMergePullInput, matcher: PreMergeCustomMatcher
     const matched = values.find((value) => regex.test(value));
     return {
       passed: matched !== undefined,
-      value: matched ?? "not matched",
-      detail: `required regex /${matcher.matches}/ in ${matcher.source}`
+      value: matched !== undefined ? "matched" : "not_matched",
+      detail: `operator=matches; source=${matcher.source}`
     };
   }
-  return { passed: false, value: "no matcher", detail: "custom matcher has no includes or matches rule" };
+  return { passed: false, value: "not_matched", detail: "operator=missing" };
+}
+
+function isExplicitDraftTitle(title: string): boolean {
+  return /^\s*(?:\[(?:wip|draft|tmp)\]|(?:wip|draft|tmp)\s*[:\-]|(?:wip|draft|tmp)$)/i.test(title);
+}
+
+function evaluateOpenLinkedIssueState(
+  linkedIssues: PreMergeLinkedIssue[],
+  requireOpen: boolean
+): { passed: boolean; value: string; detail: string } {
+  if (!requireOpen) return { passed: true, value: "not_required", detail: "open issue state is not required" };
+  if (linkedIssues.length === 0) {
+    return {
+      passed: false,
+      value: "not_applicable",
+      detail: "open issue state requires structured linked issue metadata"
+    };
+  }
+
+  const states = linkedIssues.map((issue) => normalizeIssueState(issue.state));
+  const passed = states.every((state) => state === "open");
+  return {
+    passed,
+    value: passed ? "open" : [...new Set(states)].join(","),
+    detail: "open issue required"
+  };
+}
+
+function normalizeIssueState(state: string | undefined): string {
+  if (!state?.trim()) return "unknown";
+  return state.trim().toLowerCase();
 }
 
 function valuesForMatcherSource(pull: PreMergePullInput, source: PreMergeCustomMatchSource): string[] {
@@ -443,6 +476,9 @@ function validateMatcher(
   }
   if (matcher.includes === undefined && matcher.matches === undefined) {
     errors.push({ check, field: "match", message: "Custom match requires includes or matches." });
+  }
+  if (matcher.includes !== undefined && matcher.matches !== undefined) {
+    errors.push({ check, field: "match", message: "Custom match must set exactly one of includes or matches." });
   }
   if (matcher.includes !== undefined && matcher.includes.trim().length === 0) {
     errors.push({ check, field: "match.includes", message: "includes must not be empty." });

--- a/src/pre-merge-checks.ts
+++ b/src/pre-merge-checks.ts
@@ -106,6 +106,7 @@ export interface PreMergeCheckEvaluation {
 const CUSTOM_NAME_PATTERN = /^[a-z][a-z0-9-]{1,63}$/;
 const NON_DETERMINISTIC_INSTRUCTION_PATTERN =
   /\b(ask\s+(?:the\s+)?(?:model|llm)|model\s+(?:should|must|can)|llm|ai\s+judg|judge\s+whether|best\s+judg(?:e)?ment|probably|seems\s+safe|looks\s+safe)\b/i;
+const MAX_CUSTOM_REGEX_INPUT_CHARS = 2048;
 
 export function evaluatePreMergeChecks(input: {
   pull: PreMergePullInput;
@@ -114,7 +115,7 @@ export function evaluatePreMergeChecks(input: {
   const validation = validatePreMergeCheckPolicy(input.policy);
   if (!validation.ok) {
     const blockingErrors = validation.errors.map(validationErrorToCheck);
-    return summarizeChecks([...skippedChecksForOffModes(input.policy), ...blockingErrors], validation);
+    return summarizeChecks([...skippedChecksForInvalidPolicy(input.policy), ...blockingErrors], validation);
   }
 
   const checks: PreMergeCheckResult[] = [];
@@ -268,11 +269,11 @@ function evaluateMatcher(pull: PreMergePullInput, matcher: PreMergeCustomMatcher
   }
   if (matcher.matches !== undefined) {
     const regex = new RegExp(matcher.matches);
-    const matched = values.find((value) => regex.test(value));
+    const matched = values.find((value) => regex.test(capCustomRegexInput(value)));
     return {
       passed: matched !== undefined,
       value: matched !== undefined ? "matched" : "not_matched",
-      detail: `operator=matches; source=${matcher.source}`
+      detail: `operator=matches; source=${matcher.source}; max_input_chars=${MAX_CUSTOM_REGEX_INPUT_CHARS}`
     };
   }
   return { passed: false, value: "not_matched", detail: "operator=missing" };
@@ -419,6 +420,35 @@ function skippedChecksForOffModes(policy: PreMergeCheckPolicy): PreMergeCheckRes
   return checks;
 }
 
+function skippedChecksForInvalidPolicy(policy: PreMergeCheckPolicy): PreMergeCheckResult[] {
+  const checks: PreMergeCheckResult[] = [];
+  if (policy.title) {
+    checks.push(skippedCheck("title", "Title", policy.title.mode, skippedForInvalidPolicySummary("Title", policy.title.mode)));
+  }
+  if (policy.description) {
+    checks.push(skippedCheck("description", "Description", policy.description.mode, skippedForInvalidPolicySummary("Description", policy.description.mode)));
+  }
+  if (policy.linkedIssue) {
+    checks.push(skippedCheck("linked_issue", "Linked issue", policy.linkedIssue.mode, skippedForInvalidPolicySummary("Linked issue", policy.linkedIssue.mode)));
+  }
+  for (const custom of policy.customChecks ?? []) {
+    checks.push(
+      skippedCheck(
+        `custom:${custom.name}`,
+        custom.name,
+        custom.mode,
+        skippedForInvalidPolicySummary(`Custom check ${custom.name}`, custom.mode),
+        custom.instructions
+      )
+    );
+  }
+  return checks;
+}
+
+function skippedForInvalidPolicySummary(name: string, mode: PreMergeCheckMode): string {
+  return mode === "off" ? `${name} check is disabled.` : `${name} check was not evaluated because policy validation failed.`;
+}
+
 function validateMode(
   check: string,
   mode: unknown,
@@ -488,6 +518,14 @@ function validateMatcher(
       new RegExp(matcher.matches);
     } catch {
       errors.push({ check, field: "match.matches", message: "matches must be a valid JavaScript regular expression." });
+      return;
+    }
+    if (isPotentiallyUnsafeRegex(matcher.matches)) {
+      errors.push({
+        check,
+        field: "match.matches",
+        message: "matches must avoid nested quantifiers, quantified alternation groups, backreferences, and lookaround assertions."
+      });
     }
   }
 }
@@ -534,4 +572,27 @@ function normalizeIssueRef(ref: string): string | undefined {
 
 function normalizeText(text: string | null | undefined): string {
   return (text ?? "").replace(/\s+/g, " ").trim();
+}
+
+function capCustomRegexInput(value: string): string {
+  return value.length > MAX_CUSTOM_REGEX_INPUT_CHARS ? value.slice(0, MAX_CUSTOM_REGEX_INPUT_CHARS) : value;
+}
+
+function isPotentiallyUnsafeRegex(pattern: string): boolean {
+  const stripped = stripEscapedRegexCharacters(pattern);
+  if (/\\[1-9]/.test(pattern)) return true;
+  if (/\(\?<([=!]|!)/.test(pattern) || /\(\?[=!]/.test(pattern)) return true;
+  return hasNestedQuantifiedGroup(stripped) || hasQuantifiedAlternationGroup(stripped);
+}
+
+function stripEscapedRegexCharacters(pattern: string): string {
+  return pattern.replace(/\\./g, "");
+}
+
+function hasNestedQuantifiedGroup(pattern: string): boolean {
+  return /\((?:[^()]|\([^()]*\))*[*+][^()]*\)(?:[*+]|\{\d+(?:,\d*)?\})/.test(pattern);
+}
+
+function hasQuantifiedAlternationGroup(pattern: string): boolean {
+  return /\([^()]*\|[^()]*\)(?:[*+]|\{\d+(?:,\d*)?\})/.test(pattern);
 }

--- a/src/pre-merge-checks.ts
+++ b/src/pre-merge-checks.ts
@@ -1,0 +1,501 @@
+export type PreMergeCheckMode = "off" | "warning" | "error";
+export type PreMergeCheckStatus = "pass" | "warning" | "fail" | "skipped";
+export type PreMergeReviewEvent = "COMMENT" | "REQUEST_CHANGES";
+
+export interface PreMergeLinkedIssue {
+  number?: number;
+  ref?: string;
+  url?: string;
+  state?: string;
+}
+
+export type PreMergeLinkedIssueInput = number | string | PreMergeLinkedIssue;
+
+export interface PreMergePullInput {
+  title?: string | null;
+  body?: string | null;
+  linkedIssues?: PreMergeLinkedIssueInput[];
+  linkedIssueRefs?: string[];
+  changedFiles?: string[];
+}
+
+export interface PreMergeBuiltInCheckConfig {
+  mode: PreMergeCheckMode;
+}
+
+export interface PreMergeTitleCheckConfig extends PreMergeBuiltInCheckConfig {
+  minLength?: number;
+  rejectDraftPrefixes?: boolean;
+}
+
+export interface PreMergeDescriptionCheckConfig extends PreMergeBuiltInCheckConfig {
+  minLength?: number;
+}
+
+export interface PreMergeLinkedIssueCheckConfig extends PreMergeBuiltInCheckConfig {
+  requireOpen?: boolean;
+}
+
+export type PreMergeCustomMatchSource = "title" | "description" | "title_or_description" | "changed_files" | "linked_issue_refs";
+
+export interface PreMergeCustomMatcher {
+  source: PreMergeCustomMatchSource;
+  includes?: string;
+  matches?: string;
+}
+
+export interface PreMergeCustomCheckConfig {
+  name: string;
+  mode: PreMergeCheckMode;
+  instructions: string;
+  match: PreMergeCustomMatcher;
+}
+
+export interface PreMergeCheckPolicy {
+  title?: PreMergeTitleCheckConfig;
+  description?: PreMergeDescriptionCheckConfig;
+  linkedIssue?: PreMergeLinkedIssueCheckConfig;
+  customChecks?: PreMergeCustomCheckConfig[];
+}
+
+export interface PreMergeCheckEvidence {
+  key: string;
+  value: string;
+  passed: boolean;
+  detail?: string;
+}
+
+export interface PreMergeCheckResult {
+  id: string;
+  name: string;
+  mode: PreMergeCheckMode;
+  status: PreMergeCheckStatus;
+  blocking: boolean;
+  summary: string;
+  evidence: PreMergeCheckEvidence[];
+  instructions?: string;
+}
+
+export interface PreMergePolicyValidationError {
+  check: string;
+  field: string;
+  message: string;
+}
+
+export interface PreMergePolicyValidationResult {
+  ok: boolean;
+  errors: PreMergePolicyValidationError[];
+}
+
+export interface PreMergeCheckEvaluation {
+  ok: boolean;
+  reviewEvent: PreMergeReviewEvent;
+  checks: PreMergeCheckResult[];
+  warnings: PreMergeCheckResult[];
+  blockingErrors: PreMergeCheckResult[];
+  summary: {
+    total: number;
+    passed: number;
+    warnings: number;
+    blockingErrors: number;
+    skipped: number;
+  };
+  validation: PreMergePolicyValidationResult;
+}
+
+const CUSTOM_NAME_PATTERN = /^[a-z][a-z0-9-]{1,63}$/;
+const NON_DETERMINISTIC_INSTRUCTION_PATTERN =
+  /\b(ask\s+(?:the\s+)?(?:model|llm)|model\s+(?:should|must|can)|llm|ai\s+judg|judge\s+whether|best\s+judg(?:e)?ment|probably|seems\s+safe|looks\s+safe)\b/i;
+
+export function evaluatePreMergeChecks(input: {
+  pull: PreMergePullInput;
+  policy: PreMergeCheckPolicy;
+}): PreMergeCheckEvaluation {
+  const validation = validatePreMergeCheckPolicy(input.policy);
+  if (!validation.ok) {
+    const blockingErrors = validation.errors.map(validationErrorToCheck);
+    return summarizeChecks([...skippedChecksForOffModes(input.policy), ...blockingErrors], validation);
+  }
+
+  const checks: PreMergeCheckResult[] = [];
+  if (input.policy.title) checks.push(evaluateTitleCheck(input.pull, input.policy.title));
+  if (input.policy.description) checks.push(evaluateDescriptionCheck(input.pull, input.policy.description));
+  if (input.policy.linkedIssue) checks.push(evaluateLinkedIssueCheck(input.pull, input.policy.linkedIssue));
+  for (const custom of input.policy.customChecks ?? []) checks.push(evaluateCustomCheck(input.pull, custom));
+  return summarizeChecks(checks, validation);
+}
+
+export function validatePreMergeCheckPolicy(policy: PreMergeCheckPolicy): PreMergePolicyValidationResult {
+  const errors: PreMergePolicyValidationError[] = [];
+  validateMode("title", policy.title?.mode, errors, policy.title !== undefined);
+  validateMode("description", policy.description?.mode, errors, policy.description !== undefined);
+  validateMode("linked_issue", policy.linkedIssue?.mode, errors, policy.linkedIssue !== undefined);
+  validatePositiveInteger("title", "minLength", policy.title?.minLength, errors);
+  validatePositiveInteger("description", "minLength", policy.description?.minLength, errors);
+
+  const seenCustomNames = new Set<string>();
+  for (const custom of policy.customChecks ?? []) {
+    const check = `custom:${custom.name}`;
+    validateMode(check, custom.mode, errors, true);
+    if (!CUSTOM_NAME_PATTERN.test(custom.name)) {
+      errors.push({
+        check,
+        field: "name",
+        message: "Custom check names must match /^[a-z][a-z0-9-]{1,63}$/."
+      });
+    }
+    if (seenCustomNames.has(custom.name)) {
+      errors.push({ check, field: "name", message: "Custom check names must be unique." });
+    }
+    seenCustomNames.add(custom.name);
+    validateInstructions(check, custom.instructions, errors);
+    validateMatcher(check, custom.match, errors);
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+function evaluateTitleCheck(pull: PreMergePullInput, config: PreMergeTitleCheckConfig): PreMergeCheckResult {
+  if (config.mode === "off") return skippedCheck("title", "Title", config.mode, "Title check is disabled.");
+  const title = normalizeText(pull.title);
+  const minLength = config.minLength ?? 8;
+  const rejectDraftPrefixes = config.rejectDraftPrefixes ?? true;
+  const lengthPassed = title.length >= minLength;
+  const draftPassed = !rejectDraftPrefixes || !/^\s*(?:\[?\s*)?(?:wip|draft|tmp|test)(?:\s*\]?|[:\-\s]|$)/i.test(title);
+  const passed = lengthPassed && draftPassed;
+
+  return checkFromOutcome({
+    id: "title",
+    name: "Title",
+    mode: config.mode,
+    passed,
+    passSummary: "PR title is specific enough for pre-merge review.",
+    failSummary: "PR title is missing, too short, or still marked as draft/WIP.",
+    evidence: [
+      { key: "title.length", value: String(title.length), passed: lengthPassed, detail: `minimum ${minLength}` },
+      { key: "title.not_draft_prefix", value: String(draftPassed), passed: draftPassed }
+    ]
+  });
+}
+
+function evaluateDescriptionCheck(pull: PreMergePullInput, config: PreMergeDescriptionCheckConfig): PreMergeCheckResult {
+  if (config.mode === "off") return skippedCheck("description", "Description", config.mode, "Description check is disabled.");
+  const body = normalizeText(pull.body);
+  const minLength = config.minLength ?? 20;
+  const lengthPassed = body.length >= minLength;
+  const placeholderPassed = !/^\s*(?:n\/a|none|todo|tbd|placeholder|tiny\.?)\s*$/i.test(body);
+  const passed = lengthPassed && placeholderPassed;
+
+  return checkFromOutcome({
+    id: "description",
+    name: "Description",
+    mode: config.mode,
+    passed,
+    passSummary: "PR description contains enough deterministic context.",
+    failSummary: "PR description is missing, placeholder-only, or too short.",
+    evidence: [
+      { key: "description.length", value: String(body.length), passed: lengthPassed, detail: `minimum ${minLength}` },
+      { key: "description.not_placeholder", value: String(placeholderPassed), passed: placeholderPassed }
+    ]
+  });
+}
+
+function evaluateLinkedIssueCheck(pull: PreMergePullInput, config: PreMergeLinkedIssueCheckConfig): PreMergeCheckResult {
+  if (config.mode === "off") return skippedCheck("linked_issue", "Linked issue", config.mode, "Linked issue check is disabled.");
+  const refs = collectLinkedIssueRefs(pull);
+  const hasRefs = refs.length > 0;
+  const openStatePassed = !config.requireOpen || collectLinkedIssues(pull).every((issue) => !issue.state || issue.state === "OPEN" || issue.state === "open");
+  const passed = hasRefs && openStatePassed;
+
+  return checkFromOutcome({
+    id: "linked_issue",
+    name: "Linked issue",
+    mode: config.mode,
+    passed,
+    passSummary: "PR metadata links to an issue with deterministic evidence.",
+    failSummary: "PR metadata does not link to an issue required by policy.",
+    evidence: [
+      {
+        key: "linked_issue.references",
+        value: refs.length > 0 ? refs.join(", ") : "none",
+        passed: hasRefs
+      },
+      {
+        key: "linked_issue.open_state",
+        value: String(openStatePassed),
+        passed: openStatePassed,
+        detail: config.requireOpen ? "open issue required" : "not required"
+      }
+    ]
+  });
+}
+
+function evaluateCustomCheck(pull: PreMergePullInput, custom: PreMergeCustomCheckConfig): PreMergeCheckResult {
+  const id = `custom:${custom.name}`;
+  if (custom.mode === "off") return skippedCheck(id, custom.name, custom.mode, "Custom check is disabled.", custom.instructions);
+  const match = evaluateMatcher(pull, custom.match);
+  return checkFromOutcome({
+    id,
+    name: custom.name,
+    mode: custom.mode,
+    passed: match.passed,
+    passSummary: `Custom check ${custom.name} passed.`,
+    failSummary: `Custom check ${custom.name} did not find the required deterministic evidence.`,
+    evidence: [
+      {
+        key: `custom.${custom.name}.${custom.match.source}`,
+        value: match.value,
+        passed: match.passed,
+        detail: match.detail
+      }
+    ],
+    instructions: custom.instructions
+  });
+}
+
+function evaluateMatcher(pull: PreMergePullInput, matcher: PreMergeCustomMatcher): { passed: boolean; value: string; detail: string } {
+  const values = valuesForMatcherSource(pull, matcher.source);
+  if (matcher.includes !== undefined) {
+    const needle = matcher.includes.toLowerCase();
+    const passed = values.some((value) => value.toLowerCase().includes(needle));
+    return {
+      passed,
+      value: passed ? matcher.includes : "not found",
+      detail: `required substring in ${matcher.source}`
+    };
+  }
+  if (matcher.matches !== undefined) {
+    const regex = new RegExp(matcher.matches);
+    const matched = values.find((value) => regex.test(value));
+    return {
+      passed: matched !== undefined,
+      value: matched ?? "not matched",
+      detail: `required regex /${matcher.matches}/ in ${matcher.source}`
+    };
+  }
+  return { passed: false, value: "no matcher", detail: "custom matcher has no includes or matches rule" };
+}
+
+function valuesForMatcherSource(pull: PreMergePullInput, source: PreMergeCustomMatchSource): string[] {
+  if (source === "title") return [normalizeText(pull.title)];
+  if (source === "description") return [normalizeText(pull.body)];
+  if (source === "title_or_description") return [normalizeText(pull.title), normalizeText(pull.body)];
+  if (source === "changed_files") return pull.changedFiles ?? [];
+  return collectLinkedIssueRefs(pull);
+}
+
+function checkFromOutcome(input: {
+  id: string;
+  name: string;
+  mode: Exclude<PreMergeCheckMode, "off">;
+  passed: boolean;
+  passSummary: string;
+  failSummary: string;
+  evidence: PreMergeCheckEvidence[];
+  instructions?: string;
+}): PreMergeCheckResult {
+  if (input.passed) {
+    return {
+      id: input.id,
+      name: input.name,
+      mode: input.mode,
+      status: "pass",
+      blocking: false,
+      summary: input.passSummary,
+      evidence: input.evidence,
+      instructions: input.instructions
+    };
+  }
+  return {
+    id: input.id,
+    name: input.name,
+    mode: input.mode,
+    status: input.mode === "error" ? "fail" : "warning",
+    blocking: input.mode === "error",
+    summary: input.failSummary,
+    evidence: input.evidence,
+    instructions: input.instructions
+  };
+}
+
+function skippedCheck(
+  id: string,
+  name: string,
+  mode: PreMergeCheckMode,
+  summary: string,
+  instructions?: string
+): PreMergeCheckResult {
+  return {
+    id,
+    name,
+    mode,
+    status: "skipped",
+    blocking: false,
+    summary,
+    evidence: [{ key: "mode", value: mode, passed: true }],
+    instructions
+  };
+}
+
+function summarizeChecks(
+  checks: PreMergeCheckResult[],
+  validation: PreMergePolicyValidationResult
+): PreMergeCheckEvaluation {
+  const warnings = checks.filter((check) => check.status === "warning");
+  const blockingErrors = checks.filter((check) => check.blocking);
+  return {
+    ok: blockingErrors.length === 0,
+    reviewEvent: blockingErrors.length === 0 ? "COMMENT" : "REQUEST_CHANGES",
+    checks,
+    warnings,
+    blockingErrors,
+    summary: {
+      total: checks.length,
+      passed: checks.filter((check) => check.status === "pass").length,
+      warnings: warnings.length,
+      blockingErrors: blockingErrors.length,
+      skipped: checks.filter((check) => check.status === "skipped").length
+    },
+    validation
+  };
+}
+
+function validationErrorToCheck(error: PreMergePolicyValidationError): PreMergeCheckResult {
+  return {
+    id: `policy_validation:${error.check}:${error.field}`,
+    name: "Policy validation",
+    mode: "error",
+    status: "fail",
+    blocking: true,
+    summary: error.message,
+    evidence: [
+      { key: "policy.check", value: error.check, passed: false },
+      { key: "policy.field", value: error.field, passed: false }
+    ]
+  };
+}
+
+function skippedChecksForOffModes(policy: PreMergeCheckPolicy): PreMergeCheckResult[] {
+  const checks: PreMergeCheckResult[] = [];
+  if (policy.title?.mode === "off") checks.push(skippedCheck("title", "Title", "off", "Title check is disabled."));
+  if (policy.description?.mode === "off") checks.push(skippedCheck("description", "Description", "off", "Description check is disabled."));
+  if (policy.linkedIssue?.mode === "off") checks.push(skippedCheck("linked_issue", "Linked issue", "off", "Linked issue check is disabled."));
+  for (const custom of policy.customChecks ?? []) {
+    if (custom.mode === "off") checks.push(skippedCheck(`custom:${custom.name}`, custom.name, "off", "Custom check is disabled.", custom.instructions));
+  }
+  return checks;
+}
+
+function validateMode(
+  check: string,
+  mode: unknown,
+  errors: PreMergePolicyValidationError[],
+  present: boolean
+): void {
+  if (!present) return;
+  if (mode !== "off" && mode !== "warning" && mode !== "error") {
+    errors.push({ check, field: "mode", message: "Mode must be one of: off, warning, error." });
+  }
+}
+
+function validatePositiveInteger(
+  check: string,
+  field: string,
+  value: unknown,
+  errors: PreMergePolicyValidationError[]
+): void {
+  if (value === undefined) return;
+  if (!Number.isInteger(value) || Number(value) < 1) {
+    errors.push({ check, field, message: `${field} must be a positive integer when provided.` });
+  }
+}
+
+function validateInstructions(
+  check: string,
+  instructions: unknown,
+  errors: PreMergePolicyValidationError[]
+): void {
+  if (typeof instructions !== "string" || instructions.trim().length < 12 || instructions.trim().length > 500) {
+    errors.push({ check, field: "instructions", message: "Instructions must be 12 to 500 characters." });
+    return;
+  }
+  if (NON_DETERMINISTIC_INSTRUCTION_PATTERN.test(instructions)) {
+    errors.push({
+      check,
+      field: "instructions",
+      message: "Instructions must be deterministic and must not delegate pass/fail judgment to a model."
+    });
+  }
+}
+
+function validateMatcher(
+  check: string,
+  matcher: PreMergeCustomMatcher,
+  errors: PreMergePolicyValidationError[]
+): void {
+  const validSources: PreMergeCustomMatchSource[] = ["title", "description", "title_or_description", "changed_files", "linked_issue_refs"];
+  if (!matcher || typeof matcher !== "object") {
+    errors.push({ check, field: "match", message: "Custom checks require a deterministic match rule." });
+    return;
+  }
+  if (!validSources.includes(matcher.source)) {
+    errors.push({ check, field: "match.source", message: `Match source must be one of: ${validSources.join(", ")}.` });
+  }
+  if (matcher.includes === undefined && matcher.matches === undefined) {
+    errors.push({ check, field: "match", message: "Custom match requires includes or matches." });
+  }
+  if (matcher.includes !== undefined && matcher.includes.trim().length === 0) {
+    errors.push({ check, field: "match.includes", message: "includes must not be empty." });
+  }
+  if (matcher.matches !== undefined) {
+    try {
+      new RegExp(matcher.matches);
+    } catch {
+      errors.push({ check, field: "match.matches", message: "matches must be a valid JavaScript regular expression." });
+    }
+  }
+}
+
+function collectLinkedIssueRefs(pull: PreMergePullInput): string[] {
+  const refs = new Set<string>();
+  for (const ref of pull.linkedIssueRefs ?? []) {
+    const normalized = normalizeIssueRef(ref);
+    if (normalized) refs.add(normalized);
+  }
+  for (const issue of collectLinkedIssues(pull)) {
+    const normalized = normalizeIssueRef(issue.ref ?? issue.url ?? (issue.number ? `#${issue.number}` : ""));
+    if (normalized) refs.add(normalized);
+  }
+  for (const ref of refsFromText(`${pull.title ?? ""}\n${pull.body ?? ""}`)) refs.add(ref);
+  return [...refs].sort();
+}
+
+function collectLinkedIssues(pull: PreMergePullInput): PreMergeLinkedIssue[] {
+  return (pull.linkedIssues ?? []).map((issue) => {
+    if (typeof issue === "number") return { number: issue, ref: `#${issue}` };
+    if (typeof issue === "string") return { ref: issue };
+    return issue;
+  });
+}
+
+function refsFromText(text: string): string[] {
+  const refs = new Set<string>();
+  const pattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|relate[sd]?|refs?|issue)\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)\b/gi;
+  for (const match of text.matchAll(pattern)) {
+    if (match[1]) refs.add(`#${match[1]}`);
+  }
+  return [...refs];
+}
+
+function normalizeIssueRef(ref: string): string | undefined {
+  const trimmed = ref.trim();
+  if (!trimmed) return undefined;
+  const issueNumber = trimmed.match(/#(\d+)\b/);
+  if (issueNumber?.[1]) return `#${issueNumber[1]}`;
+  if (/^\d+$/.test(trimmed)) return `#${trimmed}`;
+  return trimmed;
+}
+
+function normalizeText(text: string | null | undefined): string {
+  return (text ?? "").replace(/\s+/g, " ").trim();
+}

--- a/tests/pre-merge-checks.test.ts
+++ b/tests/pre-merge-checks.test.ts
@@ -133,6 +133,28 @@ describe("pre-merge checks", () => {
         expect.objectContaining({ key: "linked_issue.open_state", value: "closed", passed: false })
       ])
     );
+
+    const mixedIssues = evaluatePreMergeChecks({
+      pull: {
+        title: "Add pre-merge checks",
+        body: "Validation: focused tests passed.",
+        linkedIssues: [
+          { number: 42, state: "open" },
+          { number: 43, state: "closed" }
+        ]
+      },
+      policy: {
+        linkedIssue: { mode: "error", requireOpen: true }
+      }
+    });
+
+    expect(mixedIssues.ok).toBe(false);
+    expect(mixedIssues.checks.find((check) => check.id === "linked_issue")?.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "linked_issue.references", value: "#42, #43", passed: true }),
+        expect.objectContaining({ key: "linked_issue.open_state", value: "open,closed", passed: false })
+      ])
+    );
   });
 
   it("evaluates custom checks with deterministic matchers", () => {
@@ -175,6 +197,88 @@ describe("pre-merge checks", () => {
       status: "pass",
       blocking: false
     });
+  });
+
+  it("supports title_or_description and normalized linked issue refs", () => {
+    const result = evaluatePreMergeChecks({
+      pull: {
+        title: "Add runtime policy",
+        body: "Closes electricsheephq/evaos-code-review-bot#118 and refs #123.",
+        linkedIssueRefs: ["100yenadmin/evaOS-GUI#497", "456"],
+        changedFiles: ["src/pre-merge-checks.ts"]
+      },
+      policy: {
+        linkedIssue: { mode: "error" },
+        customChecks: [
+          {
+            name: "runtime-wording",
+            mode: "error",
+            instructions: "Require runtime wording in the title or description.",
+            match: { source: "title_or_description", includes: "runtime" }
+          },
+          {
+            name: "tracked-issue",
+            mode: "error",
+            instructions: "Require a deterministic linked issue reference.",
+            match: { source: "linked_issue_refs", includes: "#497" }
+          }
+        ]
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.checks.find((check) => check.id === "linked_issue")?.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "linked_issue.references", value: "#118, #123, #456, #497", passed: true })
+      ])
+    );
+    expect(result.checks.find((check) => check.id === "custom:runtime-wording")).toMatchObject({ status: "pass" });
+    expect(result.checks.find((check) => check.id === "custom:tracked-issue")).toMatchObject({ status: "pass" });
+  });
+
+  it("honors draft-prefix opt-out and title minLength boundaries", () => {
+    const atMinimum = evaluatePreMergeChecks({
+      pull: { title: "Draft: okay", body: "Closes #42", linkedIssues: [42] },
+      policy: { title: { mode: "error", minLength: 11, rejectDraftPrefixes: false } }
+    });
+    const oneBelow = evaluatePreMergeChecks({
+      pull: { title: "Draft: bad", body: "Closes #42", linkedIssues: [42] },
+      policy: { title: { mode: "error", minLength: 11, rejectDraftPrefixes: false } }
+    });
+
+    expect(atMinimum.ok).toBe(true);
+    expect(atMinimum.checks.find((check) => check.id === "title")?.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "title.length", value: "11", passed: true }),
+        expect.objectContaining({ key: "title.not_draft_prefix", value: "true", passed: true })
+      ])
+    );
+    expect(oneBelow.ok).toBe(false);
+    expect(oneBelow.checks.find((check) => check.id === "title")?.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "title.length", value: "10", passed: false })
+      ])
+    );
+  });
+
+  it("blocks explicit wip draft and tmp title prefixes", () => {
+    for (const title of ["[wip] Add pre-merge checks", "draft: Add pre-merge checks", "tmp- Add pre-merge checks"]) {
+      const result = evaluatePreMergeChecks({
+        pull: {
+          title,
+          body: "Closes #42\n\nValidation: focused tests passed.",
+          linkedIssues: [42]
+        },
+        policy: { title: { mode: "error" } }
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.checks.find((check) => check.id === "title")?.evidence).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ key: "title.not_draft_prefix", value: "false", passed: false })
+        ])
+      );
+    }
   });
 
   it("does not echo raw PR title body or changed-file values in custom matcher evidence", () => {
@@ -282,5 +386,93 @@ describe("pre-merge checks", () => {
         expect.objectContaining({ check: "custom:ambiguous-match", field: "match" })
       ])
     );
+  });
+
+  it("rejects unsafe custom regex patterns and caps regex input evidence", () => {
+    const validation = validatePreMergeCheckPolicy({
+      customChecks: [
+        {
+          name: "nested-quantifier",
+          mode: "warning",
+          instructions: "Require safe deterministic regex patterns.",
+          match: { source: "description", matches: "^(a+)+$" }
+        },
+        {
+          name: "alternation-loop",
+          mode: "warning",
+          instructions: "Require safe deterministic regex patterns.",
+          match: { source: "description", matches: "(a|a)*b" }
+        }
+      ]
+    });
+
+    expect(validation.ok).toBe(false);
+    expect(validation.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ check: "custom:nested-quantifier", field: "match.matches" }),
+        expect.objectContaining({ check: "custom:alternation-loop", field: "match.matches" })
+      ])
+    );
+
+    const result = evaluatePreMergeChecks({
+      pull: { body: `${"a".repeat(3000)}MATCH_AT_END` },
+      policy: {
+        customChecks: [
+          {
+            name: "capped-body",
+            mode: "warning",
+            instructions: "Require bounded regex input when evaluating descriptions.",
+            match: { source: "description", matches: "MATCH_AT_END$" }
+          }
+        ]
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.checks.find((check) => check.id === "custom:capped-body")).toMatchObject({
+      status: "warning",
+      evidence: [
+        expect.objectContaining({
+          value: "not_matched",
+          detail: "operator=matches; source=description; max_input_chars=2048"
+        })
+      ]
+    });
+  });
+
+  it("keeps configured checks visible when policy validation fails", () => {
+    const result = evaluatePreMergeChecks({
+      pull: {
+        title: "Add pre-merge checks",
+        body: "Closes #42\n\nValidation: focused tests passed.",
+        linkedIssues: [{ number: 42, state: "open" }]
+      },
+      policy: {
+        title: { mode: "error", minLength: 0 },
+        description: { mode: "warning" },
+        linkedIssue: { mode: "error", requireOpen: true },
+        customChecks: [
+          {
+            name: "body-marker",
+            mode: "warning",
+            instructions: "Require release notes marker in the PR body.",
+            match: { source: "description", includes: "" }
+          }
+        ]
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "title", status: "skipped", summary: "Title check was not evaluated because policy validation failed." }),
+        expect.objectContaining({ id: "description", status: "skipped", summary: "Description check was not evaluated because policy validation failed." }),
+        expect.objectContaining({ id: "linked_issue", status: "skipped", summary: "Linked issue check was not evaluated because policy validation failed." }),
+        expect.objectContaining({ id: "custom:body-marker", status: "skipped", summary: "Custom check body-marker check was not evaluated because policy validation failed." }),
+        expect.objectContaining({ id: "policy_validation:title:minLength", status: "fail" }),
+        expect.objectContaining({ id: "policy_validation:custom:body-marker:match.includes", status: "fail" })
+      ])
+    );
+    expect(result.summary.total).toBe(6);
   });
 });

--- a/tests/pre-merge-checks.test.ts
+++ b/tests/pre-merge-checks.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluatePreMergeChecks,
+  validatePreMergeCheckPolicy,
+  type PreMergeCheckPolicy
+} from "../src/pre-merge-checks.js";
+
+describe("pre-merge checks", () => {
+  it("keeps warning checks out of blocking errors", () => {
+    const result = evaluatePreMergeChecks({
+      pull: {
+        title: "WIP",
+        body: "Tiny.",
+        linkedIssues: []
+      },
+      policy: {
+        title: { mode: "warning" },
+        description: { mode: "warning" },
+        linkedIssue: { mode: "error" }
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reviewEvent).toBe("REQUEST_CHANGES");
+    expect(result.summary).toMatchObject({
+      passed: 0,
+      warnings: 2,
+      blockingErrors: 1,
+      skipped: 0
+    });
+    expect(result.warnings.map((warning) => warning.id)).toEqual(["title", "description"]);
+    expect(result.blockingErrors.map((error) => error.id)).toEqual(["linked_issue"]);
+    expect(result.warnings.every((warning) => warning.blocking === false)).toBe(true);
+    expect(result.blockingErrors.every((error) => error.blocking === true)).toBe(true);
+  });
+
+  it("emits traceable deterministic evidence for built-in checks", () => {
+    const result = evaluatePreMergeChecks({
+      pull: {
+        title: "Add billing export retry limits",
+        body: "Closes #42\n\nValidation: focused tests passed.",
+        linkedIssues: []
+      },
+      policy: {
+        title: { mode: "error" },
+        description: { mode: "error" },
+        linkedIssue: { mode: "error" }
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.reviewEvent).toBe("COMMENT");
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "title",
+          status: "pass",
+          evidence: expect.arrayContaining([
+            expect.objectContaining({ key: "title.length", value: "31", passed: true })
+          ])
+        }),
+        expect.objectContaining({
+          id: "linked_issue",
+          status: "pass",
+          evidence: expect.arrayContaining([
+            expect.objectContaining({ key: "linked_issue.references", value: "#42", passed: true })
+          ])
+        })
+      ])
+    );
+  });
+
+  it("evaluates custom checks with deterministic matchers", () => {
+    const policy: PreMergeCheckPolicy = {
+      customChecks: [
+        {
+          name: "release-notes",
+          mode: "warning",
+          instructions: "Require a Release notes section in the PR description.",
+          match: { source: "description", includes: "Release notes:" }
+        },
+        {
+          name: "test-file",
+          mode: "error",
+          instructions: "Require a focused test file in the changed files.",
+          match: { source: "changed_files", matches: "^tests/.+\\.test\\.ts$" }
+        }
+      ]
+    };
+
+    const result = evaluatePreMergeChecks({
+      pull: {
+        title: "Add pre-merge checks",
+        body: "Release notes: none needed.",
+        changedFiles: ["src/pre-merge-checks.ts", "docs/pre-merge-checks.md"]
+      },
+      policy
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.blockingErrors).toEqual([
+      expect.objectContaining({
+        id: "custom:test-file",
+        mode: "error",
+        status: "fail",
+        blocking: true
+      })
+    ]);
+    expect(result.checks.find((check) => check.id === "custom:release-notes")).toMatchObject({
+      status: "pass",
+      blocking: false
+    });
+  });
+
+  it("treats off checks as skipped without producing warnings or errors", () => {
+    const result = evaluatePreMergeChecks({
+      pull: {
+        title: "",
+        body: "",
+        linkedIssues: []
+      },
+      policy: {
+        title: { mode: "off" },
+        description: { mode: "off" },
+        linkedIssue: { mode: "off" },
+        customChecks: [
+          {
+            name: "ignored-check",
+            mode: "off",
+            instructions: "Require a marker that is not present.",
+            match: { source: "description", includes: "must-not-run" }
+          }
+        ]
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.summary).toMatchObject({ passed: 0, warnings: 0, blockingErrors: 0, skipped: 4 });
+    expect(result.warnings).toEqual([]);
+    expect(result.blockingErrors).toEqual([]);
+    expect(result.checks.every((check) => check.status === "skipped")).toBe(true);
+  });
+
+  it("validates custom check names, instructions, modes, and matchers", () => {
+    const validation = validatePreMergeCheckPolicy({
+      customChecks: [
+        {
+          name: "Bad Name",
+          mode: "warning",
+          instructions: "Ask the model to judge whether the PR seems safe.",
+          match: { source: "description", includes: "" }
+        },
+        {
+          name: "good-name",
+          mode: "error",
+          instructions: "Require a literal marker in the title.",
+          match: { source: "title", matches: "[" }
+        }
+      ]
+    });
+
+    expect(validation.ok).toBe(false);
+    expect(validation.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ check: "custom:Bad Name", field: "name" }),
+        expect.objectContaining({ check: "custom:Bad Name", field: "instructions" }),
+        expect.objectContaining({ check: "custom:Bad Name", field: "match.includes" }),
+        expect.objectContaining({ check: "custom:good-name", field: "match.matches" })
+      ])
+    );
+  });
+});

--- a/tests/pre-merge-checks.test.ts
+++ b/tests/pre-merge-checks.test.ts
@@ -70,6 +70,71 @@ describe("pre-merge checks", () => {
     );
   });
 
+  it("does not treat normal Test or Testing titles as draft markers", () => {
+    for (const title of ["Test runner config updates", "Testing infra improvements"]) {
+      const result = evaluatePreMergeChecks({
+        pull: {
+          title,
+          body: "Closes #42\n\nValidation: focused tests passed.",
+          linkedIssues: [42]
+        },
+        policy: {
+          title: { mode: "error" }
+        }
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.blockingErrors).toEqual([]);
+      expect(result.checks.find((check) => check.id === "title")).toMatchObject({
+        status: "pass",
+        evidence: expect.arrayContaining([
+          expect.objectContaining({ key: "title.not_draft_prefix", value: "true", passed: true })
+        ])
+      });
+    }
+  });
+
+  it("requires structured open issue evidence when requireOpen is enabled", () => {
+    const noRefs = evaluatePreMergeChecks({
+      pull: {
+        title: "Add pre-merge checks",
+        body: "Validation: focused tests passed.",
+        linkedIssues: []
+      },
+      policy: {
+        linkedIssue: { mode: "error", requireOpen: true }
+      }
+    });
+
+    expect(noRefs.ok).toBe(false);
+    expect(noRefs.blockingErrors).toEqual([expect.objectContaining({ id: "linked_issue" })]);
+    expect(noRefs.checks.find((check) => check.id === "linked_issue")?.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "linked_issue.references", value: "none", passed: false }),
+        expect.objectContaining({ key: "linked_issue.open_state", value: "not_applicable", passed: false })
+      ])
+    );
+
+    const closedIssue = evaluatePreMergeChecks({
+      pull: {
+        title: "Add pre-merge checks",
+        body: "Validation: focused tests passed.",
+        linkedIssues: [{ number: 42, state: "closed" }]
+      },
+      policy: {
+        linkedIssue: { mode: "error", requireOpen: true }
+      }
+    });
+
+    expect(closedIssue.ok).toBe(false);
+    expect(closedIssue.checks.find((check) => check.id === "linked_issue")?.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "linked_issue.references", value: "#42", passed: true }),
+        expect.objectContaining({ key: "linked_issue.open_state", value: "closed", passed: false })
+      ])
+    );
+  });
+
   it("evaluates custom checks with deterministic matchers", () => {
     const policy: PreMergeCheckPolicy = {
       customChecks: [
@@ -110,6 +175,48 @@ describe("pre-merge checks", () => {
       status: "pass",
       blocking: false
     });
+  });
+
+  it("does not echo raw PR title body or changed-file values in custom matcher evidence", () => {
+    const bodySecret = "Release notes: customer private rollout detail";
+    const titleSecret = "Customer private launch checklist";
+    const fileSecret = "docs/customer-private-rollout-plan.md";
+    const result = evaluatePreMergeChecks({
+      pull: {
+        title: titleSecret,
+        body: bodySecret,
+        changedFiles: [fileSecret]
+      },
+      policy: {
+        customChecks: [
+          {
+            name: "body-marker",
+            mode: "warning",
+            instructions: "Require release notes marker in the PR body.",
+            match: { source: "description", includes: "Release notes:" }
+          },
+          {
+            name: "title-marker",
+            mode: "warning",
+            instructions: "Require private launch wording in the title.",
+            match: { source: "title", includes: "private launch" }
+          },
+          {
+            name: "file-marker",
+            mode: "warning",
+            instructions: "Require matching docs path without echoing it.",
+            match: { source: "changed_files", matches: "customer-private" }
+          }
+        ]
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    const evidenceJson = JSON.stringify(result.checks.flatMap((check) => check.evidence));
+    expect(evidenceJson).not.toContain(bodySecret);
+    expect(evidenceJson).not.toContain(titleSecret);
+    expect(evidenceJson).not.toContain(fileSecret);
+    expect(result.checks.map((check) => check.evidence[0]?.value)).toEqual(["matched", "matched", "matched"]);
   });
 
   it("treats off checks as skipped without producing warnings or errors", () => {
@@ -155,6 +262,12 @@ describe("pre-merge checks", () => {
           mode: "error",
           instructions: "Require a literal marker in the title.",
           match: { source: "title", matches: "[" }
+        },
+        {
+          name: "ambiguous-match",
+          mode: "warning",
+          instructions: "Require exactly one custom matcher operator.",
+          match: { source: "description", includes: "Release notes:", matches: "Release notes:" }
         }
       ]
     });
@@ -165,7 +278,8 @@ describe("pre-merge checks", () => {
         expect.objectContaining({ check: "custom:Bad Name", field: "name" }),
         expect.objectContaining({ check: "custom:Bad Name", field: "instructions" }),
         expect.objectContaining({ check: "custom:Bad Name", field: "match.includes" }),
-        expect.objectContaining({ check: "custom:good-name", field: "match.matches" })
+        expect.objectContaining({ check: "custom:good-name", field: "match.matches" }),
+        expect.objectContaining({ check: "custom:ambiguous-match", field: "match" })
       ])
     );
   });


### PR DESCRIPTION
## Summary
- add a pure deterministic pre-merge checks module for title, description, linked issue, and custom matcher checks
- keep warning-mode failures separate from blocking error-mode failures
- validate custom check names, modes, instructions, and matchers before evaluation
- document the module contract and captain-owned integration hooks

Related: #118

## Validation
- `npx vitest run tests/pre-merge-checks.test.ts` passed on `9ca6b3a218ad280fa100f6bcc42d0acb67ebbd40`
- `npm run build` passed on `9ca6b3a218ad280fa100f6bcc42d0acb67ebbd40`
- `git diff --check` passed on `9ca6b3a218ad280fa100f6bcc42d0acb67ebbd40`

## Review Fixes
- dropped bare `test` title draft-prefix matching and added `Test` / `Testing` regression coverage
- made `requireOpen` evidence non-vacuous for no linked issues and closed issues
- changed custom matcher evidence to fixed `matched` / `not_matched` markers without raw title/body/file echoes
- rejected custom matchers that specify both `includes` and `matches`

## Scope Boundary
- This PR intentionally does not touch `src/cli.ts`, `src/config.ts`, `src/worker.ts`, or `src/walkthrough.ts`.
- No live worker restart, launchd change, package release, or GitHub App permission change was performed.

## Integration Hooks Still Needed
- config/profile parsing for pre-merge check policy
- walkthrough/status rendering without duplicate status-comment spam
- worker/review flow mapping of `blockingErrors` to `REQUEST_CHANGES`
- dry-run fixture evidence for pass/warning/error PR shapes
