### PR TITLE
Add outcome scorecard fixture runner

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,10 @@ import {
   readOutcomeLedgerInput,
   writeOutcomeLedgerPacket
 } from "./outcome-ledger.js";
+import {
+  readOutcomeScorecardInput,
+  writeOutcomeScorecardPacket
+} from "./outcome-scorecard.js";
 import { buildReviewBudgetStatus } from "./review-budget.js";
 import {
   buildOperatorDashboard,
@@ -1459,6 +1463,29 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "outcome-scorecard") {
+    if (args.input === undefined || (Array.isArray(args.input) && args.input.length === 0)) {
+      throw new Error("--input is required for outcome-scorecard");
+    }
+    if (args["output-dir"] === undefined || (Array.isArray(args["output-dir"]) && args["output-dir"].length === 0)) {
+      throw new Error("--output-dir is required for outcome-scorecard");
+    }
+    const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
+    if (!dryRun) throw new Error("outcome-scorecard is dry-run only in this release");
+    const scorecardInput = readOutcomeScorecardInput(parseSingleArg(args.input, "--input"));
+    const outputDir = parseSingleArg(args["output-dir"], "--output-dir");
+    assertEvalOutputDirSafe(outputDir);
+    const result = writeOutcomeScorecardPacket({ scorecardInput, outputDir });
+    console.log(stringifyRedactedJson({
+      command: "outcome-scorecard",
+      dryRun,
+      outputDir,
+      ...result
+    }));
+    if (!result.ok) process.exitCode = 1;
+    return;
+  }
+
   if (command === "run-once" || command === "review-pr") {
     if (command === "review-pr" && (!args.repo || !args.pr)) {
       console.log(JSON.stringify({
@@ -2612,7 +2639,8 @@ function buildHelp(command?: string) {
         "eval-offline",
         "eval-suite",
         "eval-sticky-vs-cold",
-        "outcome-ledger"
+        "outcome-ledger",
+        "outcome-scorecard"
       ]
     },
     examples: [
@@ -2662,6 +2690,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts clear-review-queue-leases --config /path/to/live.json --dry-run true --expired-only true",
       "npx tsx src/cli.ts eval-sticky-vs-cold --input /path/to/sticky-vs-cold.json --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold",
       "npx tsx src/cli.ts outcome-ledger --input /path/to/outcome-ledger-input.json --dry-run true --output-dir /path/to/evidence/outcome-ledger-run",
+      "npx tsx src/cli.ts outcome-scorecard --input /path/to/outcome-scorecard-input.json --dry-run true --output-dir /path/to/evidence/outcome-scorecard-run",
       "npx tsx src/cli.ts finishing-touch-dry-run --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD --current-head HEAD --comment-id 456 --author maintainer --trusted-authors maintainer --body '@evaos-code-review-bot explain risk'",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ],
@@ -2670,6 +2699,13 @@ function buildHelp(command?: string) {
         "The outcome-ledger command is dry-run only.",
         "--dry-run defaults to true for outcome-ledger; --dry-run false is rejected until live posting is explicitly implemented.",
         "Failed safety gates or secret redaction failures exit non-zero; unknown gates remain visible in the packet but do not fail the dry run."
+      ]
+    },
+    outcomeScorecard: {
+      notes: [
+        "The outcome-scorecard command is dry-run only.",
+        "Scores above 3 require direct evidence links.",
+        "Safety failures cap the score at 1 and all public claims remain advisory-only."
       ]
     }
   };

--- a/src/outcome-scorecard.ts
+++ b/src/outcome-scorecard.ts
@@ -1,0 +1,432 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { containsSecretLikeText, redactSecrets } from "./secrets.js";
+
+export type OutcomeScoreSurface = "pr_review" | "issue_enrichment";
+export type OutcomeMetricState = "measured" | "unmeasurable";
+
+export interface OutcomeScorecardInput {
+  evalName?: string;
+  runId: string;
+  surface: OutcomeScoreSurface;
+  scenario: {
+    id: string;
+    title: string;
+    repo?: string;
+    url?: string;
+    negativeControl?: boolean;
+  };
+  metrics: OutcomeMetricInput[];
+  hardGates?: OutcomeHardGateInput[];
+  thresholds?: Partial<OutcomeScoreThresholds>;
+}
+
+export interface OutcomeMetricInput {
+  id: string;
+  label: string;
+  weight: number;
+  rawScore?: number;
+  state?: OutcomeMetricState;
+  denominator: string;
+  dataSource: string;
+  scoringRule: string;
+  unmeasurableReason?: string;
+  evidenceUrls?: string[];
+  notes?: string[];
+}
+
+export interface OutcomeHardGateInput {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+export interface OutcomeScoreThresholds {
+  minWeightedScore: number;
+  minEvidenceScoreForScoresAboveThree: number;
+}
+
+export interface OutcomeScorecard {
+  artifactVersion: "0.1";
+  evalName: string;
+  runId: string;
+  surface: OutcomeScoreSurface;
+  scenario: OutcomeScorecardInput["scenario"];
+  ok: boolean;
+  generatedAt: string;
+  rawScoreUncapped: number;
+  weightedScore: number;
+  maxScore: number;
+  publicClaim: "advisory_only";
+  metrics: OutcomeMetric[];
+  hardGates: OutcomeHardGateInput[];
+  caps: Array<{ name: string; applied: boolean; detail: string }>;
+  thresholds: OutcomeScoreThresholds;
+  proofBoundary: string;
+  redaction: {
+    ok: boolean;
+    redactedSources: Array<{ id: string; redactedPreview: string }>;
+  };
+  sha256: string;
+}
+
+export interface OutcomeMetric extends Required<Omit<OutcomeMetricInput, "rawScore" | "state" | "evidenceUrls" | "notes" | "unmeasurableReason">> {
+  rawScore: number;
+  state: OutcomeMetricState;
+  weightedContribution: number;
+  evidenceUrls: string[];
+  notes: string[];
+  unmeasurableReason: string;
+}
+
+const DEFAULT_THRESHOLDS: OutcomeScoreThresholds = {
+  minWeightedScore: 4,
+  minEvidenceScoreForScoresAboveThree: 1
+};
+
+export function readOutcomeScorecardInput(path: string): OutcomeScorecardInput {
+  return parseOutcomeScorecardInput(JSON.parse(readFileSync(path, "utf8")));
+}
+
+export function parseOutcomeScorecardInput(value: unknown): OutcomeScorecardInput {
+  if (!isRecord(value)) throw new Error("outcome scorecard input must be an object");
+  const scenario = value.scenario;
+  if (!isRecord(scenario)) throw new Error("outcome scorecard input requires scenario");
+  const metrics = value.metrics;
+  if (!Array.isArray(metrics) || metrics.length === 0) throw new Error("outcome scorecard input requires at least one metric");
+  return {
+    evalName: optionalString(value.evalName, "evalName"),
+    runId: requiredString(value.runId, "runId"),
+    surface: parseSurface(value.surface),
+    scenario: {
+      id: requiredString(scenario.id, "scenario.id"),
+      title: requiredString(scenario.title, "scenario.title"),
+      repo: optionalString(scenario.repo, "scenario.repo"),
+      url: optionalString(scenario.url, "scenario.url"),
+      negativeControl: scenario.negativeControl === undefined ? false : requiredBoolean(scenario.negativeControl, "scenario.negativeControl")
+    },
+    metrics: metrics.map(parseMetric),
+    hardGates: optionalArray(value.hardGates, "hardGates").map(parseHardGate),
+    thresholds: parseThresholds(value.thresholds)
+  };
+}
+
+export function buildOutcomeScorecard(input: OutcomeScorecardInput, options: { now?: Date } = {}): OutcomeScorecard {
+  const generatedAt = options.now?.toISOString() ?? new Date().toISOString();
+  const thresholds = { ...DEFAULT_THRESHOLDS, ...(input.thresholds ?? {}) };
+  const redaction = buildRedactionReport(input);
+  const maxWeight = input.metrics.reduce((sum, metric) => sum + metric.weight, 0);
+  const metrics = input.metrics.map((metric) => normalizeMetric(metric, maxWeight));
+  const measuredWeight = metrics.filter((metric) => metric.state === "measured").reduce((sum, metric) => sum + metric.weight, 0);
+  const rawScoreUncapped = average(metrics.map((metric) => metric.rawScore));
+  const weightedScore = maxWeight === 0
+    ? 0
+    : metrics.reduce((sum, metric) => sum + metric.weightedContribution, 0);
+  const caps = buildCaps({ input, metrics, measuredWeight, maxWeight, redaction, thresholds });
+  const scoreCappingFailure = caps.some((cap) => cap.applied && ["evidence_required_for_high_scores", "hard_gate_cap"].includes(cap.name));
+  const capMaxScore = caps.some((cap) => cap.applied && cap.name === "safety_cap") ? 1 : scoreCappingFailure ? 3 : 5;
+  const maxScore = Math.min(5, capMaxScore);
+  const cappedWeightedScore = Math.min(weightedScore, maxScore);
+  const hardGates = input.hardGates ?? [];
+  const ok = redaction.ok &&
+    hardGates.every((gate) => gate.ok) &&
+    cappedWeightedScore >= thresholds.minWeightedScore &&
+    !caps.some((cap) => cap.applied && cap.name === "safety_cap");
+  const base = {
+    artifactVersion: "0.1" as const,
+    evalName: input.evalName ?? "evaos-outcome-scorecard-v0.1",
+    runId: sanitizeId(input.runId),
+    surface: input.surface,
+    scenario: normalizeScenario(input.scenario),
+    ok,
+    generatedAt,
+    rawScoreUncapped,
+    weightedScore: cappedWeightedScore,
+    maxScore,
+    publicClaim: "advisory_only" as const,
+    metrics,
+    hardGates: hardGates.map((gate) => ({
+      name: sanitizeId(gate.name),
+      ok: gate.ok,
+      detail: redactSecrets(gate.detail)
+    })),
+    caps,
+    thresholds,
+    proofBoundary: "Outcome scorecard fixtures are advisory and executable only for sampled scenarios. They do not prove CodeRabbit parity, calibrated 95% accuracy, release readiness, or production rollout safety.",
+    redaction
+  };
+  return {
+    ...base,
+    sha256: sha256Json({ ...base, generatedAt: undefined })
+  };
+}
+
+export function writeOutcomeScorecardPacket(input: {
+  scorecardInput: OutcomeScorecardInput;
+  outputDir: string;
+  now?: Date;
+}): OutcomeScorecard {
+  const scorecard = buildOutcomeScorecard(input.scorecardInput, { now: input.now });
+  if (existsSync(input.outputDir)) throw new Error("outputDir must not already exist for outcome-scorecard");
+  mkdirSync(input.outputDir, { recursive: true });
+  writeFileSync(join(input.outputDir, "scorecard.json"), `${JSON.stringify(scorecard, null, 2)}\n`);
+  writeFileSync(join(input.outputDir, "scorecard.md"), `${renderOutcomeScorecardMarkdown(scorecard)}\n`);
+  writeFileSync(join(input.outputDir, "redaction-report.json"), `${JSON.stringify(scorecard.redaction, null, 2)}\n`);
+  const artifacts = {
+    "scorecard.json": sha256File(join(input.outputDir, "scorecard.json")),
+    "scorecard.md": sha256File(join(input.outputDir, "scorecard.md")),
+    "redaction-report.json": sha256File(join(input.outputDir, "redaction-report.json"))
+  };
+  const manifest = {
+    artifactVersion: scorecard.artifactVersion,
+    evalName: scorecard.evalName,
+    runId: scorecard.runId,
+    ok: scorecard.ok,
+    surface: scorecard.surface,
+    rawScoreUncapped: scorecard.rawScoreUncapped,
+    weightedScore: scorecard.weightedScore,
+    maxScore: scorecard.maxScore,
+    publicClaim: scorecard.publicClaim,
+    proofBoundary: scorecard.proofBoundary,
+    scorecardSha256: scorecard.sha256,
+    artifacts,
+    packetSha256: sha256Json({
+      artifactVersion: scorecard.artifactVersion,
+      runId: scorecard.runId,
+      scorecardSha256: scorecard.sha256,
+      artifacts
+    })
+  };
+  writeFileSync(join(input.outputDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  return scorecard;
+}
+
+export function renderOutcomeScorecardMarkdown(scorecard: OutcomeScorecard): string {
+  return [
+    `# Outcome Scorecard: ${scorecard.scenario.id}`,
+    "",
+    `- Surface: \`${scorecard.surface}\``,
+    `- Weighted score: ${scorecard.weightedScore.toFixed(2)} / ${scorecard.maxScore}`,
+    `- Uncapped raw score: ${scorecard.rawScoreUncapped.toFixed(2)} / 5`,
+    `- Public claim: \`${scorecard.publicClaim}\``,
+    "",
+    "## Metrics",
+    "",
+    ...scorecard.metrics.map((metric) => `- [${metric.state}] ${metric.id}: ${metric.rawScore}/5, weight ${metric.weight}, contribution ${metric.weightedContribution.toFixed(2)}${metric.evidenceUrls.length > 0 ? `, evidence ${metric.evidenceUrls.join(", ")}` : ""}${metric.unmeasurableReason ? `, reason ${metric.unmeasurableReason}` : ""}`),
+    "",
+    "## Hard Gates",
+    "",
+    ...(scorecard.hardGates.length === 0 ? ["None."] : scorecard.hardGates.map((gate) => `- [${gate.ok ? "pass" : "fail"}] ${gate.name}: ${gate.detail}`)),
+    "",
+    "## Caps",
+    "",
+    ...scorecard.caps.map((cap) => `- [${cap.applied ? "applied" : "clear"}] ${cap.name}: ${cap.detail}`),
+    "",
+    "## Proof Boundary",
+    "",
+    scorecard.proofBoundary
+  ].join("\n");
+}
+
+function parseMetric(value: unknown): OutcomeMetricInput {
+  if (!isRecord(value)) throw new Error("metrics entries must be objects");
+  return {
+    id: requiredString(value.id, "metrics.id"),
+    label: requiredString(value.label, "metrics.label"),
+    weight: requiredPositiveNumber(value.weight, "metrics.weight"),
+    rawScore: optionalScore(value.rawScore, "metrics.rawScore"),
+    state: value.state === undefined ? undefined : parseMetricState(value.state),
+    denominator: requiredString(value.denominator, "metrics.denominator"),
+    dataSource: requiredString(value.dataSource, "metrics.dataSource"),
+    scoringRule: requiredString(value.scoringRule, "metrics.scoringRule"),
+    unmeasurableReason: optionalString(value.unmeasurableReason, "metrics.unmeasurableReason"),
+    evidenceUrls: optionalStringArray(value.evidenceUrls, "metrics.evidenceUrls"),
+    notes: optionalStringArray(value.notes, "metrics.notes")
+  };
+}
+
+function normalizeMetric(input: OutcomeMetricInput, maxWeight: number): OutcomeMetric {
+  const state = input.state ?? (input.rawScore === undefined ? "unmeasurable" : "measured");
+  const rawScore = state === "unmeasurable" ? 0 : clampScore(input.rawScore ?? 0);
+  return {
+    id: sanitizeId(input.id),
+    label: redactSecrets(input.label),
+    weight: input.weight,
+    rawScore,
+    state,
+    denominator: redactSecrets(input.denominator),
+    dataSource: redactSecrets(input.dataSource),
+    scoringRule: redactSecrets(input.scoringRule),
+    unmeasurableReason: state === "unmeasurable" ? redactSecrets(input.unmeasurableReason || "metric was not measurable") : "",
+    evidenceUrls: (input.evidenceUrls ?? []).map(redactSecrets),
+    notes: (input.notes ?? []).map(redactSecrets),
+    weightedContribution: maxWeight === 0 ? 0 : rawScore * (input.weight / maxWeight)
+  };
+}
+
+function buildCaps(input: {
+  input: OutcomeScorecardInput;
+  metrics: OutcomeMetric[];
+  measuredWeight: number;
+  maxWeight: number;
+  redaction: OutcomeScorecard["redaction"];
+  thresholds: OutcomeScoreThresholds;
+}): OutcomeScorecard["caps"] {
+  const requiredEvidenceLinks = Math.ceil(input.thresholds.minEvidenceScoreForScoresAboveThree);
+  const highScoresWithoutEvidence = input.metrics.filter((metric) => (metric.rawScore ?? 0) > 3 && metric.evidenceUrls.length < requiredEvidenceLinks);
+  const hardGateFailure = (input.input.hardGates ?? []).some((gate) => !gate.ok);
+  const safetyFailure = !input.redaction.ok ||
+    (input.input.hardGates ?? []).some((gate) => ["stale_head_post", "unredacted_secret", "invalid_inline_coordinate"].includes(gate.name) && !gate.ok);
+  return [
+    {
+      name: "evidence_required_for_high_scores",
+      applied: highScoresWithoutEvidence.length > 0,
+      detail: highScoresWithoutEvidence.length > 0
+        ? `Scores above 3 require direct evidence links: ${highScoresWithoutEvidence.map((metric) => metric.id).join(", ")}`
+        : `All scores above 3 have at least ${requiredEvidenceLinks} evidence link(s).`
+    },
+    {
+      name: "unmeasurable_no_positive_credit",
+      applied: input.measuredWeight < input.maxWeight,
+      detail: `${input.measuredWeight}/${input.maxWeight} metric weight was measurable; unmeasurable metrics contribute zero.`
+    },
+    {
+      name: "hard_gate_cap",
+      applied: hardGateFailure,
+      detail: hardGateFailure ? "One or more hard gates failed." : "No hard gates failed."
+    },
+    {
+      name: "safety_cap",
+      applied: safetyFailure,
+      detail: safetyFailure ? "Safety failure caps score at 1." : "No score-capping safety failure detected."
+    }
+  ];
+}
+
+function normalizeScenario(scenario: OutcomeScorecardInput["scenario"]): OutcomeScorecard["scenario"] {
+  return {
+    id: sanitizeId(scenario.id),
+    title: redactSecrets(scenario.title),
+    ...(scenario.repo ? { repo: redactSecrets(scenario.repo) } : {}),
+    ...(scenario.url ? { url: redactSecrets(scenario.url) } : {}),
+    negativeControl: scenario.negativeControl ?? false
+  };
+}
+
+function buildRedactionReport(input: OutcomeScorecardInput): OutcomeScorecard["redaction"] {
+  const redactedSources = collectStringSources(input)
+    .filter((source) => containsSecretLikeText(source.text))
+    .map((source) => ({
+      id: source.id,
+      redactedPreview: redactSecrets(source.text).slice(0, 240)
+    }));
+  return {
+    ok: redactedSources.length === 0,
+    redactedSources
+  };
+}
+
+function parseHardGate(value: unknown): OutcomeHardGateInput {
+  if (!isRecord(value)) throw new Error("hardGates entries must be objects");
+  return {
+    name: requiredString(value.name, "hardGates.name"),
+    ok: requiredBoolean(value.ok, "hardGates.ok"),
+    detail: requiredString(value.detail, "hardGates.detail")
+  };
+}
+
+function parseThresholds(value: unknown): Partial<OutcomeScoreThresholds> | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw new Error("thresholds must be an object");
+  return {
+    ...(value.minWeightedScore !== undefined ? { minWeightedScore: requiredScore(value.minWeightedScore, "thresholds.minWeightedScore") } : {}),
+    ...(value.minEvidenceScoreForScoresAboveThree !== undefined ? {
+      minEvidenceScoreForScoresAboveThree: requiredPositiveNumber(value.minEvidenceScoreForScoresAboveThree, "thresholds.minEvidenceScoreForScoresAboveThree")
+    } : {})
+  };
+}
+
+function collectStringSources(input: unknown, prefix = "input"): Array<{ id: string; text: string }> {
+  if (typeof input === "string") return [{ id: prefix, text: input }];
+  if (Array.isArray(input)) return input.flatMap((item, index) => collectStringSources(item, `${prefix}[${index}]`));
+  if (isRecord(input)) return Object.entries(input).flatMap(([key, value]) => collectStringSources(value, `${prefix}.${key}`));
+  return [];
+}
+
+function parseSurface(value: unknown): OutcomeScoreSurface {
+  if (value === "pr_review" || value === "issue_enrichment") return value;
+  throw new Error("surface must be pr_review or issue_enrichment");
+}
+
+function parseMetricState(value: unknown): OutcomeMetricState {
+  if (value === "measured" || value === "unmeasurable") return value;
+  throw new Error("metrics.state must be measured or unmeasurable");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) throw new Error(`${label} must be a non-empty string`);
+  return value.trim();
+}
+
+function optionalString(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") throw new Error(`${label} must be a string`);
+  return value.trim();
+}
+
+function optionalStringArray(value: unknown, label: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) throw new Error(`${label} must be an array of strings`);
+  return value.map((entry) => entry.trim()).filter(Boolean);
+}
+
+function optionalArray(value: unknown, label: string): unknown[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value;
+}
+
+function requiredBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${label} must be a boolean`);
+  return value;
+}
+
+function requiredPositiveNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) throw new Error(`${label} must be a positive number`);
+  return value;
+}
+
+function requiredScore(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 5) throw new Error(`${label} must be between 0 and 5`);
+  return value;
+}
+
+function optionalScore(value: unknown, label: string): number | undefined {
+  if (value === undefined) return undefined;
+  return requiredScore(value, label);
+}
+
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(5, value));
+}
+
+function average(values: number[]): number {
+  return values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function sanitizeId(value: string): string {
+  return redactSecrets(value).trim().replace(/[^A-Za-z0-9_.:-]/g, "-");
+}
+
+function sha256Json(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function sha256File(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}

--- a/tests/fixtures/outcome-scorecard/high-score-without-evidence.json
+++ b/tests/fixtures/outcome-scorecard/high-score-without-evidence.json
@@ -1,0 +1,26 @@
+{
+  "runId": "high-score-without-evidence",
+  "surface": "issue_enrichment",
+  "scenario": {
+    "id": "high-score-without-evidence",
+    "title": "High score without evidence must be capped"
+  },
+  "metrics": [
+    {
+      "id": "build_vs_buy_leverage",
+      "label": "Build-vs-buy leverage",
+      "weight": 100,
+      "rawScore": 5,
+      "denominator": "High scores require direct evidence.",
+      "dataSource": "missing evidence",
+      "scoringRule": "5 would require cited proof."
+    }
+  ],
+  "hardGates": [
+    {
+      "name": "unredacted_secret",
+      "ok": true,
+      "detail": "No secret."
+    }
+  ]
+}

--- a/tests/fixtures/outcome-scorecard/issue-build-borrow-buy.json
+++ b/tests/fixtures/outcome-scorecard/issue-build-borrow-buy.json
@@ -1,0 +1,97 @@
+{
+  "evalName": "evaos-outcome-scorecard-fixture-v0.1",
+  "runId": "issue-build-borrow-buy",
+  "surface": "issue_enrichment",
+  "scenario": {
+    "id": "issue-build-borrow-buy",
+    "title": "Issue enrichment should identify useful build, borrow, buy options",
+    "repo": "100yenadmin/Lossless-Codex-Orchestrator-LCO",
+    "url": "https://github.com/100yenadmin/Lossless-Codex-Orchestrator-LCO/issues/522"
+  },
+  "metrics": [
+    {
+      "id": "build_vs_buy_leverage",
+      "label": "Build-vs-buy leverage",
+      "weight": 25,
+      "rawScore": 4,
+      "denominator": "Issue handoff should reduce wasted implementation effort by finding credible external precedent.",
+      "dataSource": "issue enrichment packet and research links",
+      "scoringRule": "4 means at least one directly relevant repo/library precedent is cited with a usable implementation wedge.",
+      "evidenceUrls": [
+        "https://github.com/100yenadmin/Lossless-Codex-Orchestrator-LCO/issues/522"
+      ]
+    },
+    {
+      "id": "vision_product_alignment",
+      "label": "Vision and product alignment",
+      "weight": 20,
+      "rawScore": 3,
+      "denominator": "Enrichment should connect work to repo vision, non-goals, and user value.",
+      "dataSource": "VISION.md, repo policy, issue body",
+      "scoringRule": "3 means product fit and non-goals are stated but not yet validated by user feedback.",
+      "evidenceUrls": [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/261"
+      ]
+    },
+    {
+      "id": "implementation_readiness",
+      "label": "Implementation readiness",
+      "weight": 20,
+      "rawScore": 4,
+      "denominator": "Output should become an agent-start packet with acceptance criteria and proof plan.",
+      "dataSource": "issue enrichment markdown packet",
+      "scoringRule": "4 means acceptance criteria, proof plan, and first wedge are clear.",
+      "evidenceUrls": [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/261"
+      ]
+    },
+    {
+      "id": "downstream_agent_enablement",
+      "label": "Downstream agent enablement",
+      "weight": 15,
+      "rawScore": 4,
+      "denominator": "A follow-up agent should know what to do without rereading the whole thread.",
+      "dataSource": "agent handoff packet",
+      "scoringRule": "4 means clear next action, constraints, and evidence links.",
+      "evidenceUrls": [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/260"
+      ]
+    },
+    {
+      "id": "cost_throttle_control",
+      "label": "Cost and throttle control",
+      "weight": 10,
+      "rawScore": 4,
+      "denominator": "Research mode should be triggered and capped, not backlog-wide.",
+      "dataSource": "issue-enrichment allowlist and throttle config",
+      "scoringRule": "4 means separate allowlist, repo throttles, and no old-backlog processing by default.",
+      "evidenceUrls": [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/119"
+      ]
+    },
+    {
+      "id": "lifecycle_routing_clarity",
+      "label": "Lifecycle and routing clarity",
+      "weight": 10,
+      "rawScore": 3,
+      "denominator": "Issue enrichment should make owner, route, and follow-up status visible.",
+      "dataSource": "sticky comment and issue state",
+      "scoringRule": "3 means routing is visible but not yet integrated with a broader product roadmap lane.",
+      "evidenceUrls": [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"
+      ]
+    }
+  ],
+  "hardGates": [
+    {
+      "name": "unredacted_secret",
+      "ok": true,
+      "detail": "Fixture contains no secrets."
+    },
+    {
+      "name": "old_backlog_scan",
+      "ok": true,
+      "detail": "Fixture assumes triggered enrichment only, not backlog-wide scanning."
+    }
+  ]
+}

--- a/tests/fixtures/outcome-scorecard/pr-docs-negative-control.json
+++ b/tests/fixtures/outcome-scorecard/pr-docs-negative-control.json
@@ -1,0 +1,101 @@
+{
+  "evalName": "evaos-outcome-scorecard-fixture-v0.1",
+  "runId": "pr-docs-negative-control",
+  "surface": "pr_review",
+  "scenario": {
+    "id": "pr-docs-negative-control",
+    "title": "Docs-only PR should favor latency and low noise",
+    "repo": "electricsheephq/evaos-code-review-bot-neondiff",
+    "url": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/274",
+    "negativeControl": true
+  },
+  "thresholds": {
+    "minWeightedScore": 3.5
+  },
+  "metrics": [
+    {
+      "id": "regression_prevention",
+      "label": "Regression prevention",
+      "weight": 30,
+      "rawScore": 3,
+      "denominator": "Docs-only negative controls should not invent blocker findings.",
+      "dataSource": "sampled PR replay",
+      "scoringRule": "3 means no false blocker and no regression claim.",
+      "evidenceUrls": [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/274"
+      ]
+    },
+    {
+      "id": "signal_to_noise",
+      "label": "Signal to noise",
+      "weight": 20,
+      "rawScore": 4,
+      "denominator": "Review should stay compact on docs-only changes.",
+      "dataSource": "review packet and review comments",
+      "scoringRule": "4 means compact review with no irrelevant inline comments.",
+      "evidenceUrls": [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/274"
+      ]
+    },
+    {
+      "id": "latency_flow",
+      "label": "Latency and PR flow",
+      "weight": 20,
+      "rawScore": 4,
+      "denominator": "Fast-mode target is <=5 minutes for docs-only or metadata-only PRs.",
+      "dataSource": "review-mode router dry-run",
+      "scoringRule": "4 means target mode is fast and no deep-review escalation is requested.",
+      "evidenceUrls": [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/266"
+      ]
+    },
+    {
+      "id": "context_proof_awareness",
+      "label": "Context and proof awareness",
+      "weight": 15,
+      "rawScore": 3,
+      "denominator": "Docs-only review should still cite changed artifacts.",
+      "dataSource": "outcome ledger packet",
+      "scoringRule": "3 means changed artifacts and proof boundary are explicit.",
+      "evidenceUrls": [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/267"
+      ]
+    },
+    {
+      "id": "glm_cost_efficiency",
+      "label": "GLM cost efficiency",
+      "weight": 10,
+      "rawScore": 4,
+      "denominator": "Low-risk PRs should not burn deep-mode review budget.",
+      "dataSource": "mode selection and budget disposition",
+      "scoringRule": "4 means low budget mode selected and no context expansion requested.",
+      "evidenceUrls": [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/266"
+      ]
+    },
+    {
+      "id": "safety_lifecycle_gate",
+      "label": "Safety and lifecycle gate",
+      "weight": 5,
+      "rawScore": 4,
+      "denominator": "Review must remain current-head, no-duplicate, and advisory-only.",
+      "dataSource": "worker safety gates",
+      "scoringRule": "4 means safety gates are explicit with no failed gate.",
+      "evidenceUrls": [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/260"
+      ]
+    }
+  ],
+  "hardGates": [
+    {
+      "name": "unredacted_secret",
+      "ok": true,
+      "detail": "Fixture contains no secret-like strings."
+    },
+    {
+      "name": "stale_head_post",
+      "ok": true,
+      "detail": "Fixture is read-only and cannot post stale-head comments."
+    }
+  ]
+}

--- a/tests/fixtures/outcome-scorecard/safety-cap.json
+++ b/tests/fixtures/outcome-scorecard/safety-cap.json
@@ -1,0 +1,29 @@
+{
+  "runId": "safety-cap",
+  "surface": "pr_review",
+  "scenario": {
+    "id": "safety-cap",
+    "title": "Safety failures cap the outcome score"
+  },
+  "metrics": [
+    {
+      "id": "regression_prevention",
+      "label": "Regression prevention",
+      "weight": 100,
+      "rawScore": 5,
+      "denominator": "Safety failures override score depth.",
+      "dataSource": "synthetic safety gate",
+      "scoringRule": "5 is impossible when stale-head posting is detected.",
+      "evidenceUrls": [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"
+      ]
+    }
+  ],
+  "hardGates": [
+    {
+      "name": "stale_head_post",
+      "ok": false,
+      "detail": "Synthetic stale-head post guard failure."
+    }
+  ]
+}

--- a/tests/outcome-scorecard.test.ts
+++ b/tests/outcome-scorecard.test.ts
@@ -1,0 +1,337 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildOutcomeScorecard,
+  parseOutcomeScorecardInput,
+  writeOutcomeScorecardPacket,
+  type OutcomeScorecardInput
+} from "../src/outcome-scorecard.js";
+
+const nodeRequire = createRequire(import.meta.url);
+const tsxCli = nodeRequire.resolve("tsx/cli");
+const fixtureRoot = join(process.cwd(), "tests/fixtures/outcome-scorecard");
+
+describe("outcome scorecard fixtures", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("scores issue-enrichment build/borrow/buy fixtures on the 0-5 weighted rubric", () => {
+    const scorecard = buildOutcomeScorecard(loadFixture("issue-build-borrow-buy.json"), {
+      now: new Date("2026-07-05T15:00:00Z")
+    });
+
+    expect(scorecard).toMatchObject({
+      artifactVersion: "0.1",
+      ok: false,
+      evalName: "evaos-outcome-scorecard-fixture-v0.1",
+      runId: "issue-build-borrow-buy",
+      surface: "issue_enrichment",
+      generatedAt: "2026-07-05T15:00:00.000Z",
+      publicClaim: "advisory_only",
+      rawScoreUncapped: 3.6666666666666665,
+      weightedScore: 3.7,
+      maxScore: 5
+    });
+    expect(scorecard.proofBoundary).toContain("do not prove CodeRabbit parity");
+    expect(scorecard.metrics.find((metric) => metric.id === "build_vs_buy_leverage")).toMatchObject({
+      rawScore: 4,
+      weightedContribution: 1
+    });
+  });
+
+  it("lets negative-control docs fixtures pass only when noise and latency are evidenced", () => {
+    const scorecard = buildOutcomeScorecard(loadFixture("pr-docs-negative-control.json"));
+
+    expect(scorecard.ok).toBe(true);
+    expect(scorecard.scenario.negativeControl).toBe(true);
+    expect(scorecard.weightedScore).toBeCloseTo(3.55);
+    expect(scorecard.caps.find((cap) => cap.name === "evidence_required_for_high_scores")).toMatchObject({
+      applied: false
+    });
+  });
+
+  it("caps scores above 3 that lack direct evidence links", () => {
+    const scorecard = buildOutcomeScorecard(loadFixture("high-score-without-evidence.json"));
+
+    expect(scorecard.ok).toBe(false);
+    expect(scorecard.weightedScore).toBe(3);
+    expect(scorecard.maxScore).toBe(3);
+    expect(scorecard.caps).toContainEqual(expect.objectContaining({
+      name: "evidence_required_for_high_scores",
+      applied: true
+    }));
+  });
+
+  it("caps safety failures at 1 regardless of raw quality score", () => {
+    const scorecard = buildOutcomeScorecard(loadFixture("safety-cap.json"));
+
+    expect(scorecard.ok).toBe(false);
+    expect(scorecard.weightedScore).toBe(1);
+    expect(scorecard.maxScore).toBe(1);
+    expect(scorecard.caps).toContainEqual(expect.objectContaining({
+      name: "safety_cap",
+      applied: true
+    }));
+  });
+
+  it("gives unmeasurable metrics zero positive credit", () => {
+    const scorecard = buildOutcomeScorecard({
+      runId: "unmeasurable-metric",
+      surface: "pr_review",
+      scenario: {
+        id: "unmeasurable-metric",
+        title: "Unmeasurable metrics cannot pad the score"
+      },
+      metrics: [
+        metric({ id: "measured", rawScore: 5, weight: 50 }),
+        metric({
+          id: "unmeasurable",
+          weight: 50,
+          state: "unmeasurable",
+          unmeasurableReason: "No labeled post-merge outcome exists."
+        })
+      ]
+    });
+
+    expect(scorecard.ok).toBe(false);
+    expect(scorecard.maxScore).toBe(5);
+    expect(scorecard.weightedScore).toBe(2.5);
+    expect(scorecard.metrics.find((entry) => entry.id === "unmeasurable")).toMatchObject({
+      rawScore: 0,
+      state: "unmeasurable",
+      weightedContribution: 0,
+      unmeasurableReason: "No labeled post-merge outcome exists."
+    });
+  });
+
+  it("does not cap high weighted scores only because a low-weight metric is unmeasurable", () => {
+    const scorecard = buildOutcomeScorecard({
+      runId: "mostly-measured",
+      surface: "pr_review",
+      scenario: {
+        id: "mostly-measured",
+        title: "Mostly measured scorecard"
+      },
+      metrics: [
+        metric({ id: "measured", rawScore: 5, weight: 90 }),
+        metric({
+          id: "unmeasurable",
+          weight: 10,
+          state: "unmeasurable",
+          unmeasurableReason: "Post-merge data not available yet."
+        })
+      ]
+    });
+
+    expect(scorecard.ok).toBe(true);
+    expect(scorecard.maxScore).toBe(5);
+    expect(scorecard.weightedScore).toBe(4.5);
+    expect(scorecard.caps).toContainEqual(expect.objectContaining({
+      name: "unmeasurable_no_positive_credit",
+      applied: true
+    }));
+  });
+
+  it("redacts secret-like scorecard text and marks the packet non-ok", () => {
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+    const scorecard = buildOutcomeScorecard({
+      runId: token,
+      surface: "issue_enrichment",
+      scenario: {
+        id: token,
+        title: `Contains ${token}`
+      },
+      metrics: [
+        metric({
+          id: token,
+          rawScore: 2,
+          notes: [`raw provider log included ${token}`]
+        })
+      ],
+      hardGates: [
+        {
+          name: token,
+          ok: true,
+          detail: `gate named ${token}`
+        }
+      ]
+    });
+
+    expect(scorecard.ok).toBe(false);
+    expect(JSON.stringify(scorecard)).not.toContain(token);
+    expect(scorecard.runId).toContain("redacted-secret");
+    expect(scorecard.scenario.id).toContain("redacted-secret");
+    expect(scorecard.metrics[0].id).toContain("redacted-secret");
+    expect(scorecard.hardGates[0]?.name).toContain("redacted-secret");
+    expect(scorecard.redaction).toMatchObject({
+      ok: false,
+      redactedSources: expect.arrayContaining([
+        expect.objectContaining({ id: "input.runId" }),
+        expect.objectContaining({ id: "input.scenario.id" }),
+        expect.objectContaining({ id: "input.scenario.title" })
+      ])
+    });
+  });
+
+  it("honors the configured evidence-link threshold for scores above 3", () => {
+    const scorecard = buildOutcomeScorecard({
+      runId: "evidence-threshold",
+      surface: "issue_enrichment",
+      scenario: {
+        id: "evidence-threshold",
+        title: "Evidence threshold"
+      },
+      thresholds: {
+        minEvidenceScoreForScoresAboveThree: 2
+      },
+      metrics: [
+        metric({
+          id: "high_score_one_link",
+          rawScore: 4,
+          evidenceUrls: ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"]
+        })
+      ]
+    });
+
+    expect(scorecard.ok).toBe(false);
+    expect(scorecard.maxScore).toBe(3);
+    expect(scorecard.weightedScore).toBe(3);
+    expect(scorecard.caps).toContainEqual(expect.objectContaining({
+      name: "evidence_required_for_high_scores",
+      applied: true
+    }));
+  });
+
+  it("writes a scorecard packet with stable manifest artifacts", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-outcome-scorecard-packet-"));
+    roots.push(root);
+    const outputDir = join(root, "packet");
+
+    const scorecard = writeOutcomeScorecardPacket({
+      scorecardInput: loadFixture("pr-docs-negative-control.json"),
+      outputDir,
+      now: new Date("2026-07-05T16:00:00Z")
+    });
+
+    expect(scorecard.ok).toBe(true);
+    for (const artifact of ["scorecard.json", "scorecard.md", "redaction-report.json", "manifest.json"]) {
+      expect(existsSync(join(outputDir, artifact))).toBe(true);
+    }
+    const manifest = JSON.parse(readFileSync(join(outputDir, "manifest.json"), "utf8"));
+    expect(manifest).toMatchObject({
+      ok: true,
+      runId: "pr-docs-negative-control",
+      publicClaim: "advisory_only",
+      rawScoreUncapped: 3.6666666666666665,
+      scorecardSha256: scorecard.sha256,
+      packetSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      artifacts: {
+        "scorecard.json": expect.stringMatching(/^[a-f0-9]{64}$/)
+      }
+    });
+  });
+
+  it("exposes a dry-run-only CLI that writes executable fixture evidence", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-outcome-scorecard-cli-"));
+    roots.push(root);
+    const inputPath = join(fixtureRoot, "pr-docs-negative-control.json");
+    const outputDir = join(root, "packet");
+
+    const output = execFileSync(process.execPath, [
+      tsxCli,
+      "src/cli.ts",
+      "outcome-scorecard",
+      "--input",
+      inputPath,
+      "--dry-run",
+      "true",
+      "--output-dir",
+      outputDir
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8"
+    });
+
+    const parsed = JSON.parse(output);
+    expect(parsed).toMatchObject({
+      ok: true,
+      command: "outcome-scorecard",
+      dryRun: true
+    });
+    expect(parsed.outputDir).toContain("/packet");
+    expect(existsSync(join(outputDir, "scorecard.json"))).toBe(true);
+  });
+
+  it("defaults the CLI to dry-run when --dry-run is omitted", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-outcome-scorecard-cli-default-"));
+    roots.push(root);
+    const outputDir = join(root, "packet");
+
+    const output = execFileSync(process.execPath, [
+      tsxCli,
+      "src/cli.ts",
+      "outcome-scorecard",
+      "--input",
+      join(fixtureRoot, "pr-docs-negative-control.json"),
+      "--output-dir",
+      outputDir
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8"
+    });
+
+    const parsed = JSON.parse(output);
+    expect(parsed).toMatchObject({
+      ok: true,
+      command: "outcome-scorecard",
+      dryRun: true
+    });
+    expect(existsSync(join(outputDir, "scorecard.json"))).toBe(true);
+  });
+
+  it("refuses non-dry-run CLI execution", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-outcome-scorecard-live-"));
+    roots.push(root);
+
+    expect(() => execFileSync(process.execPath, [
+      tsxCli,
+      "src/cli.ts",
+      "outcome-scorecard",
+      "--input",
+      join(fixtureRoot, "pr-docs-negative-control.json"),
+      "--dry-run",
+      "false",
+      "--output-dir",
+      join(root, "packet")
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      stdio: "pipe"
+    })).toThrow("outcome-scorecard is dry-run only in this release");
+  });
+});
+
+function loadFixture(name: string): OutcomeScorecardInput {
+  return parseOutcomeScorecardInput(JSON.parse(readFileSync(join(fixtureRoot, name), "utf8")));
+}
+
+function metric(overrides: Partial<OutcomeScorecardInput["metrics"][number]> = {}): OutcomeScorecardInput["metrics"][number] {
+  return {
+    id: "metric",
+    label: "Metric",
+    weight: 100,
+    rawScore: 3,
+    denominator: "Sample denominator",
+    dataSource: "Sample data source",
+    scoringRule: "Sample scoring rule",
+    evidenceUrls: ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/264"],
+    ...overrides
+  };
+}


### PR DESCRIPTION
## Summary
- Adds an executable `outcome-scorecard` dry-run CLI for #264 outcome-weighted PR/issue-enrichment scorecard fixtures.
- Adds fixture scenarios for docs-only PR negative control, issue build/borrow/buy enrichment, high-score-without-evidence cap, and safety-cap failure.
- Writes advisory-only scorecard packets with `scorecard.json`, `scorecard.md`, `redaction-report.json`, and `manifest.json`.

## Proof Boundary
This is an eval/fixture runner only. It does not change live runtime behavior, launchd config, posting behavior, issue enrichment allowlists, provider retries, or calibrated confidence display.

## Validation
- `npm test -- tests/outcome-scorecard.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- CLI smoke: `npx tsx src/cli.ts outcome-scorecard --input tests/fixtures/outcome-scorecard/pr-docs-negative-control.json --dry-run true --output-dir /Volumes/LEXAR/Codex/evals/evaos-reviewer-benchmark/2026-07-05/outcome-scorecard-v0.2/executable-fixture-smoke/pr-docs-negative-control`

## Evidence
- `/Volumes/LEXAR/Codex/evals/evaos-reviewer-benchmark/2026-07-05/outcome-scorecard-v0.2/executable-fixture-smoke/pr-docs-negative-control/`

Closes #264.
