### PR TITLE
[codex] add vision and setup validation docs

### DIFF
--- a/docs/setup-validation.md
+++ b/docs/setup-validation.md
@@ -86,6 +86,11 @@ Keep long JSON output in separate files and link it from the transcript.
 Validate the package install path first. Use the version named by the docs or
 the issue under test.
 
+Public install proof currently means the npm package `neondiff@0.4.30-beta.1`.
+Source-only beta releases `v0.4.31-beta.1` through `v0.4.37-beta.1` are held
+from npm; validate those by source SHA or local build path, not by expecting a
+new public npm artifact.
+
 ```bash
 npm install -g neondiff@<version-under-test> --prefix "$tmp_prefix"
 "$tmp_prefix/bin/neondiff" help
@@ -125,6 +130,16 @@ Then edit only local, untracked values for:
 - provider id and model path
 - license settings when validating a private or commercial repo path
 
+Provider keys and NeonDiff entitlements are separate inputs. Provider keys are
+for model access; they are not proof that private-repo review is licensed.
+Record whether the transcript is proving:
+
+- public repo review on the default free path
+- public repo review with `license.publicReposFree=false`
+- private repo review with an active private entitlement
+
+Do not treat a public-only entitlement as proof for a private repo path.
+
 Evidence to capture:
 
 - `init.log`: sanitized init output
@@ -161,6 +176,11 @@ Expected shape:
 Stop if the App cannot read the target repo, the target repo is not explicitly
 selected, issue-enrichment permissions are enabled unintentionally, or the
 doctor path requires a personal access token for the PR review path.
+
+Issue enrichment is out of scope for this setup pass unless the transcript is
+explicitly about that lane. PR review allowlists do not opt a repo into issue
+enrichment, and enabling issue enrichment should not imply processing an
+existing open-issue backlog by default.
 
 ## Step 4: Provider Readiness
 
@@ -249,9 +269,19 @@ Evidence to capture:
   private keys, provider API keys, GitHub tokens, license keys, or raw customer
   data
 
+When validating a blocked private or commercial path, the expected result is an
+early license gate before checkout, file listing, provider calls, or GitHub
+review posting. Capture that path with:
+
+- `license-gate.json` or equivalent redacted gate evidence
+- `license-summary.md`: repo visibility, entitlement scope/status, and why the
+  worker stopped before review execution
+
 Stop if the command attempts to post a live review, uses `--dry-run false`,
 cannot prove current head state, writes evidence into the repo, or produces
-artifact names/fields the setup docs do not explain.
+artifact names/fields the setup docs do not explain. Stop and file a docs or
+product bug if a blocked private/commercial run reaches checkout, file listing,
+provider setup, or posting before the license gate fires.
 
 ## Clean Setup Pass Criteria
 
@@ -262,6 +292,9 @@ A transcript can be attached as setup evidence only when:
 - every expected JSON output file exists and is parseable
 - the target repo and PR are explicit
 - the dry-run review did not post comments, reviews, labels, or branch changes
+- blocked private/commercial proofs stop before checkout, file listing,
+  provider calls, and review posting while still capturing license-gate
+  evidence
 - secrets are absent from transcript and evidence
 - every deviation from README or docs/SETUP.md is listed as a docs bug or setup
   bug

--- a/docs/setup-validation.md
+++ b/docs/setup-validation.md
@@ -1,0 +1,294 @@
+# Setup Validation Plan
+
+This runbook defines the clean setup transcript plan for NeonDiff. It is a plan
+for proving the first-run path; it is not a claim that setup has already been
+fully proven.
+
+The validation target is a literal pass through:
+
+```text
+install -> init -> doctor -> providers -> first dry-run review
+```
+
+Run this twice before using the result as issue #319 evidence:
+
+- human transcript: a human follows README and [docs/SETUP.md](SETUP.md)
+  without hidden repo knowledge
+- agent transcript: an AI coding agent follows README, [AGENTS.md](../AGENTS.md),
+  and [docs/SETUP.md](SETUP.md) literally, recording every assumption
+
+## Environment Contract
+
+Use a clean machine, clean container, or clean macOS user/session. If that is
+not available, use an isolated temp npm prefix plus fresh config, state, and
+evidence directories outside the repository.
+
+Record:
+
+- date and timezone
+- OS and architecture
+- Node.js and npm versions
+- shell
+- install path or temp npm prefix
+- NeonDiff package version or source SHA
+- GitHub App installation target
+- provider path under test
+- whether the provider is local/self-hosted or hosted
+- repository, PR number, and head SHA used for the dry-run review
+
+Do not record raw private keys, provider API keys, GitHub tokens, license keys,
+raw customer data, or unredacted model transcripts.
+
+Suggested evidence root:
+
+```text
+/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/setup-validation/YYYY-MM-DD/<human-or-agent>/
+```
+
+## Transcript Format
+
+Each transcript should be a Markdown file with this shape:
+
+```markdown
+# NeonDiff Setup Validation Transcript
+
+- Runner:
+- Environment:
+- Package or SHA:
+- GitHub App:
+- Provider:
+- Target repo:
+- Target PR:
+- Target head SHA:
+- Start time:
+- End time:
+- Result: pass | blocked | failed
+
+## Commands
+
+For each command:
+
+1. exact command
+2. expected result from docs
+3. observed result
+4. sanitized output or artifact path
+5. deviation, fix, or stop condition
+
+## Proof Boundary
+
+What this transcript proves and what it does not prove.
+```
+
+Keep long JSON output in separate files and link it from the transcript.
+
+## Step 1: Install
+
+Validate the package install path first. Use the version named by the docs or
+the issue under test.
+
+```bash
+npm install -g neondiff@<version-under-test> --prefix "$tmp_prefix"
+"$tmp_prefix/bin/neondiff" help
+```
+
+If validating the installer script, dry-run first:
+
+```bash
+curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
+```
+
+Evidence to capture:
+
+- `versions.txt`: `node --version`, `npm --version`, and NeonDiff version/help
+- `install.log`: sanitized install output
+- `install-dry-run.log`: installer dry-run output when used
+- `path.txt`: resolved CLI path
+
+Stop if install requires undocumented prerequisites, writes into the repo,
+prints secrets, installs a different package/version than the docs name, or
+cannot run `neondiff help`.
+
+## Step 2: Init
+
+Create a fresh config outside tracked repo files:
+
+```bash
+neondiff init --config "$work_dir/config.local.json"
+```
+
+Then edit only local, untracked values for:
+
+- GitHub App id and private key path
+- state path
+- evidence path
+- allowed pilot repos
+- provider id and model path
+- license settings when validating a private or commercial repo path
+
+Evidence to capture:
+
+- `init.log`: sanitized init output
+- `config.redacted.json`: config with secrets and local private paths redacted
+- `config.sha256`: hash of the redacted config
+- `paths.txt`: state and evidence directories
+
+Stop if init overwrites an existing file without confirmation, writes secrets
+to tracked files, creates world-readable secret material, or leaves required
+fields undocumented.
+
+## Step 3: GitHub Doctor
+
+Check GitHub App visibility before provider or review work:
+
+```bash
+neondiff doctor github --config "$work_dir/config.local.json" --json
+```
+
+Evidence to capture:
+
+- `doctor-github.json`
+- `github-installation.md`: selected repos, App slug/id if safe, and permission
+  checklist
+
+Expected shape:
+
+- `ok` is true
+- `github.readMode` is `app_installation`
+- `github.canPostAsApp` matches the dry-run/live boundary under test
+- every enabled repo appears in `github.readChecks[]`
+- `activeRepoChecks` is greater than zero
+
+Stop if the App cannot read the target repo, the target repo is not explicitly
+selected, issue-enrichment permissions are enabled unintentionally, or the
+doctor path requires a personal access token for the PR review path.
+
+## Step 4: Provider Readiness
+
+List providers without calling models:
+
+```bash
+neondiff providers list --config "$work_dir/config.local.json" --json
+```
+
+Run provider doctor:
+
+```bash
+neondiff providers doctor --config "$work_dir/config.local.json" --json
+```
+
+For a single local OpenAI-compatible endpoint smoke, name the provider:
+
+```bash
+neondiff providers doctor \
+  --config "$work_dir/config.local.json" \
+  --provider <provider-id> \
+  --smoke true \
+  --json
+```
+
+For hosted BYOK endpoints, require an explicit operator decision before remote
+smoke:
+
+```bash
+NEONDIFF_ALLOW_REMOTE_SMOKE=true \
+  neondiff providers doctor \
+    --config "$work_dir/config.local.json" \
+    --provider <hosted-provider-id> \
+    --smoke true \
+    --json
+```
+
+Evidence to capture:
+
+- `providers-list.json`
+- `providers-doctor.json`
+- `providers-smoke.json` when smoke is in scope
+- `provider-egress.md`: local/self-hosted/hosted classification and what data
+  was allowed to leave the worker
+
+Stop if a provider check fans out to multiple authenticated hosted providers,
+prints an API key, sends PR diffs during provider smoke, or requires hosted
+egress when the run is supposed to be no-egress.
+
+## Step 5: Full Doctor
+
+Run the full readiness check after GitHub and provider checks:
+
+```bash
+neondiff doctor --config "$work_dir/config.local.json" --json
+```
+
+Evidence to capture:
+
+- `doctor.json`
+- `doctor-summary.md`: pass/fail fields and any docs mismatch
+
+Stop if `ok` is false, repo policy skips the target unexpectedly, provider
+readiness is unclear, or the output asks the runner to use undocumented flags.
+
+## Step 6: First Dry-Run Review
+
+Use a known repository, PR number, and current head SHA. Keep live posting off.
+
+```bash
+neondiff review-pr \
+  --config "$work_dir/config.local.json" \
+  --repo owner/name \
+  --pr 123 \
+  --dry-run true \
+  --zcode false
+```
+
+Evidence to capture:
+
+- `dry-run-review.json`
+- `target-pr.md`: repo, PR number, base SHA, head SHA, and why this PR is safe
+  for setup validation
+- `evidence-manifest.txt`: files written by the dry-run evidence directory
+- `redaction-check.md`: confirmation that saved artifacts do not contain
+  private keys, provider API keys, GitHub tokens, license keys, or raw customer
+  data
+
+Stop if the command attempts to post a live review, uses `--dry-run false`,
+cannot prove current head state, writes evidence into the repo, or produces
+artifact names/fields the setup docs do not explain.
+
+## Clean Setup Pass Criteria
+
+A transcript can be attached as setup evidence only when:
+
+- every command in the install -> init -> doctor -> providers -> first dry-run
+  review path is present with exact command text
+- every expected JSON output file exists and is parseable
+- the target repo and PR are explicit
+- the dry-run review did not post comments, reviews, labels, or branch changes
+- secrets are absent from transcript and evidence
+- every deviation from README or docs/SETUP.md is listed as a docs bug or setup
+  bug
+- the proof boundary states exactly which OS, package/SHA, provider, repo, PR,
+  and head SHA were tested
+
+## Stop Conditions
+
+Stop and file or update the tracked issue when any of these occur:
+
+- install cannot run from the documented commands
+- Node/npm requirements differ from docs
+- `neondiff init` needs hidden local context
+- GitHub App permissions or selected-repo install steps are missing or wrong
+- provider setup requires storing a secret in tracked config
+- hosted provider smoke runs without explicit remote-smoke consent
+- dry-run review mutates GitHub
+- evidence contains secrets or raw private/customer data
+- commands require package/source changes outside the validation issue
+- the runner cannot explain whether the failure is docs, environment, provider,
+  GitHub App, or product behavior
+
+## Proof Boundary
+
+A completed transcript proves only that the documented first-run path worked
+for the named environment, package or SHA, GitHub App installation, provider,
+repository, PR, and head SHA. It does not prove GA readiness, all-platform
+support, live-posting safety, provider quality, hosted BYOK behavior, release
+readiness, desktop readiness, marketplace readiness, or calibrated review
+accuracy.

--- a/docs/setup-validation.md
+++ b/docs/setup-validation.md
@@ -10,7 +10,8 @@ The validation target is a literal pass through:
 install -> init -> doctor -> providers -> first dry-run review
 ```
 
-Run this twice before using the result as issue #319 evidence:
+For maintainer setup-readiness evidence, run this twice before attaching the
+result to the relevant readiness tracker:
 
 - human transcript: a human follows README and [docs/SETUP.md](SETUP.md)
   without hidden repo knowledge
@@ -22,6 +23,15 @@ Run this twice before using the result as issue #319 evidence:
 Use a clean machine, clean container, or clean macOS user/session. If that is
 not available, use an isolated temp npm prefix plus fresh config, state, and
 evidence directories outside the repository.
+
+All command examples below assume these scratch paths are defined first:
+
+```bash
+export scratch_parent="${TMPDIR:-/tmp}"
+export work_dir="${work_dir:-$(mktemp -d "$scratch_parent/neondiff-setup-validation.XXXXXX")}"
+export tmp_prefix="$work_dir/npm-prefix"
+mkdir -p "$tmp_prefix" "$work_dir/evidence"
+```
 
 Record:
 
@@ -39,11 +49,14 @@ Record:
 Do not record raw private keys, provider API keys, GitHub tokens, license keys,
 raw customer data, or unredacted model transcripts.
 
-Suggested evidence root:
+Suggested local evidence root:
 
 ```text
-/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/setup-validation/YYYY-MM-DD/<human-or-agent>/
+$work_dir/evidence/setup-validation/YYYY-MM-DD/<human-or-agent>/
 ```
+
+Maintainers can copy or link the sanitized transcript from that root into the
+relevant GitHub issue or release evidence packet after the run completes.
 
 ## Transcript Format
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,128 @@
+# NeonDiff Vision
+
+NeonDiff's wedge is a local-first, evidence-backed outcome auditor for
+AI-written and high-risk pull requests.
+
+The product starts from a simple belief: review automation should make the PR
+outcome easier to trust, not just add another confident comment. NeonDiff runs
+from a local worker, uses a GitHub App with explicit repository scope, records
+redacted evidence for each review decision, and keeps provider choice under the
+operator's control.
+
+This document is directional alignment for contributors and agents. It does not
+claim GA readiness, hosted-service readiness, or parity with any hosted review
+product.
+
+## Wedge
+
+NeonDiff is built for teams and agents that already have AI-generated code in
+the review loop and need a second opinion that is:
+
+- current-head only
+- repo-policy aware
+- evidence backed
+- local-first for checkout state, config, credentials, and operator control
+- conservative about public confidence, secret handling, and mutation
+
+The core job is not to sound smart about every diff. The core job is to make
+high-risk PRs harder to merge without a visible proof trail.
+
+Useful early targets:
+
+- AI-authored PRs that touch runtime, security, release, billing, data, or
+  customer paths
+- docs or config PRs where public claims can drift ahead of shipped behavior
+- agent-produced changes that need a durable checklist before human review
+- teams that want BYOK or local-model review without handing every diff to a
+  hosted review SaaS
+
+## Calibration Loop
+
+NeonDiff treats review quality as something to measure, not something to imply.
+The intended loop is:
+
+1. Run reviews in dry-run or bounded live mode.
+2. Store redacted evidence for findings, dropped findings, validation choices,
+   provider/runtime metadata, and current-head state.
+3. Compare the bot output with later outcomes such as human review, CI, seeded
+   defects, negative controls, and post-merge incidents.
+4. Feed those labels into scorecards and calibration reports.
+5. Promote public confidence displays, request-changes thresholds, or stronger
+   routing only when the calibration policy says the evidence is good enough.
+
+Until that loop proves a claim, public comments stay conservative. Raw model
+confidence remains internal metadata, and public percentages stay hidden behind
+the calibration gate described in
+[docs/evals/confidence-calibration.md](evals/confidence-calibration.md).
+
+## Safety Posture
+
+NeonDiff should fail closed before it creates surprise work for maintainers.
+The default posture is:
+
+- review only configured repositories
+- re-check pull request head state before planning, finding placement, and live
+  posting
+- post at most one review for a given `{repo, pr, head_sha}` decision surface
+- suppress secret-looking findings instead of posting redacted secrets
+- keep findings on current RIGHT-side diff lines
+- use dry-run evidence before live posting
+- never approve PRs
+- never merge branches
+- never push repairs
+- never expand GitHub permissions just because a repo profile requests it
+- never present confidence as calibrated until the eval gate passes
+
+Strong automation should reduce ambiguity for a human maintainer. It should not
+hide the boundary between evidence, judgment, and authority.
+
+## Provider And BYOK Boundaries
+
+NeonDiff is local-first, but model egress depends on the provider path the
+operator chooses.
+
+- Local or self-hosted endpoints can keep prompts and diffs on the operator's
+  machine or network when the model runtime is actually local.
+- Hosted providers, including ZCode-backed GLM/Z.ai or hosted
+  OpenAI-compatible BYOK gateways, can receive the prompt and diff context
+  needed to produce a review.
+- Provider keys belong in environment variables, local operator wrappers, or
+  supported secret paths. They do not belong in tracked config, GitHub comments,
+  release notes, or evidence packets.
+- NeonDiff support tiers are software/support entitlement boundaries. Provider
+  and model costs stay external through BYOK or local models.
+- Provider resource catalogs are discovery aids, not proof that a provider can
+  run NeonDiff reviews.
+
+See [docs/providers.md](providers.md), [docs/pricing.md](pricing.md), and
+[docs/license-boundary.md](license-boundary.md) for the current public beta
+wording.
+
+## Deliberate Non-Goals
+
+NeonDiff is not trying to be all of these at once:
+
+- a hosted review SaaS
+- an auto-merge bot
+- an autonomous branch-repair agent
+- a replacement for human code ownership
+- a general GitHub issue mutation engine
+- a blanket security certification
+- a public-confidence product without calibration evidence
+- a universal provider marketplace
+- a GA release declaration
+- a promise that every local setup, provider, or repository shape has already
+  been proven
+
+Those may produce useful future work, but each needs its own issue, proof
+boundary, and release gate. The near-term shape is narrower: local worker,
+explicit repo scope, current-head review, redacted evidence, BYOK/local provider
+choice, and conservative outcome auditing for risky PRs.
+
+## Proof Boundary
+
+This vision document states product intent and contributor alignment. It does
+not prove setup, provider quality, release readiness, marketplace readiness,
+desktop readiness, legal readiness, or GA readiness. Those claims need their
+own validation artifacts and tracked issues before they can move into public
+product copy.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -7,7 +7,8 @@ The product starts from a simple belief: review automation should make the PR
 outcome easier to trust, not just add another confident comment. NeonDiff runs
 from a local worker, uses a GitHub App with explicit repository scope, records
 redacted evidence for each review decision, and keeps provider choice under the
-operator's control.
+operator's control. Public repositories are free by default; private repository
+review requires an active private entitlement.
 
 This document is directional alignment for contributors and agents. It does not
 claim GA readiness, hosted-service readiness, or parity with any hosted review
@@ -61,6 +62,8 @@ NeonDiff should fail closed before it creates surprise work for maintainers.
 The default posture is:
 
 - review only configured repositories
+- fail private or commercial review requests before checkout, file listing,
+  provider calls, or GitHub review posting when entitlement proof is missing
 - re-check pull request head state before planning, finding placement, and live
   posting
 - post at most one review for a given `{repo, pr, head_sha}` decision surface
@@ -89,8 +92,13 @@ operator chooses.
 - Provider keys belong in environment variables, local operator wrappers, or
   supported secret paths. They do not belong in tracked config, GitHub comments,
   release notes, or evidence packets.
+- Provider keys are not NeonDiff entitlements. They unlock model access, while
+  NeonDiff entitlements govern which repo visibilities the worker may review.
 - NeonDiff support tiers are software/support entitlement boundaries. Provider
   and model costs stay external through BYOK or local models.
+- Active private entitlement covers private repos and public repos when an
+  operator disables the default public-free path. Public-only entitlement does
+  not unlock private repos.
 - Provider resource catalogs are discovery aids, not proof that a provider can
   run NeonDiff reviews.
 
@@ -119,10 +127,26 @@ boundary, and release gate. The near-term shape is narrower: local worker,
 explicit repo scope, current-head review, redacted evidence, BYOK/local provider
 choice, and conservative outcome auditing for risky PRs.
 
+## Issue Enrichment Boundary
+
+Issue enrichment is a separate rollout lane from pull request review.
+
+- PR review allowlists do not opt repositories into issue enrichment.
+- Issue enrichment needs its own allowlist, repo-level throttles, and live-post
+  gate before comments can go out.
+- New issue-enrichment rollouts should keep
+  `processExistingOpenIssuesOnActivation=false` so enabling the lane does not
+  imply scanning or commenting on an existing 50+ issue backlog by default.
+
+See [docs/issue-enrichment.md](issue-enrichment.md) for the rollout policy and
+[docs/license-boundary.md](license-boundary.md) for the public/private
+entitlement matrix.
+
 ## Proof Boundary
 
 This vision document states product intent and contributor alignment. It does
 not prove setup, provider quality, release readiness, marketplace readiness,
 desktop readiness, legal readiness, or GA readiness. Those claims need their
 own validation artifacts and tracked issues before they can move into public
-product copy.
+product copy. It also does not prove issue-enrichment rollout readiness for any
+repo unless that repo has separate allowlist, threshold, and evidence coverage.


### PR DESCRIPTION
## Summary

- Add `docs/vision.md` with NeonDiff's local-first outcome-auditor wedge, calibration loop, safety posture, provider/BYOK boundaries, non-goals, issue-enrichment boundary, and proof boundary.
- Add `docs/setup-validation.md` as a human + agent clean setup transcript runbook for install -> init -> doctor -> providers -> first dry-run review.
- Align the docs with the v0.4.37 entitlement matrix: provider keys are not entitlements, public repos are free by default, private repos require active private entitlement, source-only beta releases remain held from npm, and issue enrichment uses a separate allowlist/throttle.

## Scope

Docs-only hopper slice for #319. This does not edit README, `docs/SETUP.md`, release governance, changelog, package files, source, tests, runtime config, launchd, or release docs.

## Validation

- `git diff --check`
- `bash -n` on the setup-validation scratch-path snippet
- `node scripts/check-public-claims.mjs`
- `node scripts/check-secret-scan.mjs`
- Spec review subagent: PASS
- Quality/safety review subagent: PASS after follow-up commit `3e81495`

## Tracking

Refs #319.
