### PR TITLE
docs: stage v0.4.27 beta release

### DIFF
--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,13 +1,13 @@
 {
-  "version": "v0.4.26-beta.1",
+  "version": "v0.4.27-beta.1",
   "releaseLevel": "source-beta",
   "packageArtifact": {
     "name": "neondiff",
     "version": "0.4.24-beta.1",
     "requiredForThisRelease": false,
     "state": "held_at_previous_npm_release",
-    "heldReason": "v0.4.26-beta.1 is a source/daemon-only live beta; no npm artifact is published for this runtime-health hotfix.",
-    "currentSourceVersion": "v0.4.26-beta.1",
+    "heldReason": "v0.4.27-beta.1 is a source/daemon-only live beta; no npm artifact is published for this runtime-safety hotfix.",
+    "currentSourceVersion": "v0.4.27-beta.1",
     "previousReleasedPackageVersion": "0.4.24-beta.1"
   },
   "source": {
@@ -15,9 +15,9 @@
     "proof": "release:status --expected-head $(git rev-parse HEAD)"
   },
   "docs": {
-    "version": "v0.4.26-beta.1",
+    "version": "v0.4.27-beta.1",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v0.4.26-beta.1.md",
+    "releaseNotesPath": "docs/releases/v0.4.27-beta.1.md",
     "websiteRepo": "electricsheephq/neon-diff-agent"
   },
   "licenseApi": {
@@ -29,13 +29,13 @@
     "cli": {
       "requiredForThisRelease": true,
       "state": "source_checkout",
-      "version": "v0.4.26-beta.1",
+      "version": "v0.4.27-beta.1",
       "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "launchd_prerelease",
-      "version": "v0.4.26-beta.1",
+      "version": "v0.4.27-beta.1",
       "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
     },
     "website": {

--- a/docs/releases/v0.4.27-beta.1.md
+++ b/docs/releases/v0.4.27-beta.1.md
@@ -1,0 +1,90 @@
+# v0.4.27-beta.1
+
+- Release type: local beta runtime-safety and confidence hardening release
+- Release source SHA: to be stamped during post-merge live promotion
+- Previous prerelease: `v0.4.26-beta.1`
+- Tracking issues / source PRs: `#283`, `#290`, `#291`, `#296`, `#297`,
+  `#299`, `#300`
+- Promoted PRs: `#290`, `#291`, `#296`, `#299`, `#300`
+- Included implementation merge SHAs:
+  `ac397b0b` (`#290`),
+  `3a499668` (`#291`),
+  `829c3436` (`#296`),
+  `5e26decb` (`#299`),
+  `c4e0b0b6` (`#300`)
+- Local operator evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/v0.4.27-beta.1/`
+- Rollback tag: `v0.4.26-beta.1`
+- Package artifact: `neondiff@0.4.24-beta.1` (held from previous npm release)
+- Rollback baseline: `v0.4.9-beta.1` remains the known-good daemon fallback
+
+## Purpose
+
+Promote the merged runtime and review-safety hardening after `v0.4.26-beta.1`.
+This release keeps the local launchd worker on a named source beta instead of
+running unrecorded `main`.
+
+The headline runtime fix is the review checkout repair path from `#299`: review
+worktrees can now recover from empty or ignorable leftover directories, owned
+Git worktrees are removed through `git worktree remove --force`, unrelated Git
+checkouts and symlink targets fail closed, and focused tests prove the mirror
+metadata is left reusable before the next checkout.
+
+This is a local live-worker beta release. It does not publish a new npm package
+or replace the public `neondiff@0.4.24-beta.1` package release.
+
+## Included Changes
+
+- Harden Wilson confidence math so calibration summaries do not overstate
+  reliability from small samples.
+- Require explicit negative-control metadata before calibration credit is
+  granted.
+- Extend confidence redaction patterns so confidence/eval surfaces do not leak
+  token-like material through public reports.
+- Repair stale or empty review runtime worktree paths without deleting
+  unrelated repositories, symlink targets, or non-benign leftovers.
+- Enforce redaction at the review-gate module boundary so findings cannot bypass
+  the deterministic redaction layer before comments or evidence are produced.
+
+## Required Gates
+
+- PRs `#290`, `#291`, `#296`, `#299`, and `#300` merged to `main`.
+- Required GitHub `Build, test, and package` checks passed for the merged PRs.
+- PR `#299` final head `f316a1b14a1dc453e40225304e79e06cb3ca2644`
+  received an App-authored evaOS exact-head review with `COMMENT` disposition
+  and no unresolved review threads before merge.
+- PR `#299` was squash-merged as `5e26decb`; the reviewed head SHA above is
+  the pre-merge branch head that produced the merge commit.
+- Focused local validation for `#299`:
+  `npm test -- tests/git.test.ts --pool=forks --maxWorkers=1`
+- `npm run build`
+- `git diff --check`
+- Post-merge live checkout fast-forwarded to current `main`.
+- Post-tag `release:status` after launchd restart at the promoted tag SHA.
+
+## Caveats
+
+- The public npm package remains `neondiff@0.4.24-beta.1`; this release tags the
+  live local worker source SHA only.
+- Optional Swift CodeQL may still be running or delayed on release PRs; branch
+  protection for `main` requires only `Build, test, and package`.
+- The current live daemon still has a separate scheduler coverage defect to
+  address next: uncovered pending heads can remain visible even while launchd is
+  running. This release does not claim that #295/#queue coverage is fixed.
+- The review bot's own assertive self-review surfaced many P2/P3 hardening
+  suggestions on `#299`; the current-head gate passed and threads were
+  adjudicated as non-blocking after the implemented data-loss protections and
+  focused tests landed.
+
+## Rollback
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v0.4.26-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -74,7 +74,7 @@ describe("NeonDiff public release readiness", () => {
       version: "0.4.24-beta.1",
       requiredForThisRelease: false,
       state: "held_at_previous_npm_release",
-      currentSourceVersion: "v0.4.26-beta.1",
+      currentSourceVersion: "v0.4.27-beta.1",
       previousReleasedPackageVersion: "0.4.24-beta.1"
     });
     expect(manifest.packageArtifact?.heldReason).toMatch(/source\/daemon-only live beta/i);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -193,16 +193,16 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.26-beta.1"
+      expectedVersion: "v0.4.27-beta.1"
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v0.4.26-beta.1",
+      version: "v0.4.27-beta.1",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v0.4.26-beta.1.md"
+        releaseNotesPath: "docs/releases/v0.4.27-beta.1.md"
       },
       updateChannels: {
         ok: true
@@ -262,13 +262,13 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v0.4.26-beta.1",
+      expectedPublicVersion: "v0.4.27-beta.1",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot"
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v0.4.26-beta.1"
+      version: "v0.4.27-beta.1"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",


### PR DESCRIPTION
## Summary
- stage the v0.4.27-beta.1 live-worker release packet
- update the public release manifest to the new source/daemon beta while keeping npm held at neondiff@0.4.24-beta.1
- update release/readiness test constants for the new source beta

## Validation
- npm test -- tests/release-status.test.ts tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1
- npm run build
- git diff --check

## Includes
- #290
- #291
- #296
- #299
- #300

Release target: v0.4.27-beta.1.