### PR TITLE
Add supported addon dry-run packet contract

### DIFF
--- a/docs/repo-wiki-packet.md
+++ b/docs/repo-wiki-packet.md
@@ -76,6 +76,24 @@ yet. Both statuses set `degraded: true` and should be treated as context hints
 only. Missing source with no sections records an excluded `packet:sections`
 entry with reason `missing_source`.
 
+## Supported Addon Dry-Run Packet
+
+Issue #123 adds a dry-run contract that summarizes the repo wiki packet beside a
+GitNexus context packet without making either addon required.
+
+`buildSupportedAddonDryRunPacket` emits a deterministic packet with:
+
+- one `openwiki-compatible-repo-wiki` addon entry
+- one `gitnexus-context` addon entry
+- packet hashes, versions, budget estimates, and redaction metadata
+- degraded-mode reasons for stale, missing, or unknown addon data
+- hard `runtimePromotion: false`
+- hard `nativeToolExpansion: false`
+
+The fixed summary itself has byte and token-ish caps. If even the fixed dry-run
+summary cannot fit those caps, the builder fails closed instead of returning an
+over-budget packet.
+
 ## Runtime Boundary
 
 This MVP intentionally does not wire packets into `src/worker.ts`,

--- a/docs/supported-addons.md
+++ b/docs/supported-addons.md
@@ -273,6 +273,24 @@ The summary should include:
 Do not store raw private diffs, secrets, raw provider prompts, raw customer
 logs, local credentials, cookies, or private keys in the evidence bundle.
 
+`src/repo-wiki-packet.ts` exposes a library-only
+`buildSupportedAddonDryRunPacket` helper for this bundle. It produces a
+deterministic Markdown summary over the OpenWiki-compatible repo wiki packet and
+GitNexus context packet, including:
+
+- packet versions and SHA-256 hashes
+- byte and token-ish estimates
+- redaction status or redaction report hashes
+- stale, missing, or unknown degraded-mode reasons
+- related and omitted GitNexus context counts
+- `runtimePromotion: false`
+- `nativeToolExpansion: false`
+
+That dry-run contract is intentionally not wired into `src/cli.ts`,
+`src/config.ts`, `src/worker.ts`, active config, release docs, daemon state, or
+GitHub App permissions. It is evidence for humans and agents to inspect before
+any later feature-flagged runtime integration.
+
 ## Non-Goals
 
 - Do not make OpenWiki or GitNexus required for v1.0 public launch.

--- a/docs/supported-addons.md
+++ b/docs/supported-addons.md
@@ -94,8 +94,8 @@ Required fields:
 - `sources`: source IDs, hashes, freshness flags, and source type.
 - `degradedMode` and `degradedReason`: machine-readable missing, stale, or
   skipped state.
-- `redactionReportSha256`: proof that source and rendered packet text passed
-  redaction checks.
+- `redactionReportSha256`: evidence hash for the redaction report; packet
+  summaries must carry a separate status when pass/fail/redacted state is known.
 
 Packet builders must fail closed when source text, metadata, or rendered packet
 content contains secret-like data. Redacted previews may be used for operator

--- a/src/repo-wiki-packet.ts
+++ b/src/repo-wiki-packet.ts
@@ -113,6 +113,61 @@ export interface BuildRepoWikiPacketInput {
   packetVersion?: string;
 }
 
+export type SupportedAddonKind = "openwiki-compatible-repo-wiki" | "gitnexus-context";
+export type SupportedAddonStatus = "fresh" | "stale" | "missing" | "unknown";
+
+export interface GitNexusContextPacketSummary {
+  packetVersion: string;
+  sha256: string;
+  byteEstimate: number;
+  tokenEstimate: number;
+  freshness: SupportedAddonStatus;
+  degradedMode: boolean;
+  degradedReason?: string;
+  relatedContextCount: number;
+  omittedContextCount: number;
+  redactionReportSha256: string;
+}
+
+export interface SupportedAddonDryRunInput {
+  repo: string;
+  generatedAt?: string;
+  maxBytes: number;
+  maxTokens?: number;
+  repoWikiPacket?: RepoWikiPacket;
+  gitnexusPacket?: GitNexusContextPacketSummary;
+}
+
+export interface SupportedAddonDryRunAddon {
+  kind: SupportedAddonKind;
+  status: SupportedAddonStatus;
+  packetVersion?: string;
+  packetSha?: string;
+  byteEstimate: number;
+  tokenEstimate: number;
+  advisory: boolean;
+  degradedMode: boolean;
+  degradedReason?: string;
+  redactionStatus: "passed" | "redacted" | "unknown";
+  redactionReportSha256?: string;
+  relatedContextCount?: number;
+  omittedContextCount?: number;
+}
+
+export interface SupportedAddonDryRunPacket {
+  packetVersion: "supported-addons-dry-run-v0.1";
+  repo: string;
+  generatedAt: string;
+  advisory: string;
+  runtimePromotion: false;
+  nativeToolExpansion: false;
+  degradedMode: boolean;
+  byteBudget: RepoWikiPacketBudget;
+  tokenBudget: RepoWikiTokenBudget;
+  addons: SupportedAddonDryRunAddon[];
+  packetSha: string;
+}
+
 export function normalizeRepoWikiSections(input: RepoWikiSectionInput[]): {
   sections: RepoWikiNormalizedSection[];
   excluded: RepoWikiExcludedSection[];
@@ -276,6 +331,94 @@ export function formatRepoWikiPacketMarkdown(packet: RepoWikiPacket): string {
 
 export function formatRepoWikiPacketJson(packet: RepoWikiPacket): string {
   return `${canonicalStringify(packet)}\n`;
+}
+
+export function buildSupportedAddonDryRunPacket(input: SupportedAddonDryRunInput): SupportedAddonDryRunPacket {
+  assertRepoName(input.repo);
+  assertBudget({ maxBytes: input.maxBytes, maxTokens: input.maxTokens });
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+  assertIsoTimestamp(generatedAt, "generatedAt");
+  const maxTokens = input.maxTokens ?? tokenEstimateForBytes(input.maxBytes);
+  const addons = [
+    summarizeRepoWikiAddon(input.repoWikiPacket),
+    summarizeGitNexusAddon(input.gitnexusPacket)
+  ];
+  const degradedMode = addons.some((addon) => addon.degradedMode);
+  const base = {
+    packetVersion: "supported-addons-dry-run-v0.1",
+    repo: input.repo,
+    generatedAt,
+    advisory: "Supported addon packets are advisory. GitHub PR diff, checkout files, and GitHub metadata remain authoritative.",
+    runtimePromotion: false,
+    nativeToolExpansion: false,
+    degradedMode,
+    byteBudget: { maxBytes: input.maxBytes, usedBytes: 0 },
+    tokenBudget: { maxTokens, usedTokens: 0 },
+    addons
+  } satisfies Omit<SupportedAddonDryRunPacket, "packetSha">;
+
+  let withoutSha = base;
+  let packetSha = sha256(canonicalStringify(withoutSha));
+  assertPacketSha(packetSha);
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const packet = { ...withoutSha, packetSha } satisfies SupportedAddonDryRunPacket;
+    const usedBytes = Buffer.byteLength(formatSupportedAddonDryRunPacketMarkdown(packet), "utf8");
+    const usedTokens = tokenEstimateForBytes(usedBytes);
+    const nextWithoutSha = {
+      ...withoutSha,
+      byteBudget: { ...withoutSha.byteBudget, usedBytes },
+      tokenBudget: { ...withoutSha.tokenBudget, usedTokens }
+    };
+    const nextSha = sha256(canonicalStringify(nextWithoutSha));
+    assertPacketSha(nextSha);
+    if (usedBytes === withoutSha.byteBudget.usedBytes && usedTokens === withoutSha.tokenBudget.usedTokens) {
+      return assertSupportedAddonDryRunBudget({ ...nextWithoutSha, packetSha: nextSha });
+    }
+    withoutSha = nextWithoutSha;
+    packetSha = nextSha;
+  }
+
+  return assertSupportedAddonDryRunBudget({ ...withoutSha, packetSha });
+}
+
+export function formatSupportedAddonDryRunPacketMarkdown(packet: SupportedAddonDryRunPacket): string {
+  const lines = [
+    "# Supported Addons Dry-Run Packet",
+    "",
+    `Repository: ${packet.repo}`,
+    `Generated at: ${packet.generatedAt}`,
+    `Packet version: ${packet.packetVersion}`,
+    `Packet SHA: ${packet.packetSha}`,
+    `Budget: ${packet.byteBudget.usedBytes}/${packet.byteBudget.maxBytes} bytes; ${packet.tokenBudget.usedTokens}/${packet.tokenBudget.maxTokens} token-ish`,
+    `Runtime promotion: ${packet.runtimePromotion}`,
+    `Native tool expansion: ${packet.nativeToolExpansion}`,
+    `Degraded mode: ${packet.degradedMode}`,
+    "",
+    packet.advisory,
+    "",
+    "## Addons"
+  ];
+
+  for (const addon of packet.addons) {
+    lines.push(
+      "",
+      `### ${addon.kind}`,
+      "",
+      `Status: ${addon.status}`,
+      `Advisory: ${addon.advisory}`,
+      `Degraded mode: ${addon.degradedMode}`,
+      ...(addon.degradedReason ? [`Degraded reason: ${addon.degradedReason}`] : []),
+      ...(addon.packetVersion ? [`Packet version: ${addon.packetVersion}`] : []),
+      ...(addon.packetSha ? [`Packet SHA: ${addon.packetSha}`] : []),
+      `Budget: ${addon.byteEstimate} bytes; ${addon.tokenEstimate} token-ish`,
+      `Redaction: ${addon.redactionStatus}`,
+      ...(addon.redactionReportSha256 ? [`Redaction report SHA: ${addon.redactionReportSha256}`] : []),
+      ...(addon.relatedContextCount !== undefined ? [`Related context count: ${addon.relatedContextCount}`] : []),
+      ...(addon.omittedContextCount !== undefined ? [`Omitted context count: ${addon.omittedContextCount}`] : [])
+    );
+  }
+
+  return `${lines.join("\n").trim()}\n`;
 }
 
 export function redactRepoWikiText(input: string): { text: string; replacementCount: number } {
@@ -502,6 +645,84 @@ function assertFinalPacketSize(packet: RepoWikiPacket): RepoWikiPacket {
   if (usedBytes !== packet.byteBudget.usedBytes || usedTokens !== packet.tokenBudget.usedTokens) {
     throw new Error(
       `repo wiki packet size invariant failed (${usedBytes}/${packet.byteBudget.usedBytes} bytes, ${usedTokens}/${packet.tokenBudget.usedTokens} token-ish)`
+    );
+  }
+  return packet;
+}
+
+function summarizeRepoWikiAddon(packet: RepoWikiPacket | undefined): SupportedAddonDryRunAddon {
+  if (!packet) {
+    return {
+      kind: "openwiki-compatible-repo-wiki",
+      status: "missing",
+      byteEstimate: 0,
+      tokenEstimate: 0,
+      advisory: true,
+      degradedMode: true,
+      degradedReason: "OpenWiki-compatible repo wiki packet was not supplied for this dry run.",
+      redactionStatus: "unknown"
+    };
+  }
+  return {
+    kind: "openwiki-compatible-repo-wiki",
+    status: packet.source.status,
+    packetVersion: packet.packetVersion,
+    packetSha: packet.packetSha,
+    byteEstimate: packet.byteBudget.usedBytes,
+    tokenEstimate: packet.tokenBudget.usedTokens,
+    advisory: true,
+    degradedMode: packet.degraded,
+    ...(packet.source.staleReason ? { degradedReason: packet.source.staleReason } : {}),
+    redactionStatus: packet.redaction.status,
+    redactionReportSha256: sha256(canonicalStringify(packet.redaction))
+  };
+}
+
+function summarizeGitNexusAddon(packet: GitNexusContextPacketSummary | undefined): SupportedAddonDryRunAddon {
+  if (!packet) {
+    return {
+      kind: "gitnexus-context",
+      status: "missing",
+      byteEstimate: 0,
+      tokenEstimate: 0,
+      advisory: true,
+      degradedMode: true,
+      degradedReason: "GitNexus context packet was not supplied for this dry run.",
+      redactionStatus: "unknown",
+      relatedContextCount: 0,
+      omittedContextCount: 0
+    };
+  }
+  assertPacketSha(packet.sha256);
+  assertPacketSha(packet.redactionReportSha256);
+  return {
+    kind: "gitnexus-context",
+    status: packet.freshness,
+    packetVersion: packet.packetVersion,
+    packetSha: packet.sha256,
+    byteEstimate: packet.byteEstimate,
+    tokenEstimate: packet.tokenEstimate,
+    advisory: true,
+    degradedMode: packet.degradedMode,
+    ...(packet.degradedReason ? { degradedReason: packet.degradedReason } : {}),
+    redactionStatus: "passed",
+    redactionReportSha256: packet.redactionReportSha256,
+    relatedContextCount: packet.relatedContextCount,
+    omittedContextCount: packet.omittedContextCount
+  };
+}
+
+function assertSupportedAddonDryRunBudget(packet: SupportedAddonDryRunPacket): SupportedAddonDryRunPacket {
+  const usedBytes = Buffer.byteLength(formatSupportedAddonDryRunPacketMarkdown(packet), "utf8");
+  const usedTokens = tokenEstimateForBytes(usedBytes);
+  if (
+    usedBytes !== packet.byteBudget.usedBytes ||
+    usedTokens !== packet.tokenBudget.usedTokens ||
+    usedBytes > packet.byteBudget.maxBytes ||
+    usedTokens > packet.tokenBudget.maxTokens
+  ) {
+    throw new Error(
+      `supported addon dry-run packet exceeds budget (${usedBytes}/${packet.byteBudget.maxBytes} bytes, ${usedTokens}/${packet.tokenBudget.maxTokens} token-ish)`
     );
   }
   return packet;

--- a/src/repo-wiki-packet.ts
+++ b/src/repo-wiki-packet.ts
@@ -126,6 +126,7 @@ export interface GitNexusContextPacketSummary {
   degradedReason?: string;
   relatedContextCount: number;
   omittedContextCount: number;
+  redactionStatus?: "passed" | "redacted" | "unknown";
   redactionReportSha256: string;
 }
 
@@ -705,7 +706,7 @@ function summarizeGitNexusAddon(packet: GitNexusContextPacketSummary | undefined
     advisory: true,
     degradedMode: packet.degradedMode,
     ...(packet.degradedReason ? { degradedReason: packet.degradedReason } : {}),
-    redactionStatus: "passed",
+    redactionStatus: packet.redactionStatus ?? "unknown",
     redactionReportSha256: packet.redactionReportSha256,
     relatedContextCount: packet.relatedContextCount,
     omittedContextCount: packet.omittedContextCount

--- a/tests/repo-wiki-packet.test.ts
+++ b/tests/repo-wiki-packet.test.ts
@@ -495,6 +495,61 @@ describe("repo wiki packets", () => {
     ]);
   });
 
+  it("does not treat a GitNexus redaction report hash as a passed redaction status", () => {
+    const contract = buildSupportedAddonDryRunPacket({
+      repo: "electricsheephq/evaos-code-review-bot",
+      generatedAt,
+      maxBytes: 40_000,
+      maxTokens: 10_000,
+      gitnexusPacket: {
+        packetVersion: "gitnexus-context-packet-v0.1",
+        sha256: "e".repeat(64),
+        byteEstimate: 1024,
+        tokenEstimate: 256,
+        freshness: "fresh",
+        degradedMode: false,
+        relatedContextCount: 1,
+        omittedContextCount: 0,
+        redactionReportSha256: "f".repeat(64)
+      }
+    });
+
+    expect(contract.addons.find((addon) => addon.kind === "gitnexus-context")).toEqual(
+      expect.objectContaining({
+        redactionStatus: "unknown",
+        redactionReportSha256: "f".repeat(64)
+      })
+    );
+  });
+
+  it("preserves an explicit GitNexus redaction status when the packet summary includes one", () => {
+    const contract = buildSupportedAddonDryRunPacket({
+      repo: "electricsheephq/evaos-code-review-bot",
+      generatedAt,
+      maxBytes: 40_000,
+      maxTokens: 10_000,
+      gitnexusPacket: {
+        packetVersion: "gitnexus-context-packet-v0.1",
+        sha256: "1".repeat(64),
+        byteEstimate: 1024,
+        tokenEstimate: 256,
+        freshness: "fresh",
+        degradedMode: false,
+        relatedContextCount: 1,
+        omittedContextCount: 0,
+        redactionStatus: "passed",
+        redactionReportSha256: "2".repeat(64)
+      }
+    });
+
+    expect(contract.addons.find((addon) => addon.kind === "gitnexus-context")).toEqual(
+      expect.objectContaining({
+        redactionStatus: "passed",
+        redactionReportSha256: "2".repeat(64)
+      })
+    );
+  });
+
   it("rejects supported-addon dry-run contracts whose fixed summary exceeds byte or token caps", () => {
     const input = {
       repo: "electricsheephq/evaos-code-review-bot",

--- a/tests/repo-wiki-packet.test.ts
+++ b/tests/repo-wiki-packet.test.ts
@@ -2,8 +2,10 @@ import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   buildRepoWikiPacket,
+  buildSupportedAddonDryRunPacket,
   formatRepoWikiPacketJson,
   formatRepoWikiPacketMarkdown,
+  formatSupportedAddonDryRunPacketMarkdown,
   normalizeRepoWikiSections,
   redactRepoWikiText,
   truncateUtf8Bytes
@@ -406,6 +408,103 @@ describe("repo wiki packets", () => {
       text: "[redacted-secret]",
       replacementCount: 1
     });
+  });
+
+  it("builds a dry-run supported-addon contract without runtime or native tool expansion", () => {
+    const wikiPacket = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: {
+        ref: "main",
+        headSha: "02c388056e6b04405bce2e6fe2de74db34db6ba7",
+        checkedAt: generatedAt,
+        status: "fresh"
+      },
+      generatedAt,
+      budget: { maxBytes: 12_000, maxTokens: 3_000 },
+      sections: [section({ id: "arch", title: "Architecture", body: "Local-first review worker." })]
+    });
+    const contract = buildSupportedAddonDryRunPacket({
+      repo: "electricsheephq/evaos-code-review-bot",
+      generatedAt,
+      maxBytes: 40_000,
+      maxTokens: 10_000,
+      repoWikiPacket: wikiPacket,
+      gitnexusPacket: {
+        packetVersion: "gitnexus-context-packet-v0.1",
+        sha256: "a".repeat(64),
+        byteEstimate: 2048,
+        tokenEstimate: 512,
+        freshness: "fresh",
+        degradedMode: false,
+        relatedContextCount: 2,
+        omittedContextCount: 0,
+        redactionReportSha256: "b".repeat(64)
+      }
+    });
+    const markdown = formatSupportedAddonDryRunPacketMarkdown(contract);
+
+    expect(contract.packetSha).toMatch(/^[a-f0-9]{64}$/);
+    expect(contract.runtimePromotion).toBe(false);
+    expect(contract.nativeToolExpansion).toBe(false);
+    expect(contract.addons.map((addon) => addon.kind)).toEqual([
+      "openwiki-compatible-repo-wiki",
+      "gitnexus-context"
+    ]);
+    expect(contract.addons.every((addon) => addon.advisory)).toBe(true);
+    expect(contract.addons.every((addon) => !addon.degradedMode)).toBe(true);
+    expect(contract.byteBudget.usedBytes).toBe(Buffer.byteLength(markdown, "utf8"));
+    expect(contract.tokenBudget.usedTokens).toBe(Math.ceil(contract.byteBudget.usedBytes / 4));
+    expect(markdown).toContain("Runtime promotion: false");
+    expect(markdown).toContain("Native tool expansion: false");
+  });
+
+  it("records missing and stale addons as degraded dry-run evidence without blocking the contract", () => {
+    const contract = buildSupportedAddonDryRunPacket({
+      repo: "electricsheephq/evaos-code-review-bot",
+      generatedAt,
+      maxBytes: 40_000,
+      maxTokens: 10_000,
+      gitnexusPacket: {
+        packetVersion: "gitnexus-context-packet-v0.1",
+        sha256: "c".repeat(64),
+        byteEstimate: 1024,
+        tokenEstimate: 256,
+        freshness: "stale",
+        degradedMode: true,
+        degradedReason: "GitNexus index commit does not match PR base/head.",
+        relatedContextCount: 0,
+        omittedContextCount: 1,
+        redactionReportSha256: "d".repeat(64)
+      }
+    });
+
+    expect(contract.degradedMode).toBe(true);
+    expect(contract.addons).toEqual([
+      expect.objectContaining({
+        kind: "openwiki-compatible-repo-wiki",
+        status: "missing",
+        degradedMode: true,
+        degradedReason: "OpenWiki-compatible repo wiki packet was not supplied for this dry run."
+      }),
+      expect.objectContaining({
+        kind: "gitnexus-context",
+        status: "stale",
+        degradedMode: true,
+        degradedReason: "GitNexus index commit does not match PR base/head."
+      })
+    ]);
+  });
+
+  it("rejects supported-addon dry-run contracts whose fixed summary exceeds byte or token caps", () => {
+    const input = {
+      repo: "electricsheephq/evaos-code-review-bot",
+      generatedAt,
+      repoWikiPacket: undefined,
+      gitnexusPacket: undefined
+    };
+
+    expect(() => buildSupportedAddonDryRunPacket({ ...input, maxBytes: 10, maxTokens: 10 })).toThrow(/supported addon dry-run packet exceeds budget/);
+    expect(() => buildSupportedAddonDryRunPacket({ ...input, maxBytes: 40_000, maxTokens: 1 })).toThrow(/supported addon dry-run packet exceeds budget/);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a deterministic supported-addon dry-run packet contract for OpenWiki-compatible repo wiki plus GitNexus context summaries
- keep the contract advisory with hard runtimePromotion/nativeToolExpansion false boundaries
- document the dry-run evidence shape and add focused budget/degraded-mode tests

Closes #123

## Validation
- npm exec vitest -- tests/repo-wiki-packet.test.ts --run --pool=forks --poolOptions.forks.maxForks=1
- npm run build
- git diff --check

## Scope
- Dry-run/packet contract only
- No live runtime promotion
- No native web/tool expansion
- No changes to src/cli.ts, src/config.ts, src/worker.ts, docs/releases, or active config