### PR TITLE
Vision doc, calibration-loop operator guide, README post-#278 pass, operator-CLI debris sweep (#319)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,13 @@ Default behavior:
 - at most one review per `{repo, pr, head_sha}`
 - never submit `APPROVE`
 - request changes only for validated high-severity findings
-- suppress secret-looking findings instead of posting redacted secrets
+- rank findings by severity, then validated confidence; the inline-comment cap
+  keeps the highest-confidence findings
+- suppress same-run near-duplicate findings and secret-looking findings instead
+  of posting them
+- learned signals (confidence floors, category precision floors, repo-memory
+  false-positive suppression, self-consistency refutation) only ever make the
+  review quieter — they demote or suppress, never escalate
 - re-fetch PR state before live operations
 - keep ZCode/model tools read-only during review
 - fail closed when credentials, provider readiness, repo policy, or current-head
@@ -201,7 +207,9 @@ Not claimed:
 - auto-merge or branch repair
 - generic GitHub issue mutation
 - enterprise or customer-ready security
-- calibrated CodeRabbit-level accuracy
+- calibrated confidence display (stays redacted until the evidence gate in
+  [docs/calibration-loop.md](docs/calibration-loop.md) passes and a human
+  flips it)
 - desktop client readiness
 
 ## Roadmap Vs Shipped
@@ -209,9 +217,20 @@ Not claimed:
 The current repo is a source-available beta implementation. The public MVP is
 tracked in [#103](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103).
 Provider registry, `.neondiff.yml`, public package publishing, license activation,
-desktop client, wiki exports, marketplace packaging, and confidence calibration
-each have separate issues and must not be treated as shipped until their PRs and
-proof gates close.
+desktop client, wiki exports, and marketplace packaging each have separate
+issues and must not be treated as shipped until their PRs and proof gates close.
+
+The ranking/scoring and calibration program
+([#278](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/278))
+is shipped: confidence-aware ranking and caps, validated-category precedence,
+same-run near-duplicate suppression, robust false-positive learning, opt-in
+self-consistency re-checks, risk-weighted queue priority, and the full
+calibration loop (post-merge outcome observer → label aggregation → human-gated
+promotion — see [docs/calibration-loop.md](docs/calibration-loop.md) and
+[docs/vision.md](docs/vision.md)). Shipping the loop's tooling does not flip
+the calibrated display: that remains off until the evidence gate passes on
+real review volume and a human applies it. See [CHANGELOG.md](CHANGELOG.md)
+for the per-version record.
 
 Use [LICENSE.md](LICENSE.md) and [docs/license-boundary.md](docs/license-boundary.md)
 as the canonical public-beta license language. Do not copy older issue comments

--- a/docs/calibration-loop.md
+++ b/docs/calibration-loop.md
@@ -1,0 +1,144 @@
+# The Calibration Loop
+
+This is the operator guide for closing NeonDiff's confidence-calibration loop:
+observing what happened to posted findings, aggregating those outcomes into
+empirical precision, and — under explicit human gates — feeding the evidence
+back into configuration.
+
+The design intent behind the loop is in [vision.md](vision.md). The short
+version: NeonDiff only earns the right to display calibrated confidence by
+measuring its own precision on your repos, and every automated step below is
+built to make the review *quieter*, never louder.
+
+## Loop Overview
+
+```
+review posts findings
+        │
+        ▼
+1. outcome-observe        — label what actually happened per finding
+        │
+        ▼
+2. calibration-aggregate  — labels → per-bin precision + Wilson lower bounds
+        │
+        ▼
+3. calibration-promote    — evidence numbers → reviewable config patch (human-gated)
+        │
+        ▼
+4. manual human edit      — flipping publicDisplay.mode is never automated
+```
+
+Steps 1–3 are CLI commands. Step 4 is deliberately not.
+
+## 1. Observe Outcomes: `neondiff outcome-observe`
+
+Revisits reviewed PRs after merge and records per-finding outcome labels
+(revert, hotfix, merged fix, human thread, none observed) into the
+`finding_outcome_labels` store.
+
+```bash
+neondiff outcome-observe \
+  --input observer-input.json \
+  --output-dir evidence/outcome-observe/$(date +%F)
+```
+
+- `--dry-run` defaults to **true**: the default invocation reads and reports
+  without persisting labels. Pass `--dry-run false` to record.
+- `--mark-negative-control` records an `explicit_control` label for a
+  verifiably-clean run — a review that posted **zero** findings. It refuses any
+  run that posted findings, and it requires `--dry-run false` because it
+  writes. Negative controls are never inferred from missing labels; a clean
+  run only counts when you explicitly mark it.
+
+## 2. Aggregate Labels: `neondiff calibration-aggregate`
+
+Reads accumulated outcome labels from the state DB and produces
+`aggregate-calibration.json` plus an evidence packet: labeled-finding counts,
+P0/P1 label counts, explicit negative-control counts, and per-confidence-bin
+empirical precision with Wilson lower bounds (the same statistics the offline
+eval harness computes — see [eval-harness.md](eval-harness.md)).
+
+```bash
+neondiff calibration-aggregate \
+  --config config.local.json \
+  --output-dir evidence/calibration-aggregate/$(date +%F)
+```
+
+This step is read-only with respect to behavior: it evaluates the
+public-confidence floors and reports eligibility, but never mutates config and
+never switches the public display.
+
+## 3. Promote Evidence: `neondiff calibration-promote`
+
+Consumes the aggregate and, only when the evidence passes every floor, writes
+the calibration **numbers** as a reviewable config patch.
+
+```bash
+neondiff calibration-promote \
+  --input evidence/calibration-aggregate/<date>/aggregate-calibration.json \
+  --output-dir evidence/calibration-promote/$(date +%F) \
+  --confirm
+```
+
+- `--confirm` is required; without it the command refuses to run.
+- Below-threshold evidence is refused with the failing gate named — nothing is
+  written.
+- The default output is a **patch file** (`calibration-config-patch.json`)
+  that you inspect and apply by hand.
+- `--apply` writes the same numbers directly and additionally requires
+  `--i-understand-live-config` (a deliberate double flag).
+- Under **no** flag does the tool write `confidenceCalibration.publicDisplay.mode`.
+  The patch carries the evidence numbers only.
+
+## 4. The Human Flip
+
+Public confidence display stays `uncalibrated` (numbers redacted from public
+surfaces) until all of the hard floors hold:
+
+| Floor | Minimum |
+|---|---|
+| `labeledFindings` | 100 |
+| `p0p1Labels` | 30 |
+| `negativeControlScenarios` (explicit only) | 10 |
+| `wilsonLowerBound` | 0.95 |
+
+When the promoted numbers meet the floors, a human — not a tool — edits
+`confidenceCalibration.publicDisplay.mode` to `"calibrated"`. Config
+validation enforces the floors again at load and fails closed, so a premature
+flip is rejected even if made by hand. See
+[neondiff-config.md](neondiff-config.md) for the full key reference.
+
+## Feeding Ranking: `reviewGate.categoryPrecisionFloors`
+
+The aggregate report also shows precision per finding category. When a
+category's measured precision is low, set a confidence floor for it under
+`reviewGate.categoryPrecisionFloors`:
+
+```json
+{
+  "reviewGate": {
+    "categoryPrecisionFloors": { "observability": 0.8 }
+  }
+}
+```
+
+A finding in a listed category loses `REQUEST_CHANGES` eligibility when its
+confidence is below the configured floor — it still posts as a comment; only
+the review event is demoted. A floor of `0` never demotes; `1` demotes
+everything below full confidence. Nothing reads the aggregate at review time,
+so the config file remains the single inspectable source of gate behavior.
+Unknown category keys are rejected at config load.
+
+## Invariants
+
+- **Quieter-only.** Every consumer of calibration evidence (confidence floors,
+  category precision floors, self-consistency refutation) demotes or
+  suppresses. Nothing learned ever escalates a review event or promotes a
+  finding.
+- **Human-gated writes.** Automated steps write evidence and patch files;
+  live-config changes require explicit double confirmation, and the calibrated
+  display flip is manual, always.
+- **Explicit controls only.** Unmeasured is not clean. Negative-control credit
+  requires a deliberate `--mark-negative-control` on a zero-finding run.
+- **Redaction everywhere.** All evidence files are written through secret
+  redaction, like every other NeonDiff evidence surface.

--- a/docs/calibration-loop.md
+++ b/docs/calibration-loop.md
@@ -106,7 +106,9 @@ When the promoted numbers meet the floors, a human — not a tool — edits
 `confidenceCalibration.publicDisplay.mode` to `"calibrated"`. Config
 validation enforces the floors again at load and fails closed, so a premature
 flip is rejected even if made by hand. See
-[neondiff-config.md](neondiff-config.md) for the full key reference.
+[neondiff-config.md](neondiff-config.md) for the full key reference and
+[evals/confidence-calibration.md](evals/confidence-calibration.md) for the
+calibration policy behind the floors.
 
 ## Feeding Ranking: `reviewGate.categoryPrecisionFloors`
 

--- a/docs/neondiff-config.md
+++ b/docs/neondiff-config.md
@@ -125,12 +125,14 @@ comments, and decides `REQUEST_CHANGES` vs `COMMENT` (`src/review-gate.ts`, `src
 | `requestChangesConfidenceFloors` | `{ P0?: number, P1?: number }` | unset (no floors) | Optional per-severity confidence floor, each `0..1`, for counting a P0/P1 finding toward `REQUEST_CHANGES` eligibility. |
 | `retryDegradedConfidencePenalty` | `number` (`0..1`) | unset (no penalty) | Optional confidence subtracted (floored at 0) from findings recovered via the strict-JSON retry path (#304) before the gate runs. |
 | `selfConsistency` | `SelfConsistencyConfig` | unset (disabled) | Opt-in second-draw re-check for high-severity findings (#303). See below. |
+| `categoryPrecisionFloors` | `{ [category]: number }` | unset (no floors) | Optional per-category confidence floor, each `0..1`, curated from the calibration aggregate report (#286). A finding whose category is listed loses `REQUEST_CHANGES` eligibility when its confidence is below the floor; it still posts as a comment. See [calibration-loop.md](calibration-loop.md). |
 
 **Safety invariants:**
 
 - **`maxInlineComments` default matches the pre-#287 hardcoded literal.** Setting it explicitly only changes *which* findings survive the cap (confidence-ranked instead of alphabetical-by-path); it does not change default behavior.
 - **`requestChangesConfidenceFloors` is quieter-only and unknown keys are rejected.** The object accepts only the literal keys `P0` and `P1` — any other key (including lowercase `p0`, or a typo) throws a config validation error rather than being silently ignored. A configured floor can only *demote* a finding out of `REQUEST_CHANGES` eligibility; a below-floor P0/P1 still posts as an inline comment, it just no longer forces the stricter review event. Leaving both floors unset is byte-identical to the pre-#287 gate.
 - **`retryDegradedConfidencePenalty` is quieter-only and default-off.** It only ever lowers a degraded finding's confidence (floored at 0), which can only remove it from ranking/cap contention or push it below a `requestChangesConfidenceFloors` floor — never raise confidence or add a finding. Unset means retry-recovered findings are scored identically to clean first-pass findings.
+- **`categoryPrecisionFloors` is quieter-only and unknown categories are rejected.** Keys must be valid regression-taxonomy categories — anything else throws a config validation error. A floor can only demote a finding out of `REQUEST_CHANGES` eligibility (the finding still posts); a floor of `0` never demotes. Nothing reads the calibration aggregate at review time — the config file remains the single inspectable source of gate behavior.
 
 #### `selfConsistency`
 

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -7,15 +7,15 @@ launchd, SQLite, or GitHub state by hand.
 Run commands from the repository checkout:
 
 ```bash
-npx tsx src/cli.ts status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot
+npx tsx src/cli.ts status --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
-After `npm run build` and `npm link`, the package exposes both the public beta
-binary and the legacy internal binary:
+After `npm run build` and `npm link`, the package exposes the `neondiff`
+binary and the `evaos-review-bot` compatibility alias (same CLI, older name):
 
 ```bash
-neondiff status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
-evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+neondiff status --config config.local.json
+evaos-review-bot status --config config.local.json
 ```
 
 ## Commands
@@ -162,7 +162,7 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
   path check, not a realpath/symlink containment proof.
   If a live `bootstrap` fails because the LaunchAgent is already loaded, rerun
   `daemon start` without `--plist` to use the kickstart-only restart path.
-- `daemon --config <config.json> --dry-run true --once true`: runs one legacy
+- `daemon --config <config.json> --dry-run true --once true`: runs one
   daemon cycle and exits. This is intended for deterministic local smoke tests
   and operator diagnostics; omit `--once true` for the normal long-running
   worker loop.
@@ -172,13 +172,13 @@ evaos-review-bot status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/conf
 Check whether the live bot is healthy:
 
 ```bash
-npx tsx src/cli.ts status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot
+npx tsx src/cli.ts status --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
 Classify whether the bot is idle, healthy-active, or blocked:
 
 ```bash
-npx tsx src/cli.ts runtime-inventory --json --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot
+npx tsx src/cli.ts runtime-inventory --json --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
 `runtime-inventory` treats issue-enrichment runtime as a separate lane from PR
@@ -199,25 +199,25 @@ new names report the same advisory-only count.
 Show the same runtime inventory as a short human summary:
 
 ```bash
-npx tsx src/cli.ts runtime-inventory --human --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot
+npx tsx src/cli.ts runtime-inventory --human --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
 See whether review agents are active, idle, or stale:
 
 ```bash
-npx tsx src/cli.ts agents --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+npx tsx src/cli.ts agents --config config.local.json
 ```
 
 Find open PR heads that still need review work:
 
 ```bash
-npx tsx src/cli.ts queue --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+npx tsx src/cli.ts queue --config config.local.json
 ```
 
 Run one scoped review pass and inspect the structured result:
 
 ```bash
-npx tsx src/cli.ts run-once --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --repo electricsheephq/evaos-code-review-bot --pr 142 --dry-run true --zcode false
+npx tsx src/cli.ts run-once --config config.local.json --repo electricsheephq/evaos-code-review-bot-neondiff --pr 142 --dry-run true --zcode false
 ```
 
 `run-once` always prints a JSON report on stdout before returning. Treat that
@@ -232,7 +232,7 @@ promoting, retrying, or treating the run as a total outage.
 Inspect only durable provider-deferred jobs:
 
 ```bash
-npx tsx src/cli.ts queue --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --state provider_deferred
+npx tsx src/cli.ts queue --config config.local.json --state provider_deferred
 ```
 
 If `queue` returns `coverageOk: true` and `runtimeOk: false`, coverage has found
@@ -243,31 +243,31 @@ restarting launchd or retrying provider work.
 Show the review dashboard:
 
 ```bash
-npx tsx src/cli.ts dashboard --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json
+npx tsx src/cli.ts dashboard --config config.local.json
 ```
 
 Show dashboard rows blocked on proof:
 
 ```bash
-npx tsx src/cli.ts dashboard --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --status blocked_on_proof
+npx tsx src/cli.ts dashboard --config config.local.json --status blocked_on_proof
 ```
 
 Include stale-only historical rows when diagnosing old heads:
 
 ```bash
-npx tsx src/cli.ts dashboard --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --include-history true
+npx tsx src/cli.ts dashboard --config config.local.json --include-history true
 ```
 
 Show one repo as a short human dashboard:
 
 ```bash
-npx tsx src/cli.ts dashboard --human --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --repo electricsheephq/evaos-code-review-bot
+npx tsx src/cli.ts dashboard --human --config config.local.json --repo electricsheephq/evaos-code-review-bot
 ```
 
 Inspect only the scheduler budget projection:
 
 ```bash
-npx tsx src/cli.ts budget-status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --launchd-label com.electricsheephq.evaos-code-review-bot
+npx tsx src/cli.ts budget-status --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
 Use `--limit <n>` to cap returned `wouldLease`/`delayed` rows and
@@ -277,13 +277,13 @@ truncation metadata when either cap is hit.
 Explain one PR:
 
 ```bash
-npx tsx src/cli.ts why --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --repo 100yenadmin/Lossless-Codex-Orchestrator-LCO --pr 253
+npx tsx src/cli.ts why --config config.local.json --repo example-org/example-repo --pr 253
 ```
 
 Inspect provider cooldowns:
 
 ```bash
-npx tsx src/cli.ts provider-cooldowns --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expired-only true
+npx tsx src/cli.ts provider-cooldowns --config config.local.json --expired-only true
 ```
 
 The provider-cooldown output includes `runtimeOk`, `healthState`, `failedGates`,
@@ -295,13 +295,13 @@ active run; wait for that run to finish before retrying.
 Dry-run stale review queue lease cleanup:
 
 ```bash
-npx tsx src/cli.ts clear-review-queue-leases --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --dry-run true --expired-only true
+npx tsx src/cli.ts clear-review-queue-leases --config config.local.json --dry-run true --expired-only true
 ```
 
 Apply expired-only cleanup after inspecting the dry-run output:
 
 ```bash
-npx tsx src/cli.ts clear-review-queue-leases --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --dry-run false --confirm true --expired-only true
+npx tsx src/cli.ts clear-review-queue-leases --config config.local.json --dry-run false --confirm true --expired-only true
 ```
 
 `--force-active true` only applies to queue jobs matched by the explicit filters.
@@ -311,7 +311,7 @@ only when they are independently expired or owned by a dead worker.
 Build a repo-memory packet for dry-run evidence:
 
 ```bash
-npx tsx src/cli.ts build-memory-packet --config <config.json> --repo electricsheephq/evaos-code-review-bot --output-dir <configured-evidence-dir>/repo-memory-packets/evaos-code-review-bot
+npx tsx src/cli.ts build-memory-packet --config <config.json> --repo electricsheephq/evaos-code-review-bot-neondiff --output-dir <configured-evidence-dir>/repo-memory-packets/evaos-code-review-bot-neondiff
 ```
 
 Use `--fingerprint <finding-fingerprint>` to include exact-match false-positive
@@ -321,7 +321,7 @@ when the packet SHA should be recorded in SQLite provenance.
 Build a GitNexus context packet for dry-run evidence:
 
 ```bash
-npx tsx src/cli.ts build-gitnexus-context-packet --config <config.json> --repo electricsheephq/evaos-code-review-bot --pr 102 --output-dir <configured-evidence-dir>/gitnexus-context/evaos-code-review-bot-pr-102
+npx tsx src/cli.ts build-gitnexus-context-packet --config <config.json> --repo electricsheephq/evaos-code-review-bot-neondiff --pr 102 --output-dir <configured-evidence-dir>/gitnexus-context/evaos-code-review-bot-neondiff-pr-102
 ```
 
 Missing or stale GitNexus indexes produce `degradedMode: true` packets and do
@@ -331,7 +331,7 @@ redacted `gitnexus-context-packet-error.json` evidence file.
 Build a GitHub related-context packet for dry-run evidence:
 
 ```bash
-npx tsx src/cli.ts build-github-related-context-packet --config <config.json> --repo electricsheephq/evaos-code-review-bot --pr 102 --output-dir <configured-evidence-dir>/github-related-context/evaos-code-review-bot-pr-102
+npx tsx src/cli.ts build-github-related-context-packet --config <config.json> --repo electricsheephq/evaos-code-review-bot-neondiff --pr 102 --output-dir <configured-evidence-dir>/github-related-context/evaos-code-review-bot-neondiff-pr-102
 ```
 
 The packet is advisory only. It cannot justify posted findings without
@@ -351,7 +351,7 @@ packet is enabled by config.
 Build a sticky enrichment comment for dry-run evidence:
 
 ```bash
-npx tsx src/cli.ts build-enrichment-comment --config <config.json> --repo electricsheephq/evaos-code-review-bot --pr 102 --output-dir <configured-evidence-dir>/enrichment/evaos-code-review-bot-pr-102
+npx tsx src/cli.ts build-enrichment-comment --config <config.json> --repo electricsheephq/evaos-code-review-bot-neondiff --pr 102 --output-dir <configured-evidence-dir>/enrichment/evaos-code-review-bot-neondiff-pr-102
 ```
 
 The dry-run output includes the hidden sticky marker used for future update
@@ -360,7 +360,7 @@ behavior, but it does not post the comment or apply suggested labels/reviewers.
 Build a sticky issue enrichment comment for dry-run evidence:
 
 ```bash
-npx tsx src/cli.ts build-enrichment-comment --config <config.json> --repo electricsheephq/evaos-code-review-bot --issue 10 --output-dir <configured-evidence-dir>/enrichment/evaos-code-review-bot-issue-10
+npx tsx src/cli.ts build-enrichment-comment --config <config.json> --repo electricsheephq/evaos-code-review-bot-neondiff --issue 10 --output-dir <configured-evidence-dir>/enrichment/evaos-code-review-bot-neondiff-issue-10
 ```
 
 Closed issues are reported as `skipped: true` with reason

--- a/docs/setup-validation.md
+++ b/docs/setup-validation.md
@@ -1,0 +1,327 @@
+# Setup Validation Plan
+
+This runbook defines the clean setup transcript plan for NeonDiff. It is a plan
+for proving the first-run path; it is not a claim that setup has already been
+fully proven.
+
+The validation target is a literal pass through:
+
+```text
+install -> init -> doctor -> providers -> first dry-run review
+```
+
+Run this twice before using the result as issue #319 evidence:
+
+- human transcript: a human follows README and [docs/SETUP.md](SETUP.md)
+  without hidden repo knowledge
+- agent transcript: an AI coding agent follows README, [AGENTS.md](../AGENTS.md),
+  and [docs/SETUP.md](SETUP.md) literally, recording every assumption
+
+## Environment Contract
+
+Use a clean machine, clean container, or clean macOS user/session. If that is
+not available, use an isolated temp npm prefix plus fresh config, state, and
+evidence directories outside the repository.
+
+Record:
+
+- date and timezone
+- OS and architecture
+- Node.js and npm versions
+- shell
+- install path or temp npm prefix
+- NeonDiff package version or source SHA
+- GitHub App installation target
+- provider path under test
+- whether the provider is local/self-hosted or hosted
+- repository, PR number, and head SHA used for the dry-run review
+
+Do not record raw private keys, provider API keys, GitHub tokens, license keys,
+raw customer data, or unredacted model transcripts.
+
+Suggested evidence root:
+
+```text
+/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/setup-validation/YYYY-MM-DD/<human-or-agent>/
+```
+
+## Transcript Format
+
+Each transcript should be a Markdown file with this shape:
+
+```markdown
+# NeonDiff Setup Validation Transcript
+
+- Runner:
+- Environment:
+- Package or SHA:
+- GitHub App:
+- Provider:
+- Target repo:
+- Target PR:
+- Target head SHA:
+- Start time:
+- End time:
+- Result: pass | blocked | failed
+
+## Commands
+
+For each command:
+
+1. exact command
+2. expected result from docs
+3. observed result
+4. sanitized output or artifact path
+5. deviation, fix, or stop condition
+
+## Proof Boundary
+
+What this transcript proves and what it does not prove.
+```
+
+Keep long JSON output in separate files and link it from the transcript.
+
+## Step 1: Install
+
+Validate the package install path first. Use the version named by the docs or
+the issue under test.
+
+Public install proof currently means the npm package `neondiff@0.4.30-beta.1`.
+Source-only beta releases `v0.4.31-beta.1` through `v0.4.37-beta.1` are held
+from npm; validate those by source SHA or local build path, not by expecting a
+new public npm artifact.
+
+```bash
+npm install -g neondiff@<version-under-test> --prefix "$tmp_prefix"
+"$tmp_prefix/bin/neondiff" help
+```
+
+If validating the installer script, dry-run first:
+
+```bash
+curl -fsSL https://www.neondiff.com/install | sh -s -- --dry-run
+```
+
+Evidence to capture:
+
+- `versions.txt`: `node --version`, `npm --version`, and NeonDiff version/help
+- `install.log`: sanitized install output
+- `install-dry-run.log`: installer dry-run output when used
+- `path.txt`: resolved CLI path
+
+Stop if install requires undocumented prerequisites, writes into the repo,
+prints secrets, installs a different package/version than the docs name, or
+cannot run `neondiff help`.
+
+## Step 2: Init
+
+Create a fresh config outside tracked repo files:
+
+```bash
+neondiff init --config "$work_dir/config.local.json"
+```
+
+Then edit only local, untracked values for:
+
+- GitHub App id and private key path
+- state path
+- evidence path
+- allowed pilot repos
+- provider id and model path
+- license settings when validating a private or commercial repo path
+
+Provider keys and NeonDiff entitlements are separate inputs. Provider keys are
+for model access; they are not proof that private-repo review is licensed.
+Record whether the transcript is proving:
+
+- public repo review on the default free path
+- public repo review with `license.publicReposFree=false`
+- private repo review with an active private entitlement
+
+Do not treat a public-only entitlement as proof for a private repo path.
+
+Evidence to capture:
+
+- `init.log`: sanitized init output
+- `config.redacted.json`: config with secrets and local private paths redacted
+- `config.sha256`: hash of the redacted config
+- `paths.txt`: state and evidence directories
+
+Stop if init overwrites an existing file without confirmation, writes secrets
+to tracked files, creates world-readable secret material, or leaves required
+fields undocumented.
+
+## Step 3: GitHub Doctor
+
+Check GitHub App visibility before provider or review work:
+
+```bash
+neondiff doctor github --config "$work_dir/config.local.json" --json
+```
+
+Evidence to capture:
+
+- `doctor-github.json`
+- `github-installation.md`: selected repos, App slug/id if safe, and permission
+  checklist
+
+Expected shape:
+
+- `ok` is true
+- `github.readMode` is `app_installation`
+- `github.canPostAsApp` matches the dry-run/live boundary under test
+- every enabled repo appears in `github.readChecks[]`
+- `activeRepoChecks` is greater than zero
+
+Stop if the App cannot read the target repo, the target repo is not explicitly
+selected, issue-enrichment permissions are enabled unintentionally, or the
+doctor path requires a personal access token for the PR review path.
+
+Issue enrichment is out of scope for this setup pass unless the transcript is
+explicitly about that lane. PR review allowlists do not opt a repo into issue
+enrichment, and enabling issue enrichment should not imply processing an
+existing open-issue backlog by default.
+
+## Step 4: Provider Readiness
+
+List providers without calling models:
+
+```bash
+neondiff providers list --config "$work_dir/config.local.json" --json
+```
+
+Run provider doctor:
+
+```bash
+neondiff providers doctor --config "$work_dir/config.local.json" --json
+```
+
+For a single local OpenAI-compatible endpoint smoke, name the provider:
+
+```bash
+neondiff providers doctor \
+  --config "$work_dir/config.local.json" \
+  --provider <provider-id> \
+  --smoke true \
+  --json
+```
+
+For hosted BYOK endpoints, require an explicit operator decision before remote
+smoke:
+
+```bash
+NEONDIFF_ALLOW_REMOTE_SMOKE=true \
+  neondiff providers doctor \
+    --config "$work_dir/config.local.json" \
+    --provider <hosted-provider-id> \
+    --smoke true \
+    --json
+```
+
+Evidence to capture:
+
+- `providers-list.json`
+- `providers-doctor.json`
+- `providers-smoke.json` when smoke is in scope
+- `provider-egress.md`: local/self-hosted/hosted classification and what data
+  was allowed to leave the worker
+
+Stop if a provider check fans out to multiple authenticated hosted providers,
+prints an API key, sends PR diffs during provider smoke, or requires hosted
+egress when the run is supposed to be no-egress.
+
+## Step 5: Full Doctor
+
+Run the full readiness check after GitHub and provider checks:
+
+```bash
+neondiff doctor --config "$work_dir/config.local.json" --json
+```
+
+Evidence to capture:
+
+- `doctor.json`
+- `doctor-summary.md`: pass/fail fields and any docs mismatch
+
+Stop if `ok` is false, repo policy skips the target unexpectedly, provider
+readiness is unclear, or the output asks the runner to use undocumented flags.
+
+## Step 6: First Dry-Run Review
+
+Use a known repository, PR number, and current head SHA. Keep live posting off.
+
+```bash
+neondiff review-pr \
+  --config "$work_dir/config.local.json" \
+  --repo owner/name \
+  --pr 123 \
+  --dry-run true \
+  --zcode false
+```
+
+Evidence to capture:
+
+- `dry-run-review.json`
+- `target-pr.md`: repo, PR number, base SHA, head SHA, and why this PR is safe
+  for setup validation
+- `evidence-manifest.txt`: files written by the dry-run evidence directory
+- `redaction-check.md`: confirmation that saved artifacts do not contain
+  private keys, provider API keys, GitHub tokens, license keys, or raw customer
+  data
+
+When validating a blocked private or commercial path, the expected result is an
+early license gate before checkout, file listing, provider calls, or GitHub
+review posting. Capture that path with:
+
+- `license-gate.json` or equivalent redacted gate evidence
+- `license-summary.md`: repo visibility, entitlement scope/status, and why the
+  worker stopped before review execution
+
+Stop if the command attempts to post a live review, uses `--dry-run false`,
+cannot prove current head state, writes evidence into the repo, or produces
+artifact names/fields the setup docs do not explain. Stop and file a docs or
+product bug if a blocked private/commercial run reaches checkout, file listing,
+provider setup, or posting before the license gate fires.
+
+## Clean Setup Pass Criteria
+
+A transcript can be attached as setup evidence only when:
+
+- every command in the install -> init -> doctor -> providers -> first dry-run
+  review path is present with exact command text
+- every expected JSON output file exists and is parseable
+- the target repo and PR are explicit
+- the dry-run review did not post comments, reviews, labels, or branch changes
+- blocked private/commercial proofs stop before checkout, file listing,
+  provider calls, and review posting while still capturing license-gate
+  evidence
+- secrets are absent from transcript and evidence
+- every deviation from README or docs/SETUP.md is listed as a docs bug or setup
+  bug
+- the proof boundary states exactly which OS, package/SHA, provider, repo, PR,
+  and head SHA were tested
+
+## Stop Conditions
+
+Stop and file or update the tracked issue when any of these occur:
+
+- install cannot run from the documented commands
+- Node/npm requirements differ from docs
+- `neondiff init` needs hidden local context
+- GitHub App permissions or selected-repo install steps are missing or wrong
+- provider setup requires storing a secret in tracked config
+- hosted provider smoke runs without explicit remote-smoke consent
+- dry-run review mutates GitHub
+- evidence contains secrets or raw private/customer data
+- commands require package/source changes outside the validation issue
+- the runner cannot explain whether the failure is docs, environment, provider,
+  GitHub App, or product behavior
+
+## Proof Boundary
+
+A completed transcript proves only that the documented first-run path worked
+for the named environment, package or SHA, GitHub App installation, provider,
+repository, PR, and head SHA. It does not prove GA readiness, all-platform
+support, live-posting safety, provider quality, hosted BYOK behavior, release
+readiness, desktop readiness, marketplace readiness, or calibrated review
+accuracy.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,117 @@
+# NeonDiff Vision
+
+**NeonDiff is the evidence-backed outcome auditor for AI-written and high-risk
+pull requests.**
+
+This document states what NeonDiff is for, the system design that serves that
+purpose, the invariants that protect it, and what NeonDiff deliberately does
+not do. It exists so contributors, operators, and agents can align with the
+product direction without reconstructing it from issue history.
+
+## The Problem
+
+AI-generated code has made pull-request volume and review fatigue worse, not
+better. Most AI reviewers respond by competing on breadth: more walkthrough
+prose, more comment types, more lifecycle features. Breadth does not fix the
+core failure mode — a reviewer that is wrong often enough gets muted, and a
+muted reviewer catches nothing.
+
+The scarce resource in code review is not commentary. It is **trust**: when
+this reviewer requests changes, is it right?
+
+## The Bet
+
+NeonDiff competes on trust, not breadth:
+
+> The reviewer that measures its own precision on your repo, and only speaks
+> when calibrated evidence says it should.
+
+That claim is only meaningful if the system can back it with data, which is why
+the core of NeonDiff is not a prompt — it is a closed measurement loop around
+every finding it posts.
+
+## The Calibration Loop
+
+1. **Findings carry validated confidence.** Every finding is schema-validated
+   (severity, category, location on current RIGHT-side diff lines, confidence
+   in `[0,1]`). Ranking is confidence-aware within each severity tier, the
+   inline-comment cap keeps the highest-confidence findings, and optional
+   per-severity confidence floors gate `REQUEST_CHANGES` so a single
+   low-confidence high-severity finding cannot block a PR on its own.
+2. **Outcomes are observed, not assumed.** A post-merge outcome observer
+   revisits reviewed PRs and records what actually happened — revert, hotfix,
+   merged fix, human thread — as per-finding outcome labels. Negative controls
+   are explicit: a clean run is only credited as clean when it is deliberately
+   marked, never inferred from the absence of labels.
+3. **Labels become empirical precision.** A batch calibration runner aggregates
+   outcome labels into per-confidence-bin precision with Wilson lower bounds —
+   the same statistics the offline eval harness uses, computed from live
+   history.
+4. **Feedback into behavior is human-gated.** The promotion tooling emits a
+   reviewable patch file; it never rewrites live config on its own, and the
+   public "calibrated" display mode is never machine-written under any flag.
+   Public confidence display stays redacted until hard evidence floors are met
+   (at minimum 100 labeled findings, 30 P0/P1 labels, 10 explicit negative
+   controls, and a 0.95 Wilson lower bound) and a human applies the change.
+
+The loop makes "evidence-backed" a property of the system rather than a
+marketing sentence: the same numbers that would justify the calibrated claim
+are the numbers that tune ranking, floors, and suppression.
+
+## Design Invariants
+
+These hold for every change, and reviewers should reject changes that break
+them:
+
+- **Quieter-only feedback.** Learned signals — confidence floors, category
+  precision floors, repo-memory false-positive suppression, self-consistency
+  refutation — may demote, suppress, or strip request-changes eligibility.
+  They never promote a finding or escalate the review verdict.
+- **Fail-closed configuration.** Unknown keys, out-of-range values, and
+  malformed shapes are rejected at load, not silently ignored.
+- **Additive and default-off.** New gate behavior ships disabled and opt-in,
+  with dry-run evidence, before anyone depends on it.
+- **Advisory proof boundaries.** NeonDiff does not claim calibrated accuracy
+  before evals prove it. Confidence numbers are redacted from public surfaces
+  until the calibration gate is legitimately passed.
+- **Posting safety.** App-authored identity, at most one review per
+  `{repo, pr, head_sha}`, current-head re-checks before every live operation,
+  no `APPROVE`, no merges, no repo mutation, and secret-looking findings are
+  suppressed rather than posted redacted.
+- **Local-first, BYOK.** Diffs go to the providers the operator configured,
+  under the operator's keys and budget — not to a hosted review service.
+
+## What NeonDiff Deliberately Does Not Do
+
+- **No breadth race.** Walkthrough prose, issue planners, and feature parity
+  with hosted reviewers are not goals. A feature earns its place by sharpening
+  precision, calibration, or safety — not by matching a competitor's tab.
+- **No autonomous repo mutation.** NeonDiff does not approve, merge, push
+  fixes, or expand its GitHub permissions by configuration alone.
+- **No unearned claims.** No "calibrated" label, accuracy percentage, or
+  benchmark claim appears on a public surface before the evidence gate passes.
+- **No hosted diff processing.** There is no NeonDiff server reading your
+  code. The worker runs where the operator runs it.
+
+## Where This Goes
+
+The near-term direction is deepening the loop, not widening the surface:
+per-category rolling precision consulted by ranking and the request-changes
+gate, relevance-scored related context, and outcome-weighted review routing
+once — and only once — a calibrated signal exists to route on. The public
+roadmap is tracked in
+[#103](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103);
+the ranking/scoring and calibration program that produced this document is
+[#278](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/278).
+
+## Related Documents
+
+- [README](../README.md) — product overview, install, safety boundaries
+- [calibration-loop.md](calibration-loop.md) — the operator guide for running
+  the loop end to end
+- [neondiff-config.md](neondiff-config.md) — the configuration surface,
+  including the review gate and calibration keys
+- [eval-harness.md](eval-harness.md) — offline evaluation and calibration
+  statistics
+- [release-governance.md](release-governance.md) — versioning and the GA line
+- [CHANGELOG](../CHANGELOG.md) — shipped changes by version

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -28,7 +28,17 @@ NeonDiff competes on trust, not breadth:
 
 That claim is only meaningful if the system can back it with data, which is why
 the core of NeonDiff is not a prompt — it is a closed measurement loop around
-every finding it posts.
+every finding it posts. The core job is not to sound smart about every diff;
+it is to make high-risk PRs harder to merge without a visible proof trail.
+
+Where NeonDiff fits first:
+
+- AI-authored PRs that touch runtime, security, release, billing, data, or
+  customer paths
+- docs or config PRs where public claims can drift ahead of shipped behavior
+- agent-produced changes that need a durable checklist before human review
+- teams that want BYOK or local-model review without handing every diff to a
+  hosted review SaaS
 
 ## The Calibration Loop
 


### PR DESCRIPTION
## Summary

Documentation-only PR for #319 (parent #278, now closed as complete):

- **docs/vision.md** (new): the wedge — evidence-backed outcome auditor — the shipped calibration-loop story, design invariants (quieter-only, fail-closed, additive/default-off, posting safety, local-first/BYOK), explicit non-goals, and where the product goes next. Supersedes the pre-ship draft from #334; grafts its early-target list and proof-trail framing.
- **docs/calibration-loop.md** (new): operator guide for the #286 loop — `outcome-observe` (dry-run-first, `--mark-negative-control` clean-runs-only) → `calibration-aggregate` → `calibration-promote` (`--confirm`; patch-file default; `--apply` double-flag; never writes `publicDisplay.mode`) → the manual human flip, with the evidence-floor table and `categoryPrecisionFloors` curation guidance (confidence-threshold semantics, per the #351 review round).
- **docs/setup-validation.md** (new): clean-transcript runbook adopted verbatim from #334 (codex lane, credited in the commit).
- **README**: Safety Boundaries now states the shipped quieter-only gate behavior; the stale "calibrated CodeRabbit-level accuracy" not-claimed line is replaced with the precise evidence-gate statement; Roadmap Vs Shipped reflects the merged #278 program and links CHANGELOG/vision/calibration-loop.
- **docs/neondiff-config.md**: `reviewGate.categoryPrecisionFloors` key + quieter-only/fail-closed invariant.
- **docs/operator-cli.md**: maintainer-machine absolute paths replaced with `config.local.json`, "legacy internal binary" reframed as the compatibility alias it is, third-party repo names neutralized, stale repo slugs fixed.

## Validation

`node scripts/check-public-claims.mjs` green on the branch; all referenced docs/files verified to exist; no doc claims an unmerged feature (branch rebased onto post-#351 main).

## Proof boundary

Docs only — no runtime, config-schema, or release change. Closing #319 still requires the setup-fix PR (in flight) and the CLI `--version`/`--help` fix.

Part of #319.