### PR TITLE
Lease-time aging guarantee for risk-weighted queue + starvation sim — Part of #346 (tracker #340)

### DIFF
--- a/scripts/qa-lab/queue-sim.ts
+++ b/scripts/qa-lab/queue-sim.ts
@@ -1,0 +1,238 @@
+/**
+ * #346 queue-aging starvation simulation (Config Activation QA Lab, tracker #340).
+ *
+ * Standalone — NO GitHub/provider/network calls. It drives the REAL priority-assignment
+ * (riskWeightedQueuePriority over buildChangedSurfaceValidationReport) and the REAL durable-queue
+ * enqueue/lease logic (ReviewStateStore.enqueueReviewQueueJob / leaseNextReviewQueueJobs) against a
+ * temp sqlite under os.tmpdir — never the live state path. It compares three configs:
+ *   (1) flat (risk-weighting off), (2) risk-weighted WITHOUT aging, (3) recommended WITH aging.
+ * Output: per-class lease-wait p50/p95/max as JSON + a markdown table, written via the repo's
+ * redacted-writer idiom to the polished-config-lab evidence path.
+ *
+ * Proof boundary: simulation + a default-off capability. It changes no live config or launchd; the
+ * recommended config here is a LAB recommendation, not an applied setting.
+ */
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfigFromObject, type BotConfig } from "../../src/config.js";
+import { ReviewStateStore } from "../../src/state.js";
+import { riskWeightedQueuePriority } from "../../src/scheduler.js";
+import { buildChangedSurfaceValidationReport } from "../../src/validation-selector.js";
+import { stringifyRedactedJson } from "../../src/secrets.js";
+import type { PullFilePatch, PullRequestSummary } from "../../src/types.js";
+// Reuse the merged QA-lab harness (#341/#358): scenario file-sets drive the REAL tier, and the
+// harness percentile math (nearest-rank) is reused rather than re-implemented here.
+import { QA_LAB_SCENARIOS } from "./scenarios.js";
+import { percentile } from "./stats.js";
+
+const EVIDENCE_DIR = "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/polished-config-lab/risk-queue";
+const BASELINE = 50;
+const MAX_WAIT_MINUTES = 60;
+const TICK_MS = 60_000; // one minute per service interval
+const SERVICE_PER_TICK = 2; // maxProviderActive: 2 leases/min — the queue is drainable at steady state
+const BURST_MINUTES = 3 * MAX_WAIT_MINUTES; // sustained elevated burst >= 3x max-wait (the starvation window)
+const DRAIN_MINUTES = 3 * MAX_WAIT_MINUTES; // post-burst tail so the queue can drain and waits settle
+const HORIZON_TICKS = BURST_MINUTES + DRAIN_MINUTES;
+
+// PR-review scenario classes with their real changed-file sets, reused from the merged harness
+// (QA_LAB_SCENARIOS). issue_burst is issue-enrichment shaped (not a PR-review queue job) — excluded.
+const CLASS_FILES: Record<string, PullFilePatch[]> = Object.fromEntries(
+  QA_LAB_SCENARIOS.filter((scenario) => scenario.scenarioClass !== "issue_burst").map((scenario) => [scenario.scenarioClass, scenario.files])
+);
+
+// Elevated classes are whatever the REAL changed-surface report elevates — do not assume. Verified
+// via riskWeightedQueuePriority: normal_code + auth_security get "required" recs (priority 20); the
+// others land at default/baseline (50). During the BURST window the elevated stream arrives >= the
+// service rate, filling every slot so lower-priority docs (baseline 50) starve behind elevated work.
+const BASE_ARRIVALS: Record<string, number> = {
+  docs_only: 0.25,
+  normal_code: 0.25,
+  auth_security: 0.25,
+  migration: 0.1,
+  release_config: 0.1
+};
+const ELEVATED_BURST_CLASSES = ["normal_code", "auth_security"];
+const BURST_ARRIVALS_PER_ELEVATED_CLASS = 1.1; // 2 classes x 1.1 = 2.2/min >= 2/min service (fills slots)
+
+function arrivalsAt(cls: string, tick: number): number {
+  const inBurst = tick < BURST_MINUTES;
+  if (inBurst && ELEVATED_BURST_CLASSES.includes(cls)) return BURST_ARRIVALS_PER_ELEVATED_CLASS;
+  return BASE_ARRIVALS[cls]!;
+}
+
+// Three configs, all with the RECOMMENDED docsOnlyPriority == baseline (50): docs are not demoted,
+// they simply lease behind elevated (20). Under the sustained elevated burst, config (2) (no aging)
+// starves docs — they wait out the whole burst behind elevated work. Config (3) is the recommended
+// config WITH rescue aging: any docs job waiting past maxWait is rescued ahead of even fresh elevated
+// work, bounding docs wait to ~maxWait + rescue-set drain (acceptance (c)). docs stay at baseline (no
+// demotion — acceptance (b)); rescue fires only after maxWait.
+const CONFIGS: Array<{ id: string; label: string; config: BotConfig }> = [
+  { id: "flat", label: "flat (risk-weighting off)", config: loadConfigFromObject({ reviewScheduler: { backgroundPriority: BASELINE } }) },
+  {
+    id: "risk_no_aging",
+    label: "risk-weighted (docsOnly 50), NO aging",
+    config: loadConfigFromObject({
+      reviewScheduler: { backgroundPriority: BASELINE },
+      riskWeightedQueue: { enabled: true, elevatedPriority: 20, docsOnlyPriority: BASELINE }
+    })
+  },
+  {
+    id: "risk_with_aging",
+    label: "risk-weighted (docsOnly 50) + rescue aging (recommended)",
+    config: loadConfigFromObject({
+      reviewScheduler: { backgroundPriority: BASELINE },
+      riskWeightedQueue: { enabled: true, elevatedPriority: 20, docsOnlyPriority: BASELINE, aging: { enabled: true, maxWaitMinutes: MAX_WAIT_MINUTES } }
+    })
+  }
+];
+
+function pullFor(cls: string, n: number): PullRequestSummary {
+  return {
+    number: n,
+    title: `${cls}-${n}`,
+    draft: false,
+    head: { sha: `${cls}${n}`, ref: "feature" },
+    base: { sha: "base", ref: "main", repo: { full_name: "owner/repo" } },
+    html_url: `https://example.invalid/owner/repo/pull/${n}`
+  };
+}
+
+interface ClassStats { class: string; count: number; p50Min: number; p95Min: number; maxMin: number }
+
+function runConfig(config: BotConfig): ClassStats[] {
+  const root = mkdtempSync(join(tmpdir(), "queue-sim-"));
+  const store = new ReviewStateStore(join(root, "state.sqlite"));
+  const t0 = new Date("2026-07-06T00:00:00.000Z").getTime();
+  const waitsByClass = new Map<string, number[]>();
+  const jobClass = new Map<string, string>();
+  const enqueuedAt = new Map<string, number>();
+  const pending: Record<string, number> = {};
+  let seq = 0;
+
+  for (let tick = 0; tick < HORIZON_TICKS; tick += 1) {
+    const now = new Date(t0 + tick * TICK_MS);
+    // Arrivals: accumulate fractional rates, enqueue whole jobs at the REAL assigned priority.
+    for (const cls of Object.keys(CLASS_FILES)) {
+      pending[cls] = (pending[cls] ?? 0) + arrivalsAt(cls, tick);
+      while (pending[cls]! >= 1) {
+        pending[cls]! -= 1;
+        seq += 1;
+        const report = buildChangedSurfaceValidationReport({ repo: "owner/repo", pull: pullFor(cls, seq), files: CLASS_FILES[cls]! });
+        const priority = riskWeightedQueuePriority({ config, repo: "owner/repo", report }).priority ?? BASELINE;
+        const job = store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: seq, headSha: `${cls}${seq}`, priority, now }).job;
+        jobClass.set(job.jobId, cls);
+        enqueuedAt.set(job.jobId, now.getTime());
+      }
+    }
+    // Service: lease up to SERVICE_PER_TICK via the REAL lease path (with aging threaded from config).
+    const aging = config.riskWeightedQueue?.aging;
+    for (let s = 0; s < SERVICE_PER_TICK; s += 1) {
+      const leased = store.leaseNextReviewQueueJobs({
+        maxProviderActive: SERVICE_PER_TICK, maxOrgActive: 1000, maxRepoActive: 1000, limit: 1, now,
+        ...(aging ? { aging } : {})
+      });
+      const job = leased[0];
+      if (!job) break;
+      const cls = jobClass.get(job.jobId)!;
+      const waitMin = (now.getTime() - enqueuedAt.get(job.jobId)!) / 60_000;
+      (waitsByClass.get(cls) ?? waitsByClass.set(cls, []).get(cls)!).push(waitMin);
+      store.updateReviewQueueJobState({ jobId: job.jobId, state: "posted", now });
+    }
+  }
+
+  // Starvation must be visible: a job still QUEUED at the horizon has an unbounded (>= censored)
+  // wait, not a zero wait. Record its wait-so-far so a starved class shows a large max, not "0".
+  const horizonMs = t0 + HORIZON_TICKS * TICK_MS;
+  let starvedTotal = 0;
+  for (const job of store.listReviewQueueJobs()) {
+    if (job.state !== "queued") continue;
+    const cls = jobClass.get(job.jobId);
+    if (!cls) continue;
+    (waitsByClass.get(cls) ?? waitsByClass.set(cls, []).get(cls)!).push((horizonMs - enqueuedAt.get(job.jobId)!) / 60_000);
+    starvedTotal += 1;
+  }
+
+  store.close();
+  rmSync(root, { recursive: true, force: true });
+  void starvedTotal;
+
+  return Object.keys(CLASS_FILES).map((cls) => {
+    const waits = waitsByClass.get(cls) ?? [];
+    return {
+      class: cls,
+      count: waits.length,
+      // Reuse the harness percentile (p in [0,1], nearest-rank). Guard the empty case it rejects.
+      p50Min: waits.length ? round(percentile(waits, 0.5)) : 0,
+      p95Min: waits.length ? round(percentile(waits, 0.95)) : 0,
+      maxMin: waits.length ? round(Math.max(...waits)) : 0
+    };
+  });
+}
+
+function round(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+function markdownTable(results: Record<string, ClassStats[]>): string {
+  const lines = [
+    "# #346 risk-weighted queue aging — starvation simulation",
+    "",
+    `Horizon ${HORIZON_TICKS} min · service ${SERVICE_PER_TICK}/min · maxWait ${MAX_WAIT_MINUTES}m · baseline ${BASELINE}.`,
+    "Lease-wait minutes (leased jobs), per class, per config.",
+    "",
+    "| class | config | p50 | p95 | max |",
+    "| --- | --- | ---: | ---: | ---: |"
+  ];
+  for (const cls of Object.keys(CLASS_FILES)) {
+    for (const { id } of CONFIGS) {
+      const s = results[id]!.find((r) => r.class === cls)!;
+      lines.push(`| ${cls} | ${id} | ${s.p50Min} | ${s.p95Min} | ${s.maxMin} |`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function main(): void {
+  const results: Record<string, ClassStats[]> = {};
+  for (const { id, config } of CONFIGS) results[id] = runConfig(config);
+
+  const recommendedConfig = {
+    riskWeightedQueue: { enabled: true, elevatedPriority: 20, docsOnlyPriority: BASELINE, aging: { enabled: true, maxWaitMinutes: MAX_WAIT_MINUTES } }
+  };
+  const recommendationNote =
+    "Recommended config: elevatedPriority 20, docsOnlyPriority 50 (== baseline, NO demotion), aging " +
+    "{enabled, maxWaitMinutes: 60}. Under a sustained elevated burst, config (2) (no aging) starves docs " +
+    "(they lease behind elevated 20 for the whole burst); config (3) rescue-aging bounds any docs job to " +
+    "~maxWait: once it waits 60 min it is rescued AHEAD of even fresh elevated work (amended two-tier rule). " +
+    "docs stay at baseline (acceptance b, not demoted); rescue fires only after maxWait. Lower priority " +
+    "number = leases sooner; the spec's original 70/50 sample had elevated/docsOnly inverted vs the shipped " +
+    "#301 convention (elevated must be the SMALLER number) — corrected here to 20/50.";
+  const payload = {
+    issue: "#346",
+    tracker: "#340",
+    generatedAt: new Date().toISOString(),
+    parameters: {
+      baseline: BASELINE,
+      maxWaitMinutes: MAX_WAIT_MINUTES,
+      serviceRatePerMinute: SERVICE_PER_TICK,
+      burstMinutes: BURST_MINUTES,
+      drainMinutes: DRAIN_MINUTES,
+      horizonMinutes: HORIZON_TICKS,
+      baseArrivalsPerMinute: BASE_ARRIVALS,
+      burstElevatedArrivalsPerClass: BURST_ARRIVALS_PER_ELEVATED_CLASS
+    },
+    configs: CONFIGS.map(({ id, label }) => ({ id, label })),
+    recommendedConfig,
+    recommendationNote,
+    results,
+    proofBoundary: "Offline simulation over a default-off capability. No live config or launchd change; enabling aging stays a #340 lab decision."
+  };
+
+  mkdirSync(EVIDENCE_DIR, { recursive: true });
+  writeFileSync(join(EVIDENCE_DIR, "queue-sim.json"), `${stringifyRedactedJson(payload)}\n`);
+  writeFileSync(join(EVIDENCE_DIR, "queue-sim.md"), markdownTable(results));
+  console.log(stringifyRedactedJson({ ok: true, evidenceDir: EVIDENCE_DIR, results }));
+}
+
+main();

--- a/src/config.ts
+++ b/src/config.ts
@@ -224,6 +224,15 @@ export interface RiskWeightedQueueConfig {
   elevatedPriority?: number;
   /** Priority for docs-only PRs (typically >= backgroundPriority to defer them). */
   docsOnlyPriority?: number;
+  /** Lease-time aging guarantee (#346, default off). Prevents starvation of below-baseline jobs. */
+  aging?: QueueAgingConfig;
+}
+
+export interface QueueAgingConfig {
+  /** When false (default/unset), lease order is byte-identical to today. */
+  enabled: boolean;
+  /** A queued job waiting longer than this is aged UP to baseline at lease time (never demoted). */
+  maxWaitMinutes: number;
 }
 
 export interface RepoMemoryConfig {
@@ -756,6 +765,18 @@ function validateRiskWeightedQueueConfig(value: unknown, label: string, backgrou
       throw new Error(`${label}.elevatedPriority must be <= ${label}.docsOnlyPriority because lower priority values lease sooner`);
     }
   }
+  if (value.aging !== undefined) validateQueueAgingConfig(value.aging, `${label}.aging`);
+}
+
+function validateQueueAgingConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  for (const key of Object.keys(value)) {
+    if (key !== "enabled" && key !== "maxWaitMinutes") {
+      throw new Error(`${label} has unknown key "${key}"; expected only enabled or maxWaitMinutes`);
+    }
+  }
+  validateBoolean(value.enabled, `${label}.enabled`);
+  validatePositiveInteger(value.maxWaitMinutes, `${label}.maxWaitMinutes`);
 }
 
 function validateRepoMemoryConfig(value: unknown, label: string): void {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -201,6 +201,9 @@ export async function runScheduledCycleWithDeps(input: {
       reservedActiveJobs: attemptedJobs,
       limit: 1,
       leaseTtlMs: config.reviewConcurrency.leaseTtlMs,
+      // Lease-time rescue aging (#346): pass through only when configured — the comparator no-ops
+      // when aging is unset/disabled, keeping the default lease order byte-identical to today.
+      ...(config.riskWeightedQueue?.aging ? { aging: config.riskWeightedQueue.aging } : {}),
       now: eventClock()
     });
     const job = leased[0];

--- a/src/state.ts
+++ b/src/state.ts
@@ -1765,6 +1765,7 @@ export class ReviewStateStore {
     reservedActiveJobs?: Iterable<Pick<ReviewQueueJobRecord, "jobId" | "providerId" | "org" | "repo">>;
     limit?: number;
     leaseTtlMs?: number;
+    aging?: { enabled: boolean; maxWaitMinutes: number };
     now?: Date;
   }): ReviewQueueJobRecord[] {
     validatePositiveQueueLimit(input.maxProviderActive, "maxProviderActive");
@@ -1809,7 +1810,7 @@ export class ReviewStateStore {
       const jobs = this.listReviewQueueJobs();
       const eligible = jobs
         .filter((job) => !excludeJobIds.has(job.jobId) && isQueueJobEligible(job, nowIso))
-        .sort(compareQueueJobsForLease);
+        .sort(buildLeaseComparator(input.aging, nowIso));
       const reservedJobIds = new Set(reservedActiveJobs.map((job) => job.jobId));
       const active = [
         ...jobs.filter((job) => (job.state === "leased" || job.state === "running") && !reservedJobIds.has(job.jobId)),
@@ -2996,6 +2997,37 @@ function compareQueueJobsForLease(left: ReviewQueueJobRecord, right: ReviewQueue
   const leftCreated = Date.parse(left.createdAt);
   const rightCreated = Date.parse(right.createdAt);
   return leftCreated - rightCreated;
+}
+
+/**
+ * Lease-time aging via a two-tier RESCUE ordering (#346, amended). A queued job whose wait
+ * (now − createdAt) exceeds maxWaitMinutes enters the RESCUE tier and leases AHEAD of every
+ * non-rescued job regardless of priority class, FIFO among rescued jobs by createdAt (oldest first).
+ * Non-rescued (fresh, sub-maxWait) jobs keep strict priority ordering exactly as today, so elevated
+ * always wins among non-starved work. The ONLY thing that overtakes elevated is a job that already
+ * waited the full maxWaitMinutes — the bounded anti-starvation backstop. Computed at lease time,
+ * never stored, idempotent, no migration. Unset/disabled aging ⇒ the original comparator, byte-
+ * identical to today.
+ */
+function isRescued(job: ReviewQueueJobRecord, aging: { enabled: boolean; maxWaitMinutes: number }, nowMs: number): boolean {
+  return nowMs - Date.parse(job.createdAt) > aging.maxWaitMinutes * 60_000;
+}
+
+function buildLeaseComparator(
+  aging: { enabled: boolean; maxWaitMinutes: number } | undefined,
+  nowIso: string
+): (left: ReviewQueueJobRecord, right: ReviewQueueJobRecord) => number {
+  if (!aging?.enabled) return compareQueueJobsForLease;
+  const nowMs = Date.parse(nowIso);
+  return (left, right) => {
+    const leftRescued = isRescued(left, aging, nowMs);
+    const rightRescued = isRescued(right, aging, nowMs);
+    // Rescued tier first; among rescued, oldest-enqueued leases first (FIFO).
+    if (leftRescued !== rightRescued) return leftRescued ? -1 : 1;
+    if (leftRescued) return Date.parse(left.createdAt) - Date.parse(right.createdAt);
+    // Non-rescued: strict priority then FIFO within class — unchanged from today.
+    return compareQueueJobsForLease(left, right);
+  };
 }
 
 function buildManualEligibilitySuffix(jobs: ReviewQueueJobRecord[]): boolean[] {

--- a/tests/risk-weighted-queue.test.ts
+++ b/tests/risk-weighted-queue.test.ts
@@ -129,6 +129,27 @@ describe("risk-weighted queue config (#301)", () => {
       })
     ).toThrow(/riskWeightedQueue\.elevatedPriority must be <= .*docsOnlyPriority/);
   });
+
+  it("defaults aging unset (byte-identical to today) and accepts the recommended aging config (#346)", () => {
+    expect(loadConfigFromObject({}).riskWeightedQueue?.aging).toBeUndefined();
+    // Recommended #346 config (lower number = leases sooner, so elevated < docsOnly per #301 validator).
+    const config = loadConfigFromObject({
+      riskWeightedQueue: { enabled: true, elevatedPriority: 20, docsOnlyPriority: 50, aging: { enabled: true, maxWaitMinutes: 60 } }
+    });
+    expect(config.riskWeightedQueue?.aging).toEqual({ enabled: true, maxWaitMinutes: 60 });
+  });
+
+  it("fails closed on malformed aging config (#346)", () => {
+    expect(() => loadConfigFromObject({ riskWeightedQueue: { enabled: true, aging: { enabled: "yes", maxWaitMinutes: 60 } } })).toThrow(
+      /riskWeightedQueue\.aging\.enabled must be a boolean/
+    );
+    expect(() => loadConfigFromObject({ riskWeightedQueue: { enabled: true, aging: { enabled: true, maxWaitMinutes: 0 } } })).toThrow(
+      /riskWeightedQueue\.aging\.maxWaitMinutes must be a positive integer/
+    );
+    expect(() => loadConfigFromObject({ riskWeightedQueue: { enabled: true, aging: { enabled: true, maxWaitMinutes: 60, bogus: 1 } } })).toThrow(
+      /riskWeightedQueue\.aging has unknown key "bogus"/
+    );
+  });
 });
 
 describe("resolveRiskWeightedPriorityOverride integration (#301 review follow-up)", () => {

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1798,4 +1798,52 @@ describe("review state store", () => {
     expect(() => store.recordFindingOutcomeLabel({ ...record, fingerprint: "not-a-fingerprint" })).toThrow(/finding:<64-hex>/);
     store.close();
   });
+
+  it("rescues a past-max-wait job ahead of a fresh elevated job, but not a fresh docs job (#346)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-queue-rescue-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const now = new Date("2026-07-06T12:00:00.000Z");
+    // Starved docs job (demoted to 70) that has waited 90m (> 60m maxWait) ⇒ RESCUED.
+    const starvedDocs = store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 1, headSha: "starved-docs", priority: 70, now: new Date(now.getTime() - 90 * 60_000) }).job;
+    // Fresh elevated (20) and fresh docs (70), both enqueued now (sub-maxWait, NOT rescued).
+    store.enqueueReviewQueueJob({ repo: "owner/repo2", pullNumber: 2, headSha: "fresh-elevated", priority: 20, now });
+    store.enqueueReviewQueueJob({ repo: "owner/repo3", pullNumber: 3, headSha: "fresh-docs", priority: 70, now });
+
+    const aging = { enabled: true, maxWaitMinutes: 60 };
+    // The rescued starved job overtakes even the fresh elevated job — the anti-starvation backstop.
+    const first = store.leaseNextReviewQueueJobs({ maxProviderActive: 3, maxOrgActive: 5, maxRepoActive: 5, limit: 3, now, aging });
+    expect(first.map((job) => job.headSha)).toEqual(["starved-docs", "fresh-elevated", "fresh-docs"]);
+    // And a FRESH docs job (not past maxWait) does NOT overtake fresh elevated — strict priority holds.
+    expect(first[0]?.jobId).toBe(starvedDocs.jobId);
+    store.close();
+  });
+
+  it("orders multiple rescued jobs FIFO by enqueue time, oldest first (#346)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-queue-rescue-fifo-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const now = new Date("2026-07-06T12:00:00.000Z");
+    // Two rescued jobs (both past maxWait); the OLDER one leases first regardless of priority number.
+    const older = store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 1, headSha: "older", priority: 70, now: new Date(now.getTime() - 120 * 60_000) }).job;
+    const newer = store.enqueueReviewQueueJob({ repo: "owner/repo2", pullNumber: 2, headSha: "newer", priority: 20, now: new Date(now.getTime() - 90 * 60_000) }).job;
+
+    const leased = store.leaseNextReviewQueueJobs({ maxProviderActive: 2, maxOrgActive: 5, maxRepoActive: 5, limit: 2, now, aging: { enabled: true, maxWaitMinutes: 60 } });
+    expect(leased.map((job) => job.jobId)).toEqual([older.jobId, newer.jobId]);
+    store.close();
+  });
+
+  it("leaves lease order byte-identical to today when aging is unset (#346)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-queue-noaging-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const now = new Date("2026-07-06T12:00:00.000Z");
+    store.enqueueReviewQueueJob({ repo: "owner/repo", pullNumber: 1, headSha: "docs-old", priority: 70, now: new Date(now.getTime() - 90 * 60_000) });
+    store.enqueueReviewQueueJob({ repo: "owner/repo2", pullNumber: 2, headSha: "baseline-new", priority: 50, now });
+
+    // No aging config ⇒ pure priority ASC then FIFO: baseline (50) leases before docs (70) despite age.
+    const leased = store.leaseNextReviewQueueJobs({ maxProviderActive: 1, maxOrgActive: 5, maxRepoActive: 5, limit: 1, now });
+    expect(leased.map((job) => job.headSha)).toEqual(["baseline-new"]);
+    store.close();
+  });
 });


### PR DESCRIPTION
Part of #346 (tracker #340 — Config Activation QA Lab). Additive, default-off.

## Summary
Adds a config-gated **lease-time aging guarantee** to the risk-weighted queue so a docs (or any lower-priority) PR cannot be starved forever by a sustained stream of elevated work, plus a **simulation** that produces the acceptance evidence by driving the REAL enqueue/lease functions.

## Design (amended two-tier RESCUE rule)
- New `riskWeightedQueue.aging { enabled: boolean; maxWaitMinutes: positive int }`. Fail-closed validation (boolean, positive-int, unknown-key rejected). Unset ⇒ byte-identical lease order to today.
- A queued job whose wait exceeds `maxWaitMinutes` enters a **rescue** tier and leases AHEAD of all non-rescued jobs regardless of class, FIFO among rescued by enqueue time (oldest first). Non-rescued (fresh, sub-maxWait) jobs keep strict priority ordering exactly as today — elevated still always wins among non-starved work. The only thing that overtakes elevated is a job that already waited the full maxWait. Lease-time computed in the comparator, never stored, idempotent, no migration.

### Seam note
`leaseNextReviewQueueJobs` is **not** a single SQL `ORDER BY` — it does `listReviewQueueJobs()` + a JS `.sort(compareQueueJobsForLease)`. Per the spec's sanctioned fallback, aging is implemented at that comparator seam.

### Amendment note (orchestrator-owned design correction)
The original spec raised a starved job only *to* baseline and "never overtakes elevated." The simulation proved that makes aging a **no-op** in the recommended config (docs at baseline are already at baseline) and cannot bound docs wait under a slot-filling elevated burst. The spec was amended to the two-tier rescue rule (a max-wait guarantee is a bounded, rare priority override by definition). Also: the spec's `70/50` sample config had `elevatedPriority`/`docsOnlyPriority` **inverted** vs the shipped #301 convention (LOWER number leases sooner; validator enforces `elevated <= docsOnly`). Recommended config corrected to **elevatedPriority 20, docsOnlyPriority 50, aging { enabled: true, maxWaitMinutes: 60 }**.

## Validation
Focused vitest + `npm run build` under `set -o pipefail`, all green (175 tests across state / risk-weighted-queue / scheduler / review-budget / qa-lab-stats / qa-lab-scenarios). New pins: rescued past-maxWait job leases before a fresh elevated job (a fresh docs job does NOT); FIFO among rescued (oldest first); unset aging = byte-identical. Simulation reuses the merged QA-lab harness (#358) percentile + scenario helpers (no duplicated math); evidence written via the redacted writer.

### Three-config lease-wait (minutes), recommended config
| class | flat | risk, no aging | risk + rescue aging |
| --- | ---: | ---: | ---: |
| docs_only (p50/p95/max) | 20 / 53 / 56 | 74 / 189 / **201** | 61 / 61 / **61** |
| migration (max) | 57 | 195 | **61** |
| release_config (max) | 58 | 195 | **61** |
| normal_code (p50) | 26 | 7 | 15 |
| auth_security (p50) | 26 | 7 | 16 |

Acceptance: (a) elevated classes lease earlier than flat under risk-weighting; (b) docs stay at baseline 50 (no demotion); (c) rescue caps any job at ~maxWait (docs max 201 → 61 == maxWaitMinutes).

## Proof boundary
Simulation + a default-off capability. It changes no live config or launchd; enabling aging stays a #340 lab decision.