### PR TITLE
Enforce redaction at the review-gate module boundary

### DIFF
--- a/src/findings.ts
+++ b/src/findings.ts
@@ -211,6 +211,29 @@ function sanitizeDroppedFindingPublicText<T extends Partial<Finding>>(finding: T
   };
 }
 
+/**
+ * Full public-safe sanitization for a dropped finding (#283): redact secret-like text AND strip
+ * uncalibrated confidence numbers from title/body/why_this_matters. This is the same treatment the
+ * secret-drop path applies inline and that worker.ts re-applies as a second pass; both redactSecrets
+ * and sanitizePublicConfidenceText are idempotent, so callers may re-run it without changing output.
+ * Exported so the review-gate module boundary can enforce redaction on drops it produces BEFORE any
+ * caller sees them, rather than relying on the caller to sanitize.
+ */
+export function sanitizeDroppedFinding<T extends Partial<Finding>>(finding: T, publicConfidencePolicy?: PublicConfidenceDisplayPolicy): T {
+  return {
+    ...finding,
+    ...(typeof finding.title === "string"
+      ? { title: sanitizePublicConfidenceText(redactSecrets(finding.title), publicConfidencePolicy) }
+      : {}),
+    ...(typeof finding.body === "string"
+      ? { body: sanitizePublicConfidenceText(redactSecrets(finding.body), publicConfidencePolicy) }
+      : {}),
+    ...(typeof finding.why_this_matters === "string"
+      ? { why_this_matters: sanitizePublicConfidenceText(redactSecrets(finding.why_this_matters), publicConfidencePolicy) }
+      : {})
+  };
+}
+
 export function decideReviewEvent(
   findings: Pick<ReviewComment, "severity" | "category" | "confidence">[],
   confidenceFloors?: RequestChangesConfidenceFloors

--- a/src/review-gate.ts
+++ b/src/review-gate.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { validateFindingLocations } from "./diff.js";
-import { decideReviewEvent, normalizeFindingsForReview } from "./findings.js";
+import { decideReviewEvent, normalizeFindingsForReview, sanitizeDroppedFinding } from "./findings.js";
 import type { PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import { countCategories, isRequestChangesEligible, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import type {
@@ -38,12 +38,17 @@ export function applyDeterministicReviewGate(input: {
     maxInlineComments: input.maxInlineComments,
     publicConfidencePolicy: input.publicConfidencePolicy
   });
+  // Enforce redaction at the module boundary (#283): every drop the gate emits — repo-memory
+  // suppressions, location drops, and schema drops that may still carry raw finding text — is
+  // sanitized here so a leak cannot depend on the caller re-sanitizing. normalized.dropped is
+  // already sanitized inside normalizeFindingsForReview; re-running the idempotent sanitizer on it
+  // is a no-op, and the same idempotency makes worker.ts's second pass a no-op too.
   const dropped = [
     ...(input.droppedFromSchema ?? []),
     ...located.dropped,
     ...repoMemoryFiltered.dropped,
     ...normalized.dropped
-  ];
+  ].map((finding) => sanitizeDroppedFinding(finding, input.publicConfidencePolicy));
   const comments = normalized.comments;
   const event = decideReviewEvent(comments, input.requestChangesConfidenceFloors);
 

--- a/tests/review-gate.test.ts
+++ b/tests/review-gate.test.ts
@@ -298,4 +298,34 @@ describe("deterministic review gate", () => {
     );
     expect(gate.summary.dropReasonCounts).toMatchObject({ repo_memory_false_positive_match: 1 });
   });
+
+  it("redacts a secret-like repo-memory-suppressed finding at the gate boundary itself (#283)", () => {
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+    const suppressed: Finding = {
+      severity: "P3",
+      category: "proof_gap",
+      path: "src/save.ts",
+      line: 2,
+      title: "Marker with 99% confidence",
+      body: `Confidence: 99%. The raw token ${token} was previously a false positive.`,
+      confidence: 0.9
+    };
+    const matchingFingerprint = buildFindingFingerprint(suppressed);
+
+    // No caller-side sanitization: the gate is called directly and must return public-safe drops.
+    const gate = applyDeterministicReviewGate({
+      files,
+      findings: [suppressed],
+      repoMemoryFalsePositiveFingerprints: [matchingFingerprint]
+    });
+
+    const droppedEntry = gate.dropped.find((entry) => entry.reason === "repo_memory_false_positive_match");
+    expect(droppedEntry).toBeDefined();
+    expect(droppedEntry).toMatchObject({ fingerprint: matchingFingerprint });
+    // Secret text is redacted and confidence numbers are stripped by default (uncalibrated policy).
+    expect(JSON.stringify(gate.dropped)).not.toContain(token);
+    expect(droppedEntry?.title).toBe("Marker with [confidence not calibrated]");
+    expect(droppedEntry?.body).toContain("Confidence: [confidence not calibrated].");
+    expect(JSON.stringify(gate.dropped)).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
+  });
 });


### PR DESCRIPTION
Closes #283. Parent: #278 (Phase 2).

## Summary
Repo-memory-suppressed drops (and any raw-text drop the gate produces) previously relied on the sole caller (worker.ts) to sanitize before evidence/logging — a defense-in-depth gap: any future second caller of `applyDeterministicReviewGate` would leak raw finding text.

- New exported `sanitizeDroppedFinding` (src/findings.ts): redactSecrets + sanitizePublicConfidenceText on title/body/why — the exact composition worker already applies, documented idempotent.
- The gate's merged `dropped` array (schema/location/repo-memory/normalized) is sanitized at the boundary before any caller sees it; worker's second pass becomes a no-op by idempotency, so no behavior change to existing output.
- publicConfidencePolicy threaded so calibrated policies preserve confidence text exactly as other drop reasons do.

## Validation
- TDD: failing test first — secret-like + confidence-numbered repo-memory-suppressed finding returns redacted and confidence-stripped from the gate ITSELF with no caller sanitization (red: raw token leaked → green).
- Focused Vitest 96/96 (review-gate, findings, worker-failure); `npm run build` exit 0 — verified under `set -o pipefail`.
- Additive; #291/#296 seams untouched.