### PR TITLE
Harden release paths for v0.4.30 beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Requirements:
 Recommended package install for the current beta:
 
 ```bash
-npm install -g neondiff@0.4.24-beta.1
+npm install -g neondiff@0.4.30-beta.1
 ```
 
 Installer script path:
@@ -195,6 +195,6 @@ For public source-beta release readiness, use
 [docs/public-release-manifest.json](docs/public-release-manifest.json) with
 `neondiff release-status --public-release-manifest docs/public-release-manifest.json --expected-public-version <public-beta-tag>`.
 Replace `<public-beta-tag>` with the actual semver prerelease tag, such as
-`v0.4.24-beta.1`; the CLI rejects literal placeholders. The manifest is the
+`v0.4.30-beta.1`; the CLI rejects literal placeholders. The manifest is the
 compact version/alignment surface for setup docs, release notes, license API
 state, and update-channel readiness.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -27,7 +27,7 @@ tokens.
 Recommended package install:
 
 ```bash
-npm install -g neondiff@0.4.24-beta.1
+npm install -g neondiff@0.4.30-beta.1
 ```
 
 Installer script:

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,23 +1,29 @@
 {
-  "version": "v0.4.29-beta.1",
+  "version": "v0.4.30-beta.1",
   "releaseLevel": "source-beta",
   "packageArtifact": {
     "name": "neondiff",
-    "version": "0.4.24-beta.1",
-    "requiredForThisRelease": false,
-    "state": "held_at_previous_npm_release",
-    "heldReason": "v0.4.29-beta.1 is a source/daemon-only live beta; no npm artifact is published for this queue terminal-state hardening release.",
-    "currentSourceVersion": "v0.4.29-beta.1",
-    "previousReleasedPackageVersion": "0.4.24-beta.1"
+    "version": "0.4.30-beta.1",
+    "requiredForThisRelease": true,
+    "state": "pending_publish_after_merge",
+    "previousReleasedPackageVersion": "0.4.24-beta.1",
+    "skippedPublicPackageVersions": [
+      "v0.4.25-beta.1",
+      "v0.4.26-beta.1",
+      "v0.4.27-beta.1",
+      "v0.4.28-beta.1",
+      "v0.4.29-beta.1"
+    ],
+    "note": "v0.4.25 through v0.4.29 were source/local-worker beta releases; v0.4.29-beta.1 is already tagged as source/daemon-only, so v0.4.30-beta.1 is the next public npm/site beta."
   },
   "source": {
-    "shaState": "set_after_manifest_reconciliation_merge",
+    "shaState": "set_after_codeql_hardening_merge",
     "proof": "release:status --expected-head $(git rev-parse HEAD)"
   },
   "docs": {
-    "version": "v0.4.29-beta.1",
+    "version": "v0.4.30-beta.1",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v0.4.29-beta.1.md",
+    "releaseNotesPath": "docs/releases/v0.4.30-beta.1.md",
     "websiteRepo": "electricsheephq/neon-diff-agent"
   },
   "licenseApi": {
@@ -28,19 +34,20 @@
   "updateChannels": {
     "cli": {
       "requiredForThisRelease": true,
-      "state": "source_checkout",
-      "version": "v0.4.29-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
+      "state": "published",
+      "version": "v0.4.30-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.29-beta.1"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "launchd_prerelease",
-      "version": "v0.4.29-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.9-beta.1"
+      "version": "v0.4.30-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.29-beta.1"
     },
     "website": {
       "requiredForThisRelease": false,
-      "state": "pending-site-sync",
+      "state": "published",
+      "version": "v0.4.30-beta.1",
       "trackingIssue": "https://github.com/electricsheephq/neon-diff-agent/issues/3"
     },
     "desktop": {

--- a/docs/releases/v0.4.30-beta.1.md
+++ b/docs/releases/v0.4.30-beta.1.md
@@ -1,0 +1,71 @@
+# v0.4.30-beta.1
+
+- Release type: public source-available beta npm/site hardening release
+- Release source SHA: to be stamped after the public beta finalization merge
+- Previous prerelease: `v0.4.29-beta.1`
+- Previous public npm package: `neondiff@0.4.24-beta.1`
+- Package artifact: `neondiff@0.4.30-beta.1`
+- Tracking issue: `#249`
+- Public install path: `npm install -g neondiff@0.4.30-beta.1`
+- Installer path: `https://www.neondiff.com/install` pinned to `0.4.30-beta.1`
+- Evidence path: `/Volumes/LEXAR/Codex/evidence/neondiff-public-product/2026-07-06/codeql-hardening/`
+
+## Purpose
+
+Promote the public package and website installer after the repo public-flip
+CodeQL hardening work. This release keeps the existing implementation repo name
+and makes the buyer-facing install path reproducible through a pinned npm beta,
+not an unbounded `latest` install.
+
+`v0.4.29-beta.1` already exists as a source/daemon-only GitHub prerelease and
+does not publish an npm artifact. To avoid reusing that tag with different
+public-package semantics, the next installable public npm/site beta is
+`v0.4.30-beta.1`.
+
+## Included Changes
+
+- Harden GitHub and license API URL construction so configured API bases cannot
+  include credentials, cannot downgrade to non-loopback HTTP, and preserve
+  GitHub Enterprise-style API base paths.
+- Replace host substring checks with URL/host-token parsing for OpenAI, Voyage,
+  and GitHub dependency classification.
+- Replace the public-version SemVer regex with bounded deterministic parsing.
+- Redact GitHub/API/model-derived evidence markdown and JSON before writing
+  local evidence artifacts.
+- Use creation-only or atomic writes for public `init` config writes and
+  temporary ZCode policy files where practical.
+- Bump package metadata, setup docs, installer script, and the public release
+  manifest to `0.4.30-beta.1`.
+
+## Required Gates
+
+- Focused local tests for changed helpers and CLI behavior:
+  `npm test -- --pool=forks --maxWorkers=1 tests/github-app-read.test.ts tests/license.test.ts tests/gitnexus-refresh-preflight.test.ts tests/provider-throttle-report.test.ts tests/release-status.test.ts tests/public-cli.test.ts tests/walkthrough-post.test.ts tests/zcode-policy.test.ts`
+- `npm run build`
+- `node scripts/check-secret-scan.mjs`
+- Public claims scan
+- Package packlist check
+- GitHub Actions `Build, test, and package`
+- CodeQL JavaScript/TypeScript and actions analysis
+- CodeQL alert closeout or explicit local-only dismissal rationale for any
+  remaining evidence-write/file-race alerts.
+- `npm view neondiff version` returns `0.4.30-beta.1` after publish.
+- `curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run` shows the
+  pinned `0.4.30-beta.1` install.
+
+## Caveats
+
+- This is a public beta, not GA or enterprise-ready certification.
+- The license boundary remains source-available beta, not open source.
+- Website source remains private; only the implementation repo is public.
+- Some local evidence-write CodeQL alerts may require dismissal instead of code
+  removal because the product intentionally writes sanitized local review
+  evidence under controlled evidence directories.
+
+## Rollback
+
+```bash
+git fetch origin --tags
+git reset --hard refs/tags/v0.4.29-beta.1
+npm install -g neondiff@0.4.24-beta.1
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neondiff",
-  "version": "0.4.24-beta.1",
+  "version": "0.4.30-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neondiff",
-      "version": "0.4.24-beta.1",
+      "version": "0.4.30-beta.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "neondiff": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neondiff",
-  "version": "0.4.24-beta.1",
+  "version": "0.4.30-beta.1",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
   "bin": {

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -7,7 +7,7 @@ const paths = [
   "docs/providers.md",
   "docs/license-boundary.md",
   "docs/pricing.md",
-  "docs/releases/v0.4.24-beta.1.md"
+  "docs/releases/v0.4.30-beta.1.md"
 ];
 
 const required = [

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-NEONDIFF_VERSION="${NEONDIFF_VERSION:-0.4.24-beta.1}"
+NEONDIFF_VERSION="${NEONDIFF_VERSION:-0.4.30-beta.1}"
 DRY_RUN=0
 NPM_PREFIX="${NPM_PREFIX:-}"
 
@@ -13,7 +13,7 @@ Usage:
   sh install.sh [--dry-run] [--prefix /path/to/prefix]
 
 Environment:
-  NEONDIFF_VERSION  Version to install, defaults to 0.4.24-beta.1.
+  NEONDIFF_VERSION  Version to install, defaults to 0.4.30-beta.1.
   NPM_PREFIX        Optional npm global prefix.
 
 Requires Node.js 26 or newer and npm.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,19 @@ import { loadConfig, validateLicenseConfigOverride, type BotConfig } from "./con
 import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
 import { collectProviderThrottleReport } from "./provider-throttle-report.js";
 import { runDaemonCycle } from "./daemon.js";
-import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from "node:fs";
 import { basename, dirname, extname, join, parse as parsePath, resolve, sep } from "node:path";
 import {
   assertEvalOutputDirSafe,
@@ -775,7 +787,7 @@ async function main(): Promise<void> {
       const safeOutputDir = assertMemoryPacketOutputDirSafe(args["output-dir"], config.evidenceDir);
       mkdirSync(safeOutputDir, { recursive: true });
       writeFileSync(join(safeOutputDir, "repo-memory-packet.json"), `${JSON.stringify(result, null, 2)}\n`);
-      writeFileSync(join(safeOutputDir, "repo-memory-packet.md"), result.packet.markdown);
+      writeFileSync(join(safeOutputDir, "repo-memory-packet.md"), redactSecrets(result.packet.markdown));
     }
     const format = args.format ?? "json";
     const jsonOutput = redactSecrets(JSON.stringify(result, null, 2));
@@ -899,7 +911,7 @@ async function main(): Promise<void> {
       mkdirSync(safeOutputDir, { recursive: true });
       const jsonName = result.ok ? "github-related-context-packet.json" : "github-related-context-packet-error.json";
       writeFileSync(join(safeOutputDir, jsonName), `${redactSecrets(JSON.stringify(result, null, 2))}\n`);
-      if (result.ok) writeFileSync(join(safeOutputDir, "github-related-context-packet.md"), result.packet.markdown);
+      if (result.ok) writeFileSync(join(safeOutputDir, "github-related-context-packet.md"), redactSecrets(result.packet.markdown));
     }
     const format = args.format ?? "json";
     if (format === "markdown") {
@@ -929,7 +941,7 @@ async function main(): Promise<void> {
       mkdirSync(safeOutputDir, { recursive: true });
       const jsonName = result.ok ? "skill-pack-context-packet.json" : "skill-pack-context-packet-error.json";
       writeFileSync(join(safeOutputDir, jsonName), `${redactSecrets(JSON.stringify(result, null, 2))}\n`);
-      if (result.ok) writeFileSync(join(safeOutputDir, "skill-pack-context-packet.md"), result.packet.markdown);
+      if (result.ok) writeFileSync(join(safeOutputDir, "skill-pack-context-packet.md"), redactSecrets(result.packet.markdown));
     }
     const jsonOutput = redactSecrets(JSON.stringify(result, null, 2));
     console.log(jsonOutput);
@@ -965,7 +977,7 @@ async function main(): Promise<void> {
         const safeOutputDir = assertMemoryPacketOutputDirSafe(args["output-dir"], config.evidenceDir);
         mkdirSync(safeOutputDir, { recursive: true });
         writeFileSync(join(safeOutputDir, "enrichment-comment.json"), `${redactSecrets(JSON.stringify(output, null, 2))}\n`);
-        if (!output.skipped) writeFileSync(join(safeOutputDir, "enrichment.md"), output.body);
+        if (!output.skipped) writeFileSync(join(safeOutputDir, "enrichment.md"), redactSecrets(output.body));
       }
       console.log(redactSecrets(JSON.stringify(output, null, 2)));
       return;
@@ -1009,7 +1021,7 @@ async function main(): Promise<void> {
       const safeOutputDir = assertMemoryPacketOutputDirSafe(args["output-dir"], config.evidenceDir);
       mkdirSync(safeOutputDir, { recursive: true });
       writeFileSync(join(safeOutputDir, "enrichment-comment.json"), `${redactSecrets(JSON.stringify(output, null, 2))}\n`);
-      writeFileSync(join(safeOutputDir, "enrichment.md"), enrichment.body);
+      writeFileSync(join(safeOutputDir, "enrichment.md"), redactSecrets(enrichment.body));
     }
     console.log(redactSecrets(JSON.stringify(output, null, 2)));
     return;
@@ -1898,7 +1910,12 @@ function runInitCommand(args: ParsedArgs): {
   }
   const backupPath = force && existsSync(configPath) ? backupInitForceTarget(configPath) : undefined;
   mkdirSync(dirname(configPath), { recursive: true });
-  writeFileSync(configPath, readFileSync(examplePath, "utf8"));
+  const exampleConfig = readFileSync(examplePath, "utf8");
+  if (force) {
+    writeFileAtomic(configPath, exampleConfig);
+  } else {
+    writeNewFile(configPath, exampleConfig);
+  }
   return {
     ok: true,
     command: "init",
@@ -1982,8 +1999,28 @@ function validateInitForceTarget(configPath: string): string | undefined {
 function backupInitForceTarget(configPath: string): string {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const backupPath = `${configPath}.${timestamp}.bak`;
-  writeFileSync(backupPath, readFileSync(configPath, "utf8"));
+  writeNewFile(backupPath, readFileSync(configPath, "utf8"));
   return backupPath;
+}
+
+function writeNewFile(path: string, contents: string): void {
+  const fd = openSync(path, "wx", 0o600);
+  try {
+    writeFileSync(fd, contents);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function writeFileAtomic(path: string, contents: string): void {
+  const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(tempPath, contents, { mode: 0o600 });
+    renameSync(tempPath, path);
+  } catch (error) {
+    rmSync(tempPath, { force: true });
+    throw error;
+  }
 }
 
 type DaemonControlResult = {

--- a/src/github.ts
+++ b/src/github.ts
@@ -4,6 +4,7 @@ import type { IssueCommentCommandSource } from "./commands.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
 import { redactSecrets } from "./secrets.js";
 import type { PullFilePatch, PullRequestSummary, RepositorySummary, ReviewComment, ReviewEvent } from "./types.js";
+import { buildApiUrl, normalizeHttpApiBaseUrl } from "./url-safety.js";
 
 export interface GitHubApiOptions {
   appId?: string;
@@ -18,7 +19,7 @@ export class GitHubApi {
   private readonly appId?: string;
   private readonly privateKey?: string;
   private readonly token?: string;
-  private readonly apiBaseUrl: string;
+  private readonly apiBaseUrl: URL;
   private readonly botLogin: string;
   private readonly requestTimeoutMs?: number;
   private installationTokens = new Map<string, { token: string; expiresAt: number }>();
@@ -27,7 +28,7 @@ export class GitHubApi {
     this.appId = options.appId;
     this.privateKey = options.privateKeyPath ? readFileSync(options.privateKeyPath, "utf8") : undefined;
     this.token = options.token;
-    this.apiBaseUrl = options.apiBaseUrl ?? "https://api.github.com";
+    this.apiBaseUrl = normalizeHttpApiBaseUrl(options.apiBaseUrl, "github.apiBaseUrl", "https://api.github.com");
     this.botLogin = options.botLogin ?? "evaos-code-review-bot[bot]";
     this.requestTimeoutMs = options.requestTimeoutMs;
   }
@@ -246,7 +247,7 @@ export class GitHubApi {
       ? setTimeout(() => controller.abort(new Error(`GitHub API request timed out after ${this.requestTimeoutMs}ms for ${path}`)), this.requestTimeoutMs)
       : undefined;
     try {
-      response = await fetch(`${this.apiBaseUrl}${path}`, {
+      response = await fetch(buildApiUrl(this.apiBaseUrl, path, "GitHub API request path"), {
         method: options.method ?? "GET",
         signal: controller?.signal,
         headers: {

--- a/src/gitnexus-refresh-preflight.ts
+++ b/src/gitnexus-refresh-preflight.ts
@@ -1,3 +1,5 @@
+import { isSameHostOrSubdomain } from "./url-safety.js";
+
 export type GitNexusRefreshAction = "analyze_with_embeddings" | "index_only_fallback" | "blocked";
 
 export interface GitNexusRefreshPreflightInput {
@@ -197,8 +199,14 @@ function parseGitNexusCommandFailures(text: string): string[] {
 
 function inferProviderFromUrl(url?: string): string | undefined {
   if (!url) return undefined;
-  if (url.includes("voyageai.com")) return "voyage";
-  if (url.includes("openai.com")) return "openai";
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return "http";
+  }
+  if (isSameHostOrSubdomain(parsed.hostname, "voyageai.com")) return "voyage";
+  if (isSameHostOrSubdomain(parsed.hostname, "openai.com")) return "openai";
   return "http";
 }
 

--- a/src/license.ts
+++ b/src/license.ts
@@ -15,6 +15,7 @@ import {
 import { hostname, platform } from "node:os";
 import { dirname } from "node:path";
 import { redactSecrets } from "./secrets.js";
+import { buildApiUrl, normalizeHttpApiBaseUrl } from "./url-safety.js";
 
 export type LicenseStorageBackend = "keychain" | "file";
 export type LicenseStatus = "active" | "expired" | "revoked" | "invalid" | "missing" | "network" | "server";
@@ -370,7 +371,8 @@ async function callLicenseApi(input: {
   const timeout = setTimeout(() => controller.abort(new Error("license API request timed out")), input.config.requestTimeoutMs);
   try {
     const fetcher = input.fetchImpl ?? fetch;
-    const response = await fetcher(`${input.config.apiBaseUrl}${input.path}`, {
+    const apiBaseUrl = normalizeHttpApiBaseUrl(input.config.apiBaseUrl, "config.license.apiBaseUrl", "");
+    const response = await fetcher(buildApiUrl(apiBaseUrl, input.path, "license API request path"), {
       method: "POST",
       signal: controller.signal,
       headers: { "Content-Type": "application/json" },

--- a/src/provider-throttle-report.ts
+++ b/src/provider-throttle-report.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
+import { textMentionsHost } from "./url-safety.js";
 
 export interface ProviderThrottleReportOptions {
   statePath: string;
@@ -497,7 +498,6 @@ function extractProviderCodes(error: string): string[] {
 
 function isNetworkOrGithubDependencySignal(normalizedError: string): boolean {
   return normalizedError.includes("github api fetch failed") ||
-    normalizedError.includes("api.github.com") ||
     normalizedError.includes("enotfound") ||
     normalizedError.includes("econnreset") ||
     normalizedError.includes("eaddrnotavail") ||
@@ -506,10 +506,7 @@ function isNetworkOrGithubDependencySignal(normalizedError: string): boolean {
     normalizedError.includes("unable to verify first certificate") ||
     (
       normalizedError.includes("fetch failed") &&
-      (
-        normalizedError.includes("github") ||
-        normalizedError.includes("api.github.com")
-      )
+      textMentionsHost(normalizedError, "github.com")
     );
 }
 

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -184,8 +184,6 @@ export interface ReleaseStatus {
 const REQUIRED_PUBLIC_UPDATE_CHANNELS = ["cli", "daemon"] as const;
 const PUBLIC_RELEASE_LEVELS = new Set(["beta", "source-beta", "stable"]);
 const MAX_PUBLIC_VERSION_TAG_LENGTH = 128;
-const PUBLIC_VERSION_PATTERN =
-  /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES = new Set(["source_checkout", "launchd_prerelease", "healthy", "published"]);
 const GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES = new Set([
   ...REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES,
@@ -716,12 +714,69 @@ function checkRollbackTarget(
 
 function isPublicVersionTag(version: string): boolean {
   if (version.length > MAX_PUBLIC_VERSION_TAG_LENGTH) return false;
-  return PUBLIC_VERSION_PATTERN.test(version);
+  if (!version.startsWith("v")) return false;
+  return isSemver(version.slice(1));
 }
 
 function isRollbackVersionTagRef(target: string): boolean {
   const prefix = "refs/tags/";
   return target.startsWith(prefix) && isPublicVersionTag(target.slice(prefix.length));
+}
+
+function isSemver(version: string): boolean {
+  const buildIndex = version.indexOf("+");
+  const withoutBuild = buildIndex === -1 ? version : version.slice(0, buildIndex);
+  const build = buildIndex === -1 ? undefined : version.slice(buildIndex + 1);
+  if (build !== undefined && !isDotSeparatedBuildMetadata(build)) return false;
+
+  const prereleaseIndex = withoutBuild.indexOf("-");
+  const core = prereleaseIndex === -1 ? withoutBuild : withoutBuild.slice(0, prereleaseIndex);
+  const prerelease = prereleaseIndex === -1 ? undefined : withoutBuild.slice(prereleaseIndex + 1);
+  const coreParts = core.split(".");
+  if (coreParts.length !== 3 || !coreParts.every(isSemverNumericIdentifier)) return false;
+  return prerelease === undefined || isDotSeparatedPrerelease(prerelease);
+}
+
+function isDotSeparatedPrerelease(value: string): boolean {
+  const parts = value.split(".");
+  return parts.length > 0 && parts.every((part) =>
+    part.length > 0 &&
+    isSemverIdentifier(part) &&
+    (!isAllAsciiDigits(part) || isSemverNumericIdentifier(part))
+  );
+}
+
+function isDotSeparatedBuildMetadata(value: string): boolean {
+  const parts = value.split(".");
+  return parts.length > 0 && parts.every((part) => part.length > 0 && isSemverIdentifier(part));
+}
+
+function isSemverNumericIdentifier(value: string): boolean {
+  if (!isAllAsciiDigits(value)) return false;
+  return value === "0" || !value.startsWith("0");
+}
+
+function isAllAsciiDigits(value: string): boolean {
+  if (value.length === 0) return false;
+  for (const char of value) {
+    if (char < "0" || char > "9") return false;
+  }
+  return true;
+}
+
+function isSemverIdentifier(value: string): boolean {
+  for (const char of value) {
+    if (
+      (char >= "0" && char <= "9") ||
+      (char >= "A" && char <= "Z") ||
+      (char >= "a" && char <= "z") ||
+      char === "-"
+    ) {
+      continue;
+    }
+    return false;
+  }
+  return true;
 }
 
 function isGitWorktree(cwd: string): boolean {

--- a/src/url-safety.ts
+++ b/src/url-safety.ts
@@ -1,0 +1,77 @@
+import { isIP } from "node:net";
+
+export function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+  if (normalized === "localhost" || normalized === "::1") return true;
+  if (isIP(normalized) === 4) return normalized.split(".")[0] === "127";
+  const mappedIpv4 = ipv4MappedIpv6Address(normalized);
+  return mappedIpv4 ? isLoopbackHost(mappedIpv4) : false;
+}
+
+export function normalizeHttpApiBaseUrl(value: string | undefined, label: string, fallback: string): URL {
+  const raw = value ?? fallback;
+  if (typeof raw !== "string" || raw.trim().length === 0) throw new Error(`${label} must be a non-empty URL`);
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`${label} must be a valid URL`);
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") throw new Error(`${label} must use http or https`);
+  if (parsed.username || parsed.password) throw new Error(`${label} must not include username or password credentials`);
+  if (parsed.protocol === "http:" && !isLoopbackHost(parsed.hostname)) {
+    throw new Error(`${label} must use https unless it points to localhost/loopback for local testing`);
+  }
+  parsed.hash = "";
+  parsed.search = "";
+  return parsed;
+}
+
+export function buildApiUrl(baseUrl: URL, requestPath: string, label: string): string {
+  if (!requestPath.startsWith("/") || requestPath.startsWith("//")) {
+    throw new Error(`${label} must be a root-relative API path`);
+  }
+  let parsedPath: URL;
+  try {
+    parsedPath = new URL(requestPath, "https://neondiff.local");
+  } catch {
+    throw new Error(`${label} must be a valid root-relative API path`);
+  }
+  if (parsedPath.origin !== "https://neondiff.local") {
+    throw new Error(`${label} must not be an absolute URL`);
+  }
+
+  const target = new URL(baseUrl.toString());
+  const basePath = target.pathname.replace(/\/+$/, "");
+  target.pathname = `${basePath}${parsedPath.pathname}`;
+  target.search = parsedPath.search;
+  target.hash = "";
+  return target.toString();
+}
+
+export function isSameHostOrSubdomain(hostname: string, domain: string): boolean {
+  const host = hostname.toLowerCase().replace(/\.$/, "");
+  const normalizedDomain = domain.toLowerCase().replace(/\.$/, "");
+  return host === normalizedDomain || host.endsWith(`.${normalizedDomain}`);
+}
+
+export function textMentionsHost(text: string, domain: string): boolean {
+  for (const token of hostTokens(text)) {
+    if (isSameHostOrSubdomain(token, domain)) return true;
+  }
+  return false;
+}
+
+function hostTokens(text: string): string[] {
+  const tokens = new Set<string>();
+  const hostPattern = /\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\b/gi;
+  for (const match of text.matchAll(hostPattern)) {
+    if (match[0]) tokens.add(match[0].toLowerCase());
+  }
+  return [...tokens];
+}
+
+function ipv4MappedIpv6Address(value: string): string | undefined {
+  const match = value.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i);
+  return match?.[1];
+}

--- a/src/walkthrough-post.ts
+++ b/src/walkthrough-post.ts
@@ -30,11 +30,11 @@ export async function postWalkthroughComment(input: {
       marker: input.walkthrough.marker,
       body: input.walkthrough.body
     });
-    writeFileSync(join(input.evidenceDir, "walkthrough-comment.json"), `${JSON.stringify(comment, null, 2)}\n`);
+    writeFileSync(join(input.evidenceDir, "walkthrough-comment.json"), `${redactSecrets(JSON.stringify(comment, null, 2))}\n`);
     return { posted: true, ...comment };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    writeFileSync(join(input.evidenceDir, "walkthrough-comment-error.txt"), redactSecrets(message));
+    writeFileSync(join(input.evidenceDir, "walkthrough-comment-error.txt"), `${redactSecrets(message)}\n`);
     return { posted: false, reason: "upsert_failed" };
   }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1276,7 +1276,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       acknowledge: false
     });
     writeRedactedJson(join(evidenceDir, "finishing-touch-draft.json"), { draft, stored });
-    writeFileSync(join(evidenceDir, "finishing-touch-draft.md"), draft.markdown);
+    writeRedactedText(join(evidenceDir, "finishing-touch-draft.md"), draft.markdown);
     return "skipped_finishing_touch_draft";
   }
 
@@ -1436,12 +1436,12 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       ...(githubRelatedContext.packet ? { githubRelatedContextPacket: githubRelatedContext.packet } : {}),
       maxPatchBytes: config.zcode.maxPatchBytes
     });
-    writeFileSync(join(evidenceDir, "repo-profile.json"), `${JSON.stringify(repoPolicy.profile, null, 2)}\n`);
-    writeFileSync(join(evidenceDir, "filter-impact.json"), `${JSON.stringify(filterImpact, null, 2)}\n`);
+    writeRedactedJson(join(evidenceDir, "repo-profile.json"), repoPolicy.profile);
+    writeRedactedJson(join(evidenceDir, "filter-impact.json"), filterImpact);
     const settingsPreview = buildReviewSettingsPreview(config, repoPolicy.profile);
     writeRedactedJson(join(evidenceDir, "review-settings-preview.json"), settingsPreview);
     if (commandDecision.action !== "none") {
-      writeFileSync(join(evidenceDir, "command.json"), `${JSON.stringify(commandDecision.command, null, 2)}\n`);
+      writeRedactedJson(join(evidenceDir, "command.json"), commandDecision.command);
     }
     writeFileSync(join(evidenceDir, "review-prompt.txt"), redactSecrets(prompt));
     writeRedactedJson(join(evidenceDir, "validation-selector.json"), validation);
@@ -1542,8 +1542,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       ...(enrichment ? { enrichment } : {})
     };
 
-    if (walkthrough) writeFileSync(join(evidenceDir, "walkthrough.md"), walkthrough.body);
-    if (enrichment) writeFileSync(join(evidenceDir, "enrichment.md"), enrichment.body);
+    if (walkthrough) writeRedactedText(join(evidenceDir, "walkthrough.md"), walkthrough.body);
+    if (enrichment) writeRedactedText(join(evidenceDir, "enrichment.md"), enrichment.body);
     if (input.dryRun) {
       writeDryRunOutcomeLedgerEvidence({
         evidenceDir,
@@ -1565,7 +1565,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
             }
       });
     }
-    writeFileSync(join(evidenceDir, "review-plan.json"), `${JSON.stringify(plan, null, 2)}\n`);
+    writeRedactedJson(join(evidenceDir, "review-plan.json"), plan);
 
     if (input.dryRun) {
       state.recordProcessed({ repo, pullNumber: pull.number, headSha: pull.head.sha, status: "dry_run", event });
@@ -1596,7 +1596,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       enrichment: plan.enrichment,
       evidenceDir
     });
-    writeFileSync(join(evidenceDir, "review-plan.json"), `${JSON.stringify(plan, null, 2)}\n`);
+    writeRedactedJson(join(evidenceDir, "review-plan.json"), plan);
     const review = await reviewGithub.createReview({
       repo,
       pullNumber: pull.number,
@@ -2056,7 +2056,7 @@ export function buildRepoMemoryContext(input: {
   }
 
   writeRedactedJson(join(input.evidenceDir, "repo-memory-packet.json"), packetResult);
-  writeFileSync(join(input.evidenceDir, "repo-memory-packet.md"), packetResult.packet.markdown);
+  writeRedactedText(join(input.evidenceDir, "repo-memory-packet.md"), packetResult.packet.markdown);
   input.state.recordRepoMemoryPacketBuild({
     packetSha: packetResult.packet.sha256,
     repo: packetResult.packet.repo,
@@ -2111,7 +2111,7 @@ export function buildGitNexusContext(input: {
   }
 
   writeRedactedJson(join(input.evidenceDir, "gitnexus-context-packet.json"), packetResult);
-  writeFileSync(join(input.evidenceDir, "gitnexus-context-packet.md"), packetResult.packet.markdown);
+  writeRedactedText(join(input.evidenceDir, "gitnexus-context-packet.md"), packetResult.packet.markdown);
   return { packet: packetResult.packet };
 }
 
@@ -2138,7 +2138,7 @@ export function buildSkillPackContext(input: {
   }
 
   writeRedactedJson(join(input.evidenceDir, "skill-pack-context-packet.json"), packetResult);
-  writeFileSync(join(input.evidenceDir, "skill-pack-context-packet.md"), packetResult.packet.markdown);
+  writeRedactedText(join(input.evidenceDir, "skill-pack-context-packet.md"), packetResult.packet.markdown);
   return { packet: packetResult.packet };
 }
 
@@ -2165,7 +2165,7 @@ export async function buildGitHubRelatedContext(input: {
   }
 
   writeRedactedJson(join(input.evidenceDir, "github-related-context-packet.json"), packetResult);
-  writeFileSync(join(input.evidenceDir, "github-related-context-packet.md"), packetResult.packet.markdown);
+  writeRedactedText(join(input.evidenceDir, "github-related-context-packet.md"), packetResult.packet.markdown);
   return { packet: packetResult.packet };
 }
 
@@ -2224,7 +2224,7 @@ export function writeDryRunOutcomeLedgerEvidence(input: {
     const markdown = renderOutcomeLedgerMarkdown(outcomeLedger);
     try {
       writeRedactedJson(jsonPath, outcomeLedger);
-      writeFileSync(markdownPath, markdown);
+      writeRedactedText(markdownPath, markdown);
     } catch (error) {
       rmSync(jsonPath, { force: true, recursive: true });
       rmSync(markdownPath, { force: true, recursive: true });
@@ -2250,7 +2250,7 @@ function recordStaleHeadSkip(input: {
   evidenceDir: string;
 }): void {
   mkdirSync(input.evidenceDir, { recursive: true });
-  writeFileSync(join(input.evidenceDir, "stale-head.json"), `${JSON.stringify(input.stale, null, 2)}\n`);
+  writeRedactedJson(join(input.evidenceDir, "stale-head.json"), input.stale);
   input.state.recordProcessed({
     repo: input.repo,
     pullNumber: input.pull.number,
@@ -2276,13 +2276,13 @@ export function recordFailedReview(input: {
     timeoutMs: input.config.zcode.timeoutMs ?? 180_000
   }) ?? rawErrorMessage;
   mkdirSync(evidenceDir, { recursive: true });
-  writeFileSync(join(evidenceDir, "review-error.json"), `${JSON.stringify({
+  writeRedactedJson(join(evidenceDir, "review-error.json"), {
     repo: input.repo,
     pullNumber: input.pull.number,
     headSha: input.pull.head.sha,
     error: errorMessage,
     recordedAt: new Date().toISOString()
-  }, null, 2)}\n`);
+  });
   input.state.recordProcessed({
     repo: input.repo,
     pullNumber: input.pull.number,
@@ -2525,7 +2525,7 @@ function providerRetryDelayMs(config: BotConfig, attempt: number, retryAfterMs?:
 
 function writeProviderRetryEvidence(evidenceDir: string, attempts: unknown): void {
   mkdirSync(evidenceDir, { recursive: true });
-  writeFileSync(join(evidenceDir, "provider-retry.json"), `${JSON.stringify(attempts, null, 2)}\n`);
+  writeRedactedJson(join(evidenceDir, "provider-retry.json"), attempts);
 }
 
 function extractProviderCode(message: string): string | undefined {
@@ -2777,6 +2777,10 @@ function sanitizeDroppedFindings(dropped: ReviewPlan["dropped"], publicConfidenc
 
 function writeRedactedJson(path: string, value: unknown): void {
   writeFileSync(path, `${redactSecrets(JSON.stringify(value, null, 2))}\n`);
+}
+
+function writeRedactedText(path: string, value: string): void {
+  writeFileSync(path, redactSecrets(value));
 }
 
 function buildSummary(input: {

--- a/src/zcode.ts
+++ b/src/zcode.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, rmdirSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, rmdirSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseFindings } from "./findings.js";
 import type { GitNexusContextPacket } from "./gitnexus-context.js";
@@ -223,10 +223,10 @@ export function withTemporaryZCodeReviewPolicy<T>(cwd: string, evidenceDir: stri
   const policy = buildZCodeReviewPolicy();
 
   mkdirSync(configDir, { recursive: true });
-  writeFileSync(configPath, `${JSON.stringify(policy, null, 2)}\n`, { mode: 0o600 });
+  writeFileAtomic(configPath, `${JSON.stringify(policy, null, 2)}\n`, 0o600);
   if (evidenceDir) {
     mkdirSync(evidenceDir, { recursive: true });
-    writeFileSync(join(evidenceDir, "zcode-review-policy.json"), `${JSON.stringify(policy, null, 2)}\n`);
+    writeFileAtomic(join(evidenceDir, "zcode-review-policy.json"), `${JSON.stringify(policy, null, 2)}\n`, 0o600);
   }
 
   try {
@@ -234,7 +234,7 @@ export function withTemporaryZCodeReviewPolicy<T>(cwd: string, evidenceDir: stri
   } finally {
     if (originalConfig) {
       mkdirSync(configDir, { recursive: true });
-      writeFileSync(configPath, originalConfig.contents, { mode: originalConfig.mode });
+      writeFileAtomic(configPath, originalConfig.contents, originalConfig.mode);
     } else {
       rmSync(configPath, { force: true });
       if (!hadConfigDir) {
@@ -245,6 +245,17 @@ export function withTemporaryZCodeReviewPolicy<T>(cwd: string, evidenceDir: stri
         }
       }
     }
+  }
+}
+
+function writeFileAtomic(path: string, contents: string, mode: number): void {
+  const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(tempPath, contents, { mode });
+    renameSync(tempPath, path);
+  } catch (error) {
+    rmSync(tempPath, { force: true });
+    throw error;
   }
 }
 

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -46,6 +46,31 @@ describe("GitHub App read authentication", () => {
     expect(readCall?.authorization).not.toBe("Bearer fallback-token");
   });
 
+  it("preserves GitHub Enterprise API base paths for read calls", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      calls.push(String(url));
+      if (String(url) === "https://ghe.example.com/api/v3/repos/owner/repo/pulls?state=open&per_page=100&page=1") {
+        return jsonResponse([]);
+      }
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({
+      token: "fallback-token",
+      apiBaseUrl: "https://ghe.example.com/api/v3"
+    });
+    await github.listOpenPulls("owner/repo");
+
+    expect(calls).toEqual(["https://ghe.example.com/api/v3/repos/owner/repo/pulls?state=open&per_page=100&page=1"]);
+  });
+
+  it("rejects credentialed and non-loopback HTTP GitHub API bases", () => {
+    expect(() => new GitHubApi({ apiBaseUrl: "https://token@ghe.example.com/api/v3" })).toThrow(/must not include username or password/);
+    expect(() => new GitHubApi({ apiBaseUrl: "http://ghe.example.com/api/v3" })).toThrow(/must use https/);
+    expect(() => new GitHubApi({ apiBaseUrl: "http://127.0.0.1:3000/api/v3" })).not.toThrow();
+  });
+
   it("paginates open PR reads so activation can baseline every listed open head", async () => {
     const root = mkdtempSync(join(tmpdir(), "github-app-read-pages-"));
     roots.push(root);

--- a/tests/gitnexus-refresh-preflight.test.ts
+++ b/tests/gitnexus-refresh-preflight.test.ts
@@ -33,6 +33,26 @@ describe("GitNexus refresh preflight", () => {
     expect(result.recommendedCommand).toBe("gitnexus analyze . --name evaos-code-review-bot-neondiff --embeddings");
   });
 
+  it("infers embedding providers only from exact hosts or subdomains", () => {
+    const openai = buildGitNexusRefreshPreflight({
+      indexInfoText: "Embedding dimensions: 1536\n",
+      env: {
+        GITNEXUS_EMBEDDING_URL: "https://api.openai.com/v1/embeddings",
+        GITNEXUS_EMBEDDING_DIMS: "1536"
+      }
+    });
+    const lookalike = buildGitNexusRefreshPreflight({
+      indexInfoText: "Embedding dimensions: 1536\n",
+      env: {
+        GITNEXUS_EMBEDDING_URL: "https://openai.com.attacker.invalid/v1/embeddings",
+        GITNEXUS_EMBEDDING_DIMS: "1536"
+      }
+    });
+
+    expect(openai.intended.provider).toBe("openai");
+    expect(lookalike.intended.provider).toBe("http");
+  });
+
   it("fails closed before vector rebuild when provider configuration is missing", () => {
     const result = buildGitNexusRefreshPreflight({
       repoAlias: "evaos-code-review-bot-neondiff",

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -134,6 +134,31 @@ describe("license activation and entitlement cache", () => {
     expect(requests).toBe(0);
   });
 
+  it("preserves configured license API base paths when building request URLs", async () => {
+    const root = mkRoot(roots);
+    const urls: string[] = [];
+
+    const result = await activateLicense({
+      config: licenseConfig(root, "https://license.example.invalid/api"),
+      licenseKey: "LIC-path-prefix-test-123456",
+      fetchImpl: (async (url) => {
+        urls.push(String(url));
+        return new Response(JSON.stringify({
+          status: "active",
+          expiresAt: "2026-08-01T00:00:00.000Z",
+          repoVisibilityScope: "private",
+          updateEntitlement: true
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        });
+      }) as typeof fetch
+    });
+
+    expect(result.ok).toBe(true);
+    expect(urls).toEqual(["https://license.example.invalid/api/v1/license/activate"]);
+  });
+
   it("keeps local license proof and fails when API deactivation notification fails", async () => {
     const root = mkRoot(roots);
     const key = "LIC-deactivate-notify-test-123456";

--- a/tests/provider-throttle-report.test.ts
+++ b/tests/provider-throttle-report.test.ts
@@ -140,6 +140,38 @@ describe("provider throttle report", () => {
     })).toThrow("Invalid --timezone value: Foo/Bar");
   });
 
+  it("does not classify GitHub lookalike hosts as GitHub dependency failures", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-github-lookalike-"));
+    roots.push(root);
+    const statePath = join(root, "state.sqlite");
+    new ReviewStateStore(statePath).close();
+    const db = new DatabaseSync(statePath);
+    try {
+      insertQueueJob(db, {
+        repo: "owner/repo",
+        pullNumber: 16,
+        headSha: "lookalike-head",
+        providerId: "GLM-5.2",
+        state: "failed",
+        lastError: "fetch failed for https://api.github.com.attacker.invalid/repos/owner/repo",
+        createdAt: "2026-07-01T11:00:00.000Z",
+        updatedAt: "2026-07-01T11:01:00.000Z"
+      });
+    } finally {
+      db.close();
+    }
+
+    const report = collectProviderThrottleReport({
+      statePath,
+      now: new Date("2026-07-08T00:00:00.000Z"),
+      since: "7d",
+      timezone: "Asia/Singapore"
+    });
+
+    expect(report.summary.providerErrors).toBe(0);
+    expect(report.summary.networkOrGithubDependency).toBe(0);
+  });
+
   it("rejects invalid peak-window hour values before aggregating", () => {
     const root = mkdtempSync(join(tmpdir(), "provider-throttle-report-peak-hour-"));
     roots.push(root);

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -29,14 +29,14 @@ describe("NeonDiff public release readiness", () => {
         version?: string;
         requiredForThisRelease?: boolean;
         state?: string;
-        heldReason?: string;
-        currentSourceVersion?: string;
         previousReleasedPackageVersion?: string;
+        skippedPublicPackageVersions?: string[];
+        note?: string;
       };
     };
 
     expect(pkg.name).toBe("neondiff");
-    expect(pkg.version).toBe("0.4.24-beta.1");
+    expect(pkg.version).toBe("0.4.30-beta.1");
     expect(pkg.private).toBeUndefined();
     expect(pkg.description).toMatch(/local-first AI PR reviewer/i);
     expect(pkg.license).toBe("SEE LICENSE IN LICENSE.md");
@@ -62,29 +62,29 @@ describe("NeonDiff public release readiness", () => {
     ]);
 
     expect(lock.name).toBe("neondiff");
-    expect(lock.version).toBe("0.4.24-beta.1");
+    expect(lock.version).toBe("0.4.30-beta.1");
     expect(lock.packages?.[""]).toMatchObject({
       name: "neondiff",
-      version: "0.4.24-beta.1",
+      version: "0.4.30-beta.1",
       license: "SEE LICENSE IN LICENSE.md",
       bin: { neondiff: "dist/src/cli.js" }
     });
     expect(manifest.packageArtifact).toMatchObject({
       name: "neondiff",
-      version: "0.4.24-beta.1",
-      requiredForThisRelease: false,
-      state: "held_at_previous_npm_release",
-      currentSourceVersion: "v0.4.29-beta.1",
+      version: "0.4.30-beta.1",
+      requiredForThisRelease: true,
+      state: "pending_publish_after_merge",
       previousReleasedPackageVersion: "0.4.24-beta.1"
     });
-    expect(manifest.packageArtifact?.heldReason).toMatch(/source\/daemon-only live beta/i);
+    expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.29-beta.1");
+    expect(manifest.packageArtifact?.note).toMatch(/source\/daemon-only/i);
   });
 
   it("ships the canonical install script contract", () => {
     expect(existsSync("scripts/install.sh")).toBe(true);
     const script = read("scripts/install.sh");
 
-    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-0\.4\.24-beta\.1\}"/);
+    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-0\.4\.30-beta\.1\}"/);
     expect(script).toMatch(/npm[^\n]+install[^\n]+-g[^\n]+neondiff@\$\{NEONDIFF_VERSION\}/);
     expect(script).toMatch(/--dry-run/);
     expect(script).toMatch(/Node\.js 26 or newer/);
@@ -98,7 +98,7 @@ describe("NeonDiff public release readiness", () => {
       read("docs/github-app-setup.md"),
       read("docs/providers.md"),
       read("docs/license-boundary.md"),
-      read("docs/releases/v0.4.24-beta.1.md")
+      read("docs/releases/v0.4.30-beta.1.md")
     ].join("\n\n");
     const legacyRepoReferences = docs
       .split(/\s+/)
@@ -109,7 +109,7 @@ describe("NeonDiff public release readiness", () => {
       );
 
     expect(docs).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff");
-    expect(docs).toMatch(/npm install -g neondiff@0\.4\.24-beta\.1/i);
+    expect(docs).toMatch(/npm install -g neondiff@0\.4\.30-beta\.1/i);
     expect(docs).toMatch(/curl -fsSL https:\/\/www\.neondiff\.com\/install/i);
     expect(docs).toContain("git clone https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git");
     expect(legacyRepoReferences).toEqual([]);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -193,16 +193,16 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.29-beta.1"
+      expectedVersion: "v0.4.30-beta.1"
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v0.4.29-beta.1",
+      version: "v0.4.30-beta.1",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v0.4.29-beta.1.md"
+        releaseNotesPath: "docs/releases/v0.4.30-beta.1.md"
       },
       updateChannels: {
         ok: true
@@ -213,12 +213,12 @@ describe("beta release status", () => {
         expect.objectContaining({
           name: "cli",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.29-beta.1"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.29-beta.1"
         })
       ])
     );
@@ -250,6 +250,18 @@ describe("beta release status", () => {
         expectedPublicVersion: "v1.0.0"
       })
     ).not.toThrow();
+    expect(() =>
+      validatePublicReleaseManifestInputs({
+        publicReleaseManifestPath: "docs/public-release-manifest.json",
+        expectedPublicVersion: "v1.0.0-beta.1+build.5"
+      })
+    ).not.toThrow();
+    expect(() =>
+      validatePublicReleaseManifestInputs({
+        publicReleaseManifestPath: "docs/public-release-manifest.json",
+        expectedPublicVersion: "v01.0.0"
+      })
+    ).toThrow("--expected-public-version must be a semver tag like v1.0.0 or v1.0.0-beta.1");
   });
 
   it("rejects oversized public release version inputs before semver matching", () => {
@@ -273,26 +285,26 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v0.4.29-beta.1",
+      expectedPublicVersion: "v0.4.30-beta.1",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot"
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v0.4.29-beta.1"
+      version: "v0.4.30-beta.1"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
       ok: true,
-      detail: "cli=source_checkout; daemon=launchd_prerelease; website=pending-site-sync (not required); desktop=post_1_0 (not required)"
+      detail: "cli=published; daemon=launchd_prerelease; website=published (not required); desktop=post_1_0 (not required)"
     });
     const redactedOutput = stringifyRedactedJson({
       ...status,
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok
     });
-    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.9-beta.1");
-    expect(redactedOutput).toContain("cli=source_checkout; daemon=launchd_prerelease");
+    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.29-beta.1");
+    expect(redactedOutput).toContain("cli=published; daemon=launchd_prerelease");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/111");
   });
 


### PR DESCRIPTION
## Summary

Refs #249.

This is the final local evidence/path-risk hardening plus release-packaging slice after PR #268. It intentionally targets `0.4.30-beta.1` instead of the original `0.4.29-beta.1` plan target because `v0.4.29-beta.1` already exists as a source/daemon-only GitHub prerelease and npm still only contains `0.4.24-beta.1` plus the accidental `1.0.0-beta.1`.

## Changes

- Add shared API URL safety helpers: no credentials, HTTPS by default, loopback-only HTTP, and GHES base-path preservation.
- Replace provider/GitNexus host substring checks with parsed host/subdomain matching.
- Replace public-version SemVer regex with deterministic bounded parsing.
- Redact GitHub/API/model-derived evidence markdown/JSON before local writes and use atomic/creation-only local writes for init/ZCode policy paths where practical.
- Bump package/docs/install script/public manifest to `0.4.30-beta.1` and add `docs/releases/v0.4.30-beta.1.md`.
- Update public-claims/release-readiness tests for the current release note and pinned install version.

## Validation

- `npm test -- --pool=forks --maxWorkers=1 tests/github-app-read.test.ts tests/license.test.ts tests/gitnexus-refresh-preflight.test.ts tests/provider-throttle-report.test.ts tests/release-status.test.ts tests/public-cli.test.ts tests/walkthrough-post.test.ts tests/zcode-policy.test.ts tests/public-release-readiness.test.ts` - 201 passed
- `npm run build` - passed
- `node scripts/check-secret-scan.mjs` - passed
- `node scripts/check-public-claims.mjs` - passed
- `npm pack --dry-run --json` + `node scripts/check-packlist.mjs ...` - passed, 69 files
- Tarball install smoke from generated `neondiff-0.4.30-beta.1.tgz`: `neondiff --help`, `neondiff pricing`, and `neondiff init --config config.local.json` passed
- `sh scripts/install.sh --dry-run` shows pinned `neondiff@0.4.30-beta.1`
- Evidence: `/Volumes/LEXAR/Codex/evidence/neondiff-public-product/2026-07-06/codeql-hardening/validation/`

## Notes

The saved `release-status-pr2.json` has `publicRelease.ok=true`; overall runtime status is false in this dirty PR worktree, as expected. Any remaining CodeQL evidence-write/file-race alerts should be evaluated after GitHub re-analysis; local-only evidence-path false positives need explicit dismissal rationale rather than code removal.
