### PR TITLE
[codex] Fix issue enrichment runtime health classification

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -181,6 +181,13 @@ Classify whether the bot is idle, healthy-active, or blocked:
 npx tsx src/cli.ts runtime-inventory --json --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
+`runtime-inventory` treats issue-enrichment runtime as a separate lane from PR
+review health. Failed issue-enrichment records remain blocking because an
+operator must inspect them before promotion. Deferred issue-enrichment records
+from normal per-repo or global throttles are advisory: they stay visible in the
+summary and recommended actions, but they do not make a clear PR-review runtime
+look blocked.
+
 Show the same runtime inventory as a short human summary:
 
 ```bash

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -450,8 +450,8 @@ export function buildOperatorStatus(input: {
           },
           {
             name: "issue_enrichment_runtime_no_retryable_deferred_records",
-            ok: issueEnrichmentRuntimeRetryableDeferred === 0,
-            detail: `${issueEnrichmentRuntimeRetryableDeferred} retryable deferred issue-enrichment record(s)`
+            ok: true,
+            detail: `${issueEnrichmentRuntimeRetryableDeferred} retryable deferred issue-enrichment record(s); advisory only`
           }
         ]
       : [])
@@ -646,8 +646,8 @@ export function buildRuntimeInventory(input: {
           },
           {
             name: "runtime_issue_enrichment_no_retryable_deferred_records",
-            ok: issueEnrichmentRuntimeRetryableDeferred === 0,
-            detail: `${issueEnrichmentRuntimeRetryableDeferred} retryable deferred issue-enrichment record(s)`
+            ok: true,
+            detail: `${issueEnrichmentRuntimeRetryableDeferred} retryable deferred issue-enrichment record(s); advisory only`
           }
         ]
       : [])
@@ -1002,7 +1002,8 @@ export function collectOperatorIssueEnrichmentRuntime(
         ? "deferred"
         : "idle";
     return {
-      ok: summary.failed === 0 && summary.retryableDeferred === 0,
+      // Deferrals are backlog signals for the separate issue-enrichment lane; only failures make this runtime unhealthy.
+      ok: summary.failed === 0,
       checkedAt,
       state,
       summary,

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -346,6 +346,112 @@ describe("operator CLI summaries", () => {
     expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
   });
 
+  it("keeps retryable issue enrichment deferrals advisory when PR runtime is clear", () => {
+    const statePath = createTempDatabase(tempDirs);
+    const db = new DatabaseSync(statePath);
+    try {
+      db.exec(`
+        create table issue_enrichment_records (
+          repo text not null,
+          issue_number integer not null,
+          issue_updated_at text,
+          status text not null,
+          reason text,
+          comment_url text,
+          error text,
+          next_eligible_at text,
+          created_at text not null,
+          updated_at text not null,
+          primary key (repo, issue_number)
+        )
+      `);
+      db
+        .prepare(
+          `insert into issue_enrichment_records
+            (repo, issue_number, issue_updated_at, status, reason, next_eligible_at, created_at, updated_at)
+           values (?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          "owner/issue-repo",
+          61,
+          "2026-07-03T03:30:00.000Z",
+          "deferred",
+          "repo_max_comments_per_cycle",
+          "2026-07-03T04:00:00.000Z",
+          "2026-07-03T03:35:00.000Z",
+          "2026-07-03T03:35:00.000Z"
+        );
+    } finally {
+      db.close();
+    }
+
+    const issueEnrichmentRuntime = collectOperatorIssueEnrichmentRuntime(statePath, {
+      now: new Date("2026-07-03T04:30:00.000Z")
+    });
+    const issueEnrichment = issueEnrichmentStatus({ state: "ready", ok: true });
+    const release = releaseStatus({ ok: true });
+    const agents = agentInventory({ ok: true });
+    const coverage = coverageReport({ ok: true });
+    const durableQueue = durableQueueSnapshot({ ok: true, summary: cleanDurableQueueSummary() });
+    const checkedAt = "2026-07-03T04:30:00.000Z";
+
+    expect(issueEnrichmentRuntime).toMatchObject({
+      ok: true,
+      state: "deferred",
+      summary: {
+        total: 1,
+        failed: 0,
+        deferred: 1,
+        retryableDeferred: 1
+      }
+    });
+
+    const status = buildOperatorStatus({
+      release,
+      coverage,
+      agents,
+      providerCooldowns: [],
+      durableQueue,
+      issueEnrichment,
+      issueEnrichmentRuntime,
+      checkedAt
+    });
+
+    expect(status.ok).toBe(true);
+    expect(status.summary.issueEnrichmentRuntimeState).toBe("deferred");
+    expect(status.failedGates).not.toContainEqual(
+      expect.objectContaining({ name: "issue_enrichment_runtime_no_retryable_deferred_records" })
+    );
+    expect(status.gates).toContainEqual({
+      name: "issue_enrichment_runtime_no_retryable_deferred_records",
+      ok: true,
+      detail: "1 retryable deferred issue-enrichment record(s); advisory only"
+    });
+    expect(status.recommendedActions).toContain("retry or inspect deferred issue-enrichment records");
+
+    const inventory = buildRuntimeInventory({
+      release,
+      coverage,
+      agents,
+      durableQueue,
+      providerCooldowns: [],
+      repoProviderCooldowns: [],
+      issueEnrichment,
+      issueEnrichmentRuntime,
+      checkedAt
+    });
+
+    expect(inventory.ok).toBe(true);
+    expect(inventory.runtimeState).toBe("healthy_idle");
+    expect(inventory.summary.issueEnrichmentRuntimeState).toBe("deferred");
+    expect(inventory.gates).toContainEqual({
+      name: "runtime_issue_enrichment_no_retryable_deferred_records",
+      ok: true,
+      detail: "1 retryable deferred issue-enrichment record(s); advisory only"
+    });
+    expect(inventory.recommendedActions).toContain("retry or inspect deferred issue-enrichment records");
+  });
+
   it("reports default-off issue enrichment runtime as disabled when there are no issue records", () => {
     const statePath = createTempDatabase(tempDirs);
     const issueEnrichmentRuntime = collectOperatorIssueEnrichmentRuntime(statePath, {


### PR DESCRIPTION
## Summary
- Treat retryable issue-enrichment deferrals as advisory operator signals instead of blocking PR runtime health.
- Keep failed issue-enrichment records as blocking gates.
- Add a regression test for the live shape where PR review is clear but issue enrichment has throttle-deferred rows.
- Document the issue-enrichment/PR-review health lane split.

Closes #288.

## Validation
- npx vitest run tests/operator-cli.test.ts --pool=forks --maxWorkers=1
- npm run build

## Runtime evidence
Observed before the fix: release-status and coverage-audit were green at main 818999e2197054155d315c76bf5481329008b4c3, but runtime-inventory was blocked solely because issueEnrichmentRuntimeState=deferred with 0 failed enrichment rows.

Evidence dir: /Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/post-277/