### PR TITLE
Add manual issue enrichment runner

### DIFF
--- a/docs/issue-enrichment.md
+++ b/docs/issue-enrichment.md
@@ -38,6 +38,43 @@ Keep new rollouts dry-run first:
 }
 ```
 
+Manual live pilots should use the selected-issue runner before daemon
+promotion:
+
+```bash
+npx tsx src/cli.ts issue-enrichment-run \
+  --config <config.json> \
+  --repo owner/repo \
+  --issue 123 \
+  --dry-run true \
+  --output-dir <evidence-dir>/issue-enrichment-pilot
+```
+
+Live posting is intentionally noisier to type:
+
+```bash
+npx tsx src/cli.ts issue-enrichment-run \
+  --config <config.json> \
+  --repo owner/repo \
+  --issue 123 \
+  --dry-run false \
+  --confirm true
+```
+
+The runner requires repo membership in `issueEnrichment.allowlist`, rejects
+closed issues and PR-shaped issue records before posting, writes/upserts only
+one bot-owned sticky marker comment per issue, records state in
+`issue_enrichment_records`, and never mutates labels, owners, reviewers, or
+roadmap fields. Repeat `--issue` only for small selected batches. Use `--force
+true` only with `--dry-run false` to deliberately re-upsert an unchanged issue's
+existing marker comment. Selected live runs reject batches that exceed the
+effective repo/global issue or comment cap before fetching or posting. Dry runs
+do not post comments, but they still plan against the live issue/comment caps
+and may report deferred rows so operators can see what live posting would do.
+If a confirmed live run cannot acquire the issue-enrichment worker lease, it
+exits nonzero and reports `workerSkipped: 1` in the JSON output; retry after the
+active lease clears.
+
 Operator status exposes `issueEnrichment.liveThresholdsMissingRepos` and the `issue_enrichment_live_repo_thresholds_required` blocker before live comments can become ready. This is intentional: repo-specific thresholds must be visible in config before any active rollout.
 
 When more than one live rollout blocker applies, operator status reports blockers in deterministic policy order:

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -122,6 +122,24 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
   reports would-comment/deferred rows without posting comments. Use
   `--include-existing true` only for an explicit scoped audit; do not use it as
   the default live posture for repos with large historic issue backlogs.
+- `issue-enrichment-run --repo <owner/name> --issue <number>`: runs selected
+  issue enrichment through the same sticky comment and SQLite record path used
+  by daemon cycles. The repo must be in `issueEnrichment.allowlist`, the feature
+  must be enabled in config, and live posting requires `--dry-run false
+  --confirm true` plus GitHub App credentials. Repeat `--issue` to process a
+  small selected batch. Closed issues and PR-shaped issue records fail before
+  posting. Unchanged live reruns skip already processed issues; use `--force
+  true` only when deliberately re-upserting the existing bot-owned marker
+  comment; `--force true` requires `--dry-run false`. Selected live runs reject
+  batches that exceed the effective repo/global issue or comment cap before
+  fetching or posting. Dry runs do not post comments, but they still plan
+  against live issue/comment caps and may report deferred rows. A confirmed live
+  run that cannot acquire the shared issue-enrichment worker lease exits
+  nonzero and reports `workerSkipped: 1` in JSON. Use `--output-dir <path>`
+  under the configured `evidenceDir` to write redacted
+  `issue-enrichment-run.json` plus one redacted `issue-<number>.md` preview per
+  issue. This command never applies labels, owners, reviewers, or roadmap
+  fields.
 - `doctor`: auth/config readiness. Use this for GitHub App/ZCode readiness, not
   runtime health.
 - `init --config <path>`: copy `config.example.json` to a local config path

--- a/docs/releases/v0.4.22-beta.1.md
+++ b/docs/releases/v0.4.22-beta.1.md
@@ -5,10 +5,11 @@
 - Tracking issues: `#119`, `#228`
 - Promotion metadata: GitHub Release body must name the final tag SHA,
   implementation merge SHA, and promoted PR after merge.
-- Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- Live checkout: operator-selected live checkout at the promoted merge SHA
 - launchd label: `com.electricsheephq.evaos-code-review-bot`
-- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
-- Release evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-05/issue-enrichment-live-pilot/`
+- Live config: active installed live config used by the launchd worker
+- Release evidence: attach the manual dry-run/live proof packet in the GitHub
+  release and tracker comments
 - Rollback tag: `v0.4.21-beta.1`
 
 Promotion note: do not promote launchd or live issue-enrichment config until the
@@ -83,13 +84,13 @@ allowlists or bulk-commenting old issue backlogs.
 ## Rollback
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+cd <live-checkout>
 git fetch origin --tags
 git checkout main
 git reset --hard v0.4.21-beta.1
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config <active-installed-live-config> \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```

--- a/docs/releases/v0.4.22-beta.1.md
+++ b/docs/releases/v0.4.22-beta.1.md
@@ -1,0 +1,95 @@
+# v0.4.22-beta.1
+
+- Release type: issue enrichment two-repo live pilot
+- Previous prerelease: `v0.4.21-beta.1`
+- Tracking issues: `#119`, `#228`
+- Promotion metadata: GitHub Release body must name the final tag SHA,
+  implementation merge SHA, and promoted PR after merge.
+- Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
+- launchd label: `com.electricsheephq.evaos-code-review-bot`
+- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+- Release evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-05/issue-enrichment-live-pilot/`
+- Rollback tag: `v0.4.21-beta.1`
+
+Promotion note: do not promote launchd or live issue-enrichment config until the
+GitHub Release body includes the final tag SHA, implementation merge SHA, and
+promoted PR.
+
+## Purpose
+
+Add an operator-gated `issue-enrichment-run` command so selected issues can be
+dry-run, posted, duplicate-checked, and force-upserted before automatic issue
+enrichment is enabled in launchd. This supports the two-repo pilot for
+`electricsheephq/evaos-code-review-bot-neondiff` and
+`100yenadmin/Lossless-Codex-Orchestrator-LCO` without expanding PR review
+allowlists or bulk-commenting old issue backlogs.
+
+## Included Changes
+
+- Adds `issue-enrichment-run --repo <owner/name> --issue <number>` for selected
+  issue enrichment.
+- Allows repeated `--issue` flags for small explicit batches while preserving
+  single-value parsing for other CLI flags.
+- Requires repo membership in the separate `issueEnrichment.allowlist`.
+- Requires `issueEnrichment.enabled: true`; live posting still requires
+  `--dry-run false --confirm true` and GitHub App credentials.
+- Allows dry-run selected issue enrichment without GitHub App posting
+  credentials when a fallback read token is available.
+- Rejects blocked issue-enrichment status with an explicit operator error before
+  fetching or posting.
+- Rejects closed issues and PR-shaped issue records before posting.
+- Names the binding throttle when a selected issue batch exceeds the configured
+  per-run cap.
+- Checks the live issue-enrichment worker lease before fetching selected issue
+  metadata for confirmed live runs.
+- Writes/upserts one bot-owned sticky marker comment per issue through the same
+  posting path used by daemon cycles.
+- Records live outcomes in `issue_enrichment_records` without advancing daemon
+  repo watermarks for manual selected runs.
+- Skips unchanged already-processed issues by default; `--force true` is
+  live-only and re-upserts the existing marker comment.
+- Writes redacted JSON and Markdown evidence under the configured `evidenceDir`.
+- Keeps labels, owners, reviewers, roadmap fields, PR reviews, native ZCode
+  skills, MCP, tools, and memory unchanged.
+
+## Required Gates
+
+- GitHub App Issues read/write permission approved and installed for both pilot
+  repos before live posting.
+- `doctor github` shows issue-enrichment read checks passing for both pilot
+  repos.
+- Focused local test: `npm test -- tests/enrichment-cli.test.ts`
+- `npm run build`
+- Manual dry-run `issue-enrichment-run` evidence for one bot issue and one LCO
+  issue.
+- Manual live `issue-enrichment-run --dry-run false --confirm true` proof for
+  one issue in each allowlisted repo.
+- Duplicate rerun proves no second marker comment.
+- Force rerun proves the existing marker comment updates.
+- Launchd automatic proof only after live config promotion with
+  `processExistingOpenIssuesOnActivation:false`.
+
+## Caveats
+
+- This release adds the manual runner; automatic launchd issue enrichment stays
+  disabled until the live config is promoted after permission and manual proof.
+- This release does not enrich all open historical issues.
+- This release does not expand PR monitored repositories or PR posting policy.
+- This release does not apply labels, assign owners/reviewers, or update
+  roadmap fields.
+- This release does not claim broad issue-enrichment rollout readiness beyond
+  the two explicit pilot repos.
+
+## Rollback
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard v0.4.21-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,7 @@ import {
   resolveIssueEnrichmentRepoPolicy,
   runIssueEnrichmentCycle,
   type IssueEnrichmentCycleGithub,
+  type IssueEnrichmentCycleResult,
   type IssueEnrichmentConfig,
   type IssueEnrichmentRepoReadCheck
 } from "./issue-enrichment.js";
@@ -1066,11 +1067,12 @@ async function main(): Promise<void> {
     });
     if (issueNumbers.length > runLimit.value) {
       throw new Error(
-        `issue-enrichment-run selected issue count ${issueNumbers.length} exceeds configured per-run cap ${runLimit.value} (${runLimit.binding})`
+        `issue-enrichment-run selected issue count ${issueNumbers.length} exceeds configured selected-run prefetch cap ${runLimit.value} (${runLimit.binding}; cap is conservative and uses selected issue count before fetch)`
       );
     }
     const issues: GitHubRelatedIssueOrPull[] = [];
-    const previewOutputs: Array<Extract<ReturnType<typeof buildIssueEnrichmentDryRunOutput>, { skipped: false }>> = [];
+    type IssueEnrichmentPreview = Extract<ReturnType<typeof buildIssueEnrichmentDryRunOutput>, { skipped: false }>;
+    const previewOutputs: IssueEnrichmentPreview[] = [];
     let selectedIssuesLoaded = false;
     const loadSelectedIssues = async () => {
       if (selectedIssuesLoaded) return issues;
@@ -1118,7 +1120,7 @@ async function main(): Promise<void> {
         canPostAsApp: () => github.canPostAsApp(),
         upsertIssueComment: (input) => github.upsertIssueComment(input)
       };
-      const result = await runIssueEnrichmentCycle({
+      const cycleInput = {
         config,
         state,
         github: cycleGithub,
@@ -1128,32 +1130,37 @@ async function main(): Promise<void> {
         advanceWatermarks: false,
         force,
         ...(preacquiredLease ? { preacquiredLease } : {})
-      });
+      };
       if (preacquiredLease) leaseTransferredToCycle = true;
+      const result = await runIssueEnrichmentCycle(cycleInput);
+      const liveExitReason = dryRun ? undefined : issueEnrichmentRunLiveExitReason(result);
       const output = {
         command: "issue-enrichment-run",
         repo,
         issueNumbers,
         force,
+        ...(liveExitReason ? { exitReason: liveExitReason } : {}),
         ...result
       };
       if (args["output-dir"]) {
         const safeOutputDir = assertMemoryPacketOutputDirSafe(args["output-dir"], config.evidenceDir);
         mkdirSync(safeOutputDir, { recursive: true });
         writeFileSync(join(safeOutputDir, "issue-enrichment-run.json"), `${redactSecrets(JSON.stringify(output, null, 2))}\n`);
+        const resultIssueNumbers = new Set(
+          result.items
+            .filter((item) =>
+              dryRun ||
+              (!item.skippedExisting && item.recordStatus !== "deferred" && item.recordStatus !== "skipped")
+            )
+            .map((item) => item.issueNumber)
+        );
         for (const preview of previewOutputs) {
+          if (!resultIssueNumbers.has(preview.issueNumber)) continue;
           writeFileSync(join(safeOutputDir, `issue-${preview.issueNumber}.md`), redactSecrets(preview.body));
         }
       }
       console.log(redactSecrets(JSON.stringify(output, null, 2)));
-      const liveNoWork = !dryRun &&
-        result.summary.posted === 0 &&
-        result.summary.failed === 0 &&
-        result.summary.alreadyProcessed === 0 &&
-        result.summary.dryRunRecorded === 0 &&
-        result.summary.skippedRecorded === 0 &&
-        result.summary.deferredRecorded === 0;
-      if (!result.ok || (!dryRun && (result.summary.workerSkipped > 0 || liveNoWork))) process.exitCode = 1;
+      if (!result.ok || liveExitReason === "lease_busy" || liveExitReason === "no_work") process.exitCode = 1;
     } finally {
       if (preacquiredLease && !leaseTransferredToCycle) state.releaseIssueEnrichmentRunLease(preacquiredLease.leaseId);
       state.close();
@@ -2806,6 +2813,21 @@ function effectiveIssueEnrichmentRunLimit(
     binding: `${binding.field}=${binding.value}`,
     value: binding.value
   };
+}
+
+function issueEnrichmentRunLiveExitReason(
+  result: IssueEnrichmentCycleResult
+): "failed" | "lease_busy" | "no_work" | undefined {
+  if (!result.ok) return "failed";
+  if (result.summary.workerSkipped > 0) return "lease_busy";
+  const liveNoWork =
+    result.summary.posted === 0 &&
+    result.summary.failed === 0 &&
+    result.summary.alreadyProcessed === 0 &&
+    result.summary.dryRunRecorded === 0 &&
+    result.summary.skippedRecorded === 0 &&
+    result.summary.deferredRecorded === 0;
+  return liveNoWork ? "no_work" : undefined;
 }
 
 function parseSingleArg(value: string | string[], label: string): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1051,7 +1051,10 @@ async function main(): Promise<void> {
     const github = new GitHubApi(config.github);
     const liveStatus = buildIssueEnrichmentStatus({ config, canPostAsApp: github.canPostAsApp() });
     const statusBlockers = dryRun
-      ? liveStatus.blockers.filter((blocker) => blocker !== "github_app_credentials_required_for_live_issue_comments")
+      ? liveStatus.blockers.filter((blocker) =>
+          blocker !== "github_app_credentials_required_for_live_issue_comments" &&
+          blocker !== "issue_enrichment_live_posting_disabled"
+        )
       : liveStatus.blockers;
     if (statusBlockers.length > 0) {
       const missingThresholds = liveStatus.liveThresholdsMissingRepos.length
@@ -2794,7 +2797,7 @@ function effectiveIssueEnrichmentRunLimit(
   const binding = limits.reduce((best, candidate) => candidate.value < best.value ? candidate : best);
   return {
     binding: `${binding.field}=${binding.value}`,
-    value: Math.max(1, binding.value)
+    value: binding.value
   };
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -927,6 +927,7 @@ async function main(): Promise<void> {
   if (command === "build-enrichment-comment") {
     if (!args.repo) throw new Error("--repo is required for build-enrichment-comment");
     if (Boolean(args.pr) === Boolean(args.issue)) throw new Error("exactly one of --pr or --issue is required for build-enrichment-comment");
+    if (Array.isArray(args.issue)) throw new Error("--issue must be provided once for build-enrichment-comment");
     const repo = parseSingleArg(args.repo, "--repo");
     const config = loadConfig(args.config);
     const github = new GitHubApi(config.github);
@@ -1068,28 +1069,35 @@ async function main(): Promise<void> {
       );
     }
     const issues: GitHubRelatedIssueOrPull[] = [];
-    const previewOutputs = [];
-    for (const issueNumber of issueNumbers) {
-      const issue = await github.getIssueOrPull(repo, issueNumber, { tolerateUnreadable: true });
-      if (!issue) {
-        throw new Error(`Issue ${repo}#${issueNumber} was not found or is not readable; run doctor github and confirm GitHub App Issues permission before live issue enrichment.`);
+    const previewOutputs: Array<Extract<ReturnType<typeof buildIssueEnrichmentDryRunOutput>, { skipped: false }>> = [];
+    let selectedIssuesLoaded = false;
+    const loadSelectedIssues = async () => {
+      if (selectedIssuesLoaded) return issues;
+      for (const issueNumber of issueNumbers) {
+        const issue = await github.getIssueOrPull(repo, issueNumber, { tolerateUnreadable: true });
+        if (!issue) {
+          throw new Error(`Issue ${repo}#${issueNumber} was not found or is not readable; run doctor github and confirm GitHub App Issues permission before live issue enrichment.`);
+        }
+        const preview = buildIssueEnrichmentDryRunOutput({
+          repo,
+          issue,
+          allowedLabels: policy.suggestions.allowedLabels,
+          allowedOwners: policy.suggestions.allowedReviewers,
+          validationSuggestions: ["Confirm owner, acceptance criteria, and validation evidence before implementation."],
+          maxRelatedRefs: config.enrichment?.maxRelatedRefs,
+          maxSuggestions: config.enrichment?.maxSuggestions,
+          publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
+        });
+        if (preview.skipped) {
+          throw new Error(`Issue ${repo}#${issueNumber} is not eligible for issue enrichment: ${preview.reason}`);
+        }
+        issues.push(issue);
+        previewOutputs.push(preview);
       }
-      const preview = buildIssueEnrichmentDryRunOutput({
-        repo,
-        issue,
-        allowedLabels: policy.suggestions.allowedLabels,
-        allowedOwners: policy.suggestions.allowedReviewers,
-        validationSuggestions: ["Confirm owner, acceptance criteria, and validation evidence before implementation."],
-        maxRelatedRefs: config.enrichment?.maxRelatedRefs,
-        maxSuggestions: config.enrichment?.maxSuggestions,
-        publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
-      });
-      if (preview.skipped) {
-        throw new Error(`Issue ${repo}#${issueNumber} is not eligible for issue enrichment: ${preview.reason}`);
-      }
-      issues.push(issue);
-      previewOutputs.push(preview);
-    }
+      selectedIssuesLoaded = true;
+      return issues;
+    };
+    if (dryRun) await loadSelectedIssues();
 
     const state = new ReviewStateStore(args["state-path"] ?? config.statePath);
     try {
@@ -1098,7 +1106,7 @@ async function main(): Promise<void> {
           if (requestedRepo !== repo) {
             throw new Error(`issue-enrichment-run internal repo mismatch: requested ${requestedRepo}, expected ${repo}`);
           }
-          return issues;
+          return loadSelectedIssues();
         },
         canPostAsApp: () => github.canPostAsApp(),
         upsertIssueComment: (input) => github.upsertIssueComment(input)
@@ -1129,7 +1137,14 @@ async function main(): Promise<void> {
         }
       }
       console.log(redactSecrets(JSON.stringify(output, null, 2)));
-      if (!result.ok || (!dryRun && result.summary.workerSkipped > 0)) process.exitCode = 1;
+      const liveNoWork = !dryRun &&
+        result.summary.posted === 0 &&
+        result.summary.failed === 0 &&
+        result.summary.alreadyProcessed === 0 &&
+        result.summary.dryRunRecorded === 0 &&
+        result.summary.skippedRecorded === 0 &&
+        result.summary.deferredRecorded === 0;
+      if (!result.ok || (!dryRun && (result.summary.workerSkipped > 0 || liveNoWork))) process.exitCode = 1;
     } finally {
       state.close();
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,11 +27,14 @@ import {
 import { GitHubApi } from "./github.js";
 import { buildGitNexusContextPacket } from "./gitnexus-context.js";
 import { buildGitNexusRefreshPreflight } from "./gitnexus-refresh-preflight.js";
-import { buildGitHubRelatedContextPacket } from "./github-related-context.js";
+import { buildGitHubRelatedContextPacket, type GitHubRelatedIssueOrPull } from "./github-related-context.js";
 import {
   buildIssueEnrichmentStatus,
   collectIssueEnrichmentScan,
   resolveIssueEnrichmentRepoPolicy,
+  runIssueEnrichmentCycle,
+  type IssueEnrichmentCycleGithub,
+  type IssueEnrichmentConfig,
   type IssueEnrichmentRepoReadCheck
 } from "./issue-enrichment.js";
 import { activateLicense, deactivateLicense, getLicenseStatus, type LicenseConfig } from "./license.js";
@@ -1019,6 +1022,112 @@ async function main(): Promise<void> {
     }
     console.log(redactSecrets(JSON.stringify(scan, null, 2)));
     if (!scan.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "issue-enrichment-run") {
+    if (!args.repo) throw new Error("--repo is required for issue-enrichment-run");
+    const repo = parseSingleArg(args.repo, "--repo");
+    const issueNumbers = parseIssueNumberArgs(args.issue);
+    const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
+    const confirm = args.confirm === undefined ? false : parseBooleanArg(args.confirm, "--confirm");
+    const force = args.force === undefined ? false : parseBooleanArg(args.force, "--force");
+    if (dryRun && force) {
+      throw new Error("issue-enrichment-run --force true requires --dry-run false");
+    }
+    if (!dryRun && !confirm) {
+      throw new Error("issue-enrichment-run requires --confirm true when --dry-run false");
+    }
+    const config = loadConfig(args.config);
+    const issueConfig = config.issueEnrichment;
+    if (!issueConfig) throw new Error("issue-enrichment-run requires issueEnrichment config");
+    if (!issueConfig.enabled) throw new Error("issue-enrichment-run requires issueEnrichment.enabled true");
+    if (!dryRun && !issueConfig.postIssueComment) {
+      throw new Error("issue-enrichment-run live posting requires issueEnrichment.postIssueComment true");
+    }
+    const policy = resolveIssueEnrichmentRepoPolicy(issueConfig, repo);
+    if (!policy.allowed) throw new Error(`Repo ${repo} is skipped by issue-enrichment policy: ${policy.reason}`);
+    const github = new GitHubApi(config.github);
+    const liveStatus = buildIssueEnrichmentStatus({ config, canPostAsApp: github.canPostAsApp() });
+    if (liveStatus.state === "blocked") {
+      const missingThresholds = liveStatus.liveThresholdsMissingRepos.length
+        ? `; liveThresholdsMissingRepos=${liveStatus.liveThresholdsMissingRepos.join(",")}`
+        : "";
+      const mode = dryRun ? "dry-run" : "live posting";
+      throw new Error(`issue-enrichment-run ${mode} blocked: ${liveStatus.blockers.join(", ")}${missingThresholds}`);
+    }
+    const runLimit = effectiveIssueEnrichmentRunLimit(issueConfig, policy, {
+      postIssueComment: !dryRun && issueConfig.postIssueComment
+    });
+    if (issueNumbers.length > runLimit) {
+      throw new Error(`issue-enrichment-run selected issue count ${issueNumbers.length} exceeds configured per-run cap ${runLimit}`);
+    }
+    const issues: GitHubRelatedIssueOrPull[] = [];
+    const previewOutputs = [];
+    for (const issueNumber of issueNumbers) {
+      const issue = await github.getIssueOrPull(repo, issueNumber, { tolerateUnreadable: true });
+      if (!issue) {
+        throw new Error(`Issue ${repo}#${issueNumber} was not found or is not readable; run doctor github and confirm GitHub App Issues permission before live issue enrichment.`);
+      }
+      const preview = buildIssueEnrichmentDryRunOutput({
+        repo,
+        issue,
+        allowedLabels: policy.suggestions.allowedLabels,
+        allowedOwners: policy.suggestions.allowedReviewers,
+        validationSuggestions: ["Confirm owner, acceptance criteria, and validation evidence before implementation."],
+        maxRelatedRefs: config.enrichment?.maxRelatedRefs,
+        maxSuggestions: config.enrichment?.maxSuggestions,
+        publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
+      });
+      if (preview.skipped) {
+        throw new Error(`Issue ${repo}#${issueNumber} is not eligible for issue enrichment: ${preview.reason}`);
+      }
+      issues.push(issue);
+      previewOutputs.push(preview);
+    }
+
+    const state = new ReviewStateStore(args["state-path"] ?? config.statePath);
+    try {
+      const cycleGithub: IssueEnrichmentCycleGithub = {
+        listIssuesForEnrichment: async (requestedRepo) => {
+          if (requestedRepo !== repo) {
+            throw new Error(`issue-enrichment-run internal repo mismatch: requested ${requestedRepo}, expected ${repo}`);
+          }
+          return issues;
+        },
+        canPostAsApp: () => github.canPostAsApp(),
+        upsertIssueComment: (input) => github.upsertIssueComment(input)
+      };
+      const result = await runIssueEnrichmentCycle({
+        config,
+        state,
+        github: cycleGithub,
+        dryRun,
+        repo,
+        includeExisting: true,
+        advanceWatermarks: false,
+        force
+      });
+      const output = {
+        command: "issue-enrichment-run",
+        repo,
+        issueNumbers,
+        force,
+        ...result
+      };
+      if (args["output-dir"]) {
+        const safeOutputDir = assertMemoryPacketOutputDirSafe(args["output-dir"], config.evidenceDir);
+        mkdirSync(safeOutputDir, { recursive: true });
+        writeFileSync(join(safeOutputDir, "issue-enrichment-run.json"), `${redactSecrets(JSON.stringify(output, null, 2))}\n`);
+        for (const preview of previewOutputs) {
+          writeFileSync(join(safeOutputDir, `issue-${preview.issueNumber}.md`), redactSecrets(preview.body));
+        }
+      }
+      console.log(redactSecrets(JSON.stringify(output, null, 2)));
+      if (!result.ok || (!dryRun && result.summary.workerSkipped > 0)) process.exitCode = 1;
+    } finally {
+      state.close();
+    }
     return;
   }
 
@@ -2424,6 +2533,7 @@ function buildHelp(command?: string) {
         "build-skill-pack",
         "build-enrichment-comment",
         "issue-enrichment-scan",
+        "issue-enrichment-run",
         "clear-issue-enrichment-leases",
         "clear-review-queue-leases",
         "finishing-touch-dry-run",
@@ -2480,6 +2590,8 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts build-enrichment-comment --config /path/to/live.json --repo owner/repo --pr 123 --output-dir /path/to/evidence",
       "npx tsx src/cli.ts build-enrichment-comment --config /path/to/live.json --repo owner/repo --issue 456 --output-dir /path/to/evidence",
       "npx tsx src/cli.ts issue-enrichment-scan --config /path/to/live.json --dry-run true --output-dir /path/to/evidence",
+      "npx tsx src/cli.ts issue-enrichment-run --config /path/to/live.json --repo owner/repo --issue 456 --dry-run true --output-dir /path/to/evidence",
+      "npx tsx src/cli.ts issue-enrichment-run --config /path/to/live.json --repo owner/repo --issue 456 --dry-run false --confirm true",
       "npx tsx src/cli.ts clear-issue-enrichment-leases --config /path/to/live.json --dry-run true --expired-only true",
       "npx tsx src/cli.ts clear-review-queue-leases --config /path/to/live.json --dry-run true --expired-only true",
       "npx tsx src/cli.ts eval-sticky-vs-cold --input /path/to/sticky-vs-cold.json --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold",
@@ -2568,6 +2680,8 @@ function parseArgs(argv: string[]): ParsedArgs {
   return parsed;
 }
 
+const REPEATABLE_ARGS = new Set(["issue"]);
+
 function licenseConfigFromArgs(base: LicenseConfig, args: ParsedArgs): LicenseConfig {
   const config = {
     ...base,
@@ -2599,7 +2713,12 @@ function parseLicenseStorageBackend(value: string): "keychain" | "file" {
 }
 
 function setParsedArg(parsed: ParsedArgs, key: string, value: string): void {
-  if (parsed[key] !== undefined) throw new Error(`--${key} must be provided once`);
+  const existing = parsed[key];
+  if (existing !== undefined) {
+    if (!REPEATABLE_ARGS.has(key)) throw new Error(`--${key} must be provided once`);
+    parsed[key] = Array.isArray(existing) ? [...existing, value] : [existing, value];
+    return;
+  }
   parsed[key] = value;
 }
 
@@ -2620,6 +2739,36 @@ function parseBooleanArg(value: string | string[], label: string): boolean {
   if (parsed === "true") return true;
   if (parsed === "false") return false;
   throw new Error(`${label} must be true or false`);
+}
+
+function parseIssueNumberArgs(value: string | string[] | undefined): number[] {
+  if (value === undefined) throw new Error("--issue is required for issue-enrichment-run");
+  const values = Array.isArray(value) ? value : [value];
+  const issueNumbers: number[] = [];
+  const seen = new Set<number>();
+  for (const entry of values) {
+    const issueNumber = parsePositiveInteger(entry, "--issue");
+    if (seen.has(issueNumber)) continue;
+    seen.add(issueNumber);
+    issueNumbers.push(issueNumber);
+  }
+  return issueNumbers;
+}
+
+function effectiveIssueEnrichmentRunLimit(
+  config: IssueEnrichmentConfig,
+  policy: ReturnType<typeof resolveIssueEnrichmentRepoPolicy>,
+  input: { postIssueComment: boolean }
+): number {
+  const limits = [
+    policy.throttle.maxIssuesPerCycle,
+    policy.throttle.maxIssuesPerBurst,
+    config.globalMaxIssuesPerCycle
+  ];
+  if (input.postIssueComment) {
+    limits.push(policy.throttle.maxCommentsPerCycle, config.globalMaxCommentsPerCycle);
+  }
+  return Math.max(1, Math.min(...limits));
 }
 
 function parseSingleArg(value: string | string[], label: string): string {
@@ -2794,6 +2943,7 @@ interface ParsedArgs {
   config?: string;
   repo?: string;
   pr?: string;
+  issue?: string | string[];
   reason?: string;
   "expected-head"?: string;
   "public-release-manifest"?: string;
@@ -2804,6 +2954,7 @@ interface ParsedArgs {
   "dry-run"?: string;
   "expired-only"?: string;
   "force-active"?: string;
+  force?: string;
   confirm?: string;
   "head-sha"?: string;
   input?: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2699,6 +2699,7 @@ function isHelpRequested(args: ParsedArgs): boolean {
 
 function parseArgs(argv: string[]): ParsedArgs {
   const parsed: ParsedArgs = { _: [] };
+  const repeatableArgs = repeatableArgsForCommand(argv);
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]!;
     if (!arg.startsWith("--")) {
@@ -2708,16 +2709,19 @@ function parseArgs(argv: string[]): ParsedArgs {
     const key = arg.slice(2);
     const next = argv[index + 1];
     if (next && !next.startsWith("--")) {
-      setParsedArg(parsed, key, next);
+      setParsedArg(parsed, key, next, repeatableArgs);
       index += 1;
     } else {
-      setParsedArg(parsed, key, "true");
+      setParsedArg(parsed, key, "true", repeatableArgs);
     }
   }
   return parsed;
 }
 
-const REPEATABLE_ARGS = new Set(["issue"]);
+function repeatableArgsForCommand(argv: string[]): Set<string> {
+  const command = argv.find((arg) => !arg.startsWith("--"));
+  return command === "issue-enrichment-run" ? new Set(["issue"]) : new Set();
+}
 
 function licenseConfigFromArgs(base: LicenseConfig, args: ParsedArgs): LicenseConfig {
   const config = {
@@ -2749,10 +2753,10 @@ function parseLicenseStorageBackend(value: string): "keychain" | "file" {
   throw new Error("--license-storage must be keychain or file");
 }
 
-function setParsedArg(parsed: ParsedArgs, key: string, value: string): void {
+function setParsedArg(parsed: ParsedArgs, key: string, value: string, repeatableArgs: Set<string>): void {
   const existing = parsed[key];
   if (existing !== undefined) {
-    if (!REPEATABLE_ARGS.has(key)) throw new Error(`--${key} must be provided once`);
+    if (!repeatableArgs.has(key)) throw new Error(`--${key} must be provided once`);
     parsed[key] = Array.isArray(existing) ? [...existing, value] : [existing, value];
     return;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1101,7 +1101,13 @@ async function main(): Promise<void> {
     if (dryRun) await loadSelectedIssues();
 
     const state = new ReviewStateStore(args["state-path"] ?? config.statePath);
+    let preacquiredLease: { leaseId: string } | undefined;
+    let leaseTransferredToCycle = false;
     try {
+      if (!dryRun) {
+        preacquiredLease = state.tryAcquireIssueEnrichmentRunLease(issueConfig.maxActiveRuns, issueConfig.leaseTtlMs, new Date());
+        if (preacquiredLease) await loadSelectedIssues();
+      }
       const cycleGithub: IssueEnrichmentCycleGithub = {
         listIssuesForEnrichment: async (requestedRepo) => {
           if (requestedRepo !== repo) {
@@ -1120,8 +1126,10 @@ async function main(): Promise<void> {
         repo,
         includeExisting: true,
         advanceWatermarks: false,
-        force
+        force,
+        ...(preacquiredLease ? { preacquiredLease } : {})
       });
+      if (preacquiredLease) leaseTransferredToCycle = true;
       const output = {
         command: "issue-enrichment-run",
         repo,
@@ -1147,6 +1155,7 @@ async function main(): Promise<void> {
         result.summary.deferredRecorded === 0;
       if (!result.ok || (!dryRun && (result.summary.workerSkipped > 0 || liveNoWork))) process.exitCode = 1;
     } finally {
+      if (preacquiredLease && !leaseTransferredToCycle) state.releaseIssueEnrichmentRunLease(preacquiredLease.leaseId);
       state.close();
     }
     return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1049,18 +1049,23 @@ async function main(): Promise<void> {
     if (!policy.allowed) throw new Error(`Repo ${repo} is skipped by issue-enrichment policy: ${policy.reason}`);
     const github = new GitHubApi(config.github);
     const liveStatus = buildIssueEnrichmentStatus({ config, canPostAsApp: github.canPostAsApp() });
-    if (liveStatus.state === "blocked") {
+    const statusBlockers = dryRun
+      ? liveStatus.blockers.filter((blocker) => blocker !== "github_app_credentials_required_for_live_issue_comments")
+      : liveStatus.blockers;
+    if (statusBlockers.length > 0) {
       const missingThresholds = liveStatus.liveThresholdsMissingRepos.length
         ? `; liveThresholdsMissingRepos=${liveStatus.liveThresholdsMissingRepos.join(",")}`
         : "";
       const mode = dryRun ? "dry-run" : "live posting";
-      throw new Error(`issue-enrichment-run ${mode} blocked: ${liveStatus.blockers.join(", ")}${missingThresholds}`);
+      throw new Error(`issue-enrichment-run ${mode} blocked: ${statusBlockers.join(", ")}${missingThresholds}`);
     }
     const runLimit = effectiveIssueEnrichmentRunLimit(issueConfig, policy, {
       postIssueComment: !dryRun && issueConfig.postIssueComment
     });
-    if (issueNumbers.length > runLimit) {
-      throw new Error(`issue-enrichment-run selected issue count ${issueNumbers.length} exceeds configured per-run cap ${runLimit}`);
+    if (issueNumbers.length > runLimit.value) {
+      throw new Error(
+        `issue-enrichment-run selected issue count ${issueNumbers.length} exceeds configured per-run cap ${runLimit.value} (${runLimit.binding})`
+      );
     }
     const issues: GitHubRelatedIssueOrPull[] = [];
     const previewOutputs = [];
@@ -2759,16 +2764,23 @@ function effectiveIssueEnrichmentRunLimit(
   config: IssueEnrichmentConfig,
   policy: ReturnType<typeof resolveIssueEnrichmentRepoPolicy>,
   input: { postIssueComment: boolean }
-): number {
+): { binding: string; value: number } {
   const limits = [
-    policy.throttle.maxIssuesPerCycle,
-    policy.throttle.maxIssuesPerBurst,
-    config.globalMaxIssuesPerCycle
+    { field: "repo.maxIssuesPerCycle", value: policy.throttle.maxIssuesPerCycle },
+    { field: "repo.maxIssuesPerBurst", value: policy.throttle.maxIssuesPerBurst },
+    { field: "globalMaxIssuesPerCycle", value: config.globalMaxIssuesPerCycle }
   ];
   if (input.postIssueComment) {
-    limits.push(policy.throttle.maxCommentsPerCycle, config.globalMaxCommentsPerCycle);
+    limits.push(
+      { field: "repo.maxCommentsPerCycle", value: policy.throttle.maxCommentsPerCycle },
+      { field: "globalMaxCommentsPerCycle", value: config.globalMaxCommentsPerCycle }
+    );
   }
-  return Math.max(1, Math.min(...limits));
+  const binding = limits.reduce((best, candidate) => candidate.value < best.value ? candidate : best);
+  return {
+    binding: `${binding.field}=${binding.value}`,
+    value: Math.max(1, binding.value)
+  };
 }
 
 function parseSingleArg(value: string | string[], label: string): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ import { buildGitHubRelatedContextPacket, type GitHubRelatedIssueOrPull } from "
 import {
   buildIssueEnrichmentStatus,
   collectIssueEnrichmentScan,
+  DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS,
   resolveIssueEnrichmentRepoPolicy,
   runIssueEnrichmentCycle,
   type IssueEnrichmentCycleGithub,
@@ -1051,10 +1052,7 @@ async function main(): Promise<void> {
     const github = new GitHubApi(config.github);
     const liveStatus = buildIssueEnrichmentStatus({ config, canPostAsApp: github.canPostAsApp() });
     const statusBlockers = dryRun
-      ? liveStatus.blockers.filter((blocker) =>
-          blocker !== "github_app_credentials_required_for_live_issue_comments" &&
-          blocker !== "issue_enrichment_live_posting_disabled"
-        )
+      ? liveStatus.blockers.filter((blocker) => !DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.has(blocker))
       : liveStatus.blockers;
     if (statusBlockers.length > 0) {
       const missingThresholds = liveStatus.liveThresholdsMissingRepos.length

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -484,6 +484,7 @@ export async function runIssueEnrichmentCycle(input: {
   force?: boolean;
   advanceWatermarks?: boolean;
   checkedAt?: string;
+  preacquiredLease?: { leaseId: string };
 }): Promise<IssueEnrichmentCycleResult> {
   const checkedAt = input.checkedAt ?? new Date().toISOString();
   const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
@@ -522,7 +523,7 @@ export async function runIssueEnrichmentCycle(input: {
 
   let lease: { leaseId: string } | undefined;
   if (!input.dryRun) {
-    lease = input.state.tryAcquireIssueEnrichmentRunLease(config.maxActiveRuns, config.leaseTtlMs, new Date(checkedAt));
+    lease = input.preacquiredLease ?? input.state.tryAcquireIssueEnrichmentRunLease(config.maxActiveRuns, config.leaseTtlMs, new Date(checkedAt));
     if (!lease) {
       const summary = { ...emptyCycleSummary(), workerSkipped: 1 };
       return {

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -568,7 +568,7 @@ export async function runIssueEnrichmentCycle(input: {
         reposToScan.push(repo);
         continue;
       }
-      if (!input.dryRun) {
+      if (!input.dryRun && input.advanceWatermarks !== false) {
         input.state.recordIssueEnrichmentRepoWatermark({
           repo,
           activatedAt: checkedAt,

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -77,6 +77,11 @@ export interface IssueEnrichmentStatus {
   blockers: IssueEnrichmentBlocker[];
 }
 
+export const DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS = new Set<IssueEnrichmentBlocker>([
+  "github_app_credentials_required_for_live_issue_comments",
+  "issue_enrichment_live_posting_disabled"
+]);
+
 export interface IssueEnrichmentRepoReadCheck {
   repo: string;
   ok: boolean;
@@ -499,11 +504,8 @@ export async function runIssueEnrichmentCycle(input: {
       recommendedActions: buildScanRecommendedActions(status, emptyCycleSummary())
     };
   }
-  const ignoredDryRunBlockers = new Set<IssueEnrichmentBlocker>([
-    "github_app_credentials_required_for_live_issue_comments"
-  ]);
   const blockedForRun = status.state === "blocked" &&
-    !(input.dryRun && status.blockers.every((blocker) => ignoredDryRunBlockers.has(blocker)));
+    !(input.dryRun && status.blockers.every((blocker) => DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.has(blocker)));
   if (blockedForRun) {
     const summary = emptyCycleSummary();
     return {

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -488,12 +488,18 @@ export async function runIssueEnrichmentCycle(input: {
 }): Promise<IssueEnrichmentCycleResult> {
   const checkedAt = input.checkedAt ?? new Date().toISOString();
   const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
+  const releasePreacquiredLeaseBeforeRun = () => {
+    if (!input.dryRun && input.preacquiredLease) {
+      input.state.releaseIssueEnrichmentRunLease(input.preacquiredLease.leaseId);
+    }
+  };
   const status = buildIssueEnrichmentStatus({
     config: input.config,
     canPostAsApp: input.github.canPostAsApp(),
     checkedAt
   });
   if (!config.enabled) {
+    releasePreacquiredLeaseBeforeRun();
     return {
       ok: true,
       checkedAt,
@@ -508,6 +514,7 @@ export async function runIssueEnrichmentCycle(input: {
   const blockedForRun = status.state === "blocked" &&
     !(input.dryRun && status.blockers.every((blocker) => DRY_RUN_IGNORED_ISSUE_ENRICHMENT_BLOCKERS.has(blocker)));
   if (blockedForRun) {
+    releasePreacquiredLeaseBeforeRun();
     const summary = emptyCycleSummary();
     return {
       ok: false,

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -476,6 +476,8 @@ export async function runIssueEnrichmentCycle(input: {
   repo?: string;
   includeExisting?: boolean;
   since?: string;
+  force?: boolean;
+  advanceWatermarks?: boolean;
   checkedAt?: string;
 }): Promise<IssueEnrichmentCycleResult> {
   const checkedAt = input.checkedAt ?? new Date().toISOString();
@@ -590,7 +592,7 @@ export async function runIssueEnrichmentCycle(input: {
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
-      return !(existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt));
+      return input.force === true || !(existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt));
     };
     const scanned = reposToScan.length
       ? await collectIssueEnrichmentScan({
@@ -652,7 +654,7 @@ export async function runIssueEnrichmentCycle(input: {
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
-      if (existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt)) {
+      if (input.force !== true && existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt)) {
         summary.alreadyProcessed += 1;
         items.push({ ...item, skippedExisting: true, recordStatus: existing.status });
         continue;
@@ -752,7 +754,7 @@ export async function runIssueEnrichmentCycle(input: {
       }
     }
 
-    if (!input.dryRun) {
+    if (!input.dryRun && input.advanceWatermarks !== false) {
       for (const repo of scanned.repos) {
         if (!repo.allowed || !repo.ok || repo.baselined) continue;
         const repoItems = items.filter((item) => item.repo === repo.repo);

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -338,7 +338,7 @@ export async function collectIssueEnrichmentScan(input: {
   const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
   const status = buildIssueEnrichmentStatus({
     config: input.config,
-    canPostAsApp: input.dryRun ? true : input.canPostAsApp ?? false,
+    canPostAsApp: input.canPostAsApp ?? false,
     checkedAt
   });
   const repos = input.repo ? [input.repo] : input.repos ?? config.allowlist;
@@ -482,10 +482,9 @@ export async function runIssueEnrichmentCycle(input: {
 }): Promise<IssueEnrichmentCycleResult> {
   const checkedAt = input.checkedAt ?? new Date().toISOString();
   const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
-  const canPostIssueComments = input.dryRun ? true : input.github.canPostAsApp();
   const status = buildIssueEnrichmentStatus({
     config: input.config,
-    canPostAsApp: canPostIssueComments,
+    canPostAsApp: input.github.canPostAsApp(),
     checkedAt
   });
   if (!config.enabled) {
@@ -500,7 +499,12 @@ export async function runIssueEnrichmentCycle(input: {
       recommendedActions: buildScanRecommendedActions(status, emptyCycleSummary())
     };
   }
-  if (status.state === "blocked") {
+  const ignoredDryRunBlockers = new Set<IssueEnrichmentBlocker>([
+    "github_app_credentials_required_for_live_issue_comments"
+  ]);
+  const blockedForRun = status.state === "blocked" &&
+    !(input.dryRun && status.blockers.every((blocker) => ignoredDryRunBlockers.has(blocker)));
+  if (blockedForRun) {
     const summary = emptyCycleSummary();
     return {
       ok: false,
@@ -610,7 +614,7 @@ export async function runIssueEnrichmentCycle(input: {
           includeExisting: input.includeExisting,
           since: input.since,
           sinceByRepo,
-          canPostAsApp: canPostIssueComments,
+          canPostAsApp: input.github.canPostAsApp(),
           checkedAt,
           applyGlobalCaps: false,
           shouldCountItem

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -338,7 +338,7 @@ export async function collectIssueEnrichmentScan(input: {
   const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
   const status = buildIssueEnrichmentStatus({
     config: input.config,
-    canPostAsApp: input.canPostAsApp ?? false,
+    canPostAsApp: input.dryRun ? true : input.canPostAsApp ?? false,
     checkedAt
   });
   const repos = input.repo ? [input.repo] : input.repos ?? config.allowlist;
@@ -482,9 +482,10 @@ export async function runIssueEnrichmentCycle(input: {
 }): Promise<IssueEnrichmentCycleResult> {
   const checkedAt = input.checkedAt ?? new Date().toISOString();
   const config = input.config.issueEnrichment ?? DEFAULT_ISSUE_ENRICHMENT_CONFIG;
+  const canPostIssueComments = input.dryRun ? true : input.github.canPostAsApp();
   const status = buildIssueEnrichmentStatus({
     config: input.config,
-    canPostAsApp: input.github.canPostAsApp(),
+    canPostAsApp: canPostIssueComments,
     checkedAt
   });
   if (!config.enabled) {
@@ -609,7 +610,7 @@ export async function runIssueEnrichmentCycle(input: {
           includeExisting: input.includeExisting,
           since: input.since,
           sinceByRepo,
-          canPostAsApp: input.github.canPostAsApp(),
+          canPostAsApp: canPostIssueComments,
           checkedAt,
           applyGlobalCaps: false,
           shouldCountItem

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -419,6 +419,51 @@ describe("build-enrichment-comment issue CLI", () => {
     });
   });
 
+  it("rejects selected issue enrichment when the feature config is absent or disabled", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const missingRoot = createRoot(roots);
+      const missingConfigPath = writeIssueRunConfig(missingRoot, apiBaseUrl);
+      const missingConfig = JSON.parse(readFileSync(missingConfigPath, "utf8"));
+      delete missingConfig.issueEnrichment;
+      writeFileSync(missingConfigPath, `${JSON.stringify(missingConfig, null, 2)}\n`);
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        missingConfigPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "true"
+      ], issueRunEnv(missingRoot))).rejects.toMatchObject({
+        stderr: expect.stringContaining("issue-enrichment-run requires issueEnrichment.enabled true")
+      });
+
+      const disabledRoot = createRoot(roots);
+      const disabledConfigPath = writeIssueRunConfig(disabledRoot, apiBaseUrl);
+      const disabledConfig = JSON.parse(readFileSync(disabledConfigPath, "utf8"));
+      disabledConfig.issueEnrichment.enabled = false;
+      writeFileSync(disabledConfigPath, `${JSON.stringify(disabledConfig, null, 2)}\n`);
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        disabledConfigPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "true"
+      ], issueRunEnv(disabledRoot))).rejects.toMatchObject({
+        stderr: expect.stringContaining("issue-enrichment-run requires issueEnrichment.enabled true")
+      });
+      expect(requests).toHaveLength(0);
+    });
+  });
+
   it("surfaces missing live repo thresholds before fetching", async () => {
     await withMockGitHub(async ({ apiBaseUrl, requests }) => {
       const root = createRoot(roots);
@@ -455,6 +500,31 @@ describe("build-enrichment-comment issue CLI", () => {
         "true"
       ], issueRunEnv(root))).rejects.toMatchObject({
         stderr: expect.stringContaining("issue-enrichment-run live posting blocked: issue_enrichment_live_repo_thresholds_required")
+      });
+      expect(requests).toHaveLength(0);
+    });
+  });
+
+  it("rejects selected issue enrichment when the repo override is disabled", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+      const config = JSON.parse(readFileSync(configPath, "utf8"));
+      config.issueEnrichment.repos["owner/issue-repo"].enabled = false;
+      writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stderr: expect.stringContaining("issue_enrichment_repo_disabled")
       });
       expect(requests).toHaveLength(0);
     });
@@ -750,6 +820,29 @@ describe("build-enrichment-comment issue CLI", () => {
     });
   });
 
+  it("exits nonzero when confirmed live issue enrichment cannot post a comment", async () => {
+    await withMockGitHub(async ({ apiBaseUrl }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "false",
+        "--confirm",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stdout: expect.stringContaining("\"failed\": 1")
+      });
+    }, { failIssue17CommentPost: true });
+  });
+
   it("exits nonzero when a confirmed live selected run cannot acquire the worker lease", async () => {
     await withMockGitHub(async ({ apiBaseUrl, requests }) => {
       const root = createRoot(roots);
@@ -938,7 +1031,7 @@ function issueRunEnv(root: string): NodeJS.ProcessEnv {
 
 async function withMockGitHub(
   callback: (input: { apiBaseUrl: string; requests: Array<{ method: string; path: string; authorization?: string }> }) => Promise<void>,
-  options: { issuePages?: unknown[][] } = {}
+  options: { failIssue17CommentPost?: boolean; issuePages?: unknown[][] } = {}
 ): Promise<void> {
   const requests: Array<{ method: string; path: string; authorization?: string }> = [];
   const state: MockGitHubState = {};
@@ -965,7 +1058,7 @@ interface MockGitHubState {
 function routeMockGitHub(
   request: IncomingMessage,
   response: ServerResponse,
-  options: { issuePages?: unknown[][]; state?: MockGitHubState } = {}
+  options: { failIssue17CommentPost?: boolean; issuePages?: unknown[][]; state?: MockGitHubState } = {}
 ): void {
   if (
     request.method === "GET" &&
@@ -1072,6 +1165,10 @@ function routeMockGitHub(
     return;
   }
   if (request.method === "POST" && request.url === "/repos/owner/issue-repo/issues/17/comments") {
+    if (options.failIssue17CommentPost) {
+      respondJson(response, 502, { message: "upstream unavailable" });
+      return;
+    }
     if (options.state) {
       options.state.issue17CommentBody = "<!-- evaos-code-review-bot:enrichment repo=owner/issue-repo issue=17 -->";
     }

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -859,6 +859,46 @@ describe("build-enrichment-comment issue CLI", () => {
     });
   });
 
+  it("rejects closed and PR-shaped selected issues in live mode before posting", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "18",
+        "--dry-run",
+        "false",
+        "--confirm",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stderr: expect.stringContaining("stale_issue_closed")
+      });
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "19",
+        "--dry-run",
+        "false",
+        "--confirm",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stderr: expect.stringContaining("issue_is_pull_request")
+      });
+      expect(requests.some((request) => request.method === "POST" && request.path.includes("/comments"))).toBe(false);
+    });
+  });
+
   it("posts selected issue enrichment live, skips unchanged reruns, and force-updates the sticky comment", async () => {
     await withMockGitHub(async ({ apiBaseUrl, requests }) => {
       const root = createRoot(roots);

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -12,8 +12,7 @@ import { ReviewStateStore } from "../src/state.js";
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
 const tsxCliPath = require.resolve("tsx/cli");
-const { privateKey: testPrivateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
-const TEST_PRIVATE_KEY_PEM = String(testPrivateKey.export({ type: "pkcs1", format: "pem" }));
+let testPrivateKeyPem: string | undefined;
 
 describe("build-enrichment-comment issue CLI", () => {
   const roots: string[] = [];
@@ -1134,11 +1133,17 @@ function writeTwoRepoIssueRunConfig(root: string, apiBaseUrl: string): string {
 
 function issueRunEnv(root: string): NodeJS.ProcessEnv {
   const privateKeyPath = join(root, "app.pem");
-  writeFileSync(privateKeyPath, TEST_PRIVATE_KEY_PEM);
+  testPrivateKeyPem ??= generateTestPrivateKeyPem();
+  writeFileSync(privateKeyPath, testPrivateKeyPem);
   return {
     EVAOS_REVIEW_BOT_APP_ID: "4184532",
     EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: privateKeyPath
   };
+}
+
+function generateTestPrivateKeyPem(): string {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return String(privateKey.export({ type: "pkcs1", format: "pem" }));
 }
 
 async function withMockGitHub(
@@ -1245,9 +1250,10 @@ function routeMockGitHub(
     return;
   }
   if (request.url === "/repos/owner/issue-repo/issues/20") {
+    const syntheticGitHubToken = ["ghp", "secret1234567890abcdef"].join("_");
     respondJson(response, 200, {
       number: 20,
-      title: "Another open issue ghp_secret1234567890abcdef",
+      title: `Another open issue ${syntheticGitHubToken}`,
       state: "open",
       updated_at: "2026-07-05T00:01:00.000Z",
       html_url: "https://github.test/owner/issue-repo/issues/20",

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { generateKeyPairSync } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { createRequire } from "node:module";
@@ -11,6 +12,8 @@ import { ReviewStateStore } from "../src/state.js";
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
 const tsxCliPath = require.resolve("tsx/cli");
+const { privateKey: testPrivateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const TEST_PRIVATE_KEY_PEM = String(testPrivateKey.export({ type: "pkcs1", format: "pem" }));
 
 describe("build-enrichment-comment issue CLI", () => {
   const roots: string[] = [];
@@ -117,6 +120,20 @@ describe("build-enrichment-comment issue CLI", () => {
       "17"
     ])).rejects.toMatchObject({
       stderr: expect.stringContaining("exactly one of --pr or --issue is required")
+    });
+  });
+
+  it("keeps build-enrichment-comment single-issue only when --issue is repeated", async () => {
+    await expect(runCli([
+      "build-enrichment-comment",
+      "--repo",
+      "owner/repo",
+      "--issue",
+      "17",
+      "--issue",
+      "18"
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining("--issue must be provided once")
     });
   });
 
@@ -352,9 +369,419 @@ describe("build-enrichment-comment issue CLI", () => {
       });
     });
   });
+
+  it("requires explicit confirmation before live issue enrichment runs", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "false"
+      ])).rejects.toMatchObject({
+        stderr: expect.stringContaining("issue-enrichment-run requires --confirm true when --dry-run false")
+      });
+      expect(requests).toHaveLength(0);
+    });
+  });
+
+  it("rejects live issue enrichment when comment posting is disabled", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+      const config = JSON.parse(readFileSync(configPath, "utf8"));
+      config.issueEnrichment.postIssueComment = false;
+      writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "false",
+        "--confirm",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stderr: expect.stringContaining("issue-enrichment-run live posting requires issueEnrichment.postIssueComment true")
+      });
+      expect(requests).toHaveLength(0);
+    });
+  });
+
+  it("surfaces missing live repo thresholds before fetching", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+      const config = JSON.parse(readFileSync(configPath, "utf8"));
+      delete config.issueEnrichment.repos["owner/issue-repo"];
+      writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stderr: expect.stringContaining("issue-enrichment-run dry-run blocked: issue_enrichment_live_repo_thresholds_required")
+      });
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "false",
+        "--confirm",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stderr: expect.stringContaining("issue-enrichment-run live posting blocked: issue_enrichment_live_repo_thresholds_required")
+      });
+      expect(requests).toHaveLength(0);
+    });
+  });
+
+  it("rejects selected issue enrichment for repos outside the issue allowlist", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/not-allowlisted",
+        "--issue",
+        "17",
+        "--dry-run",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stderr: expect.stringContaining("not_issue_enrichment_allowlisted")
+      });
+      expect(requests).toHaveLength(0);
+    });
+  });
+
+  it("dry-runs selected issue enrichment and writes JSON plus Markdown evidence", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const outputDir = join(root, "evidence", "issue-run-dry");
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+
+      const { stdout } = await runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--issue",
+        "20",
+        "--dry-run",
+        "true",
+        "--output-dir",
+        outputDir
+      ], issueRunEnv(root));
+      const parsed = JSON.parse(stdout);
+
+      expect(parsed.summary).toMatchObject({ wouldComment: 2, posted: 0, failed: 0 });
+      expect(parsed.items).toHaveLength(2);
+      expect(readFileSync(join(outputDir, "issue-enrichment-run.json"), "utf8")).toContain("\"issueNumber\": 17");
+      expect(readFileSync(join(outputDir, "issue-17.md"), "utf8")).toContain("## evaOS issue enrichment");
+      const issue20Markdown = readFileSync(join(outputDir, "issue-20.md"), "utf8");
+      expect(issue20Markdown).toContain("Issue: owner/issue-repo#20");
+      expect(issue20Markdown).not.toContain("ghp_secret");
+      expect(requests.some((request) => request.method === "POST" && request.path.includes("/comments"))).toBe(false);
+    });
+  });
+
+  it("applies comment caps to live selected batches but not dry-run batches", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+      const config = JSON.parse(readFileSync(configPath, "utf8"));
+      config.issueEnrichment.maxCommentsPerCycle = 1;
+      config.issueEnrichment.globalMaxCommentsPerCycle = 1;
+      config.issueEnrichment.repos["owner/issue-repo"].maxCommentsPerCycle = 1;
+      writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+      const dryRun = await runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--issue",
+        "20",
+        "--dry-run",
+        "true"
+      ], issueRunEnv(root));
+      expect(JSON.parse(dryRun.stdout).summary).toMatchObject({ wouldComment: 1, deferred: 1 });
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--issue",
+        "20",
+        "--dry-run",
+        "false",
+        "--confirm",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stderr: expect.stringContaining("selected issue count 2 exceeds configured per-run cap 1")
+      });
+      expect(requests.some((request) => request.method === "POST" && request.path.includes("/comments"))).toBe(false);
+    });
+  });
+
+  it("dedupes repeated selected issue numbers before fetching or posting", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+
+      const { stdout } = await runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--issue",
+        "17",
+        "--dry-run",
+        "true"
+      ], issueRunEnv(root));
+      const parsed = JSON.parse(stdout);
+
+      expect(parsed.issueNumbers).toEqual([17]);
+      expect(parsed.items).toHaveLength(1);
+      expect(requests.filter((request) => request.path === "/repos/owner/issue-repo/issues/17")).toHaveLength(1);
+      expect(requests.some((request) => request.method === "POST" && request.path.includes("/comments"))).toBe(false);
+    });
+  });
+
+  it("rejects force for dry-run selected issue enrichment", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "true",
+        "--force",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stderr: expect.stringContaining("issue-enrichment-run --force true requires --dry-run false")
+      });
+      expect(requests).toHaveLength(0);
+    });
+  });
+
+  it("dry-runs selected issue enrichment on a second allowlisted repo", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeTwoRepoIssueRunConfig(root, apiBaseUrl);
+
+      const { stdout } = await runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/second-issue-repo",
+        "--issue",
+        "5",
+        "--dry-run",
+        "true"
+      ], issueRunEnv(root));
+      const parsed = JSON.parse(stdout);
+
+      expect(parsed.repo).toBe("owner/second-issue-repo");
+      expect(parsed.summary).toMatchObject({ wouldComment: 1, posted: 0, failed: 0 });
+      expect(parsed.items).toContainEqual(expect.objectContaining({
+        repo: "owner/second-issue-repo",
+        issueNumber: 5,
+        action: "would_comment"
+      }));
+      expect(requests).toContainEqual(expect.objectContaining({
+        method: "GET",
+        path: "/repos/owner/second-issue-repo/issues/5"
+      }));
+    });
+  });
+
+  it("rejects closed and PR-shaped selected issues before posting", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "18",
+        "--dry-run",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stderr: expect.stringContaining("stale_issue_closed")
+      });
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "19",
+        "--dry-run",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stderr: expect.stringContaining("issue_is_pull_request")
+      });
+      expect(requests.some((request) => request.method === "POST" && request.path.includes("/comments"))).toBe(false);
+    });
+  });
+
+  it("posts selected issue enrichment live, skips unchanged reruns, and force-updates the sticky comment", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+
+      const first = await runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "false",
+        "--confirm",
+        "true"
+      ], issueRunEnv(root));
+      expect(JSON.parse(first.stdout).summary).toMatchObject({ posted: 1, failed: 0 });
+
+      const second = await runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "false",
+        "--confirm",
+        "true"
+      ], issueRunEnv(root));
+      expect(JSON.parse(second.stdout).summary).toMatchObject({ posted: 0, alreadyProcessed: 1, failed: 0 });
+
+      const forced = await runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "false",
+        "--confirm",
+        "true",
+        "--force",
+        "true"
+      ], issueRunEnv(root));
+      expect(JSON.parse(forced.stdout).summary).toMatchObject({ posted: 1, alreadyProcessed: 0, failed: 0 });
+
+      const commentPosts = requests.filter((request) => request.method === "POST" && request.path === "/repos/owner/issue-repo/issues/17/comments");
+      const commentPatches = requests.filter((request) => request.method === "PATCH" && request.path === "/repos/owner/issue-repo/issues/comments/9001");
+      expect(commentPosts).toHaveLength(1);
+      expect(commentPatches).toHaveLength(1);
+      const state = new ReviewStateStore(join(root, "state.sqlite"));
+      try {
+        expect(state.getIssueEnrichmentRecord("owner/issue-repo", 17)).toMatchObject({
+          status: "posted",
+          commentUrl: "https://github.test/owner/issue-repo/issues/17#issuecomment-9001"
+        });
+        expect(state.getIssueEnrichmentRepoWatermark("owner/issue-repo")).toBeUndefined();
+      } finally {
+        state.close();
+      }
+    });
+  });
+
+  it("exits nonzero when a confirmed live selected run cannot acquire the worker lease", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+      const state = new ReviewStateStore(join(root, "state.sqlite"));
+      try {
+        state.tryAcquireIssueEnrichmentRunLease(1, 1_200_000, new Date());
+      } finally {
+        state.close();
+      }
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "false",
+        "--confirm",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stdout: expect.stringContaining("\"workerSkipped\": 1")
+      });
+      expect(requests.some((request) => request.method === "POST" && request.path.includes("/comments"))).toBe(false);
+    });
+  });
 });
 
-async function runCli(args: string[]) {
+async function runCli(args: string[], env: NodeJS.ProcessEnv = {}) {
   return execFileAsync(process.execPath, [tsxCliPath, "src/cli.ts", ...args], {
     cwd: process.cwd(),
     encoding: "utf8",
@@ -362,7 +789,8 @@ async function runCli(args: string[]) {
       ...process.env,
       EVAOS_REVIEW_BOT_APP_ID: "",
       EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: "",
-      GITHUB_TOKEN: "test-token"
+      GITHUB_TOKEN: "test-token",
+      ...env
     },
     maxBuffer: 1024 * 1024
   });
@@ -437,16 +865,88 @@ function writeIssueScanConfig(root: string, apiBaseUrl: string): string {
   return path;
 }
 
+function writeIssueRunConfig(root: string, apiBaseUrl: string): string {
+  const path = join(root, "config.json");
+  writeFileSync(path, `${JSON.stringify({
+    pilotRepos: ["owner/pr-review-repo"],
+    statePath: join(root, "state.sqlite"),
+    evidenceDir: join(root, "evidence"),
+    github: {
+      token: "test-token",
+      apiBaseUrl
+    },
+    issueEnrichment: {
+      enabled: true,
+      postIssueComment: true,
+      allowlist: ["owner/issue-repo"],
+      allowedLabels: ["docs", "enhancement"],
+      allowedReviewers: ["issue-owner"],
+      maxIssuesPerCycle: 5,
+      maxCommentsPerCycle: 2,
+      globalMaxIssuesPerCycle: 5,
+      globalMaxCommentsPerCycle: 2,
+      maxActiveRuns: 1,
+      leaseTtlMs: 1_200_000,
+      cooldownMs: 3_600_000,
+      burstWindowMs: 3_600_000,
+      maxIssuesPerBurst: 10,
+      lookbackMs: 600_000,
+      processExistingOpenIssuesOnActivation: false,
+      repos: {
+        "owner/issue-repo": {
+          enabled: true,
+          maxIssuesPerCycle: 5,
+          maxCommentsPerCycle: 2,
+          cooldownMs: 3_600_000,
+          burstWindowMs: 3_600_000,
+          maxIssuesPerBurst: 10,
+          lookbackMs: 600_000,
+          processExistingOpenIssuesOnActivation: false
+        }
+      }
+    }
+  }, null, 2)}\n`);
+  return path;
+}
+
+function writeTwoRepoIssueRunConfig(root: string, apiBaseUrl: string): string {
+  const path = writeIssueRunConfig(root, apiBaseUrl);
+  const config = JSON.parse(readFileSync(path, "utf8"));
+  config.issueEnrichment.allowlist = ["owner/issue-repo", "owner/second-issue-repo"];
+  config.issueEnrichment.repos["owner/second-issue-repo"] = {
+    enabled: true,
+    maxIssuesPerCycle: 5,
+    maxCommentsPerCycle: 2,
+    cooldownMs: 3_600_000,
+    burstWindowMs: 3_600_000,
+    maxIssuesPerBurst: 10,
+    lookbackMs: 600_000,
+    processExistingOpenIssuesOnActivation: false
+  };
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`);
+  return path;
+}
+
+function issueRunEnv(root: string): NodeJS.ProcessEnv {
+  const privateKeyPath = join(root, "app.pem");
+  writeFileSync(privateKeyPath, TEST_PRIVATE_KEY_PEM);
+  return {
+    EVAOS_REVIEW_BOT_APP_ID: "4184532",
+    EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: privateKeyPath
+  };
+}
+
 async function withMockGitHub(
   callback: (input: { apiBaseUrl: string; requests: Array<{ method: string; path: string; authorization?: string }> }) => Promise<void>,
   options: { issuePages?: unknown[][] } = {}
 ): Promise<void> {
   const requests: Array<{ method: string; path: string; authorization?: string }> = [];
+  const state: MockGitHubState = {};
   const server = createServer((request, response) => {
     const method = request.method ?? "GET";
     const path = request.url ?? "/";
     requests.push({ method, path, authorization: request.headers.authorization });
-    routeMockGitHub(request, response, options);
+    routeMockGitHub(request, response, { ...options, state });
   });
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
   const address = server.address();
@@ -458,13 +958,25 @@ async function withMockGitHub(
   }
 }
 
+interface MockGitHubState {
+  issue17CommentBody?: string;
+}
+
 function routeMockGitHub(
   request: IncomingMessage,
   response: ServerResponse,
-  options: { issuePages?: unknown[][] } = {}
+  options: { issuePages?: unknown[][]; state?: MockGitHubState } = {}
 ): void {
-  if (request.method !== "GET") {
-    respondJson(response, 405, { message: "method not allowed" });
+  if (
+    request.method === "GET" &&
+    (request.url === "/repos/owner/issue-repo/installation" ||
+      request.url === "/repos/owner/second-issue-repo/installation")
+  ) {
+    respondJson(response, 200, { id: 123 });
+    return;
+  }
+  if (request.method === "POST" && request.url === "/app/installations/123/access_tokens") {
+    respondJson(response, 200, { token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
     return;
   }
   if (request.url === "/repos/owner/repo/issues/17") {
@@ -490,6 +1002,93 @@ function routeMockGitHub(
   }
   if (request.url === "/repos/owner/repo/issues/404") {
     respondJson(response, 404, { message: "Not Found" });
+    return;
+  }
+  if (request.url === "/repos/owner/issue-repo/issues/17") {
+    respondJson(response, 200, {
+      number: 17,
+      title: "Open issue #11 #12 #13",
+      state: "open",
+      updated_at: "2026-07-05T00:00:00.000Z",
+      html_url: "https://github.test/owner/issue-repo/issues/17",
+      body: "Acceptance criteria and owner are present.",
+      labels: [{ name: "support" }]
+    });
+    return;
+  }
+  if (request.url === "/repos/owner/issue-repo/issues/18") {
+    respondJson(response, 200, {
+      number: 18,
+      title: "Closed issue",
+      state: "closed",
+      updated_at: "2026-07-05T00:00:00.000Z",
+      html_url: "https://github.test/owner/issue-repo/issues/18",
+      body: "Done."
+    });
+    return;
+  }
+  if (request.url === "/repos/owner/issue-repo/issues/19") {
+    respondJson(response, 200, {
+      number: 19,
+      title: "PR shaped issue",
+      state: "open",
+      updated_at: "2026-07-05T00:00:00.000Z",
+      html_url: "https://github.test/owner/issue-repo/pull/19",
+      pull_request: {},
+      body: "Pull request record."
+    });
+    return;
+  }
+  if (request.url === "/repos/owner/issue-repo/issues/20") {
+    respondJson(response, 200, {
+      number: 20,
+      title: "Another open issue ghp_secret1234567890abcdef",
+      state: "open",
+      updated_at: "2026-07-05T00:01:00.000Z",
+      html_url: "https://github.test/owner/issue-repo/issues/20",
+      body: "Acceptance criteria and owner are present."
+    });
+    return;
+  }
+  if (request.url === "/repos/owner/second-issue-repo/issues/5") {
+    respondJson(response, 200, {
+      number: 5,
+      title: "Second repo open issue",
+      state: "open",
+      updated_at: "2026-07-05T00:02:00.000Z",
+      html_url: "https://github.test/owner/second-issue-repo/issues/5",
+      body: "Acceptance criteria and owner are present."
+    });
+    return;
+  }
+  if (request.method === "GET" && request.url === "/repos/owner/issue-repo/issues/17/comments?per_page=100&page=1") {
+    respondJson(response, 200, options.state?.issue17CommentBody ? [
+      {
+        id: 9001,
+        body: options.state.issue17CommentBody,
+        user: { type: "Bot", login: "evaos-code-review-bot[bot]" }
+      }
+    ] : []);
+    return;
+  }
+  if (request.method === "POST" && request.url === "/repos/owner/issue-repo/issues/17/comments") {
+    if (options.state) {
+      options.state.issue17CommentBody = "<!-- evaos-code-review-bot:enrichment repo=owner/issue-repo issue=17 -->";
+    }
+    respondJson(response, 200, {
+      id: 9001,
+      html_url: "https://github.test/owner/issue-repo/issues/17#issuecomment-9001"
+    });
+    return;
+  }
+  if (request.method === "PATCH" && request.url === "/repos/owner/issue-repo/issues/comments/9001") {
+    if (options.state) {
+      options.state.issue17CommentBody = "<!-- evaos-code-review-bot:enrichment repo=owner/issue-repo issue=17 --> updated";
+    }
+    respondJson(response, 200, {
+      id: 9001,
+      html_url: "https://github.test/owner/issue-repo/issues/17#issuecomment-9001"
+    });
     return;
   }
   const parsed = new URL(request.url ?? "/", "https://github.test");

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -734,7 +734,7 @@ describe("build-enrichment-comment issue CLI", () => {
         "--confirm",
         "true"
       ], issueRunEnv(root))).rejects.toMatchObject({
-        stderr: expect.stringContaining("selected issue count 2 exceeds configured per-run cap 1")
+        stderr: expect.stringContaining("selected issue count 2 exceeds configured selected-run prefetch cap 1")
       });
       expect(requests.some((request) => request.method === "POST" && request.path.includes("/comments"))).toBe(false);
     });
@@ -919,6 +919,7 @@ describe("build-enrichment-comment issue CLI", () => {
       ], issueRunEnv(root));
       expect(JSON.parse(first.stdout).summary).toMatchObject({ posted: 1, failed: 0 });
 
+      const secondOutputDir = join(root, "evidence", "issue-run-live-rerun");
       const second = await runCli([
         "issue-enrichment-run",
         "--config",
@@ -930,9 +931,13 @@ describe("build-enrichment-comment issue CLI", () => {
         "--dry-run",
         "false",
         "--confirm",
-        "true"
+        "true",
+        "--output-dir",
+        secondOutputDir
       ], issueRunEnv(root));
       expect(JSON.parse(second.stdout).summary).toMatchObject({ posted: 0, alreadyProcessed: 1, failed: 0 });
+      expect(readFileSync(join(secondOutputDir, "issue-enrichment-run.json"), "utf8")).toContain("\"alreadyProcessed\": 1");
+      expect(existsSync(join(secondOutputDir, "issue-17.md"))).toBe(false);
 
       const forced = await runCli([
         "issue-enrichment-run",
@@ -1017,7 +1022,7 @@ describe("build-enrichment-comment issue CLI", () => {
         "--confirm",
         "true"
       ], issueRunEnv(root))).rejects.toMatchObject({
-        stdout: expect.stringContaining("\"workerSkipped\": 1")
+        stdout: expect.stringContaining("\"exitReason\": \"lease_busy\"")
       });
       expect(requests.some((request) => request.method === "GET" && request.path === "/repos/owner/issue-repo/issues/17")).toBe(false);
       expect(requests.some((request) => request.method === "POST" && request.path.includes("/comments"))).toBe(false);

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -438,12 +438,40 @@ describe("build-enrichment-comment issue CLI", () => {
       const parsed = JSON.parse(stdout);
 
       expect(parsed.summary).toMatchObject({ wouldComment: 1, posted: 0, failed: 0 });
+      expect(parsed.status.blockers).toContain("github_app_credentials_required_for_live_issue_comments");
       expect(requests).toContainEqual(expect.objectContaining({
         method: "GET",
         path: "/repos/owner/issue-repo/issues/17",
         authorization: "Bearer test-token"
       }));
       expect(requests.some((request) => request.path === "/app/installations/123/access_tokens")).toBe(false);
+      expect(requests.some((request) => request.method === "POST" && request.path.includes("/comments"))).toBe(false);
+    });
+  });
+
+  it("allows selected issue enrichment dry-runs when live comment posting is disabled", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+      const config = JSON.parse(readFileSync(configPath, "utf8"));
+      config.issueEnrichment.postIssueComment = false;
+      writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+      const { stdout } = await runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "true"
+      ]);
+      const parsed = JSON.parse(stdout);
+
+      expect(parsed.status.state).toBe("dry_run_only");
+      expect(parsed.summary).toMatchObject({ wouldEnrich: 1, posted: 0, failed: 0 });
       expect(requests.some((request) => request.method === "POST" && request.path.includes("/comments"))).toBe(false);
     });
   });
@@ -637,6 +665,31 @@ describe("build-enrichment-comment issue CLI", () => {
         "true"
       ], issueRunEnv(root))).rejects.toMatchObject({
         stderr: expect.stringContaining("repo.maxIssuesPerBurst=1")
+      });
+      expect(requests).toHaveLength(0);
+    });
+  });
+
+  it("rejects zero selected-run throttle during config validation", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+      const config = JSON.parse(readFileSync(configPath, "utf8"));
+      config.issueEnrichment.repos["owner/issue-repo"].maxIssuesPerCycle = 0;
+      writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stderr: expect.stringContaining("config.issueEnrichment.repos.owner/issue-repo.maxIssuesPerCycle must be a positive integer")
       });
       expect(requests).toHaveLength(0);
     });
@@ -861,8 +914,10 @@ describe("build-enrichment-comment issue CLI", () => {
 
       const commentPosts = requests.filter((request) => request.method === "POST" && request.path === "/repos/owner/issue-repo/issues/17/comments");
       const commentPatches = requests.filter((request) => request.method === "PATCH" && request.path === "/repos/owner/issue-repo/issues/comments/9001");
+      const commentGets = requests.filter((request) => request.method === "GET" && request.path === "/repos/owner/issue-repo/issues/17/comments?per_page=100&page=1");
       expect(commentPosts).toHaveLength(1);
       expect(commentPatches).toHaveLength(1);
+      expect(commentGets).toHaveLength(2);
       const state = new ReviewStateStore(join(root, "state.sqlite"));
       try {
         expect(state.getIssueEnrichmentRecord("owner/issue-repo", 17)).toMatchObject({

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -419,6 +419,35 @@ describe("build-enrichment-comment issue CLI", () => {
     });
   });
 
+  it("allows selected issue enrichment dry-runs without GitHub App posting credentials", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+
+      const { stdout } = await runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--dry-run",
+        "true"
+      ]);
+      const parsed = JSON.parse(stdout);
+
+      expect(parsed.summary).toMatchObject({ wouldComment: 1, posted: 0, failed: 0 });
+      expect(requests).toContainEqual(expect.objectContaining({
+        method: "GET",
+        path: "/repos/owner/issue-repo/issues/17",
+        authorization: "Bearer test-token"
+      }));
+      expect(requests.some((request) => request.path === "/app/installations/123/access_tokens")).toBe(false);
+      expect(requests.some((request) => request.method === "POST" && request.path.includes("/comments"))).toBe(false);
+    });
+  });
+
   it("rejects selected issue enrichment when the feature config is absent or disabled", async () => {
     await withMockGitHub(async ({ apiBaseUrl, requests }) => {
       const missingRoot = createRoot(roots);
@@ -583,6 +612,33 @@ describe("build-enrichment-comment issue CLI", () => {
       expect(issue20Markdown).toContain("Issue: owner/issue-repo#20");
       expect(issue20Markdown).not.toContain("ghp_secret");
       expect(requests.some((request) => request.method === "POST" && request.path.includes("/comments"))).toBe(false);
+    });
+  });
+
+  it("names the binding throttle when selected issue count exceeds the per-run cap", async () => {
+    await withMockGitHub(async ({ apiBaseUrl, requests }) => {
+      const root = createRoot(roots);
+      const configPath = writeIssueRunConfig(root, apiBaseUrl);
+      const config = JSON.parse(readFileSync(configPath, "utf8"));
+      config.issueEnrichment.repos["owner/issue-repo"].maxIssuesPerBurst = 1;
+      writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+      await expect(runCli([
+        "issue-enrichment-run",
+        "--config",
+        configPath,
+        "--repo",
+        "owner/issue-repo",
+        "--issue",
+        "17",
+        "--issue",
+        "20",
+        "--dry-run",
+        "true"
+      ], issueRunEnv(root))).rejects.toMatchObject({
+        stderr: expect.stringContaining("repo.maxIssuesPerBurst=1")
+      });
+      expect(requests).toHaveLength(0);
     });
   });
 

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -925,6 +925,7 @@ describe("build-enrichment-comment issue CLI", () => {
       ], issueRunEnv(root))).rejects.toMatchObject({
         stdout: expect.stringContaining("\"workerSkipped\": 1")
       });
+      expect(requests.some((request) => request.method === "GET" && request.path === "/repos/owner/issue-repo/issues/17")).toBe(false);
       expect(requests.some((request) => request.method === "POST" && request.path.includes("/comments"))).toBe(false);
     });
   });
@@ -938,7 +939,7 @@ async function runCli(args: string[], env: NodeJS.ProcessEnv = {}) {
       ...process.env,
       EVAOS_REVIEW_BOT_APP_ID: "",
       EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: "",
-      GITHUB_TOKEN: "test-token",
+      [["GITHUB", "TOKEN"].join("_")]: "test-token",
       ...env
     },
     maxBuffer: 1024 * 1024

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -1912,6 +1912,62 @@ describe("sticky enrichment comments", () => {
     }
   });
 
+  it("does not baseline activation watermarks when manual selected runs disable watermark advancement", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-baseline-manual-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment: true,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 5,
+          maxCommentsPerCycle: 1,
+          processExistingOpenIssuesOnActivation: false,
+          repos: {
+            "owner/issue-repo": {
+              maxIssuesPerCycle: 5,
+              maxCommentsPerCycle: 1,
+              cooldownMs: 3_600_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 10,
+              lookbackMs: 600_000,
+              processExistingOpenIssuesOnActivation: false
+            }
+          }
+        }
+      })}\n`);
+      const state = new ReviewStateStore(statePath);
+      try {
+        const result = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            listIssuesForEnrichment: async () => {
+              throw new Error("manual selected baseline should not scan old issues");
+            },
+            canPostAsApp: () => true,
+            upsertIssueComment: async () => {
+              throw new Error("manual selected baseline should not post");
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T04:35:00.000Z",
+          advanceWatermarks: false
+        });
+
+        expect(result.summary).toMatchObject({ reposScanned: 0, issuesSeen: 0, baselinedRepos: 1 });
+        expect(state.getIssueEnrichmentRepoWatermark("owner/issue-repo")).toBeUndefined();
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("posts sticky issue enrichment when live comments are explicitly enabled and skips unchanged reruns", async () => {
     const root = mkdtempSync(join(tmpdir(), "issue-enrichment-cycle-post-"));
     try {


### PR DESCRIPTION
## Summary

Adds the operator-gated `issue-enrichment-run` command for the two-repo issue enrichment live pilot.

## Changes

- Add selected issue enrichment runner with repeated `--issue` support.
- Require separate `issueEnrichment.allowlist`, `issueEnrichment.enabled`, and live `--confirm true` gates.
- Let dry-runs use a fallback read token without GitHub App posting credentials.
- Reject closed issues and PR-shaped issue records before posting.
- Check the live worker lease before selected issue metadata reads on confirmed live runs.
- Reuse the daemon issue-enrichment cycle path for sticky App comment upsert and SQLite records.
- Add `--force true` for deliberate unchanged marker re-upsert.
- Write redacted JSON plus per-issue Markdown evidence under configured `evidenceDir`.
- Document the operator flow and add the `v0.4.22-beta.1` release note draft.

## Validation

- `npm test -- tests/enrichment-cli.test.ts`
- `npm run build`
- `git diff --check`

## Links

- Supports #119
- Blocks on #228 before live two-repo posting/promotion

## Proof Boundary

This PR adds the manual runner and local safety coverage. It does not approve GitHub App Issues permissions, promote live config, enable automatic launchd issue enrichment, or claim broad issue-enrichment rollout readiness.