### PR TITLE
[codex] Align public beta version to v0.4.24-beta.1

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,7 +9,7 @@ on:
       tag:
         description: Release tag to publish
         required: true
-        default: v1.0.0-beta.1
+        default: v0.4.24-beta.1
 
 permissions:
   contents: read
@@ -26,9 +26,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
 
-      - name: Require v1.0.0-beta.1
+      - name: Require v0.4.24-beta.1
         run: |
-          test "${{ github.event.inputs.tag || github.event.release.tag_name }}" = "v1.0.0-beta.1"
+          test "${{ github.event.inputs.tag || github.event.release.tag_name }}" = "v0.4.24-beta.1"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Requirements:
 Recommended package install for the current beta:
 
 ```bash
-npm install -g neondiff@1.0.0-beta.1
+npm install -g neondiff@0.4.24-beta.1
 ```
 
 Installer script path:
@@ -195,6 +195,6 @@ For public source-beta release readiness, use
 [docs/public-release-manifest.json](docs/public-release-manifest.json) with
 `neondiff release-status --public-release-manifest docs/public-release-manifest.json --expected-public-version <public-beta-tag>`.
 Replace `<public-beta-tag>` with the actual semver prerelease tag, such as
-`v1.0.0-beta.1`; the CLI rejects literal placeholders. The manifest is the
+`v0.4.24-beta.1`; the CLI rejects literal placeholders. The manifest is the
 compact version/alignment surface for setup docs, release notes, license API
 state, and update-channel readiness.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -27,7 +27,7 @@ tokens.
 Recommended package install:
 
 ```bash
-npm install -g neondiff@1.0.0-beta.1
+npm install -g neondiff@0.4.24-beta.1
 ```
 
 Installer script:

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -89,7 +89,7 @@ npm run release:status -- \
 For public source-beta releases, run the same gate with manifest checks:
 
 ```bash
-PUBLIC_BETA_TAG=v1.0.0-beta.1
+PUBLIC_BETA_TAG=v0.4.24-beta.1
 npx tsx src/cli.ts release-status \
   --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
   --expected-head "$(git rev-parse HEAD)" \

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,10 +1,10 @@
 {
-  "version": "v1.0.0-beta.1",
+  "version": "v0.4.24-beta.1",
   "releaseLevel": "source-beta",
   "docs": {
-    "version": "v1.0.0-beta.1",
+    "version": "v0.4.24-beta.1",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v1.0.0-beta.1.md",
+    "releaseNotesPath": "docs/releases/v0.4.24-beta.1.md",
     "websiteRepo": "electricsheephq/neon-diff-agent"
   },
   "licenseApi": {
@@ -16,13 +16,13 @@
     "cli": {
       "requiredForThisRelease": true,
       "state": "source_checkout",
-      "version": "v1.0.0-beta.1",
+      "version": "v0.4.24-beta.1",
       "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "launchd_prerelease",
-      "version": "v1.0.0-beta.1",
+      "version": "v0.4.24-beta.1",
       "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
     },
     "website": {

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -23,7 +23,7 @@ Use semver prerelease tags for live beta promotions:
 v0.2.5-beta.1
 v0.2.5-beta.2
 v0.3.0-beta.1
-v1.0.0-beta.1
+v0.4.24-beta.1
 ```
 
 Patch beta tags are for runtime/reliability fixes. Minor beta tags are for new

--- a/docs/releases/v0.4.24-beta.1.md
+++ b/docs/releases/v0.4.24-beta.1.md
@@ -1,0 +1,67 @@
+# v0.4.24-beta.1
+
+- Release type: public source-available beta
+- Release source SHA: to be set by the `v0.4.24-beta.1` tag
+- Public manifest: `docs/public-release-manifest.json`
+- Tracking issue: `#250`
+- Parent release tracker: `#235`
+- Supersedes: `v1.0.0-beta.1` package/release label
+
+## Purpose
+
+Correct the public NeonDiff beta version line so the npm package, install
+script, website, setup docs, public manifest, and GitHub prerelease all follow
+the implementation release train. The first public npm package was mistakenly
+published as `1.0.0-beta.1`; this release restores the public beta to
+`0.4.24-beta.1`.
+
+## Included Scope
+
+- npm package `neondiff@0.4.24-beta.1`
+- canonical install script `https://www.neondiff.com/install`
+- source-checkout setup docs for
+  `electricsheephq/evaos-code-review-bot-neondiff`
+- public source-available beta license boundary
+- npm dist-tag correction so `beta` and `latest` point at `0.4.24-beta.1`
+- deprecation of `neondiff@1.0.0-beta.1` as superseded by this version line
+
+## Required Gates For Promotion
+
+- GitHub PR merged to `main` with required checks green or explicitly
+  dispositioned.
+- `npm run build` passes.
+- Focused public release tests pass.
+- Package packlist check passes.
+- Secret scan and public-claim scan pass.
+- GitHub prerelease exists for `v0.4.24-beta.1`.
+- `npm view neondiff version` returns `0.4.24-beta.1`.
+- `curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run` prints
+  `neondiff@0.4.24-beta.1`.
+- Clean temp-prefix install can run `neondiff help`, `neondiff pricing`, and
+  `neondiff init --config <temp-config>`.
+
+## Known Deferrals
+
+- CodeQL hardening is tracked in `#249`.
+- License activation API and entitlement cache remain tracked in `#111`.
+- Desktop signing, notarization, Sparkle/appcast, and auto-update entitlement
+  remain tracked in `#116`.
+- Calibrated review accuracy and CodeRabbit parity are not claimed.
+
+## Validation Commands
+
+```bash
+npm run build
+npx vitest run tests/public-release-readiness.test.ts tests/public-community-funnel.test.ts tests/public-cli.test.ts tests/license.test.ts tests/release-status.test.ts --pool=forks --maxWorkers=1
+node scripts/check-public-claims.mjs
+node scripts/check-secret-scan.mjs
+npm pack --dry-run --json
+node scripts/check-packlist.mjs <pack-json>
+```
+
+Public install verification:
+
+```bash
+npm install -g neondiff@0.4.24-beta.1
+curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
+```

--- a/docs/releases/v1.0.0-beta.1.md
+++ b/docs/releases/v1.0.0-beta.1.md
@@ -1,108 +1,20 @@
 # v1.0.0-beta.1
 
-- Release type: public source beta release-readiness packet
-- Release source SHA: to be set by the `v1.0.0-beta.1` tag
-- Public manifest: `docs/public-release-manifest.json`
-- Tracking issue: `#232`
-- Parent roadmap: `#103`
-- Live checkout: `/Volumes/LEXAR/repos/evaos-code-review-bot`
-- launchd label: `com.electricsheephq.evaos-code-review-bot`
-- Live config: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
-- Evidence path: `/Volumes/LEXAR/Codex/evidence/neondiff-public-product/<date>/v1.0.0-beta.1/`
-- Rollback SHA/tag: `v0.4.9-beta.1`
-- Rollback command:
+- Status: superseded
+- Superseded by: `v0.4.24-beta.1`
+- Tracking issue: `#250`
+
+This release label was created during the first public npm/site release pass, but
+it incorrectly implied that the implementation had jumped from the active
+`v0.4.x` beta train to `v1.0`. NeonDiff's public package and GitHub prerelease
+now follow the implementation release train instead.
+
+Use:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
-git fetch origin --tags
-git checkout main
-git reset --hard refs/tags/v0.4.9-beta.1
-launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
-npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
-  --expected-head "$(git rev-parse HEAD)" \
-  --launchd-label com.electricsheephq.evaos-code-review-bot
+npm install -g neondiff@0.4.24-beta.1
+curl -fsSL https://www.neondiff.com/install | sh
 ```
 
-## Purpose
-
-Define the public source-beta release packet shape before the first public
-`v1.0.0-beta.1` promotion. This packet documents the gates that must pass, the
-package and install surfaces, the rollback shape, and the current non-goals. It
-does not by itself publish a public beta.
-
-## Included Scope
-
-- npm package, installer script, source-checkout fallback, and local launchd
-  daemon release path.
-- Public release manifest version alignment for setup docs and release notes.
-- `release-status` public manifest gate for docs, license API state, and update
-  channel state.
-- Explicit deferral of website download/version sync, license API activation,
-  and desktop signed update channel until their own issues close.
-
-## Required Gates For Promotion
-
-- GitHub PR merged to `main` with checks green and current-head actionable review
-  threads resolved or explicitly dispositioned.
-- `npm test` and `npm run build` pass.
-- GitHub prerelease exists for the exact tag target SHA.
-- `npm view neondiff version` returns `1.0.0-beta.1`.
-- `curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run` passes.
-- Clean temp-prefix install can run `neondiff help`, `neondiff pricing`, and
-  `neondiff init --config <temp-config>`.
-- `release-status` passes with:
-  - `--expected-head <tag-target-sha>`
-  - `--public-release-manifest docs/public-release-manifest.json`
-  - `--expected-public-version v1.0.0-beta.1`
-  - `--verify-public-rollback-refs true` after `git fetch origin --tags`
-- The default rollback gate validates command shape only for contributor and
-  smoke-test checkouts; public promotion evidence must include the strict
-  rollback-ref check above.
-- `coverage-audit` reports zero unprocessed eligible heads, or every exception
-  is named in this packet.
-- `provider-cooldowns --expired-only true` reports zero expired actionable
-  cooldowns.
-- `doctor --json` proves GitHub App read mode and provider readiness without
-  printing secrets.
-
-## Known Deferrals
-
-- Website/download portal synchronization is tracked in
-  `electricsheephq/neon-diff-agent#2` and `#3`.
-- License activation API and entitlement cache are tracked in `#111`; source
-  beta docs may describe license boundaries, but private/commercial enforcement
-  is not considered complete until that issue closes.
-- Desktop signing, notarization, Sparkle/appcast, and auto-update entitlement
-  are tracked in `#116`.
-- Calibrated review accuracy and CodeRabbit parity are not claimed.
-
-## Validation Commands
-
-```bash
-npm test -- tests/release-status.test.ts --pool=forks --maxWorkers=1
-npm run build
-npm pack --dry-run --json
-npx tsx src/cli.ts release-status \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
-  --expected-head "$(git rev-parse HEAD)" \
-  --public-release-manifest docs/public-release-manifest.json \
-  --expected-public-version v1.0.0-beta.1 \
-  --launchd-label com.electricsheephq.evaos-code-review-bot
-```
-
-Public install verification:
-
-```bash
-npm install -g neondiff@1.0.0-beta.1
-curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
-```
-
-## Notes
-
-- This packet keeps public release governance separate from the internal v0.x
-  operator packets.
-- `docs/public-release-manifest.json` is the compact machine-readable surface
-  for docs version, license API state, and update-channel readiness.
-- A passing source-beta manifest may explicitly mark the license API as
-  `pending` only when `requiredForThisRelease` is `false`.
+The npm package `neondiff@1.0.0-beta.1` is retained only as an immutable
+registry artifact and is deprecated in favor of `0.4.24-beta.1`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neondiff",
-  "version": "1.0.0-beta.1",
+  "version": "0.4.24-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neondiff",
-      "version": "1.0.0-beta.1",
+      "version": "0.4.24-beta.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "neondiff": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neondiff",
-  "version": "1.0.0-beta.1",
+  "version": "0.4.24-beta.1",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
   "bin": {

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -7,7 +7,7 @@ const paths = [
   "docs/providers.md",
   "docs/license-boundary.md",
   "docs/pricing.md",
-  "docs/releases/v1.0.0-beta.1.md"
+  "docs/releases/v0.4.24-beta.1.md"
 ];
 
 const required = [

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-NEONDIFF_VERSION="${NEONDIFF_VERSION:-1.0.0-beta.1}"
+NEONDIFF_VERSION="${NEONDIFF_VERSION:-0.4.24-beta.1}"
 DRY_RUN=0
 NPM_PREFIX="${NPM_PREFIX:-}"
 
@@ -13,7 +13,7 @@ Usage:
   sh install.sh [--dry-run] [--prefix /path/to/prefix]
 
 Environment:
-  NEONDIFF_VERSION  Version to install, defaults to 1.0.0-beta.1.
+  NEONDIFF_VERSION  Version to install, defaults to 0.4.24-beta.1.
   NPM_PREFIX        Optional npm global prefix.
 
 Requires Node.js 26 or newer and npm.

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -25,7 +25,7 @@ describe("NeonDiff public release readiness", () => {
     };
 
     expect(pkg.name).toBe("neondiff");
-    expect(pkg.version).toBe("1.0.0-beta.1");
+    expect(pkg.version).toBe("0.4.24-beta.1");
     expect(pkg.private).toBeUndefined();
     expect(pkg.description).toMatch(/local-first AI PR reviewer/i);
     expect(pkg.license).toBe("SEE LICENSE IN LICENSE.md");
@@ -51,10 +51,10 @@ describe("NeonDiff public release readiness", () => {
     ]);
 
     expect(lock.name).toBe("neondiff");
-    expect(lock.version).toBe("1.0.0-beta.1");
+    expect(lock.version).toBe("0.4.24-beta.1");
     expect(lock.packages?.[""]).toMatchObject({
       name: "neondiff",
-      version: "1.0.0-beta.1",
+      version: "0.4.24-beta.1",
       license: "SEE LICENSE IN LICENSE.md",
       bin: { neondiff: "dist/src/cli.js" }
     });
@@ -64,7 +64,7 @@ describe("NeonDiff public release readiness", () => {
     expect(existsSync("scripts/install.sh")).toBe(true);
     const script = read("scripts/install.sh");
 
-    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-1\.0\.0-beta\.1\}"/);
+    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-0\.4\.24-beta\.1\}"/);
     expect(script).toMatch(/npm[^\n]+install[^\n]+-g[^\n]+neondiff@\$\{NEONDIFF_VERSION\}/);
     expect(script).toMatch(/--dry-run/);
     expect(script).toMatch(/Node\.js 26 or newer/);
@@ -78,11 +78,11 @@ describe("NeonDiff public release readiness", () => {
       read("docs/github-app-setup.md"),
       read("docs/providers.md"),
       read("docs/license-boundary.md"),
-      read("docs/releases/v1.0.0-beta.1.md")
+      read("docs/releases/v0.4.24-beta.1.md")
     ].join("\n\n");
 
     expect(docs).toMatch(/https:\/\/github\.com\/electricsheephq\/evaos-code-review-bot-neondiff/i);
-    expect(docs).toMatch(/npm install -g neondiff@1\.0\.0-beta\.1/i);
+    expect(docs).toMatch(/npm install -g neondiff@0\.4\.24-beta\.1/i);
     expect(docs).toMatch(/curl -fsSL https:\/\/www\.neondiff\.com\/install/i);
     expect(docs).toMatch(/git clone https:\/\/github\.com\/electricsheephq\/evaos-code-review-bot-neondiff\.git/i);
     expect(docs).not.toMatch(/https:\/\/github\.com\/electricsheephq\/evaos-code-review-bot(?!-neondiff)/i);
@@ -108,6 +108,6 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/id-token:\s*write/);
     expect(publish).toMatch(/NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
     expect(publish).toMatch(/npm publish --provenance/);
-    expect(publish).toMatch(/v1\.0\.0-beta\.1/);
+    expect(publish).toMatch(/v0\.4\.24-beta\.1/);
   });
 });

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -193,16 +193,16 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v1.0.0-beta.1"
+      expectedVersion: "v0.4.24-beta.1"
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v1.0.0-beta.1",
+      version: "v0.4.24-beta.1",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+        releaseNotesPath: "docs/releases/v0.4.24-beta.1.md"
       },
       updateChannels: {
         ok: true
@@ -262,13 +262,13 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v1.0.0-beta.1",
+      expectedPublicVersion: "v0.4.24-beta.1",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot"
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v1.0.0-beta.1"
+      version: "v0.4.24-beta.1"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",


### PR DESCRIPTION
## Summary

Align the public NeonDiff beta release line with the implementation agent's existing v0.4.x beta train by moving the public package/docs/install contract from `1.0.0-beta.1` to `0.4.24-beta.1`.

Closes #250.

## Why

The first public package/release label used `1.0.0-beta.1`, which implied a major-version jump while the implementation agent is still on `v0.4.23-beta.1`. This PR makes the next buyer-facing public beta `v0.4.24-beta.1` and keeps `v1.0.0-beta.1` only as a superseded/deprecated registry artifact.

## Changed

- Updates `package.json`, lockfile, installer default, setup docs, release governance docs, public release manifest, and publish workflow to `0.4.24-beta.1`.
- Adds `docs/releases/v0.4.24-beta.1.md` as the corrected release packet.
- Replaces the `v1.0.0-beta.1` release note with a superseded notice pointing to `v0.4.24-beta.1`.
- Updates public release/readiness tests for the corrected active public version.

## Validation

From `/Volumes/LEXAR/repos/worktrees/neondiff-final-release`:

```bash
npm run build
npx vitest run tests/public-release-readiness.test.ts tests/public-community-funnel.test.ts tests/public-cli.test.ts tests/license.test.ts tests/release-status.test.ts --pool=forks --maxWorkers=1
node scripts/check-public-claims.mjs
node scripts/check-secret-scan.mjs
npm pack --dry-run --json > /Volumes/LEXAR/Codex/evidence/neondiff-public-product/2026-07-05/release-readiness/validation/version-correction-npm-pack-dry-run.json
node scripts/check-packlist.mjs /Volumes/LEXAR/Codex/evidence/neondiff-public-product/2026-07-05/release-readiness/validation/version-correction-npm-pack-dry-run.json
```

Result: build passed; 153 focused tests passed; public claims scan passed; secret scan passed over 274 tracked files; packlist passed with 64 files.
