### PR TITLE
Fill release-manifest shaState placeholder with the released head SHA (#235)

### DIFF
--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -24,7 +24,7 @@
     "note": "v0.4.25 through v0.4.29 and v0.4.31 through v0.4.37 were source/local-worker beta releases; v0.4.30-beta.1 remains the current public npm/site beta."
   },
   "source": {
-    "shaState": "set_after_codeql_hardening_merge",
+    "shaState": "77f49abfbe36e47855df3361780d0efad813d72e",
     "proof": "release:status --expected-head $(git rev-parse HEAD)"
   },
   "docs": {


### PR DESCRIPTION
One-field docs fix: `source.shaState` in docs/public-release-manifest.json still carried the `set_after_codeql_hardening_merge` placeholder from the #249 era. Nothing in src/ consumes the field (verified: zero references); set it to the v0.4.30-beta.1 released head `77f49ab` per the adjacent proof line's `--expected-head` semantics.

## Validation
JSON validity via jq; no code surface touched; CI authoritative.

## Proof boundary
Documentation-only manifest hygiene. Part of #235.