### PR TITLE
Risk-weighted review-queue priority from changed-surface analysis

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,7 @@ export interface BotConfig {
     headCountLimit: number;
   };
   reviewScheduler?: ReviewSchedulerConfig;
+  riskWeightedQueue?: RiskWeightedQueueConfig;
   providerCooldown: {
     enabled: boolean;
     durationMs: number;
@@ -196,6 +197,15 @@ export interface ReviewGateConfig {
   requestChangesConfidenceFloors?: RequestChangesConfidenceFloors;
 }
 
+export interface RiskWeightedQueueConfig {
+  /** When false (default), enqueue priority stays the flat backgroundPriority — byte-identical. */
+  enabled: boolean;
+  /** Priority for PRs whose changed surface matches a required-validation category (lower = sooner). */
+  elevatedPriority?: number;
+  /** Priority for docs-only PRs (typically >= backgroundPriority to defer them). */
+  docsOnlyPriority?: number;
+}
+
 export interface RepoMemoryConfig {
   enabled: boolean;
   memoryRoot: string;
@@ -233,6 +243,9 @@ const DEFAULT_CONFIG: BotConfig = {
     maxQueuedPerRepo: 10,
     manualCommandReserve: 1,
     backgroundPriority: 50
+  },
+  riskWeightedQueue: {
+    enabled: false
   },
   providerCooldown: {
     enabled: true,
@@ -507,6 +520,9 @@ function validateConfig(config: BotConfig): void {
   const reviewScheduler = config.reviewScheduler ?? DEFAULT_CONFIG.reviewScheduler!;
   config.reviewScheduler = reviewScheduler;
   validateReviewSchedulerConfig(reviewScheduler, "config.reviewScheduler");
+  const riskWeightedQueue = config.riskWeightedQueue ?? DEFAULT_CONFIG.riskWeightedQueue!;
+  config.riskWeightedQueue = riskWeightedQueue;
+  validateRiskWeightedQueueConfig(riskWeightedQueue, "config.riskWeightedQueue");
   validateBoolean(config.providerCooldown.enabled, "config.providerCooldown.enabled");
   validatePositiveInteger(config.providerCooldown.durationMs, "config.providerCooldown.durationMs");
   validatePositiveInteger(config.providerCooldown.requestRateLimitDurationMs, "config.providerCooldown.requestRateLimitDurationMs");
@@ -668,6 +684,13 @@ function validateReviewGateConfig(value: unknown, label: string): void {
       if (floor !== undefined) validateProbability(floor, `${label}.requestChangesConfidenceFloors.${severity}`);
     }
   }
+}
+
+function validateRiskWeightedQueueConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  validateBoolean(value.enabled, `${label}.enabled`);
+  if (value.elevatedPriority !== undefined) validateNonNegativeInteger(value.elevatedPriority, `${label}.elevatedPriority`);
+  if (value.docsOnlyPriority !== undefined) validateNonNegativeInteger(value.docsOnlyPriority, `${label}.docsOnlyPriority`);
 }
 
 function validateRepoMemoryConfig(value: unknown, label: string): void {

--- a/src/config.ts
+++ b/src/config.ts
@@ -522,7 +522,7 @@ function validateConfig(config: BotConfig): void {
   validateReviewSchedulerConfig(reviewScheduler, "config.reviewScheduler");
   const riskWeightedQueue = config.riskWeightedQueue ?? DEFAULT_CONFIG.riskWeightedQueue!;
   config.riskWeightedQueue = riskWeightedQueue;
-  validateRiskWeightedQueueConfig(riskWeightedQueue, "config.riskWeightedQueue");
+  validateRiskWeightedQueueConfig(riskWeightedQueue, "config.riskWeightedQueue", reviewScheduler.backgroundPriority);
   validateBoolean(config.providerCooldown.enabled, "config.providerCooldown.enabled");
   validatePositiveInteger(config.providerCooldown.durationMs, "config.providerCooldown.durationMs");
   validatePositiveInteger(config.providerCooldown.requestRateLimitDurationMs, "config.providerCooldown.requestRateLimitDurationMs");
@@ -686,11 +686,18 @@ function validateReviewGateConfig(value: unknown, label: string): void {
   }
 }
 
-function validateRiskWeightedQueueConfig(value: unknown, label: string): void {
+function validateRiskWeightedQueueConfig(value: unknown, label: string, backgroundPriority: number): void {
   if (!isRecord(value)) throw new Error(`${label} must be an object`);
   validateBoolean(value.enabled, `${label}.enabled`);
   if (value.elevatedPriority !== undefined) validateNonNegativeInteger(value.elevatedPriority, `${label}.elevatedPriority`);
   if (value.docsOnlyPriority !== undefined) validateNonNegativeInteger(value.docsOnlyPriority, `${label}.docsOnlyPriority`);
+  if (value.enabled) {
+    const elevatedPriority = value.elevatedPriority ?? Math.min(backgroundPriority, 10);
+    const docsOnlyPriority = value.docsOnlyPriority ?? backgroundPriority;
+    if (elevatedPriority > docsOnlyPriority) {
+      throw new Error(`${label}.elevatedPriority must be <= ${label}.docsOnlyPriority because lower priority values lease sooner`);
+    }
+  }
 }
 
 function validateRepoMemoryConfig(value: unknown, label: string): void {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -569,7 +569,9 @@ async function resolveRiskWeightedPriorityOverride(input: {
   const { priority, tier, reason } = riskWeightedQueuePriority({ config: input.config, repo: input.repo, report });
   if (tier !== "default") {
     console.warn(
-      `[risk-queue] repo=${input.repo} pr=${input.pull.number} sha=${input.pull.head.sha} tier=${tier} priority=${priority ?? "default"} reason=${reason}`
+      redactSecrets(
+        `[risk-queue] repo=${input.repo} pr=${input.pull.number} sha=${input.pull.head.sha} tier=${tier} priority=${priority ?? "default"} reason=${reason}`
+      )
     );
   }
   return priority;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -438,10 +438,6 @@ async function enqueuePullIfEligible(input: {
     return "skipped_capacity";
   }
 
-  // Risk-weighted enqueue priority (#301): only when explicitly enabled do we fetch the changed
-  // surface to derive a risk tier. Disabled (default) ⇒ no extra GitHub call, flat priority.
-  input.automaticPriorityOverride = await resolveRiskWeightedPriorityOverride(input);
-
   const activeRepoCooldown = input.state.getActiveRepoProviderCooldown(input.repo, input.now);
   if (activeRepoCooldown) {
     const queued = enqueueReviewJob(input);
@@ -475,6 +471,10 @@ async function enqueuePullIfEligible(input: {
     }
     return "provider_deferred";
   }
+
+  // Risk-weighted enqueue priority (#301): only when explicitly enabled do we fetch the changed
+  // surface to derive a risk tier. Disabled (default) ⇒ no extra GitHub call, flat priority.
+  input.automaticPriorityOverride = await resolveRiskWeightedPriorityOverride(input);
 
   const enqueued = enqueueReviewJob(input);
   recordReadinessForEnqueue({

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -35,8 +35,10 @@ import {
   type ReviewQueueJobState,
   type ReviewQueueJobSource
 } from "./state.js";
-import type { PullRequestSummary, ReviewEvent } from "./types.js";
+import type { ChangedSurfaceValidationReport, PullFilePatch, PullRequestSummary, ReviewEvent } from "./types.js";
 import type { IssueCommentCommandSource } from "./commands.js";
+import { buildChangedSurfaceValidationReport } from "./validation-selector.js";
+import { redactSecrets } from "./secrets.js";
 import {
   activateRepoForNewOnlyReview,
   isCanaryAllowed,
@@ -75,6 +77,8 @@ export interface SchedulerGitHubApi {
   listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]>;
   canPostAsApp?: ReviewStatusCommentGithub["canPostAsApp"];
   upsertIssueComment?: ReviewStatusCommentGithub["upsertIssueComment"];
+  // Optional: only invoked when riskWeightedQueue is enabled, to derive risk from changed surface.
+  listPullFiles?(repo: string, pullNumber: number): Promise<PullFilePatch[]>;
 }
 
 export async function runScheduledCycle(options: RunOnceOptions): Promise<ScheduledRunResult> {
@@ -260,6 +264,7 @@ async function enqueuePullIfEligible(input: {
   allowActivationBaselineCommandLookup?: boolean;
   onStatusCommentFailure?: () => void;
   onCommandFetchError?: () => void;
+  automaticPriorityOverride?: number;
 }): Promise<EnqueueStatus> {
   if (isClosedPull(input.pull)) {
     await retireQueuedJobsForClosedPull(input);
@@ -433,6 +438,10 @@ async function enqueuePullIfEligible(input: {
     return "skipped_capacity";
   }
 
+  // Risk-weighted enqueue priority (#301): only when explicitly enabled do we fetch the changed
+  // surface to derive a risk tier. Disabled (default) ⇒ no extra GitHub call, flat priority.
+  input.automaticPriorityOverride = await resolveRiskWeightedPriorityOverride(input);
+
   const activeRepoCooldown = input.state.getActiveRepoProviderCooldown(input.repo, input.now);
   if (activeRepoCooldown) {
     const queued = enqueueReviewJob(input);
@@ -508,11 +517,13 @@ function enqueueReviewJob(input: {
   pull: PullRequestSummary;
   providerId: string;
   now: Date;
+  automaticPriorityOverride?: number;
 }, commandDecision?: Exclude<CommandDecision, { action: "none"; shouldReview: false }>) {
   const source: ReviewQueueJobSource = commandDecision ? "manual_command" : "automatic";
   const sessionId = shouldAssignReviewerSession(commandDecision)
     ? assignReviewerSessionForQueueJob(input, source, commandDecision)?.session?.sessionId
     : undefined;
+  const automaticPriority = input.automaticPriorityOverride ?? automaticQueuePriority(input.config, input.repo);
   return input.state.enqueueReviewQueueJob({
     repo: input.repo,
     pullNumber: input.pull.number,
@@ -521,17 +532,89 @@ function enqueueReviewJob(input: {
     source,
     lane: source === "manual_command" ? "manual" : "background",
     providerId: input.providerId,
-    priority: source === "manual_command" ? undefined : automaticQueuePriority(input.config, input.repo),
+    priority: source === "manual_command" ? undefined : automaticPriority,
     ...(commandDecision ? { commentId: commandDecision.commandId } : {}),
     ...(sessionId ? { sessionId } : {}),
     now: input.now
   });
 }
 
+async function resolveRiskWeightedPriorityOverride(input: {
+  config: BotConfig;
+  github: SchedulerGitHubApi;
+  repo: string;
+  pull: PullRequestSummary;
+}): Promise<number | undefined> {
+  // Gated (#301): disabled (default) or an API that can't list files ⇒ no fetch, flat priority.
+  if (!input.config.riskWeightedQueue?.enabled || !input.github.listPullFiles) return undefined;
+  let report;
+  try {
+    const files = await input.github.listPullFiles(input.repo, input.pull.number);
+    const profile = resolveRepoProfile(input.config, input.repo);
+    report = buildChangedSurfaceValidationReport({
+      repo: input.repo,
+      pull: input.pull,
+      files,
+      ...(profile.allowed ? { profile: profile.profile } : {})
+    });
+  } catch (error) {
+    // Never block enqueue on a file-fetch failure: log and fall back to flat priority.
+    console.warn(
+      `[risk-queue] changed-surface fetch failed repo=${input.repo} pr=${input.pull.number} sha=${input.pull.head.sha}: ${
+        redactSecrets(error instanceof Error ? error.message : String(error))
+      }`
+    );
+    return undefined;
+  }
+  const { priority, tier, reason } = riskWeightedQueuePriority({ config: input.config, repo: input.repo, report });
+  if (tier !== "default") {
+    console.warn(
+      `[risk-queue] repo=${input.repo} pr=${input.pull.number} sha=${input.pull.head.sha} tier=${tier} priority=${priority ?? "default"} reason=${reason}`
+    );
+  }
+  return priority;
+}
+
 function automaticQueuePriority(config: BotConfig, repo: string): number | undefined {
   const backgroundPriority = config.reviewScheduler?.backgroundPriority;
   if (!isSelfRepo(repo)) return backgroundPriority;
   return Math.min(backgroundPriority ?? 50, 1);
+}
+
+export type RiskQueueTier = "elevated" | "docs_only" | "default";
+
+/**
+ * Risk-weighted enqueue priority (#301): derive a queue tier from the already-shipped
+ * changed-surface validation report — a PR whose changed files match a required-validation category
+ * (auth/security/migration/release/runtime) is elevated (numerically lower priority = leased
+ * sooner); a docs-only PR is deferred. When the feature is disabled or no report is available, this
+ * returns the flat automaticQueuePriority so behavior is byte-identical to today. Pure and exported
+ * for tests; no new path-classification logic (the report is the sole risk source).
+ */
+export function riskWeightedQueuePriority(input: {
+  config: BotConfig;
+  repo: string;
+  report?: ChangedSurfaceValidationReport;
+}): { priority: number | undefined; tier: RiskQueueTier; reason: string } {
+  const base = automaticQueuePriority(input.config, input.repo);
+  const risk = input.config.riskWeightedQueue;
+  if (!risk?.enabled || !input.report) {
+    return { priority: base, tier: "default", reason: "risk_weighting_disabled" };
+  }
+  const backgroundPriority = input.config.reviewScheduler?.backgroundPriority ?? 50;
+  const requiresValidation = input.report.recommendations.some((recommendation) => recommendation.status === "required");
+  if (requiresValidation) {
+    const elevated = risk.elevatedPriority ?? Math.min(backgroundPriority, 10);
+    // Never de-prioritize a self-repo below its existing elevation.
+    const priority = base === undefined ? elevated : Math.min(base, elevated);
+    return { priority, tier: "elevated", reason: "risk_elevated_required_validation" };
+  }
+  if (input.report.docsOnly) {
+    const docsOnly = risk.docsOnlyPriority ?? backgroundPriority;
+    const priority = base === undefined ? docsOnly : Math.max(base, docsOnly);
+    return { priority, tier: "docs_only", reason: "risk_docs_only" };
+  }
+  return { priority: base, tier: "default", reason: "risk_no_required_surface" };
 }
 
 const SELF_REPOS = new Set([

--- a/tests/risk-weighted-queue.test.ts
+++ b/tests/risk-weighted-queue.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { loadConfigFromObject, type BotConfig } from "../src/config.js";
+import { riskWeightedQueuePriority } from "../src/scheduler.js";
+import { buildChangedSurfaceValidationReport } from "../src/validation-selector.js";
+import type { PullFilePatch, PullRequestSummary } from "../src/types.js";
+
+function pull(): PullRequestSummary {
+  return {
+    number: 1,
+    title: "PR",
+    draft: false,
+    head: { sha: "head", ref: "feature" },
+    base: { sha: "base", ref: "main", repo: { full_name: "owner/repo" } },
+    html_url: "https://example.invalid/owner/repo/pull/1"
+  };
+}
+
+function report(files: PullFilePatch[]) {
+  return buildChangedSurfaceValidationReport({ repo: "owner/repo", pull: pull(), files });
+}
+
+const AUTH_FILES: PullFilePatch[] = [{ filename: "src/auth/session.ts" }];
+const DOCS_FILES: PullFilePatch[] = [{ filename: "docs/guide.md" }];
+
+describe("risk-weighted queue priority (#301)", () => {
+  it("keeps flat backgroundPriority for every tier when disabled (byte-identical)", () => {
+    const config = loadConfigFromObject({ reviewScheduler: { backgroundPriority: 50 } });
+
+    const auth = riskWeightedQueuePriority({ config, repo: "owner/repo", report: report(AUTH_FILES) });
+    const docs = riskWeightedQueuePriority({ config, repo: "owner/repo", report: report(DOCS_FILES) });
+
+    expect(auth.priority).toBe(50);
+    expect(docs.priority).toBe(50);
+    expect(auth.tier).toBe("default");
+    expect(docs.tier).toBe("default");
+  });
+
+  it("elevates a required-validation surface above a docs-only surface when enabled", () => {
+    const config = loadConfigFromObject({
+      reviewScheduler: { backgroundPriority: 50 },
+      riskWeightedQueue: { enabled: true, elevatedPriority: 20, docsOnlyPriority: 70 }
+    });
+
+    const auth = riskWeightedQueuePriority({ config, repo: "owner/repo", report: report(AUTH_FILES) });
+    const docs = riskWeightedQueuePriority({ config, repo: "owner/repo", report: report(DOCS_FILES) });
+
+    // Lower number = leased sooner: the required-surface PR must outrank the docs-only PR.
+    expect(auth.priority).toBe(20);
+    expect(docs.priority).toBe(70);
+    expect(auth.priority as number).toBeLessThan(docs.priority as number);
+    expect(auth.tier).toBe("elevated");
+    expect(docs.tier).toBe("docs_only");
+    expect(auth.reason).toMatch(/risk/i);
+  });
+
+  it("falls back to backgroundPriority when enabled but no report is available", () => {
+    const config = loadConfigFromObject({
+      reviewScheduler: { backgroundPriority: 50 },
+      riskWeightedQueue: { enabled: true, elevatedPriority: 20, docsOnlyPriority: 70 }
+    });
+
+    const result = riskWeightedQueuePriority({ config, repo: "owner/repo" });
+
+    expect(result.priority).toBe(50);
+    expect(result.tier).toBe("default");
+  });
+
+  it("uses backgroundPriority defaults when elevated/docs priorities are unset but enabled", () => {
+    const config = loadConfigFromObject({
+      reviewScheduler: { backgroundPriority: 50 },
+      riskWeightedQueue: { enabled: true }
+    });
+
+    const auth = riskWeightedQueuePriority({ config, repo: "owner/repo", report: report(AUTH_FILES) });
+
+    expect(auth.tier).toBe("elevated");
+    expect(auth.priority).toBeLessThanOrEqual(50);
+  });
+});
+
+describe("risk-weighted queue config (#301)", () => {
+  it("defaults to disabled", () => {
+    const config: BotConfig = loadConfigFromObject({});
+    expect(config.riskWeightedQueue).toEqual({ enabled: false });
+  });
+
+  it("accepts explicit priorities", () => {
+    const config = loadConfigFromObject({
+      riskWeightedQueue: { enabled: true, elevatedPriority: 5, docsOnlyPriority: 80 }
+    });
+    expect(config.riskWeightedQueue).toEqual({ enabled: true, elevatedPriority: 5, docsOnlyPriority: 80 });
+  });
+
+  it("fails closed on a non-boolean enabled flag", () => {
+    expect(() => loadConfigFromObject({ riskWeightedQueue: { enabled: "yes" } })).toThrow(
+      /riskWeightedQueue\.enabled must be a boolean/
+    );
+  });
+
+  it("fails closed on a negative or non-integer priority", () => {
+    expect(() => loadConfigFromObject({ riskWeightedQueue: { enabled: true, elevatedPriority: -1 } })).toThrow(
+      /riskWeightedQueue\.elevatedPriority must be a non-negative integer/
+    );
+    expect(() => loadConfigFromObject({ riskWeightedQueue: { enabled: true, docsOnlyPriority: 2.5 } })).toThrow(
+      /riskWeightedQueue\.docsOnlyPriority must be a non-negative integer/
+    );
+  });
+});

--- a/tests/risk-weighted-queue.test.ts
+++ b/tests/risk-weighted-queue.test.ts
@@ -105,4 +105,28 @@ describe("risk-weighted queue config (#301)", () => {
       /riskWeightedQueue\.docsOnlyPriority must be a non-negative integer/
     );
   });
+
+  it("fails closed when explicit priorities would lease docs-only before elevated work", () => {
+    expect(() =>
+      loadConfigFromObject({
+        riskWeightedQueue: { enabled: true, elevatedPriority: 80, docsOnlyPriority: 20 }
+      })
+    ).toThrow(/riskWeightedQueue\.elevatedPriority must be <= .*docsOnlyPriority/);
+  });
+
+  it("validates explicit priorities against default priority fallbacks", () => {
+    expect(() =>
+      loadConfigFromObject({
+        reviewScheduler: { backgroundPriority: 50 },
+        riskWeightedQueue: { enabled: true, elevatedPriority: 80 }
+      })
+    ).toThrow(/riskWeightedQueue\.elevatedPriority must be <= .*docsOnlyPriority/);
+
+    expect(() =>
+      loadConfigFromObject({
+        reviewScheduler: { backgroundPriority: 50 },
+        riskWeightedQueue: { enabled: true, docsOnlyPriority: 5 }
+      })
+    ).toThrow(/riskWeightedQueue\.elevatedPriority must be <= .*docsOnlyPriority/);
+  });
 });

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BotConfig } from "../src/config.js";
 import { runScheduledCycleWithDeps, type SchedulerGitHubApi } from "../src/scheduler.js";
 import { ReviewStateStore } from "../src/state.js";
@@ -3090,6 +3090,110 @@ describe("provider-aware review scheduler", () => {
       })
     ]);
     state.close();
+  });
+
+  it("does not fetch changed files when risk weighting is disabled", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-risk-disabled-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.riskWeightedQueue = { enabled: false };
+    const state = new ReviewStateStore(config.statePath);
+    let fileFetches = 0;
+    const github: SchedulerGitHubApi = {
+      ...githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "a1")]]
+      ])),
+      listPullFiles: async () => {
+        fileFetches += 1;
+        throw new Error("listPullFiles must not be called when risk weighting is disabled");
+      }
+    };
+    let reviewed = 0;
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: true, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewed += 1;
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "dry_run",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(fileFetches).toBe(0);
+    expect(reviewed).toBe(1);
+    expect(result.reviewed).toBe(1);
+    expect(state.listReviewQueueJobs({ repo: "org/repo-a" })).toEqual([
+      expect.objectContaining({ pullNumber: 1, priority: 50 })
+    ]);
+    state.close();
+  });
+
+  it("falls back to flat priority and redacted logs when risk file fetch fails", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-risk-fetch-fail-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.riskWeightedQueue = {
+      enabled: true,
+      elevatedPriority: 5,
+      docsOnlyPriority: 80
+    };
+    const state = new ReviewStateStore(config.statePath);
+    let fileFetches = 0;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const github: SchedulerGitHubApi = {
+      ...githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "a1")]]
+      ])),
+      listPullFiles: async () => {
+        fileFetches += 1;
+        throw new Error("GitHub failed with ghp_fake_token");
+      }
+    };
+    let reviewed = 0;
+
+    try {
+      const result = await runScheduledCycleWithDeps({
+        config,
+        github,
+        state,
+        options: { dryRun: true, useZCode: false },
+        reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+          reviewed += 1;
+          reviewState.recordProcessed({
+            repo,
+            pullNumber: reviewPull.number,
+            headSha: reviewPull.head.sha,
+            status: "dry_run",
+            event: "COMMENT"
+          });
+          return "reviewed";
+        },
+        now: new Date("2026-07-01T00:00:00.000Z")
+      });
+
+      const warning = warn.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(fileFetches).toBe(1);
+      expect(reviewed).toBe(1);
+      expect(result.reviewed).toBe(1);
+      expect(warning).toContain("[risk-queue] changed-surface fetch failed");
+      expect(warning).not.toContain("ghp_fake_token");
+      expect(state.listReviewQueueJobs({ repo: "org/repo-a" })).toEqual([
+        expect.objectContaining({ pullNumber: 1, priority: 50 })
+      ]);
+    } finally {
+      warn.mockRestore();
+      state.close();
+    }
   });
 
   it("uses repo-profile queue overflow policy to mark burst heads explicitly provider-deferred", async () => {

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -3041,6 +3041,57 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("does not fetch changed files for risk weighting while a repo provider cooldown is active", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-risk-cooldown-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.riskWeightedQueue = {
+      enabled: true,
+      elevatedPriority: 5,
+      docsOnlyPriority: 80
+    };
+    const state = new ReviewStateStore(config.statePath);
+    state.recordRepoProviderCooldown({
+      repo: "org/repo-a",
+      cooldownUntil: new Date("2026-07-01T00:05:00.000Z"),
+      reason: "provider_request_rate_limit"
+    });
+    let fileFetches = 0;
+    const github: SchedulerGitHubApi = {
+      ...githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, "a1")]]
+      ])),
+      listPullFiles: async () => {
+        fileFetches += 1;
+        return [{ filename: "src/auth/session.ts" }];
+      }
+    };
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: true, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("provider-deferred head must not run review work");
+      },
+      now: new Date("2026-07-01T00:00:00.000Z")
+    });
+
+    expect(fileFetches).toBe(0);
+    expect(result.skippedProviderCooldown).toBe(1);
+    expect(result.queue.providerDeferred).toBe(1);
+    expect(state.listReviewQueueJobs({ repo: "org/repo-a" })).toEqual([
+      expect.objectContaining({
+        pullNumber: 1,
+        state: "provider_deferred",
+        priority: 50,
+        nextEligibleAt: "2026-07-01T00:05:00.000Z"
+      })
+    ]);
+    state.close();
+  });
+
   it("uses repo-profile queue overflow policy to mark burst heads explicitly provider-deferred", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-profile-capacity-"));
     roots.push(root);


### PR DESCRIPTION
Closes #301. Parent: #278 (Phase 3, item 8).

## Summary
Queue ordering was flat priority-50 FIFO (only two hardcoded SELF_REPOS elevated) — a docs-only PR could lease before a concurrent auth/migration PR. This adds config-gated, enqueue-time risk tiering.

- **Enqueue-data discovery (flagged per spec):** changed-file paths were NOT available at enqueue (files are fetched at review time; `SchedulerGitHubApi` had no `listPullFiles`). Chosen seam: optional `listPullFiles` on the scheduler API, invoked ONLY when `riskWeightedQueue.enabled` — disabled (default) means zero extra GitHub calls and byte-identical flat behavior.
- Pure exported `riskWeightedQueuePriority`: tier derived solely from the already-shipped `buildChangedSurfaceValidationReport` (required-validation category ⇒ elevated; docs-only ⇒ deferred; else default). No new path-classification logic.
- `resolveRiskWeightedPriorityOverride`: gated fetch → report → priority; fetch failures log (secret-redacted) and fall back to flat priority — **never blocks enqueue**.
- Evidence: `[risk-queue] … tier=… priority=… reason=…` log line in the existing scheduler idiom (non-default tiers only).
- New `config.riskWeightedQueue { enabled:false, elevatedPriority?, docsOnlyPriority? }`, fail-closed validation. Only enqueue priority changes — lease/capacity/manual-reserve untouched; manual commands keep their existing priority path.

## Validation
- TDD failing-first: auth-vs-docs same-created_at ordering flips only when enabled; disabled/no-report ⇒ flat; config default/validation.
- Focused Vitest 111/111 (risk-weighted, scheduler, review-budget, review-scheduler-config, neondiff-config-schema) under `set -o pipefail`; `npm run build` exit 0.
- Additive/default-off per the program's posture.