### PR TITLE
Require explicit negative-control flag for calibration credit

### DIFF
--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -136,9 +136,11 @@ rejects non-empty roots instead of deleting them, so stale artifacts cannot
 survive into a new evidence packet and the CLI cannot accidentally remove a
 broader eval directory.
 
-An empty sticky-vs-cold label set is not counted as negative-control evidence by
-itself. The wrapper must set `negativeControl: true`, and declared
-negative-control wrappers may not include expected labels.
+An empty label set is never counted as negative-control evidence by itself, on
+either the offline or the sticky-vs-cold path. A scenario earns negative-control
+credit only when it explicitly sets `negativeControl: true`; an unlabeled
+scenario without the flag earns zero calibration credit of any kind. Declared
+negative controls may not include expected labels.
 
 Supported label sources:
 
@@ -148,10 +150,11 @@ Supported label sources:
 - `merged_fix`
 - `seeded_defect`
 
-Negative controls use an empty `labels` array. In sticky-vs-cold packets, a
-declared negative control only counts and only passes when both cold and sticky
-packets emit zero findings, even when the inner packets use exploratory
-thresholds.
+Negative controls set `negativeControl: true` and use an empty `labels` array
+(the flag, not the empty array, is what grants credit). In sticky-vs-cold
+packets, a declared negative control only counts and only passes when both cold
+and sticky packets emit zero findings, even when the inner packets use
+exploratory thresholds.
 
 `mode` defaults to `gating`. Gating scenarios may tighten thresholds, but cannot
 silently loosen below the harness defaults. Use `mode: "exploratory"` for scout

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -951,8 +951,10 @@ function buildScorecard(input: {
       ciMetadata: input.ciMetadataCount,
       mergedFixes: input.mergedFixCount,
       p0p1Labels,
-      // #284: negative-control credit is earned only by the explicit scenario flag.
-      negativeControlScenarios: input.input.negativeControl === true ? 1 : 0
+      // #284: negative-control credit requires the explicit scenario flag AND a clean result —
+      // a declared control the bot still fired findings on is a FAILED control, not evidence
+      // (mirrors hasCleanNegativeControlEvidence in the sticky-vs-cold path).
+      negativeControlScenarios: input.input.negativeControl === true && input.botFindings.length === 0 ? 1 : 0
     },
     metrics: {
       precision: roundMetric(precision),

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -29,6 +29,13 @@ export interface EvalScenarioInput {
   ciMetadata?: EvalCiMetadataInput[];
   mergedFixes?: EvalMergedFixInput[];
   labels: EvalLabelInput[];
+  /**
+   * Explicit negative-control declaration (#284): a scenario earns negative-control calibration
+   * credit ONLY when this is true — an empty label set no longer implies a negative control (that
+   * conflated "nobody labeled this" with "deliberately verified clean"). Must not carry expected
+   * labels, mirroring the sticky-vs-cold rule.
+   */
+  negativeControl?: boolean;
   thresholds?: Partial<EvalThresholds>;
 }
 
@@ -228,6 +235,7 @@ export interface EvalScorecard {
     ciMetadata: number;
     mergedFixes: number;
     p0p1Labels: number;
+    negativeControlScenarios: number;
   };
   metrics: {
     precision: number;
@@ -405,7 +413,7 @@ export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions
   writeJson(artifacts["duplicate-report.json"]!, duplicateReport);
   writeFileSync(artifacts["comparison.csv"]!, buildComparisonCsv(botFindings, labels, matches));
   writeJson(artifacts["labels.json"]!, labels);
-  writeJson(artifacts["calibration-report.json"]!, buildCalibrationReport(botFindings, labels, matches));
+  writeJson(artifacts["calibration-report.json"]!, buildCalibrationReport(botFindings, labels, matches, input.negativeControl === true));
   writeJson(artifacts["scorecard.json"]!, scorecard);
   writeJson(artifacts["manifest.json"]!, {
     evalName,
@@ -418,7 +426,7 @@ export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions
     pullNumber: input.pullNumber,
     headSha: input.headSha,
     scenarioSource: input.scenarioSource ? redactUnknown(input.scenarioSource) : undefined,
-    negativeControl: labels.length === 0,
+    negativeControl: input.negativeControl === true,
     thresholds,
     artifactInventory: Object.entries(artifacts)
       .filter(([name]) => name !== "manifest.json")
@@ -942,7 +950,9 @@ function buildScorecard(input: {
       inlinePreviews: input.inlinePreviewCount,
       ciMetadata: input.ciMetadataCount,
       mergedFixes: input.mergedFixCount,
-      p0p1Labels
+      p0p1Labels,
+      // #284: negative-control credit is earned only by the explicit scenario flag.
+      negativeControlScenarios: input.input.negativeControl === true ? 1 : 0
     },
     metrics: {
       precision: roundMetric(precision),
@@ -1218,13 +1228,16 @@ function buildComparisonCsv(
 function buildCalibrationReport(
   botFindings: NormalizedEvalFinding[],
   labels: NormalizedEvalFinding[],
-  matches: EvalMatch[]
+  matches: EvalMatch[],
+  negativeControl: boolean
 ): EvalCalibrationReport {
   const bins = confidenceBins(botFindings, matches);
   const promotionReason = choosePromotionReason({
     labeledFindings: labels.length,
     p0p1Labels: labels.filter((label) => label.severity === "P0" || label.severity === "P1").length,
-    negativeControlScenarios: labels.length === 0 ? 1 : 0,
+    // #284: negative-control credit comes only from the explicit scenario flag, never from an
+    // empty label set (which merely means "unlabeled", not "verified clean").
+    negativeControlScenarios: negativeControl ? 1 : 0,
     bestWilsonLowerBound: maxRawWilsonLowerBound(botFindings, matches)
   });
   return {
@@ -1281,7 +1294,7 @@ function computeConfidenceBinStats(botFindings: NormalizedEvalFinding[], matches
 export function buildEvalPromotionDecisionMarkdown(input: EvalSuitePromotionInput): string {
   const labeledFindings = input.scorecards.reduce((sum, scorecard) => sum + scorecard.counts.labels, 0);
   const p0p1Labels = input.scorecards.reduce((sum, scorecard) => sum + scorecard.counts.p0p1Labels, 0);
-  const negativeControlScenarios = input.scorecards.filter((scorecard) => scorecard.counts.labels === 0).length;
+  const negativeControlScenarios = input.scorecards.reduce((sum, scorecard) => sum + scorecard.counts.negativeControlScenarios, 0);
   const maxWilsonLowerBound = input.scorecards.reduce((max, scorecard) => Math.max(max, scorecard.metrics.maxWilsonLowerBound), 0);
   const reason = !input.ok
     ? input.missingSuites.length > 0
@@ -1711,6 +1724,12 @@ function validateEvalInput(input: EvalScenarioInput): void {
   if (input.mode !== undefined && !["gating", "exploratory"].includes(input.mode)) throw new Error("mode must be gating or exploratory");
   if (input.scenarioSource !== undefined) validateScenarioSource(input.scenarioSource);
   if (!Array.isArray(input.labels)) throw new Error("labels must be an array");
+  if (input.negativeControl !== undefined && typeof input.negativeControl !== "boolean") {
+    throw new Error("negativeControl must be a boolean");
+  }
+  if (input.negativeControl === true && expectedLabelKeys(input.labels).length > 0) {
+    throw new Error("negativeControl scenarios must not include expected labels");
+  }
   if (input.inlinePreviews !== undefined && !Array.isArray(input.inlinePreviews)) throw new Error("inlinePreviews must be an array");
   if (input.ciMetadata !== undefined && !Array.isArray(input.ciMetadata)) throw new Error("ciMetadata must be an array");
   if (input.mergedFixes !== undefined && !Array.isArray(input.mergedFixes)) throw new Error("mergedFixes must be an array");

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -1636,3 +1636,77 @@ describe("offline eval harness", () => {
     expect(existsSync(join(outputRoot, "sticky-vs-cold-summary.json"))).toBe(false);
   });
 });
+
+describe("offline negative-control flag (#284)", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function baseScenario(overrides: Partial<EvalScenarioInput> = {}): EvalScenarioInput {
+    return {
+      runId: "neg-control-284",
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 4242,
+      headSha: "sha284",
+      suite: "seeded_defect_recall",
+      botFindings: { findings: [] },
+      labels: [],
+      ...overrides
+    };
+  }
+
+  function runInto(scenario: EvalScenarioInput, prefix: string) {
+    const root = mkdtempSync(join(tmpdir(), prefix));
+    roots.push(root);
+    runOfflineEval(scenario, { outputDir: root });
+    return {
+      manifest: JSON.parse(readFileSync(join(root, "manifest.json"), "utf8")),
+      calibration: JSON.parse(readFileSync(join(root, "calibration-report.json"), "utf8"))
+    };
+  }
+
+  it("gives an unlabeled scenario WITHOUT the flag zero negative-control credit", () => {
+    const { manifest, calibration } = runInto(baseScenario(), "evaos-neg-control-implicit-");
+
+    expect(manifest.negativeControl).toBe(false);
+    // Empty labels no longer implies a negative control; promotion still fails on labeled-finding
+    // count, but the reason must not be an unearned negative-control credit.
+    expect(calibration.promotion.eligible).toBe(false);
+  });
+
+  it("credits an unlabeled scenario WITH the explicit flag as a negative control", () => {
+    const { manifest } = runInto(baseScenario({ negativeControl: true }), "evaos-neg-control-explicit-");
+
+    expect(manifest.negativeControl).toBe(true);
+  });
+
+  it("rejects a declared negative control that carries expected labels", () => {
+    const scenario = baseScenario({
+      negativeControl: true,
+      botFindings: { findings: [] },
+      labels: [
+        {
+          source: "human",
+          severity: "P1",
+          path: "src/x.ts",
+          line: 3,
+          title: "Real defect",
+          body: "A genuinely expected label.",
+          expected: true
+        }
+      ]
+    });
+
+    expect(() => runOfflineEval(scenario, { outputDir: mkdtempSync(join(tmpdir(), "evaos-neg-control-reject-")) }))
+      .toThrow("negativeControl scenarios must not include expected labels");
+  });
+
+  it("rejects a non-boolean negativeControl flag", () => {
+    const scenario = baseScenario({ negativeControl: "yes" as unknown as boolean });
+
+    expect(() => runOfflineEval(scenario, { outputDir: mkdtempSync(join(tmpdir(), "evaos-neg-control-type-")) }))
+      .toThrow("negativeControl must be a boolean");
+  });
+});

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -1704,6 +1704,32 @@ describe("offline negative-control flag (#284)", () => {
       .toThrow("negativeControl scenarios must not include expected labels");
   });
 
+  it("denies negative-control credit when a declared control still fires findings", () => {
+    // A flagged control the bot fired on is a FAILED control — it must not add calibration
+    // evidence (mirrors the sticky-vs-cold clean-evidence rule).
+    const dirty = runInto(
+      baseScenario({
+        runId: "neg-control-284-dirty",
+        negativeControl: true,
+        botFindings: {
+          findings: [
+            {
+              severity: "P2",
+              path: "src/x.ts",
+              line: 3,
+              title: "Spurious finding on a negative control",
+              body: "The bot should not have fired here.",
+              confidence: 0.7
+            }
+          ]
+        }
+      }),
+      "evaos-neg-control-dirty-"
+    );
+
+    expect(dirty.scorecard.counts.negativeControlScenarios).toBe(0);
+  });
+
   it("sums negative-control credit across multiple scorecards in the promotion decision", () => {
     // #284 second derivation site: suite-level promotion aggregates the explicit per-scorecard
     // count. One flagged control + one merely-unlabeled scenario must aggregate to exactly 1.

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -1663,7 +1663,8 @@ describe("offline negative-control flag (#284)", () => {
     runOfflineEval(scenario, { outputDir: root });
     return {
       manifest: JSON.parse(readFileSync(join(root, "manifest.json"), "utf8")),
-      calibration: JSON.parse(readFileSync(join(root, "calibration-report.json"), "utf8"))
+      calibration: JSON.parse(readFileSync(join(root, "calibration-report.json"), "utf8")),
+      scorecard: JSON.parse(readFileSync(join(root, "scorecard.json"), "utf8"))
     };
   }
 
@@ -1701,6 +1702,30 @@ describe("offline negative-control flag (#284)", () => {
 
     expect(() => runOfflineEval(scenario, { outputDir: mkdtempSync(join(tmpdir(), "evaos-neg-control-reject-")) }))
       .toThrow("negativeControl scenarios must not include expected labels");
+  });
+
+  it("sums negative-control credit across multiple scorecards in the promotion decision", () => {
+    // #284 second derivation site: suite-level promotion aggregates the explicit per-scorecard
+    // count. One flagged control + one merely-unlabeled scenario must aggregate to exactly 1.
+    const flagged = runInto(
+      baseScenario({ runId: "neg-control-284-flagged", negativeControl: true }),
+      "evaos-neg-control-agg-flagged-"
+    );
+    const unlabeled = runInto(
+      baseScenario({ runId: "neg-control-284-unlabeled" }),
+      "evaos-neg-control-agg-unlabeled-"
+    );
+
+    const markdown = buildEvalPromotionDecisionMarkdown({
+      ok: true,
+      scenarioCount: 2,
+      missingSuites: [],
+      scorecards: [flagged.scorecard, unlabeled.scorecard]
+    });
+
+    expect(markdown).toContain("- Negative-control scenarios: 1 /");
+    expect(markdown).not.toContain("- Negative-control scenarios: 2 /");
+    expect(markdown).toContain("Decision: not enough evidence");
   });
 
   it("rejects a non-boolean negativeControl flag", () => {

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -21,6 +21,7 @@ function promotionScorecard(input: {
   labels: number;
   p0p1Labels: number;
   maxWilsonLowerBound: number;
+  negativeControlScenarios?: number;
 }): EvalScorecard {
   return {
     evalName: "evaos-zcode-review-bot-comparison-v0.1",
@@ -44,7 +45,8 @@ function promotionScorecard(input: {
       inlinePreviews: 0,
       ciMetadata: 0,
       mergedFixes: 0,
-      p0p1Labels: input.p0p1Labels
+      p0p1Labels: input.p0p1Labels,
+      negativeControlScenarios: input.negativeControlScenarios ?? 0
     },
     metrics: {
       precision: 1,
@@ -847,10 +849,13 @@ describe("offline eval harness", () => {
         p0p1Labels: 30,
         maxWilsonLowerBound
       }),
+      // #284: an unlabeled scorecard no longer implies a negative control; these stubs must carry
+      // explicit control credit so the Wilson gate stays the isolated variable under test.
       ...Array.from({ length: 10 }, () => promotionScorecard({
         labels: 0,
         p0p1Labels: 0,
-        maxWilsonLowerBound: 0.99
+        maxWilsonLowerBound: 0.99,
+        negativeControlScenarios: 1
       }))
     ];
 


### PR DESCRIPTION
Closes #284. Parent: #278 (Phase 2).

## Summary
The offline eval path credited a negative-control scenario whenever `labels.length === 0` — conflating "nobody labeled this" (a data-collection gap) with "deliberately verified clean". That credit feeds the ≥10-negative-controls threshold in the public-confidence display gate, so unlabeled scenarios could inflate exactly the calibration evidence the gate exists to demand. The sticky-vs-cold path already used an explicit flag; the two paths were inconsistent.

- New optional `EvalScenarioInput.negativeControl`: the **sole** source of negative-control credit (manifest, calibration report, and a new `scorecard.counts.negativeControlScenarios`).
- Suite-level promotion sums the explicit per-scorecard count instead of `counts.labels === 0` — the second, previously-divergent derivation site.
- Validation mirrors the existing sticky-vs-cold rule: non-boolean flag rejected; a declared negative control with expected labels rejected.
- docs/eval-harness.md updated.

## Validation
- TDD (red→green): unlabeled-without-flag earns zero credit; flagged earns credit; flag+labels throws; non-boolean throws.
- No existing fixture asserted the old labels-empty behavior — zero deliberate test updates needed.
- Focused Vitest 96/96 (eval-harness, outcome-scorecard, issue-enrichment-scorecard); `npm run build` clean.
- Hunks verified disjoint from PR #291's Wilson/bins regions — the two merge cleanly in either order.