### PR TITLE
Fix scheduler idle queue leases

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -219,6 +219,12 @@ export async function runScheduledCycleWithDeps(input: {
     });
     applyReviewStatus(result, status);
     if (status === "skipped_provider_cooldown") {
+      result.queue.providerDeferred += deferQueuedProviderJobsForProviderThrottle({
+        config,
+        state: input.state,
+        triggerJob: job,
+        now: eventClock()
+      });
       break;
     }
   }
@@ -1177,6 +1183,46 @@ function shouldMarkJobReviewing(state: ReviewStateStore, job: ReviewQueueJobReco
   if (job.source !== "manual_command") return true;
   const existing = state.getReviewReadiness(job.repo, job.pullNumber, job.headSha);
   return existing?.commandAction ? isReviewCommandAction(existing.commandAction) : true;
+}
+
+function deferQueuedProviderJobsForProviderThrottle(input: {
+  config: BotConfig;
+  state: ReviewStateStore;
+  triggerJob: ReviewQueueJobRecord;
+  now: Date;
+}): number {
+  const cooldown = providerThrottleCooldownFromTriggerJob(input);
+  const providerId = input.triggerJob.providerId ?? "default";
+  let deferred = 0;
+  for (const job of input.state.listReviewQueueJobs({ state: "queued" })) {
+    if (job.jobId === input.triggerJob.jobId) continue;
+    if ((job.providerId ?? "default") !== providerId) continue;
+    input.state.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "provider_deferred",
+      nextEligibleAt: cooldown.cooldownUntil,
+      lastError: `provider_throttle_cycle_deferred_until=${cooldown.cooldownUntil}; reason=${cooldown.reason}; trigger_repo=${input.triggerJob.repo}`,
+      now: input.now
+    });
+    deferred += 1;
+  }
+  return deferred;
+}
+
+function providerThrottleCooldownFromTriggerJob(input: {
+  config: BotConfig;
+  state: ReviewStateStore;
+  triggerJob: ReviewQueueJobRecord;
+  now: Date;
+}): { cooldownUntil: string; reason: string } {
+  const processed = input.state.getProcessedReview(input.triggerJob.repo, input.triggerJob.pullNumber, input.triggerJob.headSha);
+  const parsed = parseProviderCooldownError(processed?.error);
+  const repoCooldown = input.state.getActiveRepoProviderCooldown(input.triggerJob.repo, input.now);
+  const fallbackCooldownUntil = new Date(input.now.getTime() + input.config.providerCooldown.durationMs).toISOString();
+  return {
+    cooldownUntil: parsed?.cooldownUntil ?? repoCooldown?.cooldownUntil ?? fallbackCooldownUntil,
+    reason: parsed?.reason ?? repoCooldown?.reason ?? "provider_cooldown"
+  };
 }
 
 function readinessStateForReviewResult(

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -180,20 +180,26 @@ export async function runScheduledCycleWithDeps(input: {
   });
   result.queue.delayedByReason = result.queue.budget.delayedByReason;
 
-  const leased = input.state.leaseNextReviewQueueJobs({
-    maxProviderActive: scheduler.maxProviderActive,
-    maxOrgActive: scheduler.maxOrgActive,
-    maxRepoActive: scheduler.maxRepoActive,
-    manualCommandReserve: scheduler.manualCommandReserve,
-    // Provider capacity is the global API throttle; org/repo caps only decide which jobs can spend that budget.
-    limit: scheduler.maxProviderActive,
-    leaseTtlMs: config.reviewConcurrency.leaseTtlMs,
-    now
-  });
-  result.queue.leased = leased.length;
-
   const budget = new ReviewRunBudget(Math.max(1, scheduler.maxProviderActive));
-  for (const [index, job] of leased.entries()) {
+  const attemptedJobIds = new Set<string>();
+  const attemptedJobs: ReviewQueueJobRecord[] = [];
+  for (let leaseAttempt = 0; leaseAttempt < scheduler.maxProviderActive; leaseAttempt += 1) {
+    const leased = input.state.leaseNextReviewQueueJobs({
+      maxProviderActive: scheduler.maxProviderActive,
+      maxOrgActive: scheduler.maxOrgActive,
+      maxRepoActive: scheduler.maxRepoActive,
+      manualCommandReserve: scheduler.manualCommandReserve,
+      excludeJobIds: attemptedJobIds,
+      reservedActiveJobs: attemptedJobs,
+      limit: 1,
+      leaseTtlMs: config.reviewConcurrency.leaseTtlMs,
+      now: eventClock()
+    });
+    const job = leased[0];
+    if (!job) break;
+    attemptedJobIds.add(job.jobId);
+    attemptedJobs.push(job);
+    result.queue.leased += 1;
     const status = await runLeasedQueueJob({
       config,
       github: input.github,
@@ -211,13 +217,6 @@ export async function runScheduledCycleWithDeps(input: {
     });
     applyReviewStatus(result, status);
     if (status === "skipped_provider_cooldown") {
-      result.queue.providerDeferred += deferUnstartedLeasedJobsForProviderThrottle({
-        config,
-        state: input.state,
-        triggerJob: job,
-        jobs: leased.slice(index + 1),
-        now: eventClock()
-      });
       break;
     }
   }
@@ -1176,42 +1175,6 @@ function shouldMarkJobReviewing(state: ReviewStateStore, job: ReviewQueueJobReco
   if (job.source !== "manual_command") return true;
   const existing = state.getReviewReadiness(job.repo, job.pullNumber, job.headSha);
   return existing?.commandAction ? isReviewCommandAction(existing.commandAction) : true;
-}
-
-function deferUnstartedLeasedJobsForProviderThrottle(input: {
-  config: BotConfig;
-  state: ReviewStateStore;
-  triggerJob: ReviewQueueJobRecord;
-  jobs: ReviewQueueJobRecord[];
-  now: Date;
-}): number {
-  const cooldown = providerThrottleCooldownFromTriggerJob(input);
-  for (const job of input.jobs) {
-    input.state.updateReviewQueueJobState({
-      jobId: job.jobId,
-      state: "provider_deferred",
-      nextEligibleAt: cooldown.cooldownUntil,
-      lastError: `provider_throttle_cycle_deferred_until=${cooldown.cooldownUntil}; reason=${cooldown.reason}; trigger_repo=${input.triggerJob.repo}`,
-      now: input.now
-    });
-  }
-  return input.jobs.length;
-}
-
-function providerThrottleCooldownFromTriggerJob(input: {
-  config: BotConfig;
-  state: ReviewStateStore;
-  triggerJob: ReviewQueueJobRecord;
-  now: Date;
-}): { cooldownUntil: string; reason: string } {
-  const processed = input.state.getProcessedReview(input.triggerJob.repo, input.triggerJob.pullNumber, input.triggerJob.headSha);
-  const parsed = parseProviderCooldownError(processed?.error);
-  const repoCooldown = input.state.getActiveRepoProviderCooldown(input.triggerJob.repo, input.now);
-  const fallbackCooldownUntil = new Date(input.now.getTime() + input.config.providerCooldown.durationMs).toISOString();
-  return {
-    cooldownUntil: parsed?.cooldownUntil ?? repoCooldown?.cooldownUntil ?? fallbackCooldownUntil,
-    reason: parsed?.reason ?? repoCooldown?.reason ?? "provider_cooldown"
-  };
 }
 
 function readinessStateForReviewResult(

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1193,10 +1193,11 @@ function deferQueuedProviderJobsForProviderThrottle(input: {
 }): number {
   const cooldown = providerThrottleCooldownFromTriggerJob(input);
   const providerId = input.triggerJob.providerId ?? "default";
+  const backgroundPriority = input.config.reviewScheduler?.backgroundPriority ?? 50;
   let deferred = 0;
   for (const job of input.state.listReviewQueueJobs({ state: "queued" })) {
-    if (job.jobId === input.triggerJob.jobId) continue;
     if ((job.providerId ?? "default") !== providerId) continue;
+    if (job.source === "manual_command" || job.lane === "manual" || job.priority < backgroundPriority) continue;
     input.state.updateReviewQueueJobState({
       jobId: job.jobId,
       state: "provider_deferred",

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -183,6 +183,8 @@ export async function runScheduledCycleWithDeps(input: {
   const budget = new ReviewRunBudget(Math.max(1, scheduler.maxProviderActive));
   const attemptedJobIds = new Set<string>();
   const attemptedJobs: ReviewQueueJobRecord[] = [];
+  // Lease just before execution to avoid idle active rows. This intentionally
+  // performs a bounded scan per provider slot, not one bulk pre-lease.
   for (let leaseAttempt = 0; leaseAttempt < scheduler.maxProviderActive; leaseAttempt += 1) {
     const leased = input.state.leaseNextReviewQueueJobs({
       maxProviderActive: scheduler.maxProviderActive,

--- a/src/state.ts
+++ b/src/state.ts
@@ -1536,7 +1536,7 @@ export class ReviewStateStore {
     maxRepoActive: number;
     manualCommandReserve?: number;
     excludeJobIds?: Iterable<string>;
-    reservedActiveJobs?: Iterable<Pick<ReviewQueueJobRecord, "providerId" | "org" | "repo">>;
+    reservedActiveJobs?: Iterable<Pick<ReviewQueueJobRecord, "jobId" | "providerId" | "org" | "repo">>;
     limit?: number;
     leaseTtlMs?: number;
     now?: Date;
@@ -1583,8 +1583,9 @@ export class ReviewStateStore {
       const eligible = jobs
         .filter((job) => !excludeJobIds.has(job.jobId) && isQueueJobEligible(job, nowIso))
         .sort(compareQueueJobsForLease);
+      const reservedJobIds = new Set(reservedActiveJobs.map((job) => job.jobId));
       const active = [
-        ...jobs.filter((job) => job.state === "leased" || job.state === "running"),
+        ...jobs.filter((job) => (job.state === "leased" || job.state === "running") && !reservedJobIds.has(job.jobId)),
         ...reservedActiveJobs
       ];
       const providerActive = countBy(active, (job) => job.providerId ?? "default");

--- a/src/state.ts
+++ b/src/state.ts
@@ -1535,6 +1535,8 @@ export class ReviewStateStore {
     maxOrgActive: number;
     maxRepoActive: number;
     manualCommandReserve?: number;
+    excludeJobIds?: Iterable<string>;
+    reservedActiveJobs?: Iterable<Pick<ReviewQueueJobRecord, "providerId" | "org" | "repo">>;
     limit?: number;
     leaseTtlMs?: number;
     now?: Date;
@@ -1556,6 +1558,8 @@ export class ReviewStateStore {
     const nowIso = (input.now ?? new Date()).toISOString();
     const legacyLeaseCutoffIso = new Date(Date.parse(nowIso) - leaseTtlMs).toISOString();
     const leaseExpiresAt = new Date(Date.parse(nowIso) + leaseTtlMs).toISOString();
+    const excludeJobIds = new Set(input.excludeJobIds ?? []);
+    const reservedActiveJobs = Array.from(input.reservedActiveJobs ?? []);
     const leased: ReviewQueueJobRecord[] = [];
 
     this.db.exec("begin immediate");
@@ -1577,9 +1581,12 @@ export class ReviewStateStore {
         .run(nowIso, nowIso, legacyLeaseCutoffIso);
       const jobs = this.listReviewQueueJobs();
       const eligible = jobs
-        .filter((job) => isQueueJobEligible(job, nowIso))
+        .filter((job) => !excludeJobIds.has(job.jobId) && isQueueJobEligible(job, nowIso))
         .sort(compareQueueJobsForLease);
-      const active = jobs.filter((job) => job.state === "leased" || job.state === "running");
+      const active = [
+        ...jobs.filter((job) => job.state === "leased" || job.state === "running"),
+        ...reservedActiveJobs
+      ];
       const providerActive = countBy(active, (job) => job.providerId ?? "default");
       const orgActive = countBy(active, (job) => job.org);
       const repoActive = countBy(active, (job) => job.repo);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -78,6 +78,63 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("leases queued jobs just in time so provider capacity does not create idle leases", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-jit-lease-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a", "org/repo-b"]);
+    config.reviewScheduler!.maxProviderActive = 2;
+    config.reviewScheduler!.maxOrgActive = 2;
+    config.reviewScheduler!.maxRepoActive = 1;
+    const state = new ReviewStateStore(config.statePath);
+    const observedDuringFirstReview: Array<{ repo: string; state: string; startedAt?: string }> = [];
+    const reviewed: string[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]],
+        ["org/repo-b", [pull("org/repo-b", 1, HEAD_B)]]
+      ])),
+      state,
+      options: { dryRun: true, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewed.push(`${repo}#${reviewPull.number}`);
+        if (repo === "org/repo-a") {
+          observedDuringFirstReview.push(...reviewState.listReviewQueueJobs()
+            .filter((job) => job.repo === "org/repo-b")
+            .map((job) => ({
+              repo: job.repo,
+              state: job.state,
+              ...(job.startedAt ? { startedAt: job.startedAt } : {})
+            })));
+        }
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "dry_run",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(result.queue).toMatchObject({
+      enqueued: 2,
+      leased: 2,
+      completed: 2,
+      remainingQueued: 2
+    });
+    expect(reviewed).toEqual(["org/repo-a#1", "org/repo-b#1"]);
+    expect(observedDuringFirstReview).toEqual([
+      { repo: "org/repo-b", state: "queued" }
+    ]);
+    expect(state.listReviewQueueJobs({ state: "leased" })).toHaveLength(0);
+    expect(state.listReviewQueueJobs({ state: "running" })).toHaveLength(0);
+    state.close();
+  });
+
   it("posts a sticky status comment from queued through completed for a live queued head", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-completed-"));
     roots.push(root);
@@ -511,7 +568,7 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
-  it("stops the current provider batch after an overload and requeues unstarted leased jobs", async () => {
+  it("stops provider leasing after an overload without touching unstarted queued jobs", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-provider-overload-stop-"));
     roots.push(root);
     const config = schedulerConfig(root, []);
@@ -556,17 +613,17 @@ describe("provider-aware review scheduler", () => {
 
     expect(attempted).toEqual(["org/repo-a"]);
     expect(result.skippedProviderCooldown).toBe(1);
-    expect(result.queue.providerDeferred).toBe(2);
+    expect(result.queue.providerDeferred).toBe(1);
     expect(state.getReviewQueueJob(first.jobId)).toMatchObject({
       state: "provider_deferred",
       nextEligibleAt: "2026-07-02T00:07:00.000Z",
       lastError: expect.stringContaining("reason=provider_overloaded")
     });
-    expect(state.getReviewQueueJob(second.jobId)).toMatchObject({
-      state: "provider_deferred",
-      nextEligibleAt: "2026-07-02T00:07:00.000Z",
-      lastError: expect.stringContaining("provider_throttle_cycle_deferred_until=2026-07-02T00:07:00.000Z")
-    });
+    const secondAfterOverload = state.getReviewQueueJob(second.jobId);
+    expect(secondAfterOverload).toMatchObject({ state: "queued" });
+    expect(secondAfterOverload?.startedAt).toBeUndefined();
+    expect(secondAfterOverload?.nextEligibleAt).toBeUndefined();
+    expect(secondAfterOverload?.lastError).toBeUndefined();
     state.close();
   });
 
@@ -1535,7 +1592,7 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
-  it("records provider throttle and stops the current leased provider batch", async () => {
+  it("records provider throttle and stops leasing more provider jobs", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-provider-throttle-"));
     roots.push(root);
     const config = schedulerConfig(root, ["org/repo-a", "org/repo-b", "org/repo-c"]);
@@ -1573,12 +1630,13 @@ describe("provider-aware review scheduler", () => {
     expect(state.getActiveRepoProviderCooldown("org/repo-a", new Date("2026-07-01T00:00:01.000Z"))).toBeDefined();
     expect(state.getActiveRepoProviderCooldown("org/repo-b", new Date("2026-07-01T00:00:01.000Z"))).toBeUndefined();
     expect(state.listReviewQueueJobs({ state: "provider_deferred" })).toEqual([
-      expect.objectContaining({ repo: "org/repo-a", pullNumber: 1, nextEligibleAt: "2026-07-01T00:01:30.000Z" }),
-      expect.objectContaining({ repo: "org/repo-b", pullNumber: 1, nextEligibleAt: "2026-07-01T00:01:30.000Z", lastError: expect.stringContaining("trigger_repo=org/repo-a") })
+      expect.objectContaining({ repo: "org/repo-a", pullNumber: 1, nextEligibleAt: "2026-07-01T00:01:30.000Z" })
     ]);
     expect(state.listReviewQueueJobs({ state: "queued" })).toEqual([
+      expect.objectContaining({ repo: "org/repo-b", pullNumber: 1 }),
       expect.objectContaining({ repo: "org/repo-c", pullNumber: 1 })
     ]);
+    expect(state.getReviewQueueJob(state.listReviewQueueJobs({ state: "queued" })[0]!.jobId)?.startedAt).toBeUndefined();
     state.close();
   });
 
@@ -2542,7 +2600,7 @@ describe("provider-aware review scheduler", () => {
       }
     };
     const state = new ReviewStateStore(config.statePath);
-    const pullMap = new Map([["org/repo-a", [pull("org/repo-a", 1, "a1")]]]);
+    const pullMap = new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]);
     const comments = new Map([
       ["org/repo-a#1", [comment(338, "100yenadmin", "@evaos-code-review-bot generate tests")]]
     ]);
@@ -2567,7 +2625,7 @@ describe("provider-aware review scheduler", () => {
       lastError: "manual_command_finishing_touch_draft_recorded"
     });
     expect(recordedJob?.sessionId).toBeUndefined();
-    expect(state.getReviewReadiness("org/repo-a", 1, "a1")).toMatchObject({
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
       state: "command_recorded",
       reason: "trusted_generate_tests_command",
       commandAction: "generate_tests",
@@ -2576,7 +2634,7 @@ describe("provider-aware review scheduler", () => {
     expect(state.getFinishingTouchDraft({
       repo: "org/repo-a",
       pullNumber: 1,
-      headSha: "a1",
+      headSha: HEAD_A,
       commandCommentId: 338
     })).toMatchObject({
       action: "generate_tests",

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -590,9 +590,20 @@ describe("provider-aware review scheduler", () => {
       pullNumber: 2,
       headSha: HEAD_B,
       baseSha: "base",
-      priority: 20,
+      priority: 50,
       providerId: "zai-coding-plan",
       now: new Date("2026-07-02T00:00:01.000Z")
+    }).job;
+    const manual = state.enqueueReviewQueueJob({
+      repo: "org/repo-c",
+      pullNumber: 3,
+      headSha: HEAD_C,
+      baseSha: "base",
+      source: "manual_command",
+      priority: 99,
+      providerId: "zai-coding-plan",
+      commentId: 123,
+      now: new Date("2026-07-02T00:00:02.000Z")
     }).job;
     const attempted: string[] = [];
 
@@ -600,7 +611,8 @@ describe("provider-aware review scheduler", () => {
       config,
       github: githubFromMap(new Map([
         ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]],
-        ["org/repo-b", [pull("org/repo-b", 2, HEAD_B)]]
+        ["org/repo-b", [pull("org/repo-b", 2, HEAD_B)]],
+        ["org/repo-c", [pull("org/repo-c", 3, HEAD_C)]]
       ])),
       state,
       options: { dryRun: false, useZCode: true },
@@ -626,6 +638,7 @@ describe("provider-aware review scheduler", () => {
       lastError: expect.stringContaining("provider_throttle_cycle_deferred_until=2026-07-02T00:07:00.000Z")
     });
     expect(secondAfterOverload?.startedAt).toBeUndefined();
+    expect(state.getReviewQueueJob(manual.jobId)).toMatchObject({ state: "queued" });
     state.close();
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -568,7 +568,7 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
-  it("stops provider leasing after an overload without touching unstarted queued jobs", async () => {
+  it("stops provider leasing after an overload without starting unstarted provider jobs", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-provider-overload-stop-"));
     roots.push(root);
     const config = schedulerConfig(root, []);
@@ -613,17 +613,19 @@ describe("provider-aware review scheduler", () => {
 
     expect(attempted).toEqual(["org/repo-a"]);
     expect(result.skippedProviderCooldown).toBe(1);
-    expect(result.queue.providerDeferred).toBe(1);
+    expect(result.queue.providerDeferred).toBe(2);
     expect(state.getReviewQueueJob(first.jobId)).toMatchObject({
       state: "provider_deferred",
       nextEligibleAt: "2026-07-02T00:07:00.000Z",
       lastError: expect.stringContaining("reason=provider_overloaded")
     });
     const secondAfterOverload = state.getReviewQueueJob(second.jobId);
-    expect(secondAfterOverload).toMatchObject({ state: "queued" });
+    expect(secondAfterOverload).toMatchObject({
+      state: "provider_deferred",
+      nextEligibleAt: "2026-07-02T00:07:00.000Z",
+      lastError: expect.stringContaining("provider_throttle_cycle_deferred_until=2026-07-02T00:07:00.000Z")
+    });
     expect(secondAfterOverload?.startedAt).toBeUndefined();
-    expect(secondAfterOverload?.nextEligibleAt).toBeUndefined();
-    expect(secondAfterOverload?.lastError).toBeUndefined();
     state.close();
   });
 
@@ -1627,16 +1629,28 @@ describe("provider-aware review scheduler", () => {
 
     expect(result.reviewed).toBe(0);
     expect(result.skippedProviderCooldown).toBe(1);
+    expect(result.queue.providerDeferred).toBe(3);
     expect(state.getActiveRepoProviderCooldown("org/repo-a", new Date("2026-07-01T00:00:01.000Z"))).toBeDefined();
     expect(state.getActiveRepoProviderCooldown("org/repo-b", new Date("2026-07-01T00:00:01.000Z"))).toBeUndefined();
     expect(state.listReviewQueueJobs({ state: "provider_deferred" })).toEqual([
-      expect.objectContaining({ repo: "org/repo-a", pullNumber: 1, nextEligibleAt: "2026-07-01T00:01:30.000Z" })
+      expect.objectContaining({ repo: "org/repo-a", pullNumber: 1, nextEligibleAt: "2026-07-01T00:01:30.000Z" }),
+      expect.objectContaining({
+        repo: "org/repo-b",
+        pullNumber: 1,
+        nextEligibleAt: "2026-07-01T00:01:30.000Z",
+        lastError: expect.stringContaining("provider_throttle_cycle_deferred_until=2026-07-01T00:01:30.000Z")
+      }),
+      expect.objectContaining({
+        repo: "org/repo-c",
+        pullNumber: 1,
+        nextEligibleAt: "2026-07-01T00:01:30.000Z",
+        lastError: expect.stringContaining("trigger_repo=org/repo-a")
+      })
     ]);
-    expect(state.listReviewQueueJobs({ state: "queued" })).toEqual([
-      expect.objectContaining({ repo: "org/repo-b", pullNumber: 1 }),
-      expect.objectContaining({ repo: "org/repo-c", pullNumber: 1 })
-    ]);
-    expect(state.getReviewQueueJob(state.listReviewQueueJobs({ state: "queued" })[0]!.jobId)?.startedAt).toBeUndefined();
+    expect(state.listReviewQueueJobs({ state: "queued" })).toEqual([]);
+    expect(state.listReviewQueueJobs({ state: "provider_deferred" })
+      .filter((job) => job.repo !== "org/repo-a")
+      .every((job) => job.startedAt === undefined)).toBe(true);
     state.close();
   });
 


### PR DESCRIPTION
## Summary
- Lease scheduler queue jobs just in time instead of pre-leasing a provider batch.
- Keep unstarted jobs queued when a provider throttle/overload happens, so they do not look in-progress or provider-deferred without an actual attempt.
- Add regression coverage for provider capacity >1 and update stale scheduler test expectations.

Fixes #214.

## Runtime note
Live config was rolled back to capacity 1 before this PR. The current live daemon is healthy again after retrying the failed self-repo #202 head; this PR is the code fix that prevents the idle-lease shape before we consider any future capacity increase.

## Validation
- `NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/scheduler.test.ts --pool forks --maxWorkers=1`
- `NODE_OPTIONS=--experimental-sqlite npm run build`
- `git diff --check`
- `npm run release:status -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expected-head e2b27eb4dc1088e47062511a02df13d34d4c77cd --launchd-label com.electricsheephq.evaos-code-review-bot` -> runtime_ok on live main after #202 retry
