### PR TITLE
Fix test URL regex CodeQL alerts

### DIFF
--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -12,7 +12,6 @@ describe("NeonDiff public community funnel", () => {
     for (const required of [
       /^# NeonDiff/m,
       /local-first AI PR reviewer/i,
-      /https:\/\/www\.neondiff\.com/i,
       /docs\/SETUP\.md/i,
       /docs\/github-app-setup\.md/i,
       /CONTRIBUTING\.md/i,
@@ -39,6 +38,7 @@ describe("NeonDiff public community funnel", () => {
     ]) {
       expect(readme).toMatch(required);
     }
+    expect(readme).toContain("https://www.neondiff.com");
 
     for (const forbidden of [
       /OpenSource replacement/i,

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -100,12 +100,19 @@ describe("NeonDiff public release readiness", () => {
       read("docs/license-boundary.md"),
       read("docs/releases/v0.4.24-beta.1.md")
     ].join("\n\n");
+    const legacyRepoReferences = docs
+      .split(/\s+/)
+      .filter(
+        (token) =>
+          token.includes("github.com/electricsheephq/evaos-code-review-bot") &&
+          !token.includes("github.com/electricsheephq/evaos-code-review-bot-neondiff")
+      );
 
-    expect(docs).toMatch(/https:\/\/github\.com\/electricsheephq\/evaos-code-review-bot-neondiff/i);
+    expect(docs).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff");
     expect(docs).toMatch(/npm install -g neondiff@0\.4\.24-beta\.1/i);
     expect(docs).toMatch(/curl -fsSL https:\/\/www\.neondiff\.com\/install/i);
-    expect(docs).toMatch(/git clone https:\/\/github\.com\/electricsheephq\/evaos-code-review-bot-neondiff\.git/i);
-    expect(docs).not.toMatch(/https:\/\/github\.com\/electricsheephq\/evaos-code-review-bot(?!-neondiff)/i);
+    expect(docs).toContain("git clone https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git");
+    expect(legacyRepoReferences).toEqual([]);
     expect(docs).not.toMatch(/npm link installs the local source-checkout shim/i);
   });
 


### PR DESCRIPTION
## Summary

- Replaces CodeQL-triggering unanchored URL regex assertions in public test coverage with exact `toContain` checks.
- Preserves the public docs claim checks for NeonDiff URLs and install commands.
- Keeps the legacy `evaos-code-review-bot` repo guard by tokenizing doc text and rejecting legacy repo references that are not the `-neondiff` public repo.

## CodeQL alerts

Addresses the test-only `js/regex/missing-regexp-anchor` alerts from #249:

- Alert #33: `tests/public-community-funnel.test.ts`
- Alert #35: `tests/public-release-readiness.test.ts`
- Alert #36: `tests/public-release-readiness.test.ts`

## Validation

- `npx vitest run tests/public-community-funnel.test.ts tests/public-release-readiness.test.ts --maxWorkers=1`
- `git diff --check`

Draft hopper PR for #249.
