### PR TITLE
Harden finishing-touch command parser gates

### DIFF
--- a/docs/maintainer-commands.md
+++ b/docs/maintainer-commands.md
@@ -30,12 +30,20 @@ Each command must appear as its own trimmed line in a PR comment:
 - `@evaos-code-review-bot explain`
 - `@evaos-code-review-bot stop`
 - `@evaos-code-review-bot generate tests`
+- `@evaos-code-review-bot draft tests`
 - `@evaos-code-review-bot generate docs`
+- `@evaos-code-review-bot draft docs`
 - `@evaos-code-review-bot generate docstrings`
 - `@evaos-code-review-bot simplify suggestion`
 - `@evaos-code-review-bot changelog draft`
+- `@evaos-code-review-bot draft changelog`
 - `@evaos-code-review-bot explain risk`
 - `@evaos-code-review-bot make review-ready`
+
+The public `@neondiff` mention uses the same parser when it is present in
+`commands.botMentions`, including `@neondiff review`, `@neondiff draft tests`,
+`@neondiff draft docs`, `@neondiff draft changelog`, and
+`@neondiff explain risk`.
 
 `review` and `re-review` route into the same ZCode review pipeline used by
 polling. They still use the current PR head SHA, current RIGHT-side diff-line
@@ -66,12 +74,12 @@ npx tsx src/cli.ts finishing-touch-dry-run \
   --config /path/to/live.json \
   --repo owner/repo \
   --pr 123 \
-  --head-sha HEAD \
-  --current-head HEAD \
+  --head-sha 0123456789abcdef0123456789abcdef01234567 \
+  --current-head 0123456789abcdef0123456789abcdef01234567 \
   --comment-id 456 \
   --author maintainer \
   --trusted-authors maintainer \
-  --body '@evaos-code-review-bot explain risk'
+  --body '@neondiff explain risk'
 ```
 
 The dry-run JSON includes a `contract` object with the target repo/PR/head,
@@ -81,7 +89,9 @@ trusted-author status, stale-head check, clean-worktree state
 booleans remain `false`; the command is `defaultOff: true` and
 `mode: "draft_only"` even when validation passes. When `--worktree-clean` is
 omitted, the dry-run contract reports `assumed_clean` rather than claiming an
-explicit Git clean check was performed.
+explicit Git clean check was performed. Validation fails closed unless both
+`--head-sha` and `--current-head` are explicit 40-character Git SHAs; placeholder
+values such as `HEAD` are not accepted as generation proof.
 
 ## Trust Boundary
 

--- a/src/finishing-touches.ts
+++ b/src/finishing-touches.ts
@@ -44,6 +44,7 @@ export type FinishingTouchRequestValidationResult =
       ok: false;
       reason:
         | "untrusted_author"
+        | "missing_explicit_head_sha"
         | "stale_head"
         | "dirty_worktree"
         | "secret_detected";
@@ -128,11 +129,11 @@ export interface FinishingTouchDryRunContract {
 }
 
 const COMMAND_PHRASES: Array<[FinishingTouchAction, string[]]> = [
-  ["generate_tests", ["generate tests", "generate unit tests"]],
-  ["generate_docs", ["generate docs", "generate documentation", "docs draft"]],
+  ["generate_tests", ["generate tests", "generate unit tests", "draft tests", "draft unit tests"]],
+  ["generate_docs", ["generate docs", "generate documentation", "docs draft", "draft docs", "draft documentation"]],
   ["generate_docstrings", ["generate docstrings"]],
   ["simplify_suggestion", ["simplify suggestion"]],
-  ["changelog_draft", ["changelog draft", "release notes draft", "draft changelog"]],
+  ["changelog_draft", ["changelog draft", "release notes draft", "draft changelog", "draft release notes"]],
   ["explain_risk", ["explain risk", "risk explanation", "explain risks"]],
   ["make_review_ready", ["make review-ready", "make review ready", "review-ready checklist"]]
 ];
@@ -174,11 +175,21 @@ export function validateFinishingTouchRequest(
       secretScan: "not_scanned"
     };
   }
-  if (input.currentHeadSha && input.currentHeadSha !== input.headSha) {
+  const targetHeadSha = input.headSha.trim();
+  const currentHeadSha = input.currentHeadSha?.trim() ?? "";
+  if (!isFullGitSha(targetHeadSha) || !isFullGitSha(currentHeadSha)) {
+    return {
+      ok: false,
+      reason: "missing_explicit_head_sha",
+      detail: "Finishing-touch commands require explicit 40-character target and current head SHAs.",
+      secretScan: "not_scanned"
+    };
+  }
+  if (currentHeadSha !== targetHeadSha) {
     return {
       ok: false,
       reason: "stale_head",
-      detail: `Command targeted ${input.headSha}, but current head is ${input.currentHeadSha}.`,
+      detail: `Command targeted ${targetHeadSha}, but current head is ${currentHeadSha}.`,
       secretScan: "not_scanned"
     };
   }

--- a/tests/finishing-touches.test.ts
+++ b/tests/finishing-touches.test.ts
@@ -24,6 +24,18 @@ describe("finishing-touch draft commands", () => {
       botMentions: ["@evaos-code-review-bot"]
     })).toMatchObject({ action: "generate_tests" });
     expect(parseFinishingTouchCommand({
+      body: "@neondiff draft tests",
+      botMentions: ["@neondiff"]
+    })).toMatchObject({ action: "generate_tests", phrase: "draft tests" });
+    expect(parseFinishingTouchCommand({
+      body: "@neondiff draft docs",
+      botMentions: ["@neondiff"]
+    })).toMatchObject({ action: "generate_docs", phrase: "draft docs" });
+    expect(parseFinishingTouchCommand({
+      body: "@neondiff draft changelog",
+      botMentions: ["@neondiff"]
+    })).toMatchObject({ action: "changelog_draft", phrase: "draft changelog" });
+    expect(parseFinishingTouchCommand({
       body: "@evaos-code-review-bot explain risk!",
       botMentions: ["@evaos-code-review-bot"]
     })).toMatchObject({ action: "explain_risk" });
@@ -84,6 +96,36 @@ describe("finishing-touch draft commands", () => {
       reason: "secret_detected",
       secretScan: "failed"
     });
+  });
+
+  it("requires explicit full target and current head SHAs before generation can pass", () => {
+    const base = {
+      repo: "electricsheephq/evaos-code-review-bot",
+      pullNumber: 157,
+      headSha: fullHeadSha,
+      currentHeadSha: fullHeadSha,
+      commentId: 123,
+      author: "100yenadmin",
+      trustedAuthors: ["100yenadmin"],
+      worktreeClean: true,
+      action: "generate_tests" as const
+    };
+
+    for (const input of [
+      { ...base, headSha: "" },
+      { ...base, headSha: "HEAD" },
+      { ...base, headSha: "0123456" },
+      { ...base, currentHeadSha: undefined },
+      { ...base, currentHeadSha: "" },
+      { ...base, currentHeadSha: "HEAD" },
+      { ...base, currentHeadSha: "0123456" }
+    ]) {
+      expect(validateFinishingTouchRequest(input), JSON.stringify(input)).toMatchObject({
+        ok: false,
+        reason: "missing_explicit_head_sha",
+        secretScan: "not_scanned"
+      });
+    }
   });
 
   it("builds draft-only proposal output without enabling mutation", () => {


### PR DESCRIPTION
## Summary
- add canonical `@neondiff draft tests/docs/changelog` finishing-touch command aliases
- require explicit full target and current head SHAs before finishing-touch generation can pass validation
- document the public `@neondiff` command vocabulary and full-SHA dry-run requirement

## Safety boundary
- outputs remain `draft_only` proposals
- mutation booleans remain false: no push, commit, approval, merge, or protected-branch commit
- validation fails closed for untrusted author, missing explicit head SHA, stale head, dirty worktree, and secret-like proposed output

## Validation
- `npm test -- tests/finishing-touches.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- diff-only secret scan matched no new secret-like strings

Refs #120.