### PR TITLE
Fix issue enrichment readiness and issue-only scans

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,12 @@ import {
 import { GitHubApi } from "./github.js";
 import { buildGitNexusContextPacket } from "./gitnexus-context.js";
 import { buildGitHubRelatedContextPacket } from "./github-related-context.js";
-import { buildIssueEnrichmentStatus, collectIssueEnrichmentScan, resolveIssueEnrichmentRepoPolicy } from "./issue-enrichment.js";
+import {
+  buildIssueEnrichmentStatus,
+  collectIssueEnrichmentScan,
+  resolveIssueEnrichmentRepoPolicy,
+  type IssueEnrichmentRepoReadCheck
+} from "./issue-enrichment.js";
 import { activateLicense, deactivateLicense, getLicenseStatus, type LicenseConfig } from "./license.js";
 import { buildReviewBudgetStatus } from "./review-budget.js";
 import {
@@ -241,7 +246,8 @@ async function main(): Promise<void> {
     }
     const issueEnrichment = buildIssueEnrichmentStatus({
       config,
-      canPostAsApp: github.canPostAsApp()
+      canPostAsApp: github.canPostAsApp(),
+      issueReadChecks: await collectIssueEnrichmentReadChecks(config, github)
     });
     const ok = readChecks.every((check) => check.ok) && issueEnrichment.ok;
     console.log(JSON.stringify({
@@ -2225,7 +2231,13 @@ async function buildDoctorGithubReport(config: BotConfig) {
     }
   }
 
-  const ok = appCredentialsConfigured && activeRepoChecks > 0 && readChecks.every((check) => check.ok);
+  const issueReadChecks = await collectIssueEnrichmentReadChecks(config, github);
+  const issueEnrichment = buildIssueEnrichmentStatus({
+    config,
+    canPostAsApp: appCredentialsConfigured,
+    issueReadChecks
+  });
+  const ok = appCredentialsConfigured && activeRepoChecks > 0 && readChecks.every((check) => check.ok) && issueEnrichment.ok;
   return {
     ok,
     command: "doctor github",
@@ -2243,6 +2255,10 @@ async function buildDoctorGithubReport(config: BotConfig) {
       botLogin: config.github.botLogin ?? "evaos-code-review-bot[bot]",
       apiBaseUrl: config.github.apiBaseUrl ?? "https://api.github.com",
       readChecks
+    },
+    issueEnrichment: {
+      ...issueEnrichment,
+      readChecks: issueReadChecks
     },
     requiredRepositoryPermissions: [
       "Metadata: read",
@@ -2269,6 +2285,48 @@ async function buildDoctorGithubReport(config: BotConfig) {
       ...(readChecks.some((check) => !check.ok) ? ["Confirm the GitHub App is installed on selected repositories with the required repository permissions."] : [])
     ]
   };
+}
+
+async function collectIssueEnrichmentReadChecks(
+  config: BotConfig,
+  github: GitHubApi
+): Promise<IssueEnrichmentRepoReadCheck[]> {
+  const issueConfig = config.issueEnrichment;
+  if (!issueConfig || issueConfig.allowlist.length === 0) return [];
+  const canRead = github.canPostAsApp() || Boolean(config.github.token);
+  const checks: IssueEnrichmentRepoReadCheck[] = [];
+  for (const repo of issueConfig.allowlist) {
+    const policy = resolveIssueEnrichmentRepoPolicy(issueConfig, repo);
+    if (!policy.allowed) {
+      checks.push({ repo, ok: true, skippedByPolicy: policy.reason });
+      continue;
+    }
+    if (!canRead) {
+      checks.push({
+        repo,
+        ok: false,
+        error: "GitHub App credentials or fallback read token are required before checking issue-enrichment repository access."
+      });
+      continue;
+    }
+    try {
+      const issues = await github.listIssuesForEnrichment(repo, {
+        state: "open",
+        perPage: 1,
+        pageLimit: 1,
+        excludePullRequests: true,
+        minIssueResults: 1
+      });
+      checks.push({ repo, ok: true, readableIssueCount: issues.length });
+    } catch (error) {
+      checks.push({
+        repo,
+        ok: false,
+        error: redactSecrets(error instanceof Error ? error.message : String(error))
+      });
+    }
+  }
+  return checks;
 }
 
 function buildHelp(command?: string) {

--- a/src/github.ts
+++ b/src/github.ts
@@ -108,12 +108,16 @@ export class GitHubApi {
       since?: string;
       perPage?: number;
       pageLimit?: number;
+      excludePullRequests?: boolean;
+      minIssueResults?: number;
     } = {}
   ): Promise<GitHubRelatedIssueOrPull[]> {
     const issues: GitHubRelatedIssueOrPull[] = [];
     const state = options.state ?? "all";
     const perPage = options.perPage ?? 100;
     const pageLimit = options.pageLimit ?? 1;
+    const excludePullRequests = options.excludePullRequests === true;
+    const minIssueResults = Math.max(0, options.minIssueResults ?? 0);
     for (let page = 1; page <= pageLimit; page += 1) {
       const params = new URLSearchParams({
         state,
@@ -126,8 +130,9 @@ export class GitHubApi {
       const chunk = await this.request<GitHubRelatedIssueOrPull[]>(`/repos/${repo}/issues?${params.toString()}`, {
         token: await this.getReadToken(repo)
       });
-      issues.push(...chunk);
+      issues.push(...(excludePullRequests ? chunk.filter((issue) => !issue.pull_request) : chunk));
       if (chunk.length < perPage) return issues;
+      if (minIssueResults > 0 && issues.length >= minIssueResults) return issues;
     }
     return issues;
   }

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -73,7 +73,16 @@ export interface IssueEnrichmentStatus {
   throttleDefaults: IssueEnrichmentThrottlePolicy;
   globalLimits: IssueEnrichmentGlobalLimits;
   repoOverrides: Array<{ repo: string } & IssueEnrichmentRepoOverride>;
+  issueReadChecks?: IssueEnrichmentRepoReadCheck[];
   blockers: IssueEnrichmentBlocker[];
+}
+
+export interface IssueEnrichmentRepoReadCheck {
+  repo: string;
+  ok: boolean;
+  readableIssueCount?: number;
+  skippedByPolicy?: "not_issue_enrichment_allowlisted" | "issue_enrichment_repo_disabled";
+  error?: string;
 }
 
 export interface IssueEnrichmentThrottlePolicy {
@@ -103,6 +112,7 @@ export type IssueEnrichmentBlocker =
   | "issue_enrichment_allowlist_empty"
   | "issue_enrichment_live_posting_disabled"
   | "github_app_credentials_required_for_live_issue_comments"
+  | "github_app_issues_permission_required"
   | "issue_enrichment_live_repo_thresholds_required";
 
 export interface IssueEnrichmentReader {
@@ -113,6 +123,8 @@ export interface IssueEnrichmentReader {
       since?: string;
       perPage?: number;
       pageLimit?: number;
+      excludePullRequests?: boolean;
+      minIssueResults?: number;
     }
   ): Promise<GitHubRelatedIssueOrPull[]>;
 }
@@ -204,9 +216,9 @@ export interface IssueEnrichmentScanItem {
 }
 
 const DEFAULT_REPO_SCAN_OPTIONS = {
-  state: "all" as const,
+  state: "open" as const,
   perPage: 100,
-  pageLimit: 1
+  pageLimit: 10
 };
 
 function issueSuggestionAllowlists(policy: IssueEnrichmentSuggestionPolicy): {
@@ -223,9 +235,15 @@ export function buildIssueEnrichmentStatus(input: {
   config: { issueEnrichment?: IssueEnrichmentConfig };
   canPostAsApp: boolean;
   checkedAt?: string;
+  issueReadChecks?: IssueEnrichmentRepoReadCheck[];
 }): IssueEnrichmentStatus {
   const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
   const blockers: IssueEnrichmentBlocker[] = [];
+  const issueReadChecks = (input.issueReadChecks ?? []).map((check) => ({
+    ...check,
+    ...(check.error ? { error: redactSecrets(check.error) } : {})
+  }));
+  const issueReadFailures = issueReadChecks.filter((check) => !check.ok);
   if (!config.enabled) blockers.push("issue_enrichment_disabled");
   if (config.allowlist.length === 0) blockers.push("issue_enrichment_allowlist_empty");
   if (!config.postIssueComment) blockers.push("issue_enrichment_live_posting_disabled");
@@ -236,9 +254,13 @@ export function buildIssueEnrichmentStatus(input: {
   if (config.enabled && config.postIssueComment && !input.canPostAsApp) {
     blockers.push("github_app_credentials_required_for_live_issue_comments");
   }
+  if (config.enabled && issueReadFailures.length > 0) {
+    blockers.push("github_app_issues_permission_required");
+  }
 
   const blocking = blockers.filter((blocker) =>
     blocker === "github_app_credentials_required_for_live_issue_comments" ||
+    blocker === "github_app_issues_permission_required" ||
     blocker === "issue_enrichment_live_repo_thresholds_required" ||
     (config.enabled && blocker === "issue_enrichment_allowlist_empty")
   );
@@ -275,6 +297,7 @@ export function buildIssueEnrichmentStatus(input: {
       leaseTtlMs: config.leaseTtlMs
     },
     repoOverrides: Object.entries(config.repos ?? {}).map(([repo, override]) => ({ repo, ...override })),
+    issueReadChecks,
     blockers
   };
 }
@@ -351,11 +374,14 @@ export async function collectIssueEnrichmentScan(input: {
     });
     const pageLimit = buildIssueScanPageLimit(policy.throttle);
     const perPage = DEFAULT_REPO_SCAN_OPTIONS.perPage;
+    const minIssueResults = buildIssueScanMinIssueResults(policy.throttle);
     let issues: GitHubRelatedIssueOrPull[] = [];
     try {
       issues = await input.reader.listIssuesForEnrichment(repo, {
         ...DEFAULT_REPO_SCAN_OPTIONS,
         pageLimit,
+        excludePullRequests: true,
+        minIssueResults,
         ...(since ? { since } : {})
       });
     } catch (error) {
@@ -402,7 +428,7 @@ export async function collectIssueEnrichmentScan(input: {
       wouldEnrich: issueItems.filter((item) => item.action === "would_enrich" || item.action === "would_comment").length,
       wouldComment: issueItems.filter((item) => item.action === "would_comment").length,
       deferred: issueItems.filter((item) => item.action === "deferred").length,
-      truncated: issues.length >= pageLimit * perPage
+      truncated: issues.length >= minIssueResults || issues.length >= pageLimit * perPage
     });
   }
 
@@ -889,7 +915,11 @@ function buildIssueScanSince(input: {
 
 function buildIssueScanPageLimit(throttle: IssueEnrichmentThrottlePolicy): number {
   const threshold = Math.max(throttle.maxIssuesPerCycle, throttle.maxIssuesPerBurst) + 1;
-  return Math.max(1, Math.min(10, Math.ceil(threshold / DEFAULT_REPO_SCAN_OPTIONS.perPage)));
+  return Math.max(DEFAULT_REPO_SCAN_OPTIONS.pageLimit, Math.min(10, Math.ceil(threshold / DEFAULT_REPO_SCAN_OPTIONS.perPage)));
+}
+
+function buildIssueScanMinIssueResults(throttle: IssueEnrichmentThrottlePolicy): number {
+  return Math.max(throttle.maxIssuesPerCycle, throttle.maxIssuesPerBurst) + 1;
 }
 
 function nextEligibleAt(input: { checkedAt: string; throttle: IssueEnrichmentThrottlePolicy }): string {

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -162,9 +162,9 @@ describe("build-enrichment-comment issue CLI", () => {
 
       expect(parsed.summary).toMatchObject({
         reposScanned: 1,
-        issuesSeen: 4,
+        issuesSeen: 3,
         eligible: 2,
-        skipped: 2,
+        skipped: 1,
         wouldComment: 1,
         deferred: 1
       });
@@ -176,12 +176,6 @@ describe("build-enrichment-comment issue CLI", () => {
       }));
       expect(parsed.items).toContainEqual(expect.objectContaining({
         repo: "owner/issue-repo",
-        issueNumber: 19,
-        action: "skipped",
-        reason: "issue_is_pull_request"
-      }));
-      expect(parsed.items).toContainEqual(expect.objectContaining({
-        repo: "owner/issue-repo",
         issueNumber: 20,
         action: "deferred",
         reason: "repo_max_comments_per_cycle"
@@ -189,6 +183,70 @@ describe("build-enrichment-comment issue CLI", () => {
       expect(readFileSync(join(outputDir, "issue-enrichment-scan.json"), "utf8")).toContain("\"repo\": \"owner/issue-repo\"");
       expect(requests.some((request) => request.path.startsWith("/repos/owner/issue-repo/issues?"))).toBe(true);
       expect(requests.some((request) => request.path.startsWith("/repos/owner/pr-review-repo/issues?"))).toBe(false);
+      const issueScanRequest = requests.find((request) => request.path.startsWith("/repos/owner/issue-repo/issues?"));
+      expect(issueScanRequest?.path).toContain("state=open");
+    });
+  });
+
+  it("continues past PR-shaped issue pages until it finds real issues", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueScanConfig(root, apiBaseUrl);
+
+      const { stdout } = await runCli([
+        "issue-enrichment-scan",
+        "--config",
+        configPath,
+        "--dry-run",
+        "true",
+        "--include-existing",
+        "true"
+      ]);
+      const parsed = JSON.parse(stdout);
+
+      expect(parsed.summary).toMatchObject({
+        reposScanned: 1,
+        issuesSeen: 3,
+        eligible: 2,
+        skipped: 1,
+        wouldComment: 1
+      });
+      expect(parsed.items.some((item: { issueNumber: number }) => item.issueNumber === 20)).toBe(true);
+      expect(requests.filter((request) => request.path.startsWith("/repos/owner/issue-repo/issues?"))).toHaveLength(2);
+    }, {
+      issuePages: [
+        Array.from({ length: 100 }, (_, index) => ({
+          number: index + 1,
+          title: `PR shaped issue ${index + 1}`,
+          state: "open",
+          html_url: `https://github.test/owner/issue-repo/pull/${index + 1}`,
+          pull_request: {},
+          body: "Pull request record."
+        })),
+        [
+          {
+            number: 17,
+            title: "Open issue",
+            state: "open",
+            html_url: "https://github.test/owner/issue-repo/issues/17",
+            body: "Acceptance criteria and owner are present."
+          },
+          {
+            number: 18,
+            title: "Closed issue",
+            state: "closed",
+            html_url: "https://github.test/owner/issue-repo/issues/18",
+            body: "Done."
+          },
+          {
+            number: 20,
+            title: "Another open issue",
+            state: "open",
+            html_url: "https://github.test/owner/issue-repo/issues/20",
+            body: "Acceptance criteria and owner are present."
+          }
+        ]
+      ]
     });
   });
 
@@ -380,14 +438,15 @@ function writeIssueScanConfig(root: string, apiBaseUrl: string): string {
 }
 
 async function withMockGitHub(
-  callback: (input: { apiBaseUrl: string; requests: Array<{ method: string; path: string; authorization?: string }> }) => Promise<void>
+  callback: (input: { apiBaseUrl: string; requests: Array<{ method: string; path: string; authorization?: string }> }) => Promise<void>,
+  options: { issuePages?: unknown[][] } = {}
 ): Promise<void> {
   const requests: Array<{ method: string; path: string; authorization?: string }> = [];
   const server = createServer((request, response) => {
     const method = request.method ?? "GET";
     const path = request.url ?? "/";
     requests.push({ method, path, authorization: request.headers.authorization });
-    routeMockGitHub(request, response);
+    routeMockGitHub(request, response, options);
   });
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
   const address = server.address();
@@ -399,7 +458,11 @@ async function withMockGitHub(
   }
 }
 
-function routeMockGitHub(request: IncomingMessage, response: ServerResponse): void {
+function routeMockGitHub(
+  request: IncomingMessage,
+  response: ServerResponse,
+  options: { issuePages?: unknown[][] } = {}
+): void {
   if (request.method !== "GET") {
     respondJson(response, 405, { message: "method not allowed" });
     return;
@@ -431,6 +494,11 @@ function routeMockGitHub(request: IncomingMessage, response: ServerResponse): vo
   }
   const parsed = new URL(request.url ?? "/", "https://github.test");
   if (parsed.pathname === "/repos/owner/issue-repo/issues") {
+    if (options.issuePages) {
+      const page = Number(parsed.searchParams.get("page") ?? "1");
+      respondJson(response, 200, options.issuePages[page - 1] ?? []);
+      return;
+    }
     respondJson(response, 200, [
       {
         number: 17,

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -932,8 +932,74 @@ describe("sticky enrichment comments", () => {
       expect(calls).toEqual([{
         repo: "owner/issue-repo",
         since: "2026-07-03T11:00:00.000Z",
-        pageLimit: 2
+        pageLimit: 10
       }]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("requests open issue-only pages so PR-heavy repositories cannot starve issue enrichment", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-issue-only-scan-"));
+    try {
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: false,
+          allowlist: ["owner/pr-heavy-repo"],
+          maxIssuesPerCycle: 3,
+          maxCommentsPerCycle: 0,
+          cooldownMs: 600_000,
+          burstWindowMs: 3_600_000,
+          maxIssuesPerBurst: 10,
+          lookbackMs: 300_000,
+          processExistingOpenIssuesOnActivation: false
+        }
+      })}\n`);
+      const calls: Array<{
+        repo: string;
+        state?: string;
+        pageLimit?: number;
+        excludePullRequests?: boolean;
+        minIssueResults?: number;
+      }> = [];
+
+      const scan = await collectIssueEnrichmentScan({
+        config: loadConfig(configPath),
+        dryRun: true,
+        checkedAt: "2026-07-03T12:00:00.000Z",
+        reader: {
+          listIssuesForEnrichment: async (repo, options) => {
+            calls.push({
+              repo,
+              state: options?.state,
+              pageLimit: options?.pageLimit,
+              excludePullRequests: options?.excludePullRequests,
+              minIssueResults: options?.minIssueResults
+            });
+            return [
+              {
+                number: 101,
+                title: "Real issue behind a PR-heavy first page",
+                state: "open",
+                updated_at: "2026-07-03T11:59:00.000Z",
+                body: "Acceptance criteria and owner present."
+              }
+            ];
+          }
+        }
+      });
+
+      expect(scan.ok).toBe(true);
+      expect(calls).toEqual([{
+        repo: "owner/pr-heavy-repo",
+        state: "open",
+        pageLimit: 10,
+        excludePullRequests: true,
+        minIssueResults: 11
+      }]);
+      expect(scan.summary).toMatchObject({ issuesSeen: 1, eligible: 1, skipped: 0 });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/issue-enrichment-policy.test.ts
+++ b/tests/issue-enrichment-policy.test.ts
@@ -157,4 +157,52 @@ describe("issue enrichment rollout policy", () => {
       liveThresholdsMissingRepos: []
     });
   });
+
+  it("blocks issue enrichment when an allowlisted repo lacks GitHub Issues API access", () => {
+    const config = loadConfigFromObject({
+      issueEnrichment: {
+        enabled: true,
+        postIssueComment: true,
+        allowlist: ["owner/issue-repo"],
+        repos: {
+          "owner/issue-repo": {
+            enabled: true,
+            maxIssuesPerCycle: 3,
+            maxCommentsPerCycle: 1,
+            cooldownMs: 3_600_000,
+            burstWindowMs: 3_600_000,
+            maxIssuesPerBurst: 6,
+            lookbackMs: 600_000,
+            processExistingOpenIssuesOnActivation: false
+          }
+        }
+      }
+    });
+
+    const status = buildIssueEnrichmentStatus({
+      config,
+      canPostAsApp: true,
+      checkedAt: "2026-07-04T11:30:00.000Z",
+      issueReadChecks: [
+        {
+          repo: "owner/issue-repo",
+          ok: false,
+          error: "GitHub API 403 for /repos/owner/issue-repo/issues?state=open: Resource not accessible by integration"
+        }
+      ]
+    });
+
+    expect(status).toMatchObject({
+      ok: false,
+      state: "blocked",
+      blockers: ["github_app_issues_permission_required"],
+      issueReadChecks: [
+        {
+          repo: "owner/issue-repo",
+          ok: false
+        }
+      ]
+    });
+    expect(JSON.stringify(status)).not.toMatch(/ghp_|PRIVATE KEY|BEGIN RSA/);
+  });
 });

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -399,6 +399,12 @@ describe("public NeonDiff CLI surface", () => {
         response.end(JSON.stringify([]));
         return;
       }
+      if (request.method === "GET" && url.pathname === "/repos/acme/demo/issues") {
+        expect(request.headers.authorization).toBe(`Bearer ${installationToken}`);
+        expect(url.searchParams.get("state")).toBe("open");
+        response.end(JSON.stringify([]));
+        return;
+      }
       response.statusCode = 404;
       response.end(JSON.stringify({ message: `unexpected ${request.method} ${url.pathname}` }));
     });
@@ -424,6 +430,18 @@ describe("public NeonDiff CLI surface", () => {
           timeoutMs: 1000,
           maxPatchBytes: 1000,
           retryMaxRetries: 0
+        },
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: false,
+          allowlist: ["acme/demo"],
+          maxIssuesPerCycle: 1,
+          maxCommentsPerCycle: 0,
+          cooldownMs: 3_600_000,
+          burstWindowMs: 3_600_000,
+          maxIssuesPerBurst: 3,
+          lookbackMs: 600_000,
+          processExistingOpenIssuesOnActivation: false
         }
       })}\n`);
 
@@ -455,6 +473,16 @@ describe("public NeonDiff CLI surface", () => {
             }
           ]
         }
+      });
+      expect(output.issueEnrichment).toMatchObject({
+        state: "dry_run_only",
+        readChecks: [
+          {
+            repo: "acme/demo",
+            ok: true,
+            readableIssueCount: 0
+          }
+        ]
       });
       expect(output.requiredRepositoryPermissions).toContain("Pull requests: read/write");
       expect(output.optionalPermissions.join(" ")).toMatch(/issue-enrichment/i);


### PR DESCRIPTION
## Summary
- Add issue-enrichment GitHub Issues API read checks to `doctor` and `doctor github` so App permission/install gaps are visible before live enablement.
- Scan `state=open` issue records and ask the GitHub client to filter PR-shaped `/issues` records while paging up to a bounded 10 pages.
- Preserve watermark safety by treating scans that stop after enough issue records as truncated.

## Evidence
- Focused tests: `npm exec vitest -- tests/issue-enrichment-policy.test.ts tests/enrichment.test.ts tests/enrichment-cli.test.ts tests/public-cli.test.ts --run`
- Build: `npm run build`
- Dry-run evidence: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-05/issue-enrichment-fix-225-226/`
- LCO dry-run scan passed with no new issues in the lookback window.
- LCO #478 direct enrichment preview generated a sticky issue enrichment body.

## Runtime notes
- No live config change and no GitHub issue comments posted.
- Doctor now reports LCO issue access OK, but `electricsheephq/evaos-code-review-bot-neondiff` still needs the electricsheephq GitHub App installation to approve Issues access; GitHub currently requires sudo/2FA to change it.

Closes #225
Closes #226