### PR TITLE
Same-run near-duplicate suppression in the live deterministic gate

### DIFF
--- a/src/findings.ts
+++ b/src/findings.ts
@@ -97,8 +97,17 @@ export function normalizeFindingsForReview(
     return a.line - b.line || a.title.localeCompare(b.title);
   });
 
-  const kept = accepted.slice(0, maxInlineComments);
-  for (const finding of accepted.slice(maxInlineComments)) {
+  // Same-run near-duplicate suppression (#281): collapse clusters where one model response flags
+  // the same root cause twice (adjacent lines / reworded title). Runs on the confidence-ranked
+  // order so the KEPT cluster member is the highest-ranked (post-#287, highest-confidence) one, and
+  // runs BEFORE the cap so a suppressed duplicate frees a slot for a distinct finding.
+  const deduped = suppressSameRunNearDuplicates(accepted);
+  for (const finding of deduped.dropped) {
+    dropped.push({ ...sanitizeDroppedFindingPublicText(finding, options.publicConfidencePolicy), reason: "same_run_near_duplicate" });
+  }
+
+  const kept = deduped.kept.slice(0, maxInlineComments);
+  for (const finding of deduped.kept.slice(maxInlineComments)) {
     dropped.push({ ...sanitizeDroppedFindingPublicText(finding, options.publicConfidencePolicy), reason: "comment_cap_exceeded" });
   }
 
@@ -128,6 +137,58 @@ export function normalizeFindingsForReview(
     }),
     dropped
   };
+}
+
+const SAME_RUN_DEDUP_MAX_LINE_DELTA = 3;
+const SAME_RUN_DEDUP_MIN_PREFIX_LENGTH = 12;
+
+/**
+ * Suppress same-run near-duplicate findings (#281): within one review response, collapse a cluster
+ * of findings that flag the same root cause. Two findings are near-duplicates when they share the
+ * same path AND the same normalized category (normalizeFindingCategory) AND their line numbers are
+ * within {@link SAME_RUN_DEDUP_MAX_LINE_DELTA} AND their normalized titles are exact-or-prefix
+ * similar. Conservative by design (no fuzzy edit-distance): a missed duplicate is cheaper than a
+ * suppressed distinct finding. The input order is authoritative — the FIRST member of a cluster is
+ * kept and later members are dropped, so callers should pass findings pre-sorted by rank.
+ */
+export function suppressSameRunNearDuplicates(findings: Finding[]): { kept: Finding[]; dropped: Finding[] } {
+  const kept: Array<{ finding: Finding; category: string; normalizedTitle: string }> = [];
+  const dropped: Finding[] = [];
+
+  for (const finding of findings) {
+    const category = normalizeFindingCategory(finding);
+    const normalizedTitle = normalizeTitleForDedup(finding.title);
+    const isDuplicate = kept.some(
+      (entry) =>
+        entry.finding.path === finding.path &&
+        entry.category === category &&
+        Math.abs(entry.finding.line - finding.line) <= SAME_RUN_DEDUP_MAX_LINE_DELTA &&
+        titlesAreNearDuplicate(entry.normalizedTitle, normalizedTitle)
+    );
+    if (isDuplicate) {
+      dropped.push(finding);
+      continue;
+    }
+    kept.push({ finding, category, normalizedTitle });
+  }
+
+  return { kept: kept.map((entry) => entry.finding), dropped };
+}
+
+function normalizeTitleForDedup(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function titlesAreNearDuplicate(a: string, b: string): boolean {
+  if (a === b) return a.length > 0;
+  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
+  // Prefix match must span a meaningful anchor so short generic titles don't collapse distinct
+  // findings; require the shared prefix (the shorter title) to be at least the min length.
+  return shorter.length >= SAME_RUN_DEDUP_MIN_PREFIX_LENGTH && longer.startsWith(shorter);
 }
 
 function redactFinding<T extends Finding>(finding: T): T {

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -490,9 +490,12 @@ describe("same-run near-duplicate suppression (#281)", () => {
     const result = normalizeFindingsForReview(findings);
 
     // A duplicate whose body contains a secret is dropped by the secret filter first (never reaches
-    // dedup), so the surviving finding posts and the dropped entry stays redacted and public-safe.
+    // dedup). Asserting the explicit secret_detected reason makes that ordering invariant loud: if
+    // the pipeline were ever reordered so dedup ran first, the reason would flip to
+    // same_run_near_duplicate and this test would fail instead of silently passing.
     expect(result.comments).toHaveLength(1);
     expect(result.comments[0]?.title).toBe("Rollback clobbers fresh state");
+    expect(result.dropped).toEqual([expect.objectContaining({ line: 43, reason: "secret_detected" })]);
     expect(JSON.stringify(result.dropped)).not.toContain(token);
   });
 });

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { decideReviewEvent, formatReviewComment, normalizeFindingsForReview, parseFindings } from "../src/findings.js";
+import { decideReviewEvent, formatReviewComment, normalizeFindingsForReview, parseFindings, suppressSameRunNearDuplicates } from "../src/findings.js";
 import type { PublicConfidenceDisplayPolicy } from "../src/public-confidence.js";
 import type { Finding } from "../src/types.js";
 
@@ -377,5 +377,122 @@ describe("finding normalization and review policy", () => {
       category: "security_boundary"
     });
     expect(decideReviewEvent(result.comments)).toBe("REQUEST_CHANGES");
+  });
+});
+
+describe("same-run near-duplicate suppression (#281)", () => {
+  function base(overrides: Partial<Finding> & Pick<Finding, "path" | "line" | "title">): Finding {
+    return {
+      severity: "P1",
+      category: "runtime_correctness",
+      body: "A concrete review comment.",
+      confidence: 0.8,
+      ...overrides
+    };
+  }
+
+  it("drops a near-duplicate on an adjacent line and keeps the higher-confidence member", () => {
+    const findings: Finding[] = [
+      base({ path: "src/save.ts", line: 42, title: "Rollback clobbers fresh state", confidence: 0.95 }),
+      base({ path: "src/save.ts", line: 44, title: "rollback clobbers fresh state!", confidence: 0.6 })
+    ];
+
+    const kept = suppressSameRunNearDuplicates(findings);
+
+    expect(kept.kept).toHaveLength(1);
+    expect(kept.kept[0]?.confidence).toBe(0.95);
+    // The pure helper returns the raw dropped finding; the caller attaches the reason (see the
+    // cap-interaction test for the reason on the normalizeFindingsForReview dropped[] output).
+    expect(kept.dropped).toEqual([expect.objectContaining({ line: 44, confidence: 0.6 })]);
+  });
+
+  it("keeps both when the line delta exceeds the window", () => {
+    const findings: Finding[] = [
+      base({ path: "src/save.ts", line: 10, title: "Rollback clobbers fresh state" }),
+      base({ path: "src/save.ts", line: 40, title: "Rollback clobbers fresh state" })
+    ];
+
+    const kept = suppressSameRunNearDuplicates(findings);
+
+    expect(kept.kept).toHaveLength(2);
+    expect(kept.dropped).toEqual([]);
+  });
+
+  it("keeps both when categories differ on adjacent lines", () => {
+    const findings: Finding[] = [
+      base({ path: "src/save.ts", line: 42, title: "Rollback clobbers fresh state", category: "runtime_correctness" }),
+      base({ path: "src/save.ts", line: 43, title: "Rollback clobbers fresh state", category: "data_loss" })
+    ];
+
+    const kept = suppressSameRunNearDuplicates(findings);
+
+    expect(kept.kept).toHaveLength(2);
+    expect(kept.dropped).toEqual([]);
+  });
+
+  it("keeps both when the same title appears on different paths", () => {
+    const findings: Finding[] = [
+      base({ path: "src/save.ts", line: 42, title: "Rollback clobbers fresh state" }),
+      base({ path: "src/load.ts", line: 42, title: "Rollback clobbers fresh state" })
+    ];
+
+    const kept = suppressSameRunNearDuplicates(findings);
+
+    expect(kept.kept).toHaveLength(2);
+    expect(kept.dropped).toEqual([]);
+  });
+
+  it("treats a normalized-title prefix as a duplicate but not a short prefix under 12 chars", () => {
+    const prefixDup: Finding[] = [
+      base({ path: "src/save.ts", line: 42, title: "Race in save path" }),
+      base({ path: "src/save.ts", line: 43, title: "Race in save path corrupts state on retry" })
+    ];
+    const shortPrefix: Finding[] = [
+      base({ path: "src/save.ts", line: 42, title: "Bad flag" }),
+      base({ path: "src/save.ts", line: 43, title: "Bad flag breaks retry accounting entirely" })
+    ];
+
+    expect(suppressSameRunNearDuplicates(prefixDup).kept).toHaveLength(1);
+    expect(suppressSameRunNearDuplicates(shortPrefix).kept).toHaveLength(2);
+  });
+
+  it("runs before the cap so a freed slot lets the distinct pair post (cap interaction)", () => {
+    const findings: Finding[] = [
+      base({ path: "src/save.ts", line: 42, title: "Rollback clobbers fresh state", confidence: 0.95 }),
+      base({ path: "src/save.ts", line: 43, title: "rollback clobbers fresh state", confidence: 0.6 }),
+      base({ path: "src/load.ts", line: 5, title: "Distinct unrelated concern", confidence: 0.9 })
+    ];
+
+    const result = normalizeFindingsForReview(findings, { maxInlineComments: 2 });
+
+    expect(result.comments).toHaveLength(2);
+    const titles = result.comments.map((comment) => comment.title);
+    expect(titles).toContain("Rollback clobbers fresh state");
+    expect(titles).toContain("Distinct unrelated concern");
+    expect(result.dropped).toEqual([
+      expect.objectContaining({ line: 43, reason: "same_run_near_duplicate" })
+    ]);
+  });
+
+  it("redacts a secret-containing dropped duplicate that reaches dropped[]", () => {
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+    const findings: Finding[] = [
+      base({ path: "src/save.ts", line: 42, title: "Rollback clobbers fresh state", confidence: 0.95 }),
+      base({
+        path: "src/save.ts",
+        line: 43,
+        title: "Rollback clobbers fresh state",
+        body: `Duplicate concern; raw token ${token} leaked here.`,
+        confidence: 0.6
+      })
+    ];
+
+    const result = normalizeFindingsForReview(findings);
+
+    // A duplicate whose body contains a secret is dropped by the secret filter first (never reaches
+    // dedup), so the surviving finding posts and the dropped entry stays redacted and public-safe.
+    expect(result.comments).toHaveLength(1);
+    expect(result.comments[0]?.title).toBe("Rollback clobbers fresh state");
+    expect(JSON.stringify(result.dropped)).not.toContain(token);
   });
 });


### PR DESCRIPTION
Closes #281. Parent: #278 (Phase 1, item 3 — completes Phase 1).

## Summary
One model response flagging the same root cause twice (adjacent lines or a reworded title) previously posted two inline comments — duplicate-suppression existed only against *historical* repo-memory fingerprints and in the offline eval harness. This ports a conservative same-run check into the live gate.

- New pure helper `suppressSameRunNearDuplicates` in `normalizeFindingsForReview`: runs after the secret-drop filter and the confidence-ranked sort, **before** the cap slice — so the kept cluster member is the highest-confidence one (#287) and a suppressed duplicate frees a cap slot for a distinct finding.
- Duplicate criterion (precision over recall, no fuzzy edit-distance): same path AND same normalized category (post-#293 asymmetric precedence) AND |line delta| ≤ 3 AND normalized-title exact-or-prefix match (min 12-char anchor).
- Dropped members carry reason `same_run_near_duplicate` through the existing sanitization path; `dropReasonCounts` picks it up automatically. Always-on. Eval-harness copy deliberately untouched (independent conservatism).

## Validation
- Failing tests first (red→green): adjacent-line dedup keeping the higher-confidence member; window/category/path negative cases; prefix similarity incl. sub-12-char non-match; cap interaction (dedup frees a slot); secret-containing duplicate arrives redacted.
- Focused Vitest 33/33 green (findings, review-gate); `npm run build` clean.
- Additive: no changes to posting safety, stale-head, repo-memory suppression, redaction, or public-confidence display. #287/#293 seams intact.