### PR TITLE
Asymmetric category precedence: model's validated category wins; inference escalates only

### DIFF
--- a/src/regression-taxonomy.ts
+++ b/src/regression-taxonomy.ts
@@ -72,9 +72,22 @@ export function isHighSeverity(severity: Severity): boolean {
 }
 
 export function normalizeFindingCategory(finding: Finding): RegressionCategory {
+  // Asymmetric precedence (#280): the model's validated category wins whenever it is present and
+  // != "unknown", with ONE exception — inference may override only when it ESCALATES across the
+  // REQUEST_CHANGES eligibility boundary (model category RC-ineligible, inferred category RC-eligible
+  // and != "unknown"). This is an escalate-only safety net: it never de-escalates a model category
+  // and never relabels within the same eligibility tier (the incidental-"token" bug #280 verified).
+  // Absent or "unknown" model category falls through to inference as before. The first-match-wins
+  // chain in inferRegressionCategory is a deliberate risk-priority arbiter (scoring was evaluated
+  // and dropped after it misclassified security findings on the overlapping needle substrate).
   const inferred = inferRegressionCategory(finding);
-  if (inferred !== "unknown") return inferred;
-  return finding.category ?? inferred;
+  if (finding.category && finding.category !== "unknown") {
+    const modelEligible = REGRESSION_CATEGORY_POLICY[finding.category].requestChangesEligible;
+    const inferredEligible = inferred !== "unknown" && REGRESSION_CATEGORY_POLICY[inferred].requestChangesEligible;
+    if (!modelEligible && inferredEligible) return inferred;
+    return finding.category;
+  }
+  return inferred;
 }
 
 export function countCategories(comments: Pick<ReviewComment, "category">[]): Partial<Record<RegressionCategory, number>> {

--- a/tests/regression-taxonomy.test.ts
+++ b/tests/regression-taxonomy.test.ts
@@ -39,18 +39,19 @@ describe("normalizeFindingCategory precedence (#280)", () => {
   });
 
   it("does not de-escalate: keeps an RC-eligible model category over a docs-only inference", () => {
-    // model data_loss (eligible) with docs-y path/text; inferred docs_only is INELIGIBLE, so the
-    // escalate-only override does not fire and the model category is preserved.
-    const result = normalizeFindingCategory(
-      full({
-        category: "data_loss",
-        path: "docs/runbook.md",
-        title: "Restore step overwrites live rows",
-        body: "The documented restore step can overwrite live customer rows."
-      })
-    );
+    // model data_loss (eligible) with docs-only path/text; inferred docs_only is INELIGIBLE, so the
+    // escalate-only override does not fire and the model category is preserved. The fixture text
+    // deliberately avoids every prose-category needle so inference genuinely resolves docs_only —
+    // asserted below so the fixture cannot rot back into a trivially-passing case.
+    const docsOnlyFinding = full({
+      category: "data_loss",
+      path: "docs/runbook.md",
+      title: "Runbook restore section is unclear",
+      body: "The runbook paragraph describing the restore workflow is confusing and needs a rewrite."
+    });
 
-    expect(result).toBe("data_loss");
+    expect(inferRegressionCategory(docsOnlyFinding)).toBe("docs_only");
+    expect(normalizeFindingCategory(docsOnlyFinding)).toBe("data_loss");
   });
 
   it("escalates across the eligibility boundary: RC-ineligible model, RC-eligible inference wins", () => {

--- a/tests/regression-taxonomy.test.ts
+++ b/tests/regression-taxonomy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { inferRegressionCategory } from "../src/regression-taxonomy.js";
+import { inferRegressionCategory, normalizeFindingCategory } from "../src/regression-taxonomy.js";
+import type { Finding } from "../src/types.js";
 
 describe("regression taxonomy", () => {
   it("keeps rollback notes in release-regression unless data/state loss is present", () => {
@@ -22,6 +23,86 @@ describe("regression taxonomy", () => {
   });
 });
 
+describe("normalizeFindingCategory precedence (#280)", () => {
+  it("keeps a validated model category even when incidental keywords would infer another", () => {
+    // Before #280 the inference chain ran first and 'token' reclassified this to auth.
+    const result = normalizeFindingCategory(
+      full({
+        category: "runtime_correctness",
+        path: "src/reviewer.ts",
+        title: "Stale token cache",
+        body: "The handler reuses a stale token and returns wrong output."
+      })
+    );
+
+    expect(result).toBe("runtime_correctness");
+  });
+
+  it("does not de-escalate: keeps an RC-eligible model category over a docs-only inference", () => {
+    // model data_loss (eligible) with docs-y path/text; inferred docs_only is INELIGIBLE, so the
+    // escalate-only override does not fire and the model category is preserved.
+    const result = normalizeFindingCategory(
+      full({
+        category: "data_loss",
+        path: "docs/runbook.md",
+        title: "Restore step overwrites live rows",
+        body: "The documented restore step can overwrite live customer rows."
+      })
+    );
+
+    expect(result).toBe("data_loss");
+  });
+
+  it("escalates across the eligibility boundary: RC-ineligible model, RC-eligible inference wins", () => {
+    // model docs_only (ineligible) but the body infers security_boundary (eligible) — the safety
+    // net escalates so a mislabeled security finding still blocks. Mirrors the main-test semantics.
+    const result = normalizeFindingCategory(
+      full({
+        category: "docs_only",
+        path: "docs/operator-cli.md",
+        title: "Leaked private key in rollback docs",
+        body: "The private key is pasted into the operator rollback instructions."
+      })
+    );
+
+    expect(result).toBe("security_boundary");
+  });
+
+  it("treats a model category of unknown as absent and falls back to inference", () => {
+    const result = normalizeFindingCategory(
+      full({
+        category: "unknown",
+        path: "src/auth.ts",
+        title: "Session token regression",
+        body: "The session token refresh returns stale credentials."
+      })
+    );
+
+    expect(result).toBe("auth");
+  });
+
+  it("falls back to inference when the model category is absent", () => {
+    const result = normalizeFindingCategory(
+      full({
+        path: "src/auth.ts",
+        title: "Session token regression",
+        body: "The session token refresh returns stale credentials."
+      })
+    );
+
+    expect(result).toBe("auth");
+  });
+});
+
 function finding(path: string, title: string, body: string) {
   return { path, title, body };
+}
+
+function full(overrides: Partial<Finding> & Pick<Finding, "path" | "title" | "body">): Finding {
+  return {
+    severity: "P1",
+    line: 1,
+    confidence: 0.8,
+    ...overrides
+  };
 }


### PR DESCRIPTION
Closes #280. Parent: #278 (Phase 1, item 2).

## Summary
`normalizeFindingCategory` previously let keyword inference override the model's schema-validated category unless inference returned `unknown` — so an incidental keyword silently relabeled findings (verified: a runtime-correctness finding mentioning "token" became `auth`), corrupting posted labels, REQUEST_CHANGES eligibility inputs, and future per-category calibration bins (#286).

**Shipped rule (refines the issue's original 'invert precedence'):** the model's validated category wins whenever present and ≠`unknown`, with one exception — inference may override only when it **escalates across the REQUEST_CHANGES-eligibility boundary** (model category RC-ineligible, inferred RC-eligible). Never de-escalates, never relabels within a tier. Absent/`unknown` model category falls through to inference exactly as before.

## Why not full inversion (design evolution, adversarially tested)
- Full inversion broke three existing tests that pin a **designed safety net**: a model under-classifying a leaked-key finding as `docs_only` gets escalated to `security_boundary` → REQUEST_CHANGES. Inverting would make the bot *quieter on security findings* — wrong direction.
- Two scored-fallback designs (path-weighted count, unweighted count) were each refuted by concrete security counterexamples on the overlapping-needle substrate (e.g. `src/auth.ts` path-bleed outvoting `security_boundary`). Scoring is dropped; `inferRegressionCategory`/`matchesAny` are byte-identical to main. Revisit only with #286 calibration data.
- The escalate-only rule enumerates the full present/absent × eligible/ineligible space: fixes the verified within-tier relabeling bug, preserves the escalation safety net, forbids de-escalation.

## Validation
- Diff scope: `git diff main -- src/regression-taxonomy.ts` touches ONLY `normalizeFindingCategory` (+ comment).
- All three pre-existing override-pin tests untouched and green; new unit pins: within-tier model-wins, no-de-escalation, upward escalation, unknown-as-absent, absent→inference.
- Focused Vitest 33/33 green (regression-taxonomy, findings, review-gate); `npm run build` clean.
- #287 confidence seams (floors, ReviewComment.confidence) untouched.