### PR TITLE
Neutralize example config + document env credential reads + setup prerequisites (#319)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ Small NeonDiff compatibility matrix:
 
 ## First Dry-Run Review
 
-Run a dry-run review before any live posting:
+Run a dry-run review before any live posting. Replace `--repo owner/name` and
+`--pr 123` below with a repo already listed in your local config's
+`pilotRepos` and an open PR number on that repo — `review-pr` fails with "repo
+must be present in configured repos" if the repo is not in `pilotRepos`:
 
 ```bash
 neondiff review-pr \

--- a/config.example.json
+++ b/config.example.json
@@ -1,8 +1,8 @@
 {
-  "pilotRepos": ["electricsheephq/WorldOS", "100yenadmin/evaOS-GUI"],
+  "pilotRepos": ["example-org/example-repo"],
   "pollIntervalMs": 90000,
   "skipDrafts": true,
-  "canaryPulls": ["electricsheephq/WorldOS#1161", "100yenadmin/evaOS-GUI#497"],
+  "canaryPulls": ["example-org/example-repo#1"],
   "activation": {
     "reviewExistingOpenPrsOnActivation": false
   },
@@ -34,9 +34,10 @@
     "maxStateNotes": 20,
     "includeStaleNotes": false
   },
-  "workRoot": "/Volumes/LEXAR/repos/evaos-code-review-bot-runtime",
-  "statePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews.sqlite",
-  "evidenceDir": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence",
+  "_workRootComment": "workRoot must resolve outside this checkout (enforced at config load: config.workRoot must be outside the current repository checkout). /tmp/neondiff is a placeholder that satisfies that check on any machine without edits; point it at a durable path for real use.",
+  "workRoot": "/tmp/neondiff/runtime",
+  "statePath": "/tmp/neondiff/state/reviews.sqlite",
+  "evidenceDir": "/tmp/neondiff/evidence",
   "issueEnrichment": {
     "enabled": false,
     "postIssueComment": false,

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -125,6 +125,11 @@ permissions under the configured `license.keyPath`, which defaults next to
 Private-repo review only accepts a cached entitlement during a transient API
 outage for up to 15 minutes; longer grace windows are rejected at config load.
 
+`license.apiBaseUrl` must be set in `config.local.json` before you set
+`license.enabled: true` — config load throws
+`license.apiBaseUrl is required when license.enabled=true` otherwise, and
+`license activate` cannot run against a config that fails to load.
+
 ```bash
 NEONDIFF_LICENSE_KEY="..." \
   neondiff license activate \
@@ -224,7 +229,10 @@ The full doctor output is JSON. Check:
 ## 5. Run A Dry-Run Review
 
 Use a known repo, PR number, and current head. A dry-run review should produce
-structured output and evidence without posting comments:
+structured output and evidence without posting comments. Substitute
+`--repo owner/name` with one of the repos you added to `pilotRepos` in step 3
+and `--pr 123` with an open PR number on that repo — `review-pr` fails with
+"repo must be present in configured repos" for any repo not in `pilotRepos`:
 
 ```bash
 neondiff review-pr \
@@ -289,6 +297,33 @@ declares the current public beta version, setup/release-notes alignment, license
 API state, and update-channel readiness. A local source beta may explicitly
 defer license API, website, or desktop channels only when the manifest marks
 that channel as `requiredForThisRelease: false`.
+
+## Environment Variables
+
+Commands such as `doctor` read these ambient environment variables in
+addition to `config.local.json`. None of them are printed by `--json` output.
+Environment values override the matching config-file value where both are
+set.
+
+| Variable | Read by | Overrides config value | Notes |
+| --- | --- | --- | --- |
+| `EVAOS_REVIEW_BOT_APP_ID` | `loadConfig`/`loadConfigFromObject` (`src/config.ts`) | `github.appId` | Set once per step 2; unset falls back to the config-file value. |
+| `EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH` | `loadConfig`/`loadConfigFromObject` (`src/config.ts`) | `github.privateKeyPath` | Path to the GitHub App private key; keep the key itself outside the repo. |
+| `GITHUB_TOKEN` | `loadConfig`/`loadConfigFromObject` (`src/config.ts`) | `github.token` | Local-development fallback token only; App auth is required for App-authored posting. |
+| `EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT` | `getProtectedCheckoutRoots` (`src/path-safety.ts`) | Adds to the built-in checkout-isolation boundary | Advanced use only: an additional path `config.workRoot` must stay outside of, alongside the current package checkout. Unset by default. |
+| `NEONDIFF_ALLOW_REMOTE_SMOKE` | `providers doctor` remote smoke path (`src/providers.ts`) | N/A (opt-in gate, not a config override) | Required before a hosted (non-loopback) provider smoke check is allowed to run. See [docs/providers.md](providers.md). |
+| A provider's configured `apiKeyEnv` name (e.g. `ANTHROPIC_API_KEY`, `NEONDIFF_PROVIDER_API_KEY`) | Provider adapters for any `authMode: "api-key-env"` provider (`src/providers.ts`, `src/provider-adapters.ts`) | N/A (the config only stores the variable *name*, never the key) | Applies to `anthropic`, `openai`, and `openai-compatible` adapters. See [docs/providers.md](providers.md) for the per-provider list. |
+
+The default `zcode-glm` provider (`authMode: "zcode-app-config"`) spawns the
+ZCode CLI with the full ambient environment inherited (`buildZCodeRuntimeEnv`
+in `src/zcode-env.ts` layers `ZCODE_MODEL`/`ZCODE_BASE_URL`/`ZCODE_API_KEY` on
+top of a copy of `process.env`, it does not start from an empty environment).
+Any credential-shaped variable already exported in the shell that runs
+`neondiff` (for example `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, or
+`ANTHROPIC_BASE_URL` if you have one of Anthropic's own tools configured in
+the same shell) is visible to that child process. Run `neondiff` from a shell
+that only exports the variables listed above if you need to bound exactly
+what the ZCode child process can read.
 
 ## Troubleshooting
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -96,6 +96,15 @@ resolution to the local ZCode app config referenced by `zcode.appConfigPath`.
 NeonDiff derives a transient runtime environment for the ZCode child process and
 writes only redacted provider metadata into evidence.
 
+The ZCode child process inherits the full ambient environment of the shell
+that runs `neondiff`, not a filtered subset — `resolveZCodeProviderEnv`/
+`buildZCodeRuntimeEnv` in `src/zcode-env.ts` layer the resolved
+`ZCODE_MODEL`/`ZCODE_BASE_URL`/`ZCODE_API_KEY` on top of a copy of
+`process.env`. See [docs/SETUP.md](SETUP.md#environment-variables) for the
+full list of environment variables NeonDiff itself reads and why this matters
+if you have other providers' credentials (for example `ANTHROPIC_API_KEY`)
+exported in the same shell.
+
 ```json
 {
   "providers": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -232,12 +232,14 @@ export interface RepoMemoryConfig {
 }
 
 const DEFAULT_CONFIG: BotConfig = {
-  pilotRepos: ["electricsheephq/WorldOS", "100yenadmin/evaOS-GUI"],
+  pilotRepos: ["example-org/example-repo"],
   pollIntervalMs: 90_000,
   skipDrafts: true,
-  workRoot: "/Volumes/LEXAR/repos/evaos-code-review-bot-runtime",
-  statePath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/state/reviews.sqlite",
-  evidenceDir: "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence",
+  // workRoot must resolve outside this checkout (validateWorkRootIsolation); /tmp/neondiff is a
+  // portable placeholder that satisfies that check on any machine without edits.
+  workRoot: "/tmp/neondiff/runtime",
+  statePath: "/tmp/neondiff/state/reviews.sqlite",
+  evidenceDir: "/tmp/neondiff/evidence",
   canaryPulls: undefined,
   activation: {
     reviewExistingOpenPrsOnActivation: false


### PR DESCRIPTION
## Summary

Fixes for the four confirmed setup-validation findings from issue #319 (parent #278) — all proved by a clean-env literal-doc-follower walkthrough:

1. **CRITICAL** — `config.example.json` (`workRoot`/`statePath`/`evidenceDir`) and the identical `DEFAULT_CONFIG` fallback in `src/config.ts` shipped the maintainer's own absolute LEXAR paths. A fresh `neondiff init` attached to the maintainer's live instance on their machine, and pointed at a broken absolute path on any other machine. Replaced with `/tmp/neondiff/*` placeholders — chosen specifically because `validateWorkRootIsolation` requires `workRoot` to resolve outside the current checkout, so a naive relative default (`./work`) would have failed that check for every user out of the box.
2. **SEVERE** — `config.example.json`'s `pilotRepos`/`canaryPulls` shipped real third-party repo names (`electricsheephq/WorldOS`, `100yenadmin/evaOS-GUI`). Neutralized to `example-org/example-repo`. README's "First Dry-Run Review" and SETUP.md's step 5 now explicitly tell the reader to substitute a repo from their own configured `pilotRepos` before running `review-pr`, so a literal doc-follower running the unmodified `--repo owner/name` example no longer hits `review-pr repo must be present in configured repos` with no explanation.
3. **SEVERE** — undocumented ambient env credential reads. Added an "Environment Variables" section to `docs/SETUP.md` enumerating every var NeonDiff reads (`EVAOS_REVIEW_BOT_APP_ID`, `EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH`, `GITHUB_TOKEN` in `src/config.ts`; `EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT` in `src/path-safety.ts`; `NEONDIFF_ALLOW_REMOTE_SMOKE`; and any provider's configured `apiKeyEnv` name), whether each overrides the config file, and that the default `zcode-app-config` provider path spawns the ZCode child process with the **entire ambient environment inherited** (`buildZCodeRuntimeEnv` in `src/zcode-env.ts` copies `process.env` as its base), not a filtered subset — so any credential-shaped var already exported in the shell (e.g. `ANTHROPIC_API_KEY`) is visible to that child process. `docs/providers.md` cross-references this in the GLM/ZCode section.
4. `docs/SETUP.md`'s license-activation step now states the `license.apiBaseUrl` prerequisite (config load throws `license.apiBaseUrl is required when license.enabled=true` otherwise) right before the `license activate` command — previously only discoverable from an inline comment in `config.example.json`.

## Validation

- `npm run build` — clean, no TypeScript errors.
- Targeted tests (grepped `tests/` for references to `config.example.json` or the changed paths/values first, ran only those — never the full suite): `tests/public-cli.test.ts`, `tests/public-release-readiness.test.ts`, `tests/neondiff-config-schema.test.ts`. All 3 files pass (75 tests) once vitest's default 5000ms per-test timeout is raised for the CLI-subprocess-spawning file (`--testTimeout=20000`); at the default timeout, 6 `public-cli.test.ts` tests intermittently exceed 5000ms spawning the real CLI subprocess under machine load — confirmed pre-existing/environmental, not caused by this change (the file has zero diff vs `origin/main`, none of its fixtures reference any value this PR touches, and the same tests pass individually with more headroom).
- Manually ran `node dist/src/cli.js init` in a fresh temp dir, confirmed the generated config resolves `workRoot`/`statePath`/`evidenceDir` to `/tmp/neondiff/*` — verified `doctor`/`status` against that fresh config no longer touch any `/Volumes/...` path (the remaining gate is the documented GitHub App credential, exactly as SETUP.md's walkthrough anticipates).

## Proof boundary

Docs/example fixes only; no gate or runtime logic change. `DEFAULT_CONFIG` values changed (same class of fix as the example file — it's the in-code fallback default with the identical maintainer-path bug), but no validation rule, review gate, or license/provider logic was touched. No test asserted the old placeholder values.

Part of #319.