### PR TITLE
fix: repair empty review worktree directories

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { assertPathOutsideProtectedRoot } from "./path-safety.js";
 
@@ -57,8 +57,12 @@ export function preparePullWorktree(input: PullWorktreeInput): PreparedWorktree 
     "+refs/heads/*:refs/heads/*"
   ]);
 
-  rmSync(worktreePath, { recursive: true, force: true });
-  run("git", ["--git-dir", mirrorPath, "worktree", "prune"]);
+  repairExistingReviewWorktreePathForCheckout({
+    worktreePath,
+    mirrorPath,
+    protectedCheckoutRoot: input.protectedCheckoutRoot,
+    protectedCheckoutRoots: input.protectedCheckoutRoots
+  });
   run("git", [
     "--git-dir",
     mirrorPath,
@@ -75,6 +79,49 @@ export function preparePullWorktree(input: PullWorktreeInput): PreparedWorktree 
   }
 
   return { path: worktreePath, headSha: actualHeadSha };
+}
+
+export function repairExistingReviewWorktreePathForCheckout(input: {
+  worktreePath: string;
+  mirrorPath: string;
+  protectedCheckoutRoot?: string;
+  protectedCheckoutRoots?: string[];
+}): void {
+  assertPathOutsideProtectedRoot({
+    path: input.worktreePath,
+    protectedRoot: input.protectedCheckoutRoot,
+    protectedRoots: input.protectedCheckoutRoots,
+    pathLabel: "worktreePath",
+    protectedRootLabel: "the protected live checkout"
+  });
+
+  if (existsSync(input.worktreePath)) {
+    const stat = lstatSync(input.worktreePath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`checkout preparation failed for ${input.worktreePath}: existing_symlink`);
+    }
+    const existingGitWorktree = existsAsGitWorktree(input.worktreePath);
+
+    if (existingGitWorktree) {
+      if (!isGitWorktreeOwnedByMirror(input)) {
+        throw new Error(`checkout preparation failed for ${input.worktreePath}: existing_git_worktree_not_owned`);
+      }
+      run("git", ["--git-dir", input.mirrorPath, "worktree", "remove", "--force", input.worktreePath]);
+    } else if (stat.isDirectory()) {
+      const entries = readdirSync(input.worktreePath);
+      const nonIgnorableEntries = entries.filter((entry) => !isIgnorableEmptyWorktreeEntry(entry));
+      if (nonIgnorableEntries.length > 0) {
+        throw new Error(
+          `checkout preparation failed for ${input.worktreePath}: existing_non_git_non_empty; refusing to remove ${nonIgnorableEntries.length} file(s)`
+        );
+      }
+      removeExistingReviewPath(input.worktreePath);
+    } else {
+      throw new Error(`checkout preparation failed for ${input.worktreePath}: existing_non_directory`);
+    }
+  }
+
+  run("git", ["--git-dir", input.mirrorPath, "worktree", "prune"]);
 }
 
 function assertReviewPathOutsideProtectedCheckout(pathLabel: string, path: string, input: PullWorktreeInput): void {
@@ -99,6 +146,60 @@ export function assertGitClean(worktreePath: string): void {
 function existsAsGitMirror(path: string): boolean {
   const result = spawnSync("git", ["--git-dir", path, "rev-parse", "--is-bare-repository"], { encoding: "utf8" });
   return result.status === 0 && result.stdout.trim() === "true";
+}
+
+function existsAsGitWorktree(path: string): boolean {
+  const result = spawnSync("git", ["-C", path, "rev-parse", "--is-inside-work-tree"], { encoding: "utf8" });
+  if (result.status === null) {
+    const message = result.error instanceof Error ? result.error.message : "git failed before returning a status";
+    throw new Error(`checkout preparation failed for ${path}: git_worktree_probe_failed: ${message}`);
+  }
+  return result.status === 0 && result.stdout.trim() === "true";
+}
+
+function isGitWorktreeOwnedByMirror(input: { mirrorPath: string; worktreePath: string }): boolean {
+  const result = spawnSync("git", ["--git-dir", input.mirrorPath, "worktree", "list", "--porcelain"], { encoding: "utf8" });
+  if (result.status === null) {
+    const message = result.error instanceof Error ? result.error.message : "git failed before returning a status";
+    throw new Error(`checkout preparation failed for ${input.worktreePath}: git_worktree_list_failed: ${message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(`checkout preparation failed for ${input.worktreePath}: git_worktree_list_failed`);
+  }
+
+  const existingRawPath = resolve(input.worktreePath);
+  const existingRealPath = maybeRealpath(input.worktreePath);
+  if (!existingRealPath) {
+    throw new Error(`checkout preparation failed for ${input.worktreePath}: existing_git_worktree_missing`);
+  }
+  for (const line of result.stdout.split(/\r?\n/)) {
+    if (!line.startsWith("worktree ")) continue;
+    const listedPath = line.slice("worktree ".length).trim();
+    if (!listedPath) continue;
+    if (resolve(listedPath) === existingRawPath) return true;
+    const listedRealPath = maybeRealpath(listedPath);
+    if (listedRealPath === existingRealPath) return true;
+  }
+  return false;
+}
+
+function maybeRealpath(path: string): string | undefined {
+  try {
+    return realpathSync(path);
+  } catch {
+    return undefined;
+  }
+}
+
+function removeExistingReviewPath(path: string): void {
+  if (lstatSync(path).isSymbolicLink()) {
+    throw new Error(`checkout preparation failed for ${path}: existing_symlink`);
+  }
+  rmSync(path, { recursive: true, force: true });
+}
+
+function isIgnorableEmptyWorktreeEntry(entry: string): boolean {
+  return entry === ".DS_Store";
 }
 
 function run(command: string, args: string[]): { stdout: string; stderr: string } {

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -1,8 +1,9 @@
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { planPullWorktreePaths } from "../src/git.js";
+import { planPullWorktreePaths, repairExistingReviewWorktreePathForCheckout } from "../src/git.js";
 
 describe("pull worktree path planning", () => {
   const roots: string[] = [];
@@ -118,5 +119,161 @@ describe("pull worktree path planning", () => {
       workRoot: root,
       protectedCheckoutRoot: liveCheckout
     })).toThrow(/mirrorPath must be outside the protected live checkout/);
+  });
+
+  it("repairs an empty existing non-git worktree directory before checkout", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    roots.push(root);
+    const mirrorPath = join(root, "mirror.git");
+    const worktreePath = join(root, "worktree");
+    execFileSync("git", ["init", "--bare", mirrorPath], { stdio: "ignore" });
+    mkdirSync(worktreePath);
+
+    repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath });
+
+    expect(existsSync(worktreePath)).toBe(false);
+    const worktrees = execFileSync("git", ["--git-dir", mirrorPath, "worktree", "list", "--porcelain"], {
+      encoding: "utf8"
+    });
+    expect(worktrees).not.toContain(`worktree ${worktreePath}`);
+  });
+
+  it("repairs an existing git worktree directory before checkout", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    roots.push(root);
+    const sourcePath = join(root, "source");
+    const mirrorPath = join(root, "mirror.git");
+    const worktreePath = join(root, "worktree");
+    execFileSync("git", ["init", sourcePath], { stdio: "ignore" });
+    execFileSync("git", ["-C", sourcePath, "config", "user.email", "bot@example.com"]);
+    execFileSync("git", ["-C", sourcePath, "config", "user.name", "Review Bot"]);
+    writeFileSync(join(sourcePath, "README.md"), "hello\n");
+    execFileSync("git", ["-C", sourcePath, "add", "README.md"], { stdio: "ignore" });
+    execFileSync("git", ["-C", sourcePath, "commit", "-m", "initial"], { stdio: "ignore" });
+    execFileSync("git", ["clone", "--mirror", sourcePath, mirrorPath], { stdio: "ignore" });
+    execFileSync("git", ["--git-dir", mirrorPath, "worktree", "add", "--detach", worktreePath, "HEAD"], { stdio: "ignore" });
+
+    repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath });
+
+    expect(existsSync(worktreePath)).toBe(false);
+  });
+
+  it("prunes stale mirror worktree metadata when the worktree path is absent", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    roots.push(root);
+    const sourcePath = join(root, "source");
+    const mirrorPath = join(root, "mirror.git");
+    const worktreePath = join(root, "worktree");
+    execFileSync("git", ["init", sourcePath], { stdio: "ignore" });
+    execFileSync("git", ["-C", sourcePath, "config", "user.email", "bot@example.com"]);
+    execFileSync("git", ["-C", sourcePath, "config", "user.name", "Review Bot"]);
+    writeFileSync(join(sourcePath, "README.md"), "hello\n");
+    execFileSync("git", ["-C", sourcePath, "add", "README.md"], { stdio: "ignore" });
+    execFileSync("git", ["-C", sourcePath, "commit", "-m", "initial"], { stdio: "ignore" });
+    execFileSync("git", ["clone", "--mirror", sourcePath, mirrorPath], { stdio: "ignore" });
+    execFileSync("git", ["--git-dir", mirrorPath, "worktree", "add", "--detach", worktreePath, "HEAD"], { stdio: "ignore" });
+    rmSync(worktreePath, { recursive: true, force: true });
+
+    repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath });
+
+    const worktrees = execFileSync("git", ["--git-dir", mirrorPath, "worktree", "list", "--porcelain"], {
+      encoding: "utf8"
+    });
+    expect(worktrees).not.toContain(`worktree ${worktreePath}`);
+  });
+
+  it("rejects an existing git checkout not owned by the mirror", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    roots.push(root);
+    const mirrorPath = join(root, "mirror.git");
+    const worktreePath = join(root, "unrelated-repo");
+    execFileSync("git", ["init", "--bare", mirrorPath], { stdio: "ignore" });
+    execFileSync("git", ["init", worktreePath], { stdio: "ignore" });
+    execFileSync("git", ["-C", worktreePath, "config", "user.email", "bot@example.com"]);
+    execFileSync("git", ["-C", worktreePath, "config", "user.name", "Review Bot"]);
+    writeFileSync(join(worktreePath, "README.md"), "do not delete\n");
+    execFileSync("git", ["-C", worktreePath, "add", "README.md"], { stdio: "ignore" });
+    execFileSync("git", ["-C", worktreePath, "commit", "-m", "initial"], { stdio: "ignore" });
+
+    expect(() => repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath })).toThrow(
+      /existing_git_worktree_not_owned/
+    );
+    expect(existsSync(join(worktreePath, "README.md"))).toBe(true);
+  });
+
+  it("rejects a symlink repair target before git-worktree deletion", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    roots.push(root);
+    const mirrorPath = join(root, "mirror.git");
+    const gitTarget = join(root, "git-target");
+    const worktreePath = join(root, "worktree-link");
+    execFileSync("git", ["init", "--bare", mirrorPath], { stdio: "ignore" });
+    execFileSync("git", ["init", gitTarget], { stdio: "ignore" });
+    symlinkSync(gitTarget, worktreePath, "dir");
+
+    expect(() => repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath })).toThrow(/existing_symlink/);
+    expect(existsSync(gitTarget)).toBe(true);
+  });
+
+  it("repairs a non-git worktree directory containing only ignorable macOS metadata", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    roots.push(root);
+    const mirrorPath = join(root, "mirror.git");
+    const worktreePath = join(root, "worktree");
+    execFileSync("git", ["init", "--bare", mirrorPath], { stdio: "ignore" });
+    mkdirSync(worktreePath);
+    writeFileSync(join(worktreePath, ".DS_Store"), "metadata");
+
+    repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath });
+
+    expect(existsSync(worktreePath)).toBe(false);
+  });
+
+  it("fails closed for a non-empty existing non-git worktree directory", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    roots.push(root);
+    const mirrorPath = join(root, "mirror.git");
+    const worktreePath = join(root, "worktree");
+    execFileSync("git", ["init", "--bare", mirrorPath], { stdio: "ignore" });
+    mkdirSync(worktreePath);
+    writeFileSync(join(worktreePath, "leftover.txt"), "not a git checkout");
+
+    expect(() => repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath })).toThrow(
+      /checkout preparation failed.*existing_non_git_non_empty/
+    );
+    expect(existsSync(join(worktreePath, "leftover.txt"))).toBe(true);
+  });
+
+  it("fails closed for an existing regular file at the worktree path", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    roots.push(root);
+    const mirrorPath = join(root, "mirror.git");
+    const worktreePath = join(root, "worktree");
+    execFileSync("git", ["init", "--bare", mirrorPath], { stdio: "ignore" });
+    writeFileSync(worktreePath, "do not delete");
+
+    expect(() => repairExistingReviewWorktreePathForCheckout({ mirrorPath, worktreePath })).toThrow(
+      /existing_non_directory/
+    );
+    expect(existsSync(worktreePath)).toBe(true);
+  });
+
+  it("rejects a repair target symlinked into the protected live checkout", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-runtime-"));
+    const liveCheckout = mkdtempSync(join(tmpdir(), "evaos-live-checkout-"));
+    roots.push(root, liveCheckout);
+    const mirrorPath = join(root, "mirror.git");
+    const worktreePath = join(root, "worktree");
+    execFileSync("git", ["init", "--bare", mirrorPath], { stdio: "ignore" });
+    symlinkSync(liveCheckout, worktreePath, "dir");
+
+    expect(() =>
+      repairExistingReviewWorktreePathForCheckout({
+        mirrorPath,
+        worktreePath,
+        protectedCheckoutRoot: liveCheckout
+      })
+    ).toThrow(/worktreePath must be outside the protected live checkout/);
+    expect(existsSync(liveCheckout)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #297 by classifying existing runtime review worktree paths before checkout.

## Changes

- Repairs empty non-git target directories under the runtime worktree root before `git worktree add`.
- Preserves existing behavior for real git worktrees by removing/recreating them after mirror prune.
- Fails closed for non-empty non-git target directories and non-directory paths with a `checkout preparation` error classification.
- Adds focused regression coverage for empty-dir repair and non-empty fail-closed behavior.

## Validation

- `git diff --check`
- `npm test -- tests/git.test.ts --pool=forks --maxWorkers=1` (9 passed)
- `npm run build`

## Notes

This touches only `src/git.ts` and `tests/git.test.ts`. It does not change worker queue semantics, launchd config, provider settings, GitNexus settings, or runtime allowlists.

Closes #297.