### PR TITLE
Harden disabled GitNexus context contract

### DIFF
--- a/src/gitnexus-context.ts
+++ b/src/gitnexus-context.ts
@@ -50,7 +50,7 @@ export interface GitNexusRelatedContext {
 
 export interface GitNexusOmittedContext {
   id: string;
-  reason: "generated_path" | "budget_exceeded" | "query_failed" | "stale_index" | "missing_index";
+  reason: "disabled" | "generated_path" | "budget_exceeded" | "query_failed" | "stale_index" | "missing_index";
   detail: string;
 }
 
@@ -133,13 +133,6 @@ export function buildGitNexusContextPacket(input: BuildGitNexusContextPacketInpu
   const generatedAtMs = Date.parse(generatedAt);
   if (!Number.isFinite(generatedAtMs)) throw new Error("generatedAt must be an ISO timestamp");
 
-  const commandRunner = input.commandRunner ?? runGitNexusCommand;
-  const listResult = input.gitnexusListText !== undefined
-    ? { ok: true, stdout: input.gitnexusListText }
-    : commandRunner(["list"], {
-      timeoutMs: input.config.commandTimeoutMs,
-      maxOutputBytes: input.config.maxCommandOutputBytes
-    });
   const redactionSources: Array<{ id: string; text: string }> = [];
   const omittedContext: GitNexusOmittedContext[] = [];
   const changedFiles = input.files
@@ -152,6 +145,39 @@ export function buildGitNexusContextPacket(input: BuildGitNexusContextPacketInpu
       detail: "Generated/build artifact path excluded from GitNexus query selection."
     });
   }
+
+  if (!input.config.enabled) {
+    omittedContext.push({
+      id: "gitnexus:disabled",
+      reason: "disabled",
+      detail: "GitNexus context is disabled by configuration."
+    });
+    return buildRenderedPacketResult({
+      repo: input.repo,
+      pull: input.pull,
+      packetVersion: input.config.packetVersion,
+      generatedAt,
+      maxPacketBytes: input.config.maxPacketBytes,
+      advisory: GITNEXUS_CONTEXT_ADVISORY_LINE,
+      gitnexus: {
+        freshness: "missing",
+        degradedMode: true,
+        degradedReason: "GitNexus context is disabled by configuration."
+      },
+      changedFiles,
+      relatedContext: [],
+      omittedContext,
+      redactionSources
+    });
+  }
+
+  const commandRunner = input.commandRunner ?? runGitNexusCommand;
+  const listResult = input.gitnexusListText !== undefined
+    ? { ok: true, stdout: input.gitnexusListText }
+    : commandRunner(["list"], {
+      timeoutMs: input.config.commandTimeoutMs,
+      maxOutputBytes: input.config.maxCommandOutputBytes
+    });
 
   let indexes: GitNexusIndexRecord[] = [];
   let alias: string | undefined;
@@ -223,23 +249,12 @@ export function buildGitNexusContextPacket(input: BuildGitNexusContextPacketInpu
     }
   }
 
-  const preRenderReport = buildRedactionReport(redactionSources);
-  if (!preRenderReport.ok) {
-    return {
-      ok: false,
-      error: "GitNexus context packet blocked: secret-like text detected in GitNexus output.",
-      redactionReport: preRenderReport,
-      omittedContext
-    };
-  }
-
-  const packetBase = {
+  return buildRenderedPacketResult({
     repo: input.repo,
-    pullNumber: input.pull.number,
-    headSha: input.pull.head.sha,
-    baseSha: input.pull.base.sha,
+    pull: input.pull,
     packetVersion: input.config.packetVersion,
     generatedAt,
+    maxPacketBytes: input.config.maxPacketBytes,
     advisory: GITNEXUS_CONTEXT_ADVISORY_LINE,
     gitnexus: {
       ...(alias ? { alias } : {}),
@@ -251,13 +266,51 @@ export function buildGitNexusContextPacket(input: BuildGitNexusContextPacketInpu
       ...(degradedReason ? { degradedReason } : {})
     },
     changedFiles,
-    omittedContext
-  };
+    relatedContext,
+    omittedContext,
+    redactionSources
+  });
+}
 
+function buildRenderedPacketResult(input: {
+  repo: string;
+  pull: PullRequestSummary;
+  packetVersion: string;
+  generatedAt: string;
+  maxPacketBytes: number;
+  advisory: string;
+  gitnexus: GitNexusContextPacket["gitnexus"];
+  changedFiles: GitNexusChangedFileContext[];
+  relatedContext: GitNexusRelatedContext[];
+  omittedContext: GitNexusOmittedContext[];
+  redactionSources: Array<{ id: string; text: string }>;
+}): GitNexusContextBuildResult {
+  const packetBase = {
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    baseSha: input.pull.base.sha,
+    packetVersion: input.packetVersion,
+    generatedAt: input.generatedAt,
+    advisory: input.advisory,
+    gitnexus: input.gitnexus,
+    changedFiles: input.changedFiles,
+    omittedContext: input.omittedContext
+  };
   const budgeted = renderWithinBudget({
     ...packetBase,
-    relatedContext
-  }, input.config.maxPacketBytes);
+    relatedContext: input.relatedContext
+  }, input.maxPacketBytes);
+  const preRenderReport = buildRedactionReport(input.redactionSources);
+  if (!preRenderReport.ok) {
+    return {
+      ok: false,
+      error: "GitNexus context packet blocked: secret-like text detected in GitNexus output.",
+      redactionReport: preRenderReport,
+      omittedContext: input.omittedContext
+    };
+  }
+
   const postRenderReport = buildRedactionReport([{ id: "packet:markdown", text: budgeted.markdown }]);
   const redactionReport = mergeRedactionReports(preRenderReport, postRenderReport);
   if (!postRenderReport.ok) {
@@ -268,7 +321,7 @@ export function buildGitNexusContextPacket(input: BuildGitNexusContextPacketInpu
       omittedContext: budgeted.omittedContext
     };
   }
-  if (Buffer.byteLength(budgeted.markdown, "utf8") > input.config.maxPacketBytes) {
+  if (Buffer.byteLength(budgeted.markdown, "utf8") > input.maxPacketBytes) {
     const budgetExceeded: GitNexusOmittedContext = {
       id: "packet:markdown",
       reason: "budget_exceeded",
@@ -276,7 +329,7 @@ export function buildGitNexusContextPacket(input: BuildGitNexusContextPacketInpu
     };
     return {
       ok: false,
-      error: `GitNexus context packet exceeded maxPacketBytes (${Buffer.byteLength(budgeted.markdown, "utf8")} > ${input.config.maxPacketBytes}).`,
+      error: `GitNexus context packet exceeded maxPacketBytes (${Buffer.byteLength(budgeted.markdown, "utf8")} > ${input.maxPacketBytes}).`,
       redactionReport,
       omittedContext: [...budgeted.omittedContext, budgetExceeded].sort(compareOmittedContext)
     };

--- a/src/gitnexus-context.ts
+++ b/src/gitnexus-context.ts
@@ -146,6 +146,8 @@ export function buildGitNexusContextPacket(input: BuildGitNexusContextPacketInpu
     });
   }
 
+  // Production entrypoints gate this earlier; this keeps the packet builder's
+  // inner contract offline for future direct callers.
   if (!input.config.enabled) {
     omittedContext.push({
       id: "gitnexus:disabled",
@@ -297,10 +299,6 @@ function buildRenderedPacketResult(input: {
     changedFiles: input.changedFiles,
     omittedContext: input.omittedContext
   };
-  const budgeted = renderWithinBudget({
-    ...packetBase,
-    relatedContext: input.relatedContext
-  }, input.maxPacketBytes);
   const preRenderReport = buildRedactionReport(input.redactionSources);
   if (!preRenderReport.ok) {
     return {
@@ -311,6 +309,10 @@ function buildRenderedPacketResult(input: {
     };
   }
 
+  const budgeted = renderWithinBudget({
+    ...packetBase,
+    relatedContext: input.relatedContext
+  }, input.maxPacketBytes);
   const postRenderReport = buildRedactionReport([{ id: "packet:markdown", text: budgeted.markdown }]);
   const redactionReport = mergeRedactionReports(preRenderReport, postRenderReport);
   if (!postRenderReport.ok) {

--- a/tests/gitnexus-context.test.ts
+++ b/tests/gitnexus-context.test.ts
@@ -65,6 +65,33 @@ describe("GitNexus context packets", () => {
     expect(result.packet.markdown).toContain("Current PR diff, checkout files, and GitHub metadata remain authoritative");
   });
 
+  it("does not invoke GitNexus when context packets are disabled", () => {
+    const result = buildGitNexusContextPacket({
+      repo,
+      pull,
+      files: [{ filename: "src/worker.ts", status: "modified", additions: 2, deletions: 1, changes: 3 }],
+      config: config({ enabled: false }),
+      generatedAt,
+      commandRunner: () => {
+        throw new Error("disabled GitNexus context must not invoke commands");
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected disabled packet build to pass");
+    expect(result.packet.gitnexus).toMatchObject({
+      freshness: "missing",
+      degradedMode: true,
+      degradedReason: "GitNexus context is disabled by configuration."
+    });
+    expect(result.packet.relatedContext).toEqual([]);
+    expect(result.packet.omittedContext).toContainEqual({
+      id: "gitnexus:disabled",
+      reason: "disabled",
+      detail: "GitNexus context is disabled by configuration."
+    });
+  });
+
   it("includes bounded related context for a fresh matching index", () => {
     const runner = queryRunner({
       "src/worker.ts buildGitNexusContext reviewPull worker": "Process ReviewPull -> buildReviewPrompt -> runZCodeReview\nsrc/worker.ts coordinates review evidence writes."

--- a/tests/gitnexus-context.test.ts
+++ b/tests/gitnexus-context.test.ts
@@ -66,7 +66,7 @@ describe("GitNexus context packets", () => {
   });
 
   it("hardens the inner packet builder contract when GitNexus context is disabled", () => {
-    const result = buildGitNexusContextPacket({
+    const input = {
       repo,
       pull,
       files: [{ filename: "src/worker.ts", status: "modified", additions: 2, deletions: 1, changes: 3 }],
@@ -75,10 +75,14 @@ describe("GitNexus context packets", () => {
       commandRunner: () => {
         throw new Error("disabled GitNexus context must not invoke commands");
       }
-    });
+    };
+    const result = buildGitNexusContextPacket(input);
+    const repeated = buildGitNexusContextPacket(input);
 
     expect(result.ok).toBe(true);
-    if (!result.ok) throw new Error("expected disabled packet build to pass");
+    expect(repeated.ok).toBe(true);
+    if (!result.ok || !repeated.ok) throw new Error("expected disabled packet builds to pass");
+    expect(result.packet.sha256).toBe(repeated.packet.sha256);
     expect(result.packet.gitnexus).toMatchObject({
       freshness: "missing",
       degradedMode: true,

--- a/tests/gitnexus-context.test.ts
+++ b/tests/gitnexus-context.test.ts
@@ -65,7 +65,7 @@ describe("GitNexus context packets", () => {
     expect(result.packet.markdown).toContain("Current PR diff, checkout files, and GitHub metadata remain authoritative");
   });
 
-  it("does not invoke GitNexus when context packets are disabled", () => {
+  it("hardens the inner packet builder contract when GitNexus context is disabled", () => {
     const result = buildGitNexusContextPacket({
       repo,
       pull,
@@ -93,7 +93,7 @@ describe("GitNexus context packets", () => {
   });
 
   it("includes bounded related context for a fresh matching index", () => {
-    const runner = queryRunner({
+    const runner = recordingQueryRunner({
       "src/worker.ts buildGitNexusContext reviewPull worker": "Process ReviewPull -> buildReviewPrompt -> runZCodeReview\nsrc/worker.ts coordinates review evidence writes."
     });
     const result = buildGitNexusContextPacket({
@@ -132,6 +132,18 @@ describe("GitNexus context packets", () => {
       id: "query:src/worker.ts",
       query: "src/worker.ts buildGitNexusContext reviewPull worker"
     });
+    expect(runner.calls).toEqual([
+      [
+        "query",
+        "src/worker.ts buildGitNexusContext reviewPull worker",
+        "--repo",
+        "evaos-code-review-bot",
+        "--limit",
+        "3",
+        "--max-tokens",
+        "2000"
+      ]
+    ]);
     expect(result.packet.changedFiles.find((file) => file.path === "src/worker.ts")).toMatchObject({
       path: "src/worker.ts",
       changedExportedSymbols: ["buildGitNexusContext", "reviewPull"],
@@ -338,6 +350,16 @@ function queryRunner(outputs: Record<string, string>): GitNexusCommandRunner {
       stdout: outputs[query] ?? `No context for ${query}.`
     };
   };
+}
+
+function recordingQueryRunner(outputs: Record<string, string>): GitNexusCommandRunner & { calls: string[][] } {
+  const calls: string[][] = [];
+  const runner: GitNexusCommandRunner & { calls: string[][] } = (args, options) => {
+    if (args[0] === "query") calls.push([...args]);
+    return queryRunner(outputs)(args, options);
+  };
+  runner.calls = calls;
+  return runner;
 }
 
 function failOnQueryRunner(): GitNexusCommandRunner {


### PR DESCRIPTION
## Summary
- harden the inner GitNexus context packet-builder contract when `gitnexusContext.enabled` is false
- return an explicit degraded advisory packet with `gitnexus:disabled` omitted-context evidence without invoking a command runner
- preserve enabled GitNexus behavior and assert that enabled fresh-index packet generation still invokes the runner and includes related advisory context
- preserve the pre-render redaction short-circuit before budget shrinking/rendering

## Why
Production review entrypoints already gate disabled GitNexus context before calling the packet builder. This PR keeps the lower-level builder defensive for future direct callers without changing enabled addon behavior or making GitNexus a hidden runtime dependency.

Refs #123

## Validation
- `npm test -- tests/gitnexus-context.test.ts`
- `npm test -- tests/repo-wiki-packet.test.ts`
- `NODE_OPTIONS=--experimental-sqlite npm run build`
- `git diff --check`

## Boundaries
- No runtime wiring, live config, launchd, release, provider adapter, scheduler, worker, walkthrough, config schema, or package metadata changes.
