### PR TITLE
Add advisory aliases for issue enrichment gates

### DIFF
--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -188,6 +188,14 @@ from normal per-repo or global throttles are advisory: they stay visible in the
 summary and recommended actions, but they do not make a clear PR-review runtime
 look blocked.
 
+For compatibility, operator JSON keeps the older advisory gate names
+`issue_enrichment_runtime_no_retryable_deferred_records` and
+`runtime_issue_enrichment_no_retryable_deferred_records`. New integrations
+should prefer the clearer aliases
+`issue_enrichment_runtime_retryable_deferred_records_advisory` and
+`runtime_issue_enrichment_retryable_deferred_records_advisory`; both old and
+new names report the same advisory-only count.
+
 Show the same runtime inventory as a short human summary:
 
 ```bash

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -452,11 +452,10 @@ export function buildOperatorStatus(input: {
             ok: issueEnrichmentRuntimeFailed === 0,
             detail: `${issueEnrichmentRuntimeFailed} failed issue-enrichment record(s)`
           },
-          {
-            name: "issue_enrichment_runtime_no_retryable_deferred_records",
-            ok: true,
-            detail: issueEnrichmentRuntimeRetryableDeferredDetail
-          },
+          issueEnrichmentRuntimeRetryableDeferredAdvisoryGate(
+            "issue_enrichment_runtime_no_retryable_deferred_records",
+            issueEnrichmentRuntimeRetryableDeferredDetail
+          ),
           issueEnrichmentRuntimeRetryableDeferredAdvisoryGate(
             "issue_enrichment_runtime_retryable_deferred_records_advisory",
             issueEnrichmentRuntimeRetryableDeferredDetail
@@ -654,11 +653,10 @@ export function buildRuntimeInventory(input: {
             ok: issueEnrichmentRuntimeFailed === 0,
             detail: `${issueEnrichmentRuntimeFailed} failed issue-enrichment record(s)`
           },
-          {
-            name: "runtime_issue_enrichment_no_retryable_deferred_records",
-            ok: true,
-            detail: issueEnrichmentRuntimeRetryableDeferredDetail
-          },
+          issueEnrichmentRuntimeRetryableDeferredAdvisoryGate(
+            "runtime_issue_enrichment_no_retryable_deferred_records",
+            issueEnrichmentRuntimeRetryableDeferredDetail
+          ),
           issueEnrichmentRuntimeRetryableDeferredAdvisoryGate(
             "runtime_issue_enrichment_retryable_deferred_records_advisory",
             issueEnrichmentRuntimeRetryableDeferredDetail

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -161,6 +161,8 @@ export interface OperatorIssueEnrichmentRuntime {
   records: OperatorIssueEnrichmentRuntimeRecord[];
 }
 
+type OperatorGate = { name: string; ok: boolean; detail: string };
+
 export interface RuntimeProcessRow {
   pid: number;
   ppid: number;
@@ -390,6 +392,8 @@ export function buildOperatorStatus(input: {
   const issueEnrichmentRuntimeState = displayIssueEnrichmentRuntimeState(issueEnrichment, issueEnrichmentRuntime);
   const issueEnrichmentRuntimeFailed = issueEnrichmentRuntime?.summary.failed ?? 0;
   const issueEnrichmentRuntimeRetryableDeferred = issueEnrichmentRuntime?.summary.retryableDeferred ?? 0;
+  const issueEnrichmentRuntimeRetryableDeferredDetail =
+    describeIssueEnrichmentRuntimeRetryableDeferred(issueEnrichmentRuntimeRetryableDeferred);
 
   const gates = [
     ...input.release.gates,
@@ -451,8 +455,12 @@ export function buildOperatorStatus(input: {
           {
             name: "issue_enrichment_runtime_no_retryable_deferred_records",
             ok: true,
-            detail: `${issueEnrichmentRuntimeRetryableDeferred} retryable deferred issue-enrichment record(s); advisory only`
-          }
+            detail: issueEnrichmentRuntimeRetryableDeferredDetail
+          },
+          issueEnrichmentRuntimeRetryableDeferredAdvisoryGate(
+            "issue_enrichment_runtime_retryable_deferred_records_advisory",
+            issueEnrichmentRuntimeRetryableDeferredDetail
+          )
         ]
       : [])
   ];
@@ -569,6 +577,8 @@ export function buildRuntimeInventory(input: {
   const issueEnrichmentRuntimeState = displayIssueEnrichmentRuntimeState(issueEnrichment, issueEnrichmentRuntime);
   const issueEnrichmentRuntimeFailed = issueEnrichmentRuntime?.summary.failed ?? 0;
   const issueEnrichmentRuntimeRetryableDeferred = issueEnrichmentRuntime?.summary.retryableDeferred ?? 0;
+  const issueEnrichmentRuntimeRetryableDeferredDetail =
+    describeIssueEnrichmentRuntimeRetryableDeferred(issueEnrichmentRuntimeRetryableDeferred);
 
   const gates = [
     ...input.release.gates,
@@ -647,8 +657,12 @@ export function buildRuntimeInventory(input: {
           {
             name: "runtime_issue_enrichment_no_retryable_deferred_records",
             ok: true,
-            detail: `${issueEnrichmentRuntimeRetryableDeferred} retryable deferred issue-enrichment record(s); advisory only`
-          }
+            detail: issueEnrichmentRuntimeRetryableDeferredDetail
+          },
+          issueEnrichmentRuntimeRetryableDeferredAdvisoryGate(
+            "runtime_issue_enrichment_retryable_deferred_records_advisory",
+            issueEnrichmentRuntimeRetryableDeferredDetail
+          )
         ]
       : [])
   ];
@@ -1736,6 +1750,18 @@ function displayIssueEnrichmentRuntimeState(
   if (!runtime) return issueEnrichment?.enabled === false ? "disabled" : undefined;
   if (issueEnrichment?.enabled === false && runtime.summary.total === 0) return "disabled";
   return runtime.state;
+}
+
+function describeIssueEnrichmentRuntimeRetryableDeferred(count: number): string {
+  return `${count} retryable deferred issue-enrichment record(s); advisory only`;
+}
+
+function issueEnrichmentRuntimeRetryableDeferredAdvisoryGate(name: string, detail: string): OperatorGate {
+  return {
+    name,
+    ok: true,
+    detail
+  };
 }
 
 function mapIssueEnrichmentRuntimeRow(

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -427,6 +427,11 @@ describe("operator CLI summaries", () => {
       ok: true,
       detail: "1 retryable deferred issue-enrichment record(s); advisory only"
     });
+    expect(status.gates).toContainEqual({
+      name: "issue_enrichment_runtime_retryable_deferred_records_advisory",
+      ok: true,
+      detail: "1 retryable deferred issue-enrichment record(s); advisory only"
+    });
     expect(status.recommendedActions).toContain("retry or inspect deferred issue-enrichment records");
 
     const inventory = buildRuntimeInventory({
@@ -446,6 +451,11 @@ describe("operator CLI summaries", () => {
     expect(inventory.summary.issueEnrichmentRuntimeState).toBe("deferred");
     expect(inventory.gates).toContainEqual({
       name: "runtime_issue_enrichment_no_retryable_deferred_records",
+      ok: true,
+      detail: "1 retryable deferred issue-enrichment record(s); advisory only"
+    });
+    expect(inventory.gates).toContainEqual({
+      name: "runtime_issue_enrichment_retryable_deferred_records_advisory",
       ok: true,
       detail: "1 retryable deferred issue-enrichment record(s); advisory only"
     });


### PR DESCRIPTION
## Summary
- add clearer advisory gate aliases for retryable issue-enrichment deferred records on `status` and `runtime-inventory`
- preserve existing `*_no_retryable_deferred_records` gate names and advisory-only detail text for compatibility
- document the old-name compatibility path and preferred new alias names in operator CLI docs

Closes #292

## Validation
- `npm test -- tests/operator-cli.test.ts`
- `npm run build`
- `git diff --check`

## Notes
- No live config, launchd, runtime DB, tags, GitHub Releases, or tracker state changed.
