### PR TITLE
Fix npm publish workflow version gate

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,7 +9,7 @@ on:
       tag:
         description: Release tag to publish
         required: true
-        default: v0.4.24-beta.1
+        default: v0.4.30-beta.1
 
 permissions:
   contents: read
@@ -26,9 +26,11 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
 
-      - name: Require v0.4.24-beta.1
+      - name: Verify release tag matches package version
         run: |
-          test "${{ github.event.inputs.tag || github.event.release.tag_name }}" = "v0.4.24-beta.1"
+          TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          test "$TAG" = "v$PACKAGE_VERSION"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -49,7 +51,15 @@ jobs:
           npm pack --dry-run --json > pack.json
           node scripts/check-packlist.mjs pack.json
 
-      - name: Publish
+      - name: Publish or verify existing package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance --access public --tag beta
+        run: |
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if npm view "neondiff@$PACKAGE_VERSION" version >/dev/null 2>&1; then
+            echo "neondiff@$PACKAGE_VERSION already exists; verifying dist-tags"
+            test "$(npm view neondiff dist-tags.latest)" = "$PACKAGE_VERSION"
+            test "$(npm view neondiff dist-tags.beta)" = "$PACKAGE_VERSION"
+            exit 0
+          fi
+          npm publish --provenance --access public --tag beta

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -136,6 +136,8 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
     expect(publish).toMatch(/npm publish --provenance/);
     expect(publish).toMatch(/--tag beta/);
-    expect(publish).toMatch(/v0\.4\.24-beta\.1/);
+    expect(publish).toMatch(/Verify release tag matches package version/);
+    expect(publish).toMatch(/require\('\.\/package\.json'\)\.version/);
+    expect(publish).toMatch(/already exists; verifying dist-tags/);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the public npm publish workflow after the `v0.4.30-beta.1` release exposed the old hardcoded `v0.4.24-beta.1` guard.

## Changes

- Default workflow dispatch tag now uses `v0.4.30-beta.1`.
- Release tag validation now checks `v${package.json.version}` instead of a hardcoded historical version.
- Publish step becomes idempotent: if `neondiff@${package.json.version}` already exists, the workflow verifies `latest` and `beta` dist-tags and exits 0 instead of failing a duplicate publish.
- Public release readiness test now asserts the generic package-version gate and idempotent existing-package path.

## Validation

- `npm test -- --pool=forks --maxWorkers=1 tests/public-release-readiness.test.ts`

Refs #249.
