### PR TITLE
fix: retire draft-skipped queue jobs

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1730,7 +1730,6 @@ function updateQueueJobAfterReviewStatus(input: {
         lastError: "legacy_review_capacity_busy"
       });
       return;
-    case "skipped_draft":
     case "skipped_canary":
     case "skipped_policy":
     case "skipped_license_gate":
@@ -1741,6 +1740,13 @@ function updateQueueJobAfterReviewStatus(input: {
         lastError: input.status === "skipped_license_gate"
           ? input.state.getReviewReadiness(input.job.repo, input.pull.number, input.pull.head.sha)?.reason ?? "license_entitlement_required"
           : `unexpected_scheduler_review_status=${input.status}`
+      });
+      return;
+    case "skipped_draft":
+      input.state.updateReviewQueueJobState({
+        jobId: input.job.jobId,
+        state: "stale_retired",
+        lastError: "draft_pr"
       });
       return;
     case "skipped_command_stop":

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1482,6 +1482,94 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("retires a queued job as skipped, not failed, when it becomes draft after in-progress", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-draft-skip-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const statusCalls: StatusCommentCall[] = [];
+    let listedPull = pull("org/repo-a", 1, HEAD_A);
+    let refetchedPull = pull("org/repo-a", 1, HEAD_A, "base", { draft: true });
+    const github: SchedulerGitHubApi = {
+      ...githubFromMap(new Map(), new Map(), statusCalls),
+      listOpenPulls: async () => [listedPull],
+      getPull: async () => refetchedPull
+    };
+
+    const first = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ pull: reviewPull }) => reviewPull.draft ? "skipped_draft" : "reviewed",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    expect(first.skippedDraft).toBe(1);
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "skipped"]);
+    expect(state.listReviewQueueJobs({ state: "failed" })).toHaveLength(0);
+    expect(state.listReviewQueueJobs({ state: "stale_retired" })).toEqual([
+      expect.objectContaining({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A, lastError: "draft_pr" })
+    ]);
+    expect(state.getProcessedReview("org/repo-a", 1, HEAD_A)).toBeUndefined();
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "skipped",
+      reason: "draft_pr"
+    });
+
+    listedPull = pull("org/repo-a", 1, HEAD_A, "base", { draft: true });
+    refetchedPull = listedPull;
+    const stillDraft = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("draft pull should skip before review work");
+      },
+      now: new Date("2026-07-02T00:00:30.000Z")
+    });
+
+    expect(stillDraft.skippedDraft).toBe(1);
+    expect(stillDraft.queue.enqueued).toBe(0);
+    expect(stillDraft.reviewed).toBe(0);
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", "skipped"]);
+    expect(state.listReviewQueueJobs({ state: "failed" })).toHaveLength(0);
+
+    listedPull = pull("org/repo-a", 1, HEAD_A);
+    refetchedPull = listedPull;
+    const second = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: `https://github.com/${repo}/pull/${reviewPull.number}#pullrequestreview-1`
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T00:01:00.000Z")
+    });
+
+    expect(second.queue.enqueued).toBe(1);
+    expect(second.reviewed).toBe(1);
+    expect(state.listReviewQueueJobs({ state: "posted" })).toEqual([
+      expect.objectContaining({ repo: "org/repo-a", pullNumber: 1, headSha: HEAD_A })
+    ]);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "ready_for_human",
+      reason: "comment_review_posted"
+    });
+    state.close();
+  });
+
   it("sets blocked proof readiness when a queued job becomes license-skipped after in-progress", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-status-license-skip-"));
     roots.push(root);
@@ -1646,6 +1734,52 @@ describe("provider-aware review scheduler", () => {
     expect(statusCalls.map(statusFromBody)).toEqual(["stale_head"]);
     expect(statusCalls[0]?.marker).toBe(`<!-- evaos-code-review-bot:review-status repo=org/repo-a pr=1 sha=${HEAD_A} -->`);
     expect(state.listReviewQueueJobs({ state: "stale_retired" })).toHaveLength(1);
+    state.close();
+  });
+
+  it("retires an expired running closed job without failing the queue", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-expired-running-closed-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const job = state.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      baseSha: "base"
+    }).job;
+    state.updateReviewQueueJobState({
+      jobId: job.jobId,
+      state: "running",
+      leaseId: "expired-running-lease",
+      leaseExpiresAt: "2026-07-02T00:00:00.000Z",
+      clearLease: false,
+      now: new Date("2026-07-01T23:58:00.000Z")
+    });
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org/repo-a", [pull("org/repo-a", 1, HEAD_A, "base", { state: "closed", mergedAt: "2026-07-02T00:00:30Z" })]]
+      ]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async () => {
+        throw new Error("expired closed active jobs must not run review work");
+      },
+      now: new Date("2026-07-02T00:01:00.000Z")
+    });
+
+    expect(result.queue.closedRetired).toBe(1);
+    expect(result.queue.failedQueueJobs).toBe(0);
+    expect(statusCalls.map(statusFromBody)).toEqual(["closed_or_merged_before_review"]);
+    expect(state.getReviewQueueJob(job.jobId)).toMatchObject({
+      state: "closed_retired",
+      lastError: "closed_or_merged_before_review state=closed"
+    });
+    expect(state.listReviewQueueJobs({ state: "failed" })).toHaveLength(0);
     state.close();
   });
 
@@ -3711,12 +3845,12 @@ function pull(
   number: number,
   headSha: string,
   baseSha = "base",
-  options: { state?: string; mergedAt?: string | null; createdAt?: string } = {}
+  options: { state?: string; mergedAt?: string | null; createdAt?: string; draft?: boolean } = {}
 ): PullRequestSummary {
   return {
     number,
     title: `${repo} PR ${number}`,
-    draft: false,
+    draft: options.draft ?? false,
     ...(options.state ? { state: options.state } : {}),
     ...(options.createdAt ? { created_at: options.createdAt } : {}),
     ...(options.mergedAt !== undefined ? { merged_at: options.mergedAt } : {}),


### PR DESCRIPTION
## Summary
- Treat leased review results of `skipped_draft` as skipped/stale-retired queue outcomes instead of failed queue jobs.
- Add regression coverage showing draft-after-lease does not write a processed row or block a later non-draft same-head review.
- Add regression coverage for an expired running closed PR retiring without review work or failed queue state.

Fixes #307.

## Validation
- `npm test -- tests/scheduler.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`

## Runtime notes
- This PR does not mutate live config, launchd, provider settings, or active allowlists.
- It intentionally avoids the outcome-ledger collision zone: `src/outcome-ledger.ts`, `src/worker.ts`, `src/cli.ts`, `tests/outcome-ledger.test.ts`, `tests/worker-settings-preview.test.ts`, and `docs/advanced-outcome-modes.md`.