### PR TITLE
[codex] Prove repo entitlement gate matrix

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -157,6 +157,26 @@ GitHub review posting unless the cached entitlement is active and covers private
 repos. Public repo review may run without a license when `license.publicReposFree`
 is true.
 
+Use this matrix when reading doctor or review evidence:
+
+| Repo visibility | License state | Provider state | Expected setup result |
+| --- | --- | --- | --- |
+| public | no license | provider present | license allows; provider output decides review success |
+| public | no license | provider absent | license allows; setup/provider check blocks |
+| public with `publicReposFree=false` | no license | provider present | license blocks before checkout/provider/post |
+| public with `publicReposFree=false` | no license | provider absent | license blocks before checkout/provider/post |
+| public with `publicReposFree=false` | active entitlement | provider present | license allows; provider output decides review success |
+| private | no license | provider present | license blocks before checkout/provider/post |
+| private | active private entitlement | provider present | license allows; provider output decides review success |
+| private | expired or revoked entitlement | provider present | license blocks before checkout/provider/post |
+| unknown | any state | provider present | fail closed before checkout/provider/post |
+
+Provider API keys are BYOK model credentials only. They do not unlock private
+repo review and should not be used as proof of a NeonDiff paid entitlement.
+For `review-pr` license blocks, the gate writes its local proof under the
+configured `evidenceDir` as
+`<date>/<owner__repo>/pr-<number>/<head-sha>/license-gate.json`.
+
 The `keychain` backend remains listed for future native macOS storage support,
 but headless CLI activation currently rejects Keychain writes rather than passing
 license keys through `security add-generic-password` process arguments.

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -100,6 +100,15 @@ pre-checkout blocker. Unknown or unreadable visibility is never public-free
 evidence; confirm the App installation scope, selected repositories, and
 permissions before widening provider/model settings.
 
+For public/private entitlement proof, keep the GitHub doctor JSON and the review
+evidence path together. The proof packet should show `visibility_result`,
+`visibility_source`, `license_gate_decision`, and `pre_checkout_gate_result`.
+Public repos with no license may pass this gate, then fail later if no provider
+is configured. Private repos without an active private entitlement, expired or
+revoked entitlements, and unknown visibility must block before checkout,
+provider calls, or GitHub review posting. A provider API key alone is not
+private-repo entitlement evidence.
+
 ## First Review Path
 
 Start with a dry run on a known PR:

--- a/docs/license-boundary.md
+++ b/docs/license-boundary.md
@@ -45,6 +45,29 @@ The default config may keep license enforcement disabled for internal beta
 workers. Public/private product installs should enable license enforcement and
 keep `license.publicReposFree` true when the public free path is intended.
 
+## Review Gate Proof Matrix
+
+The license gate is separate from provider setup. A provider API key or local
+model path can satisfy the model/provider setup gate, but it never grants
+private repository entitlement.
+
+| Repo visibility | NeonDiff entitlement | Provider configured | License gate result | Next blocking layer |
+| --- | --- | --- | --- | --- |
+| public | none | yes | allow | provider output may still fail normally |
+| public | none | no | allow | setup/provider blocked, not license blocked |
+| public with `publicReposFree=false` | none | yes | block before checkout, provider call, or post | license blocked |
+| public with `publicReposFree=false` | none | no | block before checkout, provider call, or post | license blocked |
+| public with `publicReposFree=false` | active public/private entitlement | yes | allow | provider output may still fail normally |
+| private | none | yes | block before checkout, provider call, or post | license blocked |
+| private | active private entitlement | yes | allow | provider output may still fail normally |
+| private | expired or revoked entitlement | yes | block before checkout, provider call, or post | license blocked |
+| unknown | any | yes | fail closed before checkout, provider call, or post | visibility/license blocked |
+
+Evidence should name the command, repo visibility source, license gate result,
+pre-checkout gate result, and redacted evidence path. It must not include raw
+private diffs, provider keys, GitHub App private keys, license keys, or customer
+logs.
+
 ## Product Surface Wording
 
 Use:

--- a/src/license.ts
+++ b/src/license.ts
@@ -313,17 +313,6 @@ function entitlementCoversRepoVisibility(entitlement: LicenseEntitlement, visibi
 
 function statusFromCache(entitlement: LicenseEntitlement | undefined, now: Date): LicenseStatusResult {
   if (!entitlement) return missingResult(now, "no entitlement cache exists");
-  if (!entitlementCurrentlyUsable(entitlement, now)) {
-    return {
-      ok: false,
-      status: "expired",
-      source: "cache",
-      checkedAt: now.toISOString(),
-      entitlement,
-      classification: "expired",
-      detail: `cached entitlement expired at ${entitlement.expiresAt ?? "unknown"}`
-    };
-  }
   if (entitlement.status !== "active") {
     return {
       ok: false,
@@ -333,6 +322,17 @@ function statusFromCache(entitlement: LicenseEntitlement | undefined, now: Date)
       entitlement,
       classification: entitlement.status,
       detail: `cached entitlement status is ${entitlement.status}`
+    };
+  }
+  if (!entitlementCurrentlyUsable(entitlement, now)) {
+    return {
+      ok: false,
+      status: "expired",
+      source: "cache",
+      checkedAt: now.toISOString(),
+      entitlement,
+      classification: "expired",
+      detail: `cached entitlement expired at ${entitlement.expiresAt ?? "unknown"}`
     };
   }
   return {

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -474,6 +474,106 @@ describe("license activation and entitlement cache", () => {
     expect(existsSync(join(root, "entitlement.json"))).toBe(true);
   });
 
+  it("proves public/private repo entitlement outcomes at the license gate", async () => {
+    const now = new Date("2026-07-04T00:00:30.000Z");
+    const rows: Array<{
+      name: string;
+      visibility: "public" | "private" | "unknown";
+      publicReposFree?: boolean;
+      entitlement?: "active-public" | "active-private" | "expired-private" | "revoked-private" | "revoked-expired-private";
+      expected: {
+        ok: boolean;
+        status: string;
+        reason: string | RegExp;
+      };
+    }> = [
+      {
+        name: "public repo, no license",
+        visibility: "public",
+        expected: { ok: true, status: "active", reason: "public repo path is free" }
+      },
+      {
+        name: "public repo, commercial entitlement mode, no license",
+        visibility: "public",
+        publicReposFree: false,
+        expected: { ok: false, status: "missing", reason: /public repo review requires active entitlement/ }
+      },
+      {
+        name: "public repo, commercial entitlement mode, active public entitlement",
+        visibility: "public",
+        publicReposFree: false,
+        entitlement: "active-public",
+        expected: { ok: true, status: "active", reason: "active entitlement covers public repo review" }
+      },
+      {
+        name: "public repo, commercial entitlement mode, active private entitlement",
+        visibility: "public",
+        publicReposFree: false,
+        entitlement: "active-private",
+        expected: { ok: true, status: "active", reason: "active entitlement covers public repo review" }
+      },
+      {
+        name: "private repo, no license",
+        visibility: "private",
+        expected: { ok: false, status: "missing", reason: /private repo review requires active entitlement/ }
+      },
+      {
+        name: "private repo, active private entitlement",
+        visibility: "private",
+        entitlement: "active-private",
+        expected: { ok: true, status: "active", reason: "active entitlement covers private repo review" }
+      },
+      {
+        name: "private repo, expired entitlement",
+        visibility: "private",
+        entitlement: "expired-private",
+        expected: { ok: false, status: "expired", reason: /private repo review requires active entitlement/ }
+      },
+      {
+        name: "private repo, revoked entitlement",
+        visibility: "private",
+        entitlement: "revoked-private",
+        expected: { ok: false, status: "revoked", reason: /private repo review requires active entitlement/ }
+      },
+      {
+        name: "private repo, revoked and expired entitlement",
+        visibility: "private",
+        entitlement: "revoked-expired-private",
+        expected: { ok: false, status: "revoked", reason: /private repo review requires active entitlement/ }
+      },
+      {
+        name: "unknown visibility, active private entitlement",
+        visibility: "unknown",
+        entitlement: "active-private",
+        expected: { ok: false, status: "network", reason: /repo visibility is unknown/ }
+      }
+    ];
+
+    for (const row of rows) {
+      const root = mkRoot(roots);
+      const config = licenseConfig(root, undefined);
+      config.publicReposFree = row.publicReposFree ?? true;
+      if (row.entitlement) writeEntitlementFixture(root, row.entitlement);
+
+      const result = await evaluateLicenseReviewGate({
+        config,
+        repo: `owner/${row.visibility}-matrix`,
+        visibility: row.visibility,
+        now
+      });
+
+      expect(result, row.name).toMatchObject({
+        ok: row.expected.ok,
+        status: row.expected.status
+      });
+      if (typeof row.expected.reason === "string") {
+        expect(result.reason, row.name).toBe(row.expected.reason);
+      } else {
+        expect(result.reason, row.name).toMatch(row.expected.reason);
+      }
+    }
+  });
+
   it("fails private repo review closed without an active private entitlement", async () => {
     const root = mkRoot(roots);
     const config = licenseConfig(root, undefined);
@@ -694,13 +794,39 @@ describe("license activation and entitlement cache", () => {
     expect(statSync(keyPath).mode & 0o777).toBe(0o600);
   });
 
-  it("blocks private repo worker reviews before ZCode or posting when entitlement is missing", async () => {
+  it("blocks provider-configured private repo worker reviews before checkout, provider, or posting when entitlement is missing", async () => {
     const root = mkRoot(roots);
     const state = new ReviewStateStore(join(root, "state.sqlite"));
     const config = minimalConfig(root);
+    config.zcode.providerId = "local-provider";
+    config.providers = {
+      defaultProviderId: "local-provider",
+      providers: {
+        "local-provider": {
+          enabled: true,
+          adapter: "openai-compatible",
+          displayName: "Local provider configured for license-gate ordering proof",
+          baseUrl: "http://127.0.0.1:11434/v1",
+          model: "qwen2.5-coder:7b",
+          authMode: "none",
+          capabilities: {
+            review: true,
+            jsonOutput: true,
+            local: true,
+            streaming: false
+          }
+        }
+      }
+    };
     const pull = pullSummary(7, "private-head");
     const github = new GitHubApi({});
     github.getRepo = async () => ({ full_name: "owner/private", private: true as const, visibility: "private" as const });
+    github.listPullFiles = async () => {
+      throw new Error("license gate should block before checkout/file listing/provider work");
+    };
+    github.createReview = async () => {
+      throw new Error("license gate should block before GitHub review posting");
+    };
 
     const status = await reviewPull({
       config,
@@ -1033,6 +1159,22 @@ function licenseConfig(root: string, apiBaseUrl?: string): LicenseConfig {
     privateReposRequireEntitlement: true,
     updateEntitlementRequiresLicense: true
   };
+}
+
+function writeEntitlementFixture(
+  root: string,
+  fixture: "active-public" | "active-private" | "expired-private" | "revoked-private" | "revoked-expired-private"
+): void {
+  const entitlement = {
+    status: fixture === "revoked-private" || fixture === "revoked-expired-private" ? "revoked" : "active",
+    checkedAt: "2026-07-04T00:00:00.000Z",
+    expiresAt: fixture === "expired-private" || fixture === "revoked-expired-private"
+      ? "2026-07-03T00:00:00.000Z"
+      : "2026-08-01T00:00:00.000Z",
+    repoVisibilityScope: fixture === "active-public" ? "public" : "private",
+    updateEntitlement: true
+  };
+  writeFileSync(join(root, "entitlement.json"), `${JSON.stringify(entitlement)}\n`, { mode: 0o600 });
 }
 
 function writeConfig(path: string, root: string, apiBaseUrl: string): void {


### PR DESCRIPTION
## Summary
- add an explicit public/private/unknown visibility entitlement matrix test for the license review gate
- distinguish public-free repos, commercial public entitlement mode, private entitlement, expired/revoked entitlement, and unknown visibility
- document that provider keys never unlock private repo review and that failures happen before checkout/provider/post

## Validation
- `NODE_OPTIONS="--experimental-sqlite --use-system-ca" npx vitest run tests/license.test.ts --pool=forks --maxWorkers=1`
- `NODE_OPTIONS="--experimental-sqlite --use-system-ca" npm run build`
- `git diff --check`
- `node scripts/check-secret-scan.mjs`
- `node scripts/check-public-claims.mjs`

Closes #326