### PR TITLE
Add settings profile preview matrix

### DIFF
--- a/docs/repo-profiles.md
+++ b/docs/repo-profiles.md
@@ -101,6 +101,10 @@ The preview maps current config into user-facing review behavior:
 
 - `reviewProfile` becomes the visible profile, currently `chill` or
   `assertive`.
+- `sampleProfile` records the closest public sample profile metadata:
+  conservative for `chill`, assertive for `assertive`. Balanced is documented
+  as a sample user-facing midpoint for configuration examples, but it does not
+  create a third runtime prompt mode yet.
 - `walkthrough.enabled` and `walkthrough.postIssueComment` decide whether the
   walkthrough-related sections are inline review content or a sticky issue
   comment.
@@ -113,10 +117,36 @@ The preview maps current config into user-facing review behavior:
 - label and reviewer settings remain suggestions only. Auto-applying labels or
   requesting reviewers is explicitly roadmap-only until permissions and eval
   gates justify it.
+- `unsupportedSettings` records CodeRabbit-like settings that NeonDiff can show
+  as evidence but does not execute. This matrix is deterministic so dry-run
+  evidence and docs snapshots can be compared directly.
 
 The preview is descriptive evidence only. It does not change repo eligibility,
 provider selection, App permissions, live allowlists, labels, reviewers, status
 checks, or release state.
+
+### Sample Profile Matrix
+
+The policy layer exposes these sample profiles for documentation, UI previews,
+and dry-run evidence:
+
+| Sample | Runtime profile | Default visible sections | Behavior boundary |
+| --- | --- | --- | --- |
+| Conservative | `chill` | Review summary, walkthrough, changed-files table | Minimal, low-noise rollout posture. Labels and reviewers stay suggestion-only. |
+| Balanced | `assertive` | Review summary, walkthrough, changed-files table, effort estimate, related context | Default user-facing midpoint. It is sample metadata only, not a third runtime prompt mode. |
+| Assertive | `assertive` | Review summary, walkthrough, changed-files table, effort estimate, related context, suggested labels, suggested reviewers, status comment | Higher-signal posture for release, runtime, and regression-sensitive repos. Suggestions still do not mutate GitHub state. |
+
+### Unsupported Setting Matrix
+
+The unsupported-setting evidence intentionally separates safe preview surfaces
+from mutation or enforcement features:
+
+| Setting | Status | Safe alternative |
+| --- | --- | --- |
+| Auto-apply labels | Roadmap-only | Emit `suggestedLabels` as suggestion-only preview evidence. |
+| Auto-request reviewers | Roadmap-only | Emit `suggestedReviewers` as suggestion-only preview evidence. |
+| Required status checks | Roadmap-only | Use `reviewStatusComment.enabled` for sticky descriptive status only. |
+| Auto-fix or apply suggestions | Unsupported | Open a human-reviewed follow-up PR from a separate implementation lane. |
 
 ## Changed-Surface Validation
 
@@ -131,8 +161,8 @@ evidence beside the review plan:
   `REQUEST_CHANGES` decisions after schema, diff-line, secret, cap, and taxonomy
   gates.
 - `review-settings-preview.json`: mapped review-output settings, path
-  instructions, suggestion-only labels/reviewers, and roadmap-only unsafe
-  settings.
+  instructions, sample profile metadata, suggestion-only labels/reviewers, and
+  roadmap-only or unsupported unsafe settings.
 
 These selectors do not run tests, builds, project scripts, Unity, or arbitrary
 PR code. They only decide which proof a reviewer should expect and whether that

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -47,13 +47,35 @@ export interface ReviewSettingsPreviewSection {
   mode: "inline_review" | "issue_comment" | "walkthrough" | "sticky_status" | "suggestion_only";
 }
 
+export type ReviewSettingsProfileId = "conservative" | "balanced" | "assertive";
+
+export interface ReviewSettingsProfileMetadata {
+  id: ReviewSettingsProfileId;
+  label: string;
+  description: string;
+  repoReviewProfile: NonNullable<RepoProfileConfig["reviewProfile"]>;
+  defaultSections: ReviewSettingsSectionKey[];
+  suggestionBehavior: "suggestion_only";
+}
+
 export interface ReviewSettingsPathInstruction {
   pattern: string;
   instructions: string[];
 }
 
+export type UnsupportedReviewSettingStatus = "roadmap_only" | "unsupported";
+
+export interface UnsupportedReviewSettingEvidence {
+  key: string;
+  label: string;
+  status: UnsupportedReviewSettingStatus;
+  reason: string;
+  safeAlternative: string;
+}
+
 export interface ReviewSettingsPreview {
   profile: "chill" | "assertive";
+  sampleProfile?: ReviewSettingsProfileMetadata;
   sections: ReviewSettingsPreviewSection[];
   pathInstructions: ReviewSettingsPathInstruction[];
   suggestions: {
@@ -61,6 +83,7 @@ export interface ReviewSettingsPreview {
     reviewers: string[];
     autoApply: false;
   };
+  unsupportedSettings?: UnsupportedReviewSettingEvidence[];
   roadmapOnly: string[];
 }
 
@@ -134,6 +157,81 @@ const SAFETY_INCLUDE_PATTERNS = [
   "**/*.entitlements",
   "**/*.entitlements.plist"
 ];
+
+const REVIEW_SETTINGS_PROFILE_MATRIX: ReviewSettingsProfileMetadata[] = [
+  {
+    id: "conservative",
+    label: "Conservative",
+    description: "Minimal, low-noise review posture for early rollout and sensitive repositories.",
+    repoReviewProfile: "chill",
+    defaultSections: ["reviewSummary", "walkthrough", "changedFiles"],
+    suggestionBehavior: "suggestion_only"
+  },
+  {
+    id: "balanced",
+    label: "Balanced",
+    description: "Default user-facing posture with summaries, walkthrough detail, effort, and related context.",
+    repoReviewProfile: "assertive",
+    defaultSections: ["reviewSummary", "walkthrough", "changedFiles", "effortEstimate", "relatedContext"],
+    suggestionBehavior: "suggestion_only"
+  },
+  {
+    id: "assertive",
+    label: "Assertive",
+    description: "Higher-signal review posture for release, runtime, and regression-sensitive repositories.",
+    repoReviewProfile: "assertive",
+    defaultSections: [
+      "reviewSummary",
+      "walkthrough",
+      "changedFiles",
+      "effortEstimate",
+      "relatedContext",
+      "suggestedLabels",
+      "suggestedReviewers",
+      "statusComment"
+    ],
+    suggestionBehavior: "suggestion_only"
+  }
+];
+
+const UNSUPPORTED_REVIEW_SETTINGS_MATRIX: UnsupportedReviewSettingEvidence[] = [
+  {
+    key: "autoApplyLabels",
+    label: "Auto-apply labels",
+    status: "roadmap_only",
+    reason: "Requires explicit GitHub App permission, repo opt-in, and eval evidence before mutation.",
+    safeAlternative: "Emit suggestedLabels as suggestion-only preview evidence."
+  },
+  {
+    key: "autoRequestReviewers",
+    label: "Auto-request reviewers",
+    status: "roadmap_only",
+    reason: "Requires explicit GitHub App permission, repo opt-in, and reviewer-selection eval evidence before mutation.",
+    safeAlternative: "Emit suggestedReviewers as suggestion-only preview evidence."
+  },
+  {
+    key: "requiredStatusChecks",
+    label: "Required status checks",
+    status: "roadmap_only",
+    reason: "Review status comments are descriptive; this bot does not create or enforce branch-protection checks.",
+    safeAlternative: "Use reviewStatusComment.enabled for sticky descriptive status only."
+  },
+  {
+    key: "autoFixOrApplySuggestions",
+    label: "Auto-fix or apply suggestions",
+    status: "unsupported",
+    reason: "NeonDiff review previews never mutate PR code or apply patches.",
+    safeAlternative: "Open a human-reviewed follow-up PR from a separate implementation lane."
+  }
+];
+
+export function buildReviewSettingsProfileMatrix(): ReviewSettingsProfileMetadata[] {
+  return REVIEW_SETTINGS_PROFILE_MATRIX.map(cloneReviewSettingsProfile);
+}
+
+export function buildUnsupportedReviewSettingsMatrix(): UnsupportedReviewSettingEvidence[] {
+  return UNSUPPORTED_REVIEW_SETTINGS_MATRIX.map((entry) => ({ ...entry }));
+}
 
 export function listReposToScan(config: BotConfig): string[] {
   const configured = uniqueRepos(config.pilotRepos);
@@ -212,8 +310,10 @@ export function buildReviewSettingsPreview(config: BotConfig, profile: ResolvedR
   const walkthroughMode = walkthroughPostsSeparately ? "issue_comment" : "inline_review";
   const labels = profile.suggestedLabels ?? [];
   const reviewers = profile.suggestedReviewers ?? [];
+  const unsupportedSettings = buildUnsupportedReviewSettingsMatrix();
   return {
     profile: profile.reviewProfile ?? "assertive",
+    sampleProfile: sampleProfileForReviewProfile(profile.reviewProfile ?? "assertive"),
     sections: [
       { key: "reviewSummary", label: "Review summary", enabled: true, mode: "inline_review" },
       { key: "walkthrough", label: "Walkthrough", enabled: walkthroughEnabled, mode: walkthroughMode },
@@ -233,7 +333,10 @@ export function buildReviewSettingsPreview(config: BotConfig, profile: ResolvedR
       reviewers,
       autoApply: false
     },
-    roadmapOnly: ["auto-apply labels", "auto-request reviewers"]
+    unsupportedSettings,
+    roadmapOnly: unsupportedSettings
+      .filter((entry) => entry.status === "roadmap_only")
+      .map((entry) => entry.label.toLowerCase())
   };
 }
 
@@ -302,6 +405,20 @@ function normalizeProfile(
     canonicalRepo: canonicalRepoName(repo),
     source,
     reviewProfile: profile.reviewProfile ?? "assertive"
+  };
+}
+
+function sampleProfileForReviewProfile(reviewProfile: NonNullable<RepoProfileConfig["reviewProfile"]>): ReviewSettingsProfileMetadata {
+  const id: ReviewSettingsProfileId = reviewProfile === "chill" ? "conservative" : "assertive";
+  const profile = REVIEW_SETTINGS_PROFILE_MATRIX.find((candidate) => candidate.id === id);
+  if (!profile) throw new Error(`Missing review settings profile metadata for ${id}`);
+  return cloneReviewSettingsProfile(profile);
+}
+
+function cloneReviewSettingsProfile(profile: ReviewSettingsProfileMetadata): ReviewSettingsProfileMetadata {
+  return {
+    ...profile,
+    defaultSections: [...profile.defaultSections]
   };
 }
 

--- a/tests/repo-policy.test.ts
+++ b/tests/repo-policy.test.ts
@@ -4,10 +4,12 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadConfig } from "../src/config.js";
 import {
+  buildReviewSettingsProfileMatrix,
   buildPullFileFilterImpact,
   buildRepoPolicySnapshot,
   buildRepoProfilePromptSection,
   buildReviewSettingsPreview,
+  buildUnsupportedReviewSettingsMatrix,
   filterPullFilesForProfile,
   listReposToScan,
   resolveRepoProfile
@@ -410,6 +412,23 @@ describe("repo profile registry", () => {
 
     expect(buildReviewSettingsPreview(config, profile)).toEqual({
       profile: "assertive",
+      sampleProfile: {
+        id: "assertive",
+        label: "Assertive",
+        description: "Higher-signal review posture for release, runtime, and regression-sensitive repositories.",
+        repoReviewProfile: "assertive",
+        defaultSections: [
+          "reviewSummary",
+          "walkthrough",
+          "changedFiles",
+          "effortEstimate",
+          "relatedContext",
+          "suggestedLabels",
+          "suggestedReviewers",
+          "statusComment"
+        ],
+        suggestionBehavior: "suggestion_only"
+      },
       sections: [
         { key: "reviewSummary", label: "Review summary", enabled: true, mode: "inline_review" },
         { key: "walkthrough", label: "Walkthrough", enabled: true, mode: "issue_comment" },
@@ -428,8 +447,109 @@ describe("repo profile registry", () => {
         reviewers: ["maintainer-one"],
         autoApply: false
       },
-      roadmapOnly: ["auto-apply labels", "auto-request reviewers"]
+      unsupportedSettings: [
+        {
+          key: "autoApplyLabels",
+          label: "Auto-apply labels",
+          status: "roadmap_only",
+          reason: "Requires explicit GitHub App permission, repo opt-in, and eval evidence before mutation.",
+          safeAlternative: "Emit suggestedLabels as suggestion-only preview evidence."
+        },
+        {
+          key: "autoRequestReviewers",
+          label: "Auto-request reviewers",
+          status: "roadmap_only",
+          reason: "Requires explicit GitHub App permission, repo opt-in, and reviewer-selection eval evidence before mutation.",
+          safeAlternative: "Emit suggestedReviewers as suggestion-only preview evidence."
+        },
+        {
+          key: "requiredStatusChecks",
+          label: "Required status checks",
+          status: "roadmap_only",
+          reason: "Review status comments are descriptive; this bot does not create or enforce branch-protection checks.",
+          safeAlternative: "Use reviewStatusComment.enabled for sticky descriptive status only."
+        },
+        {
+          key: "autoFixOrApplySuggestions",
+          label: "Auto-fix or apply suggestions",
+          status: "unsupported",
+          reason: "NeonDiff review previews never mutate PR code or apply patches.",
+          safeAlternative: "Open a human-reviewed follow-up PR from a separate implementation lane."
+        }
+      ],
+      roadmapOnly: ["auto-apply labels", "auto-request reviewers", "required status checks"]
     });
+  });
+
+  it("exposes deterministic conservative balanced and assertive sample profile metadata", () => {
+    expect(buildReviewSettingsProfileMatrix()).toEqual([
+      {
+        id: "conservative",
+        label: "Conservative",
+        description: "Minimal, low-noise review posture for early rollout and sensitive repositories.",
+        repoReviewProfile: "chill",
+        defaultSections: ["reviewSummary", "walkthrough", "changedFiles"],
+        suggestionBehavior: "suggestion_only"
+      },
+      {
+        id: "balanced",
+        label: "Balanced",
+        description: "Default user-facing posture with summaries, walkthrough detail, effort, and related context.",
+        repoReviewProfile: "assertive",
+        defaultSections: ["reviewSummary", "walkthrough", "changedFiles", "effortEstimate", "relatedContext"],
+        suggestionBehavior: "suggestion_only"
+      },
+      {
+        id: "assertive",
+        label: "Assertive",
+        description: "Higher-signal review posture for release, runtime, and regression-sensitive repositories.",
+        repoReviewProfile: "assertive",
+        defaultSections: [
+          "reviewSummary",
+          "walkthrough",
+          "changedFiles",
+          "effortEstimate",
+          "relatedContext",
+          "suggestedLabels",
+          "suggestedReviewers",
+          "statusComment"
+        ],
+        suggestionBehavior: "suggestion_only"
+      }
+    ]);
+  });
+
+  it("keeps unsupported CodeRabbit-like settings in a deterministic evidence matrix", () => {
+    expect(buildUnsupportedReviewSettingsMatrix()).toEqual([
+      {
+        key: "autoApplyLabels",
+        label: "Auto-apply labels",
+        status: "roadmap_only",
+        reason: "Requires explicit GitHub App permission, repo opt-in, and eval evidence before mutation.",
+        safeAlternative: "Emit suggestedLabels as suggestion-only preview evidence."
+      },
+      {
+        key: "autoRequestReviewers",
+        label: "Auto-request reviewers",
+        status: "roadmap_only",
+        reason: "Requires explicit GitHub App permission, repo opt-in, and reviewer-selection eval evidence before mutation.",
+        safeAlternative: "Emit suggestedReviewers as suggestion-only preview evidence."
+      },
+      {
+        key: "requiredStatusChecks",
+        label: "Required status checks",
+        status: "roadmap_only",
+        reason: "Review status comments are descriptive; this bot does not create or enforce branch-protection checks.",
+        safeAlternative: "Use reviewStatusComment.enabled for sticky descriptive status only."
+      },
+      {
+        key: "autoFixOrApplySuggestions",
+        label: "Auto-fix or apply suggestions",
+        status: "unsupported",
+        reason: "NeonDiff review previews never mutate PR code or apply patches.",
+        safeAlternative: "Open a human-reviewed follow-up PR from a separate implementation lane."
+      }
+    ]);
   });
 
   it("keeps review summary enabled when inline walkthrough carries the review body", () => {


### PR DESCRIPTION
## Summary
- add deterministic conservative/balanced/assertive settings profile metadata for review-preview evidence
- add unsupported/roadmap-only CodeRabbit-like setting evidence while preserving suggestion-only label/reviewer behavior
- document the profile matrix and unsupported-setting matrix in repo profile docs

Refs #117

## Validation
- `npm test -- tests/repo-policy.test.ts tests/worker-settings-preview.test.ts`
- `npm run build`

## Proof boundary
- Policy/docs/test slice only.
- No edits to `src/walkthrough.ts` or `src/worker.ts`.
- Does not auto-apply labels, request reviewers, create required status checks, mutate PR code, or change live runtime settings.