### PR TITLE
Fix ZCode timeout queue visibility

### DIFF
--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -27,7 +27,11 @@ import {
   type ReviewQueueJobState,
   type RepoProviderCooldownRecord
 } from "./state.js";
-import { buildZCodeTimeoutRetryCommand, summarizeZCodeTimeoutErrors } from "./zcode-timeout.js";
+import {
+  buildZCodeTimeoutInspectCommand,
+  buildZCodeTimeoutRetryCommandsForJobs,
+  summarizeZCodeTimeoutErrors
+} from "./zcode-timeout.js";
 
 export interface OperatorStatus {
   ok: boolean;
@@ -375,7 +379,7 @@ export function buildOperatorStatus(input: {
   const failedRows = input.release.database.errorCount;
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
-  const zcodeTimeoutRetryCommand = buildZCodeTimeoutRetryCommand({ configPath: input.release.releaseUnit.configPath });
+  const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
   const budget = input.release.budget;
   const retryableProviderDeferredJobs = actionableProviderDeferredJobs(
     budget,
@@ -461,7 +465,7 @@ export function buildOperatorStatus(input: {
     ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : []),
     ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
     ...(zcodeTimeoutQueue.total > 0
-      ? [zcodeTimeoutRetryCommand]
+      ? zcodeTimeoutRetryActions
       : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
     ...(issueEnrichment && !issueEnrichment.ok ? ["resolve issue-enrichment blockers before enabling live issue comments"] : []),
@@ -550,7 +554,7 @@ export function buildRuntimeInventory(input: {
     Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
-  const zcodeTimeoutRetryCommand = buildZCodeTimeoutRetryCommand({ configPath: input.release.releaseUnit.configPath });
+  const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
   const providerDeferredJobs = durableQueue?.summary.providerDeferred ?? 0;
   const readFailures = queue?.summary.readFailures ?? 0;
   const staleHeads = queue?.summary.staleHeads ?? 0;
@@ -664,7 +668,7 @@ export function buildRuntimeInventory(input: {
     ...(input.agents.summary.staleLeases > 0 ? ["inspect stale leases before restarting launchd"] : []),
     ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
     ...(zcodeTimeoutQueue.total > 0
-      ? [zcodeTimeoutRetryCommand]
+      ? zcodeTimeoutRetryActions
       : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
     ...(retryableExpiredProviderCooldowns > 0 ? ["retry expired provider cooldowns or inspect provider health"] : []),
@@ -1577,6 +1581,19 @@ function zcodeTimeoutQueueCounts(
       .filter((job) => job.state === "failed")
       .map((job) => job.lastError)
   );
+}
+
+function zcodeTimeoutRecommendedActions(
+  release: ReleaseStatus,
+  durableQueue?: OperatorDurableQueueSnapshot
+): string[] {
+  const retryCommands = buildZCodeTimeoutRetryCommandsForJobs({
+    configPath: release.releaseUnit.configPath,
+    jobs: durableQueue?.jobs ?? []
+  });
+  return retryCommands.length > 0
+    ? retryCommands
+    : [buildZCodeTimeoutInspectCommand(release.releaseUnit.configPath)];
 }
 
 function emptyDurableQueue(now: Date): OperatorDurableQueueSnapshot {

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -27,6 +27,7 @@ import {
   type ReviewQueueJobState,
   type RepoProviderCooldownRecord
 } from "./state.js";
+import { summarizeZCodeTimeoutErrors } from "./zcode-timeout.js";
 
 export interface OperatorStatus {
   ok: boolean;
@@ -48,6 +49,9 @@ export interface OperatorStatus {
     runningJobs: number;
     providerDeferredJobs: number;
     failedQueueJobs: number;
+    zcodeTimeoutFailedQueueJobs: number;
+    retryableZCodeTimeoutFailedQueueJobs: number;
+    exhaustedZCodeTimeoutFailedQueueJobs: number;
     budgetWouldLeaseJobs: number;
     budgetDelayedJobs: number;
     issueEnrichmentState?: IssueEnrichmentStatus["state"];
@@ -81,6 +85,9 @@ export interface RuntimeInventory {
     runningJobs: number;
     providerDeferredJobs: number;
     failedQueueJobs: number;
+    zcodeTimeoutFailedQueueJobs: number;
+    retryableZCodeTimeoutFailedQueueJobs: number;
+    exhaustedZCodeTimeoutFailedQueueJobs: number;
     retryableProviderDeferredJobs: number;
     budgetWouldLeaseJobs: number;
     budgetDelayedJobs: number;
@@ -367,6 +374,7 @@ export function buildOperatorStatus(input: {
   const staleHeads = queue?.summary.staleHeads ?? 0;
   const failedRows = input.release.database.errorCount;
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
+  const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
   const budget = input.release.budget;
   const retryableProviderDeferredJobs = actionableProviderDeferredJobs(
     budget,
@@ -408,6 +416,13 @@ export function buildOperatorStatus(input: {
       detail: `${failedQueueJobs} failed durable queue job(s)`
     },
     {
+      name: "durable_queue_no_zcode_timeout_failed_jobs",
+      ok: zcodeTimeoutQueue.total === 0,
+      detail:
+        `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
+        `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
+    },
+    {
       name: "durable_queue_no_retryable_provider_deferred_jobs",
       ok: retryableProviderDeferredJobs === 0,
       detail: describeActionableProviderDeferredJobs(budget, retryableProviderDeferredJobs)
@@ -444,6 +459,9 @@ export function buildOperatorStatus(input: {
     ...(staleHeads > 0 ? ["wait for next daemon cycle or run scoped coverage audit"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : []),
     ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(zcodeTimeoutQueue.total > 0
+      ? ["inspect timed-out ZCode queue jobs and retry exact current heads with retry-failed"]
+      : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
     ...(issueEnrichment && !issueEnrichment.ok ? ["resolve issue-enrichment blockers before enabling live issue comments"] : []),
     ...(issueEnrichmentRuntimeFailed > 0 ? ["inspect failed issue-enrichment records before promotion"] : []),
@@ -470,6 +488,9 @@ export function buildOperatorStatus(input: {
       runningJobs: durableQueue?.summary.running ?? 0,
       providerDeferredJobs: durableQueue?.summary.providerDeferred ?? 0,
       failedQueueJobs,
+      zcodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.total,
+      retryableZCodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.retryable,
+      exhaustedZCodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.exhausted,
       budgetWouldLeaseJobs: budget?.wouldLeaseCount ?? 0,
       budgetDelayedJobs: budget?.delayedCount ?? 0,
       ...(issueEnrichment ? { issueEnrichmentState: issueEnrichment.state } : {}),
@@ -527,6 +548,7 @@ export function buildRuntimeInventory(input: {
     input.release.database.retryableExpiredProviderCooldownCount ??
     Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
+  const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
   const providerDeferredJobs = durableQueue?.summary.providerDeferred ?? 0;
   const readFailures = queue?.summary.readFailures ?? 0;
   const staleHeads = queue?.summary.staleHeads ?? 0;
@@ -553,6 +575,13 @@ export function buildRuntimeInventory(input: {
       name: "runtime_no_failed_queue_jobs",
       ok: failedQueueJobs === 0,
       detail: `${failedQueueJobs} failed durable queue job(s)`
+    },
+    {
+      name: "runtime_no_zcode_timeout_failed_queue_jobs",
+      ok: zcodeTimeoutQueue.total === 0,
+      detail:
+        `${zcodeTimeoutQueue.total} ZCode timeout failed durable queue job(s); ` +
+        `retryable=${zcodeTimeoutQueue.retryable} exhausted=${zcodeTimeoutQueue.exhausted}`
     },
     {
       name: "runtime_no_retryable_provider_deferred_jobs",
@@ -632,6 +661,9 @@ export function buildRuntimeInventory(input: {
     ...(readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
     ...(input.agents.summary.staleLeases > 0 ? ["inspect stale leases before restarting launchd"] : []),
     ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
+    ...(zcodeTimeoutQueue.total > 0
+      ? ["inspect timed-out ZCode queue jobs and retry exact current heads with retry-failed"]
+      : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
     ...(retryableExpiredProviderCooldowns > 0 ? ["retry expired provider cooldowns or inspect provider health"] : []),
     ...(issueEnrichment && !issueEnrichment.ok ? ["resolve issue-enrichment blockers before enabling live issue comments"] : []),
@@ -654,6 +686,9 @@ export function buildRuntimeInventory(input: {
       runningJobs: durableQueue?.summary.running ?? 0,
       providerDeferredJobs,
       failedQueueJobs,
+      zcodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.total,
+      retryableZCodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.retryable,
+      exhaustedZCodeTimeoutFailedQueueJobs: zcodeTimeoutQueue.exhausted,
       retryableProviderDeferredJobs,
       budgetWouldLeaseJobs: budget?.wouldLeaseCount ?? 0,
       budgetDelayedJobs: budget?.delayedCount ?? 0,
@@ -1522,6 +1557,24 @@ function staleHeadQueueEntry(entry: CoverageStaleHead): OperatorQueueEntry {
 
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))];
+}
+
+function zcodeTimeoutQueueCounts(
+  release: ReleaseStatus,
+  durableQueue?: OperatorDurableQueueSnapshot
+): { total: number; retryable: number; exhausted: number } {
+  if (release.database.zcodeTimeoutFailedReviewQueueJobCount !== undefined) {
+    return {
+      total: release.database.zcodeTimeoutFailedReviewQueueJobCount,
+      retryable: release.database.retryableZCodeTimeoutFailedReviewQueueJobCount ?? 0,
+      exhausted: release.database.exhaustedZCodeTimeoutFailedReviewQueueJobCount ?? 0
+    };
+  }
+  return summarizeZCodeTimeoutErrors(
+    (durableQueue?.jobs ?? [])
+      .filter((job) => job.state === "failed")
+      .map((job) => job.lastError)
+  );
 }
 
 function emptyDurableQueue(now: Date): OperatorDurableQueueSnapshot {

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -27,7 +27,7 @@ import {
   type ReviewQueueJobState,
   type RepoProviderCooldownRecord
 } from "./state.js";
-import { summarizeZCodeTimeoutErrors } from "./zcode-timeout.js";
+import { buildZCodeTimeoutRetryCommand, summarizeZCodeTimeoutErrors } from "./zcode-timeout.js";
 
 export interface OperatorStatus {
   ok: boolean;
@@ -375,6 +375,7 @@ export function buildOperatorStatus(input: {
   const failedRows = input.release.database.errorCount;
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
+  const zcodeTimeoutRetryCommand = buildZCodeTimeoutRetryCommand({ configPath: input.release.releaseUnit.configPath });
   const budget = input.release.budget;
   const retryableProviderDeferredJobs = actionableProviderDeferredJobs(
     budget,
@@ -460,7 +461,7 @@ export function buildOperatorStatus(input: {
     ...(input.agents.summary.staleLeases > 0 ? ["inspect agents output before restarting or retiring stale work"] : []),
     ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
     ...(zcodeTimeoutQueue.total > 0
-      ? ["inspect timed-out ZCode queue jobs and retry exact current heads with retry-failed"]
+      ? [zcodeTimeoutRetryCommand]
       : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
     ...(issueEnrichment && !issueEnrichment.ok ? ["resolve issue-enrichment blockers before enabling live issue comments"] : []),
@@ -549,6 +550,7 @@ export function buildRuntimeInventory(input: {
     Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
+  const zcodeTimeoutRetryCommand = buildZCodeTimeoutRetryCommand({ configPath: input.release.releaseUnit.configPath });
   const providerDeferredJobs = durableQueue?.summary.providerDeferred ?? 0;
   const readFailures = queue?.summary.readFailures ?? 0;
   const staleHeads = queue?.summary.staleHeads ?? 0;
@@ -662,7 +664,7 @@ export function buildRuntimeInventory(input: {
     ...(input.agents.summary.staleLeases > 0 ? ["inspect stale leases before restarting launchd"] : []),
     ...(failedQueueJobs > 0 ? ["inspect operator queue failed jobs before promotion"] : []),
     ...(zcodeTimeoutQueue.total > 0
-      ? ["inspect timed-out ZCode queue jobs and retry exact current heads with retry-failed"]
+      ? [zcodeTimeoutRetryCommand]
       : []),
     ...(retryableProviderDeferredJobs > 0 ? ["retry or requeue provider-deferred jobs whose nextEligibleAt has expired"] : []),
     ...(retryableExpiredProviderCooldowns > 0 ? ["retry expired provider cooldowns or inspect provider health"] : []),

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -5,7 +5,7 @@ import { DatabaseSync } from "node:sqlite";
 import { loadConfig } from "./config.js";
 import { buildReviewBudgetStatus, type ReviewBudgetStatus } from "./review-budget.js";
 import { parseProviderCooldownError, PROVIDER_COOLDOWN_ERROR_PREFIX } from "./state.js";
-import { buildZCodeTimeoutRetryCommand, summarizeZCodeTimeoutErrors, ZCODE_TIMEOUT_ERROR_PREFIX } from "./zcode-timeout.js";
+import { buildZCodeTimeoutInspectCommand, summarizeZCodeTimeoutErrors, ZCODE_TIMEOUT_ERROR_PREFIX } from "./zcode-timeout.js";
 import type { BotConfig } from "./config.js";
 import type { ReviewQueueJobRecord } from "./state.js";
 
@@ -230,7 +230,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const retryProviderCooldownCommand =
     `npx tsx src/cli.ts retry-provider-cooldowns --config ${input.configPath} ` +
     "--expired-only true --dry-run false --zcode true";
-  const retryZCodeTimeoutCommand = buildZCodeTimeoutRetryCommand({ configPath: input.configPath });
+  const inspectZCodeTimeoutCommand = buildZCodeTimeoutInspectCommand(input.configPath);
   const runtimeGates = [
     {
       name: "expected_head",
@@ -384,7 +384,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
         ? [`npx tsx src/cli.ts clear-review-queue-leases --config ${input.configPath} --dry-run true --expired-only true`]
         : []),
       ...(!zcodeTimeoutFailedQueueJobsOk
-        ? [retryZCodeTimeoutCommand]
+        ? [inspectZCodeTimeoutCommand]
         : [])
     ],
     gates,

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -5,7 +5,7 @@ import { DatabaseSync } from "node:sqlite";
 import { loadConfig } from "./config.js";
 import { buildReviewBudgetStatus, type ReviewBudgetStatus } from "./review-budget.js";
 import { parseProviderCooldownError, PROVIDER_COOLDOWN_ERROR_PREFIX } from "./state.js";
-import { summarizeZCodeTimeoutErrors, ZCODE_TIMEOUT_ERROR_PREFIX } from "./zcode-timeout.js";
+import { buildZCodeTimeoutRetryCommand, summarizeZCodeTimeoutErrors, ZCODE_TIMEOUT_ERROR_PREFIX } from "./zcode-timeout.js";
 import type { BotConfig } from "./config.js";
 import type { ReviewQueueJobRecord } from "./state.js";
 
@@ -230,6 +230,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
   const retryProviderCooldownCommand =
     `npx tsx src/cli.ts retry-provider-cooldowns --config ${input.configPath} ` +
     "--expired-only true --dry-run false --zcode true";
+  const retryZCodeTimeoutCommand = buildZCodeTimeoutRetryCommand({ configPath: input.configPath });
   const runtimeGates = [
     {
       name: "expected_head",
@@ -383,7 +384,7 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
         ? [`npx tsx src/cli.ts clear-review-queue-leases --config ${input.configPath} --dry-run true --expired-only true`]
         : []),
       ...(!zcodeTimeoutFailedQueueJobsOk
-        ? ["inspect timed-out ZCode queue jobs and retry exact current heads with retry-failed"]
+        ? [retryZCodeTimeoutCommand]
         : [])
     ],
     gates,

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -5,6 +5,7 @@ import { DatabaseSync } from "node:sqlite";
 import { loadConfig } from "./config.js";
 import { buildReviewBudgetStatus, type ReviewBudgetStatus } from "./review-budget.js";
 import { parseProviderCooldownError, PROVIDER_COOLDOWN_ERROR_PREFIX } from "./state.js";
+import { summarizeZCodeTimeoutErrors, ZCODE_TIMEOUT_ERROR_PREFIX } from "./zcode-timeout.js";
 import type { BotConfig } from "./config.js";
 import type { ReviewQueueJobRecord } from "./state.js";
 
@@ -47,6 +48,9 @@ export interface ReleaseDatabaseStatus {
   providerDeferredReviewQueueJobCount?: number;
   retryableProviderDeferredReviewQueueJobCount?: number;
   failedReviewQueueJobCount?: number;
+  zcodeTimeoutFailedReviewQueueJobCount?: number;
+  retryableZCodeTimeoutFailedReviewQueueJobCount?: number;
+  exhaustedZCodeTimeoutFailedReviewQueueJobCount?: number;
   reviewRunLeaseCount?: number;
   staleReviewRunLeaseCount?: number;
   staleActiveReviewQueueJobCount?: number;
@@ -150,6 +154,9 @@ export interface ReleaseStatus {
     providerDeferredQueueJobs: number;
     retryableProviderDeferredQueueJobs: number;
     readyToRetryProviderDeferredJobs: number;
+    zcodeTimeoutFailedQueueJobs?: number;
+    retryableZCodeTimeoutFailedQueueJobs?: number;
+    exhaustedZCodeTimeoutFailedQueueJobs?: number;
     expiredProviderCooldowns: number;
     retryableExpiredProviderCooldowns: number;
     activeProviderCooldowns: number;
@@ -208,6 +215,10 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
     );
   const expiredProviderCooldownOk = retryableExpiredProviderCooldownCount === 0;
   const failedQueueJobsOk = (input.database.failedReviewQueueJobCount ?? 0) === 0;
+  const zcodeTimeoutFailedQueueJobCount = input.database.zcodeTimeoutFailedReviewQueueJobCount ?? 0;
+  const retryableZCodeTimeoutFailedQueueJobCount = input.database.retryableZCodeTimeoutFailedReviewQueueJobCount ?? 0;
+  const exhaustedZCodeTimeoutFailedQueueJobCount = input.database.exhaustedZCodeTimeoutFailedReviewQueueJobCount ?? 0;
+  const zcodeTimeoutFailedQueueJobsOk = zcodeTimeoutFailedQueueJobCount === 0;
   const staleReviewLeaseCount = (input.database.staleReviewRunLeaseCount ?? 0) +
     (input.database.staleActiveReviewQueueJobCount ?? 0);
   const staleReviewLeasesOk = staleReviewLeaseCount === 0;
@@ -274,6 +285,13 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       detail: `${input.database.failedReviewQueueJobCount ?? 0} failed durable queue job(s)`
     },
     {
+      name: "queue_no_zcode_timeout_failed_jobs",
+      ok: zcodeTimeoutFailedQueueJobsOk,
+      detail:
+        `${zcodeTimeoutFailedQueueJobCount} ZCode timeout failed durable queue job(s); ` +
+        `retryable=${retryableZCodeTimeoutFailedQueueJobCount} exhausted=${exhaustedZCodeTimeoutFailedQueueJobCount}`
+    },
+    {
       name: "queue_no_stale_review_leases",
       ok: staleReviewLeasesOk,
       detail:
@@ -330,6 +348,9 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
       providerDeferredQueueJobs: input.database.providerDeferredReviewQueueJobCount ?? 0,
       retryableProviderDeferredQueueJobs: input.database.retryableProviderDeferredReviewQueueJobCount ?? 0,
       readyToRetryProviderDeferredJobs: actionableProviderDeferredQueueJobs,
+      zcodeTimeoutFailedQueueJobs: zcodeTimeoutFailedQueueJobCount,
+      retryableZCodeTimeoutFailedQueueJobs: retryableZCodeTimeoutFailedQueueJobCount,
+      exhaustedZCodeTimeoutFailedQueueJobs: exhaustedZCodeTimeoutFailedQueueJobCount,
       expiredProviderCooldowns: input.database.expiredProviderCooldownCount ?? 0,
       retryableExpiredProviderCooldowns: retryableExpiredProviderCooldownCount,
       activeProviderCooldowns: input.database.activeProviderCooldownCount ?? 0
@@ -360,6 +381,9 @@ export function buildReleaseStatus(input: ReleaseStatusInput): ReleaseStatus {
           ]),
       ...(!staleReviewLeasesOk
         ? [`npx tsx src/cli.ts clear-review-queue-leases --config ${input.configPath} --dry-run true --expired-only true`]
+        : []),
+      ...(!zcodeTimeoutFailedQueueJobsOk
+        ? ["inspect timed-out ZCode queue jobs and retry exact current heads with retry-failed"]
         : [])
     ],
     gates,
@@ -1019,6 +1043,9 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       providerDeferredReviewQueueJobCount: reviewQueue.providerDeferred,
       retryableProviderDeferredReviewQueueJobCount: reviewQueue.retryableProviderDeferred,
       failedReviewQueueJobCount: reviewQueue.failed,
+      zcodeTimeoutFailedReviewQueueJobCount: reviewQueue.zcodeTimeoutFailed,
+      retryableZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.retryableZCodeTimeoutFailed,
+      exhaustedZCodeTimeoutFailedReviewQueueJobCount: reviewQueue.exhaustedZCodeTimeoutFailed,
       reviewRunLeaseCount: reviewRunLeases.total,
       staleReviewRunLeaseCount: reviewRunLeases.stale,
       staleActiveReviewQueueJobCount,
@@ -1041,13 +1068,28 @@ function readReviewQueueCounts(
   providerDeferred: number;
   retryableProviderDeferred: number;
   failed: number;
+  zcodeTimeoutFailed: number;
+  retryableZCodeTimeoutFailed: number;
+  exhaustedZCodeTimeoutFailed: number;
   byRepo: ReviewQueueRepoStatus[];
 } {
   const hasTable = db
     .prepare("select 1 from sqlite_master where type = 'table' and name = 'review_queue_jobs' limit 1")
     .get();
   if (!hasTable) {
-    return { total: 0, queued: 0, leased: 0, running: 0, providerDeferred: 0, retryableProviderDeferred: 0, failed: 0, byRepo: [] };
+    return {
+      total: 0,
+      queued: 0,
+      leased: 0,
+      running: 0,
+      providerDeferred: 0,
+      retryableProviderDeferred: 0,
+      failed: 0,
+      zcodeTimeoutFailed: 0,
+      retryableZCodeTimeoutFailed: 0,
+      exhaustedZCodeTimeoutFailed: 0,
+      byRepo: []
+    };
   }
   const nowIso = now.toISOString();
   const row = db
@@ -1079,6 +1121,14 @@ function readReviewQueueCounts(
        order by repo`
     )
     .all(nowIso) as unknown as Array<QueueCountRow & { repo: string }>;
+  const timeoutRows = db
+    .prepare(
+      `select last_error
+       from review_queue_jobs
+       where state = 'failed' and last_error like ?`
+    )
+    .all(`${ZCODE_TIMEOUT_ERROR_PREFIX}%`) as unknown as Array<{ last_error: string | null }>;
+  const timeoutCounts = summarizeZCodeTimeoutErrors(timeoutRows.map((timeoutRow) => timeoutRow.last_error));
   return {
     total: row.total ?? 0,
     queued: row.queued ?? 0,
@@ -1087,6 +1137,9 @@ function readReviewQueueCounts(
     providerDeferred: row.providerDeferred ?? 0,
     retryableProviderDeferred: row.retryableProviderDeferred ?? 0,
     failed: row.failed ?? 0,
+    zcodeTimeoutFailed: timeoutCounts.total,
+    retryableZCodeTimeoutFailed: timeoutCounts.retryable,
+    exhaustedZCodeTimeoutFailed: timeoutCounts.exhausted,
     byRepo: byRepoRows.map((repoRow) => ({
       repo: repoRow.repo,
       total: repoRow.total ?? 0,

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1063,14 +1063,13 @@ async function runLeasedQueueJob(input: {
       updateReviewerSessionJobFromQueueStatus({ ...input, job: { ...input.job, ...(sessionId ? { sessionId } : {}) } }, "assigned");
       return "skipped_provider_cooldown";
     }
-    recordFailedReview({
+    const errorMessage = recordFailedReview({
       config: input.config,
       state: input.state,
       repo: input.job.repo,
       pull,
       error
     });
-    const errorMessage = error instanceof Error ? error.message : String(error);
     input.state.updateReviewQueueJobState({
       jobId: input.job.jobId,
       state: "failed",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -64,6 +64,7 @@ import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "
 import { buildWalkthroughComment } from "./walkthrough.js";
 import { postWalkthroughComment, reviewBodyAfterWalkthroughPost } from "./walkthrough-post.js";
 import { buildReviewPrompt, runZCodeReview } from "./zcode.js";
+import { formatZCodeTimeoutFailureError } from "./zcode-timeout.js";
 import type { PullFilePatch, PullRequestSummary, RepositorySummary, ReviewPlan } from "./types.js";
 
 const LICENSE_GATE_REPO_VISIBILITY_CACHE_TTL_MS = 10 * 60_000;
@@ -1965,9 +1966,15 @@ export function recordFailedReview(input: {
   repo: string;
   pull: PullRequestSummary;
   error: unknown;
-}): void {
+}): string {
   const evidenceDir = buildEvidenceDir(input.config, input.repo, input.pull, { action: "none", shouldReview: false });
-  const errorMessage = redactSecrets(input.error instanceof Error ? input.error.message : String(input.error));
+  const previous = input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha);
+  const rawErrorMessage = redactSecrets(input.error instanceof Error ? input.error.message : String(input.error));
+  const errorMessage = formatZCodeTimeoutFailureError({
+    error: input.error,
+    previousError: previous?.error,
+    timeoutMs: input.config.zcode.timeoutMs ?? 180_000
+  }) ?? rawErrorMessage;
   mkdirSync(evidenceDir, { recursive: true });
   writeFileSync(join(evidenceDir, "review-error.json"), `${JSON.stringify({
     repo: input.repo,
@@ -1983,6 +1990,7 @@ export function recordFailedReview(input: {
     status: "failed",
     error: errorMessage
   });
+  return errorMessage;
 }
 
 export function recordProviderRateLimitCooldownIfNeeded(input: {

--- a/src/zcode-timeout.ts
+++ b/src/zcode-timeout.ts
@@ -1,0 +1,106 @@
+import { redactSecrets } from "./secrets.js";
+
+export const ZCODE_TIMEOUT_ERROR_PREFIX = "zcode_timeout_retryable";
+export const ZCODE_TIMEOUT_RETRYABLE_ATTEMPT_LIMIT = 1;
+
+export interface ParsedZCodeTimeoutError {
+  reason: string;
+  retryAttempt: number;
+  retryable: boolean;
+  timeoutMs?: number;
+  originalError?: string;
+}
+
+export interface ZCodeTimeoutCounts {
+  total: number;
+  retryable: number;
+  exhausted: number;
+}
+
+export function isZCodeTimeoutError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+  return (
+    (normalized.includes("zcode failed before completion") && normalized.includes("etimedout")) ||
+    (normalized.includes("spawnsync") && normalized.includes("etimedout")) ||
+    (normalized.includes("zcode") && normalized.includes("timed out"))
+  );
+}
+
+export function formatZCodeTimeoutFailureError(input: {
+  error: unknown;
+  previousError?: string;
+  timeoutMs: number;
+}): string | undefined {
+  if (!isZCodeTimeoutError(input.error)) return undefined;
+  const retryAttempt = nextZCodeTimeoutRetryAttempt(input.previousError);
+  const originalError = sanitizeTimeoutError(input.error instanceof Error ? input.error.message : String(input.error));
+  return [
+    ZCODE_TIMEOUT_ERROR_PREFIX,
+    "reason=zcode_hard_timeout",
+    `retry_attempt=${retryAttempt}`,
+    `timeout_ms=${Math.max(0, Math.floor(input.timeoutMs))}`,
+    `original_error=${originalError}`
+  ].join("; ");
+}
+
+export function parseZCodeTimeoutError(error?: string | null): ParsedZCodeTimeoutError | undefined {
+  if (!error || !error.includes(ZCODE_TIMEOUT_ERROR_PREFIX)) return undefined;
+  const fields = parseSemicolonFields(error);
+  const retryAttempt = parsePositiveInteger(fields.get("retry_attempt")) ?? 0;
+  if (retryAttempt <= 0) return undefined;
+  const timeoutMs = parsePositiveInteger(fields.get("timeout_ms"));
+  const parsed: ParsedZCodeTimeoutError = {
+    reason: fields.get("reason") ?? "zcode_hard_timeout",
+    retryAttempt,
+    retryable: retryAttempt <= ZCODE_TIMEOUT_RETRYABLE_ATTEMPT_LIMIT
+  };
+  if (timeoutMs !== undefined) parsed.timeoutMs = timeoutMs;
+  const originalError = fields.get("original_error");
+  if (originalError) parsed.originalError = originalError;
+  return parsed;
+}
+
+export function summarizeZCodeTimeoutErrors(errors: Array<string | null | undefined>): ZCodeTimeoutCounts {
+  return errors.reduce<ZCodeTimeoutCounts>(
+    (counts, error) => {
+      const parsed = parseZCodeTimeoutError(error);
+      if (!parsed) return counts;
+      counts.total += 1;
+      if (parsed.retryable) counts.retryable += 1;
+      else counts.exhausted += 1;
+      return counts;
+    },
+    { total: 0, retryable: 0, exhausted: 0 }
+  );
+}
+
+function nextZCodeTimeoutRetryAttempt(previousError?: string): number {
+  const previous = parseZCodeTimeoutError(previousError);
+  return (previous?.retryAttempt ?? 0) + 1;
+}
+
+function sanitizeTimeoutError(message: string): string {
+  return redactSecrets(message)
+    .replace(/\s+/g, " ")
+    .replace(/;/g, ",")
+    .trim()
+    .slice(0, 800);
+}
+
+function parseSemicolonFields(error: string): Map<string, string> {
+  const fields = new Map<string, string>();
+  for (const rawPart of error.split(";")) {
+    const part = rawPart.trim();
+    const separatorIndex = part.indexOf("=");
+    if (separatorIndex <= 0) continue;
+    fields.set(part.slice(0, separatorIndex), part.slice(separatorIndex + 1));
+  }
+  return fields;
+}
+
+function parsePositiveInteger(value?: string): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}

--- a/src/zcode-timeout.ts
+++ b/src/zcode-timeout.ts
@@ -17,6 +17,15 @@ export interface ZCodeTimeoutCounts {
   exhausted: number;
 }
 
+export interface ZCodeTimeoutRetryCommandInput {
+  configPath: string;
+  repo?: string;
+  pullNumber?: number;
+  headSha?: string;
+  dryRun?: boolean;
+  zcode?: boolean;
+}
+
 export function isZCodeTimeoutError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   const normalized = message.toLowerCase();
@@ -73,6 +82,18 @@ export function summarizeZCodeTimeoutErrors(errors: Array<string | null | undefi
     },
     { total: 0, retryable: 0, exhausted: 0 }
   );
+}
+
+export function buildZCodeTimeoutRetryCommand(input: ZCodeTimeoutRetryCommandInput): string {
+  return [
+    "npx tsx src/cli.ts retry-failed",
+    `--config ${input.configPath}`,
+    `--repo ${input.repo ?? "<repo>"}`,
+    `--pr ${input.pullNumber ?? "<number>"}`,
+    `--head-sha ${input.headSha ?? "<head-sha>"}`,
+    `--dry-run ${input.dryRun === true ? "true" : "false"}`,
+    `--zcode ${input.zcode === false ? "false" : "true"}`
+  ].join(" ");
 }
 
 function nextZCodeTimeoutRetryAttempt(previousError?: string): number {

--- a/src/zcode-timeout.ts
+++ b/src/zcode-timeout.ts
@@ -39,8 +39,7 @@ export function isZCodeTimeoutError(error: unknown): boolean {
   const normalized = message.toLowerCase();
   return (
     (normalized.includes("zcode failed before completion") && normalized.includes("etimedout")) ||
-    (normalized.includes("zcode failed before completion") && normalized.includes("timed out")) ||
-    (normalized.includes("spawnsync") && normalized.includes("etimedout"))
+    (normalized.includes("zcode failed before completion") && normalized.includes("timed out"))
   );
 }
 
@@ -64,9 +63,9 @@ export function formatZCodeTimeoutFailureError(input: {
 export function parseZCodeTimeoutError(error?: string | null): ParsedZCodeTimeoutError | undefined {
   if (!error || !error.includes(ZCODE_TIMEOUT_ERROR_PREFIX)) return undefined;
   const fields = parseSemicolonFields(error);
-  const retryAttempt = parsePositiveInteger(fields.get("retry_attempt")) ?? 0;
-  if (retryAttempt <= 0) return undefined;
-  const timeoutMs = parsePositiveInteger(fields.get("timeout_ms"));
+  const retryAttempt = parsePositiveInteger(fields.get("retry_attempt"));
+  if (retryAttempt === undefined) return undefined;
+  const timeoutMs = parseNonNegativeInteger(fields.get("timeout_ms"));
   const parsed: ParsedZCodeTimeoutError = {
     reason: fields.get("reason") ?? "zcode_hard_timeout",
     retryAttempt,
@@ -155,6 +154,12 @@ function parseSemicolonFields(error: string): Map<string, string> {
 }
 
 function parsePositiveInteger(value?: string): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseNonNegativeInteger(value?: string): number | undefined {
   if (!value) return undefined;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;

--- a/src/zcode-timeout.ts
+++ b/src/zcode-timeout.ts
@@ -19,11 +19,19 @@ export interface ZCodeTimeoutCounts {
 
 export interface ZCodeTimeoutRetryCommandInput {
   configPath: string;
-  repo?: string;
-  pullNumber?: number;
-  headSha?: string;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
   dryRun?: boolean;
   zcode?: boolean;
+}
+
+export interface ZCodeTimeoutRetryJobInput {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  state?: string;
+  lastError?: string | null;
 }
 
 export function isZCodeTimeoutError(error: unknown): boolean {
@@ -31,8 +39,8 @@ export function isZCodeTimeoutError(error: unknown): boolean {
   const normalized = message.toLowerCase();
   return (
     (normalized.includes("zcode failed before completion") && normalized.includes("etimedout")) ||
-    (normalized.includes("spawnsync") && normalized.includes("etimedout")) ||
-    (normalized.includes("zcode") && normalized.includes("timed out"))
+    (normalized.includes("zcode failed before completion") && normalized.includes("timed out")) ||
+    (normalized.includes("spawnsync") && normalized.includes("etimedout"))
   );
 }
 
@@ -88,12 +96,38 @@ export function buildZCodeTimeoutRetryCommand(input: ZCodeTimeoutRetryCommandInp
   return [
     "npx tsx src/cli.ts retry-failed",
     `--config ${input.configPath}`,
-    `--repo ${input.repo ?? "<repo>"}`,
-    `--pr ${input.pullNumber ?? "<number>"}`,
-    `--head-sha ${input.headSha ?? "<head-sha>"}`,
+    `--repo ${input.repo}`,
+    `--pr ${input.pullNumber}`,
+    `--head-sha ${input.headSha}`,
     `--dry-run ${input.dryRun === true ? "true" : "false"}`,
     `--zcode ${input.zcode === false ? "false" : "true"}`
   ].join(" ");
+}
+
+export function buildZCodeTimeoutRetryCommandsForJobs(input: {
+  configPath: string;
+  jobs: ZCodeTimeoutRetryJobInput[];
+}): string[] {
+  const seen = new Set<string>();
+  const commands: string[] = [];
+  for (const job of input.jobs) {
+    if (job.state !== "failed") continue;
+    if (!parseZCodeTimeoutError(job.lastError)) continue;
+    const key = `${job.repo}#${job.pullNumber}@${job.headSha}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    commands.push(buildZCodeTimeoutRetryCommand({
+      configPath: input.configPath,
+      repo: job.repo,
+      pullNumber: job.pullNumber,
+      headSha: job.headSha
+    }));
+  }
+  return commands;
+}
+
+export function buildZCodeTimeoutInspectCommand(configPath: string): string {
+  return `npx tsx src/cli.ts queue --config ${configPath} --state failed`;
 }
 
 function nextZCodeTimeoutRetryAttempt(previousError?: string): number {
@@ -102,11 +136,11 @@ function nextZCodeTimeoutRetryAttempt(previousError?: string): number {
 }
 
 function sanitizeTimeoutError(message: string): string {
-  return redactSecrets(message)
+  return redactSecrets(redactSecrets(message)
     .replace(/\s+/g, " ")
     .replace(/;/g, ",")
     .trim()
-    .slice(0, 800);
+    .slice(0, 800));
 }
 
 function parseSemicolonFields(error: string): Map<string, string> {

--- a/src/zcode-timeout.ts
+++ b/src/zcode-timeout.ts
@@ -37,9 +37,12 @@ export interface ZCodeTimeoutRetryJobInput {
 export function isZCodeTimeoutError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   const normalized = message.toLowerCase();
+  if (!normalized.includes("zcode failed before completion")) return false;
   return (
-    (normalized.includes("zcode failed before completion") && normalized.includes("etimedout")) ||
-    (normalized.includes("zcode failed before completion") && normalized.includes("timed out"))
+    normalized.includes("etimedout") ||
+    normalized.includes("timed out") ||
+    readErrorCode(error) === "etimedout" ||
+    (readErrorSignal(error) === "sigterm" && readErrorStatus(error) === null)
   );
 }
 
@@ -61,7 +64,7 @@ export function formatZCodeTimeoutFailureError(input: {
 }
 
 export function parseZCodeTimeoutError(error?: string | null): ParsedZCodeTimeoutError | undefined {
-  if (!error || !error.includes(ZCODE_TIMEOUT_ERROR_PREFIX)) return undefined;
+  if (!error || !error.trimStart().startsWith(ZCODE_TIMEOUT_ERROR_PREFIX)) return undefined;
   const fields = parseSemicolonFields(error);
   const retryAttempt = parsePositiveInteger(fields.get("retry_attempt"));
   if (retryAttempt === undefined) return undefined;
@@ -111,7 +114,8 @@ export function buildZCodeTimeoutRetryCommandsForJobs(input: {
   const commands: string[] = [];
   for (const job of input.jobs) {
     if (job.state !== "failed") continue;
-    if (!parseZCodeTimeoutError(job.lastError)) continue;
+    const parsed = parseZCodeTimeoutError(job.lastError);
+    if (!parsed?.retryable) continue;
     const key = `${job.repo}#${job.pullNumber}@${job.headSha}`;
     if (seen.has(key)) continue;
     seen.add(key);
@@ -163,4 +167,22 @@ function parseNonNegativeInteger(value?: string): number | undefined {
   if (!value) return undefined;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function readErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code.toLowerCase() : undefined;
+}
+
+function readErrorSignal(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const signal = (error as { signal?: unknown }).signal;
+  return typeof signal === "string" ? signal.toLowerCase() : undefined;
+}
+
+function readErrorStatus(error: unknown): number | null | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const status = (error as { status?: unknown }).status;
+  return typeof status === "number" || status === null ? status : undefined;
 }

--- a/src/zcode.ts
+++ b/src/zcode.ts
@@ -174,7 +174,12 @@ export function runZCodeReview(input: {
 
     if (result.status !== 0) {
       if (result.error) {
-        throw new Error(`ZCode failed before completion: ${result.error.message}`);
+        throw enrichZCodeProcessError({
+          error: new Error(`ZCode failed before completion: ${result.error.message}`),
+          originalError: result.error,
+          signal: result.signal,
+          status: result.status
+        });
       }
       throw new Error(`ZCode failed with status ${result.status}: ${stderr || stdout.slice(0, 1000)}`);
     }
@@ -287,6 +292,24 @@ function truncateToBudget(text: string, maxBytes: number): string {
   const bytes = Buffer.byteLength(text);
   if (bytes <= maxBytes) return text;
   return `${text.slice(0, maxBytes)}\n[patch truncated to fit prompt budget]`;
+}
+
+function enrichZCodeProcessError(input: {
+  error: Error;
+  originalError: Error;
+  signal: NodeJS.Signals | null;
+  status: number | null;
+}): Error {
+  const original = input.originalError as Error & { code?: unknown };
+  const enriched = input.error as Error & {
+    code?: unknown;
+    signal?: NodeJS.Signals | null;
+    status?: number | null;
+  };
+  if (original.code !== undefined) enriched.code = original.code;
+  enriched.signal = input.signal;
+  enriched.status = input.status;
+  return enriched;
 }
 
 export function extractZCodeResponse(stdout: string): string {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1036,7 +1036,7 @@ describe("operator CLI summaries", () => {
       detail: "1 ZCode timeout failed durable queue job(s); retryable=1 exhausted=0"
     });
     expect(status.recommendedActions).toContain(
-      "npx tsx src/cli.ts retry-failed --config /config/live.json --repo <repo> --pr <number> --head-sha <head-sha> --dry-run false --zcode true"
+      "npx tsx src/cli.ts retry-failed --config /config/live.json --repo electricsheephq/evaos-code-review-bot-neondiff --pr 216 --head-sha head-timeout --dry-run false --zcode true"
     );
   });
 
@@ -1076,7 +1076,7 @@ describe("operator CLI summaries", () => {
       detail: "1 ZCode timeout failed durable queue job(s); retryable=0 exhausted=1"
     });
     expect(status.recommendedActions).toContain(
-      "npx tsx src/cli.ts retry-failed --config /config/live.json --repo <repo> --pr <number> --head-sha <head-sha> --dry-run false --zcode true"
+      "npx tsx src/cli.ts retry-failed --config /config/live.json --repo electricsheephq/evaos-code-review-bot-neondiff --pr 216 --head-sha head-timeout --dry-run false --zcode true"
     );
   });
 

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1075,8 +1075,11 @@ describe("operator CLI summaries", () => {
       ok: false,
       detail: "1 ZCode timeout failed durable queue job(s); retryable=0 exhausted=1"
     });
-    expect(status.recommendedActions).toContain(
+    expect(status.recommendedActions).not.toContain(
       "npx tsx src/cli.ts retry-failed --config /config/live.json --repo electricsheephq/evaos-code-review-bot-neondiff --pr 216 --head-sha head-timeout --dry-run false --zcode true"
+    );
+    expect(status.recommendedActions).toContain(
+      "npx tsx src/cli.ts queue --config /config/live.json --state failed"
     );
   });
 

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -996,6 +996,50 @@ describe("operator CLI summaries", () => {
     ]);
   });
 
+  it("surfaces ZCode timeout failed queue jobs with timeout-specific operator actions", () => {
+    const timeoutJob = durableJob({
+      repo: "electricsheephq/evaos-code-review-bot-neondiff",
+      pullNumber: 216,
+      headSha: "head-timeout",
+      state: "failed",
+      priority: 1,
+      lastError: "zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=1; timeout_ms=1200000; original_error=ZCode failed before completion: spawnSync node ETIMEDOUT"
+    });
+    const status = buildOperatorStatus({
+      release: releaseStatus({
+        ok: false,
+        database: {
+          errorCount: 1,
+          failedReviewQueueJobCount: 1,
+          zcodeTimeoutFailedReviewQueueJobCount: 1,
+          retryableZCodeTimeoutFailedReviewQueueJobCount: 1,
+          exhaustedZCodeTimeoutFailedReviewQueueJobCount: 0
+        }
+      }),
+      agents: agentInventory({}),
+      durableQueue: durableQueueSnapshot({
+        summary: { total: 1, queued: 0, running: 0, providerDeferred: 0, retryableProviderDeferred: 0, failed: 1 },
+        jobs: [timeoutJob]
+      }),
+      checkedAt: "2026-07-04T13:15:00.000Z"
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.summary).toMatchObject({
+      failedQueueJobs: 1,
+      zcodeTimeoutFailedQueueJobs: 1,
+      retryableZCodeTimeoutFailedQueueJobs: 1
+    });
+    expect(status.gates).toContainEqual({
+      name: "durable_queue_no_zcode_timeout_failed_jobs",
+      ok: false,
+      detail: "1 ZCode timeout failed durable queue job(s); retryable=1 exhausted=0"
+    });
+    expect(status.recommendedActions).toContain(
+      "inspect timed-out ZCode queue jobs and retry exact current heads with retry-failed"
+    );
+  });
+
   it("keeps blocked-on-proof readiness above processed coverage for the same head", () => {
     const dashboard = buildOperatorDashboard({
       coverage: coverageReport({ ok: true, processed: [processedEntry(8, "head-proof", "posted")] }),

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -1036,7 +1036,47 @@ describe("operator CLI summaries", () => {
       detail: "1 ZCode timeout failed durable queue job(s); retryable=1 exhausted=0"
     });
     expect(status.recommendedActions).toContain(
-      "inspect timed-out ZCode queue jobs and retry exact current heads with retry-failed"
+      "npx tsx src/cli.ts retry-failed --config /config/live.json --repo <repo> --pr <number> --head-sha <head-sha> --dry-run false --zcode true"
+    );
+  });
+
+  it("surfaces exhausted ZCode timeout failed queue jobs through durable queue fallback counts", () => {
+    const timeoutJob = durableJob({
+      repo: "electricsheephq/evaos-code-review-bot-neondiff",
+      pullNumber: 216,
+      headSha: "head-timeout",
+      state: "failed",
+      priority: 1,
+      lastError: "zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=2; timeout_ms=1200000; original_error=ZCode failed before completion: spawnSync node ETIMEDOUT"
+    });
+    const status = buildOperatorStatus({
+      release: releaseStatus({
+        ok: false,
+        database: {
+          errorCount: 1,
+          failedReviewQueueJobCount: 1
+        }
+      }),
+      agents: agentInventory({}),
+      durableQueue: durableQueueSnapshot({
+        summary: { total: 1, queued: 0, running: 0, providerDeferred: 0, retryableProviderDeferred: 0, failed: 1 },
+        jobs: [timeoutJob]
+      }),
+      checkedAt: "2026-07-04T13:15:00.000Z"
+    });
+
+    expect(status.summary).toMatchObject({
+      zcodeTimeoutFailedQueueJobs: 1,
+      retryableZCodeTimeoutFailedQueueJobs: 0,
+      exhaustedZCodeTimeoutFailedQueueJobs: 1
+    });
+    expect(status.gates).toContainEqual({
+      name: "durable_queue_no_zcode_timeout_failed_jobs",
+      ok: false,
+      detail: "1 ZCode timeout failed durable queue job(s); retryable=0 exhausted=1"
+    });
+    expect(status.recommendedActions).toContain(
+      "npx tsx src/cli.ts retry-failed --config /config/live.json --repo <repo> --pr <number> --head-sha <head-sha> --dry-run false --zcode true"
     );
   });
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -3126,6 +3126,100 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
     });
   });
 
+  it("surfaces failed ZCode timeout queue jobs separately from provider cooldowns", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-zcode-timeout-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          lease_expires_at text,
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, last_error, created_at, updated_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 1, 'failed', ?, ?, ?)`
+      ).run(
+        "timeout-failed",
+        "automatic:electricsheephq/evaos-code-review-bot-neondiff#216@head-timeout",
+        "electricsheephq/evaos-code-review-bot-neondiff",
+        "electricsheephq",
+        216,
+        "head-timeout",
+        "zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=1; timeout_ms=1200000; original_error=ZCode failed before completion: spawnSync node ETIMEDOUT",
+        "2026-07-04T13:12:57.000Z",
+        "2026-07-04T13:12:57.000Z"
+      );
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-04T13:15:00.000Z")
+    });
+
+    expect(status.ok).toBe(false);
+    expect(status.summary).toMatchObject({
+      failedQueueJobs: 1,
+      zcodeTimeoutFailedQueueJobs: 1,
+      retryableZCodeTimeoutFailedQueueJobs: 1
+    });
+    expect(status.database).toMatchObject({
+      zcodeTimeoutFailedReviewQueueJobCount: 1,
+      retryableZCodeTimeoutFailedReviewQueueJobCount: 1,
+      exhaustedZCodeTimeoutFailedReviewQueueJobCount: 0
+    });
+    expect(status.gates).toContainEqual({
+      name: "queue_no_zcode_timeout_failed_jobs",
+      ok: false,
+      detail: "1 ZCode timeout failed durable queue job(s); retryable=1 exhausted=0"
+    });
+    expect(status.recommendedActions).toContain(
+      "inspect timed-out ZCode queue jobs and retry exact current heads with retry-failed"
+    );
+  });
+
   it("treats malformed provider cooldown timestamps as actionable backlog", () => {
     const root = mkdtempSync(join(tmpdir(), "release-status-db-invalid-cooldown-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -3216,7 +3216,7 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
       detail: "1 ZCode timeout failed durable queue job(s); retryable=1 exhausted=0"
     });
     expect(status.recommendedActions).toContain(
-      "inspect timed-out ZCode queue jobs and retry exact current heads with retry-failed"
+      "npx tsx src/cli.ts retry-failed --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --repo <repo> --pr <number> --head-sha <head-sha> --dry-run false --zcode true"
     );
   });
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -3216,7 +3216,7 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
       detail: "1 ZCode timeout failed durable queue job(s); retryable=1 exhausted=0"
     });
     expect(status.recommendedActions).toContain(
-      "npx tsx src/cli.ts retry-failed --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --repo <repo> --pr <number> --head-sha <head-sha> --dry-run false --zcode true"
+      "npx tsx src/cli.ts queue --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --state failed"
     );
   });
 

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -110,7 +110,21 @@ describe("worker review failures", () => {
 
   it("classifies only hard ZCode timeout failures as timeout-retryable", () => {
     expect(isZCodeTimeoutError(new Error("ZCode failed before completion: spawnSync node ETIMEDOUT"))).toBe(true);
+    expect(isZCodeTimeoutError(new Error("spawnSync git ETIMEDOUT"))).toBe(false);
     expect(isZCodeTimeoutError(new Error("zcode review timed out due to upstream provider rate limit"))).toBe(false);
+  });
+
+  it("rejects malformed ZCode timeout retry attempts", () => {
+    expect(parseZCodeTimeoutError(
+      "zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=0; timeout_ms=0; original_error=ZCode failed before completion, spawnSync node ETIMEDOUT"
+    )).toBeUndefined();
+    expect(parseZCodeTimeoutError(
+      "zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=1; timeout_ms=0; original_error=ZCode failed before completion, spawnSync node ETIMEDOUT"
+    )).toMatchObject({
+      retryAttempt: 1,
+      timeoutMs: 0,
+      retryable: true
+    });
   });
 
   it("records provider rate limits as cooldown skips instead of hard failures", () => {

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -27,6 +27,7 @@ import {
   reviewPull,
   runWithProviderRetry
 } from "../src/worker.js";
+import { parseZCodeTimeoutError } from "../src/zcode-timeout.js";
 
 describe("worker review failures", () => {
   const roots: string[] = [];
@@ -57,6 +58,53 @@ describe("worker review failures", () => {
     );
     expect(evidence).toContain("ETIMEDOUT");
     expect(evidence).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+    state.close();
+  });
+
+  it("records ZCode hard timeouts with bounded retry metadata instead of anonymous failure text", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-zcode-timeout-"));
+    roots.push(root);
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const config = minimalConfig(root);
+    const pull = pullSummary(215, "head-timeout");
+
+    recordFailedReview({
+      config,
+      state,
+      repo: "electricsheephq/evaos-code-review-bot-neondiff",
+      pull,
+      error: new Error("ZCode failed before completion: spawnSync node ETIMEDOUT with ghp_1234567890abcdefghijklmnopqrstuvwx")
+    });
+
+    const first = state.getProcessedReview("electricsheephq/evaos-code-review-bot-neondiff", 215, "head-timeout");
+    expect(first).toMatchObject({
+      status: "failed"
+    });
+    expect(first?.error).toContain("zcode_timeout_retryable");
+    expect(first?.error).toContain("reason=zcode_hard_timeout");
+    expect(first?.error).toContain("retry_attempt=1");
+    expect(first?.error).toContain("timeout_ms=1");
+    expect(first?.error).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+    expect(parseZCodeTimeoutError(first?.error)).toMatchObject({
+      retryAttempt: 1,
+      timeoutMs: 1,
+      retryable: true
+    });
+
+    recordFailedReview({
+      config,
+      state,
+      repo: "electricsheephq/evaos-code-review-bot-neondiff",
+      pull,
+      error: new Error("ZCode failed before completion: spawnSync node ETIMEDOUT")
+    });
+
+    const second = state.getProcessedReview("electricsheephq/evaos-code-review-bot-neondiff", 215, "head-timeout");
+    expect(second?.error).toContain("retry_attempt=2");
+    expect(parseZCodeTimeoutError(second?.error)).toMatchObject({
+      retryAttempt: 2,
+      retryable: false
+    });
     state.close();
   });
 

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -27,7 +27,7 @@ import {
   reviewPull,
   runWithProviderRetry
 } from "../src/worker.js";
-import { isZCodeTimeoutError, parseZCodeTimeoutError } from "../src/zcode-timeout.js";
+import { formatZCodeTimeoutFailureError, isZCodeTimeoutError, parseZCodeTimeoutError } from "../src/zcode-timeout.js";
 
 describe("worker review failures", () => {
   const roots: string[] = [];
@@ -110,6 +110,18 @@ describe("worker review failures", () => {
 
   it("classifies only hard ZCode timeout failures as timeout-retryable", () => {
     expect(isZCodeTimeoutError(new Error("ZCode failed before completion: spawnSync node ETIMEDOUT"))).toBe(true);
+    expect(isZCodeTimeoutError(Object.assign(
+      new Error("ZCode failed before completion: Command failed: node /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs"),
+      { code: "ETIMEDOUT" }
+    ))).toBe(true);
+    expect(isZCodeTimeoutError(Object.assign(
+      new Error("ZCode failed before completion: Command failed: node /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs"),
+      { signal: "SIGTERM", status: null }
+    ))).toBe(true);
+    expect(isZCodeTimeoutError(Object.assign(
+      new Error("ZCode failed before completion: Command failed: node /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs"),
+      { signal: "SIGTERM", status: 1 }
+    ))).toBe(false);
     expect(isZCodeTimeoutError(new Error("spawnSync git ETIMEDOUT"))).toBe(false);
     expect(isZCodeTimeoutError(new Error("zcode review timed out due to upstream provider rate limit"))).toBe(false);
   });
@@ -125,6 +137,29 @@ describe("worker review failures", () => {
       timeoutMs: 0,
       retryable: true
     });
+  });
+
+  it("does not treat embedded retired timeout errors as the active retry state", () => {
+    const retiredError =
+      "retired_failed_head:operator_acknowledged; previous_error=zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=1; timeout_ms=1200000; original_error=ZCode failed before completion, spawnSync node ETIMEDOUT";
+
+    expect(parseZCodeTimeoutError(retiredError)).toBeUndefined();
+    expect(formatZCodeTimeoutFailureError({
+      error: new Error("ZCode failed before completion: spawnSync node ETIMEDOUT"),
+      previousError: retiredError,
+      timeoutMs: 1200000
+    })).toContain("retry_attempt=1");
+  });
+
+  it("keeps retry attempts when structured timeout errors receive appended metadata", () => {
+    const decoratedError =
+      "zcode_timeout_retryable; reason=zcode_hard_timeout; retry_attempt=1; timeout_ms=1200000; original_error=ZCode failed before completion, spawnSync node ETIMEDOUT; operator_note=manual_inspection";
+
+    expect(formatZCodeTimeoutFailureError({
+      error: new Error("ZCode failed before completion: spawnSync node ETIMEDOUT"),
+      previousError: decoratedError,
+      timeoutMs: 1200000
+    })).toContain("retry_attempt=2");
   });
 
   it("records provider rate limits as cooldown skips instead of hard failures", () => {

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -27,7 +27,7 @@ import {
   reviewPull,
   runWithProviderRetry
 } from "../src/worker.js";
-import { parseZCodeTimeoutError } from "../src/zcode-timeout.js";
+import { isZCodeTimeoutError, parseZCodeTimeoutError } from "../src/zcode-timeout.js";
 
 describe("worker review failures", () => {
   const roots: string[] = [];
@@ -106,6 +106,11 @@ describe("worker review failures", () => {
       retryable: false
     });
     state.close();
+  });
+
+  it("classifies only hard ZCode timeout failures as timeout-retryable", () => {
+    expect(isZCodeTimeoutError(new Error("ZCode failed before completion: spawnSync node ETIMEDOUT"))).toBe(true);
+    expect(isZCodeTimeoutError(new Error("zcode review timed out due to upstream provider rate limit"))).toBe(false);
   });
 
   it("records provider rate limits as cooldown skips instead of hard failures", () => {


### PR DESCRIPTION
## Summary
- classify ZCode hard timeouts with bounded retry-attempt metadata instead of anonymous failed rows
- persist the structured timeout error into processed review evidence and durable queue job failure state
- surface timeout-specific failed queue counts, gates, and retry guidance in release-status and operator/runtime status

Closes #216

## Validation
- NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/worker-failure.test.ts tests/release-status.test.ts tests/operator-cli.test.ts --pool forks --poolOptions.forks.maxForks=1
- npm run build
- git diff --check

## Risk
- No live config or concurrency change; this only improves timeout classification and operator visibility for already-failed ZCode runs.
