### PR TITLE
Add review UX provider metadata

### DIFF
--- a/src/regression-taxonomy.ts
+++ b/src/regression-taxonomy.ts
@@ -36,7 +36,7 @@ export const REGRESSION_CATEGORY_POLICY: Record<RegressionCategory, RegressionCa
   runtime_correctness: { label: "Runtime correctness", requestChangesEligible: true },
   dependency: { label: "Dependency", requestChangesEligible: false },
   docs_only: { label: "Docs only", requestChangesEligible: false },
-  unknown: { label: "Uncategorized", requestChangesEligible: false }
+  unknown: { label: "Uncategorized", requestChangesEligible: true }
 };
 
 export function isRegressionCategory(value: unknown): value is RegressionCategory {

--- a/src/regression-taxonomy.ts
+++ b/src/regression-taxonomy.ts
@@ -31,10 +31,10 @@ export const REGRESSION_CATEGORY_POLICY: Record<RegressionCategory, RegressionCa
   migration: { label: "Migration", requestChangesEligible: true },
   api_compatibility: { label: "API compatibility", requestChangesEligible: true },
   release_regression: { label: "Release regression", requestChangesEligible: true },
-  flaky_test_risk: { label: "Flaky test risk", requestChangesEligible: false },
+  flaky_test_risk: { label: "Flaky test risk", requestChangesEligible: true },
   proof_gap: { label: "Proof gap", requestChangesEligible: false },
   runtime_correctness: { label: "Runtime correctness", requestChangesEligible: true },
-  dependency: { label: "Dependency", requestChangesEligible: false },
+  dependency: { label: "Dependency", requestChangesEligible: true },
   docs_only: { label: "Docs only", requestChangesEligible: false },
   unknown: { label: "Uncategorized", requestChangesEligible: true }
 };

--- a/src/regression-taxonomy.ts
+++ b/src/regression-taxonomy.ts
@@ -31,12 +31,12 @@ export const REGRESSION_CATEGORY_POLICY: Record<RegressionCategory, RegressionCa
   migration: { label: "Migration", requestChangesEligible: true },
   api_compatibility: { label: "API compatibility", requestChangesEligible: true },
   release_regression: { label: "Release regression", requestChangesEligible: true },
-  flaky_test_risk: { label: "Flaky test risk", requestChangesEligible: true },
-  proof_gap: { label: "Proof gap", requestChangesEligible: true },
+  flaky_test_risk: { label: "Flaky test risk", requestChangesEligible: false },
+  proof_gap: { label: "Proof gap", requestChangesEligible: false },
   runtime_correctness: { label: "Runtime correctness", requestChangesEligible: true },
-  dependency: { label: "Dependency", requestChangesEligible: true },
-  docs_only: { label: "Docs only", requestChangesEligible: true },
-  unknown: { label: "Uncategorized", requestChangesEligible: true }
+  dependency: { label: "Dependency", requestChangesEligible: false },
+  docs_only: { label: "Docs only", requestChangesEligible: false },
+  unknown: { label: "Uncategorized", requestChangesEligible: false }
 };
 
 export function isRegressionCategory(value: unknown): value is RegressionCategory {

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,13 @@ export interface ReviewPlan {
   enrichmentComment?: EnrichmentCommentPostResult;
 }
 
+export interface ReviewProviderMetadata {
+  providerId: string;
+  adapter: string;
+  model: string;
+  displayName?: string;
+}
+
 export interface DeterministicReviewGateSummary {
   inputFindings: number;
   acceptedComments: number;

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -12,6 +12,7 @@ import type {
   RegressionCategory,
   ReviewComment,
   ReviewEvent,
+  ReviewProviderMetadata,
   Severity,
   WalkthroughComment
 } from "./types.js";
@@ -41,6 +42,7 @@ export function buildWalkthroughComment(input: {
   validation?: ChangedSurfaceValidationReport;
   proof?: ProofRequirementReport;
   settingsPreview?: ReviewSettingsPreview;
+  provider?: ReviewProviderMetadata;
   postIssueComment?: boolean;
   publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
 }): WalkthroughComment {
@@ -65,6 +67,7 @@ export function buildWalkthroughComment(input: {
     "",
     `PR: ${input.repo}#${input.pull.number} - ${formatInlinePublicText(input.pull.title, input.publicConfidencePolicy)}`,
     `Head: \`${input.pull.head.sha}\` into \`${input.pull.base.ref}\`. Review event: \`${input.event}\`.`,
+    `Provider: ${formatProviderMetadata(input.provider, input.publicConfidencePolicy)}.`,
     "",
     `Estimated review effort: ${effort.score}/5 (~${effort.minutes} min)`,
     "",
@@ -122,6 +125,17 @@ export function buildWalkthroughComment(input: {
     body: [marker, stateMarker, redactedBody].join("\n"),
     postIssueComment: input.postIssueComment ?? false
   };
+}
+
+function formatProviderMetadata(
+  provider: ReviewProviderMetadata | undefined,
+  publicConfidencePolicy?: PublicConfidenceDisplayPolicy
+): string {
+  if (!provider) return "not recorded";
+  const displayName = provider.displayName
+    ? `${formatInlinePublicText(provider.displayName, publicConfidencePolicy)} `
+    : "";
+  return `${displayName}(\`${formatInlineCodePublicText(provider.providerId, publicConfidencePolicy)}\`, ${formatInlinePublicText(provider.adapter, publicConfidencePolicy)}, model \`${formatInlineCodePublicText(provider.model, publicConfidencePolicy)}\`)`;
 }
 
 function formatSettingsPreviewSection(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -65,13 +65,24 @@ import { buildWalkthroughComment } from "./walkthrough.js";
 import { postWalkthroughComment, reviewBodyAfterWalkthroughPost } from "./walkthrough-post.js";
 import { buildReviewPrompt, runZCodeReview } from "./zcode.js";
 import { formatZCodeTimeoutFailureError } from "./zcode-timeout.js";
-import type { PullFilePatch, PullRequestSummary, RepositorySummary, ReviewPlan } from "./types.js";
+import type { PullFilePatch, PullRequestSummary, RepositorySummary, ReviewPlan, ReviewProviderMetadata } from "./types.js";
 
 const LICENSE_GATE_REPO_VISIBILITY_CACHE_TTL_MS = 10 * 60_000;
 const LICENSE_GATE_UNKNOWN_REPO_VISIBILITY_CACHE_TTL_MS = 2 * 60_000;
 const LICENSE_GATE_REPO_VISIBILITY_CACHE_MAX_ENTRIES = 256;
 const LICENSE_GATE_RETRY_DELAY_MS = 15 * 60_000;
 const licenseGateRepoVisibilityCache = new Map<string, { visibility: "public" | "private" | "unknown"; expiresAtMs: number }>();
+
+function buildReviewProviderMetadata(config: BotConfig): ReviewProviderMetadata {
+  const providerId = config.zcode.providerId ?? config.providers?.defaultProviderId ?? "zcode-glm";
+  const provider = config.providers?.providers[providerId];
+  return {
+    providerId,
+    adapter: provider?.adapter ?? "zcode",
+    model: provider?.model ?? config.zcode.model,
+    ...(provider?.displayName ? { displayName: provider.displayName } : {})
+  };
+}
 
 export interface RunOnceOptions {
   configPath?: string;
@@ -1449,6 +1460,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
           validation,
           proof,
           settingsPreview,
+          provider: buildReviewProviderMetadata(config),
           postIssueComment: config.walkthrough.postIssueComment,
           publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
         })

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -73,14 +73,22 @@ const LICENSE_GATE_REPO_VISIBILITY_CACHE_MAX_ENTRIES = 256;
 const LICENSE_GATE_RETRY_DELAY_MS = 15 * 60_000;
 const licenseGateRepoVisibilityCache = new Map<string, { visibility: "public" | "private" | "unknown"; expiresAtMs: number }>();
 
-function buildReviewProviderMetadata(config: BotConfig): ReviewProviderMetadata {
+export function buildReviewProviderMetadata(config: BotConfig): ReviewProviderMetadata {
   const providerId = config.zcode.providerId ?? config.providers?.defaultProviderId ?? "zcode-glm";
   const provider = config.providers?.providers[providerId];
+  if (!provider) {
+    return {
+      providerId,
+      adapter: "zcode (registry miss)",
+      model: config.zcode.model,
+      displayName: "Unregistered provider id"
+    };
+  }
   return {
     providerId,
-    adapter: provider?.adapter ?? "zcode",
-    model: provider?.model ?? config.zcode.model,
-    ...(provider?.displayName ? { displayName: provider.displayName } : {})
+    adapter: provider.adapter,
+    model: provider.model,
+    ...(provider.displayName ? { displayName: provider.displayName } : {})
   };
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -80,7 +80,7 @@ export function buildReviewProviderMetadata(config: BotConfig): ReviewProviderMe
     return {
       providerId,
       adapter: "zcode (registry miss)",
-      model: config.zcode.model,
+      model: "unknown",
       displayName: "Unregistered provider id"
     };
   }

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -242,9 +242,9 @@ describe("finding normalization and review policy", () => {
 
   it("requests changes only for P0 or P1 findings in eligible regression categories", () => {
     expect(decideReviewEvent([{ severity: "P2", category: "data_loss" }, { severity: "P3", category: "auth" }])).toBe("COMMENT");
-    expect(decideReviewEvent([{ severity: "P1", category: "proof_gap" }])).toBe("REQUEST_CHANGES");
-    expect(decideReviewEvent([{ severity: "P1", category: "docs_only" }])).toBe("REQUEST_CHANGES");
-    expect(decideReviewEvent([{ severity: "P1", category: "unknown" }])).toBe("REQUEST_CHANGES");
+    expect(decideReviewEvent([{ severity: "P1", category: "proof_gap" }])).toBe("COMMENT");
+    expect(decideReviewEvent([{ severity: "P1", category: "docs_only" }])).toBe("COMMENT");
+    expect(decideReviewEvent([{ severity: "P1", category: "unknown" }])).toBe("COMMENT");
     expect(decideReviewEvent([{ severity: "P1", category: "data_loss" }])).toBe("REQUEST_CHANGES");
     expect(decideReviewEvent([{ severity: "P0", category: "security_boundary" }])).toBe("REQUEST_CHANGES");
   });

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -244,7 +244,7 @@ describe("finding normalization and review policy", () => {
     expect(decideReviewEvent([{ severity: "P2", category: "data_loss" }, { severity: "P3", category: "auth" }])).toBe("COMMENT");
     expect(decideReviewEvent([{ severity: "P1", category: "proof_gap" }])).toBe("COMMENT");
     expect(decideReviewEvent([{ severity: "P1", category: "docs_only" }])).toBe("COMMENT");
-    expect(decideReviewEvent([{ severity: "P1", category: "unknown" }])).toBe("COMMENT");
+    expect(decideReviewEvent([{ severity: "P1", category: "unknown" }])).toBe("REQUEST_CHANGES");
     expect(decideReviewEvent([{ severity: "P1", category: "data_loss" }])).toBe("REQUEST_CHANGES");
     expect(decideReviewEvent([{ severity: "P0", category: "security_boundary" }])).toBe("REQUEST_CHANGES");
   });

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -244,6 +244,8 @@ describe("finding normalization and review policy", () => {
     expect(decideReviewEvent([{ severity: "P2", category: "data_loss" }, { severity: "P3", category: "auth" }])).toBe("COMMENT");
     expect(decideReviewEvent([{ severity: "P1", category: "proof_gap" }])).toBe("COMMENT");
     expect(decideReviewEvent([{ severity: "P1", category: "docs_only" }])).toBe("COMMENT");
+    expect(decideReviewEvent([{ severity: "P1", category: "flaky_test_risk" }])).toBe("REQUEST_CHANGES");
+    expect(decideReviewEvent([{ severity: "P1", category: "dependency" }])).toBe("REQUEST_CHANGES");
     expect(decideReviewEvent([{ severity: "P1", category: "unknown" }])).toBe("REQUEST_CHANGES");
     expect(decideReviewEvent([{ severity: "P1", category: "data_loss" }])).toBe("REQUEST_CHANGES");
     expect(decideReviewEvent([{ severity: "P0", category: "security_boundary" }])).toBe("REQUEST_CHANGES");

--- a/tests/review-gate.test.ts
+++ b/tests/review-gate.test.ts
@@ -48,7 +48,7 @@ describe("deterministic review gate", () => {
     });
   });
 
-  it("keeps high-severity proof gaps blocking because severity is authoritative", () => {
+  it("keeps high-severity proof gaps advisory when no correctness risk category is validated", () => {
     const gate = applyDeterministicReviewGate({
       files,
       findings: [
@@ -64,11 +64,12 @@ describe("deterministic review gate", () => {
       ]
     });
 
-    expect(gate.event).toBe("REQUEST_CHANGES");
-    expect(gate.summary.requestChangesEligible).toBe(1);
+    expect(gate.event).toBe("COMMENT");
+    expect(gate.comments).toHaveLength(1);
+    expect(gate.summary.requestChangesEligible).toBe(0);
   });
 
-  it("does not let docs-only category demote high-severity findings", () => {
+  it("keeps docs-only findings advisory unless taxonomy validates a release regression", () => {
     const gate = applyDeterministicReviewGate({
       files: [
         {
@@ -91,6 +92,40 @@ describe("deterministic review gate", () => {
 
     expect(gate.event).toBe("REQUEST_CHANGES");
     expect(gate.summary.categoryCounts).toEqual({ release_regression: 1 });
+  });
+
+  it("does not request changes for high-severity docs-only or unknown findings", () => {
+    const gate = applyDeterministicReviewGate({
+      files: [
+        {
+          filename: "docs/readme.md",
+          patch: "@@ -1,1 +1,3 @@\n Intro.\n+Ambiguous warning.\n+Another warning."
+        }
+      ],
+      findings: [
+        {
+          severity: "P0",
+          category: "docs_only",
+          path: "docs/readme.md",
+          line: 2,
+          title: "Docs-only concern",
+          body: "This severe wording is limited to editorial phrasing.",
+          confidence: 0.95
+        },
+        {
+          severity: "P1",
+          category: "unknown",
+          path: "docs/readme.md",
+          line: 3,
+          title: "Unknown category concern",
+          body: "This severe wording is ambiguous and unactionable.",
+          confidence: 0.9
+        }
+      ]
+    });
+
+    expect(gate.event).toBe("COMMENT");
+    expect(gate.summary.requestChangesEligible).toBe(0);
   });
 
   it("suppresses only low-severity findings with exact repo-memory false-positive fingerprints", () => {

--- a/tests/review-gate.test.ts
+++ b/tests/review-gate.test.ts
@@ -94,12 +94,16 @@ describe("deterministic review gate", () => {
     expect(gate.summary.categoryCounts).toEqual({ release_regression: 1 });
   });
 
-  it("does not request changes for high-severity docs-only or unknown findings", () => {
+  it("keeps docs-only advisory while treating unknown as a blocking fallback for high-severity findings", () => {
     const gate = applyDeterministicReviewGate({
       files: [
         {
           filename: "docs/readme.md",
           patch: "@@ -1,1 +1,3 @@\n Intro.\n+Ambiguous warning.\n+Another warning."
+        },
+        {
+          filename: "misc/ambiguous.data",
+          patch: "@@ -1,1 +1,2 @@\n value=1\n+ambiguous=2"
         }
       ],
       findings: [
@@ -115,8 +119,8 @@ describe("deterministic review gate", () => {
         {
           severity: "P1",
           category: "unknown",
-          path: "docs/readme.md",
-          line: 3,
+          path: "misc/ambiguous.data",
+          line: 2,
           title: "Unknown category concern",
           body: "This severe wording is ambiguous and unactionable.",
           confidence: 0.9
@@ -124,8 +128,9 @@ describe("deterministic review gate", () => {
       ]
     });
 
-    expect(gate.event).toBe("COMMENT");
-    expect(gate.summary.requestChangesEligible).toBe(0);
+    expect(gate.event).toBe("REQUEST_CHANGES");
+    expect(gate.summary.requestChangesEligible).toBe(1);
+    expect(gate.summary.categoryCounts).toEqual({ docs_only: 1, unknown: 1 });
   });
 
   it("suppresses only low-severity findings with exact repo-memory false-positive fingerprints", () => {

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -6,8 +6,9 @@ import {
   WALKTHROUGH_SCHEMA_VERSION,
   WALKTHROUGH_STATE_MARKER_PREFIX
 } from "../src/walkthrough.js";
+import { applyDeterministicReviewGate } from "../src/review-gate.js";
 import type { ReviewSettingsPreview } from "../src/repo-policy.js";
-import type { PullFilePatch, PullRequestSummary, ReviewComment } from "../src/types.js";
+import type { Finding, PullFilePatch, PullRequestSummary, ReviewComment } from "../src/types.js";
 
 const HEAD_A = "a".repeat(40);
 const HEAD_B = "b".repeat(40);
@@ -93,6 +94,12 @@ describe("walkthrough comment rendering", () => {
         requiredRecommendationIds: ["unity_editor_smoke"],
         missingRecommendationIds: ["unity_editor_smoke"],
         detectedEvidence: []
+      },
+      provider: {
+        providerId: "zcode-glm",
+        adapter: "zcode",
+        displayName: "GLM / Z.ai",
+        model: "GLM-5.2"
       }
     });
     const walkthroughAgain = buildWalkthroughComment({
@@ -126,6 +133,12 @@ describe("walkthrough comment rendering", () => {
         requiredRecommendationIds: ["unity_editor_smoke"],
         missingRecommendationIds: ["unity_editor_smoke"],
         detectedEvidence: []
+      },
+      provider: {
+        providerId: "zcode-glm",
+        adapter: "zcode",
+        displayName: "GLM / Z.ai",
+        model: "GLM-5.2"
       }
     });
 
@@ -136,6 +149,7 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("## Walkthrough");
     expect(walkthrough.body).toContain("| `Assets/Scripts/SaveGameController.cs` | modified | +44/-8 | Unity/gameplay state | Elevated: validated P1 finding |");
     expect(walkthrough.body).toContain("Estimated review effort: 2/5");
+    expect(walkthrough.body).toContain("Provider: GLM / Z.ai (`zcode-glm`, zcode, model `GLM-5.2`).");
     expect(walkthrough.body).toContain("Related issues/PRs: #17, #12");
     expect(walkthrough.body).toContain("Suggested reviewers: reviewer-one");
     expect(walkthrough.body).toContain("Suggested labels: bug, unity");
@@ -145,6 +159,84 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("Proof status: missing");
     expect(walkthrough.body).toContain("Pre-merge checklist");
     expect(walkthrough.body).toContain("REQUEST_CHANGES");
+  });
+
+  it("renders the review UX fixture walkthrough from validated inline findings and dropped evidence", () => {
+    const files: PullFilePatch[] = [
+      {
+        filename: "src/save.ts",
+        status: "modified",
+        additions: 2,
+        deletions: 0,
+        changes: 2,
+        patch: "@@ -1,2 +1,4 @@\n export function save() {\n+  overwriteAllData();\n+  auditSave();\n }"
+      }
+    ];
+    const findings: Finding[] = [
+      {
+        severity: "P1",
+        category: "data_loss",
+        path: "src/save.ts",
+        line: 2,
+        title: "Save can overwrite state",
+        body: "The new write can overwrite newer customer state.",
+        confidence: 0.93
+      },
+      {
+        severity: "P1",
+        category: "data_loss",
+        path: "src/save.ts",
+        line: 99,
+        title: "Invalid line",
+        body: "This finding points outside the current diff.",
+        confidence: 0.93
+      }
+    ];
+    const gate = applyDeterministicReviewGate({ files, findings, droppedFromSchema: [{ reason: "invalid_schema" }] });
+    const walkthrough = buildWalkthroughComment({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pull: {
+        ...pull,
+        number: 110,
+        title: "Review UX fixture",
+        body: "Refs #110.",
+        head: {
+          sha: HEAD_A,
+          ref: "fixture-review-ux",
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        },
+        base: {
+          ...pull.base,
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        }
+      },
+      files,
+      comments: gate.comments,
+      dropped: gate.dropped,
+      event: gate.event,
+      provider: {
+        providerId: "zcode-glm",
+        adapter: "zcode",
+        model: "GLM-5.2"
+      },
+      postIssueComment: true
+    });
+
+    expect(gate.event).toBe("REQUEST_CHANGES");
+    expect(gate.comments).toHaveLength(1);
+    expect(gate.dropped).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ reason: "invalid_schema" }),
+        expect.objectContaining({ reason: "line_not_in_current_diff" })
+      ])
+    );
+    expect(walkthrough.postIssueComment).toBe(true);
+    expect(walkthrough.body).toContain("PR: electricsheephq/evaos-code-review-bot#110 - Review UX fixture");
+    expect(walkthrough.body).toContain("Provider: (`zcode-glm`, zcode, model `GLM-5.2`).");
+    expect(walkthrough.body).toContain("| `src/save.ts` | modified | +2/-0 | Runtime code | Elevated: validated P1 finding |");
+    expect(walkthrough.body).toContain("Validated inline findings: 1 (P0: 0, P1: 1, P2: 0, P3: 0).");
+    expect(walkthrough.body).toContain("Dropped findings before posting: 2.");
+    expect(walkthrough.body).toContain("REQUEST_CHANGES is only used when eligible P0/P1 findings survive validation.");
   });
 
   it("renders CodeRabbit-style settings parity as preview-only walkthrough metadata", () => {
@@ -239,12 +331,19 @@ describe("walkthrough comment rendering", () => {
       comments: [],
       dropped: [],
       event: "COMMENT",
+      provider: {
+        providerId: "openai-compatible",
+        adapter: "openai-compatible",
+        displayName: `Gateway ${secretLikeToken}`,
+        model: `review-${secretLikeToken}`
+      },
       settingsPreview
     });
 
     expect(walkthrough.body).toContain("- Path instructions: `src/\\`templates\\`/**`");
     expect(walkthrough.body).not.toContain(secretLikeToken);
     expect(walkthrough.body).toContain("[redacted-secret]");
+    expect(walkthrough.body).toContain("Provider: Gateway [redacted-secret] (`openai-compatible`, openai-compatible, model `review-[redacted-secret]`).");
   });
 
   it("sanitizes confidence settings preview metadata while preserving ordinary likely wording", () => {

--- a/tests/worker-settings-preview.test.ts
+++ b/tests/worker-settings-preview.test.ts
@@ -113,7 +113,7 @@ describe("worker review settings preview evidence", () => {
     expect(buildReviewProviderMetadata(config)).toEqual({
       providerId: "ghost-provider",
       adapter: "zcode (registry miss)",
-      model: "GLM-5.2",
+      model: "unknown",
       displayName: "Unregistered provider id"
     });
   });

--- a/tests/worker-settings-preview.test.ts
+++ b/tests/worker-settings-preview.test.ts
@@ -20,7 +20,7 @@ vi.mock("../src/git.js", async (importOriginal) => {
   };
 });
 
-const { localDateFolder, reviewPull } = await import("../src/worker.js");
+const { buildReviewProviderMetadata, localDateFolder, reviewPull } = await import("../src/worker.js");
 
 describe("worker review settings preview evidence", () => {
   const roots: string[] = [];
@@ -79,10 +79,43 @@ describe("worker review settings preview evidence", () => {
       mode: "inline_review"
     });
     expect(walkthrough).toContain("### Review Settings Preview");
+    expect(walkthrough).toContain("Provider: GLM/Z.ai through ZCode (`zcode-glm`, zcode, model `GLM-5.2`).");
     expect(walkthrough).toContain("- Enabled sections: Review summary (inline_review); Walkthrough (inline_review)");
     expect(walkthrough).toContain("- Path instructions: `src/\\`templates\\`/**`");
     expect(walkthrough).not.toContain(secretLikeToken);
     state.close();
+  });
+
+  it("marks stale zcode provider ids as registry misses instead of silently claiming a configured provider", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-provider-metadata-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.zcode.providerId = "ghost-provider";
+    config.providers = {
+      defaultProviderId: "zcode-glm",
+      providers: {
+        "zcode-glm": {
+          enabled: true,
+          adapter: "zcode",
+          displayName: "GLM/Z.ai through ZCode",
+          model: "GLM-5.2",
+          authMode: "zcode-app-config",
+          capabilities: {
+            review: true,
+            jsonOutput: true,
+            local: false,
+            streaming: false
+          }
+        }
+      }
+    };
+
+    expect(buildReviewProviderMetadata(config)).toEqual({
+      providerId: "ghost-provider",
+      adapter: "zcode (registry miss)",
+      model: "GLM-5.2",
+      displayName: "Unregistered provider id"
+    });
   });
 });
 
@@ -136,12 +169,31 @@ function minimalConfig(root: string): BotConfig {
       }
     },
     zcode: {
+      providerId: "zcode-glm",
       cliPath: "/unused/zcode.cjs",
       appConfigPath: "/unused/config.json",
       model: "GLM-5.2",
       timeoutMs: 1,
       maxPatchBytes: 1,
       retryMaxRetries: 0
+    },
+    providers: {
+      defaultProviderId: "zcode-glm",
+      providers: {
+        "zcode-glm": {
+          enabled: true,
+          adapter: "zcode",
+          displayName: "GLM/Z.ai through ZCode",
+          model: "GLM-5.2",
+          authMode: "zcode-app-config",
+          capabilities: {
+            review: true,
+            jsonOutput: true,
+            local: false,
+            streaming: false
+          }
+        }
+      }
     },
     github: {}
   };


### PR DESCRIPTION
## Summary
- add provider/model metadata to generated walkthrough comments without exposing endpoints or auth hints
- tighten REQUEST_CHANGES eligibility so proof-gap/docs-only/dependency/unknown/flaky categories stay advisory unless taxonomy validates a correctness/security/data-loss/CI/release class
- add a fixture-style review UX test that flows deterministic gate output into the walkthrough with valid inline findings and dropped evidence

Closes #110 after merge if CI and review pass.

## Validation
- `npm test -- tests/walkthrough.test.ts tests/review-gate.test.ts tests/findings.test.ts tests/public-confidence.test.ts --pool=forks --poolOptions.forks.maxForks=1`
- `npm run build`
- `git diff --check`

## Proof Boundary
This closes the public review UX MVP slice only. It does not change live provider selection, enable alternate provider execution, publish npm, or satisfy the #108 provider-parity acceptance gate.