### PR TITLE
Atomic per-head review claim: defend at-most-one-review-per-head against the manual/daemon race

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -94,6 +94,12 @@ export interface ReviewRunLease {
   ownerPid: number;
 }
 
+export interface ReviewHeadClaim {
+  claimId: string;
+  expiresAt: string;
+  ownerPid: number;
+}
+
 export interface IssueEnrichmentRunLease {
   leaseId: string;
   expiresAt: string;
@@ -447,6 +453,17 @@ export class ReviewStateStore {
         owner_pid integer
       );
 
+      create table if not exists review_head_claims (
+        repo text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        claim_id text not null,
+        owner_pid integer,
+        claimed_at text not null,
+        expires_at text not null,
+        primary key (repo, pull_number, head_sha)
+      );
+
       create table if not exists repo_provider_cooldowns (
         repo text primary key,
         cooldown_until text not null,
@@ -705,6 +722,11 @@ export class ReviewStateStore {
         record.reviewUrl ?? null,
         record.error ?? null
       );
+    // A recorded outcome for this head supersedes any in-flight per-head claim (#295): retire it so
+    // no stale claim row lingers to its TTL after the review is durable.
+    this.db
+      .prepare("delete from review_head_claims where repo = ? and pull_number = ? and head_sha = ?")
+      .run(record.repo, record.pullNumber, record.headSha);
   }
 
   getReviewReadiness(repo: string, pullNumber: number, headSha: string): ReviewReadinessRecord | undefined {
@@ -1094,6 +1116,62 @@ export class ReviewStateStore {
 
   releaseReviewRunLease(leaseId: string): void {
     this.db.prepare("delete from review_run_leases where lease_id = ?").run(leaseId);
+  }
+
+  /**
+   * Atomic per-head review claim (#295): defends the at-most-one-review-per-{repo,pr,head_sha}
+   * invariant against the manual-review-pr vs daemon race (both passed the getProcessedReview read
+   * window before either recordProcessed'd). The {repo, pull_number, head_sha} PRIMARY KEY makes the
+   * INSERT a compare-and-set — exactly one concurrent caller wins; the loser gets undefined. Claims
+   * are crash-safe two ways: a completed review retires the claim in recordProcessed (release-on-
+   * success), reviewPull releases it in a finally (release-on-failure), and a TTL backstop sweeps
+   * claims whose holder died mid-review — mirroring the review_run_leases TTL idiom.
+   */
+  tryClaimReviewHead(input: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    claimTtlMs: number;
+    now?: Date;
+    ownerPid?: number;
+  }): ReviewHeadClaim | undefined {
+    if (!Number.isInteger(input.claimTtlMs)) throw new Error("claimTtlMs must be an integer");
+    if (input.claimTtlMs < 1) throw new Error("claimTtlMs must be at least 1");
+    const ownerPid = input.ownerPid ?? process.pid;
+    if (!Number.isInteger(ownerPid) || ownerPid < 1) throw new Error("ownerPid must be a positive integer");
+
+    const now = input.now ?? new Date();
+    const claimId = randomUUID();
+    const claimedAt = now.toISOString();
+    const expiresAt = new Date(now.getTime() + input.claimTtlMs).toISOString();
+    this.db.exec("begin immediate");
+    try {
+      // TTL backstop: sweep this head's claim if a prior holder died mid-review without releasing.
+      this.db
+        .prepare("delete from review_head_claims where repo = ? and pull_number = ? and head_sha = ? and expires_at <= ?")
+        .run(input.repo, input.pullNumber, input.headSha, claimedAt);
+      const existing = this.db
+        .prepare("select claim_id from review_head_claims where repo = ? and pull_number = ? and head_sha = ? limit 1")
+        .get(input.repo, input.pullNumber, input.headSha) as { claim_id: string } | undefined;
+      if (existing) {
+        this.db.exec("commit");
+        return undefined;
+      }
+      this.db
+        .prepare(
+          "insert into review_head_claims (repo, pull_number, head_sha, claim_id, owner_pid, claimed_at, expires_at) values (?, ?, ?, ?, ?, ?, ?)"
+        )
+        .run(input.repo, input.pullNumber, input.headSha, claimId, ownerPid, claimedAt, expiresAt);
+      this.db.exec("commit");
+      return { claimId, expiresAt, ownerPid };
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
+  releaseReviewHeadClaim(claimId: string): void {
+    this.db.prepare("delete from review_head_claims where claim_id = ?").run(claimId);
   }
 
   tryAcquireIssueEnrichmentRunLease(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -63,6 +63,7 @@ import {
   ReviewStateStore,
   type ProcessedStatus,
   type ReviewQueueJobState,
+  type ReviewHeadClaim,
   type ReviewReadinessRecord,
   type ReviewReadinessState,
   type ReviewerSessionJobState,
@@ -1336,8 +1337,16 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   }
   const budget = input.budget ?? new ReviewRunBudget(config.reviewConcurrency.maxActiveRuns);
   let lease: ReviewRunLease | undefined;
+  let headClaim: ReviewHeadClaim | undefined;
   let budgetStarted = false;
   const releaseReviewCapacity = (): void => {
+    // Crash-safe release-on-failure (#295): if we hold the per-head claim and the finally runs
+    // before recordProcessed retired it (error/early return), release it so the head is re-claimable.
+    // recordProcessed already retires it on the success path; the state TTL is the last-resort backstop.
+    if (headClaim) {
+      state.releaseReviewHeadClaim(headClaim.claimId);
+      headClaim = undefined;
+    }
     if (lease) {
       state.releaseReviewRunLease(lease.leaseId);
       lease = undefined;
@@ -1568,8 +1577,24 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     writeRedactedJson(join(evidenceDir, "review-plan.json"), plan);
 
     if (input.dryRun) {
+      // Dry-run posts nothing public, so it does NOT acquire a per-head claim (#295): claiming would
+      // add contention/TTL churn for a run that cannot violate the at-most-one-posted-review invariant.
       state.recordProcessed({ repo, pullNumber: pull.number, headSha: pull.head.sha, status: "dry_run", event });
       return commandReviewRequested ? "reviewed_command" : "reviewed";
+    }
+
+    // Atomic per-head claim (#295): acquired here — after every eligibility/stale check and after the
+    // dry-run branch, immediately before posting — so exactly one of a racing manual-review-pr and
+    // daemon posts a review on this head. The loser records a structured skip and no-ops.
+    headClaim = state.tryClaimReviewHead({
+      repo,
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      claimTtlMs: config.reviewConcurrency.leaseTtlMs
+    });
+    if (!headClaim) {
+      recordConcurrentClaimSkip({ state, repo, pull, evidenceDir });
+      return "skipped_processed";
     }
 
     const liveBeforePost = await github.getPull(repo, pull.number);
@@ -2258,6 +2283,36 @@ function recordStaleHeadSkip(input: {
     status: "skipped",
     error: `${input.stale.reason}: live=${input.stale.liveHeadSha}`
   });
+}
+
+export function recordConcurrentClaimSkip(input: {
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  evidenceDir: string;
+}): void {
+  // The other claimant owns this head (#295). Do NOT recordProcessed here: that would `insert or
+  // replace` the winner's row AND retire the winner's live claim. Record a skipped readiness note
+  // (separate table) plus an evidence file, matching the existing skip-evidence idiom, and log it.
+  const evidence = {
+    reason: "concurrent_review_claim_held",
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    detail: "Another reviewPull (manual review-pr or daemon) holds the atomic per-head claim for this head; skipping to preserve at-most-one-review-per-head."
+  };
+  mkdirSync(input.evidenceDir, { recursive: true });
+  writeFileSync(join(input.evidenceDir, "concurrent-claim-skip.json"), `${JSON.stringify(evidence, null, 2)}\n`);
+  input.state.recordReviewReadiness({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    state: "skipped",
+    reason: "concurrent_review_claim_held"
+  });
+  console.warn(
+    `[head-claim] concurrent claim held repo=${input.repo} pr=${input.pull.number} sha=${input.pull.head.sha}: skipping duplicate same-head review`
+  );
 }
 
 export function recordFailedReview(input: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2302,7 +2302,10 @@ export function recordConcurrentClaimSkip(input: {
     detail: "Another reviewPull (manual review-pr or daemon) holds the atomic per-head claim for this head; skipping to preserve at-most-one-review-per-head."
   };
   mkdirSync(input.evidenceDir, { recursive: true });
-  writeFileSync(join(input.evidenceDir, "concurrent-claim-skip.json"), `${JSON.stringify(evidence, null, 2)}\n`);
+  // Through the redacting writer like every other evidence write (defense-in-depth; the
+  // network-data-to-evidence-file pattern itself is the evidence-packet design, triaged as a
+  // class under #249).
+  writeRedactedJson(join(input.evidenceDir, "concurrent-claim-skip.json"), evidence);
   input.state.recordReviewReadiness({
     repo: input.repo,
     pullNumber: input.pull.number,

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1690,4 +1690,78 @@ describe("review state store", () => {
     })).toThrow(/secret-like/);
     store.close();
   });
+
+  it("grants an atomic per-head review claim to exactly one concurrent claimant (#295)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-head-claim-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const head = { repo: "electricsheephq/WorldOS", pullNumber: 289, headSha: "head-abc" };
+
+    const first = store.tryClaimReviewHead({ ...head, claimTtlMs: 900_000, now: new Date("2026-07-06T00:00:00.000Z") });
+    const second = store.tryClaimReviewHead({ ...head, claimTtlMs: 900_000, now: new Date("2026-07-06T00:00:06.000Z") });
+
+    expect(first).toBeDefined();
+    expect(second).toBeUndefined();
+    store.close();
+  });
+
+  it("lets a NEW head on the same PR claim while another head is held (#295)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-head-claim-newhead-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    const held = store.tryClaimReviewHead({ repo: "r/x", pullNumber: 1, headSha: "sha-1", claimTtlMs: 900_000, now: new Date("2026-07-06T00:00:00.000Z") });
+    const newHead = store.tryClaimReviewHead({ repo: "r/x", pullNumber: 1, headSha: "sha-2", claimTtlMs: 900_000, now: new Date("2026-07-06T00:00:01.000Z") });
+
+    expect(held).toBeDefined();
+    expect(newHead).toBeDefined();
+    store.close();
+  });
+
+  it("expires a stale per-head claim after its TTL so a new claimant can proceed (#295)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-head-claim-ttl-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const head = { repo: "r/x", pullNumber: 2, headSha: "sha-ttl" };
+
+    const first = store.tryClaimReviewHead({ ...head, claimTtlMs: 1_000, now: new Date("2026-07-06T00:00:00.000Z"), ownerPid: 999_999_999 });
+    const beforeExpiry = store.tryClaimReviewHead({ ...head, claimTtlMs: 1_000, now: new Date("2026-07-06T00:00:00.500Z") });
+    const afterExpiry = store.tryClaimReviewHead({ ...head, claimTtlMs: 1_000, now: new Date("2026-07-06T00:00:01.001Z") });
+
+    expect(first).toBeDefined();
+    expect(beforeExpiry).toBeUndefined();
+    expect(afterExpiry).toBeDefined();
+    store.close();
+  });
+
+  it("releases a per-head claim so it can be re-acquired (#295)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-head-claim-release-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const head = { repo: "r/x", pullNumber: 3, headSha: "sha-rel" };
+
+    const first = store.tryClaimReviewHead({ ...head, claimTtlMs: 900_000, now: new Date("2026-07-06T00:00:00.000Z") });
+    store.releaseReviewHeadClaim(first!.claimId);
+    const afterRelease = store.tryClaimReviewHead({ ...head, claimTtlMs: 900_000, now: new Date("2026-07-06T00:00:01.000Z") });
+
+    expect(first).toBeDefined();
+    expect(afterRelease).toBeDefined();
+    store.close();
+  });
+
+  it("retires the per-head claim when the review is recorded so it is not re-claimed (#295)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-head-claim-retire-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const head = { repo: "r/x", pullNumber: 4, headSha: "sha-done" };
+
+    const claim = store.tryClaimReviewHead({ ...head, claimTtlMs: 900_000, now: new Date("2026-07-06T00:00:00.000Z") });
+    expect(claim).toBeDefined();
+    store.recordProcessed({ repo: head.repo, pullNumber: head.pullNumber, headSha: head.headSha, status: "posted" });
+
+    // A completed review supersedes the claim: the claim row is retired (no stale row lingers to TTL).
+    const afterRecord = store.tryClaimReviewHead({ ...head, claimTtlMs: 900_000, now: new Date("2026-07-06T00:00:02.000Z") });
+    expect(afterRecord).toBeDefined();
+    store.close();
+  });
 });

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -20,6 +20,7 @@ import {
   prepareFailedHeadRetry,
   providerCooldownDurationMs,
   reconcileProcessedHeadAfterDirectReview,
+  recordConcurrentClaimSkip,
   recordFailedReview,
   recordProviderRateLimitCooldownIfNeeded,
   restoreFailedRetryRowIfNeeded,
@@ -2975,6 +2976,47 @@ describe("worker review failures", () => {
     expect(isSuccessfulRetryStatus("skipped_capacity")).toBe(false);
     expect(isSuccessfulRetryStatus("skipped_provider_cooldown")).toBe(false);
     expect(isSuccessfulRetryStatus("skipped_stale_head")).toBe(false);
+  });
+
+  it("lets exactly one of two interleaved same-head claimants proceed (#295)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-head-claim-race-"));
+    roots.push(root);
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const head = { repo: "electricsheephq/WorldOS", pullNumber: 289, headSha: "race-head" };
+
+    // Manual review-pr and daemon both pass the getProcessedReview read window, then both try to
+    // claim before posting: the atomic per-head claim admits exactly one.
+    const daemon = state.tryClaimReviewHead({ ...head, claimTtlMs: 900_000, now: new Date("2026-07-06T00:00:00.000Z") });
+    const manual = state.tryClaimReviewHead({ ...head, claimTtlMs: 900_000, now: new Date("2026-07-06T00:00:06.000Z") });
+
+    expect([daemon, manual].filter(Boolean)).toHaveLength(1);
+    state.close();
+  });
+
+  it("records a concurrent-claim skip as a no-op that does not clobber the winner's processed row (#295)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-claim-skip-"));
+    roots.push(root);
+    const state = new ReviewStateStore(join(root, "state.sqlite"));
+    const repo = "electricsheephq/WorldOS";
+    const pull = pullSummary(289, "winner-head");
+
+    // The winner has posted a real review + holds no lingering claim.
+    state.recordProcessed({ repo, pullNumber: pull.number, headSha: pull.head.sha, status: "posted", event: "COMMENT", reviewUrl: "https://github.test/r/1" });
+    const evidenceDir = join(root, "evidence");
+
+    recordConcurrentClaimSkip({ state, repo, pull, evidenceDir });
+
+    // Loser must NOT overwrite the winner's processed row...
+    expect(state.getProcessedReview(repo, pull.number, pull.head.sha)).toMatchObject({ status: "posted", event: "COMMENT" });
+    // ...and records a skipped readiness note + evidence file instead.
+    expect(state.getReviewReadiness(repo, pull.number, pull.head.sha)).toMatchObject({
+      state: "skipped",
+      reason: "concurrent_review_claim_held"
+    });
+    expect(JSON.parse(readFileSync(join(evidenceDir, "concurrent-claim-skip.json"), "utf8"))).toMatchObject({
+      reason: "concurrent_review_claim_held"
+    });
+    state.close();
   });
 });
 


### PR DESCRIPTION
Closes #295. Parent: #278 (Phase 3, item 8b — folded in by the 2026-07-06 tracker audit).

## Summary
Manual `review-pr` and the daemon could both pass the check-then-act window on the same {repo, pr, head_sha} and each post a review (empirical: two bot reviews 6s apart on PR #289) — the run lease is a global slot counter with no per-head identity, and `recordProcessed` is insert-or-replace with no CAS. This violates the flagship at-most-one-review-per-head invariant.

- New `review_head_claims` table, PRIMARY KEY (repo, pull_number, head_sha); `tryClaimReviewHead` = BEGIN IMMEDIATE + expired-sweep + check + INSERT — a true compare-and-set: exactly one concurrent caller wins.
- Crash-safe three ways, mirroring the `review_run_leases` idiom: completed review retires the claim in `recordProcessed`; `reviewPull` releases in a finally on failure; TTL backstop (`= leaseTtlMs`) sweeps dead holders' claims.
- Placement: after every eligibility/stale check, immediately before the pre-post stale check + `createReview`. **Dry-run does not claim** (posts nothing; documented in code).
- Loser evidence: structured `concurrent_review_claim_held` skip + evidence JSON + log line — deliberately NOT `recordProcessed`, which would clobber the winner's row and retire its live claim.
- Always-on invariant fix (no config).

## Validation
- TDD failing-first at the state layer (RED confirmed): concurrency (exactly one wins), new-head-while-held, TTL expiry, release/re-acquire, recordProcessed retirement; worker level: interleaved claims ⇒ exactly one proceeds, loser no-op does not clobber the winner.
- Rebased onto current main; focused Vitest 114/114 (state, worker-failure) + scheduler/review-budget green pre-rebase; `npm run build` exit 0 — all under `set -o pipefail`.