### PR TITLE
Add GitNexus refresh preflight

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -129,6 +129,58 @@ Prefer `npx tsx src/cli.ts release-status ...` when writing machine-readable JSO
 to an evidence file, because `npm run release:status` prepends npm's command
 banner to stdout.
 
+### Post-Merge GitNexus Refresh Preflight
+
+Post-merge GitNexus refreshes are release hygiene only. They must not change
+live `gitnexusContext` behavior, runtime config, launchd state, monitored repos,
+or review posting behavior. Preserve the existing index embedding dimensions
+unless a separate tracked issue and release gate intentionally changes them.
+
+Before running `gitnexus analyze --embeddings`, bootstrap the intended embedding
+provider explicitly in the shell that will run the refresh. For the current
+Voyage-backed Electric Sheep indexes, that means setting the HTTP endpoint,
+model, and the dimension count that matches the existing index. Do not guess the
+dimension count: use only a GitNexus field that explicitly names embedding
+dimensions, such as `embeddingDimensions` or `Embedding dimensions`, or the
+preflight output's `current.dimensions` field after it has parsed that explicit
+GitNexus evidence.
+
+```bash
+export GITNEXUS_EMBEDDING_URL=https://api.voyageai.com/v1
+export GITNEXUS_EMBEDDING_MODEL=voyage-code-3
+export GITNEXUS_EMBEDDING_DIMS=<current-index-dimensions>
+```
+
+Then run the preflight from the clean release checkout:
+
+```bash
+npx tsx src/cli.ts gitnexus-refresh-preflight \
+  --repo-path . \
+  --repo-alias evaos-code-review-bot-neondiff
+```
+
+The preflight prints the current index dimensions only when GitNexus exposes an
+explicit embedding-dimension field, the intended provider/model/dimensions from
+the environment, and the exact recommended command. If provider configuration is
+missing, the current index dimensions cannot be proven, or the intended
+dimensions differ from the current index, do not run
+`gitnexus analyze --embeddings`. Either fix the provider bootstrap/index
+dimension evidence and rerun the preflight, or use the explicit fallback when the
+release only needs commit freshness:
+
+```bash
+npx tsx src/cli.ts gitnexus-refresh-preflight \
+  --repo-path . \
+  --repo-alias evaos-code-review-bot-neondiff \
+  --index-only-fallback true
+
+gitnexus analyze . --name evaos-code-review-bot-neondiff --index-only
+```
+
+Do not use `--allow-dimension-change true` during routine post-merge refreshes;
+that flag is only for a separate embedding migration issue with its own evidence
+packet.
+
 ## Required Gates
 
 - GitHub PR merged to `main` with checks green and no current-head actionable
@@ -177,6 +229,10 @@ npx tsx src/cli.ts review-head-gate \
   explained in the release packet.
 - GitHub tracker issue records source SHA, config path, launchd proof, DB proof,
   rollback command, and next action.
+- Post-merge GitNexus refreshes record the `gitnexus-refresh-preflight` output
+  before any `gitnexus analyze --embeddings` command; missing provider config
+  or missing/mismatched dimension evidence must block vector rebuilds or use the
+  explicit `--index-only` fallback.
 
 ## Stale Main Guard
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@ import {
 } from "./finishing-touches.js";
 import { GitHubApi } from "./github.js";
 import { buildGitNexusContextPacket } from "./gitnexus-context.js";
+import { buildGitNexusRefreshPreflight } from "./gitnexus-refresh-preflight.js";
 import { buildGitHubRelatedContextPacket } from "./github-related-context.js";
 import {
   buildIssueEnrichmentStatus,
@@ -817,6 +818,32 @@ async function main(): Promise<void> {
     } else {
       console.log(JSON.stringify(result, null, 2));
     }
+    if (!result.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "gitnexus-refresh-preflight") {
+    const repoPath = args["repo-path"] ? parseSingleArg(args["repo-path"], "--repo-path") : ".";
+    const indexInfoText = args["index-info-file"]
+      ? readFileSync(parseSingleArg(args["index-info-file"], "--index-info-file"), "utf8")
+      : collectGitNexusPreflightText(repoPath);
+    const result = buildGitNexusRefreshPreflight({
+      repoPath,
+      ...(args["repo-alias"] ? { repoAlias: parseSingleArg(args["repo-alias"], "--repo-alias") } : {}),
+      indexInfoText,
+      env: process.env,
+      indexOnlyFallback: args["index-only-fallback"] === undefined
+        ? false
+        : parseBooleanArg(args["index-only-fallback"], "--index-only-fallback"),
+      allowDimensionChange: args["allow-dimension-change"] === undefined
+        ? false
+        : parseBooleanArg(args["allow-dimension-change"], "--allow-dimension-change")
+    });
+    console.log(stringifyRedactedJson({
+      command: "gitnexus-refresh-preflight",
+      proofBoundary: "Preflight only; this command does not run gitnexus analyze or mutate the index.",
+      ...result
+    }));
     if (!result.ok) process.exitCode = 1;
     return;
   }
@@ -2369,6 +2396,7 @@ function buildHelp(command?: string) {
         "release-status",
         "review-head-gate",
         "coverage-audit",
+        "gitnexus-refresh-preflight",
         "build-memory-packet",
         "build-gitnexus-context-packet",
         "build-github-related-context-packet",
@@ -2423,6 +2451,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts provider-throttle-report --config /path/to/live.json --since 7d --timezone Asia/Singapore",
       "provider-throttle-report peak-window flags use inclusive local-hour buckets, e.g. --peak-start-hour 14 --peak-end-hour 18 includes 14:00 through 18:00",
       "npx tsx src/cli.ts why --config /path/to/live.json --repo owner/repo --pr 123",
+      "npx tsx src/cli.ts gitnexus-refresh-preflight --repo-path . --repo-alias evaos-code-review-bot-neondiff",
       "npx tsx src/cli.ts build-memory-packet --config /path/to/live.json --repo owner/repo --output-dir /path/to/evidence",
       "npx tsx src/cli.ts build-gitnexus-context-packet --config /path/to/live.json --repo owner/repo --pr 123 --output-dir /path/to/evidence",
       "npx tsx src/cli.ts build-github-related-context-packet --config /path/to/live.json --repo owner/repo --pr 123 --output-dir /path/to/evidence",
@@ -2441,6 +2470,44 @@ function buildHelp(command?: string) {
 
 function stringifyProviderOutput(input: unknown): string {
   return JSON.stringify(redactProviderOutput(input), null, 2);
+}
+
+function collectGitNexusPreflightText(repoPath: string): string {
+  const status = spawnSync("gitnexus", ["status"], {
+    cwd: repoPath,
+    encoding: "utf8",
+    timeout: 15_000,
+    maxBuffer: 1024 * 1024
+  });
+  const doctor = spawnSync("gitnexus", ["doctor"], {
+    cwd: repoPath,
+    encoding: "utf8",
+    timeout: 15_000,
+    maxBuffer: 1024 * 1024
+  });
+  return [
+    "$ gitnexus status",
+    formatSpawnSyncDiagnostics("gitnexus status", status),
+    status.stdout,
+    status.stderr,
+    "$ gitnexus doctor",
+    formatSpawnSyncDiagnostics("gitnexus doctor", doctor),
+    doctor.stdout,
+    doctor.stderr
+  ].filter(Boolean).join("\n");
+}
+
+function formatSpawnSyncDiagnostics(command: string, result: ReturnType<typeof spawnSync>): string | undefined {
+  const error = result.error as NodeJS.ErrnoException | undefined;
+  const diagnostics = [
+    `[${command} exit status=${result.status ?? "null"} signal=${result.signal ?? "null"}]`,
+    error ? `[${command} error code=${error.code ?? "unknown"} message=${formatSpawnSyncDiagnosticMessage(error.message)}]` : undefined
+  ].filter(Boolean);
+  return diagnostics.length > 0 ? diagnostics.join("\n") : undefined;
+}
+
+function formatSpawnSyncDiagnosticMessage(message: string): string {
+  return message.replaceAll("]", ")");
 }
 
 function redactProviderOutput(input: unknown, key?: string): unknown {

--- a/src/gitnexus-refresh-preflight.ts
+++ b/src/gitnexus-refresh-preflight.ts
@@ -1,0 +1,208 @@
+export type GitNexusRefreshAction = "analyze_with_embeddings" | "index_only_fallback" | "blocked";
+
+export interface GitNexusRefreshPreflightInput {
+  repoAlias?: string;
+  repoPath?: string;
+  indexInfoText?: string;
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  indexOnlyFallback?: boolean;
+  allowDimensionChange?: boolean;
+}
+
+export interface GitNexusRefreshPreflightResult {
+  ok: boolean;
+  action: GitNexusRefreshAction;
+  repoAlias?: string;
+  current: {
+    dimensions?: number;
+  };
+  intended: {
+    provider?: string;
+    model?: string;
+    dimensions?: number;
+  };
+  recommendedCommand: string;
+  warnings: string[];
+  errors: string[];
+}
+
+export function buildGitNexusRefreshPreflight(input: GitNexusRefreshPreflightInput): GitNexusRefreshPreflightResult {
+  const repoPath = input.repoPath ?? ".";
+  const indexInfoText = input.indexInfoText ?? "";
+  const currentDimensions = parseGitNexusIndexDimensions(indexInfoText);
+  const intended = resolveIntendedEmbeddingConfig(input.env ?? process.env);
+  const publicIntended = toPublicIntendedEmbeddingConfig(intended);
+  const warnings: string[] = [];
+  const errors: string[] = parseGitNexusCommandFailures(indexInfoText);
+  const providerConfigMissing = !intended.provider && !intended.model;
+  const currentDimensionsMissing = currentDimensions === undefined;
+
+  if (intended.dimensionsText !== undefined && intended.dimensions === undefined) {
+    errors.push("GITNEXUS_EMBEDDING_DIMS must be a positive integer");
+  } else if (!intended.dimensions) {
+    errors.push("GITNEXUS_EMBEDDING_DIMS is required before running gitnexus analyze --embeddings");
+  }
+  if (!intended.provider && !intended.model) {
+    errors.push("GITNEXUS_EMBEDDING_PROVIDER, GITNEXUS_EMBEDDING_MODEL, or GITNEXUS_EMBEDDING_URL is required before running gitnexus analyze --embeddings");
+  }
+  if (currentDimensionsMissing) {
+    errors.push("current index embedding dimensions are required before running gitnexus analyze --embeddings");
+  }
+  if (
+    currentDimensions !== undefined &&
+    intended.dimensions !== undefined &&
+    currentDimensions !== intended.dimensions &&
+    !input.allowDimensionChange
+  ) {
+    errors.push(`intended dimensions ${intended.dimensions} do not match current index dimensions ${currentDimensions}`);
+  }
+
+  if (errors.length > 0) {
+    if (input.indexOnlyFallback) {
+      warnings.push(providerConfigMissing
+        ? "provider configuration missing; using index-only fallback to avoid changing embedding dimensions"
+        : "embedding refresh unsafe; using index-only fallback to avoid changing embedding dimensions");
+      warnings.push(...errors);
+      return {
+        ok: true,
+        action: "index_only_fallback",
+        ...(input.repoAlias ? { repoAlias: input.repoAlias } : {}),
+        current: {
+          ...(currentDimensions !== undefined ? { dimensions: currentDimensions } : {})
+        },
+        intended: publicIntended,
+        recommendedCommand: formatGitNexusAnalyzeCommand({ repoPath, repoAlias: input.repoAlias, indexOnly: true }),
+        warnings,
+        errors: []
+      };
+    }
+    return {
+      ok: false,
+      action: "blocked",
+      ...(input.repoAlias ? { repoAlias: input.repoAlias } : {}),
+      current: {
+        ...(currentDimensions !== undefined ? { dimensions: currentDimensions } : {})
+      },
+      intended: publicIntended,
+      recommendedCommand: formatGitNexusAnalyzeCommand({ repoPath, repoAlias: input.repoAlias, indexOnly: true }),
+      warnings,
+      errors
+    };
+  }
+
+  return {
+    ok: true,
+    action: "analyze_with_embeddings",
+    ...(input.repoAlias ? { repoAlias: input.repoAlias } : {}),
+    current: {
+      ...(currentDimensions !== undefined ? { dimensions: currentDimensions } : {})
+    },
+    intended: publicIntended,
+    recommendedCommand: formatGitNexusAnalyzeCommand({
+      repoPath,
+      repoAlias: input.repoAlias,
+      embeddings: true,
+      allowDimensionChange: input.allowDimensionChange === true
+    }),
+    warnings,
+    errors
+  };
+}
+
+export function parseGitNexusIndexDimensions(text: string): number | undefined {
+  const patterns = [
+    /\bembeddingDimensions\s*[:=]\s*(\d+)\b/i,
+    /\bembedding[_ -]?dimensions\s*[:=]\s*(\d+)\b/i
+  ];
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match?.[1]) return Number(match[1]);
+  }
+  return undefined;
+}
+
+export function formatGitNexusAnalyzeCommand(input: {
+  repoPath: string;
+  repoAlias?: string;
+  embeddings?: boolean;
+  indexOnly?: boolean;
+  allowDimensionChange?: boolean;
+}): string {
+  const flags = [
+    input.repoAlias ? "--name" : undefined,
+    input.repoAlias ? shellQuote(input.repoAlias) : undefined,
+    input.embeddings ? "--embeddings" : undefined,
+    input.allowDimensionChange ? "--allow-dimension-change" : undefined,
+    input.allowDimensionChange ? "true" : undefined,
+    input.indexOnly ? "--index-only" : undefined
+  ].filter(Boolean);
+  return ["gitnexus", "analyze", shellQuote(input.repoPath), ...flags].join(" ");
+}
+
+function resolveIntendedEmbeddingConfig(env: NodeJS.ProcessEnv | Record<string, string | undefined>): {
+  provider?: string;
+  model?: string;
+  dimensions?: number;
+  dimensionsText?: string;
+} {
+  const dimensionsText = env.GITNEXUS_EMBEDDING_DIMS ?? env.GITNEXUS_EMBEDDING_DIMENSIONS;
+  const dimensions = dimensionsText && /^[1-9]\d*$/.test(dimensionsText) ? Number(dimensionsText) : undefined;
+  const model = env.GITNEXUS_EMBEDDING_MODEL;
+  const provider = env.GITNEXUS_EMBEDDING_PROVIDER ?? inferProviderFromUrl(env.GITNEXUS_EMBEDDING_URL);
+  return {
+    ...(provider ? { provider } : {}),
+    ...(model ? { model } : {}),
+    ...(Number.isInteger(dimensions) && dimensions! > 0 ? { dimensions } : {}),
+    ...(dimensionsText !== undefined ? { dimensionsText } : {})
+  };
+}
+
+function toPublicIntendedEmbeddingConfig(input: {
+  provider?: string;
+  model?: string;
+  dimensions?: number;
+}): GitNexusRefreshPreflightResult["intended"] {
+  return {
+    ...(input.provider ? { provider: input.provider } : {}),
+    ...(input.model ? { model: input.model } : {}),
+    ...(input.dimensions !== undefined ? { dimensions: input.dimensions } : {})
+  };
+}
+
+function parseGitNexusCommandFailures(text: string): string[] {
+  const failures: string[] = [];
+  const patterns = [
+    {
+      command: "status",
+      exit: /\[gitnexus status exit status=([^\s\]]+) signal=([^\]]+)\]/i,
+      error: /\[gitnexus status error code=([^\s\]]+) message=([^\]]+)\]/i
+    },
+    {
+      command: "doctor",
+      exit: /\[gitnexus doctor exit status=([^\s\]]+) signal=([^\]]+)\]/i,
+      error: /\[gitnexus doctor error code=([^\s\]]+) message=([^\]]+)\]/i
+    }
+  ];
+  for (const pattern of patterns) {
+    const exit = text.match(pattern.exit);
+    const error = text.match(pattern.error);
+    const status = exit?.[1] && exit[1] !== "0" && exit[1] !== "null" ? `status=${exit[1]}` : undefined;
+    const signal = exit?.[2] && exit[2] !== "null" ? `signal=${exit[2]}` : undefined;
+    const errorDetail = error?.[1] ? `error=${error[1]}${error[2] ? ` ${error[2]}` : ""}` : undefined;
+    const parts = [status, signal, errorDetail].filter(Boolean);
+    if (parts.length > 0) failures.push(`gitnexus ${pattern.command} failed: ${parts.join("; ")}`);
+  }
+  return failures;
+}
+
+function inferProviderFromUrl(url?: string): string | undefined {
+  if (!url) return undefined;
+  if (url.includes("voyageai.com")) return "voyage";
+  if (url.includes("openai.com")) return "openai";
+  return "http";
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/tests/gitnexus-refresh-preflight.test.ts
+++ b/tests/gitnexus-refresh-preflight.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGitNexusRefreshPreflight,
+  formatGitNexusAnalyzeCommand,
+  parseGitNexusIndexDimensions
+} from "../src/gitnexus-refresh-preflight.js";
+
+describe("GitNexus refresh preflight", () => {
+  it("reports the existing index dimensions and intended provider dimensions", () => {
+    const result = buildGitNexusRefreshPreflight({
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexInfoText: "Index: evaos-code-review-bot-neondiff\nEmbedding dimensions: 2048\nProvider: voyage-code-3\n",
+      env: {
+        GITNEXUS_EMBEDDING_URL: "https://api.voyageai.com/v1",
+        GITNEXUS_EMBEDDING_MODEL: "voyage-code-3",
+        GITNEXUS_EMBEDDING_DIMS: "2048"
+      }
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      action: "analyze_with_embeddings",
+      current: {
+        dimensions: 2048
+      },
+      intended: {
+        provider: "voyage",
+        model: "voyage-code-3",
+        dimensions: 2048
+      }
+    });
+    expect(result.warnings).toEqual([]);
+    expect(result.recommendedCommand).toBe("gitnexus analyze . --name evaos-code-review-bot-neondiff --embeddings");
+  });
+
+  it("fails closed before vector rebuild when provider configuration is missing", () => {
+    const result = buildGitNexusRefreshPreflight({
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexInfoText: "Embedding dimensions: 2048\n",
+      env: {}
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      action: "blocked",
+      current: {
+        dimensions: 2048
+      }
+    });
+    expect(result.recommendedCommand).toBe("gitnexus analyze . --name evaos-code-review-bot-neondiff --index-only");
+    expect(result.errors).toContain("GITNEXUS_EMBEDDING_DIMS is required before running gitnexus analyze --embeddings");
+  });
+
+  it("can explicitly choose index-only fallback when provider configuration is missing", () => {
+    const result = buildGitNexusRefreshPreflight({
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexInfoText: "Embedding dimensions: 2048\n",
+      env: {},
+      indexOnlyFallback: true
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      action: "index_only_fallback"
+    });
+    expect(result.recommendedCommand).toBe("gitnexus analyze . --name evaos-code-review-bot-neondiff --index-only");
+    expect(result.warnings).toContain("provider configuration missing; using index-only fallback to avoid changing embedding dimensions");
+    expect(result.errors).toEqual([]);
+  });
+
+  it("blocks mismatched intended dimensions unless force is explicit", () => {
+    const result = buildGitNexusRefreshPreflight({
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexInfoText: "Embedding dimensions: 2048\n",
+      env: {
+        GITNEXUS_EMBEDDING_PROVIDER: "local",
+        GITNEXUS_EMBEDDING_DIMS: "384"
+      }
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      action: "blocked",
+      current: {
+        dimensions: 2048
+      },
+      intended: {
+        dimensions: 384
+      }
+    });
+    expect(result.errors).toContain("intended dimensions 384 do not match current index dimensions 2048");
+  });
+
+  it("allows an explicit dimension-change override only when other proof is present", () => {
+    const result = buildGitNexusRefreshPreflight({
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexInfoText: "Embedding dimensions: 2048\n",
+      env: {
+        GITNEXUS_EMBEDDING_PROVIDER: "local",
+        GITNEXUS_EMBEDDING_DIMS: "384"
+      },
+      allowDimensionChange: true
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      action: "analyze_with_embeddings",
+      current: {
+        dimensions: 2048
+      },
+      intended: {
+        provider: "local",
+        dimensions: 384
+      }
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.recommendedCommand).toBe("gitnexus analyze . --name evaos-code-review-bot-neondiff --embeddings --allow-dimension-change true");
+  });
+
+  it("keeps missing-provider and missing-current-dimension errors even with dimension-change override", () => {
+    const result = buildGitNexusRefreshPreflight({
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexInfoText: "Repository: /repo\nStatus: stale\n",
+      env: {
+        GITNEXUS_EMBEDDING_DIMS: "384"
+      },
+      allowDimensionChange: true
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.action).toBe("blocked");
+    expect(result.errors).toContain("GITNEXUS_EMBEDDING_PROVIDER, GITNEXUS_EMBEDDING_MODEL, or GITNEXUS_EMBEDDING_URL is required before running gitnexus analyze --embeddings");
+    expect(result.errors).toContain("current index embedding dimensions are required before running gitnexus analyze --embeddings");
+  });
+
+  it("blocks embedding refresh when current index dimensions cannot be proven", () => {
+    const result = buildGitNexusRefreshPreflight({
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexInfoText: "Repository: /repo\nStatus: stale\n",
+      env: {
+        GITNEXUS_EMBEDDING_URL: "https://api.voyageai.com/v1",
+        GITNEXUS_EMBEDDING_MODEL: "voyage-code-3",
+        GITNEXUS_EMBEDDING_DIMS: "2048"
+      }
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      action: "blocked",
+      current: {},
+      intended: {
+        provider: "voyage",
+        model: "voyage-code-3",
+        dimensions: 2048
+      }
+    });
+    expect(result.recommendedCommand).toBe("gitnexus analyze . --name evaos-code-review-bot-neondiff --index-only");
+    expect(result.errors).toContain("current index embedding dimensions are required before running gitnexus analyze --embeddings");
+  });
+
+  it("allows explicit index-only fallback when embedding refresh dimensions are unsafe", () => {
+    const result = buildGitNexusRefreshPreflight({
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexInfoText: "Repository: /repo\nStatus: stale\n",
+      env: {
+        GITNEXUS_EMBEDDING_URL: "https://api.voyageai.com/v1",
+        GITNEXUS_EMBEDDING_MODEL: "voyage-code-3",
+        GITNEXUS_EMBEDDING_DIMS: "2048"
+      },
+      indexOnlyFallback: true
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      action: "index_only_fallback"
+    });
+    expect(result.recommendedCommand).toBe("gitnexus analyze . --name evaos-code-review-bot-neondiff --index-only");
+    expect(result.warnings).toContain("embedding refresh unsafe; using index-only fallback to avoid changing embedding dimensions");
+    expect(result.errors).toEqual([]);
+  });
+
+  it("parses common GitNexus dimension output shapes", () => {
+    expect(parseGitNexusIndexDimensions("Embedding dimensions: 2048")).toBe(2048);
+    expect(parseGitNexusIndexDimensions("embeddingDimensions=1024")).toBe(1024);
+    expect(parseGitNexusIndexDimensions("no vectors yet")).toBeUndefined();
+  });
+
+  it("rejects stray duration and bare non-embedding dimensions as index dimensions", () => {
+    expect(parseGitNexusIndexDimensions("Status: stale 7d\nRepo VECTOR note: exact scan limit: 10000 chunks")).toBeUndefined();
+    expect(parseGitNexusIndexDimensions("cache dimensions: 256\nmatrix dimensions=384")).toBeUndefined();
+    expect(parseGitNexusIndexDimensions("Embeddings: enabled\ncache dimensions: 2048")).toBeUndefined();
+    expect(parseGitNexusIndexDimensions("dimensions: 2048 embeddings enabled")).toBeUndefined();
+    expect(parseGitNexusIndexDimensions("Embedding dimensions changed (2048d -> 384d), discarding cache")).toBeUndefined();
+  });
+
+  it("surfaces invalid dimension environment values distinctly", () => {
+    const result = buildGitNexusRefreshPreflight({
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexInfoText: "Embedding dimensions: 2048\n",
+      env: {
+        GITNEXUS_EMBEDDING_URL: "https://api.openai.com/v1",
+        GITNEXUS_EMBEDDING_DIMS: "2048.0"
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.intended.provider).toBe("openai");
+    expect(result.intended).not.toHaveProperty("dimensionsText");
+    expect(result.errors).toContain("GITNEXUS_EMBEDDING_DIMS must be a positive integer");
+    expect(result.errors).not.toContain("GITNEXUS_EMBEDDING_DIMS is required before running gitnexus analyze --embeddings");
+  });
+
+  it("does not leak raw dimension text into successful public output", () => {
+    const result = buildGitNexusRefreshPreflight({
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexInfoText: "Embedding dimensions: 2048\n",
+      env: {
+        GITNEXUS_EMBEDDING_URL: "https://api.voyageai.com/v1",
+        GITNEXUS_EMBEDDING_MODEL: "voyage-code-3",
+        GITNEXUS_EMBEDDING_DIMS: "2048"
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.intended).toEqual({
+      provider: "voyage",
+      model: "voyage-code-3",
+      dimensions: 2048
+    });
+  });
+
+  it("surfaces the exact CLI diagnostic envelope for gitnexus status and doctor command failures", () => {
+    const result = buildGitNexusRefreshPreflight({
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexInfoText: "$ gitnexus status\n[gitnexus status exit status=1 signal=null]\n[gitnexus status error code=ENOENT message=spawn gitnexus ENOENT]\n$ gitnexus doctor\n[gitnexus doctor exit status=7 signal=null]\n",
+      env: {
+        GITNEXUS_EMBEDDING_URL: "https://api.voyageai.com/v1",
+        GITNEXUS_EMBEDDING_MODEL: "voyage-code-3",
+        GITNEXUS_EMBEDDING_DIMS: "2048"
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("gitnexus status failed: status=1; error=ENOENT spawn gitnexus ENOENT");
+    expect(result.errors).toContain("gitnexus doctor failed: status=7");
+  });
+
+  it("treats changed-dimension output as ambiguous until a fresh current dimension is present", () => {
+    const result = buildGitNexusRefreshPreflight({
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexInfoText: "Embedding dimensions changed (2048d -> 384d), discarding cache\n",
+      env: {
+        GITNEXUS_EMBEDDING_PROVIDER: "local",
+        GITNEXUS_EMBEDDING_DIMS: "384"
+      }
+    });
+
+    expect(result.current.dimensions).toBeUndefined();
+    expect(result.errors).toContain("current index embedding dimensions are required before running gitnexus analyze --embeddings");
+  });
+
+  it("parses sanitized diagnostic envelope messages containing bracket-like text", () => {
+    const result = buildGitNexusRefreshPreflight({
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexInfoText: "$ gitnexus status\n[gitnexus status exit status=null signal=null]\n[gitnexus status error code=EACCES message=spawn gitnexus EACCES at /repo/(bracketed)]\n",
+      env: {
+        GITNEXUS_EMBEDDING_PROVIDER: "local",
+        GITNEXUS_EMBEDDING_DIMS: "2048"
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("gitnexus status failed: error=EACCES spawn gitnexus EACCES at /repo/(bracketed)");
+  });
+
+  it("formats analyze commands without silently enabling vector rebuilds", () => {
+    expect(formatGitNexusAnalyzeCommand({ repoPath: ".", embeddings: true })).toBe("gitnexus analyze . --embeddings");
+    expect(formatGitNexusAnalyzeCommand({ repoPath: ".", embeddings: true, allowDimensionChange: true })).toBe("gitnexus analyze . --embeddings --allow-dimension-change true");
+    expect(formatGitNexusAnalyzeCommand({ repoPath: ".", indexOnly: true })).toBe("gitnexus analyze . --index-only");
+    expect(formatGitNexusAnalyzeCommand({
+      repoPath: "/Volumes/LEXAR/repos/evaos-code-review-bot",
+      repoAlias: "evaos-code-review-bot-neondiff",
+      indexOnly: true
+    })).toBe("gitnexus analyze /Volumes/LEXAR/repos/evaos-code-review-bot --name evaos-code-review-bot-neondiff --index-only");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `gitnexus-refresh-preflight` CLI gate that reports current index dimensions when GitNexus exposes them, intended provider/model/dimensions, and the exact safe next command before any GitNexus refresh.
- Fails closed before `gitnexus analyze --embeddings` when provider config is missing, intended dimensions mismatch, or current index dimensions cannot be proven.
- Allows an explicit `--index-only-fallback true` path for commit-freshness-only refreshes without vector rebuilds.
- Preserves the registered GitNexus alias in recommended commands via `--name <repo-alias>`.
- Documents the post-merge GitNexus embedding bootstrap and preflight requirement in the beta release runbook.

## Validation

- RED check: unknown-current-dimensions and alias-preservation tests failed before the production patches.
- `npm exec vitest -- tests/gitnexus-refresh-preflight.test.ts --run --pool=forks --poolOptions.forks.maxForks=1`
- `npm run build`
- `git diff --check`
- Real CLI smoke against `/Volumes/LEXAR/repos/evaos-code-review-bot`: provider env + unknown current dimensions blocks embeddings refresh; explicit `--index-only-fallback true` recommends `gitnexus analyze /Volumes/LEXAR/repos/evaos-code-review-bot --name evaos-code-review-bot-neondiff --index-only`.

## Boundaries

- Does not run `gitnexus analyze`.
- Does not mutate live config, launchd, tags, GitHub Releases, monitored repos, or live `gitnexusContext` behavior.
- Does not disable internal GitNexus usage for review agents; this only adds a release-hygiene preflight command and runbook gate.

Closes #222