### PR TITLE
[codex] Add proof routing taxonomy

### DIFF
--- a/src/issue-relationship-taxonomy.ts
+++ b/src/issue-relationship-taxonomy.ts
@@ -1,0 +1,368 @@
+import { containsSecretLikeText, redactSecrets } from "./secrets.js";
+import type { Severity } from "./types.js";
+
+export const ISSUE_RELATIONSHIP_CATEGORIES = [
+  "blocker",
+  "regression",
+  "reproduction_gap",
+  "stale_duplicate",
+  "dependency",
+  "release_risk",
+  "docs_only",
+  "needs_human_routing"
+] as const;
+
+export type IssueRelationshipCategoryId = typeof ISSUE_RELATIONSHIP_CATEGORIES[number];
+
+export const PROOF_REQUIREMENTS = [
+  "current_head_failure",
+  "regression_fixture",
+  "reproduction_steps",
+  "freshness_check",
+  "dependency_owner",
+  "release_gate",
+  "docs_scope",
+  "human_triage"
+] as const;
+
+export type ProofRequirementId = typeof PROOF_REQUIREMENTS[number];
+
+export type IssueRelationshipItemKind = "issue" | "pull_request" | "finding";
+export type IssueRelationshipItemState = "open" | "closed" | "merged";
+
+export interface IssueRelationshipItemInput {
+  id: string;
+  kind: IssueRelationshipItemKind;
+  title: string;
+  body?: string;
+  publicSummary?: string;
+  repo?: string;
+  number?: number;
+  state?: IssueRelationshipItemState;
+  url?: string;
+  labels?: string[];
+  paths?: string[];
+  severity?: Severity;
+  categoryHint?: IssueRelationshipCategoryId;
+  relationshipKeys?: string[];
+  relatedRefs?: string[];
+  duplicateOf?: string;
+  dependsOn?: string[];
+  blockedBy?: string[];
+  evidenceUrls?: string[];
+  suggestedLabels?: string[];
+  suggestedReviewers?: string[];
+  privateEvidence?: unknown[];
+  rawLogs?: unknown[];
+  localPaths?: string[];
+  tokens?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+  closedAt?: string;
+  mergedAt?: string;
+}
+
+export interface ClassifiedIssueRelationshipItem {
+  id: string;
+  kind: IssueRelationshipItemKind;
+  title: string;
+  summary: string;
+  category: IssueRelationshipCategoryId;
+  proofRequirements: ProofRequirementId[];
+  publicEvidenceUrls: string[];
+  suggestedLabels: string[];
+  suggestedReviewers: string[];
+  publicPaths: string[];
+  repo?: string;
+  number?: number;
+  state?: IssueRelationshipItemState;
+  url?: string;
+}
+
+export interface PublicIssueRelationshipCluster {
+  id: string;
+  categories: IssueRelationshipCategoryId[];
+  proofRequirements: ProofRequirementId[];
+  whyItMatters: string;
+  items: ClassifiedIssueRelationshipItem[];
+  suggestedLabels: string[];
+  suggestedReviewers: string[];
+}
+
+export interface IssueRelationshipClusterResult {
+  artifactVersion: "0.1";
+  publicIssueCommentState: {
+    summary: string;
+    clusters: PublicIssueRelationshipCluster[];
+  };
+  privateEvidenceBoundary: {
+    rawEvidenceOmitted: boolean;
+    privateEvidenceItems: number;
+  };
+}
+
+export interface IssueRelationshipClusterInput {
+  items: IssueRelationshipItemInput[];
+}
+
+export function classifyIssueRelationshipItem(input: IssueRelationshipItemInput): ClassifiedIssueRelationshipItem {
+  const category = resolveRelationshipCategory(input);
+  const proofRequirements = proofRequirementsFor(input, category);
+  return {
+    id: sanitizeId(input.id),
+    kind: input.kind,
+    title: publicText(input.title),
+    summary: publicText(input.publicSummary ?? input.title),
+    category,
+    proofRequirements,
+    publicEvidenceUrls: publicEvidenceUrls(input.evidenceUrls ?? []),
+    suggestedLabels: suggestedLabelsFor(input, category),
+    suggestedReviewers: publicReviewerLogins(input.suggestedReviewers ?? []),
+    publicPaths: publicPaths(input.paths ?? []),
+    ...(input.repo ? { repo: publicText(input.repo) } : {}),
+    ...(input.number !== undefined ? { number: input.number } : {}),
+    ...(input.state ? { state: input.state } : {}),
+    ...(input.url && isSafePublicUrl(input.url) ? { url: redactSecrets(input.url) } : {})
+  };
+}
+
+export function buildIssueRelationshipClusters(input: IssueRelationshipClusterInput): IssueRelationshipClusterResult {
+  const groups = new Map<string, Array<{ raw: IssueRelationshipItemInput; classified: ClassifiedIssueRelationshipItem }>>();
+  for (const item of input.items) {
+    const key = clusterKey(item);
+    const group = groups.get(key) ?? [];
+    group.push({ raw: item, classified: classifyIssueRelationshipItem(item) });
+    groups.set(key, group);
+  }
+
+  const clusters = Array.from(groups.entries()).map(([id, entries]) => {
+    const items = entries.map((entry) => entry.classified);
+    const categories = unique(items.map((item) => item.category));
+    const proofRequirements = unique(items.flatMap((item) => item.proofRequirements));
+    return {
+      id,
+      categories,
+      proofRequirements,
+      whyItMatters: whyClusterMatters(id, items, categories, proofRequirements),
+      items,
+      suggestedLabels: unique(items.flatMap((item) => item.suggestedLabels)),
+      suggestedReviewers: unique(items.flatMap((item) => item.suggestedReviewers))
+    };
+  });
+
+  const privateEvidenceItems = input.items.filter(hasPrivateEvidence).length;
+  return {
+    artifactVersion: "0.1",
+    publicIssueCommentState: {
+      summary: `${clusters.length} relationship cluster(s) across ${input.items.length} item(s). Suggestions are advisory only and perform no target-repo mutation.`,
+      clusters
+    },
+    privateEvidenceBoundary: {
+      rawEvidenceOmitted: privateEvidenceItems > 0,
+      privateEvidenceItems
+    }
+  };
+}
+
+function resolveRelationshipCategory(input: IssueRelationshipItemInput): IssueRelationshipCategoryId {
+  const inferred = inferRelationshipCategory(input);
+  return inferred === "needs_human_routing" && input.categoryHint ? input.categoryHint : inferred;
+}
+
+function inferRelationshipCategory(input: IssueRelationshipItemInput): IssueRelationshipCategoryId {
+  const haystack = searchableText(input);
+  if (hasReleaseRiskSignal(haystack)) return "release_risk";
+  if (input.severity === "P0" || input.severity === "P1" || matchesAny(haystack, ["blocker", "blocks merge", "blocking", "must fix"])) {
+    return "blocker";
+  }
+  if (matchesAny(haystack, ["reproduction gap", "missing reproduction", "no reproduction", "lacks proof", "missing proof", "missing evidence", "no command", "no head sha", "no fixture", "needs proof"])) {
+    return "reproduction_gap";
+  }
+  if (input.duplicateOf || matchesAny(haystack, ["stale duplicate", "duplicate of", "superseded by", "already covered"])) return "stale_duplicate";
+  if (matchesAny(haystack, ["dependency", "depends on", "blocked by", "upstream", "package update"]) || hasDependencyPath(input.paths ?? [])) {
+    return "dependency";
+  }
+  if (isDocsOnly(input.paths ?? []) || matchesAny(haystack, ["docs-only", "documentation-only"])) return "docs_only";
+  if (matchesAny(haystack, ["regression", "broke", "broken", "failing", "failure", "fails", "bug", "fixture update"])) return "regression";
+  if (matchesAny(haystack, ["manual triage", "needs human", "human routing", "ambiguous owner", "unknown owner"])) return "needs_human_routing";
+  return "needs_human_routing";
+}
+
+function hasReleaseRiskSignal(text: string): boolean {
+  return matchesAny(text, [
+    "release blocker",
+    "release gate",
+    "release risk",
+    "release regression",
+    "beta tag",
+    "beta release",
+    "deploy",
+    "deployment",
+    "appcast",
+    "notary",
+    "notarize",
+    "notarized",
+    "notarization",
+    "launchd",
+    "production",
+    "rollout",
+    "publish"
+  ]);
+}
+
+function proofRequirementsFor(input: IssueRelationshipItemInput, category: IssueRelationshipCategoryId): ProofRequirementId[] {
+  const requirements: ProofRequirementId[] = [];
+  if (category === "blocker") requirements.push("current_head_failure");
+  if (category === "regression") requirements.push("regression_fixture");
+  if (category === "reproduction_gap") requirements.push("reproduction_steps");
+  if (category === "stale_duplicate") requirements.push("freshness_check");
+  if (category === "dependency") requirements.push("dependency_owner");
+  if (category === "release_risk") requirements.push("release_gate");
+  if (category === "docs_only") requirements.push("docs_scope");
+  if (category === "needs_human_routing") requirements.push("human_triage");
+  if (category === "release_risk" && matchesAny(searchableText(input), ["regression", "broke", "broken", "failure", "fails"])) {
+    requirements.push("regression_fixture");
+  }
+  return unique(requirements);
+}
+
+function suggestedLabelsFor(input: IssueRelationshipItemInput, category: IssueRelationshipCategoryId): string[] {
+  const explicit = publicLabels(input.suggestedLabels ?? []);
+  if (category === "release_risk") return unique([...explicit, "release-risk"]);
+  if (category === "blocker") return unique([...explicit, "blocker"]);
+  return explicit;
+}
+
+function clusterKey(input: IssueRelationshipItemInput): string {
+  const explicit = firstPublicId(input.relationshipKeys ?? []);
+  if (explicit) return explicit;
+  const related = firstPublicId([
+    ...(input.duplicateOf ? [input.duplicateOf] : []),
+    ...(input.dependsOn ?? []),
+    ...(input.blockedBy ?? []),
+    ...(input.relatedRefs ?? [])
+  ]);
+  if (related) return related;
+  return `standalone-${sanitizeId(input.id)}`;
+}
+
+function whyClusterMatters(
+  id: string,
+  items: ClassifiedIssueRelationshipItem[],
+  categories: IssueRelationshipCategoryId[],
+  proofRequirements: ProofRequirementId[]
+): string {
+  const categoryText = categories.join(", ");
+  const proofText = proofRequirements.join(", ");
+  if (items.length > 1) {
+    return `Multiple related records share ${id}; route them together so ${categoryText} context and ${proofText} proof requirements do not drift.`;
+  }
+  if (categories.includes("stale_duplicate")) return `Stale duplicate routing keeps old reports from competing with fresher proof for ${id}.`;
+  if (categories.includes("release_risk")) return `Release-risk routing keeps beta, deploy, and rollback proof explicit for ${id}.`;
+  if (categories.includes("reproduction_gap")) return `Proof-gap routing keeps ${id} out of implementation until reproduction evidence exists.`;
+  return `Single-item routing records ${categoryText} proof requirements for ${id}.`;
+}
+
+function searchableText(input: IssueRelationshipItemInput): string {
+  return [
+    input.title,
+    input.body ?? "",
+    input.publicSummary ?? "",
+    ...(input.labels ?? []),
+    ...(input.paths ?? []),
+    ...(input.relatedRefs ?? [])
+  ].join("\n").toLowerCase();
+}
+
+function hasPrivateEvidence(input: IssueRelationshipItemInput): boolean {
+  return Boolean(
+    input.privateEvidence?.length ||
+    input.rawLogs?.length ||
+    input.localPaths?.length ||
+    input.tokens?.length ||
+    containsSecretLikeText(`${input.body ?? ""}\n${input.publicSummary ?? ""}`)
+  );
+}
+
+function publicText(value: string): string {
+  return redactSecrets(value).trim();
+}
+
+function publicEvidenceUrls(values: string[]): string[] {
+  return unique(values.filter(isSafePublicUrl).map(redactSecrets));
+}
+
+function publicPaths(values: string[]): string[] {
+  return unique(values.map((value) => value.trim()).filter((value) => value.length > 0 && !isLocalPath(value) && !containsSecretLikeText(value)));
+}
+
+function publicLabels(values: string[]): string[] {
+  return unique(values.map((value) => sanitizeId(value).toLowerCase()).filter(Boolean));
+}
+
+function publicReviewerLogins(values: string[]): string[] {
+  return unique(values.map((value) => value.trim().replace(/^@/, "")).filter((value) => /^[A-Za-z0-9-]{1,39}$/.test(value)));
+}
+
+function firstPublicId(values: string[]): string | undefined {
+  for (const value of values) {
+    const id = sanitizeId(value);
+    if (id) return id;
+  }
+  return undefined;
+}
+
+function sanitizeId(value: string): string {
+  return redactSecrets(value).trim().replace(/[^A-Za-z0-9_.:-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+}
+
+function isSafePublicUrl(value: string): boolean {
+  if (containsSecretLikeText(value)) return false;
+  try {
+    const url = new URL(value);
+    return (url.protocol === "https:" || url.protocol === "http:") && !url.username && !url.password;
+  } catch {
+    return false;
+  }
+}
+
+function isLocalPath(value: string): boolean {
+  return value.startsWith("/") || value.startsWith("~/") || value.startsWith("file:") || /^[A-Za-z]:[\\/]/.test(value);
+}
+
+function isDocsOnly(paths: string[]): boolean {
+  return paths.length > 0 && paths.every((path) => {
+    const normalized = path.toLowerCase();
+    return normalized.startsWith("docs/") || normalized.endsWith(".md") || normalized.endsWith(".mdx") || normalized === "readme.md";
+  });
+}
+
+function hasDependencyPath(paths: string[]): boolean {
+  return paths.some((path) => {
+    const normalized = path.toLowerCase();
+    return ["package.json", "package-lock.json", "pnpm-lock.yaml", "yarn.lock", "bun.lock", "requirements.txt", "poetry.lock", "cargo.lock", "go.sum"]
+      .some((suffix) => normalized === suffix || normalized.endsWith(`/${suffix}`));
+  });
+}
+
+function matchesAny(text: string, needles: string[]): boolean {
+  return needles.some((needle) => {
+    if (/[\s/_-]/.test(needle)) return text.includes(needle);
+    return new RegExp(`(^|[^a-z0-9])${escapeRegExp(needle)}([^a-z0-9]|$)`).test(text);
+  });
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function unique<T>(values: T[]): T[] {
+  const seen = new Set<T>();
+  const output: T[] = [];
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    output.push(value);
+  }
+  return output;
+}

--- a/src/issue-relationship-taxonomy.ts
+++ b/src/issue-relationship-taxonomy.ts
@@ -286,6 +286,7 @@ function whyClusterMatters(
 }
 
 function searchableText(input: IssueRelationshipItemInput): string {
+  // dependsOn and blockedBy are cluster relationships; relatedRefs is the public evidence channel for routing signals.
   return [
     input.title,
     input.body ?? "",

--- a/src/issue-relationship-taxonomy.ts
+++ b/src/issue-relationship-taxonomy.ts
@@ -177,6 +177,7 @@ function inferRelationshipCategory(input: IssueRelationshipItemInput): IssueRela
   if (input.severity === "P0" || input.severity === "P1" || matchesAny(haystack, ["blocks merge", "blocking", "must fix"])) {
     return "blocker";
   }
+  // Missing proof wins over dependency ownership so implementation is not assigned before a reproducible case exists.
   if (matchesAny(haystack, ["reproduction gap", "missing reproduction", "no reproduction", "lacks proof", "missing proof", "missing evidence", "no command", "no head sha", "no fixture", "needs proof"])) {
     return "reproduction_gap";
   }
@@ -265,7 +266,7 @@ function clusterKey(input: IssueRelationshipItemInput): string {
     ...(input.relatedRefs ?? [])
   ]);
   if (related) return related;
-  return `standalone-${sanitizeId(input.id)}`;
+  return standaloneClusterId(input.id);
 }
 
 function whyClusterMatters(
@@ -345,6 +346,22 @@ function firstPublicId(values: string[]): string | undefined {
 
 function sanitizeId(value: string): string {
   return redactSecrets(value).trim().replace(/[^A-Za-z0-9_.:-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+}
+
+function standaloneClusterId(value: string): string {
+  const redacted = redactSecrets(value).trim();
+  const sanitized = sanitizeId(value) || "item";
+  const suffix = redacted === sanitized ? "" : `-${shortStableHash(redacted)}`;
+  return `standalone-${sanitized}${suffix}`;
+}
+
+function shortStableHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36).padStart(7, "0").slice(0, 7);
 }
 
 function isSafePublicUrl(value: string): boolean {

--- a/src/issue-relationship-taxonomy.ts
+++ b/src/issue-relationship-taxonomy.ts
@@ -68,6 +68,8 @@ export interface ClassifiedIssueRelationshipItem {
   title: string;
   summary: string;
   category: IssueRelationshipCategoryId;
+  categoryHint?: IssueRelationshipCategoryId;
+  categoryHintHonored?: boolean;
   proofRequirements: ProofRequirementId[];
   publicEvidenceUrls: string[];
   suggestedLabels: string[];
@@ -108,12 +110,14 @@ export interface IssueRelationshipClusterInput {
 export function classifyIssueRelationshipItem(input: IssueRelationshipItemInput): ClassifiedIssueRelationshipItem {
   const category = resolveRelationshipCategory(input);
   const proofRequirements = proofRequirementsFor(input, category);
+  const categoryHintHonored = input.categoryHint ? category === input.categoryHint : undefined;
   return {
     id: sanitizeId(input.id),
     kind: input.kind,
     title: publicText(input.title),
     summary: publicText(input.publicSummary ?? input.title),
     category,
+    ...(input.categoryHint ? { categoryHint: input.categoryHint, categoryHintHonored } : {}),
     proofRequirements,
     publicEvidenceUrls: publicEvidenceUrls(input.evidenceUrls ?? []),
     suggestedLabels: suggestedLabelsFor(input, category),
@@ -171,10 +175,10 @@ function resolveRelationshipCategory(input: IssueRelationshipItemInput): IssueRe
 
 function inferRelationshipCategory(input: IssueRelationshipItemInput): IssueRelationshipCategoryId {
   const haystack = searchableText(input);
-  if (hasReleaseRiskSignal(haystack)) return "release_risk";
-  if (input.severity === "P0" || input.severity === "P1" || matchesAny(haystack, ["blocker", "blocks merge", "blocking", "must fix"])) {
+  if (input.severity === "P0" || input.severity === "P1" || matchesAny(haystack, ["blocks merge", "blocking", "must fix"])) {
     return "blocker";
   }
+  if (hasReleaseRiskSignal(haystack)) return "release_risk";
   if (matchesAny(haystack, ["reproduction gap", "missing reproduction", "no reproduction", "lacks proof", "missing proof", "missing evidence", "no command", "no head sha", "no fixture", "needs proof"])) {
     return "reproduction_gap";
   }
@@ -183,7 +187,7 @@ function inferRelationshipCategory(input: IssueRelationshipItemInput): IssueRela
     return "dependency";
   }
   if (isDocsOnly(input.paths ?? []) || matchesAny(haystack, ["docs-only", "documentation-only"])) return "docs_only";
-  if (matchesAny(haystack, ["regression", "broke", "broken", "failing", "failure", "fails", "bug", "fixture update"])) return "regression";
+  if (hasRegressionSignal(haystack)) return "regression";
   if (matchesAny(haystack, ["manual triage", "needs human", "human routing", "ambiguous owner", "unknown owner"])) return "needs_human_routing";
   return "needs_human_routing";
 }
@@ -224,10 +228,23 @@ function proofRequirementsFor(input: IssueRelationshipItemInput, category: Issue
   if (category === "release_risk") requirements.push("release_gate");
   if (category === "docs_only") requirements.push("docs_scope");
   if (category === "needs_human_routing") requirements.push("human_triage");
-  if (category === "release_risk" && matchesAny(searchableText(input), ["regression", "broke", "broken", "failure", "fails"])) {
+  if (category === "release_risk" && hasRegressionSignal(searchableText(input))) {
     requirements.push("regression_fixture");
   }
   return unique(requirements);
+}
+
+function hasRegressionSignal(text: string): boolean {
+  return matchesAny(text, [
+    "regression",
+    "regressed",
+    "broke",
+    "broken",
+    "failing test",
+    "test failure",
+    "ci failure",
+    "fixture update"
+  ]);
 }
 
 function suggestedLabelsFor(input: IssueRelationshipItemInput, category: IssueRelationshipCategoryId): string[] {
@@ -339,14 +356,24 @@ function isSafePublicUrl(value: string): boolean {
 }
 
 function isLocalPath(value: string): boolean {
-  return value.startsWith("/") || value.startsWith("~/") || value.startsWith("file:") || /^[A-Za-z]:[\\/]/.test(value);
+  const trimmed = value.trim();
+  return (
+    trimmed === "~" ||
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("~/") ||
+    trimmed.startsWith("~\\") ||
+    trimmed.startsWith("file:") ||
+    trimmed.startsWith("\\\\") ||
+    /^[A-Za-z]:(?:[\\/]|[^\s])/.test(trimmed)
+  );
 }
 
 function redactLocalPathLikeText(value: string): string {
-  return value
-    .replace(/file:\/\/\S+/g, "[local-path-redacted]")
-    .replace(/(?:\/Volumes|\/Users|\/private|\/tmp|~\/|[A-Za-z]:[\\/])\S*/g, "[local-path-redacted]");
+  return value.replace(LOCAL_PATH_TEXT_PATTERN, (_match, prefix: string) => `${prefix}[local-path-redacted]`);
 }
+
+const LOCAL_PATH_TEXT_PATTERN =
+  /(^|[\s([{"'`])(?:file:\/\/\S+|\\\\\S+|~(?:[\\/]\S*)?|\/(?!\/)\S+|[A-Za-z]:(?:[\\/]\S*|\S+))/g;
 
 function isDocsOnly(paths: string[]): boolean {
   return paths.length > 0 && paths.every((path) => {

--- a/src/issue-relationship-taxonomy.ts
+++ b/src/issue-relationship-taxonomy.ts
@@ -169,7 +169,7 @@ export function buildIssueRelationshipClusters(input: IssueRelationshipClusterIn
 
 function resolveRelationshipCategory(input: IssueRelationshipItemInput): IssueRelationshipCategoryId {
   const inferred = inferRelationshipCategory(input);
-  return inferred === "needs_human_routing" && input.categoryHint ? input.categoryHint : inferred;
+  return inferred === "needs_human_routing" && input.categoryHint && !hasHumanRoutingSignal(searchableText(input)) ? input.categoryHint : inferred;
 }
 
 function inferRelationshipCategory(input: IssueRelationshipItemInput): IssueRelationshipCategoryId {
@@ -183,12 +183,15 @@ function inferRelationshipCategory(input: IssueRelationshipItemInput): IssueRela
   }
   if (hasReleaseRiskSignal(haystack)) return "release_risk";
   if (input.duplicateOf || matchesAny(haystack, ["stale duplicate", "duplicate of", "superseded by", "already covered"])) return "stale_duplicate";
-  if (isDocsOnly(input.paths ?? []) || matchesAny(haystack, ["docs-only", "documentation-only"])) return "docs_only";
-  if (matchesAny(haystack, ["dependency", "depends on", "blocked by", "upstream", "package update"]) || hasDependencyPath(input.paths ?? [])) {
+  const paths = input.paths ?? [];
+  const docsOnlyByPath = isDocsOnly(paths);
+  const docsOnlyByText = matchesAny(haystack, ["docs-only", "documentation-only"]);
+  if (docsOnlyByPath || (docsOnlyByText && paths.length === 0)) return "docs_only";
+  if (matchesAny(haystack, ["dependency", "depends on", "blocked by", "upstream", "package update"]) || hasDependencyPath(paths)) {
     return "dependency";
   }
   if (hasRegressionSignal(haystack)) return "regression";
-  if (matchesAny(haystack, ["manual triage", "needs human", "human routing", "ambiguous owner", "unknown owner"])) return "needs_human_routing";
+  if (hasHumanRoutingSignal(haystack)) return "needs_human_routing";
   return "needs_human_routing";
 }
 
@@ -249,6 +252,10 @@ function hasRegressionSignal(text: string): boolean {
   ]);
 }
 
+function hasHumanRoutingSignal(text: string): boolean {
+  return matchesAny(text, ["manual triage", "needs human", "human routing", "ambiguous owner", "unknown owner"]);
+}
+
 function suggestedLabelsFor(input: IssueRelationshipItemInput, category: IssueRelationshipCategoryId): string[] {
   const explicit = publicLabels(input.suggestedLabels ?? []);
   if (category === "release_risk") return unique([...explicit, "release-risk"]);
@@ -299,18 +306,23 @@ function searchableText(input: IssueRelationshipItemInput): string {
 }
 
 function hasPrivateEvidence(input: IssueRelationshipItemInput): boolean {
+  const relationshipValues = relationshipRefValues(input);
   return Boolean(
     input.privateEvidence?.length ||
     input.rawLogs?.length ||
     input.localPaths?.length ||
     input.tokens?.length ||
     input.paths?.some(isLocalPath) ||
+    relationshipValues.some((value) => isPrivateRelationshipValue(value)) ||
     containsSecretLikeText([
       input.title,
       input.body ?? "",
       input.publicSummary ?? "",
       input.url ?? "",
       ...(input.paths ?? []),
+      ...(input.labels ?? []),
+      ...(input.evidenceUrls ?? []),
+      ...(input.suggestedLabels ?? []),
       ...(input.suggestedReviewers ?? [])
     ].join("\n"))
   );
@@ -338,10 +350,30 @@ function publicReviewerLogins(values: string[]): string[] {
 
 function firstPublicId(values: string[]): string | undefined {
   for (const value of values) {
-    const id = sanitizeId(value);
+    if (isPrivateRelationshipValue(value)) continue;
+    const redacted = redactLocalPathLikeText(redactSecrets(value.trim()));
+    if (redacted.includes("[local-path-redacted]")) continue;
+    const id = sanitizeId(redacted);
     if (id) return id;
   }
   return undefined;
+}
+
+function relationshipRefValues(input: IssueRelationshipItemInput): string[] {
+  return [
+    ...(input.relationshipKeys ?? []),
+    ...(input.duplicateOf ? [input.duplicateOf] : []),
+    ...(input.dependsOn ?? []),
+    ...(input.blockedBy ?? []),
+    ...(input.relatedRefs ?? [])
+  ];
+}
+
+function isPrivateRelationshipValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed || isLocalPath(trimmed) || containsSecretLikeText(trimmed)) return true;
+  if (/^https?:/i.test(trimmed) && !isSafePublicUrl(trimmed)) return true;
+  return false;
 }
 
 function sanitizeId(value: string): string {
@@ -368,10 +400,28 @@ function isSafePublicUrl(value: string): boolean {
   if (containsSecretLikeText(value)) return false;
   try {
     const url = new URL(value);
+    const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    if (isPrivateOrLocalHostname(hostname)) return false;
     return (url.protocol === "https:" || url.protocol === "http:") && !url.username && !url.password;
   } catch {
     return false;
   }
+}
+
+function isPrivateOrLocalHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "::1" ||
+    hostname === "0.0.0.0" ||
+    hostname.endsWith(".local") ||
+    hostname.endsWith(".internal") ||
+    (hostname.includes(":") && (hostname.startsWith("fc") || hostname.startsWith("fd"))) ||
+    /^127\./.test(hostname) ||
+    /^10\./.test(hostname) ||
+    /^169\.254\./.test(hostname) ||
+    /^172\.(1[6-9]|2\d|3[0-1])\./.test(hostname) ||
+    /^192\.168\./.test(hostname)
+  );
 }
 
 function isLocalPath(value: string): boolean {

--- a/src/issue-relationship-taxonomy.ts
+++ b/src/issue-relationship-taxonomy.ts
@@ -345,6 +345,7 @@ function publicLabels(values: string[]): string[] {
 }
 
 function publicReviewerLogins(values: string[]): string[] {
+  // Suggested reviewers are individual GitHub logins only; team slugs need a separate public field before support.
   return unique(values.map((value) => value.trim().replace(/^@/, "")).filter((value) => /^[A-Za-z0-9-]{1,39}$/.test(value)));
 }
 
@@ -411,16 +412,11 @@ function isSafePublicUrl(value: string): boolean {
 function isPrivateOrLocalHostname(hostname: string): boolean {
   return (
     hostname === "localhost" ||
-    hostname === "::1" ||
     hostname === "0.0.0.0" ||
     hostname.endsWith(".local") ||
     hostname.endsWith(".internal") ||
-    (hostname.includes(":") && (hostname.startsWith("fc") || hostname.startsWith("fd"))) ||
-    /^127\./.test(hostname) ||
-    /^10\./.test(hostname) ||
-    /^169\.254\./.test(hostname) ||
-    /^172\.(1[6-9]|2\d|3[0-1])\./.test(hostname) ||
-    /^192\.168\./.test(hostname)
+    hostname.includes(":") ||
+    /^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname)
   );
 }
 
@@ -442,7 +438,7 @@ function redactLocalPathLikeText(value: string): string {
 }
 
 const LOCAL_PATH_TEXT_PATTERN =
-  /(^|[\s([{"'`])(?:file:\/\/\S+|\\\\\S+|~(?:[\\/]\S*)?|\/(?!\/)\S+|[A-Za-z]:(?:[\\/]\S*|\S+))/g;
+  /(^|[\s([{"'`=,;?])(?:file:\/\/[^\s,;]+|\\\\[^\s,;]+|~(?:[\\/][^\s,;]*)?|\/(?!\/)[^\s,;]+|[A-Za-z]:(?:[\\/][^\s,;]*|[^\s,;]+))/g;
 
 function isDocsOnly(paths: string[]): boolean {
   return paths.length > 0 && paths.every((path) => {

--- a/src/issue-relationship-taxonomy.ts
+++ b/src/issue-relationship-taxonomy.ts
@@ -196,17 +196,21 @@ function hasReleaseRiskSignal(text: string): boolean {
     "release regression",
     "beta tag",
     "beta release",
-    "deploy",
-    "deployment",
+    "deploy release",
+    "deploy blocker",
+    "deployment blocker",
     "appcast",
     "notary",
     "notarize",
     "notarized",
     "notarization",
     "launchd",
-    "production",
-    "rollout",
-    "publish"
+    "production release",
+    "production rollout",
+    "publish release",
+    "publish blocker",
+    "rollout blocker",
+    "rollout gate"
   ]);
 }
 
@@ -280,12 +284,20 @@ function hasPrivateEvidence(input: IssueRelationshipItemInput): boolean {
     input.rawLogs?.length ||
     input.localPaths?.length ||
     input.tokens?.length ||
-    containsSecretLikeText(`${input.body ?? ""}\n${input.publicSummary ?? ""}`)
+    input.paths?.some(isLocalPath) ||
+    containsSecretLikeText([
+      input.title,
+      input.body ?? "",
+      input.publicSummary ?? "",
+      input.url ?? "",
+      ...(input.paths ?? []),
+      ...(input.suggestedReviewers ?? [])
+    ].join("\n"))
   );
 }
 
 function publicText(value: string): string {
-  return redactSecrets(value).trim();
+  return redactLocalPathLikeText(redactSecrets(value)).trim();
 }
 
 function publicEvidenceUrls(values: string[]): string[] {
@@ -330,6 +342,12 @@ function isLocalPath(value: string): boolean {
   return value.startsWith("/") || value.startsWith("~/") || value.startsWith("file:") || /^[A-Za-z]:[\\/]/.test(value);
 }
 
+function redactLocalPathLikeText(value: string): string {
+  return value
+    .replace(/file:\/\/\S+/g, "[local-path-redacted]")
+    .replace(/(?:\/Volumes|\/Users|\/private|\/tmp|~\/|[A-Za-z]:[\\/])\S*/g, "[local-path-redacted]");
+}
+
 function isDocsOnly(paths: string[]): boolean {
   return paths.length > 0 && paths.every((path) => {
     const normalized = path.toLowerCase();
@@ -348,12 +366,22 @@ function hasDependencyPath(paths: string[]): boolean {
 function matchesAny(text: string, needles: string[]): boolean {
   return needles.some((needle) => {
     if (/[\s/_-]/.test(needle)) return text.includes(needle);
-    return new RegExp(`(^|[^a-z0-9])${escapeRegExp(needle)}([^a-z0-9]|$)`).test(text);
+    return tokenNeedleRegExp(needle).test(text);
   });
 }
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const TOKEN_NEEDLE_REGEXPS = new Map<string, RegExp>();
+
+function tokenNeedleRegExp(needle: string): RegExp {
+  const cached = TOKEN_NEEDLE_REGEXPS.get(needle);
+  if (cached) return cached;
+  const pattern = new RegExp(`(^|[^a-z0-9])${escapeRegExp(needle)}([^a-z0-9]|$)`);
+  TOKEN_NEEDLE_REGEXPS.set(needle, pattern);
+  return pattern;
 }
 
 function unique<T>(values: T[]): T[] {

--- a/src/issue-relationship-taxonomy.ts
+++ b/src/issue-relationship-taxonomy.ts
@@ -131,16 +131,15 @@ export function classifyIssueRelationshipItem(input: IssueRelationshipItemInput)
 }
 
 export function buildIssueRelationshipClusters(input: IssueRelationshipClusterInput): IssueRelationshipClusterResult {
-  const groups = new Map<string, Array<{ raw: IssueRelationshipItemInput; classified: ClassifiedIssueRelationshipItem }>>();
+  const groups = new Map<string, ClassifiedIssueRelationshipItem[]>();
   for (const item of input.items) {
     const key = clusterKey(item);
     const group = groups.get(key) ?? [];
-    group.push({ raw: item, classified: classifyIssueRelationshipItem(item) });
+    group.push(classifyIssueRelationshipItem(item));
     groups.set(key, group);
   }
 
-  const clusters = Array.from(groups.entries()).map(([id, entries]) => {
-    const items = entries.map((entry) => entry.classified);
+  const clusters = Array.from(groups.entries()).map(([id, items]) => {
     const categories = unique(items.map((item) => item.category));
     const proofRequirements = unique(items.flatMap((item) => item.proofRequirements));
     return {
@@ -178,15 +177,15 @@ function inferRelationshipCategory(input: IssueRelationshipItemInput): IssueRela
   if (input.severity === "P0" || input.severity === "P1" || matchesAny(haystack, ["blocks merge", "blocking", "must fix"])) {
     return "blocker";
   }
-  if (hasReleaseRiskSignal(haystack)) return "release_risk";
   if (matchesAny(haystack, ["reproduction gap", "missing reproduction", "no reproduction", "lacks proof", "missing proof", "missing evidence", "no command", "no head sha", "no fixture", "needs proof"])) {
     return "reproduction_gap";
   }
+  if (hasReleaseRiskSignal(haystack)) return "release_risk";
   if (input.duplicateOf || matchesAny(haystack, ["stale duplicate", "duplicate of", "superseded by", "already covered"])) return "stale_duplicate";
+  if (isDocsOnly(input.paths ?? []) || matchesAny(haystack, ["docs-only", "documentation-only"])) return "docs_only";
   if (matchesAny(haystack, ["dependency", "depends on", "blocked by", "upstream", "package update"]) || hasDependencyPath(input.paths ?? [])) {
     return "dependency";
   }
-  if (isDocsOnly(input.paths ?? []) || matchesAny(haystack, ["docs-only", "documentation-only"])) return "docs_only";
   if (hasRegressionSignal(haystack)) return "regression";
   if (matchesAny(haystack, ["manual triage", "needs human", "human routing", "ambiguous owner", "unknown owner"])) return "needs_human_routing";
   return "needs_human_routing";
@@ -198,8 +197,10 @@ function hasReleaseRiskSignal(text: string): boolean {
     "release gate",
     "release risk",
     "release regression",
-    "beta tag",
-    "beta release",
+    "beta tag gate",
+    "beta tag blocker",
+    "beta release gate",
+    "beta release blocker",
     "deploy release",
     "deploy blocker",
     "deployment blocker",

--- a/tests/issue-relationship-taxonomy.test.ts
+++ b/tests/issue-relationship-taxonomy.test.ts
@@ -431,6 +431,22 @@ describe("issue relationship taxonomy", () => {
     expect(JSON.stringify(result)).not.toContain("/etc/passwd");
   });
 
+  it("redacts local paths after query and list delimiters", () => {
+    const result = classifyIssueRelationshipItem({
+      id: "issue-54a",
+      kind: "issue",
+      title: "Leak contexts query=file:///tmp/raw.log,path=/etc/passwd,list=/root/.env;next=/var/log/raw.log",
+      publicSummary: "Values are a=1,b=/home/lume/.env;file=file:///tmp/raw.log?x=1"
+    });
+
+    expect(result.title.match(/\[local-path-redacted\]/g)).toHaveLength(4);
+    expect(result.summary.match(/\[local-path-redacted\]/g)).toHaveLength(2);
+    expect(JSON.stringify(result)).not.toContain("file:///tmp");
+    expect(JSON.stringify(result)).not.toContain("/etc/passwd");
+    expect(JSON.stringify(result)).not.toContain("/root/.env");
+    expect(JSON.stringify(result)).not.toContain("/home/lume");
+  });
+
   it("redacts public summary fallback text when publicSummary is omitted", () => {
     const result = classifyIssueRelationshipItem({
       id: "issue-54b",
@@ -456,8 +472,11 @@ describe("issue relationship taxonomy", () => {
         "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/1",
         "http://127.0.0.1/private",
         "http://10.0.0.5/private",
+        "http://100.64.0.1/private",
         "http://192.168.1.20/private",
         "http://[::1]/private",
+        "http://[fe80::1]/private",
+        "https://8.8.8.8/private",
         "https://service.internal/private"
       ]
     });

--- a/tests/issue-relationship-taxonomy.test.ts
+++ b/tests/issue-relationship-taxonomy.test.ts
@@ -95,6 +95,8 @@ describe("issue relationship taxonomy", () => {
 
     expect(p0DocsHint).toMatchObject({
       category: "blocker",
+      categoryHint: "docs_only",
+      categoryHintHonored: false,
       proofRequirements: ["current_head_failure"],
       suggestedLabels: ["blocker"]
     });
@@ -110,6 +112,22 @@ describe("issue relationship taxonomy", () => {
     expect(duplicateReleaseBlocker).toMatchObject({
       category: "release_risk",
       proofRequirements: ["release_gate"]
+    });
+
+    const p0Release = classifyIssueRelationshipItem({
+      id: "issue-44b",
+      kind: "issue",
+      title: "Launchd beta release gate is down",
+      severity: "P0",
+      categoryHint: "release_risk"
+    });
+
+    expect(p0Release).toMatchObject({
+      category: "blocker",
+      categoryHint: "release_risk",
+      categoryHintHonored: false,
+      proofRequirements: ["current_head_failure"],
+      suggestedLabels: ["blocker"]
     });
   });
 
@@ -137,6 +155,22 @@ describe("issue relationship taxonomy", () => {
       body: "Document the production setup page before publishing the docs.",
       paths: ["docs/SETUP.md"]
     }).category).toBe("docs_only");
+
+    expect(classifyIssueRelationshipItem({
+      id: "issue-48",
+      kind: "issue",
+      title: "Bug in label parser",
+      body: "Minor parser failure while reading a label.",
+      paths: ["src/labels.ts"]
+    }).category).toBe("needs_human_routing");
+
+    expect(classifyIssueRelationshipItem({
+      id: "issue-49",
+      kind: "issue",
+      title: "Worker queue regression fixture update",
+      body: "The current fixture proves this regressed.",
+      paths: ["src/worker.ts"]
+    }).category).toBe("regression");
   });
 
   it("clusters related issues and PRs with public-safe relationship reasons", () => {
@@ -222,14 +256,19 @@ describe("issue relationship taxonomy", () => {
     const result = classifyIssueRelationshipItem({
       id: "issue-54",
       kind: "issue",
-      title: "Failure captured at /Volumes/LEXAR/private/raw.log",
-      publicSummary: "Repro notes live in ~/secrets/repro.md and file:///tmp/raw.log."
+      title: "Failure captured at /Volumes/LEXAR/private/raw.log and \\\\fileserver\\secrets\\config.env",
+      publicSummary: "Repro notes live in ~/secrets/repro.md, ~, C:secrets.txt, C:\\secrets\\raw.log, /etc/passwd, /var/log/raw.log, /root/.env, /home/lume/.env, /mnt/share/raw.log, /opt/app/raw.log, /srv/app/raw.log, /Library/Logs/raw.log, and file:///tmp/raw.log.",
+      paths: ["\\\\fileserver\\secrets\\config.env", "C:secrets.txt", "/etc/passwd"]
     });
 
-    expect(result.title).toBe("Failure captured at [local-path-redacted]");
-    expect(result.summary).toBe("Repro notes live in [local-path-redacted] and [local-path-redacted]");
+    expect(result.title).toBe("Failure captured at [local-path-redacted] and [local-path-redacted]");
+    expect(result.summary.match(/\[local-path-redacted\]/g)).toHaveLength(13);
+    expect(result.publicPaths).toEqual([]);
     expect(JSON.stringify(result)).not.toContain("/Volumes/LEXAR");
     expect(JSON.stringify(result)).not.toContain("~/secrets");
     expect(JSON.stringify(result)).not.toContain("file:///tmp");
+    expect(JSON.stringify(result)).not.toContain("\\\\fileserver");
+    expect(JSON.stringify(result)).not.toContain("C:secrets");
+    expect(JSON.stringify(result)).not.toContain("/etc/passwd");
   });
 });

--- a/tests/issue-relationship-taxonomy.test.ts
+++ b/tests/issue-relationship-taxonomy.test.ts
@@ -302,6 +302,16 @@ describe("issue relationship taxonomy", () => {
           title: "Slash id issue"
         },
         {
+          id: "issue 50",
+          kind: "issue",
+          title: "Space id issue"
+        },
+        {
+          id: "issue.50",
+          kind: "issue",
+          title: "Dot id issue"
+        },
+        {
           id: "issue-50",
           kind: "issue",
           title: "Hyphen id issue"
@@ -311,10 +321,11 @@ describe("issue relationship taxonomy", () => {
 
     const clusterIds = result.publicIssueCommentState.clusters.map((cluster) => cluster.id);
 
-    expect(result.publicIssueCommentState.clusters).toHaveLength(2);
-    expect(new Set(clusterIds).size).toBe(2);
+    expect(result.publicIssueCommentState.clusters).toHaveLength(4);
+    expect(new Set(clusterIds).size).toBe(4);
     expect(clusterIds).toContain("standalone-issue-50");
-    expect(clusterIds.some((id) => /^standalone-issue-50-[a-z0-9]{7}$/.test(id))).toBe(true);
+    expect(clusterIds).toContain("standalone-issue.50");
+    expect(clusterIds.filter((id) => /^standalone-issue-50-[a-z0-9]{7}$/.test(id))).toHaveLength(2);
   });
 
   it("counts private fields that are sanitized out of public output", () => {
@@ -374,6 +385,17 @@ describe("issue relationship taxonomy", () => {
     });
 
     expect(result.suggestedReviewers).toEqual(["valid-bot", "team-reviewer"]);
+  });
+
+  it("canonicalizes suggested labels for advisory public output", () => {
+    const result = classifyIssueRelationshipItem({
+      id: "issue-56",
+      kind: "issue",
+      title: "Needs label routing",
+      suggestedLabels: ["needs proof", "release/risk", "already.clean", "needs-proof"]
+    });
+
+    expect(result.suggestedLabels).toEqual(["needs-proof", "release-risk", "already.clean"]);
   });
 
   it("documents single-item routing narratives", () => {

--- a/tests/issue-relationship-taxonomy.test.ts
+++ b/tests/issue-relationship-taxonomy.test.ts
@@ -4,6 +4,7 @@ import {
   classifyIssueRelationshipItem,
   ISSUE_RELATIONSHIP_CATEGORIES,
   PROOF_REQUIREMENTS,
+  type IssueRelationshipClusterResult,
   type IssueRelationshipItemInput
 } from "../src/issue-relationship-taxonomy.js";
 
@@ -231,7 +232,7 @@ describe("issue relationship taxonomy", () => {
       }
     ];
 
-    const result = buildIssueRelationshipClusters({ items });
+    const result: IssueRelationshipClusterResult = buildIssueRelationshipClusters({ items });
 
     expect(result.publicIssueCommentState.clusters).toHaveLength(2);
     expect(result.publicIssueCommentState.clusters[0]).toMatchObject({

--- a/tests/issue-relationship-taxonomy.test.ts
+++ b/tests/issue-relationship-taxonomy.test.ts
@@ -129,6 +129,14 @@ describe("issue relationship taxonomy", () => {
       body: "Fix wording in the release notes.",
       paths: ["docs/releases/v0.4.0.md"]
     }).category).toBe("docs_only");
+
+    expect(classifyIssueRelationshipItem({
+      id: "issue-47",
+      kind: "issue",
+      title: "Publish docs typo",
+      body: "Document the production setup page before publishing the docs.",
+      paths: ["docs/SETUP.md"]
+    }).category).toBe("docs_only");
   });
 
   it("clusters related issues and PRs with public-safe relationship reasons", () => {
@@ -188,5 +196,40 @@ describe("issue relationship taxonomy", () => {
       privateEvidenceItems: 1
     });
     expect(JSON.stringify(result.publicIssueCommentState)).not.toContain("/Volumes/LEXAR");
+  });
+
+  it("counts private fields that are sanitized out of public output", () => {
+    const result = buildIssueRelationshipClusters({
+      items: [
+        {
+          id: "issue-53",
+          kind: "issue",
+          title: "Local screenshot proves the failure",
+          publicSummary: "Public summary is safe.",
+          paths: ["/Volumes/LEXAR/private/screenshot.png"]
+        }
+      ]
+    });
+
+    expect(result.privateEvidenceBoundary).toEqual({
+      rawEvidenceOmitted: true,
+      privateEvidenceItems: 1
+    });
+    expect(result.publicIssueCommentState.clusters[0]?.items[0]?.publicPaths).toEqual([]);
+  });
+
+  it("redacts local paths from public text fields", () => {
+    const result = classifyIssueRelationshipItem({
+      id: "issue-54",
+      kind: "issue",
+      title: "Failure captured at /Volumes/LEXAR/private/raw.log",
+      publicSummary: "Repro notes live in ~/secrets/repro.md and file:///tmp/raw.log."
+    });
+
+    expect(result.title).toBe("Failure captured at [local-path-redacted]");
+    expect(result.summary).toBe("Repro notes live in [local-path-redacted] and [local-path-redacted]");
+    expect(JSON.stringify(result)).not.toContain("/Volumes/LEXAR");
+    expect(JSON.stringify(result)).not.toContain("~/secrets");
+    expect(JSON.stringify(result)).not.toContain("file:///tmp");
   });
 });

--- a/tests/issue-relationship-taxonomy.test.ts
+++ b/tests/issue-relationship-taxonomy.test.ts
@@ -144,6 +144,20 @@ describe("issue relationship taxonomy", () => {
       proofRequirements: ["current_head_failure"],
       suggestedLabels: ["blocker"]
     });
+
+    const explicitHumanRouting = classifyIssueRelationshipItem({
+      id: "issue-44c",
+      kind: "issue",
+      title: "Manual triage needed for owner mapping",
+      categoryHint: "dependency"
+    });
+
+    expect(explicitHumanRouting).toMatchObject({
+      category: "needs_human_routing",
+      categoryHint: "dependency",
+      categoryHintHonored: false,
+      proofRequirements: ["human_triage"]
+    });
   });
 
   it("routes notarization and release-gate risks without over-triggering on release notes", () => {
@@ -215,6 +229,21 @@ describe("issue relationship taxonomy", () => {
       title: "Label cleanup",
       labels: ["pre-release-risk-review"]
     }).category).toBe("needs_human_routing");
+
+    expect(classifyIssueRelationshipItem({
+      id: "issue-49h",
+      kind: "issue",
+      title: "Docs-only parser broke",
+      labels: ["docs-only"],
+      paths: ["src/router.ts"]
+    }).category).toBe("regression");
+
+    expect(classifyIssueRelationshipItem({
+      id: "issue-49i",
+      kind: "issue",
+      title: "Bump lockfile version",
+      paths: ["package-lock.json"]
+    }).category).toBe("dependency");
   });
 
   it("keeps dependsOn refs as relationship metadata, not proof evidence", () => {
@@ -293,6 +322,29 @@ describe("issue relationship taxonomy", () => {
     expect(JSON.stringify(result.publicIssueCommentState)).not.toContain("/Volumes/LEXAR");
   });
 
+  it("rejects private relationship refs before public cluster ids", () => {
+    const result = buildIssueRelationshipClusters({
+      items: [
+        {
+          id: "issue-57",
+          kind: "issue",
+          title: "Private relationship ref should not leak",
+          relationshipKeys: ["/Volumes/LEXAR/private/raw.log", "public-routing-key"],
+          duplicateOf: "/Users/lume/secrets/raw.log",
+          relatedRefs: ["http://localhost:3000/private"]
+        }
+      ]
+    });
+
+    expect(result.publicIssueCommentState.clusters[0]?.id).toBe("public-routing-key");
+    expect(result.privateEvidenceBoundary).toEqual({
+      rawEvidenceOmitted: true,
+      privateEvidenceItems: 1
+    });
+    expect(JSON.stringify(result.publicIssueCommentState)).not.toContain("Volumes-LEXAR");
+    expect(JSON.stringify(result.publicIssueCommentState)).not.toContain("localhost");
+  });
+
   it("keeps standalone clusters distinct when ids sanitize to the same slug", () => {
     const result = buildIssueRelationshipClusters({
       items: [
@@ -326,6 +378,17 @@ describe("issue relationship taxonomy", () => {
     expect(clusterIds).toContain("standalone-issue-50");
     expect(clusterIds).toContain("standalone-issue.50");
     expect(clusterIds.filter((id) => /^standalone-issue-50-[a-z0-9]{7}$/.test(id))).toHaveLength(2);
+  });
+
+  it("keeps standalone cluster ids stable for repeated inputs", () => {
+    const first = buildIssueRelationshipClusters({
+      items: [{ id: "issue/50", kind: "issue", title: "Slash id issue" }]
+    });
+    const second = buildIssueRelationshipClusters({
+      items: [{ id: "issue/50", kind: "issue", title: "Slash id issue" }]
+    });
+
+    expect(first.publicIssueCommentState.clusters[0]?.id).toBe(second.publicIssueCommentState.clusters[0]?.id);
   });
 
   it("counts private fields that are sanitized out of public output", () => {
@@ -366,6 +429,43 @@ describe("issue relationship taxonomy", () => {
     expect(JSON.stringify(result)).not.toContain("\\\\fileserver");
     expect(JSON.stringify(result)).not.toContain("C:secrets");
     expect(JSON.stringify(result)).not.toContain("/etc/passwd");
+  });
+
+  it("redacts public summary fallback text when publicSummary is omitted", () => {
+    const result = classifyIssueRelationshipItem({
+      id: "issue-54b",
+      kind: "issue",
+      title: "Failure at /Volumes/LEXAR/private/raw.log",
+      body: "Raw detail includes /Users/lume/.ssh/id_rsa and token sk-test-example."
+    });
+
+    expect(result.title).toBe("Failure at [local-path-redacted]");
+    expect(result.summary).toBe("Failure at [local-path-redacted]");
+    expect(JSON.stringify(result)).not.toContain("/Volumes/LEXAR");
+    expect(JSON.stringify(result)).not.toContain("/Users/lume");
+    expect(JSON.stringify(result)).not.toContain("sk-test-example");
+  });
+
+  it("drops local and private-network evidence urls from public output", () => {
+    const result = classifyIssueRelationshipItem({
+      id: "issue-54c",
+      kind: "issue",
+      title: "Evidence URL filtering",
+      url: "http://localhost:3000/private",
+      evidenceUrls: [
+        "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/1",
+        "http://127.0.0.1/private",
+        "http://10.0.0.5/private",
+        "http://192.168.1.20/private",
+        "http://[::1]/private",
+        "https://service.internal/private"
+      ]
+    });
+
+    expect(result.url).toBeUndefined();
+    expect(result.publicEvidenceUrls).toEqual([
+      "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/1"
+    ]);
   });
 
   it("keeps only safe reviewer logins in public output", () => {

--- a/tests/issue-relationship-taxonomy.test.ts
+++ b/tests/issue-relationship-taxonomy.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildIssueRelationshipClusters,
+  classifyIssueRelationshipItem,
+  ISSUE_RELATIONSHIP_CATEGORIES,
+  PROOF_REQUIREMENTS,
+  type IssueRelationshipItemInput
+} from "../src/issue-relationship-taxonomy.js";
+
+describe("issue relationship taxonomy", () => {
+  it("exports the deterministic category and proof requirement ids", () => {
+    expect(ISSUE_RELATIONSHIP_CATEGORIES).toEqual([
+      "blocker",
+      "regression",
+      "reproduction_gap",
+      "stale_duplicate",
+      "dependency",
+      "release_risk",
+      "docs_only",
+      "needs_human_routing"
+    ]);
+    expect(PROOF_REQUIREMENTS).toEqual([
+      "current_head_failure",
+      "regression_fixture",
+      "reproduction_steps",
+      "freshness_check",
+      "dependency_owner",
+      "release_gate",
+      "docs_scope",
+      "human_triage"
+    ]);
+  });
+
+  it("classifies stale duplicate and proof-gap issues without leaking private evidence", () => {
+    const staleDuplicate = classifyIssueRelationshipItem({
+      id: "issue-41",
+      kind: "issue",
+      number: 41,
+      title: "Duplicate: stale repro from old worker queue",
+      state: "closed",
+      duplicateOf: "issue-17",
+      updatedAt: "2026-06-01T00:00:00Z",
+      publicSummary: "Old queue failure report superseded by #17.",
+      evidenceUrls: ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/17"],
+      privateEvidence: ["ssh transcript /Volumes/LEXAR/private/raw.log"],
+      rawLogs: ["example raw token placeholder"]
+    });
+
+    expect(staleDuplicate.category).toBe("stale_duplicate");
+    expect(staleDuplicate.proofRequirements).toEqual(["freshness_check"]);
+    expect(JSON.stringify(staleDuplicate)).not.toContain("raw.log");
+    expect(JSON.stringify(staleDuplicate)).not.toContain("example raw token");
+
+    const proofGap = classifyIssueRelationshipItem({
+      id: "issue-42",
+      kind: "issue",
+      title: "Regression report is missing reproduction steps",
+      body: "The queue fails sometimes but no command, head SHA, or fixture is attached.",
+      publicSummary: "Needs a deterministic reproduction before routing to implementation.",
+      evidenceUrls: []
+    });
+
+    expect(proofGap).toMatchObject({
+      category: "reproduction_gap",
+      proofRequirements: ["reproduction_steps"]
+    });
+  });
+
+  it("classifies release risks before generic regressions", () => {
+    const result = classifyIssueRelationshipItem({
+      id: "pr-99",
+      kind: "pull_request",
+      number: 99,
+      title: "Release blocker: appcast regression before beta tag",
+      body: "Deploy would publish a beta without the release gate proof.",
+      paths: ["docs/release-governance.md"],
+      publicSummary: "Release proof is missing for a beta-facing path.",
+      evidenceUrls: ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/99"]
+    });
+
+    expect(result.category).toBe("release_risk");
+    expect(result.proofRequirements).toEqual(["release_gate", "regression_fixture"]);
+    expect(result.suggestedLabels).toEqual(["release-risk"]);
+  });
+
+  it("keeps category hints advisory when higher-risk signals are present", () => {
+    const p0DocsHint = classifyIssueRelationshipItem({
+      id: "issue-43",
+      kind: "issue",
+      title: "Docs typo reported as P0",
+      paths: ["docs/SETUP.md"],
+      severity: "P0",
+      categoryHint: "docs_only"
+    });
+
+    expect(p0DocsHint).toMatchObject({
+      category: "blocker",
+      proofRequirements: ["current_head_failure"],
+      suggestedLabels: ["blocker"]
+    });
+
+    const duplicateReleaseBlocker = classifyIssueRelationshipItem({
+      id: "issue-44",
+      kind: "issue",
+      title: "Duplicate report: release blocker in notarization gate",
+      body: "Superseded by #40, but the beta release still cannot pass notarization.",
+      duplicateOf: "issue-40"
+    });
+
+    expect(duplicateReleaseBlocker).toMatchObject({
+      category: "release_risk",
+      proofRequirements: ["release_gate"]
+    });
+  });
+
+  it("routes notarization and release-gate risks without over-triggering on release notes", () => {
+    expect(classifyIssueRelationshipItem({
+      id: "issue-45",
+      kind: "issue",
+      title: "Notarization fails before beta release",
+      body: "The release gate cannot staple the app.",
+      paths: ["docs/release-governance.md"]
+    }).category).toBe("release_risk");
+
+    expect(classifyIssueRelationshipItem({
+      id: "issue-46",
+      kind: "issue",
+      title: "Release notes typo",
+      body: "Fix wording in the release notes.",
+      paths: ["docs/releases/v0.4.0.md"]
+    }).category).toBe("docs_only");
+  });
+
+  it("clusters related issues and PRs with public-safe relationship reasons", () => {
+    const items: IssueRelationshipItemInput[] = [
+      {
+        id: "issue-50",
+        kind: "issue",
+        number: 50,
+        title: "Worker queue regression lacks proof",
+        body: "Queue regression is reported but no focused fixture is linked.",
+        relationshipKeys: ["worker-queue"],
+        paths: ["src/worker.ts"],
+        publicSummary: "Regression report needs a fixture before implementation.",
+        suggestedReviewers: ["queue-owner"],
+        privateEvidence: ["local path /Volumes/LEXAR/private/queue.log"]
+      },
+      {
+        id: "pr-51",
+        kind: "pull_request",
+        number: 51,
+        title: "Fix worker queue regression",
+        body: "Closes #50 with a fixture update.",
+        relationshipKeys: ["worker-queue"],
+        paths: ["tests/worker-failure.test.ts"],
+        evidenceUrls: ["https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/51"],
+        publicSummary: "Candidate implementation linked to the proof gap.",
+        suggestedLabels: ["needs-proof"]
+      },
+      {
+        id: "issue-52",
+        kind: "issue",
+        number: 52,
+        title: "Docs-only setup typo",
+        paths: ["docs/SETUP.md"],
+        publicSummary: "Documentation-only follow-up."
+      }
+    ];
+
+    const result = buildIssueRelationshipClusters({ items });
+
+    expect(result.publicIssueCommentState.clusters).toHaveLength(2);
+    expect(result.publicIssueCommentState.clusters[0]).toMatchObject({
+      id: "worker-queue",
+      categories: ["reproduction_gap", "regression"],
+      proofRequirements: ["reproduction_steps", "regression_fixture"],
+      suggestedLabels: ["needs-proof"],
+      suggestedReviewers: ["queue-owner"]
+    });
+    expect(result.publicIssueCommentState.clusters[0]?.whyItMatters).toContain("Multiple related records");
+    expect(result.publicIssueCommentState.clusters[1]).toMatchObject({
+      id: "standalone-issue-52",
+      categories: ["docs_only"],
+      proofRequirements: ["docs_scope"]
+    });
+    expect(result.privateEvidenceBoundary).toEqual({
+      rawEvidenceOmitted: true,
+      privateEvidenceItems: 1
+    });
+    expect(JSON.stringify(result.publicIssueCommentState)).not.toContain("/Volumes/LEXAR");
+  });
+});

--- a/tests/issue-relationship-taxonomy.test.ts
+++ b/tests/issue-relationship-taxonomy.test.ts
@@ -208,18 +208,25 @@ describe("issue relationship taxonomy", () => {
       title: "Update beta release gating notes",
       paths: ["docs/beta.md"]
     }).category).toBe("docs_only");
+
+    expect(classifyIssueRelationshipItem({
+      id: "issue-49e",
+      kind: "issue",
+      title: "Label cleanup",
+      labels: ["pre-release-risk-review"]
+    }).category).toBe("needs_human_routing");
   });
 
   it("keeps dependsOn refs as relationship metadata, not proof evidence", () => {
     expect(classifyIssueRelationshipItem({
-      id: "issue-49e",
+      id: "issue-49f",
       kind: "issue",
       title: "Release gate needs beta proof",
       dependsOn: ["ci failure fixture issue"]
     }).proofRequirements).toEqual(["release_gate"]);
 
     expect(classifyIssueRelationshipItem({
-      id: "issue-49f",
+      id: "issue-49g",
       kind: "issue",
       title: "Release gate needs beta proof",
       relatedRefs: ["ci failure fixture issue"]
@@ -263,17 +270,18 @@ describe("issue relationship taxonomy", () => {
     ];
 
     const result: IssueRelationshipClusterResult = buildIssueRelationshipClusters({ items });
+    const clustersById = new Map(result.publicIssueCommentState.clusters.map((cluster) => [cluster.id, cluster]));
 
     expect(result.publicIssueCommentState.clusters).toHaveLength(2);
-    expect(result.publicIssueCommentState.clusters[0]).toMatchObject({
+    expect(clustersById.get("worker-queue")).toMatchObject({
       id: "worker-queue",
       categories: ["reproduction_gap", "regression"],
       proofRequirements: ["reproduction_steps", "regression_fixture"],
       suggestedLabels: ["needs-proof"],
       suggestedReviewers: ["queue-owner"]
     });
-    expect(result.publicIssueCommentState.clusters[0]?.whyItMatters).toContain("Multiple related records");
-    expect(result.publicIssueCommentState.clusters[1]).toMatchObject({
+    expect(clustersById.get("worker-queue")?.whyItMatters).toContain("Multiple related records");
+    expect(clustersById.get("standalone-issue-52")).toMatchObject({
       id: "standalone-issue-52",
       categories: ["docs_only"],
       proofRequirements: ["docs_scope"]

--- a/tests/issue-relationship-taxonomy.test.ts
+++ b/tests/issue-relationship-taxonomy.test.ts
@@ -171,6 +171,28 @@ describe("issue relationship taxonomy", () => {
       body: "The current fixture proves this regressed.",
       paths: ["src/worker.ts"]
     }).category).toBe("regression");
+
+    expect(classifyIssueRelationshipItem({
+      id: "issue-49b",
+      kind: "issue",
+      title: "package.json change is missing reproduction steps",
+      body: "No command or fixture is attached.",
+      paths: ["package.json"]
+    }).category).toBe("reproduction_gap");
+
+    expect(classifyIssueRelationshipItem({
+      id: "issue-49c",
+      kind: "issue",
+      title: "docs package metadata typo",
+      paths: ["docs/package.json"]
+    }).category).toBe("docs_only");
+
+    expect(classifyIssueRelationshipItem({
+      id: "issue-49d",
+      kind: "issue",
+      title: "Update beta release gating notes",
+      paths: ["docs/beta.md"]
+    }).category).toBe("docs_only");
   });
 
   it("clusters related issues and PRs with public-safe relationship reasons", () => {
@@ -270,5 +292,40 @@ describe("issue relationship taxonomy", () => {
     expect(JSON.stringify(result)).not.toContain("\\\\fileserver");
     expect(JSON.stringify(result)).not.toContain("C:secrets");
     expect(JSON.stringify(result)).not.toContain("/etc/passwd");
+  });
+
+  it("documents single-item routing narratives", () => {
+    const result = buildIssueRelationshipClusters({
+      items: [
+        {
+          id: "stale-one",
+          kind: "issue",
+          title: "Duplicate of fresher queue report",
+          duplicateOf: "queue-current"
+        },
+        {
+          id: "release-one",
+          kind: "issue",
+          title: "Appcast release gate stalled before rollout"
+        },
+        {
+          id: "proof-one",
+          kind: "issue",
+          title: "Worker issue lacks proof"
+        },
+        {
+          id: "default-one",
+          kind: "issue",
+          title: "Needs owner routing"
+        }
+      ]
+    });
+
+    const byId = new Map(result.publicIssueCommentState.clusters.map((cluster) => [cluster.id, cluster.whyItMatters]));
+
+    expect(byId.get("queue-current")).toContain("Stale duplicate routing");
+    expect(byId.get("standalone-release-one")).toContain("Release-risk routing");
+    expect(byId.get("standalone-proof-one")).toContain("Proof-gap routing");
+    expect(byId.get("standalone-default-one")).toContain("Single-item routing records");
   });
 });

--- a/tests/issue-relationship-taxonomy.test.ts
+++ b/tests/issue-relationship-taxonomy.test.ts
@@ -293,6 +293,30 @@ describe("issue relationship taxonomy", () => {
     expect(JSON.stringify(result.publicIssueCommentState)).not.toContain("/Volumes/LEXAR");
   });
 
+  it("keeps standalone clusters distinct when ids sanitize to the same slug", () => {
+    const result = buildIssueRelationshipClusters({
+      items: [
+        {
+          id: "issue/50",
+          kind: "issue",
+          title: "Slash id issue"
+        },
+        {
+          id: "issue-50",
+          kind: "issue",
+          title: "Hyphen id issue"
+        }
+      ]
+    });
+
+    const clusterIds = result.publicIssueCommentState.clusters.map((cluster) => cluster.id);
+
+    expect(result.publicIssueCommentState.clusters).toHaveLength(2);
+    expect(new Set(clusterIds).size).toBe(2);
+    expect(clusterIds).toContain("standalone-issue-50");
+    expect(clusterIds.some((id) => /^standalone-issue-50-[a-z0-9]{7}$/.test(id))).toBe(true);
+  });
+
   it("counts private fields that are sanitized out of public output", () => {
     const result = buildIssueRelationshipClusters({
       items: [
@@ -331,6 +355,25 @@ describe("issue relationship taxonomy", () => {
     expect(JSON.stringify(result)).not.toContain("\\\\fileserver");
     expect(JSON.stringify(result)).not.toContain("C:secrets");
     expect(JSON.stringify(result)).not.toContain("/etc/passwd");
+  });
+
+  it("keeps only safe reviewer logins in public output", () => {
+    const result = classifyIssueRelationshipItem({
+      id: "issue-55",
+      kind: "issue",
+      title: "Needs reviewer routing",
+      suggestedReviewers: [
+        "@valid-bot",
+        "team-reviewer",
+        "a*b!",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "/etc/passwd",
+        "owner/name",
+        "contains space"
+      ]
+    });
+
+    expect(result.suggestedReviewers).toEqual(["valid-bot", "team-reviewer"]);
   });
 
   it("documents single-item routing narratives", () => {

--- a/tests/issue-relationship-taxonomy.test.ts
+++ b/tests/issue-relationship-taxonomy.test.ts
@@ -85,6 +85,20 @@ describe("issue relationship taxonomy", () => {
   });
 
   it("keeps category hints advisory when higher-risk signals are present", () => {
+    const ownerHint = classifyIssueRelationshipItem({
+      id: "issue-42b",
+      kind: "issue",
+      title: "Needs owner routing",
+      categoryHint: "dependency"
+    });
+
+    expect(ownerHint).toMatchObject({
+      category: "dependency",
+      categoryHint: "dependency",
+      categoryHintHonored: true,
+      proofRequirements: ["dependency_owner"]
+    });
+
     const p0DocsHint = classifyIssueRelationshipItem({
       id: "issue-43",
       kind: "issue",
@@ -194,6 +208,22 @@ describe("issue relationship taxonomy", () => {
       title: "Update beta release gating notes",
       paths: ["docs/beta.md"]
     }).category).toBe("docs_only");
+  });
+
+  it("keeps dependsOn refs as relationship metadata, not proof evidence", () => {
+    expect(classifyIssueRelationshipItem({
+      id: "issue-49e",
+      kind: "issue",
+      title: "Release gate needs beta proof",
+      dependsOn: ["ci failure fixture issue"]
+    }).proofRequirements).toEqual(["release_gate"]);
+
+    expect(classifyIssueRelationshipItem({
+      id: "issue-49f",
+      kind: "issue",
+      title: "Release gate needs beta proof",
+      relatedRefs: ["ci failure fixture issue"]
+    }).proofRequirements).toEqual(["release_gate", "regression_fixture"]);
   });
 
   it("clusters related issues and PRs with public-safe relationship reasons", () => {


### PR DESCRIPTION
## Summary

Related: #262

Adds the first pure-additive proof/routing relationship taxonomy slice:

- new `src/issue-relationship-taxonomy.ts` typed category/proof requirement API
- deterministic item classification for blocker, regression, reproduction gap, stale duplicate, dependency, release risk, docs-only, and needs-human-routing
- deterministic cluster building from structured issue/PR/finding inputs
- public issue-comment state separated from private/raw evidence boundary counts
- suggestion-only labels/reviewers, with no GitHub API/provider/filesystem behavior in the module

## Safety Boundaries

- No live issue-enrichment comment wiring in this PR.
- No target repo mutation behavior added by the module.
- No runtime/config/launchd/tag/release changes.
- Avoided the active #273, #267/#270, and #274/#276/#272 hot-zone files.

## Validation

- `npm test -- tests/issue-relationship-taxonomy.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- `git diff --cached --check`

## Notes

This is intentionally advisory infrastructure only. A later slice can wire the public cluster state into issue enrichment comments after the active enrichment/comment PRs settle.
