### PR TITLE
Opt-in P0/P1 self-consistency re-check with quieter-only merge semantics

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -198,6 +198,19 @@ export interface ReviewGateConfig {
   /** Optional confidence subtracted (0..1, floor 0) from findings recovered via the strict-JSON
    * retry path (#304). Default off; quieter-only — lower confidence can only demote ranking/floors. */
   retryDegradedConfidencePenalty?: number;
+  /** Opt-in P0/P1 self-consistency re-check (#303, default off). Owner-approved; adds provider cost. */
+  selfConsistency?: SelfConsistencyConfig;
+}
+
+export interface SelfConsistencyConfig {
+  /** When false (default), no second draw runs — byte-identical output, zero extra provider calls. */
+  enabled: boolean;
+  /** Severities to re-check; default ["P0","P1"]. Only P0/P1 are permitted. */
+  severities?: Array<"P0" | "P1">;
+  /** Provider-registry id for the second draw; absent ⇒ same provider as the main review. */
+  provider?: string;
+  /** Cost bound: max findings re-checked per review, in ranked order. Default 5. */
+  maxFindingsPerReview?: number;
 }
 
 export interface RiskWeightedQueueConfig {
@@ -689,6 +702,28 @@ function validateReviewGateConfig(value: unknown, label: string): void {
   }
   if (value.retryDegradedConfidencePenalty !== undefined) {
     validateProbability(value.retryDegradedConfidencePenalty, `${label}.retryDegradedConfidencePenalty`);
+  }
+  if (value.selfConsistency !== undefined) validateSelfConsistencyConfig(value.selfConsistency, `${label}.selfConsistency`);
+}
+
+function validateSelfConsistencyConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  validateBoolean(value.enabled, `${label}.enabled`);
+  if (value.severities !== undefined) {
+    if (!Array.isArray(value.severities) || value.severities.length === 0) {
+      throw new Error(`${label}.severities must be a non-empty array of P0 or P1`);
+    }
+    for (const severity of value.severities) {
+      if (severity !== "P0" && severity !== "P1") {
+        throw new Error(`${label}.severities entries must be P0 or P1`);
+      }
+    }
+  }
+  if (value.provider !== undefined && typeof value.provider !== "string") {
+    throw new Error(`${label}.provider must be a string`);
+  }
+  if (value.maxFindingsPerReview !== undefined) {
+    validatePositiveInteger(value.maxFindingsPerReview, `${label}.maxFindingsPerReview`);
   }
 }
 

--- a/src/self-consistency.ts
+++ b/src/self-consistency.ts
@@ -1,0 +1,122 @@
+import { decideReviewEvent } from "./findings.js";
+import { isRequestChangesEligible, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
+import type { PullFilePatch, ReviewComment, ReviewEvent, Severity } from "./types.js";
+
+export interface SelfConsistencyRecheckConfig {
+  enabled: boolean;
+  severities?: Array<"P0" | "P1">;
+  provider?: string;
+  maxFindingsPerReview?: number;
+}
+
+export interface SelfConsistencySecondDrawInput {
+  comment: ReviewComment;
+  hunk: string;
+}
+
+export interface SelfConsistencySecondDrawResult {
+  verified: boolean;
+  confidence: number;
+}
+
+export interface SelfConsistencyVerdict {
+  path: string;
+  line: number;
+  severity: Severity;
+  title: string;
+  originalConfidence: number;
+  secondConfidence?: number;
+  agreed?: boolean;
+  refuted?: boolean;
+  error?: string;
+}
+
+const DEFAULT_SEVERITIES: Array<"P0" | "P1"> = ["P0", "P1"];
+const DEFAULT_MAX_FINDINGS = 5;
+
+/**
+ * Opt-in P0/P1 self-consistency re-check (#303). For each gate-accepted comment at a configured
+ * severity (post-dedup, pre-event-decision; capped by maxFindingsPerReview in the ranked order the
+ * gate already produced), issue ONE bounded second draw asking verify/refute + confidence. The merge
+ * is strictly QUIETER-ONLY: agreement keeps the original confidence (never raised); refutation sets
+ * confidence to min(original, second) AND strips REQUEST_CHANGES eligibility for that comment. Any
+ * second-draw failure leaves the comment untouched (never blocks/drops the review). The event is then
+ * re-derived from the comments that retain eligibility. Disabled ⇒ no second draw, byte-identical
+ * output. The second-draw runner is injected so callers pick the provider and tests stay hermetic.
+ */
+export function runSelfConsistencyRecheck(input: {
+  comments: ReviewComment[];
+  files: PullFilePatch[];
+  config: SelfConsistencyRecheckConfig;
+  requestChangesConfidenceFloors?: RequestChangesConfidenceFloors;
+  secondDraw: (input: SelfConsistencySecondDrawInput) => SelfConsistencySecondDrawResult;
+}): { comments: ReviewComment[]; event: ReviewEvent; verdicts: SelfConsistencyVerdict[] } {
+  if (!input.config.enabled) {
+    return {
+      comments: input.comments,
+      event: decideReviewEvent(input.comments, input.requestChangesConfidenceFloors),
+      verdicts: []
+    };
+  }
+
+  const severities = new Set<Severity>(input.config.severities ?? DEFAULT_SEVERITIES);
+  const maxFindings = input.config.maxFindingsPerReview ?? DEFAULT_MAX_FINDINGS;
+  const verdicts: SelfConsistencyVerdict[] = [];
+  const refutedKeys = new Set<string>();
+  let rechecked = 0;
+
+  // input.comments is already in the gate's ranked (highest-confidence-first) order.
+  const comments = input.comments.map((comment) => {
+    if (rechecked >= maxFindings || !severities.has(comment.severity)) return comment;
+    rechecked += 1;
+
+    const base: SelfConsistencyVerdict = {
+      path: comment.path,
+      line: comment.line,
+      severity: comment.severity,
+      title: comment.title,
+      originalConfidence: comment.confidence
+    };
+
+    let draw: SelfConsistencySecondDrawResult;
+    try {
+      draw = input.secondDraw({ comment, hunk: extractHunk(comment, input.files) });
+    } catch (error) {
+      // Failure posture: keep the finding untouched; the re-check can only make output quieter.
+      verdicts.push({ ...base, error: error instanceof Error ? error.message : String(error) });
+      return comment;
+    }
+
+    if (draw.verified) {
+      // Agreement: never raise confidence; keep the original.
+      verdicts.push({ ...base, secondConfidence: draw.confidence, agreed: true, refuted: false });
+      return comment;
+    }
+
+    // Refutation: quieter-only — lower confidence and strip REQUEST_CHANGES eligibility.
+    verdicts.push({ ...base, secondConfidence: draw.confidence, agreed: false, refuted: true });
+    refutedKeys.add(commentKey(comment));
+    return { ...comment, confidence: Math.min(comment.confidence, draw.confidence) };
+  });
+
+  // Re-derive the event: a refuted comment still POSTS but no longer counts toward REQUEST_CHANGES.
+  const eligibleComments = comments.filter((comment) => !refutedKeys.has(commentKey(comment)));
+  const event = eligibleComments.some((comment) => isRequestChangesEligible(comment, input.requestChangesConfidenceFloors))
+    ? "REQUEST_CHANGES"
+    : "COMMENT";
+
+  return { comments, event, verdicts };
+}
+
+function commentKey(comment: Pick<ReviewComment, "path" | "line" | "title">): string {
+  return `${comment.path}${comment.line}${comment.title}`;
+}
+
+/**
+ * The relevant diff hunk for a finding: the changed file's patch (bounded, already redacted upstream).
+ * Reuses the main prompt's read-only posture — no repo files are read, only the provided patch.
+ */
+export function extractHunk(comment: Pick<ReviewComment, "path">, files: PullFilePatch[]): string {
+  const file = files.find((candidate) => candidate.filename === comment.path);
+  return file?.patch ?? "";
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -73,7 +73,9 @@ import {
 import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "./validation-selector.js";
 import { buildWalkthroughComment } from "./walkthrough.js";
 import { postWalkthroughComment, reviewBodyAfterWalkthroughPost } from "./walkthrough-post.js";
-import { buildReviewPrompt, isZCodeSchemaFailureError, runZCodeReview, type ZCodeReviewResult } from "./zcode.js";
+import { buildReviewPrompt, extractJsonObject, extractZCodeResponse, isZCodeSchemaFailureError, runZCodeReview, type ZCodeReviewResult } from "./zcode.js";
+import { runSelfConsistencyRecheck, type SelfConsistencySecondDrawResult } from "./self-consistency.js";
+import type { DeterministicReviewGateResult } from "./review-gate.js";
 import { formatZCodeTimeoutFailureError } from "./zcode-timeout.js";
 import type { Finding, PullFilePatch, PullRequestSummary, RepositorySummary, ReviewEvent, ReviewPlan, ReviewProviderMetadata } from "./types.js";
 
@@ -1503,11 +1505,24 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         ? { requestChangesConfidenceFloors: config.reviewGate.requestChangesConfidenceFloors }
         : {})
     });
-    const comments = gate.comments;
+    // Opt-in P0/P1 self-consistency re-check (#303): post-dedup, pre-event-decision. Quieter-only —
+    // disagreement can lower confidence and strip REQUEST_CHANGES eligibility, never raise/add. When
+    // disabled (default) this is a no-op returning the gate's own comments/event, byte-identical.
+    const selfConsistency = applySelfConsistencyRecheck({
+      config,
+      gate,
+      files: reviewFiles,
+      worktreePath: worktree.path,
+      evidenceDir
+    });
+    if (selfConsistency.runtimeNote && Array.isArray(zcodeResult.runtime.notes)) {
+      zcodeResult.runtime.notes.push(selfConsistency.runtimeNote);
+    }
+    const comments = selfConsistency.comments;
     // Gate output is already public-safe; this second pass keeps evidence redacted
     // and relies on sanitizePublicConfidenceText/redactSecrets idempotency tests.
     const dropped = sanitizeDroppedFindings(gate.dropped, config.confidenceCalibration?.publicDisplay);
-    const event = gate.event;
+    const event = selfConsistency.event;
     writeRedactedJson(join(evidenceDir, "deterministic-gate.json"), { ...gate, dropped });
     const summary = buildSummary({
       repo,
@@ -2523,6 +2538,89 @@ function providerCooldownJitterMs(
   const max = config.providerCooldown.overloadBackoffJitterMs;
   if (max <= 0) return 0;
   return Math.floor(Math.random() * (max + 1));
+}
+
+function applySelfConsistencyRecheck(input: {
+  config: BotConfig;
+  gate: DeterministicReviewGateResult;
+  files: PullFilePatch[];
+  worktreePath: string;
+  evidenceDir: string;
+}): { comments: DeterministicReviewGateResult["comments"]; event: DeterministicReviewGateResult["event"]; runtimeNote?: string } {
+  const selfConsistencyConfig = input.config.reviewGate?.selfConsistency;
+  if (!selfConsistencyConfig?.enabled) {
+    return { comments: input.gate.comments, event: input.gate.event };
+  }
+
+  const providerId = selfConsistencyConfig.provider ?? input.config.zcode.providerId;
+  const result = runSelfConsistencyRecheck({
+    comments: input.gate.comments,
+    files: input.files,
+    config: selfConsistencyConfig,
+    ...(input.config.reviewGate?.requestChangesConfidenceFloors
+      ? { requestChangesConfidenceFloors: input.config.reviewGate.requestChangesConfidenceFloors }
+      : {}),
+    secondDraw: ({ comment, hunk }) => {
+      const draw = runZCodeReview({
+        cwd: input.worktreePath,
+        prompt: buildSelfConsistencyPrompt(comment, hunk),
+        cliPath: input.config.zcode.cliPath,
+        appConfigPath: input.config.zcode.appConfigPath,
+        model: input.config.zcode.model,
+        ...(providerId ? { providerId } : {}),
+        timeoutMs: input.config.zcode.timeoutMs,
+        retryMaxRetries: input.config.zcode.retryMaxRetries
+      });
+      return parseSelfConsistencyVerdict(draw.rawResponse);
+    }
+  });
+
+  // Redacted evidence: verdicts + both confidences, never raw model prose beyond the sanitized fields.
+  writeRedactedJson(join(input.evidenceDir, "self-consistency.json"), {
+    enabled: true,
+    provider: providerId,
+    maxFindingsPerReview: selfConsistencyConfig.maxFindingsPerReview ?? 5,
+    verdicts: result.verdicts
+  });
+
+  const agreed = result.verdicts.filter((verdict) => verdict.agreed === true).length;
+  const refuted = result.verdicts.filter((verdict) => verdict.refuted === true).length;
+  const failed = result.verdicts.filter((verdict) => verdict.error !== undefined).length;
+  const runtimeNote = result.verdicts.length
+    ? `Self-consistency re-check (#303): ${result.verdicts.length} P0/P1 finding(s) re-drawn — ${agreed} agreed, ${refuted} refuted (downgraded/ineligible), ${failed} second-draw failure(s) left untouched.`
+    : undefined;
+
+  return { comments: result.comments, event: result.event, ...(runtimeNote ? { runtimeNote } : {}) };
+}
+
+function buildSelfConsistencyPrompt(comment: DeterministicReviewGateResult["comments"][number], hunk: string): string {
+  return [
+    "You are re-checking a SINGLE prior code-review finding for self-consistency.",
+    "Do not modify files, run commands, or inspect anything beyond the finding and diff hunk below.",
+    "Decide independently whether the finding is a genuine, actionable issue on the current diff.",
+    "Return JSON ONLY: {\"verified\": true|false, \"confidence\": 0.0}. No prose, no code fences.",
+    "verified=true means you AGREE the finding is real; verified=false means you REFUTE it.",
+    "",
+    `Finding severity: ${comment.severity}`,
+    `Finding file: ${comment.path} (line ${comment.line})`,
+    `Finding title: ${comment.title}`,
+    `Finding detail: ${comment.body}`,
+    "",
+    "Relevant diff hunk:",
+    "```diff",
+    hunk,
+    "```"
+  ].join("\n");
+}
+
+function parseSelfConsistencyVerdict(rawResponse: string): SelfConsistencySecondDrawResult {
+  const parsed = JSON.parse(extractJsonObject(extractZCodeResponse(rawResponse))) as { verified?: unknown; confidence?: unknown };
+  const verified = parsed.verified === true;
+  const confidence =
+    typeof parsed.confidence === "number" && Number.isFinite(parsed.confidence)
+      ? Math.min(1, Math.max(0, parsed.confidence))
+      : verified ? 1 : 0;
+  return { verified, confidence };
 }
 
 async function runZCodeReviewWithProviderRetry(input: {

--- a/tests/confidence-config.test.ts
+++ b/tests/confidence-config.test.ts
@@ -171,6 +171,34 @@ describe("review gate config", () => {
     ).toThrow(/reviewGate\.retryDegradedConfidencePenalty must be a number from 0 to 1/);
   });
 
+  it("defaults selfConsistency to unset (off) and accepts a full valid config (#303)", () => {
+    expect(loadConfigFromObject({}).reviewGate?.selfConsistency).toBeUndefined();
+    const config = loadConfigFromObject({
+      reviewGate: { selfConsistency: { enabled: true, severities: ["P0"], provider: "zcode-glm", maxFindingsPerReview: 3 } }
+    });
+    expect(config.reviewGate?.selfConsistency).toEqual({
+      enabled: true,
+      severities: ["P0"],
+      provider: "zcode-glm",
+      maxFindingsPerReview: 3
+    });
+  });
+
+  it("fails closed on malformed selfConsistency fields (#303)", () => {
+    expect(() => loadConfigFromObject({ reviewGate: { selfConsistency: { enabled: "yes" } } })).toThrow(
+      /reviewGate\.selfConsistency\.enabled must be a boolean/
+    );
+    expect(() => loadConfigFromObject({ reviewGate: { selfConsistency: { enabled: true, maxFindingsPerReview: 0 } } })).toThrow(
+      /reviewGate\.selfConsistency\.maxFindingsPerReview must be a positive integer/
+    );
+    expect(() => loadConfigFromObject({ reviewGate: { selfConsistency: { enabled: true, severities: ["P2"] } } })).toThrow(
+      /reviewGate\.selfConsistency\.severities.* P0 or P1/
+    );
+    expect(() => loadConfigFromObject({ reviewGate: { selfConsistency: { enabled: true, provider: 42 } } })).toThrow(
+      /reviewGate\.selfConsistency\.provider must be a string/
+    );
+  });
+
   it("rejects unknown keys in the confidence floors map", () => {
     expect(() =>
       loadConfigFromObject({ reviewGate: { requestChangesConfidenceFloors: { p0: 0.8 } } })

--- a/tests/self-consistency.test.ts
+++ b/tests/self-consistency.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import { runSelfConsistencyRecheck } from "../src/self-consistency.js";
+import type { PullFilePatch, ReviewComment } from "../src/types.js";
+
+function comment(overrides: Partial<ReviewComment> & Pick<ReviewComment, "severity" | "line" | "title" | "confidence">): ReviewComment {
+  return {
+    path: "src/save.ts",
+    side: "RIGHT",
+    body: "A concrete review comment.",
+    category: "data_loss",
+    ...overrides
+  };
+}
+
+const files: PullFilePatch[] = [
+  { filename: "src/save.ts", patch: "@@ -1,2 +1,3 @@\n export function save() {\n+  overwriteAllData();\n }" }
+];
+
+describe("self-consistency re-check (#303)", () => {
+  it("is a no-op with zero second-draw calls when disabled (byte-identical)", () => {
+    const secondDraw = vi.fn();
+    const comments = [comment({ severity: "P0", line: 2, title: "Rollback clobbers state", confidence: 0.9 })];
+
+    const result = runSelfConsistencyRecheck({
+      comments,
+      files,
+      config: { enabled: false },
+      secondDraw
+    });
+
+    expect(secondDraw).not.toHaveBeenCalled();
+    expect(result.comments).toEqual(comments);
+    expect(result.event).toBe("REQUEST_CHANGES");
+    expect(result.verdicts).toEqual([]);
+  });
+
+  it("keeps confidence and eligibility on agreement, recording the verdict", () => {
+    const comments = [comment({ severity: "P0", line: 2, title: "Rollback clobbers state", confidence: 0.9 })];
+    const result = runSelfConsistencyRecheck({
+      comments,
+      files,
+      config: { enabled: true, severities: ["P0", "P1"], maxFindingsPerReview: 5 },
+      secondDraw: () => ({ verified: true, confidence: 0.7 })
+    });
+
+    expect(result.comments[0]?.confidence).toBe(0.9); // never raised, kept on agreement
+    expect(result.event).toBe("REQUEST_CHANGES");
+    expect(result.verdicts).toEqual([expect.objectContaining({ agreed: true, originalConfidence: 0.9, secondConfidence: 0.7 })]);
+  });
+
+  it("downgrades confidence and removes REQUEST_CHANGES eligibility on refutation", () => {
+    const comments = [comment({ severity: "P0", line: 2, title: "Rollback clobbers state", confidence: 0.9 })];
+    const result = runSelfConsistencyRecheck({
+      comments,
+      files,
+      config: { enabled: true, severities: ["P0", "P1"], maxFindingsPerReview: 5 },
+      secondDraw: () => ({ verified: false, confidence: 0.2 })
+    });
+
+    expect(result.comments[0]?.confidence).toBe(0.2); // min(0.9, 0.2)
+    expect(result.comments).toHaveLength(1); // still POSTS as a comment
+    expect(result.event).toBe("COMMENT"); // lost eligibility ⇒ quieter
+    expect(result.verdicts).toEqual([expect.objectContaining({ agreed: false, refuted: true })]);
+  });
+
+  it("never raises confidence even when the second draw is more confident (agreement)", () => {
+    const result = runSelfConsistencyRecheck({
+      comments: [comment({ severity: "P1", line: 2, title: "Concern", confidence: 0.4 })],
+      files,
+      config: { enabled: true, maxFindingsPerReview: 5 },
+      secondDraw: () => ({ verified: true, confidence: 0.99 })
+    });
+    expect(result.comments[0]?.confidence).toBe(0.4);
+  });
+
+  it("respects the cost bound: 6 eligible findings with max 5 ⇒ 5 calls in ranked order", () => {
+    const comments = Array.from({ length: 6 }, (_, i) =>
+      comment({ severity: "P0", line: 2 + i, title: `Finding ${i}`, confidence: 0.9 - i * 0.01 })
+    );
+    const seen: string[] = [];
+    const result = runSelfConsistencyRecheck({
+      comments,
+      files,
+      config: { enabled: true, severities: ["P0"], maxFindingsPerReview: 5 },
+      secondDraw: (input) => {
+        seen.push(input.comment.title);
+        return { verified: true, confidence: 0.8 };
+      }
+    });
+
+    expect(seen).toHaveLength(5);
+    // Ranked order = the comment order the gate already produced (highest-confidence first).
+    expect(seen).toEqual(["Finding 0", "Finding 1", "Finding 2", "Finding 3", "Finding 4"]);
+    expect(result.verdicts).toHaveLength(5);
+  });
+
+  it("only re-checks findings at configured severities (default P0/P1)", () => {
+    const secondDraw = vi.fn(() => ({ verified: true, confidence: 0.8 }));
+    runSelfConsistencyRecheck({
+      comments: [
+        comment({ severity: "P0", line: 2, title: "high", confidence: 0.9 }),
+        comment({ severity: "P2", line: 3, title: "low", category: "runtime_correctness", confidence: 0.9 })
+      ],
+      files,
+      config: { enabled: true, maxFindingsPerReview: 5 },
+      secondDraw
+    });
+    expect(secondDraw).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a finding untouched when the second draw fails (quieter-only, never blocks)", () => {
+    const comments = [comment({ severity: "P0", line: 2, title: "Rollback clobbers state", confidence: 0.9 })];
+    const result = runSelfConsistencyRecheck({
+      comments,
+      files,
+      config: { enabled: true, maxFindingsPerReview: 5 },
+      secondDraw: () => {
+        throw new Error("provider exploded");
+      }
+    });
+
+    expect(result.comments[0]?.confidence).toBe(0.9);
+    expect(result.event).toBe("REQUEST_CHANGES");
+    expect(result.verdicts).toEqual([expect.objectContaining({ error: expect.stringContaining("provider exploded") })]);
+  });
+});


### PR DESCRIPTION
Closes #303 (owner-approved 2026-07-06). Parent: #278 (Phase 3, item 10 — completes Phase 3).

## Summary
Model confidence was a single unanchored self-report (S3/S7). This adds an **opt-in, default-off, cost-bounded** second draw for high-severity findings — the cheapest real anchor for the calibration loop, and the agreement signal #286 will consume.

- `reviewGate.selfConsistency { enabled:false, severities?=["P0","P1"], provider?, maxFindingsPerReview?=5 }` — fail-closed validation.
- New `src/self-consistency.ts`: for gate-accepted findings at configured severities (ranked order, capped), one finding-scoped read-only second draw (same or a second registry provider) asking verify/refute + confidence.
- **Quieter-only by construction:** agreement keeps the original confidence; refutation takes `min(original, second)` AND strips REQUEST_CHANGES eligibility (the finding still posts); the event is re-derived from survivors. Never raises confidence or severity, never adds findings.
- **Failure posture:** any second-draw failure leaves the finding untouched — the re-check can only quiet output, never block a review.
- Verdicts + both confidences recorded via the redacting writer + ledger runtime notes.

## Validation
- TDD failing-first: disabled ⇒ zero extra calls + byte-identical; agreement/refutation semantics; cost bound (6 eligible, max 5 ⇒ 5 ranked calls); severity filter; failure ⇒ untouched; config validation.
- Rebased over #320 with union of both config surfaces; focused Vitest 96/96 (self-consistency, confidence-config, worker-failure, zcode-retry-provenance, config-schema) under `set -o pipefail`; build exit 0.