### PR TITLE
Add public confidence calibration report policy

### DIFF
--- a/docs/evals/confidence-calibration.md
+++ b/docs/evals/confidence-calibration.md
@@ -16,6 +16,9 @@ Public confidence display is allowed only when all of these are true:
 - The evaluated dataset has at least 10 negative-control scenarios.
 - The measured Wilson lower bound is at least 0.95.
 
+These numbers are hard floors. Operators may configure stricter minimums, and
+the report reflects those stricter values in `metrics.*.required`.
+
 If any field is missing, malformed, or below threshold, the public mode is
 `uncalibrated`. Public comment text must continue replacing confidence values
 with `[confidence not calibrated]`.

--- a/docs/evals/confidence-calibration.md
+++ b/docs/evals/confidence-calibration.md
@@ -1,0 +1,49 @@
+# Confidence Calibration And Public Display Policy
+
+NeonDiff stores model confidence as internal review metadata. Public comments
+must remain uncalibrated and must not show confidence percentages until a
+calibration report proves every public-display threshold.
+
+## Public Display Gate
+
+Public confidence display is allowed only when all of these are true:
+
+- The public display policy mode is `calibrated`.
+- The report links an HTTPS evidence URL.
+- The report names a non-empty dataset id.
+- The evaluated dataset has at least 100 labeled findings.
+- The evaluated dataset has at least 30 P0/P1-equivalent labels.
+- The evaluated dataset has at least 10 negative-control scenarios.
+- The measured Wilson lower bound is at least 0.95.
+
+If any field is missing, malformed, or below threshold, the public mode is
+`uncalibrated`. Public comment text must continue replacing confidence values
+with `[confidence not calibrated]`.
+
+## Calibration Report Contract
+
+The auditable report must include:
+
+- `dataset.id`: stable dataset or suite id.
+- `dataset.evidenceUrl`: HTTPS link to the CI run, eval packet, or durable proof
+  bundle.
+- `labels.labeledFindings`: total labeled findings counted for calibration.
+- `labels.p0p1Labels`: P0/P1-equivalent labels counted for severe findings.
+- `labels.negativeControlScenarios`: negative-control PRs or scenarios.
+- `metrics.wilsonLowerBound`: measured Wilson lower bound and required floor.
+- `proofBoundary`: whether public comments may display percentages, or why they
+  must remain uncalibrated.
+
+The report is a proof boundary, not a permanent feature flag. Public confidence
+percentages may appear only while the linked dataset and metrics still satisfy
+the policy.
+
+## REQUEST_CHANGES Audit Policy
+
+`REQUEST_CHANGES` confidence claims require calibrated P0/P1 bins that pass the
+same public display policy. High-severity findings may still be posted or used
+for review events according to the existing review policy, but the public
+comment must not imply 95% confidence until the calibration report passes.
+
+The default stance is conservative: uncalibrated text is public-safe, raw model
+confidence remains internal, and 95% public claims wait for measured evidence.

--- a/docs/evals/confidence-calibration.md
+++ b/docs/evals/confidence-calibration.md
@@ -18,6 +18,9 @@ Public confidence display is allowed only when all of these are true:
 
 These numbers are hard floors. Operators may configure stricter minimums, and
 the report reflects those stricter values in `metrics.*.required`.
+Malformed minimums fail closed with `blockedReason: malformed_minimum`; finite
+malformed inputs are shown as `metrics.*.rejectedMinimum` while `required`
+remains the hard floor.
 
 If any field is missing, malformed, or below threshold, the public mode is
 `uncalibrated`. Public comment text must continue replacing confidence values

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -125,13 +125,13 @@ export function buildPublicConfidencePolicy(input?: Partial<PublicConfidenceDisp
   const datasetId = input?.datasetId?.trim();
   return {
     mode: input?.mode ?? "uncalibrated",
-    minLabeledFindings: Math.max(input?.minLabeledFindings ?? PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS, PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS),
-    minP0P1Labels: Math.max(input?.minP0P1Labels ?? PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS, PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS),
-    minNegativeControlScenarios: Math.max(
-      input?.minNegativeControlScenarios ?? PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS,
+    minLabeledFindings: hardFloorPositiveInteger(input?.minLabeledFindings, PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS),
+    minP0P1Labels: hardFloorPositiveInteger(input?.minP0P1Labels, PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS),
+    minNegativeControlScenarios: hardFloorPositiveInteger(
+      input?.minNegativeControlScenarios,
       PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS
     ),
-    minWilsonLowerBound: Math.max(input?.minWilsonLowerBound ?? PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND, PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND),
+    minWilsonLowerBound: hardFloorProbability(input?.minWilsonLowerBound, PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND),
     ...(evidenceUrl ? { evidenceUrl } : {}),
     ...(datasetId ? { datasetId } : {}),
     ...(input?.labeledFindings !== undefined ? { labeledFindings: input.labeledFindings } : {}),
@@ -146,11 +146,12 @@ export function isPublicConfidenceDisplayAllowed(policy?: PublicConfidenceDispla
 }
 
 export function evaluatePublicConfidencePolicy(policy?: PublicConfidenceDisplayPolicy): PublicConfidencePolicyEvaluation {
+  const malformedMinimums = hasMalformedPolicyMinimums(policy);
   const effectivePolicy = buildPublicConfidencePolicy(policy);
-  const requiredLabeledFindings = Math.max(effectivePolicy.minLabeledFindings, PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS);
-  const requiredP0P1Labels = Math.max(effectivePolicy.minP0P1Labels, PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS);
-  const requiredNegativeControls = Math.max(effectivePolicy.minNegativeControlScenarios, PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS);
-  const requiredWilsonLowerBound = Math.max(effectivePolicy.minWilsonLowerBound, PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND);
+  const requiredLabeledFindings = hardFloorPositiveInteger(effectivePolicy.minLabeledFindings, PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS);
+  const requiredP0P1Labels = hardFloorPositiveInteger(effectivePolicy.minP0P1Labels, PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS);
+  const requiredNegativeControls = hardFloorPositiveInteger(effectivePolicy.minNegativeControlScenarios, PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS);
+  const requiredWilsonLowerBound = hardFloorProbability(effectivePolicy.minWilsonLowerBound, PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND);
   const metrics = {
     labeledFindings: thresholdMetric(effectivePolicy.labeledFindings, requiredLabeledFindings, isNonNegativeInteger),
     p0p1Labels: thresholdMetric(effectivePolicy.p0p1Labels, requiredP0P1Labels, isNonNegativeInteger),
@@ -164,12 +165,7 @@ export function evaluatePublicConfidencePolicy(policy?: PublicConfidenceDisplayP
     missingThresholds.push("calibration_evidence_url_missing_or_unusable");
   }
   if (!effectivePolicy.datasetId?.trim()) missingThresholds.push("dataset_id_missing");
-  if (
-    !isPositiveInteger(effectivePolicy.minLabeledFindings) ||
-    !isPositiveInteger(effectivePolicy.minP0P1Labels) ||
-    !isPositiveInteger(effectivePolicy.minNegativeControlScenarios) ||
-    !isProbability(effectivePolicy.minWilsonLowerBound)
-  ) {
+  if (malformedMinimums) {
     missingThresholds.push(
       "labeled_findings_below_100",
       "p0_p1_labels_below_30",
@@ -224,6 +220,24 @@ function thresholdMetric(
     return { required, passed: false };
   }
   return { actual, required, passed: actual >= required };
+}
+
+function hardFloorPositiveInteger(value: unknown, floor: number): number {
+  return isPositiveInteger(value) ? Math.max(value, floor) : floor;
+}
+
+function hardFloorProbability(value: unknown, floor: number): number {
+  return isProbability(value) ? Math.max(value, floor) : floor;
+}
+
+function hasMalformedPolicyMinimums(policy: PublicConfidenceDisplayPolicy | undefined): boolean {
+  if (!policy) return false;
+  return (
+    (policy.minLabeledFindings !== undefined && !isPositiveInteger(policy.minLabeledFindings)) ||
+    (policy.minP0P1Labels !== undefined && !isPositiveInteger(policy.minP0P1Labels)) ||
+    (policy.minNegativeControlScenarios !== undefined && !isPositiveInteger(policy.minNegativeControlScenarios)) ||
+    (policy.minWilsonLowerBound !== undefined && !isProbability(policy.minWilsonLowerBound))
+  );
 }
 
 function isPositiveInteger(value: unknown): value is number {

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -22,15 +22,16 @@ export type PublicConfidenceMissingThreshold =
   | "min_p0_p1_labels_malformed"
   | "min_negative_control_scenarios_malformed"
   | "min_wilson_lower_bound_malformed"
-  | "labeled_findings_below_100"
-  | "p0_p1_labels_below_30"
-  | "negative_controls_below_10"
-  | "wilson_lower_bound_below_0.95";
+  | "labeled_findings_below_required"
+  | "p0_p1_labels_below_required"
+  | "negative_controls_below_required"
+  | "wilson_lower_bound_below_required";
 
 export interface PublicConfidenceMetric {
   actual?: number;
   required: number;
   passed: boolean;
+  blockedReason?: "malformed_minimum";
 }
 
 export interface PublicConfidencePolicyEvaluation {
@@ -177,22 +178,22 @@ export function evaluatePublicConfidencePolicy(policy?: PublicConfidenceDisplayP
   if (malformedMinimums.labeledFindings) {
     missingThresholds.push("min_labeled_findings_malformed");
   } else if (!metrics.labeledFindings.passed) {
-    missingThresholds.push("labeled_findings_below_100");
+    missingThresholds.push("labeled_findings_below_required");
   }
   if (malformedMinimums.p0p1Labels) {
     missingThresholds.push("min_p0_p1_labels_malformed");
   } else if (!metrics.p0p1Labels.passed) {
-    missingThresholds.push("p0_p1_labels_below_30");
+    missingThresholds.push("p0_p1_labels_below_required");
   }
   if (malformedMinimums.negativeControlScenarios) {
     missingThresholds.push("min_negative_control_scenarios_malformed");
   } else if (!metrics.negativeControlScenarios.passed) {
-    missingThresholds.push("negative_controls_below_10");
+    missingThresholds.push("negative_controls_below_required");
   }
   if (malformedMinimums.wilsonLowerBound) {
     missingThresholds.push("min_wilson_lower_bound_malformed");
   } else if (!metrics.wilsonLowerBound.passed) {
-    missingThresholds.push("wilson_lower_bound_below_0.95");
+    missingThresholds.push("wilson_lower_bound_below_required");
   }
 
   const allowed = missingThresholds.length === 0;
@@ -236,7 +237,10 @@ function thresholdMetric(
   if (!isValidActual(actual)) {
     return { required, passed: false };
   }
-  return { actual, required, passed: !forceFail && actual >= required };
+  if (forceFail) {
+    return { actual, required, passed: false, blockedReason: "malformed_minimum" };
+  }
+  return { actual, required, passed: actual >= required };
 }
 
 function hardFloorPositiveInteger(value: unknown, floor: number): number {

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -32,6 +32,7 @@ export interface PublicConfidenceMetric {
   required: number;
   passed: boolean;
   blockedReason?: "malformed_minimum";
+  rejectedMinimum?: number;
 }
 
 export interface PublicConfidencePolicyEvaluation {
@@ -158,15 +159,34 @@ export function evaluatePublicConfidencePolicy(policy?: PublicConfidenceDisplayP
   const requiredNegativeControls = hardFloorPositiveInteger(effectivePolicy.minNegativeControlScenarios, PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS);
   const requiredWilsonLowerBound = hardFloorProbability(effectivePolicy.minWilsonLowerBound, PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND);
   const metrics = {
-    labeledFindings: thresholdMetric(effectivePolicy.labeledFindings, requiredLabeledFindings, isNonNegativeInteger, malformedMinimums.labeledFindings),
-    p0p1Labels: thresholdMetric(effectivePolicy.p0p1Labels, requiredP0P1Labels, isNonNegativeInteger, malformedMinimums.p0p1Labels),
+    labeledFindings: thresholdMetric(
+      effectivePolicy.labeledFindings,
+      requiredLabeledFindings,
+      isNonNegativeInteger,
+      malformedMinimums.labeledFindings,
+      finiteNumberOrUndefined(policy?.minLabeledFindings)
+    ),
+    p0p1Labels: thresholdMetric(
+      effectivePolicy.p0p1Labels,
+      requiredP0P1Labels,
+      isNonNegativeInteger,
+      malformedMinimums.p0p1Labels,
+      finiteNumberOrUndefined(policy?.minP0P1Labels)
+    ),
     negativeControlScenarios: thresholdMetric(
       effectivePolicy.negativeControlScenarios,
       requiredNegativeControls,
       isNonNegativeInteger,
-      malformedMinimums.negativeControlScenarios
+      malformedMinimums.negativeControlScenarios,
+      finiteNumberOrUndefined(policy?.minNegativeControlScenarios)
     ),
-    wilsonLowerBound: thresholdMetric(effectivePolicy.wilsonLowerBound, requiredWilsonLowerBound, isProbability, malformedMinimums.wilsonLowerBound)
+    wilsonLowerBound: thresholdMetric(
+      effectivePolicy.wilsonLowerBound,
+      requiredWilsonLowerBound,
+      isProbability,
+      malformedMinimums.wilsonLowerBound,
+      finiteNumberOrUndefined(policy?.minWilsonLowerBound)
+    )
   };
   const missingThresholds: PublicConfidenceMissingThreshold[] = [];
 
@@ -232,13 +252,20 @@ function thresholdMetric(
   actual: number | undefined,
   required: number,
   isValidActual: (value: unknown) => value is number,
-  forceFail = false
+  forceFail = false,
+  rejectedMinimum?: number
 ): PublicConfidenceMetric {
   if (!isValidActual(actual)) {
     return { required, passed: false };
   }
   if (forceFail) {
-    return { actual, required, passed: false, blockedReason: "malformed_minimum" };
+    return {
+      actual,
+      required,
+      passed: false,
+      blockedReason: "malformed_minimum",
+      ...(rejectedMinimum !== undefined ? { rejectedMinimum } : {})
+    };
   }
   return { actual, required, passed: actual >= required };
 }
@@ -249,6 +276,10 @@ function hardFloorPositiveInteger(value: unknown, floor: number): number {
 
 function hardFloorProbability(value: unknown, floor: number): number {
   return isProbability(value) ? Math.max(value, floor) : floor;
+}
+
+function finiteNumberOrUndefined(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function findMalformedPolicyMinimums(policy: PublicConfidenceDisplayPolicy | undefined): {

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -146,17 +146,22 @@ export function isPublicConfidenceDisplayAllowed(policy?: PublicConfidenceDispla
 }
 
 export function evaluatePublicConfidencePolicy(policy?: PublicConfidenceDisplayPolicy): PublicConfidencePolicyEvaluation {
-  const malformedMinimums = hasMalformedPolicyMinimums(policy);
+  const malformedMinimums = findMalformedPolicyMinimums(policy);
   const effectivePolicy = buildPublicConfidencePolicy(policy);
   const requiredLabeledFindings = hardFloorPositiveInteger(effectivePolicy.minLabeledFindings, PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS);
   const requiredP0P1Labels = hardFloorPositiveInteger(effectivePolicy.minP0P1Labels, PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS);
   const requiredNegativeControls = hardFloorPositiveInteger(effectivePolicy.minNegativeControlScenarios, PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS);
   const requiredWilsonLowerBound = hardFloorProbability(effectivePolicy.minWilsonLowerBound, PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND);
   const metrics = {
-    labeledFindings: thresholdMetric(effectivePolicy.labeledFindings, requiredLabeledFindings, isNonNegativeInteger),
-    p0p1Labels: thresholdMetric(effectivePolicy.p0p1Labels, requiredP0P1Labels, isNonNegativeInteger),
-    negativeControlScenarios: thresholdMetric(effectivePolicy.negativeControlScenarios, requiredNegativeControls, isNonNegativeInteger),
-    wilsonLowerBound: thresholdMetric(effectivePolicy.wilsonLowerBound, requiredWilsonLowerBound, isProbability)
+    labeledFindings: thresholdMetric(effectivePolicy.labeledFindings, requiredLabeledFindings, isNonNegativeInteger, malformedMinimums.labeledFindings),
+    p0p1Labels: thresholdMetric(effectivePolicy.p0p1Labels, requiredP0P1Labels, isNonNegativeInteger, malformedMinimums.p0p1Labels),
+    negativeControlScenarios: thresholdMetric(
+      effectivePolicy.negativeControlScenarios,
+      requiredNegativeControls,
+      isNonNegativeInteger,
+      malformedMinimums.negativeControlScenarios
+    ),
+    wilsonLowerBound: thresholdMetric(effectivePolicy.wilsonLowerBound, requiredWilsonLowerBound, isProbability, malformedMinimums.wilsonLowerBound)
   };
   const missingThresholds: PublicConfidenceMissingThreshold[] = [];
 
@@ -165,19 +170,10 @@ export function evaluatePublicConfidencePolicy(policy?: PublicConfidenceDisplayP
     missingThresholds.push("calibration_evidence_url_missing_or_unusable");
   }
   if (!effectivePolicy.datasetId?.trim()) missingThresholds.push("dataset_id_missing");
-  if (malformedMinimums) {
-    missingThresholds.push(
-      "labeled_findings_below_100",
-      "p0_p1_labels_below_30",
-      "negative_controls_below_10",
-      "wilson_lower_bound_below_0.95"
-    );
-  } else {
-    if (!metrics.labeledFindings.passed) missingThresholds.push("labeled_findings_below_100");
-    if (!metrics.p0p1Labels.passed) missingThresholds.push("p0_p1_labels_below_30");
-    if (!metrics.negativeControlScenarios.passed) missingThresholds.push("negative_controls_below_10");
-    if (!metrics.wilsonLowerBound.passed) missingThresholds.push("wilson_lower_bound_below_0.95");
-  }
+  if (!metrics.labeledFindings.passed) missingThresholds.push("labeled_findings_below_100");
+  if (!metrics.p0p1Labels.passed) missingThresholds.push("p0_p1_labels_below_30");
+  if (!metrics.negativeControlScenarios.passed) missingThresholds.push("negative_controls_below_10");
+  if (!metrics.wilsonLowerBound.passed) missingThresholds.push("wilson_lower_bound_below_0.95");
 
   const allowed = missingThresholds.length === 0;
   return {
@@ -193,7 +189,7 @@ export function evaluatePublicConfidencePolicy(policy?: PublicConfidenceDisplayP
 
 export function buildPublicConfidenceCalibrationReport(policy?: PublicConfidenceDisplayPolicy): PublicConfidenceCalibrationReport {
   const effectivePolicy = buildPublicConfidencePolicy(policy);
-  const evaluation = evaluatePublicConfidencePolicy(effectivePolicy);
+  const evaluation = evaluatePublicConfidencePolicy(policy);
   return {
     ...evaluation,
     dataset: {
@@ -214,12 +210,13 @@ export function buildPublicConfidenceCalibrationReport(policy?: PublicConfidence
 function thresholdMetric(
   actual: number | undefined,
   required: number,
-  isValidActual: (value: unknown) => value is number
+  isValidActual: (value: unknown) => value is number,
+  forceFail = false
 ): PublicConfidenceMetric {
   if (!isValidActual(actual)) {
     return { required, passed: false };
   }
-  return { actual, required, passed: actual >= required };
+  return { actual, required, passed: !forceFail && actual >= required };
 }
 
 function hardFloorPositiveInteger(value: unknown, floor: number): number {
@@ -230,14 +227,19 @@ function hardFloorProbability(value: unknown, floor: number): number {
   return isProbability(value) ? Math.max(value, floor) : floor;
 }
 
-function hasMalformedPolicyMinimums(policy: PublicConfidenceDisplayPolicy | undefined): boolean {
-  if (!policy) return false;
-  return (
-    (policy.minLabeledFindings !== undefined && !isPositiveInteger(policy.minLabeledFindings)) ||
-    (policy.minP0P1Labels !== undefined && !isPositiveInteger(policy.minP0P1Labels)) ||
-    (policy.minNegativeControlScenarios !== undefined && !isPositiveInteger(policy.minNegativeControlScenarios)) ||
-    (policy.minWilsonLowerBound !== undefined && !isProbability(policy.minWilsonLowerBound))
-  );
+function findMalformedPolicyMinimums(policy: PublicConfidenceDisplayPolicy | undefined): {
+  labeledFindings: boolean;
+  p0p1Labels: boolean;
+  negativeControlScenarios: boolean;
+  wilsonLowerBound: boolean;
+} {
+  return {
+    labeledFindings: policy?.minLabeledFindings !== undefined && !isPositiveInteger(policy.minLabeledFindings),
+    p0p1Labels: policy?.minP0P1Labels !== undefined && !isPositiveInteger(policy.minP0P1Labels),
+    negativeControlScenarios:
+      policy?.minNegativeControlScenarios !== undefined && !isPositiveInteger(policy.minNegativeControlScenarios),
+    wilsonLowerBound: policy?.minWilsonLowerBound !== undefined && !isProbability(policy.minWilsonLowerBound)
+  };
 }
 
 function isPositiveInteger(value: unknown): value is number {

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -18,6 +18,10 @@ export type PublicConfidenceMissingThreshold =
   | "mode_not_calibrated"
   | "calibration_evidence_url_missing_or_unusable"
   | "dataset_id_missing"
+  | "min_labeled_findings_malformed"
+  | "min_p0_p1_labels_malformed"
+  | "min_negative_control_scenarios_malformed"
+  | "min_wilson_lower_bound_malformed"
   | "labeled_findings_below_100"
   | "p0_p1_labels_below_30"
   | "negative_controls_below_10"
@@ -170,10 +174,26 @@ export function evaluatePublicConfidencePolicy(policy?: PublicConfidenceDisplayP
     missingThresholds.push("calibration_evidence_url_missing_or_unusable");
   }
   if (!effectivePolicy.datasetId?.trim()) missingThresholds.push("dataset_id_missing");
-  if (!metrics.labeledFindings.passed) missingThresholds.push("labeled_findings_below_100");
-  if (!metrics.p0p1Labels.passed) missingThresholds.push("p0_p1_labels_below_30");
-  if (!metrics.negativeControlScenarios.passed) missingThresholds.push("negative_controls_below_10");
-  if (!metrics.wilsonLowerBound.passed) missingThresholds.push("wilson_lower_bound_below_0.95");
+  if (malformedMinimums.labeledFindings) {
+    missingThresholds.push("min_labeled_findings_malformed");
+  } else if (!metrics.labeledFindings.passed) {
+    missingThresholds.push("labeled_findings_below_100");
+  }
+  if (malformedMinimums.p0p1Labels) {
+    missingThresholds.push("min_p0_p1_labels_malformed");
+  } else if (!metrics.p0p1Labels.passed) {
+    missingThresholds.push("p0_p1_labels_below_30");
+  }
+  if (malformedMinimums.negativeControlScenarios) {
+    missingThresholds.push("min_negative_control_scenarios_malformed");
+  } else if (!metrics.negativeControlScenarios.passed) {
+    missingThresholds.push("negative_controls_below_10");
+  }
+  if (malformedMinimums.wilsonLowerBound) {
+    missingThresholds.push("min_wilson_lower_bound_malformed");
+  } else if (!metrics.wilsonLowerBound.passed) {
+    missingThresholds.push("wilson_lower_bound_below_0.95");
+  }
 
   const allowed = missingThresholds.length === 0;
   return {
@@ -194,7 +214,7 @@ export function buildPublicConfidenceCalibrationReport(policy?: PublicConfidence
     ...evaluation,
     dataset: {
       ...(effectivePolicy.datasetId ? { id: effectivePolicy.datasetId } : {}),
-      ...(effectivePolicy.evidenceUrl ? { evidenceUrl: effectivePolicy.evidenceUrl } : {})
+      ...(isUsablePublicConfidenceEvidenceUrl(effectivePolicy.evidenceUrl) ? { evidenceUrl: effectivePolicy.evidenceUrl } : {})
     },
     labels: {
       ...(effectivePolicy.labeledFindings !== undefined ? { labeledFindings: effectivePolicy.labeledFindings } : {}),

--- a/src/public-confidence.ts
+++ b/src/public-confidence.ts
@@ -12,6 +12,49 @@ export interface PublicConfidenceDisplayPolicy {
   wilsonLowerBound?: number;
 }
 
+export type PublicConfidenceMode = "uncalibrated" | "calibrated";
+
+export type PublicConfidenceMissingThreshold =
+  | "mode_not_calibrated"
+  | "calibration_evidence_url_missing_or_unusable"
+  | "dataset_id_missing"
+  | "labeled_findings_below_100"
+  | "p0_p1_labels_below_30"
+  | "negative_controls_below_10"
+  | "wilson_lower_bound_below_0.95";
+
+export interface PublicConfidenceMetric {
+  actual?: number;
+  required: number;
+  passed: boolean;
+}
+
+export interface PublicConfidencePolicyEvaluation {
+  allowed: boolean;
+  publicMode: PublicConfidenceMode;
+  missingThresholds: PublicConfidenceMissingThreshold[];
+  metrics: {
+    labeledFindings: PublicConfidenceMetric;
+    p0p1Labels: PublicConfidenceMetric;
+    negativeControlScenarios: PublicConfidenceMetric;
+    wilsonLowerBound: PublicConfidenceMetric;
+  };
+  proofBoundary: string;
+}
+
+export interface PublicConfidenceCalibrationReport extends PublicConfidencePolicyEvaluation {
+  dataset: {
+    id?: string;
+    evidenceUrl?: string;
+  };
+  labels: {
+    labeledFindings?: number;
+    p0p1Labels?: number;
+    negativeControlScenarios?: number;
+  };
+  requestChangesPolicy: string;
+}
+
 export const PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS = 100;
 export const PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS = 30;
 export const PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS = 10;
@@ -99,30 +142,88 @@ export function buildPublicConfidencePolicy(input?: Partial<PublicConfidenceDisp
 }
 
 export function isPublicConfidenceDisplayAllowed(policy?: PublicConfidenceDisplayPolicy): boolean {
-  if (!policy || policy.mode !== "calibrated") return false;
-  if (!isUsablePublicConfidenceEvidenceUrl(policy.evidenceUrl) || !policy.datasetId?.trim()) return false;
+  return evaluatePublicConfidencePolicy(policy).allowed;
+}
+
+export function evaluatePublicConfidencePolicy(policy?: PublicConfidenceDisplayPolicy): PublicConfidencePolicyEvaluation {
+  const effectivePolicy = buildPublicConfidencePolicy(policy);
+  const requiredLabeledFindings = Math.max(effectivePolicy.minLabeledFindings, PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS);
+  const requiredP0P1Labels = Math.max(effectivePolicy.minP0P1Labels, PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS);
+  const requiredNegativeControls = Math.max(effectivePolicy.minNegativeControlScenarios, PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS);
+  const requiredWilsonLowerBound = Math.max(effectivePolicy.minWilsonLowerBound, PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND);
+  const metrics = {
+    labeledFindings: thresholdMetric(effectivePolicy.labeledFindings, requiredLabeledFindings, isNonNegativeInteger),
+    p0p1Labels: thresholdMetric(effectivePolicy.p0p1Labels, requiredP0P1Labels, isNonNegativeInteger),
+    negativeControlScenarios: thresholdMetric(effectivePolicy.negativeControlScenarios, requiredNegativeControls, isNonNegativeInteger),
+    wilsonLowerBound: thresholdMetric(effectivePolicy.wilsonLowerBound, requiredWilsonLowerBound, isProbability)
+  };
+  const missingThresholds: PublicConfidenceMissingThreshold[] = [];
+
+  if (effectivePolicy.mode !== "calibrated") missingThresholds.push("mode_not_calibrated");
+  if (!isUsablePublicConfidenceEvidenceUrl(effectivePolicy.evidenceUrl)) {
+    missingThresholds.push("calibration_evidence_url_missing_or_unusable");
+  }
+  if (!effectivePolicy.datasetId?.trim()) missingThresholds.push("dataset_id_missing");
   if (
-    !isPositiveInteger(policy.minLabeledFindings) ||
-    !isPositiveInteger(policy.minP0P1Labels) ||
-    !isPositiveInteger(policy.minNegativeControlScenarios) ||
-    !isProbability(policy.minWilsonLowerBound)
+    !isPositiveInteger(effectivePolicy.minLabeledFindings) ||
+    !isPositiveInteger(effectivePolicy.minP0P1Labels) ||
+    !isPositiveInteger(effectivePolicy.minNegativeControlScenarios) ||
+    !isProbability(effectivePolicy.minWilsonLowerBound)
   ) {
-    return false;
+    missingThresholds.push(
+      "labeled_findings_below_100",
+      "p0_p1_labels_below_30",
+      "negative_controls_below_10",
+      "wilson_lower_bound_below_0.95"
+    );
+  } else {
+    if (!metrics.labeledFindings.passed) missingThresholds.push("labeled_findings_below_100");
+    if (!metrics.p0p1Labels.passed) missingThresholds.push("p0_p1_labels_below_30");
+    if (!metrics.negativeControlScenarios.passed) missingThresholds.push("negative_controls_below_10");
+    if (!metrics.wilsonLowerBound.passed) missingThresholds.push("wilson_lower_bound_below_0.95");
   }
-  if (!isNonNegativeInteger(policy.labeledFindings) || policy.labeledFindings < Math.max(policy.minLabeledFindings, PUBLIC_CONFIDENCE_MIN_LABELED_FINDINGS)) {
-    return false;
+
+  const allowed = missingThresholds.length === 0;
+  return {
+    allowed,
+    publicMode: allowed ? "calibrated" : "uncalibrated",
+    missingThresholds,
+    metrics,
+    proofBoundary: allowed
+      ? "Public comments may display confidence percentages only while this report stays linked to the evaluated dataset and passing metrics."
+      : "Public comments must not display confidence percentages until all calibration thresholds pass."
+  };
+}
+
+export function buildPublicConfidenceCalibrationReport(policy?: PublicConfidenceDisplayPolicy): PublicConfidenceCalibrationReport {
+  const effectivePolicy = buildPublicConfidencePolicy(policy);
+  const evaluation = evaluatePublicConfidencePolicy(effectivePolicy);
+  return {
+    ...evaluation,
+    dataset: {
+      ...(effectivePolicy.datasetId ? { id: effectivePolicy.datasetId } : {}),
+      ...(effectivePolicy.evidenceUrl ? { evidenceUrl: effectivePolicy.evidenceUrl } : {})
+    },
+    labels: {
+      ...(effectivePolicy.labeledFindings !== undefined ? { labeledFindings: effectivePolicy.labeledFindings } : {}),
+      ...(effectivePolicy.p0p1Labels !== undefined ? { p0p1Labels: effectivePolicy.p0p1Labels } : {}),
+      ...(effectivePolicy.negativeControlScenarios !== undefined
+        ? { negativeControlScenarios: effectivePolicy.negativeControlScenarios }
+        : {})
+    },
+    requestChangesPolicy: "REQUEST_CHANGES confidence claims require calibrated P0/P1 bins that pass the public display policy."
+  };
+}
+
+function thresholdMetric(
+  actual: number | undefined,
+  required: number,
+  isValidActual: (value: unknown) => value is number
+): PublicConfidenceMetric {
+  if (!isValidActual(actual)) {
+    return { required, passed: false };
   }
-  if (!isNonNegativeInteger(policy.p0p1Labels) || policy.p0p1Labels < Math.max(policy.minP0P1Labels, PUBLIC_CONFIDENCE_MIN_P0_P1_LABELS)) return false;
-  if (
-    !isNonNegativeInteger(policy.negativeControlScenarios) ||
-    policy.negativeControlScenarios < Math.max(policy.minNegativeControlScenarios, PUBLIC_CONFIDENCE_MIN_NEGATIVE_CONTROL_SCENARIOS)
-  ) {
-    return false;
-  }
-  if (!isProbability(policy.wilsonLowerBound) || policy.wilsonLowerBound < Math.max(policy.minWilsonLowerBound, PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND)) {
-    return false;
-  }
-  return true;
+  return { actual, required, passed: actual >= required };
 }
 
 function isPositiveInteger(value: unknown): value is number {

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -351,6 +351,26 @@ describe("public confidence display policy", () => {
     }
   });
 
+  it("rejects zero and negative promotion minima from direct callers even when actual metrics pass", () => {
+    const basePolicy = buildPublicConfidencePolicy(calibratedPolicyInput());
+
+    for (const override of [
+      { minLabeledFindings: -5 },
+      { minLabeledFindings: 0 },
+      { minP0P1Labels: -5 },
+      { minP0P1Labels: 0 },
+      { minNegativeControlScenarios: -5 },
+      { minNegativeControlScenarios: 0 },
+      { minWilsonLowerBound: -0.5 }
+    ]) {
+      const policy = { ...basePolicy, ...override };
+
+      expect(evaluatePublicConfidencePolicy(policy).allowed).toBe(false);
+      expect(isPublicConfidenceDisplayAllowed(policy)).toBe(false);
+      expect(sanitizePublicConfidenceText("Confidence: 95%.", policy)).toBe("Confidence: [confidence not calibrated].");
+    }
+  });
+
   it("keeps hard promotion floors even when lower minima are supplied directly", () => {
     const policy = buildPublicConfidencePolicy({
       ...calibratedPolicyInput(),

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -371,6 +371,22 @@ describe("public confidence display policy", () => {
     }
   });
 
+  it("keeps malformed-minimum metrics aligned with missing thresholds", () => {
+    const evaluation = evaluatePublicConfidencePolicy({
+      ...buildPublicConfidencePolicy(calibratedPolicyInput()),
+      minLabeledFindings: -5
+    });
+
+    expect(evaluation.allowed).toBe(false);
+    expect(evaluation.missingThresholds).toEqual(["labeled_findings_below_100"]);
+    expect(evaluation.metrics).toMatchObject({
+      labeledFindings: { actual: 124, required: 100, passed: false },
+      p0p1Labels: { actual: 31, required: 30, passed: true },
+      negativeControlScenarios: { actual: 10, required: 10, passed: true },
+      wilsonLowerBound: { actual: 0.95, required: 0.95, passed: true }
+    });
+  });
+
   it("keeps hard promotion floors even when lower minima are supplied directly", () => {
     const policy = buildPublicConfidencePolicy({
       ...calibratedPolicyInput(),
@@ -484,6 +500,35 @@ describe("public confidence display policy", () => {
     });
   });
 
+  it("reports exact evidence and dataset threshold codes", () => {
+    const evaluation = evaluatePublicConfidencePolicy(buildPublicConfidencePolicy({
+      ...calibratedPolicyInput(),
+      evidenceUrl: " ",
+      datasetId: " "
+    }));
+
+    expect(evaluation.allowed).toBe(false);
+    expect(evaluation.missingThresholds).toEqual([
+      "calibration_evidence_url_missing_or_unusable",
+      "dataset_id_missing"
+    ]);
+
+    const report = buildPublicConfidenceCalibrationReport(buildPublicConfidencePolicy({
+      ...calibratedPolicyInput(),
+      evidenceUrl: "javascript:alert(1)",
+      datasetId: ""
+    }));
+
+    expect(report.allowed).toBe(false);
+    expect(report.missingThresholds).toEqual([
+      "calibration_evidence_url_missing_or_unusable",
+      "dataset_id_missing"
+    ]);
+    expect(report.dataset).toEqual({
+      evidenceUrl: "javascript:alert(1)"
+    });
+  });
+
   it("builds an auditable calibration report only when dataset, labels, metrics, and proof boundary are explicit", () => {
     const report = buildPublicConfidenceCalibrationReport(buildPublicConfidencePolicy(calibratedPolicyInput()));
 
@@ -534,6 +579,24 @@ describe("public confidence display policy", () => {
     ]);
     expect(report.metrics.wilsonLowerBound).toEqual({ actual: 0.949, required: 0.95, passed: false });
     expect(report.requestChangesPolicy).toBe("REQUEST_CHANGES confidence claims require calibrated P0/P1 bins that pass the public display policy.");
+    expect(report.proofBoundary).toBe("Public comments must not display confidence percentages until all calibration thresholds pass.");
+  });
+
+  it("builds a failed calibration report for malformed direct-caller minima", () => {
+    const report = buildPublicConfidenceCalibrationReport({
+      ...buildPublicConfidencePolicy(calibratedPolicyInput()),
+      minLabeledFindings: -5
+    });
+
+    expect(report.allowed).toBe(false);
+    expect(report.publicMode).toBe("uncalibrated");
+    expect(report.missingThresholds).toEqual(["labeled_findings_below_100"]);
+    expect(report.metrics).toMatchObject({
+      labeledFindings: { actual: 124, required: 100, passed: false },
+      p0p1Labels: { actual: 31, required: 30, passed: true },
+      negativeControlScenarios: { actual: 10, required: 10, passed: true },
+      wilsonLowerBound: { actual: 0.95, required: 0.95, passed: true }
+    });
     expect(report.proofBoundary).toBe("Public comments must not display confidence percentages until all calibration thresholds pass.");
   });
 });

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -378,7 +378,7 @@ describe("public confidence display policy", () => {
     });
 
     expect(evaluation.allowed).toBe(false);
-    expect(evaluation.missingThresholds).toEqual(["labeled_findings_below_100"]);
+    expect(evaluation.missingThresholds).toEqual(["min_labeled_findings_malformed"]);
     expect(evaluation.metrics).toMatchObject({
       labeledFindings: { actual: 124, required: 100, passed: false },
       p0p1Labels: { actual: 31, required: 30, passed: true },
@@ -524,9 +524,7 @@ describe("public confidence display policy", () => {
       "calibration_evidence_url_missing_or_unusable",
       "dataset_id_missing"
     ]);
-    expect(report.dataset).toEqual({
-      evidenceUrl: "javascript:alert(1)"
-    });
+    expect(report.dataset).toEqual({});
   });
 
   it("builds an auditable calibration report only when dataset, labels, metrics, and proof boundary are explicit", () => {
@@ -590,7 +588,7 @@ describe("public confidence display policy", () => {
 
     expect(report.allowed).toBe(false);
     expect(report.publicMode).toBe("uncalibrated");
-    expect(report.missingThresholds).toEqual(["labeled_findings_below_100"]);
+    expect(report.missingThresholds).toEqual(["min_labeled_findings_malformed"]);
     expect(report.metrics).toMatchObject({
       labeledFindings: { actual: 124, required: 100, passed: false },
       p0p1Labels: { actual: 31, required: 30, passed: true },

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -372,19 +372,43 @@ describe("public confidence display policy", () => {
   });
 
   it("keeps malformed-minimum metrics aligned with missing thresholds", () => {
-    const evaluation = evaluatePublicConfidencePolicy({
-      ...buildPublicConfidencePolicy(calibratedPolicyInput()),
-      minLabeledFindings: -5
-    });
+    const cases = [
+      {
+        override: { minLabeledFindings: -5 },
+        threshold: "min_labeled_findings_malformed",
+        metric: "labeledFindings",
+        expectedMetric: { actual: 124, required: 100, passed: false, blockedReason: "malformed_minimum", rejectedMinimum: -5 }
+      },
+      {
+        override: { minP0P1Labels: -5 },
+        threshold: "min_p0_p1_labels_malformed",
+        metric: "p0p1Labels",
+        expectedMetric: { actual: 31, required: 30, passed: false, blockedReason: "malformed_minimum", rejectedMinimum: -5 }
+      },
+      {
+        override: { minNegativeControlScenarios: -5 },
+        threshold: "min_negative_control_scenarios_malformed",
+        metric: "negativeControlScenarios",
+        expectedMetric: { actual: 10, required: 10, passed: false, blockedReason: "malformed_minimum", rejectedMinimum: -5 }
+      },
+      {
+        override: { minWilsonLowerBound: -0.5 },
+        threshold: "min_wilson_lower_bound_malformed",
+        metric: "wilsonLowerBound",
+        expectedMetric: { actual: 0.95, required: 0.95, passed: false, blockedReason: "malformed_minimum", rejectedMinimum: -0.5 }
+      }
+    ] as const;
 
-    expect(evaluation.allowed).toBe(false);
-    expect(evaluation.missingThresholds).toEqual(["min_labeled_findings_malformed"]);
-    expect(evaluation.metrics).toMatchObject({
-      labeledFindings: { actual: 124, required: 100, passed: false, blockedReason: "malformed_minimum" },
-      p0p1Labels: { actual: 31, required: 30, passed: true },
-      negativeControlScenarios: { actual: 10, required: 10, passed: true },
-      wilsonLowerBound: { actual: 0.95, required: 0.95, passed: true }
-    });
+    for (const testCase of cases) {
+      const evaluation = evaluatePublicConfidencePolicy({
+        ...buildPublicConfidencePolicy(calibratedPolicyInput()),
+        ...testCase.override
+      });
+
+      expect(evaluation.allowed).toBe(false);
+      expect(evaluation.missingThresholds).toEqual([testCase.threshold]);
+      expect(evaluation.metrics[testCase.metric]).toMatchObject(testCase.expectedMetric);
+    }
   });
 
   it("keeps hard promotion floors even when lower minima are supplied directly", () => {
@@ -606,7 +630,7 @@ describe("public confidence display policy", () => {
     expect(report.publicMode).toBe("uncalibrated");
     expect(report.missingThresholds).toEqual(["min_labeled_findings_malformed"]);
     expect(report.metrics).toMatchObject({
-      labeledFindings: { actual: 124, required: 100, passed: false, blockedReason: "malformed_minimum" },
+      labeledFindings: { actual: 124, required: 100, passed: false, blockedReason: "malformed_minimum", rejectedMinimum: -5 },
       p0p1Labels: { actual: 31, required: 30, passed: true },
       negativeControlScenarios: { actual: 10, required: 10, passed: true },
       wilsonLowerBound: { actual: 0.95, required: 0.95, passed: true }

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildPublicConfidenceCalibrationReport,
   buildPublicConfidencePolicy,
+  evaluatePublicConfidencePolicy,
   isPublicConfidenceDisplayAllowed,
   sanitizePublicConfidenceText
 } from "../src/public-confidence.js";
@@ -432,6 +434,53 @@ describe("public confidence display policy", () => {
     const once = sanitizePublicConfidenceText("Confidence: 95%. This has 0.91 reliability after review.");
 
     expect(sanitizePublicConfidenceText(once)).toBe(once);
+  });
+
+  it("reports uncalibrated status and every missing promotion threshold for public comments", () => {
+    const evaluation = evaluatePublicConfidencePolicy(buildPublicConfidencePolicy({
+      mode: "calibrated",
+      evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/456",
+      datasetId: "confidence-calibration-v1",
+      labeledFindings: 99,
+      p0p1Labels: 29,
+      negativeControlScenarios: 9,
+      wilsonLowerBound: 0.949
+    }));
+
+    expect(evaluation.allowed).toBe(false);
+    expect(evaluation.publicMode).toBe("uncalibrated");
+    expect(evaluation.proofBoundary).toBe("Public comments must not display confidence percentages until all calibration thresholds pass.");
+    expect(evaluation.missingThresholds).toEqual([
+      "labeled_findings_below_100",
+      "p0_p1_labels_below_30",
+      "negative_controls_below_10",
+      "wilson_lower_bound_below_0.95"
+    ]);
+    expect(evaluation.metrics).toMatchObject({
+      labeledFindings: { actual: 99, required: 100, passed: false },
+      p0p1Labels: { actual: 29, required: 30, passed: false },
+      negativeControlScenarios: { actual: 9, required: 10, passed: false },
+      wilsonLowerBound: { actual: 0.949, required: 0.95, passed: false }
+    });
+  });
+
+  it("builds an auditable calibration report only when dataset, labels, metrics, and proof boundary are explicit", () => {
+    const report = buildPublicConfidenceCalibrationReport(buildPublicConfidencePolicy(calibratedPolicyInput()));
+
+    expect(report.publicMode).toBe("calibrated");
+    expect(report.allowed).toBe(true);
+    expect(report.dataset).toEqual({
+      id: "confidence-calibration-v1",
+      evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/123"
+    });
+    expect(report.labels).toEqual({
+      labeledFindings: 124,
+      p0p1Labels: 31,
+      negativeControlScenarios: 10
+    });
+    expect(report.metrics.wilsonLowerBound).toEqual({ actual: 0.95, required: 0.95, passed: true });
+    expect(report.requestChangesPolicy).toBe("REQUEST_CHANGES confidence claims require calibrated P0/P1 bins that pass the public display policy.");
+    expect(report.proofBoundary).toBe("Public comments may display confidence percentages only while this report stays linked to the evaluated dataset and passing metrics.");
   });
 });
 

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -380,7 +380,7 @@ describe("public confidence display policy", () => {
     expect(evaluation.allowed).toBe(false);
     expect(evaluation.missingThresholds).toEqual(["min_labeled_findings_malformed"]);
     expect(evaluation.metrics).toMatchObject({
-      labeledFindings: { actual: 124, required: 100, passed: false },
+      labeledFindings: { actual: 124, required: 100, passed: false, blockedReason: "malformed_minimum" },
       p0p1Labels: { actual: 31, required: 30, passed: true },
       negativeControlScenarios: { actual: 10, required: 10, passed: true },
       wilsonLowerBound: { actual: 0.95, required: 0.95, passed: true }
@@ -487,16 +487,32 @@ describe("public confidence display policy", () => {
     expect(evaluation.publicMode).toBe("uncalibrated");
     expect(evaluation.proofBoundary).toBe("Public comments must not display confidence percentages until all calibration thresholds pass.");
     expect(evaluation.missingThresholds).toEqual([
-      "labeled_findings_below_100",
-      "p0_p1_labels_below_30",
-      "negative_controls_below_10",
-      "wilson_lower_bound_below_0.95"
+      "labeled_findings_below_required",
+      "p0_p1_labels_below_required",
+      "negative_controls_below_required",
+      "wilson_lower_bound_below_required"
     ]);
     expect(evaluation.metrics).toMatchObject({
       labeledFindings: { actual: 99, required: 100, passed: false },
       p0p1Labels: { actual: 29, required: 30, passed: false },
       negativeControlScenarios: { actual: 9, required: 10, passed: false },
       wilsonLowerBound: { actual: 0.949, required: 0.95, passed: false }
+    });
+  });
+
+  it("reports raised caller minima as below the configured required threshold", () => {
+    const report = buildPublicConfidenceCalibrationReport(buildPublicConfidencePolicy({
+      ...calibratedPolicyInput(),
+      minLabeledFindings: 150
+    }));
+
+    expect(report.allowed).toBe(false);
+    expect(report.missingThresholds).toEqual(["labeled_findings_below_required"]);
+    expect(report.metrics).toMatchObject({
+      labeledFindings: { actual: 124, required: 150, passed: false },
+      p0p1Labels: { actual: 31, required: 30, passed: true },
+      negativeControlScenarios: { actual: 10, required: 10, passed: true },
+      wilsonLowerBound: { actual: 0.95, required: 0.95, passed: true }
     });
   });
 
@@ -570,10 +586,10 @@ describe("public confidence display policy", () => {
     });
     expect(report.missingThresholds).toEqual([
       "mode_not_calibrated",
-      "labeled_findings_below_100",
-      "p0_p1_labels_below_30",
-      "negative_controls_below_10",
-      "wilson_lower_bound_below_0.95"
+      "labeled_findings_below_required",
+      "p0_p1_labels_below_required",
+      "negative_controls_below_required",
+      "wilson_lower_bound_below_required"
     ]);
     expect(report.metrics.wilsonLowerBound).toEqual({ actual: 0.949, required: 0.95, passed: false });
     expect(report.requestChangesPolicy).toBe("REQUEST_CHANGES confidence claims require calibrated P0/P1 bins that pass the public display policy.");
@@ -590,7 +606,7 @@ describe("public confidence display policy", () => {
     expect(report.publicMode).toBe("uncalibrated");
     expect(report.missingThresholds).toEqual(["min_labeled_findings_malformed"]);
     expect(report.metrics).toMatchObject({
-      labeledFindings: { actual: 124, required: 100, passed: false },
+      labeledFindings: { actual: 124, required: 100, passed: false, blockedReason: "malformed_minimum" },
       p0p1Labels: { actual: 31, required: 30, passed: true },
       negativeControlScenarios: { actual: 10, required: 10, passed: true },
       wilsonLowerBound: { actual: 0.95, required: 0.95, passed: true }

--- a/tests/public-confidence.test.ts
+++ b/tests/public-confidence.test.ts
@@ -482,6 +482,40 @@ describe("public confidence display policy", () => {
     expect(report.requestChangesPolicy).toBe("REQUEST_CHANGES confidence claims require calibrated P0/P1 bins that pass the public display policy.");
     expect(report.proofBoundary).toBe("Public comments may display confidence percentages only while this report stays linked to the evaluated dataset and passing metrics.");
   });
+
+  it("builds an uncalibrated calibration report when promotion evidence is incomplete", () => {
+    const report = buildPublicConfidenceCalibrationReport(buildPublicConfidencePolicy({
+      mode: "uncalibrated",
+      evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/456",
+      datasetId: "confidence-calibration-v1",
+      labeledFindings: 99,
+      p0p1Labels: 29,
+      negativeControlScenarios: 9,
+      wilsonLowerBound: 0.949
+    }));
+
+    expect(report.allowed).toBe(false);
+    expect(report.publicMode).toBe("uncalibrated");
+    expect(report.dataset).toEqual({
+      id: "confidence-calibration-v1",
+      evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot/actions/runs/456"
+    });
+    expect(report.labels).toEqual({
+      labeledFindings: 99,
+      p0p1Labels: 29,
+      negativeControlScenarios: 9
+    });
+    expect(report.missingThresholds).toEqual([
+      "mode_not_calibrated",
+      "labeled_findings_below_100",
+      "p0_p1_labels_below_30",
+      "negative_controls_below_10",
+      "wilson_lower_bound_below_0.95"
+    ]);
+    expect(report.metrics.wilsonLowerBound).toEqual({ actual: 0.949, required: 0.95, passed: false });
+    expect(report.requestChangesPolicy).toBe("REQUEST_CHANGES confidence claims require calibrated P0/P1 bins that pass the public display policy.");
+    expect(report.proofBoundary).toBe("Public comments must not display confidence percentages until all calibration thresholds pass.");
+  });
 });
 
 function calibratedPolicyInput() {


### PR DESCRIPTION
## Summary
- add an auditable public confidence policy evaluation/report API with explicit missing-threshold reasons
- keep public mode uncalibrated until dataset, label, negative-control, and Wilson lower-bound gates all pass
- document the confidence calibration report and REQUEST_CHANGES public-display boundary

Closes #121

## Validation
- npm test -- tests/public-confidence.test.ts
- npm run build

## Scope
- No runtime, release, active config, worker, CLI, or launchd files changed.