### PR TITLE
Stage v0.4.31 beta release

### DIFF
--- a/docs/releases/v0.4.31-beta.1.md
+++ b/docs/releases/v0.4.31-beta.1.md
@@ -1,0 +1,103 @@
+# v0.4.31-beta.1
+
+- Release type: local beta provider-adapter and operator-alias release
+- Release source SHA: to be stamped during post-merge live promotion
+- Previous prerelease: `v0.4.30-beta.1`
+- Tracking issues / source PRs: `#239`, `#240`, `#292`, `#248`, `#313`
+- Promoted PRs: `#248`, `#313`
+- Included implementation merge SHAs:
+  - `6fcc3a905a7eb7e78d58286dda098d844c9944d5` (`#248`)
+  - `0b6c5f7ed1d600313adddcc3a0e92462002d1a30` (`#313`)
+- Local operator evidence path: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/v0.4.31-beta.1/`
+- Rollback tag: `v0.4.30-beta.1`
+- Package artifact: `neondiff@0.4.30-beta.1` (held from previous public npm release)
+- Rollback baseline: `v0.4.30-beta.1`
+
+## Purpose
+
+Promote the local OpenAI-compatible review adapter fixture/proof surface and
+the issue-enrichment advisory gate alias cleanup as a named live-worker beta,
+rather than leaving the launchd checkout on untagged `main`.
+
+This release adds fixture-backed compatibility proof for running the same review
+contract through ZCode GLM and local OpenAI-compatible endpoints such as Ollama,
+LM Studio, vLLM, or gateway-shaped local servers. It also adds clearer advisory
+gate names for issue-enrichment runtime health while preserving the legacy gate
+names for existing dashboards and operator scripts.
+
+This is a local live-worker beta release. It does not publish a new npm package
+or replace the public `neondiff@0.4.30-beta.1` package release. The public
+manifest continues to describe the held public package separately from the
+source/daemon beta version.
+
+## Included Changes
+
+- Add a fixture-only OpenAI-compatible review adapter with:
+  - local-loopback target safety checks before private prompts are sent;
+  - abort coverage for slow response bodies;
+  - bounded review JSON extraction from noisy local-model output;
+  - validated review JSON output before fixture evidence is trusted;
+  - optional `temperature` and `json_object` response-format request knobs;
+  - redacted diagnostic evidence for non-OK provider responses.
+- Add same-prompt fixture proof comparing ZCode GLM and local
+  OpenAI-compatible adapter execution without exposing private prompt or diff
+  text in evidence.
+- Keep runtime review posting on the existing ZCode path. The new adapters are
+  fixture/proof surfaces only until a later tracked runtime-wiring PR proves
+  App-authored posting, stale-head handling, duplicate suppression, no checkout
+  mutation, and redaction under live traffic.
+- Add preferred issue-enrichment advisory gate aliases:
+  `issue_enrichment_runtime_retryable_deferred_records_advisory` and
+  `runtime_issue_enrichment_retryable_deferred_records_advisory`.
+- Preserve the legacy compatibility gate names:
+  `issue_enrichment_runtime_no_retryable_deferred_records` and
+  `runtime_issue_enrichment_no_retryable_deferred_records`.
+- Document the preferred advisory aliases in `docs/operator-cli.md`.
+
+## Required Gates
+
+- PR `#248` merged to `main`; required `Build, test, and package` check passed.
+- PR `#248` CodeRabbit review passed and all current-head evaOS review threads
+  were resolved or explicitly marked non-actionable proof-boundary notes.
+- Focused local validation for `#248`:
+  `NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/provider-adapters.test.ts --pool=forks --maxWorkers=1`
+  passed 46 tests.
+- `npm run build`
+- `git diff --check`
+- PR `#313` merged to `main`; required `Build, test, and package` check passed.
+- PR `#313` CodeRabbit review passed and current-head review threads were zero
+  unresolved.
+- Focused local validation for `#313`:
+  `npm test -- tests/operator-cli.test.ts`
+  passed 39 tests.
+- Release packet PR merged to `main`.
+- Post-tag `release:status` after launchd restart at the promoted tag SHA.
+- Post-promotion `coverage-audit` and expired provider cooldown audit.
+
+## Caveats
+
+- The OpenAI-compatible adapter is not wired into the live review worker in this
+  release. Live review execution continues through the existing ZCode path.
+- This release does not expand monitored repos, GitHub App permissions,
+  posting policy, native ZCode skills, MCP, memory, shell tools, or
+  auto-approval behavior.
+- This release does not claim provider quality parity, CodeRabbit parity,
+  calibrated confidence, or production all-org readiness.
+- Issue-enrichment aliases are compatibility additions only; they do not widen
+  the issue-enrichment allowlist or active posting scope.
+- The public npm package remains `neondiff@0.4.30-beta.1`; this release tags
+  the live local worker source SHA only.
+
+## Rollback
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v0.4.30-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```


### PR DESCRIPTION
## Summary

Stage the v0.4.31-beta.1 local live-worker release packet for the merged #248 OpenAI-compatible adapter proof surface and #313 issue-enrichment advisory alias cleanup.

This release packet intentionally does not bump the public npm package; `neondiff@0.4.30-beta.1` remains the held public artifact.

## Validation

- `git diff --cached --check` before commit
- Source PR #248 gates: provider adapter focused tests 46/46, build, CI/CodeQL, review threads resolved
- Source PR #313 gates: operator CLI focused tests 39/39, build, CI/CodeQL, review threads resolved

## Release Boundary

- Local live-worker beta tag only
- No monitored repo expansion
- No GitHub App permission change
- No live OpenAI-compatible provider runtime wiring
- No public npm publish

Closes #239.
Closes #240.