### PR TITLE
Add issue-enrichment scorecard fixtures

### DIFF
--- a/docs/evals/issue-enrichment-scorecard.md
+++ b/docs/evals/issue-enrichment-scorecard.md
@@ -17,7 +17,7 @@ Scores above `3` require at least one direct evidence link on that case/dimensio
 
 For example, `duplicate-same-head-comments` scored on `proof_boundary` must link to `#direct-evidence-duplicate-same-head-comments-proof-boundary`. A generic parent issue URL is not enough for high scores.
 
-Direct evidence links must be `https` URLs on the same host and path as the fixture case's `fixtureSource`. Query strings are not part of the evidence identity, so fixture authors can add tracking or version query parameters without forcing every evidence link to duplicate them. The anchor alone is not enough; synthetic links such as `https://example.com/#direct-evidence-...` fail validation.
+Fixture sources and direct evidence links must be `https` URLs on the canonical issue-enrichment evidence issue: `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264`. Query strings are not part of the evidence identity, so fixture authors can add tracking or version query parameters without forcing every evidence link to duplicate them. The anchor alone is not enough; synthetic links such as `https://example.com/#direct-evidence-...` fail validation.
 
 The current weights are intentionally differentiated so `weightedScore` is not a duplicate of `rawScore`. Proof boundary, throttling, acceptance criteria, related-context precision, and safety carry higher weight because a failure in those dimensions can create misleading readiness or noisy live-posting signals.
 

--- a/docs/evals/issue-enrichment-scorecard.md
+++ b/docs/evals/issue-enrichment-scorecard.md
@@ -1,0 +1,61 @@
+# Issue-Enrichment Scorecard
+
+This scorecard is a standalone advisory fixture contract for issue enrichment. It is not wired into the CLI or worker yet, and it does not make a public parity, calibrated-confidence, runtime-safety, or release-readiness claim.
+
+## Dimensions
+
+Each dimension is scored from `0` to `5`. The evaluator returns both:
+
+- `rawScore`: unweighted average across the ten dimensions.
+- `weightedScore`: dimension-weighted average using the executable weights in `src/issue-enrichment-scorecard.ts`.
+
+Scores above `3` require at least one direct evidence link on that case/dimension cell. The validator rejects high scores without direct `http` or `https` evidence links.
+
+The current dimensions are:
+
+- related-context precision
+- planning value
+- acceptance criteria
+- ownership/routing
+- proof boundary
+- lifecycle state
+- noise control
+- idempotency
+- safety
+- throttling
+
+## Metric Contracts
+
+Each dimension owns an executable metric contract with:
+
+- `denominator`: what population the score applies to.
+- `dataSource`: the evidence source used for scoring.
+- `scoringRule`: how to interpret the `0` to `5` score.
+- `unmeasurableState`: when the dimension should be reported as unmeasurable instead of silently scored as zero.
+- `pilotThreshold`: advisory and promotion minimums for pilot interpretation.
+
+## Fixture Coverage
+
+The sampled regression packet at `tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json` covers:
+
+- duplicate same-head comments
+- stale-head posts
+- invalid inline coordinates
+- issue-enrichment permission failure
+- launchd/config/head ambiguity
+- docs-only fast negative control
+- old-backlog negative control
+- external-precedent-required issue
+- stale or irrelevant web result
+- 30-PR provider-failure burst simulation
+
+## Proof Boundary
+
+The fixture packet is advisory fixture scoring only. It can show whether the scorecard contract, evidence-link requirements, negative controls, and unmeasurable-state handling are executable. It cannot prove live issue-comment quality, public product parity, calibrated model confidence, provider reliability, launchd safety, or release readiness.
+
+## Known Limitations
+
+- The sampled packet uses seeded regression expectations, not statistically calibrated production labels.
+- The 30-PR provider-failure burst is simulated and does not call live GitHub or provider APIs.
+- External precedent coverage is represented by sampled fixture cells, not a full current-web retrieval benchmark.
+- The evaluator does not post comments, mutate labels, update assignees, change config, restart launchd, tag, release, or promote runtime state.

--- a/docs/evals/issue-enrichment-scorecard.md
+++ b/docs/evals/issue-enrichment-scorecard.md
@@ -17,7 +17,7 @@ Scores above `3` require at least one direct evidence link on that case/dimensio
 
 For example, `duplicate-same-head-comments` scored on `proof_boundary` must link to `#direct-evidence-duplicate-same-head-comments-proof-boundary`. A generic parent issue URL is not enough for high scores.
 
-Direct evidence links must be `https` URLs on the same host and path as the fixture case's `fixtureSource`. The anchor alone is not enough; synthetic links such as `https://example.com/#direct-evidence-...` fail validation.
+Direct evidence links must be `https` URLs on the same host and path as the fixture case's `fixtureSource`. Query strings are not part of the evidence identity, so fixture authors can add tracking or version query parameters without forcing every evidence link to duplicate them. The anchor alone is not enough; synthetic links such as `https://example.com/#direct-evidence-...` fail validation.
 
 The current weights are intentionally differentiated so `weightedScore` is not a duplicate of `rawScore`. Proof boundary, throttling, acceptance criteria, related-context precision, and safety carry higher weight because a failure in those dimensions can create misleading readiness or noisy live-posting signals.
 

--- a/docs/evals/issue-enrichment-scorecard.md
+++ b/docs/evals/issue-enrichment-scorecard.md
@@ -9,7 +9,7 @@ Each dimension is scored from `0` to `5`. The evaluator returns both:
 - `rawScore`: unweighted average across the ten dimensions.
 - `weightedScore`: dimension-weighted average using the executable weights in `src/issue-enrichment-scorecard.ts`.
 
-Scores above `3` require at least one direct evidence link on that case/dimension cell. The validator rejects high scores unless an `http` or `https` evidence URL includes an exact direct-evidence anchor for the scored case and dimension:
+Scores above `3` require at least one direct evidence link on that case/dimension cell. The validator rejects high scores unless an `https` evidence URL includes an exact direct-evidence anchor for the scored case and dimension:
 
 ```text
 #direct-evidence-<case-id>-<dimension-id-with-dashes>
@@ -17,7 +17,11 @@ Scores above `3` require at least one direct evidence link on that case/dimensio
 
 For example, `duplicate-same-head-comments` scored on `proof_boundary` must link to `#direct-evidence-duplicate-same-head-comments-proof-boundary`. A generic parent issue URL is not enough for high scores.
 
+Direct evidence links must be `https` URLs on the same host and path as the fixture case's `fixtureSource`. The anchor alone is not enough; synthetic links such as `https://example.com/#direct-evidence-...` fail validation.
+
 The current weights are intentionally differentiated so `weightedScore` is not a duplicate of `rawScore`. Proof boundary, throttling, acceptance criteria, related-context precision, and safety carry higher weight because a failure in those dimensions can create misleading readiness or noisy live-posting signals.
+
+Per-dimension score records expose `weightedContribution`, which is the dimension's raw average multiplied by that dimension's weight. The top-level `weightedScore` is the normalized `0` to `100` aggregate.
 
 The current dimensions are:
 

--- a/docs/evals/issue-enrichment-scorecard.md
+++ b/docs/evals/issue-enrichment-scorecard.md
@@ -9,7 +9,13 @@ Each dimension is scored from `0` to `5`. The evaluator returns both:
 - `rawScore`: unweighted average across the ten dimensions.
 - `weightedScore`: dimension-weighted average using the executable weights in `src/issue-enrichment-scorecard.ts`.
 
-Scores above `3` require at least one direct evidence link on that case/dimension cell. The validator rejects high scores without direct `http` or `https` evidence links. In this v0.1 contract, validation proves evidence-link presence only; fixture authors must still review whether each link is relevant to the specific coverage scenario.
+Scores above `3` require at least one direct evidence link on that case/dimension cell. The validator rejects high scores unless an `http` or `https` evidence URL includes an exact direct-evidence anchor for the scored case and dimension:
+
+```text
+#direct-evidence-<case-id>-<dimension-id-with-dashes>
+```
+
+For example, `duplicate-same-head-comments` scored on `proof_boundary` must link to `#direct-evidence-duplicate-same-head-comments-proof-boundary`. A generic parent issue URL is not enough for high scores.
 
 The current weights are intentionally differentiated so `weightedScore` is not a duplicate of `rawScore`. Proof boundary, throttling, acceptance criteria, related-context precision, and safety carry higher weight because a failure in those dimensions can create misleading readiness or noisy live-posting signals.
 

--- a/docs/evals/issue-enrichment-scorecard.md
+++ b/docs/evals/issue-enrichment-scorecard.md
@@ -9,7 +9,9 @@ Each dimension is scored from `0` to `5`. The evaluator returns both:
 - `rawScore`: unweighted average across the ten dimensions.
 - `weightedScore`: dimension-weighted average using the executable weights in `src/issue-enrichment-scorecard.ts`.
 
-Scores above `3` require at least one direct evidence link on that case/dimension cell. The validator rejects high scores without direct `http` or `https` evidence links.
+Scores above `3` require at least one direct evidence link on that case/dimension cell. The validator rejects high scores without direct `http` or `https` evidence links. In this v0.1 contract, validation proves evidence-link presence only; fixture authors must still review whether each link is relevant to the specific coverage scenario.
+
+The current weights are intentionally differentiated so `weightedScore` is not a duplicate of `rawScore`. Proof boundary, throttling, acceptance criteria, related-context precision, and safety carry higher weight because a failure in those dimensions can create misleading readiness or noisy live-posting signals.
 
 The current dimensions are:
 

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -264,6 +264,10 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
         }
         continue;
       }
+      if (score.score === undefined) {
+        errors.push(`case ${fixtureCase.id} dimension ${dimension.id} score is required`);
+        continue;
+      }
       const scoreIsInRange = Number.isFinite(score.score) && score.score! >= 0 && score.score! <= 5;
       if (!scoreIsInRange) {
         errors.push(`case ${fixtureCase.id} dimension ${dimension.id} score must be between 0 and 5`);
@@ -317,11 +321,11 @@ function scoreDimension(
   for (const fixtureCase of packet.cases) {
     const score = fixtureCase.dimensions?.[dimension.id];
     if (!score) continue;
-    for (const link of score.evidenceLinks ?? []) evidenceLinks.add(link);
     if (score.unmeasurable) {
       unmeasurableCases.push(fixtureCase.id);
       continue;
     }
+    for (const link of score.evidenceLinks ?? []) evidenceLinks.add(link);
     const numericScore = normalizeScore(score.score);
     measuredScores.push(numericScore);
     if (numericScore < threshold) pilotThresholdMisses.push(fixtureCase.id);

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -108,6 +108,10 @@ export const ISSUE_ENRICHMENT_REQUIRED_FIXTURE_COVERAGE: IssueEnrichmentFixtureC
   "provider_failure_burst_30_prs"
 ];
 
+const ISSUE_ENRICHMENT_DIRECT_EVIDENCE_SOURCE = new URL(
+  "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"
+);
+
 export const ISSUE_ENRICHMENT_SCORE_DIMENSIONS: IssueEnrichmentScoreDimension[] = [
   dimension("related_context_precision", "Related-context precision", 12, {
     denominator: "Issue-enrichment comments that cite related repos, PRs, issues, docs, or web precedents.",
@@ -187,7 +191,10 @@ export function scoreIssueEnrichment(packet: IssueEnrichmentFixturePacket): Issu
   const dimensionScores = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.map((dimension) => scoreDimension(packet, dimension));
   const measuredDimensionScores = dimensionScores.filter((dimension) => dimension.measuredCases > 0);
   const rawTotal = measuredDimensionScores.reduce((sum, dimension) => sum + dimension.rawScore, 0);
-  const weightedTotal = measuredDimensionScores.reduce((sum, dimension) => sum + dimension.weightedContribution, 0);
+  const weightedTotal = measuredDimensionScores.reduce(
+    (sum, dimension) => sum + dimension.rawScore * dimension.weight,
+    0
+  );
   const maxRaw = measuredDimensionScores.length * 5;
   const maxWeighted = measuredDimensionScores.reduce((sum, dimension) => sum + dimension.weight * 5, 0);
   const unmeasurableStates = dimensionScores.flatMap((dimension) =>
@@ -252,8 +259,11 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
 
   for (const fixtureCase of packet.cases) {
     if (!fixtureCase.title?.trim()) errors.push(`case ${fixtureCase.id} title is required`);
-    if (!parseHttpsUrl(fixtureCase.fixtureSource)) {
+    const fixtureSource = parseHttpsUrl(fixtureCase.fixtureSource);
+    if (!fixtureSource) {
       errors.push(`case ${fixtureCase.id} fixtureSource must be an https URL`);
+    } else if (!isCanonicalDirectEvidencePath(fixtureSource)) {
+      errors.push(`case ${fixtureCase.id} fixtureSource must point to the canonical issue-enrichment evidence issue`);
     }
     if (!allowedCoverageIds.has(fixtureCase.coverage)) {
       errors.push(`case ${fixtureCase.id} has unknown coverage ${fixtureCase.coverage}`);
@@ -406,18 +416,22 @@ function hasDirectEvidenceLink(
   dimensionId: IssueEnrichmentScoreDimensionId
 ): boolean {
   const expectedAnchor = `direct-evidence-${fixtureCase.id.replaceAll("_", "-")}-${dimensionId.replaceAll("_", "-")}`;
-  const source = parseHttpsUrl(fixtureCase.fixtureSource);
-  if (!source) return false;
 
   return (links ?? []).some((link) => {
     const url = parseHttpsUrl(link);
     if (!url) return false;
     return (
-      url.origin === source.origin &&
-      url.pathname === source.pathname &&
+      isCanonicalDirectEvidencePath(url) &&
       url.hash.slice(1) === expectedAnchor
     );
   });
+}
+
+function isCanonicalDirectEvidencePath(url: URL): boolean {
+  return (
+    url.origin === ISSUE_ENRICHMENT_DIRECT_EVIDENCE_SOURCE.origin &&
+    url.pathname === ISSUE_ENRICHMENT_DIRECT_EVIDENCE_SOURCE.pathname
+  );
 }
 
 function parseHttpsUrl(value: string | undefined): URL | null {

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -219,7 +219,9 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
   const duplicateCaseIds = new Set<string>();
   const seenCoverageIds = new Set<IssueEnrichmentFixtureCoverageId>();
   const duplicateCoverageIds = new Set<IssueEnrichmentFixtureCoverageId>();
+  const allowedCoverageIds = new Set<string>(ISSUE_ENRICHMENT_REQUIRED_FIXTURE_COVERAGE);
 
+  if (packet.fixtureVersion !== "0.1") errors.push("fixture fixtureVersion must be 0.1");
   if (!packet.proofBoundary?.trim()) errors.push("fixture proofBoundary is required");
   if (!Array.isArray(packet.knownLimitations) || packet.knownLimitations.length === 0) {
     errors.push("fixture knownLimitations are required");
@@ -243,6 +245,13 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
   }
 
   for (const fixtureCase of packet.cases) {
+    if (!fixtureCase.title?.trim()) errors.push(`case ${fixtureCase.id} title is required`);
+    if (!parseHttpsUrl(fixtureCase.fixtureSource)) {
+      errors.push(`case ${fixtureCase.id} fixtureSource must be an https URL`);
+    }
+    if (!allowedCoverageIds.has(fixtureCase.coverage)) {
+      errors.push(`case ${fixtureCase.id} has unknown coverage ${fixtureCase.coverage}`);
+    }
     if (seenCaseIds.has(fixtureCase.id)) duplicateCaseIds.add(fixtureCase.id);
     seenCaseIds.add(fixtureCase.id);
     if (seenCoverageIds.has(fixtureCase.coverage)) duplicateCoverageIds.add(fixtureCase.coverage);

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -253,7 +253,7 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
       if (!Number.isFinite(score.score) || score.score! < 0 || score.score! > 5) {
         errors.push(`case ${fixtureCase.id} dimension ${dimension.id} score must be between 0 and 5`);
       }
-      if ((score.score ?? 0) > 3 && !hasDirectEvidenceLink(score.evidenceLinks)) {
+      if ((score.score ?? 0) > 3 && !hasDirectEvidenceLink(score.evidenceLinks, fixtureCase.id, dimension.id)) {
         errors.push(`case ${fixtureCase.id} dimension ${dimension.id} scored ${score.score} without direct evidence links`);
       }
     }
@@ -328,8 +328,20 @@ function normalizeScore(score: number | undefined): number {
   return Math.min(5, Math.max(0, score));
 }
 
-function hasDirectEvidenceLink(links: string[] | undefined): boolean {
-  return (links ?? []).some((link) => /^https?:\/\/\S+$/i.test(link));
+function hasDirectEvidenceLink(
+  links: string[] | undefined,
+  caseId: string,
+  dimensionId: IssueEnrichmentScoreDimensionId
+): boolean {
+  const expectedAnchor = `direct-evidence-${caseId.replaceAll("_", "-")}-${dimensionId.replaceAll("_", "-")}`;
+  return (links ?? []).some((link) => {
+    try {
+      const url = new URL(link);
+      return (url.protocol === "https:" || url.protocol === "http:") && url.hash.slice(1) === expectedAnchor;
+    } catch {
+      return false;
+    }
+  });
 }
 
 function percent(value: number, max: number): number {

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -374,11 +374,11 @@ function assertValidIssueEnrichmentFixture(packet: IssueEnrichmentFixturePacket)
   }
 }
 
-// scoreIssueEnrichment validates packets before scoring; keep scoreDimension private
-// so this normalization remains defense-in-depth rather than a public validation path.
 function normalizeScore(score: number | undefined): number {
-  if (score === undefined || !Number.isFinite(score)) return 0;
-  return Math.min(5, Math.max(0, score));
+  if (score === undefined || !Number.isFinite(score) || score < 0 || score > 5) {
+    throw new Error("Invalid score reached scoring path after fixture validation");
+  }
+  return score;
 }
 
 function hasDirectEvidenceLink(

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -182,6 +182,8 @@ export const ISSUE_ENRICHMENT_SCORE_DIMENSIONS: IssueEnrichmentScoreDimension[] 
 ];
 
 export function scoreIssueEnrichment(packet: IssueEnrichmentFixturePacket): IssueEnrichmentScorecardResult {
+  assertValidIssueEnrichmentFixture(packet);
+
   const dimensionScores = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.map((dimension) => scoreDimension(packet, dimension));
   const rawTotal = dimensionScores.reduce((sum, dimension) => sum + dimension.rawScore, 0);
   const weightedTotal = dimensionScores.reduce((sum, dimension) => sum + dimension.weightedContribution, 0);
@@ -345,6 +347,13 @@ function getMetricContract(
   return packet.metricContracts?.[dimension.id] ?? dimension.metricContract;
 }
 
+function assertValidIssueEnrichmentFixture(packet: IssueEnrichmentFixturePacket): void {
+  const validation = validateIssueEnrichmentFixture(packet);
+  if (!validation.ok) {
+    throw new Error(`Cannot score invalid issue-enrichment fixture: ${validation.errors.join("; ")}`);
+  }
+}
+
 function normalizeScore(score: number | undefined): number {
   if (score === undefined || !Number.isFinite(score)) return 0;
   return Math.min(5, Math.max(0, score));
@@ -362,7 +371,12 @@ function hasDirectEvidenceLink(
   return (links ?? []).some((link) => {
     const url = parseHttpsUrl(link);
     if (!url) return false;
-    return url.host === source.host && url.pathname === source.pathname && url.hash.slice(1) === expectedAnchor;
+    return (
+      url.origin === source.origin &&
+      url.pathname === source.pathname &&
+      url.search === source.search &&
+      url.hash.slice(1) === expectedAnchor
+    );
   });
 }
 

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -185,10 +185,11 @@ export function scoreIssueEnrichment(packet: IssueEnrichmentFixturePacket): Issu
   assertValidIssueEnrichmentFixture(packet);
 
   const dimensionScores = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.map((dimension) => scoreDimension(packet, dimension));
-  const rawTotal = dimensionScores.reduce((sum, dimension) => sum + dimension.rawScore, 0);
-  const weightedTotal = dimensionScores.reduce((sum, dimension) => sum + dimension.weightedContribution, 0);
-  const maxRaw = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.length * 5;
-  const maxWeighted = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.reduce((sum, dimension) => sum + dimension.weight * 5, 0);
+  const measuredDimensionScores = dimensionScores.filter((dimension) => dimension.measuredCases > 0);
+  const rawTotal = measuredDimensionScores.reduce((sum, dimension) => sum + dimension.rawScore, 0);
+  const weightedTotal = measuredDimensionScores.reduce((sum, dimension) => sum + dimension.weightedContribution, 0);
+  const maxRaw = measuredDimensionScores.length * 5;
+  const maxWeighted = measuredDimensionScores.reduce((sum, dimension) => sum + dimension.weight * 5, 0);
   const unmeasurableStates = dimensionScores.flatMap((dimension) =>
     dimension.unmeasurableCases.map((caseId) => `${caseId}:${dimension.id}`)
   );
@@ -391,6 +392,7 @@ function parseHttpsUrl(value: string | undefined): URL | null {
 }
 
 function percent(value: number, max: number): number {
+  if (max <= 0) return 0;
   return Math.round((value / max) * 100);
 }
 

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -252,6 +252,8 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
     if (!allowedCoverageIds.has(fixtureCase.coverage)) {
       errors.push(`case ${fixtureCase.id} has unknown coverage ${fixtureCase.coverage}`);
     }
+    // Record duplicate identity before per-dimension validation so malformed cases
+    // still report duplicate coverage/id errors alongside structural errors.
     if (seenCaseIds.has(fixtureCase.id)) duplicateCaseIds.add(fixtureCase.id);
     seenCaseIds.add(fixtureCase.id);
     if (seenCoverageIds.has(fixtureCase.coverage)) duplicateCoverageIds.add(fixtureCase.coverage);
@@ -372,6 +374,8 @@ function assertValidIssueEnrichmentFixture(packet: IssueEnrichmentFixturePacket)
   }
 }
 
+// scoreIssueEnrichment validates packets before scoring; keep scoreDimension private
+// so this normalization remains defense-in-depth rather than a public validation path.
 function normalizeScore(score: number | undefined): number {
   if (score === undefined || !Number.isFinite(score)) return 0;
   return Math.min(5, Math.max(0, score));

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -109,42 +109,42 @@ export const ISSUE_ENRICHMENT_REQUIRED_FIXTURE_COVERAGE: IssueEnrichmentFixtureC
 ];
 
 export const ISSUE_ENRICHMENT_SCORE_DIMENSIONS: IssueEnrichmentScoreDimension[] = [
-  dimension("related_context_precision", "Related-context precision", 10, {
+  dimension("related_context_precision", "Related-context precision", 12, {
     denominator: "Issue-enrichment comments that cite related repos, PRs, issues, docs, or web precedents.",
     dataSource: "Sampled enrichment fixture cases plus linked GitHub evidence.",
-    scoringRule: "0 means unrelated or stale context; 3 means useful but incomplete; 5 means all cited context is directly relevant and current.",
+    scoringRule: "0 means unrelated or stale context; 3 means useful but incomplete; 5 means all cited context is directly relevant and current. The validator enforces evidence-link presence for high scores; fixture authors remain responsible for relevance review.",
     unmeasurableState: "No external or internal precedent is available to judge related-context quality.",
     pilotThreshold: { advisoryMin: 3.5, promotionMin: 4.2 }
   }),
-  dimension("planning_value", "Planning value", 10, {
+  dimension("planning_value", "Planning value", 11, {
     denominator: "Issue-enrichment comments that propose next work.",
     dataSource: "Generated issue-enrichment body and fixture expectation notes.",
     scoringRule: "Score practical decomposition, sequencing, and handoff value without claiming implementation readiness.",
     unmeasurableState: "Issue lacks enough product or engineering detail to evaluate plan usefulness.",
     pilotThreshold: { advisoryMin: 3.5, promotionMin: 4.2 }
   }),
-  dimension("acceptance_criteria", "Acceptance criteria", 10, {
+  dimension("acceptance_criteria", "Acceptance criteria", 12, {
     denominator: "Issue-enrichment comments for issues with testable or reviewable outcomes.",
     dataSource: "Issue body, generated enrichment, and regression fixture labels.",
     scoringRule: "Score explicit pass/fail criteria, negative controls, and validation commands or CI gates.",
     unmeasurableState: "Issue is intentionally exploratory and has no accepted outcome contract yet.",
     pilotThreshold: { advisoryMin: 3.5, promotionMin: 4.2 }
   }),
-  dimension("ownership_routing", "Ownership/routing", 10, {
+  dimension("ownership_routing", "Ownership/routing", 9, {
     denominator: "Issue-enrichment comments that name owners, repos, lanes, or reviewer routes.",
     dataSource: "Issue labels, repo ownership metadata, and generated routing suggestions.",
     scoringRule: "Score whether ownership suggestions are specific, bounded, and do not mutate labels or assignees.",
     unmeasurableState: "No owner, repo, or lane data is available in the fixture source.",
     pilotThreshold: { advisoryMin: 3.5, promotionMin: 4.2 }
   }),
-  dimension("proof_boundary", "Proof boundary", 10, {
+  dimension("proof_boundary", "Proof boundary", 13, {
     denominator: "Issue-enrichment comments that make any evidence, readiness, or verification statement.",
     dataSource: "Generated body, fixture proof-boundary notes, and linked evidence URLs.",
     scoringRule: "Score explicit separation between advisory scoring, local evidence, CI proof, runtime proof, and release proof.",
     unmeasurableState: "No proof claim is present.",
     pilotThreshold: { advisoryMin: 4, promotionMin: 4.5 }
   }),
-  dimension("lifecycle_state", "Lifecycle state", 10, {
+  dimension("lifecycle_state", "Lifecycle state", 8, {
     denominator: "Issue-enrichment comments for open, closed, stale, backlog, or head-specific cases.",
     dataSource: "GitHub issue/PR state, head SHA metadata, and fixture lifecycle labels.",
     scoringRule: "Score correct handling of open/closed/stale/head-mismatch state and refusal to post on stale heads.",
@@ -158,21 +158,21 @@ export const ISSUE_ENRICHMENT_SCORE_DIMENSIONS: IssueEnrichmentScoreDimension[] 
     unmeasurableState: "No comparable noisy or negative-control path is present.",
     pilotThreshold: { advisoryMin: 3.5, promotionMin: 4.2 }
   }),
-  dimension("idempotency", "Idempotency", 10, {
+  dimension("idempotency", "Idempotency", 9, {
     denominator: "Repeated issue-enrichment attempts against the same issue/head/comment marker.",
     dataSource: "Same-head duplicate fixtures, sticky marker expectations, and state records.",
     scoringRule: "Score stable upsert behavior and no duplicate same-head comments.",
     unmeasurableState: "Only a single attempted enrichment exists.",
     pilotThreshold: { advisoryMin: 3.5, promotionMin: 4.2 }
   }),
-  dimension("safety", "Safety", 10, {
+  dimension("safety", "Safety", 11, {
     denominator: "Issue-enrichment comments that handle permissions, config, launchd, safety, or external references.",
     dataSource: "Permission-failure, launchd/config ambiguity, and external-precedent fixtures.",
     scoringRule: "Score fail-closed behavior, explicit non-mutation, and safe refusal when evidence is ambiguous.",
     unmeasurableState: "No safety-sensitive operation is represented.",
     pilotThreshold: { advisoryMin: 3.8, promotionMin: 4.5 }
   }),
-  dimension("throttling", "Throttling", 10, {
+  dimension("throttling", "Throttling", 15, {
     denominator: "Issue-enrichment attempts that consume GitHub API, provider, or comment budget.",
     dataSource: "Throttle config, burst simulation fixtures, provider failure records, and issue-run status.",
     scoringRule: "Score budget-aware deferral, provider-failure containment, and cap enforcement across bursts.",

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -70,7 +70,7 @@ export interface IssueEnrichmentDimensionScore {
   score: number;
   weight: number;
   rawScore: number;
-  weightedScore: number;
+  weightedContribution: number;
   measuredCases: number;
   unmeasurableCases: string[];
   pilotThresholdMisses: string[];
@@ -186,7 +186,7 @@ const DIMENSIONS_BY_ID = new Map(ISSUE_ENRICHMENT_SCORE_DIMENSIONS.map((item) =>
 export function scoreIssueEnrichment(packet: IssueEnrichmentFixturePacket): IssueEnrichmentScorecardResult {
   const dimensionScores = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.map((dimension) => scoreDimension(packet, dimension));
   const rawTotal = dimensionScores.reduce((sum, dimension) => sum + dimension.rawScore, 0);
-  const weightedTotal = dimensionScores.reduce((sum, dimension) => sum + dimension.weightedScore, 0);
+  const weightedTotal = dimensionScores.reduce((sum, dimension) => sum + dimension.weightedContribution, 0);
   const maxRaw = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.length * 5;
   const maxWeighted = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.reduce((sum, dimension) => sum + dimension.weight * 5, 0);
   const unmeasurableStates = dimensionScores.flatMap((dimension) =>
@@ -214,6 +214,10 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
   const coveredScenarioIds = ISSUE_ENRICHMENT_REQUIRED_FIXTURE_COVERAGE.filter((coverage) =>
     packet.cases.some((item) => item.coverage === coverage)
   );
+  const seenCaseIds = new Set<string>();
+  const duplicateCaseIds = new Set<string>();
+  const seenCoverageIds = new Set<IssueEnrichmentFixtureCoverageId>();
+  const duplicateCoverageIds = new Set<IssueEnrichmentFixtureCoverageId>();
 
   if (!packet.proofBoundary?.trim()) errors.push("fixture proofBoundary is required");
   if (!Array.isArray(packet.knownLimitations) || packet.knownLimitations.length === 0) {
@@ -238,6 +242,11 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
   }
 
   for (const fixtureCase of packet.cases) {
+    if (seenCaseIds.has(fixtureCase.id)) duplicateCaseIds.add(fixtureCase.id);
+    seenCaseIds.add(fixtureCase.id);
+    if (seenCoverageIds.has(fixtureCase.coverage)) duplicateCoverageIds.add(fixtureCase.coverage);
+    seenCoverageIds.add(fixtureCase.coverage);
+
     for (const dimension of ISSUE_ENRICHMENT_SCORE_DIMENSIONS) {
       const score = fixtureCase.dimensions[dimension.id];
       if (!score) {
@@ -253,10 +262,18 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
       if (!Number.isFinite(score.score) || score.score! < 0 || score.score! > 5) {
         errors.push(`case ${fixtureCase.id} dimension ${dimension.id} score must be between 0 and 5`);
       }
-      if ((score.score ?? 0) > 3 && !hasDirectEvidenceLink(score.evidenceLinks, fixtureCase.id, dimension.id)) {
+      if ((score.score ?? 0) > 3 && !hasDirectEvidenceLink(score.evidenceLinks, fixtureCase, dimension.id)) {
         errors.push(`case ${fixtureCase.id} dimension ${dimension.id} scored ${score.score} without direct evidence links`);
       }
     }
+  }
+
+  for (const caseId of [...duplicateCaseIds].sort()) {
+    errors.push(`duplicate fixture case id ${caseId}`);
+  }
+
+  for (const coverageId of [...duplicateCoverageIds].sort()) {
+    errors.push(`duplicate fixture coverage ${coverageId}`);
   }
 
   return { ok: errors.length === 0, errors, coveredScenarioIds };
@@ -315,7 +332,7 @@ function scoreDimension(
     score: round(averageScore, 2),
     weight: dimension.weight,
     rawScore: averageScore,
-    weightedScore: round(averageScore * dimension.weight, 2),
+    weightedContribution: round(averageScore * dimension.weight, 2),
     measuredCases: measuredScores.length,
     unmeasurableCases,
     pilotThresholdMisses,
@@ -330,18 +347,28 @@ function normalizeScore(score: number | undefined): number {
 
 function hasDirectEvidenceLink(
   links: string[] | undefined,
-  caseId: string,
+  fixtureCase: IssueEnrichmentFixtureCase,
   dimensionId: IssueEnrichmentScoreDimensionId
 ): boolean {
-  const expectedAnchor = `direct-evidence-${caseId.replaceAll("_", "-")}-${dimensionId.replaceAll("_", "-")}`;
+  const expectedAnchor = `direct-evidence-${fixtureCase.id.replaceAll("_", "-")}-${dimensionId.replaceAll("_", "-")}`;
+  const source = parseHttpsUrl(fixtureCase.fixtureSource);
+  if (!source) return false;
+
   return (links ?? []).some((link) => {
-    try {
-      const url = new URL(link);
-      return (url.protocol === "https:" || url.protocol === "http:") && url.hash.slice(1) === expectedAnchor;
-    } catch {
-      return false;
-    }
+    const url = parseHttpsUrl(link);
+    if (!url) return false;
+    return url.host === source.host && url.pathname === source.pathname && url.hash.slice(1) === expectedAnchor;
   });
+}
+
+function parseHttpsUrl(value: string | undefined): URL | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
 }
 
 function percent(value: number, max: number): number {

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -1,0 +1,342 @@
+export type IssueEnrichmentScoreDimensionId =
+  | "related_context_precision"
+  | "planning_value"
+  | "acceptance_criteria"
+  | "ownership_routing"
+  | "proof_boundary"
+  | "lifecycle_state"
+  | "noise_control"
+  | "idempotency"
+  | "safety"
+  | "throttling";
+
+export type IssueEnrichmentFixtureCoverageId =
+  | "duplicate_same_head_comments"
+  | "stale_head_posts"
+  | "invalid_inline_coordinates"
+  | "issue_enrichment_permission_failure"
+  | "launchd_config_head_ambiguity"
+  | "docs_only_fast_negative_control"
+  | "old_backlog_negative_control"
+  | "external_precedent_required_issue"
+  | "stale_irrelevant_web_result"
+  | "provider_failure_burst_30_prs";
+
+export interface IssueEnrichmentMetricContract {
+  denominator: string;
+  dataSource: string;
+  scoringRule: string;
+  unmeasurableState: string;
+  pilotThreshold: {
+    advisoryMin: number;
+    promotionMin: number;
+  };
+}
+
+export interface IssueEnrichmentScoreDimension {
+  id: IssueEnrichmentScoreDimensionId;
+  label: string;
+  weight: number;
+  metricContract: IssueEnrichmentMetricContract;
+}
+
+export interface IssueEnrichmentDimensionFixtureScore {
+  score?: number;
+  evidenceLinks?: string[];
+  notes?: string;
+  unmeasurable?: boolean;
+  unmeasurableReason?: string;
+}
+
+export interface IssueEnrichmentFixtureCase {
+  id: string;
+  title: string;
+  coverage: IssueEnrichmentFixtureCoverageId;
+  fixtureSource?: string;
+  dimensions: Record<IssueEnrichmentScoreDimensionId, IssueEnrichmentDimensionFixtureScore>;
+}
+
+export interface IssueEnrichmentFixturePacket {
+  fixtureVersion: "0.1";
+  proofBoundary: string;
+  knownLimitations: string[];
+  metricContracts?: Partial<Record<IssueEnrichmentScoreDimensionId, IssueEnrichmentMetricContract>>;
+  cases: IssueEnrichmentFixtureCase[];
+}
+
+export interface IssueEnrichmentDimensionScore {
+  id: IssueEnrichmentScoreDimensionId;
+  label: string;
+  score: number;
+  weight: number;
+  rawScore: number;
+  weightedScore: number;
+  measuredCases: number;
+  unmeasurableCases: string[];
+  pilotThresholdMisses: string[];
+  evidenceLinks: string[];
+}
+
+export interface IssueEnrichmentScorecardResult {
+  rawScore: number;
+  weightedScore: number;
+  publicClaim: "no_public_claim";
+  calibration: "uncalibrated";
+  dimensionScores: IssueEnrichmentDimensionScore[];
+  unmeasurableStates: string[];
+  pilotThresholdMisses: string[];
+  proofBoundary: string;
+  knownLimitations: string[];
+}
+
+export interface IssueEnrichmentFixtureValidation {
+  ok: boolean;
+  errors: string[];
+  coveredScenarioIds: IssueEnrichmentFixtureCoverageId[];
+}
+
+export const ISSUE_ENRICHMENT_REQUIRED_FIXTURE_COVERAGE: IssueEnrichmentFixtureCoverageId[] = [
+  "duplicate_same_head_comments",
+  "stale_head_posts",
+  "invalid_inline_coordinates",
+  "issue_enrichment_permission_failure",
+  "launchd_config_head_ambiguity",
+  "docs_only_fast_negative_control",
+  "old_backlog_negative_control",
+  "external_precedent_required_issue",
+  "stale_irrelevant_web_result",
+  "provider_failure_burst_30_prs"
+];
+
+export const ISSUE_ENRICHMENT_SCORE_DIMENSIONS: IssueEnrichmentScoreDimension[] = [
+  dimension("related_context_precision", "Related-context precision", 10, {
+    denominator: "Issue-enrichment comments that cite related repos, PRs, issues, docs, or web precedents.",
+    dataSource: "Sampled enrichment fixture cases plus linked GitHub evidence.",
+    scoringRule: "0 means unrelated or stale context; 3 means useful but incomplete; 5 means all cited context is directly relevant and current.",
+    unmeasurableState: "No external or internal precedent is available to judge related-context quality.",
+    pilotThreshold: { advisoryMin: 3.5, promotionMin: 4.2 }
+  }),
+  dimension("planning_value", "Planning value", 10, {
+    denominator: "Issue-enrichment comments that propose next work.",
+    dataSource: "Generated issue-enrichment body and fixture expectation notes.",
+    scoringRule: "Score practical decomposition, sequencing, and handoff value without claiming implementation readiness.",
+    unmeasurableState: "Issue lacks enough product or engineering detail to evaluate plan usefulness.",
+    pilotThreshold: { advisoryMin: 3.5, promotionMin: 4.2 }
+  }),
+  dimension("acceptance_criteria", "Acceptance criteria", 10, {
+    denominator: "Issue-enrichment comments for issues with testable or reviewable outcomes.",
+    dataSource: "Issue body, generated enrichment, and regression fixture labels.",
+    scoringRule: "Score explicit pass/fail criteria, negative controls, and validation commands or CI gates.",
+    unmeasurableState: "Issue is intentionally exploratory and has no accepted outcome contract yet.",
+    pilotThreshold: { advisoryMin: 3.5, promotionMin: 4.2 }
+  }),
+  dimension("ownership_routing", "Ownership/routing", 10, {
+    denominator: "Issue-enrichment comments that name owners, repos, lanes, or reviewer routes.",
+    dataSource: "Issue labels, repo ownership metadata, and generated routing suggestions.",
+    scoringRule: "Score whether ownership suggestions are specific, bounded, and do not mutate labels or assignees.",
+    unmeasurableState: "No owner, repo, or lane data is available in the fixture source.",
+    pilotThreshold: { advisoryMin: 3.5, promotionMin: 4.2 }
+  }),
+  dimension("proof_boundary", "Proof boundary", 10, {
+    denominator: "Issue-enrichment comments that make any evidence, readiness, or verification statement.",
+    dataSource: "Generated body, fixture proof-boundary notes, and linked evidence URLs.",
+    scoringRule: "Score explicit separation between advisory scoring, local evidence, CI proof, runtime proof, and release proof.",
+    unmeasurableState: "No proof claim is present.",
+    pilotThreshold: { advisoryMin: 4, promotionMin: 4.5 }
+  }),
+  dimension("lifecycle_state", "Lifecycle state", 10, {
+    denominator: "Issue-enrichment comments for open, closed, stale, backlog, or head-specific cases.",
+    dataSource: "GitHub issue/PR state, head SHA metadata, and fixture lifecycle labels.",
+    scoringRule: "Score correct handling of open/closed/stale/head-mismatch state and refusal to post on stale heads.",
+    unmeasurableState: "Lifecycle state is absent from the fixture source.",
+    pilotThreshold: { advisoryMin: 3.5, promotionMin: 4.2 }
+  }),
+  dimension("noise_control", "Noise control", 10, {
+    denominator: "Potential enrichment comments across selected and backlog issues.",
+    dataSource: "Fixture cases for duplicates, old backlog, docs-only negatives, and provider bursts.",
+    scoringRule: "Score duplicate suppression, negative controls, and comment avoidance when enrichment would add noise.",
+    unmeasurableState: "No comparable noisy or negative-control path is present.",
+    pilotThreshold: { advisoryMin: 3.5, promotionMin: 4.2 }
+  }),
+  dimension("idempotency", "Idempotency", 10, {
+    denominator: "Repeated issue-enrichment attempts against the same issue/head/comment marker.",
+    dataSource: "Same-head duplicate fixtures, sticky marker expectations, and state records.",
+    scoringRule: "Score stable upsert behavior and no duplicate same-head comments.",
+    unmeasurableState: "Only a single attempted enrichment exists.",
+    pilotThreshold: { advisoryMin: 3.5, promotionMin: 4.2 }
+  }),
+  dimension("safety", "Safety", 10, {
+    denominator: "Issue-enrichment comments that handle permissions, config, launchd, safety, or external references.",
+    dataSource: "Permission-failure, launchd/config ambiguity, and external-precedent fixtures.",
+    scoringRule: "Score fail-closed behavior, explicit non-mutation, and safe refusal when evidence is ambiguous.",
+    unmeasurableState: "No safety-sensitive operation is represented.",
+    pilotThreshold: { advisoryMin: 3.8, promotionMin: 4.5 }
+  }),
+  dimension("throttling", "Throttling", 10, {
+    denominator: "Issue-enrichment attempts that consume GitHub API, provider, or comment budget.",
+    dataSource: "Throttle config, burst simulation fixtures, provider failure records, and issue-run status.",
+    scoringRule: "Score budget-aware deferral, provider-failure containment, and cap enforcement across bursts.",
+    unmeasurableState: "No request, provider, or posting budget data is available.",
+    pilotThreshold: { advisoryMin: 2, promotionMin: 4 }
+  })
+];
+
+const DIMENSIONS_BY_ID = new Map(ISSUE_ENRICHMENT_SCORE_DIMENSIONS.map((item) => [item.id, item]));
+
+export function scoreIssueEnrichment(packet: IssueEnrichmentFixturePacket): IssueEnrichmentScorecardResult {
+  const dimensionScores = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.map((dimension) => scoreDimension(packet, dimension));
+  const rawTotal = dimensionScores.reduce((sum, dimension) => sum + dimension.rawScore, 0);
+  const weightedTotal = dimensionScores.reduce((sum, dimension) => sum + dimension.weightedScore, 0);
+  const maxRaw = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.length * 5;
+  const maxWeighted = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.reduce((sum, dimension) => sum + dimension.weight * 5, 0);
+  const unmeasurableStates = dimensionScores.flatMap((dimension) =>
+    dimension.unmeasurableCases.map((caseId) => `${caseId}:${dimension.id}`)
+  );
+  const pilotThresholdMisses = dimensionScores.flatMap((dimension) =>
+    dimension.pilotThresholdMisses.map((caseId) => `${caseId}:${dimension.id}`)
+  );
+
+  return {
+    rawScore: percent(rawTotal, maxRaw),
+    weightedScore: percent(weightedTotal, maxWeighted),
+    publicClaim: "no_public_claim",
+    calibration: "uncalibrated",
+    dimensionScores,
+    unmeasurableStates,
+    pilotThresholdMisses,
+    proofBoundary: packet.proofBoundary,
+    knownLimitations: [...packet.knownLimitations]
+  };
+}
+
+export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePacket): IssueEnrichmentFixtureValidation {
+  const errors: string[] = [];
+  const coveredScenarioIds = ISSUE_ENRICHMENT_REQUIRED_FIXTURE_COVERAGE.filter((coverage) =>
+    packet.cases.some((item) => item.coverage === coverage)
+  );
+
+  if (!packet.proofBoundary?.trim()) errors.push("fixture proofBoundary is required");
+  if (!Array.isArray(packet.knownLimitations) || packet.knownLimitations.length === 0) {
+    errors.push("fixture knownLimitations are required");
+  }
+
+  for (const coverage of ISSUE_ENRICHMENT_REQUIRED_FIXTURE_COVERAGE) {
+    if (!coveredScenarioIds.includes(coverage)) errors.push(`missing required fixture coverage ${coverage}`);
+  }
+
+  for (const dimension of ISSUE_ENRICHMENT_SCORE_DIMENSIONS) {
+    const contract = packet.metricContracts?.[dimension.id] ?? dimension.metricContract;
+    for (const key of ["denominator", "dataSource", "scoringRule", "unmeasurableState"] as const) {
+      if (!contract[key]?.trim()) errors.push(`dimension ${dimension.id} metric contract missing ${key}`);
+    }
+    if (!Number.isFinite(contract.pilotThreshold?.advisoryMin)) {
+      errors.push(`dimension ${dimension.id} metric contract missing pilotThreshold.advisoryMin`);
+    }
+    if (!Number.isFinite(contract.pilotThreshold?.promotionMin)) {
+      errors.push(`dimension ${dimension.id} metric contract missing pilotThreshold.promotionMin`);
+    }
+  }
+
+  for (const fixtureCase of packet.cases) {
+    for (const dimension of ISSUE_ENRICHMENT_SCORE_DIMENSIONS) {
+      const score = fixtureCase.dimensions[dimension.id];
+      if (!score) {
+        errors.push(`case ${fixtureCase.id} missing dimension ${dimension.id}`);
+        continue;
+      }
+      if (score.unmeasurable) {
+        if (!score.unmeasurableReason?.trim()) {
+          errors.push(`case ${fixtureCase.id} dimension ${dimension.id} missing unmeasurableReason`);
+        }
+        continue;
+      }
+      if (!Number.isFinite(score.score) || score.score! < 0 || score.score! > 5) {
+        errors.push(`case ${fixtureCase.id} dimension ${dimension.id} score must be between 0 and 5`);
+      }
+      if ((score.score ?? 0) > 3 && !hasDirectEvidenceLink(score.evidenceLinks)) {
+        errors.push(`case ${fixtureCase.id} dimension ${dimension.id} scored ${score.score} without direct evidence links`);
+      }
+    }
+  }
+
+  return { ok: errors.length === 0, errors, coveredScenarioIds };
+}
+
+export function summarizeIssueEnrichmentScorecard(result: IssueEnrichmentScorecardResult): string {
+  const lines = [
+    `Issue enrichment scorecard: raw ${result.rawScore}/100, weighted ${result.weightedScore}/100`,
+    `Public claim: ${result.publicClaim}`,
+    `Calibration: ${result.calibration}`,
+    `Unmeasurable dimensions: ${result.unmeasurableStates.length ? result.unmeasurableStates.join(", ") : "none"}`,
+    `Pilot threshold misses: ${result.pilotThresholdMisses.length ? result.pilotThresholdMisses.join(", ") : "none"}`
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+function dimension(
+  id: IssueEnrichmentScoreDimensionId,
+  label: string,
+  weight: number,
+  metricContract: IssueEnrichmentMetricContract
+): IssueEnrichmentScoreDimension {
+  return { id, label, weight, metricContract };
+}
+
+function scoreDimension(
+  packet: IssueEnrichmentFixturePacket,
+  dimension: IssueEnrichmentScoreDimension
+): IssueEnrichmentDimensionScore {
+  const measuredScores: number[] = [];
+  const unmeasurableCases: string[] = [];
+  const pilotThresholdMisses: string[] = [];
+  const evidenceLinks = new Set<string>();
+  const threshold = DIMENSIONS_BY_ID.get(dimension.id)?.metricContract.pilotThreshold.advisoryMin ?? 0;
+
+  for (const fixtureCase of packet.cases) {
+    const score = fixtureCase.dimensions[dimension.id];
+    if (!score) continue;
+    for (const link of score.evidenceLinks ?? []) evidenceLinks.add(link);
+    if (score.unmeasurable) {
+      unmeasurableCases.push(fixtureCase.id);
+      continue;
+    }
+    const numericScore = normalizeScore(score.score);
+    measuredScores.push(numericScore);
+    if (numericScore < threshold) pilotThresholdMisses.push(fixtureCase.id);
+  }
+
+  const averageScore = measuredScores.length
+    ? measuredScores.reduce((sum, score) => sum + score, 0) / measuredScores.length
+    : 0;
+
+  return {
+    id: dimension.id,
+    label: dimension.label,
+    score: round(averageScore, 2),
+    weight: dimension.weight,
+    rawScore: averageScore,
+    weightedScore: round(averageScore * dimension.weight, 2),
+    measuredCases: measuredScores.length,
+    unmeasurableCases,
+    pilotThresholdMisses,
+    evidenceLinks: [...evidenceLinks].sort()
+  };
+}
+
+function normalizeScore(score: number | undefined): number {
+  if (score === undefined || !Number.isFinite(score)) return 0;
+  return Math.min(5, Math.max(0, score));
+}
+
+function hasDirectEvidenceLink(links: string[] | undefined): boolean {
+  return (links ?? []).some((link) => /^https?:\/\/\S+$/i.test(link));
+}
+
+function percent(value: number, max: number): number {
+  return Math.round((value / max) * 100);
+}
+
+function round(value: number, places: number): number {
+  const factor = 10 ** places;
+  return Math.round(value * factor) / factor;
+}

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -270,29 +270,35 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
     }
 
     for (const dimension of ISSUE_ENRICHMENT_SCORE_DIMENSIONS) {
-      const score = fixtureCase.dimensions?.[dimension.id];
-      if (!score) {
+      const dimensionCell = fixtureCase.dimensions?.[dimension.id];
+      if (!dimensionCell) {
         errors.push(`case ${fixtureCase.id} missing dimension ${dimension.id}`);
         continue;
       }
-      if (score.unmeasurable) {
-        if (score.score !== undefined) {
+      if (dimensionCell.unmeasurable) {
+        if (dimensionCell.score !== undefined) {
           errors.push(`case ${fixtureCase.id} dimension ${dimension.id} cannot set score when unmeasurable`);
         }
-        if (!score.unmeasurableReason?.trim()) {
+        if (!dimensionCell.unmeasurableReason?.trim()) {
           errors.push(`case ${fixtureCase.id} dimension ${dimension.id} missing unmeasurableReason`);
         }
         continue;
       }
-      if (score.score === undefined) {
+      if (dimensionCell.score === undefined) {
         errors.push(`case ${fixtureCase.id} dimension ${dimension.id} score is required`);
         continue;
       }
-      const scoreIsInRange = Number.isFinite(score.score) && score.score! >= 0 && score.score! <= 5;
+      const scoreIsInRange =
+        Number.isFinite(dimensionCell.score) && dimensionCell.score! >= 0 && dimensionCell.score! <= 5;
       if (!scoreIsInRange) {
         errors.push(`case ${fixtureCase.id} dimension ${dimension.id} score must be between 0 and 5`);
-      } else if (score.score! > 3 && !hasDirectEvidenceLink(score.evidenceLinks, fixtureCase, dimension.id)) {
-        errors.push(`case ${fixtureCase.id} dimension ${dimension.id} scored ${score.score} without direct evidence links`);
+      } else if (
+        dimensionCell.score! > 3 &&
+        !hasDirectEvidenceLink(dimensionCell.evidenceLinks, fixtureCase, dimension.id)
+      ) {
+        errors.push(
+          `case ${fixtureCase.id} dimension ${dimension.id} scored ${dimensionCell.score} without direct evidence links`
+        );
       }
     }
   }
@@ -339,14 +345,14 @@ function scoreDimension(
   const threshold = getMetricContract(packet, dimension).pilotThreshold.advisoryMin;
 
   for (const fixtureCase of packet.cases) {
-    const score = fixtureCase.dimensions?.[dimension.id];
-    if (!score) continue;
-    if (score.unmeasurable) {
+    const dimensionCell = fixtureCase.dimensions?.[dimension.id];
+    if (!dimensionCell) continue;
+    if (dimensionCell.unmeasurable) {
       unmeasurableCases.push(fixtureCase.id);
       continue;
     }
-    for (const link of score.evidenceLinks ?? []) evidenceLinks.add(link);
-    const numericScore = normalizeScore(score.score);
+    for (const link of dimensionCell.evidenceLinks ?? []) evidenceLinks.add(link);
+    const numericScore = normalizeScore(dimensionCell.score);
     measuredScores.push(numericScore);
     if (numericScore < threshold) pilotThresholdMisses.push(fixtureCase.id);
   }

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -236,11 +236,17 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
     for (const key of ["denominator", "dataSource", "scoringRule", "unmeasurableState"] as const) {
       if (!contract[key]?.trim()) errors.push(`dimension ${dimension.id} metric contract missing ${key}`);
     }
-    if (!Number.isFinite(contract.pilotThreshold?.advisoryMin)) {
+    const advisoryMin = contract.pilotThreshold?.advisoryMin;
+    const promotionMin = contract.pilotThreshold?.promotionMin;
+    if (!Number.isFinite(advisoryMin)) {
       errors.push(`dimension ${dimension.id} metric contract missing pilotThreshold.advisoryMin`);
+    } else if (!isScoreThresholdInRange(advisoryMin)) {
+      errors.push(`dimension ${dimension.id} metric contract pilotThreshold.advisoryMin must be between 0 and 5`);
     }
-    if (!Number.isFinite(contract.pilotThreshold?.promotionMin)) {
+    if (!Number.isFinite(promotionMin)) {
       errors.push(`dimension ${dimension.id} metric contract missing pilotThreshold.promotionMin`);
+    } else if (!isScoreThresholdInRange(promotionMin)) {
+      errors.push(`dimension ${dimension.id} metric contract pilotThreshold.promotionMin must be between 0 and 5`);
     }
   }
 
@@ -270,6 +276,9 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
         continue;
       }
       if (score.unmeasurable) {
+        if (score.score !== undefined) {
+          errors.push(`case ${fixtureCase.id} dimension ${dimension.id} cannot set score when unmeasurable`);
+        }
         if (!score.unmeasurableReason?.trim()) {
           errors.push(`case ${fixtureCase.id} dimension ${dimension.id} missing unmeasurableReason`);
         }
@@ -381,6 +390,10 @@ function normalizeScore(score: number | undefined): number {
   return score;
 }
 
+function isScoreThresholdInRange(value: number | undefined): boolean {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 5;
+}
+
 function hasDirectEvidenceLink(
   links: string[] | undefined,
   fixtureCase: IssueEnrichmentFixtureCase,
@@ -396,7 +409,6 @@ function hasDirectEvidenceLink(
     return (
       url.origin === source.origin &&
       url.pathname === source.pathname &&
-      url.search === source.search &&
       url.hash.slice(1) === expectedAnchor
     );
   });

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -247,9 +247,13 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
     seenCaseIds.add(fixtureCase.id);
     if (seenCoverageIds.has(fixtureCase.coverage)) duplicateCoverageIds.add(fixtureCase.coverage);
     seenCoverageIds.add(fixtureCase.coverage);
+    if (!fixtureCase.dimensions || typeof fixtureCase.dimensions !== "object") {
+      errors.push(`case ${fixtureCase.id} missing dimensions`);
+      continue;
+    }
 
     for (const dimension of ISSUE_ENRICHMENT_SCORE_DIMENSIONS) {
-      const score = fixtureCase.dimensions[dimension.id];
+      const score = fixtureCase.dimensions?.[dimension.id];
       if (!score) {
         errors.push(`case ${fixtureCase.id} missing dimension ${dimension.id}`);
         continue;
@@ -311,7 +315,7 @@ function scoreDimension(
   const threshold = getMetricContract(packet, dimension).pilotThreshold.advisoryMin;
 
   for (const fixtureCase of packet.cases) {
-    const score = fixtureCase.dimensions[dimension.id];
+    const score = fixtureCase.dimensions?.[dimension.id];
     if (!score) continue;
     for (const link of score.evidenceLinks ?? []) evidenceLinks.add(link);
     if (score.unmeasurable) {

--- a/src/issue-enrichment-scorecard.ts
+++ b/src/issue-enrichment-scorecard.ts
@@ -181,8 +181,6 @@ export const ISSUE_ENRICHMENT_SCORE_DIMENSIONS: IssueEnrichmentScoreDimension[] 
   })
 ];
 
-const DIMENSIONS_BY_ID = new Map(ISSUE_ENRICHMENT_SCORE_DIMENSIONS.map((item) => [item.id, item]));
-
 export function scoreIssueEnrichment(packet: IssueEnrichmentFixturePacket): IssueEnrichmentScorecardResult {
   const dimensionScores = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.map((dimension) => scoreDimension(packet, dimension));
   const rawTotal = dimensionScores.reduce((sum, dimension) => sum + dimension.rawScore, 0);
@@ -259,10 +257,10 @@ export function validateIssueEnrichmentFixture(packet: IssueEnrichmentFixturePac
         }
         continue;
       }
-      if (!Number.isFinite(score.score) || score.score! < 0 || score.score! > 5) {
+      const scoreIsInRange = Number.isFinite(score.score) && score.score! >= 0 && score.score! <= 5;
+      if (!scoreIsInRange) {
         errors.push(`case ${fixtureCase.id} dimension ${dimension.id} score must be between 0 and 5`);
-      }
-      if ((score.score ?? 0) > 3 && !hasDirectEvidenceLink(score.evidenceLinks, fixtureCase, dimension.id)) {
+      } else if (score.score! > 3 && !hasDirectEvidenceLink(score.evidenceLinks, fixtureCase, dimension.id)) {
         errors.push(`case ${fixtureCase.id} dimension ${dimension.id} scored ${score.score} without direct evidence links`);
       }
     }
@@ -307,7 +305,7 @@ function scoreDimension(
   const unmeasurableCases: string[] = [];
   const pilotThresholdMisses: string[] = [];
   const evidenceLinks = new Set<string>();
-  const threshold = DIMENSIONS_BY_ID.get(dimension.id)?.metricContract.pilotThreshold.advisoryMin ?? 0;
+  const threshold = getMetricContract(packet, dimension).pilotThreshold.advisoryMin;
 
   for (const fixtureCase of packet.cases) {
     const score = fixtureCase.dimensions[dimension.id];
@@ -338,6 +336,13 @@ function scoreDimension(
     pilotThresholdMisses,
     evidenceLinks: [...evidenceLinks].sort()
   };
+}
+
+function getMetricContract(
+  packet: IssueEnrichmentFixturePacket,
+  dimension: IssueEnrichmentScoreDimension
+): IssueEnrichmentMetricContract {
+  return packet.metricContracts?.[dimension.id] ?? dimension.metricContract;
 }
 
 function normalizeScore(score: number | undefined): number {

--- a/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
+++ b/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
@@ -1,0 +1,192 @@
+{
+  "fixtureVersion": "0.1",
+  "proofBoundary": "advisory fixture scoring only; this packet does not prove public parity, calibrated confidence, runtime safety, or release readiness",
+  "knownLimitations": [
+    "Scores are seeded regression expectations, not statistically calibrated production outcomes.",
+    "Provider-failure burst coverage is simulated and does not exercise live GitHub or provider APIs.",
+    "External precedent quality is represented by sampled links and stale-link negatives, not a full web corpus.",
+    "Fixture scoring does not post comments, mutate labels, update assignees, or change live config."
+  ],
+  "cases": [
+    {
+      "id": "duplicate-same-head-comments",
+      "title": "Duplicate same-head comments",
+      "coverage": "duplicate_same_head_comments",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "dimensions": {
+        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "throttling": { "score": 2.6222, "notes": "No burst pressure in this fixture." }
+      }
+    },
+    {
+      "id": "stale_head_posts",
+      "title": "Stale-head posts",
+      "coverage": "stale_head_posts",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "dimensions": {
+        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "throttling": { "score": 2.6222, "notes": "Single stale-head rejection, no burst." }
+      }
+    },
+    {
+      "id": "invalid_inline_coordinates",
+      "title": "Invalid inline coordinates",
+      "coverage": "invalid_inline_coordinates",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "dimensions": {
+        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "throttling": { "score": 2.6222, "notes": "Coordinate validation does not exercise throttle pressure." }
+      }
+    },
+    {
+      "id": "issue_enrichment_permission_failure",
+      "title": "Issue-enrichment permission failure",
+      "coverage": "issue_enrichment_permission_failure",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "dimensions": {
+        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "throttling": { "score": 2.6222, "notes": "Permission failure exits before provider throttling." }
+      }
+    },
+    {
+      "id": "launchd_config_head_ambiguity",
+      "title": "Launchd/config/head ambiguity",
+      "coverage": "launchd_config_head_ambiguity",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "dimensions": {
+        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "throttling": { "score": 2.6222, "notes": "Ambiguity fails closed before live posting." }
+      }
+    },
+    {
+      "id": "docs_only_fast_negative_control",
+      "title": "Docs-only fast negative control",
+      "coverage": "docs_only_fast_negative_control",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "dimensions": {
+        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "throttling": { "score": 2.6222, "notes": "Fast negative avoids provider and comment spend." }
+      }
+    },
+    {
+      "id": "old_backlog_negative_control",
+      "title": "Old-backlog negative control",
+      "coverage": "old_backlog_negative_control",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "dimensions": {
+        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "throttling": { "score": 2.6222, "notes": "Backlog scan should defer rather than consume comment budget." }
+      }
+    },
+    {
+      "id": "external_precedent_required_issue",
+      "title": "External-precedent-required issue",
+      "coverage": "external_precedent_required_issue",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "dimensions": {
+        "related_context_precision": { "unmeasurable": true, "unmeasurableReason": "No current external precedent is available in the sampled fixture." },
+        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "throttling": { "score": 2.6222, "notes": "External research needed before provider budget is meaningful." }
+      }
+    },
+    {
+      "id": "stale_irrelevant_web_result",
+      "title": "Stale or irrelevant web result",
+      "coverage": "stale_irrelevant_web_result",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "dimensions": {
+        "related_context_precision": { "score": 2, "notes": "Stale web result is intentionally below advisory threshold." },
+        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "throttling": { "score": 2.6222, "notes": "Rejecting stale context avoids extra provider retries." }
+      }
+    },
+    {
+      "id": "provider_failure_burst_30_prs",
+      "title": "30-PR provider-failure burst simulation",
+      "coverage": "provider_failure_burst_30_prs",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "dimensions": {
+        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
+        "throttling": { "score": 2.6222, "notes": "Simulated provider burst exercises deferral but not promotion-ready live throttle evidence." }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
+++ b/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
@@ -632,6 +632,7 @@
         },
         "proof_boundary": {
           "score": 5,
+          "notes": "High proof-boundary score is limited to the fixture's explicit advisory caveat: the burst is simulated and does not prove live provider reliability or release readiness.",
           "evidenceLinks": [
             "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-proof-boundary"
           ]
@@ -650,12 +651,14 @@
         },
         "idempotency": {
           "score": 4,
+          "notes": "Scores deterministic retry/defer state modeling for the simulated burst; it does not claim production idempotency under live provider pressure.",
           "evidenceLinks": [
             "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-idempotency"
           ]
         },
         "safety": {
           "score": 4.4,
+          "notes": "High safety score is for fail-closed advisory handling in the simulated burst only; live runtime safety remains outside this fixture proof boundary.",
           "evidenceLinks": [
             "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-safety"
           ]

--- a/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
+++ b/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
@@ -185,7 +185,7 @@
         "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
         "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
         "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "throttling": { "score": 2.6222, "notes": "Simulated provider burst exercises deferral but not promotion-ready live throttle evidence." }
+        "throttling": { "score": 1, "notes": "Simulated provider burst stays below advisory threshold until live cap evidence exists." }
       }
     }
   ]

--- a/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
+++ b/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
@@ -12,180 +12,656 @@
       "id": "duplicate-same-head-comments",
       "title": "Duplicate same-head comments",
       "coverage": "duplicate_same_head_comments",
-      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#scenario-duplicate-same-head-comments",
       "dimensions": {
-        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "throttling": { "score": 2.6222, "notes": "No burst pressure in this fixture." }
+        "related_context_precision": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-related-context-precision"
+          ]
+        },
+        "planning_value": {
+          "score": 4.2,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-planning-value"
+          ]
+        },
+        "acceptance_criteria": {
+          "score": 4.5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-acceptance-criteria"
+          ]
+        },
+        "ownership_routing": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-ownership-routing"
+          ]
+        },
+        "proof_boundary": {
+          "score": 5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-proof-boundary"
+          ]
+        },
+        "lifecycle_state": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-lifecycle-state"
+          ]
+        },
+        "noise_control": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-noise-control"
+          ]
+        },
+        "idempotency": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-idempotency"
+          ]
+        },
+        "safety": {
+          "score": 4.4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-safety"
+          ]
+        },
+        "throttling": {
+          "score": 2.6222,
+          "notes": "No burst pressure in this fixture."
+        }
       }
     },
     {
       "id": "stale_head_posts",
       "title": "Stale-head posts",
       "coverage": "stale_head_posts",
-      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#scenario-stale-head-posts",
       "dimensions": {
-        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "throttling": { "score": 2.6222, "notes": "Single stale-head rejection, no burst." }
+        "related_context_precision": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-head-posts-related-context-precision"
+          ]
+        },
+        "planning_value": {
+          "score": 4.2,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-head-posts-planning-value"
+          ]
+        },
+        "acceptance_criteria": {
+          "score": 4.5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-head-posts-acceptance-criteria"
+          ]
+        },
+        "ownership_routing": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-head-posts-ownership-routing"
+          ]
+        },
+        "proof_boundary": {
+          "score": 5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-head-posts-proof-boundary"
+          ]
+        },
+        "lifecycle_state": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-head-posts-lifecycle-state"
+          ]
+        },
+        "noise_control": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-head-posts-noise-control"
+          ]
+        },
+        "idempotency": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-head-posts-idempotency"
+          ]
+        },
+        "safety": {
+          "score": 4.4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-head-posts-safety"
+          ]
+        },
+        "throttling": {
+          "score": 2.6222,
+          "notes": "Single stale-head rejection, no burst."
+        }
       }
     },
     {
       "id": "invalid_inline_coordinates",
       "title": "Invalid inline coordinates",
       "coverage": "invalid_inline_coordinates",
-      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#scenario-invalid-inline-coordinates",
       "dimensions": {
-        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "throttling": { "score": 2.6222, "notes": "Coordinate validation does not exercise throttle pressure." }
+        "related_context_precision": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-invalid-inline-coordinates-related-context-precision"
+          ]
+        },
+        "planning_value": {
+          "score": 4.2,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-invalid-inline-coordinates-planning-value"
+          ]
+        },
+        "acceptance_criteria": {
+          "score": 4.5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-invalid-inline-coordinates-acceptance-criteria"
+          ]
+        },
+        "ownership_routing": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-invalid-inline-coordinates-ownership-routing"
+          ]
+        },
+        "proof_boundary": {
+          "score": 5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-invalid-inline-coordinates-proof-boundary"
+          ]
+        },
+        "lifecycle_state": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-invalid-inline-coordinates-lifecycle-state"
+          ]
+        },
+        "noise_control": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-invalid-inline-coordinates-noise-control"
+          ]
+        },
+        "idempotency": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-invalid-inline-coordinates-idempotency"
+          ]
+        },
+        "safety": {
+          "score": 4.4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-invalid-inline-coordinates-safety"
+          ]
+        },
+        "throttling": {
+          "score": 2.6222,
+          "notes": "Coordinate validation does not exercise throttle pressure."
+        }
       }
     },
     {
       "id": "issue_enrichment_permission_failure",
       "title": "Issue-enrichment permission failure",
       "coverage": "issue_enrichment_permission_failure",
-      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#scenario-issue-enrichment-permission-failure",
       "dimensions": {
-        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "throttling": { "score": 2.6222, "notes": "Permission failure exits before provider throttling." }
+        "related_context_precision": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-issue-enrichment-permission-failure-related-context-precision"
+          ]
+        },
+        "planning_value": {
+          "score": 4.2,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-issue-enrichment-permission-failure-planning-value"
+          ]
+        },
+        "acceptance_criteria": {
+          "score": 4.5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-issue-enrichment-permission-failure-acceptance-criteria"
+          ]
+        },
+        "ownership_routing": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-issue-enrichment-permission-failure-ownership-routing"
+          ]
+        },
+        "proof_boundary": {
+          "score": 5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-issue-enrichment-permission-failure-proof-boundary"
+          ]
+        },
+        "lifecycle_state": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-issue-enrichment-permission-failure-lifecycle-state"
+          ]
+        },
+        "noise_control": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-issue-enrichment-permission-failure-noise-control"
+          ]
+        },
+        "idempotency": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-issue-enrichment-permission-failure-idempotency"
+          ]
+        },
+        "safety": {
+          "score": 4.4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-issue-enrichment-permission-failure-safety"
+          ]
+        },
+        "throttling": {
+          "score": 2.6222,
+          "notes": "Permission failure exits before provider throttling."
+        }
       }
     },
     {
       "id": "launchd_config_head_ambiguity",
       "title": "Launchd/config/head ambiguity",
       "coverage": "launchd_config_head_ambiguity",
-      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#scenario-launchd-config-head-ambiguity",
       "dimensions": {
-        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "throttling": { "score": 2.6222, "notes": "Ambiguity fails closed before live posting." }
+        "related_context_precision": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-launchd-config-head-ambiguity-related-context-precision"
+          ]
+        },
+        "planning_value": {
+          "score": 4.2,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-launchd-config-head-ambiguity-planning-value"
+          ]
+        },
+        "acceptance_criteria": {
+          "score": 4.5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-launchd-config-head-ambiguity-acceptance-criteria"
+          ]
+        },
+        "ownership_routing": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-launchd-config-head-ambiguity-ownership-routing"
+          ]
+        },
+        "proof_boundary": {
+          "score": 5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-launchd-config-head-ambiguity-proof-boundary"
+          ]
+        },
+        "lifecycle_state": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-launchd-config-head-ambiguity-lifecycle-state"
+          ]
+        },
+        "noise_control": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-launchd-config-head-ambiguity-noise-control"
+          ]
+        },
+        "idempotency": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-launchd-config-head-ambiguity-idempotency"
+          ]
+        },
+        "safety": {
+          "score": 4.4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-launchd-config-head-ambiguity-safety"
+          ]
+        },
+        "throttling": {
+          "score": 2.6222,
+          "notes": "Ambiguity fails closed before live posting."
+        }
       }
     },
     {
       "id": "docs_only_fast_negative_control",
       "title": "Docs-only fast negative control",
       "coverage": "docs_only_fast_negative_control",
-      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#scenario-docs-only-fast-negative-control",
       "dimensions": {
-        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "throttling": { "score": 2.6222, "notes": "Fast negative avoids provider and comment spend." }
+        "related_context_precision": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-docs-only-fast-negative-control-related-context-precision"
+          ]
+        },
+        "planning_value": {
+          "score": 4.2,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-docs-only-fast-negative-control-planning-value"
+          ]
+        },
+        "acceptance_criteria": {
+          "score": 4.5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-docs-only-fast-negative-control-acceptance-criteria"
+          ]
+        },
+        "ownership_routing": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-docs-only-fast-negative-control-ownership-routing"
+          ]
+        },
+        "proof_boundary": {
+          "score": 5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-docs-only-fast-negative-control-proof-boundary"
+          ]
+        },
+        "lifecycle_state": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-docs-only-fast-negative-control-lifecycle-state"
+          ]
+        },
+        "noise_control": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-docs-only-fast-negative-control-noise-control"
+          ]
+        },
+        "idempotency": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-docs-only-fast-negative-control-idempotency"
+          ]
+        },
+        "safety": {
+          "score": 4.4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-docs-only-fast-negative-control-safety"
+          ]
+        },
+        "throttling": {
+          "score": 2.6222,
+          "notes": "Fast negative avoids provider and comment spend."
+        }
       }
     },
     {
       "id": "old_backlog_negative_control",
       "title": "Old-backlog negative control",
       "coverage": "old_backlog_negative_control",
-      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#scenario-old-backlog-negative-control",
       "dimensions": {
-        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "throttling": { "score": 2.6222, "notes": "Backlog scan should defer rather than consume comment budget." }
+        "related_context_precision": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-old-backlog-negative-control-related-context-precision"
+          ]
+        },
+        "planning_value": {
+          "score": 4.2,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-old-backlog-negative-control-planning-value"
+          ]
+        },
+        "acceptance_criteria": {
+          "score": 4.5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-old-backlog-negative-control-acceptance-criteria"
+          ]
+        },
+        "ownership_routing": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-old-backlog-negative-control-ownership-routing"
+          ]
+        },
+        "proof_boundary": {
+          "score": 5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-old-backlog-negative-control-proof-boundary"
+          ]
+        },
+        "lifecycle_state": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-old-backlog-negative-control-lifecycle-state"
+          ]
+        },
+        "noise_control": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-old-backlog-negative-control-noise-control"
+          ]
+        },
+        "idempotency": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-old-backlog-negative-control-idempotency"
+          ]
+        },
+        "safety": {
+          "score": 4.4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-old-backlog-negative-control-safety"
+          ]
+        },
+        "throttling": {
+          "score": 2.6222,
+          "notes": "Backlog scan should defer rather than consume comment budget."
+        }
       }
     },
     {
       "id": "external_precedent_required_issue",
       "title": "External-precedent-required issue",
       "coverage": "external_precedent_required_issue",
-      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#scenario-external-precedent-required-issue",
       "dimensions": {
-        "related_context_precision": { "unmeasurable": true, "unmeasurableReason": "No current external precedent is available in the sampled fixture." },
-        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "throttling": { "score": 2.6222, "notes": "External research needed before provider budget is meaningful." }
+        "related_context_precision": {
+          "unmeasurable": true,
+          "unmeasurableReason": "No current external precedent is available in the sampled fixture."
+        },
+        "planning_value": {
+          "score": 4.2,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-external-precedent-required-issue-planning-value"
+          ]
+        },
+        "acceptance_criteria": {
+          "score": 4.5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-external-precedent-required-issue-acceptance-criteria"
+          ]
+        },
+        "ownership_routing": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-external-precedent-required-issue-ownership-routing"
+          ]
+        },
+        "proof_boundary": {
+          "score": 5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-external-precedent-required-issue-proof-boundary"
+          ]
+        },
+        "lifecycle_state": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-external-precedent-required-issue-lifecycle-state"
+          ]
+        },
+        "noise_control": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-external-precedent-required-issue-noise-control"
+          ]
+        },
+        "idempotency": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-external-precedent-required-issue-idempotency"
+          ]
+        },
+        "safety": {
+          "score": 4.4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-external-precedent-required-issue-safety"
+          ]
+        },
+        "throttling": {
+          "score": 2.6222,
+          "notes": "External research needed before provider budget is meaningful."
+        }
       }
     },
     {
       "id": "stale_irrelevant_web_result",
       "title": "Stale or irrelevant web result",
       "coverage": "stale_irrelevant_web_result",
-      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#scenario-stale-irrelevant-web-result",
       "dimensions": {
-        "related_context_precision": { "score": 2, "notes": "Stale web result is intentionally below advisory threshold." },
-        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "throttling": { "score": 2.6222, "notes": "Rejecting stale context avoids extra provider retries." }
+        "related_context_precision": {
+          "score": 2,
+          "notes": "Stale web result is intentionally below advisory threshold."
+        },
+        "planning_value": {
+          "score": 4.2,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-irrelevant-web-result-planning-value"
+          ]
+        },
+        "acceptance_criteria": {
+          "score": 4.5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-irrelevant-web-result-acceptance-criteria"
+          ]
+        },
+        "ownership_routing": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-irrelevant-web-result-ownership-routing"
+          ]
+        },
+        "proof_boundary": {
+          "score": 5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-irrelevant-web-result-proof-boundary"
+          ]
+        },
+        "lifecycle_state": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-irrelevant-web-result-lifecycle-state"
+          ]
+        },
+        "noise_control": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-irrelevant-web-result-noise-control"
+          ]
+        },
+        "idempotency": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-irrelevant-web-result-idempotency"
+          ]
+        },
+        "safety": {
+          "score": 4.4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-irrelevant-web-result-safety"
+          ]
+        },
+        "throttling": {
+          "score": 2.6222,
+          "notes": "Rejecting stale context avoids extra provider retries."
+        }
       }
     },
     {
       "id": "provider_failure_burst_30_prs",
       "title": "30-PR provider-failure burst simulation",
       "coverage": "provider_failure_burst_30_prs",
-      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264",
+      "fixtureSource": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#scenario-provider-failure-burst-30-prs",
       "dimensions": {
-        "related_context_precision": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "planning_value": { "score": 4.2, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "acceptance_criteria": { "score": 4.5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "ownership_routing": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "proof_boundary": { "score": 5, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "lifecycle_state": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "noise_control": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "idempotency": { "score": 4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "safety": { "score": 4.4, "evidenceLinks": ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"] },
-        "throttling": { "score": 1, "notes": "Simulated provider burst stays below advisory threshold until live cap evidence exists." }
+        "related_context_precision": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-related-context-precision"
+          ]
+        },
+        "planning_value": {
+          "score": 4.2,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-planning-value"
+          ]
+        },
+        "acceptance_criteria": {
+          "score": 4.5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-acceptance-criteria"
+          ]
+        },
+        "ownership_routing": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-ownership-routing"
+          ]
+        },
+        "proof_boundary": {
+          "score": 5,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-proof-boundary"
+          ]
+        },
+        "lifecycle_state": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-lifecycle-state"
+          ]
+        },
+        "noise_control": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-noise-control"
+          ]
+        },
+        "idempotency": {
+          "score": 4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-idempotency"
+          ]
+        },
+        "safety": {
+          "score": 4.4,
+          "evidenceLinks": [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-safety"
+          ]
+        },
+        "throttling": {
+          "score": 1,
+          "notes": "Simulated provider burst stays below advisory threshold until live cap evidence exists."
+        }
       }
     }
   ]

--- a/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
+++ b/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
@@ -70,7 +70,7 @@
         },
         "throttling": {
           "score": 2.6222,
-          "notes": "No burst pressure in this fixture."
+          "notes": "No burst pressure in this fixture. Seeded throttle baseline 2.6222 means partial budget evidence, no burst, and below promotion threshold; it is not calibrated production reliability."
         }
       }
     },
@@ -136,7 +136,7 @@
         },
         "throttling": {
           "score": 2.6222,
-          "notes": "Single stale-head rejection, no burst."
+          "notes": "Single stale-head rejection, no burst. Seeded throttle baseline 2.6222 means partial budget evidence, no burst, and below promotion threshold; it is not calibrated production reliability."
         }
       }
     },
@@ -202,7 +202,7 @@
         },
         "throttling": {
           "score": 2.6222,
-          "notes": "Coordinate validation does not exercise throttle pressure."
+          "notes": "Coordinate validation does not exercise throttle pressure. Seeded throttle baseline 2.6222 means partial budget evidence, no burst, and below promotion threshold; it is not calibrated production reliability."
         }
       }
     },
@@ -268,7 +268,7 @@
         },
         "throttling": {
           "score": 2.6222,
-          "notes": "Permission failure exits before provider throttling."
+          "notes": "Permission failure exits before provider throttling. Seeded throttle baseline 2.6222 means partial budget evidence, no burst, and below promotion threshold; it is not calibrated production reliability."
         }
       }
     },
@@ -334,7 +334,7 @@
         },
         "throttling": {
           "score": 2.6222,
-          "notes": "Ambiguity fails closed before live posting."
+          "notes": "Ambiguity fails closed before live posting. Seeded throttle baseline 2.6222 means partial budget evidence, no burst, and below promotion threshold; it is not calibrated production reliability."
         }
       }
     },
@@ -400,7 +400,7 @@
         },
         "throttling": {
           "score": 2.6222,
-          "notes": "Fast negative avoids provider and comment spend."
+          "notes": "Fast negative avoids provider and comment spend. Seeded throttle baseline 2.6222 means partial budget evidence, no burst, and below promotion threshold; it is not calibrated production reliability."
         }
       }
     },
@@ -466,7 +466,7 @@
         },
         "throttling": {
           "score": 2.6222,
-          "notes": "Backlog scan should defer rather than consume comment budget."
+          "notes": "Backlog scan should defer rather than consume comment budget. Seeded throttle baseline 2.6222 means partial budget evidence, no burst, and below promotion threshold; it is not calibrated production reliability."
         }
       }
     },
@@ -530,7 +530,7 @@
         },
         "throttling": {
           "score": 2.6222,
-          "notes": "External research needed before provider budget is meaningful."
+          "notes": "External research needed before provider budget is meaningful. Seeded throttle baseline 2.6222 means partial budget evidence, no burst, and below promotion threshold; it is not calibrated production reliability."
         }
       }
     },
@@ -594,7 +594,7 @@
         },
         "throttling": {
           "score": 2.6222,
-          "notes": "Rejecting stale context avoids extra provider retries."
+          "notes": "Rejecting stale context avoids extra provider retries. Seeded throttle baseline 2.6222 means partial budget evidence, no burst, and below promotion threshold; it is not calibrated production reliability."
         }
       }
     },
@@ -660,7 +660,7 @@
         },
         "throttling": {
           "score": 1,
-          "notes": "Simulated provider burst stays below advisory threshold until live cap evidence exists."
+          "notes": "Simulated provider burst score 1 means burst pressure is known unsafe until live cap evidence exists; it is deliberately below advisory and promotion thresholds and is not calibrated production reliability."
         }
       }
     }

--- a/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
+++ b/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
@@ -52,12 +52,14 @@
         },
         "noise_control": {
           "score": 4,
+          "notes": "Scores duplicate suppression as noise control: useful no-spam behavior, not perfect because live sticky-update reporting still needs broader rollout proof.",
           "evidenceLinks": [
             "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-noise-control"
           ]
         },
         "idempotency": {
           "score": 4,
+          "notes": "Scores repeated same-head behavior as idempotency: stable marker/upsert expectations are covered, but full cross-cycle state repair remains a separate runtime eval.",
           "evidenceLinks": [
             "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-idempotency"
           ]

--- a/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
+++ b/tests/fixtures/issue-enrichment-scorecard/sampled-regression-packet.json
@@ -5,6 +5,7 @@
     "Scores are seeded regression expectations, not statistically calibrated production outcomes.",
     "Provider-failure burst coverage is simulated and does not exercise live GitHub or provider APIs.",
     "External precedent quality is represented by sampled links and stale-link negatives, not a full web corpus.",
+    "Direct-evidence anchors are nominal fixture contract identifiers on issue #264; this packet validates anchor shape, not GitHub anchor resolvability.",
     "Fixture scoring does not post comments, mutate labels, update assignees, or change live config."
   ],
   "cases": [

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -26,10 +26,11 @@ function expectedTopLevelScores(fixture: IssueEnrichmentFixturePacket): { rawSco
 
     if (!scores.length) return [];
     const averageScore = scores.reduce((sum, score) => sum + score, 0) / scores.length;
+    const roundedWeightedContribution = Math.round(averageScore * dimension.weight * 100) / 100;
     return [
       {
         rawScore: averageScore,
-        weightedContribution: averageScore * dimension.weight,
+        weightedContribution: roundedWeightedContribution,
         maxWeightedScore: dimension.weight * 5
       }
     ];

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -28,11 +28,10 @@ function expectedTopLevelScores(fixture: IssueEnrichmentFixturePacket): { rawSco
 
     if (!scores.length) return [];
     const averageScore = scores.reduce((sum, score) => sum + score, 0) / scores.length;
-    const roundedWeightedContribution = Math.round(averageScore * dimension.weight * 100) / 100;
     return [
       {
         rawScore: averageScore,
-        weightedContribution: roundedWeightedContribution,
+        weightedContribution: averageScore * dimension.weight,
         maxWeightedScore: dimension.weight * 5
       }
     ];
@@ -176,7 +175,7 @@ describe("issue enrichment scorecard", () => {
     });
   });
 
-  it("rejects direct-evidence anchors that do not point at the fixture source issue", () => {
+  it("rejects direct-evidence anchors that do not point at the canonical evidence issue", () => {
     const fixture = loadFixture();
     fixture.cases[0].dimensions.proof_boundary = {
       score: 4,
@@ -186,6 +185,23 @@ describe("issue enrichment scorecard", () => {
     expect(validateIssueEnrichmentFixture(fixture)).toMatchObject({
       ok: false,
       errors: expect.arrayContaining([
+        "case duplicate-same-head-comments dimension proof_boundary scored 4 without direct evidence links"
+      ])
+    });
+  });
+
+  it("rejects self-consistent high-score evidence links on non-canonical fixture sources", () => {
+    const fixture = loadFixture();
+    fixture.cases[0].fixtureSource = "https://example.com/evidence#scenario-duplicate-same-head-comments";
+    fixture.cases[0].dimensions.proof_boundary = {
+      score: 4,
+      evidenceLinks: ["https://example.com/evidence#direct-evidence-duplicate-same-head-comments-proof-boundary"]
+    };
+
+    expect(validateIssueEnrichmentFixture(fixture)).toMatchObject({
+      ok: false,
+      errors: expect.arrayContaining([
+        "case duplicate-same-head-comments fixtureSource must point to the canonical issue-enrichment evidence issue",
         "case duplicate-same-head-comments dimension proof_boundary scored 4 without direct evidence links"
       ])
     });
@@ -412,6 +428,13 @@ describe("issue enrichment scorecard", () => {
         fixture.cases[0].fixtureSource = "http://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264";
       },
       error: "case duplicate-same-head-comments fixtureSource must be an https URL"
+    },
+    {
+      name: "non-canonical fixture source",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.cases[0].fixtureSource = "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/999";
+      },
+      error: "case duplicate-same-head-comments fixtureSource must point to the canonical issue-enrichment evidence issue"
     },
     {
       name: "unknown coverage",

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -50,14 +50,14 @@ describe("issue enrichment scorecard", () => {
     const result = scoreIssueEnrichment(fixture);
 
     expect(result.rawScore).toBe(81);
-    expect(result.weightedScore).toBe(81);
+    expect(result.weightedScore).toBe(80);
     expect(result.publicClaim).toBe("no_public_claim");
     expect(result.calibration).toBe("uncalibrated");
     expect(result).not.toHaveProperty("publicParity");
     expect(result).not.toHaveProperty("calibratedConfidence");
     expect(result.dimensionScores.find((dimension) => dimension.id === "proof_boundary")).toMatchObject({
       score: 5,
-      weightedScore: 50,
+      weightedScore: 65,
       evidenceLinks: ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"]
     });
   });
@@ -90,10 +90,84 @@ describe("issue enrichment scorecard", () => {
   it("summarizes scorecard results with unmeasurable states and pilot threshold misses", () => {
     const summary = summarizeIssueEnrichmentScorecard(scoreIssueEnrichment(loadFixture()));
 
-    expect(summary).toContain("Issue enrichment scorecard: raw 81/100, weighted 81/100");
+    expect(summary).toContain("Issue enrichment scorecard: raw 81/100, weighted 80/100");
     expect(summary).toContain("Public claim: no_public_claim");
     expect(summary).toContain("Unmeasurable dimensions: external_precedent_required_issue:related_context_precision");
-    expect(summary).toContain("Pilot threshold misses: stale_irrelevant_web_result:related_context_precision");
+    expect(summary).toContain("stale_irrelevant_web_result:related_context_precision");
+    expect(summary).toContain("provider_failure_burst_30_prs:throttling");
     expect(summary).not.toMatch(/parity|calibrated confidence|95/i);
+  });
+
+  it.each([
+    {
+      name: "empty proof boundary",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.proofBoundary = "";
+      },
+      error: "fixture proofBoundary is required"
+    },
+    {
+      name: "empty known limitations",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.knownLimitations = [];
+      },
+      error: "fixture knownLimitations are required"
+    },
+    {
+      name: "missing coverage",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.cases = fixture.cases.filter((item) => item.coverage !== "stale_head_posts");
+      },
+      error: "missing required fixture coverage stale_head_posts"
+    },
+    {
+      name: "out-of-range score",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.cases[0].dimensions.proof_boundary = { score: 6, evidenceLinks: ["https://example.com/evidence"] };
+      },
+      error: "case duplicate-same-head-comments dimension proof_boundary score must be between 0 and 5"
+    },
+    {
+      name: "unmeasurable without reason",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.cases[0].dimensions.proof_boundary = { unmeasurable: true };
+      },
+      error: "case duplicate-same-head-comments dimension proof_boundary missing unmeasurableReason"
+    },
+    {
+      name: "missing dimension",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        const { proof_boundary: _proofBoundary, ...dimensions } = fixture.cases[0].dimensions;
+        fixture.cases[0].dimensions = dimensions as IssueEnrichmentFixturePacket["cases"][number]["dimensions"];
+      },
+      error: "case duplicate-same-head-comments missing dimension proof_boundary"
+    },
+    {
+      name: "missing metric threshold",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.metricContracts = {
+          proof_boundary: {
+            denominator: "proof claims",
+            dataSource: "fixture",
+            scoringRule: "score proof boundary clarity",
+            unmeasurableState: "no proof claim",
+            pilotThreshold: {
+              advisoryMin: Number.NaN,
+              promotionMin: Number.NaN
+            }
+          }
+        };
+      },
+      error: "dimension proof_boundary metric contract missing pilotThreshold.advisoryMin"
+    }
+  ])("fails closed for invalid fixture packets: $name", ({ mutate, error }) => {
+    const fixture = loadFixture();
+
+    mutate(fixture);
+
+    expect(validateIssueEnrichmentFixture(fixture)).toMatchObject({
+      ok: false,
+      errors: expect.arrayContaining([error])
+    });
   });
 });

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -58,7 +58,18 @@ describe("issue enrichment scorecard", () => {
     expect(result.dimensionScores.find((dimension) => dimension.id === "proof_boundary")).toMatchObject({
       score: 5,
       weightedScore: 65,
-      evidenceLinks: ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"]
+      evidenceLinks: [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-docs-only-fast-negative-control-proof-boundary",
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-proof-boundary",
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-external-precedent-required-issue-proof-boundary",
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-invalid-inline-coordinates-proof-boundary",
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-issue-enrichment-permission-failure-proof-boundary",
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-launchd-config-head-ambiguity-proof-boundary",
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-old-backlog-negative-control-proof-boundary",
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-proof-boundary",
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-head-posts-proof-boundary",
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-irrelevant-web-result-proof-boundary"
+      ]
     });
   });
 
@@ -67,6 +78,21 @@ describe("issue enrichment scorecard", () => {
     fixture.cases[0].dimensions.proof_boundary = {
       score: 4,
       notes: "High score without a direct link must fail validation."
+    };
+
+    expect(validateIssueEnrichmentFixture(fixture)).toMatchObject({
+      ok: false,
+      errors: expect.arrayContaining([
+        "case duplicate-same-head-comments dimension proof_boundary scored 4 without direct evidence links"
+      ])
+    });
+  });
+
+  it("rejects generic parent issue URLs for high scores even when they are valid http links", () => {
+    const fixture = loadFixture();
+    fixture.cases[0].dimensions.proof_boundary = {
+      score: 4,
+      evidenceLinks: ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"]
     };
 
     expect(validateIssueEnrichmentFixture(fixture)).toMatchObject({
@@ -123,7 +149,10 @@ describe("issue enrichment scorecard", () => {
     {
       name: "out-of-range score",
       mutate: (fixture: IssueEnrichmentFixturePacket) => {
-        fixture.cases[0].dimensions.proof_boundary = { score: 6, evidenceLinks: ["https://example.com/evidence"] };
+        fixture.cases[0].dimensions.proof_boundary = {
+          score: 6,
+          evidenceLinks: ["https://example.com/evidence#direct-evidence-duplicate-same-head-comments-proof-boundary"]
+        };
       },
       error: "case duplicate-same-head-comments dimension proof_boundary score must be between 0 and 5"
     },

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -58,25 +58,22 @@ describe("issue enrichment scorecard", () => {
     expect(result.calibration).toBe("uncalibrated");
     expect(result).not.toHaveProperty("publicParity");
     expect(result).not.toHaveProperty("calibratedConfidence");
-    expect(result.dimensionScores.find((dimension) => dimension.id === "proof_boundary")).toMatchObject({
-      score: 5,
-      weightedContribution: expect.any(Number),
-      evidenceLinks: [
-        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-docs-only-fast-negative-control-proof-boundary",
-        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-proof-boundary",
-        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-external-precedent-required-issue-proof-boundary",
-        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-invalid-inline-coordinates-proof-boundary",
-        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-issue-enrichment-permission-failure-proof-boundary",
-        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-launchd-config-head-ambiguity-proof-boundary",
-        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-old-backlog-negative-control-proof-boundary",
-        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-provider-failure-burst-30-prs-proof-boundary",
-        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-head-posts-proof-boundary",
-        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-irrelevant-web-result-proof-boundary"
-      ]
-    });
-
     const proofBoundary = result.dimensionScores.find((dimension) => dimension.id === "proof_boundary");
-    expect(proofBoundary?.weightedContribution).toBeGreaterThan(proofBoundary?.score ?? 0);
+    expect(proofBoundary).toMatchObject({
+      score: 5,
+      weightedContribution: expect.any(Number)
+    });
+    expect(proofBoundary?.evidenceLinks).toHaveLength(fixture.cases.length);
+    for (const link of proofBoundary?.evidenceLinks ?? []) {
+      expect(link).toMatch(
+        /^https:\/\/github\.com\/electricsheephq\/evaos-code-review-bot-neondiff\/issues\/264#direct-evidence-[a-z0-9-]+-proof-boundary$/
+      );
+    }
+    const proofBoundaryConfig = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.find((dimension) => dimension.id === "proof_boundary");
+    expect(proofBoundary?.weightedContribution).toBeCloseTo(
+      (proofBoundary?.score ?? 0) * (proofBoundaryConfig?.weight ?? 0),
+      2
+    );
   });
 
   it("requires direct evidence links for every dimension score above 3", () => {
@@ -220,6 +217,42 @@ describe("issue enrichment scorecard", () => {
     expect(scoreIssueEnrichment(fixture).pilotThresholdMisses).toContain("duplicate-same-head-comments:throttling");
   });
 
+  it("excludes fully unmeasurable dimensions from top-level score denominators", () => {
+    const fixture = loadFixture();
+    const baseline = scoreIssueEnrichment(fixture);
+    const throttlingConfig = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.find((dimension) => dimension.id === "throttling");
+    expect(throttlingConfig).toBeDefined();
+
+    for (const fixtureCase of fixture.cases) {
+      fixtureCase.dimensions.throttling = {
+        unmeasurable: true,
+        unmeasurableReason: "Throttle budget data intentionally unavailable for denominator regression."
+      };
+    }
+
+    const result = scoreIssueEnrichment(fixture);
+    const measuredDimensions = result.dimensionScores.filter((dimension) => dimension.measuredCases > 0);
+    const expectedRawScore = Math.round(
+      (measuredDimensions.reduce((sum, dimension) => sum + dimension.rawScore, 0) / (measuredDimensions.length * 5)) *
+        100
+    );
+    const expectedWeightedScore = Math.round(
+      (measuredDimensions.reduce((sum, dimension) => sum + dimension.weightedContribution, 0) /
+        measuredDimensions.reduce((sum, dimension) => sum + dimension.weight * 5, 0)) *
+        100
+    );
+
+    const throttlingScore = result.dimensionScores.find((dimension) => dimension.id === "throttling");
+    expect(throttlingScore).toMatchObject({
+      measuredCases: 0,
+      unmeasurableCases: fixture.cases.map((fixtureCase) => fixtureCase.id)
+    });
+    expect(result.rawScore).toBe(expectedRawScore);
+    expect(result.weightedScore).toBe(expectedWeightedScore);
+    expect(result.weightedScore).toBeGreaterThanOrEqual(baseline.weightedScore);
+    expect(result.pilotThresholdMisses.some((miss) => miss.endsWith(":throttling"))).toBe(false);
+  });
+
   it("summarizes scorecard results with unmeasurable states and pilot threshold misses", () => {
     const summary = summarizeIssueEnrichmentScorecard(scoreIssueEnrichment(loadFixture()));
 
@@ -295,6 +328,24 @@ describe("issue enrichment scorecard", () => {
         };
       },
       error: "dimension proof_boundary metric contract missing pilotThreshold.advisoryMin"
+    },
+    {
+      name: "missing promotion threshold",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.metricContracts = {
+          proof_boundary: {
+            denominator: "proof claims",
+            dataSource: "fixture",
+            scoringRule: "score proof boundary clarity",
+            unmeasurableState: "no proof claim",
+            pilotThreshold: {
+              advisoryMin: 4,
+              promotionMin: Number.NaN
+            }
+          }
+        };
+      },
+      error: "dimension proof_boundary metric contract missing pilotThreshold.promotionMin"
     }
   ])("fails closed for invalid fixture packets: $name", ({ mutate, error }) => {
     const fixture = loadFixture();

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -7,6 +7,7 @@ import {
   scoreIssueEnrichment,
   summarizeIssueEnrichmentScorecard,
   validateIssueEnrichmentFixture,
+  type IssueEnrichmentDimensionFixtureScore,
   type IssueEnrichmentFixturePacket
 } from "../src/issue-enrichment-scorecard.js";
 
@@ -14,6 +15,37 @@ const fixturePath = join("tests", "fixtures", "issue-enrichment-scorecard", "sam
 
 function loadFixture(): IssueEnrichmentFixturePacket {
   return JSON.parse(readFileSync(fixturePath, "utf8")) as IssueEnrichmentFixturePacket;
+}
+
+function expectedTopLevelScores(fixture: IssueEnrichmentFixturePacket): { rawScore: number; weightedScore: number } {
+  const measuredDimensions = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.flatMap((dimension) => {
+    const scores = fixture.cases
+      .map((fixtureCase) => fixtureCase.dimensions?.[dimension.id])
+      .filter((score): score is IssueEnrichmentDimensionFixtureScore => Boolean(score) && !score.unmeasurable)
+      .map((score) => score.score ?? 0);
+
+    if (!scores.length) return [];
+    const averageScore = scores.reduce((sum, score) => sum + score, 0) / scores.length;
+    return [
+      {
+        rawScore: averageScore,
+        weightedContribution: averageScore * dimension.weight,
+        maxWeightedScore: dimension.weight * 5
+      }
+    ];
+  });
+
+  return {
+    rawScore: Math.round(
+      (measuredDimensions.reduce((sum, dimension) => sum + dimension.rawScore, 0) / (measuredDimensions.length * 5)) *
+        100
+    ),
+    weightedScore: Math.round(
+      (measuredDimensions.reduce((sum, dimension) => sum + dimension.weightedContribution, 0) /
+        measuredDimensions.reduce((sum, dimension) => sum + dimension.maxWeightedScore, 0)) *
+        100
+    )
+  };
 }
 
 describe("issue enrichment scorecard", () => {
@@ -48,11 +80,10 @@ describe("issue enrichment scorecard", () => {
   it("scores fixture packets with separate raw and weighted scores without public parity or calibrated-confidence claims", () => {
     const fixture = loadFixture();
     const result = scoreIssueEnrichment(fixture);
+    const expectedScores = expectedTopLevelScores(fixture);
 
-    expect(result.rawScore).toBeGreaterThanOrEqual(75);
-    expect(result.rawScore).toBeLessThanOrEqual(85);
-    expect(result.weightedScore).toBeGreaterThanOrEqual(75);
-    expect(result.weightedScore).toBeLessThanOrEqual(85);
+    expect(result.rawScore).toBe(expectedScores.rawScore);
+    expect(result.weightedScore).toBe(expectedScores.weightedScore);
     expect(result.weightedScore).not.toBe(result.rawScore);
     expect(result.publicClaim).toBe("no_public_claim");
     expect(result.calibration).toBe("uncalibrated");
@@ -87,6 +118,29 @@ describe("issue enrichment scorecard", () => {
       ok: false,
       errors: expect.arrayContaining([
         "case duplicate-same-head-comments dimension proof_boundary scored 4 without direct evidence links"
+      ])
+    });
+  });
+
+  it("documents the strict high-score evidence boundary at scores above 3", () => {
+    const exactlyThree = loadFixture();
+    exactlyThree.cases[0].dimensions.proof_boundary = {
+      score: 3,
+      notes: "Exactly 3 is useful but incomplete and does not require direct evidence."
+    };
+
+    expect(validateIssueEnrichmentFixture(exactlyThree).ok).toBe(true);
+
+    const aboveThree = loadFixture();
+    aboveThree.cases[0].dimensions.proof_boundary = {
+      score: 3.01,
+      notes: "Scores above 3 require a direct evidence link."
+    };
+
+    expect(validateIssueEnrichmentFixture(aboveThree)).toMatchObject({
+      ok: false,
+      errors: expect.arrayContaining([
+        "case duplicate-same-head-comments dimension proof_boundary scored 3.01 without direct evidence links"
       ])
     });
   });
@@ -310,6 +364,13 @@ describe("issue enrichment scorecard", () => {
         fixture.cases[0].dimensions = dimensions as IssueEnrichmentFixturePacket["cases"][number]["dimensions"];
       },
       error: "case duplicate-same-head-comments missing dimension proof_boundary"
+    },
+    {
+      name: "missing dimensions object",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.cases[0].dimensions = undefined as unknown as IssueEnrichmentFixturePacket["cases"][number]["dimensions"];
+      },
+      error: "case duplicate-same-head-comments missing dimensions"
     },
     {
       name: "missing metric threshold",

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -494,6 +494,20 @@ describe("issue enrichment scorecard", () => {
       error: "dimension proof_boundary metric contract missing pilotThreshold.advisoryMin"
     },
     {
+      name: "partial metric-contract override",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.metricContracts = {
+          proof_boundary: {
+            pilotThreshold: {
+              advisoryMin: 4,
+              promotionMin: 4.5
+            }
+          } as NonNullable<IssueEnrichmentFixturePacket["metricContracts"]>["proof_boundary"]
+        };
+      },
+      error: "dimension proof_boundary metric contract missing denominator"
+    },
+    {
       name: "missing promotion threshold",
       mutate: (fixture: IssueEnrichmentFixturePacket) => {
         fixture.metricContracts = {

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -188,7 +188,7 @@ describe("issue enrichment scorecard", () => {
     });
   });
 
-  it("rejects direct-evidence anchors with a query string that differs from the fixture source issue", () => {
+  it("accepts direct-evidence anchors on the fixture source path without query-string coupling", () => {
     const fixture = loadFixture();
     fixture.cases[0].dimensions.proof_boundary = {
       score: 4,
@@ -197,12 +197,7 @@ describe("issue enrichment scorecard", () => {
       ]
     };
 
-    expect(validateIssueEnrichmentFixture(fixture)).toMatchObject({
-      ok: false,
-      errors: expect.arrayContaining([
-        "case duplicate-same-head-comments dimension proof_boundary scored 4 without direct evidence links"
-      ])
-    });
+    expect(validateIssueEnrichmentFixture(fixture).ok).toBe(true);
   });
 
   it("does not emit a redundant missing-evidence error for an out-of-range high score", () => {
@@ -452,6 +447,17 @@ describe("issue enrichment scorecard", () => {
       error: "case duplicate-same-head-comments dimension proof_boundary missing unmeasurableReason"
     },
     {
+      name: "unmeasurable with conflicting measured score",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.cases[0].dimensions.proof_boundary = {
+          unmeasurable: true,
+          score: 4,
+          unmeasurableReason: "No proof claim is available to score."
+        };
+      },
+      error: "case duplicate-same-head-comments dimension proof_boundary cannot set score when unmeasurable"
+    },
+    {
       name: "missing dimension",
       mutate: (fixture: IssueEnrichmentFixturePacket) => {
         const { proof_boundary: _proofBoundary, ...dimensions } = fixture.cases[0].dimensions;
@@ -524,6 +530,42 @@ describe("issue enrichment scorecard", () => {
         };
       },
       error: "dimension proof_boundary metric contract missing pilotThreshold.promotionMin"
+    },
+    {
+      name: "out-of-range advisory threshold",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.metricContracts = {
+          proof_boundary: {
+            denominator: "proof claims",
+            dataSource: "fixture",
+            scoringRule: "score proof boundary clarity",
+            unmeasurableState: "no proof claim",
+            pilotThreshold: {
+              advisoryMin: 1000,
+              promotionMin: 4.5
+            }
+          }
+        };
+      },
+      error: "dimension proof_boundary metric contract pilotThreshold.advisoryMin must be between 0 and 5"
+    },
+    {
+      name: "negative promotion threshold",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.metricContracts = {
+          proof_boundary: {
+            denominator: "proof claims",
+            dataSource: "fixture",
+            scoringRule: "score proof boundary clarity",
+            unmeasurableState: "no proof claim",
+            pilotThreshold: {
+              advisoryMin: 3,
+              promotionMin: -1
+            }
+          }
+        };
+      },
+      error: "dimension proof_boundary metric contract pilotThreshold.promotionMin must be between 0 and 5"
     }
   ])("fails closed for invalid fixture packets: $name", ({ mutate, error }) => {
     const fixture = loadFixture();

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -313,12 +313,18 @@ describe("issue enrichment scorecard", () => {
 
   it("summarizes scorecard results with unmeasurable states and pilot threshold misses", () => {
     const summary = summarizeIssueEnrichmentScorecard(scoreIssueEnrichment(loadFixture()));
+    const unmeasurableLine = summary
+      .split("\n")
+      .find((line) => line.startsWith("Unmeasurable dimensions:"));
+    const pilotThresholdMissesLine = summary
+      .split("\n")
+      .find((line) => line.startsWith("Pilot threshold misses:"));
 
     expect(summary).toMatch(/Issue enrichment scorecard: raw \d+\/100, weighted \d+\/100/);
     expect(summary).toContain("Public claim: no_public_claim");
-    expect(summary).toContain("Unmeasurable dimensions: external_precedent_required_issue:related_context_precision");
-    expect(summary).toContain("stale_irrelevant_web_result:related_context_precision");
-    expect(summary).toContain("provider_failure_burst_30_prs:throttling");
+    expect(unmeasurableLine).toBe("Unmeasurable dimensions: external_precedent_required_issue:related_context_precision");
+    expect(pilotThresholdMissesLine).toContain("stale_irrelevant_web_result:related_context_precision");
+    expect(pilotThresholdMissesLine).toContain("provider_failure_burst_30_prs:throttling");
     expect(summary).not.toMatch(/parity|calibrated confidence|95/i);
   });
 

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -280,6 +280,9 @@ describe("issue enrichment scorecard", () => {
     for (const fixtureCase of fixture.cases) {
       fixtureCase.dimensions.throttling = {
         unmeasurable: true,
+        evidenceLinks: [
+          `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-${fixtureCase.id}-throttling`
+        ],
         unmeasurableReason: "Throttle budget data intentionally unavailable for denominator regression."
       };
     }
@@ -299,7 +302,8 @@ describe("issue enrichment scorecard", () => {
     const throttlingScore = result.dimensionScores.find((dimension) => dimension.id === "throttling");
     expect(throttlingScore).toMatchObject({
       measuredCases: 0,
-      unmeasurableCases: fixture.cases.map((fixtureCase) => fixtureCase.id)
+      unmeasurableCases: fixture.cases.map((fixtureCase) => fixtureCase.id),
+      evidenceLinks: []
     });
     expect(result.rawScore).toBe(expectedRawScore);
     expect(result.weightedScore).toBe(expectedWeightedScore);
@@ -371,6 +375,15 @@ describe("issue enrichment scorecard", () => {
         fixture.cases[0].dimensions = undefined as unknown as IssueEnrichmentFixturePacket["cases"][number]["dimensions"];
       },
       error: "case duplicate-same-head-comments missing dimensions"
+    },
+    {
+      name: "missing measured score",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.cases[0].dimensions.proof_boundary = {
+          notes: "Measured score omitted by fixture author."
+        };
+      },
+      error: "case duplicate-same-head-comments dimension proof_boundary score is required"
     },
     {
       name: "missing metric threshold",

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -305,7 +305,6 @@ describe("issue enrichment scorecard", () => {
 
   it("excludes fully unmeasurable dimensions from top-level score denominators", () => {
     const fixture = loadFixture();
-    const baseline = scoreIssueEnrichment(fixture);
     const throttlingConfig = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.find((dimension) => dimension.id === "throttling");
     expect(throttlingConfig).toBeDefined();
 
@@ -339,7 +338,6 @@ describe("issue enrichment scorecard", () => {
     });
     expect(result.rawScore).toBe(expectedRawScore);
     expect(result.weightedScore).toBe(expectedWeightedScore);
-    expect(result.weightedScore).toBeGreaterThanOrEqual(baseline.weightedScore);
     expect(result.pilotThresholdMisses.some((miss) => miss.endsWith(":throttling"))).toBe(false);
   });
 

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   ISSUE_ENRICHMENT_REQUIRED_FIXTURE_COVERAGE,
@@ -11,7 +11,9 @@ import {
   type IssueEnrichmentFixturePacket
 } from "../src/issue-enrichment-scorecard.js";
 
-const fixturePath = join("tests", "fixtures", "issue-enrichment-scorecard", "sampled-regression-packet.json");
+const fixturePath = fileURLToPath(
+  new URL("./fixtures/issue-enrichment-scorecard/sampled-regression-packet.json", import.meta.url)
+);
 
 function loadFixture(): IssueEnrichmentFixturePacket {
   return JSON.parse(readFileSync(fixturePath, "utf8")) as IssueEnrichmentFixturePacket;

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -49,15 +49,18 @@ describe("issue enrichment scorecard", () => {
     const fixture = loadFixture();
     const result = scoreIssueEnrichment(fixture);
 
-    expect(result.rawScore).toBe(81);
-    expect(result.weightedScore).toBe(80);
+    expect(result.rawScore).toBeGreaterThanOrEqual(75);
+    expect(result.rawScore).toBeLessThanOrEqual(85);
+    expect(result.weightedScore).toBeGreaterThanOrEqual(75);
+    expect(result.weightedScore).toBeLessThanOrEqual(85);
+    expect(result.weightedScore).not.toBe(result.rawScore);
     expect(result.publicClaim).toBe("no_public_claim");
     expect(result.calibration).toBe("uncalibrated");
     expect(result).not.toHaveProperty("publicParity");
     expect(result).not.toHaveProperty("calibratedConfidence");
     expect(result.dimensionScores.find((dimension) => dimension.id === "proof_boundary")).toMatchObject({
       score: 5,
-      weightedScore: 65,
+      weightedContribution: expect.any(Number),
       evidenceLinks: [
         "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-docs-only-fast-negative-control-proof-boundary",
         "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-proof-boundary",
@@ -71,6 +74,9 @@ describe("issue enrichment scorecard", () => {
         "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-stale-irrelevant-web-result-proof-boundary"
       ]
     });
+
+    const proofBoundary = result.dimensionScores.find((dimension) => dimension.id === "proof_boundary");
+    expect(proofBoundary?.weightedContribution).toBeGreaterThan(proofBoundary?.score ?? 0);
   });
 
   it("requires direct evidence links for every dimension score above 3", () => {
@@ -103,6 +109,37 @@ describe("issue enrichment scorecard", () => {
     });
   });
 
+  it("rejects direct-evidence anchors that do not point at the fixture source issue", () => {
+    const fixture = loadFixture();
+    fixture.cases[0].dimensions.proof_boundary = {
+      score: 4,
+      evidenceLinks: ["https://example.com/evidence#direct-evidence-duplicate-same-head-comments-proof-boundary"]
+    };
+
+    expect(validateIssueEnrichmentFixture(fixture)).toMatchObject({
+      ok: false,
+      errors: expect.arrayContaining([
+        "case duplicate-same-head-comments dimension proof_boundary scored 4 without direct evidence links"
+      ])
+    });
+  });
+
+  it("rejects duplicate fixture case ids and duplicate coverage ids", () => {
+    const fixture = loadFixture();
+    fixture.cases.push({
+      ...fixture.cases[0],
+      title: "Duplicate coverage and id"
+    });
+
+    expect(validateIssueEnrichmentFixture(fixture)).toMatchObject({
+      ok: false,
+      errors: expect.arrayContaining([
+        "duplicate fixture case id duplicate-same-head-comments",
+        "duplicate fixture coverage duplicate_same_head_comments"
+      ])
+    });
+  });
+
   it("validates proof boundary, known limitations, and the required sampled regression coverage", () => {
     const fixture = loadFixture();
     const validation = validateIssueEnrichmentFixture(fixture);
@@ -116,7 +153,7 @@ describe("issue enrichment scorecard", () => {
   it("summarizes scorecard results with unmeasurable states and pilot threshold misses", () => {
     const summary = summarizeIssueEnrichmentScorecard(scoreIssueEnrichment(loadFixture()));
 
-    expect(summary).toContain("Issue enrichment scorecard: raw 81/100, weighted 80/100");
+    expect(summary).toMatch(/Issue enrichment scorecard: raw \d+\/100, weighted \d+\/100/);
     expect(summary).toContain("Public claim: no_public_claim");
     expect(summary).toContain("Unmeasurable dimensions: external_precedent_required_issue:related_context_precision");
     expect(summary).toContain("stale_irrelevant_web_result:related_context_precision");

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -251,6 +251,25 @@ describe("issue enrichment scorecard", () => {
     });
   });
 
+  it("reports duplicate identity errors even when the duplicate case is structurally malformed", () => {
+    const fixture = loadFixture();
+    fixture.cases.push({
+      ...fixture.cases[0],
+      title: "",
+      dimensions: undefined as unknown as IssueEnrichmentFixturePacket["cases"][number]["dimensions"]
+    });
+
+    expect(validateIssueEnrichmentFixture(fixture)).toMatchObject({
+      ok: false,
+      errors: expect.arrayContaining([
+        "case duplicate-same-head-comments title is required",
+        "case duplicate-same-head-comments missing dimensions",
+        "duplicate fixture case id duplicate-same-head-comments",
+        "duplicate fixture coverage duplicate_same_head_comments"
+      ])
+    });
+  });
+
   it("validates proof boundary, known limitations, and the required sampled regression coverage", () => {
     const fixture = loadFixture();
     const validation = validateIssueEnrichmentFixture(fixture);
@@ -350,6 +369,13 @@ describe("issue enrichment scorecard", () => {
       error: "fixture fixtureVersion must be 0.1"
     },
     {
+      name: "missing fixture version",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.fixtureVersion = undefined as unknown as IssueEnrichmentFixturePacket["fixtureVersion"];
+      },
+      error: "fixture fixtureVersion must be 0.1"
+    },
+    {
       name: "empty proof boundary",
       mutate: (fixture: IssueEnrichmentFixturePacket) => {
         fixture.proofBoundary = "";
@@ -404,6 +430,18 @@ describe("issue enrichment scorecard", () => {
         fixture.cases[0].dimensions.proof_boundary = {
           score: 6,
           evidenceLinks: ["https://example.com/evidence#direct-evidence-duplicate-same-head-comments-proof-boundary"]
+        };
+      },
+      error: "case duplicate-same-head-comments dimension proof_boundary score must be between 0 and 5"
+    },
+    {
+      name: "slightly above max score",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.cases[0].dimensions.proof_boundary = {
+          score: 5.5,
+          evidenceLinks: [
+            "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-proof-boundary"
+          ]
         };
       },
       error: "case duplicate-same-head-comments dimension proof_boundary score must be between 0 and 5"

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -124,6 +124,21 @@ describe("issue enrichment scorecard", () => {
     });
   });
 
+  it("does not emit a redundant missing-evidence error for an out-of-range high score", () => {
+    const fixture = loadFixture();
+    fixture.cases[0].dimensions.proof_boundary = {
+      score: 6,
+      evidenceLinks: ["https://example.com/evidence#direct-evidence-duplicate-same-head-comments-proof-boundary"]
+    };
+
+    const validation = validateIssueEnrichmentFixture(fixture);
+
+    expect(validation.ok).toBe(false);
+    expect(validation.errors).toEqual([
+      "case duplicate-same-head-comments dimension proof_boundary score must be between 0 and 5"
+    ]);
+  });
+
   it("rejects duplicate fixture case ids and duplicate coverage ids", () => {
     const fixture = loadFixture();
     fixture.cases.push({
@@ -148,6 +163,29 @@ describe("issue enrichment scorecard", () => {
     expect(validation.coveredScenarioIds).toEqual(ISSUE_ENRICHMENT_REQUIRED_FIXTURE_COVERAGE);
     expect(fixture.proofBoundary).toContain("advisory fixture scoring only");
     expect(fixture.knownLimitations.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("uses packet metric-contract threshold overrides when scoring pilot misses", () => {
+    const fixture = loadFixture();
+    const throttlingContract = ISSUE_ENRICHMENT_SCORE_DIMENSIONS.find((dimension) => dimension.id === "throttling")
+      ?.metricContract;
+    expect(throttlingContract).toBeDefined();
+
+    expect(scoreIssueEnrichment(fixture).pilotThresholdMisses).not.toContain(
+      "duplicate-same-head-comments:throttling"
+    );
+
+    fixture.metricContracts = {
+      throttling: {
+        ...throttlingContract!,
+        pilotThreshold: {
+          advisoryMin: 3,
+          promotionMin: throttlingContract!.pilotThreshold.promotionMin
+        }
+      }
+    };
+
+    expect(scoreIssueEnrichment(fixture).pilotThresholdMisses).toContain("duplicate-same-head-comments:throttling");
   });
 
   it("summarizes scorecard results with unmeasurable states and pilot threshold misses", () => {

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -124,6 +124,23 @@ describe("issue enrichment scorecard", () => {
     });
   });
 
+  it("rejects direct-evidence anchors with a query string that differs from the fixture source issue", () => {
+    const fixture = loadFixture();
+    fixture.cases[0].dimensions.proof_boundary = {
+      score: 4,
+      evidenceLinks: [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264?query=x#direct-evidence-duplicate-same-head-comments-proof-boundary"
+      ]
+    };
+
+    expect(validateIssueEnrichmentFixture(fixture)).toMatchObject({
+      ok: false,
+      errors: expect.arrayContaining([
+        "case duplicate-same-head-comments dimension proof_boundary scored 4 without direct evidence links"
+      ])
+    });
+  });
+
   it("does not emit a redundant missing-evidence error for an out-of-range high score", () => {
     const fixture = loadFixture();
     fixture.cases[0].dimensions.proof_boundary = {
@@ -134,9 +151,24 @@ describe("issue enrichment scorecard", () => {
     const validation = validateIssueEnrichmentFixture(fixture);
 
     expect(validation.ok).toBe(false);
-    expect(validation.errors).toEqual([
-      "case duplicate-same-head-comments dimension proof_boundary score must be between 0 and 5"
-    ]);
+    expect(validation.errors).toContain("case duplicate-same-head-comments dimension proof_boundary score must be between 0 and 5");
+    expect(validation.errors).not.toContain(
+      "case duplicate-same-head-comments dimension proof_boundary scored 6 without direct evidence links"
+    );
+  });
+
+  it("refuses to score invalid fixture packets instead of silently clamping invalid scores", () => {
+    const fixture = loadFixture();
+    fixture.cases[0].dimensions.proof_boundary = {
+      score: 99,
+      evidenceLinks: [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264#direct-evidence-duplicate-same-head-comments-proof-boundary"
+      ]
+    };
+
+    expect(() => scoreIssueEnrichment(fixture)).toThrow(
+      "Cannot score invalid issue-enrichment fixture: case duplicate-same-head-comments dimension proof_boundary score must be between 0 and 5"
+    );
   });
 
   it("rejects duplicate fixture case ids and duplicate coverage ids", () => {

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  ISSUE_ENRICHMENT_REQUIRED_FIXTURE_COVERAGE,
+  ISSUE_ENRICHMENT_SCORE_DIMENSIONS,
+  scoreIssueEnrichment,
+  summarizeIssueEnrichmentScorecard,
+  validateIssueEnrichmentFixture,
+  type IssueEnrichmentFixturePacket
+} from "../src/issue-enrichment-scorecard.js";
+
+const fixturePath = join("tests", "fixtures", "issue-enrichment-scorecard", "sampled-regression-packet.json");
+
+function loadFixture(): IssueEnrichmentFixturePacket {
+  return JSON.parse(readFileSync(fixturePath, "utf8")) as IssueEnrichmentFixturePacket;
+}
+
+describe("issue enrichment scorecard", () => {
+  it("defines every required issue-enrichment dimension with executable metric contracts", () => {
+    expect(ISSUE_ENRICHMENT_SCORE_DIMENSIONS.map((dimension) => dimension.id)).toEqual([
+      "related_context_precision",
+      "planning_value",
+      "acceptance_criteria",
+      "ownership_routing",
+      "proof_boundary",
+      "lifecycle_state",
+      "noise_control",
+      "idempotency",
+      "safety",
+      "throttling"
+    ]);
+
+    for (const dimension of ISSUE_ENRICHMENT_SCORE_DIMENSIONS) {
+      expect(dimension.metricContract).toMatchObject({
+        denominator: expect.any(String),
+        dataSource: expect.any(String),
+        scoringRule: expect.any(String),
+        unmeasurableState: expect.any(String),
+        pilotThreshold: {
+          advisoryMin: expect.any(Number),
+          promotionMin: expect.any(Number)
+        }
+      });
+    }
+  });
+
+  it("scores fixture packets with separate raw and weighted scores without public parity or calibrated-confidence claims", () => {
+    const fixture = loadFixture();
+    const result = scoreIssueEnrichment(fixture);
+
+    expect(result.rawScore).toBe(81);
+    expect(result.weightedScore).toBe(81);
+    expect(result.publicClaim).toBe("no_public_claim");
+    expect(result.calibration).toBe("uncalibrated");
+    expect(result).not.toHaveProperty("publicParity");
+    expect(result).not.toHaveProperty("calibratedConfidence");
+    expect(result.dimensionScores.find((dimension) => dimension.id === "proof_boundary")).toMatchObject({
+      score: 5,
+      weightedScore: 50,
+      evidenceLinks: ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"]
+    });
+  });
+
+  it("requires direct evidence links for every dimension score above 3", () => {
+    const fixture = loadFixture();
+    fixture.cases[0].dimensions.proof_boundary = {
+      score: 4,
+      notes: "High score without a direct link must fail validation."
+    };
+
+    expect(validateIssueEnrichmentFixture(fixture)).toMatchObject({
+      ok: false,
+      errors: expect.arrayContaining([
+        "case duplicate-same-head-comments dimension proof_boundary scored 4 without direct evidence links"
+      ])
+    });
+  });
+
+  it("validates proof boundary, known limitations, and the required sampled regression coverage", () => {
+    const fixture = loadFixture();
+    const validation = validateIssueEnrichmentFixture(fixture);
+
+    expect(validation.ok).toBe(true);
+    expect(validation.coveredScenarioIds).toEqual(ISSUE_ENRICHMENT_REQUIRED_FIXTURE_COVERAGE);
+    expect(fixture.proofBoundary).toContain("advisory fixture scoring only");
+    expect(fixture.knownLimitations.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("summarizes scorecard results with unmeasurable states and pilot threshold misses", () => {
+    const summary = summarizeIssueEnrichmentScorecard(scoreIssueEnrichment(loadFixture()));
+
+    expect(summary).toContain("Issue enrichment scorecard: raw 81/100, weighted 81/100");
+    expect(summary).toContain("Public claim: no_public_claim");
+    expect(summary).toContain("Unmeasurable dimensions: external_precedent_required_issue:related_context_precision");
+    expect(summary).toContain("Pilot threshold misses: stale_irrelevant_web_result:related_context_precision");
+    expect(summary).not.toMatch(/parity|calibrated confidence|95/i);
+  });
+});

--- a/tests/issue-enrichment-scorecard.test.ts
+++ b/tests/issue-enrichment-scorecard.test.ts
@@ -62,6 +62,19 @@ describe("issue enrichment scorecard", () => {
       "safety",
       "throttling"
     ]);
+    expect(ISSUE_ENRICHMENT_SCORE_DIMENSIONS.map(({ id, weight }) => ({ id, weight }))).toEqual([
+      { id: "related_context_precision", weight: 12 },
+      { id: "planning_value", weight: 11 },
+      { id: "acceptance_criteria", weight: 12 },
+      { id: "ownership_routing", weight: 9 },
+      { id: "proof_boundary", weight: 13 },
+      { id: "lifecycle_state", weight: 8 },
+      { id: "noise_control", weight: 10 },
+      { id: "idempotency", weight: 9 },
+      { id: "safety", weight: 11 },
+      { id: "throttling", weight: 15 }
+    ]);
+    expect(new Set(ISSUE_ENRICHMENT_SCORE_DIMENSIONS.map((dimension) => dimension.weight)).size).toBeGreaterThan(1);
 
     for (const dimension of ISSUE_ENRICHMENT_SCORE_DIMENSIONS) {
       expect(dimension.metricContract).toMatchObject({
@@ -330,6 +343,13 @@ describe("issue enrichment scorecard", () => {
 
   it.each([
     {
+      name: "unknown fixture version",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.fixtureVersion = "9.9" as IssueEnrichmentFixturePacket["fixtureVersion"];
+      },
+      error: "fixture fixtureVersion must be 0.1"
+    },
+    {
       name: "empty proof boundary",
       mutate: (fixture: IssueEnrichmentFixturePacket) => {
         fixture.proofBoundary = "";
@@ -349,6 +369,34 @@ describe("issue enrichment scorecard", () => {
         fixture.cases = fixture.cases.filter((item) => item.coverage !== "stale_head_posts");
       },
       error: "missing required fixture coverage stale_head_posts"
+    },
+    {
+      name: "missing case title",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.cases[0].title = "";
+      },
+      error: "case duplicate-same-head-comments title is required"
+    },
+    {
+      name: "missing fixture source",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.cases[0].fixtureSource = undefined;
+      },
+      error: "case duplicate-same-head-comments fixtureSource must be an https URL"
+    },
+    {
+      name: "non-https fixture source",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.cases[0].fixtureSource = "http://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264";
+      },
+      error: "case duplicate-same-head-comments fixtureSource must be an https URL"
+    },
+    {
+      name: "unknown coverage",
+      mutate: (fixture: IssueEnrichmentFixturePacket) => {
+        fixture.cases[0].coverage = "typo_coverage" as IssueEnrichmentFixturePacket["cases"][number]["coverage"];
+      },
+      error: "case duplicate-same-head-comments has unknown coverage typo_coverage"
     },
     {
       name: "out-of-range score",


### PR DESCRIPTION
Closes #264.\n\n## Summary\n- add a standalone issue-enrichment scorecard module with the ten required dimensions and executable metric contracts\n- add sampled regression fixture coverage for duplicate comments, stale heads, invalid inline coordinates, permission failure, launchd/config/head ambiguity, negative controls, stale web results, external-precedent gaps, and a 30-PR provider-failure burst simulation\n- document the scorecard proof boundary, known limitations, raw vs weighted scoring, and no-public-claim boundary\n\n## Validation\n- npm test -- tests/issue-enrichment-scorecard.test.ts\n- npm run build\n- git diff --check\n\n## Proof boundary\nStandalone eval contract only. This PR does not wire the scorecard into CLI/worker runtime and does not claim public parity, calibrated confidence, runtime safety, or release readiness.