### PR TITLE
docs: stage v0.4.29 beta release

### DIFF
--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,13 +1,13 @@
 {
-  "version": "v0.4.28-beta.1",
+  "version": "v0.4.29-beta.1",
   "releaseLevel": "source-beta",
   "packageArtifact": {
     "name": "neondiff",
     "version": "0.4.24-beta.1",
     "requiredForThisRelease": false,
     "state": "held_at_previous_npm_release",
-    "heldReason": "v0.4.28-beta.1 is a source/daemon-only live beta; no npm artifact is published for this scheduler-priority hardening release.",
-    "currentSourceVersion": "v0.4.28-beta.1",
+    "heldReason": "v0.4.29-beta.1 is a source/daemon-only live beta; no npm artifact is published for this queue terminal-state hardening release.",
+    "currentSourceVersion": "v0.4.29-beta.1",
     "previousReleasedPackageVersion": "0.4.24-beta.1"
   },
   "source": {
@@ -15,9 +15,9 @@
     "proof": "release:status --expected-head $(git rev-parse HEAD)"
   },
   "docs": {
-    "version": "v0.4.28-beta.1",
+    "version": "v0.4.29-beta.1",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v0.4.28-beta.1.md",
+    "releaseNotesPath": "docs/releases/v0.4.29-beta.1.md",
     "websiteRepo": "electricsheephq/neon-diff-agent"
   },
   "licenseApi": {
@@ -29,13 +29,13 @@
     "cli": {
       "requiredForThisRelease": true,
       "state": "source_checkout",
-      "version": "v0.4.28-beta.1",
+      "version": "v0.4.29-beta.1",
       "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "launchd_prerelease",
-      "version": "v0.4.28-beta.1",
+      "version": "v0.4.29-beta.1",
       "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
     },
     "website": {

--- a/docs/releases/v0.4.29-beta.1.md
+++ b/docs/releases/v0.4.29-beta.1.md
@@ -1,0 +1,86 @@
+# v0.4.29-beta.1
+
+- Release type: local beta queue terminal-state hardening release
+- Release source SHA: to be stamped during post-merge live promotion
+- Previous prerelease: `v0.4.28-beta.1`
+- Tracking issues / source PRs: `#253`, `#254`, `#307`, `#309`
+- Promoted PRs: `#254`, `#309`
+- Included implementation merge SHAs:
+  - `2917943d1eb54f36eda268aab3ebf4ec5a67677e` (`#254`)
+  - `6225eeaf7274d664337698e24d650090b752a9ef` (`#309`)
+- Local operator evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/v0.4.29-beta.1/`
+- Rollback tag: `v0.4.28-beta.1`
+- Package artifact: `neondiff@0.4.24-beta.1` (held from previous npm release)
+- Rollback baseline: `v0.4.9-beta.1` remains the known-good daemon fallback
+
+## Purpose
+
+Promote the queue terminal-state fix for `#307` and the npm prerelease workflow
+guard from `#254` as a named live-worker beta, rather than leaving launchd
+pointed at informal `main`.
+
+This release fixes the live failure mode where a leased review returning
+`skipped_draft` could poison the durable review queue as `failed`. Draft skips
+are now terminal, non-failed queue outcomes, and the focused scheduler coverage
+proves a later non-draft same-head review can still proceed.
+
+This is a local live-worker beta release. It does not publish a new npm package
+or replace the public `neondiff@0.4.24-beta.1` package release. The public
+manifest records the held npm artifact separately from the source/daemon beta
+version.
+
+## Included Changes
+
+- Treat `skipped_draft` from an already leased review as a non-failed terminal
+  queue outcome with `lastError: draft_pr`.
+- Preserve existing readiness and review-status semantics: draft heads are
+  reported as skipped, not failed.
+- Add scheduler regression coverage for the full draft lifecycle: non-draft
+  enqueue, draft refetch, still-draft skip, then later non-draft review for the
+  same head.
+- Add scheduler regression coverage for expired running closed jobs retiring as
+  `closed_retired` without running review work or marking queue failure.
+- Add the required npm `--tag beta` flag to the prerelease publish workflow.
+
+## Required Gates
+
+- PR `#309` merged to `main`; required `Build, test, and package` check passed.
+- PR `#309` exact-head evaOS App review passed for
+  `02e6561fc754f3bb95bf81d9b70c07221d38f93a`:
+  https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/309#pullrequestreview-4632183257
+- PR `#309` current-head review threads were zero unresolved.
+- Focused local validation for `#309`:
+  `npm test -- tests/scheduler.test.ts --pool=forks --maxWorkers=1`
+  passed 74 tests.
+- `npm run build`
+- `git diff --check`
+- Release packet PR merged to `main`.
+- Post-tag `release:status` after launchd restart at the promoted tag SHA.
+- Post-promotion `coverage-audit` and expired provider cooldown audit.
+
+## Caveats
+
+- Optional Swift CodeQL may still be running or delayed on release PRs; branch
+  protection for `main` requires `Build, test, and package`.
+- The public npm package remains `neondiff@0.4.24-beta.1`; this release tags the
+  live local worker source SHA only.
+- A scoped dry-run was used to verify the current `#309` head before the live
+  daemon completed its App-authored review; dry-run proof did not satisfy the
+  merge gate, and the live App-authored review was required before merge.
+- `#309` fixed the concrete `skipped_draft` queue poisoning bug. Broader
+  scheduler coverage gaps around force-pushed self-repo heads should remain in
+  follow-up tracking if they recur.
+
+## Rollback
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v0.4.28-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -74,7 +74,7 @@ describe("NeonDiff public release readiness", () => {
       version: "0.4.24-beta.1",
       requiredForThisRelease: false,
       state: "held_at_previous_npm_release",
-      currentSourceVersion: "v0.4.28-beta.1",
+      currentSourceVersion: "v0.4.29-beta.1",
       previousReleasedPackageVersion: "0.4.24-beta.1"
     });
     expect(manifest.packageArtifact?.heldReason).toMatch(/source\/daemon-only live beta/i);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -193,16 +193,16 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.28-beta.1"
+      expectedVersion: "v0.4.29-beta.1"
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v0.4.28-beta.1",
+      version: "v0.4.29-beta.1",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v0.4.28-beta.1.md"
+        releaseNotesPath: "docs/releases/v0.4.29-beta.1.md"
       },
       updateChannels: {
         ok: true
@@ -262,13 +262,13 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v0.4.28-beta.1",
+      expectedPublicVersion: "v0.4.29-beta.1",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot"
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v0.4.28-beta.1"
+      version: "v0.4.29-beta.1"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",


### PR DESCRIPTION
## Summary
- Stage `v0.4.29-beta.1` as a source/daemon beta for the #307 queue terminal-state fix and #254 npm prerelease workflow guard.
- Update the public release manifest and release-status/readiness test pins to `v0.4.29-beta.1`.
- Document post-promotion evidence path, rollback tag, and the exact-head evaOS review proof from #309.

## Validation
- `npm test -- tests/release-status.test.ts tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`

## Runtime notes
- No npm package publish in this release packet.
- No live config or launchd mutation until after this release packet merges and the tag is created.
