### PR TITLE
Gate hosted BYOK provider smoke

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -38,8 +38,13 @@ neondiff providers doctor \
 The example `ollama-local` provider is disabled by default. Enable it in
 `config.local.json` or with a dry-run-verified config patch before running the
 smoke command; otherwise the doctor exits before calling `/models`. Smoke checks
-are local-loopback only in this beta and must include `--provider` so a single
-command cannot fan out authenticated requests to every enabled provider.
+must include `--provider` so a single command cannot fan out authenticated
+requests to every enabled provider. Local loopback endpoints can be smoked with
+`--smoke true` alone. Hosted non-loopback endpoints also require
+`--allow-remote-smoke true`; the doctor then performs one bounded `GET /models`
+request to the selected HTTPS endpoint with the configured environment-backed
+API key and does not send PR diffs, review prompts, fixture payloads, or GitHub
+mutations.
 
 ## GLM/Z.ai Through ZCode
 
@@ -128,7 +133,12 @@ Then export the key in the operator wrapper, not in JSON:
 
 ```bash
 export NEONDIFF_PROVIDER_API_KEY="..."
-neondiff providers doctor --config config.local.json --provider openai-compatible --smoke true --json
+neondiff providers doctor \
+  --config config.local.json \
+  --provider openai-compatible \
+  --smoke true \
+  --allow-remote-smoke true \
+  --json
 ```
 
 ## Error Categories

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,7 +166,10 @@ async function main(): Promise<void> {
       const result = await doctorProviderRegistry({
         registry: config.providers!,
         ...(providerId ? { providerId } : {}),
-        smoke: args.smoke === undefined ? false : parseBooleanArg(args.smoke, "--smoke")
+        smoke: args.smoke === undefined ? false : parseBooleanArg(args.smoke, "--smoke"),
+        allowRemoteSmoke: args["allow-remote-smoke"] === undefined
+          ? false
+          : parseBooleanArg(args["allow-remote-smoke"], "--allow-remote-smoke")
       });
       console.log(stringifyProviderOutput({
         ...result,
@@ -2595,6 +2598,7 @@ function buildHelp(command?: string) {
       "neondiff providers list --config config.local.json --json",
       "neondiff providers doctor --config config.local.json --json",
       "neondiff providers doctor --config config.local.json --provider ollama-local --smoke true --json",
+      "neondiff providers doctor --config config.local.json --provider openai-compatible --smoke true --allow-remote-smoke true --json",
       "neondiff license activate --config config.local.json --license-key-env NEONDIFF_LICENSE_KEY --json",
       "neondiff license status --config config.local.json --json",
       "neondiff license deactivate --config config.local.json --json",

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -1,8 +1,11 @@
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
+import { parseFindings } from "./findings.js";
+import { openAICompatibleProviderTargetError, type ProviderRegistryEntry } from "./providers.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 const EVIDENCE_PREVIEW_LIMIT = 500;
+const REVIEW_JSON_EXTRACTION_CHAR_LIMIT = 200_000;
 const EVIDENCE_PREVIEW_TRUNCATED_SENTINEL = "...[truncated]";
 const REDACTION_TOKENS = [
   "[redacted-private-evidence]",
@@ -27,6 +30,7 @@ export interface ProviderAdapterFixture {
   model: string;
   prompt: string;
   expectJsonObject?: boolean;
+  expectReviewJson?: boolean;
 }
 
 export interface ProviderAdapterExecutionInput {
@@ -45,6 +49,13 @@ export interface ProviderAdapterExecutionResult {
 export interface ProviderRuntimeAdapter {
   id: string;
   execute(input: ProviderAdapterExecutionInput): Promise<ProviderAdapterExecutionResult>;
+}
+
+export interface OpenAICompatibleReviewAdapterOptions {
+  providerId: string;
+  provider: ProviderRegistryEntry;
+  fetchImpl?: typeof fetch;
+  env?: Record<string, string | undefined>;
 }
 
 export interface ProviderAdapterFixtureEvidence {
@@ -105,14 +116,15 @@ export async function runProviderAdapterFixture(input: {
       prompt: fixture.prompt
     });
     const evidence = buildFixtureEvidence(fixture.prompt, execution);
-    if (fixture.expectJsonObject && !isJsonObject(execution.text)) {
+    const reviewJsonError = fixture.expectReviewJson ? validateReviewJsonOutput(execution.text) : undefined;
+    if (reviewJsonError || (fixture.expectJsonObject && !isJsonObject(execution.text))) {
       return {
         ok: false,
         ...baseResult,
         evidence,
         error: {
           class: "model-output",
-          message: "Adapter output was not a JSON object."
+          message: reviewJsonError ?? "Adapter output was not a JSON object."
         }
       };
     }
@@ -136,15 +148,94 @@ export async function runProviderAdapterFixture(input: {
 
 export function classifyProviderAdapterError(message: string): ProviderAdapterErrorClass {
   const normalized = message.toLowerCase();
-  if (/\b(unauthorized|forbidden|invalid[ _-]api[ _-]key|401|403)\b/.test(normalized)) return "auth";
+  if (/\b(unauthorized|forbidden|invalid[ _-]api[ _-]key|missing[ _-]api[ _-]key|401|403)\b/.test(normalized)) return "auth";
   if (/\b(rate[ _-]limit|quota|too many requests|429|insufficient[ _-]quota|throttl(?:e|ed|ing))\b/.test(normalized)) return "throttle";
   // Provider timeout wording wins over network codes in combined messages to keep cooldown evidence deterministic.
   if (/\b(time[ _-]?out|timed[ _-]out|etimedout|abort(?:ed)?|deadline exceeded)\b/.test(normalized)) return "timeout";
-  if (/\b(econnreset|econnrefused|enotfound|eai_again|socket|dns|connection[ _-]refused|connection[ _-]reset|network[ _-](?:error|failure|failed|unreachable|unavailable|down))\b/.test(normalized)) return "network";
-  if (/\b(json|schema|parseable|malformed output|invalid response|invalid output|tool call|structured output)\b/.test(normalized)) {
+  if (/\b(econnreset|econnrefused|enotfound|eai_again|socket|dns|fetch failed|service unavailable|temporarily unavailable|overload|connection[ _-]refused|connection[ _-]reset|network[ _-](?:error|failure|failed|unreachable|unavailable|down))\b/.test(normalized)) return "network";
+  if (/\b(json|schema|parseable|malformed output|invalid response|invalid output|review object|review json|tool call|structured output)\b/.test(normalized)) {
     return "model-output";
   }
   return "unknown";
+}
+
+export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleReviewAdapterOptions): ProviderRuntimeAdapter {
+  return {
+    id: "openai-compatible",
+    async execute(input) {
+      const provider = options.provider;
+      const fetchImpl = options.fetchImpl ?? fetch;
+      const env = options.env ?? process.env;
+      const baseUrl = provider.baseUrl;
+      if (!baseUrl) throw new Error("OpenAI-compatible provider requires baseUrl for review execution.");
+      const targetError = openAICompatibleProviderTargetError(baseUrl, provider, "review");
+      if (targetError) throw new Error(targetError);
+
+      const apiKey = resolveOpenAICompatibleApiKey(provider, env);
+      const timeout = createAbortSignal(provider.timeoutMs);
+      const requestBody = {
+        model: input.model,
+        temperature: 0,
+        stream: false,
+        ...(provider.capabilities.jsonOutput ? { response_format: { type: "json_object" } } : {}),
+        messages: [
+          {
+            role: "system",
+            content: "Return only the NeonDiff review JSON object. Do not include markdown, prose, tool calls, or raw diff excerpts."
+          },
+          {
+            role: "user",
+            content: input.prompt
+          }
+        ]
+      };
+      try {
+        const response = await fetchImpl(buildOpenAIChatCompletionsUrl(baseUrl), {
+          method: "POST",
+          signal: timeout.signal,
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
+          },
+          body: JSON.stringify(requestBody)
+        });
+
+        if (!response.ok) {
+          throw new Error(openAICompatibleStatusErrorMessage(response.status));
+        }
+
+        const responseText = await readResponseTextWithAbort(response, timeout.signal);
+        const parsed = parseOpenAICompatibleResponse(responseText);
+        const content = extractOpenAICompatibleMessageContent(parsed);
+        const reviewOutput = normalizeReviewJsonOutput(content);
+        if (!reviewOutput.ok) throw new Error(reviewOutput.error);
+
+        return {
+          text: reviewOutput.text,
+          rawEvidence: {
+            providerId: options.providerId,
+            adapterId: input.adapterId,
+            model: input.model,
+            baseUrl,
+            status: response.status,
+            ...(typeof parsed.id === "string" ? { responseId: parsed.id } : {}),
+            ...extractOpenAICompatibleChoiceEvidence(parsed),
+            ...extractOpenAICompatibleUsageEvidence(parsed)
+          }
+        };
+      } finally {
+        timeout.dispose();
+      }
+    }
+  };
+}
+
+export function buildOpenAIChatCompletionsUrl(baseUrl: string): string {
+  const parsed = new URL(baseUrl);
+  const pathname = parsed.pathname.replace(/\/{2,}/g, "/").replace(/\/+$/, "");
+  parsed.pathname = pathname.endsWith("/chat/completions") ? pathname : `${pathname}/chat/completions`;
+  return parsed.toString();
 }
 
 function buildFixtureEvidence(
@@ -169,6 +260,178 @@ function isJsonObject(value: string): boolean {
   } catch {
     return false;
   }
+}
+
+function validateReviewJsonOutput(value: string): string | undefined {
+  const result = normalizeReviewJsonOutput(value);
+  return result.ok ? undefined : result.error;
+}
+
+function normalizeReviewJsonOutput(value: string): { ok: true; text: string } | { ok: false; error: string } {
+  let parsed: unknown;
+  let reviewJson = value.trim();
+  try {
+    parsed = JSON.parse(reviewJson) as unknown;
+  } catch {
+    try {
+      reviewJson = extractReviewJsonObject(value);
+      parsed = JSON.parse(reviewJson) as unknown;
+    } catch {
+      return { ok: false, error: "Adapter output was not a parseable JSON review object." };
+    }
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || !Array.isArray((parsed as { findings?: unknown }).findings)) {
+    return { ok: false, error: "Adapter output did not contain a review findings array." };
+  }
+  const { dropped } = parseFindings(parsed);
+  if (dropped.length > 0) return { ok: false, error: "Adapter output contained invalid review findings." };
+  return { ok: true, text: reviewJson };
+}
+
+function extractReviewJsonObject(text: string): string {
+  const boundedText = text.slice(0, REVIEW_JSON_EXTRACTION_CHAR_LIMIT);
+  const fencedMatches = [...boundedText.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)];
+  for (const fenced of fencedMatches) {
+    const candidate = fenced[1]!.trim();
+    if (isReviewJsonObject(candidate)) return candidate;
+  }
+
+  const starts: number[] = [];
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < boundedText.length; index += 1) {
+    const char = boundedText[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === "\"") {
+      inString = true;
+      continue;
+    }
+    if (char === "{") {
+      starts.push(index);
+      continue;
+    }
+    if (char === "}") {
+      const start = starts.pop();
+      if (start === undefined) continue;
+      const candidate = boundedText.slice(start, index + 1).trim();
+      if (candidate.includes("\"findings\"") && isReviewJsonObject(candidate)) return candidate;
+    }
+  }
+  throw new Error("Adapter output did not contain a parseable JSON review object.");
+}
+
+function isReviewJsonObject(candidate: string): boolean {
+  try {
+    const parsed = JSON.parse(candidate) as { findings?: unknown };
+    return typeof parsed === "object" && parsed !== null && Array.isArray(parsed.findings);
+  } catch {
+    return false;
+  }
+}
+
+function resolveOpenAICompatibleApiKey(
+  provider: ProviderRegistryEntry,
+  env: Record<string, string | undefined>
+): string | undefined {
+  if (provider.authMode !== "api-key-env") return undefined;
+  if (!provider.apiKeyEnv) throw new Error("Missing api key environment variable name for OpenAI-compatible provider.");
+  const value = env[provider.apiKeyEnv];
+  if (!value) throw new Error(`Missing api key environment variable ${provider.apiKeyEnv}.`);
+  return value;
+}
+
+function openAICompatibleStatusErrorMessage(status: number): string {
+  if (status === 401 || status === 403) return `OpenAI-compatible chat completions endpoint returned ${status} auth failure.`;
+  if (status === 429) return "OpenAI-compatible chat completions endpoint returned 429 throttle failure.";
+  if (status === 408 || status === 504) return `OpenAI-compatible chat completions endpoint returned ${status} timeout failure.`;
+  if (status >= 500) return `OpenAI-compatible chat completions endpoint returned ${status} network failure.`;
+  // Non-auth/non-throttle 4xx statuses stay unknown until runtime wiring needs a distinct operator action.
+  return `OpenAI-compatible chat completions endpoint returned ${status}.`;
+}
+
+async function readResponseTextWithAbort(response: Response, signal: AbortSignal): Promise<string> {
+  if (signal.aborted) throw new Error("deadline exceeded");
+  let abortHandler: ((event: Event) => void) | undefined;
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    abortHandler = () => {
+      void response.body?.cancel().catch(() => undefined);
+      reject(new Error("deadline exceeded"));
+    };
+    signal.addEventListener("abort", abortHandler, { once: true });
+  });
+  try {
+    return await Promise.race([response.text(), abortPromise]);
+  } finally {
+    if (abortHandler) signal.removeEventListener("abort", abortHandler);
+  }
+}
+
+function parseOpenAICompatibleResponse(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed as Record<string, unknown>;
+  } catch {
+    // Fall through to the normalized schema error below.
+  }
+  throw new Error("OpenAI-compatible chat completions response was not valid JSON.");
+}
+
+function extractOpenAICompatibleMessageContent(parsed: Record<string, unknown>): string {
+  const choices = parsed.choices;
+  if (!Array.isArray(choices)) throw new Error("OpenAI-compatible chat completions response had invalid response schema.");
+  const firstChoice = choices[0];
+  if (!firstChoice || typeof firstChoice !== "object" || Array.isArray(firstChoice)) {
+    throw new Error("OpenAI-compatible chat completions response had invalid response schema.");
+  }
+  const message = (firstChoice as { message?: unknown }).message;
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    throw new Error("OpenAI-compatible chat completions response had invalid response schema.");
+  }
+  const content = (message as { content?: unknown }).content;
+  if (typeof content !== "string" || content.trim().length === 0) {
+    throw new Error("OpenAI-compatible chat completions response had invalid response schema.");
+  }
+  return content;
+}
+
+function extractOpenAICompatibleChoiceEvidence(parsed: Record<string, unknown>): Record<string, unknown> {
+  const firstChoice = Array.isArray(parsed.choices) ? parsed.choices[0] : undefined;
+  if (!firstChoice || typeof firstChoice !== "object" || Array.isArray(firstChoice)) return {};
+  const finishReason = (firstChoice as { finish_reason?: unknown }).finish_reason;
+  return typeof finishReason === "string" ? { finishReason } : {};
+}
+
+function extractOpenAICompatibleUsageEvidence(parsed: Record<string, unknown>): Record<string, unknown> {
+  const usage = parsed.usage;
+  if (!usage || typeof usage !== "object" || Array.isArray(usage)) return {};
+  return {
+    usage: Object.fromEntries(
+      Object.entries(usage)
+        .filter(([, value]) => typeof value === "number" && Number.isFinite(value))
+        .map(([key, value]) => [key, value])
+    )
+  };
+}
+
+function createAbortSignal(timeoutMs: number | undefined): { signal: AbortSignal; dispose: () => void } {
+  const timeout = timeoutMs && timeoutMs > 0 ? timeoutMs : 30_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  const maybeUnref = timer as { unref?: () => void };
+  if (typeof maybeUnref.unref === "function") maybeUnref.unref();
+  return {
+    signal: controller.signal,
+    dispose: () => clearTimeout(timer)
+  };
 }
 
 function previewEvidenceText(value: string): string {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,7 +1,18 @@
+import { lookup as defaultDnsLookup } from "node:dns/promises";
+import { request as httpRequest, type IncomingHttpHeaders } from "node:http";
+import { request as httpsRequest } from "node:https";
 import { isIP } from "node:net";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 const DEFAULT_PROVIDER_SMOKE_TIMEOUT_MS = 30_000;
+const MAX_PROVIDER_SMOKE_RESPONSE_BYTES = 256 * 1024;
+const REMOTE_SMOKE_OPT_IN_ERROR = "Remote OpenAI-compatible smoke checks require --allow-remote-smoke true and --provider <id>.";
+
+type DnsLookupAddress = { address: string; family: number };
+type DnsLookupImpl = (
+  hostname: string,
+  options: { all: true; verbatim?: boolean }
+) => Promise<DnsLookupAddress[]>;
 
 export type ProviderAdapter = "zcode" | "openai-compatible" | "anthropic" | "openai" | "gemini";
 export type ProviderAuthMode = "zcode-app-config" | "api-key-env" | "none";
@@ -118,7 +129,9 @@ export async function doctorProviderRegistry(input: {
   registry: ProviderRegistryConfig;
   providerId?: string;
   smoke?: boolean;
+  allowRemoteSmoke?: boolean;
   fetchImpl?: typeof fetch;
+  dnsLookupImpl?: DnsLookupImpl;
   env?: Record<string, string | undefined>;
 }): Promise<ProviderDoctorResult> {
   if (input.smoke && !input.providerId) {
@@ -187,7 +200,14 @@ export async function doctorProviderRegistry(input: {
       continue;
     }
 
-    checks.push(await smokeOpenAICompatibleProvider({ providerId, provider, fetchImpl, env }));
+    checks.push(await smokeOpenAICompatibleProvider({
+      providerId,
+      provider,
+      fetchImpl,
+      dnsLookupImpl: input.dnsLookupImpl ?? defaultDnsLookup,
+      env,
+      allowRemoteSmoke: input.allowRemoteSmoke === true
+    }));
   }
 
   return {
@@ -204,7 +224,9 @@ async function smokeOpenAICompatibleProvider(input: {
   providerId: string;
   provider: ProviderRegistryEntry;
   fetchImpl: typeof fetch;
+  dnsLookupImpl: DnsLookupImpl;
   env: Record<string, string | undefined>;
+  allowRemoteSmoke: boolean;
 }): Promise<ProviderDoctorCheck> {
   const safeProviderId = safeProviderIdForOutput(input.providerId);
   const baseCheck = {
@@ -224,23 +246,48 @@ async function smokeOpenAICompatibleProvider(input: {
   const authError = providerAuthMetadataError(input.provider);
   if (authError) return { ...baseCheck, ok: false, error: authError };
   if (!input.provider.baseUrl) return { ...baseCheck, ok: false, error: "OpenAI-compatible provider requires baseUrl for smoke checks." };
-  const targetError = providerSmokeTargetError(input.provider.baseUrl, input.provider);
-  if (targetError) return { ...baseCheck, ok: false, error: targetError };
+  const target = await resolveProviderSmokeTarget({
+    baseUrl: input.provider.baseUrl,
+    provider: input.provider,
+    env: input.env,
+    allowRemoteSmoke: input.allowRemoteSmoke,
+    dnsLookupImpl: input.dnsLookupImpl
+  });
+  if (target.error) return { ...baseCheck, ok: false, error: target.error };
   if (input.provider.authMode === "api-key-env" && input.provider.apiKeyEnv && !input.env[input.provider.apiKeyEnv]) {
     return { ...baseCheck, ok: false, error: `Missing API key environment variable ${input.provider.apiKeyEnv}.` };
   }
 
   try {
-    const response = await input.fetchImpl(buildOpenAIModelsUrl(input.provider.baseUrl), {
+    const requestUrl = buildOpenAIModelsUrl(input.provider.baseUrl);
+    const requestInit: RequestInit = {
+      method: "GET",
       signal: signalWithTimeout(input.provider.timeoutMs),
+      redirect: "manual",
       headers: {
         Accept: "application/json",
         ...(input.provider.authMode === "api-key-env" && input.provider.apiKeyEnv
           ? { Authorization: `Bearer ${input.env[input.provider.apiKeyEnv]}` }
           : {})
       }
-    });
-    const text = await response.text();
+    };
+    const response = input.fetchImpl === fetch
+      ? await fetchProviderModels(requestUrl, requestInit, target.target, input.provider.timeoutMs)
+      : await input.fetchImpl(requestUrl, requestInit);
+    let text: string;
+    try {
+      text = await readResponseTextBounded(response);
+    } catch (error) {
+      if (error instanceof ProviderSmokeResponseTooLargeError) {
+        return {
+          ...baseCheck,
+          ok: false,
+          errorCategory: "model_output_schema",
+          error: error.message
+        };
+      }
+      throw error;
+    }
     if (!response.ok) {
       const redactedText = redactProviderSmokeText(text, input.provider, input.env);
       const error = `OpenAI-compatible models endpoint returned ${response.status}: ${redactedText.slice(0, 300)}`;
@@ -278,6 +325,14 @@ async function smokeOpenAICompatibleProvider(input: {
         : {})
     };
   } catch (error) {
+    if (error instanceof ProviderSmokeResponseTooLargeError) {
+      return {
+        ...baseCheck,
+        ok: false,
+        errorCategory: "model_output_schema",
+        error: error.message
+      };
+    }
     const message = error instanceof Error ? error.message : String(error);
     const errorCategory = classifyProviderError(message);
     const redactedMessage = redactProviderSmokeText(message, input.provider, input.env);
@@ -365,8 +420,77 @@ export function openAICompatibleProviderTargetError(
   return undefined;
 }
 
-function providerSmokeTargetError(baseUrl: string, provider: ProviderRegistryEntry): string | undefined {
-  return openAICompatibleProviderTargetError(baseUrl, provider, "smoke");
+interface ProviderSmokeTarget {
+  remote: boolean;
+  pinnedAddress?: DnsLookupAddress;
+}
+
+async function resolveProviderSmokeTarget(input: {
+  baseUrl: string;
+  provider: ProviderRegistryEntry;
+  env: Record<string, string | undefined>;
+  allowRemoteSmoke: boolean;
+  dnsLookupImpl: DnsLookupImpl;
+}): Promise<{ target?: ProviderSmokeTarget; error?: string }> {
+  let parsed: URL;
+  try {
+    parsed = new URL(input.baseUrl);
+  } catch {
+    return { error: "OpenAI-compatible provider baseUrl must be a valid URL for smoke checks." };
+  }
+  if (parsed.username || parsed.password) {
+    return { error: "OpenAI-compatible smoke target must not include username or password credentials." };
+  }
+  if (containsSecretLikeText(decodeURIComponent(`${parsed.pathname}${parsed.hash}`))) {
+    return { error: "OpenAI-compatible smoke target must not include secret-like path or fragment values." };
+  }
+  for (const key of parsed.searchParams.keys()) {
+    if (/(key|token|secret|password|session|cookie)/i.test(key)) {
+      return { error: "OpenAI-compatible smoke target must not include credential query parameters." };
+    }
+  }
+  const loopback = isLoopbackHost(parsed.hostname);
+  if (loopback && input.provider.capabilities.local) return { target: { remote: false } };
+  if (isUnsafeSmokeHost(parsed.hostname)) {
+    return { error: "OpenAI-compatible smoke target must not point to private, link-local, loopback, or cloud metadata hosts." };
+  }
+  if (parsed.protocol !== "https:") {
+    return { error: "Remote OpenAI-compatible smoke target must use HTTPS." };
+  }
+  if (!input.allowRemoteSmoke) return { error: REMOTE_SMOKE_OPT_IN_ERROR };
+  if (input.provider.authMode !== "api-key-env" || !input.provider.apiKeyEnv) {
+    return { error: "Hosted remote smoke requires authMode api-key-env and apiKeyEnv." };
+  }
+  if (!input.env[input.provider.apiKeyEnv]) {
+    return { error: `Missing API key environment variable ${input.provider.apiKeyEnv}.` };
+  }
+  const pinnedAddress = await resolvePinnedRemoteSmokeAddress(parsed.hostname, input.dnsLookupImpl);
+  if (pinnedAddress.error) return { error: pinnedAddress.error };
+  return { target: { remote: true, pinnedAddress: pinnedAddress.address } };
+}
+
+async function resolvePinnedRemoteSmokeAddress(
+  hostname: string,
+  dnsLookupImpl: DnsLookupImpl
+): Promise<{ address?: DnsLookupAddress; error?: string }> {
+  let addresses: DnsLookupAddress[];
+  try {
+    addresses = await dnsLookupImpl(hostname, { all: true, verbatim: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { error: `Remote OpenAI-compatible smoke DNS lookup failed: ${redactSecrets(message)}` };
+  }
+  if (addresses.length === 0) {
+    return { error: "Remote OpenAI-compatible smoke DNS lookup returned no addresses." };
+  }
+  if (addresses.some((entry) => isUnsafeSmokeHost(entry.address))) {
+    return { error: "Remote OpenAI-compatible smoke DNS resolved to an unsafe private, link-local, loopback, or metadata address." };
+  }
+  const address = addresses.find((entry) => entry.family === 4 || entry.family === 6);
+  if (!address) {
+    return { error: "Remote OpenAI-compatible smoke DNS lookup returned no IPv4 or IPv6 addresses." };
+  }
+  return { address };
 }
 
 function isLoopbackHost(hostname: string): boolean {
@@ -428,6 +552,121 @@ function ipv4MappedIpv6Address(value: string): string | undefined {
   const low = Number.parseInt(parts[1], 16);
   if ([high, low].some((part) => !Number.isInteger(part) || part < 0 || part > 0xffff)) return undefined;
   return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+}
+
+class ProviderSmokeResponseTooLargeError extends Error {
+  constructor() {
+    super(`Models response exceeded ${MAX_PROVIDER_SMOKE_RESPONSE_BYTES} byte limit.`);
+  }
+}
+
+async function fetchProviderModels(
+  url: string,
+  init: RequestInit,
+  target: ProviderSmokeTarget | undefined,
+  timeoutMs: number | undefined
+): Promise<Response> {
+  const parsed = new URL(url);
+  const requestFn = parsed.protocol === "https:" ? httpsRequest : httpRequest;
+  const headers = new Headers(init.headers);
+  const headerObject = Object.fromEntries(headers.entries());
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const request = requestFn({
+      protocol: parsed.protocol,
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: `${parsed.pathname}${parsed.search}`,
+      method: "GET",
+      headers: headerObject,
+      timeout: timeoutMs && timeoutMs > 0 ? timeoutMs : DEFAULT_PROVIDER_SMOKE_TIMEOUT_MS,
+      ...(target?.remote && target.pinnedAddress
+        ? {
+            servername: parsed.hostname,
+            lookup: (_hostname, _options, callback) => {
+              callback(null, target.pinnedAddress!.address, target.pinnedAddress!.family);
+            }
+          }
+        : {})
+    }, (response) => {
+      const chunks: Buffer[] = [];
+      let totalBytes = 0;
+      response.on("data", (chunk: Buffer | string) => {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        totalBytes += buffer.byteLength;
+        if (totalBytes > MAX_PROVIDER_SMOKE_RESPONSE_BYTES) {
+          request.destroy(new ProviderSmokeResponseTooLargeError());
+          return;
+        }
+        chunks.push(buffer);
+      });
+      response.on("end", () => {
+        if (settled) return;
+        settled = true;
+        init.signal?.removeEventListener("abort", abort);
+        resolve(new Response(Buffer.concat(chunks), {
+          status: response.statusCode ?? 0,
+          statusText: response.statusMessage,
+          headers: responseHeadersToHeaders(response.headers)
+        }));
+      });
+    });
+    const abort = () => request.destroy(new Error("Provider smoke request aborted."));
+    init.signal?.addEventListener("abort", abort, { once: true });
+    request.on("timeout", () => request.destroy(new Error("Provider smoke request timed out.")));
+    request.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      init.signal?.removeEventListener("abort", abort);
+      reject(error);
+    });
+    request.end();
+  });
+}
+
+function responseHeadersToHeaders(headers: IncomingHttpHeaders): Headers {
+  const output = new Headers();
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const entry of value) output.append(key, entry);
+    } else {
+      output.set(key, String(value));
+    }
+  }
+  return output;
+}
+
+async function readResponseTextBounded(response: Response): Promise<string> {
+  const contentLength = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(contentLength) && contentLength > MAX_PROVIDER_SMOKE_RESPONSE_BYTES) {
+    throw new ProviderSmokeResponseTooLargeError();
+  }
+  if (!response.body) return response.text();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_PROVIDER_SMOKE_RESPONSE_BYTES) {
+        throw new ProviderSmokeResponseTooLargeError();
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const output = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(output);
 }
 
 function extractModelIds(data: unknown[]): string[] {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -327,33 +327,46 @@ function safeProviderIdForOutput(value: string): string {
   return isProviderId(value) ? value : "[invalid-provider-id]";
 }
 
-function providerSmokeTargetError(baseUrl: string, provider: ProviderRegistryEntry): string | undefined {
+type OpenAICompatibleTargetPurpose = "smoke" | "review";
+
+export function openAICompatibleProviderTargetError(
+  baseUrl: string,
+  provider: ProviderRegistryEntry,
+  purpose: OpenAICompatibleTargetPurpose
+): string | undefined {
+  const targetLabel = purpose === "review" ? "review target" : "smoke target";
+  const operationLabel = purpose === "review" ? "review execution" : "smoke checks";
+  const disabledVerb = purpose === "review" ? "is" : "are";
   let parsed: URL;
   try {
     parsed = new URL(baseUrl);
   } catch {
-    return "OpenAI-compatible provider baseUrl must be a valid URL for smoke checks.";
+    return `OpenAI-compatible provider baseUrl must be a valid URL for ${operationLabel}.`;
   }
   if (parsed.username || parsed.password) {
-    return "OpenAI-compatible smoke target must not include username or password credentials.";
+    return `OpenAI-compatible ${targetLabel} must not include username or password credentials.`;
   }
   if (containsSecretLikeText(decodeURIComponent(`${parsed.pathname}${parsed.hash}`))) {
-    return "OpenAI-compatible smoke target must not include secret-like path or fragment values.";
+    return `OpenAI-compatible ${targetLabel} must not include secret-like path or fragment values.`;
   }
   for (const key of parsed.searchParams.keys()) {
     if (/(key|token|secret|password|session|cookie)/i.test(key)) {
-      return "OpenAI-compatible smoke target must not include credential query parameters.";
+      return `OpenAI-compatible ${targetLabel} must not include credential query parameters.`;
     }
   }
   const loopback = isLoopbackHost(parsed.hostname);
   if (loopback && provider.capabilities.local) return undefined;
   if (isUnsafeSmokeHost(parsed.hostname)) {
-    return "OpenAI-compatible smoke target must not point to private, link-local, loopback, or cloud metadata hosts.";
+    return `OpenAI-compatible ${targetLabel} must not point to private, link-local, loopback, or cloud metadata hosts.`;
   }
   if (!loopback) {
-    return "Remote OpenAI-compatible smoke checks are disabled until the transport can pin the validated DNS result.";
+    return `Remote OpenAI-compatible ${operationLabel} ${disabledVerb} disabled until the transport can pin the validated DNS result.`;
   }
   return undefined;
+}
+
+function providerSmokeTargetError(baseUrl: string, provider: ProviderRegistryEntry): string | undefined {
+  return openAICompatibleProviderTargetError(baseUrl, provider, "smoke");
 }
 
 function isLoopbackHost(hostname: string): boolean {

--- a/src/zcode.ts
+++ b/src/zcode.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { parseFindings } from "./findings.js";
 import type { GitNexusContextPacket } from "./gitnexus-context.js";
 import type { GitHubRelatedContextPacket } from "./github-related-context.js";
+import type { ProviderRuntimeAdapter } from "./provider-adapters.js";
 import type { RepoMemoryPacket } from "./repo-memory.js";
 import { buildRepoProfilePromptSection, type ResolvedRepoProfile } from "./repo-policy.js";
 import { redactSecrets } from "./secrets.js";
@@ -15,6 +16,61 @@ export interface ZCodeReviewResult {
   findings: Finding[];
   droppedFromSchema: ReturnType<typeof parseFindings>["dropped"];
   rawResponse: string;
+}
+
+export interface ZCodeReviewFixtureAdapterOptions {
+  cwd: string;
+  cliPath: string;
+  appConfigPath: string;
+  evidenceDir?: string;
+  timeoutMs?: number;
+  retryMaxRetries?: number;
+  runReview?: (input: {
+    cwd: string;
+    prompt: string;
+    cliPath: string;
+    appConfigPath: string;
+    model: string;
+    providerId?: string;
+    evidenceDir?: string;
+    timeoutMs?: number;
+    retryMaxRetries?: number;
+  }) => ZCodeReviewResult;
+}
+
+/**
+ * Fixture-only wrapper for same-prompt adapter proof. Live review execution
+ * continues to call runZCodeReview directly until a separate runtime adapter
+ * proves async behavior, transport evidence, and selection policy.
+ */
+export function createZCodeReviewFixtureAdapter(options: ZCodeReviewFixtureAdapterOptions): ProviderRuntimeAdapter {
+  return {
+    id: "zcode",
+    async execute(input) {
+      const runReview = options.runReview ?? runZCodeReview;
+      const result = runReview({
+        cwd: options.cwd,
+        prompt: input.prompt,
+        cliPath: options.cliPath,
+        appConfigPath: options.appConfigPath,
+        model: input.model,
+        providerId: input.providerId,
+        ...(options.evidenceDir ? { evidenceDir: options.evidenceDir } : {}),
+        ...(options.timeoutMs ? { timeoutMs: options.timeoutMs } : {}),
+        ...(options.retryMaxRetries !== undefined ? { retryMaxRetries: options.retryMaxRetries } : {})
+      });
+      return {
+        text: result.rawResponse,
+        rawEvidence: {
+          providerId: input.providerId,
+          adapterId: input.adapterId,
+          model: input.model,
+          findings: result.findings.length,
+          droppedFromSchema: result.droppedFromSchema.length
+        }
+      };
+    }
+  };
 }
 
 export function buildReviewPrompt(input: {

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -1,12 +1,399 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
+  buildOpenAIChatCompletionsUrl,
   classifyProviderAdapterError,
+  createOpenAICompatibleReviewAdapter,
   runProviderAdapterFixture,
   type ProviderRuntimeAdapter
 } from "../src/provider-adapters.js";
+import type { ProviderRegistryEntry } from "../src/providers.js";
+import { createZCodeReviewFixtureAdapter } from "../src/zcode.js";
 
 describe("provider adapter fixtures", () => {
+  it("runs one shared review fixture through mocked ZCode and local OpenAI-compatible adapters", async () => {
+    const reviewJson = '{"findings":[],"summary":"No validated current-diff findings."}';
+    const sharedFixture = makeFixture({
+      id: "shared-review-fixture",
+      prompt: [
+        "Review this private patch content before posting a comment.",
+        "diff --git a/private.ts b/private.ts",
+        "@@ -1 +1 @@",
+        "-secret",
+        "+fixed"
+      ].join("\n"),
+      expectReviewJson: true
+    });
+    const zcodeAdapter = createZCodeReviewFixtureAdapter({
+      cwd: "/repo",
+      cliPath: "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
+      appConfigPath: "/Users/example/.zcode/app-config.json",
+      runReview(input) {
+        expect(input.prompt).toBe(sharedFixture.prompt);
+        expect(input.model).toBe("GLM-5.2");
+        expect(input.providerId).toBe("zcode-glm");
+        return {
+          findings: [],
+          droppedFromSchema: [],
+          rawResponse: reviewJson
+        };
+      }
+    });
+    const localAdapter = createOpenAICompatibleReviewAdapter({
+      providerId: "ollama-local",
+      provider: makeOpenAICompatibleProvider({
+        baseUrl: "http://127.0.0.1:11434/v1",
+        model: "qwen2.5-coder:7b",
+        authMode: "none",
+        capabilities: {
+          review: true,
+          jsonOutput: true,
+          local: true,
+          streaming: false
+        }
+      }),
+      fetchImpl: async (url, init) => {
+        expect(String(url)).toBe("http://127.0.0.1:11434/v1/chat/completions");
+        expect(new Headers(init?.headers).has("authorization")).toBe(false);
+        const body = JSON.parse(String(init?.body)) as {
+          model?: string;
+          stream?: boolean;
+          messages?: Array<{ role?: string; content?: string }>;
+          response_format?: { type?: string };
+        };
+        expect(body).toMatchObject({
+          model: "qwen2.5-coder:7b",
+          stream: false,
+          response_format: { type: "json_object" }
+        });
+        expect(body.messages?.at(-1)).toEqual({ role: "user", content: sharedFixture.prompt });
+        return jsonResponse({
+          id: "chatcmpl-local-fixture",
+          choices: [
+            {
+              message: {
+                content: reviewJson
+              }
+            }
+          ],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 5
+          }
+        });
+      }
+    });
+
+    const zcode = await runProviderAdapterFixture({
+      adapter: zcodeAdapter,
+      fixture: {
+        ...sharedFixture,
+        providerId: "zcode-glm",
+        adapterId: "zcode",
+        model: "GLM-5.2"
+      }
+    });
+    const local = await runProviderAdapterFixture({
+      adapter: localAdapter,
+      fixture: {
+        ...sharedFixture,
+        providerId: "ollama-local",
+        adapterId: "openai-compatible",
+        model: "qwen2.5-coder:7b"
+      }
+    });
+
+    expect(zcode.ok).toBe(true);
+    expect(local.ok).toBe(true);
+    expect(zcode.fixtureId).toBe(local.fixtureId);
+    expect(zcode.evidence.promptSha256).toBe(local.evidence.promptSha256);
+    expect(zcode.evidence.outputPreview).toBe(reviewJson);
+    expect(local.evidence.outputPreview).toBe(reviewJson);
+    expect(JSON.stringify([zcode, local])).not.toContain("private patch content");
+    expect(JSON.stringify([zcode, local])).not.toContain("diff --git");
+    expect(local.evidence.rawEvidencePreview).toContain('"providerId":"ollama-local"');
+    expect(local.evidence.rawEvidencePreview).not.toContain(sharedFixture.prompt);
+  });
+
+  it("executes OpenAI-compatible chat-completions reviews with env-backed bearer auth and redacted evidence", async () => {
+    const providerKey = "sk-live-openai-compatible-secret";
+    const adapter = createOpenAICompatibleReviewAdapter({
+      providerId: "openai-compatible",
+      provider: makeOpenAICompatibleProvider({
+        baseUrl: "http://localhost:1234/v1",
+        model: "lm-studio-review-model",
+        authMode: "api-key-env",
+        apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+        capabilities: {
+          review: true,
+          jsonOutput: true,
+          local: true,
+          streaming: false
+        }
+      }),
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: providerKey
+      },
+      fetchImpl: async (url, init) => {
+        expect(String(url)).toBe("http://localhost:1234/v1/chat/completions");
+        expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${providerKey}`);
+        return jsonResponse({
+          id: "chatcmpl-env-auth-fixture",
+          choices: [
+            {
+              message: {
+                content: '{"findings":[{"severity":"P2","path":"src/app.ts","line":12,"title":"Bug","body":"Fix the regression.","confidence":0.91}],"summary":"One finding."}'
+              }
+            }
+          ]
+        });
+      }
+    });
+
+    const result = await runProviderAdapterFixture({
+      adapter,
+      fixture: makeFixture({
+        id: "env-auth-openai-compatible-fixture",
+        providerId: "openai-compatible",
+        adapterId: "openai-compatible",
+        model: "lm-studio-review-model",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.outputPreview).toContain('"findings"');
+    expect(result.evidence.rawEvidencePreview).toContain('"status":200');
+    expect(result.evidence.rawEvidencePreview).not.toContain(providerKey);
+    expect(JSON.stringify(result)).not.toContain(providerKey);
+  });
+
+  it("blocks unsafe OpenAI-compatible review targets before fetching private prompts", async () => {
+    let fetched = false;
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "unsafe-openai-compatible",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://169.254.169.254/latest/meta-data",
+          capabilities: {
+            review: true,
+            jsonOutput: true,
+            local: false,
+            streaming: false
+          }
+        }),
+        fetchImpl: async () => {
+          fetched = true;
+          return jsonResponse({ unreachable: true });
+        }
+      }),
+      fixture: makeFixture({
+        id: "unsafe-openai-compatible-fixture",
+        providerId: "unsafe-openai-compatible",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(fetched).toBe(false);
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "unknown",
+        message: "OpenAI-compatible review target must not point to private, link-local, loopback, or cloud metadata hosts."
+      }
+    });
+  });
+
+  it("omits strict response_format when provider capabilities do not declare JSON mode", async () => {
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "json-parser-only-local",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://127.0.0.1:8080/v1",
+          capabilities: {
+            review: true,
+            jsonOutput: false,
+            local: true,
+            streaming: false
+          }
+        }),
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as { response_format?: unknown };
+          expect(body).not.toHaveProperty("response_format");
+          return jsonResponse({
+            choices: [
+              {
+                message: {
+                  content: '{"findings":[],"summary":"Parsed without provider-side JSON mode."}'
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "json-parser-only-local-fixture",
+        providerId: "json-parser-only-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("times out OpenAI-compatible responses that stall after headers", async () => {
+    let bodyCancelled = false;
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "slow-body-local",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://127.0.0.1:8080/v1",
+          timeoutMs: 1
+        }),
+        fetchImpl: async () => ({
+          ok: true,
+          status: 200,
+          text: async () => new Promise<string>(() => undefined),
+          body: {
+            cancel: async () => {
+              bodyCancelled = true;
+            }
+          }
+        }) as Response
+      }),
+      fixture: makeFixture({
+        id: "slow-body-openai-compatible-fixture",
+        providerId: "slow-body-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "timeout",
+        message: "deadline exceeded"
+      }
+    });
+    expect(bodyCancelled).toBe(true);
+  });
+
+  it.each([
+    {
+      expectedClass: "auth",
+      provider: makeOpenAICompatibleProvider({
+        authMode: "api-key-env",
+        apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY"
+      }),
+      env: {},
+      fetchImpl: async () => jsonResponse({ unreachable: true })
+    },
+    {
+      expectedClass: "throttle",
+      fetchImpl: async () => new Response("too many requests with sk-live-secret-secret", { status: 429 })
+    },
+    {
+      expectedClass: "network",
+      fetchImpl: async () => new Response("service unavailable with sk-live-secret-secret", { status: 503 })
+    },
+    {
+      expectedClass: "timeout",
+      fetchImpl: async () => {
+        throw new Error("deadline exceeded");
+      }
+    },
+    {
+      expectedClass: "model-output",
+      fetchImpl: async () => jsonResponse({
+        choices: [
+          {
+            message: {
+              content: "not json with sk-live-secret-secret"
+            }
+          }
+        ]
+      })
+    },
+    {
+      expectedClass: "unknown",
+      fetchImpl: async () => new Response("provider returned a teapot with sk-live-secret-secret", { status: 418 })
+    }
+  ] as const)(
+    "bounds OpenAI-compatible adapter failures as $expectedClass",
+    async ({ expectedClass, provider, env, fetchImpl }) => {
+      const result = await runProviderAdapterFixture({
+        adapter: createOpenAICompatibleReviewAdapter({
+          providerId: "openai-compatible",
+          provider: provider ?? makeOpenAICompatibleProvider(),
+          env,
+          fetchImpl
+        }),
+        fixture: makeFixture({
+          id: `${expectedClass}-openai-compatible-fixture`,
+          providerId: "openai-compatible",
+          adapterId: "openai-compatible",
+          expectReviewJson: true
+        })
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          class: expectedClass
+        }
+      });
+      expect(JSON.stringify(result)).not.toContain("sk-live-secret-secret");
+    }
+  );
+
+  it("keeps model-output wording ahead of generic HTTP status tokens", () => {
+    expect(classifyProviderAdapterError("500 invalid output from provider")).toBe("model-output");
+    expect(classifyProviderAdapterError("500 network failure from provider")).toBe("network");
+    expect(classifyProviderAdapterError("OpenAI-compatible chat completions endpoint returned 418.")).toBe("unknown");
+  });
+
+  it("builds OpenAI-compatible chat-completions URLs for Ollama, LM Studio, vLLM, and gateway shapes", () => {
+    expect(buildOpenAIChatCompletionsUrl("http://localhost:11434/v1")).toBe("http://localhost:11434/v1/chat/completions");
+    expect(buildOpenAIChatCompletionsUrl("http://127.0.0.1:1234/v1/")).toBe("http://127.0.0.1:1234/v1/chat/completions");
+    expect(buildOpenAIChatCompletionsUrl("http://localhost:8000/v1/chat/completions")).toBe("http://localhost:8000/v1/chat/completions");
+    expect(buildOpenAIChatCompletionsUrl("http://localhost:8000/v1/chat/completions/")).toBe("http://localhost:8000/v1/chat/completions");
+    expect(buildOpenAIChatCompletionsUrl("http://localhost:8000/v1//chat/completions?x=1")).toBe("http://localhost:8000/v1/chat/completions?x=1");
+    expect(buildOpenAIChatCompletionsUrl("https://gateway.example.test/openai/v1")).toBe("https://gateway.example.test/openai/v1/chat/completions");
+  });
+
+  it("bounds review JSON extraction work for large malformed local-model responses", async () => {
+    const noisyPrefix = Array.from({ length: 5_000 }, (_, index) => `{noise-${index}}`).join("");
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "noisy-local-model",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://localhost:8080/v1"
+        }),
+        fetchImpl: async () => jsonResponse({
+          choices: [
+            {
+              message: {
+                content: `${noisyPrefix} {"findings":[],"summary":"Found after noisy braces."}`
+              }
+            }
+          ]
+        })
+      }),
+      fixture: makeFixture({
+        id: "noisy-local-model-fixture",
+        providerId: "noisy-local-model",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.outputPreview).toContain('"findings":[]');
+  });
+
   it("runs adapter fixtures deterministically without exposing prompt text or secrets in evidence", async () => {
     function makeAdapter(rawEvidence: Record<string, unknown>): ProviderRuntimeAdapter {
       return {
@@ -516,6 +903,7 @@ function makeFixture(overrides: Partial<{
   model: string;
   prompt: string;
   expectJsonObject: boolean;
+  expectReviewJson: boolean;
 }> = {}) {
   return {
     id: "fixture",
@@ -525,4 +913,32 @@ function makeFixture(overrides: Partial<{
     prompt: "Review this private patch content before posting a comment.",
     ...overrides
   };
+}
+
+function makeOpenAICompatibleProvider(overrides: Partial<ProviderRegistryEntry> = {}): ProviderRegistryEntry {
+  return {
+    enabled: true,
+    adapter: "openai-compatible",
+    displayName: "OpenAI-compatible fixture endpoint",
+    baseUrl: "http://127.0.0.1:8080/v1",
+    model: "review-model",
+    authMode: "none",
+    timeoutMs: 1_000,
+    retryMaxRetries: 0,
+    capabilities: {
+      review: true,
+      jsonOutput: true,
+      local: true,
+      streaming: false
+    },
+    ...overrides
+  };
+}
+
+function jsonResponse(value: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init
+  });
 }

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -131,6 +131,304 @@ describe("provider registry", () => {
     expect(JSON.stringify(result)).not.toContain("provider-secret");
   });
 
+  it("denies hosted remote OpenAI-compatible smoke by default even with a selected provider", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "hosted-byok",
+        providers: {
+          "hosted-byok": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    });
+    let fetchCalls = 0;
+    let dnsCalls = 0;
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "hosted-byok",
+      smoke: true,
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ data: [] }));
+      },
+      dnsLookupImpl: async () => {
+        dnsCalls += 1;
+        return [{ address: "93.184.216.34", family: 4 }];
+      },
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: "provider-secret"
+      }
+    });
+
+    expect(result.checks[0]).toMatchObject({
+      ok: false,
+      smokeAttempted: true,
+      readMode: "openai_compatible_models",
+      error: "Remote OpenAI-compatible smoke checks require --allow-remote-smoke true and --provider <id>."
+    });
+    expect(fetchCalls).toBe(0);
+    expect(dnsCalls).toBe(0);
+    expect(JSON.stringify(result)).not.toContain("provider-secret");
+  });
+
+  it("allows explicitly opted-in hosted BYOK smoke after safe DNS validation", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "hosted-byok",
+        providers: {
+          "hosted-byok": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    });
+    const dnsCalls: string[] = [];
+    const fetchCalls: string[] = [];
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "hosted-byok",
+      smoke: true,
+      allowRemoteSmoke: true,
+      dnsLookupImpl: async (hostname) => {
+        dnsCalls.push(hostname);
+        return [{ address: "93.184.216.34", family: 4 }];
+      },
+      fetchImpl: async (url, init) => {
+        fetchCalls.push(String(url));
+        expect(init?.method).toBe("GET");
+        expect(init?.redirect).toBe("manual");
+        expect(init?.signal).toBeInstanceOf(AbortSignal);
+        expect(new Headers(init?.headers).get("accept")).toBe("application/json");
+        expect(new Headers(init?.headers).get("authorization")).toBe("Bearer provider-secret");
+        return new Response(JSON.stringify({ data: [{ id: "review-model" }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        });
+      },
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: "provider-secret"
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.checks[0]).toMatchObject({
+      providerId: "hosted-byok",
+      ok: true,
+      smokeAttempted: true,
+      readMode: "openai_compatible_models",
+      baseUrl: "https://gateway.example.test/v1",
+      apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+      modelCount: 1
+    });
+    expect(dnsCalls).toEqual(["gateway.example.test"]);
+    expect(fetchCalls).toEqual(["https://gateway.example.test/v1/models"]);
+    expect(JSON.stringify(result)).not.toContain("provider-secret");
+  });
+
+  it("requires hosted remote smoke to be env-key-backed before DNS or fetch", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "hosted-byok",
+        providers: {
+          "hosted-byok": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    });
+    let fetchCalls = 0;
+    let dnsCalls = 0;
+
+    const missingEnv = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "hosted-byok",
+      smoke: true,
+      allowRemoteSmoke: true,
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ data: [] }));
+      },
+      dnsLookupImpl: async () => {
+        dnsCalls += 1;
+        return [{ address: "93.184.216.34", family: 4 }];
+      },
+      env: {}
+    });
+
+    expect(missingEnv.checks[0]).toMatchObject({
+      ok: false,
+      error: "Missing API key environment variable NEONDIFF_PROVIDER_API_KEY."
+    });
+
+    const noneAuthProvider = {
+      ...config.providers!.providers["hosted-byok"],
+      authMode: "none" as const
+    };
+    delete noneAuthProvider.apiKeyEnv;
+    const noneAuth = await doctorProviderRegistry({
+      registry: {
+        ...config.providers!,
+        providers: {
+          "hosted-byok": noneAuthProvider
+        }
+      },
+      providerId: "hosted-byok",
+      smoke: true,
+      allowRemoteSmoke: true,
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ data: [] }));
+      },
+      dnsLookupImpl: async () => {
+        dnsCalls += 1;
+        return [{ address: "93.184.216.34", family: 4 }];
+      },
+      env: {}
+    });
+
+    expect(noneAuth.checks[0]).toMatchObject({
+      ok: false,
+      error: "Hosted remote smoke requires authMode api-key-env and apiKeyEnv."
+    });
+    expect(fetchCalls).toBe(0);
+    expect(dnsCalls).toBe(0);
+  });
+
+  it("rejects hosted remote DNS resolutions to unsafe networks before fetch", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "hosted-byok",
+        providers: {
+          "hosted-byok": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    });
+    let fetchCalls = 0;
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "hosted-byok",
+      smoke: true,
+      allowRemoteSmoke: true,
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ data: [] }));
+      },
+      dnsLookupImpl: async () => [{ address: "10.0.0.25", family: 4 }],
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: "provider-secret"
+      }
+    });
+
+    expect(result.checks[0]).toMatchObject({
+      ok: false,
+      error: "Remote OpenAI-compatible smoke DNS resolved to an unsafe private, link-local, loopback, or metadata address."
+    });
+    expect(fetchCalls).toBe(0);
+    expect(JSON.stringify(result)).not.toContain("provider-secret");
+  });
+
+  it("does not follow hosted remote redirects or leak provider response secrets", async () => {
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "hosted-byok",
+        providers: {
+          "hosted-byok": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    });
+
+    const result = await doctorProviderRegistry({
+      registry: config.providers!,
+      providerId: "hosted-byok",
+      smoke: true,
+      allowRemoteSmoke: true,
+      dnsLookupImpl: async () => [{ address: "93.184.216.34", family: 4 }],
+      fetchImpl: async (_url, init) => {
+        expect(init?.redirect).toBe("manual");
+        return new Response("redirect includes provider-secret and https://user:password@example.test", {
+          status: 302,
+          headers: {
+            Location: "https://redirect.example.test/v1/models"
+          }
+        });
+      },
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: "provider-secret"
+      }
+    });
+
+    expect(result.checks[0]).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("OpenAI-compatible models endpoint returned 302")
+    });
+    expect(JSON.stringify(result)).toContain("[redacted-provider-key]");
+    expect(JSON.stringify(result)).not.toContain("provider-secret");
+    expect(JSON.stringify(result)).not.toContain("password");
+  });
+
   it("classifies provider failures and redacts provider URLs", () => {
     expect(classifyProviderError("401 invalid api key")).toBe("auth");
     expect(classifyProviderError("429 too many requests")).toBe("quota_or_rate_limit");
@@ -451,7 +749,7 @@ describe("provider registry", () => {
     });
     expect(remoteResult.checks[0]).toMatchObject({
       ok: false,
-      error: "Remote OpenAI-compatible smoke checks are disabled until the transport can pin the validated DNS result."
+      error: "Remote OpenAI-compatible smoke checks require --allow-remote-smoke true and --provider <id>."
     });
     expect(fetchCalls).toBe(0);
   });

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -58,6 +58,7 @@ describe("public NeonDiff CLI surface", () => {
     expect(output.examples).toContain("neondiff providers list --config config.local.json --json");
     expect(output.examples).toContain("neondiff providers doctor --config config.local.json --json");
     expect(output.examples).toContain("neondiff providers doctor --config config.local.json --provider ollama-local --smoke true --json");
+    expect(output.examples).toContain("neondiff providers doctor --config config.local.json --provider openai-compatible --smoke true --allow-remote-smoke true --json");
     expect(output.examples).toContain("neondiff doctor github --config config.local.json --json");
     expect(output.examples).toContain("neondiff license status --config config.local.json --json");
     expect(output.examples).toContain("npx tsx src/cli.ts daemon --config /path/to/live.json --dry-run true --once true");
@@ -360,6 +361,54 @@ describe("public NeonDiff CLI surface", () => {
     } finally {
       await closeServer(server);
     }
+  });
+
+  it("fails hosted remote smoke through the public CLI without explicit remote opt-in", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-remote-provider-cli-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["acme/demo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model",
+            authMode: "api-key-env",
+            apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })}\n`);
+
+    await expect(runCli([
+      "providers",
+      "doctor",
+      "--config",
+      configPath,
+      "--provider",
+      "openai-compatible",
+      "--smoke",
+      "true"
+    ], {
+      env: {
+        NEONDIFF_PROVIDER_API_KEY: "provider-secret"
+      }
+    })).rejects.toMatchObject({
+      stdout: expect.stringContaining("Remote OpenAI-compatible smoke checks require --allow-remote-smoke true and --provider <id>.")
+    });
   });
 
   it("rejects malformed provider ids before reflecting them", async () => {


### PR DESCRIPTION
## Summary

Adds the hosted BYOK remote-smoke safety gate for OpenAI-compatible providers, stacked after #248.

Links: #241, #238
Dependency: #248

## What Changed

- Added `--allow-remote-smoke true` for `neondiff providers doctor --smoke true` remote non-loopback endpoints.
- Kept default smoke local-loopback-first: remote hosted smoke still fails closed unless a single `--provider` and explicit remote opt-in are both present.
- Enforced hosted remote smoke as HTTPS + `authMode: "api-key-env"` + present env var before DNS or fetch.
- Added DNS validation/pinning for the built-in smoke transport, manual redirect handling, bounded `/models` response reads, unsafe host/range rejection, and redacted failure output.
- Documented the hosted BYOK `/models`-only proof boundary without claiming live review/default provider promotion.

## Blocked

Draft and blocked on #248 merging first because this branch is stacked on `sprint/provider-local-239-240` at `de69a9ebab45f47173d19b980121a74585728e28`.

## Proof Boundary

This PR proves the hosted BYOK provider-doctor safety gate and mocked remote `/models` smoke path. It does not perform live remote provider calls, does not send PR diffs/prompts/fixtures to hosted providers, does not mutate GitHub review state, and does not switch the live/default provider.

## Validation

- Red first: hosted BYOK provider-registry and public CLI tests failed on missing opt-in/allowance/env/DNS/redirect/help behavior before implementation.
- `NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/provider-registry.test.ts tests/config-cli.test.ts tests/public-cli.test.ts --pool forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- `node scripts/check-public-claims.mjs`

Local evidence note: `/Volumes/LEXAR/Codex/session-notes/2026-07-05/neondiff-hosted-byok-241/implementation-notes.html`
