### PR TITLE
Add local OpenAI-compatible review adapter

### DIFF
--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -1,8 +1,11 @@
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
+import { parseFindings } from "./findings.js";
+import { openAICompatibleProviderTargetError, type ProviderRegistryEntry } from "./providers.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 const EVIDENCE_PREVIEW_LIMIT = 500;
+const REVIEW_JSON_EXTRACTION_CHAR_LIMIT = 200_000;
 const EVIDENCE_PREVIEW_TRUNCATED_SENTINEL = "...[truncated]";
 const REDACTION_TOKENS = [
   "[redacted-private-evidence]",
@@ -27,6 +30,7 @@ export interface ProviderAdapterFixture {
   model: string;
   prompt: string;
   expectJsonObject?: boolean;
+  expectReviewJson?: boolean;
 }
 
 export interface ProviderAdapterExecutionInput {
@@ -45,6 +49,13 @@ export interface ProviderAdapterExecutionResult {
 export interface ProviderRuntimeAdapter {
   id: string;
   execute(input: ProviderAdapterExecutionInput): Promise<ProviderAdapterExecutionResult>;
+}
+
+export interface OpenAICompatibleReviewAdapterOptions {
+  providerId: string;
+  provider: ProviderRegistryEntry;
+  fetchImpl?: typeof fetch;
+  env?: Record<string, string | undefined>;
 }
 
 export interface ProviderAdapterFixtureEvidence {
@@ -105,14 +116,15 @@ export async function runProviderAdapterFixture(input: {
       prompt: fixture.prompt
     });
     const evidence = buildFixtureEvidence(fixture.prompt, execution);
-    if (fixture.expectJsonObject && !isJsonObject(execution.text)) {
+    const reviewJsonError = fixture.expectReviewJson ? validateReviewJsonOutput(execution.text) : undefined;
+    if (reviewJsonError || (fixture.expectJsonObject && !isJsonObject(execution.text))) {
       return {
         ok: false,
         ...baseResult,
         evidence,
         error: {
           class: "model-output",
-          message: "Adapter output was not a JSON object."
+          message: reviewJsonError ?? "Adapter output was not a JSON object."
         }
       };
     }
@@ -136,15 +148,94 @@ export async function runProviderAdapterFixture(input: {
 
 export function classifyProviderAdapterError(message: string): ProviderAdapterErrorClass {
   const normalized = message.toLowerCase();
-  if (/\b(unauthorized|forbidden|invalid[ _-]api[ _-]key|401|403)\b/.test(normalized)) return "auth";
+  if (/\b(unauthorized|forbidden|invalid[ _-]api[ _-]key|missing[ _-]api[ _-]key|401|403)\b/.test(normalized)) return "auth";
   if (/\b(rate[ _-]limit|quota|too many requests|429|insufficient[ _-]quota|throttl(?:e|ed|ing))\b/.test(normalized)) return "throttle";
   // Provider timeout wording wins over network codes in combined messages to keep cooldown evidence deterministic.
   if (/\b(time[ _-]?out|timed[ _-]out|etimedout|abort(?:ed)?|deadline exceeded)\b/.test(normalized)) return "timeout";
-  if (/\b(econnreset|econnrefused|enotfound|eai_again|socket|dns|connection[ _-]refused|connection[ _-]reset|network[ _-](?:error|failure|failed|unreachable|unavailable|down))\b/.test(normalized)) return "network";
-  if (/\b(json|schema|parseable|malformed output|invalid response|invalid output|tool call|structured output)\b/.test(normalized)) {
+  if (/\b(econnreset|econnrefused|enotfound|eai_again|socket|dns|fetch failed|service unavailable|temporarily unavailable|overload|connection[ _-]refused|connection[ _-]reset|network[ _-](?:error|failure|failed|unreachable|unavailable|down))\b/.test(normalized)) return "network";
+  if (/\b(json|schema|parseable|malformed output|invalid response|invalid output|review object|review json|tool call|structured output)\b/.test(normalized)) {
     return "model-output";
   }
   return "unknown";
+}
+
+export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleReviewAdapterOptions): ProviderRuntimeAdapter {
+  return {
+    id: "openai-compatible",
+    async execute(input) {
+      const provider = options.provider;
+      const fetchImpl = options.fetchImpl ?? fetch;
+      const env = options.env ?? process.env;
+      const baseUrl = provider.baseUrl;
+      if (!baseUrl) throw new Error("OpenAI-compatible provider requires baseUrl for review execution.");
+      const targetError = openAICompatibleProviderTargetError(baseUrl, provider, "review");
+      if (targetError) throw new Error(targetError);
+
+      const apiKey = resolveOpenAICompatibleApiKey(provider, env);
+      const timeout = createAbortSignal(provider.timeoutMs);
+      const requestBody = {
+        model: input.model,
+        temperature: 0,
+        stream: false,
+        ...(provider.capabilities.jsonOutput ? { response_format: { type: "json_object" } } : {}),
+        messages: [
+          {
+            role: "system",
+            content: "Return only the NeonDiff review JSON object. Do not include markdown, prose, tool calls, or raw diff excerpts."
+          },
+          {
+            role: "user",
+            content: input.prompt
+          }
+        ]
+      };
+      try {
+        const response = await fetchImpl(buildOpenAIChatCompletionsUrl(baseUrl), {
+          method: "POST",
+          signal: timeout.signal,
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
+          },
+          body: JSON.stringify(requestBody)
+        });
+
+        if (!response.ok) {
+          throw new Error(openAICompatibleStatusErrorMessage(response.status));
+        }
+
+        const responseText = await readResponseTextWithAbort(response, timeout.signal);
+        const parsed = parseOpenAICompatibleResponse(responseText);
+        const content = extractOpenAICompatibleMessageContent(parsed);
+        const reviewOutput = normalizeReviewJsonOutput(content);
+        if (!reviewOutput.ok) throw new Error(reviewOutput.error);
+
+        return {
+          text: reviewOutput.text,
+          rawEvidence: {
+            providerId: options.providerId,
+            adapterId: input.adapterId,
+            model: input.model,
+            baseUrl,
+            status: response.status,
+            ...(typeof parsed.id === "string" ? { responseId: parsed.id } : {}),
+            ...extractOpenAICompatibleChoiceEvidence(parsed),
+            ...extractOpenAICompatibleUsageEvidence(parsed)
+          }
+        };
+      } finally {
+        timeout.dispose();
+      }
+    }
+  };
+}
+
+export function buildOpenAIChatCompletionsUrl(baseUrl: string): string {
+  const parsed = new URL(baseUrl);
+  const pathname = parsed.pathname.replace(/\/{2,}/g, "/").replace(/\/+$/, "");
+  parsed.pathname = pathname.endsWith("/chat/completions") ? pathname : `${pathname}/chat/completions`;
+  return parsed.toString();
 }
 
 function buildFixtureEvidence(
@@ -169,6 +260,178 @@ function isJsonObject(value: string): boolean {
   } catch {
     return false;
   }
+}
+
+function validateReviewJsonOutput(value: string): string | undefined {
+  const result = normalizeReviewJsonOutput(value);
+  return result.ok ? undefined : result.error;
+}
+
+function normalizeReviewJsonOutput(value: string): { ok: true; text: string } | { ok: false; error: string } {
+  let parsed: unknown;
+  let reviewJson = value.trim();
+  try {
+    parsed = JSON.parse(reviewJson) as unknown;
+  } catch {
+    try {
+      reviewJson = extractReviewJsonObject(value);
+      parsed = JSON.parse(reviewJson) as unknown;
+    } catch {
+      return { ok: false, error: "Adapter output was not a parseable JSON review object." };
+    }
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || !Array.isArray((parsed as { findings?: unknown }).findings)) {
+    return { ok: false, error: "Adapter output did not contain a review findings array." };
+  }
+  const { dropped } = parseFindings(parsed);
+  if (dropped.length > 0) return { ok: false, error: "Adapter output contained invalid review findings." };
+  return { ok: true, text: reviewJson };
+}
+
+function extractReviewJsonObject(text: string): string {
+  const boundedText = text.slice(0, REVIEW_JSON_EXTRACTION_CHAR_LIMIT);
+  const fencedMatches = [...boundedText.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)];
+  for (const fenced of fencedMatches) {
+    const candidate = fenced[1]!.trim();
+    if (isReviewJsonObject(candidate)) return candidate;
+  }
+
+  const starts: number[] = [];
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < boundedText.length; index += 1) {
+    const char = boundedText[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === "\"") {
+      inString = true;
+      continue;
+    }
+    if (char === "{") {
+      starts.push(index);
+      continue;
+    }
+    if (char === "}") {
+      const start = starts.pop();
+      if (start === undefined) continue;
+      const candidate = boundedText.slice(start, index + 1).trim();
+      if (candidate.includes("\"findings\"") && isReviewJsonObject(candidate)) return candidate;
+    }
+  }
+  throw new Error("Adapter output did not contain a parseable JSON review object.");
+}
+
+function isReviewJsonObject(candidate: string): boolean {
+  try {
+    const parsed = JSON.parse(candidate) as { findings?: unknown };
+    return typeof parsed === "object" && parsed !== null && Array.isArray(parsed.findings);
+  } catch {
+    return false;
+  }
+}
+
+function resolveOpenAICompatibleApiKey(
+  provider: ProviderRegistryEntry,
+  env: Record<string, string | undefined>
+): string | undefined {
+  if (provider.authMode !== "api-key-env") return undefined;
+  if (!provider.apiKeyEnv) throw new Error("Missing api key environment variable name for OpenAI-compatible provider.");
+  const value = env[provider.apiKeyEnv];
+  if (!value) throw new Error(`Missing api key environment variable ${provider.apiKeyEnv}.`);
+  return value;
+}
+
+function openAICompatibleStatusErrorMessage(status: number): string {
+  if (status === 401 || status === 403) return `OpenAI-compatible chat completions endpoint returned ${status} auth failure.`;
+  if (status === 429) return "OpenAI-compatible chat completions endpoint returned 429 throttle failure.";
+  if (status === 408 || status === 504) return `OpenAI-compatible chat completions endpoint returned ${status} timeout failure.`;
+  if (status >= 500) return `OpenAI-compatible chat completions endpoint returned ${status} network failure.`;
+  // Non-auth/non-throttle 4xx statuses stay unknown until runtime wiring needs a distinct operator action.
+  return `OpenAI-compatible chat completions endpoint returned ${status}.`;
+}
+
+async function readResponseTextWithAbort(response: Response, signal: AbortSignal): Promise<string> {
+  if (signal.aborted) throw new Error("deadline exceeded");
+  let abortHandler: ((event: Event) => void) | undefined;
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    abortHandler = () => {
+      void response.body?.cancel().catch(() => undefined);
+      reject(new Error("deadline exceeded"));
+    };
+    signal.addEventListener("abort", abortHandler, { once: true });
+  });
+  try {
+    return await Promise.race([response.text(), abortPromise]);
+  } finally {
+    if (abortHandler) signal.removeEventListener("abort", abortHandler);
+  }
+}
+
+function parseOpenAICompatibleResponse(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed as Record<string, unknown>;
+  } catch {
+    // Fall through to the normalized schema error below.
+  }
+  throw new Error("OpenAI-compatible chat completions response was not valid JSON.");
+}
+
+function extractOpenAICompatibleMessageContent(parsed: Record<string, unknown>): string {
+  const choices = parsed.choices;
+  if (!Array.isArray(choices)) throw new Error("OpenAI-compatible chat completions response had invalid response schema.");
+  const firstChoice = choices[0];
+  if (!firstChoice || typeof firstChoice !== "object" || Array.isArray(firstChoice)) {
+    throw new Error("OpenAI-compatible chat completions response had invalid response schema.");
+  }
+  const message = (firstChoice as { message?: unknown }).message;
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    throw new Error("OpenAI-compatible chat completions response had invalid response schema.");
+  }
+  const content = (message as { content?: unknown }).content;
+  if (typeof content !== "string" || content.trim().length === 0) {
+    throw new Error("OpenAI-compatible chat completions response had invalid response schema.");
+  }
+  return content;
+}
+
+function extractOpenAICompatibleChoiceEvidence(parsed: Record<string, unknown>): Record<string, unknown> {
+  const firstChoice = Array.isArray(parsed.choices) ? parsed.choices[0] : undefined;
+  if (!firstChoice || typeof firstChoice !== "object" || Array.isArray(firstChoice)) return {};
+  const finishReason = (firstChoice as { finish_reason?: unknown }).finish_reason;
+  return typeof finishReason === "string" ? { finishReason } : {};
+}
+
+function extractOpenAICompatibleUsageEvidence(parsed: Record<string, unknown>): Record<string, unknown> {
+  const usage = parsed.usage;
+  if (!usage || typeof usage !== "object" || Array.isArray(usage)) return {};
+  return {
+    usage: Object.fromEntries(
+      Object.entries(usage)
+        .filter(([, value]) => typeof value === "number" && Number.isFinite(value))
+        .map(([key, value]) => [key, value])
+    )
+  };
+}
+
+function createAbortSignal(timeoutMs: number | undefined): { signal: AbortSignal; dispose: () => void } {
+  const timeout = timeoutMs && timeoutMs > 0 ? timeoutMs : 30_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  const maybeUnref = timer as { unref?: () => void };
+  if (typeof maybeUnref.unref === "function") maybeUnref.unref();
+  return {
+    signal: controller.signal,
+    dispose: () => clearTimeout(timer)
+  };
 }
 
 function previewEvidenceText(value: string): string {

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -6,7 +6,9 @@ import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 const EVIDENCE_PREVIEW_LIMIT = 500;
 const REVIEW_JSON_EXTRACTION_CHAR_LIMIT = 200_000;
+const REVIEW_JSON_NESTED_OBJECT_MAX_DEPTH = 32;
 const EVIDENCE_PREVIEW_TRUNCATED_SENTINEL = "...[truncated]";
+const DEFAULT_OPENAI_COMPATIBLE_REVIEW_TIMEOUT_MS = 180_000;
 const REDACTION_TOKENS = [
   "[redacted-private-evidence]",
   "[redacted-private-field]",
@@ -44,6 +46,7 @@ export interface ProviderAdapterExecutionInput {
 export interface ProviderAdapterExecutionResult {
   text: string;
   rawEvidence?: unknown;
+  reviewJsonValidated?: boolean;
 }
 
 export interface ProviderRuntimeAdapter {
@@ -116,7 +119,9 @@ export async function runProviderAdapterFixture(input: {
       prompt: fixture.prompt
     });
     const evidence = buildFixtureEvidence(fixture.prompt, execution);
-    const reviewJsonError = fixture.expectReviewJson ? validateReviewJsonOutput(execution.text) : undefined;
+    const reviewJsonError = fixture.expectReviewJson && !execution.reviewJsonValidated
+      ? validateReviewJsonOutput(execution.text)
+      : undefined;
     if (reviewJsonError || (fixture.expectJsonObject && !isJsonObject(execution.text))) {
       return {
         ok: false,
@@ -152,10 +157,12 @@ export function classifyProviderAdapterError(message: string): ProviderAdapterEr
   if (/\b(rate[ _-]limit|quota|too many requests|429|insufficient[ _-]quota|throttl(?:e|ed|ing))\b/.test(normalized)) return "throttle";
   // Provider timeout wording wins over network codes in combined messages to keep cooldown evidence deterministic.
   if (/\b(time[ _-]?out|timed[ _-]out|etimedout|abort(?:ed)?|deadline exceeded)\b/.test(normalized)) return "timeout";
-  if (/\b(econnreset|econnrefused|enotfound|eai_again|socket|dns|fetch failed|service unavailable|temporarily unavailable|overload|connection[ _-]refused|connection[ _-]reset|network[ _-](?:error|failure|failed|unreachable|unavailable|down))\b/.test(normalized)) return "network";
-  if (/\b(json|schema|parseable|malformed output|invalid response|invalid output|review object|review json|tool call|structured output)\b/.test(normalized)) {
+  // Strong schema/output tokens win over transport wording; weaker wrapper terms stay below the network branch.
+  if (/\b(json|schema|parseable|malformed output|invalid output|review object|review json|findings array|tool call)\b/.test(normalized)) {
     return "model-output";
   }
+  if (/\b(econnreset|econnrefused|enotfound|eai_again|socket|dns|fetch failed|service unavailable|temporarily unavailable|overload|connection[ _-]refused|connection[ _-]reset|network[ _-](?:error|failure|failed|unreachable|unavailable|down))\b/.test(normalized)) return "network";
+  if (/\b(invalid response|structured output)\b/.test(normalized)) return "model-output";
   return "unknown";
 }
 
@@ -175,9 +182,9 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
       const timeout = createAbortSignal(provider.timeoutMs);
       const requestBody = {
         model: input.model,
-        temperature: 0,
         stream: false,
-        ...(provider.capabilities.jsonOutput ? { response_format: { type: "json_object" } } : {}),
+        ...(provider.temperature === undefined ? {} : { temperature: provider.temperature }),
+        ...(provider.capabilities.jsonOutput && provider.jsonObjectResponseFormat !== false ? { response_format: { type: "json_object" } } : {}),
         messages: [
           {
             role: "system",
@@ -202,17 +209,25 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
         });
 
         if (!response.ok) {
-          throw new Error(openAICompatibleStatusErrorMessage(response.status));
+          const responseErrorText = await readResponseTextWithAbort(response, timeout.signal);
+          throw new Error(openAICompatibleStatusErrorMessage(response.status, responseErrorText));
         }
 
         const responseText = await readResponseTextWithAbort(response, timeout.signal);
         const parsed = parseOpenAICompatibleResponse(responseText);
         const content = extractOpenAICompatibleMessageContent(parsed);
         const reviewOutput = normalizeReviewJsonOutput(content);
-        if (!reviewOutput.ok) throw new Error(reviewOutput.error);
+        if (!reviewOutput.ok) {
+          const finishReason = extractOpenAICompatibleFinishReason(parsed);
+          if (finishReason === "length") {
+            throw new Error("OpenAI-compatible review output was truncated before a parseable JSON review object (finish_reason=length).");
+          }
+          throw new Error(reviewOutput.error);
+        }
 
         return {
           text: reviewOutput.text,
+          reviewJsonValidated: true,
           rawEvidence: {
             providerId: options.providerId,
             adapterId: input.adapterId,
@@ -280,10 +295,13 @@ function normalizeReviewJsonOutput(value: string): { ok: true; text: string } | 
       return { ok: false, error: "Adapter output was not a parseable JSON review object." };
     }
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || !Array.isArray((parsed as { findings?: unknown }).findings)) {
+  const reviewObject = findReviewJsonObject(parsed);
+  if (!reviewObject) {
     return { ok: false, error: "Adapter output did not contain a review findings array." };
   }
-  const { dropped } = parseFindings(parsed);
+  // Nested provider envelopes are canonicalized; top-level review JSON keeps the adapter's original text.
+  if (reviewObject !== parsed) reviewJson = JSON.stringify(reviewObject);
+  const { dropped } = parseFindings(reviewObject);
   if (dropped.length > 0) return { ok: false, error: "Adapter output contained invalid review findings." };
   return { ok: true, text: reviewJson };
 }
@@ -293,10 +311,12 @@ function extractReviewJsonObject(text: string): string {
   const fencedMatches = [...boundedText.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)];
   for (const fenced of fencedMatches) {
     const candidate = fenced[1]!.trim();
-    if (isReviewJsonObject(candidate)) return candidate;
+    const reviewJson = reviewJsonObjectText(candidate);
+    if (reviewJson) return reviewJson;
   }
 
-  const starts: number[] = [];
+  let depth = 0;
+  let candidateStart: number | undefined;
   let inString = false;
   let escaped = false;
   for (let index = 0; index < boundedText.length; index += 1) {
@@ -316,26 +336,47 @@ function extractReviewJsonObject(text: string): string {
       continue;
     }
     if (char === "{") {
-      starts.push(index);
+      if (depth === 0) candidateStart = index;
+      depth += 1;
       continue;
     }
     if (char === "}") {
-      const start = starts.pop();
-      if (start === undefined) continue;
-      const candidate = boundedText.slice(start, index + 1).trim();
-      if (candidate.includes("\"findings\"") && isReviewJsonObject(candidate)) return candidate;
+      if (depth === 0 || candidateStart === undefined) continue;
+      depth -= 1;
+      if (depth !== 0) continue;
+      const candidate = boundedText.slice(candidateStart, index + 1).trim();
+      candidateStart = undefined;
+      if (!candidate.includes("\"findings\"")) continue;
+      const reviewJson = reviewJsonObjectText(candidate);
+      if (reviewJson) return reviewJson;
     }
   }
   throw new Error("Adapter output did not contain a parseable JSON review object.");
 }
 
-function isReviewJsonObject(candidate: string): boolean {
+function reviewJsonObjectText(candidate: string): string | undefined {
   try {
-    const parsed = JSON.parse(candidate) as { findings?: unknown };
-    return typeof parsed === "object" && parsed !== null && Array.isArray(parsed.findings);
+    const parsed = JSON.parse(candidate) as unknown;
+    const reviewObject = findReviewJsonObject(parsed);
+    if (!reviewObject) return undefined;
+    return reviewObject === parsed ? candidate : JSON.stringify(reviewObject);
   } catch {
-    return false;
+    return undefined;
   }
+}
+
+function findReviewJsonObject(value: unknown, depth = 0): Record<string, unknown> | undefined {
+  if (depth > REVIEW_JSON_NESTED_OBJECT_MAX_DEPTH) return undefined;
+  if (!value || typeof value !== "object") return undefined;
+  if (!Array.isArray(value) && Array.isArray((value as { findings?: unknown }).findings)) {
+    return value as Record<string, unknown>;
+  }
+  const children = Array.isArray(value) ? value : Object.values(value as Record<string, unknown>);
+  for (const child of children) {
+    const reviewObject = findReviewJsonObject(child, depth + 1);
+    if (reviewObject) return reviewObject;
+  }
+  return undefined;
 }
 
 function resolveOpenAICompatibleApiKey(
@@ -349,30 +390,39 @@ function resolveOpenAICompatibleApiKey(
   return value;
 }
 
-function openAICompatibleStatusErrorMessage(status: number): string {
-  if (status === 401 || status === 403) return `OpenAI-compatible chat completions endpoint returned ${status} auth failure.`;
-  if (status === 429) return "OpenAI-compatible chat completions endpoint returned 429 throttle failure.";
-  if (status === 408 || status === 504) return `OpenAI-compatible chat completions endpoint returned ${status} timeout failure.`;
-  if (status >= 500) return `OpenAI-compatible chat completions endpoint returned ${status} network failure.`;
-  // Non-auth/non-throttle 4xx statuses stay unknown until runtime wiring needs a distinct operator action.
-  return `OpenAI-compatible chat completions endpoint returned ${status}.`;
+function openAICompatibleStatusErrorMessage(status: number, responseText = ""): string {
+  const detail = previewEvidenceText(responseText).trim();
+  const suffix = detail ? `: ${detail}` : ".";
+  if (status === 401 || status === 403) return `OpenAI-compatible chat completions endpoint returned ${status} auth failure${suffix}`;
+  if (status === 429) return `OpenAI-compatible chat completions endpoint returned 429 throttle failure${suffix}`;
+  if (status === 408 || status === 504) return `OpenAI-compatible chat completions endpoint returned ${status} timeout failure${suffix}`;
+  if (status >= 500) return `OpenAI-compatible chat completions endpoint returned ${status} network failure${suffix}`;
+  // Non-special 4xx statuses keep a redacted body hint so adapter-specific auth/model-output wording can classify safely.
+  return `OpenAI-compatible chat completions endpoint returned ${status}${suffix}`;
 }
 
 async function readResponseTextWithAbort(response: Response, signal: AbortSignal): Promise<string> {
   if (signal.aborted) throw new Error("deadline exceeded");
-  let abortHandler: ((event: Event) => void) | undefined;
-  const abortPromise = new Promise<never>((_resolve, reject) => {
-    abortHandler = () => {
-      void response.body?.cancel().catch(() => undefined);
-      reject(new Error("deadline exceeded"));
+  return await new Promise<string>((resolve, reject) => {
+    let settled = false;
+    const abortHandler = () => {
+      settle(() => {
+        void response.body?.cancel().catch(() => undefined);
+        reject(new Error("deadline exceeded"));
+      });
+    };
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", abortHandler);
+      fn();
     };
     signal.addEventListener("abort", abortHandler, { once: true });
+    response.text().then(
+      (text) => settle(() => resolve(text)),
+      (error: unknown) => settle(() => reject(error))
+    );
   });
-  try {
-    return await Promise.race([response.text(), abortPromise]);
-  } finally {
-    if (abortHandler) signal.removeEventListener("abort", abortHandler);
-  }
 }
 
 function parseOpenAICompatibleResponse(value: string): Record<string, unknown> {
@@ -398,16 +448,37 @@ function extractOpenAICompatibleMessageContent(parsed: Record<string, unknown>):
   }
   const content = (message as { content?: unknown }).content;
   if (typeof content !== "string" || content.trim().length === 0) {
+    const textPart = extractOpenAICompatibleTextPart(content);
+    if (textPart) return textPart;
     throw new Error("OpenAI-compatible chat completions response had invalid response schema.");
   }
   return content;
 }
 
+function extractOpenAICompatibleTextPart(content: unknown): string | undefined {
+  if (!Array.isArray(content)) return undefined;
+  const textParts = content
+    .map((part) => {
+      if (!part || typeof part !== "object" || Array.isArray(part)) return undefined;
+      const typedPart = part as { type?: unknown; text?: unknown };
+      if (typedPart.type !== "text" || typeof typedPart.text !== "string") return undefined;
+      const text = typedPart.text.trim();
+      return text.length > 0 ? text : undefined;
+    })
+    .filter((text): text is string => Boolean(text));
+  return textParts.length === 1 ? textParts[0] : undefined;
+}
+
 function extractOpenAICompatibleChoiceEvidence(parsed: Record<string, unknown>): Record<string, unknown> {
+  const finishReason = extractOpenAICompatibleFinishReason(parsed);
+  return finishReason === undefined ? {} : { finishReason };
+}
+
+function extractOpenAICompatibleFinishReason(parsed: Record<string, unknown>): string | undefined {
   const firstChoice = Array.isArray(parsed.choices) ? parsed.choices[0] : undefined;
-  if (!firstChoice || typeof firstChoice !== "object" || Array.isArray(firstChoice)) return {};
+  if (!firstChoice || typeof firstChoice !== "object" || Array.isArray(firstChoice)) return undefined;
   const finishReason = (firstChoice as { finish_reason?: unknown }).finish_reason;
-  return typeof finishReason === "string" ? { finishReason } : {};
+  return typeof finishReason === "string" ? finishReason : undefined;
 }
 
 function extractOpenAICompatibleUsageEvidence(parsed: Record<string, unknown>): Record<string, unknown> {
@@ -423,7 +494,7 @@ function extractOpenAICompatibleUsageEvidence(parsed: Record<string, unknown>): 
 }
 
 function createAbortSignal(timeoutMs: number | undefined): { signal: AbortSignal; dispose: () => void } {
-  const timeout = timeoutMs && timeoutMs > 0 ? timeoutMs : 30_000;
+  const timeout = timeoutMs && timeoutMs > 0 ? timeoutMs : DEFAULT_OPENAI_COMPATIBLE_REVIEW_TIMEOUT_MS;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeout);
   const maybeUnref = timer as { unref?: () => void };

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -327,33 +327,46 @@ function safeProviderIdForOutput(value: string): string {
   return isProviderId(value) ? value : "[invalid-provider-id]";
 }
 
-function providerSmokeTargetError(baseUrl: string, provider: ProviderRegistryEntry): string | undefined {
+type OpenAICompatibleTargetPurpose = "smoke" | "review";
+
+export function openAICompatibleProviderTargetError(
+  baseUrl: string,
+  provider: ProviderRegistryEntry,
+  purpose: OpenAICompatibleTargetPurpose
+): string | undefined {
+  const targetLabel = purpose === "review" ? "review target" : "smoke target";
+  const operationLabel = purpose === "review" ? "review execution" : "smoke checks";
+  const disabledVerb = purpose === "review" ? "is" : "are";
   let parsed: URL;
   try {
     parsed = new URL(baseUrl);
   } catch {
-    return "OpenAI-compatible provider baseUrl must be a valid URL for smoke checks.";
+    return `OpenAI-compatible provider baseUrl must be a valid URL for ${operationLabel}.`;
   }
   if (parsed.username || parsed.password) {
-    return "OpenAI-compatible smoke target must not include username or password credentials.";
+    return `OpenAI-compatible ${targetLabel} must not include username or password credentials.`;
   }
   if (containsSecretLikeText(decodeURIComponent(`${parsed.pathname}${parsed.hash}`))) {
-    return "OpenAI-compatible smoke target must not include secret-like path or fragment values.";
+    return `OpenAI-compatible ${targetLabel} must not include secret-like path or fragment values.`;
   }
   for (const key of parsed.searchParams.keys()) {
     if (/(key|token|secret|password|session|cookie)/i.test(key)) {
-      return "OpenAI-compatible smoke target must not include credential query parameters.";
+      return `OpenAI-compatible ${targetLabel} must not include credential query parameters.`;
     }
   }
   const loopback = isLoopbackHost(parsed.hostname);
   if (loopback && provider.capabilities.local) return undefined;
   if (isUnsafeSmokeHost(parsed.hostname)) {
-    return "OpenAI-compatible smoke target must not point to private, link-local, loopback, or cloud metadata hosts.";
+    return `OpenAI-compatible ${targetLabel} must not point to private, link-local, loopback, or cloud metadata hosts.`;
   }
   if (!loopback) {
-    return "Remote OpenAI-compatible smoke checks are disabled until the transport can pin the validated DNS result.";
+    return `Remote OpenAI-compatible ${operationLabel} ${disabledVerb} disabled until the transport can pin the validated DNS result.`;
   }
   return undefined;
+}
+
+function providerSmokeTargetError(baseUrl: string, provider: ProviderRegistryEntry): string | undefined {
+  return openAICompatibleProviderTargetError(baseUrl, provider, "smoke");
 }
 
 function isLoopbackHost(hostname: string): boolean {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -24,6 +24,8 @@ export interface ProviderRegistryEntry {
   contextWindowTokens?: number;
   timeoutMs?: number;
   retryMaxRetries?: number;
+  temperature?: number;
+  jsonObjectResponseFormat?: boolean;
   capabilities: ProviderCapabilityFlags;
 }
 

--- a/src/zcode.ts
+++ b/src/zcode.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { parseFindings } from "./findings.js";
 import type { GitNexusContextPacket } from "./gitnexus-context.js";
 import type { GitHubRelatedContextPacket } from "./github-related-context.js";
+import type { ProviderRuntimeAdapter } from "./provider-adapters.js";
 import type { RepoMemoryPacket } from "./repo-memory.js";
 import { buildRepoProfilePromptSection, type ResolvedRepoProfile } from "./repo-policy.js";
 import { redactSecrets } from "./secrets.js";
@@ -15,6 +16,61 @@ export interface ZCodeReviewResult {
   findings: Finding[];
   droppedFromSchema: ReturnType<typeof parseFindings>["dropped"];
   rawResponse: string;
+}
+
+export interface ZCodeReviewFixtureAdapterOptions {
+  cwd: string;
+  cliPath: string;
+  appConfigPath: string;
+  evidenceDir?: string;
+  timeoutMs?: number;
+  retryMaxRetries?: number;
+  runReview?: (input: {
+    cwd: string;
+    prompt: string;
+    cliPath: string;
+    appConfigPath: string;
+    model: string;
+    providerId?: string;
+    evidenceDir?: string;
+    timeoutMs?: number;
+    retryMaxRetries?: number;
+  }) => ZCodeReviewResult;
+}
+
+/**
+ * Fixture-only wrapper for same-prompt adapter proof. Live review execution
+ * continues to call runZCodeReview directly until a separate runtime adapter
+ * proves async behavior, transport evidence, and selection policy.
+ */
+export function createZCodeReviewFixtureAdapter(options: ZCodeReviewFixtureAdapterOptions): ProviderRuntimeAdapter {
+  return {
+    id: "zcode",
+    async execute(input) {
+      const runReview = options.runReview ?? runZCodeReview;
+      const result = runReview({
+        cwd: options.cwd,
+        prompt: input.prompt,
+        cliPath: options.cliPath,
+        appConfigPath: options.appConfigPath,
+        model: input.model,
+        providerId: input.providerId,
+        ...(options.evidenceDir ? { evidenceDir: options.evidenceDir } : {}),
+        ...(options.timeoutMs ? { timeoutMs: options.timeoutMs } : {}),
+        ...(options.retryMaxRetries !== undefined ? { retryMaxRetries: options.retryMaxRetries } : {})
+      });
+      return {
+        text: result.rawResponse,
+        rawEvidence: {
+          providerId: input.providerId,
+          adapterId: input.adapterId,
+          model: input.model,
+          findings: result.findings.length,
+          droppedFromSchema: result.droppedFromSchema.length
+        }
+      };
+    }
+  };
 }
 
 export function buildReviewPrompt(input: {

--- a/src/zcode.ts
+++ b/src/zcode.ts
@@ -59,8 +59,10 @@ export function createZCodeReviewFixtureAdapter(options: ZCodeReviewFixtureAdapt
         ...(options.timeoutMs ? { timeoutMs: options.timeoutMs } : {}),
         ...(options.retryMaxRetries !== undefined ? { retryMaxRetries: options.retryMaxRetries } : {})
       });
+      const reviewJsonValidated = result.droppedFromSchema.length === 0;
       return {
-        text: result.rawResponse,
+        text: reviewJsonValidated ? extractJsonObject(result.rawResponse) : result.rawResponse,
+        reviewJsonValidated,
         rawEvidence: {
           providerId: input.providerId,
           adapterId: input.adapterId,

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -1,12 +1,399 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
+  buildOpenAIChatCompletionsUrl,
   classifyProviderAdapterError,
+  createOpenAICompatibleReviewAdapter,
   runProviderAdapterFixture,
   type ProviderRuntimeAdapter
 } from "../src/provider-adapters.js";
+import type { ProviderRegistryEntry } from "../src/providers.js";
+import { createZCodeReviewFixtureAdapter } from "../src/zcode.js";
 
 describe("provider adapter fixtures", () => {
+  it("runs one shared review fixture through mocked ZCode and local OpenAI-compatible adapters", async () => {
+    const reviewJson = '{"findings":[],"summary":"No validated current-diff findings."}';
+    const sharedFixture = makeFixture({
+      id: "shared-review-fixture",
+      prompt: [
+        "Review this private patch content before posting a comment.",
+        "diff --git a/private.ts b/private.ts",
+        "@@ -1 +1 @@",
+        "-secret",
+        "+fixed"
+      ].join("\n"),
+      expectReviewJson: true
+    });
+    const zcodeAdapter = createZCodeReviewFixtureAdapter({
+      cwd: "/repo",
+      cliPath: "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
+      appConfigPath: "/Users/example/.zcode/app-config.json",
+      runReview(input) {
+        expect(input.prompt).toBe(sharedFixture.prompt);
+        expect(input.model).toBe("GLM-5.2");
+        expect(input.providerId).toBe("zcode-glm");
+        return {
+          findings: [],
+          droppedFromSchema: [],
+          rawResponse: reviewJson
+        };
+      }
+    });
+    const localAdapter = createOpenAICompatibleReviewAdapter({
+      providerId: "ollama-local",
+      provider: makeOpenAICompatibleProvider({
+        baseUrl: "http://127.0.0.1:11434/v1",
+        model: "qwen2.5-coder:7b",
+        authMode: "none",
+        capabilities: {
+          review: true,
+          jsonOutput: true,
+          local: true,
+          streaming: false
+        }
+      }),
+      fetchImpl: async (url, init) => {
+        expect(String(url)).toBe("http://127.0.0.1:11434/v1/chat/completions");
+        expect(new Headers(init?.headers).has("authorization")).toBe(false);
+        const body = JSON.parse(String(init?.body)) as {
+          model?: string;
+          stream?: boolean;
+          messages?: Array<{ role?: string; content?: string }>;
+          response_format?: { type?: string };
+        };
+        expect(body).toMatchObject({
+          model: "qwen2.5-coder:7b",
+          stream: false,
+          response_format: { type: "json_object" }
+        });
+        expect(body.messages?.at(-1)).toEqual({ role: "user", content: sharedFixture.prompt });
+        return jsonResponse({
+          id: "chatcmpl-local-fixture",
+          choices: [
+            {
+              message: {
+                content: reviewJson
+              }
+            }
+          ],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 5
+          }
+        });
+      }
+    });
+
+    const zcode = await runProviderAdapterFixture({
+      adapter: zcodeAdapter,
+      fixture: {
+        ...sharedFixture,
+        providerId: "zcode-glm",
+        adapterId: "zcode",
+        model: "GLM-5.2"
+      }
+    });
+    const local = await runProviderAdapterFixture({
+      adapter: localAdapter,
+      fixture: {
+        ...sharedFixture,
+        providerId: "ollama-local",
+        adapterId: "openai-compatible",
+        model: "qwen2.5-coder:7b"
+      }
+    });
+
+    expect(zcode.ok).toBe(true);
+    expect(local.ok).toBe(true);
+    expect(zcode.fixtureId).toBe(local.fixtureId);
+    expect(zcode.evidence.promptSha256).toBe(local.evidence.promptSha256);
+    expect(zcode.evidence.outputPreview).toBe(reviewJson);
+    expect(local.evidence.outputPreview).toBe(reviewJson);
+    expect(JSON.stringify([zcode, local])).not.toContain("private patch content");
+    expect(JSON.stringify([zcode, local])).not.toContain("diff --git");
+    expect(local.evidence.rawEvidencePreview).toContain('"providerId":"ollama-local"');
+    expect(local.evidence.rawEvidencePreview).not.toContain(sharedFixture.prompt);
+  });
+
+  it("executes OpenAI-compatible chat-completions reviews with env-backed bearer auth and redacted evidence", async () => {
+    const providerKey = "sk-live-openai-compatible-secret";
+    const adapter = createOpenAICompatibleReviewAdapter({
+      providerId: "openai-compatible",
+      provider: makeOpenAICompatibleProvider({
+        baseUrl: "http://localhost:1234/v1",
+        model: "lm-studio-review-model",
+        authMode: "api-key-env",
+        apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+        capabilities: {
+          review: true,
+          jsonOutput: true,
+          local: true,
+          streaming: false
+        }
+      }),
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: providerKey
+      },
+      fetchImpl: async (url, init) => {
+        expect(String(url)).toBe("http://localhost:1234/v1/chat/completions");
+        expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${providerKey}`);
+        return jsonResponse({
+          id: "chatcmpl-env-auth-fixture",
+          choices: [
+            {
+              message: {
+                content: '{"findings":[{"severity":"P2","path":"src/app.ts","line":12,"title":"Bug","body":"Fix the regression.","confidence":0.91}],"summary":"One finding."}'
+              }
+            }
+          ]
+        });
+      }
+    });
+
+    const result = await runProviderAdapterFixture({
+      adapter,
+      fixture: makeFixture({
+        id: "env-auth-openai-compatible-fixture",
+        providerId: "openai-compatible",
+        adapterId: "openai-compatible",
+        model: "lm-studio-review-model",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.outputPreview).toContain('"findings"');
+    expect(result.evidence.rawEvidencePreview).toContain('"status":200');
+    expect(result.evidence.rawEvidencePreview).not.toContain(providerKey);
+    expect(JSON.stringify(result)).not.toContain(providerKey);
+  });
+
+  it("blocks unsafe OpenAI-compatible review targets before fetching private prompts", async () => {
+    let fetched = false;
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "unsafe-openai-compatible",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://169.254.169.254/latest/meta-data",
+          capabilities: {
+            review: true,
+            jsonOutput: true,
+            local: false,
+            streaming: false
+          }
+        }),
+        fetchImpl: async () => {
+          fetched = true;
+          return jsonResponse({ unreachable: true });
+        }
+      }),
+      fixture: makeFixture({
+        id: "unsafe-openai-compatible-fixture",
+        providerId: "unsafe-openai-compatible",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(fetched).toBe(false);
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "unknown",
+        message: "OpenAI-compatible review target must not point to private, link-local, loopback, or cloud metadata hosts."
+      }
+    });
+  });
+
+  it("omits strict response_format when provider capabilities do not declare JSON mode", async () => {
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "json-parser-only-local",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://127.0.0.1:8080/v1",
+          capabilities: {
+            review: true,
+            jsonOutput: false,
+            local: true,
+            streaming: false
+          }
+        }),
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as { response_format?: unknown };
+          expect(body).not.toHaveProperty("response_format");
+          return jsonResponse({
+            choices: [
+              {
+                message: {
+                  content: '{"findings":[],"summary":"Parsed without provider-side JSON mode."}'
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "json-parser-only-local-fixture",
+        providerId: "json-parser-only-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("times out OpenAI-compatible responses that stall after headers", async () => {
+    let bodyCancelled = false;
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "slow-body-local",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://127.0.0.1:8080/v1",
+          timeoutMs: 1
+        }),
+        fetchImpl: async () => ({
+          ok: true,
+          status: 200,
+          text: async () => new Promise<string>(() => undefined),
+          body: {
+            cancel: async () => {
+              bodyCancelled = true;
+            }
+          }
+        }) as Response
+      }),
+      fixture: makeFixture({
+        id: "slow-body-openai-compatible-fixture",
+        providerId: "slow-body-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "timeout",
+        message: "deadline exceeded"
+      }
+    });
+    expect(bodyCancelled).toBe(true);
+  });
+
+  it.each([
+    {
+      expectedClass: "auth",
+      provider: makeOpenAICompatibleProvider({
+        authMode: "api-key-env",
+        apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY"
+      }),
+      env: {},
+      fetchImpl: async () => jsonResponse({ unreachable: true })
+    },
+    {
+      expectedClass: "throttle",
+      fetchImpl: async () => new Response("too many requests with sk-live-secret-secret", { status: 429 })
+    },
+    {
+      expectedClass: "network",
+      fetchImpl: async () => new Response("service unavailable with sk-live-secret-secret", { status: 503 })
+    },
+    {
+      expectedClass: "timeout",
+      fetchImpl: async () => {
+        throw new Error("deadline exceeded");
+      }
+    },
+    {
+      expectedClass: "model-output",
+      fetchImpl: async () => jsonResponse({
+        choices: [
+          {
+            message: {
+              content: "not json with sk-live-secret-secret"
+            }
+          }
+        ]
+      })
+    },
+    {
+      expectedClass: "unknown",
+      fetchImpl: async () => new Response("provider returned a teapot with sk-live-secret-secret", { status: 418 })
+    }
+  ] as const)(
+    "bounds OpenAI-compatible adapter failures as $expectedClass",
+    async ({ expectedClass, provider, env, fetchImpl }) => {
+      const result = await runProviderAdapterFixture({
+        adapter: createOpenAICompatibleReviewAdapter({
+          providerId: "openai-compatible",
+          provider: provider ?? makeOpenAICompatibleProvider(),
+          env,
+          fetchImpl
+        }),
+        fixture: makeFixture({
+          id: `${expectedClass}-openai-compatible-fixture`,
+          providerId: "openai-compatible",
+          adapterId: "openai-compatible",
+          expectReviewJson: true
+        })
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          class: expectedClass
+        }
+      });
+      expect(JSON.stringify(result)).not.toContain("sk-live-secret-secret");
+    }
+  );
+
+  it("keeps model-output wording ahead of generic HTTP status tokens", () => {
+    expect(classifyProviderAdapterError("500 invalid output from provider")).toBe("model-output");
+    expect(classifyProviderAdapterError("500 network failure from provider")).toBe("network");
+    expect(classifyProviderAdapterError("OpenAI-compatible chat completions endpoint returned 418.")).toBe("unknown");
+  });
+
+  it("builds OpenAI-compatible chat-completions URLs for Ollama, LM Studio, vLLM, and gateway shapes", () => {
+    expect(buildOpenAIChatCompletionsUrl("http://localhost:11434/v1")).toBe("http://localhost:11434/v1/chat/completions");
+    expect(buildOpenAIChatCompletionsUrl("http://127.0.0.1:1234/v1/")).toBe("http://127.0.0.1:1234/v1/chat/completions");
+    expect(buildOpenAIChatCompletionsUrl("http://localhost:8000/v1/chat/completions")).toBe("http://localhost:8000/v1/chat/completions");
+    expect(buildOpenAIChatCompletionsUrl("http://localhost:8000/v1/chat/completions/")).toBe("http://localhost:8000/v1/chat/completions");
+    expect(buildOpenAIChatCompletionsUrl("http://localhost:8000/v1//chat/completions?x=1")).toBe("http://localhost:8000/v1/chat/completions?x=1");
+    expect(buildOpenAIChatCompletionsUrl("https://gateway.example.test/openai/v1")).toBe("https://gateway.example.test/openai/v1/chat/completions");
+  });
+
+  it("bounds review JSON extraction work for large malformed local-model responses", async () => {
+    const noisyPrefix = Array.from({ length: 5_000 }, (_, index) => `{noise-${index}}`).join("");
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "noisy-local-model",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://localhost:8080/v1"
+        }),
+        fetchImpl: async () => jsonResponse({
+          choices: [
+            {
+              message: {
+                content: `${noisyPrefix} {"findings":[],"summary":"Found after noisy braces."}`
+              }
+            }
+          ]
+        })
+      }),
+      fixture: makeFixture({
+        id: "noisy-local-model-fixture",
+        providerId: "noisy-local-model",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.outputPreview).toContain('"findings":[]');
+  });
+
   it("runs adapter fixtures deterministically without exposing prompt text or secrets in evidence", async () => {
     function makeAdapter(rawEvidence: Record<string, unknown>): ProviderRuntimeAdapter {
       return {
@@ -516,6 +903,7 @@ function makeFixture(overrides: Partial<{
   model: string;
   prompt: string;
   expectJsonObject: boolean;
+  expectReviewJson: boolean;
 }> = {}) {
   return {
     id: "fixture",
@@ -525,4 +913,32 @@ function makeFixture(overrides: Partial<{
     prompt: "Review this private patch content before posting a comment.",
     ...overrides
   };
+}
+
+function makeOpenAICompatibleProvider(overrides: Partial<ProviderRegistryEntry> = {}): ProviderRegistryEntry {
+  return {
+    enabled: true,
+    adapter: "openai-compatible",
+    displayName: "OpenAI-compatible fixture endpoint",
+    baseUrl: "http://127.0.0.1:8080/v1",
+    model: "review-model",
+    authMode: "none",
+    timeoutMs: 1_000,
+    retryMaxRetries: 0,
+    capabilities: {
+      review: true,
+      jsonOutput: true,
+      local: true,
+      streaming: false
+    },
+    ...overrides
+  };
+}
+
+function jsonResponse(value: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init
+  });
 }

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -115,6 +115,37 @@ describe("provider adapter fixtures", () => {
     expect(local.evidence.rawEvidencePreview).not.toContain(sharedFixture.prompt);
   });
 
+  it("normalizes prose-wrapped ZCode fixture responses before adapter evidence", async () => {
+    const reviewJson = '{"findings":[],"summary":"Recovered from fenced ZCode output."}';
+    const zcodeAdapter = createZCodeReviewFixtureAdapter({
+      cwd: "/repo",
+      cliPath: "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
+      appConfigPath: "/Users/example/.zcode/app-config.json",
+      runReview() {
+        return {
+          findings: [],
+          droppedFromSchema: [],
+          rawResponse: `Here is the review:\n\`\`\`json\n${reviewJson}\n\`\`\``
+        };
+      }
+    });
+
+    const result = await runProviderAdapterFixture({
+      adapter: zcodeAdapter,
+      fixture: makeFixture({
+        id: "wrapped-zcode-fixture",
+        providerId: "zcode-glm",
+        adapterId: "zcode",
+        model: "GLM-5.2",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.outputPreview).toBe(reviewJson);
+    expect(result.evidence.redactedOutputSha256).toBe(sha256(reviewJson));
+  });
+
   it("executes OpenAI-compatible chat-completions reviews with env-backed bearer auth and redacted evidence", async () => {
     const providerKey = "sk-live-openai-compatible-secret";
     const adapter = createOpenAICompatibleReviewAdapter({
@@ -219,8 +250,9 @@ describe("provider adapter fixtures", () => {
           }
         }),
         fetchImpl: async (_url, init) => {
-          const body = JSON.parse(String(init?.body)) as { response_format?: unknown };
+          const body = JSON.parse(String(init?.body)) as { response_format?: unknown; temperature?: unknown };
           expect(body).not.toHaveProperty("response_format");
+          expect(body).not.toHaveProperty("temperature");
           return jsonResponse({
             choices: [
               {
@@ -243,6 +275,80 @@ describe("provider adapter fixtures", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("can opt out of strict JSON response_format for OpenAI-compatible providers that reject it", async () => {
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "json-parser-compat-local",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://127.0.0.1:8080/v1",
+          jsonObjectResponseFormat: false
+        }),
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as { response_format?: unknown; temperature?: unknown };
+          expect(body).not.toHaveProperty("response_format");
+          expect(body).not.toHaveProperty("temperature");
+          return jsonResponse({
+            choices: [
+              {
+                message: {
+                  content: '{"findings":[],"summary":"Parsed after provider-side JSON mode opt-out."}'
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "json-parser-compat-local-fixture",
+        providerId: "json-parser-compat-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("sends configured temperature together with strict JSON response_format when supported", async () => {
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "json-temperature-local",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://127.0.0.1:8080/v1",
+          temperature: 0.2,
+          jsonObjectResponseFormat: true
+        }),
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as {
+            response_format?: { type?: string };
+            temperature?: number;
+          };
+          expect(body).toMatchObject({
+            temperature: 0.2,
+            response_format: { type: "json_object" }
+          });
+          return jsonResponse({
+            choices: [
+              {
+                message: {
+                  content: '{"findings":[],"summary":"Parsed with provider-side JSON mode and temperature."}'
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "json-temperature-local-fixture",
+        providerId: "json-temperature-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   it("times out OpenAI-compatible responses that stall after headers", async () => {
     let bodyCancelled = false;
     const result = await runProviderAdapterFixture({
@@ -250,7 +356,7 @@ describe("provider adapter fixtures", () => {
         providerId: "slow-body-local",
         provider: makeOpenAICompatibleProvider({
           baseUrl: "http://127.0.0.1:8080/v1",
-          timeoutMs: 1
+          timeoutMs: 25
         }),
         fetchImpl: async () => ({
           ok: true,
@@ -298,6 +404,10 @@ describe("provider adapter fixtures", () => {
     {
       expectedClass: "network",
       fetchImpl: async () => new Response("service unavailable with sk-live-secret-secret", { status: 503 })
+    },
+    {
+      expectedClass: "auth",
+      fetchImpl: async () => new Response("invalid api key with sk-live-secret-secret", { status: 400 })
     },
     {
       expectedClass: "timeout",
@@ -351,8 +461,38 @@ describe("provider adapter fixtures", () => {
 
   it("keeps model-output wording ahead of generic HTTP status tokens", () => {
     expect(classifyProviderAdapterError("500 invalid output from provider")).toBe("model-output");
+    expect(classifyProviderAdapterError("upstream returned invalid output: service unavailable")).toBe("model-output");
+    expect(classifyProviderAdapterError("invalid output from provider during ECONNRESET")).toBe("model-output");
+    expect(classifyProviderAdapterError("schema parse failed after provider overload")).toBe("model-output");
+    expect(classifyProviderAdapterError("structured output validation failed")).toBe("model-output");
     expect(classifyProviderAdapterError("500 network failure from provider")).toBe("network");
+    expect(classifyProviderAdapterError("network-error while parsing invalid response")).toBe("network");
     expect(classifyProviderAdapterError("OpenAI-compatible chat completions endpoint returned 418.")).toBe("unknown");
+  });
+
+  it("keeps redacted diagnostic hints for special OpenAI-compatible HTTP status failures", async () => {
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "overloaded-local-model",
+        provider: makeOpenAICompatibleProvider(),
+        fetchImpl: async () => new Response("queue full for sk-live-secret-secret", { status: 503 })
+      }),
+      fixture: makeFixture({
+        id: "overloaded-local-model-fixture",
+        providerId: "overloaded-local-model",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "network",
+        message: "OpenAI-compatible chat completions endpoint returned 503 network failure: queue full for [redacted-secret]"
+      }
+    });
+    expect(JSON.stringify(result)).not.toContain("sk-live-secret-secret");
   });
 
   it("builds OpenAI-compatible chat-completions URLs for Ollama, LM Studio, vLLM, and gateway shapes", () => {
@@ -366,6 +506,7 @@ describe("provider adapter fixtures", () => {
 
   it("bounds review JSON extraction work for large malformed local-model responses", async () => {
     const noisyPrefix = Array.from({ length: 5_000 }, (_, index) => `{noise-${index}}`).join("");
+    const extractedReviewJson = '{"findings":[],"summary":"Found after noisy braces."}';
     const result = await runProviderAdapterFixture({
       adapter: createOpenAICompatibleReviewAdapter({
         providerId: "noisy-local-model",
@@ -376,7 +517,7 @@ describe("provider adapter fixtures", () => {
           choices: [
             {
               message: {
-                content: `${noisyPrefix} {"findings":[],"summary":"Found after noisy braces."}`
+                content: `${noisyPrefix} ${extractedReviewJson}`
               }
             }
           ]
@@ -391,7 +532,231 @@ describe("provider adapter fixtures", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.evidence.outputPreview).toContain('"findings":[]');
+    expect(result.evidence.outputPreview).toBe(extractedReviewJson);
+    expect(result.evidence.redactedOutputSha256).toBe(sha256(extractedReviewJson));
+  });
+
+  it("preserves finish_reason length when OpenAI-compatible review JSON is truncated", async () => {
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "truncated-local-model",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://localhost:8080/v1"
+        }),
+        fetchImpl: async () => jsonResponse({
+          choices: [
+            {
+              finish_reason: "length",
+              message: {
+                content: '{"findings":[{"severity":"P1"'
+              }
+            }
+          ]
+        })
+      }),
+      fixture: makeFixture({
+        id: "truncated-local-model-fixture",
+        providerId: "truncated-local-model",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "model-output",
+        message: "OpenAI-compatible review output was truncated before a parseable JSON review object (finish_reason=length)."
+      }
+    });
+  });
+
+  it("extracts trailing review JSON after deeply nested non-review braces", async () => {
+    const nestedPrefix = `${"{".repeat(50_000)}${"}".repeat(50_000)}`;
+    const extractedReviewJson = '{"findings":[],"summary":"Found after nested braces."}';
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "nested-local-model",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://localhost:8080/v1"
+        }),
+        fetchImpl: async () => jsonResponse({
+          choices: [
+            {
+              message: {
+                content: `${nestedPrefix} ${extractedReviewJson}`
+              }
+            }
+          ]
+        })
+      }),
+      fixture: makeFixture({
+        id: "nested-local-model-fixture",
+        providerId: "nested-local-model",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.outputPreview).toBe(extractedReviewJson);
+    expect(result.evidence.redactedOutputSha256).toBe(sha256(extractedReviewJson));
+  });
+
+  it("extracts nested review JSON from valid OpenAI-compatible wrapper JSON", async () => {
+    const extractedReviewJson = '{"findings":[],"summary":"Inside envelope."}';
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "wrapped-local-model",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://localhost:8080/v1"
+        }),
+        fetchImpl: async () => jsonResponse({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  object: "response",
+                  body: {
+                    findings: [],
+                    summary: "Inside envelope."
+                  }
+                })
+              }
+            }
+          ]
+        })
+      }),
+      fixture: makeFixture({
+        id: "wrapped-local-model-fixture",
+        providerId: "wrapped-local-model",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.outputPreview).toBe(extractedReviewJson);
+    expect(result.evidence.redactedOutputSha256).toBe(sha256(extractedReviewJson));
+  });
+
+  it("accepts single text-part array content from OpenAI-compatible responses", async () => {
+    const reviewJson = '{"findings":[],"summary":"Recovered from array content."}';
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "array-content-local-model",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://localhost:8080/v1"
+        }),
+        fetchImpl: async () => jsonResponse({
+          choices: [
+            {
+              message: {
+                content: [
+                  {
+                    type: "text",
+                    text: reviewJson
+                  }
+                ]
+              }
+            }
+          ]
+        })
+      }),
+      fixture: makeFixture({
+        id: "array-content-local-model-fixture",
+        providerId: "array-content-local-model",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.outputPreview).toBe(reviewJson);
+  });
+
+  it("bounds nested review object traversal depth for provider-controlled JSON", async () => {
+    let nested: unknown = { findings: [], summary: "Too deeply nested." };
+    for (let index = 0; index < 40; index += 1) {
+      nested = { wrapper: nested };
+    }
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "deep-wrapper-local-model",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://localhost:8080/v1"
+        }),
+        fetchImpl: async () => jsonResponse({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify(nested)
+              }
+            }
+          ]
+        })
+      }),
+      fixture: makeFixture({
+        id: "deep-wrapper-local-model-fixture",
+        providerId: "deep-wrapper-local-model",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "model-output",
+        message: "Adapter output did not contain a review findings array."
+      }
+    });
+  });
+
+  it("does not duplicate-validate adapter-validated review JSON at the fixture layer", async () => {
+    const result = await runProviderAdapterFixture({
+      adapter: {
+        id: "validated-fixture-adapter",
+        async execute() {
+          return {
+            text: '{"findings":[{"confidence":1.0000001}]}',
+            reviewJsonValidated: true
+          };
+        }
+      },
+      fixture: makeFixture({
+        id: "adapter-validated-review-json-fixture",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.outputPreview).toBe('{"findings":[{"confidence":1.0000001}]}');
+  });
+
+  it("rejects invalid review JSON when an adapter has not already validated it", async () => {
+    const result = await runProviderAdapterFixture({
+      adapter: {
+        id: "unvalidated-fixture-adapter",
+        async execute() {
+          return {
+            text: '{"findings":[{"confidence":1.0000001}]}'
+          };
+        }
+      },
+      fixture: makeFixture({
+        id: "unvalidated-review-json-fixture",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "model-output",
+        message: "Adapter output contained invalid review findings."
+      }
+    });
   });
 
   it("runs adapter fixtures deterministically without exposing prompt text or secrets in evidence", async () => {


### PR DESCRIPTION
## Summary

Adds the non-default OpenAI-compatible review adapter path for local/self-hosted chat-completions endpoints, plus a shared review-fixture proof against mocked ZCode/GLM and local OpenAI-compatible adapters.

Links: #238, #239, #240

## What Changed

- Added `createOpenAICompatibleReviewAdapter` for OpenAI-style `/chat/completions` review JSON output.
- Added review-fixture schema validation using the existing `parseFindings` path and bounded adapter error classes: `auth`, `throttle`, `network`, `timeout`, `model-output`, and `unknown`.
- Added a `createZCodeReviewFixtureAdapter` wrapper so the current ZCode-backed path can participate in deterministic fixture proof without launching live ZCode in unit tests.
- Added tests proving redacted deterministic evidence, env-backed bearer auth redaction, local endpoint URL shapes for Ollama/LM Studio/vLLM/gateways, and failure classification.

## Proof Boundary

This PR proves mocked/current ZCode fixture compatibility and deterministic local OpenAI-compatible adapter behavior at the fixture/schema boundary. It does not prove live Ollama, LM Studio, vLLM, hosted BYOK parity, review quality, release readiness, or default-provider promotion.

Live/default provider routing remains unchanged.

## Validation

- `NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/provider-adapters.test.ts tests/provider-registry.test.ts --pool forks --maxWorkers=1`
- `npm run build`
- `git diff --check`

Local evidence note: `/Volumes/LEXAR/Codex/session-notes/2026-07-05/neondiff-provider-local-239-240/implementation-notes.html`
