### PR TITLE
docs: stage v0.4.28 beta release

### DIFF
--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,13 +1,13 @@
 {
-  "version": "v0.4.27-beta.1",
+  "version": "v0.4.28-beta.1",
   "releaseLevel": "source-beta",
   "packageArtifact": {
     "name": "neondiff",
     "version": "0.4.24-beta.1",
     "requiredForThisRelease": false,
     "state": "held_at_previous_npm_release",
-    "heldReason": "v0.4.27-beta.1 is a source/daemon-only live beta; no npm artifact is published for this runtime-safety hotfix.",
-    "currentSourceVersion": "v0.4.27-beta.1",
+    "heldReason": "v0.4.28-beta.1 is a source/daemon-only live beta; no npm artifact is published for this scheduler-priority hardening release.",
+    "currentSourceVersion": "v0.4.28-beta.1",
     "previousReleasedPackageVersion": "0.4.24-beta.1"
   },
   "source": {
@@ -15,9 +15,9 @@
     "proof": "release:status --expected-head $(git rev-parse HEAD)"
   },
   "docs": {
-    "version": "v0.4.27-beta.1",
+    "version": "v0.4.28-beta.1",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v0.4.27-beta.1.md",
+    "releaseNotesPath": "docs/releases/v0.4.28-beta.1.md",
     "websiteRepo": "electricsheephq/neon-diff-agent"
   },
   "licenseApi": {
@@ -29,13 +29,13 @@
     "cli": {
       "requiredForThisRelease": true,
       "state": "source_checkout",
-      "version": "v0.4.27-beta.1",
+      "version": "v0.4.28-beta.1",
       "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "launchd_prerelease",
-      "version": "v0.4.27-beta.1",
+      "version": "v0.4.28-beta.1",
       "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
     },
     "website": {

--- a/docs/releases/v0.4.28-beta.1.md
+++ b/docs/releases/v0.4.28-beta.1.md
@@ -1,0 +1,82 @@
+# v0.4.28-beta.1
+
+- Release type: local beta scheduler-priority hardening release
+- Release source SHA: to be stamped during post-merge live promotion
+- Previous prerelease: `v0.4.27-beta.1`
+- Tracking issues / source PRs: `#301`, `#306`, `#307`
+- Promoted PR: `#306`
+- Included implementation merge SHA: `ae2859d3a90e2814093f1376425760ab9dc2f8a2` (`#306`)
+- Local operator evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/v0.4.28-beta.1/`
+- Rollback tag: `v0.4.27-beta.1`
+- Package artifact: `neondiff@0.4.24-beta.1` (held from previous npm release)
+- Rollback baseline: `v0.4.9-beta.1` remains the known-good daemon fallback
+
+## Purpose
+
+Promote the risk-weighted review-queue priority hardening from `#306` as a
+named live-worker beta, rather than leaving launchd pointed at informal `main`.
+
+This release makes changed-surface risk scoring available behind
+`riskWeightedQueue.enabled`, so required-validation surfaces can lease before
+docs-only work when the feature is explicitly enabled. The live default remains
+off unless the active config opts into the feature.
+
+This is a local live-worker beta release. It does not publish a new npm package
+or replace the public `neondiff@0.4.24-beta.1` package release. The public
+manifest records the held npm artifact separately from the source/daemon beta
+version.
+
+## Included Changes
+
+- Add risk-weighted queue priority derived from the existing changed-surface
+  validation report.
+- Keep default behavior byte-compatible when `riskWeightedQueue.enabled` is
+  false: no changed-file GitHub API call is made and flat background priority is
+  preserved.
+- Validate risk priority configuration so elevated work cannot be configured to
+  lease after docs-only work.
+- Skip changed-file fetching while a repo-level provider cooldown is active,
+  avoiding unnecessary GitHub API pressure on deferred heads.
+- Fall back to flat priority if the changed-file fetch fails, with redacted
+  warning logs.
+
+## Required Gates
+
+- PR `#306` merged to `main`; required `Build, test, and package` check passed.
+- PR `#306` CodeRabbit review approved and all current-head review threads were
+  resolved after follow-up commits.
+- Focused local validation for `#306`:
+  `npm test -- tests/risk-weighted-queue.test.ts tests/scheduler.test.ts --pool=forks --maxWorkers=1`
+  passed 82 tests.
+- `npm run build`
+- `git diff --check`
+- Release packet PR merged to `main`.
+- Post-tag `release:status` after launchd restart at the promoted tag SHA.
+- Post-promotion `coverage-audit` and expired provider cooldown audit.
+
+## Caveats
+
+- `riskWeightedQueue.enabled` remains default-off; this release ships the safe
+  plumbing and tests, not a live priority-policy rollout.
+- Optional Swift CodeQL may still be running or delayed on release PRs; branch
+  protection for `main` requires only `Build, test, and package`.
+- The public npm package remains `neondiff@0.4.24-beta.1`; this release tags the
+  live local worker source SHA only.
+- Queue terminal-state follow-up `#307` is not fixed in this release. It remains
+  the next runtime reliability lane: `skipped_draft` should not create failed
+  durable queue rows, and stale closed/merged active jobs need clearer
+  retirement or health visibility.
+
+## Rollback
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v0.4.27-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -74,7 +74,7 @@ describe("NeonDiff public release readiness", () => {
       version: "0.4.24-beta.1",
       requiredForThisRelease: false,
       state: "held_at_previous_npm_release",
-      currentSourceVersion: "v0.4.27-beta.1",
+      currentSourceVersion: "v0.4.28-beta.1",
       previousReleasedPackageVersion: "0.4.24-beta.1"
     });
     expect(manifest.packageArtifact?.heldReason).toMatch(/source\/daemon-only live beta/i);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -193,16 +193,16 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.27-beta.1"
+      expectedVersion: "v0.4.28-beta.1"
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v0.4.27-beta.1",
+      version: "v0.4.28-beta.1",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v0.4.27-beta.1.md"
+        releaseNotesPath: "docs/releases/v0.4.28-beta.1.md"
       },
       updateChannels: {
         ok: true
@@ -262,13 +262,13 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v0.4.27-beta.1",
+      expectedPublicVersion: "v0.4.28-beta.1",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot"
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v0.4.27-beta.1"
+      version: "v0.4.28-beta.1"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",


### PR DESCRIPTION
## Summary

Stages the v0.4.28-beta.1 release packet after #306 merged, updates the public source-beta manifest from v0.4.27 to v0.4.28, and advances the manifest smoke-test pins.

## Validation

- npm test -- tests/release-status.test.ts tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1
- npm run build
- git diff --check

## Notes

- Source/daemon beta only; npm package remains neondiff@0.4.24-beta.1.
- #307 remains the next runtime queue follow-up and is explicitly called out as not fixed in this release.
