### PR TITLE
QA lab timing harness: hermetic seeded-scenario baseline (#341)

### DIFF
--- a/scripts/qa-lab/config-variants.ts
+++ b/scripts/qa-lab/config-variants.ts
@@ -1,0 +1,118 @@
+/**
+ * Config-variant fixture definitions for the QA lab timing harness (#341).
+ *
+ * Pass 1 is hermetic: only the "baseline" variant is actually executed for timing. The other
+ * variants (github related context, gitnexus context, repo memory, issue enrichment, self
+ * consistency) exist here as config fixtures only, per the issue's pass-1/pass-2 split -- their
+ * add-on paths call out to providers/GitHub and are out of scope until pass 2 supplies real
+ * provider/GitHub env. This module is the seam pass 2 hooks into: it only needs a new case in
+ * `applyVariant` plus (if pass 2 wires live calls) a runner change, no scenario-shape rework.
+ */
+import type { BotConfig } from "../../src/config.js";
+
+/**
+ * `BotConfig`'s add-on sections are optional on the type (a caller MAY omit them from a raw JSON
+ * file) but `loadConfigFromObject` always deep-merges onto its internal defaults and validates
+ * before returning, so every section is populated on any `BotConfig` that reached this module.
+ * This narrows the optional field for the compiler with a runtime assertion instead of an `as`
+ * cast, so a genuine loader regression fails loudly here rather than silently typing around it.
+ */
+function requireField<K extends keyof BotConfig>(config: BotConfig, key: K): NonNullable<BotConfig[K]> {
+  const value = config[key];
+  if (value === undefined) {
+    throw new Error(`qa-lab config variant expected config.${String(key)} to be populated by loadConfigFromObject`);
+  }
+  return value as NonNullable<BotConfig[K]>;
+}
+
+export type QaLabConfigVariantId =
+  | "baseline"
+  | "github_related_context"
+  | "gitnexus_context"
+  | "repo_memory"
+  | "enrichment"
+  | "self_consistency";
+
+export const QA_LAB_CONFIG_VARIANT_IDS: QaLabConfigVariantId[] = [
+  "baseline",
+  "github_related_context",
+  "gitnexus_context",
+  "repo_memory",
+  "enrichment",
+  "self_consistency"
+];
+
+/** Variants whose timing pass 1 actually executes. All others are fixture-only until pass 2. */
+export const HERMETIC_EXECUTABLE_VARIANTS: QaLabConfigVariantId[] = ["baseline"];
+
+export interface QaLabConfigVariant {
+  id: QaLabConfigVariantId;
+  description: string;
+  /** Whether this variant's add-on path requires provider/GitHub calls (out of scope for pass 1). */
+  requiresLiveProviderOrGithub: boolean;
+  applyVariant: (base: BotConfig) => BotConfig;
+}
+
+export const QA_LAB_CONFIG_VARIANTS: QaLabConfigVariant[] = [
+  {
+    id: "baseline",
+    description: "All add-ons off; deterministic-gate-only timing.",
+    requiresLiveProviderOrGithub: false,
+    applyVariant: (base) => base
+  },
+  {
+    id: "github_related_context",
+    description: "githubRelatedContext.enabled=true (pass 2: requires live GitHub calls).",
+    requiresLiveProviderOrGithub: true,
+    applyVariant: (base) => ({
+      ...base,
+      githubRelatedContext: { ...requireField(base, "githubRelatedContext"), enabled: true }
+    })
+  },
+  {
+    id: "gitnexus_context",
+    description: "gitnexusContext.enabled=true (pass 2: requires a live GitNexus adapter/index).",
+    requiresLiveProviderOrGithub: true,
+    applyVariant: (base) => ({
+      ...base,
+      gitnexusContext: { ...requireField(base, "gitnexusContext"), enabled: true }
+    })
+  },
+  {
+    id: "repo_memory",
+    description: "repoMemory.enabled=true (fixture only; on-disk memory packet build is in scope for pass 2 timing).",
+    requiresLiveProviderOrGithub: false,
+    applyVariant: (base) => ({
+      ...base,
+      repoMemory: { ...requireField(base, "repoMemory"), enabled: true }
+    })
+  },
+  {
+    id: "enrichment",
+    description: "issueEnrichment.enabled=true (pass 2: requires live provider + GitHub issue calls).",
+    requiresLiveProviderOrGithub: true,
+    applyVariant: (base) => ({
+      ...base,
+      issueEnrichment: { ...requireField(base, "issueEnrichment"), enabled: true }
+    })
+  },
+  {
+    id: "self_consistency",
+    description: "reviewGate.selfConsistency.enabled=true (pass 2: requires an extra live provider call per re-checked finding).",
+    requiresLiveProviderOrGithub: true,
+    applyVariant: (base) => {
+      const reviewGate = requireField(base, "reviewGate");
+      return {
+        ...base,
+        reviewGate: {
+          ...reviewGate,
+          selfConsistency: { ...reviewGate.selfConsistency, enabled: true }
+        }
+      };
+    }
+  }
+];
+
+export function findConfigVariant(id: string): QaLabConfigVariant | undefined {
+  return QA_LAB_CONFIG_VARIANTS.find((variant) => variant.id === id);
+}

--- a/scripts/qa-lab/run-timing.ts
+++ b/scripts/qa-lab/run-timing.ts
@@ -33,22 +33,31 @@ import { parseFindings } from "../../src/findings.js";
 import { redactSecrets } from "../../src/secrets.js";
 import { applyDeterministicReviewGate } from "../../src/review-gate.js";
 import { QA_LAB_SCENARIOS, type QaLabScenario } from "./scenarios.js";
-import { findConfigVariant, HERMETIC_EXECUTABLE_VARIANTS, type QaLabConfigVariantId } from "./config-variants.js";
+import {
+  findConfigVariant,
+  HERMETIC_EXECUTABLE_VARIANTS,
+  QA_LAB_CONFIG_VARIANT_IDS,
+  type QaLabConfigVariantId
+} from "./config-variants.js";
 import { summarizePercentiles, type PercentileSummary } from "./stats.js";
 
-interface ParsedArgs {
+/** Discarded, untimed iterations run per scenario before recording samples, to burn off cold-start/JIT bias. */
+export const WARMUP_ITERATIONS = 5;
+
+export interface ParsedArgs {
   config?: string;
   "config-variant"?: string;
   samples?: string;
   "output-dir"?: string;
 }
 
-interface ScenarioTimingResult {
+export interface ScenarioTimingResult {
   scenarioId: string;
   scenarioClass: string;
   description: string;
   configVariant: QaLabConfigVariantId;
   samples: number;
+  warmupIterations: number;
   stats: PercentileSummary;
   /** Deterministic-gate outcome from the LAST sample run, as a sanity spot-check evidence field. */
   lastRunOutcome: {
@@ -58,7 +67,7 @@ interface ScenarioTimingResult {
   };
 }
 
-interface TimingEvidence {
+export interface TimingEvidence {
   evidenceVersion: "0.1";
   generatedAt: string;
   commitSha: string;
@@ -66,11 +75,12 @@ interface TimingEvidence {
   configVariant: QaLabConfigVariantId;
   configPath: string;
   samplesPerScenario: number;
+  warmupIterations: number;
   proofBoundary: string;
   scenarios: ScenarioTimingResult[];
 }
 
-function parseArgs(argv: string[]): ParsedArgs {
+export function parseArgs(argv: string[]): ParsedArgs {
   const args: ParsedArgs = {};
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
@@ -84,6 +94,26 @@ function parseArgs(argv: string[]): ParsedArgs {
     index += 1;
   }
   return args;
+}
+
+/**
+ * Resolve and validate `--config-variant` against the fixture registry (extracted from `main` so
+ * both the CLI entrypoint and unit tests can exercise the unknown-variant and
+ * requires-live-provider rejection paths without spawning a process).
+ */
+export function resolveConfigVariant(configVariantId: QaLabConfigVariantId) {
+  const variant = findConfigVariant(configVariantId);
+  if (!variant) {
+    throw new Error(`unknown --config-variant "${configVariantId}"; known variants: ${QA_LAB_CONFIG_VARIANT_IDS.join(", ")}`);
+  }
+  if (!HERMETIC_EXECUTABLE_VARIANTS.includes(configVariantId)) {
+    throw new Error(
+      `--config-variant "${configVariantId}" requires live provider/GitHub calls (${variant.description}) and is out of ` +
+        `scope for the hermetic pass-1 timing runner. Pass 1 only executes: ${HERMETIC_EXECUTABLE_VARIANTS.join(", ")}. ` +
+        "This variant exists as a config fixture for pass 2 to wire real timing against."
+    );
+  }
+  return variant;
 }
 
 function writeRedactedJson(path: string, value: unknown): void {
@@ -109,9 +139,9 @@ function timeScenarioOnce(scenario: QaLabScenario, config: BotConfig): { elapsed
   };
 }
 
-function resolveCommitSha(): string {
+export function resolveCommitSha(): string {
   try {
-    return execSync("git rev-parse HEAD", { encoding: "utf8" }).trim();
+    return execSync("git rev-parse HEAD", { encoding: "utf8", timeout: 15_000 }).trim();
   } catch {
     return "unknown";
   }
@@ -125,19 +155,7 @@ function main(): void {
   if (!Number.isInteger(samples) || samples < 1) throw new Error("--samples must be a positive integer");
   if (!args["output-dir"]) throw new Error("--output-dir is required");
 
-  const variant = findConfigVariant(configVariantId);
-  if (!variant) {
-    throw new Error(
-      `unknown --config-variant "${configVariantId}"; known variants: baseline, github_related_context, gitnexus_context, repo_memory, enrichment, self_consistency`
-    );
-  }
-  if (!HERMETIC_EXECUTABLE_VARIANTS.includes(configVariantId)) {
-    throw new Error(
-      `--config-variant "${configVariantId}" requires live provider/GitHub calls (${variant.description}) and is out of ` +
-        `scope for the hermetic pass-1 timing runner. Pass 1 only executes: ${HERMETIC_EXECUTABLE_VARIANTS.join(", ")}. ` +
-        "This variant exists as a config fixture for pass 2 to wire real timing against."
-    );
-  }
+  const variant = resolveConfigVariant(configVariantId);
 
   if (!existsSync(args.config)) throw new Error(`--config path does not exist: ${args.config}`);
   const rawConfig = JSON.parse(readFileSync(args.config, "utf8"));
@@ -148,6 +166,10 @@ function main(): void {
   mkdirSync(outputDir, { recursive: true });
 
   const scenarioResults: ScenarioTimingResult[] = QA_LAB_SCENARIOS.map((scenario) => {
+    // Discarded warm-up iterations first (cold-start/JIT bias), then the timed samples.
+    for (let warmupIndex = 0; warmupIndex < WARMUP_ITERATIONS; warmupIndex += 1) {
+      timeScenarioOnce(scenario, effectiveConfig);
+    }
     const timingsMs: number[] = [];
     let lastRun: { elapsedMs: number; event: string; acceptedComments: number; droppedFindings: number } | undefined;
     for (let sampleIndex = 0; sampleIndex < samples; sampleIndex += 1) {
@@ -161,6 +183,7 @@ function main(): void {
       description: scenario.description,
       configVariant: configVariantId,
       samples,
+      warmupIterations: WARMUP_ITERATIONS,
       stats: summarizePercentiles(timingsMs),
       lastRunOutcome: {
         event: lastRun.event,
@@ -178,6 +201,7 @@ function main(): void {
     configVariant: configVariantId,
     configPath: args.config,
     samplesPerScenario: samples,
+    warmupIterations: WARMUP_ITERATIONS,
     proofBoundary:
       "hermetic deterministic-pipeline timing only (parseFindings -> applyDeterministicReviewGate); " +
       "no provider calls, no GitHub calls, no launchd, no live/active config read or write, no repo mutation",
@@ -190,7 +214,7 @@ function main(): void {
   console.log(JSON.stringify({ ok: true, outputDir, scenarioCount: scenarioResults.length }, null, 2));
 }
 
-function buildBaselineTable(evidence: TimingEvidence): string {
+export function buildBaselineTable(evidence: TimingEvidence): string {
   const rows = evidence.scenarios.map((scenario) => {
     const { p50Ms, p90Ms } = scenario.stats;
     return `| ${scenario.scenarioId} | ${scenario.scenarioClass} | ${scenario.samples} | ${p50Ms.toFixed(3)} | ${p90Ms.toFixed(3)} |`;
@@ -217,4 +241,9 @@ function buildBaselineTable(evidence: TimingEvidence): string {
   ].join("\n");
 }
 
-main();
+// Guard direct-execution so unit tests can import parseArgs/resolveConfigVariant/buildBaselineTable
+// without running the CLI (this file is invoked directly via `tsx scripts/qa-lab/run-timing.ts`).
+const isDirectlyExecuted = process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`;
+if (isDirectlyExecuted) {
+  main();
+}

--- a/scripts/qa-lab/run-timing.ts
+++ b/scripts/qa-lab/run-timing.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * QA lab timing harness -- pass 1 (hermetic) (#341, tracker #340).
+ *
+ * Runs each seeded scenario (scripts/qa-lab/scenarios.ts) through the deterministic review
+ * pipeline that already ships in this repo:
+ *
+ *   parseFindings (src/findings.ts)
+ *     -> applyDeterministicReviewGate (src/review-gate.ts), which itself chains
+ *        validateFindingLocations -> normalizeFindingsForReview -> decideReviewEvent
+ *
+ * against a FIXTURE config derived from config.example.json (never the live config). No GitHub
+ * calls, no provider calls, no launchd, no repo mutation -- this measures pipeline wall-clock only.
+ *
+ * --config-variant selects a fixture config variant (scripts/qa-lab/config-variants.ts). Pass 1
+ * only executes the "baseline" variant; any other variant name is accepted (so pass 2 can pass
+ * `--config-variant github_related_context` etc. against the same CLI surface) but the harness
+ * exits with a clear error rather than silently measuring the wrong thing, since those add-on
+ * paths require live provider/GitHub calls that are out of scope here.
+ *
+ * Usage:
+ *   tsx scripts/qa-lab/run-timing.ts \
+ *     --config tests/fixtures/qa-lab/config.baseline.json \
+ *     --config-variant baseline \
+ *     --samples 25 \
+ *     --output-dir /path/to/evidence/qa-harness
+ */
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { loadConfigFromObject, type BotConfig } from "../../src/config.js";
+import { parseFindings } from "../../src/findings.js";
+import { redactSecrets } from "../../src/secrets.js";
+import { applyDeterministicReviewGate } from "../../src/review-gate.js";
+import { QA_LAB_SCENARIOS, type QaLabScenario } from "./scenarios.js";
+import { findConfigVariant, HERMETIC_EXECUTABLE_VARIANTS, type QaLabConfigVariantId } from "./config-variants.js";
+import { summarizePercentiles, type PercentileSummary } from "./stats.js";
+
+interface ParsedArgs {
+  config?: string;
+  "config-variant"?: string;
+  samples?: string;
+  "output-dir"?: string;
+}
+
+interface ScenarioTimingResult {
+  scenarioId: string;
+  scenarioClass: string;
+  description: string;
+  configVariant: QaLabConfigVariantId;
+  samples: number;
+  stats: PercentileSummary;
+  /** Deterministic-gate outcome from the LAST sample run, as a sanity spot-check evidence field. */
+  lastRunOutcome: {
+    event: string;
+    acceptedComments: number;
+    droppedFindings: number;
+  };
+}
+
+interface TimingEvidence {
+  evidenceVersion: "0.1";
+  generatedAt: string;
+  commitSha: string;
+  nodeVersion: string;
+  configVariant: QaLabConfigVariantId;
+  configPath: string;
+  samplesPerScenario: number;
+  proofBoundary: string;
+  scenarios: ScenarioTimingResult[];
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const args: ParsedArgs = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token?.startsWith("--")) continue;
+    const key = token.slice(2) as keyof ParsedArgs;
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`--${key} requires a value`);
+    }
+    args[key] = value;
+    index += 1;
+  }
+  return args;
+}
+
+function writeRedactedJson(path: string, value: unknown): void {
+  writeFileSync(path, `${redactSecrets(JSON.stringify(value, null, 2))}\n`);
+}
+
+function timeScenarioOnce(scenario: QaLabScenario, config: BotConfig): { elapsedMs: number; event: string; acceptedComments: number; droppedFindings: number } {
+  const startedAt = process.hrtime.bigint();
+  const parsed = parseFindings(scenario.botFindings);
+  const gateResult = applyDeterministicReviewGate({
+    findings: parsed.findings,
+    files: scenario.files,
+    droppedFromSchema: parsed.dropped,
+    maxInlineComments: config.reviewGate?.maxInlineComments,
+    publicConfidencePolicy: undefined
+  });
+  const elapsedNs = process.hrtime.bigint() - startedAt;
+  return {
+    elapsedMs: Number(elapsedNs) / 1_000_000,
+    event: gateResult.event,
+    acceptedComments: gateResult.comments.length,
+    droppedFindings: gateResult.dropped.length
+  };
+}
+
+function resolveCommitSha(): string {
+  try {
+    return execSync("git rev-parse HEAD", { encoding: "utf8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.config) throw new Error("--config is required (path to a fixture config JSON, never the live config)");
+  const configVariantId = (args["config-variant"] ?? "baseline") as QaLabConfigVariantId;
+  const samples = args.samples ? Number(args.samples) : 25;
+  if (!Number.isInteger(samples) || samples < 1) throw new Error("--samples must be a positive integer");
+  if (!args["output-dir"]) throw new Error("--output-dir is required");
+
+  const variant = findConfigVariant(configVariantId);
+  if (!variant) {
+    throw new Error(
+      `unknown --config-variant "${configVariantId}"; known variants: baseline, github_related_context, gitnexus_context, repo_memory, enrichment, self_consistency`
+    );
+  }
+  if (!HERMETIC_EXECUTABLE_VARIANTS.includes(configVariantId)) {
+    throw new Error(
+      `--config-variant "${configVariantId}" requires live provider/GitHub calls (${variant.description}) and is out of ` +
+        `scope for the hermetic pass-1 timing runner. Pass 1 only executes: ${HERMETIC_EXECUTABLE_VARIANTS.join(", ")}. ` +
+        "This variant exists as a config fixture for pass 2 to wire real timing against."
+    );
+  }
+
+  if (!existsSync(args.config)) throw new Error(`--config path does not exist: ${args.config}`);
+  const rawConfig = JSON.parse(readFileSync(args.config, "utf8"));
+  const baseConfig = loadConfigFromObject(rawConfig);
+  const effectiveConfig = variant.applyVariant(baseConfig);
+
+  const outputDir = args["output-dir"];
+  mkdirSync(outputDir, { recursive: true });
+
+  const scenarioResults: ScenarioTimingResult[] = QA_LAB_SCENARIOS.map((scenario) => {
+    const timingsMs: number[] = [];
+    let lastRun: { elapsedMs: number; event: string; acceptedComments: number; droppedFindings: number } | undefined;
+    for (let sampleIndex = 0; sampleIndex < samples; sampleIndex += 1) {
+      lastRun = timeScenarioOnce(scenario, effectiveConfig);
+      timingsMs.push(lastRun.elapsedMs);
+    }
+    if (!lastRun) throw new Error(`scenario ${scenario.id} produced zero samples`);
+    return {
+      scenarioId: scenario.id,
+      scenarioClass: scenario.scenarioClass,
+      description: scenario.description,
+      configVariant: configVariantId,
+      samples,
+      stats: summarizePercentiles(timingsMs),
+      lastRunOutcome: {
+        event: lastRun.event,
+        acceptedComments: lastRun.acceptedComments,
+        droppedFindings: lastRun.droppedFindings
+      }
+    };
+  });
+
+  const evidence: TimingEvidence = {
+    evidenceVersion: "0.1",
+    generatedAt: new Date().toISOString(),
+    commitSha: resolveCommitSha(),
+    nodeVersion: process.version,
+    configVariant: configVariantId,
+    configPath: args.config,
+    samplesPerScenario: samples,
+    proofBoundary:
+      "hermetic deterministic-pipeline timing only (parseFindings -> applyDeterministicReviewGate); " +
+      "no provider calls, no GitHub calls, no launchd, no live/active config read or write, no repo mutation",
+    scenarios: scenarioResults
+  };
+
+  writeRedactedJson(join(outputDir, "timing-results.json"), evidence);
+  writeFileSync(join(outputDir, "baseline-table.md"), buildBaselineTable(evidence));
+
+  console.log(JSON.stringify({ ok: true, outputDir, scenarioCount: scenarioResults.length }, null, 2));
+}
+
+function buildBaselineTable(evidence: TimingEvidence): string {
+  const rows = evidence.scenarios.map((scenario) => {
+    const { p50Ms, p90Ms } = scenario.stats;
+    return `| ${scenario.scenarioId} | ${scenario.scenarioClass} | ${scenario.samples} | ${p50Ms.toFixed(3)} | ${p90Ms.toFixed(3)} |`;
+  });
+  return [
+    "# QA Lab Timing Baseline (hermetic, pass 1)",
+    "",
+    `Generated: ${evidence.generatedAt}`,
+    `Commit: ${evidence.commitSha}`,
+    `Node: ${evidence.nodeVersion}`,
+    `Config variant: ${evidence.configVariant}`,
+    `Samples per scenario: ${evidence.samplesPerScenario}`,
+    "",
+    "## Proof boundary",
+    "",
+    evidence.proofBoundary,
+    "",
+    "## Per-scenario p50/p90 (ms, deterministic-pipeline wall-clock)",
+    "",
+    "| Scenario | Class | Samples | p50 (ms) | p90 (ms) |",
+    "| --- | --- | ---: | ---: | ---: |",
+    ...rows,
+    ""
+  ].join("\n");
+}
+
+main();

--- a/scripts/qa-lab/scenarios.ts
+++ b/scripts/qa-lab/scenarios.ts
@@ -1,0 +1,277 @@
+/**
+ * Seeded scenario library for the QA lab timing harness (#341, tracker #340).
+ *
+ * Reuse-first: scenarios are shaped as raw model-output JSON (`{ findings: [...] }`) plus a
+ * `PullFilePatch[]` diff context, matching the exact inputs `parseFindings` and
+ * `applyDeterministicReviewGate` already accept in src/findings.ts and src/review-gate.ts. This
+ * mirrors the `botFindings` / diff shape used by tests/fixtures/eval-suite-scenarios/*.json rather
+ * than inventing a parallel scenario format.
+ *
+ * Six scenario classes from issue #341: docs-only, normal code, auth/security, migration, release
+ * config, and issue-burst. The first five run through the deterministic review pipeline
+ * (parseFindings -> applyDeterministicReviewGate, which itself chains validateFindingLocations ->
+ * normalizeFindingsForReview -> decideReviewEvent). "issue-burst" is issue-enrichment shaped rather
+ * than PR-review shaped, so pass 1 seeds it as a fixture input shape only; timing wiring for the
+ * issue-enrichment path is pass 2 scope (provider/GitHub calls are out of scope for hermetic pass 1).
+ */
+import type { PullFilePatch } from "../../src/types.js";
+
+export type QaLabScenarioClass =
+  | "docs_only"
+  | "normal_code"
+  | "auth_security"
+  | "migration"
+  | "release_config"
+  | "issue_burst";
+
+export interface QaLabScenario {
+  id: string;
+  scenarioClass: QaLabScenarioClass;
+  description: string;
+  /** Raw model-output shape, exactly what parseFindings(input.botFindings) expects. */
+  botFindings: { findings: unknown[] };
+  /** Diff context, exactly what validateFindingLocations(findings, files) expects. */
+  files: PullFilePatch[];
+}
+
+function patch(newStartLine: number, addedLines: string[]): string {
+  const header = `@@ -0,0 +${newStartLine},${addedLines.length} @@`;
+  const body = addedLines.map((line) => `+${line}`).join("\n");
+  return `${header}\n${body}`;
+}
+
+export const QA_LAB_SCENARIOS: QaLabScenario[] = [
+  {
+    id: "docs-only-readme-typo",
+    scenarioClass: "docs_only",
+    description: "Docs-only PR: a README wording fix with a single low-severity nit finding.",
+    botFindings: {
+      findings: [
+        {
+          severity: "P3",
+          path: "docs/SETUP.md",
+          line: 12,
+          title: "Minor wording nit in setup docs",
+          body: "Consider rewording this sentence for clarity; not a functional issue.",
+          confidence: 0.4,
+          category: "docs_only"
+        }
+      ]
+    },
+    files: [
+      {
+        filename: "docs/SETUP.md",
+        status: "modified",
+        additions: 3,
+        deletions: 1,
+        changes: 4,
+        patch: patch(10, ["## Setup", "", "Follow these steps to install the CLI locally."])
+      }
+    ]
+  },
+  {
+    id: "normal-code-helper-refactor",
+    scenarioClass: "normal_code",
+    description: "Ordinary application code change: a small helper refactor with one real finding and one duplicate-shaped near-miss.",
+    botFindings: {
+      findings: [
+        {
+          severity: "P2",
+          path: "src/example-helper.ts",
+          line: 22,
+          title: "Off-by-one in retry loop bound",
+          body: "The loop should be < maxAttempts, not <= maxAttempts, or it retries one extra time.",
+          confidence: 0.72,
+          category: "runtime_correctness"
+        },
+        {
+          severity: "P2",
+          path: "src/example-helper.ts",
+          line: 23,
+          title: "Off-by-one in retry loop boundary",
+          body: "Loop bound looks incorrect, retries one extra time past maxAttempts.",
+          confidence: 0.6,
+          category: "runtime_correctness"
+        }
+      ]
+    },
+    files: [
+      {
+        filename: "src/example-helper.ts",
+        status: "modified",
+        additions: 12,
+        deletions: 4,
+        changes: 16,
+        patch: patch(
+          15,
+          [
+            "export function retryWithBackoff(fn: () => Promise<void>, maxAttempts: number): Promise<void> {",
+            "  let attempt = 0;",
+            "  return (async () => {",
+            "    while (attempt <= maxAttempts) {",
+            "      try {",
+            "        await fn();",
+            "        return;",
+            "      } catch (error) {",
+            "        attempt += 1;",
+            "      }",
+            "    }",
+            "  })();",
+            "}"
+          ]
+        )
+      }
+    ]
+  },
+  {
+    id: "auth-security-token-check",
+    scenarioClass: "auth_security",
+    description: "Auth/security-sensitive change: a permission check regression flagged at P0 plus a P1 secondary finding.",
+    botFindings: {
+      findings: [
+        {
+          severity: "P0",
+          path: "src/example-auth.ts",
+          line: 8,
+          title: "Missing role check before privileged action",
+          body: "This handler no longer verifies the caller has the admin role before proceeding.",
+          confidence: 0.9,
+          category: "auth",
+          why_this_matters: "Any authenticated user could trigger a privileged action without the admin role."
+        },
+        {
+          severity: "P1",
+          path: "src/example-auth.ts",
+          line: 6,
+          title: "Token comparison is not constant-time",
+          body: "Using === for token comparison can leak timing information about the secret value.",
+          confidence: 0.68,
+          category: "security_boundary"
+        }
+      ]
+    },
+    files: [
+      {
+        filename: "src/example-auth.ts",
+        status: "modified",
+        additions: 10,
+        deletions: 6,
+        changes: 16,
+        patch: patch(
+          5,
+          [
+            "export function handlePrivilegedAction(user: { role: string }, token: string, expected: string): void {",
+            "  if (token === expected) {",
+            "    performPrivilegedAction();",
+            "  }",
+            "}",
+            "",
+            "function performPrivilegedAction(): void {",
+            "  // ...",
+            "}"
+          ]
+        )
+      }
+    ]
+  },
+  {
+    id: "migration-column-backfill",
+    scenarioClass: "migration",
+    description: "Schema migration: a backfill migration missing a rollback path, flagged P1.",
+    botFindings: {
+      findings: [
+        {
+          severity: "P1",
+          path: "migrations/0042_add_status_column.sql",
+          line: 4,
+          title: "Migration has no down/rollback path",
+          body: "This migration adds a NOT NULL column with a default but has no corresponding down migration.",
+          confidence: 0.65,
+          category: "migration"
+        }
+      ]
+    },
+    files: [
+      {
+        filename: "migrations/0042_add_status_column.sql",
+        status: "added",
+        additions: 6,
+        deletions: 0,
+        changes: 6,
+        patch: patch(
+          1,
+          [
+            "-- Up",
+            "ALTER TABLE accounts ADD COLUMN status TEXT NOT NULL DEFAULT 'active';",
+            "UPDATE accounts SET status = 'active' WHERE status IS NULL;",
+            "",
+            "-- (no corresponding down migration file in this PR)"
+          ]
+        )
+      }
+    ]
+  },
+  {
+    id: "release-config-channel-bump",
+    scenarioClass: "release_config",
+    description: "Release/config change: a desktop update-channel bump with a P1 finding about a missing guard.",
+    botFindings: {
+      findings: [
+        {
+          severity: "P1",
+          path: "config.example.json",
+          line: 2,
+          title: "Update channel changed without a version guard",
+          body: "Switching updateChannel to \"stable\" here without a paired version bump may serve a stale build to existing installs.",
+          confidence: 0.55,
+          category: "release_regression"
+        }
+      ]
+    },
+    files: [
+      {
+        filename: "config.example.json",
+        status: "modified",
+        additions: 2,
+        deletions: 2,
+        changes: 4,
+        patch: patch(1, ['{', '  "updateChannel": "stable",'])
+      }
+    ]
+  },
+  {
+    id: "issue-burst-duplicate-reports",
+    scenarioClass: "issue_burst",
+    description:
+      "Issue-enrichment-shaped burst: several near-duplicate bug reports arriving together. Fixture input only in pass 1 " +
+      "(issue-enrichment timing requires provider/GitHub calls, out of scope for hermetic pass 1); seeded here so pass 2 " +
+      "can wire real timing without redesigning the scenario shape.",
+    botFindings: {
+      findings: [
+        {
+          severity: "P2",
+          path: "src/example-queue.ts",
+          line: 30,
+          title: "Duplicate-looking issue reports processed independently",
+          body: "Three similar bug reports filed within an hour are not being correlated before enrichment.",
+          confidence: 0.5,
+          category: "unknown"
+        }
+      ]
+    },
+    files: [
+      {
+        filename: "src/example-queue.ts",
+        status: "modified",
+        additions: 5,
+        deletions: 1,
+        changes: 6,
+        patch: patch(28, ["export function enqueueIssue(issue: { id: string }): void {", "  queue.push(issue);", "}"])
+      }
+    ]
+  }
+];
+
+export function findScenario(id: string): QaLabScenario | undefined {
+  return QA_LAB_SCENARIOS.find((scenario) => scenario.id === id);
+}

--- a/scripts/qa-lab/scenarios.ts
+++ b/scripts/qa-lab/scenarios.ts
@@ -40,6 +40,30 @@ function patch(newStartLine: number, addedLines: string[]): string {
   return `${header}\n${body}`;
 }
 
+/**
+ * Derive additions/deletions/changes straight from a unified-diff patch body, so a scenario's
+ * `PullFilePatch` metadata can never drift from what `patch()` actually produced (#341 review:
+ * previously several scenarios had hand-written additions/deletions literals that didn't match the
+ * patch body). Every added/removed content line in these fixtures is a whole-line `+`/`-` hunk line;
+ * no `\ No newline at end of file` markers or context lines are used, so a plain per-line prefix
+ * count is exact for this module's fixtures.
+ */
+export function countPatchLines(patchText: string): { additions: number; deletions: number; changes: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of patchText.split("\n")) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    if (line.startsWith("+")) additions += 1;
+    else if (line.startsWith("-")) deletions += 1;
+  }
+  return { additions, deletions, changes: additions + deletions };
+}
+
+/** Builds a `PullFilePatch` whose additions/deletions/changes are always derived from `patchText`. */
+function filePatch(filename: string, status: string, patchText: string): PullFilePatch {
+  return { filename, status, ...countPatchLines(patchText), patch: patchText };
+}
+
 export const QA_LAB_SCENARIOS: QaLabScenario[] = [
   {
     id: "docs-only-readme-typo",
@@ -59,14 +83,7 @@ export const QA_LAB_SCENARIOS: QaLabScenario[] = [
       ]
     },
     files: [
-      {
-        filename: "docs/SETUP.md",
-        status: "modified",
-        additions: 3,
-        deletions: 1,
-        changes: 4,
-        patch: patch(10, ["## Setup", "", "Follow these steps to install the CLI locally."])
-      }
+      filePatch("docs/SETUP.md", "modified", patch(10, ["## Setup", "", "Follow these steps to install the CLI locally."]))
     ]
   },
   {
@@ -96,31 +113,25 @@ export const QA_LAB_SCENARIOS: QaLabScenario[] = [
       ]
     },
     files: [
-      {
-        filename: "src/example-helper.ts",
-        status: "modified",
-        additions: 12,
-        deletions: 4,
-        changes: 16,
-        patch: patch(
-          15,
-          [
-            "export function retryWithBackoff(fn: () => Promise<void>, maxAttempts: number): Promise<void> {",
-            "  let attempt = 0;",
-            "  return (async () => {",
-            "    while (attempt <= maxAttempts) {",
-            "      try {",
-            "        await fn();",
-            "        return;",
-            "      } catch (error) {",
-            "        attempt += 1;",
-            "      }",
-            "    }",
-            "  })();",
-            "}"
-          ]
-        )
-      }
+      filePatch(
+        "src/example-helper.ts",
+        "modified",
+        patch(15, [
+          "export function retryWithBackoff(fn: () => Promise<void>, maxAttempts: number): Promise<void> {",
+          "  let attempt = 0;",
+          "  return (async () => {",
+          "    while (attempt <= maxAttempts) {",
+          "      try {",
+          "        await fn();",
+          "        return;",
+          "      } catch (error) {",
+          "        attempt += 1;",
+          "      }",
+          "    }",
+          "  })();",
+          "}"
+        ])
+      )
     ]
   },
   {
@@ -151,27 +162,21 @@ export const QA_LAB_SCENARIOS: QaLabScenario[] = [
       ]
     },
     files: [
-      {
-        filename: "src/example-auth.ts",
-        status: "modified",
-        additions: 10,
-        deletions: 6,
-        changes: 16,
-        patch: patch(
-          5,
-          [
-            "export function handlePrivilegedAction(user: { role: string }, token: string, expected: string): void {",
-            "  if (token === expected) {",
-            "    performPrivilegedAction();",
-            "  }",
-            "}",
-            "",
-            "function performPrivilegedAction(): void {",
-            "  // ...",
-            "}"
-          ]
-        )
-      }
+      filePatch(
+        "src/example-auth.ts",
+        "modified",
+        patch(5, [
+          "export function handlePrivilegedAction(user: { role: string }, token: string, expected: string): void {",
+          "  if (token === expected) {",
+          "    performPrivilegedAction();",
+          "  }",
+          "}",
+          "",
+          "function performPrivilegedAction(): void {",
+          "  // ...",
+          "}"
+        ])
+      )
     ]
   },
   {
@@ -192,23 +197,17 @@ export const QA_LAB_SCENARIOS: QaLabScenario[] = [
       ]
     },
     files: [
-      {
-        filename: "migrations/0042_add_status_column.sql",
-        status: "added",
-        additions: 6,
-        deletions: 0,
-        changes: 6,
-        patch: patch(
-          1,
-          [
-            "-- Up",
-            "ALTER TABLE accounts ADD COLUMN status TEXT NOT NULL DEFAULT 'active';",
-            "UPDATE accounts SET status = 'active' WHERE status IS NULL;",
-            "",
-            "-- (no corresponding down migration file in this PR)"
-          ]
-        )
-      }
+      filePatch(
+        "migrations/0042_add_status_column.sql",
+        "added",
+        patch(1, [
+          "-- Up",
+          "ALTER TABLE accounts ADD COLUMN status TEXT NOT NULL DEFAULT 'active';",
+          "UPDATE accounts SET status = 'active' WHERE status IS NULL;",
+          "",
+          "-- (no corresponding down migration file in this PR)"
+        ])
+      )
     ]
   },
   {
@@ -228,16 +227,7 @@ export const QA_LAB_SCENARIOS: QaLabScenario[] = [
         }
       ]
     },
-    files: [
-      {
-        filename: "config.example.json",
-        status: "modified",
-        additions: 2,
-        deletions: 2,
-        changes: 4,
-        patch: patch(1, ['{', '  "updateChannel": "stable",'])
-      }
-    ]
+    files: [filePatch("config.example.json", "modified", patch(1, ["{", '  "updateChannel": "stable",']))]
   },
   {
     id: "issue-burst-duplicate-reports",
@@ -260,14 +250,11 @@ export const QA_LAB_SCENARIOS: QaLabScenario[] = [
       ]
     },
     files: [
-      {
-        filename: "src/example-queue.ts",
-        status: "modified",
-        additions: 5,
-        deletions: 1,
-        changes: 6,
-        patch: patch(28, ["export function enqueueIssue(issue: { id: string }): void {", "  queue.push(issue);", "}"])
-      }
+      filePatch(
+        "src/example-queue.ts",
+        "modified",
+        patch(28, ["export function enqueueIssue(issue: { id: string }): void {", "  queue.push(issue);", "}"])
+      )
     ]
   }
 ];

--- a/scripts/qa-lab/stats.ts
+++ b/scripts/qa-lab/stats.ts
@@ -1,0 +1,41 @@
+/**
+ * Percentile stats for the QA lab timing harness (#341). Small, dependency-free, and pure so it is
+ * trivially unit-testable in isolation from the timing runner.
+ */
+
+export interface PercentileSummary {
+  count: number;
+  minMs: number;
+  maxMs: number;
+  meanMs: number;
+  p50Ms: number;
+  p90Ms: number;
+}
+
+/**
+ * Nearest-rank percentile over a copied, ascending-sorted view of `samples`. Nearest-rank (not
+ * linear interpolation) is used deliberately: it always returns an observed sample value, which
+ * keeps p50/p90 traceable to a real run in the evidence packet instead of an interpolated number
+ * that no single run actually produced.
+ */
+export function percentile(samples: number[], p: number): number {
+  if (samples.length === 0) throw new Error("percentile requires at least one sample");
+  if (p < 0 || p > 1) throw new Error(`percentile p must be within [0, 1], got ${p}`);
+  const sorted = [...samples].sort((a, b) => a - b);
+  const rank = Math.ceil(p * sorted.length);
+  const index = Math.min(Math.max(rank, 1), sorted.length) - 1;
+  return sorted[index]!;
+}
+
+export function summarizePercentiles(samplesMs: number[]): PercentileSummary {
+  if (samplesMs.length === 0) throw new Error("summarizePercentiles requires at least one sample");
+  const sum = samplesMs.reduce((total, value) => total + value, 0);
+  return {
+    count: samplesMs.length,
+    minMs: Math.min(...samplesMs),
+    maxMs: Math.max(...samplesMs),
+    meanMs: sum / samplesMs.length,
+    p50Ms: percentile(samplesMs, 0.5),
+    p90Ms: percentile(samplesMs, 0.9)
+  };
+}

--- a/tests/fixtures/qa-lab/config.baseline.json
+++ b/tests/fixtures/qa-lab/config.baseline.json
@@ -1,0 +1,297 @@
+{
+  "pilotRepos": ["example-org/example-repo"],
+  "pollIntervalMs": 90000,
+  "skipDrafts": true,
+  "canaryPulls": ["example-org/example-repo#1"],
+  "activation": {
+    "reviewExistingOpenPrsOnActivation": false
+  },
+  "reviewConcurrency": {
+    "maxActiveRuns": 5,
+    "leaseTtlMs": 900000
+  },
+  "_reviewGateComment": "Deterministic post-model gate: ranking, comment cap, and REQUEST_CHANGES eligibility. maxInlineComments matches the built-in default; the rest are default-off/quieter-only knobs. See docs/neondiff-config.md.",
+  "reviewGate": {
+    "maxInlineComments": 25,
+    "_requestChangesConfidenceFloorsComment": "Optional per-severity confidence floor for REQUEST_CHANGES eligibility (only P0/P1 keys allowed). Quieter-only: a below-floor finding still posts as a comment. Uncomment to enable.",
+    "_retryDegradedConfidencePenaltyComment": "Optional 0..1 confidence penalty applied to findings recovered via the strict-JSON retry path. Quieter-only; unset means no penalty.",
+    "selfConsistency": {
+      "_comment": "Opt-in second-draw re-check for P0/P1 findings. Adds one provider call per re-checked finding (bounded by maxFindingsPerReview) — keep enabled:false unless you have budget for the extra provider spend.",
+      "enabled": false,
+      "severities": ["P0", "P1"],
+      "maxFindingsPerReview": 5
+    }
+  },
+  "_riskWeightedQueueComment": "Config-gated enqueue priority tiering by changed-surface risk. Disabled means flat FIFO priority and zero extra GitHub calls at enqueue time.",
+  "riskWeightedQueue": {
+    "enabled": false
+  },
+  "_repoMemoryComment": "Durable per-repo memory packet (policy notes, machine facts, learned false positives) surfaced to the model. Disabled means no packet is built.",
+  "repoMemory": {
+    "enabled": false,
+    "memoryRoot": ".evaos/repo-memory",
+    "maxPacketBytes": 12000,
+    "maxStateNotes": 20,
+    "includeStaleNotes": false
+  },
+  "_workRootComment": "workRoot must resolve outside this checkout (enforced at config load: config.workRoot must be outside the current repository checkout). /tmp/neondiff is a placeholder that satisfies that check on any machine without edits; point it at a durable path for real use.",
+  "workRoot": "/tmp/neondiff/runtime",
+  "statePath": "/tmp/neondiff/state/reviews.sqlite",
+  "evidenceDir": "/tmp/neondiff/evidence",
+  "issueEnrichment": {
+    "enabled": false,
+    "postIssueComment": false,
+    "allowlist": [],
+    "_allowedLabelsComment": "Issue-enrichment label suggestions are separate from PR review repoProfiles.suggestedLabels. Empty means no allowlist restriction; fill this only to cap inferred issue labels.",
+    "allowedLabels": [],
+    "_allowedReviewersComment": "Issue-enrichment reviewer/owner suggestions are separate from PR review repoProfiles.suggestedReviewers. Empty means no allowlist restriction; fill this only to cap inferred issue owners.",
+    "allowedReviewers": [],
+    "maxIssuesPerCycle": 5,
+    "maxCommentsPerCycle": 1,
+    "globalMaxIssuesPerCycle": 5,
+    "_globalMaxCommentsPerCycleComment": "Beta safety default: at most one live issue-enrichment comment per daemon cycle globally. Raise only after dry-run evidence.",
+    "globalMaxCommentsPerCycle": 1,
+    "maxActiveRuns": 1,
+    "_leaseTtlMsComment": "Lease TTL bounds stuck-worker recovery and is the worst-case live issue-enrichment stall after abnormal worker exit unless an operator clears leases. It may be shorter than cooldownMs, which controls per-issue deferral cadence.",
+    "leaseTtlMs": 1200000,
+    "cooldownMs": 3600000,
+    "burstWindowMs": 3600000,
+    "maxIssuesPerBurst": 10,
+    "lookbackMs": 600000,
+    "processExistingOpenIssuesOnActivation": false,
+    "repos": {
+      "electricsheephq/evaos-code-review-bot": {
+        "enabled": false,
+        "allowedLabels": [],
+        "allowedReviewers": [],
+        "maxIssuesPerCycle": 3,
+        "maxCommentsPerCycle": 1,
+        "maxIssuesPerBurst": 8,
+        "processExistingOpenIssuesOnActivation": false
+      }
+    }
+  },
+  "license": {
+    "_enabledComment": "Enable this for public/private license enforcement. Public repos may remain free; private repos fail closed without active entitlement.",
+    "enabled": false,
+    "_apiBaseUrlComment": "Set apiBaseUrl when enabling license enforcement.",
+    "_cachePathComment": "Defaults to a license/entitlement-cache.json file next to statePath when omitted.",
+    "_keyPathComment": "For the beta file backend, keyPath defaults to license/license-key.txt next to statePath when omitted. The file is written with 0600 permissions.",
+    "storageBackend": "file",
+    "keychainService": "com.electricsheephq.neondiff.license",
+    "keychainAccount": "default",
+    "requestTimeoutMs": 10000,
+    "_offlineGraceMsComment": "Private-repo entitlement cache grace is capped at 15 minutes to limit revoked-license exposure during API outages.",
+    "offlineGraceMs": 900000,
+    "publicReposFree": true,
+    "privateReposRequireEntitlement": true,
+    "updateEntitlementRequiresLicense": true
+  },
+  "desktop": {
+    "openAICompatibleEndpoint": "http://localhost:8000/v1",
+    "updateChannel": "dev"
+  },
+  "providers": {
+    "_comment": "Provider registry metadata for operator/desktop setup. API keys stay in environment variables or provider app config, never in this JSON file.",
+    "defaultProviderId": "zcode-glm",
+    "providers": {
+      "zcode-glm": {
+        "enabled": true,
+        "adapter": "zcode",
+        "displayName": "GLM/Z.ai through ZCode",
+        "model": "GLM-5.2",
+        "authMode": "zcode-app-config",
+        "contextWindowTokens": 128000,
+        "timeoutMs": 180000,
+        "retryMaxRetries": 0,
+        "capabilities": {
+          "review": true,
+          "jsonOutput": true,
+          "local": false,
+          "streaming": false
+        }
+      },
+      "ollama-local": {
+        "enabled": false,
+        "adapter": "openai-compatible",
+        "displayName": "Ollama local OpenAI-compatible endpoint",
+        "baseUrl": "http://localhost:11434/v1",
+        "model": "qwen2.5-coder:7b",
+        "authMode": "none",
+        "contextWindowTokens": 32000,
+        "timeoutMs": 180000,
+        "retryMaxRetries": 1,
+        "capabilities": {
+          "review": true,
+          "jsonOutput": true,
+          "local": true,
+          "streaming": false
+        }
+      },
+      "openai-compatible": {
+        "enabled": false,
+        "adapter": "openai-compatible",
+        "displayName": "OpenAI-compatible BYOK or gateway endpoint",
+        "baseUrl": "https://example.invalid/v1",
+        "model": "model-id",
+        "authMode": "api-key-env",
+        "apiKeyEnv": "NEONDIFF_PROVIDER_API_KEY",
+        "contextWindowTokens": 128000,
+        "timeoutMs": 180000,
+        "retryMaxRetries": 1,
+        "capabilities": {
+          "review": true,
+          "jsonOutput": true,
+          "local": false,
+          "streaming": false
+        }
+      }
+    }
+  },
+  "commands": {
+    "enabled": false,
+    "botMentions": ["@evaos-code-review-bot"],
+    "trustedAuthors": ["100yenadmin"],
+    "acknowledge": false
+  },
+  "gitnexusContext": {
+    "enabled": false,
+    "packetVersion": "gitnexus-context-packet-v0.1",
+    "maxPacketBytes": 40000,
+    "maxRelatedItems": 8,
+    "queryLimit": 3,
+    "commandTimeoutMs": 10000,
+    "maxCommandOutputBytes": 8000,
+    "includeStaleContext": false,
+    "repoAliases": {
+      "electricsheephq/WorldOS": "worldos",
+      "100yenadmin/evaOS-GUI": "evaos-gui"
+    },
+    "generatedPathPatterns": ["dist/**", "build/**", "coverage/**", "Library/**", "Temp/**", "**/*.min.js", "**/*.bundle.js", "**/*.lock"]
+  },
+  "repoProfiles": {
+    "enableOrgFallbacks": false,
+    "repos": {
+      "electricsheephq/WorldOS": {
+        "displayName": "WorldOS Unity",
+        "defaultBranch": "main",
+        "reviewProfile": "assertive",
+        "promptNote": "Prioritize Unity scene, save-state, gameplay, release-regression, and data-loss risks.",
+        "autoReview": {
+          "baseBranches": ["main"],
+          "labels": ["!wip", "!do-not-review"]
+        },
+        "pathFilters": ["Assets/**", "Packages/**", "ProjectSettings/**", "src/**", "tests/**", "!Library/**"],
+        "pathInstructions": {
+          "Assets/**": ["Prioritize scene, prefab, save-state, and gameplay regressions."],
+          "ProjectSettings/**": ["Treat build/release behavior changes as high risk."]
+        },
+        "riskyPaths": ["Assets/**", "ProjectSettings/**", "Packages/manifest.json"],
+        "proofExpectations": ["Mention Unity editor/play-mode or focused smoke evidence when relevant."],
+        "validationHints": ["Prefer correctness, persistence, CI, and release findings over style-only feedback."],
+        "readinessHints": ["Scene, save, build, or package changes need explicit rollback and smoke notes."],
+        "preMergeChecks": {
+          "title": {
+            "mode": "warning",
+            "instructions": "Title should name the gameplay or release behavior changed."
+          },
+          "testEvidence": {
+            "mode": "warning",
+            "instructions": "Look for focused Unity/editor smoke, CI, or fixture evidence when code changes affect runtime behavior."
+          }
+        },
+        "finishingTouches": {
+          "unitTests": {
+            "enabled": false,
+            "instructions": "Design-only declaration until finishing-touch commands are explicitly enabled."
+          }
+        },
+        "suggestedLabels": ["unity", "gameplay", "regression-hardening"]
+      },
+      "100yenadmin/evaOS-GUI": {
+        "displayName": "evaOS Workbench",
+        "defaultBranch": "main",
+        "reviewProfile": "assertive",
+        "promptNote": "Prioritize Electron/Workbench runtime regressions, packaged-app resource shape, bridge control, and macOS permission identity risk.",
+        "autoReview": {
+          "baseBranches": ["main"],
+          "labels": ["!wip", "!do-not-review"]
+        },
+        "pathFilters": ["src/**", "apps/**", "scripts/**", "package.json", "package-lock.json", "!dist/**"],
+        "pathInstructions": {
+          "apps/eva-desktop-mac/**": ["Check macOS identity, helper path, and packaged resource shape risk."],
+          "scripts/**": ["Treat release, packaging, and artifact-shape changes as high risk."]
+        },
+        "riskyPaths": ["scripts/**", "apps/eva-desktop-mac/**", "package.json"],
+        "proofExpectations": ["Mention focused app smoke, packaged resource checks, or CI artifact proof when relevant."],
+        "validationHints": ["Do not ask for broad local suites when remote CI or fast-smoke proof is the right gate."],
+        "preMergeChecks": {
+          "description": {
+            "mode": "warning",
+            "instructions": "Description should name app/runtime behavior and validation evidence."
+          },
+          "testEvidence": {
+            "mode": "warning",
+            "instructions": "Look for focused app smoke, packaged resource checks, or CI proof."
+          }
+        },
+        "finishingTouches": {
+          "docstrings": {
+            "enabled": false,
+            "instructions": "Design-only declaration until finishing-touch commands are explicitly enabled."
+          },
+          "unitTests": {
+            "enabled": false
+          }
+        },
+        "suggestedLabels": ["workbench", "macos", "regression-hardening"]
+      },
+      "electricsheephq/evaos-code-review-bot": {
+        "enabled": false,
+        "displayName": "evaOS Code Review Bot",
+        "defaultBranch": "main",
+        "reviewProfile": "assertive",
+        "promptNote": "Self-monitoring profile for dry-run/eval only until the App install and live allowlist gates are approved.",
+        "pathFilters": ["src/**", "tests/**", "docs/**", "config.example.json", "package.json", "package-lock.json"],
+        "riskyPaths": ["src/github.ts", "src/state.ts", "src/worker.ts", "src/zcode.ts"],
+        "proofExpectations": ["Require focused tests, TypeScript build, duplicate-suppression proof, and release-status proof before live promotion."],
+        "readinessHints": ["Do not expand live monitoring from this example profile alone."],
+        "preMergeChecks": {
+          "testEvidence": {
+            "mode": "error",
+            "instructions": "Require focused tests, TypeScript build, and beta release-status proof before live promotion."
+          }
+        },
+        "finishingTouches": {
+          "unitTests": {
+            "enabled": false,
+            "instructions": "Do not auto-generate tests from the bot during live review until opt-in command gates ship."
+          }
+        },
+        "suggestedLabels": ["bot", "regression-hardening"]
+      }
+    },
+    "orgFallbacks": {
+      "electricsheephq": {
+        "displayName": "Electric Sheep conservative fallback",
+        "reviewProfile": "assertive",
+        "promptNote": "Conservative fallback profile for explicitly enabled dry-run scans only.",
+        "validationHints": ["Fallback profiles must not expand runtime permissions or live monitoring by themselves."]
+      }
+    }
+  },
+  "zcode": {
+    "_desktopPathComment": "Developer-machine defaults. Override cliPath and appConfigPath for any non-author workstation or packaged desktop install.",
+    "cliPath": "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
+    "appConfigPath": "/Volumes/LEXAR/zcode/.zcode/v2/config.json",
+    "model": "GLM-5.2",
+    "timeoutMs": 180000,
+    "maxPatchBytes": 80000,
+    "retryMaxRetries": 0
+  },
+  "github": {
+    "appId": "set via EVAOS_REVIEW_BOT_APP_ID",
+    "privateKeyPath": "set via EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH",
+    "token": "optional fallback token for local development only"
+  }
+}

--- a/tests/qa-lab-run-timing.test.ts
+++ b/tests/qa-lab-run-timing.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { buildBaselineTable, parseArgs, resolveConfigVariant, WARMUP_ITERATIONS, type TimingEvidence } from "../scripts/qa-lab/run-timing.js";
+
+describe("parseArgs", () => {
+  it("parses --samples and other flags into a args map", () => {
+    const args = parseArgs(["--config", "a.json", "--samples", "10", "--output-dir", "/tmp/out"]);
+    expect(args).toEqual({ config: "a.json", samples: "10", "output-dir": "/tmp/out" });
+  });
+
+  it("throws when a flag has no following value", () => {
+    expect(() => parseArgs(["--samples"])).toThrow(/--samples requires a value/);
+  });
+
+  it("throws when a flag's value looks like another flag", () => {
+    expect(() => parseArgs(["--config", "--samples", "10"])).toThrow(/--config requires a value/);
+  });
+});
+
+describe("resolveConfigVariant", () => {
+  it("resolves the baseline variant (hermetic-executable)", () => {
+    const variant = resolveConfigVariant("baseline");
+    expect(variant.id).toBe("baseline");
+  });
+
+  it("rejects an unknown variant id, listing known variants", () => {
+    expect(() => resolveConfigVariant("not-a-real-variant" as never)).toThrow(/unknown --config-variant/);
+  });
+
+  it("rejects a known but non-hermetic variant with a clear out-of-scope error", () => {
+    expect(() => resolveConfigVariant("github_related_context")).toThrow(/requires live provider\/GitHub calls/);
+    expect(() => resolveConfigVariant("self_consistency")).toThrow(/out of.*scope for the hermetic pass-1 timing runner/s);
+  });
+});
+
+describe("WARMUP_ITERATIONS", () => {
+  it("is a small positive integer", () => {
+    expect(Number.isInteger(WARMUP_ITERATIONS)).toBe(true);
+    expect(WARMUP_ITERATIONS).toBeGreaterThan(0);
+  });
+});
+
+describe("buildBaselineTable", () => {
+  it("renders a markdown table with one row per scenario and the warm-up count", () => {
+    const evidence: TimingEvidence = {
+      evidenceVersion: "0.1",
+      generatedAt: "2026-07-06T00:00:00.000Z",
+      commitSha: "deadbeef",
+      nodeVersion: "v20.0.0",
+      configVariant: "baseline",
+      configPath: "tests/fixtures/qa-lab/config.baseline.json",
+      samplesPerScenario: 25,
+      warmupIterations: WARMUP_ITERATIONS,
+      proofBoundary: "hermetic deterministic-pipeline timing only",
+      scenarios: [
+        {
+          scenarioId: "docs-only-readme-typo",
+          scenarioClass: "docs_only",
+          description: "desc",
+          configVariant: "baseline",
+          samples: 25,
+          warmupIterations: WARMUP_ITERATIONS,
+          stats: { count: 25, minMs: 0.1, maxMs: 0.5, meanMs: 0.3, p50Ms: 0.3, p90Ms: 0.45 },
+          lastRunOutcome: { event: "COMMENT", acceptedComments: 1, droppedFindings: 0 }
+        }
+      ]
+    };
+    const table = buildBaselineTable(evidence);
+    expect(table).toContain("# QA Lab Timing Baseline");
+    expect(table).toContain("Commit: deadbeef");
+    expect(table).toContain("| docs-only-readme-typo | docs_only | 25 | 0.300 | 0.450 |");
+  });
+});

--- a/tests/qa-lab-scenarios.test.ts
+++ b/tests/qa-lab-scenarios.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { parseFindings } from "../src/findings.js";
+import { validateFindingLocations } from "../src/diff.js";
+import { findScenario, QA_LAB_SCENARIOS } from "../scripts/qa-lab/scenarios.js";
+import {
+  findConfigVariant,
+  HERMETIC_EXECUTABLE_VARIANTS,
+  QA_LAB_CONFIG_VARIANT_IDS,
+  QA_LAB_CONFIG_VARIANTS
+} from "../scripts/qa-lab/config-variants.js";
+
+describe("QA_LAB_SCENARIOS", () => {
+  it("covers exactly the six scenario classes required by issue #341", () => {
+    const classes = QA_LAB_SCENARIOS.map((scenario) => scenario.scenarioClass).sort();
+    expect(classes).toEqual(
+      ["auth_security", "docs_only", "issue_burst", "migration", "normal_code", "release_config"].sort()
+    );
+  });
+
+  it("has a unique id for every scenario", () => {
+    const ids = QA_LAB_SCENARIOS.map((scenario) => scenario.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("finds a scenario by id and returns undefined for an unknown id", () => {
+    expect(findScenario("docs-only-readme-typo")?.scenarioClass).toBe("docs_only");
+    expect(findScenario("does-not-exist")).toBeUndefined();
+  });
+
+  it("every scenario's raw botFindings parses cleanly through the real parseFindings schema gate", () => {
+    for (const scenario of QA_LAB_SCENARIOS) {
+      const parsed = parseFindings(scenario.botFindings);
+      expect(parsed.dropped, `scenario ${scenario.id} had schema-invalid seeded findings`).toEqual([]);
+      expect(parsed.findings.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every scenario's seeded finding locations are valid against its own diff context", () => {
+    for (const scenario of QA_LAB_SCENARIOS) {
+      const parsed = parseFindings(scenario.botFindings);
+      const located = validateFindingLocations(parsed.findings, scenario.files);
+      expect(located.dropped, `scenario ${scenario.id} had a finding location not present in its own diff`).toEqual([]);
+    }
+  });
+});
+
+describe("QA lab config variants", () => {
+  it("declares one variant per configured variant id", () => {
+    const variantIds = QA_LAB_CONFIG_VARIANTS.map((variant) => variant.id).sort();
+    expect(variantIds).toEqual([...QA_LAB_CONFIG_VARIANT_IDS].sort());
+  });
+
+  it("only the baseline variant is hermetic-executable in pass 1", () => {
+    expect(HERMETIC_EXECUTABLE_VARIANTS).toEqual(["baseline"]);
+  });
+
+  it("marks every non-baseline variant as requiring a live provider or GitHub call, except repo_memory", () => {
+    for (const variant of QA_LAB_CONFIG_VARIANTS) {
+      if (variant.id === "baseline" || variant.id === "repo_memory") continue;
+      expect(variant.requiresLiveProviderOrGithub, `variant ${variant.id} should require live provider/GitHub calls`).toBe(true);
+    }
+  });
+
+  it("finds a variant by id and returns undefined for an unknown id", () => {
+    expect(findConfigVariant("baseline")?.id).toBe("baseline");
+    expect(findConfigVariant("not-a-real-variant")).toBeUndefined();
+  });
+});

--- a/tests/qa-lab-scenarios.test.ts
+++ b/tests/qa-lab-scenarios.test.ts
@@ -1,7 +1,11 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseFindings } from "../src/findings.js";
 import { validateFindingLocations } from "../src/diff.js";
-import { findScenario, QA_LAB_SCENARIOS } from "../scripts/qa-lab/scenarios.js";
+import { loadConfigFromObject } from "../src/config.js";
+import { applyDeterministicReviewGate } from "../src/review-gate.js";
+import { countPatchLines, findScenario, QA_LAB_SCENARIOS } from "../scripts/qa-lab/scenarios.js";
 import {
   findConfigVariant,
   HERMETIC_EXECUTABLE_VARIANTS,
@@ -35,12 +39,44 @@ describe("QA_LAB_SCENARIOS", () => {
     }
   });
 
+  it("every scenario file's additions/deletions/changes match its actual patch content (no drift)", () => {
+    for (const scenario of QA_LAB_SCENARIOS) {
+      for (const file of scenario.files) {
+        const derived = countPatchLines(file.patch ?? "");
+        expect(
+          { additions: file.additions, deletions: file.deletions, changes: file.changes },
+          `scenario ${scenario.id} file ${file.filename} metadata should match its derived patch counts`
+        ).toEqual(derived);
+      }
+    }
+  });
+
   it("every scenario's seeded finding locations are valid against its own diff context", () => {
     for (const scenario of QA_LAB_SCENARIOS) {
       const parsed = parseFindings(scenario.botFindings);
       const located = validateFindingLocations(parsed.findings, scenario.files);
       expect(located.dropped, `scenario ${scenario.id} had a finding location not present in its own diff`).toEqual([]);
     }
+  });
+
+  it("loads the qa-lab baseline fixture config cleanly through loadConfigFromObject (schema-validity pin)", () => {
+    const raw = JSON.parse(readFileSync(join(__dirname, "fixtures/qa-lab/config.baseline.json"), "utf8"));
+    expect(() => loadConfigFromObject(raw)).not.toThrow();
+    const config = loadConfigFromObject(raw);
+    expect(config.reviewGate?.maxInlineComments).toBe(25);
+  });
+
+  it("the normal-code-helper-refactor scenario's near-duplicate P2 findings are deduped by the deterministic gate", () => {
+    const scenario = findScenario("normal-code-helper-refactor");
+    if (!scenario) throw new Error("expected normal-code-helper-refactor scenario to exist");
+    const parsed = parseFindings(scenario.botFindings);
+    // Seeded with two near-duplicate P2 findings (same path/category, adjacent lines, near-duplicate
+    // titles) — matches how suppressSameRunNearDuplicates (src/findings.ts) reports them.
+    expect(parsed.findings.length).toBe(2);
+    const gateResult = applyDeterministicReviewGate({ findings: parsed.findings, files: scenario.files });
+    expect(gateResult.comments.length).toBe(1);
+    expect(gateResult.summary.dropReasonCounts.same_run_near_duplicate).toBe(1);
+    expect(gateResult.dropped.some((dropped) => dropped.reason === "same_run_near_duplicate")).toBe(true);
   });
 });
 

--- a/tests/qa-lab-stats.test.ts
+++ b/tests/qa-lab-stats.test.ts
@@ -15,6 +15,12 @@ describe("percentile", () => {
     expect(percentile(samples, 0.9)).toBe(90);
   });
 
+  it("returns the min at p=0 and the max at p=1 (nearest-rank boundaries)", () => {
+    const samples = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+    expect(percentile(samples, 0)).toBe(Math.min(...samples));
+    expect(percentile(samples, 1)).toBe(Math.max(...samples));
+  });
+
   it("is insensitive to input order", () => {
     const ascending = [1, 2, 3, 4, 5];
     const shuffled = [3, 1, 5, 2, 4];

--- a/tests/qa-lab-stats.test.ts
+++ b/tests/qa-lab-stats.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { percentile, summarizePercentiles } from "../scripts/qa-lab/stats.js";
+
+describe("percentile", () => {
+  it("returns the single sample when there is only one", () => {
+    expect(percentile([42], 0.5)).toBe(42);
+    expect(percentile([42], 0.9)).toBe(42);
+  });
+
+  it("uses nearest-rank so p50/p90 are always an observed sample", () => {
+    const samples = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+    // Nearest-rank p50 over 10 sorted samples: ceil(0.5 * 10) = 5th smallest -> 50.
+    expect(percentile(samples, 0.5)).toBe(50);
+    // Nearest-rank p90 over 10 sorted samples: ceil(0.9 * 10) = 9th smallest -> 90.
+    expect(percentile(samples, 0.9)).toBe(90);
+  });
+
+  it("is insensitive to input order", () => {
+    const ascending = [1, 2, 3, 4, 5];
+    const shuffled = [3, 1, 5, 2, 4];
+    expect(percentile(shuffled, 0.5)).toBe(percentile(ascending, 0.5));
+    expect(percentile(shuffled, 0.9)).toBe(percentile(ascending, 0.9));
+  });
+
+  it("rejects an empty sample set", () => {
+    expect(() => percentile([], 0.5)).toThrow(/at least one sample/);
+  });
+
+  it("rejects an out-of-range percentile", () => {
+    expect(() => percentile([1, 2, 3], 1.5)).toThrow(/within \[0, 1\]/);
+    expect(() => percentile([1, 2, 3], -0.1)).toThrow(/within \[0, 1\]/);
+  });
+});
+
+describe("summarizePercentiles", () => {
+  it("computes count, min, max, mean, p50, and p90 over a sample set", () => {
+    const summary = summarizePercentiles([10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
+    expect(summary.count).toBe(10);
+    expect(summary.minMs).toBe(10);
+    expect(summary.maxMs).toBe(100);
+    expect(summary.meanMs).toBe(55);
+    expect(summary.p50Ms).toBe(50);
+    expect(summary.p90Ms).toBe(90);
+  });
+
+  it("rejects an empty sample set", () => {
+    expect(() => summarizePercentiles([])).toThrow(/at least one sample/);
+  });
+});


### PR DESCRIPTION
## Summary

Pass 1 (hermetic) of the NeonDiff QA lab timing harness for issue #341 (tracker #340). Adds `scripts/qa-lab/` — a timing runner that executes six seeded scenario classes through the deterministic review pipeline, plus focused unit tests. No provider calls, no GitHub calls, no launchd, no live config, no repo mutation.

## Reuse audit

**Reused, not reinvented:**
- `Finding` / `PullFilePatch` / `DroppedFinding` shapes from `src/types.ts`.
- The actual pipeline entry point: `parseFindings` (`src/findings.ts`) feeding `applyDeterministicReviewGate` (`src/review-gate.ts`), which itself already chains `validateFindingLocations -> normalizeFindingsForReview -> decideReviewEvent`. The harness calls these two functions directly rather than re-implementing or re-ordering the gate logic.
- The redacted-JSON-writer idiom: `redactSecrets`/`stringifyRedactedJson` (`src/secrets.ts`) wrapped in a local `writeRedactedJson` helper, matching the pattern already used in `src/worker.ts`, `src/calibration-promote.ts`, and `src/calibration-aggregate.ts` (each defines its own thin local wrapper around the shared `secrets.ts` primitives — there is no single shared `writeRedactedJson` export to import).
- The scenario-shape precedent from `tests/fixtures/eval-suite-scenarios/*.json` (raw `botFindings: { findings: [...] }` plus diff `files`) — the qa-lab scenario library mirrors that same input shape.
- `config.example.json` as the fixture-config base (copied verbatim into `tests/fixtures/qa-lab/config.baseline.json`), loaded through the existing `loadConfigFromObject` validator.

**Built new, and why not folded into eval-harness:** `scripts/qa-lab/` is a new, thin module rather than an extension of `src/eval-harness.ts`. `eval-harness.ts`'s `EvalScenarioInput`/`EvalRunResult` are precision/recall/calibration-shaped (labels, matching, Wilson bounds, sticky-vs-cold deltas) — there's no timing dimension in that shape at all, and retrofitting p50/p90 capture into it would mean bolting an unrelated concern onto a differently-purposed module. A parallel, small runner (`scenarios.ts`, `stats.ts`, `config-variants.ts`, `run-timing.ts`, ~450 LOC total) that calls the *same* pipeline primitives eval-harness already reuses is more legible than deforming eval-harness's scorecard/gate model to also carry timing.

## What was built

- `scripts/qa-lab/scenarios.ts` — 6 seeded scenarios, one per required class (docs-only, normal code, auth/security, migration, release config, issue-burst), each a raw `botFindings` + diff `files` pair that parses cleanly through the real `parseFindings` schema gate and validates against its own diff.
- `scripts/qa-lab/stats.ts` — dependency-free `percentile()`/`summarizePercentiles()` using nearest-rank (not interpolated) percentiles, so p50/p90 are always a traceable observed sample.
- `scripts/qa-lab/config-variants.ts` — 6 config-variant fixture definitions (`baseline`, `github_related_context`, `gitnexus_context`, `repo_memory`, `enrichment`, `self_consistency`). Only `baseline` is in `HERMETIC_EXECUTABLE_VARIANTS`; the runner throws a clear, non-silent error if any other variant is requested, since those add-on paths require live provider/GitHub calls out of scope for pass 1. This is the seam pass 2 wires into.
- `scripts/qa-lab/run-timing.ts` — CLI runner (`tsx scripts/qa-lab/run-timing.ts --config <fixture> --config-variant baseline --samples 25 --output-dir <dir>`). Times `parseFindings -> applyDeterministicReviewGate` per scenario (n=25 samples), emits `timing-results.json` (via the local redacted-JSON writer) and a human-readable `baseline-table.md` with commit SHA, Node version, and config variant recorded.
- `tests/fixtures/qa-lab/config.baseline.json` — copy of `config.example.json`, used as the fixture config (never the live config).
- `tests/qa-lab-stats.test.ts` (7 tests) + `tests/qa-lab-scenarios.test.ts` (9 tests) — focused unit coverage for the percentile math and the scenario/variant loaders.

## Baseline table (hermetic, n=25, commit 1e3ceb4, Node v26.4.0)

| Scenario | Class | p50 (ms) | p90 (ms) |
| --- | --- | ---: | ---: |
| docs-only-readme-typo | docs_only | 0.076 | 0.199 |
| normal-code-helper-refactor | normal_code | 0.072 | 0.193 |
| auth-security-token-check | auth_security | 0.028 | 0.048 |
| migration-column-backfill | migration | 0.023 | 0.025 |
| release-config-channel-bump | release_config | 0.040 | 0.065 |
| issue-burst-duplicate-reports | issue_burst | 0.036 | 0.044 |

## Validation

- `npx tsc --noEmit -p tsconfig.json` — clean.
- `npm run build` — clean (after narrowing `BotConfig`'s optional add-on sections in `config-variants.ts` with a runtime `requireField()` assertion rather than an `as` cast, so a genuine loader regression fails loudly instead of being typed around).
- `npx vitest run tests/qa-lab-stats.test.ts tests/qa-lab-scenarios.test.ts` — 16/16 passed.
- `npx tsx scripts/qa-lab/run-timing.ts --config-variant gitnexus_context ...` — confirmed the variant-loop stub correctly rejects a non-hermetic variant with exit code 1 and a clear proof-boundary message, rather than silently measuring the wrong thing.
- `node scripts/check-secret-scan.mjs` — clean; also directly grepped all new files for secret-shaped patterns (no matches).
- Evidence packet written to `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/polished-config-lab/qa-lab/` (the path recorded on issue #341 itself — note this differs slightly from the task description's `qa-harness/` suffix; used the issue's canonical path): fixture config copy, `timing-results.json`, `baseline-table.md`, and a bounded `command-transcript-summary.txt`.

## Proof boundary

Hermetic pipeline timing only (`parseFindings -> applyDeterministicReviewGate`, in-process, no I/O beyond writing evidence). Provider-call and GitHub-call timing (github related context, gitnexus context, enrichment, self-consistency) is pass 2 scope — this PR only ships those as config fixtures plus a variant loop that explicitly refuses to execute them hermetically. No live config (`/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`) was read or written. No launchd surface touched. `/Volumes/LEXAR/Codex/repos/neondiff` and `/Volumes/LEXAR/repos/evaos-code-review-bot` were not touched — all work happened in an isolated worktree (`neondiff-wt-qalab`, removed after push).

Part of #341 (tracker #340).