### PR TITLE
[codex] Require beta tag for npm prerelease publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -52,4 +52,4 @@ jobs:
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag beta

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -128,6 +128,7 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/id-token:\s*write/);
     expect(publish).toMatch(/NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
     expect(publish).toMatch(/npm publish --provenance/);
+    expect(publish).toMatch(/--tag beta/);
     expect(publish).toMatch(/v0\.4\.24-beta\.1/);
   });
 });


### PR DESCRIPTION
## Summary

Fix the npm publish workflow so prerelease publishes include the required npm dist-tag.

Closes #253.

## Why

The `v0.4.24-beta.1` release workflow built and verified the package, then failed at `npm publish` because npm requires `--tag` for prerelease versions. The package was published through the approved Keychain fallback, but the workflow should not keep the same broken command.

## Changed

- Adds `--tag beta` to the `npm publish --provenance --access public` command.
- Adds a public release readiness assertion so the beta tag cannot regress silently.

## Validation

From `/Volumes/LEXAR/repos/worktrees/neondiff-final-release`:

```bash
npx vitest run tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1
node scripts/check-public-claims.mjs
```

Result: 4/4 tests passed; public claims scan passed.

## Current-Head Gate

After #259 merged, this PR was merged forward from current `main` and pushed at head `309501959253f42dd2ff7f70981ad2274471c042`.

- evaOS exact-head review: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/254#pullrequestreview-4631359023
- `review-head-gate`: passed for `309501959253f42dd2ff7f70981ad2274471c042`; event `COMMENT`; no validated inline findings.
- CI/CodeQL/Socket are expected to be green before merge. At the time this description was updated, Swift CodeQL was still in progress.

## Release / Rollback Note

This PR fixes the GitHub Actions npm publish command only. It does not publish a new package by itself. If a future prerelease publish needs rollback, remove or revert the release/tag created by that future publish; this PR only changes the workflow so prerelease versions publish with npm dist-tag `beta` instead of failing at `npm publish`.
