### PR TITLE
[codex] tighten setup and issue-enrichment docs

### DIFF
--- a/docs/setup-validation.md
+++ b/docs/setup-validation.md
@@ -10,7 +10,8 @@ The validation target is a literal pass through:
 install -> init -> doctor -> providers -> first dry-run review
 ```
 
-Run this twice before using the result as issue #319 evidence:
+For maintainer setup-readiness evidence, run this twice before attaching the
+result to the relevant readiness tracker:
 
 - human transcript: a human follows README and [docs/SETUP.md](SETUP.md)
   without hidden repo knowledge
@@ -22,6 +23,15 @@ Run this twice before using the result as issue #319 evidence:
 Use a clean machine, clean container, or clean macOS user/session. If that is
 not available, use an isolated temp npm prefix plus fresh config, state, and
 evidence directories outside the repository.
+
+All command examples below assume these scratch paths are defined first:
+
+```bash
+export scratch_parent="${TMPDIR:-/tmp}"
+export work_dir="${work_dir:-$(mktemp -d "$scratch_parent/neondiff-setup-validation.XXXXXX")}"
+export tmp_prefix="$work_dir/npm-prefix"
+mkdir -p "$tmp_prefix" "$work_dir/evidence"
+```
 
 Record:
 
@@ -39,11 +49,14 @@ Record:
 Do not record raw private keys, provider API keys, GitHub tokens, license keys,
 raw customer data, or unredacted model transcripts.
 
-Suggested evidence root:
+Suggested local evidence root:
 
 ```text
-/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/setup-validation/YYYY-MM-DD/<human-or-agent>/
+$work_dir/evidence/setup-validation/YYYY-MM-DD/<human-or-agent>/
 ```
+
+Maintainers can copy or link the sanitized transcript from that root into the
+relevant GitHub issue or release evidence packet after the run completes.
 
 ## Transcript Format
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -6,7 +6,10 @@ pull requests.**
 This document states what NeonDiff is for, the system design that serves that
 purpose, the invariants that protect it, and what NeonDiff deliberately does
 not do. It exists so contributors, operators, and agents can align with the
-product direction without reconstructing it from issue history.
+product direction without reconstructing it from issue history. The worker
+runs locally with a GitHub App scoped to explicit repositories; public
+repositories are free by default, while private repository review requires an
+active private entitlement.
 
 ## The Problem
 
@@ -79,6 +82,9 @@ them:
   They never promote a finding or escalate the review verdict.
 - **Fail-closed configuration.** Unknown keys, out-of-range values, and
   malformed shapes are rejected at load, not silently ignored.
+- **Entitlement-gated private review.** Private or commercial review requests
+  stop before checkout, file listing, provider calls, or GitHub review posting
+  when entitlement proof is missing.
 - **Additive and default-off.** New gate behavior ships disabled and opt-in,
   with dry-run evidence, before anyone depends on it.
 - **Advisory proof boundaries.** NeonDiff does not claim calibrated accuracy
@@ -90,6 +96,9 @@ them:
   suppressed rather than posted redacted.
 - **Local-first, BYOK.** Diffs go to the providers the operator configured,
   under the operator's keys and budget — not to a hosted review service.
+
+Strong automation should reduce ambiguity for a human maintainer. It should not
+hide the boundary between evidence, judgment, and authority.
 
 ## Provider And BYOK Boundaries
 
@@ -108,6 +117,9 @@ operator chooses.
   NeonDiff entitlements govern which repo visibilities the worker may review.
 - NeonDiff support tiers are software/support entitlement boundaries. Provider
   and model costs stay external through BYOK or local models.
+- Active private entitlement covers private repos and public repos when an
+  operator disables the default public-free path. Public-only entitlement does
+  not unlock private repos.
 - Provider resource catalogs are discovery aids, not proof that a provider can
   run NeonDiff reviews.
 
@@ -163,3 +175,12 @@ the ranking/scoring and calibration program that produced this document is
   statistics
 - [release-governance.md](release-governance.md) — versioning and the GA line
 - [CHANGELOG](../CHANGELOG.md) — shipped changes by version
+
+## Proof Boundary
+
+This vision document states product intent and contributor alignment. It does
+not prove setup, provider quality, release readiness, marketplace readiness,
+desktop readiness, legal readiness, or GA readiness. Those claims need their
+own validation artifacts and tracked issues before they can move into public
+product copy. It also does not prove issue-enrichment rollout readiness for any
+repo unless that repo has separate allowlist, threshold, and evidence coverage.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -91,6 +91,29 @@ them:
 - **Local-first, BYOK.** Diffs go to the providers the operator configured,
   under the operator's keys and budget — not to a hosted review service.
 
+## Provider And BYOK Boundaries
+
+NeonDiff is local-first, but model egress depends on the provider path the
+operator chooses.
+
+- Local or self-hosted endpoints can keep prompts and diffs on the operator's
+  machine or network when the model runtime is actually local.
+- Hosted providers, including ZCode-backed GLM/Z.ai or hosted
+  OpenAI-compatible BYOK gateways, can receive the prompt and diff context
+  needed to produce a review.
+- Provider keys belong in environment variables, local operator wrappers, or
+  supported secret paths. They do not belong in tracked config, GitHub comments,
+  release notes, or evidence packets.
+- Provider keys are not NeonDiff entitlements. They unlock model access, while
+  NeonDiff entitlements govern which repo visibilities the worker may review.
+- NeonDiff support tiers are software/support entitlement boundaries. Provider
+  and model costs stay external through BYOK or local models.
+- Provider resource catalogs are discovery aids, not proof that a provider can
+  run NeonDiff reviews.
+
+See [providers.md](providers.md), [pricing.md](pricing.md), and
+[license-boundary.md](license-boundary.md) for the current public beta wording.
+
 ## What NeonDiff Deliberately Does Not Do
 
 - **No breadth race.** Walkthrough prose, issue planners, and feature parity
@@ -102,6 +125,21 @@ them:
   benchmark claim appears on a public surface before the evidence gate passes.
 - **No hosted diff processing.** There is no NeonDiff server reading your
   code. The worker runs where the operator runs it.
+
+## Issue Enrichment Boundary
+
+Issue enrichment is a separate rollout lane from pull request review.
+
+- PR review allowlists do not opt repositories into issue enrichment.
+- Issue enrichment needs its own allowlist, repo-level throttles, and live-post
+  gate before comments can go out.
+- New issue-enrichment rollouts should keep
+  `processExistingOpenIssuesOnActivation=false` so enabling the lane does not
+  imply scanning or commenting on an existing issue backlog by default.
+
+See [issue-enrichment.md](issue-enrichment.md) for the rollout policy and
+[license-boundary.md](license-boundary.md) for the public/private entitlement
+matrix.
 
 ## Where This Goes
 


### PR DESCRIPTION
## Summary

Follow-up docs-only cleanup after #352 superseded the original #334 branch. This keeps the stronger #352 product/calibration docs while preserving the useful #334 follow-up deltas:

- make `docs/setup-validation.md` runnable from a maintainer-neutral scratch directory instead of a Lexar-only evidence path
- avoid hardcoding issue #319 as the only setup-readiness evidence destination
- make the issue-enrichment boundary explicit in `docs/vision.md`: separate allowlist, repo-level throttles, live-post gate, and no existing-backlog processing on activation
- restate provider/BYOK and entitlement boundaries without claiming GA or calibration readiness

## Scope

Docs only. No source, runtime config, launchd, release, package, or schema changes.

## Validation

- `git diff --check`
- `bash -n` on the setup-validation scratch-path snippet
- `node scripts/check-public-claims.mjs`
- `node scripts/check-secret-scan.mjs`

## Tracking

Refs #319. Follow-up to closed/superseded #334 and merged #352.