### PR TITLE
Add provider adapter fixture groundwork

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -157,14 +157,16 @@ mocked adapter runs:
 - `unknown`
 
 Fixture evidence is deterministic after redaction: it records fixture, provider,
-adapter, model, prompt/output hashes, redacted output previews, and bounded
-raw-evidence previews. Raw-evidence previews remove or replace private-looking
-keys and fail closed for secret-like values, fixture prompts, and diff-shaped
-text. Treat the preview as an operator debugging aid, not as a blanket
-public-safe guarantee for arbitrary provider payloads. Fixtures prove adapter
-contract behavior and evidence boundary handling. They do not prove live
-provider parity, provider quality, cooldown behavior, production runtime
-selection, or exhaustive redaction of every possible private value.
+adapter, model, prompt hashes, redacted-output hashes, redacted output previews,
+and bounded raw-evidence previews. Redacted-output hashes fingerprint only the
+operator-visible redacted projection, not raw provider output. Raw-evidence
+previews remove or replace private-looking keys and fail closed for secret-like
+values, fixture prompts, and diff-shaped text. Treat the preview as an operator
+debugging aid, not as a blanket public-safe guarantee for arbitrary provider
+payloads. Fixtures prove adapter contract behavior and evidence boundary
+handling. They do not prove live provider parity, provider quality, cooldown
+behavior, production runtime selection, or exhaustive redaction of every
+possible private value.
 
 ## Proof Boundary
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -156,12 +156,15 @@ mocked adapter runs:
 - `model-output`
 - `unknown`
 
-Fixture evidence is deterministic and public-safe by default: it records fixture,
-provider, adapter, model, prompt/output hashes, redacted output previews, and
-redacted raw-evidence previews with prompt/diff/patch/content fields removed.
-Fixtures prove adapter contract behavior and evidence boundaries. They do not
-prove live provider parity, provider quality, cooldown behavior, or production
-runtime selection.
+Fixture evidence is deterministic after redaction: it records fixture, provider,
+adapter, model, prompt/output hashes, redacted output previews, and bounded
+raw-evidence previews. Raw-evidence previews remove or replace private-looking
+keys and fail closed for secret-like values, fixture prompts, and diff-shaped
+text. Treat the preview as an operator debugging aid, not as a blanket
+public-safe guarantee for arbitrary provider payloads. Fixtures prove adapter
+contract behavior and evidence boundary handling. They do not prove live
+provider parity, provider quality, cooldown behavior, production runtime
+selection, or exhaustive redaction of every possible private value.
 
 ## Proof Boundary
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -146,6 +146,23 @@ Provider checks normalize common failures into these categories:
 Retries and cooldowns must stay bounded and observable. A transient provider
 error should not kill the daemon or globally pause unrelated providers.
 
+Adapter fixture execution uses a narrower provider-runtime classification for
+mocked adapter runs:
+
+- `auth`
+- `throttle`
+- `network`
+- `timeout`
+- `model-output`
+- `unknown`
+
+Fixture evidence is deterministic and public-safe by default: it records fixture,
+provider, adapter, model, prompt/output hashes, redacted output previews, and
+redacted raw-evidence previews with prompt/diff/patch/content fields removed.
+Fixtures prove adapter contract behavior and evidence boundaries. They do not
+prove live provider parity, provider quality, cooldown behavior, or production
+runtime selection.
+
 ## Proof Boundary
 
 This registry does not claim CodeRabbit parity, calibrated review accuracy, or

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -1,0 +1,191 @@
+import { createHash } from "node:crypto";
+import { redactSecrets } from "./secrets.js";
+
+export type ProviderAdapterErrorClass =
+  | "auth"
+  | "throttle"
+  | "network"
+  | "timeout"
+  | "model-output"
+  | "unknown";
+
+export interface ProviderAdapterFixture {
+  id: string;
+  providerId: string;
+  adapterId: string;
+  model: string;
+  prompt: string;
+  expectJsonObject?: boolean;
+}
+
+export interface ProviderAdapterExecutionInput {
+  fixtureId: string;
+  providerId: string;
+  adapterId: string;
+  model: string;
+  prompt: string;
+}
+
+export interface ProviderAdapterExecutionResult {
+  text: string;
+  rawEvidence?: unknown;
+}
+
+export interface ProviderRuntimeAdapter {
+  id: string;
+  execute(input: ProviderAdapterExecutionInput): Promise<ProviderAdapterExecutionResult>;
+}
+
+export interface ProviderAdapterFixtureEvidence {
+  promptSha256: string;
+  outputSha256?: string;
+  outputPreview?: string;
+  rawEvidencePreview?: string;
+}
+
+export interface ProviderAdapterFixtureError {
+  class: ProviderAdapterErrorClass;
+  message: string;
+}
+
+export interface ProviderAdapterFixtureResult {
+  ok: boolean;
+  fixtureId: string;
+  providerId: string;
+  adapterId: string;
+  model: string;
+  evidence: ProviderAdapterFixtureEvidence;
+  error?: ProviderAdapterFixtureError;
+}
+
+export async function runProviderAdapterFixture(input: {
+  adapter: ProviderRuntimeAdapter;
+  fixture: ProviderAdapterFixture;
+}): Promise<ProviderAdapterFixtureResult> {
+  const { adapter, fixture } = input;
+  const baseResult = {
+    fixtureId: fixture.id,
+    providerId: fixture.providerId,
+    adapterId: fixture.adapterId,
+    model: fixture.model,
+    evidence: {
+      promptSha256: sha256(fixture.prompt)
+    }
+  };
+
+  try {
+    const execution = await adapter.execute({
+      fixtureId: fixture.id,
+      providerId: fixture.providerId,
+      adapterId: fixture.adapterId,
+      model: fixture.model,
+      prompt: fixture.prompt
+    });
+    const evidence = buildFixtureEvidence(fixture.prompt, execution);
+    if (fixture.expectJsonObject && !isJsonObject(execution.text)) {
+      return {
+        ok: false,
+        ...baseResult,
+        evidence,
+        error: {
+          class: "model-output",
+          message: "Adapter output was not a JSON object."
+        }
+      };
+    }
+    return {
+      ok: true,
+      ...baseResult,
+      evidence
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      ...baseResult,
+      error: {
+        class: classifyProviderAdapterError(message),
+        message: redactAdapterEvidenceText(message)
+      }
+    };
+  }
+}
+
+export function classifyProviderAdapterError(message: string): ProviderAdapterErrorClass {
+  const normalized = message.toLowerCase();
+  if (/\b(unauthorized|forbidden|invalid api key|invalid_api_key|401|403)\b/.test(normalized)) return "auth";
+  if (/\b(rate limit|rate_limit|quota|too many requests|429|insufficient_quota|throttl(?:e|ed|ing))\b/.test(normalized)) return "throttle";
+  if (/\b(timeout|timed out|etimedout|abort(?:ed)?|deadline exceeded)\b/.test(normalized)) return "timeout";
+  if (/\b(econnreset|econnrefused|enotfound|eai_again|network|socket|dns|connection refused|connection reset)\b/.test(normalized)) return "network";
+  if (/\b(json|schema|parseable|malformed output|invalid response|invalid output|tool call|structured output)\b/.test(normalized)) {
+    return "model-output";
+  }
+  return "unknown";
+}
+
+function buildFixtureEvidence(
+  prompt: string,
+  execution: ProviderAdapterExecutionResult
+): ProviderAdapterFixtureEvidence {
+  return {
+    promptSha256: sha256(prompt),
+    outputSha256: sha256(execution.text),
+    outputPreview: previewEvidenceText(execution.text),
+    ...(execution.rawEvidence === undefined
+      ? {}
+      : { rawEvidencePreview: previewEvidenceText(stableStringify(stripPrivateEvidenceFields(execution.rawEvidence))) })
+  };
+}
+
+function isJsonObject(value: string): boolean {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Boolean(parsed && typeof parsed === "object" && !Array.isArray(parsed));
+  } catch {
+    return false;
+  }
+}
+
+function previewEvidenceText(value: string): string {
+  return redactAdapterEvidenceText(value).slice(0, 500);
+}
+
+function redactAdapterEvidenceText(value: string): string {
+  return redactSecrets(
+    value
+      .replace(/\bsk-[A-Za-z0-9._-]{8,}\b/g, "[redacted-secret]")
+      .replace(/\bAIza[0-9A-Za-z_-]{20,}\b/g, "[redacted-secret]")
+  );
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortJsonValue(value));
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => sortJsonValue(item));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entryValue]) => [key, sortJsonValue(entryValue)])
+    );
+  }
+  return value;
+}
+
+function stripPrivateEvidenceFields(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => stripPrivateEvidenceFields(item));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([key]) => !/(prompt|diff|patch|content)/i.test(key))
+        .map(([key, entryValue]) => [key, stripPrivateEvidenceFields(entryValue)])
+    );
+  }
+  return value;
+}

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -127,11 +127,11 @@ export function classifyProviderAdapterError(message: string): ProviderAdapterEr
   const normalized = message.toLowerCase();
   if (/\b(unauthorized|forbidden|invalid[ _-]api[ _-]key|401|403)\b/.test(normalized)) return "auth";
   if (/\b(rate[ _-]limit|quota|too many requests|429|insufficient[ _-]quota|throttl(?:e|ed|ing))\b/.test(normalized)) return "throttle";
-  if (/\b(time[ _-]?out|timed[ _-]out|etimedout|abort(?:ed)?|deadline exceeded)\b/.test(normalized)) return "timeout";
-  if (/\b(econnreset|econnrefused|enotfound|eai_again|network|socket|dns|connection refused|connection reset)\b/.test(normalized)) return "network";
   if (/\b(json|schema|parseable|malformed output|invalid response|invalid output|tool call|structured output)\b/.test(normalized)) {
     return "model-output";
   }
+  if (/\b(time[ _-]?out|timed[ _-]out|etimedout|abort(?:ed)?|deadline exceeded)\b/.test(normalized)) return "timeout";
+  if (/\b(econnreset|econnrefused|enotfound|eai_again|network|socket|dns|connection refused|connection reset)\b/.test(normalized)) return "network";
   return "unknown";
 }
 
@@ -215,11 +215,37 @@ function redactPrivateEvidenceText(value: string, prompt: string): string {
 }
 
 function isPrivateEvidenceKey(key: string): boolean {
-  return /(prompt|diff|patch|content|body|source|code|completion|response|message|stdout|stderr|log)/i.test(key);
+  const tokens = evidenceKeyTokens(key);
+  const normalized = tokens.join("");
+  const hasToken = (token: string) => tokens.includes(token);
+  const hasAnyToken = (candidates: readonly string[]) => candidates.some((candidate) => hasToken(candidate));
+
+  if (hasAnyToken(["prompt", "diff", "patch", "completion", "stdout", "stderr", "transcript"])) return true;
+  if (["body", "source", "code", "log"].includes(normalized)) return true;
+  if (hasToken("code") && hasAnyToken(["raw", "source", "generated", "original", "full", "unredacted"])) return true;
+  if (hasToken("log") && !hasToken("level")) return true;
+  if (
+    hasAnyToken(["raw", "original", "full", "unredacted"])
+    && hasAnyToken(["body", "content", "message", "output", "request", "response", "result"])
+  ) {
+    return true;
+  }
+  if (hasToken("text") && hasAnyToken(["body", "content", "message", "output", "request", "response", "result"])) {
+    return true;
+  }
+  return false;
 }
 
 function isSensitiveEvidenceKey(key: string): boolean {
   return /(api[ _-]?key|authorization|auth|bearer|cookie|credential|password|secret|session|token)/i.test(key);
+}
+
+function evidenceKeyTokens(key: string): string[] {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
 }
 
 function containsPrivateEvidenceLikeText(value: string, prompt: string): boolean {

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -2,6 +2,9 @@ import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
+const EVIDENCE_PREVIEW_LIMIT = 500;
+const EVIDENCE_PREVIEW_TRUNCATED_SENTINEL = "...[truncated]";
+
 export type ProviderAdapterErrorClass =
   | "auth"
   | "throttle"
@@ -128,11 +131,11 @@ export function classifyProviderAdapterError(message: string): ProviderAdapterEr
   const normalized = message.toLowerCase();
   if (/\b(unauthorized|forbidden|invalid[ _-]api[ _-]key|401|403)\b/.test(normalized)) return "auth";
   if (/\b(rate[ _-]limit|quota|too many requests|429|insufficient[ _-]quota|throttl(?:e|ed|ing))\b/.test(normalized)) return "throttle";
+  if (/\b(time[ _-]?out|timed[ _-]out|etimedout|abort(?:ed)?|deadline exceeded)\b/.test(normalized)) return "timeout";
+  if (/\b(econnreset|econnrefused|enotfound|eai_again|socket|dns|connection[ _-]refused|connection[ _-]reset|network[ _-](?:error|failure|failed|unreachable|unavailable|down))\b/.test(normalized)) return "network";
   if (/\b(json|schema|parseable|malformed output|invalid response|invalid output|tool call|structured output)\b/.test(normalized)) {
     return "model-output";
   }
-  if (/\b(time[ _-]?out|timed[ _-]out|etimedout|abort(?:ed)?|deadline exceeded)\b/.test(normalized)) return "timeout";
-  if (/\b(econnreset|econnrefused|enotfound|eai_again|network|socket|dns|connection refused|connection reset)\b/.test(normalized)) return "network";
   return "unknown";
 }
 
@@ -144,7 +147,7 @@ function buildFixtureEvidence(
   return {
     promptSha256: sha256(prompt),
     outputSha256: sha256(redactedOutput),
-    outputPreview: redactedOutput.slice(0, 500),
+    outputPreview: previewEvidenceText(redactedOutput),
     ...(execution.rawEvidence === undefined
       ? {}
       : { rawEvidencePreview: previewEvidenceText(stableStringify(redactPrivateEvidenceValue(execution.rawEvidence, prompt))) })
@@ -161,7 +164,20 @@ function isJsonObject(value: string): boolean {
 }
 
 function previewEvidenceText(value: string): string {
-  return redactAdapterEvidenceText(value).slice(0, 500);
+  const redacted = redactAdapterEvidenceText(value);
+  if (redacted.length <= EVIDENCE_PREVIEW_LIMIT) return redacted;
+
+  const targetLength = EVIDENCE_PREVIEW_LIMIT - EVIDENCE_PREVIEW_TRUNCATED_SENTINEL.length;
+  const preview = trimDanglingRedactionToken(redacted.slice(0, targetLength));
+  return `${preview}${EVIDENCE_PREVIEW_TRUNCATED_SENTINEL}`;
+}
+
+function trimDanglingRedactionToken(value: string): string {
+  const redactionStart = value.lastIndexOf("[redacted-");
+  if (redactionStart === -1) return value;
+
+  const redactionEnd = value.indexOf("]", redactionStart);
+  return redactionEnd === -1 ? value.slice(0, redactionStart) : value;
 }
 
 function redactAdapterEvidenceText(value: string): string {

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
@@ -186,11 +187,16 @@ function sortJsonValue(value: unknown): unknown {
   if (value && typeof value === "object") {
     return Object.fromEntries(
       Object.entries(value)
-        .sort(([left], [right]) => left.localeCompare(right))
+        .sort(([left], [right]) => compareStableJsonKey(left, right))
         .map(([key, entryValue]) => [key, sortJsonValue(entryValue)])
     );
   }
   return value;
+}
+
+function compareStableJsonKey(left: string, right: string): number {
+  if (left === right) return 0;
+  return Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8"));
 }
 
 function redactPrivateEvidenceValue(value: unknown, prompt: string): unknown {

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -4,6 +4,12 @@ import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 const EVIDENCE_PREVIEW_LIMIT = 500;
 const EVIDENCE_PREVIEW_TRUNCATED_SENTINEL = "...[truncated]";
+const REDACTION_TOKENS = [
+  "[redacted-private-evidence]",
+  "[redacted-private-field]",
+  "[redacted-secret]",
+  "[redacted-sensitive-field]"
+] as const;
 
 export type ProviderAdapterErrorClass =
   | "auth"
@@ -173,20 +179,30 @@ function previewEvidenceText(value: string): string {
 }
 
 function trimDanglingRedactionToken(value: string): string {
-  const redactionStart = value.lastIndexOf("[redacted-");
-  if (redactionStart === -1) return value;
+  const danglingStart = findDanglingRedactionTokenStart(value);
+  return danglingStart === undefined ? value : value.slice(0, danglingStart);
+}
 
-  const redactionEnd = value.indexOf("]", redactionStart);
-  return redactionEnd === -1 ? value.slice(0, redactionStart) : value;
+function findDanglingRedactionTokenStart(value: string): number | undefined {
+  for (const token of REDACTION_TOKENS) {
+    for (let length = 1; length < token.length; length += 1) {
+      const prefix = token.slice(0, length);
+      if (value.endsWith(prefix)) return value.length - prefix.length;
+    }
+  }
+  return undefined;
 }
 
 function redactAdapterEvidenceText(value: string): string {
   return redactSecrets(
     value
-      .replace(/(["']?(?:x-)?api[-_]?key["']?\s*[:=]\s*["']?)[A-Za-z0-9._~+/=-]{8,}(["']?)/gi, "$1[redacted-secret]$2")
-      .replace(/\bsk-[A-Za-z0-9._-]{8,}\b/g, "[redacted-secret]")
-      .replace(/\bAIza[0-9A-Za-z_-]{20,}\b/g, "[redacted-secret]")
-      .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, "[redacted-secret]")
+      .replace(
+        /(["']?(?:x-)?api[-_]?key["']?\s*[:=]\s*["']?)[A-Za-z0-9._~+/=-]{8,}(["']?)/gi,
+        `$1${REDACTION_TOKENS[2]}$2`
+      )
+      .replace(/\bsk-[A-Za-z0-9._-]{8,}\b/g, REDACTION_TOKENS[2])
+      .replace(/\bAIza[0-9A-Za-z_-]{20,}\b/g, REDACTION_TOKENS[2])
+      .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, REDACTION_TOKENS[2])
   );
 }
 
@@ -211,6 +227,7 @@ function sortJsonValue(value: unknown): unknown {
 }
 
 function compareStableJsonKey(left: string, right: string): number {
+  // UTF-8 byte order keeps evidence output and hashing deterministic across locales and Node ICU builds.
   if (left === right) return 0;
   return Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8"));
 }
@@ -222,8 +239,8 @@ function redactPrivateEvidenceValue(value: unknown, prompt: string): unknown {
     return Object.fromEntries(
       Object.entries(value)
         .map(([key, entryValue]) => {
-          if (isPrivateEvidenceKey(key)) return [key, "[redacted-private-field]"];
-          if (isSensitiveEvidenceKey(key)) return [key, "[redacted-sensitive-field]"];
+          if (isPrivateEvidenceKey(key)) return [key, REDACTION_TOKENS[1]];
+          if (isSensitiveEvidenceKey(key)) return [key, REDACTION_TOKENS[3]];
           return [key, redactPrivateEvidenceValue(entryValue, prompt)];
         })
     );
@@ -232,7 +249,7 @@ function redactPrivateEvidenceValue(value: unknown, prompt: string): unknown {
 }
 
 function redactPrivateEvidenceText(value: string, prompt: string): string {
-  if (containsPrivateEvidenceLikeText(value, prompt)) return "[redacted-private-evidence]";
+  if (containsPrivateEvidenceLikeText(value, prompt)) return REDACTION_TOKENS[0];
   return redactAdapterEvidenceText(value);
 }
 

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -8,7 +8,8 @@ const REDACTION_TOKENS = [
   "[redacted-private-evidence]",
   "[redacted-private-field]",
   "[redacted-secret]",
-  "[redacted-sensitive-field]"
+  "[redacted-sensitive-field]",
+  "[redacted-unserializable-evidence]"
 ] as const;
 
 export type ProviderAdapterErrorClass =
@@ -137,6 +138,7 @@ export function classifyProviderAdapterError(message: string): ProviderAdapterEr
   const normalized = message.toLowerCase();
   if (/\b(unauthorized|forbidden|invalid[ _-]api[ _-]key|401|403)\b/.test(normalized)) return "auth";
   if (/\b(rate[ _-]limit|quota|too many requests|429|insufficient[ _-]quota|throttl(?:e|ed|ing))\b/.test(normalized)) return "throttle";
+  // Provider timeout wording wins over network codes in combined messages to keep cooldown evidence deterministic.
   if (/\b(time[ _-]?out|timed[ _-]out|etimedout|abort(?:ed)?|deadline exceeded)\b/.test(normalized)) return "timeout";
   if (/\b(econnreset|econnrefused|enotfound|eai_again|socket|dns|connection[ _-]refused|connection[ _-]reset|network[ _-](?:error|failure|failed|unreachable|unavailable|down))\b/.test(normalized)) return "network";
   if (/\b(json|schema|parseable|malformed output|invalid response|invalid output|tool call|structured output)\b/.test(normalized)) {
@@ -201,8 +203,13 @@ function redactAdapterEvidenceText(value: string): string {
         `$1${REDACTION_TOKENS[2]}$2`
       )
       .replace(/\bsk-[A-Za-z0-9._-]{8,}\b/g, REDACTION_TOKENS[2])
+      .replace(/\bsk-ant-[A-Za-z0-9._-]{8,}\b/g, REDACTION_TOKENS[2])
       .replace(/\bAIza[0-9A-Za-z_-]{20,}\b/g, REDACTION_TOKENS[2])
+      .replace(/\bya29\.[A-Za-z0-9._-]{16,}\b/g, REDACTION_TOKENS[2])
       .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, REDACTION_TOKENS[2])
+      .replace(/-----BEGIN\s*$/g, REDACTION_TOKENS[2])
+      .replace(/(?:[A-Z ]*PRIVATE KEY-----|-----END [A-Z ]*PRIVATE KEY-----)/g, REDACTION_TOKENS[2])
+      .replace(/(?:[A-Za-z0-9+/]{48,}={0,2}|[A-Za-z0-9_-]{48,})/g, REDACTION_TOKENS[2])
   );
 }
 
@@ -211,7 +218,11 @@ function sha256(value: string): string {
 }
 
 function stableStringify(value: unknown): string {
-  return JSON.stringify(sortJsonValue(value));
+  try {
+    return JSON.stringify(sortJsonValue(value)) ?? REDACTION_TOKENS[4];
+  } catch {
+    return REDACTION_TOKENS[4];
+  }
 }
 
 function sortJsonValue(value: unknown): unknown {

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -117,7 +117,7 @@ export async function runProviderAdapterFixture(input: {
       ...baseResult,
       error: {
         class: classifyProviderAdapterError(message),
-        message: redactAdapterEvidenceText(message)
+        message: redactPrivateEvidenceText(message, fixture.prompt)
       }
     };
   }
@@ -139,10 +139,11 @@ function buildFixtureEvidence(
   prompt: string,
   execution: ProviderAdapterExecutionResult
 ): ProviderAdapterFixtureEvidence {
+  const redactedOutput = redactPrivateEvidenceText(execution.text, prompt);
   return {
     promptSha256: sha256(prompt),
-    outputSha256: sha256(execution.text),
-    outputPreview: previewEvidenceText(execution.text),
+    outputSha256: sha256(redactedOutput),
+    outputPreview: redactedOutput.slice(0, 500),
     ...(execution.rawEvidence === undefined
       ? {}
       : { rawEvidencePreview: previewEvidenceText(stableStringify(redactPrivateEvidenceValue(execution.rawEvidence, prompt))) })
@@ -210,9 +211,7 @@ function redactPrivateEvidenceValue(value: unknown, prompt: string): unknown {
 
 function redactPrivateEvidenceText(value: string, prompt: string): string {
   if (containsPrivateEvidenceLikeText(value, prompt)) return "[redacted-private-evidence]";
-  const redacted = redactAdapterEvidenceText(value);
-  if (redacted !== value) return redacted;
-  return value;
+  return redactAdapterEvidenceText(value);
 }
 
 function isPrivateEvidenceKey(key: string): boolean {
@@ -226,7 +225,7 @@ function isSensitiveEvidenceKey(key: string): boolean {
 function containsPrivateEvidenceLikeText(value: string, prompt: string): boolean {
   return (
     containsSecretLikeText(value)
-    || /(^|\n)(diff --git|@@ |--- |\+\+\+ )/m.test(value)
+    || /(^|\n|\s)(diff --git|@@ |--- |\+\+\+ )/m.test(value)
     || (prompt.length > 0 && value.includes(prompt))
   );
 }

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -281,6 +281,7 @@ function isSensitiveEvidenceKey(key: string): boolean {
 
 function evidenceKeyTokens(key: string): string[] {
   return key
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
     .toLowerCase()
     .split(/[^a-z0-9]+/)

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { redactSecrets } from "./secrets.js";
+import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 export type ProviderAdapterErrorClass =
   | "auth"
@@ -48,15 +48,27 @@ export interface ProviderAdapterFixtureError {
   message: string;
 }
 
-export interface ProviderAdapterFixtureResult {
-  ok: boolean;
+export interface ProviderAdapterFixtureResultBase {
   fixtureId: string;
   providerId: string;
   adapterId: string;
   model: string;
   evidence: ProviderAdapterFixtureEvidence;
-  error?: ProviderAdapterFixtureError;
 }
+
+export interface ProviderAdapterFixtureSuccessResult extends ProviderAdapterFixtureResultBase {
+  ok: true;
+  error?: never;
+}
+
+export interface ProviderAdapterFixtureFailureResult extends ProviderAdapterFixtureResultBase {
+  ok: false;
+  error: ProviderAdapterFixtureError;
+}
+
+export type ProviderAdapterFixtureResult =
+  | ProviderAdapterFixtureSuccessResult
+  | ProviderAdapterFixtureFailureResult;
 
 export async function runProviderAdapterFixture(input: {
   adapter: ProviderRuntimeAdapter;
@@ -113,9 +125,9 @@ export async function runProviderAdapterFixture(input: {
 
 export function classifyProviderAdapterError(message: string): ProviderAdapterErrorClass {
   const normalized = message.toLowerCase();
-  if (/\b(unauthorized|forbidden|invalid api key|invalid_api_key|401|403)\b/.test(normalized)) return "auth";
-  if (/\b(rate limit|rate_limit|quota|too many requests|429|insufficient_quota|throttl(?:e|ed|ing))\b/.test(normalized)) return "throttle";
-  if (/\b(timeout|timed out|etimedout|abort(?:ed)?|deadline exceeded)\b/.test(normalized)) return "timeout";
+  if (/\b(unauthorized|forbidden|invalid[ _-]api[ _-]key|401|403)\b/.test(normalized)) return "auth";
+  if (/\b(rate[ _-]limit|quota|too many requests|429|insufficient[ _-]quota|throttl(?:e|ed|ing))\b/.test(normalized)) return "throttle";
+  if (/\b(time[ _-]?out|timed[ _-]out|etimedout|abort(?:ed)?|deadline exceeded)\b/.test(normalized)) return "timeout";
   if (/\b(econnreset|econnrefused|enotfound|eai_again|network|socket|dns|connection refused|connection reset)\b/.test(normalized)) return "network";
   if (/\b(json|schema|parseable|malformed output|invalid response|invalid output|tool call|structured output)\b/.test(normalized)) {
     return "model-output";
@@ -133,7 +145,7 @@ function buildFixtureEvidence(
     outputPreview: previewEvidenceText(execution.text),
     ...(execution.rawEvidence === undefined
       ? {}
-      : { rawEvidencePreview: previewEvidenceText(stableStringify(stripPrivateEvidenceFields(execution.rawEvidence))) })
+      : { rawEvidencePreview: previewEvidenceText(stableStringify(redactPrivateEvidenceValue(execution.rawEvidence, prompt))) })
   };
 }
 
@@ -153,8 +165,10 @@ function previewEvidenceText(value: string): string {
 function redactAdapterEvidenceText(value: string): string {
   return redactSecrets(
     value
+      .replace(/(["']?(?:x-)?api[-_]?key["']?\s*[:=]\s*["']?)[A-Za-z0-9._~+/=-]{8,}(["']?)/gi, "$1[redacted-secret]$2")
       .replace(/\bsk-[A-Za-z0-9._-]{8,}\b/g, "[redacted-secret]")
       .replace(/\bAIza[0-9A-Za-z_-]{20,}\b/g, "[redacted-secret]")
+      .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, "[redacted-secret]")
   );
 }
 
@@ -178,14 +192,41 @@ function sortJsonValue(value: unknown): unknown {
   return value;
 }
 
-function stripPrivateEvidenceFields(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map((item) => stripPrivateEvidenceFields(item));
+function redactPrivateEvidenceValue(value: unknown, prompt: string): unknown {
+  if (typeof value === "string") return redactPrivateEvidenceText(value, prompt);
+  if (Array.isArray(value)) return value.map((item) => redactPrivateEvidenceValue(item, prompt));
   if (value && typeof value === "object") {
     return Object.fromEntries(
       Object.entries(value)
-        .filter(([key]) => !/(prompt|diff|patch|content)/i.test(key))
-        .map(([key, entryValue]) => [key, stripPrivateEvidenceFields(entryValue)])
+        .map(([key, entryValue]) => {
+          if (isPrivateEvidenceKey(key)) return [key, "[redacted-private-field]"];
+          if (isSensitiveEvidenceKey(key)) return [key, "[redacted-sensitive-field]"];
+          return [key, redactPrivateEvidenceValue(entryValue, prompt)];
+        })
     );
   }
   return value;
+}
+
+function redactPrivateEvidenceText(value: string, prompt: string): string {
+  if (containsPrivateEvidenceLikeText(value, prompt)) return "[redacted-private-evidence]";
+  const redacted = redactAdapterEvidenceText(value);
+  if (redacted !== value) return redacted;
+  return value;
+}
+
+function isPrivateEvidenceKey(key: string): boolean {
+  return /(prompt|diff|patch|content|body|source|code|completion|response|message|stdout|stderr|log)/i.test(key);
+}
+
+function isSensitiveEvidenceKey(key: string): boolean {
+  return /(api[ _-]?key|authorization|auth|bearer|cookie|credential|password|secret|session|token)/i.test(key);
+}
+
+function containsPrivateEvidenceLikeText(value: string, prompt: string): boolean {
+  return (
+    containsSecretLikeText(value)
+    || /(^|\n)(diff --git|@@ |--- |\+\+\+ )/m.test(value)
+    || (prompt.length > 0 && value.includes(prompt))
+  );
 }

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -49,7 +49,7 @@ export interface ProviderRuntimeAdapter {
 
 export interface ProviderAdapterFixtureEvidence {
   promptSha256: string;
-  outputSha256?: string;
+  redactedOutputSha256?: string;
   outputPreview?: string;
   rawEvidencePreview?: string;
 }
@@ -154,7 +154,7 @@ function buildFixtureEvidence(
   const redactedOutput = redactPrivateEvidenceText(execution.text, prompt);
   return {
     promptSha256: sha256(prompt),
-    outputSha256: sha256(redactedOutput),
+    redactedOutputSha256: sha256(redactedOutput),
     outputPreview: previewEvidenceText(redactedOutput),
     ...(execution.rawEvidence === undefined
       ? {}
@@ -209,8 +209,19 @@ function redactAdapterEvidenceText(value: string): string {
       .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, REDACTION_TOKENS[2])
       .replace(/-----BEGIN\s*$/g, REDACTION_TOKENS[2])
       .replace(/(?:[A-Z ]*PRIVATE KEY-----|-----END [A-Z ]*PRIVATE KEY-----)/g, REDACTION_TOKENS[2])
-      .replace(/(?:[A-Za-z0-9+/]{48,}={0,2}|[A-Za-z0-9_-]{48,})/g, REDACTION_TOKENS[2])
+      .replace(/[A-Za-z0-9][A-Za-z0-9_+/=-]{47,}/g, (candidate) =>
+        isHighRiskLongEvidenceToken(candidate) ? REDACTION_TOKENS[2] : candidate
+      )
   );
+}
+
+function isHighRiskLongEvidenceToken(candidate: string): boolean {
+  if (/^[a-f0-9]{40,128}$/i.test(candidate)) return false;
+  if (/^(?:req|request|trace|span|run|job|evt|msg|resp|thread|file|batch)_[A-Za-z0-9_-]{16,}$/i.test(candidate)) {
+    return false;
+  }
+  if (/[+/=]/.test(candidate)) return true;
+  return candidate.length >= 64 && /[a-z]/.test(candidate) && /[A-Z]/.test(candidate) && /\d/.test(candidate);
 }
 
 function sha256(value: string): string {

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   classifyProviderAdapterError,
@@ -7,22 +8,35 @@ import {
 
 describe("provider adapter fixtures", () => {
   it("runs adapter fixtures deterministically without exposing prompt text or secrets in evidence", async () => {
-    const adapter: ProviderRuntimeAdapter = {
-      id: "fixture-openai-compatible",
-      async execute(input) {
-        expect(input.fixtureId).toBe("review-json-fixture");
-        expect(input.prompt).toContain("private patch content");
-        return {
-          text: '{"findings":[]}',
-          rawEvidence: {
-            echoedPrompt: input.prompt,
-            note: input.prompt,
-            providerUrl: "https://gateway.example.test/v1?api_key=secret-provider-key-123456",
-            authorization: "Bearer provider-secret-1234567890"
-          }
-        };
-      }
-    };
+    function makeAdapter(rawEvidence: Record<string, unknown>): ProviderRuntimeAdapter {
+      return {
+        id: "fixture-openai-compatible",
+        async execute(input) {
+          expect(input.fixtureId).toBe("review-json-fixture");
+          expect(input.prompt).toContain("private patch content");
+          return {
+            text: '{"findings":[]}',
+            rawEvidence
+          };
+        }
+      };
+    }
+    const firstAdapter = makeAdapter({
+      echoedPrompt: "Review this private patch content with sk-live-secret-secret.",
+      note: "Review this private patch content with sk-live-secret-secret.",
+      providerUrl: "https://gateway.example.test/v1?api_key=secret-provider-key-123456",
+      authorization: "Bearer provider-secret-1234567890",
+      b: 2,
+      a: 1
+    });
+    const secondAdapter = makeAdapter({
+      a: 1,
+      b: 2,
+      authorization: "Bearer provider-secret-1234567890",
+      providerUrl: "https://gateway.example.test/v1?api_key=secret-provider-key-123456",
+      note: "Review this private patch content with sk-live-secret-secret.",
+      echoedPrompt: "Review this private patch content with sk-live-secret-secret."
+    });
 
     const fixture = {
       id: "review-json-fixture",
@@ -33,8 +47,8 @@ describe("provider adapter fixtures", () => {
       expectJsonObject: true
     };
 
-    const first = await runProviderAdapterFixture({ adapter, fixture });
-    const second = await runProviderAdapterFixture({ adapter, fixture });
+    const first = await runProviderAdapterFixture({ adapter: firstAdapter, fixture });
+    const second = await runProviderAdapterFixture({ adapter: secondAdapter, fixture });
 
     expect(first).toEqual(second);
     expect(first).toMatchObject({
@@ -58,6 +72,61 @@ describe("provider adapter fixtures", () => {
     expect(serialized).toContain("[redacted-private-field]");
   });
 
+  it("redacts private adapter error messages with the same evidence boundary", async () => {
+    const fixture = {
+      id: "runtime-private-error-fixture",
+      providerId: "openai-compatible",
+      adapterId: "openai-compatible",
+      model: "review-model",
+      prompt: "Review this private patch content before posting a comment.",
+      expectJsonObject: true
+    };
+    const adapter: ProviderRuntimeAdapter = {
+      id: "fixture-openai-compatible",
+      async execute() {
+        throw new Error("failed processing diff --git a/private.ts b/private.ts with Review this private patch content");
+      }
+    };
+
+    const result = await runProviderAdapterFixture({ adapter, fixture });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "unknown",
+        message: "[redacted-private-evidence]"
+      }
+    });
+    expect(JSON.stringify(result)).not.toContain("diff --git");
+    expect(JSON.stringify(result)).not.toContain("private patch content");
+  });
+
+  it("hashes redacted provider output instead of raw private output", async () => {
+    const fixture = {
+      id: "private-output-fixture",
+      providerId: "openai-compatible",
+      adapterId: "openai-compatible",
+      model: "review-model",
+      prompt: "Review this private patch content before posting a comment."
+    };
+    const result = await runProviderAdapterFixture({
+      adapter: {
+        id: "fixture-openai-compatible",
+        async execute() {
+          return {
+            text: "Review this private patch content before posting a comment."
+          };
+        }
+      },
+      fixture
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.outputPreview).toBe("[redacted-private-evidence]");
+    expect(result.evidence.outputSha256).toBe(sha256("[redacted-private-evidence]"));
+    expect(result.evidence.outputSha256).not.toBe(sha256("Review this private patch content before posting a comment."));
+  });
+
   it("classifies adapter runtime errors into provider-safe categories with redacted evidence", async () => {
     expect(classifyProviderAdapterError("401 invalid api key")).toBe("auth");
     expect(classifyProviderAdapterError("429 rate limit exceeded")).toBe("throttle");
@@ -66,6 +135,7 @@ describe("provider adapter fixtures", () => {
     expect(classifyProviderAdapterError("request timed out")).toBe("timeout");
     expect(classifyProviderAdapterError("request timed-out")).toBe("timeout");
     expect(classifyProviderAdapterError("model returned malformed JSON")).toBe("model-output");
+    expect(classifyProviderAdapterError("network reachable but returned unexpected json")).toBe("network");
 
     const fixture = {
       id: "runtime-error-fixture",
@@ -89,7 +159,7 @@ describe("provider adapter fixtures", () => {
       ok: false,
       error: {
         class: "throttle",
-        message: expect.stringContaining("[redacted-secret]")
+        message: "[redacted-private-evidence]"
       }
     });
     expect(JSON.stringify(result)).not.toContain("provider-secret-1234567890");
@@ -123,7 +193,7 @@ describe("provider adapter fixtures", () => {
         message: "Adapter output was not a JSON object."
       },
       evidence: {
-        outputPreview: "not json with leaked token [redacted-secret] {\"x-api-key\":\"[redacted-secret]\"} [redacted-secret]"
+        outputPreview: "[redacted-private-evidence]"
       }
     });
     expect(JSON.stringify(result)).not.toContain("sk-live-secret-secret");
@@ -170,3 +240,7 @@ describe("provider adapter fixtures", () => {
     expect(serialized).not.toContain("secret");
   });
 });
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -135,7 +135,12 @@ describe("provider adapter fixtures", () => {
     expect(classifyProviderAdapterError("request timed out")).toBe("timeout");
     expect(classifyProviderAdapterError("request timed-out")).toBe("timeout");
     expect(classifyProviderAdapterError("model returned malformed JSON")).toBe("model-output");
-    expect(classifyProviderAdapterError("network reachable but returned unexpected json")).toBe("network");
+    expect(classifyProviderAdapterError("network reachable but returned unexpected json")).toBe("model-output");
+    expect(classifyProviderAdapterError("request timed out while validating structured output schema")).toBe(
+      "model-output"
+    );
+    expect(classifyProviderAdapterError("401 invalid api key while validating json schema")).toBe("auth");
+    expect(classifyProviderAdapterError("429 rate limit while parsing invalid response")).toBe("throttle");
 
     const fixture = {
       id: "runtime-error-fixture",
@@ -164,6 +169,51 @@ describe("provider adapter fixtures", () => {
     });
     expect(JSON.stringify(result)).not.toContain("provider-secret-1234567890");
   });
+
+  it.each([
+    {
+      expectedClass: "auth",
+      message: "401 invalid api key for Bearer provider-secret-1234567890"
+    },
+    {
+      expectedClass: "timeout",
+      message: "request timed out while using Bearer provider-secret-1234567890"
+    },
+    {
+      expectedClass: "network",
+      message: "ECONNRESET from gateway with Bearer provider-secret-1234567890"
+    }
+  ] as const)(
+    "redacts $expectedClass adapter errors through fixture execution",
+    async ({ expectedClass, message }) => {
+      const fixture = {
+        id: `${expectedClass}-runtime-error-fixture`,
+        providerId: "openai-compatible",
+        adapterId: "openai-compatible",
+        model: "review-model",
+        prompt: "Prompt containing provider-secret-1234567890",
+        expectJsonObject: true
+      };
+
+      const adapter: ProviderRuntimeAdapter = {
+        id: "fixture-openai-compatible",
+        async execute() {
+          throw new Error(message);
+        }
+      };
+
+      const result = await runProviderAdapterFixture({ adapter, fixture });
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          class: expectedClass,
+          message: "[redacted-private-evidence]"
+        }
+      });
+      expect(JSON.stringify(result)).not.toContain("provider-secret-1234567890");
+    }
+  );
 
   it("marks schema failures as model-output without preserving raw invalid output", async () => {
     const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZGFwdGVyLWZpeHR1cmUifQ.signature12345";
@@ -221,7 +271,16 @@ describe("provider adapter fixtures", () => {
               note: input.prompt,
               metadata: {
                 label: "adapter fixture",
-                harmless: true
+                harmless: true,
+                content: "benign token-count metadata",
+                message: "provider reported finished",
+                response: {
+                  id: "response-id-only",
+                  statusCode: 200
+                }
+              },
+              rawResponse: {
+                content: "Review this private patch content before posting a comment."
               },
               transcript: "diff --git a/private.ts b/private.ts\n@@ -1 +1 @@\n-secret\n+fixed"
             }
@@ -234,7 +293,12 @@ describe("provider adapter fixtures", () => {
     const serialized = JSON.stringify(result);
     expect(result.ok).toBe(true);
     expect(serialized).toContain("[redacted-private-evidence]");
+    expect(serialized).toContain("[redacted-private-field]");
     expect(serialized).toContain("adapter fixture");
+    expect(serialized).toContain("benign token-count metadata");
+    expect(serialized).toContain("provider reported finished");
+    expect(serialized).toContain("response-id-only");
+    expect(serialized).toContain("statusCode");
     expect(serialized).not.toContain("private patch content");
     expect(serialized).not.toContain("diff --git");
     expect(serialized).not.toContain("secret");

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -145,7 +145,8 @@ describe("provider adapter fixtures", () => {
     "[redacted-private-evidence]",
     "[redacted-private-field]",
     "[redacted-secret]",
-    "[redacted-sensitive-field]"
+    "[redacted-sensitive-field]",
+    "[redacted-unserializable-evidence]"
   ])("truncates output previews without splitting the %s token", async (redactionToken) => {
     const result = await runProviderAdapterFixture({
       adapter: {
@@ -189,6 +190,28 @@ describe("provider adapter fixtures", () => {
     expect(result.evidence.outputSha256).not.toBe(sha256("Review this private patch content before posting a comment."));
   });
 
+  it("omits raw evidence preview when adapter returns no raw evidence", async () => {
+    const result = await runProviderAdapterFixture({
+      adapter: {
+        id: "fixture-openai-compatible",
+        async execute() {
+          return {
+            text: '{"findings":[]}'
+          };
+        }
+      },
+      fixture: makeFixture({ id: "no-raw-evidence-fixture" })
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      evidence: {
+        outputPreview: '{"findings":[]}'
+      }
+    });
+    expect(result.evidence).not.toHaveProperty("rawEvidencePreview");
+  });
+
   it("classifies adapter runtime errors into provider-safe categories with redacted evidence", async () => {
     expect(classifyProviderAdapterError("401 invalid api key")).toBe("auth");
     expect(classifyProviderAdapterError("429 rate limit exceeded")).toBe("throttle");
@@ -201,6 +224,7 @@ describe("provider adapter fixtures", () => {
     expect(classifyProviderAdapterError("network-error while parsing invalid response")).toBe("network");
     expect(classifyProviderAdapterError("request timed out while validating structured output schema")).toBe("timeout");
     expect(classifyProviderAdapterError("ECONNRESET before structured output completed")).toBe("network");
+    expect(classifyProviderAdapterError("ECONNRESET after request timed out")).toBe("timeout");
     expect(classifyProviderAdapterError("401 invalid api key while validating json schema")).toBe("auth");
     expect(classifyProviderAdapterError("429 rate limit while parsing invalid response")).toBe("throttle");
 
@@ -364,6 +388,90 @@ describe("provider adapter fixtures", () => {
     expect(serialized).not.toContain("id-token-secret-value");
     expect(serialized).not.toContain("diff --git");
     expect(serialized).not.toContain("secret");
+  });
+
+  it("redacts provider token, base64, and split PEM shapes from raw evidence values", async () => {
+    const anthropicToken = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890";
+    const googleToken = "ya29.a0AfH6SMDabcdefghijklmnopqrstuvwxyz1234567890";
+    const base64Blob = "VGhpcy1sb29rcy1saWtlLWVuY29kZWQtcHJvdmlkZXItZXZpZGVuY2UtdGhhdC1zaG91bGQtYmUtcmVkYWN0ZWQ=";
+    const result = await runProviderAdapterFixture({
+      adapter: {
+        id: "fixture-openai-compatible",
+        async execute() {
+          return {
+            text: '{"findings":[]}',
+            rawEvidence: {
+              providerText: `anthropic ${anthropicToken}`,
+              googleText: `google ${googleToken}`,
+              encodedPayload: base64Blob,
+              pemParts: ["-----BEGIN ", "PRIVATE KEY-----", "abc123", "-----END PRIVATE KEY-----"]
+            }
+          };
+        }
+      },
+      fixture: makeFixture({ id: "provider-token-raw-evidence-fixture" })
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(result.ok).toBe(true);
+    expect(serialized).toContain("[redacted-secret]");
+    expect(serialized).not.toContain(anthropicToken);
+    expect(serialized).not.toContain(googleToken);
+    expect(serialized).not.toContain(base64Blob);
+    expect(serialized).not.toContain("PRIVATE KEY");
+  });
+
+  it("does not throw when raw evidence contains non-json primitives", async () => {
+    const result = await runProviderAdapterFixture({
+      adapter: {
+        id: "fixture-openai-compatible",
+        async execute() {
+          return {
+            text: '{"findings":[]}',
+            rawEvidence: {
+              bigint: BigInt(1),
+              missing: undefined,
+              notANumber: Number.NaN,
+              positiveInfinity: Number.POSITIVE_INFINITY
+            }
+          };
+        }
+      },
+      fixture: makeFixture({ id: "non-json-raw-evidence-fixture" })
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      evidence: {
+        rawEvidencePreview: "[redacted-unserializable-evidence]"
+      }
+    });
+  });
+
+  it("redacts root-level array raw evidence", async () => {
+    const result = await runProviderAdapterFixture({
+      adapter: {
+        id: "fixture-openai-compatible",
+        async execute(input) {
+          return {
+            text: '{"findings":[]}',
+            rawEvidence: [
+              "public marker",
+              input.prompt,
+              "diff --git a/private.ts b/private.ts\n@@ -1 +1 @@\n-secret\n+fixed"
+            ]
+          };
+        }
+      },
+      fixture: makeFixture({ id: "array-raw-evidence-fixture" })
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(result.ok).toBe(true);
+    expect(serialized).toContain("public marker");
+    expect(serialized).toContain("[redacted-private-evidence]");
+    expect(serialized).not.toContain("private patch content");
+    expect(serialized).not.toContain("diff --git");
   });
 });
 

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -26,12 +26,24 @@ describe("provider adapter fixtures", () => {
       note: "Review this private patch content with sk-live-secret-secret.",
       providerUrl: "https://gateway.example.test/v1?api_key=secret-provider-key-123456",
       authorization: "Bearer provider-secret-1234567890",
+      Z: "upper-z",
+      A: "upper-a",
+      Aa: "upper-aa",
+      _: "underscore",
+      aA: "lower-upper",
+      aa: "lower-aa",
       b: 2,
       a: 1
     });
     const secondAdapter = makeAdapter({
       a: 1,
       b: 2,
+      aa: "lower-aa",
+      aA: "lower-upper",
+      _: "underscore",
+      Aa: "upper-aa",
+      A: "upper-a",
+      Z: "upper-z",
       authorization: "Bearer provider-secret-1234567890",
       providerUrl: "https://gateway.example.test/v1?api_key=secret-provider-key-123456",
       note: "Review this private patch content with sk-live-secret-secret.",
@@ -60,7 +72,9 @@ describe("provider adapter fixtures", () => {
       evidence: {
         promptSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
         outputSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
-        outputPreview: '{"findings":[]}'
+        outputPreview: '{"findings":[]}',
+        rawEvidencePreview:
+          '{"A":"upper-a","Aa":"upper-aa","Z":"upper-z","_":"underscore","a":1,"aA":"lower-upper","aa":"lower-aa","authorization":"[redacted-sensitive-field]","b":2,"echoedPrompt":"[redacted-private-field]","note":"[redacted-private-evidence]","providerUrl":"[redacted-private-evidence]"}'
       }
     });
     const serialized = JSON.stringify(first);

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -50,14 +50,11 @@ describe("provider adapter fixtures", () => {
       echoedPrompt: "Review this private patch content with sk-live-secret-secret."
     });
 
-    const fixture = {
+    const fixture = makeFixture({
       id: "review-json-fixture",
-      providerId: "openai-compatible",
-      adapterId: "openai-compatible",
-      model: "review-model",
       prompt: "Review this private patch content with sk-live-secret-secret.",
       expectJsonObject: true
-    };
+    });
 
     const first = await runProviderAdapterFixture({ adapter: firstAdapter, fixture });
     const second = await runProviderAdapterFixture({ adapter: secondAdapter, fixture });
@@ -87,14 +84,10 @@ describe("provider adapter fixtures", () => {
   });
 
   it("redacts private adapter error messages with the same evidence boundary", async () => {
-    const fixture = {
+    const fixture = makeFixture({
       id: "runtime-private-error-fixture",
-      providerId: "openai-compatible",
-      adapterId: "openai-compatible",
-      model: "review-model",
-      prompt: "Review this private patch content before posting a comment.",
       expectJsonObject: true
-    };
+    });
     const adapter: ProviderRuntimeAdapter = {
       id: "fixture-openai-compatible",
       async execute() {
@@ -116,14 +109,10 @@ describe("provider adapter fixtures", () => {
   });
 
   it("truncates raw evidence previews with an explicit sentinel without splitting redaction tokens", async () => {
-    const fixture = {
+    const fixture = makeFixture({
       id: "truncated-raw-evidence-fixture",
-      providerId: "openai-compatible",
-      adapterId: "openai-compatible",
-      model: "review-model",
-      prompt: "Review this private patch content before posting a comment.",
       expectJsonObject: true
-    };
+    });
     const result = await runProviderAdapterFixture({
       adapter: {
         id: "fixture-openai-compatible",
@@ -167,13 +156,10 @@ describe("provider adapter fixtures", () => {
           };
         }
       },
-      fixture: {
+      fixture: makeFixture({
         id: `truncated-output-${redactionToken.replace(/[^a-z]/g, "-")}`,
-        providerId: "openai-compatible",
-        adapterId: "openai-compatible",
-        model: "review-model",
         prompt: "review patch"
-      }
+      })
     });
 
     expect(result.ok).toBe(true);
@@ -184,13 +170,7 @@ describe("provider adapter fixtures", () => {
   });
 
   it("hashes redacted provider output instead of raw private output", async () => {
-    const fixture = {
-      id: "private-output-fixture",
-      providerId: "openai-compatible",
-      adapterId: "openai-compatible",
-      model: "review-model",
-      prompt: "Review this private patch content before posting a comment."
-    };
+    const fixture = makeFixture({ id: "private-output-fixture" });
     const result = await runProviderAdapterFixture({
       adapter: {
         id: "fixture-openai-compatible",
@@ -224,14 +204,11 @@ describe("provider adapter fixtures", () => {
     expect(classifyProviderAdapterError("401 invalid api key while validating json schema")).toBe("auth");
     expect(classifyProviderAdapterError("429 rate limit while parsing invalid response")).toBe("throttle");
 
-    const fixture = {
+    const fixture = makeFixture({
       id: "runtime-error-fixture",
-      providerId: "openai-compatible",
-      adapterId: "openai-compatible",
-      model: "review-model",
       prompt: "Prompt containing provider-secret-1234567890",
       expectJsonObject: true
-    };
+    });
 
     const adapter: ProviderRuntimeAdapter = {
       id: "fixture-openai-compatible",
@@ -268,14 +245,11 @@ describe("provider adapter fixtures", () => {
   ] as const)(
     "redacts $expectedClass adapter errors through fixture execution",
     async ({ expectedClass, message }) => {
-      const fixture = {
+      const fixture = makeFixture({
         id: `${expectedClass}-runtime-error-fixture`,
-        providerId: "openai-compatible",
-        adapterId: "openai-compatible",
-        model: "review-model",
         prompt: "Prompt containing provider-secret-1234567890",
         expectJsonObject: true
-      };
+      });
 
       const adapter: ProviderRuntimeAdapter = {
         id: "fixture-openai-compatible",
@@ -308,14 +282,11 @@ describe("provider adapter fixtures", () => {
           };
         }
       },
-      fixture: {
+      fixture: makeFixture({
         id: "invalid-json-fixture",
-        providerId: "openai-compatible",
-        adapterId: "openai-compatible",
-        model: "review-model",
         prompt: "review patch",
         expectJsonObject: true
-      }
+      })
     });
 
     expect(result).toMatchObject({
@@ -334,14 +305,10 @@ describe("provider adapter fixtures", () => {
   });
 
   it("fails closed for raw private evidence stored under innocuous field names", async () => {
-    const fixture = {
+    const fixture = makeFixture({
       id: "raw-evidence-fixture",
-      providerId: "openai-compatible",
-      adapterId: "openai-compatible",
-      model: "review-model",
-      prompt: "Review this private patch content before posting a comment.",
       expectJsonObject: true
-    };
+    });
 
     const result = await runProviderAdapterFixture({
       adapter: {
@@ -364,6 +331,15 @@ describe("provider adapter fixtures", () => {
               rawResponse: {
                 content: "Review this private patch content before posting a comment."
               },
+              rawAPIResponse: {
+                status: 200,
+                data: "private api response text"
+              },
+              fullJSONOutput: {
+                findings: ["private json output"]
+              },
+              originalHTTPBody: "private http body",
+              rawIDToken: "id-token-secret-value",
               transcript: "diff --git a/private.ts b/private.ts\n@@ -1 +1 @@\n-secret\n+fixed"
             }
           };
@@ -382,6 +358,10 @@ describe("provider adapter fixtures", () => {
     expect(serialized).toContain("response-id-only");
     expect(serialized).toContain("statusCode");
     expect(serialized).not.toContain("private patch content");
+    expect(serialized).not.toContain("private api response text");
+    expect(serialized).not.toContain("private json output");
+    expect(serialized).not.toContain("private http body");
+    expect(serialized).not.toContain("id-token-secret-value");
     expect(serialized).not.toContain("diff --git");
     expect(serialized).not.toContain("secret");
   });
@@ -389,4 +369,22 @@ describe("provider adapter fixtures", () => {
 
 function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
+}
+
+function makeFixture(overrides: Partial<{
+  id: string;
+  providerId: string;
+  adapterId: string;
+  model: string;
+  prompt: string;
+  expectJsonObject: boolean;
+}> = {}) {
+  return {
+    id: "fixture",
+    providerId: "openai-compatible",
+    adapterId: "openai-compatible",
+    model: "review-model",
+    prompt: "Review this private patch content before posting a comment.",
+    ...overrides
+  };
 }

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -115,6 +115,43 @@ describe("provider adapter fixtures", () => {
     expect(JSON.stringify(result)).not.toContain("private patch content");
   });
 
+  it("truncates raw evidence previews with an explicit sentinel without splitting redaction tokens", async () => {
+    const fixture = {
+      id: "truncated-raw-evidence-fixture",
+      providerId: "openai-compatible",
+      adapterId: "openai-compatible",
+      model: "review-model",
+      prompt: "Review this private patch content before posting a comment.",
+      expectJsonObject: true
+    };
+    const result = await runProviderAdapterFixture({
+      adapter: {
+        id: "fixture-openai-compatible",
+        async execute() {
+          return {
+            text: '{"findings":[]}',
+            rawEvidence: Object.fromEntries(
+              Array.from({ length: 40 }, (_, index) => [
+                `rawResponse${String(index).padStart(2, "0")}`,
+                {
+                  message: "Review this private patch content before posting a comment."
+                }
+              ])
+            )
+          };
+        }
+      },
+      fixture
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.rawEvidencePreview).toBeDefined();
+    expect(result.evidence.rawEvidencePreview?.length).toBeLessThanOrEqual(500);
+    expect(result.evidence.rawEvidencePreview).toMatch(/\.\.\.\[truncated\]$/);
+    expect(result.evidence.rawEvidencePreview).not.toMatch(/\[redacted-[^\]]*$/);
+    expect(JSON.stringify(result)).not.toContain("private patch content");
+  });
+
   it("hashes redacted provider output instead of raw private output", async () => {
     const fixture = {
       id: "private-output-fixture",
@@ -150,9 +187,9 @@ describe("provider adapter fixtures", () => {
     expect(classifyProviderAdapterError("request timed-out")).toBe("timeout");
     expect(classifyProviderAdapterError("model returned malformed JSON")).toBe("model-output");
     expect(classifyProviderAdapterError("network reachable but returned unexpected json")).toBe("model-output");
-    expect(classifyProviderAdapterError("request timed out while validating structured output schema")).toBe(
-      "model-output"
-    );
+    expect(classifyProviderAdapterError("network-error while parsing invalid response")).toBe("network");
+    expect(classifyProviderAdapterError("request timed out while validating structured output schema")).toBe("timeout");
+    expect(classifyProviderAdapterError("ECONNRESET before structured output completed")).toBe("network");
     expect(classifyProviderAdapterError("401 invalid api key while validating json schema")).toBe("auth");
     expect(classifyProviderAdapterError("429 rate limit while parsing invalid response")).toBe("throttle");
 

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -68,7 +68,7 @@ describe("provider adapter fixtures", () => {
       model: "review-model",
       evidence: {
         promptSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
-        outputSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+        redactedOutputSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
         outputPreview: '{"findings":[]}',
         rawEvidencePreview:
           '{"A":"upper-a","Aa":"upper-aa","Z":"upper-z","_":"underscore","a":1,"aA":"lower-upper","aa":"lower-aa","authorization":"[redacted-sensitive-field]","b":2,"echoedPrompt":"[redacted-private-field]","note":"[redacted-private-evidence]","providerUrl":"[redacted-private-evidence]"}'
@@ -186,8 +186,9 @@ describe("provider adapter fixtures", () => {
 
     expect(result.ok).toBe(true);
     expect(result.evidence.outputPreview).toBe("[redacted-private-evidence]");
-    expect(result.evidence.outputSha256).toBe(sha256("[redacted-private-evidence]"));
-    expect(result.evidence.outputSha256).not.toBe(sha256("Review this private patch content before posting a comment."));
+    expect(result.evidence.redactedOutputSha256).toBe(sha256("[redacted-private-evidence]"));
+    expect(result.evidence.redactedOutputSha256).not.toBe(sha256("Review this private patch content before posting a comment."));
+    expect(result.evidence).not.toHaveProperty("outputSha256");
   });
 
   it("omits raw evidence preview when adapter returns no raw evidence", async () => {
@@ -419,6 +420,35 @@ describe("provider adapter fixtures", () => {
     expect(serialized).not.toContain(googleToken);
     expect(serialized).not.toContain(base64Blob);
     expect(serialized).not.toContain("PRIVATE KEY");
+  });
+
+  it("preserves benign long hashes and request ids while redacting high-risk base64 blobs", async () => {
+    const sha256Hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const requestId = "req_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    const base64Blob = "VGhpcy1sb29rcy1saWtlLWVuY29kZWQtcHJvdmlkZXItZXZpZGVuY2UtdGhhdC1zaG91bGQtYmUtcmVkYWN0ZWQ=";
+    const result = await runProviderAdapterFixture({
+      adapter: {
+        id: "fixture-openai-compatible",
+        async execute() {
+          return {
+            text: '{"findings":[]}',
+            rawEvidence: {
+              sha256Hex,
+              requestId,
+              encodedPayload: base64Blob
+            }
+          };
+        }
+      },
+      fixture: makeFixture({ id: "benign-long-id-raw-evidence-fixture" })
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(result.ok).toBe(true);
+    expect(serialized).toContain(sha256Hex);
+    expect(serialized).toContain(requestId);
+    expect(serialized).toContain("[redacted-secret]");
+    expect(serialized).not.toContain(base64Blob);
   });
 
   it("does not throw when raw evidence contains non-json primitives", async () => {

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -152,6 +152,37 @@ describe("provider adapter fixtures", () => {
     expect(JSON.stringify(result)).not.toContain("private patch content");
   });
 
+  it.each([
+    "[redacted-private-evidence]",
+    "[redacted-private-field]",
+    "[redacted-secret]",
+    "[redacted-sensitive-field]"
+  ])("truncates output previews without splitting the %s token", async (redactionToken) => {
+    const result = await runProviderAdapterFixture({
+      adapter: {
+        id: "fixture-openai-compatible",
+        async execute() {
+          return {
+            text: `${"x".repeat(480)}${redactionToken.repeat(40)}`
+          };
+        }
+      },
+      fixture: {
+        id: `truncated-output-${redactionToken.replace(/[^a-z]/g, "-")}`,
+        providerId: "openai-compatible",
+        adapterId: "openai-compatible",
+        model: "review-model",
+        prompt: "review patch"
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.outputPreview).toBeDefined();
+    expect(result.evidence.outputPreview?.length).toBeLessThanOrEqual(500);
+    expect(result.evidence.outputPreview).toMatch(/\.\.\.\[truncated\]$/);
+    expect(result.evidence.outputPreview).not.toMatch(/\[redacted-[^\]]*$/);
+  });
+
   it("hashes redacted provider output instead of raw private output", async () => {
     const fixture = {
       id: "private-output-fixture",

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -16,6 +16,7 @@ describe("provider adapter fixtures", () => {
           text: '{"findings":[]}',
           rawEvidence: {
             echoedPrompt: input.prompt,
+            note: input.prompt,
             providerUrl: "https://gateway.example.test/v1?api_key=secret-provider-key-123456",
             authorization: "Bearer provider-secret-1234567890"
           }
@@ -53,14 +54,17 @@ describe("provider adapter fixtures", () => {
     expect(serialized).not.toContain("sk-live-secret-secret");
     expect(serialized).not.toContain("secret-provider-key-123456");
     expect(serialized).not.toContain("provider-secret-1234567890");
-    expect(serialized).toContain("[redacted-secret]");
+    expect(serialized).toContain("[redacted-private-evidence]");
+    expect(serialized).toContain("[redacted-private-field]");
   });
 
   it("classifies adapter runtime errors into provider-safe categories with redacted evidence", async () => {
     expect(classifyProviderAdapterError("401 invalid api key")).toBe("auth");
     expect(classifyProviderAdapterError("429 rate limit exceeded")).toBe("throttle");
+    expect(classifyProviderAdapterError("rate-limit exceeded")).toBe("throttle");
     expect(classifyProviderAdapterError("ECONNRESET from gateway")).toBe("network");
     expect(classifyProviderAdapterError("request timed out")).toBe("timeout");
+    expect(classifyProviderAdapterError("request timed-out")).toBe("timeout");
     expect(classifyProviderAdapterError("model returned malformed JSON")).toBe("model-output");
 
     const fixture = {
@@ -92,12 +96,13 @@ describe("provider adapter fixtures", () => {
   });
 
   it("marks schema failures as model-output without preserving raw invalid output", async () => {
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZGFwdGVyLWZpeHR1cmUifQ.signature12345";
     const result = await runProviderAdapterFixture({
       adapter: {
         id: "fixture-openai-compatible",
         async execute() {
           return {
-            text: "not json with leaked token sk-live-secret-secret"
+            text: `not json with leaked token sk-live-secret-secret {"x-api-key":"rawapikey1234567890"} ${jwt}`
           };
         }
       },
@@ -118,9 +123,50 @@ describe("provider adapter fixtures", () => {
         message: "Adapter output was not a JSON object."
       },
       evidence: {
-        outputPreview: "not json with leaked token [redacted-secret]"
+        outputPreview: "not json with leaked token [redacted-secret] {\"x-api-key\":\"[redacted-secret]\"} [redacted-secret]"
       }
     });
     expect(JSON.stringify(result)).not.toContain("sk-live-secret-secret");
+    expect(JSON.stringify(result)).not.toContain("rawapikey1234567890");
+    expect(JSON.stringify(result)).not.toContain(jwt);
+  });
+
+  it("fails closed for raw private evidence stored under innocuous field names", async () => {
+    const fixture = {
+      id: "raw-evidence-fixture",
+      providerId: "openai-compatible",
+      adapterId: "openai-compatible",
+      model: "review-model",
+      prompt: "Review this private patch content before posting a comment.",
+      expectJsonObject: true
+    };
+
+    const result = await runProviderAdapterFixture({
+      adapter: {
+        id: "fixture-openai-compatible",
+        async execute(input) {
+          return {
+            text: '{"findings":[]}',
+            rawEvidence: {
+              note: input.prompt,
+              metadata: {
+                label: "adapter fixture",
+                harmless: true
+              },
+              transcript: "diff --git a/private.ts b/private.ts\n@@ -1 +1 @@\n-secret\n+fixed"
+            }
+          };
+        }
+      },
+      fixture
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(result.ok).toBe(true);
+    expect(serialized).toContain("[redacted-private-evidence]");
+    expect(serialized).toContain("adapter fixture");
+    expect(serialized).not.toContain("private patch content");
+    expect(serialized).not.toContain("diff --git");
+    expect(serialized).not.toContain("secret");
   });
 });

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyProviderAdapterError,
+  runProviderAdapterFixture,
+  type ProviderRuntimeAdapter
+} from "../src/provider-adapters.js";
+
+describe("provider adapter fixtures", () => {
+  it("runs adapter fixtures deterministically without exposing prompt text or secrets in evidence", async () => {
+    const adapter: ProviderRuntimeAdapter = {
+      id: "fixture-openai-compatible",
+      async execute(input) {
+        expect(input.fixtureId).toBe("review-json-fixture");
+        expect(input.prompt).toContain("private patch content");
+        return {
+          text: '{"findings":[]}',
+          rawEvidence: {
+            echoedPrompt: input.prompt,
+            providerUrl: "https://gateway.example.test/v1?api_key=secret-provider-key-123456",
+            authorization: "Bearer provider-secret-1234567890"
+          }
+        };
+      }
+    };
+
+    const fixture = {
+      id: "review-json-fixture",
+      providerId: "openai-compatible",
+      adapterId: "openai-compatible",
+      model: "review-model",
+      prompt: "Review this private patch content with sk-live-secret-secret.",
+      expectJsonObject: true
+    };
+
+    const first = await runProviderAdapterFixture({ adapter, fixture });
+    const second = await runProviderAdapterFixture({ adapter, fixture });
+
+    expect(first).toEqual(second);
+    expect(first).toMatchObject({
+      ok: true,
+      fixtureId: "review-json-fixture",
+      providerId: "openai-compatible",
+      adapterId: "openai-compatible",
+      model: "review-model",
+      evidence: {
+        promptSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+        outputSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+        outputPreview: '{"findings":[]}'
+      }
+    });
+    const serialized = JSON.stringify(first);
+    expect(serialized).not.toContain("private patch content");
+    expect(serialized).not.toContain("sk-live-secret-secret");
+    expect(serialized).not.toContain("secret-provider-key-123456");
+    expect(serialized).not.toContain("provider-secret-1234567890");
+    expect(serialized).toContain("[redacted-secret]");
+  });
+
+  it("classifies adapter runtime errors into provider-safe categories with redacted evidence", async () => {
+    expect(classifyProviderAdapterError("401 invalid api key")).toBe("auth");
+    expect(classifyProviderAdapterError("429 rate limit exceeded")).toBe("throttle");
+    expect(classifyProviderAdapterError("ECONNRESET from gateway")).toBe("network");
+    expect(classifyProviderAdapterError("request timed out")).toBe("timeout");
+    expect(classifyProviderAdapterError("model returned malformed JSON")).toBe("model-output");
+
+    const fixture = {
+      id: "runtime-error-fixture",
+      providerId: "openai-compatible",
+      adapterId: "openai-compatible",
+      model: "review-model",
+      prompt: "Prompt containing provider-secret-1234567890",
+      expectJsonObject: true
+    };
+
+    const adapter: ProviderRuntimeAdapter = {
+      id: "fixture-openai-compatible",
+      async execute() {
+        throw new Error("429 quota exhausted for Bearer provider-secret-1234567890");
+      }
+    };
+
+    const result = await runProviderAdapterFixture({ adapter, fixture });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "throttle",
+        message: expect.stringContaining("[redacted-secret]")
+      }
+    });
+    expect(JSON.stringify(result)).not.toContain("provider-secret-1234567890");
+  });
+
+  it("marks schema failures as model-output without preserving raw invalid output", async () => {
+    const result = await runProviderAdapterFixture({
+      adapter: {
+        id: "fixture-openai-compatible",
+        async execute() {
+          return {
+            text: "not json with leaked token sk-live-secret-secret"
+          };
+        }
+      },
+      fixture: {
+        id: "invalid-json-fixture",
+        providerId: "openai-compatible",
+        adapterId: "openai-compatible",
+        model: "review-model",
+        prompt: "review patch",
+        expectJsonObject: true
+      }
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "model-output",
+        message: "Adapter output was not a JSON object."
+      },
+      evidence: {
+        outputPreview: "not json with leaked token [redacted-secret]"
+      }
+    });
+    expect(JSON.stringify(result)).not.toContain("sk-live-secret-secret");
+  });
+});


### PR DESCRIPTION
## Summary
- add a deterministic provider runtime adapter fixture runner with prompt/output hashes and redacted public-safe evidence previews
- add provider-runtime error classes for auth, throttle, network, timeout, and model-output failures
- document the fixture proof boundary without claiming live provider parity

Related #108

## Validation
- `NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/provider-adapters.test.ts --pool forks`
- `NODE_OPTIONS=--experimental-sqlite npm run build`
- `git diff --check`

## Proof boundary
This PR proves deterministic fixture execution, adapter error classification, and redacted evidence boundaries only. It does not change live config, select alternate providers at runtime, prove GLM/Ollama parity, or promote live provider adapter execution.