### PR TITLE
Harden runtime CodeQL blockers

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -265,7 +265,7 @@ async function main(): Promise<void> {
       issueReadChecks: await collectIssueEnrichmentReadChecks(config, github)
     });
     const ok = readChecks.every((check) => check.ok) && issueEnrichment.ok;
-    console.log(JSON.stringify({
+    console.log(stringifyRedactedJson({
       ok,
       pilotRepos: config.pilotRepos,
       monitoredRepos,
@@ -286,7 +286,7 @@ async function main(): Promise<void> {
         hasFallbackReadToken: Boolean(config.github.token),
         readChecks
       }
-    }, null, 2));
+    }));
     if (!ok) process.exitCode = 1;
     return;
   }
@@ -386,7 +386,7 @@ async function main(): Promise<void> {
         detail: `${failed} failed durable queue job(s)`
       }
     ];
-    console.log(JSON.stringify({
+    console.log(stringifyRedactedJson({
       ok,
       healthState: ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: ok,
@@ -404,7 +404,7 @@ async function main(): Promise<void> {
       ],
       gates,
       budget: status.budget
-    }, null, 2));
+    }));
     if (!ok) process.exitCode = 1;
     return;
   }
@@ -484,7 +484,7 @@ async function main(): Promise<void> {
       }),
       issueEnrichmentRuntime
     });
-    console.log(JSON.stringify(status, null, 2));
+    console.log(stringifyRedactedJson(status));
     if (!status.ok) process.exitCode = 1;
     return;
   }
@@ -633,7 +633,7 @@ async function main(): Promise<void> {
         ...(args.limit ? { limit: parsePositiveInteger(args.limit, "--limit") } : {})
       }
     });
-    console.log(args.human === "true" ? formatOperatorDashboardHuman(dashboard) : JSON.stringify(dashboard, null, 2));
+    console.log(args.human === "true" ? formatOperatorDashboardHuman(dashboard) : stringifyRedactedJson(dashboard));
     if (!dashboard.ok) process.exitCode = 1;
     return;
   }
@@ -830,7 +830,7 @@ async function main(): Promise<void> {
     } else if (format === "both" && result.ok) {
       console.log(`${JSON.stringify(result, null, 2)}\n\n${result.packet.markdown}`);
     } else {
-      console.log(JSON.stringify(result, null, 2));
+      console.log(stringifyRedactedJson(result));
     }
     if (!result.ok) process.exitCode = 1;
     return;
@@ -1797,7 +1797,7 @@ async function main(): Promise<void> {
     const daemonAction = args._[1];
     if (daemonAction === "start" || daemonAction === "stop" || daemonAction === "status") {
       const result = runDaemonControlCommandSafely(daemonAction, args);
-      console.log(JSON.stringify(result, null, 2));
+      console.log(stringifyRedactedJson(result));
       if (!result.ok) process.exitCode = 1;
       return;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -822,14 +822,15 @@ async function main(): Promise<void> {
       mkdirSync(safeOutputDir, { recursive: true });
       const jsonName = result.ok ? "gitnexus-context-packet.json" : "gitnexus-context-packet-error.json";
       writeFileSync(join(safeOutputDir, jsonName), `${redactSecrets(JSON.stringify(result, null, 2))}\n`);
-      if (result.ok) writeFileSync(join(safeOutputDir, "gitnexus-context-packet.md"), result.packet.markdown);
+      if (result.ok) writeFileSync(join(safeOutputDir, "gitnexus-context-packet.md"), redactSecrets(result.packet.markdown));
     }
     const format = args.format ?? "json";
     const redactedJson = stringifyRedactedJson(result);
+    const redactedMarkdown = result.ok ? redactSecrets(result.packet.markdown) : undefined;
     if (format === "markdown") {
-      console.log(result.ok ? result.packet.markdown : redactedJson);
+      console.log(redactedMarkdown ?? redactedJson);
     } else if (format === "both" && result.ok) {
-      console.log(`${redactedJson}\n\n${result.packet.markdown}`);
+      console.log(`${redactedJson}\n\n${redactedMarkdown}`);
     } else {
       console.log(redactedJson);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -825,12 +825,13 @@ async function main(): Promise<void> {
       if (result.ok) writeFileSync(join(safeOutputDir, "gitnexus-context-packet.md"), result.packet.markdown);
     }
     const format = args.format ?? "json";
+    const redactedJson = stringifyRedactedJson(result);
     if (format === "markdown") {
-      console.log(result.ok ? result.packet.markdown : JSON.stringify(result, null, 2));
+      console.log(result.ok ? result.packet.markdown : redactedJson);
     } else if (format === "both" && result.ok) {
-      console.log(`${JSON.stringify(result, null, 2)}\n\n${result.packet.markdown}`);
+      console.log(`${redactedJson}\n\n${result.packet.markdown}`);
     } else {
-      console.log(stringifyRedactedJson(result));
+      console.log(redactedJson);
     }
     if (!result.ok) process.exitCode = 1;
     return;

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -457,7 +457,7 @@ export function validatePublicReleaseManifestInputs(input: {
     throw new Error("--public-release-manifest is required when --expected-public-version is provided");
   }
   if (input.expectedPublicVersion && input.expectedPublicVersion.length > MAX_PUBLIC_VERSION_TAG_LENGTH) {
-    throw new Error(`--expected-public-version is too long (max ${MAX_PUBLIC_VERSION_TAG_LENGTH} chars)`);
+    throw new Error(`--expected-public-version is too long (max ${MAX_PUBLIC_VERSION_TAG_LENGTH} characters)`);
   }
   if (input.expectedPublicVersion && !isPublicVersionTag(input.expectedPublicVersion)) {
     throw new Error("--expected-public-version must be a semver tag like v1.0.0 or v1.0.0-beta.1");

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -183,6 +183,7 @@ export interface ReleaseStatus {
 
 const REQUIRED_PUBLIC_UPDATE_CHANNELS = ["cli", "daemon"] as const;
 const PUBLIC_RELEASE_LEVELS = new Set(["beta", "source-beta", "stable"]);
+const MAX_PUBLIC_VERSION_TAG_LENGTH = 128;
 const PUBLIC_VERSION_PATTERN =
   /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES = new Set(["source_checkout", "launchd_prerelease", "healthy", "published"]);
@@ -455,6 +456,9 @@ export function validatePublicReleaseManifestInputs(input: {
   if (input.expectedPublicVersion && !input.publicReleaseManifestPath) {
     throw new Error("--public-release-manifest is required when --expected-public-version is provided");
   }
+  if (input.expectedPublicVersion && input.expectedPublicVersion.length > MAX_PUBLIC_VERSION_TAG_LENGTH) {
+    throw new Error("--expected-public-version is too long");
+  }
   if (input.expectedPublicVersion && !isPublicVersionTag(input.expectedPublicVersion)) {
     throw new Error("--expected-public-version must be a semver tag like v1.0.0 or v1.0.0-beta.1");
   }
@@ -711,6 +715,7 @@ function checkRollbackTarget(
 }
 
 function isPublicVersionTag(version: string): boolean {
+  if (version.length > MAX_PUBLIC_VERSION_TAG_LENGTH) return false;
   return PUBLIC_VERSION_PATTERN.test(version);
 }
 

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -457,7 +457,7 @@ export function validatePublicReleaseManifestInputs(input: {
     throw new Error("--public-release-manifest is required when --expected-public-version is provided");
   }
   if (input.expectedPublicVersion && input.expectedPublicVersion.length > MAX_PUBLIC_VERSION_TAG_LENGTH) {
-    throw new Error("--expected-public-version is too long");
+    throw new Error(`--expected-public-version is too long (max ${MAX_PUBLIC_VERSION_TAG_LENGTH} chars)`);
   }
   if (input.expectedPublicVersion && !isPublicVersionTag(input.expectedPublicVersion)) {
     throw new Error("--expected-public-version must be a semver tag like v1.0.0 or v1.0.0-beta.1");

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -7,27 +7,34 @@ const SECRET_PATTERNS: RegExp[] = [
   /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,
   /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/gi,
   /[?&](?:access[_-]?token|auth[_-]?token|api[_-]?key|token|secret|session|cookie)=[A-Za-z0-9._~+/=-]{16,}/gi,
-  /\bCookie\s*:\s*(?:[^;\n]*;\s*)*[^=\n;]*(?:session|token|auth|secret|cookie)[^=\n;]*=[^;\n]{16,}/gi,
   /\bcustomer[_-]?id\b\s*[:=]\s*["']?cus_[A-Za-z0-9]{8,}/gi,
   /\b(?:customer|client)[_-]?ssn\b\s*[:=]\s*["']?\d{3}-\d{2}-\d{4}\b/gi,
   /\b(?:customer|client)[_-]?phone\b\s*[:=]\s*["']?\+?\d[\d ().-]{7,}\d\b/gi,
   /\b(?:api[_-]?key|token|secret|password|cookie|session)\b\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{16,}/gi,
-  /\b(?:NEONDIFF|NDL|LIC)[_-][A-Za-z0-9][A-Za-z0-9_-]{11,}\b/gi,
+  /\b(?:NEONDIFF|NDL)[_-][A-Z0-9][A-Z0-9_-]{11,}\b/g,
+  /\bLIC[_-][A-Za-z0-9][A-Za-z0-9_-]{11,}\b/g,
   /\b[A-Za-z0-9]{3,}[-_](?:secret|token|password|cookie)[-_][A-Za-z0-9_-]{3,}\b/gi,
   /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*/g
 ];
 
+const COOKIE_HEADER_PREFIX = "cookie:";
+const SENSITIVE_COOKIE_NAME_PATTERN = /(?:session|token|auth|secret|cookie)/i;
+const MAX_COOKIE_ATTRIBUTE_SCAN = 1_000;
+
 export function containsSecretLikeText(input: string): boolean {
-  return SECRET_PATTERNS.some((pattern) => {
+  return containsSensitiveCookieHeader(input) || SECRET_PATTERNS.some((pattern) => {
     pattern.lastIndex = 0;
     return pattern.test(input);
   });
 }
 
 export function redactSecrets(input: string): string {
-  return SECRET_PATTERNS.reduce((text, pattern) => text.replace(pattern, "[redacted-secret]"), input);
+  return SECRET_PATTERNS.reduce(
+    (text, pattern) => text.replace(pattern, "[redacted-secret]"),
+    redactSensitiveCookieHeaders(input)
+  );
 }
 
 export function stringifyRedactedJson(input: unknown): string {
@@ -44,4 +51,33 @@ function redactJsonValue(input: unknown): unknown {
     return output;
   }
   return input;
+}
+
+function containsSensitiveCookieHeader(input: string): boolean {
+  return input.split(/\r?\n/).some((line) => readSensitiveCookieHeader(line) !== undefined);
+}
+
+function redactSensitiveCookieHeaders(input: string): string {
+  return input
+    .split(/(\r?\n)/)
+    .map((segment) => readSensitiveCookieHeader(segment) === undefined ? segment : "[redacted-secret]")
+    .join("");
+}
+
+function readSensitiveCookieHeader(line: string): string | undefined {
+  const trimmedStart = line.trimStart();
+  if (trimmedStart.slice(0, COOKIE_HEADER_PREFIX.length).toLowerCase() !== COOKIE_HEADER_PREFIX) {
+    return undefined;
+  }
+  const colonIndex = line.indexOf(":");
+  if (colonIndex < 0) return undefined;
+  const attributes = line.slice(colonIndex + 1).split(";", MAX_COOKIE_ATTRIBUTE_SCAN);
+  for (const attribute of attributes) {
+    const equalsIndex = attribute.indexOf("=");
+    if (equalsIndex <= 0) continue;
+    const name = attribute.slice(0, equalsIndex).trim();
+    const value = attribute.slice(equalsIndex + 1).trim();
+    if (value.length >= 16 && SENSITIVE_COOKIE_NAME_PATTERN.test(name)) return line;
+  }
+  return undefined;
 }

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -11,8 +11,8 @@ const SECRET_PATTERNS: RegExp[] = [
   /\b(?:customer|client)[_-]?ssn\b\s*[:=]\s*["']?\d{3}-\d{2}-\d{4}\b/gi,
   /\b(?:customer|client)[_-]?phone\b\s*[:=]\s*["']?\+?\d[\d ().-]{7,}\d\b/gi,
   /\b(?:api[_-]?key|token|secret|password|cookie|session)\b\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{16,}/gi,
-  /\b(?:NEONDIFF|NDL)[_-][A-Z0-9][A-Z0-9_-]{11,}\b/g,
-  /\bLIC[_-][A-Za-z0-9][A-Za-z0-9_-]{11,}\b/g,
+  /\b(?:NEONDIFF|NDL|LIC)_[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/gi,
+  /\b(?:NEONDIFF|NDL|LIC)-[A-Z0-9][A-Z0-9_-]{11,}\b/g,
   /\b[A-Za-z0-9]{3,}[-_](?:secret|token|password|cookie)[-_][A-Za-z0-9_-]{3,}\b/gi,
   /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
@@ -71,7 +71,8 @@ function readSensitiveCookieHeader(line: string): string | undefined {
   }
   const colonIndex = line.indexOf(":");
   if (colonIndex < 0) return undefined;
-  const attributes = line.slice(colonIndex + 1).split(";", MAX_COOKIE_ATTRIBUTE_SCAN);
+  const attributes = line.slice(colonIndex + 1).split(";", MAX_COOKIE_ATTRIBUTE_SCAN + 1);
+  if (attributes.length > MAX_COOKIE_ATTRIBUTE_SCAN) return line;
   for (const attribute of attributes) {
     const equalsIndex = attribute.indexOf("=");
     if (equalsIndex <= 0) continue;

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -78,7 +78,7 @@ function readSensitiveCookieHeader(line: string): string | undefined {
     if (equalsIndex <= 0) continue;
     const name = attribute.slice(0, equalsIndex).trim();
     const value = attribute.slice(equalsIndex + 1).trim();
-    if (value.length >= 16 && SENSITIVE_COOKIE_NAME_PATTERN.test(name)) return line;
+    if (value.length > 0 && SENSITIVE_COOKIE_NAME_PATTERN.test(name)) return line;
   }
   return undefined;
 }

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -135,7 +135,7 @@ function formatProviderMetadata(
   const displayName = provider.displayName
     ? `${formatInlinePublicText(provider.displayName, publicConfidencePolicy)} `
     : "";
-  return `${displayName}(\`${formatInlineCodePublicText(provider.providerId, publicConfidencePolicy)}\`, ${formatInlinePublicText(provider.adapter, publicConfidencePolicy)}, model \`${formatInlineCodePublicText(provider.model, publicConfidencePolicy)}\`)`;
+  return `${displayName}(${formatInlineCodePublicText(provider.providerId, publicConfidencePolicy)}, ${formatInlinePublicText(provider.adapter, publicConfidencePolicy)}, model ${formatInlineCodePublicText(provider.model, publicConfidencePolicy)})`;
 }
 
 function formatSettingsPreviewSection(
@@ -165,7 +165,7 @@ function formatSettingsPathInstructions(
 ): string[] {
   if (settings.pathInstructions.length === 0) return ["- Path instructions: none"];
   return settings.pathInstructions.map((entry) =>
-    `- Path instructions: \`${formatInlineCodePublicText(entry.pattern, publicConfidencePolicy)}\` - ${entry.instructions.map((instruction) => formatInlinePublicText(instruction, publicConfidencePolicy)).join("; ")}`
+    `- Path instructions: ${formatInlineCodePublicText(entry.pattern, publicConfidencePolicy)} - ${entry.instructions.map((instruction) => formatInlinePublicText(instruction, publicConfidencePolicy)).join("; ")}`
   );
 }
 
@@ -212,9 +212,19 @@ function formatInlinePublicText(value: string | undefined, publicConfidencePolic
 }
 
 function formatInlineCodePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
-  return formatInlinePublicText(value, publicConfidencePolicy)
-    .replace(/\\/g, "\\\\")
-    .replace(/`/g, "\\`");
+  return formatMarkdownCodeSpan(formatInlinePublicText(value, publicConfidencePolicy));
+}
+
+function formatMarkdownCodeSpan(value: string): string {
+  let longestBacktickRun = 0;
+  for (const match of value.matchAll(/`+/g)) {
+    longestBacktickRun = Math.max(longestBacktickRun, match[0].length);
+  }
+  const delimiter = "`".repeat(longestBacktickRun + 1);
+  const padding = value.startsWith("`") || value.endsWith("`") || value.startsWith(" ") || value.endsWith(" ")
+    ? " "
+    : "";
+  return `${delimiter}${padding}${value}${padding}${delimiter}`;
 }
 
 function summarizeFile(file: PullFilePatch, comments: ReviewComment[]): {

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -212,7 +212,9 @@ function formatInlinePublicText(value: string | undefined, publicConfidencePolic
 }
 
 function formatInlineCodePublicText(value: string | undefined, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): string {
-  return formatInlinePublicText(value, publicConfidencePolicy).replace(/`/g, "\\`");
+  return formatInlinePublicText(value, publicConfidencePolicy)
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`");
 }
 
 function summarizeFile(file: PullFilePatch, comments: ReviewComment[]): {

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -221,7 +221,7 @@ function formatMarkdownCodeSpan(value: string): string {
     longestBacktickRun = Math.max(longestBacktickRun, match[0].length);
   }
   const delimiter = "`".repeat(longestBacktickRun + 1);
-  const padding = value.startsWith("`") || value.endsWith("`") || value.startsWith(" ") || value.endsWith(" ")
+  const padding = value.startsWith("`") || value.endsWith("`")
     ? " "
     : "";
   return `${delimiter}${padding}${value}${padding}${delimiter}`;

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -1,11 +1,11 @@
 import { execFile } from "node:child_process";
 import { generateKeyPairSync } from "node:crypto";
-import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { createRequire } from "node:module";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
@@ -72,6 +72,50 @@ describe("public NeonDiff CLI surface", () => {
       "npx tsx src/cli.ts review-head-gate --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD"
     );
     expect(output.examples).toContain("desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}");
+  });
+
+  it("redacts secret-like values from structured status JSON stdout", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-cli-status-"));
+    roots.push(root);
+    const secretSegment = "config-secret-value";
+    const configPath = join(root, secretSegment, "config.json");
+    const statePath = join(root, "state.sqlite");
+    const workRoot = join(root, "work");
+    const evidenceDir = join(root, "evidence");
+    const fakeGithubToken = ["ghp", "abcdefghijklmnopqrstuvwxyz123456"].join("_");
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({
+      workRoot,
+      statePath,
+      evidenceDir,
+      github: {
+        token: fakeGithubToken
+      }
+    }));
+
+    let failure: unknown;
+    try {
+      await runCli([
+        "daemon",
+        "status",
+        "--config",
+        configPath,
+        "--state-path",
+        statePath,
+        "--launchd-label",
+        "com.example.neondiff"
+      ]);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toMatchObject({ stdout: expect.any(String) });
+    const stdout = (failure as { stdout: string }).stdout;
+    const output = JSON.parse(stdout);
+
+    expect(output.status.releaseUnit.configPath).toContain("[redacted-secret]");
+    expect(stdout).not.toContain(secretSegment);
+    expect(stdout).not.toContain(fakeGithubToken);
   });
 
   it("prints finishing-touch dry-run output as a default-off draft-only contract", async () => {

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -118,6 +118,145 @@ describe("public NeonDiff CLI surface", () => {
     expect(stdout).not.toContain(fakeGithubToken);
   });
 
+  it("redacts gitnexus context packet JSON stdout for markdown and both formats", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-gitnexus-cli-"));
+    roots.push(root);
+    const baseSha = "b".repeat(40);
+    const headSha = "a".repeat(40);
+    const fakeToken = ["ghp", "abcdefghijklmnopqrstuvwxyz123456"].join("_");
+    const binDir = join(root, "bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(binDir, "gitnexus"), `#!/bin/sh
+	if [ "$1" = "list" ]; then
+	  if [ "$GITNEXUS_SECRET_MODE" = "1" ]; then
+	    index_path="/repos/${fakeToken}/acme-demo"
+	  else
+	    index_path="/repos/acme-demo"
+	  fi
+	  printf '%s\\n' "Indexed Repositories" "  acme-demo" "    Path: $index_path" "    Indexed: 2026-07-05T00:00:00Z" "    Commit: ${baseSha}"
+	  exit 0
+	fi
+	if [ "$1" = "query" ]; then
+	  echo "safe related context"
+	  exit 0
+	fi
+echo "unexpected gitnexus args: $*" >&2
+exit 1
+`, { mode: 0o755 });
+
+    const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      response.setHeader("Content-Type", "application/json");
+      if (request.method === "GET" && url.pathname === "/repos/acme/demo/pulls/7") {
+        response.end(JSON.stringify({
+          number: 7,
+          title: "Review GitNexus CLI output",
+          draft: false,
+          body: "",
+          html_url: "https://github.com/acme/demo/pull/7",
+          requested_reviewers: [],
+          head: {
+            sha: headSha,
+            ref: "feature/gitnexus",
+            repo: { full_name: "acme/demo" }
+          },
+          base: {
+            sha: baseSha,
+            ref: "main",
+            repo: { full_name: "acme/demo" }
+          }
+        }));
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/repos/acme/demo/pulls/7/files") {
+        response.end(JSON.stringify([
+          {
+            filename: "src/index.ts",
+            status: "modified",
+            additions: 2,
+            deletions: 1,
+            changes: 3
+          }
+        ]));
+        return;
+      }
+      response.statusCode = 404;
+      response.end(JSON.stringify({ message: `unexpected ${request.method} ${url.pathname}` }));
+    });
+
+    await listen(server);
+    try {
+      const address = server.address() as AddressInfo;
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, JSON.stringify({
+        workRoot: join(root, "work"),
+        statePath: join(root, "state.sqlite"),
+        evidenceDir: join(root, "evidence"),
+        github: {
+          token: fakeToken,
+          apiBaseUrl: `http://127.0.0.1:${address.port}`
+        },
+        gitnexusContext: {
+          enabled: true,
+          packetVersion: "gitnexus-context-packet-v0.1",
+          maxPacketBytes: 40_000,
+          maxRelatedItems: 1,
+          queryLimit: 1,
+          commandTimeoutMs: 1_000,
+          maxCommandOutputBytes: 1_000,
+          includeStaleContext: false,
+          repoAliases: { "acme/demo": "acme-demo" },
+          generatedPathPatterns: []
+        }
+      }));
+      const env = { PATH: `${binDir}:${process.env.PATH ?? ""}` };
+      let markdownFailure: unknown;
+      try {
+        await runCli([
+          "build-gitnexus-context-packet",
+          "--config",
+          configPath,
+          "--repo",
+          "acme/demo",
+          "--pr",
+          "7",
+          "--format",
+          "markdown",
+          "--generated-at",
+          "2026-07-05T00:00:00.000Z"
+        ], { env: { ...env, GITNEXUS_SECRET_MODE: "1" } });
+      } catch (error) {
+        markdownFailure = error;
+      }
+
+      expect(markdownFailure).toMatchObject({ stdout: expect.any(String) });
+      const markdownOutput = JSON.parse((markdownFailure as { stdout: string }).stdout);
+      expect(markdownOutput.ok).toBe(false);
+      expect((markdownFailure as { stdout: string }).stdout).toContain("[redacted-secret]");
+      expect((markdownFailure as { stdout: string }).stdout).not.toContain(fakeToken);
+
+      const { stdout } = await runCli([
+        "build-gitnexus-context-packet",
+        "--config",
+        configPath,
+        "--repo",
+        "acme/demo",
+        "--pr",
+        "7",
+        "--format",
+        "both",
+        "--generated-at",
+        "2026-07-05T00:00:00.000Z"
+      ], { env });
+      const [jsonPart, markdownPart] = stdout.split("\n\n# GitNexus context packet");
+      expect(JSON.parse(jsonPart!).ok).toBe(true);
+      expect(markdownPart).toContain("Repository: acme/demo");
+      expect(stdout).not.toContain(fakeToken);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
   it("prints finishing-touch dry-run output as a default-off draft-only contract", async () => {
     const { stdout } = await runCli([
       "finishing-touch-dry-run",

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -252,6 +252,22 @@ exit 1
       expect(JSON.parse(jsonPart!).ok).toBe(true);
       expect(markdownPart).toContain("Repository: acme/demo");
       expect(stdout).not.toContain(fakeToken);
+
+      const markdownSuccess = await runCli([
+        "build-gitnexus-context-packet",
+        "--config",
+        configPath,
+        "--repo",
+        "acme/demo",
+        "--pr",
+        "7",
+        "--format",
+        "markdown",
+        "--generated-at",
+        "2026-07-05T00:00:00.000Z"
+      ], { env });
+      expect(markdownSuccess.stdout).toContain("# GitNexus context packet");
+      expect(markdownSuccess.stdout).not.toContain(fakeToken);
     } finally {
       await closeServer(server);
     }

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -260,7 +260,7 @@ describe("beta release status", () => {
         publicReleaseManifestPath: "docs/public-release-manifest.json",
         expectedPublicVersion: oversizedVersion
       })
-    ).toThrow("--expected-public-version is too long (max 128 chars)");
+    ).toThrow("--expected-public-version is too long (max 128 characters)");
   });
 
   it("collects public release manifest gates through release-status wiring", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -260,7 +260,7 @@ describe("beta release status", () => {
         publicReleaseManifestPath: "docs/public-release-manifest.json",
         expectedPublicVersion: oversizedVersion
       })
-    ).toThrow("--expected-public-version is too long");
+    ).toThrow("--expected-public-version is too long (max 128 chars)");
   });
 
   it("collects public release manifest gates through release-status wiring", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -252,6 +252,17 @@ describe("beta release status", () => {
     ).not.toThrow();
   });
 
+  it("rejects oversized public release version inputs before semver matching", () => {
+    const oversizedVersion = `v1.0.0-${"a.".repeat(300)}`;
+
+    expect(() =>
+      validatePublicReleaseManifestInputs({
+        publicReleaseManifestPath: "docs/public-release-manifest.json",
+        expectedPublicVersion: oversizedVersion
+      })
+    ).toThrow("--expected-public-version is too long");
+  });
+
   it("collects public release manifest gates through release-status wiring", () => {
     // Intentional shipped-manifest smoke: surrounding repo/live-path status is machine-local.
     const root = mkdtempSync(join(tmpdir(), "release-status-public-manifest-"));

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -17,6 +17,20 @@ describe("secret redaction", () => {
     expect(redactSecrets(text)).toBe("Use [redacted-secret] only via env.");
   });
 
+  it("redacts NeonDiff license-shaped values case-insensitively", () => {
+    const license = "neondiff_abcd1234efgh5678";
+
+    expect(containsSecretLikeText(license)).toBe(true);
+    expect(redactSecrets(`license=${license}`)).toBe("license=[redacted-secret]");
+  });
+
+  it("does not redact ordinary lowercase hyphenated NeonDiff paths as license tokens", () => {
+    const path = "/tmp/neondiff-launchd-plist-Ov4D5v/com.example.neondiff.plist";
+
+    expect(containsSecretLikeText(path)).toBe(false);
+    expect(redactSecrets(path)).toBe(path);
+  });
+
   it("detects credential URLs, cookie headers, query tokens, and private key bodies", () => {
     const longSecret = ["123456789012", "345678901234"].join("");
     const password = ["password", "1234567890"].join("");
@@ -102,6 +116,15 @@ describe("secret redaction", () => {
     const longCookiePrefix = Array.from({ length: 600 }, (_, index) => `pref${index}=value`).join("; ");
     const sessionToken = "123456789012345678901234";
     const text = `Cookie: ${longCookiePrefix}; session=${sessionToken}`;
+
+    expect(containsSecretLikeText(text)).toBe(true);
+    expect(redactSecrets(text)).toBe("[redacted-secret]");
+  });
+
+  it("fails closed when a cookie header exceeds the bounded scan cap", () => {
+    const longCookiePrefix = Array.from({ length: 1_000 }, (_, index) => `pref${index}=value`).join("; ");
+    const hiddenSessionToken = "123456789012345678901234";
+    const text = `Cookie: ${longCookiePrefix}; session=${hiddenSessionToken}`;
 
     expect(containsSecretLikeText(text)).toBe(true);
     expect(redactSecrets(text)).toBe("[redacted-secret]");

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -97,4 +97,13 @@ describe("secret redaction", () => {
     expect(parsed.message).toBe("status payload");
     expect(typeof parsed.token).toBe("string");
   });
+
+  it("redacts sensitive long cookie headers without scanning unbounded attribute chains", () => {
+    const longCookiePrefix = Array.from({ length: 600 }, (_, index) => `pref${index}=value`).join("; ");
+    const sessionToken = "123456789012345678901234";
+    const text = `Cookie: ${longCookiePrefix}; session=${sessionToken}`;
+
+    expect(containsSecretLikeText(text)).toBe(true);
+    expect(redactSecrets(text)).toBe("[redacted-secret]");
+  });
 });

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -121,6 +121,13 @@ describe("secret redaction", () => {
     expect(redactSecrets(text)).toBe("[redacted-secret]");
   });
 
+  it("fails closed on short sensitive cookie values", () => {
+    const text = "Cookie: theme=light; session=short";
+
+    expect(containsSecretLikeText(text)).toBe(true);
+    expect(redactSecrets(text)).toBe("[redacted-secret]");
+  });
+
   it("fails closed when a cookie header exceeds the bounded scan cap", () => {
     const longCookiePrefix = Array.from({ length: 1_000 }, (_, index) => `pref${index}=value`).join("; ");
     const hiddenSessionToken = "123456789012345678901234";

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -32,6 +32,18 @@ const pull: PullRequestSummary = {
   requested_reviewers: [{ login: "reviewer-one" }]
 };
 
+function expectPathInstructionCodeSpan(body: string, expectedContent: string): void {
+  const line = body.split("\n").find((candidate) => candidate.startsWith("- Path instructions: "));
+  expect(line).toBeDefined();
+  const remainder = line!.slice("- Path instructions: ".length);
+  const delimiter = remainder.match(/^`+/)?.[0];
+  expect(delimiter).toBeDefined();
+  const closingIndex = remainder.indexOf(delimiter!, delimiter!.length);
+  expect(closingIndex).toBeGreaterThan(delimiter!.length - 1);
+  expect(remainder.slice(delimiter!.length, closingIndex)).toBe(expectedContent);
+  expect(remainder.slice(closingIndex + delimiter!.length)).toMatch(/^ - /);
+}
+
 describe("walkthrough comment rendering", () => {
   it("renders a stable marked walkthrough with files, effort, related refs, and text-only suggestions", () => {
     const files: PullFilePatch[] = [
@@ -341,13 +353,13 @@ describe("walkthrough comment rendering", () => {
       settingsPreview
     });
 
-    expect(walkthrough.body).toContain("- Path instructions: `src/\\`templates\\`/**`");
+    expectPathInstructionCodeSpan(walkthrough.body, "src/`templates`/**");
     expect(walkthrough.body).not.toContain(secretLikeToken);
     expect(walkthrough.body).toContain("[redacted-secret]");
     expect(walkthrough.body).toContain("Provider: Gateway [redacted-secret] (`openai-compatible`, openai-compatible, model `review-[redacted-secret]`).");
   });
 
-  it("escapes backslashes before backticks inside inline-code markdown", () => {
+  it("uses variable-length code spans for backticks inside inline-code markdown", () => {
     const settingsPreview: ReviewSettingsPreview = {
       profile: "assertive",
       sections: [
@@ -384,10 +396,16 @@ describe("walkthrough comment rendering", () => {
       comments: [],
       dropped: [],
       event: "COMMENT",
+      provider: {
+        providerId: "provider`id",
+        adapter: "openai-compatible",
+        model: "model`name"
+      },
       settingsPreview
     });
 
-    expect(walkthrough.body).toContain("- Path instructions: `src/path\\\\\\`template\\\\\\`/**`");
+    expectPathInstructionCodeSpan(walkthrough.body, "src/path\\`template\\`/**");
+    expect(walkthrough.body).toContain("Provider: (``provider`id``, openai-compatible, model ``model`name``).");
   });
 
   it("sanitizes confidence settings preview metadata while preserving ordinary likely wording", () => {

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -347,6 +347,49 @@ describe("walkthrough comment rendering", () => {
     expect(walkthrough.body).toContain("Provider: Gateway [redacted-secret] (`openai-compatible`, openai-compatible, model `review-[redacted-secret]`).");
   });
 
+  it("escapes backslashes before backticks inside inline-code markdown", () => {
+    const settingsPreview: ReviewSettingsPreview = {
+      profile: "assertive",
+      sections: [
+        { key: "reviewSummary", label: "Review summary", enabled: true, mode: "inline_review" }
+      ],
+      pathInstructions: [
+        {
+          pattern: "src/path\\`template\\`/**",
+          instructions: ["Keep inline code markdown intact."]
+        }
+      ],
+      suggestions: {
+        labels: [],
+        reviewers: [],
+        autoApply: false
+      },
+      roadmapOnly: []
+    };
+
+    const walkthrough = buildWalkthroughComment({
+      repo: "electricsheephq/evaos-code-review-bot",
+      pull: {
+        ...pull,
+        head: {
+          ...pull.head,
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        },
+        base: {
+          ...pull.base,
+          repo: { full_name: "electricsheephq/evaos-code-review-bot" }
+        }
+      },
+      files: [{ filename: "src/walkthrough.ts", status: "modified", additions: 2, deletions: 1, changes: 3 }],
+      comments: [],
+      dropped: [],
+      event: "COMMENT",
+      settingsPreview
+    });
+
+    expect(walkthrough.body).toContain("- Path instructions: `src/path\\\\\\`template\\\\\\`/**`");
+  });
+
   it("sanitizes confidence settings preview metadata while preserving ordinary likely wording", () => {
     const settingsPreview: ReviewSettingsPreview = {
       profile: "assertive",

--- a/tests/worker-settings-preview.test.ts
+++ b/tests/worker-settings-preview.test.ts
@@ -82,7 +82,7 @@ describe("worker review settings preview evidence", () => {
     expect(walkthrough).toContain("### Review Settings Preview");
     expect(walkthrough).toContain("Provider: GLM/Z.ai through ZCode (`zcode-glm`, zcode, model `GLM-5.2`).");
     expect(walkthrough).toContain("- Enabled sections: Review summary (inline_review); Walkthrough (inline_review)");
-    expect(walkthrough).toContain("- Path instructions: `src/\\`templates\\`/**`");
+    expectSettingsPathInstructionCodeSpan(walkthrough, "src/`templates`/**");
     expect(walkthrough).not.toContain(secretLikeToken);
     expect(ledger.runtime).toMatchObject({
       provider: "zcode-glm",
@@ -174,6 +174,18 @@ describe("worker review settings preview evidence", () => {
     });
   });
 });
+
+function expectSettingsPathInstructionCodeSpan(body: string, expectedPattern: string): void {
+  const line = body.split("\n").find((candidate) => candidate.startsWith("- Path instructions: "));
+  expect(line).toBeDefined();
+  const remainder = line!.slice("- Path instructions: ".length);
+  const delimiter = remainder.match(/^`+/)?.[0];
+  expect(delimiter).toBeDefined();
+  const closingIndex = remainder.indexOf(delimiter!, delimiter!.length);
+  expect(closingIndex).toBeGreaterThan(delimiter!.length - 1);
+  expect(remainder.slice(delimiter!.length, closingIndex)).toBe(expectedPattern);
+  expect(remainder.slice(closingIndex + delimiter!.length)).toBe(" - Do not quote [redacted-secret] in public comments.");
+}
 
 function minimalConfig(root: string): BotConfig {
   return {


### PR DESCRIPTION
## Summary

Focused runtime hardening for #249 CodeQL blockers:

- route status-style structured CLI JSON through `stringifyRedactedJson`
- bound public-version semver validation before regex matching
- replace the nested cookie-header secret regex with bounded cookie-attribute scanning
- escape backslashes before backticks in walkthrough inline-code markdown

## Root Cause

CodeQL flagged runtime paths where structured status output could print raw config/runtime fields, where broad regexes accepted unbounded attacker-controlled input, and where inline-code markdown escaping only handled backticks without preserving preceding backslashes.

## Impact

CLI status JSON is safer to copy into evidence, long malformed public-version inputs fail before regex evaluation, cookie redaction keeps behavior without the nested regex, and walkthrough settings metadata renders inline-code spans more robustly.

## Validation

- `npm test -- --pool=forks --maxWorkers=1 tests/secrets.test.ts tests/release-status.test.ts tests/walkthrough.test.ts tests/public-cli.test.ts`
  - 4 files passed, 139 tests passed
- `npm run build`
  - TypeScript build passed
- `git diff --check`
  - passed

## Scope Notes

Did not touch live config, launchd state, tags, releases, active runtime state, existing PR branches, `tests/public-community-funnel.test.ts`, or `tests/public-release-readiness.test.ts`.

Closes #249 for the focused runtime blocker slice; remaining issue-level CodeQL categories can stay tracked separately if they are outside this PR scope.
