### PR TITLE
Align public release URLs with existing NeonDiff repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ If you are a coding agent working in this repository:
 - Private and commercial repos require a paid license.
 - License keys support paid/private usage and update entitlement.
 - Exact license text, public/private grants, and commercial terms are governed
-  by https://github.com/electricsheephq/neondiff/issues/104. Public beta
-  release readiness is tracked by https://github.com/electricsheephq/neondiff/issues/232.
+  by https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/104. Public beta
+  release readiness is tracked by https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/232.
 
 Do not claim open-source/MIT status, public launch completion, GA readiness,
 CodeRabbit parity, enterprise readiness, or legal adequacy from this file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ contributions are focused, test-backed, and careful about public claims.
 - [GitHub App setup](docs/github-app-setup.md)
 - [Security policy](SECURITY.md)
 - [Code of Conduct](CODE_OF_CONDUCT.md)
-- [Product roadmap](https://github.com/electricsheephq/neondiff/issues/103)
-- [Public beta release readiness](https://github.com/electricsheephq/neondiff/issues/232)
+- [Product roadmap](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103)
+- [Public beta release readiness](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/232)
 
 ## Issue Routing
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ source-available beta, not an open-source or GA release.
 [Code of Conduct](CODE_OF_CONDUCT.md) · [License](LICENSE.md) ·
 [License Boundary](docs/license-boundary.md) · [Pricing](docs/pricing.md) ·
 [Providers](docs/providers.md) ·
-[Roadmap](https://github.com/electricsheephq/neondiff/issues/103) ·
-[Repository](https://github.com/electricsheephq/neondiff)
+[Roadmap](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103) ·
+[Repository](https://github.com/electricsheephq/evaos-code-review-bot-neondiff)
 
 ## Why It Matters
 
@@ -71,20 +71,20 @@ npm install -g neondiff@1.0.0-beta.1
 Installer script path:
 
 ```bash
-curl -fsSL https://neondiff.sh/install | sh
+curl -fsSL https://www.neondiff.com/install | sh
 ```
 
 The installer script checks for Node.js 26 or newer and installs the same npm
 package. To preview without changing your machine:
 
 ```bash
-curl -fsSL https://neondiff.sh/install | sh -s -- --dry-run
+curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
 ```
 
 Source checkout fallback:
 
 ```bash
-git clone https://github.com/electricsheephq/neondiff.git neondiff
+git clone https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git neondiff
 cd neondiff
 npm install
 npm run build
@@ -142,11 +142,11 @@ If you are contributing as an AI coding agent:
 
 Useful public-product issues:
 
-- [#103 NeonDiff public product roadmap](https://github.com/electricsheephq/neondiff/issues/103)
-- [#104 license and commercial boundary](https://github.com/electricsheephq/neondiff/issues/104)
-- [#105 pricing implementation](https://github.com/electricsheephq/neondiff/issues/105)
-- [#107 CLI package and local daemon public install flow](https://github.com/electricsheephq/neondiff/issues/107)
-- [#113 agent-first CLI and API documentation contract](https://github.com/electricsheephq/neondiff/issues/113)
+- [#103 NeonDiff public product roadmap](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103)
+- [#104 license and commercial boundary](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/104)
+- [#105 pricing implementation](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/105)
+- [#107 CLI package and local daemon public install flow](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/107)
+- [#113 agent-first CLI and API documentation contract](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/113)
 
 ## Safety Boundaries
 
@@ -177,7 +177,7 @@ Not claimed:
 ## Roadmap Vs Shipped
 
 The current repo is a source-available beta implementation. The public MVP is
-tracked in [#103](https://github.com/electricsheephq/neondiff/issues/103).
+tracked in [#103](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103).
 Provider registry, `.neondiff.yml`, public package publishing, license activation,
 desktop client, wiki exports, marketplace packaging, and confidence calibration
 each have separate issues and must not be treated as shipped until their PRs and

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -33,27 +33,27 @@ npm install -g neondiff@1.0.0-beta.1
 Installer script:
 
 ```bash
-curl -fsSL https://neondiff.sh/install | sh
+curl -fsSL https://www.neondiff.com/install | sh
 ```
 
 Preview the installer without changing your machine:
 
 ```bash
-curl -fsSL https://neondiff.sh/install | sh -s -- --dry-run
+curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
 ```
 
 Use a temp npm prefix for isolated install proof:
 
 ```bash
 tmp_prefix="$(mktemp -d)"
-curl -fsSL https://neondiff.sh/install | sh -s -- --prefix "$tmp_prefix"
+curl -fsSL https://www.neondiff.com/install | sh -s -- --prefix "$tmp_prefix"
 "$tmp_prefix/bin/neondiff" help
 ```
 
 Source checkout fallback:
 
 ```bash
-git clone https://github.com/electricsheephq/neondiff.git neondiff
+git clone https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git neondiff
 cd neondiff
 npm install
 npm run build

--- a/docs/license-boundary.md
+++ b/docs/license-boundary.md
@@ -96,8 +96,8 @@ Private-repo failure copy should say:
 
 ## Tracking
 
-- Public product roadmap: https://github.com/electricsheephq/neondiff/issues/103
-- License/commercial boundary gate: https://github.com/electricsheephq/neondiff/issues/104
-- Pricing implementation: https://github.com/electricsheephq/neondiff/issues/105
-- License activation implementation: https://github.com/electricsheephq/neondiff/issues/111
-- Public beta release readiness: https://github.com/electricsheephq/neondiff/issues/232
+- Public product roadmap: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103
+- License/commercial boundary gate: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/104
+- Pricing implementation: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/105
+- License activation implementation: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/111
+- Public beta release readiness: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/232

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -10,7 +10,7 @@
   "licenseApi": {
     "requiredForThisRelease": false,
     "state": "pending",
-    "trackingIssue": "https://github.com/electricsheephq/neondiff/issues/111"
+    "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/111"
   },
   "updateChannels": {
     "cli": {
@@ -33,7 +33,7 @@
     "desktop": {
       "requiredForThisRelease": false,
       "state": "post_1_0",
-      "trackingIssue": "https://github.com/electricsheephq/neondiff/issues/116"
+      "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/116"
     }
   }
 }

--- a/docs/releases/v1.0.0-beta.1.md
+++ b/docs/releases/v1.0.0-beta.1.md
@@ -48,7 +48,7 @@ does not by itself publish a public beta.
 - `npm test` and `npm run build` pass.
 - GitHub prerelease exists for the exact tag target SHA.
 - `npm view neondiff version` returns `1.0.0-beta.1`.
-- `curl -fsSL https://neondiff.sh/install | sh -s -- --dry-run` passes.
+- `curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run` passes.
 - Clean temp-prefix install can run `neondiff help`, `neondiff pricing`, and
   `neondiff init --config <temp-config>`.
 - `release-status` passes with:
@@ -95,7 +95,7 @@ Public install verification:
 
 ```bash
 npm install -g neondiff@1.0.0-beta.1
-curl -fsSL https://neondiff.sh/install | sh -s -- --dry-run
+curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
 ```
 
 ## Notes

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://www.neondiff.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/electricsheephq/neondiff.git"
+    "url": "git+https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git"
   },
   "files": [
     "dist/src",

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -31,11 +31,11 @@ describe("NeonDiff public community funnel", () => {
       /source-available beta/i,
       /GitHub App/i,
       /dry-run review/i,
-      /electricsheephq\/neondiff\/issues\/103/i,
-      /electricsheephq\/neondiff\/issues\/104/i,
-      /electricsheephq\/neondiff\/issues\/105/i,
-      /electricsheephq\/neondiff\/issues\/107/i,
-      /electricsheephq\/neondiff\/issues\/113/i
+      /electricsheephq\/evaos-code-review-bot-neondiff\/issues\/103/i,
+      /electricsheephq\/evaos-code-review-bot-neondiff\/issues\/104/i,
+      /electricsheephq\/evaos-code-review-bot-neondiff\/issues\/105/i,
+      /electricsheephq\/evaos-code-review-bot-neondiff\/issues\/107/i,
+      /electricsheephq\/evaos-code-review-bot-neondiff\/issues\/113/i
     ]) {
       expect(readme).toMatch(required);
     }

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -32,7 +32,7 @@ describe("NeonDiff public release readiness", () => {
     expect(pkg.homepage).toBe("https://www.neondiff.com");
     expect(pkg.repository).toMatchObject({
       type: "git",
-      url: "git+https://github.com/electricsheephq/neondiff.git"
+      url: "git+https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git"
     });
     expect(pkg.bin).toEqual({ neondiff: "dist/src/cli.js" });
     expect(pkg.files).toEqual([
@@ -71,7 +71,7 @@ describe("NeonDiff public release readiness", () => {
     expect(script).not.toMatch(/ghp_|github_pat_|BEGIN (RSA|OPENSSH|PRIVATE) KEY|sk-[A-Za-z0-9]/);
   });
 
-  it("public setup docs point to npm, install script, source fallback, and the planned public repo", () => {
+  it("public setup docs point to npm, install script, source fallback, and the public implementation repo", () => {
     const docs = [
       read("README.md"),
       read("docs/SETUP.md"),
@@ -81,10 +81,10 @@ describe("NeonDiff public release readiness", () => {
       read("docs/releases/v1.0.0-beta.1.md")
     ].join("\n\n");
 
-    expect(docs).toMatch(/https:\/\/github\.com\/electricsheephq\/neondiff/i);
+    expect(docs).toMatch(/https:\/\/github\.com\/electricsheephq\/evaos-code-review-bot-neondiff/i);
     expect(docs).toMatch(/npm install -g neondiff@1\.0\.0-beta\.1/i);
-    expect(docs).toMatch(/curl -fsSL https:\/\/neondiff\.sh\/install/i);
-    expect(docs).toMatch(/git clone https:\/\/github\.com\/electricsheephq\/neondiff\.git/i);
+    expect(docs).toMatch(/curl -fsSL https:\/\/www\.neondiff\.com\/install/i);
+    expect(docs).toMatch(/git clone https:\/\/github\.com\/electricsheephq\/evaos-code-review-bot-neondiff\.git/i);
     expect(docs).not.toMatch(/https:\/\/github\.com\/electricsheephq\/evaos-code-review-bot(?!-neondiff)/i);
     expect(docs).not.toMatch(/npm link installs the local source-checkout shim/i);
   });

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -282,7 +282,7 @@ describe("beta release status", () => {
     });
     expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.9-beta.1");
     expect(redactedOutput).toContain("cli=source_checkout; daemon=launchd_prerelease");
-    expect(redactedOutput).toContain("https://github.com/electricsheephq/neondiff/issues/111");
+    expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/111");
   });
 
   it("fails closed without throwing when collectReleaseStatus receives a missing public manifest path", () => {


### PR DESCRIPTION
## Summary

- keep the existing implementation repo URL as the public source surface: `electricsheephq/evaos-code-review-bot-neondiff`
- update package metadata, setup docs, release manifest, release notes, and claim tests away from the planned `electricsheephq/neondiff` rename
- use the live `https://www.neondiff.com/install` route instead of unresolved `https://neondiff.sh/install`

Closes part of #235 by removing the unnecessary repo-rename dependency from public release readiness.

## Validation

- `npm test -- tests/public-release-readiness.test.ts tests/release-status.test.ts --pool=forks --poolOptions.forks.maxForks=1`
- `npm run build`
- `node scripts/check-public-claims.mjs`
- `node scripts/check-secret-scan.mjs`
- `npm pack --dry-run --json` + `node scripts/check-packlist.mjs`
- `git diff --check`

## Proof Boundary

This aligns the documented/package public repo and installer URL. It does not flip repository visibility, publish npm, cut `v1.0.0-beta.1`, or prove final clean-room install from npm.
