### PR TITLE
Fix v0.4.25 beta release manifest

### DIFF
--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,10 +1,23 @@
 {
-  "version": "v0.4.24-beta.1",
+  "version": "v0.4.25-beta.1",
   "releaseLevel": "source-beta",
+  "packageArtifact": {
+    "name": "neondiff",
+    "version": "0.4.24-beta.1",
+    "requiredForThisRelease": false,
+    "state": "held_at_previous_npm_release",
+    "heldReason": "v0.4.25-beta.1 is a source/daemon-only live beta; no npm artifact is published for this hotfix.",
+    "currentSourceVersion": "v0.4.25-beta.1",
+    "previousReleasedPackageVersion": "0.4.24-beta.1"
+  },
+  "source": {
+    "shaState": "set_after_manifest_reconciliation_merge",
+    "proof": "release:status --expected-head $(git rev-parse HEAD)"
+  },
   "docs": {
-    "version": "v0.4.24-beta.1",
+    "version": "v0.4.25-beta.1",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v0.4.24-beta.1.md",
+    "releaseNotesPath": "docs/releases/v0.4.25-beta.1.md",
     "websiteRepo": "electricsheephq/neon-diff-agent"
   },
   "licenseApi": {
@@ -16,13 +29,13 @@
     "cli": {
       "requiredForThisRelease": true,
       "state": "source_checkout",
-      "version": "v0.4.24-beta.1",
+      "version": "v0.4.25-beta.1",
       "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "launchd_prerelease",
-      "version": "v0.4.24-beta.1",
+      "version": "v0.4.25-beta.1",
       "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
     },
     "website": {

--- a/docs/releases/v0.4.25-beta.1.md
+++ b/docs/releases/v0.4.25-beta.1.md
@@ -1,13 +1,15 @@
 # v0.4.25-beta.1
 
 - Release type: local beta issue-enrichment duplicate-suppression hotfix
-- Release source SHA: to be set by the `v0.4.25-beta.1` tag
+- Release source SHA: to be stamped during post-merge live promotion
 - Previous prerelease: `v0.4.24-beta.1`
 - Tracking issues: `#244`, `#119`
 - Promoted PR: `#247`
 - Implementation merge SHA: `d2524a4045d3f50e06c1e78597e4a298f4d97271`
 - Release evidence: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-05/v0.4.25-beta.1/`
 - Rollback tag: `v0.4.24-beta.1`
+- Package artifact: `neondiff@0.4.24-beta.1` (held from previous npm release)
+- Rollback baseline: `v0.4.9-beta.1` remains the known-good daemon fallback
 
 ## Purpose
 
@@ -17,6 +19,9 @@ the bot's own comment advanced GitHub `issue.updated_at`.
 
 This is a local live-worker beta release. It does not publish a new npm package
 or replace the public `neondiff@0.4.24-beta.1` package release.
+The public manifest records the held npm artifact separately from the
+source/daemon beta version so operators do not confuse the installable npm
+package with the live source checkout.
 
 ## Included Changes
 

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -23,6 +23,17 @@ describe("NeonDiff public release readiness", () => {
       version?: string;
       packages?: Record<string, { name?: string; version?: string; license?: string; bin?: Record<string, string> }>;
     };
+    const manifest = JSON.parse(read("docs/public-release-manifest.json")) as {
+      packageArtifact?: {
+        name?: string;
+        version?: string;
+        requiredForThisRelease?: boolean;
+        state?: string;
+        heldReason?: string;
+        currentSourceVersion?: string;
+        previousReleasedPackageVersion?: string;
+      };
+    };
 
     expect(pkg.name).toBe("neondiff");
     expect(pkg.version).toBe("0.4.24-beta.1");
@@ -58,6 +69,15 @@ describe("NeonDiff public release readiness", () => {
       license: "SEE LICENSE IN LICENSE.md",
       bin: { neondiff: "dist/src/cli.js" }
     });
+    expect(manifest.packageArtifact).toMatchObject({
+      name: "neondiff",
+      version: "0.4.24-beta.1",
+      requiredForThisRelease: false,
+      state: "held_at_previous_npm_release",
+      currentSourceVersion: "v0.4.25-beta.1",
+      previousReleasedPackageVersion: "0.4.24-beta.1"
+    });
+    expect(manifest.packageArtifact?.heldReason).toMatch(/source\/daemon-only live beta/i);
   });
 
   it("ships the canonical install script contract", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -193,16 +193,16 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.24-beta.1"
+      expectedVersion: "v0.4.25-beta.1"
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v0.4.24-beta.1",
+      version: "v0.4.25-beta.1",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v0.4.24-beta.1.md"
+        releaseNotesPath: "docs/releases/v0.4.25-beta.1.md"
       },
       updateChannels: {
         ok: true
@@ -262,13 +262,13 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v0.4.24-beta.1",
+      expectedPublicVersion: "v0.4.25-beta.1",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot"
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v0.4.24-beta.1"
+      version: "v0.4.25-beta.1"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",


### PR DESCRIPTION
## Summary\n- update docs/public-release-manifest.json to advertise v0.4.25-beta.1 for source/daemon release governance\n- point the manifest release notes path at docs/releases/v0.4.25-beta.1.md\n- stamp the v0.4.25 release note with the live tag SHA\n\n## Notes\n- package.json, package-lock.json, and docs/SETUP.md intentionally remain at 0.4.24-beta.1 because v0.4.25 did not publish a new npm package; it promoted the live local worker source tag only.\n\n## Verification\n- node -e manifest version/releaseNotesPath check\n- git diff --check\n\nCloses #256