### PR TITLE
Fix issue enrichment self-trigger reruns

### DIFF
--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -119,16 +119,18 @@ export function buildEnrichmentComment(input: {
     "No labels or reviewers were applied by this bot."
   ].join("\n");
   const redactedVisibleBody = redactSecrets(visibleBody);
+  const bodyHash = hashBody(redactedVisibleBody);
   const stateMarker = buildStateMarker({
     repo: input.repo,
     pullNumber: input.pull.number,
     headSha: input.pull.head.sha,
-    bodyHash: hashBody(redactedVisibleBody)
+    bodyHash
   });
 
   return {
     marker,
     body: [marker, stateMarker, redactedVisibleBody].join("\n"),
+    bodyHash,
     postIssueComment: input.postIssueComment ?? false
   };
 }
@@ -194,16 +196,18 @@ export function buildIssueEnrichmentComment(input: {
     "No labels, owners, reviewers, or roadmap fields were changed by this bot."
   ].join("\n");
   const redactedVisibleBody = redactSecrets(visibleBody);
+  const bodyHash = hashBody(redactedVisibleBody);
   const stateMarker = buildIssueStateMarker({
     repo: input.repo,
     issueNumber: input.issue.number,
     state,
-    bodyHash: hashBody(redactedVisibleBody)
+    bodyHash
   });
 
   return {
     marker,
     body: [marker, stateMarker, redactedVisibleBody].join("\n"),
+    bodyHash,
     postIssueComment: input.postIssueComment ?? false
   };
 }

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -2,6 +2,7 @@ import {
   buildIssueEnrichmentComment,
   buildIssueEnrichmentDryRunOutput,
   postEnrichmentComment,
+  type EnrichmentComment,
   type EnrichmentCommentGithub
 } from "./enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
@@ -603,11 +604,37 @@ export async function runIssueEnrichmentCycle(input: {
     }
 
     const issuesByKey = new Map<string, GitHubRelatedIssueOrPull>();
+    const plannedEnrichmentByIssue = new Map<string, EnrichmentComment>();
+    const plannedBodyHashByIssue = new Map<string, string | undefined>();
+    const plannedEnrichmentForItem = (item: IssueEnrichmentScanItem): EnrichmentComment | undefined => {
+      if (!isIssueEnrichmentCommentAction(item.action)) return undefined;
+      const key = issueKey(item.repo, item.issueNumber);
+      const cached = plannedEnrichmentByIssue.get(key);
+      if (cached) return cached;
+      const issue = issuesByKey.get(key);
+      if (!issue) return undefined;
+      const enrichment = buildIssueEnrichmentForCycle(config, item.repo, issue);
+      plannedEnrichmentByIssue.set(key, enrichment);
+      return enrichment;
+    };
+    const plannedBodyHashForItem = (item: IssueEnrichmentScanItem): string | undefined => {
+      if (!isIssueEnrichmentCommentAction(item.action)) return undefined;
+      const key = issueKey(item.repo, item.issueNumber);
+      if (plannedBodyHashByIssue.has(key)) return plannedBodyHashByIssue.get(key);
+      const enrichment = plannedEnrichmentForItem(item);
+      const bodyHash = enrichment?.bodyHash;
+      plannedBodyHashByIssue.set(key, bodyHash);
+      return bodyHash;
+    };
     const shouldCountItem = (item: IssueEnrichmentScanItem) => {
+      if (input.force === true) return true;
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
-      return input.force === true || !(existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt));
+      const bodyHash = issue && shouldCompareIssueEnrichmentBodyHash(existing, issueUpdatedAt)
+        ? plannedBodyHashForItem(item)
+        : undefined;
+      return !(existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, bodyHash, item.action));
     };
     const scanned = reposToScan.length
       ? await collectIssueEnrichmentScan({
@@ -669,7 +696,26 @@ export async function runIssueEnrichmentCycle(input: {
       const issue = issuesByKey.get(issueKey(item.repo, item.issueNumber));
       const issueUpdatedAt = canonicalIssueUpdatedAt(issue, checkedAt);
       const existing = input.state.getIssueEnrichmentRecord(item.repo, item.issueNumber);
-      if (input.force !== true && existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt)) {
+      const bodyHash = shouldCompareIssueEnrichmentBodyHash(existing, issueUpdatedAt) ||
+        shouldBackfillIssueEnrichmentBodyHash(existing, issueUpdatedAt, item.action)
+        ? plannedBodyHashForItem(item)
+        : undefined;
+      if (input.force !== true && existing && shouldSkipIssueEnrichmentRecord(existing, issueUpdatedAt, checkedAt, bodyHash, item.action)) {
+        const refreshedBodyHash = existing.bodyHash ?? bodyHash;
+        if (!input.dryRun && (existing.issueUpdatedAt !== issueUpdatedAt || refreshedBodyHash !== existing.bodyHash)) {
+          input.state.recordIssueEnrichment({
+            repo: item.repo,
+            issueNumber: item.issueNumber,
+            issueUpdatedAt,
+            ...(refreshedBodyHash ? { bodyHash: refreshedBodyHash } : {}),
+            status: existing.status,
+            ...(existing.reason ? { reason: existing.reason } : {}),
+            ...(existing.commentUrl ? { commentUrl: existing.commentUrl } : {}),
+            ...(existing.error ? { error: existing.error } : {}),
+            ...(existing.nextEligibleAt ? { nextEligibleAt: existing.nextEligibleAt } : {}),
+            now: new Date(checkedAt)
+          });
+        }
         summary.alreadyProcessed += 1;
         items.push({ ...item, skippedExisting: true, recordStatus: existing.status });
         continue;
@@ -709,10 +755,12 @@ export async function runIssueEnrichmentCycle(input: {
       }
 
       if (!config.postIssueComment || item.action === "would_enrich") {
+        const dryRunBodyHash = plannedBodyHashForItem(item);
         input.state.recordIssueEnrichment({
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
+          ...(dryRunBodyHash ? { bodyHash: dryRunBodyHash } : {}),
           status: "dry_run",
           reason: "dry_run_only",
           now: new Date(checkedAt)
@@ -724,15 +772,9 @@ export async function runIssueEnrichmentCycle(input: {
 
       try {
         if (!issue) throw new Error(`Issue metadata missing for ${item.repo}#${item.issueNumber}`);
-        const policy = resolveIssueEnrichmentRepoPolicy(config, item.repo);
-        const allowlists = issueSuggestionAllowlists(policy.suggestions);
-        const enrichment = buildIssueEnrichmentComment({
-          repo: item.repo,
-          issue,
-          allowedLabels: allowlists.allowedLabels,
-          allowedOwners: allowlists.allowedOwners,
-          postIssueComment: true
-        });
+        const plannedEnrichment = plannedEnrichmentForItem(item);
+        const enrichment = plannedEnrichment ?? buildIssueEnrichmentForCycle(config, item.repo, issue);
+        const postBodyHash = plannedBodyHashForItem(item) ?? enrichment.bodyHash;
         const post = await postEnrichmentComment({
           enabled: true,
           dryRun: false,
@@ -747,6 +789,7 @@ export async function runIssueEnrichmentCycle(input: {
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
+          ...(postBodyHash ? { bodyHash: postBodyHash } : {}),
           status: "posted",
           ...(commentUrl ? { commentUrl } : {}),
           now: new Date(checkedAt)
@@ -759,6 +802,7 @@ export async function runIssueEnrichmentCycle(input: {
           repo: item.repo,
           issueNumber: item.issueNumber,
           issueUpdatedAt,
+          ...(bodyHash ? { bodyHash } : {}),
           status: "failed",
           reason: "post_failed",
           error: message,
@@ -1095,20 +1139,66 @@ function canonicalIssueUpdatedAt(issue: GitHubRelatedIssueOrPull | undefined, ch
 function shouldSkipIssueEnrichmentRecord(
   existing: IssueEnrichmentRecord,
   issueUpdatedAt: string,
-  checkedAt: string
+  checkedAt: string,
+  bodyHash?: string,
+  action?: IssueEnrichmentScanAction
 ): boolean {
-  if (existing.issueUpdatedAt !== issueUpdatedAt) return false;
   if (existing.status === "failed") return false;
   if (existing.status === "deferred" && existing.nextEligibleAt) {
     const nextEligibleAt = Date.parse(existing.nextEligibleAt);
     const now = Date.parse(checkedAt);
     if (Number.isFinite(nextEligibleAt) && Number.isFinite(now) && nextEligibleAt <= now) return false;
   }
+  if (existing.bodyHash && bodyHash && existing.status === "posted") {
+    return existing.bodyHash === bodyHash.toLowerCase();
+  }
+  if (existing.status === "dry_run" && action === "would_comment") return false;
+  if (existing.issueUpdatedAt !== issueUpdatedAt) return false;
   return true;
+}
+
+function shouldCompareIssueEnrichmentBodyHash(
+  existing: IssueEnrichmentRecord | undefined,
+  issueUpdatedAt: string
+): boolean {
+  return existing?.status === "posted" &&
+    Boolean(existing.bodyHash) &&
+    existing.issueUpdatedAt !== issueUpdatedAt;
+}
+
+function shouldBackfillIssueEnrichmentBodyHash(
+  existing: IssueEnrichmentRecord | undefined,
+  issueUpdatedAt: string,
+  action: IssueEnrichmentScanAction
+): boolean {
+  return existing?.status === "posted" &&
+    !existing.bodyHash &&
+    existing.issueUpdatedAt === issueUpdatedAt &&
+    isIssueEnrichmentCommentAction(action);
 }
 
 function issueKey(repo: string, issueNumber: number): string {
   return `${repo}#${issueNumber}`;
+}
+
+function isIssueEnrichmentCommentAction(action: IssueEnrichmentScanAction): boolean {
+  return action === "would_comment" || action === "would_enrich";
+}
+
+function buildIssueEnrichmentForCycle(
+  config: IssueEnrichmentConfig,
+  repo: string,
+  issue: GitHubRelatedIssueOrPull
+): EnrichmentComment {
+  const policy = resolveIssueEnrichmentRepoPolicy(config, repo);
+  const allowlists = issueSuggestionAllowlists(policy.suggestions);
+  return buildIssueEnrichmentComment({
+    repo,
+    issue,
+    allowedLabels: allowlists.allowedLabels,
+    allowedOwners: allowlists.allowedOwners,
+    postIssueComment: true
+  });
 }
 
 function sum<T extends keyof Pick<IssueEnrichmentRepoScan, "issuesSeen" | "eligible" | "skipped" | "wouldEnrich" | "wouldComment" | "deferred">>(

--- a/src/state.ts
+++ b/src/state.ts
@@ -320,6 +320,7 @@ export interface IssueEnrichmentRecord {
   repo: string;
   issueNumber: number;
   issueUpdatedAt?: string;
+  bodyHash?: string;
   status: IssueEnrichmentRecordStatus;
   reason?: string;
   commentUrl?: string;
@@ -341,6 +342,7 @@ export interface RecordIssueEnrichmentInput {
   repo: string;
   issueNumber: number;
   issueUpdatedAt?: string;
+  bodyHash?: string;
   status: IssueEnrichmentRecordStatus;
   reason?: string;
   commentUrl?: string;
@@ -589,6 +591,7 @@ export class ReviewStateStore {
         repo text not null,
         issue_number integer not null,
         issue_updated_at text,
+        body_hash text,
         status text not null,
         reason text,
         comment_url text,
@@ -619,6 +622,7 @@ export class ReviewStateStore {
         owner_pid integer
       );
     `);
+    this.ensureIssueEnrichmentBodyHashColumn();
     this.ensureDaemonHeartbeatColumns();
     this.ensureReviewRunLeaseColumns();
     this.ensureReviewQueueJobColumns();
@@ -841,17 +845,19 @@ export class ReviewStateStore {
     const existing = this.getIssueEnrichmentRecord(input.repo, input.issueNumber);
     const nowIso = (input.now ?? new Date()).toISOString();
     const reason = input.reason ? redactSecrets(input.reason).trim().slice(0, 500) : undefined;
+    const bodyHash = input.bodyHash ? input.bodyHash.trim().toLowerCase() : undefined;
     const commentUrl = input.commentUrl ? redactSecrets(input.commentUrl).trim().slice(0, 500) : undefined;
     const error = input.error ? redactSecrets(input.error).trim().slice(0, 1_000) : undefined;
     const nextEligibleAt = input.nextEligibleAt ? new Date(Date.parse(input.nextEligibleAt)).toISOString() : undefined;
     this.db
       .prepare(
         `insert into issue_enrichment_records
-          (repo, issue_number, issue_updated_at, status, reason, comment_url, error,
+          (repo, issue_number, issue_updated_at, body_hash, status, reason, comment_url, error,
            next_eligible_at, created_at, updated_at)
-         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          on conflict(repo, issue_number) do update set
            issue_updated_at = excluded.issue_updated_at,
+           body_hash = excluded.body_hash,
            status = excluded.status,
            reason = excluded.reason,
            comment_url = excluded.comment_url,
@@ -863,6 +869,7 @@ export class ReviewStateStore {
         input.repo,
         input.issueNumber,
         input.issueUpdatedAt ?? null,
+        bodyHash ?? null,
         input.status,
         reason ?? null,
         commentUrl ?? null,
@@ -878,7 +885,7 @@ export class ReviewStateStore {
     validateRepoIssue(repo, issueNumber);
     const row = this.db
       .prepare(
-        `select repo, issue_number, issue_updated_at, status, reason, comment_url, error,
+        `select repo, issue_number, issue_updated_at, body_hash, status, reason, comment_url, error,
                 next_eligible_at, created_at, updated_at
          from issue_enrichment_records
          where repo = ? and issue_number = ?
@@ -915,7 +922,7 @@ export class ReviewStateStore {
     if (input.limit) params.push(input.limit);
     const rows = this.db
       .prepare(
-        `select repo, issue_number, issue_updated_at, status, reason, comment_url, error,
+        `select repo, issue_number, issue_updated_at, body_hash, status, reason, comment_url, error,
                 next_eligible_at, created_at, updated_at
          from issue_enrichment_records
          ${where}
@@ -2438,6 +2445,13 @@ export class ReviewStateStore {
     this.db.close();
   }
 
+  private ensureIssueEnrichmentBodyHashColumn(): void {
+    const columns = this.db.prepare("pragma table_info(issue_enrichment_records)").all() as unknown as Array<{ name: string }>;
+    if (!columns.some((column) => column.name === "body_hash")) {
+      this.db.exec("alter table issue_enrichment_records add column body_hash text");
+    }
+  }
+
   private ensureDaemonHeartbeatColumns(): void {
     const columns = this.db
       .prepare("pragma table_info(daemon_heartbeat)")
@@ -2582,6 +2596,9 @@ function validateIssueEnrichmentInput(input: RecordIssueEnrichmentInput): void {
   if (input.issueUpdatedAt !== undefined && !isCanonicalIsoTimestamp(input.issueUpdatedAt)) {
     throw new Error("issueUpdatedAt must be a canonical ISO timestamp");
   }
+  if (input.bodyHash !== undefined && !/^[0-9a-f]{64}$/i.test(input.bodyHash)) {
+    throw new Error("bodyHash must be a 64-character hex digest");
+  }
   if (input.nextEligibleAt !== undefined && !Number.isFinite(Date.parse(input.nextEligibleAt))) {
     throw new Error("nextEligibleAt must be an ISO timestamp");
   }
@@ -2592,6 +2609,7 @@ function validateIssueEnrichmentInput(input: RecordIssueEnrichmentInput): void {
     input.repo,
     String(input.issueNumber),
     input.issueUpdatedAt ?? "",
+    input.bodyHash ?? "",
     input.reason ?? "",
     input.commentUrl ?? "",
     input.error ?? "",
@@ -2925,6 +2943,7 @@ interface IssueEnrichmentRecordRow {
   repo: string;
   issue_number: number;
   issue_updated_at: string | null;
+  body_hash: string | null;
   status: IssueEnrichmentRecordStatus;
   reason: string | null;
   comment_url: string | null;
@@ -2991,6 +3010,7 @@ function mapIssueEnrichmentRecordRow(row: IssueEnrichmentRecordRow): IssueEnrich
     repo: row.repo,
     issueNumber: row.issue_number,
     ...(row.issue_updated_at ? { issueUpdatedAt: row.issue_updated_at } : {}),
+    ...(row.body_hash ? { bodyHash: row.body_hash } : {}),
     status: row.status,
     ...(row.reason ? { reason: row.reason } : {}),
     ...(row.comment_url ? { commentUrl: row.comment_url } : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,6 +164,7 @@ export type WalkthroughCommentPostResult =
 export interface EnrichmentComment {
   marker: string;
   body: string;
+  bodyHash: string;
   postIssueComment: boolean;
 }
 

--- a/tests/enrichment-cli.test.ts
+++ b/tests/enrichment-cli.test.ts
@@ -899,7 +899,7 @@ describe("build-enrichment-comment issue CLI", () => {
     });
   });
 
-  it("posts selected issue enrichment live, skips unchanged reruns, and force-updates the sticky comment", async () => {
+  it("posts selected issue enrichment live, skips bot-comment updated_at reruns, and force-updates the sticky comment", async () => {
     await withMockGitHub(async ({ apiBaseUrl, requests }) => {
       const root = createRoot(roots);
       const configPath = writeIssueRunConfig(root, apiBaseUrl);
@@ -1215,6 +1215,7 @@ async function withMockGitHub(
 
 interface MockGitHubState {
   issue17CommentBody?: string;
+  issue17UpdatedAt?: string;
 }
 
 function routeMockGitHub(
@@ -1264,7 +1265,7 @@ function routeMockGitHub(
       number: 17,
       title: "Open issue #11 #12 #13",
       state: "open",
-      updated_at: "2026-07-05T00:00:00.000Z",
+      updated_at: options.state?.issue17UpdatedAt ?? "2026-07-05T00:00:00.000Z",
       html_url: "https://github.test/owner/issue-repo/issues/17",
       body: "Acceptance criteria and owner are present.",
       labels: [{ name: "support" }]
@@ -1334,6 +1335,7 @@ function routeMockGitHub(
     }
     if (options.state) {
       options.state.issue17CommentBody = "<!-- evaos-code-review-bot:enrichment repo=owner/issue-repo issue=17 -->";
+      options.state.issue17UpdatedAt = "2026-07-05T00:00:01.000Z";
     }
     respondJson(response, 200, {
       id: 9001,
@@ -1344,6 +1346,7 @@ function routeMockGitHub(
   if (request.method === "PATCH" && request.url === "/repos/owner/issue-repo/issues/comments/9001") {
     if (options.state) {
       options.state.issue17CommentBody = "<!-- evaos-code-review-bot:enrichment repo=owner/issue-repo issue=17 --> updated";
+      options.state.issue17UpdatedAt = "2026-07-05T00:00:02.000Z";
     }
     respondJson(response, 200, {
       id: 9001,

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -411,6 +411,9 @@ describe("sticky enrichment comments", () => {
     });
 
     expect(comment.marker).toBe(buildIssueEnrichmentMarker({ repo: "electricsheephq/evaos-code-review-bot", issueNumber: 88 }));
+    const stateHash = comment.body.match(/<!-- evaos-code-review-bot:enrichment-state\b[^>]*\bhash=([0-9a-f]{64}) -->/)?.[1];
+    expect(comment.bodyHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(stateHash).toBe(comment.bodyHash);
     expect(comment.body).toContain(`${ENRICHMENT_MARKER_PREFIX} repo=electricsheephq/evaos-code-review-bot issue=88 -->`);
     expect(comment.body).toContain(`${ENRICHMENT_STATE_MARKER_PREFIX} version=1 repo=electricsheephq/evaos-code-review-bot issue=88 state=open`);
     expect(comment.body).toMatch(/^<!-- evaos-code-review-bot:enrichment repo=electricsheephq\/evaos-code-review-bot issue=88 -->\n<!-- evaos-code-review-bot:enrichment-state version=1 repo=electricsheephq\/evaos-code-review-bot issue=88 state=open hash=[0-9a-f]{64} -->\n## evaOS issue enrichment/);
@@ -1413,6 +1416,97 @@ describe("sticky enrichment comments", () => {
     }
   });
 
+  it("does not let a dry-run-only body hash suppress the first live issue comment", async () => {
+    const root = mkdtempSync(join(tmpdir(), "issue-enrichment-dry-run-to-live-"));
+    try {
+      const configPath = join(root, "config.json");
+      const statePath = join(root, "state.sqlite");
+      const writeConfig = (postIssueComment: boolean) => writeFileSync(configPath, `${JSON.stringify({
+        statePath,
+        issueEnrichment: {
+          enabled: true,
+          postIssueComment,
+          allowlist: ["owner/issue-repo"],
+          maxIssuesPerCycle: 5,
+          maxCommentsPerCycle: 1,
+          processExistingOpenIssuesOnActivation: true,
+          repos: {
+            "owner/issue-repo": {
+              maxIssuesPerCycle: 5,
+              maxCommentsPerCycle: 1,
+              cooldownMs: 60_000,
+              burstWindowMs: 3_600_000,
+              maxIssuesPerBurst: 10,
+              lookbackMs: 600_000
+            }
+          }
+        }
+      })}\n`);
+      writeConfig(false);
+      const state = new ReviewStateStore(statePath);
+      try {
+        const issue: GitHubRelatedIssueOrPull = {
+          number: 32,
+          title: "Promote issue enrichment comments",
+          state: "open",
+          updated_at: "2026-07-03T01:00:00.000Z",
+          body: "Acceptance criteria and owner present."
+        };
+        const reader = { listIssuesForEnrichment: async () => [issue] };
+        const posted: number[] = [];
+
+        const dryRunOnly = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            ...reader,
+            canPostAsApp: () => false,
+            upsertIssueComment: async () => {
+              throw new Error("should not post while issue comments are disabled");
+            }
+          },
+          dryRun: false,
+          checkedAt: "2026-07-03T01:05:00.000Z"
+        });
+        const dryRunRecord = state.getIssueEnrichmentRecord("owner/issue-repo", 32);
+        writeConfig(true);
+        const live = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github: {
+            ...reader,
+            canPostAsApp: () => true,
+            upsertIssueComment: async (input: { issueNumber: number }) => {
+              posted.push(input.issueNumber);
+              return {
+                action: "created" as const,
+                id: input.issueNumber,
+                html_url: `https://github.test/owner/issue-repo/issues/${input.issueNumber}#issuecomment-${input.issueNumber}`
+              };
+            }
+          },
+          dryRun: false,
+          includeExisting: true,
+          checkedAt: "2026-07-03T01:06:00.000Z"
+        });
+
+        expect(dryRunOnly.summary).toMatchObject({ dryRunRecorded: 1, alreadyProcessed: 0, posted: 0, failed: 0 });
+        expect(dryRunRecord).toMatchObject({ status: "dry_run", bodyHash: expect.stringMatching(/^[a-f0-9]{64}$/) });
+        expect(live.summary).toMatchObject({ posted: 1, alreadyProcessed: 0, failed: 0 });
+        expect(posted).toEqual([32]);
+        expect(state.getIssueEnrichmentRecord("owner/issue-repo", 32)).toMatchObject({
+          status: "posted",
+          bodyHash: dryRunRecord?.bodyHash,
+          commentUrl: "https://github.test/owner/issue-repo/issues/32#issuecomment-32"
+        });
+      } finally {
+        state.close();
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not let already processed issues consume live global caps forever", async () => {
     const root = mkdtempSync(join(tmpdir(), "issue-enrichment-global-cap-progress-"));
     try {
@@ -2023,6 +2117,15 @@ describe("sticky enrichment comments", () => {
           dryRun: false,
           checkedAt: "2026-07-03T02:05:00.000Z"
         });
+        const firstRecord = state.getIssueEnrichmentRecord("owner/issue-repo", 41);
+        state.recordIssueEnrichment({
+          repo: "owner/issue-repo",
+          issueNumber: 41,
+          issueUpdatedAt: "2026-07-03T02:00:00.000Z",
+          status: "posted",
+          commentUrl: "https://github.test/comment/1",
+          now: new Date("2026-07-03T02:05:30.000Z")
+        });
         const second = await runIssueEnrichmentCycle({
           config: loadConfig(configPath),
           state,
@@ -2030,11 +2133,32 @@ describe("sticky enrichment comments", () => {
           dryRun: false,
           checkedAt: "2026-07-03T02:06:00.000Z"
         });
+        const backfilledRecord = state.getIssueEnrichmentRecord("owner/issue-repo", 41);
+        issue.updated_at = "2026-07-03T02:07:00.000Z";
+        const third = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github,
+          dryRun: false,
+          checkedAt: "2026-07-03T02:08:00.000Z"
+        });
+        const refreshedRecord = state.getIssueEnrichmentRecord("owner/issue-repo", 41);
+        issue.updated_at = "2026-07-03T02:09:00.000Z";
+        issue.body = "Acceptance criteria and owner present. Update the docs runbook. Link follow-up #99.";
+        const fourth = await runIssueEnrichmentCycle({
+          config: loadConfig(configPath),
+          state,
+          github,
+          dryRun: false,
+          checkedAt: "2026-07-03T02:10:00.000Z"
+        });
 
-      expect(first.summary).toMatchObject({ posted: 1, alreadyProcessed: 0, failed: 0 });
-      expect(second.summary).toMatchObject({ posted: 0, alreadyProcessed: 1, failed: 0 });
-      expect(second.repos[0]).toMatchObject({ eligible: 0, wouldEnrich: 0, wouldComment: 0, deferred: 0 });
-      expect(posts).toHaveLength(1);
+        expect(first.summary).toMatchObject({ posted: 1, alreadyProcessed: 0, failed: 0 });
+        expect(second.summary).toMatchObject({ posted: 0, alreadyProcessed: 1, failed: 0 });
+        expect(second.repos[0]).toMatchObject({ eligible: 0, wouldEnrich: 0, wouldComment: 0, deferred: 0 });
+        expect(third.summary).toMatchObject({ posted: 0, alreadyProcessed: 1, failed: 0 });
+        expect(fourth.summary).toMatchObject({ posted: 1, alreadyProcessed: 0, failed: 0 });
+        expect(posts).toHaveLength(2);
         expect(posts[0]!.marker).toContain("issue=41");
         expect(posts[0]!.body).toContain("## evaOS issue enrichment");
         expect(posts[0]!.body).toContain("Suggested labels: docs.");
@@ -2042,11 +2166,34 @@ describe("sticky enrichment comments", () => {
         expect(posts[0]!.body).toContain("Suggested owners: none.");
         expect(posts[0]!.body).not.toContain("issue-owner");
         expect(posts[0]!.body).not.toContain("incident-reviewer");
-        expect(state.getIssueEnrichmentRecord("owner/issue-repo", 41)).toMatchObject({
+        expect(firstRecord).toMatchObject({
           status: "posted",
           issueUpdatedAt: "2026-07-03T02:00:00.000Z",
           commentUrl: "https://github.test/comment/1"
         });
+        expect(firstRecord?.bodyHash).toMatch(/^[a-f0-9]{64}$/);
+        expect(backfilledRecord).toMatchObject({
+          status: "posted",
+          issueUpdatedAt: "2026-07-03T02:00:00.000Z",
+          commentUrl: "https://github.test/comment/1",
+          bodyHash: firstRecord?.bodyHash
+        });
+        expect(posts[0]!.body).toContain(`hash=${firstRecord?.bodyHash} -->`);
+        expect(refreshedRecord).toMatchObject({
+          status: "posted",
+          issueUpdatedAt: "2026-07-03T02:07:00.000Z",
+          commentUrl: "https://github.test/comment/1",
+          bodyHash: firstRecord?.bodyHash
+        });
+        const changedRecord = state.getIssueEnrichmentRecord("owner/issue-repo", 41);
+        expect(changedRecord).toMatchObject({
+          status: "posted",
+          issueUpdatedAt: "2026-07-03T02:09:00.000Z",
+          commentUrl: "https://github.test/comment/2"
+        });
+        expect(changedRecord?.bodyHash).toMatch(/^[a-f0-9]{64}$/);
+        expect(changedRecord?.bodyHash).not.toBe(firstRecord?.bodyHash);
+        expect(posts[1]!.body).toContain(`hash=${changedRecord?.bodyHash} -->`);
       } finally {
         state.close();
       }

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -31,6 +31,88 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("stores normalized issue enrichment body hashes and rejects invalid hashes", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-issue-enrichment-body-hash-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    const record = store.recordIssueEnrichment({
+      repo: "owner/issue-repo",
+      issueNumber: 17,
+      issueUpdatedAt: "2026-07-03T00:00:00.000Z",
+      bodyHash: "A".repeat(64),
+      status: "posted",
+      commentUrl: "https://github.test/owner/issue-repo/issues/17#issuecomment-17",
+      now: new Date("2026-07-03T00:00:01.000Z")
+    });
+
+    expect(record).toMatchObject({
+      repo: "owner/issue-repo",
+      issueNumber: 17,
+      issueUpdatedAt: "2026-07-03T00:00:00.000Z",
+      bodyHash: "a".repeat(64),
+      status: "posted",
+      commentUrl: "https://github.test/owner/issue-repo/issues/17#issuecomment-17"
+    });
+    expect(() => store.recordIssueEnrichment({
+      repo: "owner/issue-repo",
+      issueNumber: 18,
+      bodyHash: "not-a-64-hex-digest",
+      status: "dry_run"
+    })).toThrow("bodyHash must be a 64-character hex digest");
+    store.close();
+  });
+
+  it("migrates pre-body-hash issue enrichment records before storing hashes", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-issue-enrichment-body-hash-migration-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const legacyDb = new DatabaseSync(dbPath);
+    legacyDb.exec(`
+      create table issue_enrichment_records (
+        repo text not null,
+        issue_number integer not null,
+        issue_updated_at text,
+        status text not null,
+        reason text,
+        comment_url text,
+        error text,
+        next_eligible_at text,
+        created_at text not null,
+        updated_at text not null,
+        primary key (repo, issue_number)
+      );
+    `);
+    legacyDb.close();
+
+    const store = new ReviewStateStore(dbPath);
+    const bodyHash = "b".repeat(64);
+    const record = store.recordIssueEnrichment({
+      repo: "owner/issue-repo",
+      issueNumber: 19,
+      issueUpdatedAt: "2026-07-03T00:00:00.000Z",
+      bodyHash,
+      status: "dry_run",
+      reason: "dry_run_only",
+      now: new Date("2026-07-03T00:00:01.000Z")
+    });
+    store.close();
+
+    const migratedDb = new DatabaseSync(dbPath);
+    try {
+      const columns = migratedDb.prepare("pragma table_info(issue_enrichment_records)").all() as Array<{ name: string }>;
+      const row = migratedDb
+        .prepare("select body_hash from issue_enrichment_records where repo = ? and issue_number = ?")
+        .get("owner/issue-repo", 19) as { body_hash: string } | undefined;
+
+      expect(columns.map((column) => column.name)).toContain("body_hash");
+      expect(record).toMatchObject({ status: "dry_run", bodyHash });
+      expect(row).toEqual({ body_hash: bodyHash });
+    } finally {
+      migratedDb.close();
+    }
+  });
+
   it("leases issue enrichment live workers separately from PR review runs", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-issue-enrichment-lease-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- store deterministic issue-enrichment body hashes in SQLite records
- skip no-force live reruns when the generated enrichment body is unchanged, even if the bot's own sticky comment advanced GitHub issue updated_at
- keep --force true behavior updating the sticky comment deliberately

Fixes #244.

## Validation
- npm test -- tests/enrichment-cli.test.ts --pool=forks --poolOptions.forks.maxForks=1
- npm test -- tests/enrichment.test.ts tests/enrichment-cli.test.ts --pool=forks --poolOptions.forks.maxForks=1
- npm test -- tests/state.test.ts tests/operator-cli.test.ts --pool=forks --poolOptions.forks.maxForks=1
- npm run build
- git diff --check