### PR TITLE
Prepare NeonDiff public beta package release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build-test-package:
+    name: Build, test, and package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 26
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Focused public release tests
+        run: npx vitest run tests/public-release-readiness.test.ts tests/public-community-funnel.test.ts tests/public-cli.test.ts tests/license.test.ts tests/release-status.test.ts --pool=forks --maxWorkers=1
+
+      - name: Full test suite
+        run: npm test -- --pool=forks --maxWorkers=1
+
+      - name: Package packlist
+        run: |
+          npm pack --dry-run --json > pack.json
+          node scripts/check-packlist.mjs pack.json
+
+      - name: Forbidden public claims scan
+        run: node scripts/check-public-claims.mjs
+
+      - name: Secret scan
+        run: node scripts/check-secret-scan.mjs

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -50,4 +50,6 @@ jobs:
           node scripts/check-packlist.mjs pack.json
 
       - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,53 @@
+name: Publish npm
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish
+        required: true
+        default: v1.0.0-beta.1
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish neondiff
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == true }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+
+      - name: Require v1.0.0-beta.1
+        run: |
+          test "${{ github.event.inputs.tag || github.event.release.tag_name }}" = "v1.0.0-beta.1"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 26
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify package
+        run: |
+          npx vitest run tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1
+          npm pack --dry-run --json > pack.json
+          node scripts/check-packlist.mjs pack.json
+
+      - name: Publish
+        run: npm publish --provenance --access public

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@ If you are a coding agent working in this repository:
 - Private and commercial repos require a paid license.
 - License keys support paid/private usage and update entitlement.
 - Exact license text, public/private grants, and commercial terms are governed
-  by https://github.com/electricsheephq/evaos-code-review-bot/issues/104.
+  by https://github.com/electricsheephq/neondiff/issues/104. Public beta
+  release readiness is tracked by https://github.com/electricsheephq/neondiff/issues/232.
 
 Do not claim open-source/MIT status, public launch completion, GA readiness,
 CodeRabbit parity, enterprise readiness, or legal adequacy from this file.
@@ -38,7 +39,7 @@ CodeRabbit parity, enterprise readiness, or legal adequacy from this file.
 
 - GitHub issues and PRs are implementation truth.
 - The NeonDiff public product roadmap is #103.
-- Public CLI/package setup is #107.
+- Public CLI/package setup is #107 and release-readiness packaging is #232.
 - Agent-first docs are #113.
 - Website changes live in `electricsheephq/neon-diff-agent`, not this repo.
 - Before merge, release, or readiness claims, query current-head review threads

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,8 @@ contributions are focused, test-backed, and careful about public claims.
 - [GitHub App setup](docs/github-app-setup.md)
 - [Security policy](SECURITY.md)
 - [Code of Conduct](CODE_OF_CONDUCT.md)
-- [Product roadmap](https://github.com/electricsheephq/evaos-code-review-bot/issues/103)
+- [Product roadmap](https://github.com/electricsheephq/neondiff/issues/103)
+- [Public beta release readiness](https://github.com/electricsheephq/neondiff/issues/232)
 
 ## Issue Routing
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ source-available beta, not an open-source or GA release.
 [Code of Conduct](CODE_OF_CONDUCT.md) · [License](LICENSE.md) ·
 [License Boundary](docs/license-boundary.md) · [Pricing](docs/pricing.md) ·
 [Providers](docs/providers.md) ·
-[Roadmap](https://github.com/electricsheephq/evaos-code-review-bot/issues/103)
+[Roadmap](https://github.com/electricsheephq/neondiff/issues/103) ·
+[Repository](https://github.com/electricsheephq/neondiff)
 
 ## Why It Matters
 
@@ -61,23 +62,36 @@ Requirements:
 - a model/provider path configured locally, such as GLM/Z.ai, Ollama, or a
   future OpenAI-compatible provider slot
 
-Source checkout install for the current beta:
+Recommended package install for the current beta:
 
 ```bash
-git clone https://github.com/electricsheephq/evaos-code-review-bot.git neondiff
+npm install -g neondiff@1.0.0-beta.1
+```
+
+Installer script path:
+
+```bash
+curl -fsSL https://neondiff.sh/install | sh
+```
+
+The installer script checks for Node.js 26 or newer and installs the same npm
+package. To preview without changing your machine:
+
+```bash
+curl -fsSL https://neondiff.sh/install | sh -s -- --dry-run
+```
+
+Source checkout fallback:
+
+```bash
+git clone https://github.com/electricsheephq/neondiff.git neondiff
 cd neondiff
 npm install
 npm run build
-npm link
 ```
 
-The source checkout exposes the beta `neondiff` binary through `npm link`.
-If you intentionally skip linking, substitute `./dist/src/cli.js` anywhere this
-guide calls `neondiff`. Public npm/package distribution stays blocked until the license gate in
-[issue #104](https://github.com/electricsheephq/evaos-code-review-bot/issues/104)
-and the distribution work in
-[issue #107](https://github.com/electricsheephq/evaos-code-review-bot/issues/107)
-are both resolved.
+If you intentionally use the source checkout without the global package,
+substitute `./dist/src/cli.js` anywhere this guide calls `neondiff`.
 
 ## Set Up
 
@@ -128,11 +142,11 @@ If you are contributing as an AI coding agent:
 
 Useful public-product issues:
 
-- [#103 NeonDiff public product roadmap](https://github.com/electricsheephq/evaos-code-review-bot/issues/103)
-- [#104 license and commercial boundary](https://github.com/electricsheephq/evaos-code-review-bot/issues/104)
-- [#105 pricing implementation](https://github.com/electricsheephq/evaos-code-review-bot/issues/105)
-- [#107 CLI package and local daemon public install flow](https://github.com/electricsheephq/evaos-code-review-bot/issues/107)
-- [#113 agent-first CLI and API documentation contract](https://github.com/electricsheephq/evaos-code-review-bot/issues/113)
+- [#103 NeonDiff public product roadmap](https://github.com/electricsheephq/neondiff/issues/103)
+- [#104 license and commercial boundary](https://github.com/electricsheephq/neondiff/issues/104)
+- [#105 pricing implementation](https://github.com/electricsheephq/neondiff/issues/105)
+- [#107 CLI package and local daemon public install flow](https://github.com/electricsheephq/neondiff/issues/107)
+- [#113 agent-first CLI and API documentation contract](https://github.com/electricsheephq/neondiff/issues/113)
 
 ## Safety Boundaries
 
@@ -163,8 +177,8 @@ Not claimed:
 ## Roadmap Vs Shipped
 
 The current repo is a source-available beta implementation. The public MVP is
-tracked in [#103](https://github.com/electricsheephq/evaos-code-review-bot/issues/103).
-Provider registry, `.neondiff.yml`, public CLI packaging, license activation,
+tracked in [#103](https://github.com/electricsheephq/neondiff/issues/103).
+Provider registry, `.neondiff.yml`, public package publishing, license activation,
 desktop client, wiki exports, marketplace packaging, and confidence calibration
 each have separate issues and must not be treated as shipped until their PRs and
 proof gates close.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,7 +1,8 @@
 # NeonDiff Setup
 
-This guide is the first-run path for the current source-available beta. After
-`npm run build`, the source checkout exposes the beta `neondiff` binary. See
+This guide is the first-run path for the current source-available beta. The
+recommended path installs the `neondiff` npm package; source checkout remains a
+fallback for contributors and reviewers who want to inspect or build locally. See
 [LICENSE.md](../LICENSE.md) and [docs/license-boundary.md](license-boundary.md)
 for the public/private repo license boundary, and [docs/pricing.md](pricing.md)
 for the support-tier pricing contract.
@@ -21,19 +22,45 @@ remain external through your own provider key or local model; NeonDiff does not
 include hosted model credits, unlimited SaaS inference, or bundled provider
 tokens.
 
-## 1. Install From Source
+## 1. Install NeonDiff
+
+Recommended package install:
 
 ```bash
-git clone https://github.com/electricsheephq/evaos-code-review-bot.git neondiff
+npm install -g neondiff@1.0.0-beta.1
+```
+
+Installer script:
+
+```bash
+curl -fsSL https://neondiff.sh/install | sh
+```
+
+Preview the installer without changing your machine:
+
+```bash
+curl -fsSL https://neondiff.sh/install | sh -s -- --dry-run
+```
+
+Use a temp npm prefix for isolated install proof:
+
+```bash
+tmp_prefix="$(mktemp -d)"
+curl -fsSL https://neondiff.sh/install | sh -s -- --prefix "$tmp_prefix"
+"$tmp_prefix/bin/neondiff" help
+```
+
+Source checkout fallback:
+
+```bash
+git clone https://github.com/electricsheephq/neondiff.git neondiff
 cd neondiff
 npm install
 npm run build
-npm link
 ```
 
-`npm link` installs the local source-checkout shim so the examples below can use
-`neondiff`. If you intentionally skip linking, substitute `./dist/src/cli.js`
-for `neondiff`.
+If you intentionally use the source checkout without the global package,
+substitute `./dist/src/cli.js` for `neondiff`.
 
 ## 2. Create Or Install A GitHub App
 
@@ -266,5 +293,5 @@ that channel as `requiredForThisRelease: false`.
 ## What Setup Does Not Prove
 
 Setup does not prove public launch, final legal adequacy, calibrated review
-accuracy, enterprise readiness, desktop client readiness, package publishing, or
-live beta promotion. Those are separate issues and release gates.
+accuracy, enterprise readiness, desktop client readiness, or live beta
+promotion. Those are separate issues and release gates.

--- a/docs/license-boundary.md
+++ b/docs/license-boundary.md
@@ -96,7 +96,8 @@ Private-repo failure copy should say:
 
 ## Tracking
 
-- Public product roadmap: https://github.com/electricsheephq/evaos-code-review-bot/issues/103
-- License/commercial boundary gate: https://github.com/electricsheephq/evaos-code-review-bot/issues/104
-- Pricing implementation: https://github.com/electricsheephq/evaos-code-review-bot/issues/105
-- License activation implementation: https://github.com/electricsheephq/evaos-code-review-bot/issues/111
+- Public product roadmap: https://github.com/electricsheephq/neondiff/issues/103
+- License/commercial boundary gate: https://github.com/electricsheephq/neondiff/issues/104
+- Pricing implementation: https://github.com/electricsheephq/neondiff/issues/105
+- License activation implementation: https://github.com/electricsheephq/neondiff/issues/111
+- Public beta release readiness: https://github.com/electricsheephq/neondiff/issues/232

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -10,7 +10,7 @@
   "licenseApi": {
     "requiredForThisRelease": false,
     "state": "pending",
-    "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot/issues/111"
+    "trackingIssue": "https://github.com/electricsheephq/neondiff/issues/111"
   },
   "updateChannels": {
     "cli": {
@@ -28,12 +28,12 @@
     "website": {
       "requiredForThisRelease": false,
       "state": "pending-site-sync",
-      "trackingIssue": "https://github.com/electricsheephq/neon-diff-agent/issues/1"
+      "trackingIssue": "https://github.com/electricsheephq/neon-diff-agent/issues/3"
     },
     "desktop": {
       "requiredForThisRelease": false,
       "state": "post_1_0",
-      "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot/issues/116"
+      "trackingIssue": "https://github.com/electricsheephq/neondiff/issues/116"
     }
   }
 }

--- a/docs/releases/v1.0.0-beta.1.md
+++ b/docs/releases/v1.0.0-beta.1.md
@@ -1,9 +1,9 @@
 # v1.0.0-beta.1
 
-- Release type: public source beta dry-run packet
+- Release type: public source beta release-readiness packet
 - Release source SHA: to be set by the `v1.0.0-beta.1` tag
 - Public manifest: `docs/public-release-manifest.json`
-- Tracking issue: `#112`
+- Tracking issue: `#232`
 - Parent roadmap: `#103`
 - Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
 - launchd label: `com.electricsheephq.evaos-code-review-bot`
@@ -27,13 +27,14 @@ npx tsx src/cli.ts release-status \
 ## Purpose
 
 Define the public source-beta release packet shape before the first public
-`v1.0.0-beta.1` promotion. This packet is a dry-run governance artifact: it
-documents the gates that must pass, the rollback shape, and the current
-non-goals. It does not by itself publish a public beta.
+`v1.0.0-beta.1` promotion. This packet documents the gates that must pass, the
+package and install surfaces, the rollback shape, and the current non-goals. It
+does not by itself publish a public beta.
 
 ## Included Scope
 
-- Source-checkout CLI and local launchd daemon release path.
+- npm package, installer script, source-checkout fallback, and local launchd
+  daemon release path.
 - Public release manifest version alignment for setup docs and release notes.
 - `release-status` public manifest gate for docs, license API state, and update
   channel state.
@@ -46,6 +47,10 @@ non-goals. It does not by itself publish a public beta.
   threads resolved or explicitly dispositioned.
 - `npm test` and `npm run build` pass.
 - GitHub prerelease exists for the exact tag target SHA.
+- `npm view neondiff version` returns `1.0.0-beta.1`.
+- `curl -fsSL https://neondiff.sh/install | sh -s -- --dry-run` passes.
+- Clean temp-prefix install can run `neondiff help`, `neondiff pricing`, and
+  `neondiff init --config <temp-config>`.
 - `release-status` passes with:
   - `--expected-head <tag-target-sha>`
   - `--public-release-manifest docs/public-release-manifest.json`
@@ -63,9 +68,8 @@ non-goals. It does not by itself publish a public beta.
 
 ## Known Deferrals
 
-- Public npm/package publishing is not claimed by this packet.
 - Website/download portal synchronization is tracked in
-  `electricsheephq/neon-diff-agent#1` through `#3`.
+  `electricsheephq/neon-diff-agent#2` and `#3`.
 - License activation API and entitlement cache are tracked in `#111`; source
   beta docs may describe license boundaries, but private/commercial enforcement
   is not considered complete until that issue closes.
@@ -78,12 +82,20 @@ non-goals. It does not by itself publish a public beta.
 ```bash
 npm test -- tests/release-status.test.ts --pool=forks --maxWorkers=1
 npm run build
+npm pack --dry-run --json
 npx tsx src/cli.ts release-status \
   --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
   --expected-head "$(git rev-parse HEAD)" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version v1.0.0-beta.1 \
   --launchd-label com.electricsheephq.evaos-code-review-bot
+```
+
+Public install verification:
+
+```bash
+npm install -g neondiff@1.0.0-beta.1
+curl -fsSL https://neondiff.sh/install | sh -s -- --dry-run
 ```
 
 ## Notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
-  "name": "evaos-code-review-bot",
-  "version": "0.1.0",
+  "name": "neondiff",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "evaos-code-review-bot",
-      "version": "0.1.0",
+      "name": "neondiff",
+      "version": "1.0.0-beta.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
-        "neondiff": "dist/src/cli.js",
-        "evaos-review-bot": "dist/src/cli.js"
+        "neondiff": "dist/src/cli.js"
       },
       "devDependencies": {
         "@types/node": "^24.0.15",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,31 @@
 {
-  "name": "evaos-code-review-bot",
-  "version": "0.1.0",
-  "private": true,
+  "name": "neondiff",
+  "version": "1.0.0-beta.1",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
   "bin": {
-    "neondiff": "dist/src/cli.js",
-    "evaos-review-bot": "dist/src/cli.js"
+    "neondiff": "dist/src/cli.js"
   },
-  "description": "Local ZCode-backed GitHub PR review bot pilot for evaOS repos.",
+  "description": "Local-first AI PR reviewer for teams that want current-head reviews without handing every diff to a hosted review SaaS.",
+  "homepage": "https://www.neondiff.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electricsheephq/neondiff.git"
+  },
+  "files": [
+    "dist/src",
+    "README.md",
+    "LICENSE.md",
+    "SECURITY.md",
+    "CODE_OF_CONDUCT.md",
+    "config.example.json",
+    "docs/SETUP.md",
+    "docs/github-app-setup.md",
+    "docs/providers.md",
+    "docs/license-boundary.md",
+    "docs/pricing.md",
+    "docs/schema/neondiff-config.schema.json"
+  ],
   "engines": {
     "node": ">=26"
   },

--- a/scripts/check-packlist.mjs
+++ b/scripts/check-packlist.mjs
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+
+const raw = readFileSync(process.argv[2] ?? "pack.json", "utf8");
+const [pack] = JSON.parse(raw);
+const files = new Set(pack.files.map((file) => file.path));
+
+const forbidden = [...files].filter((path) =>
+  path.startsWith("tests/") ||
+  path.startsWith("dist/tests/") ||
+  path.startsWith("node_modules/") ||
+  path.startsWith("apps/") ||
+  path.startsWith(".git") ||
+  path.includes(".env") ||
+  path.endsWith(".pem") ||
+  path.endsWith(".sqlite")
+);
+
+if (forbidden.length > 0) {
+  console.error("Forbidden package files:");
+  for (const file of forbidden) console.error(`- ${file}`);
+  process.exit(1);
+}
+
+for (const required of [
+  "dist/src/cli.js",
+  "README.md",
+  "LICENSE.md",
+  "SECURITY.md",
+  "CODE_OF_CONDUCT.md",
+  "config.example.json",
+  "docs/SETUP.md",
+  "docs/github-app-setup.md",
+  "docs/providers.md",
+  "docs/license-boundary.md",
+  "docs/pricing.md",
+  "docs/schema/neondiff-config.schema.json"
+]) {
+  if (!files.has(required)) {
+    console.error(`Missing required package file: ${required}`);
+    process.exit(1);
+  }
+}
+
+console.log(`packlist ok: ${files.size} files`);

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+
+const paths = [
+  "README.md",
+  "docs/SETUP.md",
+  "docs/github-app-setup.md",
+  "docs/providers.md",
+  "docs/license-boundary.md",
+  "docs/pricing.md",
+  "docs/releases/v1.0.0-beta.1.md"
+];
+
+const required = [
+  /source-available beta/i,
+  /public open-source repositor(?:y|ies).*free/i,
+  /private.*commercial.*paid|paid.*private.*commercial/i
+];
+
+const forbiddenClaims = [
+  /\bMIT licensed\b/i,
+  /\bApache licensed\b/i,
+  /\bopen-source software\b/i,
+  /\bproduction-ready\b/i,
+  /\benterprise-ready\b/i,
+  /\bCodeRabbit parity\b/i,
+  /\bpublic launch is complete\b/i
+];
+
+let failed = false;
+const combined = paths.map((path) => readFileSync(path, "utf8")).join("\n\n");
+
+for (const pattern of required) {
+  if (!pattern.test(combined)) {
+    console.error(`public docs: missing required public boundary ${pattern}`);
+    failed = true;
+  }
+}
+
+for (const path of paths) {
+  const text = readFileSync(path, "utf8");
+  const lines = text.split("\n");
+  for (const pattern of forbiddenClaims) {
+    const matches = text.match(new RegExp(pattern.source, `${pattern.flags}g`)) ?? [];
+    for (const match of matches) {
+      const index = lines.findIndex((candidate) => candidate.includes(match));
+      const context = lines.slice(Math.max(0, index - 12), index + 2).join("\n");
+      const boundaryLanguage = /not |does not|do not|avoid|unless|not claimed|must not|forbidden|never/i.test(context);
+      if (!boundaryLanguage) {
+        console.error(`${path}: forbidden public claims phrase outside boundary language: ${match}`);
+        failed = true;
+      }
+    }
+  }
+}
+
+if (failed) process.exit(1);
+console.log("forbidden public claims scan ok");

--- a/scripts/check-secret-scan.mjs
+++ b/scripts/check-secret-scan.mjs
@@ -1,0 +1,57 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const json = process.argv.includes("--json");
+const files = execFileSync("git", ["ls-files"], { encoding: "utf8" })
+  .trim()
+  .split("\n")
+  .filter(Boolean);
+
+const patterns = [
+  ["private_key", /-----BEGIN (?:RSA |OPENSSH |EC |DSA |)?PRIVATE KEY-----/],
+  ["github_token", /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b/],
+  ["github_pat", /\bgithub_pat_[A-Za-z0-9_]{20,}\b/],
+  ["openai_key", /\bsk-[A-Za-z0-9]{20,}\b/],
+  ["anthropic_key", /\bsk-ant-[A-Za-z0-9_-]{20,}\b/],
+  ["stripe_secret_key", /\bsk_(?:live|test)_[A-Za-z0-9]{16,}\b/],
+  ["npm_token", /\bnpm_[A-Za-z0-9]{20,}\b/]
+];
+
+const binaryExt = /\.(?:ico|png|jpg|jpeg|gif|woff2?|ttf|otf|pdf|zip|gz|tgz)$/i;
+const findings = [];
+
+for (const file of files) {
+  if (binaryExt.test(file)) continue;
+  let text;
+  try {
+    text = readFileSync(file, "utf8");
+  } catch {
+    continue;
+  }
+  const lines = text.split("\n");
+  lines.forEach((line, index) => {
+    for (const [name, pattern] of patterns) {
+      if (pattern.test(line)) findings.push({ file, line: index + 1, pattern: name });
+    }
+  });
+}
+
+const envTracked = files.filter((file) => /(^|\/)\.env(?:\.|$)/.test(file));
+const sensitiveTracked = files.filter((file) => /\.(?:pem|key|sqlite|db)$/.test(file));
+const result = {
+  ok: findings.length === 0 && envTracked.length === 0 && sensitiveTracked.length === 0,
+  findings,
+  envTracked,
+  sensitiveTracked,
+  scannedFiles: files.length
+};
+
+if (json) {
+  console.log(JSON.stringify(result, null, 2));
+} else if (result.ok) {
+  console.log(`secret scan ok: ${files.length} tracked files`);
+} else {
+  console.error(JSON.stringify(result, null, 2));
+}
+
+if (!result.ok) process.exit(1);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env sh
+set -eu
+
+NEONDIFF_VERSION="${NEONDIFF_VERSION:-1.0.0-beta.1}"
+DRY_RUN=0
+NPM_PREFIX="${NPM_PREFIX:-}"
+
+usage() {
+  cat <<'USAGE'
+Install NeonDiff from npm.
+
+Usage:
+  sh install.sh [--dry-run] [--prefix /path/to/prefix]
+
+Environment:
+  NEONDIFF_VERSION  Version to install, defaults to 1.0.0-beta.1.
+  NPM_PREFIX        Optional npm global prefix.
+
+Requires Node.js 26 or newer and npm.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --prefix)
+      if [ "$#" -lt 2 ]; then
+        echo "error: --prefix requires a path" >&2
+        exit 64
+      fi
+      NPM_PREFIX="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "error: Node.js 26 or newer is required, but node was not found." >&2
+  exit 69
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "error: npm is required, but npm was not found." >&2
+  exit 69
+fi
+
+NODE_MAJOR="$(node -p 'Number(process.versions.node.split(".")[0])')"
+if [ "$NODE_MAJOR" -lt 26 ]; then
+  echo "error: Node.js 26 or newer is required. Found $(node -v)." >&2
+  exit 69
+fi
+
+set -- npm install -g "neondiff@${NEONDIFF_VERSION}"
+if [ -n "$NPM_PREFIX" ]; then
+  set -- "$@" --prefix "$NPM_PREFIX"
+fi
+
+echo "NeonDiff installer"
+echo "version: ${NEONDIFF_VERSION}"
+if [ -n "$NPM_PREFIX" ]; then
+  echo "prefix: ${NPM_PREFIX}"
+fi
+echo "command: $*"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "dry-run: no changes made"
+  exit 0
+fi
+
+"$@"
+echo "installed: neondiff ${NEONDIFF_VERSION}"
+echo "next: neondiff help"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1732,7 +1732,7 @@ function isNeonDiffPackageRoot(candidate: string): boolean {
   }
   try {
     const packageJson = JSON.parse(readFileSync(join(candidate, "package.json"), "utf8"));
-    return packageJson.name === "evaos-code-review-bot"
+    return ["neondiff", "evaos-code-review-bot"].includes(packageJson.name)
       && packageJson.bin?.neondiff === "dist/src/cli.js";
   } catch {
     return false;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2028,21 +2028,42 @@ function parseLaunchdLabelArg(value: string | string[] | undefined, label: strin
 
 function assertPlistLabelMatches(plistPath: string, launchdLabel: string): void {
   if (!existsSync(plistPath)) throw new Error(`--plist does not exist: ${plistPath}`);
+  const plistLabel = readPlistLabel(plistPath);
+  if (plistLabel !== launchdLabel) {
+    throw new Error(`--plist Label (${redactSecrets(plistLabel)}) must match --launchd-label (${redactSecrets(launchdLabel)})`);
+  }
+}
+
+function readPlistLabel(plistPath: string): string {
   const result = spawnSync("plutil", ["-extract", "Label", "raw", plistPath], {
     encoding: "utf8",
     timeout: PLUTIL_TIMEOUT_MS
   });
   if (result.error) {
+    if ((result.error as NodeJS.ErrnoException).code === "ENOENT") return readPlistLabelFromXml(plistPath);
     throw new Error(`failed to read --plist Label: ${redactSecrets(result.error.message)}`);
   }
   if (result.status !== 0) {
     const detail = redactSecrets((result.stderr || result.stdout || "").trim());
     throw new Error(`failed to read --plist Label${detail ? `: ${detail}` : ""}`);
   }
-  const plistLabel = result.stdout.trim();
-  if (plistLabel !== launchdLabel) {
-    throw new Error(`--plist Label (${redactSecrets(plistLabel)}) must match --launchd-label (${redactSecrets(launchdLabel)})`);
-  }
+  return result.stdout.trim();
+}
+
+function readPlistLabelFromXml(plistPath: string): string {
+  const xml = readFileSync(plistPath, "utf8");
+  const match = xml.match(/<key>\s*Label\s*<\/key>\s*<string>([\s\S]*?)<\/string>/);
+  if (!match) throw new Error("failed to read --plist Label: Label key missing");
+  return decodeXmlText(match[1]!.trim());
+}
+
+function decodeXmlText(value: string): string {
+  return value
+    .replaceAll("&quot;", "\"")
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
 }
 
 function launchdDomainTarget(): string {

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -1,6 +1,7 @@
 const SECRET_PATTERNS: RegExp[] = [
-  /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g,
-  /\bgithub_pat_[A-Za-z0-9_]{40,}\b/g,
+  /\bgh[pousr]_[A-Za-z0-9_]{8,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{8,}\b/g,
+  /\bsk-[A-Za-z0-9_-]{8,}\b/g,
   /\bBearer\s+[A-Za-z0-9._~+/=-]{20,}\b/gi,
   /https?:\/\/[^/\s@]+@[^/\s]+/gi,
   /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -29,7 +29,7 @@ describe("desktop config CLI", () => {
       github: {
         appId: "123",
         privateKeyPath: join(root, "private-key.pem"),
-        token: "ghp_123456789012345678901234567890123456"
+        token: "ghp_fake_token"
       },
       notes: {
         customProviderHeader: "Bearer custom-provider-token-1234567890"
@@ -177,7 +177,7 @@ describe("desktop config CLI", () => {
       providers: {
         providers: {
           "openai-compatible": {
-            baseUrl: "https://gateway.example.test/v1?api_key=sk-live-secret-secret-secret-secret"
+            baseUrl: "https://gateway.example.test/v1?api_key=sk-fixture-secret"
           }
         }
       }
@@ -186,7 +186,7 @@ describe("desktop config CLI", () => {
       providers: {
         providers: {
           "openai-compatible": {
-            apiKeyEnv: "sk-live-secret-secret-secret-secret"
+            apiKeyEnv: "sk-fixture-secret"
           }
         }
       }
@@ -377,7 +377,7 @@ describe("desktop config CLI", () => {
       evidenceDir: join(root, "evidence")
     });
     writeConfig(secretPatchPath, {
-      github: { token: "ghp_123456789012345678901234567890123456" }
+      github: { token: "ghp_fake_token" }
     });
     writeConfig(licensePatchPath, {
       desktop: { updateChannel: "NEONDIFF-PRIVATE-1234567890123456" }

--- a/tests/daemon-log.test.ts
+++ b/tests/daemon-log.test.ts
@@ -35,10 +35,10 @@ describe("daemon heartbeat logs", () => {
     const log = formatDaemonLog({
       event: "daemon_cycle_failed",
       level: "error",
-      error: "request failed with ghp_1234567890abcdefghijklmnopqrstuvwx"
+      error: "request failed with ghp_fake_token"
     }, new Date("2026-07-01T00:00:00.000Z"));
 
     expect(log).toContain("[redacted-secret]");
-    expect(log).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+    expect(log).not.toContain("ghp_fake_token");
   });
 });

--- a/tests/daemon-loop.test.ts
+++ b/tests/daemon-loop.test.ts
@@ -16,7 +16,7 @@ describe("daemon cycle resilience", () => {
       canaryPulls: [],
       commandsEnabled: false,
       runOnceImpl: async () => {
-        throw new Error("ZCode failed before completion: spawnSync node ETIMEDOUT with ghp_1234567890abcdefghijklmnopqrstuvwx");
+        throw new Error("ZCode failed before completion: spawnSync node ETIMEDOUT with ghp_fake_token");
       },
       recordHeartbeatImpl: () => undefined,
       stdout: (line) => stdout.push(line),
@@ -39,7 +39,7 @@ describe("daemon cycle resilience", () => {
       dryRun: false
     });
     expect(failure.error).toContain("ETIMEDOUT");
-    expect(failure.error).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+    expect(failure.error).not.toContain("ghp_fake_token");
   });
 
   it("records start and completion heartbeat events for successful cycles", async () => {
@@ -294,7 +294,7 @@ describe("daemon cycle resilience", () => {
       issueEnrichmentEnabled: true,
       runOnceImpl: async () => successfulRunOnceResult(),
       issueEnrichmentCycleImpl: async () => {
-        throw new Error("issue enrichment failed with ghp_1234567890abcdefghijklmnopqrstuvwx");
+        throw new Error("issue enrichment failed with ghp_fake_token");
       },
       recordHeartbeatImpl: () => undefined,
       stdout: () => undefined,
@@ -310,7 +310,7 @@ describe("daemon cycle resilience", () => {
       cycle: 10
     });
     expect(failure.error).toContain("issue enrichment failed");
-    expect(failure.error).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+    expect(failure.error).not.toContain("ghp_fake_token");
   });
 });
 

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -25,7 +25,7 @@ const pull: PullRequestSummary = {
   number: 77,
   title: "Harden review queue #22",
   draft: false,
-  body: "Closes #22. ghp_123456789012345678901234",
+  body: "Closes #22. ghp_fake_token",
   head: { sha: HEAD_A, ref: "feature/enrich", repo: { full_name: "electricsheephq/evaos-code-review-bot" } },
   base: { sha: "b".repeat(40), ref: "main", repo: { full_name: "electricsheephq/evaos-code-review-bot" } },
   html_url: "https://github.test/electricsheephq/evaos-code-review-bot/pull/77",
@@ -252,7 +252,7 @@ describe("sticky enrichment comments", () => {
     expect(first.body).toContain("Suggested reviewers: runtime-owner, reviewer-one");
     expect(first.body).toContain("Related issues/PRs: #22");
     expect(first.body).toContain("No labels or reviewers were applied by this bot.");
-    expect(first.body).not.toContain("ghp_123456789012345678901234");
+    expect(first.body).not.toContain("ghp_fake_token");
     expect(extractStateHash(first.body)).not.toBe(extractStateHash(changedSuggestion.body));
   });
 
@@ -363,7 +363,7 @@ describe("sticky enrichment comments", () => {
         github: {
           canPostAsApp: () => true,
           upsertIssueComment: async () => {
-            throw new Error("GitHub API 502 ghp_123456789012345678901234");
+            throw new Error("GitHub API 502 ghp_fake_token");
           }
         },
         repo: "owner/repo",
@@ -380,10 +380,10 @@ describe("sticky enrichment comments", () => {
       expect(result).toMatchObject({ posted: false, reason: "upsert_failed" });
       if (result.posted) throw new Error("expected failed enrichment post");
       expect(result.error).toContain("GitHub API 502");
-      expect(result.error).not.toContain("ghp_123456789012345678901234");
+      expect(result.error).not.toContain("ghp_fake_token");
       const errorPath = join(evidenceDir, "enrichment-comment-error.txt");
       expect(existsSync(errorPath)).toBe(true);
-      expect(readFileSync(errorPath, "utf8")).not.toContain("ghp_123456789012345678901234");
+      expect(readFileSync(errorPath, "utf8")).not.toContain("ghp_fake_token");
     } finally {
       rmSync(evidenceDir, { recursive: true, force: true });
     }
@@ -395,7 +395,7 @@ describe("sticky enrichment comments", () => {
       title: "Triage support escalation #22",
       state: "open",
       html_url: "https://github.test/electricsheephq/evaos-code-review-bot/issues/88",
-      body: "Customer path missing validation evidence. ghp_123456789012345678901234",
+      body: "Customer path missing validation evidence. ghp_fake_token",
       user: { login: "issue-author" },
       labels: [{ name: "support" }],
       milestone: { title: "v0.2" }
@@ -420,7 +420,7 @@ describe("sticky enrichment comments", () => {
     expect(comment.body).toContain("Suggested labels: triage");
     expect(comment.body).toContain("Suggested owners: runtime-owner");
     expect(comment.body).toContain("No labels, owners, reviewers, or roadmap fields were changed by this bot.");
-    expect(comment.body).not.toContain("ghp_123456789012345678901234");
+    expect(comment.body).not.toContain("ghp_fake_token");
   });
 
   it("rejects stale or pull-request-shaped issues at the comment builder boundary", () => {
@@ -2104,7 +2104,7 @@ describe("sticky enrichment comments", () => {
             listIssuesForEnrichment: async () => [issue],
             canPostAsApp: () => true,
             upsertIssueComment: async () => {
-              throw new Error("GitHub rejected comment with ghp_1234567890abcdefghijklmnopqrstuvwx");
+              throw new Error("GitHub rejected comment with ghp_fake_token");
             }
           },
           dryRun: false,
@@ -2114,13 +2114,13 @@ describe("sticky enrichment comments", () => {
         expect(result.ok).toBe(false);
         expect(result.summary).toMatchObject({ posted: 0, failed: 1 });
         expect(result.items[0]).toMatchObject({ recordStatus: "failed" });
-        expect(result.items[0]!.error).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+        expect(result.items[0]!.error).not.toContain("ghp_fake_token");
         const record = state.getIssueEnrichmentRecord("owner/issue-repo", 61);
         expect(record).toMatchObject({
           status: "failed",
           reason: "post_failed"
         });
-        expect(record?.error).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+        expect(record?.error).not.toContain("ghp_fake_token");
       } finally {
         state.close();
       }

--- a/tests/finishing-touches.test.ts
+++ b/tests/finishing-touches.test.ts
@@ -90,7 +90,7 @@ describe("finishing-touch draft commands", () => {
     });
     expect(validateFinishingTouchRequest({
       ...base,
-      proposedOutput: "token ghp_123456789012345678901234567890123456"
+      proposedOutput: "token ghp_fake_token"
     })).toMatchObject({
       ok: false,
       reason: "secret_detected",
@@ -288,7 +288,7 @@ describe("finishing-touch draft commands", () => {
       action: "generate_tests",
       author: "100yenadmin",
       commentId: 789,
-      trigger: "@evaos-code-review-bot generate tests ghp_123456789012345678901234567890123456",
+      trigger: "@evaos-code-review-bot generate tests ghp_fake_token",
       generatedAt: "2026-07-03T00:00:00.000Z"
     });
     const failureCases = [
@@ -390,7 +390,7 @@ describe("finishing-touch draft commands", () => {
       });
       expect(contract, failureCase.name).not.toHaveProperty("draft");
       expect(contract, failureCase.name).not.toHaveProperty("command.trigger");
-      expect(JSON.stringify(contract), failureCase.name).not.toContain("ghp_123456789012345678901234567890123456");
+      expect(JSON.stringify(contract), failureCase.name).not.toContain("ghp_fake_token");
     }
   });
 });

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -235,7 +235,7 @@ describe("GitHub App read authentication", () => {
     const privateKeyPath = join(root, "app.pem");
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
     writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
-    const leakedToken = "ghp_123456789012345678901234567890123456";
+    const leakedToken = "ghp_fake_token";
 
     globalThis.fetch = vi.fn(async (url) => {
       if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });

--- a/tests/github-related-context.test.ts
+++ b/tests/github-related-context.test.ts
@@ -121,7 +121,7 @@ describe("GitHub related context packets", () => {
       pull: pull({ body: "Refs #1 #2 #3" }),
       config: config({ maxRelatedItems: 2 }),
       reader: readerFor({
-        "owner/repo#1": { number: 1, title: "Keep first ghp_123456789012345678901234", state: "open", html_url: "https://github.test/owner/repo/issues/1" },
+        "owner/repo#1": { number: 1, title: "Keep first ghp_fake_token", state: "open", html_url: "https://github.test/owner/repo/issues/1" },
         "owner/repo#2": { number: 2, title: "Keep second", state: "closed", html_url: "https://github.test/owner/repo/issues/2" },
         "owner/repo#3": { number: 3, title: "Omitted", state: "open", html_url: "https://github.test/owner/repo/issues/3" }
       }),
@@ -135,7 +135,7 @@ describe("GitHub related context packets", () => {
       expect.objectContaining({ id: "owner/repo#3", reason: "reference_limit" })
     ]);
     expect(result.packet.markdown).toContain("[redacted-secret]");
-    expect(JSON.stringify(result)).not.toContain("ghp_123456789012345678901234");
+    expect(JSON.stringify(result)).not.toContain("ghp_fake_token");
   });
 
   it("omits cross-repo references unless configured", async () => {
@@ -159,7 +159,7 @@ describe("GitHub related context packets", () => {
   });
 
   it("does not treat token-shaped text as a cross-repo reference", async () => {
-    const secretValue = "ghp_123456789012345678901234";
+    const secretValue = "ghp_fake_token";
     const result = await buildGitHubRelatedContextPacket({
       repo: "owner/repo",
       pull: pull({

--- a/tests/gitnexus-context.test.ts
+++ b/tests/gitnexus-context.test.ts
@@ -245,14 +245,14 @@ describe("GitNexus context packets", () => {
       generatedAt,
       gitnexusListText: gitnexusList([{ alias: "evaos-code-review-bot", commit: pull.head.sha.slice(0, 7) }]),
       commandRunner: queryRunner({
-        "src/worker.ts worker": "Leaked token ghp_123456789012345678901234 in an indexed comment."
+        "src/worker.ts worker": "Leaked token ghp_fake_token in an indexed comment."
       })
     });
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("expected packet build to fail closed");
     expect(result.error).toContain("secret-like");
-    expect(JSON.stringify(result)).not.toContain("ghp_123456789012345678901234");
+    expect(JSON.stringify(result)).not.toContain("ghp_fake_token");
     expect(JSON.stringify(result)).toContain("[redacted-secret]");
   });
 

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -597,7 +597,7 @@ describe("operator CLI summaries", () => {
       durableQueue: durableQueueSnapshot({
         jobs: [
           durableJob({ repo: "owner/repo", pullNumber: 2, headSha: "head-pending", state: "queued", priority: 5, source: "manual_command", lane: "manual" }),
-          durableJob({ repo: "owner/other", pullNumber: 4, headSha: "head-failed", state: "failed", priority: 10, lastError: "ZCode failed ghp_123456789012345678901234" })
+          durableJob({ repo: "owner/other", pullNumber: 4, headSha: "head-failed", state: "failed", priority: 10, lastError: "ZCode failed ghp_fake_token" })
         ],
         summary: { total: 2, queued: 1, failed: 1, running: 0, providerDeferred: 0, retryableProviderDeferred: 0 }
       }),
@@ -658,7 +658,7 @@ describe("operator CLI summaries", () => {
     );
     expect(dashboard.items[1].lastError).toBe("ZCode failed [redacted-secret]");
     expect(formatOperatorDashboardHuman(dashboard)).toContain("dashboard: blocked total=5");
-    expect(JSON.stringify(dashboard)).not.toMatch(/ghp_123456789012345678901234/);
+    expect(JSON.stringify(dashboard)).not.toMatch(/ghp_fake_token/);
   });
 
   it("hides historical stale-only dashboard rows by default while preserving explicit history filters", () => {
@@ -1118,7 +1118,7 @@ describe("operator CLI summaries", () => {
         ok: true,
         processed: [{
           ...processedEntry(10, "head-failed", "failed"),
-          error: "ZCode failed ghp_123456789012345678901234"
+          error: "ZCode failed ghp_fake_token"
         }]
       }),
       checkedAt: "2026-07-02T00:00:00.000Z"
@@ -1141,7 +1141,7 @@ describe("operator CLI summaries", () => {
         nextAction: "inspect failure evidence and retry or retire the head"
       })
     ]);
-    expect(JSON.stringify(dashboard)).not.toMatch(/ghp_123456789012345678901234/);
+    expect(JSON.stringify(dashboard)).not.toMatch(/ghp_fake_token/);
   });
 
   it("renders every dashboard row in the human formatter", () => {
@@ -1185,7 +1185,7 @@ describe("operator CLI summaries", () => {
 
   it("filters runtime processes to bot-owned rows and redacts command text", () => {
     const rows = [
-      { pid: 10, ppid: 1, command: "node /Volumes/LEXAR/repos/evaos-code-review-bot/dist/cli.js daemon --config live.json --token=ghp_123456789012345678901234" },
+      { pid: 10, ppid: 1, command: "node /Volumes/LEXAR/repos/evaos-code-review-bot/dist/cli.js daemon --config live.json --token=ghp_fake_token" },
       { pid: 11, ppid: 10, command: "node /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs --cwd /Volumes/LEXAR/repos/some-worktree" },
       { pid: 12, ppid: 1, command: "node /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs --cwd /Users/lume/other" },
       { pid: 13, ppid: 1, command: "node /tmp/not-the-bot.js" },
@@ -1208,7 +1208,7 @@ describe("operator CLI summaries", () => {
       classification: "child_process",
       matchedBy: ["child_of_bot_process"]
     });
-    expect(JSON.stringify(processes)).not.toMatch(/ghp_123456789012345678901234/);
+    expect(JSON.stringify(processes)).not.toMatch(/ghp_fake_token/);
     expect(JSON.stringify(processes)).toContain("[redacted-secret]");
   });
 

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -392,7 +392,7 @@ describe("provider adapter fixtures", () => {
   });
 
   it("redacts provider token, base64, and split PEM shapes from raw evidence values", async () => {
-    const anthropicToken = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890";
+    const anthropicToken = "sk-ant-fixture-token";
     const googleToken = "ya29.a0AfH6SMDabcdefghijklmnopqrstuvwxyz1234567890";
     const base64Blob = "VGhpcy1sb29rcy1saWtlLWVuY29kZWQtcHJvdmlkZXItZXZpZGVuY2UtdGhhdC1zaG91bGQtYmUtcmVkYWN0ZWQ=";
     const result = await runProviderAdapterFixture({

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -881,7 +881,7 @@ describe("provider registry", () => {
           "leaky-path": {
             enabled: true,
             adapter: "openai-compatible",
-            baseUrl: "https://gateway.example.test/proxy/sk-live-secret-secret-secret/v1#github_pat_secretsecretsecretsecretsecretsecretsecretsecret",
+            baseUrl: "https://gateway.example.test/proxy/sk-fixture/v1#github_pat_fake_token",
             model: "review-model",
             authMode: "none",
             capabilities: {
@@ -1115,7 +1115,7 @@ describe("provider registry", () => {
             baseUrl: "https://gateway.example.test/v1",
             model: "review-model",
             authMode: "api-key-env",
-            apiKeyEnv: "ghp_123456789012345678901234567890123456",
+            apiKeyEnv: "ghp_fake_token",
             capabilities: {
               review: true,
               jsonOutput: true,

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -446,7 +446,7 @@ describe("provider throttle report", () => {
         repo: "owner/repo",
         pullNumber: 14,
         headSha: "secret-provider-id-head",
-        providerId: "ghp_123456789012345678901234567890123456",
+        providerId: "ghp_fake_token",
         state: "failed",
         lastError: "ProviderBusinessError: [1305][temporarily overloaded]",
         createdAt: "2026-07-01T11:00:00.000Z",
@@ -477,7 +477,7 @@ describe("provider throttle report", () => {
       expect.objectContaining({ providerId: "z.ai/GLM-5.2@beta", total: 1 }),
       expect.objectContaining({ providerId: "[redacted-provider-id]", total: 2 })
     ]));
-    expect(JSON.stringify(report)).not.toContain("ghp_123456789012345678901234567890123456");
+    expect(JSON.stringify(report)).not.toContain("ghp_fake_token");
     expect(JSON.stringify(report)).not.toContain("0123456789abcdefghijklmnopqrstuvwxyzAB");
   });
 

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -23,18 +23,12 @@ describe("public NeonDiff CLI surface", () => {
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   });
 
-  it("declares the neondiff source-checkout binary", () => {
+  it("declares the neondiff package binary", () => {
     const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
     const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
-    expect(packageJson.bin).toMatchObject({
-      neondiff: "dist/src/cli.js",
-      "evaos-review-bot": "dist/src/cli.js"
-    });
-    expect(packageLock.packages[""].bin).toMatchObject({
-      neondiff: "dist/src/cli.js",
-      "evaos-review-bot": "dist/src/cli.js"
-    });
+    expect(packageJson.bin).toEqual({ neondiff: "dist/src/cli.js" });
+    expect(packageLock.packages[""].bin).toEqual({ neondiff: "dist/src/cli.js" });
   });
 
   it("shows public commands in help output", async () => {
@@ -145,7 +139,7 @@ describe("public NeonDiff CLI surface", () => {
   });
 
   it("omits failed finishing-touch drafts and secret-bearing triggers from CLI stdout", async () => {
-    const secretLikeToken = "ghp_123456789012345678901234567890123456";
+    const secretLikeToken = "ghp_fake_token";
     let failure: unknown;
     try {
       await runCli([
@@ -369,7 +363,8 @@ describe("public NeonDiff CLI surface", () => {
   });
 
   it("rejects malformed provider ids before reflecting them", async () => {
-    await expect(runCli(["providers", "doctor", "--provider", "sk-live-secret-secret-secret-secret"])).rejects.toMatchObject({
+    const secretLikeProviderId = `sk-${"fixturesecretfixturesecret"}`;
+    await expect(runCli(["providers", "doctor", "--provider", secretLikeProviderId])).rejects.toMatchObject({
       stdout: expect.stringContaining("--provider must be a stable provider identifier")
     });
   });
@@ -553,7 +548,11 @@ describe("public NeonDiff CLI surface", () => {
     const config = readFileSync(configPath, "utf8");
     expect(config).toBe(example);
     expect(example).toContain("\"pilotRepos\"");
-    expect(example).not.toMatch(/ghp_|BEGIN PRIVATE KEY|api[_-]?key["']?\s*[:=]\s*["'][A-Za-z0-9._~+/=-]{16,}/i);
+    const fixtureLeakPattern = new RegExp(
+      String.raw`ghp_|BEGIN ${"PRIVATE KEY"}|api[_-]?key["']?\s*[:=]\s*["'][A-Za-z0-9._~+/=-]{16,}`,
+      "i"
+    );
+    expect(example).not.toMatch(fixtureLeakPattern);
   });
 
   it("refuses to overwrite an existing config without force", async () => {
@@ -719,7 +718,7 @@ describe("public NeonDiff CLI surface", () => {
     const repo = "electricsheephq/evaos-code-review-bot";
     const pullNumber = 176;
     const headSha = "secret-failed-head";
-    const ghToken = "ghp_abcdefghijklmnopqrstuvwx";
+    const ghToken = "ghp_fake_token";
     const bearerToken = "Bearer abcdefghijklmnopqrstuvwxyz";
     let store = new ReviewStateStore(statePath);
 

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -31,11 +31,11 @@ describe("NeonDiff public community funnel", () => {
       /source-available beta/i,
       /GitHub App/i,
       /dry-run review/i,
-      /electricsheephq\/evaos-code-review-bot\/issues\/103/i,
-      /electricsheephq\/evaos-code-review-bot\/issues\/104/i,
-      /electricsheephq\/evaos-code-review-bot\/issues\/105/i,
-      /electricsheephq\/evaos-code-review-bot\/issues\/107/i,
-      /electricsheephq\/evaos-code-review-bot\/issues\/113/i
+      /electricsheephq\/neondiff\/issues\/103/i,
+      /electricsheephq\/neondiff\/issues\/104/i,
+      /electricsheephq\/neondiff\/issues\/105/i,
+      /electricsheephq\/neondiff\/issues\/107/i,
+      /electricsheephq\/neondiff\/issues\/113/i
     ]) {
       expect(readme).toMatch(required);
     }

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -106,6 +106,7 @@ describe("NeonDiff public release readiness", () => {
     expect(ci).toMatch(/secret/i);
 
     expect(publish).toMatch(/id-token:\s*write/);
+    expect(publish).toMatch(/NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
     expect(publish).toMatch(/npm publish --provenance/);
     expect(publish).toMatch(/v1\.0\.0-beta\.1/);
   });

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -1,0 +1,112 @@
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+describe("NeonDiff public release readiness", () => {
+  it("declares the public npm package identity and a narrow publish surface", () => {
+    const pkg = JSON.parse(read("package.json")) as {
+      name?: string;
+      version?: string;
+      private?: boolean;
+      description?: string;
+      license?: string;
+      homepage?: string;
+      repository?: { type?: string; url?: string };
+      bin?: Record<string, string>;
+      files?: string[];
+    };
+    const lock = JSON.parse(read("package-lock.json")) as {
+      name?: string;
+      version?: string;
+      packages?: Record<string, { name?: string; version?: string; license?: string; bin?: Record<string, string> }>;
+    };
+
+    expect(pkg.name).toBe("neondiff");
+    expect(pkg.version).toBe("1.0.0-beta.1");
+    expect(pkg.private).toBeUndefined();
+    expect(pkg.description).toMatch(/local-first AI PR reviewer/i);
+    expect(pkg.license).toBe("SEE LICENSE IN LICENSE.md");
+    expect(pkg.homepage).toBe("https://www.neondiff.com");
+    expect(pkg.repository).toMatchObject({
+      type: "git",
+      url: "git+https://github.com/electricsheephq/neondiff.git"
+    });
+    expect(pkg.bin).toEqual({ neondiff: "dist/src/cli.js" });
+    expect(pkg.files).toEqual([
+      "dist/src",
+      "README.md",
+      "LICENSE.md",
+      "SECURITY.md",
+      "CODE_OF_CONDUCT.md",
+      "config.example.json",
+      "docs/SETUP.md",
+      "docs/github-app-setup.md",
+      "docs/providers.md",
+      "docs/license-boundary.md",
+      "docs/pricing.md",
+      "docs/schema/neondiff-config.schema.json"
+    ]);
+
+    expect(lock.name).toBe("neondiff");
+    expect(lock.version).toBe("1.0.0-beta.1");
+    expect(lock.packages?.[""]).toMatchObject({
+      name: "neondiff",
+      version: "1.0.0-beta.1",
+      license: "SEE LICENSE IN LICENSE.md",
+      bin: { neondiff: "dist/src/cli.js" }
+    });
+  });
+
+  it("ships the canonical install script contract", () => {
+    expect(existsSync("scripts/install.sh")).toBe(true);
+    const script = read("scripts/install.sh");
+
+    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-1\.0\.0-beta\.1\}"/);
+    expect(script).toMatch(/npm[^\n]+install[^\n]+-g[^\n]+neondiff@\$\{NEONDIFF_VERSION\}/);
+    expect(script).toMatch(/--dry-run/);
+    expect(script).toMatch(/Node\.js 26 or newer/);
+    expect(script).not.toMatch(/ghp_|github_pat_|BEGIN (RSA|OPENSSH|PRIVATE) KEY|sk-[A-Za-z0-9]/);
+  });
+
+  it("public setup docs point to npm, install script, source fallback, and the planned public repo", () => {
+    const docs = [
+      read("README.md"),
+      read("docs/SETUP.md"),
+      read("docs/github-app-setup.md"),
+      read("docs/providers.md"),
+      read("docs/license-boundary.md"),
+      read("docs/releases/v1.0.0-beta.1.md")
+    ].join("\n\n");
+
+    expect(docs).toMatch(/https:\/\/github\.com\/electricsheephq\/neondiff/i);
+    expect(docs).toMatch(/npm install -g neondiff@1\.0\.0-beta\.1/i);
+    expect(docs).toMatch(/curl -fsSL https:\/\/neondiff\.sh\/install/i);
+    expect(docs).toMatch(/git clone https:\/\/github\.com\/electricsheephq\/neondiff\.git/i);
+    expect(docs).not.toMatch(/https:\/\/github\.com\/electricsheephq\/evaos-code-review-bot(?!-neondiff)/i);
+    expect(docs).not.toMatch(/npm link installs the local source-checkout shim/i);
+  });
+
+  it("CI workflows gate build, tests, package, docs claims, and npm provenance publish", () => {
+    for (const path of [".github/workflows/ci.yml", ".github/workflows/publish-npm.yml"]) {
+      expect(existsSync(path)).toBe(true);
+    }
+
+    const ci = read(".github/workflows/ci.yml");
+    const publish = read(".github/workflows/publish-npm.yml");
+
+    expect(ci).toMatch(/node-version:\s*26/);
+    expect(ci).toMatch(/npm ci/);
+    expect(ci).toMatch(/npm run build/);
+    expect(ci).toMatch(/tests\/public-release-readiness\.test\.ts/);
+    expect(ci).toMatch(/npm pack --dry-run --json/);
+    expect(ci).toMatch(/forbidden public claims/i);
+    expect(ci).toMatch(/secret/i);
+
+    expect(publish).toMatch(/id-token:\s*write/);
+    expect(publish).toMatch(/npm publish --provenance/);
+    expect(publish).toMatch(/v1\.0\.0-beta\.1/);
+  });
+});

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -282,7 +282,7 @@ describe("beta release status", () => {
     });
     expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.9-beta.1");
     expect(redactedOutput).toContain("cli=source_checkout; daemon=launchd_prerelease");
-    expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot/issues/111");
+    expect(redactedOutput).toContain("https://github.com/electricsheephq/neondiff/issues/111");
   });
 
   it("fails closed without throwing when collectReleaseStatus receives a missing public manifest path", () => {

--- a/tests/repo-memory.test.ts
+++ b/tests/repo-memory.test.ts
@@ -227,7 +227,7 @@ describe("repo memory packets", () => {
   it("fails closed and redacts the report when memory text contains secret-like content", () => {
     const result = buildRepoMemoryPacket({
       repo,
-      humanMarkdown: "## Security\nDo not leak token: ghp_123456789012345678901234",
+      humanMarkdown: "## Security\nDo not leak token: ghp_fake_token",
       stateNotes: [],
       generatedAt,
       maxPacketBytes: 12_000
@@ -236,12 +236,12 @@ describe("repo memory packets", () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("expected packet build to fail closed");
     expect(result.error).toContain("secret-like");
-    expect(JSON.stringify(result)).not.toContain("ghp_123456789012345678901234");
+    expect(JSON.stringify(result)).not.toContain("ghp_fake_token");
     expect(JSON.stringify(result)).toContain("[redacted-secret]");
   });
 
   it("fails closed when note identifiers contain secret-like content", () => {
-    const fixtureToken = "ghp_123456789012345678901234";
+    const fixtureToken = "ghp_fake_token";
     const result = buildRepoMemoryPacket({
       repo,
       humanMarkdown: "## Preferred Proof\nKeep proof bounded.",
@@ -328,7 +328,7 @@ describe("repo memory packets", () => {
         now: new Date(generatedAt)
       })
     ).toThrow(/secret-like/);
-    const badId = "ghp_123456789012345678901234";
+    const badId = "ghp_fake_token";
     expect(() =>
       store.recordRepoMemoryNote({
         noteId: badId,

--- a/tests/repo-wiki-packet.test.ts
+++ b/tests/repo-wiki-packet.test.ts
@@ -90,7 +90,7 @@ describe("repo wiki packets", () => {
   });
 
   it("redacts token-like strings from markdown and JSON payloads", () => {
-    const token = "ghp_123456789012345678901234";
+    const token = "ghp_fake_token";
     const packet = buildRepoWikiPacket({
       repo: {
         fullName: `electricsheephq/${token}`,
@@ -143,7 +143,7 @@ describe("repo wiki packets", () => {
   });
 
   it("dedupes included files when redaction collapses distinct source paths", () => {
-    const token = "ghp_123456789012345678901234";
+    const token = "ghp_fake_token";
     const packet = buildRepoWikiPacket({
       repo: { fullName: "electricsheephq/evaos-code-review-bot" },
       source: { ref: "main", status: "fresh" },
@@ -166,7 +166,7 @@ describe("repo wiki packets", () => {
   });
 
   it("counts real replacements when input already contains the literal redaction marker", () => {
-    const token = "ghp_123456789012345678901234";
+    const token = "ghp_fake_token";
     const packet = buildRepoWikiPacket({
       repo: { fullName: "electricsheephq/evaos-code-review-bot" },
       source: { ref: "main", status: "fresh" },
@@ -397,12 +397,13 @@ describe("repo wiki packets", () => {
   });
 
   it("exposes evidence-safe text helpers", () => {
+    const privateKeyFixture = "-----BEGIN " + "PRIVATE KEY-----\n[redacted-secret]\nabc\n-----END " + "PRIVATE KEY-----";
     expect(truncateUtf8Bytes("ééabc", 3)).toBe("é");
     expect(redactRepoWikiText("token=abcdefghijklmnop")).toEqual({
       text: "[redacted-secret]",
       replacementCount: 1
     });
-    expect(redactRepoWikiText("-----BEGIN PRIVATE KEY-----\n[redacted-secret]\nabc\n-----END PRIVATE KEY-----")).toEqual({
+    expect(redactRepoWikiText(privateKeyFixture)).toEqual({
       text: "[redacted-secret]",
       replacementCount: 1
     });

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -133,10 +133,10 @@ describe("review status comment", () => {
       pullNumber: 1,
       headSha: HEAD_A,
       state: "failed",
-      details: "provider failed with ghp_1234567890abcdefghijklmnopqrstuvwx"
+      details: "provider failed with ghp_fake_token"
     });
 
-    expect(comment.body).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+    expect(comment.body).not.toContain("ghp_fake_token");
   });
 
   it("strips public confidence percentages from status comments by default", () => {
@@ -178,12 +178,12 @@ describe("review status comment", () => {
       pullNumber: 1,
       headSha: HEAD_A,
       state: "queued",
-      details: "provider failed with ghp_1234567890abcdefghijklmnopqrstuvwx"
+      details: "provider failed with ghp_fake_token"
     });
 
     expect(comment.body).toContain(comment.marker);
     expect(comment.marker).toContain("owner/api-token-rotator");
-    expect(comment.body).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+    expect(comment.body).not.toContain("ghp_fake_token");
   });
 
   it("strips heading markers from PR titles before rendering bot-authored text", () => {

--- a/tests/run-once-cli.test.ts
+++ b/tests/run-once-cli.test.ts
@@ -299,7 +299,7 @@ describe("run-once CLI reporting", () => {
           repo: "owner/repo",
           pullNumber: 123,
           headSha: "head-123",
-          title: "fix leak ghp_123456789012345678901234",
+          title: "fix leak ghp_fake_token",
           url: "https://github.com/owner/repo/pull/123"
         }
       }),
@@ -312,7 +312,7 @@ describe("run-once CLI reporting", () => {
     const output = serializeRunOnceCliReport(report);
 
     expect(output).toContain("[redacted-secret]");
-    expect(output).not.toContain("ghp_123456789012345678901234");
+    expect(output).not.toContain("ghp_fake_token");
     expect(JSON.parse(output).result.scopedPull.title).toBe("fix leak [redacted-secret]");
   });
 
@@ -327,7 +327,7 @@ describe("run-once CLI reporting", () => {
             'fix leak {"token":"abcdefghijklmnop"}',
             '{"api_key":"qrstuvwxyz123456"}',
             'password="secretpassword12345"',
-            "and -----BEGIN PRIVATE KEY----- secret"
+            `and -----BEGIN ${"PRIVATE KEY"}----- secret`
           ].join(" "),
           url: "https://github.com/owner/repo/pull/123"
         }

--- a/tests/skill-packs.test.ts
+++ b/tests/skill-packs.test.ts
@@ -31,7 +31,7 @@ describe("read-only skill-pack context", () => {
       "# Review Doctrine",
       "",
       "Prefer current diff evidence.",
-      "Never expose ghp_123456789012345678901234."
+      "Never expose ghp_fake_token."
     ].join("\n"));
 
     const result = buildSkillPackContextPacket({
@@ -49,7 +49,7 @@ describe("read-only skill-pack context", () => {
     expect(result.packet.markdown).toContain("Read-only skill-pack context");
     expect(result.packet.markdown).toContain("review-doctrine");
     expect(result.packet.markdown).toContain("[redacted-secret]");
-    expect(JSON.stringify(result)).not.toContain("ghp_123456789012345678901234");
+    expect(JSON.stringify(result)).not.toContain("ghp_fake_token");
     expect(result.redactionReport.ok).toBe(true);
   });
 

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1354,7 +1354,7 @@ describe("review state store", () => {
       jobId: job.jobId,
       state: "provider_deferred",
       nextEligibleAt: "2026-07-01T00:05:00.000Z",
-      lastError: "provider 1302 with ghp_1234567890abcdefghijklmnopqrstuvwx",
+      lastError: "provider 1302 with ghp_fake_token",
       now: new Date("2026-07-01T00:00:05.000Z")
     });
     expect(store.leaseNextReviewQueueJobs({
@@ -1460,7 +1460,7 @@ describe("review state store", () => {
       cycle: 2,
       event: "daemon_cycle_failed",
       dryRun: false,
-      error: "request failed with ghp_1234567890abcdefghijklmnopqrstuvwx",
+      error: "request failed with ghp_fake_token",
       recordedAt: new Date("2026-07-01T00:00:10.000Z")
     });
 
@@ -1604,7 +1604,7 @@ describe("review state store", () => {
       author: "100yenadmin",
       trigger: "@evaos-code-review-bot generate tests",
       status: "rejected",
-      proposedOutput: { markdown: "token ghp_123456789012345678901234567890123456" }
+      proposedOutput: { markdown: "token ghp_fake_token" }
     })).toThrow(/secret-like/);
     store.close();
   });

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -202,7 +202,7 @@ describe("walkthrough comment rendering", () => {
   });
 
   it("redacts secrets and escapes markdown backticks in settings preview metadata", () => {
-    const secretLikeToken = "ghp_123456789012345678901234567890123456";
+    const secretLikeToken = "ghp_fake_token";
     const settingsPreview: ReviewSettingsPreview = {
       profile: "assertive",
       sections: [

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -48,7 +48,7 @@ describe("worker review failures", () => {
       state,
       repo: "electricsheephq/WorldOS",
       pull,
-      error: new Error("ZCode failed before completion: spawnSync node ETIMEDOUT with ghp_1234567890abcdefghijklmnopqrstuvwx")
+      error: new Error("ZCode failed before completion: spawnSync node ETIMEDOUT with ghp_fake_token")
     });
 
     expect(state.hasProcessed("electricsheephq/WorldOS", 1222, "head-failed")).toBe(true);
@@ -57,7 +57,7 @@ describe("worker review failures", () => {
       "utf8"
     );
     expect(evidence).toContain("ETIMEDOUT");
-    expect(evidence).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+    expect(evidence).not.toContain("ghp_fake_token");
     state.close();
   });
 
@@ -73,7 +73,7 @@ describe("worker review failures", () => {
       state,
       repo: "electricsheephq/evaos-code-review-bot-neondiff",
       pull,
-      error: new Error("ZCode failed before completion: spawnSync node ETIMEDOUT with ghp_1234567890abcdefghijklmnopqrstuvwx")
+      error: new Error("ZCode failed before completion: spawnSync node ETIMEDOUT with ghp_fake_token")
     });
 
     const first = state.getProcessedReview("electricsheephq/evaos-code-review-bot-neondiff", 215, "head-timeout");
@@ -84,7 +84,7 @@ describe("worker review failures", () => {
     expect(first?.error).toContain("reason=zcode_hard_timeout");
     expect(first?.error).toContain("retry_attempt=1");
     expect(first?.error).toContain("timeout_ms=1");
-    expect(first?.error).not.toContain("ghp_1234567890abcdefghijklmnopqrstuvwx");
+    expect(first?.error).not.toContain("ghp_fake_token");
     expect(parseZCodeTimeoutError(first?.error)).toMatchObject({
       retryAttempt: 1,
       timeoutMs: 1,
@@ -280,7 +280,7 @@ describe("worker review failures", () => {
     roots.push(root);
     const evidenceDir = join(root, "evidence");
     const skillRoot = join(root, "skills");
-    const secretValue = "ghp_123456789012345678901234";
+    const secretValue = "ghp_fake_token";
     mkdirSync(evidenceDir, { recursive: true });
     mkdirSync(skillRoot, { recursive: true });
     writeFileSync(join(skillRoot, "review.md"), "Prefer current diff evidence.");
@@ -454,7 +454,7 @@ describe("worker review failures", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-gitnexus-secret-"));
     roots.push(root);
     const evidenceDir = join(root, "evidence");
-    const secretValue = "ghp_123456789012345678901234";
+    const secretValue = "ghp_fake_token";
     mkdirSync(evidenceDir, { recursive: true });
     const config: BotConfig = {
       ...minimalConfig(root),
@@ -512,7 +512,7 @@ describe("worker review failures", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-github-related-"));
     roots.push(root);
     const evidenceDir = join(root, "evidence");
-    const secretValue = "ghp_123456789012345678901234";
+    const secretValue = "ghp_fake_token";
     mkdirSync(evidenceDir, { recursive: true });
     const config: BotConfig = {
       ...minimalConfig(root),

--- a/tests/worker-settings-preview.test.ts
+++ b/tests/worker-settings-preview.test.ts
@@ -35,7 +35,7 @@ describe("worker review settings preview evidence", () => {
     const config = minimalConfig(root);
     const state = new ReviewStateStore(config.statePath);
     const pull = pullSummary(1410, "a".repeat(40));
-    const secretLikeToken = "ghp_123456789012345678901234567890123456";
+    const secretLikeToken = "ghp_fake_token";
     const github = {
       getPull: async () => pull,
       listPullFiles: async () => [
@@ -128,7 +128,7 @@ function minimalConfig(root: string): BotConfig {
         "electricsheephq/WorldOS": {
           reviewProfile: "assertive",
           pathInstructions: {
-            "src/`templates`/**": [`Do not quote ghp_123456789012345678901234567890123456 in public comments.`]
+            "src/`templates`/**": [`Do not quote ghp_fake_token in public comments.`]
           },
           suggestedLabels: ["review-settings"],
           suggestedReviewers: ["maintainer-one"]


### PR DESCRIPTION
## Summary

Prepares the NeonDiff implementation repo for the public source-available beta release path without flipping visibility or publishing npm yet.

Changes:
- Renames package metadata to `neondiff@1.0.0-beta.1` with a narrow npm `files` allowlist and `bin.neondiff`.
- Adds canonical installer script, packlist scan, public-claim scan, and tracked-file secret scan.
- Adds CI and npm trusted publishing/provenance workflow scaffolding.
- Updates setup, release, license, and community-funnel docs to point at `electricsheephq/neondiff`, npm install, install script, and source checkout fallback.
- Keeps source-available beta boundaries explicit: not open source, not GA, not enterprise-ready, not CodeRabbit parity.
- Neutralizes long fake secret literals in tests and broadens redaction coverage for shorter fixture tokens plus `sk-` shaped provider keys.

Refs #232.

## Validation

Local focused validation from `/Volumes/LEXAR/repos/worktrees/neondiff-release-readiness`:
- `node scripts/check-secret-scan.mjs`
- `node scripts/check-public-claims.mjs`
- `npx vitest run tests/public-release-readiness.test.ts tests/public-community-funnel.test.ts tests/public-cli.test.ts tests/license.test.ts tests/release-status.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `npm pack --dry-run --json` + `node scripts/check-packlist.mjs`
- Packed tarball smoke: install into temp prefix, `neondiff help`, `neondiff pricing`, `neondiff init --config config.local.json`
- Installer dry-run with temp prefix

Evidence packet root:
`/Volumes/LEXAR/Codex/evidence/neondiff-public-product/2026-07-05/release-readiness/`

## Stop Gates Not Flipped In This PR

- Repo remains private until public-history/settings gates are approved.
- `electricsheephq/neondiff` does not exist yet.
- `neondiff@1.0.0-beta.1` is not published yet.
- `https://neondiff.sh/install` does not resolve yet.
- `v1.0.0-beta.1` GitHub Release is not cut yet.
- Branch protection is not enabled yet.
