### PR TITLE
Retry-degraded provenance, optional quieter-only confidence penalty, bounded schema-failure retry

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -195,6 +195,9 @@ export interface ReviewGateConfig {
   maxInlineComments: number;
   /** Optional per-severity confidence floors for REQUEST_CHANGES eligibility (default off). */
   requestChangesConfidenceFloors?: RequestChangesConfidenceFloors;
+  /** Optional confidence subtracted (0..1, floor 0) from findings recovered via the strict-JSON
+   * retry path (#304). Default off; quieter-only — lower confidence can only demote ranking/floors. */
+  retryDegradedConfidencePenalty?: number;
 }
 
 export interface RiskWeightedQueueConfig {
@@ -683,6 +686,9 @@ function validateReviewGateConfig(value: unknown, label: string): void {
       const floor = value.requestChangesConfidenceFloors[severity];
       if (floor !== undefined) validateProbability(floor, `${label}.requestChangesConfidenceFloors.${severity}`);
     }
+  }
+  if (value.retryDegradedConfidencePenalty !== undefined) {
+    validateProbability(value.retryDegradedConfidencePenalty, `${label}.retryDegradedConfidencePenalty`);
   }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -72,9 +72,9 @@ import {
 import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "./validation-selector.js";
 import { buildWalkthroughComment } from "./walkthrough.js";
 import { postWalkthroughComment, reviewBodyAfterWalkthroughPost } from "./walkthrough-post.js";
-import { buildReviewPrompt, runZCodeReview, type ZCodeReviewResult } from "./zcode.js";
+import { buildReviewPrompt, isZCodeSchemaFailureError, runZCodeReview, type ZCodeReviewResult } from "./zcode.js";
 import { formatZCodeTimeoutFailureError } from "./zcode-timeout.js";
-import type { PullFilePatch, PullRequestSummary, RepositorySummary, ReviewEvent, ReviewPlan, ReviewProviderMetadata } from "./types.js";
+import type { Finding, PullFilePatch, PullRequestSummary, RepositorySummary, ReviewEvent, ReviewPlan, ReviewProviderMetadata } from "./types.js";
 
 const LICENSE_GATE_REPO_VISIBILITY_CACHE_TTL_MS = 10 * 60_000;
 const LICENSE_GATE_UNKNOWN_REPO_VISIBILITY_CACHE_TTL_MS = 2 * 60_000;
@@ -176,7 +176,7 @@ export interface RetryProviderCooldownsResult {
   };
 }
 
-export type ProviderErrorCategory = "none" | "request_rate_limit" | "overloaded" | "quota_exhausted";
+export type ProviderErrorCategory = "none" | "request_rate_limit" | "overloaded" | "quota_exhausted" | "model_output_schema";
 
 export interface ProviderErrorClassification {
   category: ProviderErrorCategory;
@@ -1458,6 +1458,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
           findings: [],
           droppedFromSchema: [],
           rawResponse: "{\"findings\":[]}",
+          attempts: 0,
+          degradedRecovery: false,
           runtime: {
             provider: config.zcode.providerId,
             model: config.zcode.model,
@@ -1475,8 +1477,13 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       return "skipped_stale_head";
     }
 
+    const gatedFindings = applyRetryDegradedConfidencePenalty(
+      zcodeResult.findings,
+      zcodeResult.degradedRecovery,
+      config.reviewGate?.retryDegradedConfidencePenalty
+    );
     const gate = applyDeterministicReviewGate({
-      findings: zcodeResult.findings,
+      findings: gatedFindings,
       files: reviewFiles,
       droppedFromSchema: zcodeResult.droppedFromSchema,
       maxInlineComments: config.reviewGate?.maxInlineComments ?? 25,
@@ -2329,6 +2336,27 @@ export function recordProviderRateLimitCooldownIfNeeded(input: {
   return true;
 }
 
+/**
+ * Config-gated retry-degraded confidence penalty (#304, default off). When a review's findings came
+ * from a degraded (strict-JSON retry) parse and a penalty is configured, subtract it from each
+ * finding's confidence (floored at 0) BEFORE the gate. Quieter-only by construction: lower confidence
+ * can only demote ranking/floor eligibility, never promote. A no-op when not degraded or unconfigured.
+ */
+export function applyRetryDegradedConfidencePenalty(
+  findings: Finding[],
+  degradedRecovery: boolean,
+  penalty: number | undefined
+): Finding[] {
+  if (!degradedRecovery || penalty === undefined || penalty <= 0) return findings;
+  return findings.map((finding) => ({ ...finding, confidence: Math.max(0, finding.confidence - penalty) }));
+}
+
+/** Runtime-note provenance line for the outcome ledger (#304); undefined for a clean first-pass parse. */
+export function buildRetryDegradedRuntimeNote(attempts: number, degradedRecovery: boolean): string | undefined {
+  if (!degradedRecovery) return undefined;
+  return `Findings recovered via the strict-JSON retry path (degraded): parsed on attempt ${attempts} of the ZCode review, not the first pass.`;
+}
+
 export function classifyProviderError(error: unknown): ProviderErrorClassification {
   const message = error instanceof Error ? error.message : String(error);
   const normalized = message.toLowerCase();
@@ -2367,6 +2395,12 @@ export function classifyProviderError(error: unknown): ProviderErrorClassificati
   }
   if (requestRateLimited) {
     return { ...base, category: "request_rate_limit", reason: "provider_request_rate_limit", retryable: true, cooldown: true };
+  }
+  // Persistent model-output-schema/parse failures (#304): retryable within runWithProviderRetry's
+  // bounded attempt budget (attempt < maxAttempts), but NOT a provider cooldown — it is a model
+  // formatting problem, not a rate/quota/overload signal. The bound guarantees no infinite loop.
+  if (isZCodeSchemaFailureError(error)) {
+    return { ...base, category: "model_output_schema", reason: "model_output_schema_failure", retryable: true, cooldown: false };
   }
   return {
     ...base,
@@ -2456,7 +2490,12 @@ async function runZCodeReviewWithProviderRetry(input: {
       latencyMs: completedAt.getTime() - startedAt.getTime(),
       notes: [
         `Observed outer provider retry attempts: ${providerAttempts}.`,
-        "Internal ZCode retry attempts and token usage are not exposed by the configured provider path; providerAttempts and token metrics remain null."
+        "Internal ZCode retry attempts and token usage are not exposed by the configured provider path; providerAttempts and token metrics remain null.",
+        // Retry-degraded provenance (#304): surfaced only when the strict-JSON retry path produced
+        // the accepted parse, so evidence packets and the ledger runtime honestly flag it.
+        ...(result.degradedRecovery
+          ? [buildRetryDegradedRuntimeNote(result.attempts, result.degradedRecovery)!]
+          : [])
       ]
     }
   };

--- a/src/zcode.ts
+++ b/src/zcode.ts
@@ -16,6 +16,44 @@ export interface ZCodeReviewResult {
   findings: Finding[];
   droppedFromSchema: ReturnType<typeof parseFindings>["dropped"];
   rawResponse: string;
+  // Provenance (#304): how many parse attempts ran and whether the strict-JSON retry path produced
+  // the accepted parse. degradedRecovery is true iff a non-first attempt supplied the findings.
+  attempts: number;
+  degradedRecovery: boolean;
+}
+
+// Distinct, detectable schema/parse-failure marker so runWithProviderRetry can classify persistent
+// model_output_schema failures as their own bounded retryable category instead of falling through
+// as non-retryable (#304).
+export const ZCODE_SCHEMA_FAILURE_ERROR_PREFIX = "zcode_model_output_schema_failure";
+
+export function isZCodeSchemaFailureError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes(ZCODE_SCHEMA_FAILURE_ERROR_PREFIX);
+}
+
+/**
+ * Parse the first attempt whose stdout yields a valid review JSON (#304). Attempt 1 is the original
+ * prompt; later attempts are strict-JSON retries. Returns provenance so callers can tag degraded
+ * recoveries. Throws a ZCODE_SCHEMA_FAILURE_ERROR_PREFIX error when no attempt parses.
+ */
+export function parseZCodeReviewOutput(rawStdouts: string[]): ZCodeReviewResult {
+  let lastParseError: unknown;
+  for (let attempt = 1; attempt <= rawStdouts.length; attempt += 1) {
+    try {
+      const rawResponse = extractZCodeResponse(rawStdouts[attempt - 1]!);
+      const parsed = JSON.parse(extractJsonObject(rawResponse));
+      const { findings, dropped } = parseFindings(parsed);
+      return { findings, droppedFromSchema: dropped, rawResponse, attempts: attempt, degradedRecovery: attempt > 1 };
+    } catch (error) {
+      lastParseError = error;
+    }
+  }
+  throw new Error(
+    `${ZCODE_SCHEMA_FAILURE_ERROR_PREFIX}: ZCode response did not contain a parseable JSON review after ${rawStdouts.length} attempts: ${
+      lastParseError instanceof Error ? lastParseError.message : String(lastParseError)
+    }`
+  );
 }
 
 export interface ZCodeReviewFixtureAdapterOptions {
@@ -246,14 +284,15 @@ export function runZCodeReview(input: {
       const rawResponse = extractZCodeResponse(result.stdout);
       const parsed = JSON.parse(extractJsonObject(rawResponse));
       const { findings, dropped } = parseFindings(parsed);
-      return { findings, droppedFromSchema: dropped, rawResponse };
+      // Provenance (#304): a non-first successful attempt is a degraded (strict-JSON retry) recovery.
+      return { findings, droppedFromSchema: dropped, rawResponse, attempts: attempt, degradedRecovery: attempt > 1 };
     } catch (error) {
       lastParseError = error;
     }
   }
 
   throw new Error(
-    `ZCode response did not contain a parseable JSON review after ${prompts.length} attempts: ${
+    `${ZCODE_SCHEMA_FAILURE_ERROR_PREFIX}: ZCode response did not contain a parseable JSON review after ${prompts.length} attempts: ${
       lastParseError instanceof Error ? lastParseError.message : String(lastParseError)
     }`
   );

--- a/tests/confidence-config.test.ts
+++ b/tests/confidence-config.test.ts
@@ -152,6 +152,25 @@ describe("review gate config", () => {
     );
   });
 
+  it("defaults retryDegradedConfidencePenalty to unset (off) and accepts a valid penalty (#304)", () => {
+    expect(loadConfigFromObject({}).reviewGate?.retryDegradedConfidencePenalty).toBeUndefined();
+    expect(
+      loadConfigFromObject({ reviewGate: { retryDegradedConfidencePenalty: 0.2 } }).reviewGate?.retryDegradedConfidencePenalty
+    ).toBe(0.2);
+  });
+
+  it("rejects an out-of-range or non-number retryDegradedConfidencePenalty (#304)", () => {
+    expect(() => loadConfigFromObject({ reviewGate: { retryDegradedConfidencePenalty: -0.1 } })).toThrow(
+      /reviewGate\.retryDegradedConfidencePenalty must be a number from 0 to 1/
+    );
+    expect(() => loadConfigFromObject({ reviewGate: { retryDegradedConfidencePenalty: 1.5 } })).toThrow(
+      /reviewGate\.retryDegradedConfidencePenalty must be a number from 0 to 1/
+    );
+    expect(() =>
+      loadConfigFromObject({ reviewGate: { retryDegradedConfidencePenalty: "high" as unknown as number } })
+    ).toThrow(/reviewGate\.retryDegradedConfidencePenalty must be a number from 0 to 1/);
+  });
+
   it("rejects unknown keys in the confidence floors map", () => {
     expect(() =>
       loadConfigFromObject({ reviewGate: { requestChangesConfidenceFloors: { p0: 0.8 } } })

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -35,7 +35,9 @@ describe("provider adapter fixtures", () => {
         return {
           findings: [],
           droppedFromSchema: [],
-          rawResponse: reviewJson
+          rawResponse: reviewJson,
+          attempts: 1,
+          degradedRecovery: false
         };
       }
     });
@@ -125,7 +127,9 @@ describe("provider adapter fixtures", () => {
         return {
           findings: [],
           droppedFromSchema: [],
-          rawResponse: `Here is the review:\n\`\`\`json\n${reviewJson}\n\`\`\``
+          rawResponse: `Here is the review:\n\`\`\`json\n${reviewJson}\n\`\`\``,
+          attempts: 1,
+          degradedRecovery: false
         };
       }
     });

--- a/tests/zcode-retry-provenance.test.ts
+++ b/tests/zcode-retry-provenance.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  ZCODE_SCHEMA_FAILURE_ERROR_PREFIX,
+  isZCodeSchemaFailureError,
+  parseZCodeReviewOutput
+} from "../src/zcode.js";
+import { applyRetryDegradedConfidencePenalty, buildRetryDegradedRuntimeNote, classifyProviderError } from "../src/worker.js";
+import type { Finding } from "../src/types.js";
+
+// A ZCode stdout envelope wrapping a valid review-JSON string (what extractZCodeResponse consumes).
+const CLEAN = JSON.stringify({
+  response: JSON.stringify({
+    findings: [{ severity: "P2", path: "src/x.ts", line: 3, title: "Concern", body: "A concrete review comment.", confidence: 0.8 }],
+    summary: "ok"
+  })
+});
+
+describe("zcode retry-degraded provenance (#304)", () => {
+  it("marks a clean first-pass parse as non-degraded on attempt 1", () => {
+    const result = parseZCodeReviewOutput([CLEAN]);
+    expect(result.attempts).toBe(1);
+    expect(result.degradedRecovery).toBe(false);
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it("flags degradedRecovery when the first attempt fails to parse and a later attempt succeeds", () => {
+    const result = parseZCodeReviewOutput(["not json at all", CLEAN]);
+    expect(result.attempts).toBe(2);
+    expect(result.degradedRecovery).toBe(true);
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it("throws a distinct, detectable schema-failure error when no attempt parses", () => {
+    let thrown: unknown;
+    try {
+      parseZCodeReviewOutput(["nope", "still nope"]);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain(ZCODE_SCHEMA_FAILURE_ERROR_PREFIX);
+    expect(isZCodeSchemaFailureError(thrown)).toBe(true);
+  });
+});
+
+describe("retry-degraded confidence penalty (#304)", () => {
+  const findings: Finding[] = [
+    { severity: "P2", category: "runtime_correctness", path: "a.ts", line: 1, title: "One", body: "b", confidence: 0.9 },
+    { severity: "P3", category: "runtime_correctness", path: "a.ts", line: 2, title: "Two", body: "b", confidence: 0.1 }
+  ];
+
+  it("is a no-op when the parse was not degraded", () => {
+    const out = applyRetryDegradedConfidencePenalty(findings, false, 0.3);
+    expect(out.map((f) => f.confidence)).toEqual([0.9, 0.1]);
+  });
+
+  it("is a no-op when no penalty is configured", () => {
+    const out = applyRetryDegradedConfidencePenalty(findings, true, undefined);
+    expect(out.map((f) => f.confidence)).toEqual([0.9, 0.1]);
+  });
+
+  it("subtracts the penalty (floored at 0) only for degraded findings — quieter-only", () => {
+    const out = applyRetryDegradedConfidencePenalty(findings, true, 0.3);
+    expect(out[0]?.confidence).toBeCloseTo(0.6, 10);
+    expect(out[1]?.confidence).toBe(0); // 0.1 - 0.3 floored at 0
+    // Penalty can only lower confidence, never raise it.
+    for (const [i, f] of out.entries()) expect(f.confidence).toBeLessThanOrEqual(findings[i]!.confidence);
+  });
+});
+
+describe("schema-failure provider classification (#304)", () => {
+  it("classifies a schema-failure error as its own bounded retryable category", () => {
+    const error = new Error(`${ZCODE_SCHEMA_FAILURE_ERROR_PREFIX}: did not parse after 2 attempts`);
+    const classification = classifyProviderError(error);
+    expect(classification.category).toBe("model_output_schema");
+    expect(classification.retryable).toBe(true);
+    expect(classification.cooldown).toBe(false);
+  });
+
+  it("leaves unrelated errors non-retryable", () => {
+    expect(classifyProviderError(new Error("some other failure")).category).toBe("none");
+    expect(classifyProviderError(new Error("some other failure")).retryable).toBe(false);
+  });
+});
+
+describe("outcome-ledger retry-degraded runtime note (#304)", () => {
+  it("emits a provenance note only when the parse was degraded", () => {
+    expect(buildRetryDegradedRuntimeNote(1, false)).toBeUndefined();
+    const note = buildRetryDegradedRuntimeNote(2, true);
+    expect(note).toBeDefined();
+    expect(note).toMatch(/degraded/i);
+    expect(note).toContain("2");
+  });
+});


### PR DESCRIPTION
Closes #304. Parent: #278 (Phase 3, item 11).

## Summary
Findings recovered via the strict-JSON retry path were indistinguishable from clean first-pass findings, and schema/parse failures fell through provider-retry classification as non-retryable.

- `ZCodeReviewResult` gains `{ attempts, degradedRecovery }`; a degraded recovery appends a provenance note to the outcome-ledger runtime (existing idiom).
- Optional `reviewGate.retryDegradedConfidencePenalty` (0..1, **default off**, fail-closed validation): subtracted (floor 0) from degraded findings before the gate — quieter-only by construction.
- Schema failures throw a detectable prefix and classify as a new bounded-retryable `model_output_schema` category inside the existing attempt budget (no cooldown; no infinite loop — pinned).

## Validation
- TDD failing-first: provenance present iff retry path fired; penalty no-op unless configured AND degraded, floored, quieter-only; ledger note only on degraded; bounded retry pinned; config validation fail-closed.
- Focused Vitest 169/169 (zcode-retry-provenance, confidence-config, worker-failure, findings, provider-adapters, config-schema) under `set -o pipefail`; `npm run build` exit 0.
- Additive/default-off.