### PR TITLE
[codex] Skip npm publish for source-only prereleases

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -26,13 +26,29 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
 
-      - name: Verify release tag matches package version
+      - name: Classify npm package release
+        id: package_release
         run: |
           TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          test "$TAG" = "v$PACKAGE_VERSION"
+          if [ "$TAG" != "v$PACKAGE_VERSION" ]; then
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "::error::Manual npm publish tag $TAG does not match package.json version v$PACKAGE_VERSION"
+              exit 1
+            fi
+            SKIPPED_SOURCE_RELEASE="$(TAG="$TAG" node -e 'const manifest = require("./docs/public-release-manifest.json"); const skippedVersions = manifest.packageArtifact?.skippedPublicPackageVersions ?? []; process.stdout.write(manifest.releaseLevel === "source-beta" && skippedVersions.includes(process.env.TAG) ? "true" : "false");')"
+            if [ "$SKIPPED_SOURCE_RELEASE" = "true" ]; then
+              echo "::notice::Skipping npm publish for source-only prerelease $TAG; package.json remains v$PACKAGE_VERSION"
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::Release tag $TAG does not match package.json version v$PACKAGE_VERSION and is not listed in docs/public-release-manifest.json packageArtifact.skippedPublicPackageVersions"
+            exit 1
+          fi
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
+        if: steps.package_release.outputs.should_publish == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 26
@@ -40,18 +56,22 @@ jobs:
           cache: npm
 
       - name: Install dependencies
+        if: steps.package_release.outputs.should_publish == 'true'
         run: npm ci
 
       - name: Build
+        if: steps.package_release.outputs.should_publish == 'true'
         run: npm run build
 
       - name: Verify package
+        if: steps.package_release.outputs.should_publish == 'true'
         run: |
           npx vitest run tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1
           npm pack --dry-run --json > pack.json
           node scripts/check-packlist.mjs pack.json
 
       - name: Publish or verify existing package
+        if: steps.package_release.outputs.should_publish == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -12,9 +12,14 @@
       "v0.4.26-beta.1",
       "v0.4.27-beta.1",
       "v0.4.28-beta.1",
-      "v0.4.29-beta.1"
+      "v0.4.29-beta.1",
+      "v0.4.31-beta.1",
+      "v0.4.32-beta.1",
+      "v0.4.33-beta.1",
+      "v0.4.34-beta.1",
+      "v0.4.35-beta.1"
     ],
-    "note": "v0.4.25 through v0.4.29 were source/local-worker beta releases; v0.4.29-beta.1 is already tagged as source/daemon-only, so v0.4.30-beta.1 is the next public npm/site beta."
+    "note": "v0.4.25 through v0.4.29 and v0.4.31 through v0.4.35 were source/local-worker beta releases; v0.4.30-beta.1 remains the current public npm/site beta."
   },
   "source": {
     "shaState": "set_after_codeql_hardening_merge",

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -77,7 +77,8 @@ describe("NeonDiff public release readiness", () => {
       previousReleasedPackageVersion: "0.4.24-beta.1"
     });
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.29-beta.1");
-    expect(manifest.packageArtifact?.note).toMatch(/source\/daemon-only/i);
+    expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.35-beta.1");
+    expect(manifest.packageArtifact?.note).toMatch(/source\/local-worker/i);
   });
 
   it("ships the canonical install script contract", () => {
@@ -136,7 +137,12 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
     expect(publish).toMatch(/npm publish --provenance/);
     expect(publish).toMatch(/--tag beta/);
-    expect(publish).toMatch(/Verify release tag matches package version/);
+    expect(publish).toMatch(/Classify npm package release/);
+    expect(publish).toMatch(/Skipping npm publish for source-only prerelease/);
+    expect(publish).toMatch(/Manual npm publish tag .* does not match package\.json version/);
+    expect(publish).toMatch(/docs\/public-release-manifest\.json/);
+    expect(publish).toMatch(/skippedPublicPackageVersions/);
+    expect(publish.match(/if: steps\.package_release\.outputs\.should_publish == 'true'/g)).toHaveLength(5);
     expect(publish).toMatch(/require\('\.\/package\.json'\)\.version/);
     expect(publish).toMatch(/already exists; verifying dist-tags/);
   });


### PR DESCRIPTION
## Summary
- classify release-event prereleases whose tag does not match package.json as source-only and skip npm publish successfully
- keep workflow_dispatch tag/package mismatches as hard failures for explicit manual package publish attempts
- gate install/build/pack/publish steps behind the package-release classifier

Closes #337

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-npm.yml"); puts "yaml ok"'
- git diff --check

## Notes
This fixes the recurring red Publish npm workflow on source-only beta GitHub Releases such as v0.4.35-beta.1, without publishing a new npm package.