### PR TITLE
CLI --version and per-command --help (#319)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -113,6 +113,11 @@ async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const command = args._[0];
 
+  if (args.version === "true" || command === "-v") {
+    console.log(resolvePackageVersion());
+    return;
+  }
+
   if (!command || command === "help" || command === "--help" || command === "-h") {
     console.log(JSON.stringify(buildHelp(), null, 2));
     return;
@@ -2047,6 +2052,14 @@ function resolvePackageRoot(): string {
   return process.cwd();
 }
 
+function resolvePackageVersion(): string {
+  const packageJson = JSON.parse(readFileSync(join(resolvePackageRoot(), "package.json"), "utf8"));
+  if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
+    throw new Error("package.json is missing a version string");
+  }
+  return packageJson.version;
+}
+
 function isNeonDiffPackageRoot(candidate: string): boolean {
   if (!existsSync(join(candidate, "package.json")) || !existsSync(join(candidate, "config.example.json"))) {
     return false;
@@ -2811,10 +2824,102 @@ async function collectIssueEnrichmentReadChecks(
   return checks;
 }
 
+interface CommandUsageFlag {
+  name: string;
+  description: string;
+}
+
+interface CommandUsage {
+  description: string;
+  flags: CommandUsageFlag[];
+}
+
+// Minimal per-command usage registry for `neondiff <command> --help`. Kept
+// intentionally small (not every command) - see AGENTS.md "do not rewrite the
+// help system" guidance in issue #319. Unlisted commands fall back to the
+// generic command list in buildHelp, same as before this registry existed.
+const COMMAND_USAGE: Record<string, CommandUsage> = {
+  init: {
+    description: "Create a local config.local.json from the packaged config.example.json.",
+    flags: [
+      { name: "--config", description: "Path to write the local config file (default config.local.json)." },
+      { name: "--force", description: "Overwrite an existing JSON config-looking file at --config." }
+    ]
+  },
+  pricing: {
+    description: "Print the redacted local pricing/cost model output.",
+    flags: []
+  },
+  doctor: {
+    description: "Check repo read access, provider env, and issue-enrichment readiness (add `github` for GitHub-only checks).",
+    flags: [
+      { name: "--config", description: "Path to the config file (default config.local.json)." }
+    ]
+  },
+  status: {
+    description: "Report combined release, coverage, agent, provider-cooldown, and durable-queue health as one gate.",
+    flags: [
+      { name: "--config", description: "Path to the config file (default config.local.json)." },
+      { name: "--repo", description: "Scope provider-cooldown and durable-queue rows to a single repo." },
+      { name: "--limit", description: "Cap the number of provider-cooldown/durable-queue rows returned." },
+      { name: "--expected-head", description: "Expected release head SHA to verify against." },
+      { name: "--launchd-label", description: "launchd label to inspect for daemon liveness." },
+      { name: "--state-path", description: "Override the SQLite state path (defaults to config.statePath)." }
+    ]
+  },
+  "review-pr": {
+    description: "Run a single dry-run-by-default PR review for one repo/PR (public alias of run-once, scoped to one PR).",
+    flags: [
+      { name: "--config", description: "Path to the config file." },
+      { name: "--repo", description: "Repo to review, owner/name (required)." },
+      { name: "--pr", description: "Pull request number to review (required)." },
+      { name: "--dry-run", description: "true (default) or false; false requires --confirm true." },
+      { name: "--confirm", description: "Must be true to allow --dry-run false." }
+    ]
+  },
+  "run-once": {
+    description: "Run a single review cycle across configured repos (internal/operator alias of review-pr's cycle).",
+    flags: [
+      { name: "--config", description: "Path to the config file." },
+      { name: "--repo", description: "Optional repo to scope the cycle to, owner/name." },
+      { name: "--dry-run", description: "true (default) or false; false requires --confirm true." },
+      { name: "--confirm", description: "Must be true to allow --dry-run false." }
+    ]
+  },
+  daemon: {
+    description: "Control or run the review daemon: `daemon start|stop|status`, or no subcommand to run the poll loop directly.",
+    flags: [
+      { name: "--config", description: "Path to the config file." },
+      { name: "--launchd-label", description: "launchd label for start/stop/status subcommands." },
+      { name: "--dry-run", description: "true (default) or false for the direct poll loop." },
+      { name: "--once", description: "true to run a single cycle instead of looping (direct poll loop only)." }
+    ]
+  },
+  providers: {
+    description: "Inspect the provider registry: `providers list` or `providers doctor`.",
+    flags: [
+      { name: "--config", description: "Path to the config file." },
+      { name: "--provider", description: "Scope providers doctor to a single provider id." },
+      { name: "--smoke", description: "true to run a live smoke check in providers doctor." }
+    ]
+  },
+  license: {
+    description: "Manage the license: `license activate|status|deactivate`.",
+    flags: [
+      { name: "--config", description: "Path to the config file." },
+      { name: "--license-key-env", description: "Env var name holding the license key (activate only)." },
+      { name: "--repo", description: "Repo to scope activation/status to, owner/name." },
+      { name: "--refresh", description: "true to force a fresh status check instead of cached." }
+    ]
+  }
+};
+
 function buildHelp(command?: string) {
+  const usage = command ? COMMAND_USAGE[command] : undefined;
   return {
     ok: true,
     ...(command ? { command } : {}),
+    ...(usage ? { usage: { command, ...usage } } : {}),
     commands: {
       public: [
         "init",

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -934,6 +934,88 @@ exit 1
     }
   });
 
+  it("prints command-scoped usage for a known command's --help instead of only the generic list", async () => {
+    const { stdout } = await runCli(["doctor", "--help"]);
+    const output = JSON.parse(stdout);
+
+    expect(output.ok).toBe(true);
+    expect(output.command).toBe("doctor");
+    // Command-scoped usage must be distinguishable from the generic fallback:
+    // it names the specific command's own flags/description, not just the
+    // full command list every other command's --help would also show.
+    expect(output.usage).toBeDefined();
+    expect(output.usage.command).toBe("doctor");
+    expect(typeof output.usage.description).toBe("string");
+    expect(output.usage.description.length).toBeGreaterThan(0);
+    expect(Array.isArray(output.usage.flags)).toBe(true);
+    expect(output.usage.flags.some((flag: { name: string }) => flag.name === "--config")).toBe(true);
+    // Generic list stays present for backward compatibility with existing callers.
+    expect(output.commands.existing).toContain("doctor");
+  });
+
+  it("prints distinct command-scoped usage per command, not the same generic block reused", async () => {
+    const [doctorResult, statusResult] = await Promise.all([
+      runCli(["doctor", "--help"]),
+      runCli(["status", "--help"])
+    ]);
+    const doctorOutput = JSON.parse(doctorResult.stdout);
+    const statusOutput = JSON.parse(statusResult.stdout);
+
+    expect(doctorOutput.usage.command).toBe("doctor");
+    expect(statusOutput.usage.command).toBe("status");
+    expect(doctorOutput.usage.description).not.toBe(statusOutput.usage.description);
+  });
+
+  it("keeps generic top-level help unscoped when no command is given", async () => {
+    const { stdout } = await runCli(["help"]);
+    const output = JSON.parse(stdout);
+
+    expect(output.command).toBeUndefined();
+    expect(output.usage).toBeUndefined();
+  });
+
+  it("falls back to the generic command list for an unrecognized command's --help", async () => {
+    const { stdout } = await runCli(["totally-unknown-command", "--help"]);
+    const output = JSON.parse(stdout);
+
+    expect(output.ok).toBe(true);
+    expect(output.command).toBe("totally-unknown-command");
+    expect(output.usage).toBeUndefined();
+    expect(output.commands.existing).toContain("doctor");
+  });
+
+  it("prints the package.json version and exits 0 for --version", async () => {
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+
+    const { stdout, stderr } = await runCli(["--version"]);
+
+    expect(stdout.trim()).toBe(packageJson.version);
+    expect(stderr).toBe("");
+  });
+
+  it("prints the package.json version and exits 0 for the -v shorthand", async () => {
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+
+    const { stdout, stderr } = await runCli(["-v"]);
+
+    expect(stdout.trim()).toBe(packageJson.version);
+    expect(stderr).toBe("");
+  });
+
+  it("does not execute a command's logic when --version is requested standalone", async () => {
+    const { stdout } = await runCli(["--version"]);
+
+    expect(stdout).not.toContain("\"dryRun\"");
+    expect(stdout).not.toContain("\"reposScanned\"");
+  });
+
+  it("still shows the generic command list and exits nonzero for a bare unknown command (regression pin)", async () => {
+    await expect(runCli(["totally-unknown-command"])).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("Unknown command: totally-unknown-command")
+    });
+  });
+
   it("initializes a local config from the packaged example outside the repo cwd", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-init-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- `neondiff --version` and `neondiff -v` now print the `package.json` version string and exit 0, instead of silently falling through to the generic top-level command list. Version is read at runtime via a new `resolvePackageVersion()` helper that reuses the existing `resolvePackageRoot()` walk-up-and-read pattern (same one `init` already uses for `config.example.json`) — never hardcoded.
- `neondiff <command> --help` for a small registry of known commands (`init`, `pricing`, `doctor`, `status`, `review-pr`, `run-once`, `daemon`, `providers`, `license`) now returns a `usage` block (`description` + `flags`) scoped to that command, instead of silently reusing the exact same generic `commands`/`examples` object every other command's `--help` also produces. The existing generic `commands` list stays present in the output for backward compatibility with the pre-existing `"prints command help without executing run-once, review-pr, or daemon paths"` test. Commands outside the registry (and no command at all) keep the current generic-fallback behavior unchanged.

## Validation
- New TDD failing-first tests added to `tests/public-cli.test.ts`: `--version`/`-v` print exact `package.json` version + exit 0 without executing command logic; `doctor --help` returns a `usage` block distinguishable from the generic list; `doctor --help` vs `status --help` produce distinct scoped usage (not the same block reused); no-command `help` stays unscoped; an unrecognized command's `--help` falls back to the generic list; a bare unknown command still shows the generic list and exits nonzero (regression pin, verified against current behavior before pinning).
- `npx vitest run tests/public-cli.test.ts --pool=forks --maxWorkers=1` (matches this repo's CI pool/worker flags): **64/64 passed**, ~18.6s. Also re-verified with the local `singleThread` vitest config (`--testTimeout=20000` to route around a local-machine-only concurrency artifact unrelated to this change — confirmed by reverting the diff and reproducing the same artifact on an unmodified pre-existing test).
- `npm run build`: clean, no type errors.

## Proof boundary
CLI help/version surface only; no review, gate, or posting logic touched.

Part of #319