### PR TITLE
Batch calibration aggregation over finding-outcome labels (calibration loop part B)

### DIFF
--- a/src/calibration-aggregate.ts
+++ b/src/calibration-aggregate.ts
@@ -1,0 +1,152 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { computeConfidenceBinStats, PUBLIC_CONFIDENCE_POLICY, type ConfidenceBinStat } from "./eval-harness.js";
+import { redactSecrets } from "./secrets.js";
+import type { FindingOutcomeLabelRecord } from "./state.js";
+
+export interface CategoryPrecision {
+  category: string;
+  labeled: number;
+  matched: number;
+  precision: number;
+}
+
+export interface CalibrationAggregateThresholds {
+  minLabeledFindings: number;
+  minP0P1Labels: number;
+  minNegativeControlScenarios: number;
+  minWilsonLowerBound: number;
+}
+
+export interface CalibrationAggregate {
+  labeledFindings: number;
+  p0p1Labels: number;
+  negativeControlScenarios: number;
+  bins: ConfidenceBinStat[];
+  bestWilsonLowerBound: number;
+  categoryPrecision: CategoryPrecision[];
+  thresholds: CalibrationAggregateThresholds;
+  eligible: boolean;
+  reason: string;
+}
+
+/**
+ * Batch calibration aggregation (#286 PR B). Reads finding_outcome_labels and produces the SAME
+ * Wilson bins the eval-harness computes by mapping labels into computeConfidenceBinStats's inputs —
+ * the math is REUSED, never forked. A true_positive label is a matched (validated) finding; a
+ * false_positive is a present-but-unmatched finding; an unvalidated label earns NOTHING and is
+ * excluded entirely. The public-confidence floors are EVALUATED and reported but NEVER applied here —
+ * this function computes evidence; flipping public display remains a human config edit downstream.
+ *
+ * negativeControlScenarios is 0 by construction: the label store has no explicit-control concept yet,
+ * and none_observed/unvalidated labels are NOT negative controls (that conflation is exactly the bug
+ * #296 fixed on the eval path). A principled explicit-control source must be added before this can be
+ * non-zero.
+ */
+export function aggregateCalibrationLabels(labels: FindingOutcomeLabelRecord[]): CalibrationAggregate {
+  const validated = labels.filter((label) => label.verdict !== "unvalidated");
+  const findings = validated.map((label) => ({ id: label.fingerprint, confidence: label.confidence }));
+  const matches = validated
+    .filter((label) => label.verdict === "true_positive")
+    .map((label) => ({ botFindingId: label.fingerprint }));
+
+  const bins = computeConfidenceBinStats(findings, matches);
+  const bestWilsonLowerBound = bins.reduce((max, bin) => Math.max(max, bin.rawWilsonLowerBound), 0);
+  const labeledFindings = validated.length;
+  const p0p1Labels = validated.filter((label) => label.severity === "P0" || label.severity === "P1").length;
+  const negativeControlScenarios = 0;
+
+  const categoryPrecision = computeCategoryPrecision(validated);
+  const thresholds: CalibrationAggregateThresholds = {
+    minLabeledFindings: PUBLIC_CONFIDENCE_POLICY.minLabeledFindings,
+    minP0P1Labels: PUBLIC_CONFIDENCE_POLICY.minP0P1Labels,
+    minNegativeControlScenarios: PUBLIC_CONFIDENCE_POLICY.minNegativeControlScenarios,
+    minWilsonLowerBound: PUBLIC_CONFIDENCE_POLICY.minWilsonLowerBound
+  };
+  const { eligible, reason } = evaluateThresholds({
+    labeledFindings,
+    p0p1Labels,
+    negativeControlScenarios,
+    bestWilsonLowerBound,
+    thresholds
+  });
+
+  return {
+    labeledFindings,
+    p0p1Labels,
+    negativeControlScenarios,
+    bins,
+    bestWilsonLowerBound,
+    categoryPrecision,
+    thresholds,
+    eligible,
+    reason
+  };
+}
+
+function computeCategoryPrecision(validated: FindingOutcomeLabelRecord[]): CategoryPrecision[] {
+  const byCategory = new Map<string, { labeled: number; matched: number }>();
+  for (const label of validated) {
+    const entry = byCategory.get(label.category) ?? { labeled: 0, matched: 0 };
+    entry.labeled += 1;
+    if (label.verdict === "true_positive") entry.matched += 1;
+    byCategory.set(label.category, entry);
+  }
+  return [...byCategory.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([category, entry]) => ({
+      category,
+      labeled: entry.labeled,
+      matched: entry.matched,
+      precision: entry.labeled === 0 ? 0 : entry.matched / entry.labeled
+    }));
+}
+
+// Evaluated, never applied: reports whether the aggregate would clear the public-confidence floors.
+function evaluateThresholds(input: {
+  labeledFindings: number;
+  p0p1Labels: number;
+  negativeControlScenarios: number;
+  bestWilsonLowerBound: number;
+  thresholds: CalibrationAggregateThresholds;
+}): { eligible: boolean; reason: string } {
+  if (input.labeledFindings < input.thresholds.minLabeledFindings) return { eligible: false, reason: "insufficient_labeled_findings" };
+  if (input.p0p1Labels < input.thresholds.minP0P1Labels) return { eligible: false, reason: "insufficient_p0_p1_labels" };
+  if (input.negativeControlScenarios < input.thresholds.minNegativeControlScenarios) return { eligible: false, reason: "insufficient_negative_controls" };
+  if (input.bestWilsonLowerBound < input.thresholds.minWilsonLowerBound) return { eligible: false, reason: "wilson_lower_bound_below_threshold" };
+  return { eligible: true, reason: "eligible" };
+}
+
+export interface CalibrationAggregatePacketResult {
+  ok: boolean;
+  outputDir: string;
+  aggregate: CalibrationAggregate;
+}
+
+/**
+ * Write the aggregate calibration evidence packet + machine-readable aggregate-calibration.json via
+ * the redacted writer. The packet's proof boundary is explicit: it ENABLES calibration claims; it
+ * never switches public display by itself.
+ */
+export function writeCalibrationAggregatePacket(input: {
+  labels: FindingOutcomeLabelRecord[];
+  outputDir: string;
+  now?: Date;
+}): CalibrationAggregatePacketResult {
+  const aggregate = aggregateCalibrationLabels(input.labels);
+  const packet = {
+    ok: true,
+    generatedAt: (input.now ?? new Date()).toISOString(),
+    aggregate,
+    proofBoundary:
+      "Aggregate offline calibration evidence only. It reports whether the public-confidence floors are met; it does NOT switch public calibrated-confidence display or mutate any config."
+  };
+  mkdirSync(input.outputDir, { recursive: true });
+  writeRedactedJson(join(input.outputDir, "aggregate-calibration.json"), aggregate);
+  writeRedactedJson(join(input.outputDir, "calibration-aggregate-packet.json"), packet);
+  return { ok: true, outputDir: input.outputDir, aggregate };
+}
+
+function writeRedactedJson(path: string, value: unknown): void {
+  writeFileSync(path, `${redactSecrets(JSON.stringify(value, null, 2))}\n`);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,6 +99,7 @@ import {
   type ReviewQueueJobState
 } from "./state.js";
 import { readOutcomeObserverInput, runOutcomeObserverFromInput } from "./outcome-observer.js";
+import { writeCalibrationAggregatePacket } from "./calibration-aggregate.js";
 import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "./validation-selector.js";
 import { isSuccessfulRetryStatus, retryFailedHead, retryProviderCooldowns } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
@@ -1525,6 +1526,37 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "calibration-aggregate") {
+    if (args["output-dir"] === undefined || (Array.isArray(args["output-dir"]) && args["output-dir"].length === 0)) {
+      throw new Error("--output-dir is required for calibration-aggregate");
+    }
+    // Read-only aggregation (#286 PR B): reads finding_outcome_labels; evaluates the public-confidence
+    // floors and reports eligibility, but NEVER mutates config or switches public display.
+    const config = loadConfig(args.config ? parseSingleArg(args.config, "--config") : undefined);
+    const outputDir = parseSingleArg(args["output-dir"], "--output-dir");
+    assertEvalOutputDirSafe(outputDir);
+    const repo = args.repo ? parseSingleArg(args.repo, "--repo") : undefined;
+    const store = new ReviewStateStore(config.statePath);
+    try {
+      const labels = store.listFindingOutcomeLabels(repo ? { repo } : {});
+      const result = writeCalibrationAggregatePacket({ labels, outputDir });
+      console.log(stringifyRedactedJson({
+        command: "calibration-aggregate",
+        outputDir,
+        ok: result.ok,
+        labeledFindings: result.aggregate.labeledFindings,
+        p0p1Labels: result.aggregate.p0p1Labels,
+        negativeControlScenarios: result.aggregate.negativeControlScenarios,
+        eligible: result.aggregate.eligible,
+        reason: result.aggregate.reason
+      }));
+      if (!result.ok) process.exitCode = 1;
+    } finally {
+      store.close();
+    }
+    return;
+  }
+
   if (command === "run-once" || command === "review-pr") {
     if (command === "review-pr" && (!args.repo || !args.pr)) {
       console.log(JSON.stringify({
@@ -2705,7 +2737,8 @@ function buildHelp(command?: string) {
         "eval-sticky-vs-cold",
         "outcome-ledger",
         "outcome-scorecard",
-        "outcome-observe"
+        "outcome-observe",
+        "calibration-aggregate"
       ]
     },
     examples: [
@@ -2757,6 +2790,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts outcome-ledger --input /path/to/outcome-ledger-input.json --dry-run true --output-dir /path/to/evidence/outcome-ledger-run",
       "npx tsx src/cli.ts outcome-scorecard --input /path/to/outcome-scorecard-input.json --dry-run true --output-dir /path/to/evidence/outcome-scorecard-run",
       "npx tsx src/cli.ts outcome-observe --config /path/to/live.json --input /path/to/outcome-observer-input.json --dry-run true --output-dir /path/to/evidence/outcome-observe-run",
+      "npx tsx src/cli.ts calibration-aggregate --config /path/to/live.json --output-dir /path/to/evidence/calibration-aggregate-run",
       "npx tsx src/cli.ts finishing-touch-dry-run --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD --current-head HEAD --comment-id 456 --author maintainer --trusted-authors maintainer --body '@evaos-code-review-bot explain risk'",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ],

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -1270,14 +1270,32 @@ function maxRawWilsonLowerBound(botFindings: NormalizedEvalFinding[], matches: E
   return Math.max(0, ...computeConfidenceBinStats(botFindings, matches).map((bin) => bin.rawWilsonLowerBound));
 }
 
-function computeConfidenceBinStats(botFindings: NormalizedEvalFinding[], matches: EvalMatch[]): Array<{
+export interface ConfidenceBinStat {
   minConfidence: number;
   maxConfidence: number;
   findings: number;
   matched: number;
   empiricalPrecision: number;
   rawWilsonLowerBound: number;
-}> {
+}
+
+/** Minimal shapes computeConfidenceBinStats needs — satisfied by NormalizedEvalFinding/EvalMatch and by the label-store adapter. */
+export interface ConfidenceBinFinding {
+  id: string;
+  confidence: number;
+}
+
+export interface ConfidenceBinMatch {
+  botFindingId: string;
+}
+
+/**
+ * Shared Wilson-bin math (#286 PR B reuses this verbatim; never fork). Given normalized findings and
+ * the matches that validated them, returns per-bin finding/matched counts, empirical precision, and
+ * the raw (unrounded) Wilson lower bound. The batch calibration aggregator maps outcome labels into
+ * these same inputs so per-run and cross-run bins are computed by identical code.
+ */
+export function computeConfidenceBinStats(botFindings: ConfidenceBinFinding[], matches: ConfidenceBinMatch[]): ConfidenceBinStat[] {
   const matchedBotIds = new Set(matches.map((match) => match.botFindingId));
   return CONFIDENCE_BINS.map((bin) => {
     const findings = botFindings.filter((finding) => finding.confidence >= bin.minConfidence && finding.confidence < bin.maxConfidence);

--- a/tests/calibration-aggregate.test.ts
+++ b/tests/calibration-aggregate.test.ts
@@ -1,0 +1,156 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { aggregateCalibrationLabels, writeCalibrationAggregatePacket } from "../src/calibration-aggregate.js";
+import { computeConfidenceBinStats, PUBLIC_CONFIDENCE_POLICY } from "../src/eval-harness.js";
+import { ReviewStateStore, type FindingOutcomeLabelRecord } from "../src/state.js";
+
+const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
+
+let seq = 0;
+function label(overrides: Partial<FindingOutcomeLabelRecord> & Pick<FindingOutcomeLabelRecord, "confidence" | "verdict">): FindingOutcomeLabelRecord {
+  seq += 1;
+  return {
+    fingerprint: `finding:${String(seq).padStart(64, "0")}`,
+    repo: "owner/repo",
+    pullNumber: seq,
+    headSha: `sha${seq}`,
+    severity: "P1",
+    category: "data_loss",
+    labelSource: "merged_fix",
+    observedAt: "2026-07-06T00:00:00.000Z",
+    ...overrides
+  };
+}
+
+describe("calibration aggregation (#286 PR B)", () => {
+  it("computes per-bin stats identically to computeConfidenceBinStats on the same label set", () => {
+    const labels: FindingOutcomeLabelRecord[] = [
+      label({ confidence: 0.9, verdict: "true_positive" }),
+      label({ confidence: 0.85, verdict: "false_positive" }),
+      label({ confidence: 0.6, verdict: "true_positive" }),
+      label({ confidence: 0.2, verdict: "false_positive" }),
+      label({ confidence: 0.95, verdict: "unvalidated" }) // earns nothing
+    ];
+
+    const aggregate = aggregateCalibrationLabels(labels);
+
+    // Build the SAME inputs the aggregator feeds the shared math and assert byte-equal bins.
+    const validated = labels.filter((l) => l.verdict !== "unvalidated");
+    const findings = validated.map((l) => ({ id: l.fingerprint, confidence: l.confidence }));
+    const matches = validated.filter((l) => l.verdict === "true_positive").map((l) => ({ botFindingId: l.fingerprint }));
+    expect(aggregate.bins).toEqual(computeConfidenceBinStats(findings, matches));
+  });
+
+  it("counts labeledFindings and p0p1Labels from validated labels only (unvalidated earns nothing)", () => {
+    const aggregate = aggregateCalibrationLabels([
+      label({ confidence: 0.9, verdict: "true_positive", severity: "P0" }),
+      label({ confidence: 0.8, verdict: "false_positive", severity: "P1" }),
+      label({ confidence: 0.7, verdict: "true_positive", severity: "P2" }),
+      label({ confidence: 0.6, verdict: "unvalidated", severity: "P0" })
+    ]);
+
+    expect(aggregate.labeledFindings).toBe(3); // the unvalidated one excluded
+    expect(aggregate.p0p1Labels).toBe(2); // P0 tp + P1 fp; P2 not counted; unvalidated P0 excluded
+  });
+
+  it("reports negativeControlScenarios as 0 (no explicit-control source in the label store yet)", () => {
+    const aggregate = aggregateCalibrationLabels([
+      label({ confidence: 0.9, verdict: "true_positive" }),
+      label({ confidence: 0.5, verdict: "false_positive", labelSource: "none_observed" })
+    ]);
+    expect(aggregate.negativeControlScenarios).toBe(0);
+  });
+
+  it("computes per-category rolling precision from validated labels", () => {
+    const aggregate = aggregateCalibrationLabels([
+      label({ confidence: 0.9, verdict: "true_positive", category: "data_loss" }),
+      label({ confidence: 0.8, verdict: "true_positive", category: "data_loss" }),
+      label({ confidence: 0.7, verdict: "false_positive", category: "data_loss" }),
+      label({ confidence: 0.6, verdict: "true_positive", category: "auth" }),
+      label({ confidence: 0.5, verdict: "unvalidated", category: "auth" }) // excluded
+    ]);
+
+    const byCategory = Object.fromEntries(aggregate.categoryPrecision.map((c) => [c.category, c]));
+    expect(byCategory.data_loss).toMatchObject({ labeled: 3, matched: 2 });
+    expect(byCategory.data_loss?.precision).toBeCloseTo(2 / 3, 10);
+    expect(byCategory.auth).toMatchObject({ labeled: 1, matched: 1, precision: 1 });
+  });
+
+  it("evaluates the public-confidence floors but reports NOT eligible without mutating anything", () => {
+    const aggregate = aggregateCalibrationLabels([label({ confidence: 0.9, verdict: "true_positive" })]);
+
+    expect(aggregate.thresholds).toMatchObject({
+      minLabeledFindings: PUBLIC_CONFIDENCE_POLICY.minLabeledFindings,
+      minP0P1Labels: PUBLIC_CONFIDENCE_POLICY.minP0P1Labels,
+      minNegativeControlScenarios: PUBLIC_CONFIDENCE_POLICY.minNegativeControlScenarios,
+      minWilsonLowerBound: PUBLIC_CONFIDENCE_POLICY.minWilsonLowerBound
+    });
+    expect(aggregate.eligible).toBe(false);
+    expect(aggregate.reason).toMatch(/insufficient/i);
+  });
+
+  it("produces a clean zero-evidence aggregate from an empty label set", () => {
+    const aggregate = aggregateCalibrationLabels([]);
+    expect(aggregate.labeledFindings).toBe(0);
+    expect(aggregate.p0p1Labels).toBe(0);
+    expect(aggregate.categoryPrecision).toEqual([]);
+    expect(aggregate.eligible).toBe(false);
+    expect(aggregate.bins).toHaveLength(3);
+    expect(aggregate.bins.every((bin) => bin.findings === 0)).toBe(true);
+  });
+});
+
+describe("calibration aggregate packet + CLI (#286 PR B)", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("writes a redacted evidence packet + machine-readable aggregate json", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evaos-calib-packet-"));
+    roots.push(dir);
+    const token = ["ghp", "1234567890abcdefghijklmnopqrstuvwx"].join("_");
+    // A category name carrying secret-like text must be redacted in the written packet.
+    const result = writeCalibrationAggregatePacket({
+      labels: [label({ confidence: 0.9, verdict: "true_positive", category: `data_loss ${token}` })],
+      outputDir: join(dir, "packet")
+    });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(dir, "packet", "aggregate-calibration.json"))).toBe(true);
+    expect(existsSync(join(dir, "packet", "calibration-aggregate-packet.json"))).toBe(true);
+    const packet = readFileSync(join(dir, "packet", "calibration-aggregate-packet.json"), "utf8");
+    expect(packet).not.toContain(token);
+    expect(packet).toContain("proofBoundary");
+  });
+
+  it("exposes a read-only CLI that reads the store and never mutates config", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evaos-calib-cli-"));
+    roots.push(dir);
+    const configPath = join(dir, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(dir, "runtime"),
+      statePath: join(dir, "state.sqlite"),
+      evidenceDir: join(dir, "evidence")
+    })}\n`);
+    const store = new ReviewStateStore(join(dir, "state.sqlite"));
+    store.recordFindingOutcomeLabel(label({ confidence: 0.9, verdict: "true_positive" }));
+    store.close();
+    const outputDir = join(dir, "packet");
+
+    const output = execFileSync(process.execPath, [
+      tsxCli, "src/cli.ts", "calibration-aggregate", "--config", configPath, "--output-dir", outputDir
+    ], { cwd: process.cwd(), encoding: "utf8" });
+
+    const parsed = JSON.parse(output);
+    expect(parsed).toMatchObject({ command: "calibration-aggregate", ok: true, labeledFindings: 1, eligible: false });
+    expect(existsSync(join(outputDir, "aggregate-calibration.json"))).toBe(true);
+    // Config file is untouched by an aggregation run.
+    expect(readFileSync(configPath, "utf8")).not.toContain("calibrated");
+  });
+});


### PR DESCRIPTION
Part of #286 (part C follows). Parent: #278 Phase 4.

## Summary
The aggregate runner docs/eval-harness.md always said was missing: `calibration-aggregate` reads the part-A label store and produces the evidence the public-confidence gate demands — via the eval-harness's own math.

- `computeConfidenceBinStats` exported with narrowed input interfaces, **body unchanged**; the aggregation maps labels → the same inputs and calls the shared function. Equivalence pinned: aggregate bins are byte-equal to the harness's.
- Emits labeledFindings, p0p1Labels, per-bin precision + Wilson LB, per-category rolling precision; `unvalidated` labels earn nothing.
- Thresholds evaluated against the public-confidence floors and REPORTED (eligible/reason) — never applied; a CLI test pins that config is untouched. Explicit proof-boundary string in the packet.
- **negativeControlScenarios is 0 by construction** — the label store has no explicit-control concept, and none_observed/unvalidated must not be conflated with verified-clean (the #296 rule). The principled explicit-control source lands in part C; until then the public gate correctly remains unreachable on that floor.

## Validation
TDD failing-first incl. the equivalence pin, mixed verdicts, threshold-eval-without-apply, empty-store zero-evidence, redaction, config-untouched. Rebased; focused Vitest 71/71 (aggregate, eval-harness, observer) + CLI batches pre-rebase; build exit 0; pipefail.