### PR TITLE
Fix review queue burst backpressure

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -38,6 +38,8 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
   has the scheduler table. The command reports both `coverageOk` and
   `runtimeOk`; `coverageOk: true` can still pair with `runtimeOk: false` when
   every PR head is covered but a durable queue row is failed or ready to retry.
+  Durable queue summaries include the oldest waiting repo/head age so burst
+  backlogs can be diagnosed without hand-querying SQLite.
 - `dashboard`: read-only PR review dashboard over coverage, durable queue,
   readiness lifecycle rows, GitHub PR links, and local evidence-path hints.
   Filter with `--repo`, `--status`, `--priority`, `--stale-head-reason`, and
@@ -54,7 +56,8 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
   such as `provider_cooldown`, `provider_capacity`, `org_capacity`,
   `repo_capacity`, `manual_reserve`, and `lease_limit`. Broad status commands
   include only compact budget counts and reason histograms; use this command for
-  capped row-level details.
+  capped row-level details. Repo profiles may lower effective active/queued
+  scheduler caps for bursty repositories without changing global capacity.
 - `review-head-gate --repo <owner/name> --pr <number> --head-sha <sha>`:
   read-only pre-merge guard for self-repo and release-critical PRs. It checks
   the exact `{repo, pr, head_sha}` against processed reviews, durable queue

--- a/src/config.ts
+++ b/src/config.ts
@@ -122,8 +122,15 @@ export interface RepoProfileConfig {
   autoReview?: RepoAutoReviewConfig;
   preMergeChecks?: RepoPreMergeChecksConfig;
   finishingTouches?: RepoFinishingTouchesConfig;
+  reviewScheduler?: RepoReviewSchedulerConfig;
   suggestedLabels?: string[];
   suggestedReviewers?: string[];
+}
+
+export interface RepoReviewSchedulerConfig {
+  maxActiveHeads?: number;
+  maxQueuedHeads?: number;
+  overflowAction?: "defer" | "skip";
 }
 
 export interface RepoAutoReviewConfig {
@@ -1081,6 +1088,17 @@ function validateProfileRecord(record: Record<string, RepoProfileConfig> | undef
     validateAutoReview(profile.autoReview, `${label}.${key}.autoReview`);
     validatePreMergeChecks(profile.preMergeChecks, `${label}.${key}.preMergeChecks`);
     validateFinishingTouches(profile.finishingTouches, `${label}.${key}.finishingTouches`);
+    validateRepoReviewSchedulerConfig(profile.reviewScheduler, `${label}.${key}.reviewScheduler`);
+  }
+}
+
+function validateRepoReviewSchedulerConfig(value: unknown, label: string): void {
+  if (value === undefined) return;
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  if (value.maxActiveHeads !== undefined) validatePositiveInteger(value.maxActiveHeads, `${label}.maxActiveHeads`);
+  if (value.maxQueuedHeads !== undefined) validatePositiveInteger(value.maxQueuedHeads, `${label}.maxQueuedHeads`);
+  if (value.overflowAction !== undefined && value.overflowAction !== "defer" && value.overflowAction !== "skip") {
+    throw new Error(`${label}.overflowAction must be "defer" or "skip"`);
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -130,6 +130,7 @@ export interface RepoProfileConfig {
 export interface RepoReviewSchedulerConfig {
   maxActiveHeads?: number;
   maxQueuedHeads?: number;
+  /** Terminal for the exact PR head when set to "skip"; use "defer" for transient bursts. */
   overflowAction?: "defer" | "skip";
 }
 

--- a/src/coverage-audit.ts
+++ b/src/coverage-audit.ts
@@ -8,6 +8,8 @@ import {
   parseProviderCooldownError,
   type RepoActivationRecord,
   type ReviewQueueJobState,
+  type ReviewReadinessRecord,
+  type ReviewReadinessState,
   type RepoProviderCooldownRecord,
   type StoredProcessedReviewRecord
 } from "./state.js";
@@ -123,6 +125,7 @@ export interface CoverageStateLookup {
     now: Date,
     leaseTtlMs: number
   ): CoverageQueueJobCoverage | undefined;
+  getReviewReadiness?(repo: string, pullNumber: number, headSha: string): ReviewReadinessRecord | undefined;
   getActiveRepoProviderCooldown?(repo: string, now?: Date): RepoProviderCooldownRecord | undefined;
   getActiveProviderCooldown?(now?: Date): RepoProviderCooldownRecord | undefined;
 }
@@ -205,6 +208,21 @@ export class CoverageStateReader implements CoverageStateLookup {
     return row ? mapReviewQueueJobCoverageRow(row) : undefined;
   }
 
+  getReviewReadiness(repo: string, pullNumber: number, headSha: string): ReviewReadinessRecord | undefined {
+    if (!this.db) return undefined;
+    if (!this.hasReviewReadinessTable()) return undefined;
+    const row = this.db
+      .prepare(
+        `select repo, pull_number, head_sha, state, reason, event, review_url,
+                command_action, command_comment_id, created_at, updated_at
+         from review_readiness
+         where repo = ? and pull_number = ? and head_sha = ?
+         limit 1`
+      )
+      .get(repo, pullNumber, headSha) as ReviewReadinessRow | undefined;
+    return row ? mapReviewReadinessRow(row) : undefined;
+  }
+
   getActiveRepoProviderCooldown(repo: string, now = new Date()): RepoProviderCooldownRecord | undefined {
     if (!this.db) return undefined;
     if (!this.hasRepoProviderCooldownTable()) return undefined;
@@ -268,6 +286,15 @@ export class CoverageStateReader implements CoverageStateLookup {
     return Boolean(
       this.db
         .prepare("select 1 from sqlite_master where type = 'table' and name = 'repo_activation_watermarks' limit 1")
+        .get()
+    );
+  }
+
+  private hasReviewReadinessTable(): boolean {
+    if (!this.db) return false;
+    return Boolean(
+      this.db
+        .prepare("select 1 from sqlite_master where type = 'table' and name = 'review_readiness' limit 1")
         .get()
     );
   }
@@ -510,6 +537,21 @@ function pushProcessedOrUnprocessed(
     return;
   }
 
+  const readiness = state.getReviewReadiness?.(repo, pull.number, pull.head.sha);
+  if (isCapacityDeferredReadiness(readiness)) {
+    report.providerDeferred.push({
+      ...pullEntry(repo, pull),
+      status: "skipped",
+      error: readiness.reason,
+      createdAt: readiness.createdAt,
+      updatedAt: readiness.updatedAt,
+      cooldownUntil: readiness.updatedAt,
+      reason: readiness.reason
+    });
+    report.summary.providerDeferred += 1;
+    return;
+  }
+
   const providerCooldown = state.getActiveProviderCooldown?.(now);
   if (providerCooldown) {
     report.providerDeferred.push({
@@ -660,6 +702,20 @@ interface ReviewQueueJobCoverageRow {
   updated_at: string;
 }
 
+interface ReviewReadinessRow {
+  repo: string;
+  pull_number: number;
+  head_sha: string;
+  state: ReviewReadinessState;
+  reason: string | null;
+  event: "COMMENT" | "REQUEST_CHANGES" | null;
+  review_url: string | null;
+  command_action: string | null;
+  command_comment_id: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
 interface CoverageQueueJobCoverage {
   queueState: ReviewQueueJobState;
   source: string;
@@ -703,6 +759,26 @@ function mapReviewQueueJobCoverageRow(row: ReviewQueueJobCoverageRow): CoverageQ
     ...(row.next_eligible_at ? { nextEligibleAt: row.next_eligible_at } : {}),
     ...(row.last_error ? { lastError: row.last_error } : {})
   };
+}
+
+function mapReviewReadinessRow(row: ReviewReadinessRow): ReviewReadinessRecord {
+  return {
+    repo: row.repo,
+    pullNumber: row.pull_number,
+    headSha: row.head_sha,
+    state: row.state,
+    ...(row.reason ? { reason: row.reason } : {}),
+    ...(row.event ? { event: row.event } : {}),
+    ...(row.review_url ? { reviewUrl: row.review_url } : {}),
+    ...(row.command_action ? { commandAction: row.command_action as ReviewReadinessRecord["commandAction"] } : {}),
+    ...(row.command_comment_id ? { commandCommentId: row.command_comment_id } : {}),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function isCapacityDeferredReadiness(readiness: ReviewReadinessRecord | undefined): readiness is ReviewReadinessRecord {
+  return readiness?.state === "provider_deferred" && readiness.reason === "repo_queue_capacity_full";
 }
 
 function isCoverageQueueJobCurrent(

--- a/src/coverage-audit.ts
+++ b/src/coverage-audit.ts
@@ -53,7 +53,7 @@ export interface CoverageUnprocessedEntry extends CoverageAuditPullEntry {
 }
 
 export interface CoverageProviderDeferredEntry extends CoverageProcessedEntry {
-  cooldownUntil: string;
+  cooldownUntil?: string;
   reason?: string;
   updatedAt: string;
 }
@@ -545,7 +545,6 @@ function pushProcessedOrUnprocessed(
       error: readiness.reason,
       createdAt: readiness.createdAt,
       updatedAt: readiness.updatedAt,
-      cooldownUntil: readiness.updatedAt,
       reason: readiness.reason
     });
     report.summary.providerDeferred += 1;

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1576,7 +1576,19 @@ function oldestWaitingQueueJob(jobs: ReviewQueueJobRecord[]): ReviewQueueJobReco
       job.state === "provider_deferred" ||
       job.state === "blocked_on_proof"
     )
-    .sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt))[0];
+    .sort(compareWaitingQueueJobCreatedAt)[0];
+}
+
+function compareWaitingQueueJobCreatedAt(left: ReviewQueueJobRecord, right: ReviewQueueJobRecord): number {
+  const leftMs = createdAtSortMs(left.createdAt);
+  const rightMs = createdAtSortMs(right.createdAt);
+  if (leftMs !== rightMs) return leftMs - rightMs;
+  return left.jobId.localeCompare(right.jobId);
+}
+
+function createdAtSortMs(createdAt: string): number {
+  const createdAtMs = Date.parse(createdAt);
+  return Number.isFinite(createdAtMs) ? createdAtMs : Number.POSITIVE_INFINITY;
 }
 
 function waitingAgeMs(createdAt: string, now: Date): number | undefined {

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -307,6 +307,7 @@ export interface OperatorDurableQueueSnapshot {
     oldestWaitingRepo?: string;
     oldestWaitingAt?: string;
     oldestWaitingAgeMs?: number;
+    oldestWaitingAtMalformed?: boolean;
   };
   jobs: ReviewQueueJobRecord[];
   byRepo: Array<{
@@ -323,6 +324,7 @@ export interface OperatorDurableQueueSnapshot {
     retired: number;
     oldestWaitingAt?: string;
     oldestWaitingAgeMs?: number;
+    oldestWaitingAtMalformed?: boolean;
   }>;
 }
 
@@ -1548,6 +1550,7 @@ function buildDurableQueueSnapshot(
 function summarizeDurableQueueJobs(jobs: ReviewQueueJobRecord[], now: Date): OperatorDurableQueueSnapshot["summary"] {
   const oldestWaiting = oldestWaitingQueueJob(jobs);
   const oldestWaitingAgeMs = oldestWaiting ? waitingAgeMs(oldestWaiting.createdAt, now) : undefined;
+  const oldestWaitingAtMalformed = oldestWaiting ? !isParseableTimestamp(oldestWaiting.createdAt) : false;
   return {
     total: jobs.length,
     queued: jobs.filter((job) => job.state === "queued").length,
@@ -1563,7 +1566,8 @@ function summarizeDurableQueueJobs(jobs: ReviewQueueJobRecord[], now: Date): Ope
       ? {
           oldestWaitingRepo: oldestWaiting.repo,
           oldestWaitingAt: oldestWaiting.createdAt,
-          ...(oldestWaitingAgeMs !== undefined ? { oldestWaitingAgeMs } : {})
+          ...(oldestWaitingAgeMs !== undefined ? { oldestWaitingAgeMs } : {}),
+          ...(oldestWaitingAtMalformed ? { oldestWaitingAtMalformed: true } : {})
         }
       : {})
   };
@@ -1589,6 +1593,10 @@ function compareWaitingQueueJobCreatedAt(left: ReviewQueueJobRecord, right: Revi
 function createdAtSortMs(createdAt: string): number {
   const createdAtMs = Date.parse(createdAt);
   return Number.isFinite(createdAtMs) ? createdAtMs : Number.POSITIVE_INFINITY;
+}
+
+function isParseableTimestamp(value: string): boolean {
+  return Number.isFinite(Date.parse(value));
 }
 
 function waitingAgeMs(createdAt: string, now: Date): number | undefined {

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1547,6 +1547,7 @@ function buildDurableQueueSnapshot(
 
 function summarizeDurableQueueJobs(jobs: ReviewQueueJobRecord[], now: Date): OperatorDurableQueueSnapshot["summary"] {
   const oldestWaiting = oldestWaitingQueueJob(jobs);
+  const oldestWaitingAgeMs = oldestWaiting ? waitingAgeMs(oldestWaiting.createdAt, now) : undefined;
   return {
     total: jobs.length,
     queued: jobs.filter((job) => job.state === "queued").length,
@@ -1562,7 +1563,7 @@ function summarizeDurableQueueJobs(jobs: ReviewQueueJobRecord[], now: Date): Ope
       ? {
           oldestWaitingRepo: oldestWaiting.repo,
           oldestWaitingAt: oldestWaiting.createdAt,
-          oldestWaitingAgeMs: Math.max(0, now.getTime() - Date.parse(oldestWaiting.createdAt))
+          ...(oldestWaitingAgeMs !== undefined ? { oldestWaitingAgeMs } : {})
         }
       : {})
   };
@@ -1576,6 +1577,12 @@ function oldestWaitingQueueJob(jobs: ReviewQueueJobRecord[]): ReviewQueueJobReco
       job.state === "blocked_on_proof"
     )
     .sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt))[0];
+}
+
+function waitingAgeMs(createdAt: string, now: Date): number | undefined {
+  const createdAtMs = Date.parse(createdAt);
+  if (!Number.isFinite(createdAtMs)) return undefined;
+  return Math.max(0, now.getTime() - createdAtMs);
 }
 
 function isRetryableQueueJob(job: ReviewQueueJobRecord, now: Date): boolean {

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -304,6 +304,9 @@ export interface OperatorDurableQueueSnapshot {
     posted: number;
     failed: number;
     retired: number;
+    oldestWaitingRepo?: string;
+    oldestWaitingAt?: string;
+    oldestWaitingAgeMs?: number;
   };
   jobs: ReviewQueueJobRecord[];
   byRepo: Array<{
@@ -318,6 +321,8 @@ export interface OperatorDurableQueueSnapshot {
     posted: number;
     failed: number;
     retired: number;
+    oldestWaitingAt?: string;
+    oldestWaitingAgeMs?: number;
   }>;
 }
 
@@ -1541,6 +1546,7 @@ function buildDurableQueueSnapshot(
 }
 
 function summarizeDurableQueueJobs(jobs: ReviewQueueJobRecord[], now: Date): OperatorDurableQueueSnapshot["summary"] {
+  const oldestWaiting = oldestWaitingQueueJob(jobs);
   return {
     total: jobs.length,
     queued: jobs.filter((job) => job.state === "queued").length,
@@ -1551,8 +1557,25 @@ function summarizeDurableQueueJobs(jobs: ReviewQueueJobRecord[], now: Date): Ope
     commandRecorded: jobs.filter((job) => job.state === "command_recorded").length,
     posted: jobs.filter((job) => job.state === "posted").length,
     failed: jobs.filter((job) => job.state === "failed").length,
-    retired: jobs.filter((job) => job.state === "stale_retired" || job.state === "closed_retired").length
+    retired: jobs.filter((job) => job.state === "stale_retired" || job.state === "closed_retired").length,
+    ...(oldestWaiting
+      ? {
+          oldestWaitingRepo: oldestWaiting.repo,
+          oldestWaitingAt: oldestWaiting.createdAt,
+          oldestWaitingAgeMs: Math.max(0, now.getTime() - Date.parse(oldestWaiting.createdAt))
+        }
+      : {})
   };
+}
+
+function oldestWaitingQueueJob(jobs: ReviewQueueJobRecord[]): ReviewQueueJobRecord | undefined {
+  return jobs
+    .filter((job) =>
+      job.state === "queued" ||
+      job.state === "provider_deferred" ||
+      job.state === "blocked_on_proof"
+    )
+    .sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt))[0];
 }
 
 function isRetryableQueueJob(job: ReviewQueueJobRecord, now: Date): boolean {

--- a/src/review-budget.ts
+++ b/src/review-budget.ts
@@ -166,6 +166,15 @@ export function buildReviewBudgetStatus(input: {
   const jobs = input.jobs.map((job) =>
     normalizeExpiredLeaseJob(job, now, input.config.reviewConcurrency.leaseTtlMs)
   );
+  const repoActiveLimitCache = new Map<string, number>();
+  const cachedRepoActiveLimit = (repo: string): number => {
+    const key = repo.toLowerCase();
+    const cached = repoActiveLimitCache.get(key);
+    if (cached !== undefined) return cached;
+    const limit = repoActiveLimitFor(input.config, scheduler, repo);
+    repoActiveLimitCache.set(key, limit);
+    return limit;
+  };
   const active = jobs.filter((job) => isActiveQueueJob(job));
   const activeProvider = countBy(active, (job) => providerKey(job));
   const activeOrg = countBy(active, (job) => job.org);
@@ -198,7 +207,7 @@ export function buildReviewBudgetStatus(input: {
     const providerCount = simulatedProviderActive.get(provider) ?? 0;
     const orgCount = simulatedOrgActive.get(job.org) ?? 0;
     const repoCount = simulatedRepoActive.get(job.repo) ?? 0;
-    const repoActiveLimit = repoActiveLimitFor(input.config, scheduler, job.repo);
+    const repoActiveLimit = cachedRepoActiveLimit(job.repo);
     const capacityReason = capacityDelayReason(job, {
       scheduler,
       providerCount,
@@ -262,7 +271,7 @@ export function buildReviewBudgetStatus(input: {
       background: active.filter((job) => job.lane === "background").length,
       byProvider: capacityRows(activeProvider, scheduler.maxProviderActive),
       byOrg: capacityRows(activeOrg, scheduler.maxOrgActive),
-      byRepo: capacityRows(activeRepo, (repo) => repoActiveLimitFor(input.config, scheduler, repo))
+      byRepo: capacityRows(activeRepo, cachedRepoActiveLimit)
     },
     queued: {
       total: queued.length,

--- a/src/review-budget.ts
+++ b/src/review-budget.ts
@@ -1,4 +1,5 @@
 import type { BotConfig } from "./config.js";
+import { resolveRepoProfile } from "./repo-policy.js";
 import type { ReviewQueueJobRecord } from "./state.js";
 
 export type ReviewQueueDelayReason =
@@ -197,11 +198,13 @@ export function buildReviewBudgetStatus(input: {
     const providerCount = simulatedProviderActive.get(provider) ?? 0;
     const orgCount = simulatedOrgActive.get(job.org) ?? 0;
     const repoCount = simulatedRepoActive.get(job.repo) ?? 0;
+    const repoActiveLimit = repoActiveLimitFor(input.config, scheduler, job.repo);
     const capacityReason = capacityDelayReason(job, {
       scheduler,
       providerCount,
       orgCount,
       repoCount,
+      repoActiveLimit,
       hasManualAfter: hasManualAfter[index] ?? false
     });
     if (capacityReason) {
@@ -259,7 +262,7 @@ export function buildReviewBudgetStatus(input: {
       background: active.filter((job) => job.lane === "background").length,
       byProvider: capacityRows(activeProvider, scheduler.maxProviderActive),
       byOrg: capacityRows(activeOrg, scheduler.maxOrgActive),
-      byRepo: capacityRows(activeRepo, scheduler.maxRepoActive)
+      byRepo: capacityRows(activeRepo, (repo) => repoActiveLimitFor(input.config, scheduler, repo))
     },
     queued: {
       total: queued.length,
@@ -363,12 +366,13 @@ function capacityDelayReason(
     providerCount: number;
     orgCount: number;
     repoCount: number;
+    repoActiveLimit: number;
     hasManualAfter: boolean;
   }
 ): ReviewQueueDelayReason | undefined {
   if (input.providerCount >= input.scheduler.maxProviderActive) return "provider_capacity";
   if (input.orgCount >= input.scheduler.maxOrgActive) return "org_capacity";
-  if (input.repoCount >= input.scheduler.maxRepoActive) return "repo_capacity";
+  if (input.repoCount >= input.repoActiveLimit) return "repo_capacity";
   if (
     job.lane === "background" &&
     input.hasManualAfter &&
@@ -415,15 +419,28 @@ function delay(job: ReviewQueueJobRecord, reason: ReviewQueueDelayReason): Revie
   };
 }
 
-function capacityRows(counts: Map<string, number>, limit: number): ReviewBudgetCapacity[] {
+function repoActiveLimitFor(
+  config: BotConfig,
+  scheduler: NonNullable<BotConfig["reviewScheduler"]>,
+  repo: string
+): number {
+  const resolution = resolveRepoProfile(config, repo);
+  if (!resolution.allowed) return scheduler.maxRepoActive;
+  return resolution.profile.reviewScheduler?.maxActiveHeads ?? scheduler.maxRepoActive;
+}
+
+function capacityRows(counts: Map<string, number>, limit: number | ((name: string) => number)): ReviewBudgetCapacity[] {
   return [...counts.entries()]
     .sort(([left], [right]) => left.localeCompare(right))
-    .map(([name, active]) => ({
-      name,
-      active,
-      limit,
-      remaining: Math.max(0, limit - active)
-    }));
+    .map(([name, active]) => {
+      const resolvedLimit = typeof limit === "function" ? limit(name) : limit;
+      return {
+        name,
+        active,
+        limit: resolvedLimit,
+        remaining: Math.max(0, resolvedLimit - active)
+      };
+    });
 }
 
 function applyDetailLimit<T>(items: T[], limit?: number): T[] {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,5 +1,5 @@
 import { isPreActivationExistingPull } from "./activation-policy.js";
-import { loadConfig, type BotConfig } from "./config.js";
+import { loadConfig, type BotConfig, type RepoReviewSchedulerConfig } from "./config.js";
 import {
   collectTrustedReviewCommands,
   decideCommandAction,
@@ -190,6 +190,7 @@ export async function runScheduledCycleWithDeps(input: {
       maxProviderActive: scheduler.maxProviderActive,
       maxOrgActive: scheduler.maxOrgActive,
       maxRepoActive: scheduler.maxRepoActive,
+      maxRepoActiveByRepo: buildRepoActiveLimitOverrides(config, input.state.listReviewQueueJobs()),
       manualCommandReserve: scheduler.manualCommandReserve,
       excludeJobIds: attemptedJobIds,
       reservedActiveJobs: attemptedJobs,
@@ -371,13 +372,57 @@ async function enqueuePullIfEligible(input: {
     backfillReadinessFromActiveQueueJob(input.state, input.repo, input.pull, activeQueueJob, input.now);
     return "already_queued";
   }
-  if (!hasRepoQueueCapacity(input.state, input.repo, input.config.reviewScheduler?.maxQueuedPerRepo ?? 10)) {
+  const repoScheduler = resolveRepoReviewScheduler(input.config, input.repo);
+  const maxQueuedHeads = repoScheduler?.maxQueuedHeads ?? input.config.reviewScheduler?.maxQueuedPerRepo ?? 10;
+  if (!hasRepoQueueCapacity(input.state, input.repo, maxQueuedHeads)) {
+    const overflowAction = repoScheduler?.overflowAction ?? "defer";
+    const deferredDetails = `Repo review queue capacity is full for this repo (limit ${maxQueuedHeads}).`;
+    if (overflowAction === "skip") {
+      input.state.recordProcessed({
+        repo: input.repo,
+        pullNumber: input.pull.number,
+        headSha: input.pull.head.sha,
+        status: "skipped",
+        error: "repo_queue_capacity_full"
+      });
+      recordReadinessTransition({
+        state: input.state,
+        repo: input.repo,
+        pull: input.pull,
+        readinessState: "skipped",
+        reason: "repo_queue_capacity_full",
+        now: input.now
+      });
+      await syncReviewStatusComment({
+        config: input.config,
+        github: input.github,
+        dryRun: input.dryRun,
+        repo: input.repo,
+        pull: input.pull,
+        state: "skipped",
+        details: `${deferredDetails} Repo policy skips excess burst heads.`,
+        onStatusCommentFailure: input.onStatusCommentFailure,
+        now: input.now
+      });
+      return "skipped_capacity";
+    }
     recordReadinessTransition({
       state: input.state,
       repo: input.repo,
       pull: input.pull,
       readinessState: "provider_deferred",
       reason: "repo_queue_capacity_full",
+      now: input.now
+    });
+    await syncReviewStatusComment({
+      config: input.config,
+      github: input.github,
+      dryRun: input.dryRun,
+      repo: input.repo,
+      pull: input.pull,
+      state: "provider_deferred",
+      details: deferredDetails,
+      onStatusCommentFailure: input.onStatusCommentFailure,
       now: input.now
     });
     return "skipped_capacity";
@@ -480,24 +525,31 @@ function enqueueReviewJob(input: {
 
 function automaticQueuePriority(config: BotConfig, repo: string): number | undefined {
   const backgroundPriority = config.reviewScheduler?.backgroundPriority;
-  if (repo.toLowerCase() !== SELF_REPO) return backgroundPriority;
+  if (!isSelfRepo(repo)) return backgroundPriority;
   return Math.min(backgroundPriority ?? 50, 1);
 }
 
-const SELF_REPO = "electricsheephq/evaos-code-review-bot";
+const SELF_REPOS = new Set([
+  "electricsheephq/evaos-code-review-bot",
+  "electricsheephq/evaos-code-review-bot-neondiff"
+]);
 const LICENSE_GATE_RETRY_DELAY_MS = 15 * 60_000;
+
+function isSelfRepo(repo: string): boolean {
+  return SELF_REPOS.has(repo.toLowerCase());
+}
 
 function reprioritizeExistingSelfRepoQueueJobs(input: {
   config: BotConfig;
   state: ReviewStateStore;
   now: Date;
 }): number {
-  const targetPriority = automaticQueuePriority(input.config, SELF_REPO);
-  if (targetPriority === undefined) return 0;
   let updated = 0;
   for (const job of input.state.listReviewQueueJobs({ states: ["queued", "provider_deferred", "blocked_on_proof"] })) {
-    if (job.repo.toLowerCase() !== SELF_REPO) continue;
+    if (!isSelfRepo(job.repo)) continue;
     if (job.source !== "automatic" || job.lane !== "background") continue;
+    const targetPriority = automaticQueuePriority(input.config, job.repo);
+    if (targetPriority === undefined) continue;
     if (job.priority <= targetPriority) continue;
     input.state.updateReviewQueueJobPriority({
       jobId: job.jobId,
@@ -507,6 +559,24 @@ function reprioritizeExistingSelfRepoQueueJobs(input: {
     updated += 1;
   }
   return updated;
+}
+
+function resolveRepoReviewScheduler(config: BotConfig, repo: string): RepoReviewSchedulerConfig | undefined {
+  const resolution = resolveRepoProfile(config, repo);
+  if (!resolution.allowed) return undefined;
+  return resolution.profile.reviewScheduler;
+}
+
+function buildRepoActiveLimitOverrides(
+  config: BotConfig,
+  jobs: Pick<ReviewQueueJobRecord, "repo">[]
+): Record<string, number> | undefined {
+  const overrides: Record<string, number> = {};
+  for (const job of jobs) {
+    const maxActiveHeads = resolveRepoReviewScheduler(config, job.repo)?.maxActiveHeads;
+    if (maxActiveHeads !== undefined) overrides[job.repo.toLowerCase()] = maxActiveHeads;
+  }
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 
 function recordReadinessForEnqueue(input: {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -183,6 +183,7 @@ export async function runScheduledCycleWithDeps(input: {
   const budget = new ReviewRunBudget(Math.max(1, scheduler.maxProviderActive));
   const attemptedJobIds = new Set<string>();
   const attemptedJobs: ReviewQueueJobRecord[] = [];
+  const repoActiveLimitOverrides = buildRepoActiveLimitOverrides(config, input.state.listReviewQueueJobs());
   // Lease just before execution to avoid idle active rows. This intentionally
   // performs a bounded scan per provider slot, not one bulk pre-lease.
   for (let leaseAttempt = 0; leaseAttempt < scheduler.maxProviderActive; leaseAttempt += 1) {
@@ -190,7 +191,7 @@ export async function runScheduledCycleWithDeps(input: {
       maxProviderActive: scheduler.maxProviderActive,
       maxOrgActive: scheduler.maxOrgActive,
       maxRepoActive: scheduler.maxRepoActive,
-      maxRepoActiveByRepo: buildRepoActiveLimitOverrides(config, input.state.listReviewQueueJobs()),
+      maxRepoActiveByRepo: repoActiveLimitOverrides,
       manualCommandReserve: scheduler.manualCommandReserve,
       excludeJobIds: attemptedJobIds,
       reservedActiveJobs: attemptedJobs,
@@ -406,25 +407,27 @@ async function enqueuePullIfEligible(input: {
       });
       return "skipped_capacity";
     }
-    recordReadinessTransition({
-      state: input.state,
-      repo: input.repo,
-      pull: input.pull,
-      readinessState: "provider_deferred",
-      reason: "repo_queue_capacity_full",
-      now: input.now
-    });
-    await syncReviewStatusComment({
-      config: input.config,
-      github: input.github,
-      dryRun: input.dryRun,
-      repo: input.repo,
-      pull: input.pull,
-      state: "provider_deferred",
-      details: deferredDetails,
-      onStatusCommentFailure: input.onStatusCommentFailure,
-      now: input.now
-    });
+    if (!isCapacityDeferredReadiness(input.state, input.repo, input.pull)) {
+      recordReadinessTransition({
+        state: input.state,
+        repo: input.repo,
+        pull: input.pull,
+        readinessState: "provider_deferred",
+        reason: "repo_queue_capacity_full",
+        now: input.now
+      });
+      await syncReviewStatusComment({
+        config: input.config,
+        github: input.github,
+        dryRun: input.dryRun,
+        repo: input.repo,
+        pull: input.pull,
+        state: "provider_deferred",
+        details: deferredDetails,
+        onStatusCommentFailure: input.onStatusCommentFailure,
+        now: input.now
+      });
+    }
     return "skipped_capacity";
   }
 
@@ -577,6 +580,15 @@ function buildRepoActiveLimitOverrides(
     if (maxActiveHeads !== undefined) overrides[job.repo.toLowerCase()] = maxActiveHeads;
   }
   return Object.keys(overrides).length > 0 ? overrides : undefined;
+}
+
+function isCapacityDeferredReadiness(
+  state: ReviewStateStore,
+  repo: string,
+  pull: PullRequestSummary
+): boolean {
+  const readiness = state.getReviewReadiness(repo, pull.number, pull.head.sha);
+  return readiness?.state === "provider_deferred" && readiness.reason === "repo_queue_capacity_full";
 }
 
 function recordReadinessForEnqueue(input: {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -379,6 +379,8 @@ async function enqueuePullIfEligible(input: {
     const overflowAction = repoScheduler?.overflowAction ?? "defer";
     const deferredDetails = `Repo review queue capacity is full for this repo (limit ${maxQueuedHeads}).`;
     if (overflowAction === "skip") {
+      // Explicit policy escape hatch: "skip" is terminal for this exact head.
+      // The default "defer" path keeps transient burst heads eligible once capacity frees.
       input.state.recordProcessed({
         repo: input.repo,
         pullNumber: input.pull.number,
@@ -576,10 +578,27 @@ function buildRepoActiveLimitOverrides(
 ): Record<string, number> | undefined {
   const overrides: Record<string, number> = {};
   for (const job of jobs) {
+    const repo = job.repo.toLowerCase();
+    if (!isValidRepoName(repo)) continue;
     const maxActiveHeads = resolveRepoReviewScheduler(config, job.repo)?.maxActiveHeads;
-    if (maxActiveHeads !== undefined) overrides[job.repo.toLowerCase()] = maxActiveHeads;
+    if (maxActiveHeads !== undefined) overrides[repo] = maxActiveHeads;
   }
   return Object.keys(overrides).length > 0 ? overrides : undefined;
+}
+
+function isValidRepoName(repo: string): boolean {
+  const [owner, name, extra] = repo.split("/");
+  return (
+    extra === undefined &&
+    Boolean(owner) &&
+    Boolean(name) &&
+    owner !== "." &&
+    owner !== ".." &&
+    name !== "." &&
+    name !== ".." &&
+    /^[A-Za-z0-9_.-]+$/.test(owner) &&
+    /^[A-Za-z0-9_.-]+$/.test(name)
+  );
 }
 
 function isCapacityDeferredReadiness(

--- a/src/state.ts
+++ b/src/state.ts
@@ -1534,6 +1534,7 @@ export class ReviewStateStore {
     maxProviderActive: number;
     maxOrgActive: number;
     maxRepoActive: number;
+    maxRepoActiveByRepo?: Record<string, number>;
     manualCommandReserve?: number;
     excludeJobIds?: Iterable<string>;
     reservedActiveJobs?: Iterable<Pick<ReviewQueueJobRecord, "jobId" | "providerId" | "org" | "repo">>;
@@ -1544,6 +1545,7 @@ export class ReviewStateStore {
     validatePositiveQueueLimit(input.maxProviderActive, "maxProviderActive");
     validatePositiveQueueLimit(input.maxOrgActive, "maxOrgActive");
     validatePositiveQueueLimit(input.maxRepoActive, "maxRepoActive");
+    const maxRepoActiveByRepo = normalizeRepoActiveLimitOverrides(input.maxRepoActiveByRepo);
     const manualCommandReserve = input.manualCommandReserve ?? 0;
     if (!Number.isInteger(manualCommandReserve) || manualCommandReserve < 0) {
       throw new Error("manualCommandReserve must be a non-negative integer");
@@ -1599,7 +1601,8 @@ export class ReviewStateStore {
         const providerCount = (providerActive.get(provider) ?? 0);
         if (providerCount >= input.maxProviderActive) continue;
         if ((orgActive.get(job.org) ?? 0) >= input.maxOrgActive) continue;
-        if ((repoActive.get(job.repo) ?? 0) >= input.maxRepoActive) continue;
+        const repoActiveLimit = maxRepoActiveByRepo.get(job.repo.toLowerCase()) ?? input.maxRepoActive;
+        if ((repoActive.get(job.repo) ?? 0) >= repoActiveLimit) continue;
         if (
           job.lane === "background" &&
           hasManualAfter[index] &&
@@ -2684,6 +2687,17 @@ function validateRepoName(repo: string, label: string): void {
 
 function validatePositiveQueueLimit(value: number, label: string): void {
   if (!Number.isInteger(value) || value < 1) throw new Error(`${label} must be a positive integer`);
+}
+
+function normalizeRepoActiveLimitOverrides(value: Record<string, number> | undefined): Map<string, number> {
+  const result = new Map<string, number>();
+  if (!value) return result;
+  for (const [repo, limit] of Object.entries(value)) {
+    validateRepoName(repo, "maxRepoActiveByRepo");
+    validatePositiveQueueLimit(limit, `maxRepoActiveByRepo.${repo}`);
+    result.set(repo.toLowerCase(), limit);
+  }
+  return result;
 }
 
 function buildReviewQueueAttemptId(input: {

--- a/tests/coverage-audit.test.ts
+++ b/tests/coverage-audit.test.ts
@@ -335,6 +335,49 @@ describe("coverage audit", () => {
     reader.close();
   });
 
+  it("reports capacity-deferred readiness rows in the provider-deferred bucket without a queue row", async () => {
+    const { root, state } = createState();
+    state.recordReviewReadiness({
+      repo: "owner/allowed",
+      pullNumber: 26,
+      headSha: "head-capacity-deferred",
+      state: "provider_deferred",
+      reason: "repo_queue_capacity_full",
+      now: new Date("2026-07-01T00:01:00.000Z")
+    });
+    state.close();
+    const reader = CoverageStateReader.open(join(root, "state.sqlite"));
+
+    const audit = await collectCoverageAudit({
+      config: minimalConfig(root),
+      github: {
+        listOpenPulls: async () => [pull(26, "head-capacity-deferred")]
+      } as unknown as GitHubApi,
+      state: reader,
+      now: new Date("2026-07-01T00:03:00.000Z")
+    });
+
+    expect(audit.ok).toBe(true);
+    expect(audit.summary).toMatchObject({
+      providerDeferred: 1,
+      queued: 0,
+      unprocessed: 0
+    });
+    expect(audit.providerDeferred).toEqual([
+      expect.objectContaining({
+        repo: "owner/allowed",
+        pullNumber: 26,
+        headSha: "head-capacity-deferred",
+        status: "skipped",
+        error: "repo_queue_capacity_full",
+        reason: "repo_queue_capacity_full",
+        createdAt: "2026-07-01T00:01:00.000Z",
+        updatedAt: "2026-07-01T00:01:00.000Z"
+      })
+    ]);
+    reader.close();
+  });
+
   it("falls back to a stable reason for provider-deferred queue rows with raw errors", async () => {
     const { root, state } = createState();
     state.enqueueReviewQueueJob({

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1319,12 +1319,14 @@ describe("operator CLI summaries", () => {
 
     expect(queue.summary).toMatchObject({
       oldestWaitingRepo: "owner/repo",
-      oldestWaitingAt: "not-a-date"
+      oldestWaitingAt: "not-a-date",
+      oldestWaitingAtMalformed: true
     });
     expect(queue.summary.oldestWaitingAgeMs).toBeUndefined();
     expect(queue.byRepo[0]).toMatchObject({
       repo: "owner/repo",
-      oldestWaitingAt: "not-a-date"
+      oldestWaitingAt: "not-a-date",
+      oldestWaitingAtMalformed: true
     });
     expect(queue.byRepo[0]?.oldestWaitingAgeMs).toBeUndefined();
   });
@@ -1353,11 +1355,13 @@ describe("operator CLI summaries", () => {
       oldestWaitingAt: "2026-07-01T00:00:00.000Z",
       oldestWaitingAgeMs: 5 * 60_000
     });
+    expect(queue.summary.oldestWaitingAtMalformed).toBeUndefined();
     expect(queue.byRepo[0]).toMatchObject({
       repo: "owner/repo",
       oldestWaitingAt: "2026-07-01T00:00:00.000Z",
       oldestWaitingAgeMs: 5 * 60_000
     });
+    expect(queue.byRepo[0]?.oldestWaitingAtMalformed).toBeUndefined();
   });
 
   it("builds queue buckets from coverage audit output", () => {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1302,6 +1302,33 @@ describe("operator CLI summaries", () => {
     ]);
   });
 
+  it("omits oldest waiting age when durable queue timestamps are malformed", () => {
+    const statePath = createTempDatabase(tempDirs);
+    const db = new DatabaseSync(statePath);
+    try {
+      db.exec("create table review_queue_jobs (job_id text primary key, attempt_id text not null unique, source text not null, lane text not null, repo text not null, org text not null, pull_number integer not null, head_sha text not null, base_sha text, provider_id text, priority integer not null, state text not null, next_eligible_at text, lease_id text, session_id text, comment_id integer, review_url text, last_error text, created_at text not null, updated_at text not null, started_at text, finished_at text)");
+      insertQueueJob(db, "queued", "owner/repo", 1, "head-queued");
+      db.prepare("update review_queue_jobs set created_at = 'not-a-date' where pull_number = 1").run();
+    } finally {
+      db.close();
+    }
+
+    const queue = collectOperatorReviewQueue(statePath, {
+      now: new Date("2026-07-01T00:05:00.000Z")
+    });
+
+    expect(queue.summary).toMatchObject({
+      oldestWaitingRepo: "owner/repo",
+      oldestWaitingAt: "not-a-date"
+    });
+    expect(queue.summary.oldestWaitingAgeMs).toBeUndefined();
+    expect(queue.byRepo[0]).toMatchObject({
+      repo: "owner/repo",
+      oldestWaitingAt: "not-a-date"
+    });
+    expect(queue.byRepo[0]?.oldestWaitingAgeMs).toBeUndefined();
+  });
+
   it("builds queue buckets from coverage audit output", () => {
     const queue = buildOperatorQueue(coverageReport({
       processed: [processedEntry(1, "head-posted", "posted")],

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1329,6 +1329,37 @@ describe("operator CLI summaries", () => {
     expect(queue.byRepo[0]?.oldestWaitingAgeMs).toBeUndefined();
   });
 
+  it("selects the oldest valid durable queue timestamp before malformed timestamps", () => {
+    const statePath = createTempDatabase(tempDirs);
+    const db = new DatabaseSync(statePath);
+    try {
+      db.exec("create table review_queue_jobs (job_id text primary key, attempt_id text not null unique, source text not null, lane text not null, repo text not null, org text not null, pull_number integer not null, head_sha text not null, base_sha text, provider_id text, priority integer not null, state text not null, next_eligible_at text, lease_id text, session_id text, comment_id integer, review_url text, last_error text, created_at text not null, updated_at text not null, started_at text, finished_at text)");
+      insertQueueJob(db, "queued", "owner/repo", 1, "head-invalid");
+      insertQueueJob(db, "queued", "owner/repo", 2, "head-old");
+      insertQueueJob(db, "queued", "owner/repo", 3, "head-recent");
+      db.prepare("update review_queue_jobs set created_at = 'not-a-date' where pull_number = 1").run();
+      db.prepare("update review_queue_jobs set created_at = '2026-07-01T00:00:00.000Z' where pull_number = 2").run();
+      db.prepare("update review_queue_jobs set created_at = '2026-07-01T00:04:00.000Z' where pull_number = 3").run();
+    } finally {
+      db.close();
+    }
+
+    const queue = collectOperatorReviewQueue(statePath, {
+      now: new Date("2026-07-01T00:05:00.000Z")
+    });
+
+    expect(queue.summary).toMatchObject({
+      oldestWaitingRepo: "owner/repo",
+      oldestWaitingAt: "2026-07-01T00:00:00.000Z",
+      oldestWaitingAgeMs: 5 * 60_000
+    });
+    expect(queue.byRepo[0]).toMatchObject({
+      repo: "owner/repo",
+      oldestWaitingAt: "2026-07-01T00:00:00.000Z",
+      oldestWaitingAgeMs: 5 * 60_000
+    });
+  });
+
   it("builds queue buckets from coverage audit output", () => {
     const queue = buildOperatorQueue(coverageReport({
       processed: [processedEntry(1, "head-posted", "posted")],

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1271,11 +1271,22 @@ describe("operator CLI summaries", () => {
       running: 1,
       providerDeferred: 2,
       retryableProviderDeferred: 1,
-      failed: 1
+      failed: 1,
+      oldestWaitingRepo: "owner/repo",
+      oldestWaitingAt: "2026-07-01T00:00:00.000Z",
+      oldestWaitingAgeMs: 5 * 60_000
     });
     expect(queue.byRepo).toEqual([
       expect.objectContaining({ repo: "owner/other", total: 2, providerDeferred: 1, retryableProviderDeferred: 0, failed: 1 }),
-      expect.objectContaining({ repo: "owner/repo", total: 3, queued: 1, running: 1, retryableProviderDeferred: 1 })
+      expect.objectContaining({
+        repo: "owner/repo",
+        total: 3,
+        queued: 1,
+        running: 1,
+        retryableProviderDeferred: 1,
+        oldestWaitingAt: "2026-07-01T00:00:00.000Z",
+        oldestWaitingAgeMs: 5 * 60_000
+      })
     ]);
     expect(collectOperatorReviewQueue(statePath, { repo: "owner/repo" }).jobs).toHaveLength(3);
 

--- a/tests/review-budget.test.ts
+++ b/tests/review-budget.test.ts
@@ -231,6 +231,62 @@ describe("review run budget", () => {
     ]);
   });
 
+  it("uses repo-profile scheduler active caps in budget projection", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-budget-repo-profile-"));
+    roots.push(root);
+    const config = {
+      ...minimalConfig(root),
+      reviewScheduler: {
+        enabled: true,
+        maxProviderActive: 3,
+        maxOrgActive: 10,
+        maxRepoActive: 3,
+        maxQueuedPerRepo: 10,
+        manualCommandReserve: 0,
+        backgroundPriority: 50
+      },
+      repoProfiles: {
+        repos: {
+          "100yenadmin/Lossless-Codex-Orchestrator-LCO": {
+            reviewScheduler: {
+              maxActiveHeads: 1
+            }
+          }
+        }
+      }
+    };
+
+    const status = buildReviewBudgetStatus({
+      config,
+      now: new Date("2026-07-04T00:00:00.000Z"),
+      jobs: [
+        queueJob("lco-active", {
+          repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+          state: "running",
+          priority: 1,
+          updatedAt: "2026-07-04T00:00:00.000Z"
+        }),
+        queueJob("lco-queued", { repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO", state: "queued", priority: 2 }),
+        queueJob("self-queued", { repo: "electricsheephq/evaos-code-review-bot-neondiff", state: "queued", priority: 3 })
+      ]
+    });
+
+    expect(status.active.byRepo).toEqual([
+      expect.objectContaining({
+        name: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+        active: 1,
+        limit: 1,
+        remaining: 0
+      })
+    ]);
+    expect(status.delayed).toEqual([
+      expect.objectContaining({ jobId: "lco-queued", reason: "repo_capacity" })
+    ]);
+    expect(status.wouldLease).toEqual([
+      expect.objectContaining({ jobId: "self-queued" })
+    ]);
+  });
+
   it("does not count expired leased or running jobs against active capacity", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-budget-expired-lease-"));
     roots.push(root);

--- a/tests/review-scheduler-config.test.ts
+++ b/tests/review-scheduler-config.test.ts
@@ -74,6 +74,17 @@ describe("review scheduler config", () => {
         repos: {
           "owner/repo": {
             reviewScheduler: {
+              maxActiveHeads: 0
+            }
+          }
+        }
+      }
+    }))).toThrow("repoProfiles.repos.owner/repo.reviewScheduler.maxActiveHeads must be a positive integer");
+    expect(() => loadConfig(writeConfig({
+      repoProfiles: {
+        repos: {
+          "owner/repo": {
+            reviewScheduler: {
               overflowAction: "park"
             }
           }

--- a/tests/review-scheduler-config.test.ts
+++ b/tests/review-scheduler-config.test.ts
@@ -38,6 +38,50 @@ describe("review scheduler config", () => {
     }))).toThrow("config.reviewScheduler.manualCommandReserve must be <= config.reviewScheduler.maxProviderActive");
   });
 
+  it("loads and validates repo-profile scheduler burst overrides", () => {
+    const config = loadConfig(writeConfig({
+      repoProfiles: {
+        repos: {
+          "100yenadmin/Lossless-Codex-Orchestrator-LCO": {
+            reviewScheduler: {
+              maxActiveHeads: 1,
+              maxQueuedHeads: 3,
+              overflowAction: "defer"
+            }
+          }
+        }
+      }
+    }));
+
+    expect(config.repoProfiles?.repos?.["100yenadmin/Lossless-Codex-Orchestrator-LCO"]?.reviewScheduler).toEqual({
+      maxActiveHeads: 1,
+      maxQueuedHeads: 3,
+      overflowAction: "defer"
+    });
+    expect(() => loadConfig(writeConfig({
+      repoProfiles: {
+        repos: {
+          "owner/repo": {
+            reviewScheduler: {
+              maxQueuedHeads: 0
+            }
+          }
+        }
+      }
+    }))).toThrow("repoProfiles.repos.owner/repo.reviewScheduler.maxQueuedHeads must be a positive integer");
+    expect(() => loadConfig(writeConfig({
+      repoProfiles: {
+        repos: {
+          "owner/repo": {
+            reviewScheduler: {
+              overflowAction: "park"
+            }
+          }
+        }
+      }
+    }))).toThrow('repoProfiles.repos.owner/repo.reviewScheduler.overflowAction must be "defer" or "skip"');
+  });
+
   it("validates provider overload backoff settings", () => {
     expect(() => loadConfig(writeConfig({
       providerCooldown: {

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -13,6 +13,7 @@ const HEAD_B = "b".repeat(40);
 const HEAD_C = "c".repeat(40);
 const HEAD_D = "d".repeat(40);
 const HEAD_F = "f".repeat(40);
+const SELF_REPO_CURRENT = "electricsheephq/evaos-code-review-bot-neondiff";
 
 describe("provider-aware review scheduler", () => {
   const roots: string[] = [];
@@ -645,7 +646,7 @@ describe("provider-aware review scheduler", () => {
   it("prioritizes self-repo release PR heads ahead of ordinary background queue work", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-self-repo-priority-"));
     roots.push(root);
-    const config = schedulerConfig(root, ["org/repo-a", "electricsheephq/evaos-code-review-bot"]);
+    const config = schedulerConfig(root, ["org/repo-a", SELF_REPO_CURRENT]);
     config.reviewScheduler!.maxProviderActive = 1;
     const state = new ReviewStateStore(config.statePath);
     const reviewed: string[] = [];
@@ -654,7 +655,7 @@ describe("provider-aware review scheduler", () => {
       config,
       github: githubFromMap(new Map([
         ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]],
-        ["electricsheephq/evaos-code-review-bot", [pull("electricsheephq/evaos-code-review-bot", 165, HEAD_B)]]
+        [SELF_REPO_CURRENT, [pull(SELF_REPO_CURRENT, 165, HEAD_B)]]
       ])),
       state,
       options: { dryRun: false, useZCode: false },
@@ -674,8 +675,8 @@ describe("provider-aware review scheduler", () => {
 
     expect(result.queue.enqueued).toBe(2);
     expect(result.reviewed).toBe(1);
-    expect(reviewed).toEqual(["electricsheephq/evaos-code-review-bot#165"]);
-    expect(state.listReviewQueueJobs({ repo: "electricsheephq/evaos-code-review-bot" })).toEqual([
+    expect(reviewed).toEqual([`${SELF_REPO_CURRENT}#165`]);
+    expect(state.listReviewQueueJobs({ repo: SELF_REPO_CURRENT })).toEqual([
       expect.objectContaining({ pullNumber: 165, priority: 1, lastError: "reviewed" })
     ]);
     expect(state.listReviewQueueJobs({ repo: "org/repo-a", state: "queued" })).toEqual([
@@ -687,13 +688,13 @@ describe("provider-aware review scheduler", () => {
   it("reprioritizes existing queued self-repo jobs before ordinary backlog", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-self-repo-existing-priority-"));
     roots.push(root);
-    const config = schedulerConfig(root, ["org/repo-a", "electricsheephq/evaos-code-review-bot"]);
+    const config = schedulerConfig(root, ["org/repo-a", SELF_REPO_CURRENT]);
     config.reviewScheduler!.maxProviderActive = 1;
     config.reviewScheduler!.maxOrgActive = 1;
     config.reviewScheduler!.manualCommandReserve = 0;
     const state = new ReviewStateStore(config.statePath);
     const selfRepoJob = state.enqueueReviewQueueJob({
-      repo: "electricsheephq/evaos-code-review-bot",
+      repo: SELF_REPO_CURRENT,
       pullNumber: 172,
       headSha: HEAD_A,
       baseSha: "base",
@@ -716,8 +717,8 @@ describe("provider-aware review scheduler", () => {
       config,
       github: githubFromMap(new Map([
         ["org/repo-a", [pull("org/repo-a", 1, HEAD_B)]],
-        ["electricsheephq/evaos-code-review-bot", [
-          pull("electricsheephq/evaos-code-review-bot", 172, HEAD_A, "base", { state: "closed", mergedAt: "2026-07-03T00:00:30Z" })
+        [SELF_REPO_CURRENT, [
+          pull(SELF_REPO_CURRENT, 172, HEAD_A, "base", { state: "closed", mergedAt: "2026-07-03T00:00:30Z" })
         ]]
       ])),
       state,
@@ -2996,6 +2997,61 @@ describe("provider-aware review scheduler", () => {
         nextEligibleAt: "2026-07-01T00:05:00.000Z"
       })
     ]);
+    state.close();
+  });
+
+  it("uses repo-profile queue overflow policy to mark burst heads explicitly provider-deferred", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-profile-capacity-"));
+    roots.push(root);
+    const repo = "100yenadmin/Lossless-Codex-Orchestrator-LCO";
+    const config = schedulerConfig(root, [repo]);
+    config.reviewStatusComment!.enabled = true;
+    config.reviewScheduler!.maxProviderActive = 2;
+    config.reviewScheduler!.maxQueuedPerRepo = 10;
+    config.repoProfiles = {
+      repos: {
+        [repo]: {
+          reviewScheduler: {
+            maxQueuedHeads: 1,
+            overflowAction: "defer"
+          }
+        }
+      }
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        [repo, [pull(repo, 461, HEAD_A), pull(repo, 462, HEAD_B)]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo: reviewRepo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo: reviewRepo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-04T12:00:00.000Z")
+    });
+
+    expect(result.queue.enqueued).toBe(1);
+    expect(result.skippedCapacity).toBe(1);
+    expect(state.listReviewQueueJobs({ repo })).toEqual([
+      expect.objectContaining({ pullNumber: 461, headSha: HEAD_A })
+    ]);
+    expect(state.getReviewReadiness(repo, 462, HEAD_B)).toMatchObject({
+      state: "provider_deferred",
+      reason: "repo_queue_capacity_full"
+    });
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "provider_deferred", "in_progress", "completed"]);
+    expect(statusCalls.find((call) => call.issueNumber === 462)?.body).toContain("Repo review queue capacity is full");
     state.close();
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -14,6 +14,7 @@ const HEAD_C = "c".repeat(40);
 const HEAD_D = "d".repeat(40);
 const HEAD_F = "f".repeat(40);
 const SELF_REPO_CURRENT = "electricsheephq/evaos-code-review-bot-neondiff";
+const SELF_REPO_LEGACY = "electricsheephq/evaos-code-review-bot";
 
 describe("provider-aware review scheduler", () => {
   const roots: string[] = [];
@@ -683,6 +684,46 @@ describe("provider-aware review scheduler", () => {
       expect.objectContaining({ pullNumber: 1, priority: 50 })
     ]);
     state.close();
+  });
+
+  it("pins priority-1 scheduling for both self-repo identities", async () => {
+    for (const selfRepo of [SELF_REPO_CURRENT, SELF_REPO_LEGACY]) {
+      const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-self-repo-identity-"));
+      roots.push(root);
+      const config = schedulerConfig(root, ["org/repo-a", selfRepo]);
+      config.reviewScheduler!.maxProviderActive = 1;
+      const state = new ReviewStateStore(config.statePath);
+      const reviewed: string[] = [];
+
+      const result = await runScheduledCycleWithDeps({
+        config,
+        github: githubFromMap(new Map([
+          ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]],
+          [selfRepo, [pull(selfRepo, 165, HEAD_B)]]
+        ])),
+        state,
+        options: { dryRun: false, useZCode: false },
+        reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+          reviewed.push(`${repo}#${reviewPull.number}`);
+          reviewState.recordProcessed({
+            repo,
+            pullNumber: reviewPull.number,
+            headSha: reviewPull.head.sha,
+            status: "posted",
+            event: "COMMENT"
+          });
+          return "reviewed";
+        },
+        now: new Date("2026-07-02T00:00:00.000Z")
+      });
+
+      expect(result.reviewed).toBe(1);
+      expect(reviewed).toEqual([`${selfRepo}#165`]);
+      expect(state.listReviewQueueJobs({ repo: selfRepo })).toEqual([
+        expect.objectContaining({ pullNumber: 165, priority: 1, lastError: "reviewed" })
+      ]);
+      state.close();
+    }
   });
 
   it("reprioritizes existing queued self-repo jobs before ordinary backlog", async () => {
@@ -3052,6 +3093,86 @@ describe("provider-aware review scheduler", () => {
     });
     expect(statusCalls.map(statusFromBody)).toEqual(["queued", "provider_deferred", "in_progress", "completed"]);
     expect(statusCalls.find((call) => call.issueNumber === 462)?.body).toContain("Repo review queue capacity is full");
+    state.close();
+  });
+
+  it("does not re-post capacity-deferred status when a repo stays at queue capacity", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-profile-capacity-idempotent-"));
+    roots.push(root);
+    const repo = "100yenadmin/Lossless-Codex-Orchestrator-LCO";
+    const config = schedulerConfig(root, [repo]);
+    config.reviewStatusComment!.enabled = true;
+    config.reviewScheduler!.maxQueuedPerRepo = 10;
+    config.reviewScheduler!.maxProviderActive = 1;
+    config.repoProfiles = {
+      repos: {
+        [repo]: {
+          reviewScheduler: {
+            maxQueuedHeads: 1,
+            overflowAction: "defer"
+          }
+        }
+      }
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const blocking = state.enqueueReviewQueueJob({
+      repo,
+      pullNumber: 460,
+      headSha: HEAD_A,
+      baseSha: "base",
+      source: "automatic",
+      lane: "background",
+      providerId: "zai-coding-plan",
+      now: new Date("2026-07-04T12:00:00.000Z")
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: blocking.jobId,
+      state: "running",
+      leaseId: "blocking-lease",
+      leaseExpiresAt: "2026-07-04T12:10:00.000Z",
+      clearLease: false,
+      now: new Date("2026-07-04T12:00:01.000Z")
+    });
+    const statusCalls: StatusCommentCall[] = [];
+
+    const first = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        [repo, [pull(repo, 462, HEAD_B)]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("capacity-deferred head must not run review work");
+      },
+      now: new Date("2026-07-04T12:01:00.000Z")
+    });
+
+    expect(first.skippedCapacity).toBe(1);
+    expect(statusCalls.map(statusFromBody)).toEqual(["provider_deferred"]);
+    const readiness = state.getReviewReadiness(repo, 462, HEAD_B);
+    expect(readiness).toMatchObject({
+      state: "provider_deferred",
+      reason: "repo_queue_capacity_full",
+      updatedAt: "2026-07-04T12:01:00.000Z"
+    });
+
+    const second = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        [repo, [pull(repo, 462, HEAD_B)]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("capacity-deferred head must not run review work");
+      },
+      now: new Date("2026-07-04T12:02:00.000Z")
+    });
+
+    expect(second.skippedCapacity).toBe(1);
+    expect(statusCalls.map(statusFromBody)).toEqual(["provider_deferred"]);
+    expect(state.getReviewReadiness(repo, 462, HEAD_B)).toEqual(readiness);
     state.close();
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -3098,6 +3098,57 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("applies repo-profile active caps to freshly enqueued jobs in the same cycle", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-profile-active-cap-"));
+    roots.push(root);
+    const repo = "100yenadmin/Lossless-Codex-Orchestrator-LCO";
+    const config = schedulerConfig(root, [repo]);
+    config.reviewScheduler!.maxProviderActive = 2;
+    config.reviewScheduler!.maxRepoActive = 2;
+    config.repoProfiles = {
+      repos: {
+        [repo]: {
+          reviewScheduler: {
+            maxActiveHeads: 1,
+            maxQueuedHeads: 10,
+            overflowAction: "defer"
+          }
+        }
+      }
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const reviewed: number[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        [repo, [pull(repo, 461, HEAD_A), pull(repo, 462, HEAD_B)]]
+      ])),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo: reviewRepo, pull: reviewPull }) => {
+        reviewed.push(reviewPull.number);
+        reviewState.recordProcessed({
+          repo: reviewRepo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-04T12:00:00.000Z")
+    });
+
+    expect(result.queue.enqueued).toBe(2);
+    expect(result.reviewed).toBe(1);
+    expect(reviewed).toEqual([461]);
+    expect(state.listReviewQueueJobs({ repo, state: "queued" })).toEqual([
+      expect.objectContaining({ pullNumber: 462, headSha: HEAD_B })
+    ]);
+    state.close();
+  });
+
   it("does not re-post capacity-deferred status when a repo stays at queue capacity", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-profile-capacity-idempotent-"));
     roots.push(root);
@@ -3175,6 +3226,41 @@ describe("provider-aware review scheduler", () => {
     expect(second.skippedCapacity).toBe(1);
     expect(statusCalls.map(statusFromBody)).toEqual(["provider_deferred"]);
     expect(state.getReviewReadiness(repo, 462, HEAD_B)).toEqual(readiness);
+
+    state.updateReviewQueueJobState({
+      jobId: blocking.jobId,
+      state: "posted",
+      reviewUrl: "https://github.com/100yenadmin/Lossless-Codex-Orchestrator-LCO/pull/460#pullrequestreview-1",
+      lastError: "reviewed",
+      now: new Date("2026-07-04T12:02:30.000Z")
+    });
+    const third = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        [repo, [pull(repo, 462, HEAD_B)]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo: reviewRepo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo: reviewRepo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-04T12:03:00.000Z")
+    });
+
+    expect(third.queue.enqueued).toBe(1);
+    expect(third.reviewed).toBe(1);
+    expect(statusCalls.map(statusFromBody)).toEqual(["provider_deferred", "queued", "in_progress", "completed"]);
+    expect(state.getReviewReadiness(repo, 462, HEAD_B)).toMatchObject({
+      state: "ready_for_human",
+      reason: "comment_review_posted"
+    });
     state.close();
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -3055,6 +3055,78 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("treats repo-profile skip overflow as an explicit terminal skip for the exact head", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-profile-capacity-skip-"));
+    roots.push(root);
+    const repo = "100yenadmin/Lossless-Codex-Orchestrator-LCO";
+    const config = schedulerConfig(root, [repo]);
+    config.reviewStatusComment!.enabled = true;
+    config.reviewScheduler!.maxProviderActive = 2;
+    config.reviewScheduler!.maxQueuedPerRepo = 10;
+    config.repoProfiles = {
+      repos: {
+        [repo]: {
+          reviewScheduler: {
+            maxQueuedHeads: 1,
+            overflowAction: "skip"
+          }
+        }
+      }
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const statusCalls: StatusCommentCall[] = [];
+
+    const first = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        [repo, [pull(repo, 461, HEAD_A), pull(repo, 462, HEAD_B)]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo: reviewRepo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo: reviewRepo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-04T12:00:00.000Z")
+    });
+
+    expect(first.queue.enqueued).toBe(1);
+    expect(first.skippedCapacity).toBe(1);
+    expect(state.getProcessedReview(repo, 462, HEAD_B)).toMatchObject({
+      status: "skipped",
+      error: "repo_queue_capacity_full"
+    });
+    expect(state.getReviewReadiness(repo, 462, HEAD_B)).toMatchObject({
+      state: "skipped",
+      reason: "repo_queue_capacity_full"
+    });
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "skipped", "in_progress", "completed"]);
+
+    const second = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        [repo, [pull(repo, 462, HEAD_B)]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("terminal skip overflow heads must not be re-enqueued automatically");
+      },
+      now: new Date("2026-07-04T12:05:00.000Z")
+    });
+
+    expect(second.skippedProcessed).toBe(1);
+    expect(state.listReviewQueueJobs({ repo }).filter((job) => job.pullNumber === 462)).toHaveLength(0);
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "skipped", "in_progress", "completed"]);
+    state.close();
+  });
+
   it("skips pre-activation PRs when their head changes after repo activation", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-preactivation-head-"));
     roots.push(root);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -3087,6 +3087,8 @@ describe("provider-aware review scheduler", () => {
     expect(state.listReviewQueueJobs({ repo })).toEqual([
       expect.objectContaining({ pullNumber: 461, headSha: HEAD_A })
     ]);
+    expect(result.queue.remainingQueued).toBe(0);
+    expect(result.queue.budget?.queued.total).toBe(1);
     expect(state.getReviewReadiness(repo, 462, HEAD_B)).toMatchObject({
       state: "provider_deferred",
       reason: "repo_queue_capacity_full"

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -942,6 +942,53 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("honors repo-specific active caps while leasing queued work", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-repo-specific-lease-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const now = new Date("2026-07-04T00:00:00.000Z");
+
+    const firstLco = store.enqueueReviewQueueJob({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 461,
+      headSha: "lco-head-a",
+      providerId: "zai",
+      now
+    }).job;
+    const secondLco = store.enqueueReviewQueueJob({
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      pullNumber: 462,
+      headSha: "lco-head-b",
+      providerId: "zai",
+      now: new Date("2026-07-04T00:00:01.000Z")
+    }).job;
+    const otherRepo = store.enqueueReviewQueueJob({
+      repo: "electricsheephq/evaos-code-review-bot-neondiff",
+      pullNumber: 218,
+      headSha: "self-head",
+      providerId: "zai",
+      now: new Date("2026-07-04T00:00:02.000Z")
+    }).job;
+
+    const leased = store.leaseNextReviewQueueJobs({
+      maxProviderActive: 3,
+      maxOrgActive: 3,
+      maxRepoActive: 3,
+      maxRepoActiveByRepo: {
+        "100yenadmin/lossless-codex-orchestrator-lco": 1
+      },
+      manualCommandReserve: 0,
+      limit: 3,
+      now: new Date("2026-07-04T00:00:10.000Z")
+    });
+
+    expect(leased.map((job) => job.jobId)).toEqual([firstLco.jobId, otherRepo.jobId]);
+    expect(store.getReviewQueueJob(firstLco.jobId)).toMatchObject({ state: "leased" });
+    expect(store.getReviewQueueJob(secondLco.jobId)).toMatchObject({ state: "queued" });
+    expect(store.getReviewQueueJob(otherRepo.jobId)).toMatchObject({ state: "leased" });
+    store.close();
+  });
+
   it("requeues expired durable queue leases before leasing new work", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-expired-lease-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- add repo-profile scheduler burst overrides for max active heads, max queued heads, and defer/skip overflow handling
- mark excess burst heads with explicit sticky provider_deferred/skipped status instead of leaving agents stuck on ambiguous queued state
- keep self-repo release priority working for the current `evaos-code-review-bot-neondiff` slug as well as the legacy slug
- surface oldest waiting durable queue age by repo in operator queue summaries

Fixes #217

## GitNexus non-regression
- #218 disabled-by-default GitNexus behavior is preserved for user-facing config
- enabled GitNexus context path remains covered by `tests/gitnexus-context.test.ts`

## Validation
- RED run observed expected failures in config/scheduler/state/budget/operator tests before implementation
- `NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/review-scheduler-config.test.ts tests/scheduler.test.ts tests/state.test.ts tests/review-budget.test.ts tests/operator-cli.test.ts --pool forks`
- `npm run build`
- `NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/gitnexus-context.test.ts --pool forks`
- `git diff --check`

## Release note
- Do not promote live config changes until release gates pass. A later release captain step can opt LCO into conservative per-repo burst caps if desired.