### PR TITLE
[codex] Add outcome ledger dry-run

### DIFF
--- a/docs/advanced-outcome-modes.md
+++ b/docs/advanced-outcome-modes.md
@@ -1,0 +1,82 @@
+# Advanced Outcome Modes
+
+NeonDiff's next step is not to replace the stable reviewer. It is to add
+measured advanced modes that can prove they save time, catch regressions, and
+improve agent handoffs before they affect live review behavior.
+
+## Stable Default
+
+- `stable` remains the default live behavior.
+- Advanced work starts as dry-run/evidence-only.
+- Live launchd config, PR allowlists, issue-enrichment allowlists, provider
+  retry behavior, and posting policy must not change from this lane unless a
+  later release explicitly promotes a proven mode.
+
+## Modes
+
+- `advanced_dry_run`: computes outcome ledger, mode decision, timing, and
+  scorecard evidence without posting comments.
+- `advanced_pr_review`: later opt-in PR review mode for selected repos or PRs.
+- `advanced_issue_research`: later opt-in issue enrichment mode with separate
+  issue allowlist, repo throttles, and triggered research only.
+- `advanced_full`: deferred combined mode after separate PR and issue pilots
+  pass.
+
+## Build Order
+
+1. [#267](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/267)
+   Outcome Ledger dry-run.
+2. [#266](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/266)
+   review mode router and GLM budget evidence.
+3. [#264](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264)
+   weekly outcome scorecard fixtures/report.
+4. [#261](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/261)
+   advanced issue planner/research packet.
+
+Sprint tracker:
+[#269](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/269).
+Parent tracker:
+[#260](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/260).
+
+## Outcome Ledger
+
+The first artifact is an internal ledger for high-risk or AI-written PRs. It
+captures:
+
+- source issue or PR intent;
+- base and head SHA;
+- changed artifacts;
+- evidence records;
+- risk claims;
+- proof gaps;
+- safety gates;
+- reviewer decision;
+- GLM/runtime metrics when available;
+- post-merge outcome placeholder.
+
+The ledger is internal evidence. Public comments stay compact and redacted.
+
+## Weekly Routine
+
+Codex automation `neondiff-weekly-outcome-scorecard` runs weekly on Sunday. It
+should inspect #260/#269 and child issues, generate or update a scorecard
+packet, and comment with:
+
+- current PR review score;
+- current issue-enrichment score;
+- confidence trend toward 95;
+- timing, queue, and GLM/provider evidence;
+- useful findings, misses, and false-positive drag when labeled;
+- advanced-mode progress;
+- next recommended experiment.
+
+If the scorecard CLI does not exist yet, the automation produces a manual
+read-only packet from GitHub issues, PRs, and existing evidence. It must not
+mutate live config or post PR reviews.
+
+## Proof Boundary
+
+The current outcome scorecard is advisory at 90.2/100 confidence. Weekly
+iterations may raise or lower that confidence based on evidence. This lane must
+not claim CodeRabbit, ClawSweeper, or Looper parity, production readiness, or
+95% calibrated review accuracy until labeled evals support that claim.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2664,6 +2664,7 @@ function buildHelp(command?: string) {
     outcomeLedger: {
       notes: [
         "The outcome-ledger command is dry-run only.",
+        "--dry-run defaults to true for outcome-ledger; --dry-run false is rejected until live posting is explicitly implemented.",
         "Failed safety gates or secret redaction failures exit non-zero; unknown gates remain visible in the packet but do not fail the dry run."
       ]
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1877,7 +1877,7 @@ function runInitCommand(args: ParsedArgs): {
       `neondiff doctor --config ${configPath} --json`,
       `neondiff review-pr --config ${configPath} --repo owner/name --pr 123 --dry-run true --zcode false`,
       `neondiff status --config ${configPath} --json`
-    ]
+    ],
   };
 }
 
@@ -2657,10 +2657,16 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts clear-issue-enrichment-leases --config /path/to/live.json --dry-run true --expired-only true",
       "npx tsx src/cli.ts clear-review-queue-leases --config /path/to/live.json --dry-run true --expired-only true",
       "npx tsx src/cli.ts eval-sticky-vs-cold --input /path/to/sticky-vs-cold.json --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold",
-      "npx tsx src/cli.ts outcome-ledger --input /path/to/outcome-ledger-input.json --dry-run true --output-dir /Volumes/LEXAR/Codex/evals/evaos-reviewer-benchmark/$(date +%F)/advanced-outcome-modes-v0.1/run-id",
+      "npx tsx src/cli.ts outcome-ledger --input /path/to/outcome-ledger-input.json --dry-run true --output-dir /path/to/evidence/outcome-ledger-run",
       "npx tsx src/cli.ts finishing-touch-dry-run --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD --current-head HEAD --comment-id 456 --author maintainer --trusted-authors maintainer --body '@evaos-code-review-bot explain risk'",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
-    ]
+    ],
+    outcomeLedger: {
+      notes: [
+        "The outcome-ledger command is dry-run only.",
+        "Failed safety gates or secret redaction failures exit non-zero; unknown gates remain visible in the packet but do not fail the dry run."
+      ]
+    }
   };
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1437,8 +1437,12 @@ async function main(): Promise<void> {
   }
 
   if (command === "outcome-ledger") {
-    if (!args.input) throw new Error("--input is required for outcome-ledger");
-    if (!args["output-dir"]) throw new Error("--output-dir is required for outcome-ledger");
+    if (args.input === undefined || (Array.isArray(args.input) && args.input.length === 0)) {
+      throw new Error("--input is required for outcome-ledger");
+    }
+    if (args["output-dir"] === undefined || (Array.isArray(args["output-dir"]) && args["output-dir"].length === 0)) {
+      throw new Error("--output-dir is required for outcome-ledger");
+    }
     const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
     if (!dryRun) throw new Error("outcome-ledger is dry-run only in this release");
     const ledgerInput = readOutcomeLedgerInput(parseSingleArg(args.input, "--input"));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,11 @@ import {
   type IssueEnrichmentRepoReadCheck
 } from "./issue-enrichment.js";
 import { activateLicense, deactivateLicense, getLicenseStatus, type LicenseConfig } from "./license.js";
+import {
+  assertOutcomeLedgerOutputDirEmpty,
+  readOutcomeLedgerInput,
+  writeOutcomeLedgerPacket
+} from "./outcome-ledger.js";
 import { buildReviewBudgetStatus } from "./review-budget.js";
 import {
   buildOperatorDashboard,
@@ -1431,6 +1436,25 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "outcome-ledger") {
+    if (!args.input) throw new Error("--input is required for outcome-ledger");
+    if (!args["output-dir"]) throw new Error("--output-dir is required for outcome-ledger");
+    const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
+    if (!dryRun) throw new Error("outcome-ledger is dry-run only in this release");
+    const ledgerInput = readOutcomeLedgerInput(parseSingleArg(args.input, "--input"));
+    const outputDir = parseSingleArg(args["output-dir"], "--output-dir");
+    assertEvalOutputDirSafe(outputDir);
+    assertOutcomeLedgerOutputDirEmpty(outputDir);
+    const result = writeOutcomeLedgerPacket({ ledgerInput, outputDir });
+    console.log(stringifyRedactedJson({
+      command: "outcome-ledger",
+      dryRun,
+      ...result
+    }));
+    if (!result.ok) process.exitCode = 1;
+    return;
+  }
+
   if (command === "run-once" || command === "review-pr") {
     if (command === "review-pr" && (!args.repo || !args.pr)) {
       console.log(JSON.stringify({
@@ -2583,7 +2607,8 @@ function buildHelp(command?: string) {
         "daemon",
         "eval-offline",
         "eval-suite",
-        "eval-sticky-vs-cold"
+        "eval-sticky-vs-cold",
+        "outcome-ledger"
       ]
     },
     examples: [
@@ -2632,6 +2657,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts clear-issue-enrichment-leases --config /path/to/live.json --dry-run true --expired-only true",
       "npx tsx src/cli.ts clear-review-queue-leases --config /path/to/live.json --dry-run true --expired-only true",
       "npx tsx src/cli.ts eval-sticky-vs-cold --input /path/to/sticky-vs-cold.json --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold",
+      "npx tsx src/cli.ts outcome-ledger --input /path/to/outcome-ledger-input.json --dry-run true --output-dir /Volumes/LEXAR/Codex/evals/evaos-reviewer-benchmark/$(date +%F)/advanced-outcome-modes-v0.1/run-id",
       "npx tsx src/cli.ts finishing-touch-dry-run --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD --current-head HEAD --comment-id 456 --author maintainer --trusted-authors maintainer --body '@evaos-code-review-bot explain risk'",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ]

--- a/src/outcome-ledger.ts
+++ b/src/outcome-ledger.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 import type { PullFilePatch, PullRequestSummary, ReviewPlan } from "./types.js";
@@ -359,26 +359,36 @@ export function writeOutcomeLedgerPacket(input: {
   mkdirSync(input.outputDir, { recursive: true });
   const markdown = renderOutcomeLedgerMarkdown(ledger);
   const artifacts: Record<string, string> = {};
+  const writtenArtifactNames: string[] = [];
   const writeArtifact = (name: string, value: string): void => {
     const path = join(input.outputDir, name);
     writeFileSync(path, value);
     artifacts[name] = sha256File(path);
+    writtenArtifactNames.push(name);
   };
-  writeArtifact("outcome-ledger.json", `${JSON.stringify(ledger, null, 2)}\n`);
-  writeArtifact("outcome-ledger.md", `${markdown}\n`);
-  writeArtifact("redaction-report.json", `${JSON.stringify(ledger.redaction, null, 2)}\n`);
-  const manifestArtifactInventory = { ...artifacts };
-  writeArtifact("manifest.json", `${JSON.stringify({
-    artifactVersion: "0.1",
-    ok: ledger.ok,
-    generatedAt: ledger.generatedAt,
-    runId: ledger.runId,
-    mode: ledger.mode,
-    subject: ledger.subject,
-    proofBoundary: ledger.proofBoundary,
-    artifactInventory: manifestArtifactInventory
-  }, null, 2)}\n`);
-  artifacts["manifest.json"] = sha256File(join(input.outputDir, "manifest.json"));
+  try {
+    writeArtifact("outcome-ledger.json", `${JSON.stringify(ledger, null, 2)}\n`);
+    writeArtifact("outcome-ledger.md", `${markdown}\n`);
+    writeArtifact("redaction-report.json", `${JSON.stringify(ledger.redaction, null, 2)}\n`);
+    const manifestArtifactInventory = { ...artifacts };
+    writeArtifact("manifest.json", `${JSON.stringify({
+      artifactVersion: "0.1",
+      ok: ledger.ok,
+      generatedAt: ledger.generatedAt,
+      runId: ledger.runId,
+      mode: ledger.mode,
+      subject: ledger.subject,
+      proofBoundary: ledger.proofBoundary,
+      artifactInventory: manifestArtifactInventory
+    }, null, 2)}\n`);
+    artifacts["manifest.json"] = sha256File(join(input.outputDir, "manifest.json"));
+  } catch (error) {
+    for (const artifactName of writtenArtifactNames) {
+      rmSync(join(input.outputDir, artifactName), { force: true, recursive: true });
+      delete artifacts[artifactName];
+    }
+    throw error;
+  }
   return {
     ok: ledger.ok,
     outputDir: input.outputDir,

--- a/src/outcome-ledger.ts
+++ b/src/outcome-ledger.ts
@@ -275,8 +275,22 @@ export function buildOutcomeLedgerInputFromReviewPlan(input: {
   runId?: string;
   mode?: OutcomeLedgerMode;
   runtime?: OutcomeLedgerRuntimeInput;
+  safetyGateEvidence?: {
+    currentHead?: OutcomeLedgerSafetyGateInput;
+    inlineCoordinateValidation?: OutcomeLedgerSafetyGateInput;
+  };
 }): OutcomeLedgerInput {
   const sourceIssue = extractFirstRelatedIssue(`${input.pull.title}\n${input.pull.body ?? ""}`);
+  const currentHeadGate = input.safetyGateEvidence?.currentHead ?? {
+    name: "current_head",
+    status: "unknown" as const,
+    detail: "Generic review-plan ledger builder did not re-run stale-head validation; caller must supply inherited worker evidence to mark this gate pass."
+  };
+  const inlineCoordinateGate = input.safetyGateEvidence?.inlineCoordinateValidation ?? {
+    name: "inline_coordinate_validation",
+    status: "unknown" as const,
+    detail: `${input.plan.comments.length} accepted inline comment(s) are present, but this generic builder did not re-run deterministic location validation.`
+  };
   return {
     ledgerName: "review-plan-outcome-ledger",
     runId: input.runId ?? `${input.repo.replaceAll("/", "__")}-pr-${input.pull.number}-${input.pull.head.sha.slice(0, 12)}`,
@@ -316,21 +330,13 @@ export function buildOutcomeLedgerInputFromReviewPlan(input: {
     })),
     proofGaps: buildProofGaps(input.plan),
     safetyGates: [
-      {
-        name: "current_head",
-        status: "pass",
-        detail: "Worker reached review-plan construction after stale-head preflight."
-      },
+      currentHeadGate,
       {
         name: "duplicate_same_head",
         status: input.dryRun ? "pass" : "unknown",
         detail: input.dryRun ? "Dry-run ledger does not post public comments." : "Live duplicate state is outside this dry-run ledger."
       },
-      {
-        name: "inline_coordinate_validation",
-        status: "pass",
-        detail: `${input.plan.comments.length} accepted inline comment(s) survived deterministic location validation.`
-      }
+      inlineCoordinateGate
     ],
     reviewerDecision: {
       status: mapReviewPlanDecision(input.plan),

--- a/src/outcome-ledger.ts
+++ b/src/outcome-ledger.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 import type { PullFilePatch, PullRequestSummary, ReviewPlan } from "./types.js";
 
@@ -360,12 +360,17 @@ export function writeOutcomeLedgerPacket(input: {
   now?: Date;
 }): OutcomeLedgerPacketResult {
   const ledger = buildOutcomeLedger(input.ledgerInput, { now: input.now });
-  mkdirSync(input.outputDir, { recursive: true });
+  const parentDir = dirname(input.outputDir);
+  const outputBase = basename(input.outputDir);
+  const tempDir = join(parentDir, `.${outputBase}.tmp-${process.pid}-${Date.now()}`);
+  mkdirSync(parentDir, { recursive: true });
+  rmSync(tempDir, { recursive: true, force: true });
+  mkdirSync(tempDir, { recursive: true });
   const markdown = renderOutcomeLedgerMarkdown(ledger);
   const artifacts: Record<string, string> = {};
   const writtenArtifactNames: string[] = [];
   const writeArtifact = (name: string, value: string): void => {
-    const path = join(input.outputDir, name);
+    const path = join(tempDir, name);
     writeFileSync(path, value);
     artifacts[name] = sha256File(path);
     writtenArtifactNames.push(name);
@@ -385,12 +390,20 @@ export function writeOutcomeLedgerPacket(input: {
       proofBoundary: ledger.proofBoundary,
       artifactInventory: manifestArtifactInventory
     }, null, 2)}\n`);
-    artifacts["manifest.json"] = sha256File(join(input.outputDir, "manifest.json"));
+    artifacts["manifest.json"] = sha256File(join(tempDir, "manifest.json"));
+    if (existsSync(input.outputDir)) {
+      const stat = statSync(input.outputDir);
+      if (!stat.isDirectory()) throw new Error("outputDir must be a directory when it already exists");
+      if (readdirSync(input.outputDir).length > 0) throw new Error("outputDir must be empty before publishing outcome ledger packet");
+      rmSync(input.outputDir, { recursive: true, force: true });
+    }
+    renameSync(tempDir, input.outputDir);
   } catch (error) {
     for (const artifactName of writtenArtifactNames) {
-      rmSync(join(input.outputDir, artifactName), { force: true, recursive: true });
+      rmSync(join(tempDir, artifactName), { force: true, recursive: true });
       delete artifacts[artifactName];
     }
+    rmSync(tempDir, { recursive: true, force: true });
     throw error;
   }
   return {
@@ -450,12 +463,12 @@ export function renderOutcomeLedgerMarkdown(ledger: OutcomeLedger): string {
 function normalizeSubject(subject: OutcomeLedgerSubjectInput): OutcomeLedger["subject"] {
   return {
     type: subject.type,
-    repo: redact(subject.repo),
+    repo: subject.repo,
     number: subject.number,
     ...(subject.title ? { title: redact(subject.title) } : {}),
     ...(subject.url ? { url: redact(subject.url) } : {}),
-    ...(subject.baseSha ? { baseSha: redact(subject.baseSha) } : {}),
-    ...(subject.headSha ? { headSha: redact(subject.headSha) } : {}),
+    ...(subject.baseSha ? { baseSha: subject.baseSha } : {}),
+    ...(subject.headSha ? { headSha: subject.headSha } : {}),
     ...(subject.author ? { author: redact(subject.author) } : {}),
     labels: (subject.labels ?? []).map(redact).sort()
   };

--- a/src/outcome-ledger.ts
+++ b/src/outcome-ledger.ts
@@ -326,7 +326,7 @@ export function buildOutcomeLedgerInputFromReviewPlan(input: {
       category: comment.category,
       claim: `${comment.title}: ${comment.body}`,
       evidenceIds: [],
-      status: "validated"
+      status: "unvalidated"
     })),
     proofGaps: buildProofGaps(input.plan),
     safetyGates: [
@@ -564,7 +564,7 @@ function buildHardGateStatus(safetyGates: Required<Pick<OutcomeLedgerSafetyGateI
   const failed = safetyGates.filter((gate) => gate.status === "fail").map((gate) => gate.name);
   const unknown = safetyGates.filter((gate) => gate.status === "unknown").map((gate) => gate.name);
   return {
-    ok: failed.length === 0,
+    ok: failed.length === 0 && unknown.length === 0,
     failed,
     unknown
   };

--- a/src/outcome-ledger.ts
+++ b/src/outcome-ledger.ts
@@ -1,0 +1,887 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { containsSecretLikeText, redactSecrets } from "./secrets.js";
+import type { PullFilePatch, PullRequestSummary, ReviewPlan } from "./types.js";
+
+export type OutcomeLedgerSubjectType = "pull_request" | "issue";
+export type OutcomeLedgerMode =
+  | "stable"
+  | "advanced_dry_run"
+  | "advanced_pr_review"
+  | "advanced_issue_research"
+  | "advanced_full";
+export type OutcomeLedgerDecisionStatus =
+  | "block"
+  | "warn"
+  | "accept_with_evidence"
+  | "defer"
+  | "human_review"
+  | "unknown";
+export type OutcomeLedgerSafetyGateStatus = "pass" | "fail" | "not_applicable" | "unknown";
+export type OutcomeLedgerPostMergeStatus =
+  | "unknown"
+  | "not_merged"
+  | "no_incident_seen"
+  | "regression_seen"
+  | "reverted"
+  | "hotfixed";
+
+export interface OutcomeLedgerInput {
+  ledgerName?: string;
+  runId: string;
+  mode?: OutcomeLedgerMode;
+  subject: OutcomeLedgerSubjectInput;
+  intent?: OutcomeLedgerIntentInput;
+  changedArtifacts?: OutcomeLedgerChangedArtifactInput[];
+  evidence?: OutcomeLedgerEvidenceInput[];
+  riskClaims?: OutcomeLedgerRiskClaimInput[];
+  proofGaps?: OutcomeLedgerProofGapInput[];
+  safetyGates?: OutcomeLedgerSafetyGateInput[];
+  reviewerDecision?: OutcomeLedgerReviewerDecisionInput;
+  runtime?: OutcomeLedgerRuntimeInput;
+  postMergeOutcome?: OutcomeLedgerPostMergeOutcomeInput;
+}
+
+export interface OutcomeLedgerSubjectInput {
+  type: OutcomeLedgerSubjectType;
+  repo: string;
+  number: number;
+  title?: string;
+  url?: string;
+  baseSha?: string;
+  headSha?: string;
+  author?: string;
+  labels?: string[];
+}
+
+export interface OutcomeLedgerIntentInput {
+  summary?: string;
+  sourceIssue?: string;
+  acceptanceCriteria?: string[];
+  nonGoals?: string[];
+}
+
+export interface OutcomeLedgerChangedArtifactInput {
+  path: string;
+  changeType?: "added" | "modified" | "removed" | "renamed" | "unknown";
+  summary?: string;
+  riskAreas?: string[];
+}
+
+export interface OutcomeLedgerEvidenceInput {
+  id?: string;
+  kind: string;
+  title: string;
+  status?: "pass" | "fail" | "pending" | "missing" | "unknown";
+  url?: string;
+  path?: string;
+  summary?: string;
+}
+
+export interface OutcomeLedgerRiskClaimInput {
+  id?: string;
+  severity?: "P0" | "P1" | "P2" | "P3";
+  category?: string;
+  claim: string;
+  evidenceIds?: string[];
+  status?: "validated" | "unvalidated" | "dismissed" | "unknown";
+}
+
+export interface OutcomeLedgerProofGapInput {
+  id?: string;
+  severity?: "P0" | "P1" | "P2" | "P3";
+  summary: string;
+  owner?: string;
+  requiredEvidence?: string[];
+}
+
+export interface OutcomeLedgerSafetyGateInput {
+  name: string;
+  status: OutcomeLedgerSafetyGateStatus;
+  detail?: string;
+}
+
+export interface OutcomeLedgerReviewerDecisionInput {
+  status: OutcomeLedgerDecisionStatus;
+  reason?: string;
+  requestedReviewer?: string;
+}
+
+export interface OutcomeLedgerRuntimeInput {
+  provider?: string;
+  model?: string;
+  startedAt?: string;
+  completedAt?: string;
+  latencyMs?: number;
+  providerAttempts?: number;
+  promptTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  notes?: string[];
+}
+
+export interface OutcomeLedgerPostMergeOutcomeInput {
+  status: OutcomeLedgerPostMergeStatus;
+  checkedAt?: string;
+  summary?: string;
+}
+
+export interface OutcomeLedger {
+  artifactVersion: "0.1";
+  ok: boolean;
+  ledgerName: string;
+  runId: string;
+  mode: OutcomeLedgerMode;
+  generatedAt: string;
+  subject: Required<Pick<OutcomeLedgerSubjectInput, "type" | "repo" | "number">> & Omit<OutcomeLedgerSubjectInput, "type" | "repo" | "number">;
+  intent: Required<OutcomeLedgerIntentInput>;
+  changedArtifacts: Required<OutcomeLedgerChangedArtifactInput>[];
+  evidence: Array<Required<Pick<OutcomeLedgerEvidenceInput, "id" | "kind" | "title" | "status">> & OutcomeLedgerEvidenceInput>;
+  riskClaims: Array<Required<Pick<OutcomeLedgerRiskClaimInput, "id" | "severity" | "category" | "claim" | "status">> & OutcomeLedgerRiskClaimInput>;
+  proofGaps: Array<Required<Pick<OutcomeLedgerProofGapInput, "id" | "severity" | "summary">> & OutcomeLedgerProofGapInput>;
+  safetyGates: Required<Pick<OutcomeLedgerSafetyGateInput, "name" | "status" | "detail">>[];
+  reviewerDecision: Required<OutcomeLedgerReviewerDecisionInput>;
+  runtime: Required<OutcomeLedgerRuntimeInput>;
+  postMergeOutcome: Required<OutcomeLedgerPostMergeOutcomeInput>;
+  hardGateStatus: {
+    ok: boolean;
+    failed: string[];
+    unknown: string[];
+  };
+  metrics: {
+    changedArtifacts: number;
+    evidenceRecords: number;
+    riskClaims: number;
+    proofGaps: number;
+    failedSafetyGates: number;
+    unknownSafetyGates: number;
+    latencyMs: number | null;
+    providerAttempts: number | null;
+    estimatedTokens: number | null;
+  };
+  redaction: OutcomeLedgerRedactionReport;
+  proofBoundary: string;
+  sha256: string;
+}
+
+export interface OutcomeLedgerRedactionReport {
+  ok: boolean;
+  checkedSources: number;
+  redactedSources: Array<{ id: string; redactedPreview: string }>;
+}
+
+export interface OutcomeLedgerPacketResult {
+  ok: boolean;
+  outputDir: string;
+  ledger: OutcomeLedger;
+  artifacts: Record<string, string>;
+}
+
+const REPO_SLUG_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+const DEFAULT_PROOF_BOUNDARY =
+  "Outcome Ledger dry-run proves evidence-packet construction only. It does not post comments, change live runtime behavior, prove review accuracy, or claim production readiness.";
+
+export function readOutcomeLedgerInput(path: string): OutcomeLedgerInput {
+  return parseOutcomeLedgerInput(JSON.parse(readFileSync(path, "utf8")));
+}
+
+export function parseOutcomeLedgerInput(value: unknown): OutcomeLedgerInput {
+  if (!isRecord(value)) throw new Error("outcome ledger input must be an object");
+  const subject = value.subject;
+  if (!isRecord(subject)) throw new Error("outcome ledger input requires subject");
+  const input: OutcomeLedgerInput = {
+    ledgerName: optionalString(value.ledgerName, "ledgerName"),
+    runId: requiredString(value.runId, "runId"),
+    mode: parseMode(value.mode),
+    subject: {
+      type: parseSubjectType(subject.type),
+      repo: requiredString(subject.repo, "subject.repo"),
+      number: requiredPositiveInteger(subject.number, "subject.number"),
+      title: optionalString(subject.title, "subject.title"),
+      url: optionalString(subject.url, "subject.url"),
+      baseSha: optionalString(subject.baseSha, "subject.baseSha"),
+      headSha: optionalString(subject.headSha, "subject.headSha"),
+      author: optionalString(subject.author, "subject.author"),
+      labels: optionalStringArray(subject.labels, "subject.labels")
+    },
+    intent: parseIntent(value.intent),
+    changedArtifacts: optionalArray(value.changedArtifacts, "changedArtifacts").map(parseChangedArtifact),
+    evidence: optionalArray(value.evidence, "evidence").map(parseEvidence),
+    riskClaims: optionalArray(value.riskClaims, "riskClaims").map(parseRiskClaim),
+    proofGaps: optionalArray(value.proofGaps, "proofGaps").map(parseProofGap),
+    safetyGates: optionalArray(value.safetyGates, "safetyGates").map(parseSafetyGate),
+    reviewerDecision: parseReviewerDecision(value.reviewerDecision),
+    runtime: parseRuntime(value.runtime),
+    postMergeOutcome: parsePostMergeOutcome(value.postMergeOutcome)
+  };
+  validateSubject(input.subject);
+  return input;
+}
+
+export function buildOutcomeLedger(input: OutcomeLedgerInput, options: { now?: Date } = {}): OutcomeLedger {
+  validateSubject(input.subject);
+  const generatedAt = options.now?.toISOString() ?? new Date().toISOString();
+  const redaction = buildRedactionReport(input);
+  const safetyGates = (input.safetyGates ?? []).map((gate) => normalizeSafetyGate(gate, redaction));
+  const hardGateStatus = buildHardGateStatus(safetyGates);
+  const runtime = normalizeRuntime(input.runtime);
+  const postMergeOutcome = normalizePostMergeOutcome(input.postMergeOutcome);
+  const base = {
+    artifactVersion: "0.1" as const,
+    ok: redaction.ok && hardGateStatus.ok,
+    ledgerName: redact(input.ledgerName ?? "outcome-ledger"),
+    runId: sanitizeRunId(input.runId),
+    mode: input.mode ?? "advanced_dry_run",
+    generatedAt,
+    subject: normalizeSubject(input.subject),
+    intent: normalizeIntent(input.intent),
+    changedArtifacts: (input.changedArtifacts ?? []).map(normalizeChangedArtifact),
+    evidence: (input.evidence ?? []).map(normalizeEvidence),
+    riskClaims: (input.riskClaims ?? []).map(normalizeRiskClaim),
+    proofGaps: (input.proofGaps ?? []).map(normalizeProofGap),
+    safetyGates,
+    reviewerDecision: normalizeReviewerDecision(input.reviewerDecision),
+    runtime,
+    postMergeOutcome,
+    hardGateStatus,
+    metrics: {
+      changedArtifacts: input.changedArtifacts?.length ?? 0,
+      evidenceRecords: input.evidence?.length ?? 0,
+      riskClaims: input.riskClaims?.length ?? 0,
+      proofGaps: input.proofGaps?.length ?? 0,
+      failedSafetyGates: hardGateStatus.failed.length,
+      unknownSafetyGates: hardGateStatus.unknown.length,
+      latencyMs: runtime.latencyMs >= 0 ? runtime.latencyMs : null,
+      providerAttempts: runtime.providerAttempts >= 0 ? runtime.providerAttempts : null,
+      estimatedTokens: runtime.totalTokens >= 0 ? runtime.totalTokens : null
+    },
+    redaction,
+    proofBoundary: DEFAULT_PROOF_BOUNDARY
+  };
+  return {
+    ...base,
+    sha256: sha256Json(base)
+  };
+}
+
+export function buildOutcomeLedgerInputFromReviewPlan(input: {
+  repo: string;
+  pull: PullRequestSummary;
+  files: PullFilePatch[];
+  plan: ReviewPlan;
+  dryRun: boolean;
+  runId?: string;
+  mode?: OutcomeLedgerMode;
+  runtime?: OutcomeLedgerRuntimeInput;
+}): OutcomeLedgerInput {
+  const sourceIssue = extractFirstRelatedIssue(`${input.pull.title}\n${input.pull.body ?? ""}`);
+  return {
+    ledgerName: "review-plan-outcome-ledger",
+    runId: input.runId ?? `${input.repo.replaceAll("/", "__")}-pr-${input.pull.number}-${input.pull.head.sha.slice(0, 12)}`,
+    mode: input.mode ?? "advanced_dry_run",
+    subject: {
+      type: "pull_request",
+      repo: input.repo,
+      number: input.pull.number,
+      title: input.pull.title,
+      url: input.pull.html_url,
+      baseSha: input.pull.base.sha,
+      headSha: input.pull.head.sha,
+      labels: input.pull.labels?.map((label) => label.name) ?? []
+    },
+    intent: {
+      summary: input.pull.body?.trim() || input.pull.title,
+      ...(sourceIssue ? { sourceIssue } : {}),
+      acceptanceCriteria: inferAcceptanceCriteria(input.pull.body ?? ""),
+      nonGoals: []
+    },
+    changedArtifacts: input.files.map((file) => ({
+      path: file.filename,
+      changeType: normalizePullFileStatus(file.status),
+      summary: `${file.changes ?? 0} changed line(s)`,
+      riskAreas: input.plan.validation?.recommendations
+        .filter((recommendation) => recommendation.matchedPaths.includes(file.filename))
+        .map((recommendation) => recommendation.title) ?? []
+    })),
+    evidence: buildPlanEvidence(input.plan),
+    riskClaims: input.plan.comments.map((comment, index) => ({
+      id: `finding-${index + 1}`,
+      severity: comment.severity,
+      category: comment.category,
+      claim: `${comment.title}: ${comment.body}`,
+      evidenceIds: [],
+      status: "validated"
+    })),
+    proofGaps: buildProofGaps(input.plan),
+    safetyGates: [
+      {
+        name: "current_head",
+        status: "pass",
+        detail: "Worker reached review-plan construction after stale-head preflight."
+      },
+      {
+        name: "duplicate_same_head",
+        status: input.dryRun ? "pass" : "unknown",
+        detail: input.dryRun ? "Dry-run ledger does not post public comments." : "Live duplicate state is outside this dry-run ledger."
+      },
+      {
+        name: "inline_coordinate_validation",
+        status: "pass",
+        detail: `${input.plan.comments.length} accepted inline comment(s) survived deterministic location validation.`
+      }
+    ],
+    reviewerDecision: {
+      status: mapReviewPlanDecision(input.plan),
+      reason: input.plan.summary
+    },
+    runtime: input.runtime,
+    postMergeOutcome: {
+      status: "unknown",
+      summary: "Post-merge outcome is not observed at ledger creation time."
+    }
+  };
+}
+
+export function writeOutcomeLedgerPacket(input: {
+  ledgerInput: OutcomeLedgerInput;
+  outputDir: string;
+  now?: Date;
+}): OutcomeLedgerPacketResult {
+  const ledger = buildOutcomeLedger(input.ledgerInput, { now: input.now });
+  mkdirSync(input.outputDir, { recursive: true });
+  const markdown = renderOutcomeLedgerMarkdown(ledger);
+  const artifacts: Record<string, string> = {};
+  const writeArtifact = (name: string, value: string): void => {
+    const path = join(input.outputDir, name);
+    writeFileSync(path, value);
+    artifacts[name] = sha256File(path);
+  };
+  writeArtifact("outcome-ledger.json", `${JSON.stringify(ledger, null, 2)}\n`);
+  writeArtifact("outcome-ledger.md", `${markdown}\n`);
+  writeArtifact("redaction-report.json", `${JSON.stringify(ledger.redaction, null, 2)}\n`);
+  const manifestArtifactInventory = { ...artifacts };
+  writeArtifact("manifest.json", `${JSON.stringify({
+    artifactVersion: "0.1",
+    ok: ledger.ok,
+    generatedAt: ledger.generatedAt,
+    runId: ledger.runId,
+    mode: ledger.mode,
+    subject: ledger.subject,
+    proofBoundary: ledger.proofBoundary,
+    artifactInventory: manifestArtifactInventory
+  }, null, 2)}\n`);
+  artifacts["manifest.json"] = sha256File(join(input.outputDir, "manifest.json"));
+  return {
+    ok: ledger.ok,
+    outputDir: input.outputDir,
+    ledger,
+    artifacts
+  };
+}
+
+export function renderOutcomeLedgerMarkdown(ledger: OutcomeLedger): string {
+  return [
+    `# Outcome Ledger: ${ledger.subject.repo}#${ledger.subject.number}`,
+    "",
+    `- Mode: \`${ledger.mode}\``,
+    `- Decision: \`${ledger.reviewerDecision.status}\``,
+    `- OK: \`${ledger.ok ? "true" : "false"}\``,
+    `- Head: \`${ledger.subject.headSha ?? "n/a"}\``,
+    "",
+    "## Intent",
+    "",
+    ledger.intent.summary || "No intent summary provided.",
+    "",
+    "## Changed Artifacts",
+    "",
+    ...listOrNone(ledger.changedArtifacts.map((artifact) => `- \`${artifact.path}\` (${artifact.changeType}): ${artifact.summary || "no summary"}`)),
+    "",
+    "## Evidence",
+    "",
+    ...listOrNone(ledger.evidence.map((item) => `- [${item.status}] ${item.id}: ${item.title}${item.url ? ` (${item.url})` : ""}`)),
+    "",
+    "## Risk Claims",
+    "",
+    ...listOrNone(ledger.riskClaims.map((claim) => `- [${claim.severity}/${claim.status}] ${claim.id}: ${claim.claim}`)),
+    "",
+    "## Proof Gaps",
+    "",
+    ...listOrNone(ledger.proofGaps.map((gap) => `- [${gap.severity}] ${gap.id}: ${gap.summary}`)),
+    "",
+    "## Safety Gates",
+    "",
+    ...listOrNone(ledger.safetyGates.map((gate) => `- [${gate.status}] ${gate.name}${gate.detail ? `: ${gate.detail}` : ""}`)),
+    "",
+    "## Runtime",
+    "",
+    `- Provider: ${ledger.runtime.provider || "unknown"}`,
+    `- Model: ${ledger.runtime.model || "unknown"}`,
+    `- Latency: ${ledger.metrics.latencyMs ?? "unknown"} ms`,
+    `- Attempts: ${ledger.metrics.providerAttempts ?? "unknown"}`,
+    "",
+    "## Proof Boundary",
+    "",
+    ledger.proofBoundary
+  ].join("\n");
+}
+
+function normalizeSubject(subject: OutcomeLedgerSubjectInput): OutcomeLedger["subject"] {
+  return {
+    type: subject.type,
+    repo: redact(subject.repo),
+    number: subject.number,
+    ...(subject.title ? { title: redact(subject.title) } : {}),
+    ...(subject.url ? { url: redact(subject.url) } : {}),
+    ...(subject.baseSha ? { baseSha: redact(subject.baseSha) } : {}),
+    ...(subject.headSha ? { headSha: redact(subject.headSha) } : {}),
+    ...(subject.author ? { author: redact(subject.author) } : {}),
+    labels: (subject.labels ?? []).map(redact).sort()
+  };
+}
+
+function normalizeIntent(intent?: OutcomeLedgerIntentInput): Required<OutcomeLedgerIntentInput> {
+  return {
+    summary: redact(intent?.summary ?? ""),
+    sourceIssue: redact(intent?.sourceIssue ?? ""),
+    acceptanceCriteria: (intent?.acceptanceCriteria ?? []).map(redact),
+    nonGoals: (intent?.nonGoals ?? []).map(redact)
+  };
+}
+
+function normalizeChangedArtifact(artifact: OutcomeLedgerChangedArtifactInput): Required<OutcomeLedgerChangedArtifactInput> {
+  return {
+    path: redact(artifact.path),
+    changeType: artifact.changeType ?? "unknown",
+    summary: redact(artifact.summary ?? ""),
+    riskAreas: (artifact.riskAreas ?? []).map(redact).sort()
+  };
+}
+
+function normalizeEvidence(item: OutcomeLedgerEvidenceInput, index: number): Required<Pick<OutcomeLedgerEvidenceInput, "id" | "kind" | "title" | "status">> & OutcomeLedgerEvidenceInput {
+  return {
+    id: redact(item.id ?? `evidence-${index + 1}`),
+    kind: redact(item.kind),
+    title: redact(item.title),
+    status: item.status ?? "unknown",
+    ...(item.url ? { url: redact(item.url) } : {}),
+    ...(item.path ? { path: redact(item.path) } : {}),
+    ...(item.summary ? { summary: redact(item.summary) } : {})
+  };
+}
+
+function normalizeRiskClaim(claim: OutcomeLedgerRiskClaimInput, index: number): Required<Pick<OutcomeLedgerRiskClaimInput, "id" | "severity" | "category" | "claim" | "status">> & OutcomeLedgerRiskClaimInput {
+  return {
+    id: redact(claim.id ?? `risk-${index + 1}`),
+    severity: claim.severity ?? "P3",
+    category: redact(claim.category ?? "unknown"),
+    claim: redact(claim.claim),
+    evidenceIds: (claim.evidenceIds ?? []).map(redact),
+    status: claim.status ?? "unknown"
+  };
+}
+
+function normalizeProofGap(gap: OutcomeLedgerProofGapInput, index: number): Required<Pick<OutcomeLedgerProofGapInput, "id" | "severity" | "summary">> & OutcomeLedgerProofGapInput {
+  return {
+    id: redact(gap.id ?? `proof-gap-${index + 1}`),
+    severity: gap.severity ?? "P3",
+    summary: redact(gap.summary),
+    ...(gap.owner ? { owner: redact(gap.owner) } : {}),
+    requiredEvidence: (gap.requiredEvidence ?? []).map(redact)
+  };
+}
+
+function normalizeReviewerDecision(decision?: OutcomeLedgerReviewerDecisionInput): Required<OutcomeLedgerReviewerDecisionInput> {
+  return {
+    status: decision?.status ?? "unknown",
+    reason: redact(decision?.reason ?? ""),
+    requestedReviewer: redact(decision?.requestedReviewer ?? "")
+  };
+}
+
+function normalizeRuntime(runtime?: OutcomeLedgerRuntimeInput): Required<OutcomeLedgerRuntimeInput> {
+  return {
+    provider: redact(runtime?.provider ?? ""),
+    model: redact(runtime?.model ?? ""),
+    startedAt: redact(runtime?.startedAt ?? ""),
+    completedAt: redact(runtime?.completedAt ?? ""),
+    latencyMs: normalizeNonNegative(runtime?.latencyMs),
+    providerAttempts: normalizeNonNegative(runtime?.providerAttempts),
+    promptTokens: normalizeNonNegative(runtime?.promptTokens),
+    outputTokens: normalizeNonNegative(runtime?.outputTokens),
+    totalTokens: normalizeNonNegative(runtime?.totalTokens),
+    notes: (runtime?.notes ?? []).map(redact)
+  };
+}
+
+function normalizePostMergeOutcome(outcome?: OutcomeLedgerPostMergeOutcomeInput): Required<OutcomeLedgerPostMergeOutcomeInput> {
+  return {
+    status: outcome?.status ?? "unknown",
+    checkedAt: redact(outcome?.checkedAt ?? ""),
+    summary: redact(outcome?.summary ?? "")
+  };
+}
+
+function normalizeSafetyGate(
+  gate: OutcomeLedgerSafetyGateInput,
+  redaction: OutcomeLedgerRedactionReport
+): Required<Pick<OutcomeLedgerSafetyGateInput, "name" | "status" | "detail">> {
+  const name = redact(gate.name);
+  if (name === "secret_redaction") {
+    return {
+      name,
+      status: redaction.ok ? "pass" : "fail",
+      detail: redaction.ok
+        ? redact(gate.detail ?? "No secret-like text detected.")
+        : "Secret-like text detected; see redaction report."
+    };
+  }
+  return {
+    name,
+    status: gate.status,
+    detail: redact(gate.detail ?? "")
+  };
+}
+
+function buildHardGateStatus(safetyGates: Required<Pick<OutcomeLedgerSafetyGateInput, "name" | "status" | "detail">>[]): OutcomeLedger["hardGateStatus"] {
+  const failed = safetyGates.filter((gate) => gate.status === "fail").map((gate) => gate.name);
+  const unknown = safetyGates.filter((gate) => gate.status === "unknown").map((gate) => gate.name);
+  return {
+    ok: failed.length === 0,
+    failed,
+    unknown
+  };
+}
+
+function buildRedactionReport(input: OutcomeLedgerInput): OutcomeLedgerRedactionReport {
+  const sources = collectStringSources(input);
+  const redactedSources = sources
+    .filter((source) => containsSecretLikeText(source.text))
+    .map((source) => ({
+      id: source.id,
+      redactedPreview: redactSecrets(source.text).slice(0, 240)
+    }));
+  return {
+    ok: redactedSources.length === 0,
+    checkedSources: sources.length,
+    redactedSources
+  };
+}
+
+function collectStringSources(input: unknown, prefix = "input"): Array<{ id: string; text: string }> {
+  if (typeof input === "string") return [{ id: prefix, text: input }];
+  if (Array.isArray(input)) {
+    return input.flatMap((item, index) => collectStringSources(item, `${prefix}[${index}]`));
+  }
+  if (isRecord(input)) {
+    return Object.entries(input).flatMap(([key, value]) => collectStringSources(value, `${prefix}.${key}`));
+  }
+  return [];
+}
+
+function parseIntent(value: unknown): OutcomeLedgerIntentInput | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw new Error("intent must be an object");
+  return {
+    summary: optionalString(value.summary, "intent.summary"),
+    sourceIssue: optionalString(value.sourceIssue, "intent.sourceIssue"),
+    acceptanceCriteria: optionalStringArray(value.acceptanceCriteria, "intent.acceptanceCriteria"),
+    nonGoals: optionalStringArray(value.nonGoals, "intent.nonGoals")
+  };
+}
+
+function parseChangedArtifact(value: unknown): OutcomeLedgerChangedArtifactInput {
+  if (!isRecord(value)) throw new Error("changedArtifacts entries must be objects");
+  return {
+    path: requiredString(value.path, "changedArtifacts.path"),
+    changeType: parseChangeType(value.changeType),
+    summary: optionalString(value.summary, "changedArtifacts.summary"),
+    riskAreas: optionalStringArray(value.riskAreas, "changedArtifacts.riskAreas")
+  };
+}
+
+function parseEvidence(value: unknown): OutcomeLedgerEvidenceInput {
+  if (!isRecord(value)) throw new Error("evidence entries must be objects");
+  return {
+    id: optionalString(value.id, "evidence.id"),
+    kind: requiredString(value.kind, "evidence.kind"),
+    title: requiredString(value.title, "evidence.title"),
+    status: parseEvidenceStatus(value.status),
+    url: optionalString(value.url, "evidence.url"),
+    path: optionalString(value.path, "evidence.path"),
+    summary: optionalString(value.summary, "evidence.summary")
+  };
+}
+
+function parseRiskClaim(value: unknown): OutcomeLedgerRiskClaimInput {
+  if (!isRecord(value)) throw new Error("riskClaims entries must be objects");
+  return {
+    id: optionalString(value.id, "riskClaims.id"),
+    severity: parseSeverity(value.severity),
+    category: optionalString(value.category, "riskClaims.category"),
+    claim: requiredString(value.claim, "riskClaims.claim"),
+    evidenceIds: optionalStringArray(value.evidenceIds, "riskClaims.evidenceIds"),
+    status: parseRiskStatus(value.status)
+  };
+}
+
+function parseProofGap(value: unknown): OutcomeLedgerProofGapInput {
+  if (!isRecord(value)) throw new Error("proofGaps entries must be objects");
+  return {
+    id: optionalString(value.id, "proofGaps.id"),
+    severity: parseSeverity(value.severity),
+    summary: requiredString(value.summary, "proofGaps.summary"),
+    owner: optionalString(value.owner, "proofGaps.owner"),
+    requiredEvidence: optionalStringArray(value.requiredEvidence, "proofGaps.requiredEvidence")
+  };
+}
+
+function parseSafetyGate(value: unknown): OutcomeLedgerSafetyGateInput {
+  if (!isRecord(value)) throw new Error("safetyGates entries must be objects");
+  return {
+    name: requiredString(value.name, "safetyGates.name"),
+    status: parseSafetyGateStatus(value.status),
+    detail: optionalString(value.detail, "safetyGates.detail")
+  };
+}
+
+function parseReviewerDecision(value: unknown): OutcomeLedgerReviewerDecisionInput | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw new Error("reviewerDecision must be an object");
+  return {
+    status: parseDecisionStatus(value.status),
+    reason: optionalString(value.reason, "reviewerDecision.reason"),
+    requestedReviewer: optionalString(value.requestedReviewer, "reviewerDecision.requestedReviewer")
+  };
+}
+
+function parseRuntime(value: unknown): OutcomeLedgerRuntimeInput | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw new Error("runtime must be an object");
+  return {
+    provider: optionalString(value.provider, "runtime.provider"),
+    model: optionalString(value.model, "runtime.model"),
+    startedAt: optionalString(value.startedAt, "runtime.startedAt"),
+    completedAt: optionalString(value.completedAt, "runtime.completedAt"),
+    latencyMs: optionalNonNegative(value.latencyMs, "runtime.latencyMs"),
+    providerAttempts: optionalNonNegative(value.providerAttempts, "runtime.providerAttempts"),
+    promptTokens: optionalNonNegative(value.promptTokens, "runtime.promptTokens"),
+    outputTokens: optionalNonNegative(value.outputTokens, "runtime.outputTokens"),
+    totalTokens: optionalNonNegative(value.totalTokens, "runtime.totalTokens"),
+    notes: optionalStringArray(value.notes, "runtime.notes")
+  };
+}
+
+function parsePostMergeOutcome(value: unknown): OutcomeLedgerPostMergeOutcomeInput | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw new Error("postMergeOutcome must be an object");
+  return {
+    status: parsePostMergeStatus(value.status),
+    checkedAt: optionalString(value.checkedAt, "postMergeOutcome.checkedAt"),
+    summary: optionalString(value.summary, "postMergeOutcome.summary")
+  };
+}
+
+function validateSubject(subject: OutcomeLedgerSubjectInput): void {
+  if (!REPO_SLUG_PATTERN.test(subject.repo)) throw new Error("subject.repo must be owner/repo");
+  if (subject.type === "pull_request") {
+    if (!subject.baseSha || !SHA_PATTERN.test(subject.baseSha)) throw new Error("pull_request subject requires 40-character baseSha");
+    if (!subject.headSha || !SHA_PATTERN.test(subject.headSha)) throw new Error("pull_request subject requires 40-character headSha");
+  }
+  if (subject.type === "issue" && (subject.baseSha || subject.headSha)) {
+    throw new Error("issue subject must not include baseSha or headSha");
+  }
+}
+
+function optionalArray(value: unknown, label: string): unknown[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value;
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) throw new Error(`${label} must be a non-empty string`);
+  return value.trim();
+}
+
+function optionalString(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") throw new Error(`${label} must be a string`);
+  return value.trim();
+}
+
+function optionalStringArray(value: unknown, label: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    throw new Error(`${label} must be an array of strings`);
+  }
+  return value.map((item) => item.trim()).filter(Boolean);
+}
+
+function requiredPositiveInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) throw new Error(`${label} must be a positive integer`);
+  return value;
+}
+
+function optionalNonNegative(value: unknown, label: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isFinite(value) || Number(value) < 0) throw new Error(`${label} must be a non-negative number`);
+  return Number(value);
+}
+
+function normalizeNonNegative(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : -1;
+}
+
+function parseMode(value: unknown): OutcomeLedgerMode | undefined {
+  if (value === undefined) return undefined;
+  return parseEnum(value, ["stable", "advanced_dry_run", "advanced_pr_review", "advanced_issue_research", "advanced_full"] as const, "mode");
+}
+
+function parseSubjectType(value: unknown): OutcomeLedgerSubjectType {
+  return parseEnum(value, ["pull_request", "issue"] as const, "subject.type");
+}
+
+function parseChangeType(value: unknown): OutcomeLedgerChangedArtifactInput["changeType"] {
+  if (value === undefined) return undefined;
+  return parseEnum(value, ["added", "modified", "removed", "renamed", "unknown"] as const, "changedArtifacts.changeType");
+}
+
+function parseEvidenceStatus(value: unknown): OutcomeLedgerEvidenceInput["status"] {
+  if (value === undefined) return undefined;
+  return parseEnum(value, ["pass", "fail", "pending", "missing", "unknown"] as const, "evidence.status");
+}
+
+function parseSeverity(value: unknown): "P0" | "P1" | "P2" | "P3" | undefined {
+  if (value === undefined) return undefined;
+  return parseEnum(value, ["P0", "P1", "P2", "P3"] as const, "severity");
+}
+
+function parseRiskStatus(value: unknown): OutcomeLedgerRiskClaimInput["status"] {
+  if (value === undefined) return undefined;
+  return parseEnum(value, ["validated", "unvalidated", "dismissed", "unknown"] as const, "riskClaims.status");
+}
+
+function parseSafetyGateStatus(value: unknown): OutcomeLedgerSafetyGateStatus {
+  return parseEnum(value, ["pass", "fail", "not_applicable", "unknown"] as const, "safetyGates.status");
+}
+
+function parseDecisionStatus(value: unknown): OutcomeLedgerDecisionStatus {
+  return parseEnum(value, ["block", "warn", "accept_with_evidence", "defer", "human_review", "unknown"] as const, "reviewerDecision.status");
+}
+
+function parsePostMergeStatus(value: unknown): OutcomeLedgerPostMergeStatus {
+  return parseEnum(value, ["unknown", "not_merged", "no_incident_seen", "regression_seen", "reverted", "hotfixed"] as const, "postMergeOutcome.status");
+}
+
+function parseEnum<T extends string>(value: unknown, allowed: readonly T[], label: string): T {
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
+    throw new Error(`${label} must be one of: ${allowed.join(", ")}`);
+  }
+  return value as T;
+}
+
+function sanitizeRunId(value: string): string {
+  const sanitized = value.trim().replaceAll(/[^A-Za-z0-9._-]+/g, "-").replaceAll(/^-+|-+$/g, "");
+  if (!sanitized) throw new Error("runId must contain at least one safe path character");
+  return sanitized.slice(0, 120);
+}
+
+function redact(value: string): string {
+  return redactSecrets(value);
+}
+
+function sha256Json(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function sha256File(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function listOrNone(items: string[]): string[] {
+  return items.length ? items : ["- none"];
+}
+
+function buildPlanEvidence(plan: ReviewPlan): OutcomeLedgerEvidenceInput[] {
+  const evidence: OutcomeLedgerEvidenceInput[] = [
+    {
+      id: "deterministic-gate",
+      kind: "review_gate",
+      title: "Deterministic review gate",
+      status: "pass",
+      summary: plan.deterministicGate
+        ? `${plan.deterministicGate.acceptedComments} accepted, ${plan.deterministicGate.droppedFindings} dropped.`
+        : "No deterministic gate summary available."
+    }
+  ];
+  if (plan.validation) {
+    evidence.push({
+      id: "changed-surface-validation",
+      kind: "validation",
+      title: "Changed surface validation",
+      status: "pass",
+      summary: plan.validation.summary
+    });
+  }
+  if (plan.proof) {
+    evidence.push({
+      id: "proof-requirements",
+      kind: "proof",
+      title: "Proof requirements",
+      status: plan.proof.status === "missing" ? "missing" : plan.proof.status === "sufficient" ? "pass" : "unknown",
+      summary: plan.proof.summary
+    });
+  }
+  return evidence;
+}
+
+function buildProofGaps(plan: ReviewPlan): OutcomeLedgerProofGapInput[] {
+  if (!plan.proof || plan.proof.missingRecommendationIds.length === 0) return [];
+  return plan.proof.missingRecommendationIds.map((id) => ({
+    id: `missing-${id}`,
+    severity: "P2",
+    summary: `Missing proof for recommendation ${id}.`,
+    requiredEvidence: [id]
+  }));
+}
+
+function mapReviewPlanDecision(plan: ReviewPlan): OutcomeLedgerDecisionStatus {
+  if (plan.event === "REQUEST_CHANGES") return "block";
+  if (plan.proof?.status === "missing") return "warn";
+  if (plan.comments.length > 0) return "warn";
+  return "accept_with_evidence";
+}
+
+function normalizePullFileStatus(status: string | undefined): OutcomeLedgerChangedArtifactInput["changeType"] {
+  if (status === "added" || status === "removed" || status === "renamed" || status === "modified") return status;
+  return "unknown";
+}
+
+function extractFirstRelatedIssue(text: string): string | undefined {
+  const match = text.match(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#(\d+)/i);
+  if (!match) return undefined;
+  return match[1] ? `${match[1]}#${match[2]}` : `#${match[2]}`;
+}
+
+function inferAcceptanceCriteria(body: string): string[] {
+  const lines = body.split(/\r?\n/).map((line) => line.trim());
+  const criteria = lines
+    .filter((line) => /^[-*]\s+\[[ xX]\]/.test(line) || /^[-*]\s+(acceptance|prove|verify|test)/i.test(line))
+    .map((line) => line.replace(/^[-*]\s+/, "").trim());
+  return criteria.slice(0, 8);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function assertOutcomeLedgerOutputDirEmpty(outputDir: string): void {
+  if (!existsSync(outputDir)) return;
+  const stat = statSync(outputDir);
+  if (!stat.isDirectory()) throw new Error("outputDir must be a directory when it already exists");
+  if (readdirSync(outputDir).length > 0) {
+    throw new Error("outputDir must be empty before writing outcome ledger evidence; choose a fresh output directory");
+  }
+}

--- a/src/outcome-ledger.ts
+++ b/src/outcome-ledger.ts
@@ -181,7 +181,7 @@ export interface OutcomeLedgerPacketResult {
 const REPO_SLUG_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const SHA_PATTERN = /^[0-9a-f]{40}$/i;
 const DEFAULT_PROOF_BOUNDARY =
-  "Outcome Ledger dry-run proves evidence-packet construction only. It does not post comments, change live runtime behavior, prove review accuracy, or claim production readiness.";
+  "Outcome Ledger dry-run proves evidence-packet construction only. It does not post comments, change live runtime behavior, prove review accuracy, or claim production readiness. The sha256 digest covers the redacted ledger content, not raw pre-redaction input.";
 
 export function readOutcomeLedgerInput(path: string): OutcomeLedgerInput {
   return parseOutcomeLedgerInput(JSON.parse(readFileSync(path, "utf8")));
@@ -277,6 +277,7 @@ export function buildOutcomeLedgerInputFromReviewPlan(input: {
   runtime?: OutcomeLedgerRuntimeInput;
   safetyGateEvidence?: {
     currentHead?: OutcomeLedgerSafetyGateInput;
+    duplicateSameHead?: OutcomeLedgerSafetyGateInput;
     inlineCoordinateValidation?: OutcomeLedgerSafetyGateInput;
   };
 }): OutcomeLedgerInput {
@@ -290,6 +291,13 @@ export function buildOutcomeLedgerInputFromReviewPlan(input: {
     name: "inline_coordinate_validation",
     status: "unknown" as const,
     detail: `${input.plan.comments.length} accepted inline comment(s) are present, but this generic builder did not re-run deterministic location validation.`
+  };
+  const duplicateSameHeadGate = input.safetyGateEvidence?.duplicateSameHead ?? {
+    name: "duplicate_same_head",
+    status: "unknown" as const,
+    detail: input.dryRun
+      ? "Dry-run ledger does not post public comments, but this generic builder did not check existing processed-head state."
+      : "Live duplicate state is outside this dry-run ledger."
   };
   return {
     ledgerName: "review-plan-outcome-ledger",
@@ -331,11 +339,7 @@ export function buildOutcomeLedgerInputFromReviewPlan(input: {
     proofGaps: buildProofGaps(input.plan),
     safetyGates: [
       currentHeadGate,
-      {
-        name: "duplicate_same_head",
-        status: input.dryRun ? "pass" : "unknown",
-        detail: input.dryRun ? "Dry-run ledger does not post public comments." : "Live duplicate state is outside this dry-run ledger."
-      },
+      duplicateSameHeadGate,
       inlineCoordinateGate
     ],
     reviewerDecision: {
@@ -884,7 +888,11 @@ function extractFirstRelatedIssue(text: string): string | undefined {
 function inferAcceptanceCriteria(body: string): string[] {
   const lines = body.split(/\r?\n/).map((line) => line.trim());
   const criteria = lines
-    .filter((line) => /^[-*]\s+\[[ xX]\]/.test(line) || /^[-*]\s+(acceptance|prove|verify|test)/i.test(line))
+    .filter((line) => (
+      /^[-*]\s+\[[ xX]\]/.test(line) ||
+      /^[-*]\s+(acceptance|prove|verify|test)/i.test(line) ||
+      /^[-*]\s+(must|should|needs?|requires?)\b.*\b(test|smoke|proof|evidence|verify|validation)\b/i.test(line)
+    ))
     .map((line) => line.replace(/^[-*]\s+/, "").trim());
   return criteria.slice(0, 8);
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -39,7 +39,12 @@ import {
   resolveRepoProfile
 } from "./repo-policy.js";
 import { applyDeterministicReviewGate } from "./review-gate.js";
-import { buildOutcomeLedger, buildOutcomeLedgerInputFromReviewPlan, renderOutcomeLedgerMarkdown } from "./outcome-ledger.js";
+import {
+  buildOutcomeLedger,
+  buildOutcomeLedgerInputFromReviewPlan,
+  renderOutcomeLedgerMarkdown,
+  type OutcomeLedgerRuntimeInput
+} from "./outcome-ledger.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown, type RepoMemoryPacket } from "./repo-memory.js";
 import { ReviewRunBudget } from "./review-budget.js";
 import { sanitizePublicConfidenceText, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
@@ -66,7 +71,7 @@ import {
 import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "./validation-selector.js";
 import { buildWalkthroughComment } from "./walkthrough.js";
 import { postWalkthroughComment, reviewBodyAfterWalkthroughPost } from "./walkthrough-post.js";
-import { buildReviewPrompt, runZCodeReview } from "./zcode.js";
+import { buildReviewPrompt, runZCodeReview, type ZCodeReviewResult } from "./zcode.js";
 import { formatZCodeTimeoutFailureError } from "./zcode-timeout.js";
 import type { PullFilePatch, PullRequestSummary, RepositorySummary, ReviewEvent, ReviewPlan, ReviewProviderMetadata } from "./types.js";
 
@@ -1448,7 +1453,17 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
           prompt,
           evidenceDir
         })
-      : { findings: [], droppedFromSchema: [], rawResponse: "{\"findings\":[]}" };
+      : {
+          findings: [],
+          droppedFromSchema: [],
+          rawResponse: "{\"findings\":[]}",
+          runtime: {
+            provider: config.zcode.providerId,
+            model: config.zcode.model,
+            providerAttempts: 0,
+            notes: ["ZCode execution disabled for this dry-run; provider latency and token usage were not measured."]
+          }
+        };
 
     assertGitClean(worktree.path);
 
@@ -1532,8 +1547,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         pull,
         files: reviewFiles,
         plan,
-        provider: config.zcode.providerId,
-        model: config.zcode.model
+        runtime: zcodeResult.runtime
       });
     }
     writeFileSync(join(evidenceDir, "review-plan.json"), `${JSON.stringify(plan, null, 2)}\n`);
@@ -2157,6 +2171,7 @@ export function writeDryRunOutcomeLedgerEvidence(input: {
   plan: ReviewPlan;
   provider?: string;
   model?: string;
+  runtime?: OutcomeLedgerRuntimeInput;
 }): { ok: true } | { ok: false; error: string } {
   try {
     const outcomeLedger = buildOutcomeLedger(buildOutcomeLedgerInputFromReviewPlan({
@@ -2178,8 +2193,9 @@ export function writeDryRunOutcomeLedgerEvidence(input: {
         }
       },
       runtime: {
-        provider: input.provider,
-        model: input.model
+        ...input.runtime,
+        provider: input.provider ?? input.runtime?.provider,
+        model: input.model ?? input.runtime?.model
       }
     }));
     const jsonPath = join(input.evidenceDir, "outcome-ledger.json");
@@ -2387,22 +2403,40 @@ async function runZCodeReviewWithProviderRetry(input: {
   worktreePath: string;
   prompt: string;
   evidenceDir: string;
-}): Promise<ReturnType<typeof runZCodeReview>> {
-  return runWithProviderRetry({
+}): Promise<ZCodeReviewResult & { runtime: OutcomeLedgerRuntimeInput }> {
+  const startedAt = new Date();
+  let providerAttempts = 0;
+  const result = await runWithProviderRetry({
     config: input.config,
     evidenceDir: input.evidenceDir,
-    operation: () => runZCodeReview({
-      cwd: input.worktreePath,
-      prompt: input.prompt,
-      cliPath: input.config.zcode.cliPath,
-      appConfigPath: input.config.zcode.appConfigPath,
-      model: input.config.zcode.model,
-      providerId: input.config.zcode.providerId,
-      evidenceDir: input.evidenceDir,
-      timeoutMs: input.config.zcode.timeoutMs,
-      retryMaxRetries: input.config.zcode.retryMaxRetries
-    })
+    operation: () => {
+      providerAttempts += 1;
+      return runZCodeReview({
+        cwd: input.worktreePath,
+        prompt: input.prompt,
+        cliPath: input.config.zcode.cliPath,
+        appConfigPath: input.config.zcode.appConfigPath,
+        model: input.config.zcode.model,
+        providerId: input.config.zcode.providerId,
+        evidenceDir: input.evidenceDir,
+        timeoutMs: input.config.zcode.timeoutMs,
+        retryMaxRetries: input.config.zcode.retryMaxRetries
+      });
+    }
   });
+  const completedAt = new Date();
+  return {
+    ...result,
+    runtime: {
+      provider: input.config.zcode.providerId,
+      model: input.config.zcode.model,
+      startedAt: startedAt.toISOString(),
+      completedAt: completedAt.toISOString(),
+      latencyMs: completedAt.getTime() - startedAt.getTime(),
+      providerAttempts,
+      notes: ["Token usage is not exposed by the configured ZCode provider path; token metrics remain null."]
+    }
+  };
 }
 
 export async function runWithProviderRetry<T>(input: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -39,6 +39,7 @@ import {
   resolveRepoProfile
 } from "./repo-policy.js";
 import { applyDeterministicReviewGate } from "./review-gate.js";
+import { buildOutcomeLedger, buildOutcomeLedgerInputFromReviewPlan, renderOutcomeLedgerMarkdown } from "./outcome-ledger.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown, type RepoMemoryPacket } from "./repo-memory.js";
 import { ReviewRunBudget } from "./review-budget.js";
 import { sanitizePublicConfidenceText, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
@@ -1524,6 +1525,17 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
 
     if (walkthrough) writeFileSync(join(evidenceDir, "walkthrough.md"), walkthrough.body);
     if (enrichment) writeFileSync(join(evidenceDir, "enrichment.md"), enrichment.body);
+    if (input.dryRun) {
+      writeDryRunOutcomeLedgerEvidence({
+        evidenceDir,
+        repo,
+        pull,
+        files: reviewFiles,
+        plan,
+        provider: config.zcode.providerId,
+        model: config.zcode.model
+      });
+    }
     writeFileSync(join(evidenceDir, "review-plan.json"), `${JSON.stringify(plan, null, 2)}\n`);
 
     if (input.dryRun) {
@@ -2135,6 +2147,41 @@ export function createGitHubRelatedContextReader(config: BotConfig, fallback: Gi
     ...config.github,
     requestTimeoutMs: relatedConfig.requestTimeoutMs
   });
+}
+
+export function writeDryRunOutcomeLedgerEvidence(input: {
+  evidenceDir: string;
+  repo: string;
+  pull: PullRequestSummary;
+  files: PullFilePatch[];
+  plan: ReviewPlan;
+  provider?: string;
+  model?: string;
+}): { ok: true } | { ok: false; error: string } {
+  try {
+    const outcomeLedger = buildOutcomeLedger(buildOutcomeLedgerInputFromReviewPlan({
+      repo: input.repo,
+      pull: input.pull,
+      files: input.files,
+      plan: input.plan,
+      dryRun: true,
+      runtime: {
+        provider: input.provider,
+        model: input.model
+      }
+    }));
+    writeRedactedJson(join(input.evidenceDir, "outcome-ledger.json"), outcomeLedger);
+    writeFileSync(join(input.evidenceDir, "outcome-ledger.md"), renderOutcomeLedgerMarkdown(outcomeLedger));
+    return { ok: true };
+  } catch (error) {
+    const message = redactSecrets(error instanceof Error ? error.message : String(error));
+    writeRedactedJson(join(input.evidenceDir, "outcome-ledger-error.json"), {
+      ok: false,
+      error: message,
+      proofBoundary: "Outcome Ledger dry-run evidence failed to build; stable review-plan evidence must continue."
+    });
+    return { ok: false, error: message };
+  }
 }
 
 function recordStaleHeadSkip(input: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -43,7 +43,8 @@ import {
   buildOutcomeLedger,
   buildOutcomeLedgerInputFromReviewPlan,
   renderOutcomeLedgerMarkdown,
-  type OutcomeLedgerRuntimeInput
+  type OutcomeLedgerRuntimeInput,
+  type OutcomeLedgerSafetyGateInput
 } from "./outcome-ledger.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown, type RepoMemoryPacket } from "./repo-memory.js";
 import { ReviewRunBudget } from "./review-budget.js";
@@ -1547,7 +1548,18 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         pull,
         files: reviewFiles,
         plan,
-        runtime: zcodeResult.runtime
+        runtime: zcodeResult.runtime,
+        duplicateSameHead: processed
+          ? {
+              name: "duplicate_same_head",
+              status: "unknown",
+              detail: `A processed row already existed with status ${processed.status}; dry-run review proceeded under the current processed-head policy and posts no public comments.`
+            }
+          : {
+              name: "duplicate_same_head",
+              status: "pass",
+              detail: "ReviewPull processed-head preflight found no existing processed row for this head; dry-run posts no public comments."
+            }
       });
     }
     writeFileSync(join(evidenceDir, "review-plan.json"), `${JSON.stringify(plan, null, 2)}\n`);
@@ -2172,6 +2184,7 @@ export function writeDryRunOutcomeLedgerEvidence(input: {
   provider?: string;
   model?: string;
   runtime?: OutcomeLedgerRuntimeInput;
+  duplicateSameHead?: OutcomeLedgerSafetyGateInput;
 }): { ok: true } | { ok: false; error: string } {
   try {
     const outcomeLedger = buildOutcomeLedger(buildOutcomeLedgerInputFromReviewPlan({
@@ -2185,6 +2198,11 @@ export function writeDryRunOutcomeLedgerEvidence(input: {
           name: "current_head",
           status: "pass",
           detail: "Worker reached dry-run review-plan construction after stale-head preflight."
+        },
+        duplicateSameHead: input.duplicateSameHead ?? {
+          name: "duplicate_same_head",
+          status: "pass",
+          detail: "Caller did not provide processed-head state; dry-run helper writes no public comments."
         },
         inlineCoordinateValidation: {
           name: "inline_coordinate_validation",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { isPreActivationExistingPull } from "./activation-policy.js";
 import {
@@ -2165,13 +2165,34 @@ export function writeDryRunOutcomeLedgerEvidence(input: {
       files: input.files,
       plan: input.plan,
       dryRun: true,
+      safetyGateEvidence: {
+        currentHead: {
+          name: "current_head",
+          status: "pass",
+          detail: "Worker reached dry-run review-plan construction after stale-head preflight."
+        },
+        inlineCoordinateValidation: {
+          name: "inline_coordinate_validation",
+          status: "pass",
+          detail: `${input.plan.comments.length} accepted inline comment(s) survived deterministic location validation before review-plan evidence was written.`
+        }
+      },
       runtime: {
         provider: input.provider,
         model: input.model
       }
     }));
-    writeRedactedJson(join(input.evidenceDir, "outcome-ledger.json"), outcomeLedger);
-    writeFileSync(join(input.evidenceDir, "outcome-ledger.md"), renderOutcomeLedgerMarkdown(outcomeLedger));
+    const jsonPath = join(input.evidenceDir, "outcome-ledger.json");
+    const markdownPath = join(input.evidenceDir, "outcome-ledger.md");
+    const markdown = renderOutcomeLedgerMarkdown(outcomeLedger);
+    try {
+      writeRedactedJson(jsonPath, outcomeLedger);
+      writeFileSync(markdownPath, markdown);
+    } catch (error) {
+      rmSync(jsonPath, { force: true });
+      rmSync(markdownPath, { force: true });
+      throw error;
+    }
     return { ok: true };
   } catch (error) {
     const message = redactSecrets(error instanceof Error ? error.message : String(error));

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2451,8 +2451,10 @@ async function runZCodeReviewWithProviderRetry(input: {
       startedAt: startedAt.toISOString(),
       completedAt: completedAt.toISOString(),
       latencyMs: completedAt.getTime() - startedAt.getTime(),
-      providerAttempts,
-      notes: ["Token usage is not exposed by the configured ZCode provider path; token metrics remain null."]
+      notes: [
+        `Observed outer provider retry attempts: ${providerAttempts}.`,
+        "Internal ZCode retry attempts and token usage are not exposed by the configured provider path; providerAttempts and token metrics remain null."
+      ]
     }
   };
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2189,8 +2189,8 @@ export function writeDryRunOutcomeLedgerEvidence(input: {
       writeRedactedJson(jsonPath, outcomeLedger);
       writeFileSync(markdownPath, markdown);
     } catch (error) {
-      rmSync(jsonPath, { force: true });
-      rmSync(markdownPath, { force: true });
+      rmSync(jsonPath, { force: true, recursive: true });
+      rmSync(markdownPath, { force: true, recursive: true });
       throw error;
     }
     return { ok: true };

--- a/tests/outcome-ledger.test.ts
+++ b/tests/outcome-ledger.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -195,7 +195,8 @@ describe("outcome ledger", () => {
       },
       safetyGates: expect.arrayContaining([
         expect.objectContaining({ name: "duplicate_same_head", status: "pass" }),
-        expect.objectContaining({ name: "inline_coordinate_validation", status: "pass" })
+        expect.objectContaining({ name: "current_head", status: "unknown" }),
+        expect.objectContaining({ name: "inline_coordinate_validation", status: "unknown" })
       ])
     });
   });
@@ -303,6 +304,26 @@ describe("outcome ledger", () => {
       ok: false,
       proofBoundary: "Outcome Ledger dry-run evidence failed to build; stable review-plan evidence must continue."
     });
+  });
+
+  it("removes partial worker success artifacts when markdown write fails", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-outcome-ledger-worker-partial-"));
+    roots.push(root);
+    mkdirSync(join(root, "outcome-ledger.md"));
+
+    const result = writeDryRunOutcomeLedgerEvidence({
+      evidenceDir: root,
+      repo: "owner/repo",
+      pull: samplePull(),
+      files: sampleFiles(),
+      plan: sampleReviewPlan(),
+      provider: "zcode",
+      model: "glm-5.2"
+    });
+
+    expect(result).toMatchObject({ ok: false });
+    expect(existsSync(join(root, "outcome-ledger-error.json"))).toBe(true);
+    expect(existsSync(join(root, "outcome-ledger.json"))).toBe(false);
   });
 });
 

--- a/tests/outcome-ledger.test.ts
+++ b/tests/outcome-ledger.test.ts
@@ -84,6 +84,23 @@ describe("outcome ledger", () => {
     expect(ledger.metrics.failedSafetyGates).toBe(1);
   });
 
+  it("marks unknown safety gates non-ok without treating them as failed", () => {
+    const ledger = buildOutcomeLedger(sampleInput({
+      safetyGates: [
+        { name: "current_head", status: "unknown", detail: "not checked in this dry run" }
+      ]
+    }));
+
+    expect(ledger.ok).toBe(false);
+    expect(ledger.hardGateStatus).toMatchObject({
+      ok: false,
+      failed: [],
+      unknown: ["current_head"]
+    });
+    expect(ledger.metrics.unknownSafetyGates).toBe(1);
+  });
+
+
   it("redacts secret-like evidence and marks the packet non-ok", () => {
     const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
     const ledger = buildOutcomeLedger(sampleInput({
@@ -194,7 +211,7 @@ describe("outcome ledger", () => {
     const ledger = buildOutcomeLedger(ledgerInput);
 
     expect(ledger).toMatchObject({
-      ok: true,
+      ok: false,
       subject: {
         repo: "owner/repo",
         number: 42,
@@ -214,7 +231,7 @@ describe("outcome ledger", () => {
         {
           severity: "P1",
           category: "runtime_correctness",
-          status: "validated"
+          status: "unvalidated"
         }
       ],
       reviewerDecision: {
@@ -224,7 +241,12 @@ describe("outcome ledger", () => {
         expect.objectContaining({ name: "duplicate_same_head", status: "pass" }),
         expect.objectContaining({ name: "current_head", status: "unknown" }),
         expect.objectContaining({ name: "inline_coordinate_validation", status: "unknown" })
-      ])
+      ]),
+      hardGateStatus: {
+        ok: false,
+        failed: [],
+        unknown: ["current_head", "inline_coordinate_validation"]
+      }
     });
   });
 

--- a/tests/outcome-ledger.test.ts
+++ b/tests/outcome-ledger.test.ts
@@ -142,6 +142,33 @@ describe("outcome ledger", () => {
       ok: true,
       runId: "lco-461-agent-provenance"
     });
+    expect(Object.keys(manifest.artifactInventory).sort()).toEqual([
+      "outcome-ledger.json",
+      "outcome-ledger.md",
+      "redaction-report.json"
+    ].sort());
+    expect(Object.keys(result.artifacts).sort()).toEqual([
+      "manifest.json",
+      "outcome-ledger.json",
+      "outcome-ledger.md",
+      "redaction-report.json"
+    ].sort());
+  });
+
+  it("removes packet artifacts written before a mid-sequence failure", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-outcome-ledger-partial-packet-"));
+    roots.push(root);
+    mkdirSync(join(root, "outcome-ledger.md"));
+
+    expect(() => writeOutcomeLedgerPacket({
+      ledgerInput: sampleInput(),
+      outputDir: root,
+      now: new Date("2026-07-05T12:00:00Z")
+    })).toThrow();
+
+    expect(existsSync(join(root, "outcome-ledger.json"))).toBe(false);
+    expect(existsSync(join(root, "redaction-report.json"))).toBe(false);
+    expect(existsSync(join(root, "manifest.json"))).toBe(false);
   });
 
   it("rejects invalid pull request subjects without base and head shas", () => {

--- a/tests/outcome-ledger.test.ts
+++ b/tests/outcome-ledger.test.ts
@@ -135,6 +135,45 @@ describe("outcome ledger", () => {
     ]));
   });
 
+  it("overrides a caller-supplied passing secret redaction gate when secrets are present", () => {
+    const token = ["ghp", "abcdef1234567890abcdef1234567890abcd"].join("_");
+    const ledger = buildOutcomeLedger({
+      runId: "secret-gate-override",
+      subject: {
+        type: "issue",
+        repo: "owner/repo",
+        number: 123
+      },
+      evidence: [
+        {
+          kind: "log",
+          title: "Provider output",
+          summary: `raw output included ${token}`
+        }
+      ],
+      safetyGates: [
+        { name: "secret_redaction", status: "pass", detail: "caller claimed clean" }
+      ],
+      reviewerDecision: {
+        status: "warn"
+      },
+      postMergeOutcome: {
+        status: "unknown"
+      }
+    });
+
+    expect(ledger.ok).toBe(false);
+    expect(JSON.stringify(ledger)).not.toContain(token);
+    expect(ledger.safetyGates).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: "secret_redaction",
+        status: "fail",
+        detail: "Secret-like text detected; see redaction report."
+      })
+    ]));
+  });
+
+
   it("writes a JSON, Markdown, redaction, and manifest evidence packet", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-outcome-ledger-"));
     roots.push(root);
@@ -218,7 +257,11 @@ describe("outcome ledger", () => {
         headSha: "2222222222222222222222222222222222222222"
       },
       intent: {
-        sourceIssue: "owner/repo#41"
+        sourceIssue: "owner/repo#41",
+        acceptanceCriteria: [
+          "[ ] Verify runtime smoke",
+          "Must include focused test evidence"
+        ]
       },
       changedArtifacts: [
         {
@@ -238,14 +281,14 @@ describe("outcome ledger", () => {
         status: "block"
       },
       safetyGates: expect.arrayContaining([
-        expect.objectContaining({ name: "duplicate_same_head", status: "pass" }),
+        expect.objectContaining({ name: "duplicate_same_head", status: "unknown" }),
         expect.objectContaining({ name: "current_head", status: "unknown" }),
         expect.objectContaining({ name: "inline_coordinate_validation", status: "unknown" })
       ]),
       hardGateStatus: {
         ok: false,
         failed: [],
-        unknown: ["current_head", "inline_coordinate_validation"]
+        unknown: ["current_head", "duplicate_same_head", "inline_coordinate_validation"]
       }
     });
   });
@@ -474,7 +517,7 @@ function samplePull(): PullRequestSummary {
     number: 42,
     title: "Fixes owner/repo#41 runtime handoff",
     draft: false,
-    body: "- [ ] Verify runtime smoke",
+    body: "- [ ] Verify runtime smoke\n- Must include focused test evidence",
     head: {
       sha: "2222222222222222222222222222222222222222",
       ref: "feature/runtime"

--- a/tests/outcome-ledger.test.ts
+++ b/tests/outcome-ledger.test.ts
@@ -1,0 +1,489 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildOutcomeLedger,
+  buildOutcomeLedgerInputFromReviewPlan,
+  parseOutcomeLedgerInput,
+  writeOutcomeLedgerPacket,
+  type OutcomeLedgerInput
+} from "../src/outcome-ledger.js";
+import type { PullFilePatch, PullRequestSummary, ReviewPlan } from "../src/types.js";
+import { writeDryRunOutcomeLedgerEvidence } from "../src/worker.js";
+
+const nodeRequire = createRequire(import.meta.url);
+const tsxCli = nodeRequire.resolve("tsx/cli");
+
+describe("outcome ledger", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("builds a dry-run ledger with normalized outcome fields and hard gates", () => {
+    const ledger = buildOutcomeLedger(sampleInput(), {
+      now: new Date("2026-07-05T12:00:00Z")
+    });
+
+    expect(ledger).toMatchObject({
+      artifactVersion: "0.1",
+      ok: true,
+      runId: "lco-461-agent-provenance",
+      mode: "advanced_dry_run",
+      generatedAt: "2026-07-05T12:00:00.000Z",
+      subject: {
+        type: "pull_request",
+        repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+        number: 461,
+        headSha: "144d0cc9506b8d2dba7115174b86b67c03b371cc"
+      },
+      reviewerDecision: {
+        status: "warn"
+      },
+      hardGateStatus: {
+        ok: true,
+        failed: []
+      },
+      metrics: {
+        changedArtifacts: 1,
+        evidenceRecords: 2,
+        riskClaims: 1,
+        proofGaps: 1,
+        failedSafetyGates: 0,
+        latencyMs: 420000,
+        providerAttempts: 1,
+        estimatedTokens: 5000
+      },
+      redaction: {
+        ok: true
+      }
+    });
+    expect(ledger.sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(ledger.proofBoundary).toContain("does not post comments");
+  });
+
+  it("fails closed when a hard safety gate fails", () => {
+    const input = sampleInput({
+      safetyGates: [
+        { name: "current_head", status: "pass", detail: "head matched" },
+        { name: "duplicate_same_head", status: "fail", detail: "duplicate marker found" }
+      ]
+    });
+
+    const ledger = buildOutcomeLedger(input);
+
+    expect(ledger.ok).toBe(false);
+    expect(ledger.hardGateStatus).toMatchObject({
+      ok: false,
+      failed: ["duplicate_same_head"]
+    });
+    expect(ledger.metrics.failedSafetyGates).toBe(1);
+  });
+
+  it("redacts secret-like evidence and marks the packet non-ok", () => {
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+    const ledger = buildOutcomeLedger(sampleInput({
+      evidence: [
+        {
+          id: "raw-log",
+          kind: "log",
+          title: "Raw provider log",
+          status: "pass",
+          summary: `provider emitted ${token}`
+        }
+      ]
+    }));
+
+    expect(ledger.ok).toBe(false);
+    expect(JSON.stringify(ledger)).not.toContain(token);
+    expect(ledger.redaction).toMatchObject({
+      ok: false,
+      redactedSources: [
+        {
+          id: "input.evidence[0].summary",
+          redactedPreview: "provider emitted [redacted-secret]"
+        }
+      ]
+    });
+    expect(ledger.safetyGates).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: "secret_redaction",
+        status: "fail",
+        detail: "Secret-like text detected; see redaction report."
+      })
+    ]));
+  });
+
+  it("writes a JSON, Markdown, redaction, and manifest evidence packet", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-outcome-ledger-"));
+    roots.push(root);
+
+    const result = writeOutcomeLedgerPacket({
+      ledgerInput: sampleInput(),
+      outputDir: root,
+      now: new Date("2026-07-05T12:00:00Z")
+    });
+
+    expect(result.ok).toBe(true);
+    for (const artifact of ["outcome-ledger.json", "outcome-ledger.md", "redaction-report.json", "manifest.json"]) {
+      expect(existsSync(join(root, artifact)), artifact).toBe(true);
+      expect(result.artifacts[artifact]).toMatch(/^[a-f0-9]{64}$/);
+    }
+    const markdown = readFileSync(join(root, "outcome-ledger.md"), "utf8");
+    expect(markdown).toContain("# Outcome Ledger: 100yenadmin/Lossless-Codex-Orchestrator-LCO#461");
+    expect(markdown).toContain("Outcome Ledger dry-run proves evidence-packet construction only.");
+    const manifest = JSON.parse(readFileSync(join(root, "manifest.json"), "utf8"));
+    expect(manifest).toMatchObject({
+      artifactVersion: "0.1",
+      ok: true,
+      runId: "lco-461-agent-provenance"
+    });
+  });
+
+  it("rejects invalid pull request subjects without base and head shas", () => {
+    expect(() => parseOutcomeLedgerInput({
+      runId: "bad",
+      subject: {
+        type: "pull_request",
+        repo: "owner/repo",
+        number: 1
+      }
+    })).toThrow("pull_request subject requires 40-character baseSha");
+  });
+
+  it("derives a ledger input from an existing dry-run review plan", () => {
+    const ledgerInput = buildOutcomeLedgerInputFromReviewPlan({
+      repo: "owner/repo",
+      pull: samplePull(),
+      files: sampleFiles(),
+      plan: sampleReviewPlan(),
+      dryRun: true
+    });
+
+    const ledger = buildOutcomeLedger(ledgerInput);
+
+    expect(ledger).toMatchObject({
+      ok: true,
+      subject: {
+        repo: "owner/repo",
+        number: 42,
+        headSha: "2222222222222222222222222222222222222222"
+      },
+      intent: {
+        sourceIssue: "owner/repo#41"
+      },
+      changedArtifacts: [
+        {
+          path: "src/runtime.ts",
+          changeType: "modified",
+          riskAreas: ["Runtime smoke"]
+        }
+      ],
+      riskClaims: [
+        {
+          severity: "P1",
+          category: "runtime_correctness",
+          status: "validated"
+        }
+      ],
+      reviewerDecision: {
+        status: "block"
+      },
+      safetyGates: expect.arrayContaining([
+        expect.objectContaining({ name: "duplicate_same_head", status: "pass" }),
+        expect.objectContaining({ name: "inline_coordinate_validation", status: "pass" })
+      ])
+    });
+  });
+
+  it("exposes a dry-run-only CLI that writes an evidence packet", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-outcome-ledger-cli-"));
+    roots.push(root);
+    const inputPath = join(root, "input.json");
+    const outputDir = join(root, "packet");
+    writeFileSync(inputPath, `${JSON.stringify(sampleInput(), null, 2)}\n`);
+
+    const output = execFileSync(process.execPath, [
+      tsxCli,
+      "src/cli.ts",
+      "outcome-ledger",
+      "--input",
+      inputPath,
+      "--dry-run",
+      "true",
+      "--output-dir",
+      outputDir
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8"
+    });
+
+    const parsed = JSON.parse(output);
+    expect(parsed).toMatchObject({
+      ok: true,
+      command: "outcome-ledger",
+      dryRun: true
+    });
+    expect(parsed.outputDir).toContain("/packet");
+    expect(existsSync(join(outputDir, "outcome-ledger.json"))).toBe(true);
+  });
+
+  it("requires output-dir for CLI portability", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-outcome-ledger-output-required-"));
+    roots.push(root);
+    const inputPath = join(root, "input.json");
+    writeFileSync(inputPath, `${JSON.stringify(sampleInput(), null, 2)}\n`);
+
+    expect(() => execFileSync(process.execPath, [
+      tsxCli,
+      "src/cli.ts",
+      "outcome-ledger",
+      "--input",
+      inputPath
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      stdio: "pipe"
+    })).toThrow("--output-dir is required for outcome-ledger");
+  });
+
+  it("refuses non-dry-run CLI execution", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-outcome-ledger-live-"));
+    roots.push(root);
+    const inputPath = join(root, "input.json");
+    writeFileSync(inputPath, `${JSON.stringify(sampleInput(), null, 2)}\n`);
+
+    expect(() => execFileSync(process.execPath, [
+      tsxCli,
+      "src/cli.ts",
+      "outcome-ledger",
+      "--input",
+      inputPath,
+      "--dry-run",
+      "false",
+      "--output-dir",
+      join(root, "packet")
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      stdio: "pipe"
+    })).toThrow("outcome-ledger is dry-run only in this release");
+  });
+
+  it("isolates dry-run worker ledger build failures into an error artifact", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-outcome-ledger-worker-error-"));
+    roots.push(root);
+    const invalidPull = {
+      ...samplePull(),
+      head: {
+        ...samplePull().head,
+        sha: "short"
+      }
+    };
+
+    const result = writeDryRunOutcomeLedgerEvidence({
+      evidenceDir: root,
+      repo: "owner/repo",
+      pull: invalidPull,
+      files: sampleFiles(),
+      plan: sampleReviewPlan(),
+      provider: "zcode",
+      model: "glm-5.2"
+    });
+
+    expect(result).toMatchObject({ ok: false });
+    expect(existsSync(join(root, "outcome-ledger-error.json"))).toBe(true);
+    expect(existsSync(join(root, "outcome-ledger.json"))).toBe(false);
+    const error = JSON.parse(readFileSync(join(root, "outcome-ledger-error.json"), "utf8"));
+    expect(error).toMatchObject({
+      ok: false,
+      proofBoundary: "Outcome Ledger dry-run evidence failed to build; stable review-plan evidence must continue."
+    });
+  });
+});
+
+function sampleInput(overrides: Partial<OutcomeLedgerInput> = {}): OutcomeLedgerInput {
+  return {
+    ledgerName: "Outcome Ledger fixture",
+    runId: "lco-461-agent-provenance",
+    mode: "advanced_dry_run",
+    subject: {
+      type: "pull_request",
+      repo: "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+      number: 461,
+      title: "[codex] Add agent provenance schema parser",
+      url: "https://github.com/100yenadmin/Lossless-Codex-Orchestrator-LCO/pull/461",
+      baseSha: "0000000000000000000000000000000000000000",
+      headSha: "144d0cc9506b8d2dba7115174b86b67c03b371cc",
+      author: "codex",
+      labels: ["codex"]
+    },
+    intent: {
+      summary: "Add provenance parsing so downstream agents can reason about who created generated artifacts.",
+      sourceIssue: "100yenadmin/Lossless-Codex-Orchestrator-LCO#460",
+      acceptanceCriteria: ["Parses known provenance schema", "Rejects malformed provenance payloads"],
+      nonGoals: ["Do not change agent scheduling"]
+    },
+    changedArtifacts: [
+      {
+        path: "src/provenance/schema.ts",
+        changeType: "added",
+        summary: "Adds schema parser.",
+        riskAreas: ["agent handoff", "metadata compatibility"]
+      }
+    ],
+    evidence: [
+      {
+        id: "focused-test",
+        kind: "test",
+        title: "Focused parser tests",
+        status: "pass",
+        summary: "Parser fixtures passed."
+      },
+      {
+        id: "stable-mode",
+        kind: "runtime",
+        title: "Stable mode untouched",
+        status: "pass",
+        summary: "No launchd or active config change."
+      }
+    ],
+    riskClaims: [
+      {
+        id: "schema-compat",
+        severity: "P2",
+        category: "api_compatibility",
+        claim: "Malformed provenance payloads could block downstream agents.",
+        evidenceIds: ["focused-test"],
+        status: "validated"
+      }
+    ],
+    proofGaps: [
+      {
+        id: "integration-smoke",
+        severity: "P3",
+        summary: "Needs downstream agent handoff smoke before claiming workflow improvement.",
+        requiredEvidence: ["agent handoff transcript"]
+      }
+    ],
+    safetyGates: [
+      { name: "current_head", status: "pass", detail: "head matched" },
+      { name: "duplicate_same_head", status: "pass", detail: "no public posting in dry-run" },
+      { name: "secret_redaction", status: "pass", detail: "no secret-like content" }
+    ],
+    reviewerDecision: {
+      status: "warn",
+      reason: "Useful but needs downstream smoke for outcome claim."
+    },
+    runtime: {
+      provider: "zcode",
+      model: "glm-5.2",
+      startedAt: "2026-07-05T11:53:00.000Z",
+      completedAt: "2026-07-05T12:00:00.000Z",
+      latencyMs: 420000,
+      providerAttempts: 1,
+      promptTokens: 3000,
+      outputTokens: 2000,
+      totalTokens: 5000
+    },
+    postMergeOutcome: {
+      status: "unknown",
+      checkedAt: "2026-07-05T12:00:00.000Z",
+      summary: "Not merged at ledger creation time."
+    },
+    ...overrides
+  };
+}
+
+function samplePull(): PullRequestSummary {
+  return {
+    number: 42,
+    title: "Fixes owner/repo#41 runtime handoff",
+    draft: false,
+    body: "- [ ] Verify runtime smoke",
+    head: {
+      sha: "2222222222222222222222222222222222222222",
+      ref: "feature/runtime"
+    },
+    base: {
+      sha: "1111111111111111111111111111111111111111",
+      ref: "main",
+      repo: {
+        full_name: "owner/repo"
+      }
+    },
+    html_url: "https://github.com/owner/repo/pull/42",
+    labels: [{ name: "runtime" }]
+  };
+}
+
+function sampleFiles(): PullFilePatch[] {
+  return [
+    {
+      filename: "src/runtime.ts",
+      status: "modified",
+      changes: 12,
+      additions: 8,
+      deletions: 4
+    }
+  ];
+}
+
+function sampleReviewPlan(): ReviewPlan {
+  return {
+    event: "REQUEST_CHANGES",
+    comments: [
+      {
+        path: "src/runtime.ts",
+        line: 10,
+        side: "RIGHT",
+        body: "Runtime handoff can still lose provider state.",
+        severity: "P1",
+        category: "runtime_correctness",
+        title: "Preserve provider state"
+      }
+    ],
+    dropped: [],
+    summary: "Found a runtime correctness blocker.",
+    deterministicGate: {
+      inputFindings: 1,
+      acceptedComments: 1,
+      droppedFindings: 0,
+      event: "REQUEST_CHANGES",
+      requestChangesEligible: 1,
+      categoryCounts: {
+        runtime_correctness: 1
+      },
+      dropReasonCounts: {}
+    },
+    validation: {
+      summary: "Runtime code changed.",
+      docsOnly: false,
+      recommendations: [
+        {
+          id: "runtime-smoke",
+          title: "Runtime smoke",
+          status: "required",
+          reason: "Runtime handoff changed.",
+          matchedPaths: ["src/runtime.ts"],
+          proofTypes: ["smoke"]
+        }
+      ],
+      profileHints: {
+        validationHints: [],
+        proofExpectations: []
+      }
+    },
+    proof: {
+      status: "sufficient",
+      summary: "Focused smoke proof was provided.",
+      requiredRecommendationIds: ["runtime-smoke"],
+      missingRecommendationIds: [],
+      detectedEvidence: ["smoke"]
+    }
+  };
+}

--- a/tests/worker-settings-preview.test.ts
+++ b/tests/worker-settings-preview.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -83,6 +83,55 @@ describe("worker review settings preview evidence", () => {
     expect(walkthrough).toContain("- Enabled sections: Review summary (inline_review); Walkthrough (inline_review)");
     expect(walkthrough).toContain("- Path instructions: `src/\\`templates\\`/**`");
     expect(walkthrough).not.toContain(secretLikeToken);
+    state.close();
+  });
+
+  it("keeps dry-run review-plan evidence when outcome ledger build fails", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-outcome-ledger-failure-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    config.walkthrough.enabled = false;
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(1411, "short-head-sha");
+    const github = {
+      getPull: async () => pull,
+      listPullFiles: async () => [
+        {
+          filename: "src/runtime.ts",
+          status: "modified",
+          additions: 1,
+          deletions: 1,
+          changes: 2
+        }
+      ],
+      canPostAsApp: () => false
+    } as unknown as GitHubApi;
+
+    const result = await reviewPull({
+      config,
+      github,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: true,
+      useZCode: false
+    });
+
+    expect(result).toBe("reviewed");
+    const evidenceDir = join(
+      root,
+      "evidence",
+      localDateFolder(),
+      "electricsheephq__WorldOS",
+      "pr-1411",
+      pull.head.sha
+    );
+    expect(existsSync(join(evidenceDir, "review-plan.json"))).toBe(true);
+    expect(existsSync(join(evidenceDir, "outcome-ledger-error.json"))).toBe(true);
+    expect(existsSync(join(evidenceDir, "outcome-ledger.json"))).toBe(false);
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "dry_run"
+    });
     state.close();
   });
 

--- a/tests/worker-settings-preview.test.ts
+++ b/tests/worker-settings-preview.test.ts
@@ -71,6 +71,7 @@ describe("worker review settings preview evidence", () => {
     );
     const preview = JSON.parse(readFileSync(join(evidenceDir, "review-settings-preview.json"), "utf8"));
     const walkthrough = readFileSync(join(evidenceDir, "walkthrough.md"), "utf8");
+    const ledger = JSON.parse(readFileSync(join(evidenceDir, "outcome-ledger.json"), "utf8"));
 
     expect(preview.sections).toContainEqual({
       key: "reviewSummary",
@@ -83,6 +84,12 @@ describe("worker review settings preview evidence", () => {
     expect(walkthrough).toContain("- Enabled sections: Review summary (inline_review); Walkthrough (inline_review)");
     expect(walkthrough).toContain("- Path instructions: `src/\\`templates\\`/**`");
     expect(walkthrough).not.toContain(secretLikeToken);
+    expect(ledger.runtime).toMatchObject({
+      provider: "zcode-glm",
+      model: "GLM-5.2",
+      providerAttempts: 0,
+      notes: ["ZCode execution disabled for this dry-run; provider latency and token usage were not measured."]
+    });
     state.close();
   });
 


### PR DESCRIPTION
## Summary

Closes #267. Part of #269 and #260.

Adds the first Advanced Outcome Modes artifact: an internal Outcome Ledger that records PR/issue intent, changed artifacts, evidence, risk claims, proof gaps, safety gates, reviewer decision, runtime metrics, and post-merge placeholder.

## What changed

- Added `src/outcome-ledger.ts` as a pure artifact builder/renderer with redaction and hard-gate status.
- Added `outcome-ledger` CLI command, dry-run only in this release.
- Added worker dry-run evidence output: `outcome-ledger.json` and `outcome-ledger.md` beside `review-plan.json`.
- Saved the Advanced Outcome Modes rollout plan in `docs/advanced-outcome-modes.md`.
- Added focused tests for builder, CLI, redaction, hard gates, and review-plan-derived ledgers.

## Non-goals

- No live posting changes.
- No launchd or active config changes.
- No scheduler/provider retry changes.
- No calibrated 95% accuracy or competitor parity claim.

## Evidence

Local evidence packet generated with the new CLI:

`/Volumes/LEXAR/Codex/evals/evaos-reviewer-benchmark/2026-07-05/advanced-outcome-modes-v0.1/lco-461-agent-provenance/`

Artifacts: `outcome-ledger.json`, `outcome-ledger.md`, `redaction-report.json`, `manifest.json`.

## Validation

- `npm test -- tests/outcome-ledger.test.ts tests/worker-failure.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `npx tsx src/cli.ts outcome-ledger --input /Volumes/LEXAR/Codex/evals/evaos-reviewer-benchmark/2026-07-05/advanced-outcome-modes-v0.1/fixture-inputs/lco-461-agent-provenance.json --dry-run true --output-dir /Volumes/LEXAR/Codex/evals/evaos-reviewer-benchmark/2026-07-05/advanced-outcome-modes-v0.1/lco-461-agent-provenance`

## Proof boundary

This proves dry-run outcome-ledger packet construction and worker dry-run evidence emission only. It does not prove live review quality, production readiness, CodeRabbit/ClawSweeper/Looper parity, or calibrated confidence.
