### PR TITLE
[codex] Add license service admin status slice

### DIFF
--- a/docs/license-service-admin.md
+++ b/docs/license-service-admin.md
@@ -1,0 +1,107 @@
+# License Service Admin Readiness
+
+Issue: [#327](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327)
+Status: source-only readiness slice; mock-only proof
+
+This document defines the operator/admin boundary for NeonDiff's hosted or
+direct license service integration. It does not prove a staging endpoint,
+admin credential, billing webhook, production service, or customer-ready
+private-repo entitlement flow.
+
+## Current Proof Boundary
+
+The source tree can model and test license-service outcomes locally. The proof
+in this slice is limited to mocked API responses and local cache behavior:
+
+- the client recognizes `expired`, `revoked`, `invalid`, `scope_mismatch`,
+  `rate_limited`, `unsupported_client`, `clock_skew`, `network`, and `server`
+  status outcomes;
+- private and unknown repo review gates still fail closed when entitlement is
+  missing, stale, non-active, or not scoped for the requested visibility;
+- active entitlement cache metadata can include the license fingerprint, plan,
+  repo visibility coverage, private-repo allowance, update entitlement,
+  expiry, offline grace metadata, and revocation reason when supplied by a
+  service response;
+- secret-bearing values remain outside tracked config, GitHub evidence, and
+  operator docs.
+
+This is not GA readiness, not production readiness, and not a calibrated review
+quality claim.
+
+## Expected Admin Outcomes
+
+The license service or admin console should eventually let an authorized
+operator perform these actions without exposing raw license keys, payment data,
+private repo contents, provider keys, or customer secrets:
+
+| Admin outcome | Client-facing status | Operator note |
+| --- | --- | --- |
+| License covers the requested repo visibility | `active` | Review may proceed to the next setup/provider gate. |
+| License exists but does not cover the requested repo or visibility | `scope_mismatch` | Keep the gate closed and inspect entitlement scope. |
+| License is expired | `expired` | Keep the gate closed until billing/support resolves renewal. |
+| License is revoked, refunded, charged back, or manually disabled | `revoked` | Keep the gate closed and include a redacted revocation reason when available. |
+| License key is malformed or unknown | `invalid` | Keep the gate closed without echoing the submitted key. |
+| Service throttles validation or activation | `rate_limited` | Keep the gate closed; do not treat throttling as live readiness. |
+| Client version is too old for the service contract | `unsupported_client` | Ask the operator to upgrade before retrying. |
+| Client/server time drift is outside service tolerance | `clock_skew` | Ask the operator to correct time sync before retrying. |
+| Network or service failure | `network` or `server` | Use only the existing short offline cache grace for active cached entitlements; otherwise fail closed. |
+
+Legacy service responses remain supported: for example, a bare HTTP 403 without
+an explicit `scope_mismatch` body remains classified as `revoked`.
+
+## Entitlement Metadata
+
+The client-side entitlement model may preserve these fields when a service
+response supplies them:
+
+- `licenseFingerprint`: short local fingerprint derived from the submitted
+  license key, never the raw key;
+- `plan`: human-readable support or entitlement tier;
+- `repoVisibilityScope`: `public`, `private`, or `all`;
+- `privateRepoAllowed`: whether private-repo review is allowed by this
+  entitlement;
+- `updateEntitlement`: whether update-channel access is allowed;
+- `expiresAt`: entitlement expiry time;
+- `offlineGraceMs` and `graceUntil`: cache-grace metadata for operator
+  diagnosis;
+- `revocationReason`: redacted reason such as refund, chargeback, manual
+  disable, or policy violation.
+
+Metadata is evidence, not authority. Review gating still requires an active
+entitlement that covers the requested repo visibility and passes the existing
+freshness rules.
+
+## Required Live Readiness Inputs
+
+A future PR or release gate needs all of the following before claiming live
+license-service readiness:
+
+- a staging license API base URL;
+- staging admin credentials or delegated operator access;
+- a non-secret test license or fixture account with documented allowed scope;
+- redacted activation, status, refresh, and deactivate evidence;
+- proof that the admin path can issue, inspect, revoke, and restore an
+  entitlement without exposing private repo contents;
+- secret scan and public-claims scan results for the exact evidence packet.
+
+Without those inputs, operators may claim only mocked/local contract coverage.
+
+## Stop Conditions
+
+Stop and return to the release captain if any of these occur:
+
+- staging endpoint or admin credential is missing;
+- a raw license key, payment identifier, provider key, GitHub token, private
+  diff, or customer secret appears in logs, docs, evidence, or GitHub;
+- private repo visibility is unknown and a live path tries to proceed;
+- the service returns a status outside the documented taxonomy;
+- live validation requires expanding GitHub App permissions;
+- evidence would imply production, GA, enterprise, marketplace, or calibrated
+  review-quality readiness from mocked responses alone.
+
+## Follow-Up
+
+The next slice should connect this source contract to a staging-only admin
+smoke once the endpoint and credentials exist. That follow-up should update
+issue `#327` with a redacted evidence path under
+`/Volumes/LEXAR/Codex/evidence/neondiff/<date>/production-license-service/`.

--- a/docs/license-service-admin.md
+++ b/docs/license-service-admin.md
@@ -46,8 +46,10 @@ private repo contents, provider keys, or customer secrets:
 | Client/server time drift is outside service tolerance | `clock_skew` | Ask the operator to correct time sync before retrying. |
 | Network or service failure | `network` or `server` | Use only the existing short offline cache grace for active cached entitlements; otherwise fail closed. |
 
-Legacy service responses remain supported: for example, a bare HTTP 403 without
-an explicit `scope_mismatch` body remains classified as `revoked`.
+When a response body provides an explicit non-`active` status, that status is
+authoritative and takes precedence over the HTTP-status fallback. Legacy service
+responses remain supported: for example, a bare HTTP 403 without an explicit
+`scope_mismatch` body remains classified as `revoked`.
 
 ## Entitlement Metadata
 

--- a/docs/license-service-admin.md
+++ b/docs/license-service-admin.md
@@ -18,10 +18,10 @@ in this slice is limited to mocked API responses and local cache behavior:
   status outcomes;
 - private and unknown repo review gates still fail closed when entitlement is
   missing, stale, non-active, or not scoped for the requested visibility;
-- active entitlement cache metadata can include the license fingerprint, plan,
+- entitlement cache metadata can include the license fingerprint, plan,
   repo visibility coverage, private-repo allowance, update entitlement,
-  expiry, offline grace metadata, and revocation reason when supplied by a
-  service response;
+  expiry, offline grace metadata, and non-active revocation reason when supplied
+  by a service response;
 - secret-bearing values remain outside tracked config, GitHub evidence, and
   operator docs.
 
@@ -36,7 +36,7 @@ private repo contents, provider keys, or customer secrets:
 
 | Admin outcome | Client-facing status | Operator note |
 | --- | --- | --- |
-| License covers the requested repo visibility | `active` | Review may proceed to the next setup/provider gate. |
+| License covers the requested repo visibility | `active` | Review may proceed to the next setup/provider gate unless `privateRepoAllowed=false` denies a private repo. |
 | License exists but does not cover the requested repo or visibility | `scope_mismatch` | Keep the gate closed and inspect entitlement scope. |
 | License is expired | `expired` | Keep the gate closed until billing/support resolves renewal. |
 | License is revoked, refunded, charged back, or manually disabled | `revoked` | Keep the gate closed and include a redacted revocation reason when available. |
@@ -46,10 +46,15 @@ private repo contents, provider keys, or customer secrets:
 | Client/server time drift is outside service tolerance | `clock_skew` | Ask the operator to correct time sync before retrying. |
 | Network or service failure | `network` or `server` | Use only the existing short offline cache grace for active cached entitlements; otherwise fail closed. |
 
-When a response body provides an explicit non-`active` status, that status is
-authoritative and takes precedence over the HTTP-status fallback. Legacy service
+When a 2xx response body provides a non-`active` status, that status is
+authoritative and the gate fails closed without writing an active cache.
+For non-2xx responses, durable denial statuses (`expired`, `revoked`, `invalid`,
+`scope_mismatch`, and `unsupported_client`) are authoritative when present in the
+body. Transient statuses only override when the HTTP code matches the transient
+contract (`429` for `rate_limited`, `400` for `clock_skew`). Legacy service
 responses remain supported: for example, a bare HTTP 403 without an explicit
-`scope_mismatch` body remains classified as `revoked`.
+`scope_mismatch` body remains classified as `revoked`, and a bare HTTP 409
+remains classified as `scope_mismatch`.
 
 ## Entitlement Metadata
 
@@ -60,18 +65,21 @@ response supplies them:
   license key, never the raw key;
 - `plan`: human-readable support or entitlement tier;
 - `repoVisibilityScope`: `public`, `private`, or `all`;
-- `privateRepoAllowed`: whether private-repo review is allowed by this
-  entitlement;
+- `privateRepoAllowed`: when present as `false`, private-repo review fails
+  closed even if `repoVisibilityScope` is `private` or `all`;
 - `updateEntitlement`: whether update-channel access is allowed;
 - `expiresAt`: entitlement expiry time;
 - `offlineGraceMs` and `graceUntil`: cache-grace metadata for operator
-  diagnosis;
+  diagnosis; local `config.license.offlineGraceMs` remains the authority for
+  whether cached entitlement grace is accepted;
 - `revocationReason`: redacted, printable, length-capped reason such as refund,
-  chargeback, manual disable, or policy violation.
+  chargeback, manual disable, or policy violation; preserved only when the
+  entitlement status is not `active`.
 
-Metadata is evidence, not authority. Review gating still requires an active
-entitlement that covers the requested repo visibility and passes the existing
-freshness rules.
+Metadata is evidence, not authority, except that `privateRepoAllowed=false` is
+treated as an explicit fail-closed private-repo denial. Review gating still
+requires an active entitlement that covers the requested repo visibility and
+passes the existing freshness rules.
 
 ## Required Live Readiness Inputs
 

--- a/docs/license-service-admin.md
+++ b/docs/license-service-admin.md
@@ -66,8 +66,8 @@ response supplies them:
 - `expiresAt`: entitlement expiry time;
 - `offlineGraceMs` and `graceUntil`: cache-grace metadata for operator
   diagnosis;
-- `revocationReason`: redacted reason such as refund, chargeback, manual
-  disable, or policy violation.
+- `revocationReason`: redacted, printable, length-capped reason such as refund,
+  chargeback, manual disable, or policy violation.
 
 Metadata is evidence, not authority. Review gating still requires an active
 entitlement that covers the requested repo visibility and passes the existing

--- a/docs/license-service-admin.md
+++ b/docs/license-service-admin.md
@@ -114,4 +114,5 @@ Stop and return to the release captain if any of these occur:
 The next slice should connect this source contract to a staging-only admin
 smoke once the endpoint and credentials exist. That follow-up should update
 issue `#327` with a redacted evidence path under
-`/Volumes/LEXAR/Codex/evidence/neondiff/<date>/production-license-service/`.
+the operator-configured `evidenceDir`, for example
+`<evidenceDir>/<date>/production-license-service/`.

--- a/src/license.ts
+++ b/src/license.ts
@@ -33,6 +33,7 @@ export type LicenseStatus =
 type LicenseApiBodyStatus = Exclude<LicenseStatus, "missing" | "network" | "server">;
 type LicenseFailureClassification = Exclude<LicenseStatus, "active">;
 export type RepoVisibilityScope = "public" | "private" | "all";
+const MAX_REVOCATION_REASON_LENGTH = 240;
 
 export interface LicenseConfig {
   enabled: boolean;
@@ -460,6 +461,7 @@ function normalizeEntitlement(body: unknown, licenseKey: string, now: Date): Lic
   const status = readBodyStatus(record);
   const repoVisibilityScope = readRepoVisibilityScope(record);
   if (!status || !repoVisibilityScope) return undefined;
+  const revocationReason = sanitizeRevocationReason(readString(record, "revocationReason"), licenseKey);
   return {
     status,
     checkedAt: now.toISOString(),
@@ -469,7 +471,7 @@ function normalizeEntitlement(body: unknown, licenseKey: string, now: Date): Lic
     updateEntitlement: readBoolean(record, "updateEntitlement") ?? false,
     ...(readNumber(record, "offlineGraceMs") !== undefined ? { offlineGraceMs: readNumber(record, "offlineGraceMs")! } : {}),
     ...(readString(record, "graceUntil") ? { graceUntil: readString(record, "graceUntil")! } : {}),
-    ...(readString(record, "revocationReason") ? { revocationReason: readString(record, "revocationReason")! } : {}),
+    ...(revocationReason ? { revocationReason } : {}),
     ...(readString(record, "plan") ? { plan: readString(record, "plan")! } : {}),
     ...(readNumber(record, "seats") !== undefined ? { seats: readNumber(record, "seats")! } : {}),
     licenseFingerprint: fingerprintLicenseKey(licenseKey)
@@ -540,6 +542,7 @@ function readLicenseCache(path: string): LicenseEntitlement | undefined {
   const repoVisibilityScope = readRepoVisibilityScope(parsed);
   const checkedAt = readString(parsed, "checkedAt");
   if (!status || !repoVisibilityScope || !checkedAt) return undefined;
+  const revocationReason = sanitizeRevocationReason(readString(parsed, "revocationReason"));
   return {
     status,
     checkedAt,
@@ -549,7 +552,7 @@ function readLicenseCache(path: string): LicenseEntitlement | undefined {
     updateEntitlement: readBoolean(parsed, "updateEntitlement") ?? false,
     ...(readNumber(parsed, "offlineGraceMs") !== undefined ? { offlineGraceMs: readNumber(parsed, "offlineGraceMs")! } : {}),
     ...(readString(parsed, "graceUntil") ? { graceUntil: readString(parsed, "graceUntil")! } : {}),
-    ...(readString(parsed, "revocationReason") ? { revocationReason: readString(parsed, "revocationReason")! } : {}),
+    ...(revocationReason ? { revocationReason } : {}),
     ...(readString(parsed, "plan") ? { plan: readString(parsed, "plan")! } : {}),
     ...(readNumber(parsed, "seats") !== undefined ? { seats: readNumber(parsed, "seats")! } : {}),
     ...(readString(parsed, "licenseFingerprint") ? { licenseFingerprint: readString(parsed, "licenseFingerprint")! } : {})
@@ -689,6 +692,18 @@ function redactSubmittedLicenseKey(text: string, licenseKey: string): string {
   const genericRedacted = redactSecrets(text);
   if (!licenseKey) return genericRedacted;
   return genericRedacted.split(licenseKey).join("[REDACTED_LICENSE_KEY]");
+}
+
+function sanitizeRevocationReason(value: string | undefined, licenseKey = ""): string | undefined {
+  if (!value) return undefined;
+  const redacted = licenseKey ? redactSubmittedLicenseKey(value, licenseKey) : redactSecrets(value);
+  const normalized = redacted
+    .replace(/[^\x20-\x7E]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!normalized) return undefined;
+  if (normalized.length <= MAX_REVOCATION_REASON_LENGTH) return normalized;
+  return `${normalized.slice(0, MAX_REVOCATION_REASON_LENGTH - 3)}...`;
 }
 
 function localMachineId(): string {

--- a/src/license.ts
+++ b/src/license.ts
@@ -154,7 +154,7 @@ export async function getLicenseStatus(input: {
   fetchImpl?: typeof fetch;
 }): Promise<LicenseStatusResult> {
   const now = input.now ?? new Date();
-  const cached = readLicenseCache(input.config.cachePath, readCacheRedactionLicenseKey(input.config));
+  const cached = readLicenseCache(input.config.cachePath, () => readCacheRedactionLicenseKey(input.config));
   if (!input.refresh) return statusFromCache(cached, now);
 
   const licenseKey = readLicenseKey(input.config);
@@ -537,7 +537,7 @@ function invalidApiResult(now: Date, detail: string): LicenseStatusResult {
   };
 }
 
-function readLicenseCache(path: string, licenseKey = ""): LicenseEntitlement | undefined {
+function readLicenseCache(path: string, readRedactionLicenseKey?: () => string | undefined): LicenseEntitlement | undefined {
   if (!existsSync(path)) return undefined;
   const parsed = safeJsonParse(readFileSync(path, "utf8"));
   if (!isRecord(parsed)) return undefined;
@@ -545,7 +545,10 @@ function readLicenseCache(path: string, licenseKey = ""): LicenseEntitlement | u
   const repoVisibilityScope = readRepoVisibilityScope(parsed);
   const checkedAt = readString(parsed, "checkedAt");
   if (!status || !repoVisibilityScope || !checkedAt) return undefined;
-  const revocationReason = status === "active" ? undefined : sanitizeRevocationReason(readString(parsed, "revocationReason"), licenseKey);
+  const rawRevocationReason = readString(parsed, "revocationReason");
+  const revocationReason = status === "active" || !rawRevocationReason
+    ? undefined
+    : sanitizeRevocationReason(rawRevocationReason, readRedactionLicenseKey?.() ?? "");
   return {
     status,
     checkedAt,

--- a/src/license.ts
+++ b/src/license.ts
@@ -31,6 +31,7 @@ export type LicenseStatus =
   | "unsupported_client"
   | "clock_skew";
 type LicenseApiBodyStatus = Exclude<LicenseStatus, "missing" | "network" | "server">;
+type LicenseApiErrorStatus = Exclude<LicenseStatus, "active" | "missing" | "network">;
 type LicenseFailureClassification = Exclude<LicenseStatus, "active">;
 export type RepoVisibilityScope = "public" | "private" | "all";
 const MAX_REVOCATION_REASON_LENGTH = 240;
@@ -152,7 +153,7 @@ export async function getLicenseStatus(input: {
   fetchImpl?: typeof fetch;
 }): Promise<LicenseStatusResult> {
   const now = input.now ?? new Date();
-  const cached = readLicenseCache(input.config.cachePath);
+  const cached = readLicenseCache(input.config.cachePath, readCacheRedactionLicenseKey(input.config));
   if (!input.refresh) return statusFromCache(cached, now);
 
   const licenseKey = readLicenseKey(input.config);
@@ -192,10 +193,7 @@ export async function getLicenseStatus(input: {
       detail: `using cached entitlement after ${response.status} license API failure`
     };
   }
-  if (
-    (response.status === "expired" || response.status === "revoked" || response.status === "invalid") &&
-    cachedEntitlementMatchesLicenseKey(cached, licenseKey)
-  ) {
+  if (shouldDeleteLicenseCacheForStatus(response.status) && cachedEntitlementMatchesLicenseKey(cached, licenseKey)) {
     deleteLicenseCache(input.config.cachePath);
   }
   return response;
@@ -297,13 +295,16 @@ export async function evaluateLicenseReviewGate(input: {
     };
   }
   if (!entitlementCoversRepoVisibility(status.entitlement, input.visibility)) {
+    const reason = input.visibility === "private" && status.entitlement.privateRepoAllowed === false
+      ? "entitlement privateRepoAllowed=false does not allow private repos"
+      : `entitlement scope ${status.entitlement.repoVisibilityScope} does not cover ${input.visibility} repos`;
     return {
       ok: false,
       repo: input.repo,
       visibility: input.visibility,
       status: status.status,
       entitlement: status.entitlement,
-      reason: `entitlement scope ${status.entitlement.repoVisibilityScope} does not cover ${input.visibility} repos`
+      reason
     };
   }
   return {
@@ -323,6 +324,7 @@ function repoVisibilityRequiresEntitlement(visibility: "public" | "private" | "u
 }
 
 function entitlementCoversRepoVisibility(entitlement: LicenseEntitlement, visibility: "public" | "private" | "unknown"): boolean {
+  if (visibility === "private" && entitlement.privateRepoAllowed === false) return false;
   if (entitlement.repoVisibilityScope === "all") return true;
   if (visibility === "public") return entitlement.repoVisibilityScope === "public" || entitlement.repoVisibilityScope === "private";
   if (visibility === "private") return entitlement.repoVisibilityScope === "private";
@@ -444,9 +446,9 @@ function apiFailureResult(statusCode: number, body: unknown, now: Date, licenseK
   };
 }
 
-function statusFromApiError(statusCode: number, body: unknown): Exclude<LicenseStatus, "active" | "missing"> {
+function statusFromApiError(statusCode: number, body: unknown): LicenseApiErrorStatus {
   const bodyStatus = readBodyStatus(body);
-  if (bodyStatus && bodyStatus !== "active") return bodyStatus;
+  if (bodyStatus && bodyStatus !== "active" && shouldTrustApiBodyStatusForError(statusCode, bodyStatus)) return bodyStatus;
   if (statusCode === 402) return "expired";
   if (statusCode === 429) return "rate_limited";
   if (statusCode === 426) return "unsupported_client";
@@ -461,7 +463,7 @@ function normalizeEntitlement(body: unknown, licenseKey: string, now: Date): Lic
   const status = readBodyStatus(record);
   const repoVisibilityScope = readRepoVisibilityScope(record);
   if (!status || !repoVisibilityScope) return undefined;
-  const revocationReason = sanitizeRevocationReason(readString(record, "revocationReason"), licenseKey);
+  const revocationReason = status === "active" ? undefined : sanitizeRevocationReason(readString(record, "revocationReason"), licenseKey);
   return {
     status,
     checkedAt: now.toISOString(),
@@ -534,7 +536,7 @@ function invalidApiResult(now: Date, detail: string): LicenseStatusResult {
   };
 }
 
-function readLicenseCache(path: string): LicenseEntitlement | undefined {
+function readLicenseCache(path: string, licenseKey = ""): LicenseEntitlement | undefined {
   if (!existsSync(path)) return undefined;
   const parsed = safeJsonParse(readFileSync(path, "utf8"));
   if (!isRecord(parsed)) return undefined;
@@ -542,7 +544,7 @@ function readLicenseCache(path: string): LicenseEntitlement | undefined {
   const repoVisibilityScope = readRepoVisibilityScope(parsed);
   const checkedAt = readString(parsed, "checkedAt");
   if (!status || !repoVisibilityScope || !checkedAt) return undefined;
-  const revocationReason = sanitizeRevocationReason(readString(parsed, "revocationReason"));
+  const revocationReason = status === "active" ? undefined : sanitizeRevocationReason(readString(parsed, "revocationReason"), licenseKey);
   return {
     status,
     checkedAt,
@@ -635,6 +637,11 @@ function readFileLicenseKey(path: string | undefined): string | undefined {
   return key || undefined;
 }
 
+function readCacheRedactionLicenseKey(config: LicenseConfig): string | undefined {
+  if (config.storageBackend !== "file") return undefined;
+  return readFileLicenseKey(config.keyPath);
+}
+
 function readKeychainLicenseKey(config: LicenseConfig): string | undefined {
   if (platform() !== "darwin") {
     throw new Error("macOS Keychain license storage is only available on darwin; use storageBackend=file for headless Linux/CI");
@@ -688,10 +695,26 @@ function cachedEntitlementMatchesLicenseKey(entitlement: LicenseEntitlement | un
   return entitlement?.licenseFingerprint === fingerprintLicenseKey(licenseKey);
 }
 
+function shouldDeleteLicenseCacheForStatus(status: LicenseStatus): boolean {
+  return (
+    status === "expired" ||
+    status === "revoked" ||
+    status === "invalid" ||
+    status === "scope_mismatch" ||
+    status === "unsupported_client"
+  );
+}
+
+function shouldTrustApiBodyStatusForError(statusCode: number, status: Exclude<LicenseApiBodyStatus, "active">): boolean {
+  if (shouldDeleteLicenseCacheForStatus(status)) return true;
+  if (status === "rate_limited") return statusCode === 429;
+  if (status === "clock_skew") return statusCode === 400;
+  return false;
+}
+
 function redactSubmittedLicenseKey(text: string, licenseKey: string): string {
-  const genericRedacted = redactSecrets(text);
-  if (!licenseKey) return genericRedacted;
-  return genericRedacted.split(licenseKey).join("[REDACTED_LICENSE_KEY]");
+  if (!licenseKey) return redactSecrets(text);
+  return redactSecrets(text.split(licenseKey).join("[REDACTED_LICENSE_KEY]"));
 }
 
 function sanitizeRevocationReason(value: string | undefined, licenseKey = ""): string | undefined {

--- a/src/license.ts
+++ b/src/license.ts
@@ -31,6 +31,7 @@ export type LicenseStatus =
   | "unsupported_client"
   | "clock_skew";
 type LicenseApiBodyStatus = Exclude<LicenseStatus, "missing" | "network" | "server">;
+type NonActiveLicenseApiBodyStatus = Exclude<LicenseApiBodyStatus, "active">;
 type LicenseApiErrorStatus = Exclude<LicenseStatus, "active" | "missing" | "network">;
 type LicenseFailureClassification = Exclude<LicenseStatus, "active">;
 export type RepoVisibilityScope = "public" | "private" | "all";
@@ -448,7 +449,7 @@ function apiFailureResult(statusCode: number, body: unknown, now: Date, licenseK
 
 function statusFromApiError(statusCode: number, body: unknown): LicenseApiErrorStatus {
   const bodyStatus = readBodyStatus(body);
-  if (bodyStatus && bodyStatus !== "active" && shouldTrustApiBodyStatusForError(statusCode, bodyStatus)) return bodyStatus;
+  if (bodyStatus && shouldTrustApiBodyStatusForError(statusCode, bodyStatus)) return bodyStatus;
   if (statusCode === 402) return "expired";
   if (statusCode === 429) return "rate_limited";
   if (statusCode === 426) return "unsupported_client";
@@ -638,8 +639,11 @@ function readFileLicenseKey(path: string | undefined): string | undefined {
 }
 
 function readCacheRedactionLicenseKey(config: LicenseConfig): string | undefined {
-  if (config.storageBackend !== "file") return undefined;
-  return readFileLicenseKey(config.keyPath);
+  try {
+    return readLicenseKey(config);
+  } catch {
+    return undefined;
+  }
 }
 
 function readKeychainLicenseKey(config: LicenseConfig): string | undefined {
@@ -705,7 +709,8 @@ function shouldDeleteLicenseCacheForStatus(status: LicenseStatus): boolean {
   );
 }
 
-function shouldTrustApiBodyStatusForError(statusCode: number, status: Exclude<LicenseApiBodyStatus, "active">): boolean {
+function shouldTrustApiBodyStatusForError(statusCode: number, status: LicenseApiBodyStatus): status is NonActiveLicenseApiBodyStatus {
+  if (status === "active") return false;
   if (shouldDeleteLicenseCacheForStatus(status)) return true;
   if (status === "rate_limited") return statusCode === 429;
   if (status === "clock_skew") return statusCode === 400;

--- a/src/license.ts
+++ b/src/license.ts
@@ -18,7 +18,20 @@ import { redactSecrets } from "./secrets.js";
 import { buildApiUrl, normalizeHttpApiBaseUrl } from "./url-safety.js";
 
 export type LicenseStorageBackend = "keychain" | "file";
-export type LicenseStatus = "active" | "expired" | "revoked" | "invalid" | "missing" | "network" | "server";
+export type LicenseStatus =
+  | "active"
+  | "expired"
+  | "revoked"
+  | "invalid"
+  | "missing"
+  | "network"
+  | "server"
+  | "scope_mismatch"
+  | "rate_limited"
+  | "unsupported_client"
+  | "clock_skew";
+type LicenseApiBodyStatus = Exclude<LicenseStatus, "missing" | "network" | "server">;
+type LicenseFailureClassification = Exclude<LicenseStatus, "active">;
 export type RepoVisibilityScope = "public" | "private" | "all";
 
 export interface LicenseConfig {
@@ -37,11 +50,15 @@ export interface LicenseConfig {
 }
 
 export interface LicenseEntitlement {
-  status: Exclude<LicenseStatus, "missing" | "network" | "server">;
+  status: LicenseApiBodyStatus;
   checkedAt: string;
   expiresAt?: string;
   repoVisibilityScope: RepoVisibilityScope;
+  privateRepoAllowed?: boolean;
   updateEntitlement: boolean;
+  offlineGraceMs?: number;
+  graceUntil?: string;
+  revocationReason?: string;
   plan?: string;
   seats?: number;
   licenseFingerprint?: string;
@@ -54,7 +71,7 @@ export interface LicenseStatusResult {
   checkedAt: string;
   entitlement?: LicenseEntitlement;
   stale?: boolean;
-  classification?: "missing" | "expired" | "revoked" | "invalid" | "network" | "server";
+  classification?: LicenseFailureClassification;
   detail: string;
 }
 
@@ -428,8 +445,11 @@ function apiFailureResult(statusCode: number, body: unknown, now: Date, licenseK
 
 function statusFromApiError(statusCode: number, body: unknown): Exclude<LicenseStatus, "active" | "missing"> {
   const bodyStatus = readBodyStatus(body);
-  if (bodyStatus === "expired" || bodyStatus === "revoked" || bodyStatus === "invalid") return bodyStatus;
+  if (bodyStatus && bodyStatus !== "active") return bodyStatus;
   if (statusCode === 402) return "expired";
+  if (statusCode === 429) return "rate_limited";
+  if (statusCode === 426) return "unsupported_client";
+  if (statusCode === 409) return "scope_mismatch";
   if (statusCode === 403 || statusCode === 410) return "revoked";
   if (statusCode === 401 || statusCode === 404) return "invalid";
   return "server";
@@ -445,16 +465,31 @@ function normalizeEntitlement(body: unknown, licenseKey: string, now: Date): Lic
     checkedAt: now.toISOString(),
     ...(readString(record, "expiresAt") ? { expiresAt: readString(record, "expiresAt")! } : {}),
     repoVisibilityScope,
+    ...(readBoolean(record, "privateRepoAllowed") !== undefined ? { privateRepoAllowed: readBoolean(record, "privateRepoAllowed")! } : {}),
     updateEntitlement: readBoolean(record, "updateEntitlement") ?? false,
+    ...(readNumber(record, "offlineGraceMs") !== undefined ? { offlineGraceMs: readNumber(record, "offlineGraceMs")! } : {}),
+    ...(readString(record, "graceUntil") ? { graceUntil: readString(record, "graceUntil")! } : {}),
+    ...(readString(record, "revocationReason") ? { revocationReason: readString(record, "revocationReason")! } : {}),
     ...(readString(record, "plan") ? { plan: readString(record, "plan")! } : {}),
     ...(readNumber(record, "seats") !== undefined ? { seats: readNumber(record, "seats")! } : {}),
     licenseFingerprint: fingerprintLicenseKey(licenseKey)
   };
 }
 
-function readBodyStatus(body: unknown): Exclude<LicenseStatus, "missing" | "network" | "server"> | undefined {
+function readBodyStatus(body: unknown): LicenseApiBodyStatus | undefined {
   const value = readString(body, "status");
-  if (value === "active" || value === "expired" || value === "revoked" || value === "invalid") return value;
+  if (
+    value === "active" ||
+    value === "expired" ||
+    value === "revoked" ||
+    value === "invalid" ||
+    value === "scope_mismatch" ||
+    value === "rate_limited" ||
+    value === "unsupported_client" ||
+    value === "clock_skew"
+  ) {
+    return value;
+  }
   return undefined;
 }
 
@@ -510,7 +545,11 @@ function readLicenseCache(path: string): LicenseEntitlement | undefined {
     checkedAt,
     ...(readString(parsed, "expiresAt") ? { expiresAt: readString(parsed, "expiresAt")! } : {}),
     repoVisibilityScope,
+    ...(readBoolean(parsed, "privateRepoAllowed") !== undefined ? { privateRepoAllowed: readBoolean(parsed, "privateRepoAllowed")! } : {}),
     updateEntitlement: readBoolean(parsed, "updateEntitlement") ?? false,
+    ...(readNumber(parsed, "offlineGraceMs") !== undefined ? { offlineGraceMs: readNumber(parsed, "offlineGraceMs")! } : {}),
+    ...(readString(parsed, "graceUntil") ? { graceUntil: readString(parsed, "graceUntil")! } : {}),
+    ...(readString(parsed, "revocationReason") ? { revocationReason: readString(parsed, "revocationReason")! } : {}),
     ...(readString(parsed, "plan") ? { plan: readString(parsed, "plan")! } : {}),
     ...(readNumber(parsed, "seats") !== undefined ? { seats: readNumber(parsed, "seats")! } : {}),
     ...(readString(parsed, "licenseFingerprint") ? { licenseFingerprint: readString(parsed, "licenseFingerprint")! } : {})

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -12,7 +12,7 @@ const SECRET_PATTERNS: RegExp[] = [
   /\b(?:customer|client)[_-]?phone\b\s*[:=]\s*["']?\+?\d[\d ().-]{7,}\d\b/gi,
   /\b(?:api[_-]?key|token|secret|password|cookie|session)\b\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{16,}/gi,
   /\b(?:NEONDIFF|NDL|LIC)_[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/gi,
-  /\b(?:NEONDIFF|NDL|LIC)-[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/g,
+  /(?<![A-Za-z0-9_./-])(?:NEONDIFF|NDL|LIC)-[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/gi,
   /\b[A-Za-z0-9]{3,}[-_](?:secret|token|password|cookie)[-_][A-Za-z0-9_-]{3,}\b/gi,
   /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -12,7 +12,7 @@ const SECRET_PATTERNS: RegExp[] = [
   /\b(?:customer|client)[_-]?phone\b\s*[:=]\s*["']?\+?\d[\d ().-]{7,}\d\b/gi,
   /\b(?:api[_-]?key|token|secret|password|cookie|session)\b\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{16,}/gi,
   /\b(?:NEONDIFF|NDL|LIC)_[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/gi,
-  /(?<![A-Za-z0-9_./-])(?:NEONDIFF|NDL|LIC)-[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/gi,
+  /(?<![A-Za-z0-9_./-])(?:NEONDIFF|NDL|LIC)-(?=(?:[A-Za-z0-9_-]*\d){4})[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/gi,
   /\b[A-Za-z0-9]{3,}[-_](?:secret|token|password|cookie)[-_][A-Za-z0-9_-]{3,}\b/gi,
   /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -12,7 +12,7 @@ const SECRET_PATTERNS: RegExp[] = [
   /\b(?:customer|client)[_-]?phone\b\s*[:=]\s*["']?\+?\d[\d ().-]{7,}\d\b/gi,
   /\b(?:api[_-]?key|token|secret|password|cookie|session)\b\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{16,}/gi,
   /\b(?:NEONDIFF|NDL|LIC)_[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/gi,
-  /\b(?:NEONDIFF|NDL|LIC)-[A-Z0-9][A-Z0-9_-]{11,}\b/g,
+  /\b(?:NEONDIFF|NDL|LIC)-[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/g,
   /\b[A-Za-z0-9]{3,}[-_](?:secret|token|password|cookie)[-_][A-Za-z0-9_-]{3,}\b/gi,
   /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -12,7 +12,7 @@ const SECRET_PATTERNS: RegExp[] = [
   /\b(?:customer|client)[_-]?phone\b\s*[:=]\s*["']?\+?\d[\d ().-]{7,}\d\b/gi,
   /\b(?:api[_-]?key|token|secret|password|cookie|session)\b\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{16,}/gi,
   /\b(?:NEONDIFF|NDL|LIC)_[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/gi,
-  /(?<![A-Za-z0-9_./-])(?:NEONDIFF|NDL|LIC)-(?=(?:[A-Za-z0-9_-]*\d){4})[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/gi,
+  /(?<![A-Za-z0-9_./-])(?:[Nn][Ee][Oo][Nn][Dd][Ii][Ff][Ff]|[Nn][Dd][Ll]|[Ll][Ii][Cc])-(?=[A-Za-z0-9_-]*[A-Z0-9])[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/g,
   /\b[A-Za-z0-9]{3,}[-_](?:secret|token|password|cookie)[-_][A-Za-z0-9_-]{3,}\b/gi,
   /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -157,6 +157,61 @@ describe("license activation and entitlement cache", () => {
     });
   });
 
+  it("treats a non-active body status on a 2xx response as authoritative and fail-closed", async () => {
+    const root = mkRoot(roots);
+    const server = await startLicenseServer((_req, res) => {
+      writeJson(res, 200, {
+        status: "scope_mismatch",
+        repoVisibilityScope: "private",
+        updateEntitlement: false
+      });
+    });
+    servers.push(server);
+
+    const result = await activateLicense({
+      config: licenseConfig(root, server.url),
+      licenseKey: "LIC-2xx-denial-test-123456",
+      now: new Date("2026-07-04T00:00:00.000Z")
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "scope_mismatch",
+      classification: "scope_mismatch",
+      entitlement: {
+        status: "scope_mismatch",
+        repoVisibilityScope: "private"
+      }
+    });
+    expect(existsSync(join(root, "entitlement.json"))).toBe(false);
+  });
+
+  it("redacts revocation reason metadata before returning or caching it", async () => {
+    const root = mkRoot(roots);
+    const key = "LIC-revocation-reason-test-123456";
+    const server = await startLicenseServer((_req, res) => {
+      writeJson(res, 200, {
+        status: "active",
+        repoVisibilityScope: "private",
+        updateEntitlement: true,
+        revocationReason: `manual disable for ${key}`
+      });
+    });
+    servers.push(server);
+
+    const activated = await activateLicense({
+      config: licenseConfig(root, server.url),
+      licenseKey: key,
+      now: new Date("2026-07-04T00:00:00.000Z")
+    });
+    const cacheText = readFileSync(join(root, "entitlement.json"), "utf8");
+
+    expect(activated.entitlement?.revocationReason).toBe("manual disable for [REDACTED_LICENSE_KEY]");
+    expect(cacheText).toContain("[REDACTED_LICENSE_KEY]");
+    expect(JSON.stringify(activated)).not.toContain(key);
+    expect(cacheText).not.toContain(key);
+  });
+
   it("rejects keychain activation before contacting the API", async () => {
     const root = mkRoot(roots);
     let requests = 0;

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -283,6 +283,33 @@ describe("license activation and entitlement cache", () => {
     expect(JSON.stringify(status)).not.toContain(key);
   });
 
+  it("redacts cached opaque revocation reason metadata with the stored license key", async () => {
+    const root = mkRoot(roots);
+    const key = "opaque_local_license_value_123456";
+    writeFileSync(join(root, "license.key"), `${key}\n`, { mode: 0o600 });
+    writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({
+      status: "revoked",
+      checkedAt: "2026-07-04T00:00:00.000Z",
+      repoVisibilityScope: "private",
+      updateEntitlement: false,
+      revocationReason: `manual disable for ${key}`
+    })}\n`, { mode: 0o600 });
+
+    const status = await getLicenseStatus({
+      config: licenseConfig(root, undefined),
+      now: new Date("2026-07-04T00:00:30.000Z")
+    });
+
+    expect(status).toMatchObject({
+      ok: false,
+      status: "revoked",
+      entitlement: {
+        revocationReason: "manual disable for [REDACTED_LICENSE_KEY]"
+      }
+    });
+    expect(JSON.stringify(status)).not.toContain(key);
+  });
+
   it("redacts cached non-active revocation reason metadata without a stored file key", async () => {
     const root = mkRoot(roots);
     const key = "LIC-cached-keychain-style-test-123456";

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -336,6 +336,37 @@ describe("license activation and entitlement cache", () => {
     expect(JSON.stringify(status)).not.toContain(key);
   });
 
+  it("keeps keychain-backed non-active cache reads non-throwing when the key is unavailable", async () => {
+    const root = mkRoot(roots);
+    const key = "LIC-keychain-cache-missing-test-123456";
+    writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({
+      status: "revoked",
+      checkedAt: "2026-07-04T00:00:00.000Z",
+      repoVisibilityScope: "private",
+      updateEntitlement: false,
+      revocationReason: `manual disable for ${key}`
+    })}\n`, { mode: 0o600 });
+    const config = licenseConfig(root, undefined);
+    config.storageBackend = "keychain";
+    config.keyPath = undefined;
+    config.keychainService = `test.neondiff.missing.${Date.now()}`;
+    config.keychainAccount = `test-${Math.random().toString(16).slice(2)}`;
+
+    const status = await getLicenseStatus({
+      config,
+      now: new Date("2026-07-04T00:00:30.000Z")
+    });
+
+    expect(status).toMatchObject({
+      ok: false,
+      status: "revoked",
+      entitlement: {
+        revocationReason: "manual disable for [redacted-secret]"
+      }
+    });
+    expect(JSON.stringify(status)).not.toContain(key);
+  });
+
   it("rejects keychain activation before contacting the API", async () => {
     const root = mkRoot(roots);
     let requests = 0;

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -91,11 +91,24 @@ describe("license activation and entitlement cache", () => {
     const invalid = await startLicenseServer((_req, res) => writeJson(res, 401, { status: "invalid", detail: "bad key" }));
     const server = await startLicenseServer((_req, res) => writeJson(res, 503, { detail: "try later" }));
     const scopeMismatch = await startLicenseServer((_req, res) => writeJson(res, 403, { status: "scope_mismatch", detail: "repo not covered" }));
-    const statusPrecedence = await startLicenseServer((_req, res) => writeJson(res, 401, { status: "clock_skew", detail: "body status wins" }));
+    const scopeMismatchFallback = await startLicenseServer((_req, res) => writeJson(res, 409, { detail: "repo not covered" }));
+    const mismatchedTransientStatus = await startLicenseServer((_req, res) => writeJson(res, 401, { status: "clock_skew", detail: "HTTP status wins for mismatched transient body" }));
     const rateLimited = await startLicenseServer((_req, res) => writeJson(res, 429, { detail: "try later" }));
     const unsupportedClient = await startLicenseServer((_req, res) => writeJson(res, 426, { status: "unsupported_client", detail: "upgrade required" }));
     const clockSkew = await startLicenseServer((_req, res) => writeJson(res, 400, { status: "clock_skew", detail: "clock skew too large" }));
-    servers.push(expired, revoked, legacyForbidden, invalid, server, scopeMismatch, statusPrecedence, rateLimited, unsupportedClient, clockSkew);
+    servers.push(
+      expired,
+      revoked,
+      legacyForbidden,
+      invalid,
+      server,
+      scopeMismatch,
+      scopeMismatchFallback,
+      mismatchedTransientStatus,
+      rateLimited,
+      unsupportedClient,
+      clockSkew
+    );
 
     await expectStatus(licenseConfig(root, expired.url), "expired");
     await expectStatus(licenseConfig(root, revoked.url), "revoked");
@@ -103,7 +116,8 @@ describe("license activation and entitlement cache", () => {
     await expectStatus(licenseConfig(root, invalid.url), "invalid");
     await expectStatus(licenseConfig(root, server.url), "server");
     await expectStatus(licenseConfig(root, scopeMismatch.url), "scope_mismatch");
-    await expectStatus(licenseConfig(root, statusPrecedence.url), "clock_skew");
+    await expectStatus(licenseConfig(root, scopeMismatchFallback.url), "scope_mismatch");
+    await expectStatus(licenseConfig(root, mismatchedTransientStatus.url), "invalid");
     await expectStatus(licenseConfig(root, rateLimited.url), "rate_limited");
     await expectStatus(licenseConfig(root, unsupportedClient.url), "unsupported_client");
     await expectStatus(licenseConfig(root, clockSkew.url), "clock_skew");
@@ -186,7 +200,7 @@ describe("license activation and entitlement cache", () => {
     expect(existsSync(join(root, "entitlement.json"))).toBe(false);
   });
 
-  it("redacts revocation reason metadata before returning or caching it", async () => {
+  it("drops active revocation reason metadata before returning or caching it", async () => {
     const root = mkRoot(roots);
     const key = "LIC-revocation-reason-test-123456";
     const server = await startLicenseServer((_req, res) => {
@@ -206,10 +220,93 @@ describe("license activation and entitlement cache", () => {
     });
     const cacheText = readFileSync(join(root, "entitlement.json"), "utf8");
 
-    expect(activated.entitlement?.revocationReason).toBe("manual disable for [REDACTED_LICENSE_KEY]");
-    expect(cacheText).toContain("[REDACTED_LICENSE_KEY]");
+    expect(activated.entitlement?.revocationReason).toBeUndefined();
+    expect(cacheText).not.toContain("revocationReason");
     expect(JSON.stringify(activated)).not.toContain(key);
     expect(cacheText).not.toContain(key);
+  });
+
+  it("redacts non-active revocation reason metadata before returning it", async () => {
+    const root = mkRoot(roots);
+    const key = "LIC-returned-revocation-test-123456";
+    const server = await startLicenseServer((_req, res) => {
+      writeJson(res, 200, {
+        status: "revoked",
+        repoVisibilityScope: "private",
+        updateEntitlement: false,
+        revocationReason: `manual disable for ${key}`
+      });
+    });
+    servers.push(server);
+
+    const status = await activateLicense({
+      config: licenseConfig(root, server.url),
+      licenseKey: key,
+      now: new Date("2026-07-04T00:00:00.000Z")
+    });
+
+    expect(status).toMatchObject({
+      ok: false,
+      status: "revoked",
+      entitlement: {
+        revocationReason: "manual disable for [REDACTED_LICENSE_KEY]"
+      }
+    });
+    expect(JSON.stringify(status)).not.toContain(key);
+    expect(existsSync(join(root, "entitlement.json"))).toBe(false);
+  });
+
+  it("redacts cached non-active revocation reason metadata with the stored license key", async () => {
+    const root = mkRoot(roots);
+    const key = "LIC-cached-revocation-test-123456";
+    writeFileSync(join(root, "license.key"), `${key}\n`, { mode: 0o600 });
+    writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({
+      status: "revoked",
+      checkedAt: "2026-07-04T00:00:00.000Z",
+      repoVisibilityScope: "private",
+      updateEntitlement: false,
+      revocationReason: `manual disable for ${key}`
+    })}\n`, { mode: 0o600 });
+
+    const status = await getLicenseStatus({
+      config: licenseConfig(root, undefined),
+      now: new Date("2026-07-04T00:00:30.000Z")
+    });
+
+    expect(status).toMatchObject({
+      ok: false,
+      status: "revoked",
+      entitlement: {
+        revocationReason: "manual disable for [REDACTED_LICENSE_KEY]"
+      }
+    });
+    expect(JSON.stringify(status)).not.toContain(key);
+  });
+
+  it("redacts cached non-active revocation reason metadata without a stored file key", async () => {
+    const root = mkRoot(roots);
+    const key = "LIC-cached-keychain-style-test-123456";
+    writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({
+      status: "revoked",
+      checkedAt: "2026-07-04T00:00:00.000Z",
+      repoVisibilityScope: "private",
+      updateEntitlement: false,
+      revocationReason: `manual disable for ${key}`
+    })}\n`, { mode: 0o600 });
+
+    const status = await getLicenseStatus({
+      config: licenseConfig(root, undefined),
+      now: new Date("2026-07-04T00:00:30.000Z")
+    });
+
+    expect(status).toMatchObject({
+      ok: false,
+      status: "revoked",
+      entitlement: {
+        revocationReason: "manual disable for [redacted-secret]"
+      }
+    });
+    expect(JSON.stringify(status)).not.toContain(key);
   });
 
   it("rejects keychain activation before contacting the API", async () => {
@@ -479,6 +576,38 @@ describe("license activation and entitlement cache", () => {
     });
   });
 
+  it("treats entitlement offline grace metadata as diagnostic only", async () => {
+    const root = mkRoot(roots);
+    const config = licenseConfig(root, "http://127.0.0.1:9");
+    config.offlineGraceMs = 1_000;
+    const licenseKey = "LIC-config-grace-test-123456";
+    writeFileSync(join(root, "license.key"), `${licenseKey}\n`, { mode: 0o600 });
+    writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({
+      status: "active",
+      checkedAt: "2026-07-04T00:00:00.000Z",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      repoVisibilityScope: "private",
+      updateEntitlement: true,
+      offlineGraceMs: 600_000,
+      graceUntil: "2026-07-04T00:10:00.000Z",
+      licenseFingerprint: testLicenseFingerprint(licenseKey)
+    })}\n`, { mode: 0o600 });
+
+    const status = await getLicenseStatus({
+      config,
+      refresh: true,
+      now: new Date("2026-07-04T00:02:00.000Z")
+    });
+
+    expect(status).toMatchObject({
+      ok: false,
+      status: "network",
+      source: "none",
+      classification: "network"
+    });
+    expect(status.stale).toBeUndefined();
+  });
+
   it("stamps API entitlement checkedAt locally instead of trusting server time", async () => {
     const root = mkRoot(roots);
     const now = new Date("2026-07-04T00:00:00.000Z");
@@ -539,6 +668,112 @@ describe("license activation and entitlement cache", () => {
     servers.push(server);
     const config = licenseConfig(root, server.url);
     const licenseKey = "LIC-revoked-cache-test-123456";
+    writeFileSync(join(root, "license.key"), `${licenseKey}\n`, { mode: 0o600 });
+    writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({
+      status: "active",
+      checkedAt: "2026-07-04T00:00:00.000Z",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      repoVisibilityScope: "private",
+      updateEntitlement: true,
+      licenseFingerprint: testLicenseFingerprint(licenseKey)
+    })}\n`, { mode: 0o600 });
+
+    const status = await getLicenseStatus({
+      config,
+      refresh: true,
+      now: new Date("2026-07-04T00:00:30.000Z")
+    });
+
+    expect(status).toMatchObject({ ok: false, status: "revoked", source: "api" });
+    expect(existsSync(join(root, "entitlement.json"))).toBe(false);
+  });
+
+  it("clears cached active entitlement after durable hosted admin denials", async () => {
+    const rows = [
+      { name: "2xx-scope-mismatch", status: "scope_mismatch", statusCode: 200 },
+      { status: "scope_mismatch", statusCode: 403 },
+      { status: "unsupported_client", statusCode: 426 }
+    ] as const;
+
+    for (const row of rows) {
+      const root = mkRoot(roots);
+      const server = await startLicenseServer((_req, res) => writeJson(res, row.statusCode, {
+        status: row.status,
+        repoVisibilityScope: "private",
+        updateEntitlement: false,
+        detail: `${row.status} denial`
+      }));
+      servers.push(server);
+      const config = licenseConfig(root, server.url);
+      const licenseKey = `LIC-${row.status}-cache-test-123456`;
+      writeFileSync(join(root, "license.key"), `${licenseKey}\n`, { mode: 0o600 });
+      writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({
+        status: "active",
+        checkedAt: "2026-07-04T00:00:00.000Z",
+        expiresAt: "2026-08-01T00:00:00.000Z",
+        repoVisibilityScope: "private",
+        updateEntitlement: true,
+        licenseFingerprint: testLicenseFingerprint(licenseKey)
+      })}\n`, { mode: 0o600 });
+
+      const status = await getLicenseStatus({
+        config,
+        refresh: true,
+        now: new Date("2026-07-04T00:00:30.000Z")
+      });
+
+      const label = "name" in row ? row.name : row.status;
+      expect(status, label).toMatchObject({ ok: false, status: row.status, source: "api" });
+      expect(existsSync(join(root, "entitlement.json")), label).toBe(false);
+    }
+  });
+
+  it("retains cached active entitlement after transient refresh denial without consuming offline grace", async () => {
+    const rows = [
+      { status: "clock_skew", statusCode: 400, detail: "client clock drift" },
+      { status: "rate_limited", statusCode: 429, detail: "try later" }
+    ] as const;
+
+    for (const row of rows) {
+      const root = mkRoot(roots);
+      const server = await startLicenseServer((_req, res) => writeJson(res, row.statusCode, {
+        status: row.status,
+        detail: row.detail
+      }));
+      servers.push(server);
+      const config = licenseConfig(root, server.url);
+      const licenseKey = `LIC-${row.status}-cache-test-123456`;
+      writeFileSync(join(root, "license.key"), `${licenseKey}\n`, { mode: 0o600 });
+      writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({
+        status: "active",
+        checkedAt: "2026-07-04T00:00:00.000Z",
+        expiresAt: "2026-08-01T00:00:00.000Z",
+        repoVisibilityScope: "private",
+        updateEntitlement: true,
+        licenseFingerprint: testLicenseFingerprint(licenseKey)
+      })}\n`, { mode: 0o600 });
+
+      const status = await getLicenseStatus({
+        config,
+        refresh: true,
+        now: new Date("2026-07-04T00:00:30.000Z")
+      });
+
+      expect(status, row.status).toMatchObject({ ok: false, status: row.status, source: "api" });
+      expect(status.stale, row.status).toBeUndefined();
+      expect(existsSync(join(root, "entitlement.json")), row.status).toBe(true);
+    }
+  });
+
+  it("trusts durable body denial on transient HTTP code and clears matching cached entitlement", async () => {
+    const root = mkRoot(roots);
+    const server = await startLicenseServer((_req, res) => writeJson(res, 429, {
+      status: "revoked",
+      detail: "revocation body is authoritative"
+    }));
+    servers.push(server);
+    const config = licenseConfig(root, server.url);
+    const licenseKey = "LIC-429-revoked-cache-test-123456";
     writeFileSync(join(root, "license.key"), `${licenseKey}\n`, { mode: 0o600 });
     writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({
       status: "active",
@@ -744,6 +979,44 @@ describe("license activation and entitlement cache", () => {
     expect(stale).toMatchObject({
       ok: false,
       reason: expect.stringContaining("fresh entitlement cache")
+    });
+
+    writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({
+      status: "active",
+      checkedAt: "2026-07-04T00:00:00.000Z",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      repoVisibilityScope: "private",
+      privateRepoAllowed: false,
+      updateEntitlement: true
+    })}\n`, { mode: 0o600 });
+    const privateNotAllowed = await evaluateLicenseReviewGate({
+      config,
+      repo: "owner/private",
+      visibility: "private",
+      now: new Date("2026-07-04T00:00:00.000Z")
+    });
+    expect(privateNotAllowed).toMatchObject({
+      ok: false,
+      reason: "entitlement privateRepoAllowed=false does not allow private repos"
+    });
+
+    writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({
+      status: "active",
+      checkedAt: "2026-07-04T00:00:00.000Z",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      repoVisibilityScope: "all",
+      privateRepoAllowed: false,
+      updateEntitlement: true
+    })}\n`, { mode: 0o600 });
+    const allScopePrivateNotAllowed = await evaluateLicenseReviewGate({
+      config,
+      repo: "owner/private",
+      visibility: "private",
+      now: new Date("2026-07-04T00:00:00.000Z")
+    });
+    expect(allScopePrivateNotAllowed).toMatchObject({
+      ok: false,
+      reason: "entitlement privateRepoAllowed=false does not allow private repos"
     });
 
     writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -83,23 +83,76 @@ describe("license activation and entitlement cache", () => {
     expect(existsSync(join(root, "entitlement.json"))).toBe(false);
   });
 
-  it("classifies expired, revoked, invalid, network, and server states", async () => {
+  it("classifies expired, revoked, invalid, network, server, and hosted admin denial states", async () => {
     const root = mkRoot(roots);
     const expired = await startLicenseServer((_req, res) => writeJson(res, 402, { status: "expired", detail: "expired" }));
     const revoked = await startLicenseServer((_req, res) => writeJson(res, 410, { status: "revoked", detail: "revoked" }));
+    const legacyForbidden = await startLicenseServer((_req, res) => writeJson(res, 403, { detail: "legacy forbidden" }));
     const invalid = await startLicenseServer((_req, res) => writeJson(res, 401, { status: "invalid", detail: "bad key" }));
     const server = await startLicenseServer((_req, res) => writeJson(res, 503, { detail: "try later" }));
-    servers.push(expired, revoked, invalid, server);
+    const scopeMismatch = await startLicenseServer((_req, res) => writeJson(res, 403, { status: "scope_mismatch", detail: "repo not covered" }));
+    const rateLimited = await startLicenseServer((_req, res) => writeJson(res, 429, { detail: "try later" }));
+    const unsupportedClient = await startLicenseServer((_req, res) => writeJson(res, 426, { status: "unsupported_client", detail: "upgrade required" }));
+    const clockSkew = await startLicenseServer((_req, res) => writeJson(res, 400, { status: "clock_skew", detail: "clock skew too large" }));
+    servers.push(expired, revoked, legacyForbidden, invalid, server, scopeMismatch, rateLimited, unsupportedClient, clockSkew);
 
     await expectStatus(licenseConfig(root, expired.url), "expired");
     await expectStatus(licenseConfig(root, revoked.url), "revoked");
+    await expectStatus(licenseConfig(root, legacyForbidden.url), "revoked");
     await expectStatus(licenseConfig(root, invalid.url), "invalid");
     await expectStatus(licenseConfig(root, server.url), "server");
+    await expectStatus(licenseConfig(root, scopeMismatch.url), "scope_mismatch");
+    await expectStatus(licenseConfig(root, rateLimited.url), "rate_limited");
+    await expectStatus(licenseConfig(root, unsupportedClient.url), "unsupported_client");
+    await expectStatus(licenseConfig(root, clockSkew.url), "clock_skew");
     const network = await activateLicense({
       config: licenseConfig(root, "http://127.0.0.1:9"),
       licenseKey: "LIC-network-test-123456"
     });
     expect(network).toMatchObject({ ok: false, status: "network", classification: "network" });
+  });
+
+  it("preserves entitlement metadata from hosted admin status responses in the cache", async () => {
+    const root = mkRoot(roots);
+    const server = await startLicenseServer((_req, res) => {
+      writeJson(res, 200, {
+        status: "active",
+        expiresAt: "2026-08-01T00:00:00.000Z",
+        repoVisibilityScope: "private",
+        privateRepoAllowed: true,
+        updateEntitlement: true,
+        offlineGraceMs: 60_000,
+        graceUntil: "2026-07-04T00:15:00.000Z",
+        plan: "supporter"
+      });
+    });
+    servers.push(server);
+
+    const activated = await activateLicense({
+      config: licenseConfig(root, server.url),
+      licenseKey: "LIC-admin-metadata-test-123456",
+      now: new Date("2026-07-04T00:00:00.000Z")
+    });
+
+    expect(activated.entitlement).toMatchObject({
+      status: "active",
+      repoVisibilityScope: "private",
+      privateRepoAllowed: true,
+      updateEntitlement: true,
+      offlineGraceMs: 60_000,
+      graceUntil: "2026-07-04T00:15:00.000Z",
+      plan: "supporter"
+    });
+
+    const cached = await getLicenseStatus({
+      config: licenseConfig(root, server.url),
+      now: new Date("2026-07-04T00:01:00.000Z")
+    });
+    expect(cached.entitlement).toMatchObject({
+      privateRepoAllowed: true,
+      offlineGraceMs: 60_000,
+      graceUntil: "2026-07-04T00:15:00.000Z"
+    });
   });
 
   it("rejects keychain activation before contacting the API", async () => {

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -91,10 +91,11 @@ describe("license activation and entitlement cache", () => {
     const invalid = await startLicenseServer((_req, res) => writeJson(res, 401, { status: "invalid", detail: "bad key" }));
     const server = await startLicenseServer((_req, res) => writeJson(res, 503, { detail: "try later" }));
     const scopeMismatch = await startLicenseServer((_req, res) => writeJson(res, 403, { status: "scope_mismatch", detail: "repo not covered" }));
+    const statusPrecedence = await startLicenseServer((_req, res) => writeJson(res, 401, { status: "clock_skew", detail: "body status wins" }));
     const rateLimited = await startLicenseServer((_req, res) => writeJson(res, 429, { detail: "try later" }));
     const unsupportedClient = await startLicenseServer((_req, res) => writeJson(res, 426, { status: "unsupported_client", detail: "upgrade required" }));
     const clockSkew = await startLicenseServer((_req, res) => writeJson(res, 400, { status: "clock_skew", detail: "clock skew too large" }));
-    servers.push(expired, revoked, legacyForbidden, invalid, server, scopeMismatch, rateLimited, unsupportedClient, clockSkew);
+    servers.push(expired, revoked, legacyForbidden, invalid, server, scopeMismatch, statusPrecedence, rateLimited, unsupportedClient, clockSkew);
 
     await expectStatus(licenseConfig(root, expired.url), "expired");
     await expectStatus(licenseConfig(root, revoked.url), "revoked");
@@ -102,6 +103,7 @@ describe("license activation and entitlement cache", () => {
     await expectStatus(licenseConfig(root, invalid.url), "invalid");
     await expectStatus(licenseConfig(root, server.url), "server");
     await expectStatus(licenseConfig(root, scopeMismatch.url), "scope_mismatch");
+    await expectStatus(licenseConfig(root, statusPrecedence.url), "clock_skew");
     await expectStatus(licenseConfig(root, rateLimited.url), "rate_limited");
     await expectStatus(licenseConfig(root, unsupportedClient.url), "unsupported_client");
     await expectStatus(licenseConfig(root, clockSkew.url), "clock_skew");

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -606,7 +606,7 @@ describe("license activation and entitlement cache", () => {
   it("treats entitlement offline grace metadata as diagnostic only", async () => {
     const root = mkRoot(roots);
     const config = licenseConfig(root, "http://127.0.0.1:9");
-    config.offlineGraceMs = 1_000;
+    config.offlineGraceMs = 119_000;
     const licenseKey = "LIC-config-grace-test-123456";
     writeFileSync(join(root, "license.key"), `${licenseKey}\n`, { mode: 0o600 });
     writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({
@@ -633,6 +633,36 @@ describe("license activation and entitlement cache", () => {
       classification: "network"
     });
     expect(status.stale).toBeUndefined();
+
+    const secondRoot = mkRoot(roots);
+    const secondConfig = licenseConfig(secondRoot, "http://127.0.0.1:9");
+    secondConfig.offlineGraceMs = 300_000;
+    const secondLicenseKey = "LIC-config-grace-positive-test-123456";
+    writeFileSync(join(secondRoot, "license.key"), `${secondLicenseKey}\n`, { mode: 0o600 });
+    writeFileSync(join(secondRoot, "entitlement.json"), `${JSON.stringify({
+      status: "active",
+      checkedAt: "2026-07-04T00:00:00.000Z",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      repoVisibilityScope: "private",
+      updateEntitlement: true,
+      offlineGraceMs: 1_000,
+      graceUntil: "2026-07-04T00:00:01.000Z",
+      licenseFingerprint: testLicenseFingerprint(secondLicenseKey)
+    })}\n`, { mode: 0o600 });
+
+    const secondStatus = await getLicenseStatus({
+      config: secondConfig,
+      refresh: true,
+      now: new Date("2026-07-04T00:02:00.000Z")
+    });
+
+    expect(secondStatus).toMatchObject({
+      ok: true,
+      status: "active",
+      source: "cache",
+      stale: true,
+      classification: "network"
+    });
   });
 
   it("stamps API entitlement checkedAt locally instead of trusting server time", async () => {

--- a/tests/license.test.ts
+++ b/tests/license.test.ts
@@ -689,6 +689,34 @@ describe("license activation and entitlement cache", () => {
     expect(gate).toMatchObject({ ok: true, status: "active" });
   });
 
+  it("allows private review from active cached entitlement with hosted admin metadata", async () => {
+    const root = mkRoot(roots);
+    const config = licenseConfig(root, undefined);
+    writeFileSync(join(root, "entitlement.json"), `${JSON.stringify({
+      status: "active",
+      checkedAt: "2026-07-04T00:00:00.000Z",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      repoVisibilityScope: "private",
+      privateRepoAllowed: true,
+      updateEntitlement: true,
+      offlineGraceMs: 60_000,
+      graceUntil: "2026-07-04T00:15:00.000Z"
+    })}\n`, { mode: 0o600 });
+
+    const gate = await evaluateLicenseReviewGate({
+      config,
+      repo: "owner/private",
+      visibility: "private",
+      now: new Date("2026-07-04T00:00:30.000Z")
+    });
+
+    expect(gate).toMatchObject({
+      ok: true,
+      status: "active",
+      reason: "active entitlement covers private repo review"
+    });
+  });
+
   it("clears cached active entitlement after terminal API denial", async () => {
     const root = mkRoot(roots);
     const server = await startLicenseServer((_req, res) => writeJson(res, 410, { status: "revoked", detail: "revoked" }));

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -24,6 +24,13 @@ describe("secret redaction", () => {
     expect(redactSecrets(`license=${license}`)).toBe("license=[redacted-secret]");
   });
 
+  it("redacts hyphenated license-shaped values case-insensitively", () => {
+    const license = "LIC-revocation-reason-test-123456";
+
+    expect(containsSecretLikeText(license)).toBe(true);
+    expect(redactSecrets(`license=${license}`)).toBe("license=[redacted-secret]");
+  });
+
   it("does not redact ordinary lowercase hyphenated NeonDiff paths as license tokens", () => {
     const path = "/tmp/neondiff-launchd-plist-Ov4D5v/com.example.neondiff.plist";
 

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -25,7 +25,7 @@ describe("secret redaction", () => {
   });
 
   it("redacts hyphenated license-shaped values case-insensitively", () => {
-    const license = "LIC-revocation-reason-test-123456";
+    const license = "neondiff-revocation-reason-test-123456";
 
     expect(containsSecretLikeText(license)).toBe(true);
     expect(redactSecrets(`license=${license}`)).toBe("license=[redacted-secret]");

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -26,9 +26,12 @@ describe("secret redaction", () => {
 
   it("redacts hyphenated license-shaped values case-insensitively", () => {
     const license = "neondiff-revocation-reason-test-123456";
+    const digitPoorLicense = "NDL-XQKM-RPYB-SUTE";
 
     expect(containsSecretLikeText(license)).toBe(true);
     expect(redactSecrets(`license=${license}`)).toBe("license=[redacted-secret]");
+    expect(containsSecretLikeText(digitPoorLicense)).toBe(true);
+    expect(redactSecrets(`license=${digitPoorLicense}`)).toBe("license=[redacted-secret]");
   });
 
   it("does not redact ordinary lowercase hyphenated NeonDiff paths or labels as license tokens", () => {

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -31,11 +31,14 @@ describe("secret redaction", () => {
     expect(redactSecrets(`license=${license}`)).toBe("license=[redacted-secret]");
   });
 
-  it("does not redact ordinary lowercase hyphenated NeonDiff paths as license tokens", () => {
+  it("does not redact ordinary lowercase hyphenated NeonDiff paths or labels as license tokens", () => {
     const path = "/tmp/neondiff-launchd-plist-Ov4D5v/com.example.neondiff.plist";
+    const label = "lic-diagnostic-reference-without-key-material";
 
     expect(containsSecretLikeText(path)).toBe(false);
     expect(redactSecrets(path)).toBe(path);
+    expect(containsSecretLikeText(label)).toBe(false);
+    expect(redactSecrets(label)).toBe(label);
   });
 
   it("detects credential URLs, cookie headers, query tokens, and private key bodies", () => {


### PR DESCRIPTION
Refs #327.

## Summary
- Extend the license status taxonomy for `scope_mismatch`, `rate_limited`, `unsupported_client`, and `clock_skew` while preserving bare HTTP 403 as legacy `revoked`.
- Preserve hosted/admin entitlement metadata that naturally fits the existing `LicenseEntitlement` model.
- Add mock-only operator/admin readiness docs with entitlement metadata, staging requirements, and stop conditions.

## Proof Boundary
This is a source-only, mock-only slice. It does not prove a staging endpoint, admin credentials, production license-service readiness, GA readiness, customer readiness, or calibrated review quality.

## Validation
- `NODE_OPTIONS=--experimental-sqlite ./node_modules/.bin/vitest run tests/license.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- `node scripts/check-public-claims.mjs`
- `node scripts/check-secret-scan.mjs`
