### PR TITLE
[codex] Add evidence-only review mode router

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -10,6 +10,104 @@
     "maxActiveRuns": 5,
     "leaseTtlMs": 900000
   },
+  "reviewModes": {
+    "_comment": "Evidence-only beta controls for selecting the cheapest useful PR/issue depth. These settings are recorded in review-mode evidence; they do not change scheduler/provider/posting behavior until a later rollout explicitly enables enforcement.",
+    "enabled": false,
+    "defaultMode": "fast",
+    "_safetyComment": "Depth escalation stays disabled while provider-deferred/retryable backlog exists during beta.",
+    "modes": {
+      "fast": {
+        "targetMinutes": 5,
+        "wholeRunDeadlineMs": 600000,
+        "perAttemptTimeoutMs": 300000,
+        "maxPatchBytes": 20000,
+        "maxContextBytes": 8000,
+        "maxProviderAttempts": 1,
+        "allowedContextSources": ["patch"],
+        "queueWeight": 10,
+        "leaseTtlMs": 2700000,
+        "heartbeatMs": 60000,
+        "escalation": {
+          "allowDepthEscalation": false,
+          "allowDepthEscalationWhileProviderBacklog": false,
+          "allowManualCommand": true,
+          "allowRequestChanges": false
+        }
+      },
+      "standard": {
+        "targetMinutes": 15,
+        "wholeRunDeadlineMs": 1200000,
+        "perAttemptTimeoutMs": 900000,
+        "maxPatchBytes": 80000,
+        "maxContextBytes": 40000,
+        "maxProviderAttempts": 2,
+        "allowedContextSources": ["patch", "repo_memory", "gitnexus", "github_related", "skill_packs"],
+        "queueWeight": 50,
+        "leaseTtlMs": 2700000,
+        "heartbeatMs": 60000,
+        "escalation": {
+          "allowDepthEscalation": true,
+          "allowDepthEscalationWhileProviderBacklog": false,
+          "allowManualCommand": true,
+          "allowRequestChanges": true
+        }
+      },
+      "deep": {
+        "targetMinutes": 25,
+        "wholeRunDeadlineMs": 2100000,
+        "perAttemptTimeoutMs": 1500000,
+        "maxPatchBytes": 80000,
+        "maxContextBytes": 40000,
+        "maxProviderAttempts": 2,
+        "allowedContextSources": ["patch", "repo_memory", "gitnexus", "github_related", "skill_packs"],
+        "queueWeight": 90,
+        "leaseTtlMs": 2700000,
+        "heartbeatMs": 60000,
+        "escalation": {
+          "allowDepthEscalation": true,
+          "allowDepthEscalationWhileProviderBacklog": false,
+          "allowManualCommand": true,
+          "allowRequestChanges": true
+        }
+      },
+      "product_pm": {
+        "targetMinutes": 15,
+        "wholeRunDeadlineMs": 1500000,
+        "perAttemptTimeoutMs": 900000,
+        "maxPatchBytes": 80000,
+        "maxContextBytes": 24000,
+        "maxProviderAttempts": 1,
+        "allowedContextSources": ["patch", "repo_memory", "gitnexus", "github_related", "skill_packs"],
+        "queueWeight": 40,
+        "leaseTtlMs": 2700000,
+        "heartbeatMs": 60000,
+        "escalation": {
+          "allowDepthEscalation": false,
+          "allowDepthEscalationWhileProviderBacklog": false,
+          "allowManualCommand": true,
+          "allowRequestChanges": false
+        }
+      },
+      "research": {
+        "targetMinutes": 20,
+        "wholeRunDeadlineMs": 1800000,
+        "perAttemptTimeoutMs": 1200000,
+        "maxPatchBytes": 0,
+        "maxContextBytes": 32000,
+        "maxProviderAttempts": 1,
+        "allowedContextSources": ["repo_memory", "gitnexus", "github_related", "skill_packs"],
+        "queueWeight": 30,
+        "leaseTtlMs": 2700000,
+        "heartbeatMs": 60000,
+        "escalation": {
+          "allowDepthEscalation": false,
+          "allowDepthEscalationWhileProviderBacklog": false,
+          "allowManualCommand": true,
+          "allowRequestChanges": false
+        }
+      }
+    }
+  },
   "workRoot": "/Volumes/LEXAR/repos/evaos-code-review-bot-runtime",
   "statePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews.sqlite",
   "evidenceDir": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,7 @@ import {
   writeOutcomeLedgerPacket
 } from "./outcome-ledger.js";
 import { buildReviewBudgetStatus } from "./review-budget.js";
+import { selectReviewMode, type ReviewModeSelectionInput } from "./review-mode-router.js";
 import {
   buildOperatorDashboard,
   buildRuntimeInventory,
@@ -1459,6 +1460,29 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "review-mode") {
+    if (args.input === undefined || (Array.isArray(args.input) && args.input.length === 0)) {
+      throw new Error("--input is required for review-mode");
+    }
+    const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
+    if (!dryRun) throw new Error("review-mode is dry-run only in this release");
+    const input = readJsonInput(parseSingleArg(args.input, "--input"), "--input") as ReviewModeSelectionInput;
+    const result = selectReviewMode(input);
+    if (args["output-dir"] !== undefined) {
+      const outputDir = parseSingleArg(args["output-dir"], "--output-dir");
+      assertEvalOutputDirSafe(outputDir);
+      mkdirSync(outputDir, { recursive: true });
+      writeFileSync(join(outputDir, "review-mode.json"), `${stringifyRedactedJson(result)}\n`);
+    }
+    console.log(stringifyRedactedJson({
+      ok: true,
+      command: "review-mode",
+      dryRun,
+      result
+    }));
+    return;
+  }
+
   if (command === "run-once" || command === "review-pr") {
     if (command === "review-pr" && (!args.repo || !args.pr)) {
       console.log(JSON.stringify({
@@ -2612,7 +2636,8 @@ function buildHelp(command?: string) {
         "eval-offline",
         "eval-suite",
         "eval-sticky-vs-cold",
-        "outcome-ledger"
+        "outcome-ledger",
+        "review-mode"
       ]
     },
     examples: [
@@ -2662,6 +2687,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts clear-review-queue-leases --config /path/to/live.json --dry-run true --expired-only true",
       "npx tsx src/cli.ts eval-sticky-vs-cold --input /path/to/sticky-vs-cold.json --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold",
       "npx tsx src/cli.ts outcome-ledger --input /path/to/outcome-ledger-input.json --dry-run true --output-dir /path/to/evidence/outcome-ledger-run",
+      "npx tsx src/cli.ts review-mode --input /path/to/review-mode-input.json --dry-run true --output-dir /path/to/evidence/review-mode-run",
       "npx tsx src/cli.ts finishing-touch-dry-run --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD --current-head HEAD --comment-id 456 --author maintainer --trusted-authors maintainer --body '@evaos-code-review-bot explain risk'",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ],
@@ -2670,6 +2696,12 @@ function buildHelp(command?: string) {
         "The outcome-ledger command is dry-run only.",
         "--dry-run defaults to true for outcome-ledger; --dry-run false is rejected until live posting is explicitly implemented.",
         "Failed safety gates or secret redaction failures exit non-zero; unknown gates remain visible in the packet but do not fail the dry run."
+      ]
+    },
+    reviewMode: {
+      notes: [
+        "The review-mode command is dry-run only.",
+        "It previews fast, standard, deep, product_pm, or research routing and budget disposition without changing scheduler, provider timeout, posting policy, or live runtime behavior."
       ]
     }
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ import {
 } from "./public-confidence.js";
 import { isApiKeyEnvName, isProviderId, type ProviderRegistryConfig } from "./providers.js";
 import { containsSecretLikeText } from "./secrets.js";
+import type { ReviewMode, ReviewModeContextSource, ReviewModesConfig, ReviewModeRuntimeConfig } from "./review-mode-types.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
 
 const MAX_LICENSE_OFFLINE_GRACE_MS = 15 * 60_000;
@@ -44,6 +45,7 @@ export interface BotConfig {
     headCountLimit: number;
   };
   reviewScheduler?: ReviewSchedulerConfig;
+  reviewModes?: ReviewModesConfig;
   providerCooldown: {
     enabled: boolean;
     durationMs: number;
@@ -187,6 +189,97 @@ export interface ReviewSchedulerConfig {
   backgroundPriority: number;
 }
 
+function buildDefaultReviewModesConfig(): ReviewModesConfig {
+  const base = {
+    maxPatchBytes: 80_000,
+    maxContextBytes: 40_000,
+    allowedContextSources: ["patch", "repo_memory", "gitnexus", "github_related", "skill_packs"] as ReviewModeContextSource[],
+    leaseTtlMs: 45 * 60_000,
+    heartbeatMs: 60_000
+  };
+  const mode = (input: {
+    targetMinutes: number;
+    hardTimeoutMinutes: number;
+    maxProviderAttempts: number;
+    queueWeight: number;
+    allowDepthEscalation: boolean;
+    allowRequestChanges: boolean;
+    maxPatchBytes?: number;
+    maxContextBytes?: number;
+    allowedContextSources?: ReviewModeContextSource[];
+  }): ReviewModeRuntimeConfig => ({
+    targetMinutes: input.targetMinutes,
+    wholeRunDeadlineMs: input.hardTimeoutMinutes * 60_000,
+    perAttemptTimeoutMs: input.targetMinutes * 60_000,
+    maxPatchBytes: input.maxPatchBytes ?? base.maxPatchBytes,
+    maxContextBytes: input.maxContextBytes ?? base.maxContextBytes,
+    maxProviderAttempts: input.maxProviderAttempts,
+    allowedContextSources: input.allowedContextSources ?? base.allowedContextSources,
+    queueWeight: input.queueWeight,
+    leaseTtlMs: base.leaseTtlMs,
+    heartbeatMs: base.heartbeatMs,
+    escalation: {
+      allowDepthEscalation: input.allowDepthEscalation,
+      allowDepthEscalationWhileProviderBacklog: false,
+      allowManualCommand: true,
+      allowRequestChanges: input.allowRequestChanges
+    }
+  });
+  return {
+    enabled: false,
+    defaultMode: "fast",
+    modes: {
+      fast: mode({
+        targetMinutes: 5,
+        hardTimeoutMinutes: 10,
+        maxProviderAttempts: 1,
+        queueWeight: 10,
+        allowDepthEscalation: false,
+        allowRequestChanges: false,
+        maxPatchBytes: 20_000,
+        maxContextBytes: 8_000,
+        allowedContextSources: ["patch"]
+      }),
+      standard: mode({
+        targetMinutes: 15,
+        hardTimeoutMinutes: 20,
+        maxProviderAttempts: 2,
+        queueWeight: 50,
+        allowDepthEscalation: true,
+        allowRequestChanges: true
+      }),
+      deep: mode({
+        targetMinutes: 25,
+        hardTimeoutMinutes: 35,
+        maxProviderAttempts: 2,
+        queueWeight: 90,
+        allowDepthEscalation: true,
+        allowRequestChanges: true
+      }),
+      product_pm: mode({
+        targetMinutes: 15,
+        hardTimeoutMinutes: 25,
+        maxProviderAttempts: 1,
+        queueWeight: 40,
+        allowDepthEscalation: false,
+        allowRequestChanges: false,
+        maxContextBytes: 24_000
+      }),
+      research: mode({
+        targetMinutes: 20,
+        hardTimeoutMinutes: 30,
+        maxProviderAttempts: 1,
+        queueWeight: 30,
+        allowDepthEscalation: false,
+        allowRequestChanges: false,
+        maxPatchBytes: 0,
+        maxContextBytes: 32_000,
+        allowedContextSources: ["repo_memory", "gitnexus", "github_related", "skill_packs"]
+      })
+    }
+  };
+}
+
 export interface RepoMemoryConfig {
   enabled: boolean;
   memoryRoot: string;
@@ -225,6 +318,7 @@ const DEFAULT_CONFIG: BotConfig = {
     manualCommandReserve: 1,
     backgroundPriority: 50
   },
+  reviewModes: buildDefaultReviewModesConfig(),
   providerCooldown: {
     enabled: true,
     durationMs: 15 * 60_000,
@@ -495,6 +589,9 @@ function validateConfig(config: BotConfig): void {
   const reviewScheduler = config.reviewScheduler ?? DEFAULT_CONFIG.reviewScheduler!;
   config.reviewScheduler = reviewScheduler;
   validateReviewSchedulerConfig(reviewScheduler, "config.reviewScheduler");
+  const reviewModes = config.reviewModes ?? DEFAULT_CONFIG.reviewModes!;
+  config.reviewModes = reviewModes;
+  validateReviewModesConfig(reviewModes, "config.reviewModes");
   validateBoolean(config.providerCooldown.enabled, "config.providerCooldown.enabled");
   validatePositiveInteger(config.providerCooldown.durationMs, "config.providerCooldown.durationMs");
   validatePositiveInteger(config.providerCooldown.requestRateLimitDurationMs, "config.providerCooldown.requestRateLimitDurationMs");
@@ -1165,6 +1262,51 @@ function validateReviewSchedulerConfig(value: unknown, label: string): void {
   const manualCommandReserve = Number(value.manualCommandReserve);
   if (manualCommandReserve > maxProviderActive) {
     throw new Error(`${label}.manualCommandReserve must be <= ${label}.maxProviderActive`);
+  }
+}
+
+function validateReviewModesConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  validateBoolean(value.enabled, `${label}.enabled`);
+  if (!["fast", "standard", "deep", "product_pm"].includes(String(value.defaultMode))) {
+    throw new Error(`${label}.defaultMode must be fast, standard, deep, or product_pm`);
+  }
+  if (!isRecord(value.modes)) throw new Error(`${label}.modes must be an object`);
+  for (const mode of ["fast", "standard", "deep", "product_pm", "research"] as ReviewMode[]) {
+    validateReviewModeRuntimeConfig(value.modes[mode], `${label}.modes.${mode}`);
+  }
+}
+
+function validateReviewModeRuntimeConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  validatePositiveInteger(value.targetMinutes, `${label}.targetMinutes`);
+  validatePositiveInteger(value.wholeRunDeadlineMs, `${label}.wholeRunDeadlineMs`);
+  validatePositiveInteger(value.perAttemptTimeoutMs, `${label}.perAttemptTimeoutMs`);
+  validateNonNegativeInteger(value.maxPatchBytes, `${label}.maxPatchBytes`);
+  validateNonNegativeInteger(value.maxContextBytes, `${label}.maxContextBytes`);
+  validatePositiveInteger(value.maxProviderAttempts, `${label}.maxProviderAttempts`);
+  validatePositiveInteger(value.queueWeight, `${label}.queueWeight`);
+  validatePositiveInteger(value.leaseTtlMs, `${label}.leaseTtlMs`);
+  validatePositiveInteger(value.heartbeatMs, `${label}.heartbeatMs`);
+  validateStringArray(value.allowedContextSources, `${label}.allowedContextSources`);
+  for (const source of value.allowedContextSources as string[]) {
+    if (!["patch", "repo_memory", "gitnexus", "github_related", "skill_packs"].includes(source)) {
+      throw new Error(`${label}.allowedContextSources entries must be patch, repo_memory, gitnexus, github_related, or skill_packs`);
+    }
+  }
+  if (!isRecord(value.escalation)) throw new Error(`${label}.escalation must be an object`);
+  validateBoolean(value.escalation.allowDepthEscalation, `${label}.escalation.allowDepthEscalation`);
+  validateBoolean(value.escalation.allowDepthEscalationWhileProviderBacklog, `${label}.escalation.allowDepthEscalationWhileProviderBacklog`);
+  validateBoolean(value.escalation.allowManualCommand, `${label}.escalation.allowManualCommand`);
+  validateBoolean(value.escalation.allowRequestChanges, `${label}.escalation.allowRequestChanges`);
+  if ((value.escalation.allowDepthEscalationWhileProviderBacklog as boolean) === true) {
+    throw new Error(`${label}.escalation.allowDepthEscalationWhileProviderBacklog must remain false during beta`);
+  }
+  if (Number(value.perAttemptTimeoutMs) > Number(value.wholeRunDeadlineMs)) {
+    throw new Error(`${label}.perAttemptTimeoutMs must be <= ${label}.wholeRunDeadlineMs`);
+  }
+  if (Number(value.heartbeatMs) >= Number(value.leaseTtlMs)) {
+    throw new Error(`${label}.heartbeatMs must be < ${label}.leaseTtlMs`);
   }
 }
 

--- a/src/outcome-ledger.ts
+++ b/src/outcome-ledger.ts
@@ -2,7 +2,8 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
-import type { PullFilePatch, PullRequestSummary, ReviewPlan } from "./types.js";
+import type { ReviewMode, ReviewModeBudgetDisposition, ReviewModeSelection } from "./review-mode-types.js";
+import type { PullFilePatch, PullRequestSummary, RegressionCategory, ReviewPlan } from "./types.js";
 
 export type OutcomeLedgerSubjectType = "pull_request" | "issue";
 export type OutcomeLedgerMode =
@@ -39,6 +40,7 @@ export interface OutcomeLedgerInput {
   proofGaps?: OutcomeLedgerProofGapInput[];
   safetyGates?: OutcomeLedgerSafetyGateInput[];
   reviewerDecision?: OutcomeLedgerReviewerDecisionInput;
+  reviewMode?: ReviewModeSelection;
   runtime?: OutcomeLedgerRuntimeInput;
   postMergeOutcome?: OutcomeLedgerPostMergeOutcomeInput;
 }
@@ -142,6 +144,7 @@ export interface OutcomeLedger {
   proofGaps: Array<Required<Pick<OutcomeLedgerProofGapInput, "id" | "severity" | "summary">> & OutcomeLedgerProofGapInput>;
   safetyGates: Required<Pick<OutcomeLedgerSafetyGateInput, "name" | "status" | "detail">>[];
   reviewerDecision: Required<OutcomeLedgerReviewerDecisionInput>;
+  reviewMode?: ReviewModeSelection;
   runtime: Required<OutcomeLedgerRuntimeInput>;
   postMergeOutcome: Required<OutcomeLedgerPostMergeOutcomeInput>;
   hardGateStatus: {
@@ -213,6 +216,7 @@ export function parseOutcomeLedgerInput(value: unknown): OutcomeLedgerInput {
     proofGaps: optionalArray(value.proofGaps, "proofGaps").map(parseProofGap),
     safetyGates: optionalArray(value.safetyGates, "safetyGates").map(parseSafetyGate),
     reviewerDecision: parseReviewerDecision(value.reviewerDecision),
+    reviewMode: parseReviewModeSelection(value.reviewMode),
     runtime: parseRuntime(value.runtime),
     postMergeOutcome: parsePostMergeOutcome(value.postMergeOutcome)
   };
@@ -243,6 +247,7 @@ export function buildOutcomeLedger(input: OutcomeLedgerInput, options: { now?: D
     proofGaps: (input.proofGaps ?? []).map(normalizeProofGap),
     safetyGates,
     reviewerDecision: normalizeReviewerDecision(input.reviewerDecision),
+    ...(input.reviewMode ? { reviewMode: normalizeReviewModeSelection(input.reviewMode) } : {}),
     runtime,
     postMergeOutcome,
     hardGateStatus,
@@ -346,6 +351,7 @@ export function buildOutcomeLedgerInputFromReviewPlan(input: {
       status: mapReviewPlanDecision(input.plan),
       reason: input.plan.summary
     },
+    ...(input.plan.reviewMode ? { reviewMode: input.plan.reviewMode } : {}),
     runtime: input.runtime,
     postMergeOutcome: {
       status: "unknown",
@@ -419,6 +425,7 @@ export function renderOutcomeLedgerMarkdown(ledger: OutcomeLedger): string {
     `# Outcome Ledger: ${ledger.subject.repo}#${ledger.subject.number}`,
     "",
     `- Mode: \`${ledger.mode}\``,
+    ...(ledger.reviewMode ? [`- Review depth: \`${ledger.reviewMode.mode}\` (${ledger.reviewMode.budget.targetMinutes} min target)`] : []),
     `- Decision: \`${ledger.reviewerDecision.status}\``,
     `- OK: \`${ledger.ok ? "true" : "false"}\``,
     `- Head: \`${ledger.subject.headSha ?? "n/a"}\``,
@@ -446,6 +453,19 @@ export function renderOutcomeLedgerMarkdown(ledger: OutcomeLedger): string {
     "## Safety Gates",
     "",
     ...listOrNone(ledger.safetyGates.map((gate) => `- [${gate.status}] ${gate.name}${gate.detail ? `: ${gate.detail}` : ""}`)),
+    ...(ledger.reviewMode ? [
+      "",
+      "## Review Mode",
+      "",
+      `- Selected: \`${ledger.reviewMode.mode}\``,
+      `- Target use: ${ledger.reviewMode.targetUse}`,
+      `- Outcome weights: regression=${ledger.reviewMode.outcomeWeights.regressionPrevention}, signal=${ledger.reviewMode.outcomeWeights.signalToNoise}, latency=${ledger.reviewMode.outcomeWeights.latencyFlow}, context=${ledger.reviewMode.outcomeWeights.contextProofAwareness}, cost=${ledger.reviewMode.outcomeWeights.glmCostEfficiency}, safety=${ledger.reviewMode.outcomeWeights.safetyLifecycle}`,
+      `- Budget: ${ledger.reviewMode.budget.targetMinutes} min target / ${ledger.reviewMode.budget.hardTimeoutMinutes} min hard timeout`,
+      `- Budget disposition: \`${ledger.reviewMode.budget.disposition}\``,
+      `- Signals: ${ledger.reviewMode.matchedSignals.length > 0 ? ledger.reviewMode.matchedSignals.join(", ") : "none"}`,
+      "",
+      ...listOrNone(ledger.reviewMode.reasons.map((reason) => `- ${reason}`))
+    ] : []),
     "",
     "## Runtime",
     "",
@@ -458,6 +478,46 @@ export function renderOutcomeLedgerMarkdown(ledger: OutcomeLedger): string {
     "",
     ledger.proofBoundary
   ].join("\n");
+}
+
+function normalizeReviewModeSelection(selection: ReviewModeSelection): ReviewModeSelection {
+  const budget = selection.budget ?? {
+    targetMinutes: 0,
+    targetMs: 0,
+    hardTimeoutMinutes: 0,
+    hardTimeoutMs: 0,
+    disposition: "timeout_risk" as const,
+    detail: "Review mode budget was missing; treating as timeout risk."
+  };
+  return {
+    mode: selection.mode ?? "standard",
+    targetUse: selection.targetUse ?? "pull_request_review",
+    confidence: clampConfidence(selection.confidence),
+    outcomeWeights: normalizeOutcomeWeights(selection.outcomeWeights),
+    reasons: (selection.reasons ?? []).map(redact),
+    matchedSignals: (selection.matchedSignals ?? []).map(redact).sort(),
+    riskAreas: [...(selection.riskAreas ?? [])].sort(),
+    budget: {
+      targetMinutes: normalizeNonNegative(budget.targetMinutes),
+      targetMs: normalizeNonNegative(budget.targetMs),
+      hardTimeoutMinutes: normalizeNonNegative(budget.hardTimeoutMinutes),
+      hardTimeoutMs: normalizeNonNegative(budget.hardTimeoutMs),
+      disposition: budget.disposition,
+      detail: redact(budget.detail)
+    },
+    proofBoundary: redact(selection.proofBoundary ?? "Review mode routing is evidence-only in this release.")
+  };
+}
+
+function normalizeOutcomeWeights(weights: ReviewModeSelection["outcomeWeights"] | undefined): ReviewModeSelection["outcomeWeights"] {
+  return {
+    regressionPrevention: normalizeNonNegative(weights?.regressionPrevention),
+    signalToNoise: normalizeNonNegative(weights?.signalToNoise),
+    latencyFlow: normalizeNonNegative(weights?.latencyFlow),
+    contextProofAwareness: normalizeNonNegative(weights?.contextProofAwareness),
+    glmCostEfficiency: normalizeNonNegative(weights?.glmCostEfficiency),
+    safetyLifecycle: normalizeNonNegative(weights?.safetyLifecycle)
+  };
 }
 
 function normalizeSubject(subject: OutcomeLedgerSubjectInput): OutcomeLedger["subject"] {
@@ -706,6 +766,53 @@ function parseRuntime(value: unknown): OutcomeLedgerRuntimeInput | undefined {
   };
 }
 
+function parseReviewModeSelection(value: unknown): ReviewModeSelection | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw new Error("reviewMode must be an object");
+  const budget = value.budget;
+  if (!isRecord(budget)) throw new Error("reviewMode.budget must be an object");
+  return {
+    mode: parseReviewMode(value.mode, "reviewMode.mode"),
+    targetUse: parseEnum(value.targetUse, ["pull_request_review", "issue_enrichment"] as const, "reviewMode.targetUse"),
+    confidence: optionalNonNegative(value.confidence, "reviewMode.confidence") ?? 0,
+    outcomeWeights: parseReviewModeOutcomeWeights(value.outcomeWeights),
+    reasons: optionalStringArray(value.reasons, "reviewMode.reasons") ?? [],
+    matchedSignals: optionalStringArray(value.matchedSignals, "reviewMode.matchedSignals") ?? [],
+    riskAreas: optionalArray(value.riskAreas, "reviewMode.riskAreas").map((area) => parseRegressionCategory(area, "reviewMode.riskAreas")),
+    budget: {
+      targetMinutes: requiredPositiveInteger(budget.targetMinutes, "reviewMode.budget.targetMinutes"),
+      targetMs: requiredPositiveInteger(budget.targetMs, "reviewMode.budget.targetMs"),
+      hardTimeoutMinutes: requiredPositiveInteger(budget.hardTimeoutMinutes, "reviewMode.budget.hardTimeoutMinutes"),
+      hardTimeoutMs: requiredPositiveInteger(budget.hardTimeoutMs, "reviewMode.budget.hardTimeoutMs"),
+      disposition: parseReviewModeBudgetDisposition(budget.disposition, "reviewMode.budget.disposition"),
+      detail: requiredString(budget.detail, "reviewMode.budget.detail")
+    },
+    proofBoundary: requiredString(value.proofBoundary, "reviewMode.proofBoundary")
+  };
+}
+
+function parseReviewModeOutcomeWeights(value: unknown): ReviewModeSelection["outcomeWeights"] {
+  if (value === undefined) {
+    return {
+      regressionPrevention: 0,
+      signalToNoise: 0,
+      latencyFlow: 0,
+      contextProofAwareness: 0,
+      glmCostEfficiency: 0,
+      safetyLifecycle: 0
+    };
+  }
+  if (!isRecord(value)) throw new Error("reviewMode.outcomeWeights must be an object");
+  return {
+    regressionPrevention: optionalNonNegative(value.regressionPrevention, "reviewMode.outcomeWeights.regressionPrevention") ?? 0,
+    signalToNoise: optionalNonNegative(value.signalToNoise, "reviewMode.outcomeWeights.signalToNoise") ?? 0,
+    latencyFlow: optionalNonNegative(value.latencyFlow, "reviewMode.outcomeWeights.latencyFlow") ?? 0,
+    contextProofAwareness: optionalNonNegative(value.contextProofAwareness, "reviewMode.outcomeWeights.contextProofAwareness") ?? 0,
+    glmCostEfficiency: optionalNonNegative(value.glmCostEfficiency, "reviewMode.outcomeWeights.glmCostEfficiency") ?? 0,
+    safetyLifecycle: optionalNonNegative(value.safetyLifecycle, "reviewMode.outcomeWeights.safetyLifecycle") ?? 0
+  };
+}
+
 function parsePostMergeOutcome(value: unknown): OutcomeLedgerPostMergeOutcomeInput | undefined {
   if (value === undefined) return undefined;
   if (!isRecord(value)) throw new Error("postMergeOutcome must be an object");
@@ -767,9 +874,41 @@ function normalizeNonNegative(value: number | undefined): number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : -1;
 }
 
+function clampConfidence(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
 function parseMode(value: unknown): OutcomeLedgerMode | undefined {
   if (value === undefined) return undefined;
   return parseEnum(value, ["stable", "advanced_dry_run", "advanced_pr_review", "advanced_issue_research", "advanced_full"] as const, "mode");
+}
+
+function parseReviewMode(value: unknown, label: string): ReviewMode {
+  return parseEnum(value, ["fast", "standard", "deep", "product_pm", "research"] as const, label);
+}
+
+function parseReviewModeBudgetDisposition(value: unknown, label: string): ReviewModeBudgetDisposition {
+  return parseEnum(value, ["within_budget", "partial", "timeout_risk", "deferred"] as const, label);
+}
+
+function parseRegressionCategory(value: unknown, label: string): RegressionCategory {
+  return parseEnum(value, [
+    "data_loss",
+    "auth",
+    "ci_build",
+    "unity_scene_prefab",
+    "security_boundary",
+    "migration",
+    "api_compatibility",
+    "release_regression",
+    "flaky_test_risk",
+    "proof_gap",
+    "runtime_correctness",
+    "dependency",
+    "docs_only",
+    "unknown"
+  ] as const, label);
 }
 
 function parseSubjectType(value: unknown): OutcomeLedgerSubjectType {

--- a/src/outcome-ledger.ts
+++ b/src/outcome-ledger.ts
@@ -769,8 +769,17 @@ function parseRuntime(value: unknown): OutcomeLedgerRuntimeInput | undefined {
 function parseReviewModeSelection(value: unknown): ReviewModeSelection | undefined {
   if (value === undefined) return undefined;
   if (!isRecord(value)) throw new Error("reviewMode must be an object");
-  const budget = value.budget;
-  if (!isRecord(budget)) throw new Error("reviewMode.budget must be an object");
+  const rawBudget = value.budget;
+  if (rawBudget !== undefined && !isRecord(rawBudget)) throw new Error("reviewMode.budget must be an object");
+  const budgetWasMissing = rawBudget === undefined;
+  const budget = rawBudget ?? {
+    targetMinutes: 0,
+    targetMs: 0,
+    hardTimeoutMinutes: 0,
+    hardTimeoutMs: 0,
+    disposition: "timeout_risk",
+    detail: "Review mode budget was missing; treating as timeout risk."
+  };
   return {
     mode: parseReviewMode(value.mode, "reviewMode.mode"),
     targetUse: parseEnum(value.targetUse, ["pull_request_review", "issue_enrichment"] as const, "reviewMode.targetUse"),
@@ -780,14 +789,14 @@ function parseReviewModeSelection(value: unknown): ReviewModeSelection | undefin
     matchedSignals: optionalStringArray(value.matchedSignals, "reviewMode.matchedSignals") ?? [],
     riskAreas: optionalArray(value.riskAreas, "reviewMode.riskAreas").map((area) => parseRegressionCategory(area, "reviewMode.riskAreas")),
     budget: {
-      targetMinutes: requiredPositiveInteger(budget.targetMinutes, "reviewMode.budget.targetMinutes"),
-      targetMs: requiredPositiveInteger(budget.targetMs, "reviewMode.budget.targetMs"),
-      hardTimeoutMinutes: requiredPositiveInteger(budget.hardTimeoutMinutes, "reviewMode.budget.hardTimeoutMinutes"),
-      hardTimeoutMs: requiredPositiveInteger(budget.hardTimeoutMs, "reviewMode.budget.hardTimeoutMs"),
+      targetMinutes: budgetWasMissing ? 0 : requiredPositiveInteger(budget.targetMinutes, "reviewMode.budget.targetMinutes"),
+      targetMs: budgetWasMissing ? 0 : requiredPositiveInteger(budget.targetMs, "reviewMode.budget.targetMs"),
+      hardTimeoutMinutes: budgetWasMissing ? 0 : requiredPositiveInteger(budget.hardTimeoutMinutes, "reviewMode.budget.hardTimeoutMinutes"),
+      hardTimeoutMs: budgetWasMissing ? 0 : requiredPositiveInteger(budget.hardTimeoutMs, "reviewMode.budget.hardTimeoutMs"),
       disposition: parseReviewModeBudgetDisposition(budget.disposition, "reviewMode.budget.disposition"),
       detail: requiredString(budget.detail, "reviewMode.budget.detail")
     },
-    proofBoundary: requiredString(value.proofBoundary, "reviewMode.proofBoundary")
+    proofBoundary: optionalString(value.proofBoundary, "reviewMode.proofBoundary") ?? "Review mode routing is evidence-only in this release."
   };
 }
 

--- a/src/review-mode-router.ts
+++ b/src/review-mode-router.ts
@@ -69,6 +69,7 @@ export function selectReviewMode(input: ReviewModeSelectionInput): ReviewModeSel
     reasons.push("Changed surface is docs/metadata only, so deep review would likely waste GLM time.");
     matchedSignals.add("docs_only_surface");
     riskAreas.add("docs_only");
+    recordDocsOnlySignals(files, text, matchedSignals, riskAreas);
     return buildSelection("fast", "pull_request_review", 0.9, reasons, matchedSignals, riskAreas, input.expectedRuntimeMs, input.providerTimeoutMs, input.reviewModes);
   }
 
@@ -170,7 +171,7 @@ function buildBudget(mode: ReviewMode, expectedRuntimeMs?: number, providerTimeo
   const targetMinutes = configured?.targetMinutes ?? fallback.targetMinutes;
   const targetMs = targetMinutes * 60_000;
   const hardTimeoutMs = configured?.wholeRunDeadlineMs ?? fallback.hardTimeoutMinutes * 60_000;
-  const hardTimeoutMinutes = Math.ceil(hardTimeoutMs / 60_000);
+  const hardTimeoutMinutes = Math.max(1, Math.floor(hardTimeoutMs / 60_000));
   if (providerTimeoutMs !== undefined && providerTimeoutMs < targetMs) {
     const disposition: ReviewModeBudgetDisposition = mode === "fast" ? "timeout_risk" : "partial";
     return {
@@ -254,7 +255,9 @@ function hasDeepSignal(files: PullFilePatch[], matchedSignals: Set<string>, risk
 
 function hasDeepTextSignal(text: string, matchedSignals: Set<string>, riskAreas: Set<RegressionCategory>): boolean {
   const patterns: Array<{ pattern: RegExp; area: RegressionCategory; signal: string }> = [
-    { pattern: /\b(auth|security|permission|data loss|migration|release|provider|runtime|queue|scheduler|zcode|glm)\b/i, area: "runtime_correctness", signal: "deep_text" },
+    { pattern: /\b(auth|permission|data loss|migration|zcode|glm)\b/i, area: "runtime_correctness", signal: "deep_text" },
+    { pattern: /\b(security boundary|security disclosure|vulnerability|credential leak|secret leak)\b/i, area: "security_boundary", signal: "security_text" },
+    { pattern: /\b(release blocker|release regression|release gate|runtime crash|runtime failure|provider outage|provider throttle|provider overload|queue stuck|queue backlog|scheduler deadlock|scheduler lease)\b/i, area: "runtime_correctness", signal: "corroborated_runtime_text" },
     { pattern: /\b(unity|scene|prefab|save state|save-state)\b/i, area: "unity_scene_prefab", signal: "unity_text" }
   ];
   let matched = false;
@@ -266,6 +269,18 @@ function hasDeepTextSignal(text: string, matchedSignals: Set<string>, riskAreas:
     }
   }
   return matched;
+}
+
+function recordDocsOnlySignals(files: PullFilePatch[], text: string, matchedSignals: Set<string>, riskAreas: Set<RegressionCategory>): void {
+  const docsRiskAreas = new Set<RegressionCategory>();
+  const docsSignals = new Set<string>();
+  hasDeepSignal(files, docsSignals, docsRiskAreas);
+  for (const signal of docsSignals) matchedSignals.add(`docs_${signal}`);
+  for (const area of docsRiskAreas) riskAreas.add(area);
+  if (hasProductSignal(text)) {
+    matchedSignals.add("docs_product_pm_text");
+    riskAreas.add("api_compatibility");
+  }
 }
 
 function hasProductSignal(text: string): boolean {

--- a/src/review-mode-router.ts
+++ b/src/review-mode-router.ts
@@ -1,0 +1,281 @@
+import type { ReviewMode, ReviewModeBudget, ReviewModeBudgetDisposition, ReviewModesConfig, ReviewModeSelection } from "./review-mode-types.js";
+import type { PullFilePatch, PullRequestSummary, RegressionCategory } from "./types.js";
+
+export interface ReviewModeSelectionInput {
+  subject: "pull_request" | "issue";
+  pull?: PullRequestSummary;
+  files?: PullFilePatch[];
+  labels?: string[];
+  title?: string;
+  body?: string | null;
+  docsOnly?: boolean;
+  expectedRuntimeMs?: number;
+  providerTimeoutMs?: number;
+  reviewModes?: ReviewModesConfig;
+  researchRequested?: boolean;
+}
+
+const MODE_BUDGETS: Record<ReviewMode, { targetMinutes: number; hardTimeoutMinutes: number }> = {
+  fast: { targetMinutes: 5, hardTimeoutMinutes: 10 },
+  standard: { targetMinutes: 15, hardTimeoutMinutes: 20 },
+  deep: { targetMinutes: 25, hardTimeoutMinutes: 35 },
+  product_pm: { targetMinutes: 15, hardTimeoutMinutes: 25 },
+  research: { targetMinutes: 20, hardTimeoutMinutes: 30 }
+};
+
+const PATH_TOKEN_BOUNDARY = "([/._-]|$)";
+
+const DEEP_PATH_PATTERNS: Array<{ pattern: RegExp; area: RegressionCategory; signal: string }> = [
+  { pattern: new RegExp(`(^|/)(auth|oauth|session|token|permission|entitlement)s?${PATH_TOKEN_BOUNDARY}`, "i"), area: "auth", signal: "auth/security path" },
+  { pattern: new RegExp(`(^|/)(security|secrets?|credential|keychain)${PATH_TOKEN_BOUNDARY}`, "i"), area: "security_boundary", signal: "security boundary path" },
+  { pattern: new RegExp(`(^|/)(migration|migrations|schema|database|sqlite|postgres)${PATH_TOKEN_BOUNDARY}`, "i"), area: "migration", signal: "migration/data path" },
+  { pattern: new RegExp(`(^|/)(release|launchd|daemon|scheduler|worker|queue|provider|zcode|state)${PATH_TOKEN_BOUNDARY}`, "i"), area: "runtime_correctness", signal: "runtime/provider path" },
+  { pattern: new RegExp(`(^|/)(ci|workflow|workflows|build|deploy)${PATH_TOKEN_BOUNDARY}|\\.github/workflows/`, "i"), area: "ci_build", signal: "CI/release path" },
+  { pattern: /\.(unity|prefab|asset|scene)$/i, area: "unity_scene_prefab", signal: "Unity scene/prefab asset" },
+  { pattern: /(^|\/)(pricing|billing|payments?|stripe)([/.]|$)/i, area: "api_compatibility", signal: "billing/pricing path" }
+];
+
+const PRODUCT_TEXT_PATTERNS = [
+  /\b(ux|ui|onboarding|pricing|roadmap|product|conversion|activation|retention|copy|funnel|checkout)\b/i,
+  /\b(user experience|landing page|marketing|website|dashboard|settings|workflow)\b/i
+];
+
+const DOC_PATH_PATTERN = /(^|\/)(docs?|readme|changelog|code_of_conduct|license)([/.]|$)|(^|\/)security\.(md|mdx|txt|rst)$|\.(md|mdx|txt|rst)$/i;
+
+export function selectReviewMode(input: ReviewModeSelectionInput): ReviewModeSelection {
+  const files = input.files ?? [];
+  const labels = normalizeLabels(input.labels ?? input.pull?.labels?.map((label) => label.name) ?? []);
+  const title = input.title ?? input.pull?.title ?? "";
+  const body = input.body ?? input.pull?.body ?? "";
+  const text = `${title}\n${body}\n${labels.join("\n")}`;
+  const reasons: string[] = [];
+  const matchedSignals = new Set<string>();
+  const riskAreas = new Set<RegressionCategory>();
+
+  if (input.subject === "issue" && !input.researchRequested) {
+    reasons.push("Issue-shaped input did not explicitly request research mode; issue enrichment routing stays opt-in.");
+    matchedSignals.add("issue_research_not_requested");
+    return buildSelection("standard", "issue_enrichment", 0.64, reasons, matchedSignals, riskAreas, input.expectedRuntimeMs, input.providerTimeoutMs, input.reviewModes);
+  }
+
+  if (input.subject === "issue" && input.researchRequested) {
+    reasons.push("Issue enrichment explicitly requested research/build-vs-buy mode.");
+    matchedSignals.add("research_requested");
+    return buildSelection("research", "issue_enrichment", 0.86, reasons, matchedSignals, riskAreas, input.expectedRuntimeMs, input.providerTimeoutMs, input.reviewModes);
+  }
+
+  const docsOnly = input.docsOnly ?? (files.length > 0 && files.every((file) => isDocsOnlyPath(file.filename)));
+  if (docsOnly) {
+    reasons.push("Changed surface is docs/metadata only, so deep review would likely waste GLM time.");
+    matchedSignals.add("docs_only_surface");
+    riskAreas.add("docs_only");
+    return buildSelection("fast", "pull_request_review", 0.9, reasons, matchedSignals, riskAreas, input.expectedRuntimeMs, input.providerTimeoutMs, input.reviewModes);
+  }
+
+  const deep = hasDeepSignal(files, matchedSignals, riskAreas) || hasDeepTextSignal(text, matchedSignals, riskAreas);
+  if (deep) {
+    reasons.push("High-risk runtime/security/release/data/Unity/provider signal requires deeper regression review.");
+    return buildSelection("deep", "pull_request_review", 0.82, reasons, matchedSignals, riskAreas, input.expectedRuntimeMs, input.providerTimeoutMs, input.reviewModes);
+  }
+
+  if (hasProductSignal(text)) {
+    reasons.push("Product, UX, pricing, onboarding, or roadmap signal should use product/PM review criteria.");
+    matchedSignals.add("product_pm_text");
+    return buildSelection("product_pm", "pull_request_review", 0.78, reasons, matchedSignals, riskAreas, input.expectedRuntimeMs, input.providerTimeoutMs, input.reviewModes);
+  }
+
+  reasons.push("No fast-path, deep-risk, or product/PM trigger matched; use normal code review depth.");
+  matchedSignals.add("default_standard");
+  return buildSelection("standard", "pull_request_review", 0.7, reasons, matchedSignals, riskAreas, input.expectedRuntimeMs, input.providerTimeoutMs, input.reviewModes);
+}
+
+function buildSelection(
+  mode: ReviewMode,
+  targetUse: ReviewModeSelection["targetUse"],
+  confidence: number,
+  reasons: string[],
+  matchedSignals: Set<string>,
+  riskAreas: Set<RegressionCategory>,
+  expectedRuntimeMs?: number,
+  providerTimeoutMs?: number,
+  reviewModes?: ReviewModesConfig
+): ReviewModeSelection {
+  return {
+    mode,
+    targetUse,
+    confidence,
+    outcomeWeights: outcomeWeightsForMode(mode),
+    reasons,
+    matchedSignals: [...matchedSignals].sort(),
+    riskAreas: [...riskAreas].sort(),
+    budget: buildBudget(mode, expectedRuntimeMs, providerTimeoutMs, reviewModes),
+    proofBoundary: "Review mode routing is evidence-only in this release. It records the cheapest useful intended depth and budget target, but does not change scheduler concurrency, ZCode timeout, posting policy, or live runtime behavior."
+  };
+}
+
+function outcomeWeightsForMode(mode: ReviewMode): ReviewModeSelection["outcomeWeights"] {
+  if (mode === "fast") {
+    return {
+      regressionPrevention: 10,
+      signalToNoise: 30,
+      latencyFlow: 30,
+      contextProofAwareness: 10,
+      glmCostEfficiency: 15,
+      safetyLifecycle: 5
+    };
+  }
+  if (mode === "deep") {
+    return {
+      regressionPrevention: 35,
+      signalToNoise: 15,
+      latencyFlow: 10,
+      contextProofAwareness: 20,
+      glmCostEfficiency: 10,
+      safetyLifecycle: 10
+    };
+  }
+  if (mode === "product_pm") {
+    return {
+      regressionPrevention: 15,
+      signalToNoise: 20,
+      latencyFlow: 20,
+      contextProofAwareness: 25,
+      glmCostEfficiency: 10,
+      safetyLifecycle: 10
+    };
+  }
+  if (mode === "research") {
+    return {
+      regressionPrevention: 10,
+      signalToNoise: 15,
+      latencyFlow: 15,
+      contextProofAwareness: 30,
+      glmCostEfficiency: 15,
+      safetyLifecycle: 15
+    };
+  }
+  return {
+    regressionPrevention: 30,
+    signalToNoise: 20,
+    latencyFlow: 20,
+    contextProofAwareness: 15,
+    glmCostEfficiency: 10,
+    safetyLifecycle: 5
+  };
+}
+
+function buildBudget(mode: ReviewMode, expectedRuntimeMs?: number, providerTimeoutMs?: number, reviewModes?: ReviewModesConfig): ReviewModeBudget {
+  const fallback = MODE_BUDGETS[mode];
+  const configured = reviewModes?.modes[mode];
+  const targetMinutes = configured?.targetMinutes ?? fallback.targetMinutes;
+  const targetMs = targetMinutes * 60_000;
+  const hardTimeoutMs = configured?.wholeRunDeadlineMs ?? fallback.hardTimeoutMinutes * 60_000;
+  const hardTimeoutMinutes = Math.ceil(hardTimeoutMs / 60_000);
+  if (providerTimeoutMs !== undefined && providerTimeoutMs < targetMs) {
+    const disposition: ReviewModeBudgetDisposition = mode === "fast" ? "timeout_risk" : "partial";
+    return {
+      targetMinutes,
+      targetMs,
+      hardTimeoutMinutes,
+      hardTimeoutMs,
+      disposition,
+      detail: `Configured provider timeout ${providerTimeoutMs}ms is below the ${targetMinutes} minute mode target; evidence must treat this route as ${disposition} unless timeout is raised or review depth is cut.`
+    };
+  }
+  if (providerTimeoutMs !== undefined && providerTimeoutMs < hardTimeoutMs) {
+    return {
+      targetMinutes,
+      targetMs,
+      hardTimeoutMinutes,
+      hardTimeoutMs,
+      disposition: "timeout_risk",
+      detail: `Configured provider timeout ${providerTimeoutMs}ms is below the ${hardTimeoutMinutes} minute hard timeout; route can start but may need partial/deferred handling if GLM runs long.`
+    };
+  }
+  if (expectedRuntimeMs === undefined) {
+    return {
+      targetMinutes,
+      targetMs,
+      hardTimeoutMinutes,
+      hardTimeoutMs,
+      disposition: "within_budget",
+      detail: "No observed runtime supplied; route records target budget only."
+    };
+  }
+  if (expectedRuntimeMs <= targetMs) {
+    return {
+      targetMinutes,
+      targetMs,
+      hardTimeoutMinutes,
+      hardTimeoutMs,
+      disposition: "within_budget",
+      detail: `Observed or expected runtime ${expectedRuntimeMs}ms is within the ${targetMinutes} minute target.`
+    };
+  }
+  if (expectedRuntimeMs <= hardTimeoutMs) {
+    return {
+      targetMinutes,
+      targetMs,
+      hardTimeoutMinutes,
+      hardTimeoutMs,
+      disposition: "partial",
+      detail: `Observed or expected runtime ${expectedRuntimeMs}ms exceeds target but is below hard timeout; reviewer output should be marked partial if depth is cut short.`
+    };
+  }
+  return {
+    targetMinutes,
+    targetMs,
+    hardTimeoutMinutes,
+    hardTimeoutMs,
+    disposition: mode === "deep" || mode === "research" ? "deferred" : "timeout_risk",
+    detail: `Observed or expected runtime ${expectedRuntimeMs}ms exceeds hard timeout; route should defer or mark timeout rather than silently blocking queue progress.`
+  };
+}
+
+function hasDeepSignal(files: PullFilePatch[], matchedSignals: Set<string>, riskAreas: Set<RegressionCategory>): boolean {
+  let matched = false;
+  for (const file of files) {
+    for (const entry of DEEP_PATH_PATTERNS) {
+      if (entry.pattern.test(file.filename)) {
+        matched = true;
+        matchedSignals.add(entry.signal);
+        riskAreas.add(entry.area);
+      }
+    }
+    const churn = file.changes ?? (file.additions ?? 0) + (file.deletions ?? 0);
+    if (churn >= 500) {
+      matched = true;
+      matchedSignals.add("high_churn_file");
+      riskAreas.add("release_regression");
+    }
+  }
+  return matched;
+}
+
+function hasDeepTextSignal(text: string, matchedSignals: Set<string>, riskAreas: Set<RegressionCategory>): boolean {
+  const patterns: Array<{ pattern: RegExp; area: RegressionCategory; signal: string }> = [
+    { pattern: /\b(auth|security|permission|data loss|migration|release|provider|runtime|queue|scheduler|zcode|glm)\b/i, area: "runtime_correctness", signal: "deep_text" },
+    { pattern: /\b(unity|scene|prefab|save state|save-state)\b/i, area: "unity_scene_prefab", signal: "unity_text" }
+  ];
+  let matched = false;
+  for (const entry of patterns) {
+    if (entry.pattern.test(text)) {
+      matched = true;
+      matchedSignals.add(entry.signal);
+      riskAreas.add(entry.area);
+    }
+  }
+  return matched;
+}
+
+function hasProductSignal(text: string): boolean {
+  return PRODUCT_TEXT_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function isDocsOnlyPath(path: string): boolean {
+  return DOC_PATH_PATTERN.test(path);
+}
+
+function normalizeLabels(labels: string[]): string[] {
+  return labels.map((label) => label.trim().toLowerCase()).filter(Boolean).sort();
+}

--- a/src/review-mode-types.ts
+++ b/src/review-mode-types.ts
@@ -1,0 +1,62 @@
+import type { RegressionCategory } from "./types.js";
+
+export type ReviewMode = "fast" | "standard" | "deep" | "product_pm" | "research";
+
+export type ReviewModeBudgetDisposition = "within_budget" | "partial" | "timeout_risk" | "deferred";
+
+export interface ReviewModeBudget {
+  targetMinutes: number;
+  targetMs: number;
+  hardTimeoutMinutes: number;
+  hardTimeoutMs: number;
+  disposition: ReviewModeBudgetDisposition;
+  detail: string;
+}
+
+export interface ReviewModeSelection {
+  mode: ReviewMode;
+  targetUse: "pull_request_review" | "issue_enrichment";
+  confidence: number;
+  outcomeWeights: {
+    regressionPrevention: number;
+    signalToNoise: number;
+    latencyFlow: number;
+    contextProofAwareness: number;
+    glmCostEfficiency: number;
+    safetyLifecycle: number;
+  };
+  reasons: string[];
+  matchedSignals: string[];
+  riskAreas: RegressionCategory[];
+  budget: ReviewModeBudget;
+  proofBoundary: string;
+}
+
+export type ReviewModeContextSource = "patch" | "repo_memory" | "gitnexus" | "github_related" | "skill_packs";
+
+export interface ReviewModeEscalationConfig {
+  allowDepthEscalation: boolean;
+  allowDepthEscalationWhileProviderBacklog: boolean;
+  allowManualCommand: boolean;
+  allowRequestChanges: boolean;
+}
+
+export interface ReviewModeRuntimeConfig {
+  targetMinutes: number;
+  wholeRunDeadlineMs: number;
+  perAttemptTimeoutMs: number;
+  maxPatchBytes: number;
+  maxContextBytes: number;
+  maxProviderAttempts: number;
+  allowedContextSources: ReviewModeContextSource[];
+  queueWeight: number;
+  leaseTtlMs: number;
+  heartbeatMs: number;
+  escalation: ReviewModeEscalationConfig;
+}
+
+export interface ReviewModesConfig {
+  enabled: boolean;
+  defaultMode: Exclude<ReviewMode, "research">;
+  modes: Record<ReviewMode, ReviewModeRuntimeConfig>;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { ReviewModeSelection } from "./review-mode-types.js";
+
 export type Severity = "P0" | "P1" | "P2" | "P3";
 
 export type ReviewEvent = "COMMENT" | "REQUEST_CHANGES";
@@ -98,6 +100,7 @@ export interface ReviewPlan {
   comments: ReviewComment[];
   dropped: DroppedFinding[];
   summary: string;
+  reviewMode?: ReviewModeSelection;
   deterministicGate?: DeterministicReviewGateSummary;
   validation?: ChangedSurfaceValidationReport;
   proof?: ProofRequirementReport;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -48,6 +48,8 @@ import {
 } from "./outcome-ledger.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown, type RepoMemoryPacket } from "./repo-memory.js";
 import { ReviewRunBudget } from "./review-budget.js";
+import { selectReviewMode } from "./review-mode-router.js";
+import type { ReviewModeSelection } from "./review-mode-types.js";
 import { sanitizePublicConfidenceText, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import {
   postReviewStatusComment,
@@ -1446,7 +1448,6 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     writeFileSync(join(evidenceDir, "review-prompt.txt"), redactSecrets(prompt));
     writeRedactedJson(join(evidenceDir, "validation-selector.json"), validation);
     writeRedactedJson(join(evidenceDir, "proof-requirements.json"), proof);
-
     const zcodeResult = input.useZCode
       ? await runZCodeReviewWithProviderRetry({
           config,
@@ -1465,6 +1466,16 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
             notes: ["ZCode execution disabled for this dry-run; provider latency and token usage were not measured."]
           }
         };
+
+    const reviewMode = buildReviewModeEvidence({
+      evidenceDir,
+      pull,
+      files: reviewFiles,
+      docsOnly: validation.docsOnly,
+      expectedRuntimeMs: zcodeResult.runtime.latencyMs,
+      providerTimeoutMs: config.zcode.timeoutMs,
+      reviewModes: config.reviewModes
+    });
 
     assertGitClean(worktree.path);
 
@@ -1533,6 +1544,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       dropped,
       summary,
       deterministicGate: gate.summary,
+      ...(reviewMode ? { reviewMode } : {}),
       validation,
       proof,
       ...(walkthrough ? { walkthrough } : {}),
@@ -2236,6 +2248,42 @@ export function writeDryRunOutcomeLedgerEvidence(input: {
       proofBoundary: "Outcome Ledger dry-run evidence failed to build; stable review-plan evidence must continue."
     });
     return { ok: false, error: message };
+  }
+}
+
+export function buildReviewModeEvidence(input: {
+  evidenceDir: string;
+  pull: PullRequestSummary;
+  files: PullFilePatch[];
+  docsOnly: boolean;
+  expectedRuntimeMs?: number;
+  providerTimeoutMs?: number;
+  reviewModes?: BotConfig["reviewModes"];
+}): ReviewModeSelection | undefined {
+  try {
+    const reviewMode = selectReviewMode({
+      subject: "pull_request",
+      pull: input.pull,
+      files: input.files,
+      docsOnly: input.docsOnly,
+      expectedRuntimeMs: input.expectedRuntimeMs,
+      providerTimeoutMs: input.providerTimeoutMs,
+      reviewModes: input.reviewModes
+    });
+    writeRedactedJson(join(input.evidenceDir, "review-mode.json"), reviewMode);
+    return reviewMode;
+  } catch (error) {
+    try {
+      writeRedactedJson(join(input.evidenceDir, "review-mode-error.json"), {
+        ok: false,
+        error: redactSecrets(error instanceof Error ? error.message : String(error)),
+        proofBoundary: "Review mode routing is evidence-only in this release; failures must not block stable review execution."
+      });
+    } catch {
+      // Review-mode routing is advisory evidence only; stable review must continue
+      // even when the evidence directory itself is not writable.
+    }
+    return undefined;
   }
 }
 

--- a/tests/outcome-ledger.test.ts
+++ b/tests/outcome-ledger.test.ts
@@ -8,6 +8,7 @@ import {
   buildOutcomeLedger,
   buildOutcomeLedgerInputFromReviewPlan,
   parseOutcomeLedgerInput,
+  renderOutcomeLedgerMarkdown,
   writeOutcomeLedgerPacket,
   type OutcomeLedgerInput
 } from "../src/outcome-ledger.js";
@@ -98,6 +99,72 @@ describe("outcome ledger", () => {
       unknown: ["current_head"]
     });
     expect(ledger.metrics.unknownSafetyGates).toBe(1);
+  });
+
+  it("includes selected review mode and budget in the ledger packet", () => {
+    const ledger = buildOutcomeLedger(sampleInput({
+      reviewMode: {
+        mode: "deep",
+        targetUse: "pull_request_review",
+        confidence: 0.82,
+        outcomeWeights: {
+          regressionPrevention: 35,
+          signalToNoise: 15,
+          latencyFlow: 10,
+          contextProofAwareness: 20,
+          glmCostEfficiency: 10,
+          safetyLifecycle: 10
+        },
+        reasons: ["Runtime provider path changed."],
+        matchedSignals: ["runtime/provider path"],
+        riskAreas: ["runtime_correctness"],
+        budget: {
+          targetMinutes: 25,
+          targetMs: 1_500_000,
+          hardTimeoutMinutes: 35,
+          hardTimeoutMs: 2_100_000,
+          disposition: "within_budget",
+          detail: "No observed runtime supplied; route records target budget only."
+        },
+        proofBoundary: "Review mode routing is evidence-only in this release."
+      }
+    }));
+
+    expect(ledger.reviewMode).toMatchObject({
+      mode: "deep",
+      targetUse: "pull_request_review",
+      budget: {
+        targetMinutes: 25,
+        hardTimeoutMinutes: 35,
+        disposition: "within_budget"
+      }
+    });
+    const markdown = renderOutcomeLedgerMarkdown(ledger);
+    expect(markdown).toContain("## Review Mode");
+    expect(markdown).toContain("- Selected: `deep`");
+    expect(markdown).toContain("Outcome weights: regression=35");
+    expect(markdown).toContain("- Budget disposition: `within_budget`");
+  });
+
+  it("normalizes partial direct reviewMode inputs without crashing", () => {
+    const ledger = buildOutcomeLedger(sampleInput({
+      reviewMode: {
+        mode: "standard",
+        targetUse: "pull_request_review"
+      } as NonNullable<OutcomeLedgerInput["reviewMode"]>
+    }));
+
+    expect(ledger.reviewMode).toMatchObject({
+      mode: "standard",
+      targetUse: "pull_request_review",
+      outcomeWeights: {
+        regressionPrevention: -1
+      },
+      budget: {
+        disposition: "timeout_risk",
+        detail: "Review mode budget was missing; treating as timeout risk."
+      }
+    });
   });
 
 
@@ -280,6 +347,10 @@ describe("outcome ledger", () => {
       reviewerDecision: {
         status: "block"
       },
+      reviewMode: {
+        mode: "deep",
+        targetUse: "pull_request_review"
+      },
       safetyGates: expect.arrayContaining([
         expect.objectContaining({ name: "duplicate_same_head", status: "unknown" }),
         expect.objectContaining({ name: "current_head", status: "unknown" }),
@@ -323,6 +394,64 @@ describe("outcome ledger", () => {
     });
     expect(parsed.outputDir).toContain("/packet");
     expect(existsSync(join(outputDir, "outcome-ledger.json"))).toBe(true);
+  });
+
+  it("preserves reviewMode when reading outcome-ledger CLI input", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-outcome-ledger-cli-mode-"));
+    roots.push(root);
+    const inputPath = join(root, "input.json");
+    const outputDir = join(root, "packet");
+    writeFileSync(inputPath, `${JSON.stringify(sampleInput({
+      reviewMode: {
+        mode: "product_pm",
+        targetUse: "pull_request_review",
+        confidence: 0.78,
+        outcomeWeights: {
+          regressionPrevention: 15,
+          signalToNoise: 20,
+          latencyFlow: 20,
+          contextProofAwareness: 25,
+          glmCostEfficiency: 10,
+          safetyLifecycle: 10
+        },
+        reasons: ["UX copy changed."],
+        matchedSignals: ["product_pm_text"],
+        riskAreas: [],
+        budget: {
+          targetMinutes: 15,
+          targetMs: 900_000,
+          hardTimeoutMinutes: 25,
+          hardTimeoutMs: 1_500_000,
+          disposition: "within_budget",
+          detail: "No observed runtime supplied; route records target budget only."
+        },
+        proofBoundary: "Review mode routing is evidence-only in this release."
+      }
+    }), null, 2)}\n`);
+
+    execFileSync(process.execPath, [
+      tsxCli,
+      "src/cli.ts",
+      "outcome-ledger",
+      "--input",
+      inputPath,
+      "--dry-run",
+      "true",
+      "--output-dir",
+      outputDir
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8"
+    });
+
+    const ledger = JSON.parse(readFileSync(join(outputDir, "outcome-ledger.json"), "utf8"));
+    expect(ledger.reviewMode).toMatchObject({
+      mode: "product_pm",
+      matchedSignals: ["product_pm_text"],
+      budget: {
+        disposition: "within_budget"
+      }
+    });
   });
 
   it("requires output-dir for CLI portability", () => {
@@ -597,6 +726,31 @@ function sampleReviewPlan(): ReviewPlan {
       requiredRecommendationIds: ["runtime-smoke"],
       missingRecommendationIds: [],
       detectedEvidence: ["smoke"]
+    },
+    reviewMode: {
+      mode: "deep",
+      targetUse: "pull_request_review",
+      confidence: 0.8,
+      outcomeWeights: {
+        regressionPrevention: 35,
+        signalToNoise: 15,
+        latencyFlow: 10,
+        contextProofAwareness: 20,
+        glmCostEfficiency: 10,
+        safetyLifecycle: 10
+      },
+      reasons: ["Runtime path changed."],
+      matchedSignals: ["runtime/provider path"],
+      riskAreas: ["runtime_correctness"],
+      budget: {
+        targetMinutes: 25,
+        targetMs: 1_500_000,
+        hardTimeoutMinutes: 35,
+        hardTimeoutMs: 2_100_000,
+        disposition: "within_budget",
+        detail: "No observed runtime supplied; route records target budget only."
+      },
+      proofBoundary: "Review mode routing is evidence-only in this release."
     }
   };
 }

--- a/tests/outcome-ledger.test.ts
+++ b/tests/outcome-ledger.test.ts
@@ -167,6 +167,34 @@ describe("outcome ledger", () => {
     });
   });
 
+  it("parses partial reviewMode inputs with the same timeout-risk placeholder", () => {
+    const parsed = parseOutcomeLedgerInput(sampleInput({
+      reviewMode: {
+        mode: "standard",
+        targetUse: "pull_request_review"
+      } as NonNullable<OutcomeLedgerInput["reviewMode"]>
+    }));
+
+    expect(parsed.reviewMode).toMatchObject({
+      mode: "standard",
+      targetUse: "pull_request_review",
+      budget: {
+        disposition: "timeout_risk",
+        detail: "Review mode budget was missing; treating as timeout risk."
+      }
+    });
+  });
+
+  it("still rejects malformed reviewMode budget values", () => {
+    expect(() => parseOutcomeLedgerInput(sampleInput({
+      reviewMode: {
+        mode: "standard",
+        targetUse: "pull_request_review",
+        budget: "bad"
+      } as unknown as NonNullable<OutcomeLedgerInput["reviewMode"]>
+    }))).toThrow("reviewMode.budget must be an object");
+  });
+
 
   it("redacts secret-like evidence and marks the packet non-ok", () => {
     const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");

--- a/tests/review-mode-router.test.ts
+++ b/tests/review-mode-router.test.ts
@@ -39,7 +39,7 @@ describe("review mode router", () => {
     expect(selection.proofBoundary).toContain("does not change scheduler");
   });
 
-  it("keeps security or product docs in fast mode because docs-only wins", () => {
+  it("keeps security or product docs fast while recording hidden risk signals", () => {
     const selection = selectReviewMode({
       subject: "pull_request",
       title: "Update pricing and security docs",
@@ -55,6 +55,11 @@ describe("review mode router", () => {
       targetUse: "pull_request_review"
     });
     expect(selection.riskAreas).toContain("docs_only");
+    expect(selection.riskAreas).toContain("security_boundary");
+    expect(selection.riskAreas).toContain("api_compatibility");
+    expect(selection.matchedSignals).toContain("docs_security boundary path");
+    expect(selection.matchedSignals).toContain("docs_billing/pricing path");
+    expect(selection.matchedSignals).toContain("docs_product_pm_text");
   });
 
   it("does not classify security source directories as docs-only", () => {
@@ -118,6 +123,34 @@ describe("review mode router", () => {
     });
   });
 
+  it("does not report hardTimeoutMinutes beyond a non-minute wholeRunDeadlineMs", () => {
+    const hardTimeoutMs = 1_500_001;
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "refactor parser utility",
+      files: [{ filename: "src/parser.ts", status: "modified", changes: 20 }],
+      providerTimeoutMs: 2_000_000,
+      reviewModes: {
+        enabled: true,
+        defaultMode: "standard",
+        modes: {
+          fast: modeConfig(5, 10),
+          standard: {
+            ...modeConfig(15, 20),
+            wholeRunDeadlineMs: hardTimeoutMs
+          },
+          deep: modeConfig(25, 35),
+          product_pm: modeConfig(15, 25),
+          research: modeConfig(20, 30)
+        }
+      }
+    });
+
+    expect(selection.mode).toBe("standard");
+    expect(selection.budget.hardTimeoutMs).toBe(hardTimeoutMs);
+    expect(selection.budget.hardTimeoutMinutes * 60_000).toBeLessThanOrEqual(hardTimeoutMs);
+  });
+
   it("selects deep mode for runtime and provider risk paths", () => {
     const selection = selectReviewMode({
       subject: "pull_request",
@@ -147,6 +180,50 @@ describe("review mode router", () => {
 
     expect(selection.mode).toBe("deep");
     expect(selection.matchedSignals).toContain("runtime/provider path");
+  });
+
+  it("keeps generic runtime or release wording standard without corroborating risk", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "fix runtime typo in release notes script",
+      body: "Adds queue length wording to the status panel.",
+      files: [
+        { filename: "src/components/ReleaseNotesCopy.tsx", status: "modified", changes: 16 }
+      ]
+    });
+
+    expect(selection.mode).toBe("standard");
+    expect(selection.matchedSignals).toContain("default_standard");
+    expect(selection.matchedSignals).not.toContain("deep_text");
+    expect(selection.matchedSignals).not.toContain("corroborated_runtime_text");
+  });
+
+  it("uses deep mode for corroborated runtime incident wording", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "fix provider throttle queue backlog",
+      files: [
+        { filename: "src/components/ProviderStatus.tsx", status: "modified", changes: 16 }
+      ]
+    });
+
+    expect(selection.mode).toBe("deep");
+    expect(selection.matchedSignals).toContain("corroborated_runtime_text");
+    expect(selection.riskAreas).toContain("runtime_correctness");
+  });
+
+  it("selects deep mode for high churn files through additions/deletions fallback", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "refactor utility module",
+      files: [
+        { filename: "src/utils/formatters.ts", status: "modified", additions: 260, deletions: 240 }
+      ]
+    });
+
+    expect(selection.mode).toBe("deep");
+    expect(selection.matchedSignals).toContain("high_churn_file");
+    expect(selection.riskAreas).toContain("release_regression");
   });
 
   it("selects product_pm mode for UX and product intent when no deep risk matched", () => {

--- a/tests/review-mode-router.test.ts
+++ b/tests/review-mode-router.test.ts
@@ -1,0 +1,371 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { selectReviewMode, type ReviewModeSelectionInput } from "../src/review-mode-router.js";
+
+const nodeRequire = createRequire(import.meta.url);
+const tsxCli = nodeRequire.resolve("tsx/cli");
+
+describe("review mode router", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("selects fast mode for docs-only pull requests", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "docs: clarify setup",
+      docsOnly: true,
+      files: [
+        { filename: "docs/SETUP.md", status: "modified", changes: 8 },
+        { filename: "README.md", status: "modified", changes: 3 }
+      ]
+    });
+
+    expect(selection).toMatchObject({
+      mode: "fast",
+      targetUse: "pull_request_review",
+      budget: {
+        targetMinutes: 5,
+        disposition: "within_budget"
+      }
+    });
+    expect(selection.matchedSignals).toContain("docs_only_surface");
+    expect(selection.proofBoundary).toContain("does not change scheduler");
+  });
+
+  it("keeps security or product docs in fast mode because docs-only wins", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "Update pricing and security docs",
+      docsOnly: true,
+      files: [
+        { filename: "SECURITY.md", status: "modified", changes: 8 },
+        { filename: "docs/pricing.md", status: "modified", changes: 3 }
+      ]
+    });
+
+    expect(selection).toMatchObject({
+      mode: "fast",
+      targetUse: "pull_request_review"
+    });
+    expect(selection.riskAreas).toContain("docs_only");
+  });
+
+  it("does not classify security source directories as docs-only", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "small refactor",
+      files: [
+        { filename: "src/security/auth.ts", status: "modified", changes: 8 }
+      ]
+    });
+
+    expect(selection).toMatchObject({
+      mode: "deep",
+      targetUse: "pull_request_review"
+    });
+    expect(selection.riskAreas).toContain("security_boundary");
+  });
+
+  it("records outcome-weighted scoring dimensions for selected mode", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "fix provider retry queue",
+      files: [{ filename: "src/scheduler.ts", status: "modified", changes: 120 }]
+    });
+
+    expect(selection.mode).toBe("deep");
+    expect(selection.outcomeWeights).toMatchObject({
+      regressionPrevention: 35,
+      contextProofAwareness: 20,
+      safetyLifecycle: 10
+    });
+  });
+
+  it("uses explicit reviewModes config for budget disposition evidence", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "fix provider retry queue",
+      files: [{ filename: "src/scheduler.ts", status: "modified", changes: 120 }],
+      expectedRuntimeMs: 23 * 60_000,
+      providerTimeoutMs: 40 * 60_000,
+      reviewModes: {
+        enabled: true,
+        defaultMode: "fast",
+        modes: {
+          fast: modeConfig(5, 10),
+          standard: modeConfig(15, 20),
+          deep: modeConfig(22, 33),
+          product_pm: modeConfig(15, 25),
+          research: modeConfig(20, 30)
+        }
+      }
+    });
+
+    expect(selection).toMatchObject({
+      mode: "deep",
+      budget: {
+        targetMinutes: 22,
+        hardTimeoutMinutes: 33,
+        disposition: "partial"
+      }
+    });
+  });
+
+  it("selects deep mode for runtime and provider risk paths", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "fix provider retry queue",
+      files: [
+        { filename: "src/scheduler.ts", status: "modified", changes: 120 },
+        { filename: "src/zcode-timeout.ts", status: "modified", changes: 12 }
+      ]
+    });
+
+    expect(selection.mode).toBe("deep");
+    expect(selection.riskAreas).toContain("runtime_correctness");
+    expect(selection.matchedSignals).toContain("runtime/provider path");
+    expect(selection.budget.targetMinutes).toBe(25);
+  });
+
+  it("selects deep mode for hyphenated runtime provider filenames with neutral title", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "small refactor",
+      files: [
+        { filename: "src/provider-throttle.ts", status: "modified", changes: 8 },
+        { filename: "src/zcode-timeout.ts", status: "modified", changes: 8 },
+        { filename: "src/release-gate.ts", status: "modified", changes: 8 }
+      ]
+    });
+
+    expect(selection.mode).toBe("deep");
+    expect(selection.matchedSignals).toContain("runtime/provider path");
+  });
+
+  it("selects product_pm mode for UX and product intent when no deep risk matched", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "Improve onboarding conversion UX",
+      body: "Adjust dashboard copy and first-run workflow.",
+      files: [
+        { filename: "src/components/WelcomePanel.tsx", status: "modified", changes: 44 }
+      ]
+    });
+
+    expect(selection).toMatchObject({
+      mode: "product_pm",
+      budget: {
+        targetMinutes: 15
+      }
+    });
+    expect(selection.matchedSignals).toContain("product_pm_text");
+  });
+
+  it("keeps research mode scoped to issue enrichment", () => {
+    const issueSelection = selectReviewMode({
+      subject: "issue",
+      researchRequested: true,
+      title: "Should we build or borrow this integration?"
+    });
+    const prSelection = selectReviewMode({
+      subject: "pull_request",
+      researchRequested: true,
+      title: "Regular code change",
+      files: [{ filename: "src/index.ts", status: "modified", changes: 10 }]
+    });
+
+    expect(issueSelection.mode).toBe("research");
+    expect(issueSelection.targetUse).toBe("issue_enrichment");
+    expect(prSelection.mode).toBe("standard");
+  });
+
+  it("keeps non-triggered issue inputs out of research mode", () => {
+    const selection = selectReviewMode({
+      subject: "issue",
+      title: "Triage small follow-up"
+    });
+
+    expect(selection).toMatchObject({
+      mode: "standard",
+      targetUse: "issue_enrichment"
+    });
+    expect(selection.matchedSignals).toContain("issue_research_not_requested");
+  });
+
+  it("marks over-budget deep reviews as deferred instead of silent queue blockers", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "release runtime provider queue fix",
+      files: [{ filename: "src/provider-throttle-report.ts", status: "modified", changes: 80 }],
+      expectedRuntimeMs: 40 * 60_000
+    });
+
+    expect(selection.mode).toBe("deep");
+    expect(selection.budget).toMatchObject({
+      disposition: "deferred",
+      hardTimeoutMinutes: 35
+    });
+    expect(selection.budget.detail).toContain("silently blocking queue");
+  });
+
+  it("marks observed over-target reviews partial even when provider timeout allows completion", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "refactor parser utility",
+      files: [{ filename: "src/parser.ts", status: "modified", changes: 20 }],
+      expectedRuntimeMs: 16 * 60_000,
+      providerTimeoutMs: 25 * 60_000
+    });
+
+    expect(selection).toMatchObject({
+      mode: "standard",
+      budget: {
+        targetMinutes: 15,
+        disposition: "partial"
+      }
+    });
+    expect(selection.budget.detail).toContain("exceeds target");
+  });
+
+  it("marks deep review partial when configured provider timeout is below target", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "release runtime provider queue fix",
+      files: [{ filename: "src/scheduler.ts", status: "modified", changes: 80 }],
+      providerTimeoutMs: 20 * 60_000
+    });
+
+    expect(selection.mode).toBe("deep");
+    expect(selection.budget).toMatchObject({
+      targetMinutes: 25,
+      disposition: "partial"
+    });
+    expect(selection.budget.detail).toContain("Configured provider timeout");
+    expect(selection.proofBoundary).toContain("evidence-only");
+  });
+
+  it("keeps fast docs route within budget under a normal provider timeout", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "docs: clarify setup",
+      files: [{ filename: "docs/SETUP.md", status: "modified", changes: 2 }],
+      providerTimeoutMs: 20 * 60_000
+    });
+
+    expect(selection).toMatchObject({
+      mode: "fast",
+      budget: {
+        targetMinutes: 5,
+        disposition: "within_budget"
+      }
+    });
+  });
+
+  it("marks standard route timeout_risk when provider timeout is below hard timeout but above target", () => {
+    const selection = selectReviewMode({
+      subject: "pull_request",
+      title: "refactor parser utility",
+      files: [{ filename: "src/parser.ts", status: "modified", changes: 20 }],
+      providerTimeoutMs: 17 * 60_000
+    });
+
+    expect(selection).toMatchObject({
+      mode: "standard",
+      budget: {
+        targetMinutes: 15,
+        hardTimeoutMinutes: 20,
+        disposition: "timeout_risk"
+      }
+    });
+    expect(selection.budget.detail).toContain("below the 20 minute hard timeout");
+  });
+
+  it("exposes a dry-run-only CLI that can write evidence", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-mode-"));
+    roots.push(root);
+    const inputPath = join(root, "input.json");
+    const outputDir = join(root, "evidence");
+    const input: ReviewModeSelectionInput = {
+      subject: "pull_request",
+      title: "docs only",
+      files: [{ filename: "docs/README.md", status: "modified", changes: 1 }]
+    };
+    writeFileSync(inputPath, `${JSON.stringify(input, null, 2)}\n`);
+
+    const output = execFileSync(process.execPath, [
+      tsxCli,
+      "src/cli.ts",
+      "review-mode",
+      "--input",
+      inputPath,
+      "--dry-run",
+      "true",
+      "--output-dir",
+      outputDir
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8"
+    });
+
+    const parsed = JSON.parse(output);
+    expect(parsed).toMatchObject({
+      ok: true,
+      command: "review-mode",
+      dryRun: true,
+      result: {
+        mode: "fast"
+      }
+    });
+    expect(existsSync(join(outputDir, "review-mode.json"))).toBe(true);
+    expect(readFileSync(join(outputDir, "review-mode.json"), "utf8")).toContain("\"mode\": \"fast\"");
+  });
+
+  it("refuses live review-mode execution", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-mode-live-"));
+    roots.push(root);
+    const inputPath = join(root, "input.json");
+    writeFileSync(inputPath, `${JSON.stringify({ subject: "pull_request" }, null, 2)}\n`);
+
+    expect(() => execFileSync(process.execPath, [
+      tsxCli,
+      "src/cli.ts",
+      "review-mode",
+      "--input",
+      inputPath,
+      "--dry-run",
+      "false"
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      stdio: "pipe"
+    })).toThrow("review-mode is dry-run only in this release");
+  });
+});
+
+function modeConfig(targetMinutes: number, hardTimeoutMinutes: number) {
+  return {
+    targetMinutes,
+    wholeRunDeadlineMs: hardTimeoutMinutes * 60_000,
+    perAttemptTimeoutMs: targetMinutes * 60_000,
+    maxPatchBytes: 80_000,
+    maxContextBytes: 40_000,
+    maxProviderAttempts: 1,
+    allowedContextSources: ["patch" as const],
+    queueWeight: 50,
+    leaseTtlMs: 45 * 60_000,
+    heartbeatMs: 60_000,
+    escalation: {
+      allowDepthEscalation: false,
+      allowDepthEscalationWhileProviderBacklog: false,
+      allowManualCommand: true,
+      allowRequestChanges: false
+    }
+  };
+}

--- a/tests/review-scheduler-config.test.ts
+++ b/tests/review-scheduler-config.test.ts
@@ -27,6 +27,86 @@ describe("review scheduler config", () => {
       overloadBackoffMaxDurationMs: 10 * 60_000,
       overloadBackoffJitterMs: 30_000
     });
+    expect(config.reviewModes).toMatchObject({
+      enabled: false,
+      defaultMode: "fast",
+      modes: {
+        fast: {
+          targetMinutes: 5,
+          wholeRunDeadlineMs: 10 * 60_000,
+          maxProviderAttempts: 1,
+          allowedContextSources: ["patch"],
+          escalation: {
+            allowDepthEscalation: false,
+            allowDepthEscalationWhileProviderBacklog: false
+          }
+        },
+        deep: {
+          targetMinutes: 25,
+          wholeRunDeadlineMs: 35 * 60_000,
+          queueWeight: 90
+        },
+        research: {
+          maxPatchBytes: 0,
+          allowedContextSources: ["repo_memory", "gitnexus", "github_related", "skill_packs"]
+        }
+      }
+    });
+  });
+
+  it("loads explicit review mode budget and escalation policy overrides", () => {
+    const config = loadConfig(writeConfig({
+      reviewModes: {
+        enabled: true,
+        modes: {
+          deep: {
+            targetMinutes: 22,
+            wholeRunDeadlineMs: 33 * 60_000,
+            perAttemptTimeoutMs: 11 * 60_000,
+            maxPatchBytes: 90_000,
+            maxContextBytes: 50_000,
+            maxProviderAttempts: 3,
+            allowedContextSources: ["patch", "repo_memory"],
+            queueWeight: 80,
+            leaseTtlMs: 50 * 60_000,
+            heartbeatMs: 60_000,
+            escalation: {
+              allowDepthEscalation: true,
+              allowDepthEscalationWhileProviderBacklog: false,
+              allowManualCommand: true,
+              allowRequestChanges: true
+            }
+          }
+        }
+      }
+    }));
+
+    expect(config.reviewModes).toMatchObject({
+      enabled: true,
+      modes: {
+        deep: {
+          targetMinutes: 22,
+          wholeRunDeadlineMs: 33 * 60_000,
+          perAttemptTimeoutMs: 11 * 60_000,
+          maxProviderAttempts: 3,
+          allowedContextSources: ["patch", "repo_memory"]
+        }
+      }
+    });
+  });
+
+  it("rejects review mode configs that allow depth escalation while provider backlog exists", () => {
+    expect(() => loadConfig(writeConfig({
+      reviewModes: {
+        modes: {
+          standard: {
+            escalation: {
+              allowDepthEscalationWhileProviderBacklog: true
+            }
+          }
+        }
+      }
+    }))).toThrow("config.reviewModes.modes.standard.escalation.allowDepthEscalationWhileProviderBacklog must remain false during beta");
   });
 
   it("rejects scheduler settings that cannot preserve manual reserve capacity", () => {

--- a/tests/worker-settings-preview.test.ts
+++ b/tests/worker-settings-preview.test.ts
@@ -70,6 +70,8 @@ describe("worker review settings preview evidence", () => {
       pull.head.sha
     );
     const preview = JSON.parse(readFileSync(join(evidenceDir, "review-settings-preview.json"), "utf8"));
+    const reviewMode = JSON.parse(readFileSync(join(evidenceDir, "review-mode.json"), "utf8"));
+    const reviewPlan = JSON.parse(readFileSync(join(evidenceDir, "review-plan.json"), "utf8"));
     const walkthrough = readFileSync(join(evidenceDir, "walkthrough.md"), "utf8");
     const ledger = JSON.parse(readFileSync(join(evidenceDir, "outcome-ledger.json"), "utf8"));
 
@@ -84,6 +86,25 @@ describe("worker review settings preview evidence", () => {
     expect(walkthrough).toContain("- Enabled sections: Review summary (inline_review); Walkthrough (inline_review)");
     expect(walkthrough).toContain("- Path instructions: `src/\\`templates\\`/**`");
     expect(walkthrough).not.toContain(secretLikeToken);
+    expect(reviewMode).toMatchObject({
+      mode: "standard",
+      budget: {
+        disposition: "partial",
+        detail: expect.stringContaining("Configured provider timeout 1ms")
+      }
+    });
+    expect(reviewPlan.reviewMode).toMatchObject({
+      mode: reviewMode.mode,
+      budget: {
+        disposition: reviewMode.budget.disposition
+      }
+    });
+    expect(ledger.reviewMode).toMatchObject({
+      mode: reviewMode.mode,
+      budget: {
+        disposition: reviewMode.budget.disposition
+      }
+    });
     expect(ledger.runtime).toMatchObject({
       provider: "zcode-glm",
       model: "GLM-5.2",


### PR DESCRIPTION
## Summary

Implements #266 as an evidence-only review mode router and GLM budget guard.

- adds `fast`, `standard`, `deep`, `product_pm`, and `research` mode selection
- records outcome-weighted dimensions, routing reasons, matched signals, risk areas, and budget disposition
- adds explicit `reviewModes` config defaults/validation for target minutes, whole-run deadline, per-attempt timeout, patch/context caps, max provider attempts, allowed context sources, queue weight, lease/heartbeat, and escalation permissions
- adds dry-run CLI preview: `review-mode`
- writes `review-mode.json` beside review evidence and threads the result into `review-plan.json` / `outcome-ledger.json`
- keeps router evidence non-fatal so stable review continues if router evidence fails
- preserves existing scheduler, provider timeout, posting policy, launchd config, and live runtime behavior

## Proof Boundary

This PR does not enforce mode routing live. It only records the selected mode, configured mode budget, and budget disposition in dry-run/evidence surfaces. No `95%` accuracy, parity, production-readiness, or live enforcement claim.

## Validation

- `npm test -- tests/review-mode-router.test.ts tests/outcome-ledger.test.ts tests/worker-settings-preview.test.ts tests/review-scheduler-config.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- CLI smoke: `npm run cli -- review-mode --input /Volumes/LEXAR/Codex/evals/evaos-reviewer-benchmark/2026-07-05/advanced-outcome-modes-v0.1/mode-router-smoke/input.json --dry-run true --output-dir /Volumes/LEXAR/Codex/evals/evaos-reviewer-benchmark/2026-07-05/advanced-outcome-modes-v0.1/mode-router-smoke/evidence`

## Evidence

- `/Volumes/LEXAR/Codex/evals/evaos-reviewer-benchmark/2026-07-05/advanced-outcome-modes-v0.1/mode-router-smoke/`
- `/Volumes/LEXAR/Codex/session-notes/2026-07-05/neondiff-advanced-outcome-modes/reviews/`

Closes #266.
