### PR TITLE
Guard Wilson confidence promotion math

### DIFF
--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -319,6 +319,12 @@ export const REQUIRED_SUITES: EvalSuiteName[] = [
   "duplicate_suppression"
 ];
 
+const CONFIDENCE_BINS = [
+  { minConfidence: 0, maxConfidence: 0.5 },
+  { minConfidence: 0.5, maxConfidence: 0.8 },
+  { minConfidence: 0.8, maxConfidence: 1.01 }
+] as const;
+
 const DEFAULT_STICKY_VS_COLD_THRESHOLDS: StickyVsColdThresholds = {
   maxFalsePositiveDelta: 0,
   maxFalseNegativeDelta: 0,
@@ -1234,38 +1240,42 @@ function buildCalibrationReport(
 }
 
 function confidenceBins(botFindings: NormalizedEvalFinding[], matches: EvalMatch[]): EvalCalibrationReport["bins"] {
+  return computeConfidenceBinStats(botFindings, matches).map((bin) => ({
+    minConfidence: bin.minConfidence,
+    maxConfidence: bin.maxConfidence,
+    findings: bin.findings,
+    matched: bin.matched,
+    empiricalPrecision: roundMetric(bin.empiricalPrecision),
+    wilsonLowerBound: roundMetric(bin.rawWilsonLowerBound),
+    publicLabel: "uncalibrated" as const
+  }));
+}
+
+function maxRawWilsonLowerBound(botFindings: NormalizedEvalFinding[], matches: EvalMatch[]): number {
+  return Math.max(0, ...computeConfidenceBinStats(botFindings, matches).map((bin) => bin.rawWilsonLowerBound));
+}
+
+function computeConfidenceBinStats(botFindings: NormalizedEvalFinding[], matches: EvalMatch[]): Array<{
+  minConfidence: number;
+  maxConfidence: number;
+  findings: number;
+  matched: number;
+  empiricalPrecision: number;
+  rawWilsonLowerBound: number;
+}> {
   const matchedBotIds = new Set(matches.map((match) => match.botFindingId));
-  return [
-    { minConfidence: 0, maxConfidence: 0.5 },
-    { minConfidence: 0.5, maxConfidence: 0.8 },
-    { minConfidence: 0.8, maxConfidence: 1.01 }
-  ].map((bin) => {
+  return CONFIDENCE_BINS.map((bin) => {
     const findings = botFindings.filter((finding) => finding.confidence >= bin.minConfidence && finding.confidence < bin.maxConfidence);
     const matched = findings.filter((finding) => matchedBotIds.has(finding.id)).length;
-    const wilsonLowerBound = wilsonLowerBound95(matched, findings.length);
     return {
       minConfidence: bin.minConfidence,
       maxConfidence: bin.maxConfidence === 1.01 ? 1 : bin.maxConfidence,
       findings: findings.length,
       matched,
-      empiricalPrecision: roundMetric(findings.length === 0 ? 0 : matched / findings.length),
-      wilsonLowerBound: roundMetric(wilsonLowerBound),
-      publicLabel: "uncalibrated" as const
+      empiricalPrecision: findings.length === 0 ? 0 : matched / findings.length,
+      rawWilsonLowerBound: wilsonLowerBound95(matched, findings.length)
     };
   });
-}
-
-function maxRawWilsonLowerBound(botFindings: NormalizedEvalFinding[], matches: EvalMatch[]): number {
-  const matchedBotIds = new Set(matches.map((match) => match.botFindingId));
-  return Math.max(0, ...[
-    { minConfidence: 0, maxConfidence: 0.5 },
-    { minConfidence: 0.5, maxConfidence: 0.8 },
-    { minConfidence: 0.8, maxConfidence: 1.01 }
-  ].map((bin) => {
-    const findings = botFindings.filter((finding) => finding.confidence >= bin.minConfidence && finding.confidence < bin.maxConfidence);
-    const matched = findings.filter((finding) => matchedBotIds.has(finding.id)).length;
-    return wilsonLowerBound95(matched, findings.length);
-  }));
 }
 
 export function buildEvalPromotionDecisionMarkdown(input: EvalSuitePromotionInput): string {
@@ -1321,12 +1331,16 @@ function choosePromotionReason(input: {
   if (input.labeledFindings < PUBLIC_CONFIDENCE_POLICY.minLabeledFindings) return "insufficient_labeled_findings";
   if (input.p0p1Labels < PUBLIC_CONFIDENCE_POLICY.minP0P1Labels) return "insufficient_p0_p1_labels";
   if (input.negativeControlScenarios < PUBLIC_CONFIDENCE_POLICY.minNegativeControlScenarios) return "insufficient_negative_controls";
-  if (input.bestWilsonLowerBound < PUBLIC_CONFIDENCE_POLICY.minWilsonLowerBound) return "wilson_lower_bound_below_threshold";
+  if (
+    !Number.isFinite(input.bestWilsonLowerBound) ||
+    input.bestWilsonLowerBound < PUBLIC_CONFIDENCE_POLICY.minWilsonLowerBound ||
+    input.bestWilsonLowerBound > 1
+  ) return "wilson_lower_bound_below_threshold";
   return "eligible";
 }
 
 function wilsonLowerBound95(successes: number, total: number): number {
-  if (total <= 0) return 0;
+  if (!Number.isFinite(successes) || !Number.isFinite(total) || total <= 0 || successes < 0 || successes > total) return 0;
   const z = 1.96;
   const p = successes / total;
   const denominator = 1 + z ** 2 / total;
@@ -1334,6 +1348,12 @@ function wilsonLowerBound95(successes: number, total: number): number {
   const margin = z * Math.sqrt((p * (1 - p) + z ** 2 / (4 * total)) / total);
   return Math.max(0, (centre - margin) / denominator);
 }
+
+export const __evalHarnessTestHooks = {
+  computeConfidenceBinStats,
+  maxRawWilsonLowerBound,
+  wilsonLowerBound95
+};
 
 function buildInlinePreviews(
   inputPreviews: EvalInlinePreviewInput[] | undefined,

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -4,10 +4,65 @@ import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { runOfflineEval, runStickyVsColdEval, type EvalScenarioInput, type StickyVsColdScenarioInput } from "../src/eval-harness.js";
+import {
+  __evalHarnessTestHooks,
+  buildEvalPromotionDecisionMarkdown,
+  runOfflineEval,
+  runStickyVsColdEval,
+  type EvalScenarioInput,
+  type EvalScorecard,
+  type StickyVsColdScenarioInput
+} from "../src/eval-harness.js";
 
 const nodeRequire = createRequire(import.meta.url);
 const tsxCli = nodeRequire.resolve("tsx/cli");
+
+function promotionScorecard(input: {
+  labels: number;
+  p0p1Labels: number;
+  maxWilsonLowerBound: number;
+}): EvalScorecard {
+  return {
+    evalName: "evaos-zcode-review-bot-comparison-v0.1",
+    runId: "promotion-scorecard",
+    suite: "canary_shadow",
+    repo: "electricsheephq/evaos-code-review-bot",
+    pullNumber: 282,
+    headSha: "abc123",
+    counts: {
+      botFindings: input.labels,
+      labels: input.labels,
+      truePositive: input.labels,
+      falsePositive: 0,
+      falseNegative: 0,
+      exactLineMatches: input.labels,
+      nearbyLineMatches: 0,
+      semanticMatches: 0,
+      droppedFromSchema: 0,
+      secretFindings: 0,
+      duplicateFindings: 0,
+      inlinePreviews: 0,
+      ciMetadata: 0,
+      mergedFixes: 0,
+      p0p1Labels: input.p0p1Labels
+    },
+    metrics: {
+      precision: 1,
+      recall: 1,
+      seededRecall: 1,
+      maxWilsonLowerBound: input.maxWilsonLowerBound
+    },
+    matchedLabelKeys: [],
+    thresholds: {
+      minPrecision: 0.8,
+      minRecall: 0.6,
+      minSeededRecall: 1,
+      maxSecretFindings: 0,
+      maxDuplicateFindings: 0
+    },
+    gates: []
+  };
+}
 
 describe("offline eval harness", () => {
   const roots: string[] = [];
@@ -731,6 +786,84 @@ describe("offline eval harness", () => {
     expect(result.scorecard.metrics.maxWilsonLowerBound).toBeGreaterThan(0.949);
     const calibration = JSON.parse(readFileSync(join(root, "calibration-report.json"), "utf8"));
     expect(calibration.bins[2].wilsonLowerBound).toBe(0.95);
+  });
+
+  it("fails closed instead of returning NaN for malformed Wilson success counts", () => {
+    expect(__evalHarnessTestHooks.wilsonLowerBound95(2, 1)).toBe(0);
+    expect(__evalHarnessTestHooks.wilsonLowerBound95(Number.POSITIVE_INFINITY, 10)).toBe(0);
+    expect(__evalHarnessTestHooks.wilsonLowerBound95(Number.NaN, 10)).toBe(0);
+  });
+
+  it("keeps raw promotion Wilson math aligned with confidence-bin stats", () => {
+    const botFindings = [
+      {
+        id: "bot-low",
+        source: "bot" as const,
+        severity: "P2" as const,
+        path: "src/a.ts",
+        line: 10,
+        title: "Low-confidence match",
+        body: "Low confidence bin should be counted.",
+        confidence: 0.25
+      },
+      {
+        id: "bot-mid",
+        source: "bot" as const,
+        severity: "P2" as const,
+        path: "src/b.ts",
+        line: 20,
+        title: "Mid-confidence miss",
+        body: "Mid confidence bin should be counted.",
+        confidence: 0.65
+      },
+      {
+        id: "bot-high",
+        source: "bot" as const,
+        severity: "P1" as const,
+        path: "src/c.ts",
+        line: 30,
+        title: "High-confidence match",
+        body: "High confidence bin should be counted.",
+        confidence: 0.95
+      }
+    ];
+    const matches = [
+      { botFindingId: "bot-low", labelId: "label-low", kind: "exact_line" as const },
+      { botFindingId: "bot-high", labelId: "label-high", kind: "semantic" as const }
+    ];
+    const stats = __evalHarnessTestHooks.computeConfidenceBinStats(botFindings, matches);
+    const maxFromBins = Math.max(0, ...stats.map((bin) => bin.rawWilsonLowerBound));
+
+    expect(__evalHarnessTestHooks.maxRawWilsonLowerBound(botFindings, matches)).toBe(maxFromBins);
+  });
+
+  it.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY]
+  ])("fails closed when promotion Wilson evidence is %s", (_name, maxWilsonLowerBound) => {
+    const scorecards = [
+      promotionScorecard({
+        labels: 100,
+        p0p1Labels: 30,
+        maxWilsonLowerBound
+      }),
+      ...Array.from({ length: 10 }, () => promotionScorecard({
+        labels: 0,
+        p0p1Labels: 0,
+        maxWilsonLowerBound: 0.99
+      }))
+    ];
+
+    const markdown = buildEvalPromotionDecisionMarkdown({
+      ok: true,
+      scenarioCount: scorecards.length,
+      missingSuites: [],
+      scorecards
+    });
+
+    expect(markdown).toContain("Decision: not enough evidence");
+    expect(markdown).toContain("Calibrated public confidence: disabled");
+    expect(markdown).toContain("- wilson_lower_bound_below_threshold");
   });
 
   it("writes suite-level summary and promotion decision artifacts for eval-suite", () => {


### PR DESCRIPTION
## Summary
- fail closed on non-finite or out-of-range Wilson lower bounds before promotion eligibility
- dedupe confidence-bin math behind shared stats used by both calibration display and raw promotion gating
- add regression coverage for malformed Wilson counts, non-finite promotion evidence, and raw/bin equivalence

Closes #282

## Validation
- npm test -- tests/eval-harness.test.ts --maxWorkers=1
- npm run build

## Notes
- Scope stayed in src/eval-harness.ts and tests/eval-harness.test.ts; no public-confidence files touched, so no overlap with #285.
