### PR TITLE
Post-merge outcome observer and finding-outcome label store (calibration loop part A)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,6 +98,7 @@ import {
   type ReviewQueueJobRecord,
   type ReviewQueueJobState
 } from "./state.js";
+import { readOutcomeObserverInput, runOutcomeObserverFromInput } from "./outcome-observer.js";
 import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "./validation-selector.js";
 import { isSuccessfulRetryStatus, retryFailedHead, retryProviderCooldowns } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
@@ -1500,6 +1501,30 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "outcome-observe") {
+    if (args.input === undefined || (Array.isArray(args.input) && args.input.length === 0)) {
+      throw new Error("--input is required for outcome-observe");
+    }
+    if (args["output-dir"] === undefined || (Array.isArray(args["output-dir"]) && args["output-dir"].length === 0)) {
+      throw new Error("--output-dir is required for outcome-observe");
+    }
+    // Dry-run-first (#286 PR A): default reads-and-reports without persisting labels.
+    const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
+    const config = loadConfig(args.config ? parseSingleArg(args.config, "--config") : undefined);
+    const outputDir = parseSingleArg(args["output-dir"], "--output-dir");
+    assertEvalOutputDirSafe(outputDir);
+    const entries = readOutcomeObserverInput(parseSingleArg(args.input, "--input"));
+    const store = new ReviewStateStore(config.statePath);
+    try {
+      const result = runOutcomeObserverFromInput({ store, entries, evidenceDir: outputDir, dryRun });
+      console.log(stringifyRedactedJson({ command: "outcome-observe", dryRun, outputDir, ...result }));
+      if (!result.ok) process.exitCode = 1;
+    } finally {
+      store.close();
+    }
+    return;
+  }
+
   if (command === "run-once" || command === "review-pr") {
     if (command === "review-pr" && (!args.repo || !args.pr)) {
       console.log(JSON.stringify({
@@ -2679,7 +2704,8 @@ function buildHelp(command?: string) {
         "eval-suite",
         "eval-sticky-vs-cold",
         "outcome-ledger",
-        "outcome-scorecard"
+        "outcome-scorecard",
+        "outcome-observe"
       ]
     },
     examples: [
@@ -2730,6 +2756,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts eval-sticky-vs-cold --input /path/to/sticky-vs-cold.json --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold",
       "npx tsx src/cli.ts outcome-ledger --input /path/to/outcome-ledger-input.json --dry-run true --output-dir /path/to/evidence/outcome-ledger-run",
       "npx tsx src/cli.ts outcome-scorecard --input /path/to/outcome-scorecard-input.json --dry-run true --output-dir /path/to/evidence/outcome-scorecard-run",
+      "npx tsx src/cli.ts outcome-observe --config /path/to/live.json --input /path/to/outcome-observer-input.json --dry-run true --output-dir /path/to/evidence/outcome-observe-run",
       "npx tsx src/cli.ts finishing-touch-dry-run --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD --current-head HEAD --comment-id 456 --author maintainer --trusted-authors maintainer --body '@evaos-code-review-bot explain risk'",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ],

--- a/src/outcome-observer.ts
+++ b/src/outcome-observer.ts
@@ -1,0 +1,277 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { redactSecrets } from "./secrets.js";
+import type { OutcomeLedgerPostMergeStatus } from "./outcome-ledger.js";
+import type {
+  FindingOutcomeLabelRecord,
+  FindingOutcomeLabelSource,
+  FindingOutcomeVerdict,
+  ReviewStateStore
+} from "./state.js";
+import type { Severity } from "./types.js";
+
+const OUTCOME_LINE_WINDOW = 3;
+
+export interface ObservedFinding {
+  fingerprint: string;
+  path: string;
+  line: number;
+  severity: Severity;
+  category: string;
+  confidence: number;
+}
+
+/**
+ * The read-only post-merge signals the observer derives labels from. `mergedFixLines`/`hotfixLines`
+ * are path -> changed-line sets, produced by collectRightSideLines over the relevant diffs so the
+ * "touches flagged lines" logic reuses the same matching primitive as the review gate (no fork).
+ */
+export interface ObservedPullOutcome {
+  merged: boolean;
+  revertedFlaggedChange: boolean;
+  hotfixLines: Map<string, Set<number>>;
+  mergedFixLines: Map<string, Set<number>>;
+  humanThreadResolved: boolean;
+  evidenceRef?: string;
+}
+
+export interface DerivedOutcomeLabel {
+  labelSource: FindingOutcomeLabelSource;
+  verdict: FindingOutcomeVerdict;
+  postMergeStatus: OutcomeLedgerPostMergeStatus;
+  riskClaimStatus: "validated" | "dismissed" | "unvalidated";
+}
+
+/**
+ * Pure precedence resolver (#286 PR A): revert > hotfix-touching-flagged > merged-fix-diff-touching-
+ * flagged > human-thread-resolution > none_observed. Revert/hotfix/merged-fix all VALIDATE the
+ * finding (true_positive); a human thread that resolved it without any code touching the flagged
+ * lines DISMISSES it (false_positive); nothing observed stays unvalidated.
+ */
+export function deriveOutcomeLabel(input: { finding: ObservedFinding; observed: ObservedPullOutcome }): DerivedOutcomeLabel {
+  const { finding, observed } = input;
+  if (observed.revertedFlaggedChange) {
+    return { labelSource: "revert", verdict: "true_positive", postMergeStatus: "reverted", riskClaimStatus: "validated" };
+  }
+  if (diffTouchesFinding(observed.hotfixLines, finding)) {
+    return { labelSource: "hotfix", verdict: "true_positive", postMergeStatus: "hotfixed", riskClaimStatus: "validated" };
+  }
+  if (diffTouchesFinding(observed.mergedFixLines, finding)) {
+    return { labelSource: "merged_fix", verdict: "true_positive", postMergeStatus: "regression_seen", riskClaimStatus: "validated" };
+  }
+  if (observed.humanThreadResolved) {
+    return { labelSource: "human_thread", verdict: "false_positive", postMergeStatus: "no_incident_seen", riskClaimStatus: "dismissed" };
+  }
+  return { labelSource: "none_observed", verdict: "unvalidated", postMergeStatus: "no_incident_seen", riskClaimStatus: "unvalidated" };
+}
+
+function diffTouchesFinding(lines: Map<string, Set<number>>, finding: ObservedFinding): boolean {
+  const touched = lines.get(finding.path);
+  if (!touched) return false;
+  for (const line of touched) {
+    if (Math.abs(line - finding.line) <= OUTCOME_LINE_WINDOW) return true;
+  }
+  return false;
+}
+
+export interface OutcomeObserverReview {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  findings: ObservedFinding[];
+}
+
+export interface OutcomeObserverResult {
+  ok: boolean;
+  observed: number;
+  skipped: number;
+  labeled: number;
+  observations: OutcomeObserverObservation[];
+}
+
+interface OutcomeObserverObservation {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  postMergeOutcome: { status: OutcomeLedgerPostMergeStatus };
+  riskClaims: Array<{ fingerprint: string; severity: Severity; category: string; status: string; labelSource: FindingOutcomeLabelSource }>;
+}
+
+/**
+ * Batch, read-only observer (#286 PR A). Walks the supplied merged reviews, derives an outcome label
+ * per flagged finding, records labels (idempotent upsert), and writes a redacted evidence packet that
+ * fills the ledger's postMergeOutcome/riskClaims.status. UNMERGED reviews are SKIPPED (never labeled).
+ * `fetchOutcome` is injected so the caller owns the read-only GitHub access and tests stay hermetic.
+ * `dryRun` (default true) still writes the evidence packet but does not persist labels.
+ */
+export function runOutcomeObserver(input: {
+  store: ReviewStateStore;
+  evidenceDir: string;
+  reviews: OutcomeObserverReview[];
+  fetchOutcome: (review: OutcomeObserverReview) => ObservedPullOutcome;
+  now?: Date;
+  dryRun?: boolean;
+}): OutcomeObserverResult {
+  const observedAt = (input.now ?? new Date()).toISOString();
+  const dryRun = input.dryRun ?? false;
+  const observations: OutcomeObserverObservation[] = [];
+  let skipped = 0;
+  let labeled = 0;
+
+  for (const review of input.reviews) {
+    const outcome = input.fetchOutcome(review);
+    if (!outcome.merged) {
+      // Unmerged PRs are skipped, not labeled: no post-merge signal exists yet.
+      skipped += 1;
+      continue;
+    }
+
+    const riskClaims: OutcomeObserverObservation["riskClaims"] = [];
+    let postMergeStatus: OutcomeLedgerPostMergeStatus = "no_incident_seen";
+    for (const finding of review.findings) {
+      const derived = deriveOutcomeLabel({ finding, observed: outcome });
+      postMergeStatus = escalatePostMergeStatus(postMergeStatus, derived.postMergeStatus);
+      const record: FindingOutcomeLabelRecord = {
+        fingerprint: finding.fingerprint,
+        repo: review.repo,
+        pullNumber: review.pullNumber,
+        headSha: review.headSha,
+        severity: finding.severity,
+        category: finding.category,
+        confidence: finding.confidence,
+        labelSource: derived.labelSource,
+        verdict: derived.verdict,
+        observedAt,
+        ...(outcome.evidenceRef ? { evidenceRef: outcome.evidenceRef } : {})
+      };
+      if (!dryRun) {
+        input.store.recordFindingOutcomeLabel(record);
+        labeled += 1;
+      }
+      riskClaims.push({
+        fingerprint: finding.fingerprint,
+        severity: finding.severity,
+        category: finding.category,
+        status: derived.riskClaimStatus,
+        labelSource: derived.labelSource
+      });
+    }
+
+    observations.push({
+      repo: review.repo,
+      pullNumber: review.pullNumber,
+      headSha: review.headSha,
+      postMergeOutcome: { status: postMergeStatus },
+      riskClaims
+    });
+  }
+
+  const packet = { ok: true, dryRun, observedAt, observed: input.reviews.length, skipped, labeled, observations };
+  mkdirSync(input.evidenceDir, { recursive: true });
+  writeFileSync(join(input.evidenceDir, "outcome-observer.json"), `${redactSecrets(JSON.stringify(packet, null, 2))}\n`);
+
+  return { ok: true, observed: input.reviews.length, skipped, labeled, observations };
+}
+
+interface OutcomeObserverInputEntry {
+  review: OutcomeObserverReview;
+  observed: ObservedPullOutcome;
+}
+
+/**
+ * Parse a dry-run observer input file (mirrors the outcome-scorecard dry-run-input CLI posture).
+ * Live GitHub walking is intentionally NOT part of PR A — the batch command consumes an evidence-
+ * derived input so the observer + label store can ship and be exercised read-only first.
+ */
+export function readOutcomeObserverInput(path: string): OutcomeObserverInputEntry[] {
+  const value = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  if (typeof value !== "object" || value === null || !Array.isArray((value as { reviews?: unknown }).reviews)) {
+    throw new Error("outcome observer input requires a reviews array");
+  }
+  return (value as { reviews: unknown[] }).reviews.map((raw, index) => parseObserverInputEntry(raw, index));
+}
+
+export function runOutcomeObserverFromInput(input: {
+  store: ReviewStateStore;
+  entries: OutcomeObserverInputEntry[];
+  evidenceDir: string;
+  dryRun: boolean;
+  now?: Date;
+}): OutcomeObserverResult {
+  const byKey = new Map<string, ObservedPullOutcome>();
+  for (const entry of input.entries) {
+    byKey.set(`${entry.review.repo}#${entry.review.pullNumber}@${entry.review.headSha}`, entry.observed);
+  }
+  return runOutcomeObserver({
+    store: input.store,
+    evidenceDir: input.evidenceDir,
+    reviews: input.entries.map((entry) => entry.review),
+    fetchOutcome: (review) => byKey.get(`${review.repo}#${review.pullNumber}@${review.headSha}`)!,
+    dryRun: input.dryRun,
+    ...(input.now ? { now: input.now } : {})
+  });
+}
+
+function parseObserverInputEntry(raw: unknown, index: number): OutcomeObserverInputEntry {
+  if (typeof raw !== "object" || raw === null) throw new Error(`reviews[${index}] must be an object`);
+  const record = raw as Record<string, unknown>;
+  const repo = requireString(record.repo, `reviews[${index}].repo`);
+  const pullNumber = record.pullNumber;
+  if (!Number.isInteger(pullNumber) || (pullNumber as number) < 1) throw new Error(`reviews[${index}].pullNumber must be a positive integer`);
+  const headSha = requireString(record.headSha, `reviews[${index}].headSha`);
+  const findings = Array.isArray(record.findings)
+    ? record.findings.map((finding, findingIndex) => parseObservedFinding(finding, `reviews[${index}].findings[${findingIndex}]`))
+    : [];
+  const observedRaw = (record.observed ?? {}) as Record<string, unknown>;
+  const observed: ObservedPullOutcome = {
+    merged: observedRaw.merged === true,
+    revertedFlaggedChange: observedRaw.revertedFlaggedChange === true,
+    hotfixLines: toLineMap(observedRaw.hotfixLines),
+    mergedFixLines: toLineMap(observedRaw.mergedFixLines),
+    humanThreadResolved: observedRaw.humanThreadResolved === true,
+    ...(typeof observedRaw.evidenceRef === "string" ? { evidenceRef: observedRaw.evidenceRef } : {})
+  };
+  return { review: { repo, pullNumber: pullNumber as number, headSha, findings }, observed };
+}
+
+function parseObservedFinding(raw: unknown, label: string): ObservedFinding {
+  if (typeof raw !== "object" || raw === null) throw new Error(`${label} must be an object`);
+  const record = raw as Record<string, unknown>;
+  const line = record.line;
+  if (!Number.isInteger(line) || (line as number) < 1) throw new Error(`${label}.line must be a positive integer`);
+  return {
+    fingerprint: requireString(record.fingerprint, `${label}.fingerprint`),
+    path: requireString(record.path, `${label}.path`),
+    line: line as number,
+    severity: requireString(record.severity, `${label}.severity`) as Severity,
+    category: requireString(record.category, `${label}.category`),
+    confidence: typeof record.confidence === "number" ? record.confidence : 0
+  };
+}
+
+function toLineMap(value: unknown): Map<string, Set<number>> {
+  const map = new Map<string, Set<number>>();
+  if (typeof value !== "object" || value === null) return map;
+  for (const [path, lines] of Object.entries(value as Record<string, unknown>)) {
+    if (Array.isArray(lines)) map.set(path, new Set(lines.filter((line): line is number => Number.isInteger(line))));
+  }
+  return map;
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+
+// Prefer the most severe observed post-merge status across a PR's findings for the ledger summary.
+function escalatePostMergeStatus(current: OutcomeLedgerPostMergeStatus, next: OutcomeLedgerPostMergeStatus): OutcomeLedgerPostMergeStatus {
+  const rank: Record<OutcomeLedgerPostMergeStatus, number> = {
+    unknown: 0,
+    not_merged: 0,
+    no_incident_seen: 1,
+    regression_seen: 2,
+    hotfixed: 3,
+    reverted: 4
+  };
+  return rank[next] > rank[current] ? next : current;
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -67,6 +67,30 @@ export interface StoredProcessedReviewRecord extends ProcessedReviewRecord {
   createdAt: string;
 }
 
+export type FindingOutcomeLabelSource =
+  | "merged_fix"
+  | "revert"
+  | "hotfix"
+  | "human_thread"
+  | "ci_failure"
+  | "none_observed";
+
+export type FindingOutcomeVerdict = "true_positive" | "false_positive" | "unvalidated";
+
+export interface FindingOutcomeLabelRecord {
+  fingerprint: string;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  severity: string;
+  category: string;
+  confidence: number;
+  labelSource: FindingOutcomeLabelSource;
+  verdict: FindingOutcomeVerdict;
+  observedAt: string;
+  evidenceRef?: string;
+}
+
 export interface RepoActivationRecord {
   repo: string;
   activatedAt: string;
@@ -451,6 +475,21 @@ export class ReviewStateStore {
         primary key (repo, pull_number, head_sha)
       );
 
+      create table if not exists finding_outcome_labels (
+        fingerprint text not null,
+        repo text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        severity text not null,
+        category text not null,
+        confidence real not null,
+        label_source text not null,
+        verdict text not null,
+        observed_at text not null,
+        evidence_ref text,
+        primary key (fingerprint, repo, pull_number, head_sha)
+      );
+
       create table if not exists repo_activation_watermarks (
         repo text primary key,
         activated_at text not null,
@@ -744,6 +783,65 @@ export class ReviewStateStore {
     this.db
       .prepare("delete from review_head_claims where repo = ? and pull_number = ? and head_sha = ?")
       .run(record.repo, record.pullNumber, record.headSha);
+  }
+
+  recordFindingOutcomeLabel(record: FindingOutcomeLabelRecord): void {
+    validateRepoName(record.repo, "repo");
+    if (!/^finding:[a-f0-9]{64}$/.test(record.fingerprint)) {
+      throw new Error("finding outcome label fingerprint must match finding:<64-hex>");
+    }
+    if (!Number.isInteger(record.pullNumber) || record.pullNumber < 1) throw new Error("pullNumber must be a positive integer");
+    if (!Number.isFinite(record.confidence) || record.confidence < 0 || record.confidence > 1) {
+      throw new Error("confidence must be a number from 0 to 1");
+    }
+    // Idempotent (#286 PR A): re-observing the same finding on the same head UPSERTs, so a re-run
+    // never accumulates duplicate labels. evidence_ref is redacted before it can reach evidence.
+    this.db
+      .prepare(
+        `insert or replace into finding_outcome_labels
+          (fingerprint, repo, pull_number, head_sha, severity, category, confidence,
+           label_source, verdict, observed_at, evidence_ref)
+         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        record.fingerprint,
+        record.repo,
+        record.pullNumber,
+        record.headSha,
+        record.severity,
+        record.category,
+        record.confidence,
+        record.labelSource,
+        record.verdict,
+        record.observedAt,
+        record.evidenceRef ? redactSecrets(record.evidenceRef).trim() : null
+      );
+  }
+
+  hasFindingOutcomeLabel(fingerprint: string, repo: string, pullNumber: number, headSha: string): boolean {
+    const row = this.db
+      .prepare("select 1 from finding_outcome_labels where fingerprint = ? and repo = ? and pull_number = ? and head_sha = ? limit 1")
+      .get(fingerprint, repo, pullNumber, headSha);
+    return Boolean(row);
+  }
+
+  listFindingOutcomeLabels(input: { repo?: string } = {}): FindingOutcomeLabelRecord[] {
+    const rows = (input.repo
+      ? this.db
+          .prepare(
+            `select fingerprint, repo, pull_number, head_sha, severity, category, confidence,
+                    label_source, verdict, observed_at, evidence_ref
+             from finding_outcome_labels where repo = ? order by datetime(observed_at) desc`
+          )
+          .all(input.repo)
+      : this.db
+          .prepare(
+            `select fingerprint, repo, pull_number, head_sha, severity, category, confidence,
+                    label_source, verdict, observed_at, evidence_ref
+             from finding_outcome_labels order by datetime(observed_at) desc`
+          )
+          .all()) as unknown as FindingOutcomeLabelRow[];
+    return rows.map(mapFindingOutcomeLabelRow);
   }
 
   getReviewReadiness(repo: string, pullNumber: number, headSha: string): ReviewReadinessRecord | undefined {
@@ -2941,6 +3039,20 @@ interface ProcessedReviewRow {
   created_at: string;
 }
 
+interface FindingOutcomeLabelRow {
+  fingerprint: string;
+  repo: string;
+  pull_number: number;
+  head_sha: string;
+  severity: string;
+  category: string;
+  confidence: number;
+  label_source: FindingOutcomeLabelSource;
+  verdict: FindingOutcomeVerdict;
+  observed_at: string;
+  evidence_ref: string | null;
+}
+
 interface RepoActivationRow {
   repo: string;
   activated_at: string;
@@ -3114,6 +3226,22 @@ function mapProcessedReviewRow(row: ProcessedReviewRow): StoredProcessedReviewRe
     ...(row.review_url ? { reviewUrl: row.review_url } : {}),
     ...(row.error ? { error: row.error } : {}),
     createdAt: row.created_at
+  };
+}
+
+function mapFindingOutcomeLabelRow(row: FindingOutcomeLabelRow): FindingOutcomeLabelRecord {
+  return {
+    fingerprint: row.fingerprint,
+    repo: row.repo,
+    pullNumber: row.pull_number,
+    headSha: row.head_sha,
+    severity: row.severity,
+    category: row.category,
+    confidence: row.confidence,
+    labelSource: row.label_source,
+    verdict: row.verdict,
+    observedAt: row.observed_at,
+    ...(row.evidence_ref ? { evidenceRef: row.evidence_ref } : {})
   };
 }
 

--- a/tests/outcome-observer.test.ts
+++ b/tests/outcome-observer.test.ts
@@ -1,0 +1,193 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ReviewStateStore } from "../src/state.js";
+
+const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
+import { deriveOutcomeLabel, runOutcomeObserver, type ObservedPullOutcome } from "../src/outcome-observer.js";
+
+const FINDING = {
+  fingerprint: `finding:${"a".repeat(64)}`,
+  path: "src/save.ts",
+  line: 42,
+  severity: "P1" as const,
+  category: "data_loss",
+  confidence: 0.9
+};
+
+describe("outcome-observer label derivation precedence (#286 PR A)", () => {
+  const cases: Array<{ name: string; observed: Partial<ObservedPullOutcome>; source: string; verdict: string }> = [
+    { name: "revert wins over everything", observed: { revertedFlaggedChange: true, hotfixLines: mapOf(), mergedFixLines: mapOf({ "src/save.ts": [42] }), humanThreadResolved: true }, source: "revert", verdict: "true_positive" },
+    { name: "hotfix touching flagged lines beats merged-fix + human", observed: { hotfixLines: mapOf({ "src/save.ts": [43] }), mergedFixLines: mapOf({ "src/save.ts": [42] }), humanThreadResolved: true }, source: "hotfix", verdict: "true_positive" },
+    { name: "merged-fix diff touching flagged lines beats human thread", observed: { mergedFixLines: mapOf({ "src/save.ts": [42] }), humanThreadResolved: true }, source: "merged_fix", verdict: "true_positive" },
+    { name: "human thread resolution when no diff touch", observed: { humanThreadResolved: true }, source: "human_thread", verdict: "false_positive" },
+    { name: "none observed when nothing signals", observed: {}, source: "none_observed", verdict: "unvalidated" }
+  ];
+
+  for (const testCase of cases) {
+    it(testCase.name, () => {
+      const label = deriveOutcomeLabel({ finding: FINDING, observed: fullObserved(testCase.observed) });
+      expect(label.labelSource).toBe(testCase.source);
+      expect(label.verdict).toBe(testCase.verdict);
+    });
+  }
+
+  it("does not coarse-match a hotfix that touches a DIFFERENT far line", () => {
+    const label = deriveOutcomeLabel({ finding: FINDING, observed: fullObserved({ hotfixLines: mapOf({ "src/save.ts": [200] }) }) });
+    expect(label.labelSource).toBe("none_observed");
+  });
+});
+
+describe("outcome-observer run (#286 PR A)", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function seedReview(store: ReviewStateStore, repo: string, pull: number, sha: string) {
+    store.recordProcessed({ repo, pullNumber: pull, headSha: sha, status: "posted", event: "REQUEST_CHANGES" });
+  }
+
+  it("skips an unmerged PR (no label written)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-observer-unmerged-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    seedReview(store, "owner/repo", 1, "sha1");
+
+    const result = runOutcomeObserver({
+      store,
+      evidenceDir: join(root, "evidence"),
+      reviews: [{ repo: "owner/repo", pullNumber: 1, headSha: "sha1", findings: [FINDING] }],
+      fetchOutcome: () => ({ merged: false }) as ObservedPullOutcome
+    });
+
+    expect(store.listFindingOutcomeLabels()).toHaveLength(0);
+    expect(result.skipped).toBe(1);
+    expect(result.labeled).toBe(0);
+    store.close();
+  });
+
+  it("labels a merged PR and is idempotent on re-observe (no duplicate rows)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-observer-idem-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    seedReview(store, "owner/repo", 2, "sha2");
+    const observer = () =>
+      runOutcomeObserver({
+        store,
+        evidenceDir: join(root, "evidence"),
+        reviews: [{ repo: "owner/repo", pullNumber: 2, headSha: "sha2", findings: [FINDING] }],
+        fetchOutcome: () => fullObserved({ merged: true, mergedFixLines: mapOf({ "src/save.ts": [42] }) })
+      });
+
+    observer();
+    observer();
+
+    const labels = store.listFindingOutcomeLabels();
+    expect(labels).toHaveLength(1);
+    expect(labels[0]).toMatchObject({ labelSource: "merged_fix", verdict: "true_positive", fingerprint: FINDING.fingerprint });
+    store.close();
+  });
+
+  it("redacts secret-like text in evidence_ref before it is stored or written", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-observer-redact-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    seedReview(store, "owner/repo", 3, "sha3");
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+
+    runOutcomeObserver({
+      store,
+      evidenceDir: join(root, "evidence"),
+      reviews: [{ repo: "owner/repo", pullNumber: 3, headSha: "sha3", findings: [FINDING] }],
+      fetchOutcome: () => fullObserved({ merged: true, revertedFlaggedChange: true, evidenceRef: `revert commit ${token}` })
+    });
+
+    const labels = store.listFindingOutcomeLabels();
+    expect(labels[0]?.evidenceRef).not.toContain(token);
+    const packet = readFileSync(join(root, "evidence", "outcome-observer.json"), "utf8");
+    expect(packet).not.toContain(token);
+    store.close();
+  });
+
+  it("fills the ledger postMergeOutcome and riskClaims status in the evidence packet", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-observer-ledger-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    seedReview(store, "owner/repo", 4, "sha4");
+
+    runOutcomeObserver({
+      store,
+      evidenceDir: join(root, "evidence"),
+      reviews: [{ repo: "owner/repo", pullNumber: 4, headSha: "sha4", findings: [FINDING] }],
+      fetchOutcome: () => fullObserved({ merged: true, revertedFlaggedChange: true })
+    });
+
+    const packet = JSON.parse(readFileSync(join(root, "evidence", "outcome-observer.json"), "utf8"));
+    const entry = packet.observations[0];
+    expect(entry.postMergeOutcome.status).toBe("reverted");
+    expect(entry.riskClaims[0].status).toBe("validated");
+    store.close();
+  });
+});
+
+describe("outcome-observe CLI (#286 PR A)", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("defaults to dry-run, writes the evidence packet, and does NOT persist labels", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evaos-observe-cli-"));
+    roots.push(dir);
+    const configPath = join(dir, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(dir, "runtime"),
+      statePath: join(dir, "state.sqlite"),
+      evidenceDir: join(dir, "evidence")
+    })}\n`);
+    const inputPath = join(dir, "input.json");
+    writeFileSync(inputPath, `${JSON.stringify({
+      reviews: [{
+        repo: "owner/repo",
+        pullNumber: 7,
+        headSha: "sha7",
+        findings: [{ fingerprint: FINDING.fingerprint, path: "src/save.ts", line: 42, severity: "P1", category: "data_loss", confidence: 0.9 }],
+        observed: { merged: true, mergedFixLines: { "src/save.ts": [42] } }
+      }]
+    })}\n`);
+    const outputDir = join(dir, "packet");
+
+    const output = execFileSync(process.execPath, [
+      tsxCli, "src/cli.ts", "outcome-observe", "--config", configPath, "--input", inputPath, "--output-dir", outputDir
+    ], { cwd: process.cwd(), encoding: "utf8" });
+
+    const parsed = JSON.parse(output);
+    expect(parsed).toMatchObject({ ok: true, command: "outcome-observe", dryRun: true, observed: 1, labeled: 0 });
+    expect(existsSync(join(outputDir, "outcome-observer.json"))).toBe(true);
+
+    // Dry-run persisted nothing.
+    const store = new ReviewStateStore(join(dir, "state.sqlite"));
+    expect(store.listFindingOutcomeLabels()).toHaveLength(0);
+    store.close();
+  });
+});
+
+function mapOf(entries: Record<string, number[]> = {}): Map<string, Set<number>> {
+  return new Map(Object.entries(entries).map(([path, lines]) => [path, new Set(lines)]));
+}
+
+function fullObserved(overrides: Partial<ObservedPullOutcome>): ObservedPullOutcome {
+  return {
+    merged: true,
+    revertedFlaggedChange: false,
+    hotfixLines: mapOf(),
+    mergedFixLines: mapOf(),
+    humanThreadResolved: false,
+    ...overrides
+  };
+}

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1764,4 +1764,38 @@ describe("review state store", () => {
     expect(afterRecord).toBeDefined();
     store.close();
   });
+
+  it("stores finding outcome labels idempotently with a redacted evidence_ref (#286 PR A)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-outcome-labels-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const fingerprint = `finding:${"d".repeat(64)}`;
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+    const record = {
+      fingerprint,
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 289,
+      headSha: "sha-label",
+      severity: "P1",
+      category: "data_loss",
+      confidence: 0.9,
+      labelSource: "merged_fix" as const,
+      verdict: "true_positive" as const,
+      observedAt: "2026-07-06T00:00:00.000Z",
+      evidenceRef: `merge commit ${token}`
+    };
+
+    store.recordFindingOutcomeLabel(record);
+    store.recordFindingOutcomeLabel({ ...record, verdict: "false_positive", labelSource: "human_thread" });
+
+    const labels = store.listFindingOutcomeLabels();
+    expect(labels).toHaveLength(1); // UPSERT on the unique key ⇒ no duplicate row
+    expect(labels[0]).toMatchObject({ verdict: "false_positive", labelSource: "human_thread" });
+    expect(labels[0]?.evidenceRef).not.toContain(token);
+    expect(store.hasFindingOutcomeLabel(fingerprint, record.repo, 289, "sha-label")).toBe(true);
+    expect(store.hasFindingOutcomeLabel(fingerprint, record.repo, 289, "other-head")).toBe(false);
+
+    expect(() => store.recordFindingOutcomeLabel({ ...record, fingerprint: "not-a-fingerprint" })).toThrow(/finding:<64-hex>/);
+    store.close();
+  });
 });


### PR DESCRIPTION
Part of #286 (does not close it — parts B/C follow). Parent: #278 Phase 4.

## Summary
The ledger's `riskClaims` were permanently `unvalidated` and `postMergeOutcome` permanently `unknown` — nothing ever observed what happened after merge, so the calibration bins starve. Part A builds the observer + the label store they will feed.

- **Store:** `finding_outcome_labels` (ensure-pattern; unique on fingerprint+repo+pr+head), idempotent UPSERT, fingerprint validation, evidence_ref through redaction.
- **Observer:** pure `deriveOutcomeLabel` with exact precedence revert > hotfix-touching-flagged > merged-fix-touching-flagged > human-thread > none_observed; **unmerged PRs are skipped, never labeled** (pinned). `outcome-observe` CLI: batch, read-only, `--dry-run true` default, always writes a redacted evidence packet filling ledger `postMergeOutcome`/`riskClaims.status`.
- **Reuse:** the diff-touches-finding primitive reuses the gate's path→line-set shape; the finding-vs-finding matchers were deliberately NOT reused (wrong primitive — would be a false abstraction).

## Scope notes (deliberate, for parts B/C)
- Live GitHub commit-diff walking is deferred: the CLI consumes evidence-derived input (mirrors the outcome-scorecard CLI posture), keeping part A hermetic and read-only per the spec's "not a daemon change" rule.
- Human-thread signals currently map to dismissal (false_positive) only — confirmation-direction thread semantics are a flagged refinement once real usage shows the shapes.

## Validation
TDD failing-first: precedence table (5 sources + far-line non-match), unmerged⇒skipped, idempotent re-observe, redaction (store + packet), ledger fields, CLI dry-run persistence-free. Rebased onto current main; focused Vitest 76/76 (observer, state, outcome-ledger) + 154-test CLI batch pre-rebase; build exit 0; pipefail throughout.