### PR TITLE
Gate issue enrichment live rollout with separate allowlist thresholds

### DIFF
--- a/docs/issue-enrichment.md
+++ b/docs/issue-enrichment.md
@@ -1,0 +1,41 @@
+# Issue Enrichment Rollout Policy
+
+Issue enrichment is a separate lane from PR review monitoring. `pilotRepos`, `canaryPulls`, `repoProfiles.repos`, and `repoProfiles.suggestedLabels` or `suggestedReviewers` do not opt a repo into issue enrichment.
+
+Use `issueEnrichment.allowlist` for issue scanning and comment eligibility. Use `issueEnrichment.allowedLabels` and `issueEnrichment.allowedReviewers` for issue suggestions only; repo-level `issueEnrichment.repos.<owner/repo>.allowedLabels` and `allowedReviewers` override those suggestion allowlists for that issue repo.
+
+Live issue comments are blocked until all of these are true:
+
+- `issueEnrichment.enabled` is `true`.
+- `issueEnrichment.postIssueComment` is `true`.
+- `issueEnrichment.allowlist` contains at least one repo.
+- the GitHub App credential path can post as the App.
+- every live allowlisted repo has explicit repo-level thresholds for `maxIssuesPerCycle`, `maxCommentsPerCycle`, `cooldownMs`, `burstWindowMs`, `maxIssuesPerBurst`, and `lookbackMs`.
+
+Keep new rollouts dry-run first:
+
+```json
+{
+  "issueEnrichment": {
+    "enabled": true,
+    "postIssueComment": false,
+    "allowlist": ["owner/repo"],
+    "allowedLabels": ["bug", "docs"],
+    "allowedReviewers": ["maintainer-login"],
+    "repos": {
+      "owner/repo": {
+        "enabled": true,
+        "maxIssuesPerCycle": 3,
+        "maxCommentsPerCycle": 1,
+        "cooldownMs": 3600000,
+        "burstWindowMs": 3600000,
+        "maxIssuesPerBurst": 6,
+        "lookbackMs": 600000,
+        "processExistingOpenIssuesOnActivation": false
+      }
+    }
+  }
+}
+```
+
+Operator status exposes `issueEnrichment.liveThresholdsMissingRepos` and the `issue_enrichment_live_repo_thresholds_required` blocker before live comments can become ready. This is intentional: repo-specific thresholds must be visible in config before any active rollout.

--- a/docs/issue-enrichment.md
+++ b/docs/issue-enrichment.md
@@ -39,3 +39,13 @@ Keep new rollouts dry-run first:
 ```
 
 Operator status exposes `issueEnrichment.liveThresholdsMissingRepos` and the `issue_enrichment_live_repo_thresholds_required` blocker before live comments can become ready. This is intentional: repo-specific thresholds must be visible in config before any active rollout.
+
+When more than one live rollout blocker applies, operator status reports blockers in deterministic policy order:
+
+1. feature disabled
+2. empty issue enrichment allowlist
+3. live posting disabled
+4. missing per-repo live thresholds
+5. missing GitHub App posting credentials
+
+Threshold blockers intentionally appear before credential blockers so operators fix unsafe rollout scope before debugging App identity.

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -69,6 +69,7 @@ export interface IssueEnrichmentStatus {
   postIssueComment: boolean;
   separateAllowlist: true;
   allowlist: string[];
+  liveThresholdsMissingRepos: string[];
   throttleDefaults: IssueEnrichmentThrottlePolicy;
   globalLimits: IssueEnrichmentGlobalLimits;
   repoOverrides: Array<{ repo: string } & IssueEnrichmentRepoOverride>;
@@ -101,7 +102,8 @@ export type IssueEnrichmentBlocker =
   | "issue_enrichment_disabled"
   | "issue_enrichment_allowlist_empty"
   | "issue_enrichment_live_posting_disabled"
-  | "github_app_credentials_required_for_live_issue_comments";
+  | "github_app_credentials_required_for_live_issue_comments"
+  | "issue_enrichment_live_repo_thresholds_required";
 
 export interface IssueEnrichmentReader {
   listIssuesForEnrichment(
@@ -227,12 +229,17 @@ export function buildIssueEnrichmentStatus(input: {
   if (!config.enabled) blockers.push("issue_enrichment_disabled");
   if (config.allowlist.length === 0) blockers.push("issue_enrichment_allowlist_empty");
   if (!config.postIssueComment) blockers.push("issue_enrichment_live_posting_disabled");
+  const liveThresholdsMissingRepos = config.enabled && config.postIssueComment
+    ? reposMissingLiveIssueEnrichmentThresholds(config)
+    : [];
+  if (liveThresholdsMissingRepos.length > 0) blockers.push("issue_enrichment_live_repo_thresholds_required");
   if (config.enabled && config.postIssueComment && !input.canPostAsApp) {
     blockers.push("github_app_credentials_required_for_live_issue_comments");
   }
 
   const blocking = blockers.filter((blocker) =>
     blocker === "github_app_credentials_required_for_live_issue_comments" ||
+    blocker === "issue_enrichment_live_repo_thresholds_required" ||
     (config.enabled && blocker === "issue_enrichment_allowlist_empty")
   );
   const state = !config.enabled
@@ -251,6 +258,7 @@ export function buildIssueEnrichmentStatus(input: {
     postIssueComment: config.postIssueComment,
     separateAllowlist: true,
     allowlist: [...config.allowlist],
+    liveThresholdsMissingRepos,
     throttleDefaults: {
       maxIssuesPerCycle: config.maxIssuesPerCycle,
       maxCommentsPerCycle: config.maxCommentsPerCycle,
@@ -269,6 +277,24 @@ export function buildIssueEnrichmentStatus(input: {
     repoOverrides: Object.entries(config.repos ?? {}).map(([repo, override]) => ({ repo, ...override })),
     blockers
   };
+}
+
+const LIVE_REPO_THRESHOLD_FIELDS = [
+  "maxIssuesPerCycle",
+  "maxCommentsPerCycle",
+  "cooldownMs",
+  "burstWindowMs",
+  "maxIssuesPerBurst",
+  "lookbackMs"
+] satisfies Array<keyof IssueEnrichmentRepoOverride>;
+
+function reposMissingLiveIssueEnrichmentThresholds(config: IssueEnrichmentConfig): string[] {
+  return config.allowlist.filter((repo) => {
+    const override = config.repos?.[repo];
+    if (override?.enabled === false) return false;
+    return override === undefined ||
+      LIVE_REPO_THRESHOLD_FIELDS.some((field) => override[field] === undefined);
+  });
 }
 
 export async function collectIssueEnrichmentScan(input: {

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -350,6 +350,7 @@ function successfulIssueEnrichmentCycleResult(): IssueEnrichmentCycleResult {
       postIssueComment: false,
       separateAllowlist: true,
       allowlist: ["owner/repo"],
+      liveThresholdsMissingRepos: [],
       throttleDefaults: {
         maxIssuesPerCycle: 5,
         maxCommentsPerCycle: 0,

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -1390,7 +1390,17 @@ describe("sticky enrichment comments", () => {
           globalMaxCommentsPerCycle: 2,
           cooldownMs: 60_000,
           maxIssuesPerBurst: 10,
-          processExistingOpenIssuesOnActivation: true
+          processExistingOpenIssuesOnActivation: true,
+          repos: {
+            "owner/issue-repo": {
+              maxIssuesPerCycle: 10,
+              maxCommentsPerCycle: 2,
+              cooldownMs: 60_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 10,
+              lookbackMs: 600_000
+            }
+          }
         }
       })}\n`);
       const state = new ReviewStateStore(statePath);
@@ -1624,7 +1634,20 @@ describe("sticky enrichment comments", () => {
           maxCommentsPerCycle: 0,
           cooldownMs: 60_000,
           repos: {
+            "owner/deferred-repo": {
+              maxIssuesPerCycle: 5,
+              maxCommentsPerCycle: 0,
+              cooldownMs: 60_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 10,
+              lookbackMs: 600_000
+            },
             "owner/failed-repo": {
+              maxIssuesPerCycle: 5,
+              cooldownMs: 60_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 10,
+              lookbackMs: 600_000,
               maxCommentsPerCycle: 1
             }
           }
@@ -1798,7 +1821,17 @@ describe("sticky enrichment comments", () => {
           allowedReviewers: ["issue-owner", "incident-reviewer"],
           maxIssuesPerCycle: 5,
           maxCommentsPerCycle: 2,
-          processExistingOpenIssuesOnActivation: true
+          processExistingOpenIssuesOnActivation: true,
+          repos: {
+            "owner/issue-repo": {
+              maxIssuesPerCycle: 5,
+              maxCommentsPerCycle: 2,
+              cooldownMs: 3_600_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 10,
+              lookbackMs: 600_000
+            }
+          }
         }
       })}\n`);
       const state = new ReviewStateStore(statePath);
@@ -1873,7 +1906,17 @@ describe("sticky enrichment comments", () => {
           allowlist: ["owner/issue-repo"],
           maxIssuesPerCycle: 5,
           maxCommentsPerCycle: 2,
-          processExistingOpenIssuesOnActivation: true
+          processExistingOpenIssuesOnActivation: true,
+          repos: {
+            "owner/issue-repo": {
+              maxIssuesPerCycle: 5,
+              maxCommentsPerCycle: 2,
+              cooldownMs: 3_600_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 10,
+              lookbackMs: 600_000
+            }
+          }
         }
       })}\n`);
       const state = new ReviewStateStore(statePath);
@@ -1926,7 +1969,17 @@ describe("sticky enrichment comments", () => {
           allowlist: ["owner/issue-repo"],
           maxIssuesPerCycle: 5,
           maxCommentsPerCycle: 2,
-          processExistingOpenIssuesOnActivation: true
+          processExistingOpenIssuesOnActivation: true,
+          repos: {
+            "owner/issue-repo": {
+              maxIssuesPerCycle: 5,
+              maxCommentsPerCycle: 2,
+              cooldownMs: 3_600_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 10,
+              lookbackMs: 600_000
+            }
+          }
         }
       })}\n`);
       const state = new ReviewStateStore(statePath);
@@ -2025,7 +2078,17 @@ describe("sticky enrichment comments", () => {
           globalMaxCommentsPerCycle: 1,
           maxActiveRuns: 1,
           leaseTtlMs: 1_200_000,
-          processExistingOpenIssuesOnActivation: true
+          processExistingOpenIssuesOnActivation: true,
+          repos: {
+            "owner/issue-repo": {
+              maxIssuesPerCycle: 5,
+              maxCommentsPerCycle: 1,
+              cooldownMs: 3_600_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 10,
+              lookbackMs: 600_000
+            }
+          }
         }
       })}\n`);
       const state = new ReviewStateStore(statePath);
@@ -2080,7 +2143,17 @@ describe("sticky enrichment comments", () => {
           globalMaxCommentsPerCycle: 1,
           maxActiveRuns: 1,
           leaseTtlMs: 1_200_000,
-          processExistingOpenIssuesOnActivation: true
+          processExistingOpenIssuesOnActivation: true,
+          repos: {
+            "owner/issue-repo": {
+              maxIssuesPerCycle: 5,
+              maxCommentsPerCycle: 1,
+              cooldownMs: 3_600_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 10,
+              lookbackMs: 600_000
+            }
+          }
         }
       })}\n`);
       const state = new ReviewStateStore(statePath);

--- a/tests/issue-enrichment-policy.test.ts
+++ b/tests/issue-enrichment-policy.test.ts
@@ -65,6 +65,64 @@ describe("issue enrichment rollout policy", () => {
     });
   });
 
+  it("reports threshold blockers before missing App credentials for live operator triage", () => {
+    const config = loadConfigFromObject({
+      issueEnrichment: {
+        enabled: true,
+        postIssueComment: true,
+        allowlist: ["owner/issue-repo"]
+      }
+    });
+
+    const status = buildIssueEnrichmentStatus({
+      config,
+      canPostAsApp: false,
+      checkedAt: "2026-07-04T11:30:00.000Z"
+    });
+
+    expect(status).toMatchObject({
+      ok: false,
+      state: "blocked",
+      blockers: [
+        "issue_enrichment_live_repo_thresholds_required",
+        "github_app_credentials_required_for_live_issue_comments"
+      ],
+      liveThresholdsMissingRepos: ["owner/issue-repo"]
+    });
+  });
+
+  it("treats partial repo thresholds as incomplete but exempts disabled repos", () => {
+    const config = loadConfigFromObject({
+      issueEnrichment: {
+        enabled: true,
+        postIssueComment: true,
+        allowlist: ["owner/partial-repo", "owner/disabled-repo"],
+        repos: {
+          "owner/partial-repo": {
+            enabled: true,
+            maxIssuesPerCycle: 3
+          },
+          "owner/disabled-repo": {
+            enabled: false
+          }
+        }
+      }
+    });
+
+    const status = buildIssueEnrichmentStatus({
+      config,
+      canPostAsApp: true,
+      checkedAt: "2026-07-04T11:30:00.000Z"
+    });
+
+    expect(status).toMatchObject({
+      ok: false,
+      state: "blocked",
+      blockers: ["issue_enrichment_live_repo_thresholds_required"],
+      liveThresholdsMissingRepos: ["owner/partial-repo"]
+    });
+  });
+
   it("allows live issue comments only after repo-specific throttle thresholds are configured", () => {
     const config = loadConfigFromObject({
       issueEnrichment: {

--- a/tests/issue-enrichment-policy.test.ts
+++ b/tests/issue-enrichment-policy.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { loadConfigFromObject } from "../src/config.js";
+import { buildIssueEnrichmentStatus, resolveIssueEnrichmentRepoPolicy } from "../src/issue-enrichment.js";
+
+describe("issue enrichment rollout policy", () => {
+  it("keeps issue enrichment allowlist and suggestions separate from PR review monitoring", () => {
+    const config = loadConfigFromObject({
+      pilotRepos: ["owner/pr-review-repo"],
+      repoProfiles: {
+        repos: {
+          "owner/pr-review-repo": {
+            suggestedLabels: ["pr-label"],
+            suggestedReviewers: ["pr-reviewer"]
+          }
+        }
+      },
+      issueEnrichment: {
+        enabled: true,
+        postIssueComment: false,
+        allowlist: ["owner/issue-repo"],
+        allowedLabels: ["issue-label"],
+        allowedReviewers: ["issue-reviewer"],
+        repos: {
+          "owner/issue-repo": {
+            allowedLabels: ["repo-issue-label"],
+            allowedReviewers: ["repo-issue-reviewer"]
+          }
+        }
+      }
+    });
+
+    expect(resolveIssueEnrichmentRepoPolicy(config.issueEnrichment!, "owner/pr-review-repo")).toMatchObject({
+      allowed: false,
+      reason: "not_issue_enrichment_allowlisted"
+    });
+    expect(resolveIssueEnrichmentRepoPolicy(config.issueEnrichment!, "owner/issue-repo")).toMatchObject({
+      allowed: true,
+      suggestions: {
+        allowedLabels: ["repo-issue-label"],
+        allowedReviewers: ["repo-issue-reviewer"]
+      }
+    });
+  });
+
+  it("blocks live issue comments until every allowlisted repo has explicit repo throttle thresholds", () => {
+    const config = loadConfigFromObject({
+      issueEnrichment: {
+        enabled: true,
+        postIssueComment: true,
+        allowlist: ["owner/issue-repo"]
+      }
+    });
+
+    const status = buildIssueEnrichmentStatus({
+      config,
+      canPostAsApp: true,
+      checkedAt: "2026-07-04T11:30:00.000Z"
+    });
+
+    expect(status).toMatchObject({
+      ok: false,
+      state: "blocked",
+      blockers: ["issue_enrichment_live_repo_thresholds_required"],
+      liveThresholdsMissingRepos: ["owner/issue-repo"]
+    });
+  });
+
+  it("allows live issue comments only after repo-specific throttle thresholds are configured", () => {
+    const config = loadConfigFromObject({
+      issueEnrichment: {
+        enabled: true,
+        postIssueComment: true,
+        allowlist: ["owner/issue-repo"],
+        repos: {
+          "owner/issue-repo": {
+            enabled: true,
+            maxIssuesPerCycle: 3,
+            maxCommentsPerCycle: 1,
+            cooldownMs: 3_600_000,
+            burstWindowMs: 3_600_000,
+            maxIssuesPerBurst: 6,
+            lookbackMs: 600_000,
+            processExistingOpenIssuesOnActivation: false
+          }
+        }
+      }
+    });
+
+    const status = buildIssueEnrichmentStatus({
+      config,
+      canPostAsApp: true,
+      checkedAt: "2026-07-04T11:30:00.000Z"
+    });
+
+    expect(status).toMatchObject({
+      ok: true,
+      state: "ready",
+      blockers: [],
+      liveThresholdsMissingRepos: []
+    });
+  });
+});

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -174,6 +174,7 @@ describe("operator CLI summaries", () => {
       postIssueComment: true,
       separateAllowlist: true,
       allowlist: ["owner/issue-repo"],
+      liveThresholdsMissingRepos: [],
       throttleDefaults: {
         maxIssuesPerCycle: 5,
         maxCommentsPerCycle: 2,
@@ -221,7 +222,17 @@ describe("operator CLI summaries", () => {
       issueEnrichment: {
         enabled: true,
         postIssueComment: true,
-        allowlist: ["owner/issue-repo"]
+        allowlist: ["owner/issue-repo"],
+        repos: {
+          "owner/issue-repo": {
+            maxIssuesPerCycle: 5,
+            maxCommentsPerCycle: 1,
+            cooldownMs: 3_600_000,
+            burstWindowMs: 3_600_000,
+            maxIssuesPerBurst: 10,
+            lookbackMs: 600_000
+          }
+        }
       }
     })}\n`);
 
@@ -1728,6 +1739,7 @@ function issueEnrichmentStatus(input: Partial<IssueEnrichmentStatus> = {}): Issu
     postIssueComment: input.postIssueComment ?? false,
     separateAllowlist: true,
     allowlist: input.allowlist ?? ["owner/issue-repo"],
+    liveThresholdsMissingRepos: input.liveThresholdsMissingRepos ?? [],
     throttleDefaults: input.throttleDefaults ?? {
       maxIssuesPerCycle: 5,
       maxCommentsPerCycle: 0,


### PR DESCRIPTION
## Summary
- keep issue enrichment policy explicitly separate from PR review monitoring allowlists and suggestions
- block live issue-enrichment comments until every live allowlisted repo has explicit repo throttle thresholds
- document dry-run-first/operator semantics for issue enrichment rollout

Refs #119

## Validation
- npm test -- tests/issue-enrichment-policy.test.ts
- npm test -- tests/issue-enrichment-policy.test.ts tests/enrichment.test.ts tests/operator-cli.test.ts tests/daemon-loop.test.ts
- npm run build

## Notes
- Active live config was not changed.
- This is a bounded policy/config/operator slice and does not claim the full issue #119 public acceptance is complete.