### PR TITLE
Human-gated calibration promotion + explicit negative controls + category precision floors (#286, Part C)

### DIFF
--- a/src/calibration-aggregate.ts
+++ b/src/calibration-aggregate.ts
@@ -38,13 +38,16 @@ export interface CalibrationAggregate {
  * excluded entirely. The public-confidence floors are EVALUATED and reported but NEVER applied here —
  * this function computes evidence; flipping public display remains a human config edit downstream.
  *
- * negativeControlScenarios is 0 by construction: the label store has no explicit-control concept yet,
- * and none_observed/unvalidated labels are NOT negative controls (that conflation is exactly the bug
- * #296 fixed on the eval path). A principled explicit-control source must be added before this can be
- * non-zero.
+ * negativeControlScenarios counts ONLY explicit_control labels (#286 PR C) — operator-declared,
+ * verifiably-clean runs. none_observed/unvalidated labels are NOT negative controls (that conflation
+ * is exactly the bug #296 fixed on the eval path), so they never count here.
  */
 export function aggregateCalibrationLabels(labels: FindingOutcomeLabelRecord[]): CalibrationAggregate {
-  const validated = labels.filter((label) => label.verdict !== "unvalidated");
+  // Explicit negative controls (#286 PR C) are clean-run markers, NOT findings: they count toward
+  // negativeControlScenarios but never enter the finding-based bins/precision math. Unvalidated
+  // labels earn nothing at all.
+  const negativeControlScenarios = labels.filter((label) => label.labelSource === "explicit_control").length;
+  const validated = labels.filter((label) => label.verdict !== "unvalidated" && label.labelSource !== "explicit_control");
   const findings = validated.map((label) => ({ id: label.fingerprint, confidence: label.confidence }));
   const matches = validated
     .filter((label) => label.verdict === "true_positive")
@@ -54,7 +57,6 @@ export function aggregateCalibrationLabels(labels: FindingOutcomeLabelRecord[]):
   const bestWilsonLowerBound = bins.reduce((max, bin) => Math.max(max, bin.rawWilsonLowerBound), 0);
   const labeledFindings = validated.length;
   const p0p1Labels = validated.filter((label) => label.severity === "P0" || label.severity === "P1").length;
-  const negativeControlScenarios = 0;
 
   const categoryPrecision = computeCategoryPrecision(validated);
   const thresholds: CalibrationAggregateThresholds = {

--- a/src/calibration-promote.ts
+++ b/src/calibration-promote.ts
@@ -1,0 +1,132 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { buildPublicConfidencePolicy } from "./public-confidence.js";
+import { redactSecrets } from "./secrets.js";
+
+export interface AggregateCalibrationInput {
+  labeledFindings: number;
+  p0p1Labels: number;
+  negativeControlScenarios: number;
+  bestWilsonLowerBound: number;
+}
+
+export interface CalibrationPromotionGate {
+  eligible: boolean;
+  failingGate?: string;
+  numbers: {
+    labeledFindings: number;
+    p0p1Labels: number;
+    negativeControlScenarios: number;
+    wilsonLowerBound: number;
+  };
+}
+
+/**
+ * Evaluate aggregate calibration evidence against the public-confidence HARD floors (#286 PR C). This
+ * is the SAME floor source (buildPublicConfidencePolicy) the live gate uses. Returns the failing gate
+ * by name when below threshold. It NEVER decides display mode — that stays a human edit.
+ */
+export function evaluateCalibrationPromotion(aggregate: AggregateCalibrationInput): CalibrationPromotionGate {
+  const floors = buildPublicConfidencePolicy();
+  const numbers = {
+    labeledFindings: aggregate.labeledFindings,
+    p0p1Labels: aggregate.p0p1Labels,
+    negativeControlScenarios: aggregate.negativeControlScenarios,
+    wilsonLowerBound: aggregate.bestWilsonLowerBound
+  };
+  if (numbers.labeledFindings < floors.minLabeledFindings) return { eligible: false, failingGate: "min_labeled_findings", numbers };
+  if (numbers.p0p1Labels < floors.minP0P1Labels) return { eligible: false, failingGate: "min_p0_p1_labels", numbers };
+  if (numbers.negativeControlScenarios < floors.minNegativeControlScenarios) {
+    return { eligible: false, failingGate: "min_negative_control_scenarios", numbers };
+  }
+  if (numbers.wilsonLowerBound < floors.minWilsonLowerBound) return { eligible: false, failingGate: "min_wilson_lower_bound", numbers };
+  return { eligible: true, numbers };
+}
+
+export interface CalibrationPromotionResult {
+  ok: boolean;
+  eligible: boolean;
+  failingGate?: string;
+  mode: "patch" | "apply";
+  outputPath?: string;
+  numbers: CalibrationPromotionGate["numbers"];
+  note: string;
+}
+
+const MODE_NOTE =
+  "This writes the calibration evidence NUMBERS only. Flipping confidenceCalibration.publicDisplay.mode to \"calibrated\" remains a MANUAL human edit — this tool never sets mode.";
+
+/**
+ * Promote aggregate calibration evidence (#286 PR C). REQUIRES an explicit confirm. Below-threshold
+ * evidence is refused with the failing gate named — nothing is written. On eligible evidence:
+ *  - default (apply=false): write a config PATCH FILE (redacted) the operator applies by hand;
+ *  - apply=true: additionally REQUIRES iUnderstandLiveConfig (double flag) and writes the same patch
+ *    shape to the apply path, but STILL never sets publicDisplay.mode — the calibrated flip stays
+ *    a deliberate human edit, stated loudly in the output.
+ */
+export function runCalibrationPromotion(input: {
+  aggregatePath: string;
+  outputDir: string;
+  confirm: boolean;
+  apply?: boolean;
+  iUnderstandLiveConfig?: boolean;
+  now?: Date;
+}): CalibrationPromotionResult {
+  if (!input.confirm) throw new Error("calibration-promote requires --confirm to acknowledge it writes calibration evidence");
+  const apply = input.apply === true;
+  if (apply && input.iUnderstandLiveConfig !== true) {
+    throw new Error("calibration-promote --apply additionally requires --i-understand-live-config (double confirmation)");
+  }
+
+  const aggregate = readAggregate(input.aggregatePath);
+  const gate = evaluateCalibrationPromotion(aggregate);
+  if (!gate.eligible) {
+    throw new Error(`calibration-promote refuses below-threshold evidence: failing gate ${gate.failingGate}`);
+  }
+
+  // The patch NEVER carries mode: setting it "calibrated" is a manual human edit.
+  const patch = {
+    confidenceCalibration: {
+      publicDisplay: {
+        labeledFindings: gate.numbers.labeledFindings,
+        p0p1Labels: gate.numbers.p0p1Labels,
+        negativeControlScenarios: gate.numbers.negativeControlScenarios,
+        wilsonLowerBound: gate.numbers.wilsonLowerBound
+      }
+    },
+    _note: MODE_NOTE
+  };
+
+  mkdirSync(input.outputDir, { recursive: true });
+  const fileName = apply ? "calibration-config-apply-patch.json" : "calibration-config-patch.json";
+  const outputPath = join(input.outputDir, fileName);
+  writeRedactedJson(outputPath, patch);
+
+  return {
+    ok: true,
+    eligible: true,
+    mode: apply ? "apply" : "patch",
+    outputPath,
+    numbers: gate.numbers,
+    note: MODE_NOTE
+  };
+}
+
+function readAggregate(path: string): AggregateCalibrationInput {
+  const value = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+  return {
+    labeledFindings: requireNumber(value.labeledFindings, "labeledFindings"),
+    p0p1Labels: requireNumber(value.p0p1Labels, "p0p1Labels"),
+    negativeControlScenarios: requireNumber(value.negativeControlScenarios, "negativeControlScenarios"),
+    bestWilsonLowerBound: requireNumber(value.bestWilsonLowerBound, "bestWilsonLowerBound")
+  };
+}
+
+function requireNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`aggregate-calibration.${label} must be a number`);
+  return value;
+}
+
+function writeRedactedJson(path: string, value: unknown): void {
+  writeFileSync(path, `${redactSecrets(JSON.stringify(value, null, 2))}\n`);
+}

--- a/src/calibration-promote.ts
+++ b/src/calibration-promote.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { buildPublicConfidencePolicy } from "./public-confidence.js";
+import { buildPublicConfidencePolicy, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import { redactSecrets } from "./secrets.js";
 
 export interface AggregateCalibrationInput {
@@ -22,12 +22,18 @@ export interface CalibrationPromotionGate {
 }
 
 /**
- * Evaluate aggregate calibration evidence against the public-confidence HARD floors (#286 PR C). This
- * is the SAME floor source (buildPublicConfidencePolicy) the live gate uses. Returns the failing gate
- * by name when below threshold. It NEVER decides display mode — that stays a human edit.
+ * Evaluate aggregate calibration evidence against the public-confidence floors (#286 PR C). Uses the
+ * SAME floor source (buildPublicConfidencePolicy) the live gate uses, which applies Math.max(hard,
+ * configured): when the operator's publicDisplay policy is supplied, its RAISED minimums govern so
+ * promote never declares numbers eligible that the live config validation would fail-closed reject.
+ * Without an override it evaluates against the hard floors. Returns the failing gate by name when
+ * below threshold. It NEVER decides display mode — that stays a human edit.
  */
-export function evaluateCalibrationPromotion(aggregate: AggregateCalibrationInput): CalibrationPromotionGate {
-  const floors = buildPublicConfidencePolicy();
+export function evaluateCalibrationPromotion(
+  aggregate: AggregateCalibrationInput,
+  policyOverride?: Partial<PublicConfidenceDisplayPolicy>
+): CalibrationPromotionGate {
+  const floors = buildPublicConfidencePolicy(policyOverride);
   const numbers = {
     labeledFindings: aggregate.labeledFindings,
     p0p1Labels: aggregate.p0p1Labels,
@@ -70,6 +76,7 @@ export function runCalibrationPromotion(input: {
   confirm: boolean;
   apply?: boolean;
   iUnderstandLiveConfig?: boolean;
+  policyOverride?: Partial<PublicConfidenceDisplayPolicy>;
   now?: Date;
 }): CalibrationPromotionResult {
   if (!input.confirm) throw new Error("calibration-promote requires --confirm to acknowledge it writes calibration evidence");
@@ -79,7 +86,7 @@ export function runCalibrationPromotion(input: {
   }
 
   const aggregate = readAggregate(input.aggregatePath);
-  const gate = evaluateCalibrationPromotion(aggregate);
+  const gate = evaluateCalibrationPromotion(aggregate, input.policyOverride);
   if (!gate.eligible) {
     throw new Error(`calibration-promote refuses below-threshold evidence: failing gate ${gate.failingGate}`);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1581,6 +1581,11 @@ async function main(): Promise<void> {
     // publicDisplay.mode — flipping to "calibrated" stays a deliberate manual human edit.
     const outputDir = parseSingleArg(args["output-dir"], "--output-dir");
     assertEvalOutputDirSafe(outputDir);
+    // When --config is supplied, gate against the operator's EFFECTIVE floors (Math.max(hard,
+    // configured)) so promote can't declare numbers eligible that the live config would reject.
+    const policyOverride = args.config
+      ? loadConfig(parseSingleArg(args.config, "--config")).confidenceCalibration?.publicDisplay
+      : undefined;
     const result = runCalibrationPromotion({
       aggregatePath: parseSingleArg(args.input, "--input"),
       outputDir,
@@ -1588,7 +1593,8 @@ async function main(): Promise<void> {
       apply: args.apply === undefined ? false : parseBooleanArg(args.apply, "--apply"),
       iUnderstandLiveConfig: args["i-understand-live-config"] === undefined
         ? false
-        : parseBooleanArg(args["i-understand-live-config"], "--i-understand-live-config")
+        : parseBooleanArg(args["i-understand-live-config"], "--i-understand-live-config"),
+      ...(policyOverride ? { policyOverride } : {})
     });
     console.log(stringifyRedactedJson({ command: "calibration-promote", ...result }));
     if (!result.ok) process.exitCode = 1;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,8 +98,9 @@ import {
   type ReviewQueueJobRecord,
   type ReviewQueueJobState
 } from "./state.js";
-import { readOutcomeObserverInput, runOutcomeObserverFromInput } from "./outcome-observer.js";
+import { readOutcomeObserverInput, recordNegativeControlLabels, runOutcomeObserverFromInput } from "./outcome-observer.js";
 import { writeCalibrationAggregatePacket } from "./calibration-aggregate.js";
+import { runCalibrationPromotion } from "./calibration-promote.js";
 import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "./validation-selector.js";
 import { isSuccessfulRetryStatus, retryFailedHead, retryProviderCooldowns } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
@@ -1511,12 +1512,23 @@ async function main(): Promise<void> {
     }
     // Dry-run-first (#286 PR A): default reads-and-reports without persisting labels.
     const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
+    const markNegativeControl = args["mark-negative-control"] === undefined
+      ? false
+      : parseBooleanArg(args["mark-negative-control"], "--mark-negative-control");
     const config = loadConfig(args.config ? parseSingleArg(args.config, "--config") : undefined);
     const outputDir = parseSingleArg(args["output-dir"], "--output-dir");
     assertEvalOutputDirSafe(outputDir);
     const entries = readOutcomeObserverInput(parseSingleArg(args.input, "--input"));
     const store = new ReviewStateStore(config.statePath);
     try {
+      if (markNegativeControl) {
+        // Explicit negative control (#286 PR C): a WRITE, so it requires --dry-run false. Refuses any
+        // run that posted findings (recordNegativeControlLabels enforces the clean-run precondition).
+        if (dryRun) throw new Error("outcome-observe --mark-negative-control requires --dry-run false because it records explicit_control labels");
+        const result = recordNegativeControlLabels({ store, reviews: entries.map((entry) => entry.review) });
+        console.log(stringifyRedactedJson({ command: "outcome-observe", mode: "mark-negative-control", dryRun, outputDir, ok: true, recorded: result.recorded }));
+        return;
+      }
       const result = runOutcomeObserverFromInput({ store, entries, evidenceDir: outputDir, dryRun });
       console.log(stringifyRedactedJson({ command: "outcome-observe", dryRun, outputDir, ...result }));
       if (!result.ok) process.exitCode = 1;
@@ -1554,6 +1566,32 @@ async function main(): Promise<void> {
     } finally {
       store.close();
     }
+    return;
+  }
+
+  if (command === "calibration-promote") {
+    if (args.input === undefined || (Array.isArray(args.input) && args.input.length === 0)) {
+      throw new Error("--input is required for calibration-promote (the aggregate-calibration.json)");
+    }
+    if (args["output-dir"] === undefined || (Array.isArray(args["output-dir"]) && args["output-dir"].length === 0)) {
+      throw new Error("--output-dir is required for calibration-promote");
+    }
+    // Human-gated (#286 PR C): requires --confirm; default writes a config PATCH FILE the operator
+    // applies by hand. --apply additionally requires --i-understand-live-config. It NEVER sets
+    // publicDisplay.mode — flipping to "calibrated" stays a deliberate manual human edit.
+    const outputDir = parseSingleArg(args["output-dir"], "--output-dir");
+    assertEvalOutputDirSafe(outputDir);
+    const result = runCalibrationPromotion({
+      aggregatePath: parseSingleArg(args.input, "--input"),
+      outputDir,
+      confirm: args.confirm === undefined ? false : parseBooleanArg(args.confirm, "--confirm"),
+      apply: args.apply === undefined ? false : parseBooleanArg(args.apply, "--apply"),
+      iUnderstandLiveConfig: args["i-understand-live-config"] === undefined
+        ? false
+        : parseBooleanArg(args["i-understand-live-config"], "--i-understand-live-config")
+    });
+    console.log(stringifyRedactedJson({ command: "calibration-promote", ...result }));
+    if (!result.ok) process.exitCode = 1;
     return;
   }
 
@@ -2831,7 +2869,8 @@ function buildHelp(command?: string) {
         "outcome-ledger",
         "outcome-scorecard",
         "outcome-observe",
-        "calibration-aggregate"
+        "calibration-aggregate",
+        "calibration-promote"
       ]
     },
     examples: [
@@ -2884,6 +2923,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts outcome-scorecard --input /path/to/outcome-scorecard-input.json --dry-run true --output-dir /path/to/evidence/outcome-scorecard-run",
       "npx tsx src/cli.ts outcome-observe --config /path/to/live.json --input /path/to/outcome-observer-input.json --dry-run true --output-dir /path/to/evidence/outcome-observe-run",
       "npx tsx src/cli.ts calibration-aggregate --config /path/to/live.json --output-dir /path/to/evidence/calibration-aggregate-run",
+      "npx tsx src/cli.ts calibration-promote --input /path/to/evidence/calibration-aggregate-run/aggregate-calibration.json --output-dir /path/to/evidence/calibration-promote-run --confirm true",
       "npx tsx src/cli.ts finishing-touch-dry-run --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD --current-head HEAD --comment-id 456 --author maintainer --trusted-authors maintainer --body '@evaos-code-review-bot explain risk'",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ],

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ import {
   type PublicConfidenceDisplayPolicy
 } from "./public-confidence.js";
 import { isApiKeyEnvName, isProviderId, type ProviderRegistryConfig } from "./providers.js";
-import type { RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
+import { REGRESSION_CATEGORIES, type CategoryPrecisionFloors, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import { containsSecretLikeText } from "./secrets.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
 
@@ -200,6 +200,10 @@ export interface ReviewGateConfig {
   retryDegradedConfidencePenalty?: number;
   /** Opt-in P0/P1 self-consistency re-check (#303, default off). Owner-approved; adds provider cost. */
   selfConsistency?: SelfConsistencyConfig;
+  /** Optional per-category precision floors (#286 PR C, default off). Operator-curated from the
+   * aggregate calibration report: a listed category loses REQUEST_CHANGES eligibility (quieter-only).
+   * Values come from the aggregate via the operator; nothing reads the aggregate at review time. */
+  categoryPrecisionFloors?: CategoryPrecisionFloors;
 }
 
 export interface SelfConsistencyConfig {
@@ -702,6 +706,17 @@ function validateReviewGateConfig(value: unknown, label: string): void {
   }
   if (value.retryDegradedConfidencePenalty !== undefined) {
     validateProbability(value.retryDegradedConfidencePenalty, `${label}.retryDegradedConfidencePenalty`);
+  }
+  if (value.categoryPrecisionFloors !== undefined) {
+    if (!isRecord(value.categoryPrecisionFloors)) {
+      throw new Error(`${label}.categoryPrecisionFloors must be an object`);
+    }
+    for (const [category, floor] of Object.entries(value.categoryPrecisionFloors)) {
+      if (!(REGRESSION_CATEGORIES as string[]).includes(category)) {
+        throw new Error(`${label}.categoryPrecisionFloors has unknown category "${category}"`);
+      }
+      validateProbability(floor, `${label}.categoryPrecisionFloors.${category}`);
+    }
   }
   if (value.selfConsistency !== undefined) validateSelfConsistencyConfig(value.selfConsistency, `${label}.selfConsistency`);
 }

--- a/src/findings.ts
+++ b/src/findings.ts
@@ -1,5 +1,5 @@
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
-import { categoryLabel, isRegressionCategory, isRequestChangesEligible, normalizeFindingCategory, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
+import { categoryLabel, isRegressionCategory, isRequestChangesEligible, normalizeFindingCategory, type CategoryPrecisionFloors, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import { sanitizePublicConfidenceText, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import type { DroppedFinding, Finding, ReviewComment, ReviewEvent, Severity } from "./types.js";
 
@@ -236,9 +236,12 @@ export function sanitizeDroppedFinding<T extends Partial<Finding>>(finding: T, p
 
 export function decideReviewEvent(
   findings: Pick<ReviewComment, "severity" | "category" | "confidence">[],
-  confidenceFloors?: RequestChangesConfidenceFloors
+  confidenceFloors?: RequestChangesConfidenceFloors,
+  categoryPrecisionFloors?: CategoryPrecisionFloors
 ): ReviewEvent {
-  return findings.some((finding) => isRequestChangesEligible(finding, confidenceFloors)) ? "REQUEST_CHANGES" : "COMMENT";
+  return findings.some((finding) => isRequestChangesEligible(finding, confidenceFloors, categoryPrecisionFloors))
+    ? "REQUEST_CHANGES"
+    : "COMMENT";
 }
 
 export function formatReviewComment(

--- a/src/outcome-observer.ts
+++ b/src/outcome-observer.ts
@@ -194,26 +194,29 @@ export function recordNegativeControlLabels(input: {
     }
   }
   const observedAt = (input.now ?? new Date()).toISOString();
-  let recorded = 0;
-  for (const review of input.reviews) {
-    input.store.recordFindingOutcomeLabel({
-      fingerprint: negativeControlFingerprint(review),
-      repo: review.repo,
-      pullNumber: review.pullNumber,
-      headSha: review.headSha,
-      severity: "P3",
-      category: "unknown",
-      confidence: 0,
-      labelSource: "explicit_control",
-      verdict: "unvalidated",
-      observedAt,
-      evidenceRef: "operator-declared negative control (zero findings posted)"
-    });
-    recorded += 1;
-  }
-  return { recorded };
+  const records: FindingOutcomeLabelRecord[] = input.reviews.map((review) => ({
+    fingerprint: negativeControlFingerprint(review),
+    repo: review.repo,
+    pullNumber: review.pullNumber,
+    headSha: review.headSha,
+    severity: "P3",
+    category: "unknown",
+    confidence: 0,
+    labelSource: "explicit_control",
+    verdict: "unvalidated",
+    observedAt,
+    evidenceRef: "operator-declared negative control (zero findings posted)"
+  }));
+  // Atomic: a mid-batch write failure leaves zero explicit_control rows, never a partial mark.
+  input.store.recordFindingOutcomeLabels(records);
+  return { recorded: records.length };
 }
 
+// SYNTHETIC control marker (#286 PR C) — never treat as a finding. Consumers must branch on
+// label_source === "explicit_control" FIRST (calibration-aggregate does: it counts these toward
+// negative controls and excludes them from the finding bins/precision). The fingerprint is derived
+// from the review coordinates (a clean run has no finding fingerprint) so re-marking is idempotent;
+// it must never be joined back as a real finding, whose category "unknown" would be RC-eligible.
 function negativeControlFingerprint(review: OutcomeObserverReview): string {
   const canonical = JSON.stringify({ control: "explicit", repo: review.repo, pullNumber: review.pullNumber, headSha: review.headSha });
   return `finding:${createHash("sha256").update(canonical).digest("hex")}`;

--- a/src/outcome-observer.ts
+++ b/src/outcome-observer.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { redactSecrets } from "./secrets.js";
@@ -171,6 +172,51 @@ export function runOutcomeObserver(input: {
   writeFileSync(join(input.evidenceDir, "outcome-observer.json"), `${redactSecrets(JSON.stringify(packet, null, 2))}\n`);
 
   return { ok: true, observed: input.reviews.length, skipped, labeled, observations };
+}
+
+/**
+ * Record an explicit negative-control label for each supplied review (#286 PR C, --mark-negative-
+ * control). A negative control is EXPLICIT + verifiably CLEAN: it is recorded only for a review that
+ * posted ZERO findings. Any review that posted findings is refused with a clear error — mirroring the
+ * #296 rule that an empty/quiet run is never a negative control by itself. The control marker uses a
+ * deterministic synthetic fingerprint over the review coordinates so re-marking is idempotent.
+ */
+export function recordNegativeControlLabels(input: {
+  store: ReviewStateStore;
+  reviews: OutcomeObserverReview[];
+  now?: Date;
+}): { recorded: number } {
+  for (const review of input.reviews) {
+    if (review.findings.length > 0) {
+      throw new Error(
+        `Refusing to mark ${review.repo}#${review.pullNumber}@${review.headSha} as a negative control: it posted findings. Explicit negative controls require a verifiably clean (zero-finding) run.`
+      );
+    }
+  }
+  const observedAt = (input.now ?? new Date()).toISOString();
+  let recorded = 0;
+  for (const review of input.reviews) {
+    input.store.recordFindingOutcomeLabel({
+      fingerprint: negativeControlFingerprint(review),
+      repo: review.repo,
+      pullNumber: review.pullNumber,
+      headSha: review.headSha,
+      severity: "P3",
+      category: "unknown",
+      confidence: 0,
+      labelSource: "explicit_control",
+      verdict: "unvalidated",
+      observedAt,
+      evidenceRef: "operator-declared negative control (zero findings posted)"
+    });
+    recorded += 1;
+  }
+  return { recorded };
+}
+
+function negativeControlFingerprint(review: OutcomeObserverReview): string {
+  const canonical = JSON.stringify({ control: "explicit", repo: review.repo, pullNumber: review.pullNumber, headSha: review.headSha });
+  return `finding:${createHash("sha256").update(canonical).digest("hex")}`;
 }
 
 interface OutcomeObserverInputEntry {

--- a/src/regression-taxonomy.ts
+++ b/src/regression-taxonomy.ts
@@ -53,8 +53,10 @@ export interface RequestChangesConfidenceFloors {
   P1?: number;
 }
 
-/** Optional per-category precision floors (#286 PR C). A category present here has been marked
- * below-floor by the operator (from the aggregate calibration report) and loses eligibility. */
+/** Optional per-category confidence floors (#286 PR C), operator-curated from the aggregate
+ * calibration report. A finding in a listed category loses REQUEST_CHANGES eligibility when its
+ * confidence is BELOW the category's floor (value 0..1). The value is load-bearing: {cat: 0} never
+ * demotes, {cat: 1} demotes everything below confidence 1.0. Quieter-only — it can only demote. */
 export type CategoryPrecisionFloors = Partial<Record<RegressionCategory, number>>;
 
 export function isRequestChangesEligible(
@@ -65,10 +67,13 @@ export function isRequestChangesEligible(
   if (!isHighSeverity(input.severity) || !REGRESSION_CATEGORY_POLICY[input.category].requestChangesEligible) {
     return false;
   }
-  // Category precision floor (#286 PR C, quieter-only): a category the operator configured below its
-  // floor loses REQUEST_CHANGES eligibility. The finding still POSTS as a comment; only the event is
-  // demoted. Values are operator-curated from the aggregate report — nothing is read at review time.
-  if (categoryPrecisionFloors && typeof categoryPrecisionFloors[input.category] === "number") return false;
+  // Category precision floor (#286 PR C, quieter-only): a finding whose category is configured with a
+  // floor loses REQUEST_CHANGES eligibility only when its confidence is BELOW that floor. The value is
+  // load-bearing ({cat: 0} never demotes, {cat: 1} demotes everything below 1.0). The finding still
+  // POSTS as a comment; only the event is demoted. Floors are operator-curated from the aggregate
+  // report — nothing is read at review time.
+  const categoryFloor = categoryPrecisionFloors?.[input.category];
+  if (typeof categoryFloor === "number" && input.confidence < categoryFloor) return false;
   const floor = confidenceFloors?.[input.severity as "P0" | "P1"];
   // A configured floor may only make the gate quieter: below-floor findings stop counting toward
   // REQUEST_CHANGES but still post as comments. When unset, behavior is byte-identical to before.

--- a/src/regression-taxonomy.ts
+++ b/src/regression-taxonomy.ts
@@ -53,13 +53,22 @@ export interface RequestChangesConfidenceFloors {
   P1?: number;
 }
 
+/** Optional per-category precision floors (#286 PR C). A category present here has been marked
+ * below-floor by the operator (from the aggregate calibration report) and loses eligibility. */
+export type CategoryPrecisionFloors = Partial<Record<RegressionCategory, number>>;
+
 export function isRequestChangesEligible(
   input: Pick<ReviewComment, "severity" | "category" | "confidence">,
-  confidenceFloors?: RequestChangesConfidenceFloors
+  confidenceFloors?: RequestChangesConfidenceFloors,
+  categoryPrecisionFloors?: CategoryPrecisionFloors
 ): boolean {
   if (!isHighSeverity(input.severity) || !REGRESSION_CATEGORY_POLICY[input.category].requestChangesEligible) {
     return false;
   }
+  // Category precision floor (#286 PR C, quieter-only): a category the operator configured below its
+  // floor loses REQUEST_CHANGES eligibility. The finding still POSTS as a comment; only the event is
+  // demoted. Values are operator-curated from the aggregate report — nothing is read at review time.
+  if (categoryPrecisionFloors && typeof categoryPrecisionFloors[input.category] === "number") return false;
   const floor = confidenceFloors?.[input.severity as "P0" | "P1"];
   // A configured floor may only make the gate quieter: below-floor findings stop counting toward
   // REQUEST_CHANGES but still post as comments. When unset, behavior is byte-identical to before.

--- a/src/review-gate.ts
+++ b/src/review-gate.ts
@@ -9,7 +9,7 @@ import {
   titlesAreNearDuplicate
 } from "./findings.js";
 import type { PublicConfidenceDisplayPolicy } from "./public-confidence.js";
-import { countCategories, isRequestChangesEligible, normalizeFindingCategory, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
+import { countCategories, isRequestChangesEligible, normalizeFindingCategory, type CategoryPrecisionFloors, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import type {
   DeterministicReviewGateSummary,
   DroppedFinding,
@@ -51,6 +51,7 @@ export function applyDeterministicReviewGate(input: {
   repoMemoryFalsePositives?: RepoMemoryFalsePositiveEntry[];
   publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
   requestChangesConfidenceFloors?: RequestChangesConfidenceFloors;
+  categoryPrecisionFloors?: CategoryPrecisionFloors;
 }): DeterministicReviewGateResult {
   const located = validateFindingLocations(input.findings, input.files);
   // Memory suppression intentionally precedes normalization; dropReasonCounts reflects that ordering.
@@ -75,7 +76,7 @@ export function applyDeterministicReviewGate(input: {
     ...normalized.dropped
   ].map((finding) => sanitizeDroppedFinding(finding, input.publicConfidencePolicy));
   const comments = normalized.comments;
-  const event = decideReviewEvent(comments, input.requestChangesConfidenceFloors);
+  const event = decideReviewEvent(comments, input.requestChangesConfidenceFloors, input.categoryPrecisionFloors);
 
   return {
     event,
@@ -86,7 +87,7 @@ export function applyDeterministicReviewGate(input: {
       acceptedComments: comments.length,
       droppedFindings: dropped.length,
       event,
-      requestChangesEligible: comments.filter((comment) => isRequestChangesEligible(comment, input.requestChangesConfidenceFloors)).length,
+      requestChangesEligible: comments.filter((comment) => isRequestChangesEligible(comment, input.requestChangesConfidenceFloors, input.categoryPrecisionFloors)).length,
       categoryCounts: countCategories(comments),
       dropReasonCounts: countDropReasons(dropped)
     }

--- a/src/self-consistency.ts
+++ b/src/self-consistency.ts
@@ -1,5 +1,5 @@
 import { decideReviewEvent } from "./findings.js";
-import { isRequestChangesEligible, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
+import { isRequestChangesEligible, type CategoryPrecisionFloors, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import type { PullFilePatch, ReviewComment, ReviewEvent, Severity } from "./types.js";
 
 export interface SelfConsistencyRecheckConfig {
@@ -49,12 +49,13 @@ export function runSelfConsistencyRecheck(input: {
   files: PullFilePatch[];
   config: SelfConsistencyRecheckConfig;
   requestChangesConfidenceFloors?: RequestChangesConfidenceFloors;
+  categoryPrecisionFloors?: CategoryPrecisionFloors;
   secondDraw: (input: SelfConsistencySecondDrawInput) => SelfConsistencySecondDrawResult;
 }): { comments: ReviewComment[]; event: ReviewEvent; verdicts: SelfConsistencyVerdict[] } {
   if (!input.config.enabled) {
     return {
       comments: input.comments,
-      event: decideReviewEvent(input.comments, input.requestChangesConfidenceFloors),
+      event: decideReviewEvent(input.comments, input.requestChangesConfidenceFloors, input.categoryPrecisionFloors),
       verdicts: []
     };
   }
@@ -101,7 +102,7 @@ export function runSelfConsistencyRecheck(input: {
 
   // Re-derive the event: a refuted comment still POSTS but no longer counts toward REQUEST_CHANGES.
   const eligibleComments = comments.filter((comment) => !refutedKeys.has(commentKey(comment)));
-  const event = eligibleComments.some((comment) => isRequestChangesEligible(comment, input.requestChangesConfidenceFloors))
+  const event = eligibleComments.some((comment) => isRequestChangesEligible(comment, input.requestChangesConfidenceFloors, input.categoryPrecisionFloors))
     ? "REQUEST_CHANGES"
     : "COMMENT";
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -790,6 +790,27 @@ export class ReviewStateStore {
   }
 
   recordFindingOutcomeLabel(record: FindingOutcomeLabelRecord): void {
+    this.writeFindingOutcomeLabel(record);
+  }
+
+  /**
+   * Atomic batch write (#286 PR C): all records land or none do. The inserts execute inside a single
+   * BEGIN IMMEDIATE transaction (mirroring the review_run_leases idiom), so a mid-batch validation or
+   * write failure rolls back to zero rows rather than leaving a partial write.
+   */
+  recordFindingOutcomeLabels(records: FindingOutcomeLabelRecord[]): void {
+    if (records.length === 0) return;
+    this.db.exec("begin immediate");
+    try {
+      for (const record of records) this.writeFindingOutcomeLabel(record);
+      this.db.exec("commit");
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
+  private writeFindingOutcomeLabel(record: FindingOutcomeLabelRecord): void {
     validateRepoName(record.repo, "repo");
     if (!/^finding:[a-f0-9]{64}$/.test(record.fingerprint)) {
       throw new Error("finding outcome label fingerprint must match finding:<64-hex>");

--- a/src/state.ts
+++ b/src/state.ts
@@ -73,7 +73,11 @@ export type FindingOutcomeLabelSource =
   | "hotfix"
   | "human_thread"
   | "ci_failure"
-  | "none_observed";
+  | "none_observed"
+  // Explicit, operator-declared negative control (#286 PR C): recorded ONLY for a run that posted
+  // zero findings (verifiably clean) AND was flagged by the operator — mirrors the #296 semantics
+  // that an empty label set is never a negative control by itself.
+  | "explicit_control";
 
 export type FindingOutcomeVerdict = "true_positive" | "false_positive" | "unvalidated";
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1503,6 +1503,9 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       publicConfidencePolicy: config.confidenceCalibration?.publicDisplay,
       ...(config.reviewGate?.requestChangesConfidenceFloors
         ? { requestChangesConfidenceFloors: config.reviewGate.requestChangesConfidenceFloors }
+        : {}),
+      ...(config.reviewGate?.categoryPrecisionFloors
+        ? { categoryPrecisionFloors: config.reviewGate.categoryPrecisionFloors }
         : {})
     });
     // Opt-in P0/P1 self-consistency re-check (#303): post-dedup, pre-event-decision. Quieter-only —
@@ -2559,6 +2562,9 @@ function applySelfConsistencyRecheck(input: {
     config: selfConsistencyConfig,
     ...(input.config.reviewGate?.requestChangesConfidenceFloors
       ? { requestChangesConfidenceFloors: input.config.reviewGate.requestChangesConfidenceFloors }
+      : {}),
+    ...(input.config.reviewGate?.categoryPrecisionFloors
+      ? { categoryPrecisionFloors: input.config.reviewGate.categoryPrecisionFloors }
       : {}),
     secondDraw: ({ comment, hunk }) => {
       const draw = runZCodeReview({

--- a/tests/calibration-aggregate.test.ts
+++ b/tests/calibration-aggregate.test.ts
@@ -57,7 +57,21 @@ describe("calibration aggregation (#286 PR B)", () => {
     expect(aggregate.p0p1Labels).toBe(2); // P0 tp + P1 fp; P2 not counted; unvalidated P0 excluded
   });
 
-  it("reports negativeControlScenarios as 0 (no explicit-control source in the label store yet)", () => {
+  it("counts explicit_control labels toward negativeControlScenarios but not toward findings (#286 PR C)", () => {
+    const aggregate = aggregateCalibrationLabels([
+      label({ confidence: 0.9, verdict: "true_positive" }),
+      label({ confidence: 0.5, verdict: "false_positive", labelSource: "none_observed" }),
+      label({ confidence: 0, verdict: "unvalidated", labelSource: "explicit_control", severity: "P0" }),
+      label({ confidence: 0, verdict: "unvalidated", labelSource: "explicit_control", severity: "P1" })
+    ]);
+    expect(aggregate.negativeControlScenarios).toBe(2);
+    // Explicit controls are clean-run markers, not findings: they never inflate labeled counts.
+    // The two real labels default to P1, so p0p1Labels counts them but NOT the excluded controls.
+    expect(aggregate.labeledFindings).toBe(2);
+    expect(aggregate.p0p1Labels).toBe(2);
+  });
+
+  it("still reports negativeControlScenarios as 0 when no explicit controls are present", () => {
     const aggregate = aggregateCalibrationLabels([
       label({ confidence: 0.9, verdict: "true_positive" }),
       label({ confidence: 0.5, verdict: "false_positive", labelSource: "none_observed" })

--- a/tests/calibration-promote.test.ts
+++ b/tests/calibration-promote.test.ts
@@ -1,0 +1,96 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { evaluateCalibrationPromotion, runCalibrationPromotion } from "../src/calibration-promote.js";
+
+const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
+
+const ELIGIBLE = { labeledFindings: 120, p0p1Labels: 35, negativeControlScenarios: 12, bestWilsonLowerBound: 0.96 };
+
+function writeAggregate(dir: string, overrides: Partial<typeof ELIGIBLE> = {}): string {
+  const path = join(dir, "aggregate-calibration.json");
+  writeFileSync(path, `${JSON.stringify({ ...ELIGIBLE, ...overrides })}\n`);
+  return path;
+}
+
+describe("calibration promotion gate (#286 PR C)", () => {
+  it("names the failing gate for each below-threshold input", () => {
+    expect(evaluateCalibrationPromotion({ ...ELIGIBLE, labeledFindings: 99 }).failingGate).toBe("min_labeled_findings");
+    expect(evaluateCalibrationPromotion({ ...ELIGIBLE, p0p1Labels: 29 }).failingGate).toBe("min_p0_p1_labels");
+    expect(evaluateCalibrationPromotion({ ...ELIGIBLE, negativeControlScenarios: 9 }).failingGate).toBe("min_negative_control_scenarios");
+    expect(evaluateCalibrationPromotion({ ...ELIGIBLE, bestWilsonLowerBound: 0.94 }).failingGate).toBe("min_wilson_lower_bound");
+    expect(evaluateCalibrationPromotion(ELIGIBLE).eligible).toBe(true);
+  });
+});
+
+describe("calibration promotion run (#286 PR C)", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("requires --confirm", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evaos-promote-confirm-"));
+    roots.push(dir);
+    expect(() =>
+      runCalibrationPromotion({ aggregatePath: writeAggregate(dir), outputDir: join(dir, "out"), confirm: false })
+    ).toThrow(/--confirm/);
+  });
+
+  it("writes a config PATCH FILE that never sets publicDisplay.mode (default patch mode)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evaos-promote-patch-"));
+    roots.push(dir);
+    const result = runCalibrationPromotion({ aggregatePath: writeAggregate(dir), outputDir: join(dir, "out"), confirm: true });
+
+    expect(result.mode).toBe("patch");
+    const patch = readFileSync(result.outputPath!, "utf8");
+    const parsed = JSON.parse(patch);
+    // The patch carries the numbers but NEVER the mode field: the calibrated flip is a manual edit.
+    expect(parsed.confidenceCalibration.publicDisplay).toMatchObject({ labeledFindings: 120, p0p1Labels: 35, negativeControlScenarios: 12, wilsonLowerBound: 0.96 });
+    expect(parsed.confidenceCalibration.publicDisplay.mode).toBeUndefined();
+    // The loud note explains mode stays manual; assert no publicDisplay.mode key exists anywhere.
+    expect(JSON.stringify(parsed.confidenceCalibration.publicDisplay)).not.toMatch(/"mode"/);
+  });
+
+  it("refuses below-threshold evidence with the failing gate named (nothing written)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evaos-promote-below-"));
+    roots.push(dir);
+    expect(() =>
+      runCalibrationPromotion({ aggregatePath: writeAggregate(dir, { p0p1Labels: 5 }), outputDir: join(dir, "out"), confirm: true })
+    ).toThrow(/min_p0_p1_labels/);
+    expect(existsSync(join(dir, "out"))).toBe(false);
+  });
+
+  it("--apply requires the --i-understand-live-config double flag and still never sets mode", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evaos-promote-apply-"));
+    roots.push(dir);
+    expect(() =>
+      runCalibrationPromotion({ aggregatePath: writeAggregate(dir), outputDir: join(dir, "out"), confirm: true, apply: true })
+    ).toThrow(/i-understand-live-config/);
+
+    const ok = runCalibrationPromotion({
+      aggregatePath: writeAggregate(dir), outputDir: join(dir, "out2"), confirm: true, apply: true, iUnderstandLiveConfig: true
+    });
+    expect(ok.mode).toBe("apply");
+    const applied = JSON.parse(readFileSync(ok.outputPath!, "utf8"));
+    expect(applied.confidenceCalibration.publicDisplay.mode).toBeUndefined();
+  });
+
+  it("exposes a CLI that requires --confirm and writes a patch, never mutating a live config", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evaos-promote-cli-"));
+    roots.push(dir);
+    const aggregatePath = writeAggregate(dir);
+    const outputDir = join(dir, "out");
+
+    const output = execFileSync(process.execPath, [
+      tsxCli, "src/cli.ts", "calibration-promote", "--input", aggregatePath, "--output-dir", outputDir, "--confirm", "true"
+    ], { cwd: process.cwd(), encoding: "utf8" });
+
+    const parsed = JSON.parse(output);
+    expect(parsed).toMatchObject({ command: "calibration-promote", ok: true, mode: "patch", eligible: true });
+    expect(existsSync(join(outputDir, "calibration-config-patch.json"))).toBe(true);
+  });
+});

--- a/tests/calibration-promote.test.ts
+++ b/tests/calibration-promote.test.ts
@@ -24,6 +24,14 @@ describe("calibration promotion gate (#286 PR C)", () => {
     expect(evaluateCalibrationPromotion({ ...ELIGIBLE, bestWilsonLowerBound: 0.94 }).failingGate).toBe("min_wilson_lower_bound");
     expect(evaluateCalibrationPromotion(ELIGIBLE).eligible).toBe(true);
   });
+
+  it("evaluates against the operator's RAISED effective floors when a policy override is supplied (#286 PR C)", () => {
+    // ELIGIBLE clears the hard floor (30 P0/P1) but the operator raised the minimum to 50.
+    expect(evaluateCalibrationPromotion(ELIGIBLE).eligible).toBe(true);
+    const gate = evaluateCalibrationPromotion(ELIGIBLE, { minP0P1Labels: 50 });
+    expect(gate.eligible).toBe(false);
+    expect(gate.failingGate).toBe("min_p0_p1_labels");
+  });
 });
 
 describe("calibration promotion run (#286 PR C)", () => {

--- a/tests/confidence-config.test.ts
+++ b/tests/confidence-config.test.ts
@@ -152,6 +152,21 @@ describe("review gate config", () => {
     );
   });
 
+  it("accepts categoryPrecisionFloors and defaults it unset (#286 PR C)", () => {
+    expect(loadConfigFromObject({}).reviewGate?.categoryPrecisionFloors).toBeUndefined();
+    const config = loadConfigFromObject({ reviewGate: { categoryPrecisionFloors: { data_loss: 0.9, auth: 0.8 } } });
+    expect(config.reviewGate?.categoryPrecisionFloors).toEqual({ data_loss: 0.9, auth: 0.8 });
+  });
+
+  it("fails closed on malformed categoryPrecisionFloors (#286 PR C)", () => {
+    expect(() => loadConfigFromObject({ reviewGate: { categoryPrecisionFloors: { data_loss: 1.5 } } })).toThrow(
+      /reviewGate\.categoryPrecisionFloors\.data_loss must be a number from 0 to 1/
+    );
+    expect(() => loadConfigFromObject({ reviewGate: { categoryPrecisionFloors: { not_a_category: 0.5 } } })).toThrow(
+      /reviewGate\.categoryPrecisionFloors has unknown category "not_a_category"/
+    );
+  });
+
   it("defaults retryDegradedConfidencePenalty to unset (off) and accepts a valid penalty (#304)", () => {
     expect(loadConfigFromObject({}).reviewGate?.retryDegradedConfidencePenalty).toBeUndefined();
     expect(

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -330,14 +330,28 @@ describe("finding normalization and review policy", () => {
     expect(decideReviewEvent([{ severity: "P0", category: "security_boundary", confidence: 0.9 }])).toBe("REQUEST_CHANGES");
   });
 
-  it("strips REQUEST_CHANGES eligibility for a category configured below its precision floor (#286 PR C)", () => {
-    const comments = [{ severity: "P1" as const, category: "data_loss" as const, confidence: 0.99 }];
+  it("demotes REQUEST_CHANGES only when confidence is below the category precision floor (#286 PR C)", () => {
+    const belowFloor = [{ severity: "P1" as const, category: "data_loss" as const, confidence: 0.6 }];
+    const atFloor = [{ severity: "P1" as const, category: "data_loss" as const, confidence: 0.9 }];
     // No floors ⇒ eligible as before.
-    expect(decideReviewEvent(comments)).toBe("REQUEST_CHANGES");
-    // data_loss configured below-floor ⇒ demoted to COMMENT (quieter-only).
-    expect(decideReviewEvent(comments, undefined, { data_loss: 0.9 })).toBe("COMMENT");
+    expect(decideReviewEvent(belowFloor)).toBe("REQUEST_CHANGES");
+    // Confidence 0.6 < floor 0.9 ⇒ demoted to COMMENT (quieter-only). The finding still POSTS.
+    expect(decideReviewEvent(belowFloor, undefined, { data_loss: 0.9 })).toBe("COMMENT");
+    // Confidence 0.9 >= floor 0.9 ⇒ stays REQUEST_CHANGES (value is load-bearing, not mere presence).
+    expect(decideReviewEvent(atFloor, undefined, { data_loss: 0.9 })).toBe("REQUEST_CHANGES");
+    // A 0 floor never demotes.
+    expect(decideReviewEvent(belowFloor, undefined, { data_loss: 0 })).toBe("REQUEST_CHANGES");
     // A different category's floor does not affect this finding.
-    expect(decideReviewEvent(comments, undefined, { auth: 0.9 })).toBe("REQUEST_CHANGES");
+    expect(decideReviewEvent(belowFloor, undefined, { auth: 0.99 })).toBe("REQUEST_CHANGES");
+  });
+
+  it("keeps a below-category-floor finding posting as a comment (quieter-only, never dropped) (#286 PR C)", () => {
+    const result = normalizeFindingsForReview([
+      { severity: "P1", category: "data_loss", path: "a.ts", line: 1, title: "Low-confidence data loss", body: "A concern.", confidence: 0.3 }
+    ]);
+    // The finding survives normalization as a posted comment; only its RC-eligibility is stripped.
+    expect(result.comments).toHaveLength(1);
+    expect(decideReviewEvent(result.comments, undefined, { data_loss: 0.9 })).toBe("COMMENT");
   });
 
   it("ignores unsupported optional model categories without dropping the finding", () => {

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -330,6 +330,16 @@ describe("finding normalization and review policy", () => {
     expect(decideReviewEvent([{ severity: "P0", category: "security_boundary", confidence: 0.9 }])).toBe("REQUEST_CHANGES");
   });
 
+  it("strips REQUEST_CHANGES eligibility for a category configured below its precision floor (#286 PR C)", () => {
+    const comments = [{ severity: "P1" as const, category: "data_loss" as const, confidence: 0.99 }];
+    // No floors ⇒ eligible as before.
+    expect(decideReviewEvent(comments)).toBe("REQUEST_CHANGES");
+    // data_loss configured below-floor ⇒ demoted to COMMENT (quieter-only).
+    expect(decideReviewEvent(comments, undefined, { data_loss: 0.9 })).toBe("COMMENT");
+    // A different category's floor does not affect this finding.
+    expect(decideReviewEvent(comments, undefined, { auth: 0.9 })).toBe("REQUEST_CHANGES");
+  });
+
   it("ignores unsupported optional model categories without dropping the finding", () => {
     const parsed = parseFindings({
       findings: [

--- a/tests/outcome-observer.test.ts
+++ b/tests/outcome-observer.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { ReviewStateStore } from "../src/state.js";
 
 const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
-import { deriveOutcomeLabel, runOutcomeObserver, type ObservedPullOutcome } from "../src/outcome-observer.js";
+import { deriveOutcomeLabel, recordNegativeControlLabels, runOutcomeObserver, type ObservedPullOutcome } from "../src/outcome-observer.js";
 
 const FINDING = {
   fingerprint: `finding:${"a".repeat(64)}`,
@@ -172,6 +172,46 @@ describe("outcome-observe CLI (#286 PR A)", () => {
 
     // Dry-run persisted nothing.
     const store = new ReviewStateStore(join(dir, "state.sqlite"));
+    expect(store.listFindingOutcomeLabels()).toHaveLength(0);
+    store.close();
+  });
+});
+
+describe("explicit negative-control marking (#286 PR C)", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("records an explicit_control label for a verifiably-clean (zero-finding) run", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-negctl-clean-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    const result = recordNegativeControlLabels({
+      store,
+      reviews: [{ repo: "owner/repo", pullNumber: 9, headSha: "sha9", findings: [] }],
+      now: new Date("2026-07-06T00:00:00.000Z")
+    });
+
+    const labels = store.listFindingOutcomeLabels();
+    expect(labels).toHaveLength(1);
+    expect(labels[0]).toMatchObject({ labelSource: "explicit_control", verdict: "unvalidated" });
+    expect(result.recorded).toBe(1);
+    store.close();
+  });
+
+  it("refuses to mark a run that posted findings (mirrors #296: explicit + clean only)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-negctl-dirty-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    expect(() =>
+      recordNegativeControlLabels({
+        store,
+        reviews: [{ repo: "owner/repo", pullNumber: 10, headSha: "sha10", findings: [FINDING] }]
+      })
+    ).toThrow(/posted findings/i);
     expect(store.listFindingOutcomeLabels()).toHaveLength(0);
     store.close();
   });

--- a/tests/outcome-observer.test.ts
+++ b/tests/outcome-observer.test.ts
@@ -215,6 +215,26 @@ describe("explicit negative-control marking (#286 PR C)", () => {
     expect(store.listFindingOutcomeLabels()).toHaveLength(0);
     store.close();
   });
+
+  it("writes the batch atomically: a mid-batch failure leaves zero explicit_control rows (#286 PR C)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-negctl-atomic-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+
+    // Both reviews are clean (zero findings) so the precondition passes, but the second has an
+    // invalid pullNumber that the write validation rejects — the whole batch must roll back.
+    expect(() =>
+      recordNegativeControlLabels({
+        store,
+        reviews: [
+          { repo: "owner/repo", pullNumber: 11, headSha: "sha11", findings: [] },
+          { repo: "owner/repo", pullNumber: 0, headSha: "sha0", findings: [] }
+        ]
+      })
+    ).toThrow(/pullNumber/i);
+    expect(store.listFindingOutcomeLabels()).toHaveLength(0);
+    store.close();
+  });
 });
 
 function mapOf(entries: Record<string, number[]> = {}): Map<string, Set<number>> {


### PR DESCRIPTION
## Summary

Completes the #286 calibration loop (Part C of C — Part A observed outcomes, Part B aggregated them; this PR consumes the aggregate under strict human gates). Parent program: #278.

1. **Explicit negative controls** — new `explicit_control` label source; `outcome-observe --mark-negative-control` records it ONLY for a verifiably-clean (zero-finding) run and refuses any run that posted findings. `calibration-aggregate` counts explicit controls toward `negativeControlScenarios` and excludes them from finding-based bins. Wilson/bin math stays reused via `computeConfidenceBinStats` — never forked.
2. **`calibration-promote` CLI** — `--confirm` required; below-threshold evidence refused with the failing public-confidence gate named (same floor source the live gate uses). Default output is a config **patch file** the operator applies by hand; `--apply` additionally requires `--i-understand-live-config` (double flag). **`publicDisplay.mode` is never written under any flag** — flipping to "calibrated" stays a manual human edit, stated loudly in output and in the patch itself.
3. **`reviewGate.categoryPrecisionFloors`** (default off, quieter-only) — a category the operator curated below its floor (from the aggregate report) loses REQUEST_CHANGES eligibility; the finding still posts as a comment. Fail-closed validation; unknown-category keys rejected. Nothing reads the aggregate at review time.

## Validation

TDD failing-first; focused Vitest (7 touched suites, 94 tests post-rebase) + `npm run build` green under `set -o pipefail` on the rebased head. Covers: each failing promotion floor named; patch path never mutates config; `--apply` double-flag enforced; mode never written; explicit control refuses non-clean runs; aggregate counts explicit controls; category floor strips eligibility only (finding still posts); config validation fail-closed.

## Proof boundary

Ships the promotion *tooling* only. No live config is changed by this PR; the public confidence display remains `uncalibrated` until an operator runs the loop on real volume, the evidence gate passes, and a human applies the patch and manually flips the mode.

Closes #286