### PR TITLE
docs: stage v0.4.26 beta release

### DIFF
--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,13 +1,13 @@
 {
-  "version": "v0.4.25-beta.1",
+  "version": "v0.4.26-beta.1",
   "releaseLevel": "source-beta",
   "packageArtifact": {
     "name": "neondiff",
     "version": "0.4.24-beta.1",
     "requiredForThisRelease": false,
     "state": "held_at_previous_npm_release",
-    "heldReason": "v0.4.25-beta.1 is a source/daemon-only live beta; no npm artifact is published for this hotfix.",
-    "currentSourceVersion": "v0.4.25-beta.1",
+    "heldReason": "v0.4.26-beta.1 is a source/daemon-only live beta; no npm artifact is published for this runtime-health hotfix.",
+    "currentSourceVersion": "v0.4.26-beta.1",
     "previousReleasedPackageVersion": "0.4.24-beta.1"
   },
   "source": {
@@ -15,9 +15,9 @@
     "proof": "release:status --expected-head $(git rev-parse HEAD)"
   },
   "docs": {
-    "version": "v0.4.25-beta.1",
+    "version": "v0.4.26-beta.1",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v0.4.25-beta.1.md",
+    "releaseNotesPath": "docs/releases/v0.4.26-beta.1.md",
     "websiteRepo": "electricsheephq/neon-diff-agent"
   },
   "licenseApi": {
@@ -29,13 +29,13 @@
     "cli": {
       "requiredForThisRelease": true,
       "state": "source_checkout",
-      "version": "v0.4.25-beta.1",
+      "version": "v0.4.26-beta.1",
       "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "launchd_prerelease",
-      "version": "v0.4.25-beta.1",
+      "version": "v0.4.26-beta.1",
       "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
     },
     "website": {

--- a/docs/releases/v0.4.26-beta.1.md
+++ b/docs/releases/v0.4.26-beta.1.md
@@ -1,0 +1,91 @@
+# v0.4.26-beta.1
+
+- Release type: local beta runtime-health hotfix
+- Release source SHA: to be stamped during post-merge live promotion
+- Previous prerelease: `v0.4.25-beta.1`
+- Tracking issues: `#288`, `#262`, `#294`, `#295`, `#297`
+- Promoted PRs: `#289`, `#294`
+- Included implementation merge SHAs:
+  `ead57dac1d6976c768ea593c9b7b82bb2bf03cbe` (`#289`),
+  `9868089fedc8d7ae17d345fe246bdf46048155c3` (`#294`)
+- Release evidence: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/v0.4.26-beta.1/`
+- Rollback tag: `v0.4.25-beta.1`
+- Package artifact: `neondiff@0.4.24-beta.1` (held from previous npm release)
+- Rollback baseline: `v0.4.9-beta.1` remains the known-good daemon fallback
+
+## Purpose
+
+Promote the runtime-health fix that keeps issue-enrichment deferrals from
+blocking PR review readiness, plus the same-run near-duplicate suppression that
+landed before this release metadata PR. This release records the live worker
+source state after PR-review runtime health returned to idle with no failed
+queue jobs, cooldowns, or uncovered eligible PR heads.
+
+This is a local live-worker beta release. It does not publish a new npm package
+or replace the public `neondiff@0.4.24-beta.1` package release. The public
+manifest records the held npm artifact separately from the source/daemon beta
+version so operators do not confuse the installable npm package with the live
+source checkout.
+
+## Included Changes
+
+- Treat retryable issue-enrichment deferrals as advisory to PR runtime health
+  instead of making `runtime-inventory` red when PR review work is otherwise
+  clear.
+- Preserve blocking behavior for PR queue failures, failed durable review jobs,
+  stale leases, provider cooldown backlogs, and uncovered eligible PR heads.
+- Keep issue-enrichment state visible in runtime summaries so operators can
+  distinguish PR-review health from deferred enrichment work.
+- Suppress same-run near-duplicate findings in the deterministic gate so live
+  review comments do not repeat equivalent issues within one model run.
+- Record two follow-up reliability defects found during live validation:
+  manual/daemon same-head review races (`#295`) and empty runtime checkout
+  repair (`#297`).
+
+## Required Gates
+
+- PR `#289` merged to `main`; required `Build, test, and package` check passed.
+- PR `#294` merged to `main`; required `Build, test, and package` check passed.
+- PR `#289` pre-merge head
+  `c3968ca2cea05529fae377416820fde51fb8771a` received an App-authored evaOS
+  review with no blocking findings before merge. The live source checkout was
+  later fast-forwarded past the `#289` merge SHA to include `#294`.
+- Post-merge `release:status` at
+  `9868089fedc8d7ae17d345fe246bdf46048155c3` returned `ok: true` with
+  launchd running from the active installed live config.
+- Post-merge `runtime-inventory` reached `healthy_idle` with zero active queue
+  jobs, zero failed queue jobs, zero provider deferrals, zero expired provider
+  cooldowns, and zero uncovered pending heads.
+- LCO PR review backlog was backfilled for the then-current `#576` head, and
+  later daemon cycles returned to idle without stuck queued work.
+- Focused release metadata validation:
+  `npm test -- tests/release-status.test.ts tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1`
+- `npm run build`
+- `git diff --check`
+- Post-tag `release:status` after launchd restart at the promoted tag SHA.
+
+## Caveats
+
+- Automatic issue enrichment remains limited to its separate allowlist and
+  throttle config. Deferred issue-enrichment rows are intentionally not a PR
+  runtime blocker, but they remain visible for follow-up.
+- PR `#291` and PR `#290` are separate confidence-calibration follow-ups and
+  are not bundled into this release.
+- Optional Swift CodeQL may still be running or delayed on release PRs; branch
+  protection for `main` requires only `Build, test, and package`.
+- The public npm package remains `neondiff@0.4.24-beta.1`; this release tags the
+  live local worker source SHA.
+
+## Rollback
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard v0.4.25-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -74,7 +74,7 @@ describe("NeonDiff public release readiness", () => {
       version: "0.4.24-beta.1",
       requiredForThisRelease: false,
       state: "held_at_previous_npm_release",
-      currentSourceVersion: "v0.4.25-beta.1",
+      currentSourceVersion: "v0.4.26-beta.1",
       previousReleasedPackageVersion: "0.4.24-beta.1"
     });
     expect(manifest.packageArtifact?.heldReason).toMatch(/source\/daemon-only live beta/i);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -193,16 +193,16 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.25-beta.1"
+      expectedVersion: "v0.4.26-beta.1"
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v0.4.25-beta.1",
+      version: "v0.4.26-beta.1",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v0.4.25-beta.1.md"
+        releaseNotesPath: "docs/releases/v0.4.26-beta.1.md"
       },
       updateChannels: {
         ok: true
@@ -262,13 +262,13 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v0.4.25-beta.1",
+      expectedPublicVersion: "v0.4.26-beta.1",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot"
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v0.4.25-beta.1"
+      version: "v0.4.26-beta.1"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",


### PR DESCRIPTION
## Summary

Stages the source/daemon-only `v0.4.26-beta.1` release metadata for the post-#289 runtime-health hotfix plus the #294 same-run duplicate-suppression fix that landed before release tagging.

## Changes

- Adds `docs/releases/v0.4.26-beta.1.md`.
- Updates `docs/public-release-manifest.json` from `v0.4.25-beta.1` to `v0.4.26-beta.1` while keeping the npm artifact held at `neondiff@0.4.24-beta.1`.
- Updates release/readiness tests that intentionally pin the shipped source beta version.
- Reconciles release proof SHAs so #289 pre-merge review head, #289 merge SHA, #294 merge SHA, and the eventual release tag SHA are distinct.

## Evidence

- `git diff --check`
- `npm test -- tests/release-status.test.ts tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1` (69 passed)
- `npm run build`
- Live evidence packet: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/v0.4.26-beta.1/`
- Live release-status after fast-forward/restart at `9868089fedc8d7ae17d345fe246bdf46048155c3`: ok/runtime_ok
- Runtime inventory: healthy_active only due covered queued/running heads; zero failed queue jobs, zero provider deferrals, zero expired cooldowns, zero uncovered pending heads
- Coverage audit before #294 fast-forward: 19 repos scanned, 72 PRs seen, zero unprocessed eligible heads
- Provider cooldown audit: zero expired/active provider cooldown backlog

## Notes

This is release metadata only. It does not change runtime config, provider config, issue-enrichment allowlists, GitNexus settings, or npm package version.

Closes no implementation issue directly; it records the already-merged #289/#294 runtime hotfixes for beta release governance.