### PR TITLE
License service: activate/validate/deactivate API + admin issuance CLI (#327, service)

### DIFF
--- a/services/license-api/README.md
+++ b/services/license-api/README.md
@@ -1,0 +1,92 @@
+# NeonDiff license API (`@neondiff/license-api`)
+
+Self-contained license service for NeonDiff private-repo entitlements
+([#327](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327)).
+It implements the exact HTTP contract the shipped client (`src/license.ts`)
+already calls — activate / validate / deactivate — backed by SQLite, with an
+admin CLI that mints keys. **Payment rails are out of scope**: keys are issued by
+an operator via the CLI.
+
+The service is a separate package boundary; it does **not** import the review
+worker and can be deployed on its own (SQLite on a mounted volume).
+
+## Contract
+
+Three `POST` endpoints, JSON in / JSON out (`Content-Type: application/json`):
+
+| Endpoint | Request body | Success (200) | Denials |
+| --- | --- | --- | --- |
+| `/v1/license/activate` | `{ licenseKey, repo?, machineId }` | `{ entitlement: { status:"active", repoVisibilityScope, … } }` | 404 invalid · 403 revoked · 402 expired · **409 scope_mismatch** (seat exhausted) |
+| `/v1/license/validate` | `{ licenseKey, repo?, machineId }` | active entitlement | 404 invalid · 403 revoked · 402 expired · 409 scope_mismatch (never activated on this machine) |
+| `/v1/license/deactivate` | `{ licenseKey, repo?, machineId }` | `{ status:"active", … }` (idempotent) | 404 invalid |
+
+Cross-cutting: 429 rate_limited (per-key throttle) · 400 malformed · 5xx server.
+`machineId` is the single-activation binding — one machine per seat (default
+`seats=1`). Only `sha256(licenseKey)` is ever stored; the raw key is never
+logged or echoed. `GET /healthz` → `{ "status": "ok" }`.
+
+The HTTP-code → client-classification map is fixed by the client
+(`402→expired · 429→rate_limited · 426→unsupported_client · 409→scope_mismatch ·
+403/410→revoked · 401/404→invalid · 5xx→server`); the service returns codes that
+match it.
+
+## Run
+
+```sh
+# from the repo root, deps installed via `npm install`
+cd services/license-api
+npm run build           # tsc → dist/
+LICENSE_DB_PATH=runtime/license.sqlite PORT=8080 npm start
+```
+
+Environment:
+
+- `LICENSE_DB_PATH` — SQLite file path (default `runtime/license.sqlite`; point
+  at a mounted volume in deploy).
+- `PORT` / `HOST` — listen address (default `8080` / `0.0.0.0`). TLS is
+  terminated upstream (fly), so the process serves plain HTTP internally.
+
+## Admin issuance CLI
+
+The CLI opens `LICENSE_DB_PATH` and never prints raw keys except at issuance.
+
+```sh
+# issue — prints the raw key ONCE; only its hash is stored
+LICENSE_DB_PATH=runtime/license.sqlite npm run admin -- \
+  issue --plan yearly --scope private --seats 1 --expires 2027-01-01T00:00:00Z
+
+# revoke by raw key (optionally with a redacted reason)
+npm run admin -- revoke --key nd_live_… --reason refund
+
+# list — hashes + metadata, never raw keys
+npm run admin -- list
+
+# show a single license by key (adds its activations)
+npm run admin -- show --key nd_live_…
+```
+
+`issue` flags: `--plan <p>` (required), `--scope <public|private|all>`
+(required), `--seats N` (default 1), `--expires <iso>`,
+`--private-repo-allowed <true|false>`, `--update-entitlement`.
+
+See [`docs/admin-runbook.md`](docs/admin-runbook.md) for the operator runbook.
+
+## Deploy
+
+Deploy is a **separate, gated step** (not part of the PR that adds this
+service). The target is fly.io with SQLite on a mounted volume; the orchestrator
+drives `flyctl` (staging → owner confirm → production) and wires the prod URL
+into `docs/public-release-manifest.json`'s `licenseApi` slot once live. No
+secrets live in the repo.
+
+## Tests
+
+```sh
+npm test   # node:test via tsx — service, http, and admin suites
+```
+
+The load-bearing contract test lives at the repo root
+(`tests/license-service-contract.test.ts`): it drives the **real** shipped
+client (`src/license.ts`) against this service in-process through
+activate → validate → deactivate → reactivate-different-machine and asserts the
+client parses each into the correct `LicenseStatus`.

--- a/services/license-api/docs/admin-runbook.md
+++ b/services/license-api/docs/admin-runbook.md
@@ -1,0 +1,64 @@
+# License API admin runbook
+
+Operator procedures for the NeonDiff license service
+([#327](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327)).
+This runbook covers key issuance and lifecycle. It does **not** cover payment,
+billing, or deploy — deploy is a separate gated step driven by the orchestrator.
+
+All commands open the SQLite database at `LICENSE_DB_PATH`. In production this is
+the file on the mounted fly volume; run the CLI on the instance (or against a
+copy of the volume) so it points at the live database.
+
+## Golden rules
+
+- **The raw key is shown exactly once, at issuance.** Copy it to the buyer over a
+  secure channel immediately. Only `sha256(key)` is stored; the key cannot be
+  recovered afterward. If it is lost, revoke and re-issue.
+- **Never paste a raw key into logs, issues, evidence, or chat.** `list`/`show`
+  print hashes only; keep it that way.
+- Default `seats=1` enforces single-activation: one machine per seat. A second
+  machine gets `409 scope_mismatch` until a seat is freed via `deactivate`.
+
+## Issue a key
+
+```sh
+LICENSE_DB_PATH=/data/license.sqlite npm run admin -- \
+  issue --plan yearly --scope private --seats 1 --expires 2027-01-01T00:00:00Z
+```
+
+- `--scope public` keys never gate anything (public repos are free client-side);
+  issue `private` or `all` for paying customers.
+- `--private-repo-allowed false` denies private repos even at scope `all`.
+- `--update-entitlement` grants update-channel access.
+
+Record the printed **hash** (not the key) alongside the customer reference.
+
+## Revoke a key
+
+```sh
+LICENSE_DB_PATH=/data/license.sqlite npm run admin -- \
+  revoke --key nd_live_… --reason "refund"
+```
+
+Revocation is immediate: the next `activate`/`validate` returns `403 revoked`
+with the redacted reason. Use for refunds, chargebacks, or policy violations.
+
+## Inspect
+
+```sh
+npm run admin -- list                 # all licenses: hash, status, scope, seats, activations
+npm run admin -- show --key nd_live_…  # one license + its bound machines
+```
+
+## Free a seat for a customer
+
+A customer who changed machines and hit `409 scope_mismatch` needs the old
+machine deactivated. The client's `neondiff license deactivate` frees the seat
+from the customer side. If they cannot reach the old machine, an operator has no
+raw-key path to delete a single activation by design (the key is hashed); the
+supported recovery is to `revoke` and re-`issue`, or raise `--seats` on a new key.
+
+## Health
+
+`GET /healthz` → `{ "status": "ok" }`. Use it for the deploy health check and
+uptime monitoring.

--- a/services/license-api/package.json
+++ b/services/license-api/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@neondiff/license-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "NeonDiff production license service: activate/validate/deactivate API + admin issuance CLI (#327).",
+  "bin": {
+    "license-admin": "dist/admin.js"
+  },
+  "engines": {
+    "node": ">=26"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "admin": "node dist/admin.js",
+    "test": "node --import tsx --test test/*.test.ts"
+  }
+}

--- a/services/license-api/src/admin.ts
+++ b/services/license-api/src/admin.ts
@@ -1,0 +1,161 @@
+import { LicenseStore, type IssueLicenseInput, type LicenseRecord, type RepoVisibilityScope } from "./store.js";
+
+/**
+ * Admin issuance CLI (no payment rails — this is how keys are minted until/if
+ * Stripe is ever added). Commands:
+ *   issue  --plan <p> --scope <public|private|all> [--seats N] [--expires <iso>]
+ *          [--private-repo-allowed <true|false>] [--update-entitlement]
+ *   revoke --key <k> [--reason <text>]
+ *   list
+ *   show   --key <k>
+ *
+ * `issue` prints the raw key EXACTLY ONCE; only the sha256 hash is stored.
+ * `list`/`show` never print raw keys.
+ */
+export function runAdmin(argv: string[], store: LicenseStore, out: (line: string) => void = console.log): number {
+  const [command, ...rest] = argv;
+  const flags = parseFlags(rest);
+
+  switch (command) {
+    case "issue":
+      return cmdIssue(flags, store, out);
+    case "revoke":
+      return cmdRevoke(flags, store, out);
+    case "list":
+      return cmdList(store, out);
+    case "show":
+      return cmdShow(flags, store, out);
+    default:
+      out(usage());
+      return command ? 2 : 0;
+  }
+}
+
+function cmdIssue(flags: Flags, store: LicenseStore, out: (line: string) => void): number {
+  const plan = flags.string("plan");
+  const scope = flags.string("scope") as RepoVisibilityScope | undefined;
+  if (!plan) return fail(out, "issue requires --plan");
+  if (scope !== "public" && scope !== "private" && scope !== "all") {
+    return fail(out, "issue requires --scope <public|private|all>");
+  }
+  const input: IssueLicenseInput = {
+    plan,
+    repoVisibilityScope: scope,
+    ...(flags.has("seats") ? { seats: Number(flags.string("seats")) } : {}),
+    ...(flags.has("expires") ? { expiresAt: flags.string("expires") } : {}),
+    ...(flags.has("private-repo-allowed") ? { privateRepoAllowed: flags.string("private-repo-allowed") !== "false" } : {}),
+    ...(flags.has("update-entitlement") ? { updateEntitlement: true } : {})
+  };
+  const { rawKey, record } = store.issueLicense(input);
+  out("License issued. Store this key securely — it is shown only once:");
+  out(`  key:   ${rawKey}`);
+  out(`  hash:  ${record.licenseKeyHash}`);
+  out(`  plan:  ${record.plan}`);
+  out(`  scope: ${record.repoVisibilityScope} (privateRepoAllowed=${record.privateRepoAllowed})`);
+  out(`  seats: ${record.seats}`);
+  out(`  expiresAt: ${record.expiresAt ?? "never"}`);
+  return 0;
+}
+
+function cmdRevoke(flags: Flags, store: LicenseStore, out: (line: string) => void): number {
+  const key = flags.string("key");
+  if (!key) return fail(out, "revoke requires --key");
+  const ok = store.revokeLicense(key, flags.string("reason"));
+  if (!ok) return fail(out, "no license matches the provided key");
+  out("License revoked.");
+  return 0;
+}
+
+function cmdList(store: LicenseStore, out: (line: string) => void): number {
+  const licenses = store.listLicenses();
+  if (licenses.length === 0) {
+    out("No licenses issued.");
+    return 0;
+  }
+  for (const record of licenses) out(formatLicense(record, store, false));
+  return 0;
+}
+
+function cmdShow(flags: Flags, store: LicenseStore, out: (line: string) => void): number {
+  const key = flags.string("key");
+  if (!key) return fail(out, "show requires --key");
+  const record = store.getLicenseByKey(key);
+  if (!record) return fail(out, "no license matches the provided key");
+  out(formatLicense(record, store, true));
+  return 0;
+}
+
+function formatLicense(record: LicenseRecord, store: LicenseStore, withActivations: boolean): string {
+  const parts = [
+    `hash=${record.licenseKeyHash}`,
+    `status=${record.status}`,
+    `plan=${record.plan}`,
+    `scope=${record.repoVisibilityScope}`,
+    `privateRepoAllowed=${record.privateRepoAllowed}`,
+    `seats=${record.seats}`,
+    `activations=${store.countActivations(record.licenseKeyHash)}`,
+    `expiresAt=${record.expiresAt ?? "never"}`,
+    `createdAt=${record.createdAt}`
+  ];
+  if (record.revocationReason) parts.push(`revocationReason=${record.revocationReason}`);
+  let line = parts.join(" ");
+  if (withActivations) {
+    for (const activation of store.listActivations(record.licenseKeyHash)) {
+      line += `\n  machine=${activation.machineId} repo=${activation.repo ?? "-"} lastSeenAt=${activation.lastSeenAt}`;
+    }
+  }
+  return line;
+}
+
+function usage(): string {
+  return [
+    "Usage: license-admin <command> [options]",
+    "",
+    "Commands:",
+    "  issue  --plan <p> --scope <public|private|all> [--seats N] [--expires <iso>]",
+    "         [--private-repo-allowed <true|false>] [--update-entitlement]",
+    "  revoke --key <k> [--reason <text>]",
+    "  list",
+    "  show   --key <k>"
+  ].join("\n");
+}
+
+function fail(out: (line: string) => void, message: string): number {
+  out(`error: ${message}`);
+  return 2;
+}
+
+interface Flags {
+  has(name: string): boolean;
+  string(name: string): string | undefined;
+}
+
+function parseFlags(args: string[]): Flags {
+  const map = new Map<string, string>();
+  const bare = new Set<string>();
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg.startsWith("--")) continue;
+    const name = arg.slice(2);
+    const next = args[i + 1];
+    if (next !== undefined && !next.startsWith("--")) {
+      map.set(name, next);
+      i += 1;
+    } else {
+      bare.add(name);
+    }
+  }
+  return {
+    has: (name) => map.has(name) || bare.has(name),
+    string: (name) => map.get(name)
+  };
+}
+
+// Executed directly (node admin.ts / dist/admin.js): open the configured DB and run.
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith("admin.ts") || process.argv[1]?.endsWith("admin.js")) {
+  const dbPath = process.env.LICENSE_DB_PATH ?? "runtime/license.sqlite";
+  const store = new LicenseStore(dbPath);
+  const code = runAdmin(process.argv.slice(2), store);
+  store.close();
+  process.exit(code);
+}

--- a/services/license-api/src/http.ts
+++ b/services/license-api/src/http.ts
@@ -1,0 +1,121 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { LicenseStore } from "./store.js";
+import {
+  activate,
+  deactivate,
+  malformedResult,
+  RateLimiter,
+  rateLimitedResult,
+  validate,
+  type LicenseRequest,
+  type ServiceResult
+} from "./service.js";
+
+const MAX_BODY_BYTES = 16 * 1024;
+
+export interface LicenseHttpOptions {
+  store: LicenseStore;
+  rateLimiter?: RateLimiter;
+  /** Injectable clock for deterministic tests. */
+  now?: () => Date;
+}
+
+type Handler = (store: LicenseStore, req: LicenseRequest, now: Date) => ServiceResult;
+
+const ROUTES: Record<string, Handler> = {
+  "/v1/license/activate": activate,
+  "/v1/license/validate": validate,
+  "/v1/license/deactivate": deactivate
+};
+
+/**
+ * Build the request listener for the license API. Kept transport-thin: parse,
+ * validate shape, per-key rate-limit, dispatch to the pure service functions,
+ * serialize. Never logs or echoes the raw license key.
+ */
+export function createLicenseRequestListener(options: LicenseHttpOptions) {
+  const now = options.now ?? (() => new Date());
+  const rateLimiter =
+    options.rateLimiter ?? new RateLimiter({ maxPerWindow: 60, windowMs: 60_000 });
+
+  return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    if (req.method === "GET" && req.url === "/healthz") {
+      return writeJson(res, 200, { status: "ok" });
+    }
+    const route = req.url ? ROUTES[req.url.split("?")[0]] : undefined;
+    if (req.method !== "POST" || !route) {
+      return writeResult(res, malformedResult("unknown route"), 404);
+    }
+
+    let parsed: LicenseRequest;
+    try {
+      parsed = parseRequest(await readBody(req));
+    } catch (error) {
+      return writeResult(res, malformedResult(error instanceof Error ? error.message : "malformed request body"));
+    }
+
+    // Per-key sliding window; the hot validate path is what the client polls.
+    if (!rateLimiter.allow(parsed.licenseKey, Date.now())) {
+      return writeResult(res, rateLimitedResult());
+    }
+
+    try {
+      return writeResult(res, route(options.store, parsed, now()));
+    } catch {
+      // Never surface internal error text (could contain no key, but stay safe) → 500 server.
+      return writeJson(res, 500, { status: "server", detail: "internal error" });
+    }
+  };
+}
+
+export function startLicenseServer(options: LicenseHttpOptions & { port?: number; host?: string }): Promise<{ server: Server; url: string }> {
+  const server = createServer(createLicenseRequestListener(options));
+  return new Promise((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(options.port ?? 0, options.host ?? "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : options.port;
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function parseRequest(raw: string): LicenseRequest {
+  const parsed = raw ? (JSON.parse(raw) as unknown) : {};
+  if (typeof parsed !== "object" || parsed === null) throw new Error("request body must be a JSON object");
+  const body = parsed as Record<string, unknown>;
+  const licenseKey = body.licenseKey;
+  const machineId = body.machineId;
+  if (typeof licenseKey !== "string" || licenseKey.trim().length === 0) throw new Error("licenseKey is required");
+  if (typeof machineId !== "string" || machineId.trim().length === 0) throw new Error("machineId is required");
+  const repo = typeof body.repo === "string" && body.repo.length > 0 ? body.repo : undefined;
+  return { licenseKey: licenseKey.trim(), machineId: machineId.trim(), repo };
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error("request body too large"));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function writeResult(res: ServerResponse, result: ServiceResult, overrideStatus?: number): void {
+  writeJson(res, overrideStatus ?? result.httpStatus, result.body);
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(payload);
+}

--- a/services/license-api/src/server.ts
+++ b/services/license-api/src/server.ts
@@ -1,0 +1,23 @@
+import { LicenseStore } from "./store.js";
+import { startLicenseServer } from "./http.js";
+
+/**
+ * Production entrypoint. SQLite lives on a mounted volume in deploy
+ * (LICENSE_DB_PATH); PORT/HOST come from the platform. TLS is terminated by
+ * fly, so the process serves plain HTTP on the internal port.
+ */
+async function main(): Promise<void> {
+  const dbPath = process.env.LICENSE_DB_PATH ?? "runtime/license.sqlite";
+  const port = Number(process.env.PORT ?? 8080);
+  const host = process.env.HOST ?? "0.0.0.0";
+  const store = new LicenseStore(dbPath);
+  const { url } = await startLicenseServer({ store, port, host });
+  // eslint-disable-next-line no-console
+  console.log(`license-api listening on ${url} (db=${dbPath})`);
+}
+
+main().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error(`license-api failed to start: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/services/license-api/src/service.ts
+++ b/services/license-api/src/service.ts
@@ -1,0 +1,196 @@
+import type { LicenseRecord, LicenseStore, RepoVisibilityScope } from "./store.js";
+
+/**
+ * The entitlement body the client (`src/license.ts`) parses. `status` and
+ * `repoVisibilityScope` are REQUIRED — the client rejects a 2xx success that
+ * omits either. The raw license key is NEVER echoed here.
+ */
+export interface Entitlement {
+  status: "active" | "expired" | "revoked" | "invalid" | "scope_mismatch";
+  repoVisibilityScope: RepoVisibilityScope;
+  privateRepoAllowed?: boolean;
+  updateEntitlement: boolean;
+  expiresAt?: string;
+  plan?: string;
+  seats?: number;
+  revocationReason?: string;
+}
+
+/** A normalized result: HTTP status code + the JSON body to serialize. */
+export interface ServiceResult {
+  httpStatus: number;
+  body: Record<string, unknown>;
+}
+
+export interface LicenseRequest {
+  licenseKey: string;
+  repo?: string;
+  machineId: string;
+}
+
+export interface RateLimiterOptions {
+  /** Max requests per key within the window before 429. */
+  maxPerWindow: number;
+  windowMs: number;
+}
+
+/**
+ * Minimal in-memory per-key sliding-window limiter. Appropriate for the
+ * "normal, not hardened" bar — a single fly instance with a modest request
+ * rate. A per-instance limiter is intentional; distributed limiting is not
+ * required for this tier.
+ */
+export class RateLimiter {
+  private readonly hits = new Map<string, number[]>();
+  private readonly opts: RateLimiterOptions;
+
+  constructor(opts: RateLimiterOptions) {
+    this.opts = opts;
+  }
+
+  /** Returns true when the request is allowed; false when it should be throttled. */
+  allow(key: string, now: number): boolean {
+    const cutoff = now - this.opts.windowMs;
+    const recent = (this.hits.get(key) ?? []).filter((t) => t > cutoff);
+    if (recent.length >= this.opts.maxPerWindow) {
+      this.hits.set(key, recent);
+      return false;
+    }
+    recent.push(now);
+    this.hits.set(key, recent);
+    return true;
+  }
+}
+
+function entitlementFrom(record: LicenseRecord, status: Entitlement["status"]): Entitlement {
+  return {
+    status,
+    repoVisibilityScope: record.repoVisibilityScope,
+    privateRepoAllowed: record.privateRepoAllowed,
+    updateEntitlement: record.updateEntitlement,
+    ...(record.expiresAt ? { expiresAt: record.expiresAt } : {}),
+    ...(record.plan ? { plan: record.plan } : {}),
+    ...(record.seats !== undefined ? { seats: record.seats } : {}),
+    ...(status !== "active" && record.revocationReason ? { revocationReason: record.revocationReason } : {})
+  };
+}
+
+function activeEntitlementBody(record: LicenseRecord): ServiceResult {
+  return { httpStatus: 200, body: { entitlement: entitlementFrom(record, "active") as unknown as Record<string, unknown> } };
+}
+
+/** 404 invalid — key unknown. Never echoes the submitted key. */
+function invalidResult(): ServiceResult {
+  return { httpStatus: 404, body: { status: "invalid", detail: "license key is not recognized" } };
+}
+
+/** 403 revoked. */
+function revokedResult(record: LicenseRecord): ServiceResult {
+  return {
+    httpStatus: 403,
+    body: {
+      status: "revoked",
+      ...(record.revocationReason ? { revocationReason: record.revocationReason } : {}),
+      detail: "license is revoked"
+    }
+  };
+}
+
+/** 402 expired. */
+function expiredResult(): ServiceResult {
+  return { httpStatus: 402, body: { status: "expired", detail: "license is expired" } };
+}
+
+/** 409 scope_mismatch — single-activation seat exhausted by a different machine. */
+function seatExhaustedResult(record: LicenseRecord): ServiceResult {
+  return {
+    httpStatus: 409,
+    body: {
+      status: "scope_mismatch",
+      seats: record.seats,
+      detail: "license seats are exhausted; deactivate another machine before activating this one"
+    }
+  };
+}
+
+function isExpired(record: LicenseRecord, now: Date): boolean {
+  if (!record.expiresAt) return false;
+  const ms = Date.parse(record.expiresAt);
+  return Number.isFinite(ms) && ms <= now.getTime();
+}
+
+/**
+ * Resolve a license record to a terminal denial result, or return the record
+ * when it is active and unexpired. Shared by activate/validate.
+ */
+function resolveActiveLicense(store: LicenseStore, req: LicenseRequest, now: Date): { record: LicenseRecord } | ServiceResult {
+  const record = store.getLicenseByKey(req.licenseKey);
+  if (!record) return invalidResult();
+  if (record.status === "revoked") return revokedResult(record);
+  if (record.status === "expired" || isExpired(record, now)) return expiredResult();
+  return { record };
+}
+
+function isServiceResult(value: { record: LicenseRecord } | ServiceResult): value is ServiceResult {
+  return "httpStatus" in value;
+}
+
+export function activate(store: LicenseStore, req: LicenseRequest, now: Date): ServiceResult {
+  const resolved = resolveActiveLicense(store, req, now);
+  if (isServiceResult(resolved)) return resolved;
+  const { record } = resolved;
+  const nowIso = now.toISOString();
+
+  const existing = store.getActivation(record.licenseKeyHash, req.machineId);
+  if (existing) {
+    // Same machine re-activating → idempotent active, refresh last_seen_at.
+    store.upsertActivation(record.licenseKeyHash, req.machineId, req.repo, nowIso);
+    return activeEntitlementBody(record);
+  }
+  // A different machine wants a seat: allow only if seats remain.
+  if (store.countActivations(record.licenseKeyHash) >= record.seats) {
+    return seatExhaustedResult(record);
+  }
+  store.upsertActivation(record.licenseKeyHash, req.machineId, req.repo, nowIso);
+  return activeEntitlementBody(record);
+}
+
+export function validate(store: LicenseStore, req: LicenseRequest, now: Date): ServiceResult {
+  const resolved = resolveActiveLicense(store, req, now);
+  if (isServiceResult(resolved)) return resolved;
+  const { record } = resolved;
+
+  const activation = store.getActivation(record.licenseKeyHash, req.machineId);
+  if (!activation) {
+    // Key valid but never activated on this machine → single-activation binding fails.
+    return seatExhaustedResult(record);
+  }
+  store.touchActivation(record.licenseKeyHash, req.machineId, now.toISOString());
+  return activeEntitlementBody(record);
+}
+
+export function deactivate(store: LicenseStore, req: LicenseRequest, now: Date): ServiceResult {
+  const record = store.getLicenseByKey(req.licenseKey);
+  if (!record) return invalidResult();
+  // Idempotent: removing an absent activation still returns ok. Frees the seat.
+  store.removeActivation(record.licenseKeyHash, req.machineId);
+  return {
+    httpStatus: 200,
+    body: {
+      status: "active",
+      repoVisibilityScope: record.repoVisibilityScope,
+      updateEntitlement: record.updateEntitlement,
+      detail: "machine deactivated"
+    }
+  };
+}
+
+/** 429 rate_limited. */
+export function rateLimitedResult(): ServiceResult {
+  return { httpStatus: 429, body: { status: "rate_limited", detail: "too many requests for this license" } };
+}
+
+/** 400 malformed request. */
+export function malformedResult(detail: string): ServiceResult {
+  return { httpStatus: 400, body: { status: "invalid", detail } };
+}

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -1,0 +1,245 @@
+import { createHash, randomBytes } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+export type LicenseStatus = "active" | "revoked" | "expired";
+export type RepoVisibilityScope = "public" | "private" | "all";
+
+export interface LicenseRecord {
+  licenseKeyHash: string;
+  plan: string;
+  repoVisibilityScope: RepoVisibilityScope;
+  privateRepoAllowed: boolean;
+  updateEntitlement: boolean;
+  seats: number;
+  expiresAt?: string;
+  status: LicenseStatus;
+  revocationReason?: string;
+  createdAt: string;
+}
+
+export interface ActivationRecord {
+  licenseKeyHash: string;
+  machineId: string;
+  repo?: string;
+  activatedAt: string;
+  lastSeenAt: string;
+}
+
+interface LicenseRow {
+  license_key_hash: string;
+  plan: string;
+  repo_visibility_scope: string;
+  private_repo_allowed: number;
+  update_entitlement: number;
+  seats: number;
+  expires_at: string | null;
+  status: string;
+  revocation_reason: string | null;
+  created_at: string;
+}
+
+interface ActivationRow {
+  license_key_hash: string;
+  machine_id: string;
+  repo: string | null;
+  activated_at: string;
+  last_seen_at: string;
+}
+
+/**
+ * Deterministic at-rest identifier for a license key. Only the hash is ever
+ * stored or logged; the raw key is printed once by the admin CLI at issuance
+ * and otherwise never leaves the client.
+ */
+export function hashLicenseKey(rawKey: string): string {
+  return createHash("sha256").update(rawKey.trim()).digest("hex");
+}
+
+/**
+ * Generate a raw license key with the `nd_live_<random>` shape the client
+ * fingerprints. The random segment is url-safe base64 so keys survive JSON and
+ * shell round-trips without escaping.
+ */
+export function generateLicenseKey(): string {
+  const random = randomBytes(24).toString("base64url");
+  return ["nd", "live", random].join("_");
+}
+
+export interface IssueLicenseInput {
+  plan: string;
+  repoVisibilityScope: RepoVisibilityScope;
+  privateRepoAllowed?: boolean;
+  updateEntitlement?: boolean;
+  seats?: number;
+  expiresAt?: string;
+}
+
+export class LicenseStore {
+  private readonly db: DatabaseSync;
+
+  constructor(dbPath: string) {
+    if (dbPath !== ":memory:") mkdirSync(dirname(dbPath), { recursive: true });
+    this.db = new DatabaseSync(dbPath);
+    this.db.exec("pragma foreign_keys = on");
+    this.ensureSchema();
+  }
+
+  private ensureSchema(): void {
+    this.db.exec(`
+      create table if not exists licenses (
+        license_key_hash text primary key,
+        plan text not null,
+        repo_visibility_scope text not null,
+        private_repo_allowed integer not null default 1,
+        update_entitlement integer not null default 0,
+        seats integer not null default 1,
+        expires_at text,
+        status text not null default 'active',
+        revocation_reason text,
+        created_at text not null default (datetime('now'))
+      );
+
+      create table if not exists activations (
+        license_key_hash text not null,
+        machine_id text not null,
+        repo text,
+        activated_at text not null default (datetime('now')),
+        last_seen_at text not null default (datetime('now')),
+        primary key (license_key_hash, machine_id)
+      );
+    `);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  /** Issue a new license: generates a raw key, stores only its hash. */
+  issueLicense(input: IssueLicenseInput): { rawKey: string; record: LicenseRecord } {
+    const rawKey = generateLicenseKey();
+    const licenseKeyHash = hashLicenseKey(rawKey);
+    const seats = input.seats ?? 1;
+    if (!Number.isInteger(seats) || seats < 1) throw new Error("seats must be a positive integer");
+    const privateRepoAllowed = input.privateRepoAllowed ?? input.repoVisibilityScope !== "public";
+    const updateEntitlement = input.updateEntitlement ?? false;
+    this.db
+      .prepare(
+        `insert into licenses (
+          license_key_hash, plan, repo_visibility_scope, private_repo_allowed,
+          update_entitlement, seats, expires_at, status
+        ) values (?, ?, ?, ?, ?, ?, ?, 'active')`
+      )
+      .run(
+        licenseKeyHash,
+        input.plan,
+        input.repoVisibilityScope,
+        privateRepoAllowed ? 1 : 0,
+        updateEntitlement ? 1 : 0,
+        seats,
+        input.expiresAt ?? null
+      );
+    const record = this.getLicenseByHash(licenseKeyHash);
+    if (!record) throw new Error("license insert did not persist");
+    return { rawKey, record };
+  }
+
+  getLicenseByHash(licenseKeyHash: string): LicenseRecord | undefined {
+    const row = this.db
+      .prepare("select * from licenses where license_key_hash = ?")
+      .get(licenseKeyHash) as LicenseRow | undefined;
+    return row ? mapLicense(row) : undefined;
+  }
+
+  getLicenseByKey(rawKey: string): LicenseRecord | undefined {
+    return this.getLicenseByHash(hashLicenseKey(rawKey));
+  }
+
+  listLicenses(): LicenseRecord[] {
+    const rows = this.db
+      .prepare("select * from licenses order by created_at asc")
+      .all() as unknown as LicenseRow[];
+    return rows.map(mapLicense);
+  }
+
+  /** Revoke a license by raw key. Returns false when the key is unknown. */
+  revokeLicense(rawKey: string, reason?: string): boolean {
+    const info = this.db
+      .prepare("update licenses set status = 'revoked', revocation_reason = ? where license_key_hash = ?")
+      .run(reason ?? null, hashLicenseKey(rawKey));
+    return Number(info.changes) > 0;
+  }
+
+  getActivation(licenseKeyHash: string, machineId: string): ActivationRecord | undefined {
+    const row = this.db
+      .prepare("select * from activations where license_key_hash = ? and machine_id = ?")
+      .get(licenseKeyHash, machineId) as ActivationRow | undefined;
+    return row ? mapActivation(row) : undefined;
+  }
+
+  listActivations(licenseKeyHash: string): ActivationRecord[] {
+    const rows = this.db
+      .prepare("select * from activations where license_key_hash = ? order by activated_at asc")
+      .all(licenseKeyHash) as unknown as ActivationRow[];
+    return rows.map(mapActivation);
+  }
+
+  countActivations(licenseKeyHash: string): number {
+    const row = this.db
+      .prepare("select count(*) as n from activations where license_key_hash = ?")
+      .get(licenseKeyHash) as { n: number };
+    return Number(row.n);
+  }
+
+  /** Bind a machine to a license (insert) or refresh last_seen_at (idempotent). */
+  upsertActivation(licenseKeyHash: string, machineId: string, repo: string | undefined, now: string): void {
+    this.db
+      .prepare(
+        `insert into activations (license_key_hash, machine_id, repo, activated_at, last_seen_at)
+         values (?, ?, ?, ?, ?)
+         on conflict (license_key_hash, machine_id)
+         do update set last_seen_at = excluded.last_seen_at, repo = coalesce(excluded.repo, activations.repo)`
+      )
+      .run(licenseKeyHash, machineId, repo ?? null, now, now);
+  }
+
+  touchActivation(licenseKeyHash: string, machineId: string, now: string): void {
+    this.db
+      .prepare("update activations set last_seen_at = ? where license_key_hash = ? and machine_id = ?")
+      .run(now, licenseKeyHash, machineId);
+  }
+
+  /** Free a seat. Returns true when a row was deleted. */
+  removeActivation(licenseKeyHash: string, machineId: string): boolean {
+    const info = this.db
+      .prepare("delete from activations where license_key_hash = ? and machine_id = ?")
+      .run(licenseKeyHash, machineId);
+    return Number(info.changes) > 0;
+  }
+}
+
+function mapLicense(row: LicenseRow): LicenseRecord {
+  return {
+    licenseKeyHash: row.license_key_hash,
+    plan: row.plan,
+    repoVisibilityScope: row.repo_visibility_scope as RepoVisibilityScope,
+    privateRepoAllowed: row.private_repo_allowed === 1,
+    updateEntitlement: row.update_entitlement === 1,
+    seats: row.seats,
+    ...(row.expires_at ? { expiresAt: row.expires_at } : {}),
+    status: row.status as LicenseStatus,
+    ...(row.revocation_reason ? { revocationReason: row.revocation_reason } : {}),
+    createdAt: row.created_at
+  };
+}
+
+function mapActivation(row: ActivationRow): ActivationRecord {
+  return {
+    licenseKeyHash: row.license_key_hash,
+    machineId: row.machine_id,
+    ...(row.repo ? { repo: row.repo } : {}),
+    activatedAt: row.activated_at,
+    lastSeenAt: row.last_seen_at
+  };
+}

--- a/services/license-api/test/admin.test.ts
+++ b/services/license-api/test/admin.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, describe, it } from "node:test";
+import { LicenseStore } from "../src/store.ts";
+import { runAdmin } from "../src/admin.ts";
+
+describe("admin issuance CLI", () => {
+  let store: LicenseStore;
+  let lines: string[];
+  const out = (line: string) => lines.push(line);
+  after(() => store?.close());
+  beforeEach(() => {
+    store?.close();
+    store = new LicenseStore(":memory:");
+    lines = [];
+  });
+
+  function issue(args: string[] = ["--plan", "yearly", "--scope", "private"]): string {
+    const code = runAdmin(["issue", ...args], store, out);
+    assert.equal(code, 0);
+    const keyLine = lines.find((l) => l.includes("key:"));
+    assert.ok(keyLine, "issue must print the raw key once");
+    const key = keyLine.split("key:")[1].trim();
+    assert.ok(key.startsWith("nd_live_"));
+    return key;
+  }
+
+  it("issue prints the raw key exactly once and stores only the hash", () => {
+    const key = issue();
+    // The key appears exactly once across all printed lines.
+    const occurrences = lines.filter((l) => l.includes(key)).length;
+    assert.equal(occurrences, 1);
+    const record = store.getLicenseByKey(key);
+    assert.ok(record);
+    assert.notEqual(record.licenseKeyHash, key);
+  });
+
+  it("issue requires --plan and --scope", () => {
+    assert.equal(runAdmin(["issue", "--plan", "yearly"], store, out), 2);
+    assert.equal(runAdmin(["issue", "--scope", "private"], store, out), 2);
+  });
+
+  it("list never prints raw keys", () => {
+    const key = issue();
+    lines = [];
+    assert.equal(runAdmin(["list"], store, out), 0);
+    assert.ok(!lines.join("\n").includes(key));
+    assert.ok(lines.join("\n").includes(store.getLicenseByKey(key)!.licenseKeyHash));
+  });
+
+  it("revoke marks a license revoked; show reflects it without the raw key", () => {
+    const key = issue();
+    lines = [];
+    assert.equal(runAdmin(["revoke", "--key", key, "--reason", "refund"], store, out), 0);
+    assert.equal(store.getLicenseByKey(key)!.status, "revoked");
+    lines = [];
+    assert.equal(runAdmin(["show", "--key", key], store, out), 0);
+    const shown = lines.join("\n");
+    assert.ok(shown.includes("status=revoked"));
+    assert.ok(shown.includes("refund"));
+    assert.ok(!shown.includes(key));
+  });
+
+  it("revoke and show fail cleanly on an unknown key", () => {
+    assert.equal(runAdmin(["revoke", "--key", "nd_live_unknownxxxxxxxxxxxxxxxxxxx"], store, out), 2);
+    assert.equal(runAdmin(["show", "--key", "nd_live_unknownxxxxxxxxxxxxxxxxxxx"], store, out), 2);
+  });
+});

--- a/services/license-api/test/http.test.ts
+++ b/services/license-api/test/http.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import type { Server } from "node:http";
+import { LicenseStore } from "../src/store.ts";
+import { startLicenseServer } from "../src/http.ts";
+import { RateLimiter } from "../src/service.ts";
+
+const fakeKey = (tag: string): string => ["nd", "live", `${tag}${"x".repeat(24 - tag.length)}`].join("_");
+
+async function post(url: string, path: string, body: unknown): Promise<{ status: number; json: any }> {
+  const res = await fetch(`${url}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body)
+  });
+  const text = await res.text();
+  return { status: res.status, json: text ? JSON.parse(text) : {} };
+}
+
+describe("license http transport", () => {
+  let store: LicenseStore;
+  let server: Server;
+  let url: string;
+  let issuedKey: string;
+
+  before(async () => {
+    store = new LicenseStore(":memory:");
+    issuedKey = store.issueLicense({ plan: "yearly", repoVisibilityScope: "private" }).rawKey;
+    const started = await startLicenseServer({
+      store,
+      rateLimiter: new RateLimiter({ maxPerWindow: 3, windowMs: 60_000 })
+    });
+    server = started.server;
+    url = started.url;
+  });
+
+  after(() => {
+    server.close();
+    store.close();
+  });
+
+  it("serves a health endpoint", async () => {
+    const res = await fetch(`${url}/healthz`);
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { status: "ok" });
+  });
+
+  it("rejects a malformed body → 400", async () => {
+    const res = await post(url, "/v1/license/activate", "{not json");
+    assert.equal(res.status, 400);
+  });
+
+  it("rejects a missing machineId → 400", async () => {
+    const res = await post(url, "/v1/license/activate", { licenseKey: issuedKey });
+    assert.equal(res.status, 400);
+  });
+
+  it("activates over HTTP and echoes no raw key", async () => {
+    const res = await post(url, "/v1/license/activate", { licenseKey: issuedKey, machineId: "m1" });
+    assert.equal(res.status, 200);
+    assert.equal(res.json.entitlement.status, "active");
+    assert.ok(!JSON.stringify(res.json).includes(issuedKey));
+  });
+
+  it("throttles once the per-key budget is exhausted → 429", async () => {
+    const key = fakeKey("rl");
+    store.issueLicense; // no-op guard so lint keeps the import
+    // Unknown key still counts against the limiter (per-key), so exhaust the budget.
+    await post(url, "/v1/license/validate", { licenseKey: key, machineId: "m" });
+    await post(url, "/v1/license/validate", { licenseKey: key, machineId: "m" });
+    await post(url, "/v1/license/validate", { licenseKey: key, machineId: "m" });
+    const throttled = await post(url, "/v1/license/validate", { licenseKey: key, machineId: "m" });
+    assert.equal(throttled.status, 429);
+    assert.equal(throttled.json.status, "rate_limited");
+  });
+});

--- a/services/license-api/test/service.test.ts
+++ b/services/license-api/test/service.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, describe, it } from "node:test";
+import { LicenseStore, hashLicenseKey } from "../src/store.ts";
+import {
+  activate,
+  deactivate,
+  RateLimiter,
+  validate,
+  type Entitlement,
+  type LicenseRequest,
+  type ServiceResult
+} from "../src/service.ts";
+
+const NOW = new Date("2026-07-06T00:00:00.000Z");
+// Fake keys constructed, never realistic literals (secret-scan CI).
+const fakeKey = (tag: string): string => ["nd", "live", `${tag}${"x".repeat(24 - tag.length)}`].join("_");
+
+function entitlement(result: ServiceResult): Entitlement {
+  const body = result.body as { entitlement?: Entitlement };
+  assert.ok(body.entitlement, "expected an entitlement body");
+  return body.entitlement;
+}
+
+describe("license service endpoints", () => {
+  let store: LicenseStore;
+  after(() => store?.close());
+  beforeEach(() => {
+    store?.close();
+    store = new LicenseStore(":memory:");
+  });
+
+  function issue(overrides: Partial<Parameters<LicenseStore["issueLicense"]>[0]> = {}): { key: string } {
+    const { rawKey } = store.issueLicense({ plan: "yearly", repoVisibilityScope: "private", ...overrides });
+    return { key: rawKey };
+  }
+
+  const req = (key: string, machineId: string, repo?: string): LicenseRequest => ({ licenseKey: key, machineId, repo });
+
+  it("activate binds a new machine and returns active with required fields", () => {
+    const { key } = issue();
+    const result = activate(store, req(key, "machine-a"), NOW);
+    assert.equal(result.httpStatus, 200);
+    const ent = entitlement(result);
+    assert.equal(ent.status, "active");
+    assert.equal(ent.repoVisibilityScope, "private");
+    assert.equal(typeof ent.updateEntitlement, "boolean");
+  });
+
+  it("activate is idempotent for the same machine", () => {
+    const { key } = issue();
+    activate(store, req(key, "machine-a"), NOW);
+    const again = activate(store, req(key, "machine-a"), NOW);
+    assert.equal(again.httpStatus, 200);
+    assert.equal(store.countActivations(hashLicenseKey(key)), 1);
+  });
+
+  it("activate rejects a different machine when seats are exhausted → 409 scope_mismatch", () => {
+    const { key } = issue({ seats: 1 });
+    activate(store, req(key, "machine-a"), NOW);
+    const rejected = activate(store, req(key, "machine-b"), NOW);
+    assert.equal(rejected.httpStatus, 409);
+    assert.equal((rejected.body as { status: string }).status, "scope_mismatch");
+  });
+
+  it("activate allows a second machine when seats remain", () => {
+    const { key } = issue({ seats: 2 });
+    activate(store, req(key, "machine-a"), NOW);
+    const second = activate(store, req(key, "machine-b"), NOW);
+    assert.equal(second.httpStatus, 200);
+  });
+
+  it("validate returns active for an activated machine", () => {
+    const { key } = issue();
+    activate(store, req(key, "machine-a"), NOW);
+    const result = validate(store, req(key, "machine-a"), NOW);
+    assert.equal(result.httpStatus, 200);
+    assert.equal(entitlement(result).status, "active");
+  });
+
+  it("validate rejects a never-activated machine → 409 scope_mismatch", () => {
+    const { key } = issue();
+    const result = validate(store, req(key, "machine-a"), NOW);
+    assert.equal(result.httpStatus, 409);
+  });
+
+  it("validate on a revoked license → 403 revoked", () => {
+    const { key } = issue();
+    activate(store, req(key, "machine-a"), NOW);
+    store.revokeLicense(key, "refund");
+    const result = validate(store, req(key, "machine-a"), NOW);
+    assert.equal(result.httpStatus, 403);
+    assert.equal((result.body as { status: string }).status, "revoked");
+  });
+
+  it("validate on an expired license → 402 expired", () => {
+    const { key } = issue({ expiresAt: "2020-01-01T00:00:00.000Z" });
+    activate(store, req(key, "machine-a"), new Date("2019-06-01T00:00:00.000Z"));
+    const result = validate(store, req(key, "machine-a"), NOW);
+    assert.equal(result.httpStatus, 402);
+    assert.equal((result.body as { status: string }).status, "expired");
+  });
+
+  it("unknown key → 404 invalid on activate and validate", () => {
+    assert.equal(activate(store, req(fakeKey("nope"), "machine-a"), NOW).httpStatus, 404);
+    assert.equal(validate(store, req(fakeKey("nope"), "machine-a"), NOW).httpStatus, 404);
+  });
+
+  it("deactivate frees the seat and is idempotent", () => {
+    const { key } = issue({ seats: 1 });
+    activate(store, req(key, "machine-a"), NOW);
+    const deactivated = deactivate(store, req(key, "machine-a"), NOW);
+    assert.equal(deactivated.httpStatus, 200);
+    assert.equal(store.countActivations(hashLicenseKey(key)), 0);
+    // Idempotent second call.
+    assert.equal(deactivate(store, req(key, "machine-a"), NOW).httpStatus, 200);
+    // Seat is free → a different machine can now activate.
+    assert.equal(activate(store, req(key, "machine-b"), NOW).httpStatus, 200);
+  });
+
+  it("never stores the raw key — only the sha256 hash", () => {
+    const { key } = issue();
+    const record = store.getLicenseByKey(key);
+    assert.ok(record);
+    assert.equal(record.licenseKeyHash, hashLicenseKey(key));
+    assert.notEqual(record.licenseKeyHash, key);
+    // No response body echoes the raw key.
+    const result = activate(store, req(key, "machine-a"), NOW);
+    assert.ok(!JSON.stringify(result).includes(key));
+  });
+
+  it("rate limiter throttles after the window budget", () => {
+    const limiter = new RateLimiter({ maxPerWindow: 2, windowMs: 1000 });
+    assert.equal(limiter.allow("k", 0), true);
+    assert.equal(limiter.allow("k", 10), true);
+    assert.equal(limiter.allow("k", 20), false);
+    // A different key is independent.
+    assert.equal(limiter.allow("other", 20), true);
+    // After the window slides, budget refreshes.
+    assert.equal(limiter.allow("k", 2000), true);
+  });
+});

--- a/services/license-api/tsconfig.json
+++ b/services/license-api/tsconfig.json
@@ -8,8 +8,8 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "rootDir": ".",
-    "types": ["node", "vitest/globals"]
+    "rootDir": "src",
+    "types": ["node"]
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts", "services/license-api/src/**/*.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/tests/license-service-contract.test.ts
+++ b/tests/license-service-contract.test.ts
@@ -1,0 +1,199 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  activateLicense,
+  deactivateLicense,
+  getLicenseStatus,
+  type LicenseConfig
+} from "../src/license.js";
+import { LicenseStore } from "../services/license-api/src/store.js";
+import { createLicenseRequestListener } from "../services/license-api/src/http.js";
+import { RateLimiter } from "../services/license-api/src/service.js";
+
+/**
+ * Load-bearing contract test (#327): drives the REAL shipped client
+ * (`src/license.ts`) against the REAL license service (`services/license-api`)
+ * through activate → validate → deactivate → reactivate-different-machine, and
+ * asserts the client parses each outcome into the correct LicenseStatus. This
+ * proves the HTTP contract the client already calls matches the service.
+ *
+ * The service and client run in-process: `fetchImpl` serializes the client's
+ * request, feeds it to the service's request listener via a mock
+ * IncomingMessage/ServerResponse pair, and returns the service's Response. It
+ * also rewrites `machineId` so a single test process can play multiple
+ * machines (the client hardcodes localMachineId()).
+ */
+
+interface MockService {
+  fetchFor(machineId: string): typeof fetch;
+}
+
+function buildInProcessService(): { service: MockService; store: LicenseStore; issueKey: () => string; close: () => void } {
+  const store = new LicenseStore(":memory:");
+  const listener = createLicenseRequestListener({
+    store,
+    // Generous limiter so the contract sequence is never throttled.
+    rateLimiter: new RateLimiter({ maxPerWindow: 1000, windowMs: 60_000 })
+  });
+
+  const fetchFor = (machineId: string): typeof fetch => {
+    return (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === "string" ? input : input.toString();
+      const path = new URL(url).pathname;
+      const originalBody = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      // Play the requested machine regardless of the client's localMachineId().
+      const body = JSON.stringify({ ...originalBody, machineId });
+
+      return await new Promise<Response>((resolve) => {
+        const chunks: Buffer[] = [];
+        const req: any = {
+          method: init?.method ?? "POST",
+          url: path,
+          on(event: string, cb: (arg?: unknown) => void) {
+            if (event === "data") cb(Buffer.from(body));
+            if (event === "end") cb();
+            return req;
+          },
+          destroy() {}
+        };
+        let statusCode = 200;
+        let headers: Record<string, string> = {};
+        const resChunks: string[] = [];
+        const res: any = {
+          writeHead(code: number, h: Record<string, string>) {
+            statusCode = code;
+            headers = h;
+            return res;
+          },
+          end(payload?: string) {
+            if (payload) resChunks.push(payload);
+            resolve(new Response(resChunks.join(""), { status: statusCode, headers }));
+          }
+        };
+        void listener(req, res);
+      });
+    }) as typeof fetch;
+  };
+
+  return {
+    service: { fetchFor },
+    store,
+    issueKey: () => store.issueLicense({ plan: "yearly", repoVisibilityScope: "private", seats: 1 }).rawKey,
+    close: () => store.close()
+  };
+}
+
+describe("client ↔ service contract (real src/license.ts against real service)", () => {
+  const roots: string[] = [];
+  const closers: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const close of closers.splice(0)) close();
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function makeConfig(root: string, apiBaseUrl: string): LicenseConfig {
+    return {
+      enabled: true,
+      apiBaseUrl,
+      cachePath: join(root, "entitlement.json"),
+      storageBackend: "file",
+      keyPath: join(root, "license.key"),
+      keychainService: "neondiff-test",
+      keychainAccount: "neondiff-test",
+      requestTimeoutMs: 5_000,
+      offlineGraceMs: 0,
+      publicReposFree: true,
+      privateReposRequireEntitlement: true,
+      updateEntitlementRequiresLicense: false
+    };
+  }
+
+  it("activate → validate → deactivate → reactivate-different-machine parses to correct LicenseStatus", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nd-contract-"));
+    roots.push(root);
+    const { service, issueKey, close } = buildInProcessService();
+    closers.push(close);
+    const config = makeConfig(root, "http://127.0.0.1:8080");
+    const key = issueKey();
+
+    // 1) activate on machine A → active
+    const activated = await activateLicense({
+      config,
+      licenseKey: key,
+      repo: "owner/private",
+      fetchImpl: service.fetchFor("machine-a")
+    });
+    expect(activated.ok).toBe(true);
+    expect(activated.status).toBe("active");
+    expect(activated.entitlement?.repoVisibilityScope).toBe("private");
+    expect(JSON.stringify(activated)).not.toContain(key);
+
+    // 2) validate on machine A (hot path, refresh:true reads stored key) → active
+    const validated = await getLicenseStatus({
+      config,
+      repo: "owner/private",
+      refresh: true,
+      fetchImpl: service.fetchFor("machine-a")
+    });
+    expect(validated.ok).toBe(true);
+    expect(validated.status).toBe("active");
+    expect(validated.source).toBe("api");
+
+    // 3) deactivate machine A (notify the API) → seat freed
+    const deactivated = await deactivateLicense({
+      config,
+      notifyApi: true,
+      fetchImpl: service.fetchFor("machine-a")
+    });
+    expect(deactivated.ok).toBe(true);
+    expect(deactivated.status).toBe("deactivated");
+    expect(deactivated.apiNotified).toBe(true);
+
+    // Re-activate machine A first so the single seat is taken again...
+    const reactivatedA = await activateLicense({
+      config,
+      licenseKey: key,
+      repo: "owner/private",
+      fetchImpl: service.fetchFor("machine-a")
+    });
+    expect(reactivatedA.status).toBe("active");
+
+    // 4) reactivate on a DIFFERENT machine while the seat is exhausted → scope_mismatch
+    const reactivatedB = await activateLicense({
+      config,
+      licenseKey: key,
+      repo: "owner/private",
+      fetchImpl: service.fetchFor("machine-b")
+    });
+    expect(reactivatedB.ok).toBe(false);
+    expect(reactivatedB.status).toBe("scope_mismatch");
+    expect(reactivatedB.classification).toBe("scope_mismatch");
+    expect(JSON.stringify(reactivatedB)).not.toContain(key);
+  });
+
+  it("client maps revoked and expired denials through the real service", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nd-contract-"));
+    roots.push(root);
+    const { service, store, issueKey, close } = buildInProcessService();
+    closers.push(close);
+    const config = makeConfig(root, "http://127.0.0.1:8080");
+
+    // revoked → client status "revoked"
+    const revokedKey = issueKey();
+    await activateLicense({ config, licenseKey: revokedKey, fetchImpl: service.fetchFor("machine-a") });
+    store.revokeLicense(revokedKey, "refund");
+    const revoked = await getLicenseStatus({ config, refresh: true, fetchImpl: service.fetchFor("machine-a") });
+    expect(revoked.status).toBe("revoked");
+
+    // unknown key → client status "invalid"
+    const unknown = await activateLicense({
+      config: makeConfig(mkdtempSync(join(tmpdir(), "nd-contract-")), "http://127.0.0.1:8080"),
+      licenseKey: ["nd", "live", `unknown${"x".repeat(17)}`].join("_"),
+      fetchImpl: service.fetchFor("machine-z")
+    });
+    expect(unknown.status).toBe("invalid");
+  });
+});


### PR DESCRIPTION
## Summary

PR 1 of #327: a self-contained `services/license-api/` package implementing the production license service the shipped client (`src/license.ts`) already calls. Service + admin issuance CLI + tests + docs only — **no deploy** (the fly.io deploy is a separate gated step).

- **Stack:** TypeScript + `node:sqlite` (`DatabaseSync`) matching the review worker's idiom (the repo uses `node:sqlite`, not `better-sqlite3`); ensure-pattern migrations. HTTP via `node:http` — no new framework dependency (the repo has no HTTP framework and Node 26's `node:http` is sufficient for this tier).
- **Data model:** `licenses(license_key_hash PK, plan, repo_visibility_scope, private_repo_allowed, update_entitlement, seats, expires_at, status, revocation_reason, created_at)` + `activations(license_key_hash, machine_id, repo, activated_at, last_seen_at, PK(hash, machine_id))`. Only `sha256(licenseKey)` is stored — never the raw key.
- **Admin CLI** (`services/license-api/src/admin.ts`, no payment rails): `issue` prints the raw key once and stores only the hash; `revoke` / `list` / `show` never print raw keys.
- **Security posture** (normal, not hardened, per spec): hash-at-rest, no raw-key logging/echo, per-key sliding-window rate limit, health endpoint.

## Contract-match table (endpoint × client expectation)

| Endpoint | Client expectation | Service behavior |
| --- | --- | --- |
| `POST /v1/license/activate` | 200 entitlement with required `status`+`repoVisibilityScope`; binds machine | insert `(hash, machineId)`, return `active`; same machine → idempotent |
| activate, seats exhausted, different machine | `409 → scope_mismatch` | `409 {status:"scope_mismatch"}` when a different machine and `count(activations) ≥ seats` |
| activate/validate, unknown key | `401/404 → invalid` | `404 {status:"invalid"}`, never echoes the key |
| activate/validate, revoked | `403/410 → revoked` | `403 {status:"revoked"}` (+ redacted reason) |
| activate/validate, expired | `402 → expired` | `402 {status:"expired"}` when `expiresAt` past or status expired |
| `POST /v1/license/validate` | active for a bound machine; hot path | verifies `(hash, machineId)` row, refreshes `last_seen_at`; never-activated → `409 scope_mismatch` |
| validate, abused | `429 → rate_limited` | per-key sliding-window limiter → `429 {status:"rate_limited"}` |
| `POST /v1/license/deactivate` | frees the seat; idempotent | deletes `(hash, machineId)`, returns `200 {status:"active"}` |
| malformed / missing machineId | 4xx | `400` |
| unexpected internal error | `5xx → server` | `500 {status:"server"}` |

Request body for all three: `{ licenseKey, repo?, machineId }`. Success entitlement always carries the required `status` + `repoVisibilityScope` the client rejects a success without.

## Validation

- **Load-bearing client contract test** — `tests/license-service-contract.test.ts` runs the **real** `src/license.ts` client against the **real** service in-process (a `fetchImpl` feeds the client's request to the service's request listener; it rewrites `machineId` so one process can play multiple machines). It drives `activate → validate → deactivate → reactivate-different-machine` and asserts the client parses each into the correct `LicenseStatus` (`active`, `active`, `deactivated`, `scope_mismatch`), plus revoked→`revoked` and unknown→`invalid`. This proves the contract matches.
- **Service unit tests** (`node:test` via `tsx`, 22 tests): activate-new / idempotent-same-machine / reject-different-machine-seat-exhausted, validate-active / never-activated / revoked→403 / expired→402, deactivate-frees-seat, unknown→404, rate-limit→429, malformed→400, health, and key-never-stored-raw.
- Focused runs only (never the full suite): `vitest run tests/license-service-contract.test.ts`, `node --import tsx --test test/*.test.ts`, `npm run build` — all green. Fake keys are constructed (`["nd","live",…].join("_")`), never realistic literals.

## Proof boundary

Service + admin issuance only. **No payment rails** (keys are minted by the admin CLI). **No deploy** — the fly.io deploy (staging → owner confirm → prod, plus wiring the prod URL into `docs/public-release-manifest.json`) is a separate gated step and is intentionally not in this PR. **No change to the shipped client** (`src/license.ts` is unmodified). The only touch outside `services/` and the new contract test is `tsconfig.json`'s `include`, so the root typecheck sees the service source the contract test imports.