### PR TITLE
Public review/re-review command policy with per-head cooldown (#345)

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -25,14 +25,20 @@ export interface ReviewCommand {
   url?: string;
 }
 
+export type UnauthorizedCommandReason = "untrusted" | "not_public_action" | "public_disabled";
+
 export interface UnauthorizedReviewCommand {
   action: ReviewCommandAction;
   commentId: number;
   author: string;
+  reason?: UnauthorizedCommandReason;
 }
 
 export interface CollectedReviewCommands {
   commands: ReviewCommand[];
+  /** Public-eligible candidates (#345): review/re-review from a non-trusted author when publicCommands
+   * is enabled. NOT yet authorized — the caller must apply the stateful bot + cooldown gate. */
+  publicEligible: ReviewCommand[];
   unauthorized: UnauthorizedReviewCommand[];
 }
 
@@ -64,31 +70,37 @@ export function collectTrustedReviewCommands(
   comments: IssueCommentCommandSource[],
   config: CommandConfig
 ): CollectedReviewCommands {
-  if (!config.enabled) return { commands: [], unauthorized: [] };
+  if (!config.enabled) return { commands: [], publicEligible: [], unauthorized: [] };
 
   const commands: ReviewCommand[] = [];
+  const publicEligible: ReviewCommand[] = [];
   const unauthorized: UnauthorizedReviewCommand[] = [];
   for (const comment of comments) {
     const action = parseCommandAction(comment.body, config.botMentions);
     if (!action) continue;
     const author = comment.user?.login ?? "(unknown)";
-    if (!isTrustedAuthor(author, config)) {
-      unauthorized.push({ action, commentId: comment.id, author });
-      continue;
+    const command: ReviewCommand = { action, commentId: comment.id, author, body: comment.body ?? "", url: comment.html_url };
+    const authorization = classifyCommandAuthorization({ action, author }, config);
+    if (authorization === "trusted") {
+      commands.push(command);
+    } else if (authorization === "public-eligible") {
+      // Pure classification only — the stateful bot + cooldown gate runs in the caller (scheduler).
+      publicEligible.push(command);
+    } else {
+      unauthorized.push({ action, commentId: comment.id, author, reason: publicUnauthorizedReason(action, config) });
     }
-    commands.push({
-      action,
-      commentId: comment.id,
-      author,
-      body: comment.body ?? "",
-      url: comment.html_url
-    });
   }
 
   return {
     commands: commands.sort((left, right) => left.commentId - right.commentId),
+    publicEligible: publicEligible.sort((left, right) => left.commentId - right.commentId),
     unauthorized
   };
+}
+
+function publicUnauthorizedReason(action: ReviewCommandAction, config: CommandConfig): UnauthorizedCommandReason {
+  if (!config.publicCommands?.enabled) return "public_disabled";
+  return isReviewCommandAction(action) ? "untrusted" : "not_public_action";
 }
 
 export function decideCommandAction(input: {
@@ -115,6 +127,38 @@ export function decideCommandAction(input: {
     command: latest,
     shouldReview: isReviewCommandAction(latest.action)
   };
+}
+
+export type CommandAuthorization = "trusted" | "public-eligible" | "unauthorized";
+
+/**
+ * Pure authorization classification (#345, NO DB). A trusted author is allowed for ALL actions
+ * exactly as today. A non-trusted author is "public-eligible" ONLY when publicCommands is enabled
+ * AND the action is in publicCommands.actions (structurally only review/re-review can pass) —
+ * otherwise "unauthorized" exactly as today. The stateful bot-author and rate-limit checks run in
+ * the worker (where the store + head SHA are in scope); this classifier never touches them.
+ */
+export function classifyCommandAuthorization(
+  command: { action: ReviewCommandAction; author: string },
+  config: CommandConfig
+): CommandAuthorization {
+  if (isTrustedAuthor(command.author, config)) return "trusted";
+  const publicCommands = config.publicCommands;
+  if (publicCommands?.enabled && (publicCommands.actions as ReviewCommandAction[]).includes(command.action)) {
+    return "public-eligible";
+  }
+  return "unauthorized";
+}
+
+/**
+ * The single source of truth for "is this comment authored by a bot" in the public-command path
+ * (#345). A comment is a bot command when its GitHub user type is "Bot" (any bot, including our own
+ * app login botLogin). Trusted-author authorization is unaffected — this only guards the public path.
+ * GitHubApi.isBotAuthoredComment delegates here so there is no second identity definition.
+ */
+export function isBotCommandComment(user: { login: string; type?: string } | null | undefined, botLogin: string): boolean {
+  if (!user) return false;
+  return user.type === "Bot" || user.login === botLogin;
 }
 
 export function isReviewCommandAction(action: ReviewCommandAction): boolean {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -25,13 +25,10 @@ export interface ReviewCommand {
   url?: string;
 }
 
-export type UnauthorizedCommandReason = "untrusted" | "not_public_action" | "public_disabled";
-
 export interface UnauthorizedReviewCommand {
   action: ReviewCommandAction;
   commentId: number;
   author: string;
-  reason?: UnauthorizedCommandReason;
 }
 
 export interface CollectedReviewCommands {
@@ -87,7 +84,7 @@ export function collectTrustedReviewCommands(
       // Pure classification only — the stateful bot + cooldown gate runs in the caller (scheduler).
       publicEligible.push(command);
     } else {
-      unauthorized.push({ action, commentId: comment.id, author, reason: publicUnauthorizedReason(action, config) });
+      unauthorized.push({ action, commentId: comment.id, author });
     }
   }
 
@@ -96,11 +93,6 @@ export function collectTrustedReviewCommands(
     publicEligible: publicEligible.sort((left, right) => left.commentId - right.commentId),
     unauthorized
   };
-}
-
-function publicUnauthorizedReason(action: ReviewCommandAction, config: CommandConfig): UnauthorizedCommandReason {
-  if (!config.publicCommands?.enabled) return "public_disabled";
-  return isReviewCommandAction(action) ? "untrusted" : "not_public_action";
 }
 
 export function decideCommandAction(input: {
@@ -151,10 +143,16 @@ export function classifyCommandAuthorization(
 }
 
 /**
- * The single source of truth for "is this comment authored by a bot" in the public-command path
- * (#345). A comment is a bot command when its GitHub user type is "Bot" (any bot, including our own
- * app login botLogin). Trusted-author authorization is unaffected — this only guards the public path.
- * GitHubApi.isBotAuthoredComment delegates here so there is no second identity definition.
+ * Public-command bot rejection (#345, loop protection). Deliberately BROAD: any Bot-type actor OR the
+ * app's own login is blocked from triggering a public command. The breadth is intentional — a public
+ * path must never let ANY automated actor (dependabot, another app, or ourselves) spin up reviews,
+ * so we reject on user.type === "Bot" OR login === botLogin.
+ *
+ * This is intentionally DIFFERENT from GitHubApi.isBotAuthoredComment, which is the NARROWER
+ * app-own-comment check (type === "Bot" AND login === botLogin) used to detect the bot's OWN status
+ * comments for marker matching. Different questions ("is this any bot?" vs "is this MY comment?"), so
+ * they are not unified; both derive the identity from the same botLogin config value. Trusted-author
+ * authorization is unaffected — this only guards the public path.
  */
 export function isBotCommandComment(user: { login: string; type?: string } | null | undefined, botLogin: string): boolean {
   if (!user) return false;

--- a/src/config.ts
+++ b/src/config.ts
@@ -178,6 +178,17 @@ export interface CommandConfig {
   botMentions: string[];
   trustedAuthors: string[];
   acknowledge: boolean;
+  /** Public review/re-review command policy (#345, default off). Separate from trustedAuthors. */
+  publicCommands?: PublicCommandsConfig;
+}
+
+export interface PublicCommandsConfig {
+  /** When false (default/unset), only trusted authors trigger anything — byte-identical to today. */
+  enabled: boolean;
+  /** Actions a non-trusted author may trigger. Validation permits ONLY "review"/"re-review". */
+  actions: Array<"review" | "re-review">;
+  /** Per-{repo,pr,head,author,action} cooldown window for public invocations. */
+  cooldownMinutes: number;
 }
 
 export interface ReviewSchedulerConfig {
@@ -618,6 +629,9 @@ function validateConfig(config: BotConfig): void {
   validateStringArray(config.commands.botMentions, "config.commands.botMentions");
   validateStringArray(config.commands.trustedAuthors, "config.commands.trustedAuthors");
   validateBoolean(config.commands.acknowledge, "config.commands.acknowledge");
+  if (config.commands.publicCommands !== undefined) {
+    validatePublicCommandsConfig(config.commands.publicCommands, "config.commands.publicCommands");
+  }
   validateNonEmptyString(config.zcode.cliPath, "config.zcode.cliPath");
   validateNonEmptyString(config.zcode.appConfigPath, "config.zcode.appConfigPath");
   validateNonEmptyString(config.zcode.model, "config.zcode.model");
@@ -696,6 +710,25 @@ function validatePublicConfidenceDisplayFloorOverrides(value: unknown, label: st
   if (value.minWilsonLowerBound !== undefined && (value.minWilsonLowerBound as number) < PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND) {
     throw new Error(`${label}.minWilsonLowerBound must be >= ${PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND}`);
   }
+}
+
+function validatePublicCommandsConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  for (const key of Object.keys(value)) {
+    if (key !== "enabled" && key !== "actions" && key !== "cooldownMinutes") {
+      throw new Error(`${label} has unknown key "${key}"; expected only enabled, actions, or cooldownMinutes`);
+    }
+  }
+  validateBoolean(value.enabled, `${label}.enabled`);
+  if (!Array.isArray(value.actions) || value.actions.length === 0) {
+    throw new Error(`${label}.actions must be a non-empty array`);
+  }
+  for (const action of value.actions) {
+    if (action !== "review" && action !== "re-review") {
+      throw new Error(`${label}.actions entries must be one of review, re-review`);
+    }
+  }
+  validatePositiveInteger(value.cooldownMinutes, `${label}.cooldownMinutes`);
 }
 
 function validateReviewGateConfig(value: unknown, label: string): void {

--- a/src/github.ts
+++ b/src/github.ts
@@ -6,6 +6,9 @@ import { redactSecrets } from "./secrets.js";
 import type { PullFilePatch, PullRequestSummary, RepositorySummary, ReviewComment, ReviewEvent } from "./types.js";
 import { buildApiUrl, normalizeHttpApiBaseUrl } from "./url-safety.js";
 
+/** The bot's own GitHub App login — single source of truth for "who am I" (#345 reuse). */
+export const DEFAULT_BOT_LOGIN = "evaos-code-review-bot[bot]";
+
 export interface GitHubApiOptions {
   appId?: string;
   privateKeyPath?: string;
@@ -81,7 +84,7 @@ export class GitHubApi {
     this.privateKey = options.privateKeyPath ? readFileSync(options.privateKeyPath, "utf8") : undefined;
     this.token = options.token;
     this.apiBaseUrl = normalizeHttpApiBaseUrl(options.apiBaseUrl, "github.apiBaseUrl", "https://api.github.com");
-    this.botLogin = options.botLogin ?? "evaos-code-review-bot[bot]";
+    this.botLogin = options.botLogin ?? DEFAULT_BOT_LOGIN;
     this.requestTimeoutMs = options.requestTimeoutMs;
   }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -3,12 +3,14 @@ import { loadConfig, type BotConfig, type RepoReviewSchedulerConfig } from "./co
 import {
   collectTrustedReviewCommands,
   decideCommandAction,
+  isBotCommandComment,
   isFinishingTouchCommandAction,
   isReviewCommandAction,
-  type CommandDecision
+  type CommandDecision,
+  type ReviewCommand
 } from "./commands.js";
 import { isFinishingTouchActionEnabled } from "./finishing-touches.js";
-import { GitHubApi } from "./github.js";
+import { DEFAULT_BOT_LOGIN, GitHubApi } from "./github.js";
 import { listReposToScan, resolveRepoProfile } from "./repo-policy.js";
 import {
   postReviewStatusComment,
@@ -868,8 +870,21 @@ async function resolveSchedulerCommandDecision(input: {
   }
   const collected = collectTrustedReviewCommands(comments, input.config.commands);
   const repoProfile = resolveRepoProfile(input.config, input.repo);
+  // Public review/re-review policy (#345): the stateful bot + per-head cooldown gate runs HERE, where
+  // the store and head SHA are in scope (mirrors the #295 per-head-claim placement). Admitted public
+  // commands then flow through the exact same pipeline as trusted ones — authorization only decides
+  // whether a command may enqueue a review; nothing downstream changes.
+  const admittedPublic = admitPublicCommands({
+    config: input.config,
+    state: input.state,
+    repo: input.repo,
+    pull: input.pull,
+    publicEligible: collected.publicEligible,
+    comments
+  });
+  const authorizedCommands = [...collected.commands, ...admittedPublic].sort((left, right) => left.commentId - right.commentId);
   return decideCommandAction({
-    commands: collected.commands.filter((command) =>
+    commands: authorizedCommands.filter((command) =>
       !isFinishingTouchCommandAction(command.action) ||
       (repoProfile.allowed && isFinishingTouchActionEnabled(command.action, repoProfile.profile.finishingTouches))
     ),
@@ -879,6 +894,39 @@ async function resolveSchedulerCommandDecision(input: {
     hasProcessedCommand: (repo, pullNumber, headSha, commentId) =>
       input.state.hasProcessedCommand(repo, pullNumber, headSha, commentId)
   });
+}
+
+export function admitPublicCommands(input: {
+  config: BotConfig;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  publicEligible: ReviewCommand[];
+  comments: IssueCommentCommandSource[];
+  now?: Date;
+}): ReviewCommand[] {
+  const publicCommands = input.config.commands.publicCommands;
+  if (!publicCommands?.enabled || input.publicEligible.length === 0) return [];
+  const botLogin = input.config.github.botLogin ?? DEFAULT_BOT_LOGIN;
+  const commentsById = new Map(input.comments.map((comment) => [comment.id, comment]));
+  const admitted: ReviewCommand[] = [];
+  for (const command of input.publicEligible) {
+    // Bot-author rejection (loop protection): a bot's own review comment never triggers a review.
+    const source = commentsById.get(command.commentId);
+    if (isBotCommandComment(source?.user, botLogin)) continue;
+    // Atomic per-{repo,pr,head,author,action} cooldown — denied invocations are a no-op.
+    const allowed = input.state.tryRecordPublicCommandInvocation({
+      repo: input.repo,
+      pullNumber: input.pull.number,
+      headSha: input.pull.head.sha,
+      author: command.author,
+      action: command.action,
+      cooldownMs: publicCommands.cooldownMinutes * 60_000,
+      ...(input.now ? { now: input.now } : {})
+    });
+    if (allowed) admitted.push(command);
+  }
+  return admitted;
 }
 
 function shouldAssignReviewerSession(commandDecision?: Exclude<CommandDecision, { action: "none"; shouldReview: false }>): boolean {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -915,6 +915,12 @@ export function admitPublicCommands(input: {
     const source = commentsById.get(command.commentId);
     if (isBotCommandComment(source?.user, botLogin)) continue;
     // Atomic per-{repo,pr,head,author,action} cooldown — denied invocations are a no-op.
+    // DELIBERATE: the cooldown is recorded at ADMISSION time (here), before the review runs, not
+    // after a successful review. This is admission-time RATE LIMITING of how often a public author may
+    // TRIGGER the command — recording only after success would let an attacker spam commands that
+    // transiently skip (closed PR, provider cooldown) with no rate limit. The window is short (default
+    // 10m) and per-exact-head, so a new push (new head) is never blocked; only a same-head re-issue
+    // within the window after a transient skip sees one "cooled down" response, which is acceptable.
     const allowed = input.state.tryRecordPublicCommandInvocation({
       repo: input.repo,
       pullNumber: input.pull.number,

--- a/src/state.ts
+++ b/src/state.ts
@@ -518,6 +518,16 @@ export class ReviewStateStore {
         primary key (repo, pull_number, head_sha)
       );
 
+      create table if not exists public_command_invocations (
+        repo text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        author text not null,
+        action text not null,
+        invoked_at text not null,
+        primary key (repo, pull_number, head_sha, author, action)
+      );
+
       create table if not exists repo_provider_cooldowns (
         repo text primary key,
         cooldown_until text not null,
@@ -1312,6 +1322,56 @@ export class ReviewStateStore {
 
   releaseReviewHeadClaim(claimId: string): void {
     this.db.prepare("delete from review_head_claims where claim_id = ?").run(claimId);
+  }
+
+  /**
+   * Atomic public-command rate limit (#345), keyed per {repo, pr, head_sha, author, action}. Returns
+   * true (allowed) and records the invocation when no prior invocation for the tuple falls within the
+   * cooldown window; returns false (cooled-down) without recording otherwise. Consult-and-record run
+   * inside one BEGIN IMMEDIATE transaction (the #295 CAS idiom) so two concurrent public commands on
+   * the same tuple can never both pass. The window is per exact head SHA, so a genuinely new push is
+   * never blocked by a prior head's invocation.
+   */
+  tryRecordPublicCommandInvocation(input: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    author: string;
+    action: string;
+    cooldownMs: number;
+    now?: Date;
+  }): boolean {
+    if (!Number.isInteger(input.cooldownMs) || input.cooldownMs < 1) throw new Error("cooldownMs must be a positive integer");
+    const now = input.now ?? new Date();
+    const invokedAt = now.toISOString();
+    const windowStart = new Date(now.getTime() - input.cooldownMs).toISOString();
+    this.db.exec("begin immediate");
+    try {
+      const existing = this.db
+        .prepare(
+          `select invoked_at from public_command_invocations
+           where repo = ? and pull_number = ? and head_sha = ? and author = ? and action = ?
+             and datetime(invoked_at) > datetime(?)
+           limit 1`
+        )
+        .get(input.repo, input.pullNumber, input.headSha, input.author, input.action, windowStart);
+      if (existing) {
+        this.db.exec("commit");
+        return false;
+      }
+      this.db
+        .prepare(
+          `insert or replace into public_command_invocations
+            (repo, pull_number, head_sha, author, action, invoked_at)
+           values (?, ?, ?, ?, ?, ?)`
+        )
+        .run(input.repo, input.pullNumber, input.headSha, input.author, input.action, invokedAt);
+      this.db.exec("commit");
+      return true;
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
   }
 
   tryAcquireIssueEnrichmentRunLease(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2904,8 +2904,11 @@ async function resolvePullCommandDecision(input: {
   const comments = await input.github.listIssueComments(input.repo, input.pull.number);
   const collected = collectTrustedReviewCommands(comments, input.config.commands);
   const repoProfile = resolveRepoProfile(input.config, input.repo);
+  // A public command (#345) reaching this re-resolution path was already authorized (bot + cooldown
+  // gated) at enqueue, so match it by its known commentId without re-running the cooldown. Without a
+  // specific commentId, only trusted commands act here — the scheduler owns public admission.
   const commands = input.commandCommentId
-    ? collected.commands.filter((command) => command.commentId === input.commandCommentId)
+    ? [...collected.commands, ...collected.publicEligible].filter((command) => command.commentId === input.commandCommentId)
     : collected.commands;
   return decideCommandAction({
     commands: commands.filter((command) =>

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyCommandAuthorization,
   collectTrustedReviewCommands,
   decideCommandAction,
+  isBotCommandComment,
   isRecordOnlyCommandAction,
   parseReviewCommand
 } from "../src/commands.js";
+import { loadConfigFromObject } from "../src/config.js";
 
 describe("maintainer command parsing", () => {
   const config = {
@@ -178,6 +181,72 @@ describe("maintainer command parsing", () => {
       headSha: "head-1",
       hasProcessedCommand: (_repo, _pull, _head, commentId) => commentId === 101
     })).toEqual({ action: "none", shouldReview: false });
+  });
+});
+
+describe("public command authorization classification (#345)", () => {
+  const trusted = { enabled: true, botMentions: ["@bot"], trustedAuthors: ["100yenadmin"], acknowledge: false };
+  const withPublic = { ...trusted, publicCommands: { enabled: true, actions: ["review", "re-review"] as Array<"review" | "re-review">, cooldownMinutes: 10 } };
+
+  it("classifies a trusted author as trusted for every action", () => {
+    for (const action of ["review", "re-review", "explain", "stop"] as const) {
+      expect(classifyCommandAuthorization({ action, author: "100yenadmin" }, trusted)).toBe("trusted");
+      expect(classifyCommandAuthorization({ action, author: "100yenadmin" }, withPublic)).toBe("trusted");
+    }
+  });
+
+  it("classifies a non-trusted author as unauthorized when publicCommands is absent/disabled (byte-identical)", () => {
+    expect(classifyCommandAuthorization({ action: "review", author: "randopublic" }, trusted)).toBe("unauthorized");
+    const disabled = { ...trusted, publicCommands: { enabled: false, actions: ["review"] as Array<"review" | "re-review">, cooldownMinutes: 10 } };
+    expect(classifyCommandAuthorization({ action: "review", author: "randopublic" }, disabled)).toBe("unauthorized");
+  });
+
+  it("classifies a non-trusted author as public-eligible only for review/re-review when enabled", () => {
+    expect(classifyCommandAuthorization({ action: "review", author: "randopublic" }, withPublic)).toBe("public-eligible");
+    expect(classifyCommandAuthorization({ action: "re-review", author: "randopublic" }, withPublic)).toBe("public-eligible");
+    // Non-review actions are never public-eligible even with publicCommands enabled.
+    for (const action of ["explain", "stop"] as const) {
+      expect(classifyCommandAuthorization({ action, author: "randopublic" }, withPublic)).toBe("unauthorized");
+    }
+  });
+
+  it("respects a narrowed public actions set (review only)", () => {
+    const reviewOnly = { ...trusted, publicCommands: { enabled: true, actions: ["review"] as Array<"review" | "re-review">, cooldownMinutes: 10 } };
+    expect(classifyCommandAuthorization({ action: "review", author: "randopublic" }, reviewOnly)).toBe("public-eligible");
+    expect(classifyCommandAuthorization({ action: "re-review", author: "randopublic" }, reviewOnly)).toBe("unauthorized");
+  });
+});
+
+describe("public command bot-author identity (#345)", () => {
+  it("identifies a comment authored by the bot's own login/type as a bot command", () => {
+    expect(isBotCommandComment({ login: "evaos-code-review-bot[bot]", type: "Bot" }, "evaos-code-review-bot[bot]")).toBe(true);
+    // A GitHub App bot with matching Bot type but different login is still a bot actor.
+    expect(isBotCommandComment({ login: "dependabot[bot]", type: "Bot" }, "evaos-code-review-bot[bot]")).toBe(true);
+    // A human author is not a bot.
+    expect(isBotCommandComment({ login: "randopublic", type: "User" }, "evaos-code-review-bot[bot]")).toBe(false);
+    expect(isBotCommandComment(null, "evaos-code-review-bot[bot]")).toBe(false);
+  });
+});
+
+describe("public command config validation (#345)", () => {
+  const baseCommands = { commands: { enabled: true, botMentions: ["@bot"], trustedAuthors: ["100yenadmin"], acknowledge: false } };
+
+  it("defaults publicCommands unset (byte-identical) and accepts a valid config", () => {
+    expect(loadConfigFromObject({ ...baseCommands }).commands.publicCommands).toBeUndefined();
+    const config = loadConfigFromObject({
+      commands: { ...baseCommands.commands, publicCommands: { enabled: true, actions: ["review", "re-review"], cooldownMinutes: 10 } }
+    });
+    expect(config.commands.publicCommands).toEqual({ enabled: true, actions: ["review", "re-review"], cooldownMinutes: 10 });
+  });
+
+  it("fails closed on non-review actions, empty actions, bad cooldown, and unknown keys", () => {
+    const pub = (publicCommands: unknown) => () => loadConfigFromObject({ commands: { ...baseCommands.commands, publicCommands } });
+    expect(pub({ enabled: "yes", actions: ["review"], cooldownMinutes: 10 })).toThrow(/publicCommands\.enabled must be a boolean/);
+    expect(pub({ enabled: true, actions: ["review", "explain"], cooldownMinutes: 10 })).toThrow(/publicCommands\.actions entries must be one of review, re-review/);
+    expect(pub({ enabled: true, actions: ["stop"], cooldownMinutes: 10 })).toThrow(/publicCommands\.actions entries must be one of review, re-review/);
+    expect(pub({ enabled: true, actions: [], cooldownMinutes: 10 })).toThrow(/publicCommands\.actions must be a non-empty array/);
+    expect(pub({ enabled: true, actions: ["review"], cooldownMinutes: 0 })).toThrow(/publicCommands\.cooldownMinutes must be a positive integer/);
+    expect(pub({ enabled: true, actions: ["review"], cooldownMinutes: 10, bogus: 1 })).toThrow(/publicCommands has unknown key "bogus"/);
   });
 });
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -226,6 +226,14 @@ describe("public command bot-author identity (#345)", () => {
     expect(isBotCommandComment({ login: "randopublic", type: "User" }, "evaos-code-review-bot[bot]")).toBe(false);
     expect(isBotCommandComment(null, "evaos-code-review-bot[bot]")).toBe(false);
   });
+
+  it("rejects ANY Bot-type actor, not just the app's own login (deliberate breadth, loop protection)", () => {
+    // Pins the intended breadth vs the narrower GitHubApi.isBotAuthoredComment (which needs BOTH
+    // type === "Bot" AND login === botLogin). A third-party bot triggering a public review must be
+    // blocked, so type === "Bot" alone (any login) rejects.
+    expect(isBotCommandComment({ login: "third-party-app[bot]", type: "Bot" }, "evaos-code-review-bot[bot]")).toBe(true);
+    expect(isBotCommandComment({ login: "renovate[bot]", type: "Bot" }, "evaos-code-review-bot[bot]")).toBe(true);
+  });
 });
 
 describe("public command config validation (#345)", () => {

--- a/tests/public-command-admission.test.ts
+++ b/tests/public-command-admission.test.ts
@@ -1,0 +1,114 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { admitPublicCommands } from "../src/scheduler.js";
+import { collectTrustedReviewCommands, decideCommandAction } from "../src/commands.js";
+import { loadConfigFromObject, type BotConfig } from "../src/config.js";
+import { ReviewStateStore } from "../src/state.js";
+import type { IssueCommentCommandSource } from "../src/commands.js";
+import type { PullRequestSummary } from "../src/types.js";
+
+const BOT_LOGIN = "evaos-code-review-bot[bot]";
+
+function config(publicEnabled: boolean): BotConfig {
+  return loadConfigFromObject({
+    github: { botLogin: BOT_LOGIN },
+    commands: {
+      enabled: true,
+      botMentions: ["@evaos-code-review-bot"],
+      trustedAuthors: ["100yenadmin"],
+      acknowledge: false,
+      ...(publicEnabled ? { publicCommands: { enabled: true, actions: ["review", "re-review"], cooldownMinutes: 10 } } : {})
+    }
+  });
+}
+
+function pull(headSha: string): PullRequestSummary {
+  return { number: 7, title: "PR", draft: false, head: { sha: headSha, ref: "f" }, base: { sha: "b", ref: "main", repo: { full_name: "owner/repo" } }, html_url: "x" };
+}
+
+function comment(id: number, login: string, body: string, type = "User"): IssueCommentCommandSource {
+  return { id, body, html_url: `https://github.test/${id}`, user: { login, type } };
+}
+
+function admit(store: ReviewStateStore, cfg: BotConfig, comments: IssueCommentCommandSource[], headSha: string, now?: Date) {
+  const collected = collectTrustedReviewCommands(comments, cfg.commands);
+  return admitPublicCommands({ config: cfg, state: store, repo: "owner/repo", pull: pull(headSha), publicEligible: collected.publicEligible, comments, ...(now ? { now } : {}) });
+}
+
+describe("public command admission (#345)", () => {
+  const roots: string[] = [];
+  afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+  function store() {
+    const root = mkdtempSync(join(tmpdir(), "evaos-pubadmit-"));
+    roots.push(root);
+    return new ReviewStateStore(join(root, "state.sqlite"));
+  }
+
+  it("admits a public review/re-review from a non-trusted human when enabled", () => {
+    const s = store();
+    const admitted = admit(s, config(true), [
+      comment(101, "randopublic", "@evaos-code-review-bot review"),
+      comment(102, "randopublic", "@evaos-code-review-bot re-review")
+    ], "head-1");
+    expect(admitted.map((c) => c.commentId)).toEqual([101, 102]);
+    s.close();
+  });
+
+  it("admits nothing when publicCommands is disabled (byte-identical to today)", () => {
+    const s = store();
+    // Disabled ⇒ publicEligible is empty from the collector, so nothing to admit.
+    const collected = collectTrustedReviewCommands([comment(101, "randopublic", "@evaos-code-review-bot review")], config(false).commands);
+    expect(collected.publicEligible).toEqual([]);
+    expect(admit(s, config(false), [comment(101, "randopublic", "@evaos-code-review-bot review")], "head-1")).toEqual([]);
+    s.close();
+  });
+
+  it("never admits a bot's own review comment (loop protection)", () => {
+    const s = store();
+    const admitted = admit(s, config(true), [
+      comment(101, BOT_LOGIN, "@evaos-code-review-bot review", "Bot"),
+      comment(102, "some-other-bot[bot]", "@evaos-code-review-bot review", "Bot")
+    ], "head-1");
+    expect(admitted).toEqual([]);
+    s.close();
+  });
+
+  it("flows an admitted public command through the SAME dedup/decision gate as a trusted one (#345 §5)", () => {
+    const s = store();
+    const admitted = admit(s, config(true), [comment(101, "randopublic", "@evaos-code-review-bot re-review")], "head-1");
+    expect(admitted.map((c) => c.commentId)).toEqual([101]);
+
+    // Same downstream decision path as trusted commands: an already-processed head is a no-op (the
+    // per-head claim / hasProcessedCommand short-circuit is shared — public authorization changes
+    // nothing downstream).
+    const decision = decideCommandAction({
+      commands: admitted, repo: "owner/repo", pullNumber: 7, headSha: "head-1",
+      hasProcessedCommand: (_r, _p, _h, commentId) => commentId === 101
+    });
+    expect(decision).toEqual({ action: "none", shouldReview: false });
+
+    // Not yet processed ⇒ the admitted public re-review drives a review exactly like a trusted one.
+    const active = decideCommandAction({
+      commands: admitted, repo: "owner/repo", pullNumber: 7, headSha: "head-1", hasProcessedCommand: () => false
+    });
+    expect(active).toMatchObject({ action: "re-review", shouldReview: true, commandId: 101 });
+    s.close();
+  });
+
+  it("cools down a repeat public command on the same head/author/action, but allows a new head", () => {
+    const s = store();
+    const cfg = config(true);
+    const t0 = new Date("2026-07-06T12:00:00.000Z");
+    // First invocation admitted.
+    expect(admit(s, cfg, [comment(101, "randopublic", "@evaos-code-review-bot review")], "head-1", t0).length).toBe(1);
+    // Repeat within the cooldown window ⇒ denied.
+    expect(admit(s, cfg, [comment(102, "randopublic", "@evaos-code-review-bot review")], "head-1", new Date(t0.getTime() + 60_000))).toEqual([]);
+    // A genuinely new push (new head) is not blocked by the prior head's invocation.
+    expect(admit(s, cfg, [comment(103, "randopublic", "@evaos-code-review-bot review")], "head-2", new Date(t0.getTime() + 60_000)).length).toBe(1);
+    // After the window, the same head is allowed again.
+    expect(admit(s, cfg, [comment(104, "randopublic", "@evaos-code-review-bot review")], "head-1", new Date(t0.getTime() + 11 * 60_000)).length).toBe(1);
+    s.close();
+  });
+});

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1846,4 +1846,40 @@ describe("review state store", () => {
     expect(leased.map((job) => job.headSha)).toEqual(["baseline-new"]);
     store.close();
   });
+
+  it("atomically rate-limits a public command per {repo,pr,head,author,action} within the cooldown window (#345)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-pubcmd-cooldown-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const tuple = { repo: "owner/repo", pullNumber: 42, headSha: "head-a", author: "randopublic", action: "review", cooldownMs: 10 * 60_000 };
+    const t0 = new Date("2026-07-06T12:00:00.000Z");
+
+    // First invocation is allowed and recorded.
+    expect(store.tryRecordPublicCommandInvocation({ ...tuple, now: t0 })).toBe(true);
+    // Second within the window is denied (cooled down), no new record.
+    expect(store.tryRecordPublicCommandInvocation({ ...tuple, now: new Date(t0.getTime() + 5 * 60_000) })).toBe(false);
+    // After the window it is allowed again.
+    expect(store.tryRecordPublicCommandInvocation({ ...tuple, now: new Date(t0.getTime() + 11 * 60_000) })).toBe(true);
+    store.close();
+  });
+
+  it("scopes the public-command cooldown per head, author, and action (#345)", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-pubcmd-scope-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const base = { repo: "owner/repo", pullNumber: 42, headSha: "head-a", author: "randopublic", action: "review", cooldownMs: 10 * 60_000 };
+    const t0 = new Date("2026-07-06T12:00:00.000Z");
+    const soon = new Date(t0.getTime() + 60_000);
+
+    expect(store.tryRecordPublicCommandInvocation({ ...base, now: t0 })).toBe(true);
+    // Same tuple within window → denied.
+    expect(store.tryRecordPublicCommandInvocation({ ...base, now: soon })).toBe(false);
+    // A NEW head (genuinely new push) is not blocked by the prior head's invocation.
+    expect(store.tryRecordPublicCommandInvocation({ ...base, headSha: "head-b", now: soon })).toBe(true);
+    // A different author on the same head is independent.
+    expect(store.tryRecordPublicCommandInvocation({ ...base, author: "otherpublic", now: soon })).toBe(true);
+    // A different action on the same head/author is independent.
+    expect(store.tryRecordPublicCommandInvocation({ ...base, action: "re-review", now: soon })).toBe(true);
+    store.close();
+  });
 });


### PR DESCRIPTION
Closes #345, parent #340 (Config Activation QA Lab). Additive, **default-off**.

## Summary
Lets a **non-trusted** author trigger ONLY `review` / `re-review` on a PR, rate-limited per head, **without** opening the trusted-command surface. Absent or `enabled:false` ⇒ byte-identical to today (only trusted authors trigger anything).

## Design (link: `.dispatch/345-public-command-policy-spec.md`)
- **Config, separate from trustedAuthors, fail-closed:** `commands.publicCommands { enabled; actions: subset of {review,re-review}; cooldownMinutes: positive int }`. Validation rejects any other action (explain/stop/finishing-touch/unknown), empty actions, non-positive cooldown, and unknown keys.
- **Pure parse + stateful gate:** `parseReviewCommand` stays pure. New pure `classifyCommandAuthorization(command, config)` → `trusted | public-eligible | unauthorized`; `collectTrustedReviewCommands` also surfaces `publicEligible` candidates. The stateful bot + cooldown gate runs in the scheduler (`admitPublicCommands`), where the store + head SHA are in scope — mirroring the #295 per-head-claim placement. Admitted public commands then flow through the **exact same** pipeline as trusted ones.
- **Bot-author rejection (loop protection):** `isBotCommandComment(user, botLogin)` rejects a bot-authored public command (`user.type === "Bot"` or the app's own login). Single source of truth for "who am I": `DEFAULT_BOT_LOGIN` exported from `github.ts` and reused. The bot's own review comment never triggers a review.
- **Atomic rate limit, per {repo,pr,head_sha,author,action}:** new `public_command_invocations` table (ensure-pattern, additive, no destructive change). `tryRecordPublicCommandInvocation` consults-and-records inside one `BEGIN IMMEDIATE` transaction (the #295 CAS idiom). Window is per exact head SHA, so a genuinely new push is never blocked by a prior head's invocation.
- **Every existing safety property preserved:** a public command runs the identical downstream pipeline — stale-head re-check, the #295 atomic per-head review claim (a public re-review cannot double-post on an already-reviewed head), secret redaction, no-APPROVE, quieter-only gate — all unchanged. Authorization ONLY decides whether a command may enqueue a review.

## Validation
TDD, full spec matrix, all green under `set -o pipefail` + `npm run build`:
- trusted author still gets all actions (regression pin); public review/re-review allowed when enabled; disabled ⇒ byte-identical; public explain/stop/finishing-touch rejected even when enabled; bot author rejected; cooldown (second invocation same tuple within window denied, after window allowed, different head/author/action allowed); admitted public command flows through the same dedup/decision gate as a trusted one; config validation (actions subset, cooldown positive-int, unknown keys, empty actions).
- Suites: commands, state, public-command-admission (new), plus scheduler/worker-failure/config-schema regressions. Fake tokens via `["ghp","x".repeat(36)].join("_")`.

## Proof boundary
Default-off; only review/re-review can ever be public; all downstream safety unchanged; no posting-surface change. Enabling the policy stays an operator config decision.