### PR TITLE
[codex] Prepare NeonDiff 0.4.37 org pricing release

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,7 +9,7 @@ on:
       tag:
         description: Release tag to publish
         required: true
-        default: v0.4.30-beta.1
+        default: v0.4.37-beta.1
 
 permissions:
   contents: read
@@ -76,10 +76,16 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          if npm view "neondiff@$PACKAGE_VERSION" version >/dev/null 2>&1; then
-            echo "neondiff@$PACKAGE_VERSION already exists; verifying dist-tags"
-            test "$(npm view neondiff dist-tags.latest)" = "$PACKAGE_VERSION"
+          ensure_dist_tags() {
+            npm dist-tag add "neondiff@$PACKAGE_VERSION" beta
+            npm dist-tag add "neondiff@$PACKAGE_VERSION" latest
             test "$(npm view neondiff dist-tags.beta)" = "$PACKAGE_VERSION"
+            test "$(npm view neondiff dist-tags.latest)" = "$PACKAGE_VERSION"
+          }
+          if npm view "neondiff@$PACKAGE_VERSION" version >/dev/null 2>&1; then
+            echo "neondiff@$PACKAGE_VERSION already exists; ensuring dist-tags"
+            ensure_dist_tags
             exit 0
           fi
           npm publish --provenance --access public --tag beta
+          ensure_dist_tags

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ with your GitHub installation, your provider keys, your repo policy, and
 public-safe evidence for every live posting decision.
 
 Public open-source repos are free. Private and commercial repos require a paid
-NeonDiff support license: $1/month, $10/year, or $100 lifetime. NeonDiff is a
-source-available beta, not an open-source or GA release.
+NeonDiff support license: $1/month, $10/year, or $100/year for an
+organization. NeonDiff is a source-available beta, not an open-source or GA
+release.
 
 [Website](https://www.neondiff.com) · [Setup](docs/SETUP.md) ·
 [GitHub App Install](docs/github-app-setup.md) · [Contributing](CONTRIBUTING.md) ·
@@ -62,10 +63,10 @@ Requirements:
 - a model/provider path configured locally, such as GLM/Z.ai, Ollama, or a
   future OpenAI-compatible provider slot
 
-Recommended package install for the current beta:
+Recommended package install:
 
 ```bash
-npm install -g neondiff@0.4.30-beta.1
+npm install -g neondiff
 ```
 
 Installer script path:
@@ -75,10 +76,17 @@ curl -fsSL https://www.neondiff.com/install | sh
 ```
 
 The installer script checks for Node.js 26 or newer and installs the same npm
-package. To preview without changing your machine:
+package from npm's current `latest` dist-tag. To preview without changing your
+machine:
 
 ```bash
 curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
+```
+
+For exact release replay, pin the package explicitly:
+
+```bash
+NEONDIFF_VERSION=0.4.37-beta.1 curl -fsSL https://www.neondiff.com/install | sh
 ```
 
 Source checkout fallback:
@@ -225,6 +233,6 @@ For public source-beta release readiness, use
 [docs/public-release-manifest.json](docs/public-release-manifest.json) with
 `neondiff release-status --public-release-manifest docs/public-release-manifest.json --expected-public-version <public-beta-tag>`.
 Replace `<public-beta-tag>` with the actual semver prerelease tag, such as
-`v0.4.30-beta.1`; the CLI rejects literal placeholders. The manifest is the
+`v0.4.37-beta.1`; the CLI rejects literal placeholders. The manifest is the
 compact version/alignment surface for setup docs, release notes, license API
 state, and update-channel readiness.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -16,18 +16,18 @@ for the support-tier pricing contract.
 - optional NeonDiff license key for private or commercial repo use
 
 Public open-source repos are free. Private and commercial repos require a paid
-support license: $1/month, $10/year, or $100 lifetime. Paid support includes
-private repo review, commercial usage, and auto-updates. Provider/model costs
-remain external through your own provider key or local model; NeonDiff does not
-include hosted model credits, unlimited SaaS inference, or bundled provider
-tokens.
+support license: $1/month, $10/year, or $100/year for an organization. Paid
+support includes private repo review, commercial usage, and auto-updates.
+Provider/model costs remain external through your own provider key or local
+model; NeonDiff does not include hosted model credits, unlimited SaaS inference,
+or bundled provider tokens.
 
 ## 1. Install NeonDiff
 
 Recommended package install:
 
 ```bash
-npm install -g neondiff@0.4.30-beta.1
+npm install -g neondiff
 ```
 
 Installer script:
@@ -40,6 +40,12 @@ Preview the installer without changing your machine:
 
 ```bash
 curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
+```
+
+For exact release replay, set `NEONDIFF_VERSION`:
+
+```bash
+NEONDIFF_VERSION=0.4.37-beta.1 curl -fsSL https://www.neondiff.com/install | sh
 ```
 
 Use a temp npm prefix for isolated install proof:

--- a/docs/license-boundary.md
+++ b/docs/license-boundary.md
@@ -12,9 +12,9 @@ proprietary, hosted, marketplace, binary redistribution, and auto-updates requir
 an active paid NeonDiff license.
 
 Public open-source repositories are free. Private and commercial repository
-review requires a paid NeonDiff support license: $1/month, $10/year, or $100
-lifetime. NeonDiff support tiers do not include hosted model credits, unlimited
-SaaS inference, or bundled provider tokens.
+review requires a paid NeonDiff support license: $1/month, $10/year, or
+$100/year for an organization. NeonDiff support tiers do not include hosted
+model credits, unlimited SaaS inference, or bundled provider tokens.
 
 ## Allowed Without A Paid License
 
@@ -52,7 +52,7 @@ Use:
 - "source-available beta"
 - "free for public open-source repositories"
 - "private and commercial repository review requires a paid NeonDiff license"
-- "$1/month, $10/year, or $100 lifetime support license"
+- "$1/month, $10/year, or $100/year organization support license"
 - "bring your own provider key or local model"
 - "local worker; current-head, secret-redacted review evidence"
 
@@ -86,8 +86,8 @@ CLI setup/help copy should say:
 > NeonDiff is source-available beta software. Public open-source repository
 > review is free. Private, internal, and commercial repository review requires
 > an active paid NeonDiff license. Support tiers are $1/month, $10/year, or
-> $100 lifetime; provider/model costs stay external through BYOK or local
-> providers.
+> $100/year for an organization; provider/model costs stay external through
+> BYOK or local providers.
 
 Private-repo failure copy should say:
 

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -15,7 +15,7 @@ credits, unlimited SaaS inference, or bundled provider tokens.
 | Free OSS | $0 | Public open-source projects | No | No | No | Not included |
 | Monthly Support | $1/mo | Low-friction private or commercial use | Yes | Yes | Yes | Not included |
 | Yearly Support | $10/yr | Annual support license | Yes | Yes | Yes | Not included |
-| Lifetime Support | $100 lifetime | One-time support license | Yes | Yes | Yes | Not included |
+| Organization Yearly | $100/yr | Flat organization support license | Yes | Yes | Yes | Not included |
 
 ## CLI Contract
 
@@ -29,7 +29,7 @@ neondiff pricing
 The pricing command emits JSON by default and does not call the network. It reports:
 
 - public open-source repositories are free
-- paid support tiers are `$1/mo`, `$10/yr`, and `$100 lifetime`
+- paid support tiers are `$1/mo`, `$10/yr`, and `$100/yr` for organizations
 - paid support includes private repo review, commercial usage, and auto-updates
 - provider/model costs stay external through BYOK or local providers
 - hosted model credits and unlimited SaaS inference are not included
@@ -42,7 +42,11 @@ usage, and auto-updates:
 
 - `monthly_support`
 - `yearly_support`
-- `lifetime_support`
+- `organization_yearly`
+- `lifetime_support` as legacy read-only compatibility only
+
+Existing legacy lifetime entitlements, if any, remain readable for continuity,
+but lifetime support is no longer an active public sale tier.
 
 Runtime license enforcement is outside this pricing command. This document only
 defines the pricing and entitlement vocabulary that enforcement code and setup
@@ -50,6 +54,7 @@ docs should use.
 
 ## Tracking
 
-- Public product roadmap: https://github.com/electricsheephq/evaos-code-review-bot/issues/103
-- License/commercial boundary gate: https://github.com/electricsheephq/evaos-code-review-bot/issues/104
-- Pricing implementation: https://github.com/electricsheephq/evaos-code-review-bot/issues/105
+- Public product roadmap: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103
+- License/commercial boundary gate: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/104
+- Pricing implementation: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/105
+- Organization entitlement follow-up: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/329

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,12 +1,12 @@
 {
-  "version": "v0.4.30-beta.1",
+  "version": "v0.4.37-beta.1",
   "releaseLevel": "source-beta",
   "packageArtifact": {
     "name": "neondiff",
-    "version": "0.4.30-beta.1",
+    "version": "0.4.37-beta.1",
     "requiredForThisRelease": true,
     "state": "pending_publish_after_merge",
-    "previousReleasedPackageVersion": "0.4.24-beta.1",
+    "previousReleasedPackageVersion": "0.4.30-beta.1",
     "skippedPublicPackageVersions": [
       "v0.4.25-beta.1",
       "v0.4.26-beta.1",
@@ -20,16 +20,16 @@
       "v0.4.35-beta.1",
       "v0.4.36-beta.1"
     ],
-    "note": "v0.4.25 through v0.4.29 and v0.4.31 through v0.4.36 were source/local-worker beta releases; v0.4.30-beta.1 remains the current public npm/site beta."
+    "note": "v0.4.31 through v0.4.36 were source/local-worker beta releases that held the public npm package at 0.4.30-beta.1; v0.4.37-beta.1 is the next public npm/site beta."
   },
   "source": {
     "shaState": "set_after_codeql_hardening_merge",
     "proof": "release:status --expected-head $(git rev-parse HEAD)"
   },
   "docs": {
-    "version": "v0.4.30-beta.1",
+    "version": "v0.4.37-beta.1",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v0.4.30-beta.1.md",
+    "releaseNotesPath": "docs/releases/v0.4.37-beta.1.md",
     "websiteRepo": "electricsheephq/neon-diff-agent"
   },
   "licenseApi": {
@@ -41,19 +41,19 @@
     "cli": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v0.4.30-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.29-beta.1"
+      "version": "v0.4.37-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.36-beta.1"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "launchd_prerelease",
-      "version": "v0.4.30-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.29-beta.1"
+      "version": "v0.4.37-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.36-beta.1"
     },
     "website": {
       "requiredForThisRelease": false,
       "state": "published",
-      "version": "v0.4.30-beta.1",
+      "version": "v0.4.37-beta.1",
       "trackingIssue": "https://github.com/electricsheephq/neon-diff-agent/issues/3"
     },
     "desktop": {

--- a/docs/releases/v0.4.37-beta.1.md
+++ b/docs/releases/v0.4.37-beta.1.md
@@ -1,0 +1,70 @@
+# v0.4.37-beta.1
+
+- Release type: public npm/site pricing and install-alignment beta
+- Release source SHA: to be stamped after merge
+- Previous prerelease: `v0.4.36-beta.1`
+- Previous public npm package: `neondiff@0.4.30-beta.1`
+- Package artifact: `neondiff@0.4.37-beta.1`
+- Tracking issues: `electricsheephq/neon-diff-agent#18`, `#103`, `#326`, `#327`, `#329`
+- Public install path: `npm install -g neondiff`
+- Exact replay path: `NEONDIFF_VERSION=0.4.37-beta.1 curl -fsSL https://www.neondiff.com/install | sh`
+- Evidence path: `/Volumes/LEXAR/Codex/evidence/neondiff-public-product/2026-07-06/site-pricing-comparison-refresh/`
+
+## Purpose
+
+Refresh the public package contract and buyer-facing install/pricing language so
+the website can follow npm dist-tags instead of requiring manual version edits
+for every beta release.
+
+This release replaces the public lifetime sale tier with a flat yearly
+organization tier while preserving legacy lifetime entitlement readability for
+any existing buyers.
+
+`v0.4.36-beta.1` is already used for a source-only release-governance hotfix.
+This public npm/site refresh therefore uses `v0.4.37-beta.1` to keep the beta
+release line unambiguous.
+
+## Included Changes
+
+- Bump the public npm package to `0.4.37-beta.1`.
+- Change the installer default from a pinned beta version to npm `latest`, while
+  keeping `NEONDIFF_VERSION=<version>` for exact release replay.
+- Replace new `lifetime_support` sales with `organization_yearly`; keep
+  `lifetime_support` readable as a legacy entitlement id only.
+- Update pricing, setup, license-boundary, and release-manifest docs to the
+  public pricing shape: free public OSS, $1/month individual, $10/year
+  individual, and $100/year organization.
+- Keep provider/model costs external through BYOK or local providers; no hosted
+  model credits or unlimited SaaS inference are included.
+- Ensure the npm publish workflow sets both `beta` and `latest` dist-tags to the
+  public package version.
+
+## Required Gates
+
+- Focused pricing and public-readiness tests:
+  `npm test -- tests/public-cli.test.ts tests/public-community-funnel.test.ts tests/public-release-readiness.test.ts tests/release-status.test.ts --pool=forks --maxWorkers=1`
+- `npm run build`
+- `node scripts/check-public-claims.mjs`
+- `node scripts/check-secret-scan.mjs`
+- `npm pack --dry-run --json` plus packlist check
+- GitHub Actions `Build, test, and package`
+- `npm view neondiff dist-tags.latest` and `npm view neondiff dist-tags.beta`
+  both return `0.4.37-beta.1` after publish
+- `curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run` shows the
+  `latest` install command after the website publish
+
+## Caveats
+
+- This is a public beta, not GA or enterprise-ready certification.
+- The license boundary remains source-available beta, not open source.
+- Organization yearly is a flat license tier; seats, org allowlists, audit logs,
+  and update rings remain tracked follow-up work under `#329`.
+- This release does not claim CodeRabbit parity or calibrated review accuracy.
+
+## Rollback
+
+```bash
+git fetch origin --tags
+git reset --hard refs/tags/v0.4.36-beta.1
+npm install -g neondiff@0.4.30-beta.1
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neondiff",
-  "version": "0.4.30-beta.1",
+  "version": "0.4.37-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neondiff",
-      "version": "0.4.30-beta.1",
+      "version": "0.4.37-beta.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "neondiff": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neondiff",
-  "version": "0.4.30-beta.1",
+  "version": "0.4.37-beta.1",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
   "bin": {

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -7,13 +7,14 @@ const paths = [
   "docs/providers.md",
   "docs/license-boundary.md",
   "docs/pricing.md",
-  "docs/releases/v0.4.30-beta.1.md"
+  "docs/releases/v0.4.37-beta.1.md"
 ];
 
 const required = [
   /source-available beta/i,
   /public open-source repositor(?:y|ies).*free/i,
-  /private.*commercial.*paid|paid.*private.*commercial/i
+  /private.*commercial.*paid|paid.*private.*commercial/i,
+  /\$100\/year|\$100\/yr/i
 ];
 
 const forbiddenClaims = [

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-NEONDIFF_VERSION="${NEONDIFF_VERSION:-0.4.30-beta.1}"
+NEONDIFF_VERSION="${NEONDIFF_VERSION:-latest}"
 DRY_RUN=0
 NPM_PREFIX="${NPM_PREFIX:-}"
 
@@ -13,7 +13,7 @@ Usage:
   sh install.sh [--dry-run] [--prefix /path/to/prefix]
 
 Environment:
-  NEONDIFF_VERSION  Version to install, defaults to 0.4.30-beta.1.
+  NEONDIFF_VERSION  Version or dist-tag to install, defaults to latest.
   NPM_PREFIX        Optional npm global prefix.
 
 Requires Node.js 26 or newer and npm.

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,18 +1,23 @@
-export type NeonDiffPricingPlanId = "free_oss" | "monthly_support" | "yearly_support" | "lifetime_support";
+export type NeonDiffPricingPlanId =
+  | "free_oss"
+  | "monthly_support"
+  | "yearly_support"
+  | "organization_yearly"
+  | "lifetime_support";
 
 export interface NeonDiffPricingPlan {
   id: NeonDiffPricingPlanId;
   name: string;
   priceUsd: number;
   displayPrice: string;
-  cadence: "public open-source repositories" | "month" | "year" | "lifetime";
+  cadence: "public open-source repositories" | "month" | "year";
   summary: string;
   requiresPaidLicense: boolean;
   repoVisibilityScope: "public" | "private";
   commercialUse: boolean;
   autoUpdates: boolean;
   providerCreditsIncluded: false;
-  entitlementPlan?: "monthly_support" | "yearly_support" | "lifetime_support";
+  entitlementPlan?: "monthly_support" | "yearly_support" | "organization_yearly" | "lifetime_support";
 }
 
 export const NEONDIFF_PRICING_PLANS: readonly NeonDiffPricingPlan[] = [
@@ -58,18 +63,18 @@ export const NEONDIFF_PRICING_PLANS: readonly NeonDiffPricingPlan[] = [
     entitlementPlan: "yearly_support"
   },
   {
-    id: "lifetime_support",
-    name: "Lifetime Support",
+    id: "organization_yearly",
+    name: "Organization Yearly",
     priceUsd: 100,
-    displayPrice: "$100 lifetime",
-    cadence: "lifetime",
-    summary: "Lifetime paid support tier for private repo review, commercial use, and auto-updates.",
+    displayPrice: "$100/yr",
+    cadence: "year",
+    summary: "Flat yearly organization support tier for private repo review, commercial use, and auto-updates.",
     requiresPaidLicense: true,
     repoVisibilityScope: "private",
     commercialUse: true,
     autoUpdates: true,
     providerCreditsIncluded: false,
-    entitlementPlan: "lifetime_support"
+    entitlementPlan: "organization_yearly"
   }
 ] as const;
 
@@ -105,13 +110,15 @@ export function buildPricingOutput() {
         requiresPaidLicense: true,
         commercialUse: true,
         autoUpdates: true,
-        acceptedPlanIds: ["monthly_support", "yearly_support", "lifetime_support"]
+        acceptedPlanIds: ["monthly_support", "yearly_support", "organization_yearly", "lifetime_support"],
+        legacyReadOnlyPlanIds: ["lifetime_support"]
       }
     },
     sourceOfTruth: {
-      roadmap: "https://github.com/electricsheephq/evaos-code-review-bot/issues/103",
-      licenseBoundary: "https://github.com/electricsheephq/evaos-code-review-bot/issues/104",
-      pricingImplementation: "https://github.com/electricsheephq/evaos-code-review-bot/issues/105"
+      roadmap: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103",
+      licenseBoundary: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/104",
+      pricingImplementation: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/105",
+      organizationEntitlements: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/329"
     },
     forbiddenClaims: [
       "hosted model credits included",

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -420,7 +420,8 @@ exit 1
           requiresPaidLicense: true,
           commercialUse: true,
           autoUpdates: true,
-          acceptedPlanIds: ["monthly_support", "yearly_support", "lifetime_support"]
+          acceptedPlanIds: ["monthly_support", "yearly_support", "organization_yearly", "lifetime_support"],
+          legacyReadOnlyPlanIds: ["lifetime_support"]
         }
       }
     });
@@ -448,8 +449,8 @@ exit 1
         providerCreditsIncluded: false
       }),
       expect.objectContaining({
-        id: "lifetime_support",
-        displayPrice: "$100 lifetime",
+        id: "organization_yearly",
+        displayPrice: "$100/yr",
         requiresPaidLicense: true,
         commercialUse: true,
         autoUpdates: true,

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -25,7 +25,7 @@ describe("NeonDiff public community funnel", () => {
       /public open-source repos.*free/i,
       /\$1\/month/i,
       /\$10\/year/i,
-      /\$100 lifetime/i,
+      /\$100\/year/i,
       /private.*commercial.*paid/i,
       /source-available beta/i,
       /GitHub App/i,
@@ -86,7 +86,7 @@ describe("NeonDiff public community funnel", () => {
       expect(text).toMatch(/public open-source/i);
       expect(text).toMatch(/\$1\/mo|\$1\/month/i);
       expect(text).toMatch(/\$10\/yr|\$10\/year/i);
-      expect(text).toMatch(/\$100 lifetime/i);
+      expect(text).toMatch(/\$100\/yr|\$100\/year/i);
       expect(text).toMatch(/private repo review|private.*repo/i);
       expect(text).toMatch(/commercial/i);
       expect(text).toMatch(/auto-updates/i);
@@ -100,7 +100,8 @@ describe("NeonDiff public community funnel", () => {
     expect(pricing).toMatch(/neondiff pricing/i);
     expect(pricing).toMatch(/monthly_support/i);
     expect(pricing).toMatch(/yearly_support/i);
-    expect(pricing).toMatch(/lifetime_support/i);
+    expect(pricing).toMatch(/organization_yearly/i);
+    expect(pricing).toMatch(/legacy lifetime entitlement/i);
     expect(issueTemplate).toMatch(/docs\/pricing\.md/i);
   });
 

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -36,7 +36,7 @@ describe("NeonDiff public release readiness", () => {
     };
 
     expect(pkg.name).toBe("neondiff");
-    expect(pkg.version).toBe("0.4.30-beta.1");
+    expect(pkg.version).toBe("0.4.37-beta.1");
     expect(pkg.private).toBeUndefined();
     expect(pkg.description).toMatch(/local-first AI PR reviewer/i);
     expect(pkg.license).toBe("SEE LICENSE IN LICENSE.md");
@@ -62,21 +62,22 @@ describe("NeonDiff public release readiness", () => {
     ]);
 
     expect(lock.name).toBe("neondiff");
-    expect(lock.version).toBe("0.4.30-beta.1");
+    expect(lock.version).toBe("0.4.37-beta.1");
     expect(lock.packages?.[""]).toMatchObject({
       name: "neondiff",
-      version: "0.4.30-beta.1",
+      version: "0.4.37-beta.1",
       license: "SEE LICENSE IN LICENSE.md",
       bin: { neondiff: "dist/src/cli.js" }
     });
     expect(manifest.packageArtifact).toMatchObject({
       name: "neondiff",
-      version: "0.4.30-beta.1",
+      version: "0.4.37-beta.1",
       requiredForThisRelease: true,
       state: "pending_publish_after_merge",
-      previousReleasedPackageVersion: "0.4.24-beta.1"
+      previousReleasedPackageVersion: "0.4.30-beta.1"
     });
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.29-beta.1");
+    expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.35-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.36-beta.1");
     expect(manifest.packageArtifact?.note).toMatch(/source\/local-worker/i);
   });
@@ -85,7 +86,7 @@ describe("NeonDiff public release readiness", () => {
     expect(existsSync("scripts/install.sh")).toBe(true);
     const script = read("scripts/install.sh");
 
-    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-0\.4\.30-beta\.1\}"/);
+    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-latest\}"/);
     expect(script).toMatch(/npm[^\n]+install[^\n]+-g[^\n]+neondiff@\$\{NEONDIFF_VERSION\}/);
     expect(script).toMatch(/--dry-run/);
     expect(script).toMatch(/Node\.js 26 or newer/);
@@ -99,7 +100,7 @@ describe("NeonDiff public release readiness", () => {
       read("docs/github-app-setup.md"),
       read("docs/providers.md"),
       read("docs/license-boundary.md"),
-      read("docs/releases/v0.4.30-beta.1.md")
+      read("docs/releases/v0.4.37-beta.1.md")
     ].join("\n\n");
     const legacyRepoReferences = docs
       .split(/\s+/)
@@ -110,7 +111,8 @@ describe("NeonDiff public release readiness", () => {
       );
 
     expect(docs).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff");
-    expect(docs).toMatch(/npm install -g neondiff@0\.4\.30-beta\.1/i);
+    expect(docs).toMatch(/npm install -g neondiff/i);
+    expect(docs).toMatch(/NEONDIFF_VERSION=0\.4\.37-beta\.1/i);
     expect(docs).toMatch(/curl -fsSL https:\/\/www\.neondiff\.com\/install/i);
     expect(docs).toContain("git clone https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git");
     expect(legacyRepoReferences).toEqual([]);
@@ -137,6 +139,8 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
     expect(publish).toMatch(/npm publish --provenance/);
     expect(publish).toMatch(/--tag beta/);
+    expect(publish).toMatch(/npm dist-tag add "neondiff@\$PACKAGE_VERSION" beta/);
+    expect(publish).toMatch(/npm dist-tag add "neondiff@\$PACKAGE_VERSION" latest/);
     expect(publish).toMatch(/Classify npm package release/);
     expect(publish).toMatch(/Skipping npm publish for source-only prerelease/);
     expect(publish).toMatch(/Manual npm publish tag .* does not match package\.json version/);
@@ -144,6 +148,6 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/skippedPublicPackageVersions/);
     expect(publish.match(/if: steps\.package_release\.outputs\.should_publish == 'true'/g)).toHaveLength(5);
     expect(publish).toMatch(/require\('\.\/package\.json'\)\.version/);
-    expect(publish).toMatch(/already exists; verifying dist-tags/);
+    expect(publish).toMatch(/already exists; ensuring dist-tags/);
   });
 });

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -193,16 +193,16 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.30-beta.1"
+      expectedVersion: "v0.4.37-beta.1"
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v0.4.30-beta.1",
+      version: "v0.4.37-beta.1",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v0.4.30-beta.1.md"
+        releaseNotesPath: "docs/releases/v0.4.37-beta.1.md"
       },
       updateChannels: {
         ok: true
@@ -213,12 +213,12 @@ describe("beta release status", () => {
         expect.objectContaining({
           name: "cli",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.29-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.36-beta.1"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.29-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.36-beta.1"
         })
       ])
     );
@@ -285,13 +285,13 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v0.4.30-beta.1",
+      expectedPublicVersion: "v0.4.37-beta.1",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot"
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v0.4.30-beta.1"
+      version: "v0.4.37-beta.1"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
@@ -303,7 +303,7 @@ describe("beta release status", () => {
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok
     });
-    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.29-beta.1");
+    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.36-beta.1");
     expect(redactedOutput).toContain("cli=published; daemon=launchd_prerelease");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/111");
   });


### PR DESCRIPTION
## Summary

Prepares the next buyer-facing NeonDiff public npm/site beta as `0.4.37-beta.1`.

`v0.4.36-beta.1` is already a published source-only release-governance hotfix, so this package/site refresh intentionally moved to `v0.4.37-beta.1` instead of rewriting the existing release tag.

## Changes

- Bumps the public npm package metadata to `0.4.37-beta.1`.
- Keeps the installer default on npm `latest`, with `NEONDIFF_VERSION=0.4.37-beta.1` for exact replay.
- Replaces new lifetime sales with `organization_yearly` at `$100/year` while preserving `lifetime_support` as a legacy read-only entitlement id.
- Updates pricing/setup/license/release docs and public release manifest for the buyer-facing beta.
- Updates the npm publish workflow so a successful publish ensures both `beta` and `latest` dist-tags point at the package version.

## Validation

Local validation from `/Volumes/LEXAR/repos/worktrees/neondiff-pricing-org-yearly`:

```text
npm test -- tests/public-cli.test.ts tests/public-community-funnel.test.ts tests/public-release-readiness.test.ts tests/release-status.test.ts --pool=forks --maxWorkers=1
Test Files 4 passed (4)
Tests 133 passed (133)

npm run build
node scripts/check-public-claims.mjs
node scripts/check-secret-scan.mjs
npm pack --dry-run --json + node scripts/check-packlist.mjs
```

All passed locally. Remote CI is expected to rerun on current head `395245e`.

Closes/links: #103, #326, #327, #329, electricsheephq/neon-diff-agent#18.
