### PR TITLE
[codex] Add GitHub install-scope proof to doctor

### DIFF
--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -81,10 +81,24 @@ Expected signs of a usable install:
 - `github.canPostAsApp: true`
 - each enabled repo has `ok: true`
 - `activeRepoChecks` is greater than zero
+- each enabled repo read check includes:
+  - `repo_full_name`
+  - `visibility_result`: `public`, `private`, `internal`, or `unknown`
+  - `visibility_source`: `repository_api`, `private_flag`, or `unavailable`
+  - `installation_id_present: true`
+  - `app_can_read_metadata: true`
+  - `app_can_read_pull_requests: true`
+  - `license_gate_decision`
+  - `pre_checkout_gate_result`
 
 If a repo is disabled by repo policy, the doctor reports it as
 `skippedByPolicy`; that is useful config evidence, but it is not proof that the
 App can read or review that repo.
+
+Treat `visibility_result: "unknown"` or any `app_can_read_*: false` as a
+pre-checkout blocker. Unknown or unreadable visibility is never public-free
+evidence; confirm the App installation scope, selected repositories, and
+permissions before widening provider/model settings.
 
 ## First Review Path
 
@@ -139,6 +153,13 @@ To remove NeonDiff from a user or organization:
 - A repo read fails with 404 or "Resource not accessible by integration":
   confirm the App is installed on that selected repo and has the permissions
   listed above.
+- `doctor github` reports `github_api_error_class: "suspended_installation"`:
+  unsuspend or reinstall the App before running reviews.
+- `doctor github` reports `github_api_error_class: "renamed_or_transferred"`:
+  update the repo name in the local config and rerun the doctor.
+- `doctor github` reports `github_api_error_class: "rate_limited"`:
+  wait for the GitHub API window to recover, then rerun the doctor before
+  treating the repo as install-proven.
 - `activeRepoChecks` is zero: the config has no enabled repo to prove; add a
   selected installed repo to `pilotRepos`.
 - Private repo review fails before provider calls: check license status before

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,7 +36,7 @@ import {
   validateFinishingTouchRequest,
   type FinishingTouchAction
 } from "./finishing-touches.js";
-import { GitHubApi } from "./github.js";
+import { GitHubApi, type GitHubRepositoryAccessProof, type GitHubRepositoryVisibility } from "./github.js";
 import { buildGitNexusContextPacket } from "./gitnexus-context.js";
 import { buildGitNexusRefreshPreflight } from "./gitnexus-refresh-preflight.js";
 import { buildGitHubRelatedContextPacket, type GitHubRelatedIssueOrPull } from "./github-related-context.js";
@@ -2563,9 +2563,41 @@ async function buildDoctorGithubReport(config: BotConfig) {
       });
       continue;
     }
+    if (appCredentialsConfigured) {
+      const proof = await github.probeRepositoryAccess(repo);
+      const gatePreview = buildDoctorGithubLicenseGatePreview(config, proof);
+      readChecks.push({
+        repo,
+        ok: proof.app_can_read_metadata && proof.app_can_read_pull_requests,
+        policy,
+        ...proof,
+        ...gatePreview
+      });
+      continue;
+    }
     try {
       const pulls = await github.listOpenPulls(repo);
-      readChecks.push({ repo, ok: true, policy, openPullCount: pulls.length });
+      const gatePreview = buildDoctorGithubLicenseGatePreview(config, {
+        visibility_result: "unknown",
+        app_can_read_metadata: false,
+        app_can_read_pull_requests: false
+      });
+      readChecks.push({
+        repo,
+        ok: false,
+        policy,
+        openPullCount: pulls.length,
+        repo_full_name: repo,
+        readMode: "fallback_token",
+        visibility_result: "unknown",
+        visibility_source: "unavailable",
+        installation_id_present: false,
+        app_can_read_metadata: false,
+        app_can_read_pull_requests: false,
+        github_api_error_class: "missing_app_credentials",
+        github_api_error: "Fallback-token reads are not GitHub App installation-scope proof.",
+        ...gatePreview
+      });
     } catch (error) {
       readChecks.push({
         repo,
@@ -2630,6 +2662,67 @@ async function buildDoctorGithubReport(config: BotConfig) {
       ...(readChecks.some((check) => !check.ok) ? ["Confirm the GitHub App is installed on selected repositories with the required repository permissions."] : [])
     ]
   };
+}
+
+function buildDoctorGithubLicenseGatePreview(
+  config: BotConfig,
+  proof: Pick<GitHubRepositoryAccessProof, "visibility_result" | "app_can_read_metadata" | "app_can_read_pull_requests">
+): {
+  license_gate_decision: string;
+  pre_checkout_gate_result: string;
+} {
+  const visibility: GitHubRepositoryVisibility = proof.visibility_result;
+  const publicReposFree = config.license?.publicReposFree ?? true;
+  const privateReposRequireEntitlement = config.license?.privateReposRequireEntitlement ?? true;
+  const appScopeBlocksCheckout = !proof.app_can_read_metadata || !proof.app_can_read_pull_requests;
+  if (appScopeBlocksCheckout) {
+    return {
+      license_gate_decision: licenseGateDecisionForVisibility(visibility, publicReposFree, privateReposRequireEntitlement),
+      pre_checkout_gate_result: "blocked_before_checkout"
+    };
+  }
+  if (visibility === "public" && publicReposFree) {
+    return {
+      license_gate_decision: "public_free_allowed",
+      pre_checkout_gate_result: "allowed"
+    };
+  }
+  if (visibility === "unknown" && privateReposRequireEntitlement) {
+    return {
+      license_gate_decision: "unknown_visibility_fail_closed",
+      pre_checkout_gate_result: "blocked_before_checkout"
+    };
+  }
+  if ((visibility === "private" || visibility === "internal") && privateReposRequireEntitlement) {
+    return {
+      license_gate_decision: "active_private_entitlement_required",
+      pre_checkout_gate_result: "blocked_until_entitlement_proof"
+    };
+  }
+  if (visibility === "public" && !publicReposFree) {
+    return {
+      license_gate_decision: "active_public_entitlement_required",
+      pre_checkout_gate_result: "blocked_until_entitlement_proof"
+    };
+  }
+  return {
+    license_gate_decision: "repo_visibility_allowed_by_policy",
+    pre_checkout_gate_result: "allowed"
+  };
+}
+
+function licenseGateDecisionForVisibility(
+  visibility: GitHubRepositoryVisibility,
+  publicReposFree: boolean,
+  privateReposRequireEntitlement: boolean
+): string {
+  if (visibility === "public" && publicReposFree) return "public_free_allowed";
+  if (visibility === "public" && !publicReposFree) return "active_public_entitlement_required";
+  if (visibility === "unknown" && privateReposRequireEntitlement) return "unknown_visibility_fail_closed";
+  if (visibility === "private" || visibility === "internal") {
+    return privateReposRequireEntitlement ? "active_private_entitlement_required" : "repo_visibility_allowed_by_policy";
+  }
+  return "app_installation_scope_required";
 }
 
 async function collectIssueEnrichmentReadChecks(

--- a/src/github.ts
+++ b/src/github.ts
@@ -15,6 +15,57 @@ export interface GitHubApiOptions {
   requestTimeoutMs?: number;
 }
 
+export type GitHubRepositoryVisibility = "public" | "private" | "internal" | "unknown";
+export type GitHubRepositoryVisibilitySource = "repository_api" | "private_flag" | "unavailable";
+export type GitHubRepositoryAccessErrorClass =
+  | "missing_app_credentials"
+  | "not_found"
+  | "forbidden"
+  | "resource_not_accessible"
+  | "rate_limited"
+  | "suspended_installation"
+  | "renamed_or_transferred"
+  | "server_error"
+  | "network"
+  | "unknown";
+
+export interface GitHubRepositoryAccessProof {
+  repo_full_name: string;
+  readMode: "app_installation" | "fallback_token" | "unconfigured";
+  visibility_result: GitHubRepositoryVisibility;
+  visibility_source: GitHubRepositoryVisibilitySource;
+  installation_id_present: boolean;
+  app_can_read_metadata: boolean;
+  app_can_read_pull_requests: boolean;
+  openPullCount?: number;
+  github_api_status?: number;
+  github_api_error_class?: GitHubRepositoryAccessErrorClass;
+  github_api_error?: string;
+}
+
+export class GitHubApiRequestError extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  readonly path: string;
+  readonly responseText: string;
+
+  constructor(input: { status: number; statusText: string; path: string; responseText: string }) {
+    const responseText = redactSecrets(input.responseText);
+    super(`GitHub API ${input.status} ${input.statusText} for ${input.path}: ${responseText.slice(0, 400)}`);
+    this.name = "GitHubApiRequestError";
+    this.status = input.status;
+    this.statusText = input.statusText;
+    this.path = input.path;
+    this.responseText = responseText;
+    Object.defineProperty(this, "responseText", {
+      value: responseText,
+      enumerable: false,
+      configurable: false,
+      writable: false
+    });
+  }
+}
+
 export class GitHubApi {
   private readonly appId?: string;
   private readonly privateKey?: string;
@@ -23,6 +74,7 @@ export class GitHubApi {
   private readonly botLogin: string;
   private readonly requestTimeoutMs?: number;
   private installationTokens = new Map<string, { token: string; expiresAt: number }>();
+  private repoInstallationTokens = new Map<string, { installationId: number; token: string; expiresAt: number }>();
 
   constructor(options: GitHubApiOptions) {
     this.appId = options.appId;
@@ -59,6 +111,73 @@ export class GitHubApi {
     return this.request<RepositorySummary>(`/repos/${repo}`, {
       token: await this.getReadToken(repo)
     });
+  }
+
+  async probeRepositoryAccess(repo: string): Promise<GitHubRepositoryAccessProof> {
+    const readMode = this.canPostAsApp() ? "app_installation" : this.token ? "fallback_token" : "unconfigured";
+    const base: GitHubRepositoryAccessProof = {
+      repo_full_name: repo,
+      readMode,
+      visibility_result: "unknown",
+      visibility_source: "unavailable",
+      installation_id_present: false,
+      app_can_read_metadata: false,
+      app_can_read_pull_requests: false
+    };
+    if (!this.canPostAsApp()) {
+      return {
+        ...base,
+        github_api_error_class: "missing_app_credentials",
+        github_api_error: "GitHub App credentials are required for installation-scope proof."
+      };
+    }
+
+    let installationId: number;
+    try {
+      installationId = await this.getInstallationId(repo, { followRedirects: false });
+    } catch (error) {
+      return { ...base, ...describeGitHubAccessError(error) };
+    }
+
+    let token: string;
+    try {
+      token = await this.getInstallationTokenForId(repo, installationId);
+    } catch (error) {
+      return { ...base, installation_id_present: true, ...describeGitHubAccessError(error) };
+    }
+
+    let metadata: RepositorySummary;
+    try {
+      metadata = await this.request<RepositorySummary>(`/repos/${repo}`, { token, followRedirects: false });
+    } catch (error) {
+      return { ...base, installation_id_present: true, ...describeGitHubAccessError(error) };
+    }
+
+    const visibility = visibilityFromRepositorySummary(metadata);
+    try {
+      const pulls = await this.listOpenPullsWithToken(repo, token, { followRedirects: false });
+      return {
+        repo_full_name: metadata.full_name || repo,
+        readMode,
+        visibility_result: visibility.result,
+        visibility_source: visibility.source,
+        installation_id_present: true,
+        app_can_read_metadata: true,
+        app_can_read_pull_requests: true,
+        openPullCount: pulls.length
+      };
+    } catch (error) {
+      return {
+        repo_full_name: metadata.full_name || repo,
+        readMode,
+        visibility_result: visibility.result,
+        visibility_source: visibility.source,
+        installation_id_present: true,
+        app_can_read_metadata: true,
+        app_can_read_pull_requests: false,
+        ...describeGitHubAccessError(error)
+      };
+    }
   }
 
   async listPullFiles(repo: string, pullNumber: number): Promise<PullFilePatch[]> {
@@ -213,22 +332,73 @@ export class GitHubApi {
   }
 
   private async getInstallationToken(repo: string): Promise<string> {
-    const cached = this.installationTokens.get(repo);
+    const cached = this.repoInstallationTokens.get(repo);
     if (cached && cached.expiresAt > Date.now() + 60_000) return cached.token;
     if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
 
+    const installationId = await this.getInstallationId(repo);
+    return this.getInstallationTokenForId(repo, installationId);
+  }
+
+  private async getInstallationId(repo: string, options: { followRedirects?: boolean } = {}): Promise<number> {
+    if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
     const jwt = createAppJwt(this.appId, this.privateKey);
-    const installation = await this.request<{ id: number }>(`/repos/${repo}/installation`, { token: jwt });
+    const installation = await this.request<{ id: number }>(`/repos/${repo}/installation`, {
+      token: jwt,
+      followRedirects: options.followRedirects
+    });
+    return installation.id;
+  }
+
+  private async getInstallationTokenForId(repo: string, installationId: number): Promise<string> {
+    const repoCached = this.repoInstallationTokens.get(repo);
+    if (repoCached && repoCached.installationId === installationId && repoCached.expiresAt > Date.now() + 60_000) {
+      return repoCached.token;
+    }
+    const tokenCacheKey = `${repo}:${installationId}`;
+    const cached = this.installationTokens.get(tokenCacheKey);
+    if (cached && cached.expiresAt > Date.now() + 60_000) {
+      this.repoInstallationTokens.set(repo, {
+        installationId,
+        token: cached.token,
+        expiresAt: cached.expiresAt
+      });
+      return cached.token;
+    }
+    if (!this.appId || !this.privateKey) throw new Error("Missing GitHub App credentials.");
+    const jwt = createAppJwt(this.appId, this.privateKey);
     const token = await this.request<{ token: string; expires_at: string }>(
-      `/app/installations/${installation.id}/access_tokens`,
+      `/app/installations/${installationId}/access_tokens`,
       { method: "POST", token: jwt, body: { repositories: [repo.split("/")[1]] } }
     );
 
-    this.installationTokens.set(repo, {
+    const expiresAt = new Date(token.expires_at).getTime();
+    this.installationTokens.set(tokenCacheKey, {
       token: token.token,
-      expiresAt: new Date(token.expires_at).getTime()
+      expiresAt
+    });
+    this.repoInstallationTokens.set(repo, {
+      installationId,
+      token: token.token,
+      expiresAt
     });
     return token.token;
+  }
+
+  private async listOpenPullsWithToken(
+    repo: string,
+    token: string,
+    options: { followRedirects?: boolean } = {}
+  ): Promise<PullRequestSummary[]> {
+    const pulls: PullRequestSummary[] = [];
+    for (let page = 1; ; page += 1) {
+      const chunk = await this.request<PullRequestSummary[]>(`/repos/${repo}/pulls?state=open&per_page=100&page=${page}`, {
+        token,
+        followRedirects: options.followRedirects
+      });
+      pulls.push(...chunk.map(normalizePullRequestSummary));
+      if (chunk.length < 100) return pulls;
+    }
   }
 
   private async getReadToken(repo: string): Promise<string | undefined> {
@@ -238,7 +408,7 @@ export class GitHubApi {
 
   private async request<T>(
     path: string,
-    options: { method?: string; token?: string; body?: unknown } = {}
+    options: { method?: string; token?: string; body?: unknown; followRedirects?: boolean } = {}
   ): Promise<T> {
     const token = options.token ?? this.token;
     let response: Response;
@@ -249,6 +419,7 @@ export class GitHubApi {
     try {
       response = await fetch(buildApiUrl(this.apiBaseUrl, path, "GitHub API request path"), {
         method: options.method ?? "GET",
+        ...(options.followRedirects === false ? { redirect: "manual" } : {}),
         signal: controller?.signal,
         headers: {
           Accept: "application/vnd.github+json",
@@ -266,7 +437,12 @@ export class GitHubApi {
 
     if (!response.ok) {
       const text = await response.text();
-      throw new Error(`GitHub API ${response.status} ${response.statusText} for ${path}: ${redactSecrets(text).slice(0, 400)}`);
+      throw new GitHubApiRequestError({
+        status: response.status,
+        statusText: response.statusText,
+        path,
+        responseText: text
+      });
     }
 
     return (await response.json()) as T;
@@ -293,6 +469,47 @@ function normalizePullRepoSummary<T extends PullRequestSummary["base"]["repo"]>(
     ...repo,
     ...(visibility ? { visibility } : {})
   };
+}
+
+function visibilityFromRepositorySummary(repository: RepositorySummary): {
+  result: GitHubRepositoryVisibility;
+  source: GitHubRepositoryVisibilitySource;
+} {
+  if (repository.visibility === "public" || repository.visibility === "private" || repository.visibility === "internal") {
+    return { result: repository.visibility, source: "repository_api" };
+  }
+  if (repository.private === true) return { result: "private", source: "private_flag" };
+  if (repository.private === false) return { result: "public", source: "private_flag" };
+  return { result: "unknown", source: "unavailable" };
+}
+
+function describeGitHubAccessError(error: unknown): Pick<
+  GitHubRepositoryAccessProof,
+  "github_api_status" | "github_api_error_class" | "github_api_error"
+> {
+  if (error instanceof GitHubApiRequestError) {
+    return {
+      github_api_status: error.status,
+      github_api_error_class: classifyGitHubApiRequestError(error),
+      github_api_error: `GitHub API ${error.status} ${error.statusText} for ${error.path}: ${error.responseText.slice(0, 400)}`
+    };
+  }
+  return {
+    github_api_error_class: error instanceof Error && /fetch failed|timed out|AbortError/i.test(error.message) ? "network" : "unknown",
+    github_api_error: redactSecrets(error instanceof Error ? error.message : String(error))
+  };
+}
+
+function classifyGitHubApiRequestError(error: GitHubApiRequestError): GitHubRepositoryAccessErrorClass {
+  const body = error.responseText;
+  if (/\bsuspended\b/i.test(body)) return "suspended_installation";
+  if (/\b(rate limit|secondary rate limit|abuse detection)\b/i.test(body)) return "rate_limited";
+  if (/\bResource not accessible by integration\b/i.test(body)) return "resource_not_accessible";
+  if (error.status === 404) return "not_found";
+  if (error.status === 301 || error.status === 302 || error.status === 307 || error.status === 308) return "renamed_or_transferred";
+  if (error.status === 403) return "forbidden";
+  if (error.status >= 500) return "server_error";
+  return "unknown";
 }
 
 function isIssueLookupMissingOrUnreadable(message: string, path: string): boolean {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -131,6 +131,214 @@ describe("GitHub App read authentication", () => {
     expect(result.base.repo.visibility).toBe("private");
   });
 
+  it("probes App installation scope, repo visibility, and pull request read access", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-scope-proof-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+
+    const calls: Array<{ url: string; authorization?: string }> = [];
+    globalThis.fetch = vi.fn(async (url, init) => {
+      const authorization = new Headers(init?.headers).get("authorization") ?? undefined;
+      calls.push({ url: String(url), authorization });
+      if (String(url).endsWith("/repos/owner/repo/installation")) {
+        return jsonResponse({ id: 123 });
+      }
+      if (String(url).endsWith("/app/installations/123/access_tokens")) {
+        return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      }
+      if (String(url).endsWith("/repos/owner/repo")) {
+        return jsonResponse({ full_name: "owner/repo", private: false, visibility: "public" });
+      }
+      if (String(url).endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=1")) {
+        return jsonResponse([pull(1, { private: false, visibility: "public" })]);
+      }
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+    const proof = await github.probeRepositoryAccess("owner/repo");
+
+    expect(proof).toMatchObject({
+      repo_full_name: "owner/repo",
+      readMode: "app_installation",
+      visibility_result: "public",
+      visibility_source: "repository_api",
+      installation_id_present: true,
+      app_can_read_metadata: true,
+      app_can_read_pull_requests: true,
+      openPullCount: 1
+    });
+    expect(calls.find((call) => call.url.endsWith("/repos/owner/repo"))?.authorization).toBe("Bearer installation-token");
+    expect(calls.find((call) => call.url.endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=1"))?.authorization)
+      .toBe("Bearer installation-token");
+  });
+
+  it("classifies App install-scope and visibility lookup failures without treating them as public", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-scope-failures-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+
+    const scenarios: Array<{
+      name: string;
+      handler: (url: string) => Response;
+      expected: Record<string, unknown>;
+    }> = [
+      {
+        name: "missing installation",
+        handler: (url) => url.endsWith("/repos/owner/repo/installation")
+          ? jsonResponse({ message: "Not Found" }, 404, "Not Found")
+          : jsonResponse({ message: "unexpected" }, 404),
+        expected: {
+          installation_id_present: false,
+          app_can_read_metadata: false,
+          app_can_read_pull_requests: false,
+          github_api_status: 404,
+          github_api_error_class: "not_found"
+        }
+      },
+      {
+        name: "suspended installation",
+        handler: (url) => url.endsWith("/repos/owner/repo/installation")
+          ? jsonResponse({ message: "This installation has been suspended" }, 403, "Forbidden")
+          : jsonResponse({ message: "unexpected" }, 404),
+        expected: {
+          installation_id_present: false,
+          github_api_status: 403,
+          github_api_error_class: "suspended_installation"
+        }
+      },
+      {
+        name: "metadata resource inaccessible",
+        handler: installThenTokenThen((url) => url.endsWith("/repos/owner/repo")
+          ? jsonResponse({ message: "Resource not accessible by integration" }, 403, "Forbidden")
+          : jsonResponse({ message: "unexpected" }, 404)),
+        expected: {
+          installation_id_present: true,
+          app_can_read_metadata: false,
+          github_api_status: 403,
+          github_api_error_class: "resource_not_accessible"
+        }
+      },
+      {
+        name: "removed repo metadata",
+        handler: installThenTokenThen((url) => url.endsWith("/repos/owner/repo")
+          ? jsonResponse({ message: "Not Found" }, 404, "Not Found")
+          : jsonResponse({ message: "unexpected" }, 404)),
+        expected: {
+          installation_id_present: true,
+          app_can_read_metadata: false,
+          github_api_status: 404,
+          github_api_error_class: "not_found"
+        }
+      },
+      {
+        name: "renamed or transferred repo metadata",
+        handler: installThenTokenThen((url) => url.endsWith("/repos/owner/repo")
+          ? jsonResponse({ message: "Moved Permanently" }, 301, "Moved Permanently")
+          : jsonResponse({ message: "unexpected" }, 404)),
+        expected: {
+          installation_id_present: true,
+          app_can_read_metadata: false,
+          github_api_status: 301,
+          github_api_error_class: "renamed_or_transferred"
+        }
+      },
+      {
+        name: "rate limited metadata",
+        handler: installThenTokenThen((url) => url.endsWith("/repos/owner/repo")
+          ? jsonResponse({ message: "API rate limit exceeded" }, 403, "Forbidden")
+          : jsonResponse({ message: "unexpected" }, 404)),
+        expected: {
+          installation_id_present: true,
+          app_can_read_metadata: false,
+          github_api_status: 403,
+          github_api_error_class: "rate_limited"
+        }
+      },
+      {
+        name: "missing pull request permission",
+        handler: installThenTokenThen((url) => {
+          if (url.endsWith("/repos/owner/repo")) {
+            return jsonResponse({ full_name: "owner/repo", private: true, visibility: "private" });
+          }
+          if (url.endsWith("/repos/owner/repo/pulls?state=open&per_page=100&page=1")) {
+            return jsonResponse({ message: "Resource not accessible by integration" }, 403, "Forbidden");
+          }
+          return jsonResponse({ message: "unexpected" }, 404);
+        }),
+        expected: {
+          visibility_result: "private",
+          visibility_source: "repository_api",
+          installation_id_present: true,
+          app_can_read_metadata: true,
+          app_can_read_pull_requests: false,
+          github_api_status: 403,
+          github_api_error_class: "resource_not_accessible"
+        }
+      }
+    ];
+
+    for (const scenario of scenarios) {
+      globalThis.fetch = vi.fn(async (url) => scenario.handler(String(url))) as typeof fetch;
+      const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+
+      await expect(github.probeRepositoryAccess("owner/repo")).resolves.toMatchObject({
+        repo_full_name: "owner/repo",
+        visibility_result: scenario.expected.visibility_result ?? "unknown",
+        visibility_source: scenario.expected.visibility_source ?? "unavailable",
+        ...scenario.expected
+      });
+    }
+  });
+
+  it("keeps manual redirects scoped to access probes and reuses installation-specific tokens", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-redirect-scope-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+
+    const calls: Array<{ url: string; method: string; redirect?: RequestRedirect }> = [];
+    globalThis.fetch = vi.fn(async (url, init) => {
+      const requestUrl = String(url);
+      const method = init?.method ?? "GET";
+      const redirect = init?.redirect;
+      calls.push({ url: requestUrl, method, redirect });
+      if (requestUrl.endsWith("/repos/owner/repo/installation")) {
+        return jsonResponse({ id: 123 });
+      }
+      if (requestUrl.endsWith("/app/installations/123/access_tokens")) {
+        return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      }
+      if (requestUrl.endsWith("/repos/owner/repo") && redirect === "manual") {
+        return jsonResponse({ message: "Moved Permanently" }, 301, "Moved Permanently");
+      }
+      if (requestUrl.endsWith("/repos/owner/repo/pulls/42/files?per_page=100&page=1")) {
+        return jsonResponse([{ filename: "src/index.ts", patch: "@@ -1 +1 @@" }]);
+      }
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+    await expect(github.probeRepositoryAccess("owner/repo")).resolves.toMatchObject({
+      visibility_result: "unknown",
+      github_api_status: 301,
+      github_api_error_class: "renamed_or_transferred"
+    });
+    await expect(github.listPullFiles("owner/repo", 42)).resolves.toEqual([{ filename: "src/index.ts", patch: "@@ -1 +1 @@" }]);
+
+    const tokenCalls = calls.filter((call) => call.url.endsWith("/app/installations/123/access_tokens"));
+    expect(tokenCalls).toHaveLength(1);
+    const installationCalls = calls.filter((call) => call.url.endsWith("/repos/owner/repo/installation"));
+    expect(installationCalls).toHaveLength(1);
+    const fileReadCall = calls.find((call) => call.url.endsWith("/repos/owner/repo/pulls/42/files?per_page=100&page=1"));
+    expect(fileReadCall?.redirect).toBeUndefined();
+  });
+
   it("uses installation tokens for related issue reads", async () => {
     const root = mkdtempSync(join(tmpdir(), "github-app-related-issue-"));
     roots.push(root);
@@ -392,6 +600,16 @@ function jsonResponse(body: unknown, status = 200, statusText = ""): Response {
     statusText,
     headers: { "Content-Type": "application/json" }
   });
+}
+
+function installThenTokenThen(handler: (url: string) => Response): (url: string) => Response {
+  return (url: string) => {
+    if (url.endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+    if (url.endsWith("/app/installations/123/access_tokens")) {
+      return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+    }
+    return handler(url);
+  };
 }
 
 function pull(number: number, repo: { private?: boolean; visibility?: "public" | "private" | "internal" } = {}) {

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -636,6 +636,11 @@ exit 1
         response.end(JSON.stringify({ token: installationToken, expires_at: "2099-01-01T00:00:00Z" }));
         return;
       }
+      if (request.method === "GET" && url.pathname === "/repos/acme/demo") {
+        expect(request.headers.authorization).toBe(`Bearer ${installationToken}`);
+        response.end(JSON.stringify({ full_name: "acme/demo", private: false, visibility: "public" }));
+        return;
+      }
       if (request.method === "GET" && url.pathname === "/repos/acme/demo/pulls") {
         expect(request.headers.authorization).toBe(`Bearer ${installationToken}`);
         response.end(JSON.stringify([]));
@@ -711,6 +716,14 @@ exit 1
             {
               repo: "acme/demo",
               ok: true,
+              repo_full_name: "acme/demo",
+              visibility_result: "public",
+              visibility_source: "repository_api",
+              installation_id_present: true,
+              app_can_read_metadata: true,
+              app_can_read_pull_requests: true,
+              license_gate_decision: "public_free_allowed",
+              pre_checkout_gate_result: "allowed",
               openPullCount: 0
             }
           ]
@@ -732,6 +745,153 @@ exit 1
       expect(stdout).not.toContain(privateKeyPem);
       expect(stdout).not.toContain(privateKeyPath);
       expect(stdout).not.toContain(installationToken);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("doctor github blocks pre-checkout when public repo PR permission is missing", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-doctor-github-pr-scope-"));
+    roots.push(root);
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const privateKeyPath = join(root, "neondiff.private-key.pem");
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs8", format: "pem" }).toString());
+
+    const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      response.setHeader("Content-Type", "application/json");
+      if (request.method === "GET" && url.pathname === "/repos/acme/demo/installation") {
+        response.end(JSON.stringify({ id: 42 }));
+        return;
+      }
+      if (request.method === "POST" && url.pathname === "/app/installations/42/access_tokens") {
+        response.end(JSON.stringify({ token: "installation-token", expires_at: "2099-01-01T00:00:00Z" }));
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/repos/acme/demo") {
+        response.end(JSON.stringify({ full_name: "acme/demo", private: false, visibility: "public" }));
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/repos/acme/demo/pulls") {
+        response.statusCode = 403;
+        response.end(JSON.stringify({ message: "Resource not accessible by integration" }));
+        return;
+      }
+      response.statusCode = 404;
+      response.end(JSON.stringify({ message: `unexpected ${request.method} ${url.pathname}` }));
+    });
+
+    await listen(server);
+    try {
+      const address = server.address() as AddressInfo;
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        pilotRepos: ["acme/demo"],
+        workRoot: join(root, "runtime"),
+        statePath: join(root, "state.sqlite"),
+        evidenceDir: join(root, "evidence"),
+        github: {
+          appId: "12345",
+          privateKeyPath,
+          apiBaseUrl: `http://127.0.0.1:${address.port}`
+        },
+        zcode: {
+          cliPath: "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
+          appConfigPath: join(root, "zcode-config.json"),
+          model: "GLM-5.2",
+          timeoutMs: 1000,
+          maxPatchBytes: 1000,
+          retryMaxRetries: 0
+        }
+      })}\n`);
+
+      let stdout = "";
+      try {
+        await runCli(["doctor", "github", "--config", configPath], {
+          env: {
+            EVAOS_REVIEW_BOT_APP_ID: "12345",
+            EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: privateKeyPath
+          }
+        });
+      } catch (error) {
+        stdout = (error as { stdout?: string }).stdout ?? "";
+      }
+      const output = JSON.parse(stdout);
+      expect(output.github.readChecks[0]).toMatchObject({
+        ok: false,
+        visibility_result: "public",
+        app_can_read_metadata: true,
+        app_can_read_pull_requests: false,
+        github_api_error_class: "resource_not_accessible",
+        license_gate_decision: "public_free_allowed",
+        pre_checkout_gate_result: "blocked_before_checkout"
+      });
+      expect(output.github.readChecks[0]).not.toHaveProperty("openPullCount");
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("doctor github does not treat fallback-token reads as App installation proof", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-doctor-github-fallback-token-"));
+    roots.push(root);
+    const fallbackToken = "github-token-secret";
+    const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      response.setHeader("Content-Type", "application/json");
+      if (request.method === "GET" && url.pathname === "/repos/acme/demo/pulls") {
+        expect(request.headers.authorization).toBe(`Bearer ${fallbackToken}`);
+        response.end(JSON.stringify([]));
+        return;
+      }
+      response.statusCode = 404;
+      response.end(JSON.stringify({ message: `unexpected ${request.method} ${url.pathname}` }));
+    });
+
+    await listen(server);
+    try {
+      const address = server.address() as AddressInfo;
+      const configPath = join(root, "config.json");
+      writeFileSync(configPath, `${JSON.stringify({
+        pilotRepos: ["acme/demo"],
+        workRoot: join(root, "runtime"),
+        statePath: join(root, "state.sqlite"),
+        evidenceDir: join(root, "evidence"),
+        github: {
+          apiBaseUrl: `http://127.0.0.1:${address.port}`
+        },
+        zcode: {
+          cliPath: "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
+          appConfigPath: join(root, "zcode-config.json"),
+          model: "GLM-5.2",
+          timeoutMs: 1000,
+          maxPatchBytes: 1000,
+          retryMaxRetries: 0
+        }
+      })}\n`);
+
+      let stdout = "";
+      try {
+        await runCli(["doctor", "github", "--config", configPath], {
+          env: { GITHUB_TOKEN: fallbackToken }
+        });
+      } catch (error) {
+        stdout = (error as { stdout?: string }).stdout ?? "";
+      }
+      const output = JSON.parse(stdout);
+      expect(output.ok).toBe(false);
+      expect(output.github.readMode).toBe("fallback_token");
+      expect(output.github.readChecks[0]).toMatchObject({
+        ok: false,
+        readMode: "fallback_token",
+        visibility_result: "unknown",
+        installation_id_present: false,
+        app_can_read_metadata: false,
+        app_can_read_pull_requests: false,
+        github_api_error_class: "missing_app_credentials",
+        pre_checkout_gate_result: "blocked_before_checkout"
+      });
+      expect(stdout).not.toContain(fallbackToken);
     } finally {
       await closeServer(server);
     }


### PR DESCRIPTION
## Summary
- add structured GitHub App repository access proof for `doctor github`
- report visibility source/result, App installation presence, metadata/PR read ability, and license pre-checkout decision per repo
- classify missing install, suspended install, removed repo, renamed/transferred repo, rate-limit, and permission failures without treating unknown visibility as public

Closes #328.

## Validation
- `NODE_OPTIONS=--experimental-sqlite vitest run tests/github-app-read.test.ts tests/public-cli.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- `node scripts/check-secret-scan.mjs`
- `node scripts/check-public-claims.mjs`

## Runtime
- No live config or launchd changes in this PR.
- Does not touch worker checkout/provider/posting paths.