### PR TITLE
Robust false-positive learning: coarse fallback fingerprint and human-confirmed severity override

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -275,7 +275,7 @@ const DEFAULT_CONFIG: BotConfig = {
   repoMemory: {
     enabled: false,
     memoryRoot: ".evaos/repo-memory",
-    packetVersion: "repo-memory-packet-v0.1",
+    packetVersion: "repo-memory-packet-v0.2",
     maxPacketBytes: 12_000,
     maxStateNotes: 20,
     includeStaleNotes: false

--- a/src/findings.ts
+++ b/src/findings.ts
@@ -139,8 +139,8 @@ export function normalizeFindingsForReview(
   };
 }
 
-const SAME_RUN_DEDUP_MAX_LINE_DELTA = 3;
-const SAME_RUN_DEDUP_MIN_PREFIX_LENGTH = 12;
+export const SAME_RUN_DEDUP_MAX_LINE_DELTA = 3;
+export const SAME_RUN_DEDUP_MIN_PREFIX_LENGTH = 12;
 
 /**
  * Suppress same-run near-duplicate findings (#281): within one review response, collapse a cluster
@@ -175,7 +175,7 @@ export function suppressSameRunNearDuplicates(findings: Finding[]): { kept: Find
   return { kept: kept.map((entry) => entry.finding), dropped };
 }
 
-function normalizeTitleForDedup(title: string): string {
+export function normalizeTitleForDedup(title: string): string {
   return title
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, " ")
@@ -183,7 +183,7 @@ function normalizeTitleForDedup(title: string): string {
     .replace(/\s+/g, " ");
 }
 
-function titlesAreNearDuplicate(a: string, b: string): boolean {
+export function titlesAreNearDuplicate(a: string, b: string): boolean {
   if (a === b) return a.length > 0;
   const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
   // Prefix match must span a meaningful anchor so short generic titles don't collapse distinct

--- a/src/repo-memory.ts
+++ b/src/repo-memory.ts
@@ -3,7 +3,9 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
-export const REPO_MEMORY_PACKET_VERSION = "repo-memory-packet-v0.1";
+// v0.2 additively carries coarse false-positive-match fields + confirmedByHuman (#302). Older v0.1
+// notes simply lack them and fall back to exact-only matching.
+export const REPO_MEMORY_PACKET_VERSION = "repo-memory-packet-v0.2";
 export const REPO_MEMORY_ADVISORY_LINE =
   "This memory is advisory. Current PR diff and current repository files override memory.";
 
@@ -23,6 +25,13 @@ export interface RepoMemoryNote {
   source: string;
   confidence?: number;
   fingerprint?: string;
+  // Coarse false-positive-match fields (#302, additive): present on false_positive notes so the gate
+  // can match a reworded / line-shifted recurrence. confirmedByHuman gates the P0/P1 override.
+  coarsePath?: string;
+  coarseCategory?: string;
+  coarseLine?: number;
+  coarseTitle?: string;
+  confirmedByHuman?: boolean;
   createdAt: string;
   updatedAt: string;
   expiresAt?: string;

--- a/src/review-gate.ts
+++ b/src/review-gate.ts
@@ -1,8 +1,15 @@
 import { createHash } from "node:crypto";
 import { validateFindingLocations } from "./diff.js";
-import { decideReviewEvent, normalizeFindingsForReview, sanitizeDroppedFinding } from "./findings.js";
+import {
+  decideReviewEvent,
+  normalizeFindingsForReview,
+  normalizeTitleForDedup,
+  sanitizeDroppedFinding,
+  SAME_RUN_DEDUP_MAX_LINE_DELTA,
+  titlesAreNearDuplicate
+} from "./findings.js";
 import type { PublicConfidenceDisplayPolicy } from "./public-confidence.js";
-import { countCategories, isRequestChangesEligible, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
+import { countCategories, isRequestChangesEligible, normalizeFindingCategory, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import type {
   DeterministicReviewGateSummary,
   DroppedFinding,
@@ -19,12 +26,29 @@ export interface DeterministicReviewGateResult {
   summary: DeterministicReviewGateSummary;
 }
 
+/**
+ * A remembered false-positive, structured so the gate can match it two ways (#302): the exact
+ * sha256 `fingerprint` (unchanged #294 semantics) AND a coarse fallback consulted only on exact-miss
+ * (path + normalized category + line window + normalized-title near-match). Coarse fields must be
+ * carried on the note so a diff-churn line shift or model rewording can still be learned away.
+ * `confirmedByHuman` gates the P0/P1 override: auto-learned notes stay P2/P3-only.
+ */
+export interface RepoMemoryFalsePositiveEntry {
+  fingerprint: string;
+  path: string;
+  category: string;
+  line: number;
+  title: string;
+  confirmedByHuman?: boolean;
+}
+
 export function applyDeterministicReviewGate(input: {
   findings: Finding[];
   files: PullFilePatch[];
   droppedFromSchema?: DroppedFinding[];
   maxInlineComments?: number;
   repoMemoryFalsePositiveFingerprints?: string[];
+  repoMemoryFalsePositives?: RepoMemoryFalsePositiveEntry[];
   publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
   requestChangesConfidenceFloors?: RequestChangesConfidenceFloors;
 }): DeterministicReviewGateResult {
@@ -32,7 +56,8 @@ export function applyDeterministicReviewGate(input: {
   // Memory suppression intentionally precedes normalization; dropReasonCounts reflects that ordering.
   const repoMemoryFiltered = applyRepoMemoryFalsePositiveSuppressions(
     located.valid,
-    input.repoMemoryFalsePositiveFingerprints ?? []
+    input.repoMemoryFalsePositiveFingerprints ?? [],
+    input.repoMemoryFalsePositives ?? []
   );
   const normalized = normalizeFindingsForReview(repoMemoryFiltered.findings, {
     maxInlineComments: input.maxInlineComments,
@@ -85,16 +110,34 @@ export function buildFindingFingerprint(
 
 function applyRepoMemoryFalsePositiveSuppressions(
   findings: Finding[],
-  fingerprints: string[]
+  fingerprints: string[],
+  entries: RepoMemoryFalsePositiveEntry[]
 ): { findings: Finding[]; dropped: DroppedFinding[] } {
-  if (!fingerprints.length) return { findings, dropped: [] };
-  const fingerprintSet = new Set(fingerprints);
+  if (!fingerprints.length && !entries.length) return { findings, dropped: [] };
+  // Exact fingerprints from the legacy input and from the structured entries share one exact index.
+  const exactFingerprints = new Map<string, RepoMemoryFalsePositiveEntry | undefined>();
+  for (const fingerprint of fingerprints) if (!exactFingerprints.has(fingerprint)) exactFingerprints.set(fingerprint, undefined);
+  for (const entry of entries) if (!exactFingerprints.has(entry.fingerprint)) exactFingerprints.set(entry.fingerprint, entry);
   const accepted: Finding[] = [];
   const dropped: DroppedFinding[] = [];
   for (const finding of findings) {
     const fingerprint = buildFindingFingerprint(finding);
-    if (isMemorySuppressible(finding) && fingerprintSet.has(fingerprint)) {
-      dropped.push({ ...finding, reason: "repo_memory_false_positive_match", fingerprint });
+    // Exact match first: unchanged #294 semantics. Auto-learned notes stay P2/P3-only; a matched
+    // entry known to be human-confirmed may suppress any severity even on the exact path.
+    if (exactFingerprints.has(fingerprint)) {
+      const exactEntry = exactFingerprints.get(fingerprint);
+      if (isMemorySuppressible(finding, exactEntry?.confirmedByHuman)) {
+        dropped.push({ ...finding, reason: "repo_memory_false_positive_match", fingerprint });
+        continue;
+      }
+      accepted.push(finding);
+      continue;
+    }
+    // Coarse fallback: ONLY on exact-miss, reusing the #294 near-match semantics so the two can
+    // never drift. A missed FP is cheaper than suppressing a genuine distinct finding.
+    const coarse = findCoarseFalsePositiveMatch(finding, entries);
+    if (coarse && isMemorySuppressible(finding, coarse.confirmedByHuman)) {
+      dropped.push({ ...finding, reason: "repo_memory_false_positive_coarse_match", fingerprint: coarse.fingerprint });
       continue;
     }
     accepted.push(finding);
@@ -102,7 +145,25 @@ function applyRepoMemoryFalsePositiveSuppressions(
   return { findings: accepted, dropped };
 }
 
-function isMemorySuppressible(finding: Finding): boolean {
+function findCoarseFalsePositiveMatch(
+  finding: Finding,
+  entries: RepoMemoryFalsePositiveEntry[]
+): RepoMemoryFalsePositiveEntry | undefined {
+  if (!entries.length) return undefined;
+  const category = normalizeFindingCategory(finding);
+  const normalizedTitle = normalizeTitleForDedup(finding.title);
+  return entries.find(
+    (entry) =>
+      entry.path === finding.path &&
+      entry.category === category &&
+      Math.abs(entry.line - finding.line) <= SAME_RUN_DEDUP_MAX_LINE_DELTA &&
+      titlesAreNearDuplicate(normalizedTitle, normalizeTitleForDedup(entry.title))
+  );
+}
+
+function isMemorySuppressible(finding: Finding, confirmedByHuman?: boolean): boolean {
+  // Human-confirmed false positives may suppress ANY severity; auto-learned notes stay P2/P3-only.
+  if (confirmedByHuman === true) return true;
   return finding.severity === "P2" || finding.severity === "P3";
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -298,6 +298,11 @@ export interface RepoMemoryNoteRecord {
   source: string;
   confidence?: number;
   fingerprint?: string;
+  coarsePath?: string;
+  coarseCategory?: string;
+  coarseLine?: number;
+  coarseTitle?: string;
+  confirmedByHuman?: boolean;
   createdAt: string;
   updatedAt: string;
   expiresAt?: string;
@@ -312,6 +317,12 @@ export interface RecordRepoMemoryNoteInput {
   source: string;
   confidence?: number;
   fingerprint?: string;
+  // Coarse false-positive-match fields (#302, additive). confirmedByHuman gates P0/P1 suppression.
+  coarsePath?: string;
+  coarseCategory?: string;
+  coarseLine?: number;
+  coarseTitle?: string;
+  confirmedByHuman?: boolean;
   expiresAt?: string;
   now?: Date;
 }
@@ -561,6 +572,11 @@ export class ReviewStateStore {
         source text not null,
         confidence real,
         fingerprint text,
+        coarse_path text,
+        coarse_category text,
+        coarse_line integer,
+        coarse_title text,
+        confirmed_by_human integer,
         created_at text not null,
         updated_at text not null,
         expires_at text,
@@ -626,6 +642,7 @@ export class ReviewStateStore {
     this.ensureDaemonHeartbeatColumns();
     this.ensureReviewRunLeaseColumns();
     this.ensureReviewQueueJobColumns();
+    this.ensureRepoMemoryNoteCoarseColumns();
     this.db.exec(`
       create table if not exists processed_commands (
         repo text not null,
@@ -2335,8 +2352,10 @@ export class ReviewStateStore {
     this.db
       .prepare(
         `insert into repo_memory_notes
-          (note_id, repo, kind, title, body, source, confidence, fingerprint, created_at, updated_at, expires_at)
-         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          (note_id, repo, kind, title, body, source, confidence, fingerprint,
+           coarse_path, coarse_category, coarse_line, coarse_title, confirmed_by_human,
+           created_at, updated_at, expires_at)
+         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          on conflict(repo, note_id) do update set
            kind = excluded.kind,
            title = excluded.title,
@@ -2344,6 +2363,11 @@ export class ReviewStateStore {
            source = excluded.source,
            confidence = excluded.confidence,
            fingerprint = excluded.fingerprint,
+           coarse_path = excluded.coarse_path,
+           coarse_category = excluded.coarse_category,
+           coarse_line = excluded.coarse_line,
+           coarse_title = excluded.coarse_title,
+           confirmed_by_human = excluded.confirmed_by_human,
            updated_at = excluded.updated_at,
            expires_at = excluded.expires_at`
       )
@@ -2356,6 +2380,11 @@ export class ReviewStateStore {
         redactSecrets(input.source).trim(),
         input.confidence ?? null,
         input.fingerprint ? redactSecrets(input.fingerprint).trim() : null,
+        input.coarsePath ? redactSecrets(input.coarsePath).trim() : null,
+        input.coarseCategory ?? null,
+        input.coarseLine ?? null,
+        input.coarseTitle ? redactSecrets(input.coarseTitle).trim() : null,
+        input.confirmedByHuman === undefined ? null : input.confirmedByHuman ? 1 : 0,
         existing?.createdAt ?? nowIso,
         nowIso,
         input.expiresAt ?? null
@@ -2368,7 +2397,9 @@ export class ReviewStateStore {
     if (!noteId.trim()) throw new Error("noteId must be non-empty");
     const row = this.db
       .prepare(
-        `select note_id, repo, kind, title, body, source, confidence, fingerprint, created_at, updated_at, expires_at
+        `select note_id, repo, kind, title, body, source, confidence, fingerprint,
+                coarse_path, coarse_category, coarse_line, coarse_title, confirmed_by_human,
+                created_at, updated_at, expires_at
          from repo_memory_notes
          where repo = ? and note_id = ?
          limit 1`
@@ -2478,6 +2509,18 @@ export class ReviewStateStore {
       this.db.exec("alter table review_queue_jobs add column lease_expires_at text");
     }
   }
+
+  private ensureRepoMemoryNoteCoarseColumns(): void {
+    // Additive migration (#302): older DBs gain the coarse false-positive-match columns; existing
+    // rows keep NULLs and fall back to exact-only matching.
+    const columns = this.db.prepare("pragma table_info(repo_memory_notes)").all() as unknown as Array<{ name: string }>;
+    const names = new Set(columns.map((column) => column.name));
+    if (!names.has("coarse_path")) this.db.exec("alter table repo_memory_notes add column coarse_path text");
+    if (!names.has("coarse_category")) this.db.exec("alter table repo_memory_notes add column coarse_category text");
+    if (!names.has("coarse_line")) this.db.exec("alter table repo_memory_notes add column coarse_line integer");
+    if (!names.has("coarse_title")) this.db.exec("alter table repo_memory_notes add column coarse_title text");
+    if (!names.has("confirmed_by_human")) this.db.exec("alter table repo_memory_notes add column confirmed_by_human integer");
+  }
 }
 
 export function listRepoMemoryNotesReadOnly(dbPath: string, input: ListRepoMemoryNotesInput): RepoMemoryNoteRecord[] {
@@ -2517,7 +2560,9 @@ function listRepoMemoryNotesFromDb(db: DatabaseSync, input: ListRepoMemoryNotesI
   if (input.limit) params.push(input.limit);
   const rows = db
     .prepare(
-      `select note_id, repo, kind, title, body, source, confidence, fingerprint, created_at, updated_at, expires_at
+      `select note_id, repo, kind, title, body, source, confidence, fingerprint,
+              coarse_path, coarse_category, coarse_line, coarse_title, confirmed_by_human,
+              created_at, updated_at, expires_at
        from repo_memory_notes
        where ${predicates.join(" and ")}
        order by datetime(updated_at) desc, note_id asc
@@ -2922,6 +2967,11 @@ interface RepoMemoryNoteRow {
   source: string;
   confidence: number | null;
   fingerprint: string | null;
+  coarse_path: string | null;
+  coarse_category: string | null;
+  coarse_line: number | null;
+  coarse_title: string | null;
+  confirmed_by_human: number | null;
   created_at: string;
   updated_at: string;
   expires_at: string | null;
@@ -3151,6 +3201,11 @@ function mapRepoMemoryNoteRow(row: RepoMemoryNoteRow): RepoMemoryNoteRecord {
     source: row.source,
     ...(row.confidence !== null ? { confidence: row.confidence } : {}),
     ...(row.fingerprint ? { fingerprint: row.fingerprint } : {}),
+    ...(row.coarse_path ? { coarsePath: row.coarse_path } : {}),
+    ...(row.coarse_category ? { coarseCategory: row.coarse_category } : {}),
+    ...(row.coarse_line !== null ? { coarseLine: row.coarse_line } : {}),
+    ...(row.coarse_title ? { coarseTitle: row.coarse_title } : {}),
+    ...(row.confirmed_by_human !== null ? { confirmedByHuman: row.confirmed_by_human === 1 } : {}),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     ...(row.expires_at ? { expiresAt: row.expires_at } : {})

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -38,7 +38,7 @@ import {
   listReposToScan,
   resolveRepoProfile
 } from "./repo-policy.js";
-import { applyDeterministicReviewGate } from "./review-gate.js";
+import { applyDeterministicReviewGate, type RepoMemoryFalsePositiveEntry } from "./review-gate.js";
 import {
   buildOutcomeLedger,
   buildOutcomeLedgerInputFromReviewPlan,
@@ -1481,6 +1481,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       droppedFromSchema: zcodeResult.droppedFromSchema,
       maxInlineComments: config.reviewGate?.maxInlineComments ?? 25,
       repoMemoryFalsePositiveFingerprints: repoMemory.falsePositiveFingerprints,
+      repoMemoryFalsePositives: repoMemory.falsePositives,
       publicConfidencePolicy: config.confidenceCalibration?.publicDisplay,
       ...(config.reviewGate?.requestChangesConfidenceFloors
         ? { requestChangesConfidenceFloors: config.reviewGate.requestChangesConfidenceFloors }
@@ -2014,9 +2015,9 @@ export function buildRepoMemoryContext(input: {
   state: ReviewStateStore;
   repo: string;
   evidenceDir: string;
-}): { packet?: RepoMemoryPacket; falsePositiveFingerprints: string[] } {
+}): { packet?: RepoMemoryPacket; falsePositiveFingerprints: string[]; falsePositives: RepoMemoryFalsePositiveEntry[] } {
   const repoMemoryConfig = input.config.repoMemory;
-  if (!repoMemoryConfig?.enabled) return { falsePositiveFingerprints: [] };
+  if (!repoMemoryConfig?.enabled) return { falsePositiveFingerprints: [], falsePositives: [] };
 
   const generatedAt = new Date().toISOString();
   const generatedAtDate = new Date(generatedAt);
@@ -2034,9 +2035,22 @@ export function buildRepoMemoryContext(input: {
     limit: repoMemoryConfig.maxStateNotes,
     kind: "false_positive"
   });
-  const falsePositiveFingerprints = falsePositiveNotes
-    .filter((note) => note.kind === "false_positive" && note.fingerprint && !isRepoMemoryNoteExpired(note, generatedAtDate))
-    .map((note) => note.fingerprint!);
+  const liveFalsePositiveNotes = falsePositiveNotes.filter(
+    (note) => note.kind === "false_positive" && note.fingerprint && !isRepoMemoryNoteExpired(note, generatedAtDate)
+  );
+  const falsePositiveFingerprints = liveFalsePositiveNotes.map((note) => note.fingerprint!);
+  // Structured entries carry the coarse-match fields (#302) when the note has them (v0.2+); notes
+  // that predate the coarse fields still supply their exact fingerprint via the list above.
+  const falsePositives: RepoMemoryFalsePositiveEntry[] = liveFalsePositiveNotes
+    .filter((note) => note.coarsePath && note.coarseCategory && typeof note.coarseLine === "number" && note.coarseTitle)
+    .map((note) => ({
+      fingerprint: note.fingerprint!,
+      path: note.coarsePath!,
+      category: note.coarseCategory!,
+      line: note.coarseLine!,
+      title: note.coarseTitle!,
+      ...(note.confirmedByHuman !== undefined ? { confirmedByHuman: note.confirmedByHuman } : {})
+    }));
   const packetResult = buildRepoMemoryPacket({
     repo: input.repo,
     humanMarkdown: readRepoMemoryMarkdown(repoMemoryConfig.memoryRoot, input.repo),
@@ -2050,7 +2064,7 @@ export function buildRepoMemoryContext(input: {
   if (!packetResult.ok) {
     writeRedactedJson(join(input.evidenceDir, "repo-memory-packet-error.json"), packetResult);
     if (isRepoMemoryBudgetFailure(packetResult)) {
-      return { falsePositiveFingerprints };
+      return { falsePositiveFingerprints, falsePositives };
     }
     throw new Error(`Repo memory packet failed closed: ${packetResult.error}`);
   }
@@ -2068,7 +2082,7 @@ export function buildRepoMemoryContext(input: {
     redactionStatus: packetResult.redactionReport.ok ? "passed" : "failed",
     memoryRoot: repoMemoryConfig.memoryRoot
   });
-  return { packet: packetResult.packet, falsePositiveFingerprints };
+  return { packet: packetResult.packet, falsePositiveFingerprints, falsePositives };
 }
 
 function isRepoMemoryBudgetFailure(packetResult: ReturnType<typeof buildRepoMemoryPacket>): boolean {

--- a/tests/repo-memory.test.ts
+++ b/tests/repo-memory.test.ts
@@ -509,6 +509,58 @@ describe("repo memory packets", () => {
     store.close();
   });
 
+  it("round-trips coarse false-positive-match fields and the confirmedByHuman flag (#302)", () => {
+    const root = mkdtempSync(join(tmpdir(), "repo-memory-coarse-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const fingerprint = `finding:${"b".repeat(64)}`;
+
+    store.recordRepoMemoryNote({
+      noteId: "confirmed-fp",
+      repo,
+      kind: "false_positive",
+      title: "Confirmed noisy rollback finding",
+      body: "Operator-confirmed false positive to suppress on coarse recurrence.",
+      source: "operator",
+      fingerprint,
+      coarsePath: "src/save.ts",
+      coarseCategory: "data_loss",
+      coarseLine: 42,
+      coarseTitle: "Rollback clobbers fresh state",
+      confirmedByHuman: true,
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      now: new Date(generatedAt)
+    });
+
+    const stored = store.getRepoMemoryNote(repo, "confirmed-fp");
+    expect(stored).toMatchObject({
+      coarsePath: "src/save.ts",
+      coarseCategory: "data_loss",
+      coarseLine: 42,
+      coarseTitle: "Rollback clobbers fresh state",
+      confirmedByHuman: true
+    });
+
+    // An auto note without the flag reads back without confirmedByHuman (stays P2/P3-only downstream).
+    store.recordRepoMemoryNote({
+      noteId: "auto-fp",
+      repo,
+      kind: "false_positive",
+      title: "Auto-learned churn",
+      body: "Auto-learned false positive with coarse fields but no human confirmation.",
+      source: "review#91",
+      fingerprint: `finding:${"c".repeat(64)}`,
+      coarsePath: "src/save.ts",
+      coarseCategory: "runtime_correctness",
+      coarseLine: 10,
+      coarseTitle: "Retry accounting is wrong",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      now: new Date(generatedAt)
+    });
+    expect(store.getRepoMemoryNote(repo, "auto-fp")?.confirmedByHuman).toBeUndefined();
+    store.close();
+  });
+
   it("reads human repo-memory.md outside the target checkout", () => {
     const root = mkdtempSync(join(tmpdir(), "repo-memory-root-"));
     roots.push(root);

--- a/tests/review-gate.test.ts
+++ b/tests/review-gate.test.ts
@@ -329,3 +329,147 @@ describe("deterministic review gate", () => {
     expect(JSON.stringify(gate.dropped)).not.toMatch(/\b\d+(?:\.\d+)?\s*%/);
   });
 });
+
+describe("robust false-positive learning — coarse fallback (#302)", () => {
+  const files: PullFilePatch[] = [
+    {
+      filename: "src/save.ts",
+      patch: "@@ -40,3 +40,6 @@ export function save() {\n+  const a = 1;\n+  const b = 2;\n+  overwriteAllData();\n+  const c = 3;\n }"
+    }
+  ];
+
+  function finding(overrides: Partial<Finding> & Pick<Finding, "severity" | "line" | "title">): Finding {
+    return {
+      category: "runtime_correctness",
+      path: "src/save.ts",
+      body: "A concrete review comment about the save path.",
+      confidence: 0.8,
+      ...overrides
+    };
+  }
+
+  it("suppresses a reworded, line-shifted P3 finding via the coarse path with the distinct reason (#302)", () => {
+    const current = finding({ severity: "P3", line: 44, title: "Save path retry accounting is wrong" });
+    const gate = applyDeterministicReviewGate({
+      files,
+      findings: [current],
+      repoMemoryFalsePositives: [
+        {
+          // Remembered at line 42 with a slightly different title; exact fingerprint won't match.
+          fingerprint: buildFindingFingerprint({ ...current, line: 42, title: "Save path retry accounting" }),
+          path: "src/save.ts",
+          category: "runtime_correctness",
+          line: 42,
+          title: "Save path retry accounting"
+        }
+      ]
+    });
+
+    expect(gate.comments).toHaveLength(0);
+    expect(gate.dropped).toContainEqual(expect.objectContaining({ reason: "repo_memory_false_positive_coarse_match" }));
+    expect(gate.summary.dropReasonCounts).toMatchObject({ repo_memory_false_positive_coarse_match: 1 });
+  });
+
+  it("does NOT coarse-suppress a different genuine finding at a nearby line with a non-matching title (#302)", () => {
+    const current = finding({ severity: "P3", line: 43, title: "Null deref in error branch" });
+    const gate = applyDeterministicReviewGate({
+      files,
+      findings: [current],
+      repoMemoryFalsePositives: [
+        {
+          fingerprint: buildFindingFingerprint({ ...current, line: 42, title: "Save path retry accounting" }),
+          path: "src/save.ts",
+          category: "runtime_correctness",
+          line: 42,
+          title: "Save path retry accounting"
+        }
+      ]
+    });
+
+    expect(gate.comments).toHaveLength(1);
+    expect(gate.dropped).not.toContainEqual(expect.objectContaining({ reason: "repo_memory_false_positive_coarse_match" }));
+  });
+
+  it("does NOT coarse-suppress a P1 finding from an AUTO false-positive note (#302)", () => {
+    const current = finding({ severity: "P1", category: "data_loss", line: 44, title: "Rollback clobbers fresh state on retry" });
+    const gate = applyDeterministicReviewGate({
+      files,
+      findings: [current],
+      repoMemoryFalsePositives: [
+        {
+          fingerprint: buildFindingFingerprint({ ...current, line: 42, title: "Rollback clobbers fresh state" }),
+          path: "src/save.ts",
+          category: "data_loss",
+          line: 42,
+          title: "Rollback clobbers fresh state"
+          // confirmedByHuman omitted ⇒ auto note ⇒ P0/P1 must NOT be suppressed.
+        }
+      ]
+    });
+
+    expect(gate.comments).toHaveLength(1);
+    expect(gate.dropped).not.toContainEqual(expect.objectContaining({ reason: "repo_memory_false_positive_coarse_match" }));
+  });
+
+  it("coarse-suppresses a P1 finding when the false-positive note is human-confirmed (#302)", () => {
+    const current = finding({ severity: "P1", category: "data_loss", line: 44, title: "Rollback clobbers fresh state on retry" });
+    const gate = applyDeterministicReviewGate({
+      files,
+      findings: [current],
+      repoMemoryFalsePositives: [
+        {
+          fingerprint: buildFindingFingerprint({ ...current, line: 42, title: "Rollback clobbers fresh state" }),
+          path: "src/save.ts",
+          category: "data_loss",
+          line: 42,
+          title: "Rollback clobbers fresh state",
+          confirmedByHuman: true
+        }
+      ]
+    });
+
+    expect(gate.comments).toHaveLength(0);
+    expect(gate.dropped).toContainEqual(expect.objectContaining({ reason: "repo_memory_false_positive_coarse_match" }));
+  });
+
+  it("prefers the exact reason and does not double-count when the exact fingerprint matches (#302)", () => {
+    const current = finding({ severity: "P3", line: 42, title: "Save path retry accounting" });
+    const exactFingerprint = buildFindingFingerprint(current);
+    const gate = applyDeterministicReviewGate({
+      files,
+      findings: [current],
+      repoMemoryFalsePositives: [
+        { fingerprint: exactFingerprint, path: "src/save.ts", category: "runtime_correctness", line: 42, title: "Save path retry accounting" }
+      ]
+    });
+
+    expect(gate.summary.dropReasonCounts).toMatchObject({ repo_memory_false_positive_match: 1 });
+    expect(gate.summary.dropReasonCounts.repo_memory_false_positive_coarse_match).toBeUndefined();
+  });
+
+  it("redacts a secret-bearing coarse-suppressed finding at the gate boundary (#302)", () => {
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+    const current = finding({
+      severity: "P3",
+      line: 44,
+      title: "Save path retry accounting is wrong",
+      body: `Leaked token ${token} in the save path retry accounting.`
+    });
+    const gate = applyDeterministicReviewGate({
+      files,
+      findings: [current],
+      repoMemoryFalsePositives: [
+        {
+          fingerprint: buildFindingFingerprint({ ...current, line: 42, title: "Save path retry accounting" }),
+          path: "src/save.ts",
+          category: "runtime_correctness",
+          line: 42,
+          title: "Save path retry accounting"
+        }
+      ]
+    });
+
+    expect(gate.dropped).toContainEqual(expect.objectContaining({ reason: "repo_memory_false_positive_coarse_match" }));
+    expect(JSON.stringify(gate.dropped)).not.toContain(token);
+  });
+});


### PR DESCRIPTION
Closes #302. Parent: #278 (Phase 3, item 9).

## Summary
Repo-memory FP suppression required an exact sha256 over title+body+line+path+category — any diff-churn line shift or model rewording defeated learning, and `isMemorySuppressible`'s P2/P3 limit meant confirmed high-severity noise could never be learned away.

- **Coarse fallback, consulted only on exact-miss:** path + normalized category (post-#293 semantics) + line window (|Δ|≤3) + normalized-title exact-or-prefix — REUSING the #294 same-run-dedup helpers (now exported) so the two near-match semantics can never drift. Coarse hits drop with distinct reason `repo_memory_false_positive_coarse_match` through the #300 boundary sanitizer.
- **Human-confirmed pathway:** `confirmedByHuman` on a note may suppress any severity (exact or coarse); auto-learned notes remain P2/P3-only. This PR only honors confirmed notes — nothing auto-creates them.
- **Additive note schema (packet v0.1→v0.2):** nullable coarse fields + confirmed flag via the existing ensure-columns migration pattern; legacy notes lacking fields fall back to exact-only.

## Validation
- TDD failing-first pins: reworded/line-shifted FP coarse-suppresses with the distinct reason; a different genuine finding at a nearby line does NOT suppress; auto P1 does NOT suppress; human-confirmed P1 does; exact-match precedence (no double-count); secret-bearing coarse-drop arrives redacted; state round-trip for new fields.
- Focused Vitest 192/192 (review-gate, findings, repo-memory, state, worker-failure, config-schema, confidence-config) under `set -o pipefail`; `npm run build` exit 0.
- Additive; conservative-by-design (a missed duplicate FP is cheaper than suppressing a genuine finding).