### PR TITLE
Wire confidence into ranking, comment-cap selection, and REQUEST_CHANGES gating

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -658,6 +658,11 @@ function validateReviewGateConfig(value: unknown, label: string): void {
     if (!isRecord(value.requestChangesConfidenceFloors)) {
       throw new Error(`${label}.requestChangesConfidenceFloors must be an object`);
     }
+    for (const key of Object.keys(value.requestChangesConfidenceFloors)) {
+      if (key !== "P0" && key !== "P1") {
+        throw new Error(`${label}.requestChangesConfidenceFloors has unknown key "${key}"; expected only P0 or P1`);
+      }
+    }
     for (const severity of ["P0", "P1"] as const) {
       const floor = value.requestChangesConfidenceFloors[severity];
       if (floor !== undefined) validateProbability(floor, `${label}.requestChangesConfidenceFloors.${severity}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ import {
   type PublicConfidenceDisplayPolicy
 } from "./public-confidence.js";
 import { isApiKeyEnvName, isProviderId, type ProviderRegistryConfig } from "./providers.js";
+import type { RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import { containsSecretLikeText } from "./secrets.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
 
@@ -66,6 +67,7 @@ export interface BotConfig {
   confidenceCalibration?: {
     publicDisplay: PublicConfidenceDisplayPolicy;
   };
+  reviewGate?: ReviewGateConfig;
   repoMemory?: RepoMemoryConfig;
   gitnexusContext?: GitNexusContextConfig;
   githubRelatedContext?: GitHubRelatedContextConfig;
@@ -187,6 +189,13 @@ export interface ReviewSchedulerConfig {
   backgroundPriority: number;
 }
 
+export interface ReviewGateConfig {
+  /** Max inline comments posted per review; the highest-ranked findings survive the cap. */
+  maxInlineComments: number;
+  /** Optional per-severity confidence floors for REQUEST_CHANGES eligibility (default off). */
+  requestChangesConfidenceFloors?: RequestChangesConfidenceFloors;
+}
+
 export interface RepoMemoryConfig {
   enabled: boolean;
   memoryRoot: string;
@@ -246,6 +255,9 @@ const DEFAULT_CONFIG: BotConfig = {
   },
   confidenceCalibration: {
     publicDisplay: buildPublicConfidencePolicy()
+  },
+  reviewGate: {
+    maxInlineComments: 25
   },
   repoMemory: {
     enabled: false,
@@ -521,6 +533,9 @@ function validateConfig(config: BotConfig): void {
   confidenceCalibration.publicDisplay = buildPublicConfidencePolicy(confidenceCalibration.publicDisplay);
   validatePublicConfidenceDisplayConfig(confidenceCalibration.publicDisplay, "config.confidenceCalibration.publicDisplay");
   config.confidenceCalibration = confidenceCalibration;
+  const reviewGate = config.reviewGate ?? DEFAULT_CONFIG.reviewGate!;
+  config.reviewGate = reviewGate;
+  validateReviewGateConfig(reviewGate, "config.reviewGate");
   const repoMemory = config.repoMemory ?? DEFAULT_CONFIG.repoMemory!;
   config.repoMemory = repoMemory;
   validateRepoMemoryConfig(repoMemory, "config.repoMemory");
@@ -633,6 +648,20 @@ function validatePublicConfidenceDisplayFloorOverrides(value: unknown, label: st
   }
   if (value.minWilsonLowerBound !== undefined && (value.minWilsonLowerBound as number) < PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND) {
     throw new Error(`${label}.minWilsonLowerBound must be >= ${PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND}`);
+  }
+}
+
+function validateReviewGateConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  validatePositiveInteger(value.maxInlineComments, `${label}.maxInlineComments`);
+  if (value.requestChangesConfidenceFloors !== undefined) {
+    if (!isRecord(value.requestChangesConfidenceFloors)) {
+      throw new Error(`${label}.requestChangesConfidenceFloors must be an object`);
+    }
+    for (const severity of ["P0", "P1"] as const) {
+      const floor = value.requestChangesConfidenceFloors[severity];
+      if (floor !== undefined) validateProbability(floor, `${label}.requestChangesConfidenceFloors.${severity}`);
+    }
   }
 }
 

--- a/src/findings.ts
+++ b/src/findings.ts
@@ -1,5 +1,5 @@
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
-import { categoryLabel, isRegressionCategory, isRequestChangesEligible, normalizeFindingCategory } from "./regression-taxonomy.js";
+import { categoryLabel, isRegressionCategory, isRequestChangesEligible, normalizeFindingCategory, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import { sanitizePublicConfidenceText, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import type { DroppedFinding, Finding, ReviewComment, ReviewEvent, Severity } from "./types.js";
 
@@ -89,6 +89,9 @@ export function normalizeFindingsForReview(
   accepted.sort((a, b) => {
     const severity = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
     if (severity !== 0) return severity;
+    // Within a severity tier, higher-confidence findings rank first so the cap keeps them.
+    const confidence = b.confidence - a.confidence;
+    if (confidence !== 0) return confidence;
     const path = a.path.localeCompare(b.path);
     if (path !== 0) return path;
     return a.line - b.line || a.title.localeCompare(b.title);
@@ -113,6 +116,8 @@ export function normalizeFindingsForReview(
         side: "RIGHT",
         severity: finding.severity,
         category,
+        // Internal gating/evidence metadata; never rendered into the public body/title.
+        confidence: finding.confidence,
         title: publicTitle,
         body: formatReviewComment(
           { ...finding, category, title: publicTitle, body: publicBody, ...(publicWhy ? { why_this_matters: publicWhy } : {}) },
@@ -145,8 +150,11 @@ function sanitizeDroppedFindingPublicText<T extends Partial<Finding>>(finding: T
   };
 }
 
-export function decideReviewEvent(findings: Pick<ReviewComment, "severity" | "category">[]): ReviewEvent {
-  return findings.some((finding) => isRequestChangesEligible(finding)) ? "REQUEST_CHANGES" : "COMMENT";
+export function decideReviewEvent(
+  findings: Pick<ReviewComment, "severity" | "category" | "confidence">[],
+  confidenceFloors?: RequestChangesConfidenceFloors
+): ReviewEvent {
+  return findings.some((finding) => isRequestChangesEligible(finding, confidenceFloors)) ? "REQUEST_CHANGES" : "COMMENT";
 }
 
 export function formatReviewComment(

--- a/src/regression-taxonomy.ts
+++ b/src/regression-taxonomy.ts
@@ -47,8 +47,24 @@ export function categoryLabel(category: RegressionCategory): string {
   return REGRESSION_CATEGORY_POLICY[category].label;
 }
 
-export function isRequestChangesEligible(input: Pick<ReviewComment, "severity" | "category">): boolean {
-  return isHighSeverity(input.severity) && REGRESSION_CATEGORY_POLICY[input.category].requestChangesEligible;
+/** Optional per-severity confidence floors for REQUEST_CHANGES eligibility (default off). */
+export interface RequestChangesConfidenceFloors {
+  P0?: number;
+  P1?: number;
+}
+
+export function isRequestChangesEligible(
+  input: Pick<ReviewComment, "severity" | "category" | "confidence">,
+  confidenceFloors?: RequestChangesConfidenceFloors
+): boolean {
+  if (!isHighSeverity(input.severity) || !REGRESSION_CATEGORY_POLICY[input.category].requestChangesEligible) {
+    return false;
+  }
+  const floor = confidenceFloors?.[input.severity as "P0" | "P1"];
+  // A configured floor may only make the gate quieter: below-floor findings stop counting toward
+  // REQUEST_CHANGES but still post as comments. When unset, behavior is byte-identical to before.
+  if (typeof floor === "number" && input.confidence < floor) return false;
+  return true;
 }
 
 export function isHighSeverity(severity: Severity): boolean {

--- a/src/review-gate.ts
+++ b/src/review-gate.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { validateFindingLocations } from "./diff.js";
 import { decideReviewEvent, normalizeFindingsForReview } from "./findings.js";
 import type { PublicConfidenceDisplayPolicy } from "./public-confidence.js";
-import { countCategories, isRequestChangesEligible } from "./regression-taxonomy.js";
+import { countCategories, isRequestChangesEligible, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import type {
   DeterministicReviewGateSummary,
   DroppedFinding,
@@ -26,6 +26,7 @@ export function applyDeterministicReviewGate(input: {
   maxInlineComments?: number;
   repoMemoryFalsePositiveFingerprints?: string[];
   publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
+  requestChangesConfidenceFloors?: RequestChangesConfidenceFloors;
 }): DeterministicReviewGateResult {
   const located = validateFindingLocations(input.findings, input.files);
   // Memory suppression intentionally precedes normalization; dropReasonCounts reflects that ordering.
@@ -44,7 +45,7 @@ export function applyDeterministicReviewGate(input: {
     ...normalized.dropped
   ];
   const comments = normalized.comments;
-  const event = decideReviewEvent(comments);
+  const event = decideReviewEvent(comments, input.requestChangesConfidenceFloors);
 
   return {
     event,
@@ -55,7 +56,7 @@ export function applyDeterministicReviewGate(input: {
       acceptedComments: comments.length,
       droppedFindings: dropped.length,
       event,
-      requestChangesEligible: comments.filter((comment) => isRequestChangesEligible(comment)).length,
+      requestChangesEligible: comments.filter((comment) => isRequestChangesEligible(comment, input.requestChangesConfidenceFloors)).length,
       categoryCounts: countCategories(comments),
       dropReasonCounts: countDropReasons(dropped)
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,8 @@ export interface ReviewComment {
   body: string;
   severity: Severity;
   category: RegressionCategory;
+  /** Model confidence (0..1); internal gating/evidence metadata, never rendered publicly. */
+  confidence: number;
   title: string;
 }
 

--- a/src/walkthrough.ts
+++ b/src/walkthrough.ts
@@ -59,7 +59,7 @@ export function buildWalkthroughComment(input: {
   const suggestedReviewers = input.pull.requested_reviewers?.map((reviewer) => reviewer.login).filter(Boolean) ?? [];
   const severityCounts = countSeverities(input.comments);
   const highSeverity = severityCounts.P0 + severityCounts.P1;
-  const requestChangesEligible = input.comments.filter(isRequestChangesEligible).length;
+  const requestChangesEligible = input.comments.filter((comment) => isRequestChangesEligible(comment)).length;
   const settingsPreviewSection = formatSettingsPreviewSection(input.settingsPreview, input.publicConfidencePolicy);
 
   const visibleBody = [

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1479,9 +1479,12 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       findings: zcodeResult.findings,
       files: reviewFiles,
       droppedFromSchema: zcodeResult.droppedFromSchema,
-      maxInlineComments: 25,
+      maxInlineComments: config.reviewGate?.maxInlineComments ?? 25,
       repoMemoryFalsePositiveFingerprints: repoMemory.falsePositiveFingerprints,
-      publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
+      publicConfidencePolicy: config.confidenceCalibration?.publicDisplay,
+      ...(config.reviewGate?.requestChangesConfidenceFloors
+        ? { requestChangesConfidenceFloors: config.reviewGate.requestChangesConfidenceFloors }
+        : {})
     });
     const comments = gate.comments;
     // Gate output is already public-safe; this second pass keeps evidence redacted

--- a/tests/confidence-config.test.ts
+++ b/tests/confidence-config.test.ts
@@ -121,6 +121,52 @@ describe("confidence calibration config", () => {
   });
 });
 
+describe("review gate config", () => {
+  it("defaults review gate to the built-in inline comment cap without confidence floors", () => {
+    const config = loadConfigFromObject({});
+
+    expect(config.reviewGate).toMatchObject({ maxInlineComments: 25 });
+    expect(config.reviewGate?.requestChangesConfidenceFloors).toBeUndefined();
+  });
+
+  it("accepts an explicit inline comment cap and per-severity confidence floors", () => {
+    const config = loadConfigFromObject({
+      reviewGate: {
+        maxInlineComments: 10,
+        requestChangesConfidenceFloors: { P0: 0.8, P1: 0.6 }
+      }
+    });
+
+    expect(config.reviewGate).toMatchObject({
+      maxInlineComments: 10,
+      requestChangesConfidenceFloors: { P0: 0.8, P1: 0.6 }
+    });
+  });
+
+  it("rejects a non-positive-integer inline comment cap", () => {
+    expect(() => loadConfigFromObject({ reviewGate: { maxInlineComments: 0 } })).toThrow(
+      /reviewGate\.maxInlineComments must be a positive integer/
+    );
+    expect(() => loadConfigFromObject({ reviewGate: { maxInlineComments: 2.5 } })).toThrow(
+      /reviewGate\.maxInlineComments must be a positive integer/
+    );
+  });
+
+  it("rejects out-of-range or non-number confidence floors", () => {
+    expect(() =>
+      loadConfigFromObject({ reviewGate: { requestChangesConfidenceFloors: { P0: -0.1 } } })
+    ).toThrow(/reviewGate\.requestChangesConfidenceFloors\.P0 must be a number from 0 to 1/);
+    expect(() =>
+      loadConfigFromObject({ reviewGate: { requestChangesConfidenceFloors: { P1: 1.5 } } })
+    ).toThrow(/reviewGate\.requestChangesConfidenceFloors\.P1 must be a number from 0 to 1/);
+    expect(() =>
+      loadConfigFromObject({
+        reviewGate: { requestChangesConfidenceFloors: { P0: "high" as unknown as number } }
+      })
+    ).toThrow(/reviewGate\.requestChangesConfidenceFloors\.P0 must be a number from 0 to 1/);
+  });
+});
+
 function calibratedPublicDisplay() {
   return {
     mode: "calibrated" as const,

--- a/tests/confidence-config.test.ts
+++ b/tests/confidence-config.test.ts
@@ -152,6 +152,15 @@ describe("review gate config", () => {
     );
   });
 
+  it("rejects unknown keys in the confidence floors map", () => {
+    expect(() =>
+      loadConfigFromObject({ reviewGate: { requestChangesConfidenceFloors: { p0: 0.8 } } })
+    ).toThrow(/reviewGate\.requestChangesConfidenceFloors has unknown key "p0"; expected only P0 or P1/);
+    expect(() =>
+      loadConfigFromObject({ reviewGate: { requestChangesConfidenceFloors: { P2: 0.5 } } })
+    ).toThrow(/reviewGate\.requestChangesConfidenceFloors has unknown key "P2"; expected only P0 or P1/);
+  });
+
   it("rejects out-of-range or non-number confidence floors", () => {
     expect(() =>
       loadConfigFromObject({ reviewGate: { requestChangesConfidenceFloors: { P0: -0.1 } } })

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -4,6 +4,85 @@ import type { PublicConfidenceDisplayPolicy } from "../src/public-confidence.js"
 import type { Finding } from "../src/types.js";
 
 describe("finding normalization and review policy", () => {
+  it("orders same-severity findings by confidence and caps the lowest-confidence first", () => {
+    const findings: Finding[] = [
+      {
+        severity: "P2",
+        category: "runtime_correctness",
+        path: "a.ts",
+        line: 1,
+        title: "Low confidence concern",
+        body: "A concrete review comment.",
+        confidence: 0.1
+      },
+      {
+        severity: "P2",
+        category: "runtime_correctness",
+        path: "a.ts",
+        line: 1,
+        title: "High confidence concern",
+        body: "A concrete review comment.",
+        confidence: 0.99
+      }
+    ];
+
+    const result = normalizeFindingsForReview(findings, { maxInlineComments: 1 });
+
+    expect(result.comments).toHaveLength(1);
+    expect(result.comments[0]?.title).toBe("High confidence concern");
+    expect(result.comments[0]?.confidence).toBe(0.99);
+    expect(result.dropped).toEqual([
+      expect.objectContaining({ title: "Low confidence concern", reason: "comment_cap_exceeded" })
+    ]);
+  });
+
+  it("keeps cross-severity ordering independent of confidence", () => {
+    const findings: Finding[] = [
+      {
+        severity: "P2",
+        category: "runtime_correctness",
+        path: "a.ts",
+        line: 1,
+        title: "High confidence low severity",
+        body: "A concrete review comment.",
+        confidence: 0.99
+      },
+      {
+        severity: "P1",
+        category: "runtime_correctness",
+        path: "a.ts",
+        line: 1,
+        title: "Low confidence high severity",
+        body: "A concrete review comment.",
+        confidence: 0.1
+      }
+    ];
+
+    const result = normalizeFindingsForReview(findings);
+
+    expect(result.comments[0]?.severity).toBe("P1");
+    expect(result.comments[0]?.title).toBe("Low confidence high severity");
+    expect(result.comments[1]?.severity).toBe("P2");
+  });
+
+  it("carries confidence metadata on review comments without rendering it in the body or title", () => {
+    const result = normalizeFindingsForReview([
+      {
+        severity: "P1",
+        category: "runtime_correctness",
+        path: "src/reviewer.ts",
+        line: 12,
+        title: "Regression concern",
+        body: "A concrete review comment.",
+        confidence: 0.73
+      }
+    ]);
+
+    expect(result.comments[0]?.confidence).toBe(0.73);
+    expect(result.comments[0]?.title).not.toContain("0.73");
+    expect(result.comments[0]?.body).not.toContain("0.73");
+  });
+
   it("keeps validated findings, caps aggressive inline comments, and sorts by severity", () => {
     const findings: Finding[] = Array.from({ length: 30 }, (_, index) => ({
       severity: index === 29 ? "P0" : index % 2 === 0 ? "P2" : "P3",
@@ -241,14 +320,14 @@ describe("finding normalization and review policy", () => {
   });
 
   it("requests changes only for P0 or P1 findings in eligible regression categories", () => {
-    expect(decideReviewEvent([{ severity: "P2", category: "data_loss" }, { severity: "P3", category: "auth" }])).toBe("COMMENT");
-    expect(decideReviewEvent([{ severity: "P1", category: "proof_gap" }])).toBe("COMMENT");
-    expect(decideReviewEvent([{ severity: "P1", category: "docs_only" }])).toBe("COMMENT");
-    expect(decideReviewEvent([{ severity: "P1", category: "flaky_test_risk" }])).toBe("REQUEST_CHANGES");
-    expect(decideReviewEvent([{ severity: "P1", category: "dependency" }])).toBe("REQUEST_CHANGES");
-    expect(decideReviewEvent([{ severity: "P1", category: "unknown" }])).toBe("REQUEST_CHANGES");
-    expect(decideReviewEvent([{ severity: "P1", category: "data_loss" }])).toBe("REQUEST_CHANGES");
-    expect(decideReviewEvent([{ severity: "P0", category: "security_boundary" }])).toBe("REQUEST_CHANGES");
+    expect(decideReviewEvent([{ severity: "P2", category: "data_loss", confidence: 0.9 }, { severity: "P3", category: "auth", confidence: 0.9 }])).toBe("COMMENT");
+    expect(decideReviewEvent([{ severity: "P1", category: "proof_gap", confidence: 0.9 }])).toBe("COMMENT");
+    expect(decideReviewEvent([{ severity: "P1", category: "docs_only", confidence: 0.9 }])).toBe("COMMENT");
+    expect(decideReviewEvent([{ severity: "P1", category: "flaky_test_risk", confidence: 0.9 }])).toBe("REQUEST_CHANGES");
+    expect(decideReviewEvent([{ severity: "P1", category: "dependency", confidence: 0.9 }])).toBe("REQUEST_CHANGES");
+    expect(decideReviewEvent([{ severity: "P1", category: "unknown", confidence: 0.9 }])).toBe("REQUEST_CHANGES");
+    expect(decideReviewEvent([{ severity: "P1", category: "data_loss", confidence: 0.9 }])).toBe("REQUEST_CHANGES");
+    expect(decideReviewEvent([{ severity: "P0", category: "security_boundary", confidence: 0.9 }])).toBe("REQUEST_CHANGES");
   });
 
   it("ignores unsupported optional model categories without dropping the finding", () => {

--- a/tests/outcome-ledger.test.ts
+++ b/tests/outcome-ledger.test.ts
@@ -557,6 +557,7 @@ function sampleReviewPlan(): ReviewPlan {
         body: "Runtime handoff can still lose provider state.",
         severity: "P1",
         category: "runtime_correctness",
+        confidence: 0.9,
         title: "Preserve provider state"
       }
     ],

--- a/tests/review-gate.test.ts
+++ b/tests/review-gate.test.ts
@@ -133,6 +133,73 @@ describe("deterministic review gate", () => {
     expect(gate.summary.categoryCounts).toEqual({ docs_only: 1, unknown: 1 });
   });
 
+  it("leaves REQUEST_CHANGES gating unchanged when no confidence floor is configured", () => {
+    const findings: Finding[] = [
+      {
+        severity: "P0",
+        category: "data_loss",
+        path: "src/save.ts",
+        line: 2,
+        title: "Rollback can clobber fresh state",
+        body: "The added call can overwrite newer data after a failed save.",
+        confidence: 0.2
+      }
+    ];
+
+    const gate = applyDeterministicReviewGate({ findings, files });
+
+    expect(gate.event).toBe("REQUEST_CHANGES");
+    expect(gate.summary.requestChangesEligible).toBe(1);
+  });
+
+  it("keeps a below-floor P0 finding as a comment without requesting changes", () => {
+    const findings: Finding[] = [
+      {
+        severity: "P0",
+        category: "data_loss",
+        path: "src/save.ts",
+        line: 2,
+        title: "Rollback can clobber fresh state",
+        body: "The added call can overwrite newer data after a failed save.",
+        confidence: 0.5
+      }
+    ];
+
+    const gate = applyDeterministicReviewGate({
+      findings,
+      files,
+      requestChangesConfidenceFloors: { P0: 0.8 }
+    });
+
+    expect(gate.event).toBe("COMMENT");
+    expect(gate.comments).toHaveLength(1);
+    expect(gate.comments[0]).toMatchObject({ severity: "P0", line: 2 });
+    expect(gate.summary.requestChangesEligible).toBe(0);
+  });
+
+  it("requests changes for an at-or-above-floor P0 finding", () => {
+    const findings: Finding[] = [
+      {
+        severity: "P0",
+        category: "data_loss",
+        path: "src/save.ts",
+        line: 2,
+        title: "Rollback can clobber fresh state",
+        body: "The added call can overwrite newer data after a failed save.",
+        confidence: 0.9
+      }
+    ];
+
+    const gate = applyDeterministicReviewGate({
+      findings,
+      files,
+      requestChangesConfidenceFloors: { P0: 0.8 }
+    });
+
+    expect(gate.event).toBe("REQUEST_CHANGES");
+    expect(gate.summary.requestChangesEligible).toBe(1);
+  });
+
   it("suppresses only low-severity findings with exact repo-memory false-positive fingerprints", () => {
     const lowSeverityFinding: Finding = {
       severity: "P3",

--- a/tests/review-gate.test.ts
+++ b/tests/review-gate.test.ts
@@ -200,6 +200,60 @@ describe("deterministic review gate", () => {
     expect(gate.summary.requestChangesEligible).toBe(1);
   });
 
+  it("requests changes for a P0 finding exactly at the floor (floor is inclusive)", () => {
+    const findings: Finding[] = [
+      {
+        severity: "P0",
+        category: "data_loss",
+        path: "src/save.ts",
+        line: 2,
+        title: "Rollback can clobber fresh state",
+        body: "The added call can overwrite newer data after a failed save.",
+        confidence: 0.8
+      }
+    ];
+
+    const gate = applyDeterministicReviewGate({
+      findings,
+      files,
+      requestChangesConfidenceFloors: { P0: 0.8 }
+    });
+
+    expect(gate.event).toBe("REQUEST_CHANGES");
+    expect(gate.summary.requestChangesEligible).toBe(1);
+  });
+
+  it("keeps a below-P1-floor finding as a comment and requests changes at or above it", () => {
+    const finding: Finding = {
+      severity: "P1",
+      category: "data_loss",
+      path: "src/save.ts",
+      line: 2,
+      title: "Rollback can clobber fresh state",
+      body: "The added call can overwrite newer data after a failed save.",
+      confidence: 0.5
+    };
+
+    const below = applyDeterministicReviewGate({
+      findings: [finding],
+      files,
+      requestChangesConfidenceFloors: { P1: 0.6 }
+    });
+
+    expect(below.event).toBe("COMMENT");
+    expect(below.comments).toHaveLength(1);
+    expect(below.summary.requestChangesEligible).toBe(0);
+
+    const atFloor = applyDeterministicReviewGate({
+      findings: [{ ...finding, confidence: 0.6 }],
+      files,
+      requestChangesConfidenceFloors: { P1: 0.6 }
+    });
+
+    expect(atFloor.event).toBe("REQUEST_CHANGES");
+    expect(atFloor.summary.requestChangesEligible).toBe(1);
+  });
+
   it("suppresses only low-severity findings with exact repo-memory false-positive fingerprints", () => {
     const lowSeverityFinding: Finding = {
       severity: "P3",

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -58,6 +58,7 @@ describe("walkthrough comment rendering", () => {
         side: "RIGHT",
         severity: "P1",
         category: "data_loss",
+        confidence: 0.9,
         title: "Rollback can overwrite fresh saves",
         body: "The rollback path can clobber newer save data."
       }
@@ -416,6 +417,7 @@ describe("walkthrough comment rendering", () => {
           side: "RIGHT",
           severity: "P3",
           category: "security_boundary",
+          confidence: 0.91,
           title: "Confidence: 95% should never be quoted",
           body: "The model says 0.91 reliability in raw finding prose."
         }
@@ -542,6 +544,7 @@ describe("walkthrough comment rendering", () => {
           side: "RIGHT",
           severity: "P2",
           category: "runtime_correctness",
+          confidence: 0.88,
           title: "Model says 88% confidence",
           body: "Confidence: 88%. The model is 0.88 confident."
         }
@@ -590,6 +593,7 @@ describe("walkthrough comment rendering", () => {
           side: "RIGHT",
           severity: "P1",
           category: "runtime_correctness",
+          confidence: 0.91,
           title: "Regression with 99% confidence",
           body: "Model body says `0.91` likely."
         }


### PR DESCRIPTION
Closes #279. Parent: #278 (Phase 1, item 1).

## Summary
- Within each severity tier, findings now sort by `confidence` DESC (then path → line → title), so the inline-comment cap keeps the highest-confidence findings instead of alphabetical-by-path ties.
- `ReviewComment` carries `confidence` as internal gating/evidence metadata — never rendered into the public body/title (public-confidence display gate unchanged).
- New optional `config.reviewGate` section: `maxInlineComments` (default 25 — replaces the hardcoded literal at the sole gate call site) and `requestChangesConfidenceFloors` (`{P0?, P1?}`, **default off**). When a floor is set, a below-floor P0/P1 still posts as a comment but no longer forces REQUEST_CHANGES — the gate can only get quieter, never louder. Unset ⇒ byte-identical behavior.

## Validation
- Failing tests written first (red → green): confidence ordering + cap survival, floor gating (below-floor ⇒ COMMENT, above-floor ⇒ REQUEST_CHANGES), floor-unset identity, no confidence in rendered text, config validation (fail-closed on malformed cap/floors).
- Focused Vitest green: tests/findings.test.ts, tests/review-gate.test.ts (24 passed) + confidence-config/walkthrough/outcome-ledger/config-schema/config-cli.
- `npm run build` (tsc) clean.
- Additive/default-off: no changes to posting safety, stale-head checks, secret redaction, duplicate suppression, or public confidence display. Zero new model calls.

## Proof boundary
This PR changes finding ordering and adds an opt-in quieter-only gate floor. It does not claim calibrated confidence; display remains governed by the existing uncalibrated redaction policy.