### PR TITLE
Part of #327

### DIFF
--- a/services/license-api/.dockerignore
+++ b/services/license-api/.dockerignore
@@ -1,0 +1,26 @@
+# Applies when building with build context = repo root:
+#   docker build -f services/license-api/Dockerfile .
+# (see Dockerfile header). Keeps the build context small and keeps local
+# SQLite files / dependency trees out of the image entirely.
+
+**/node_modules
+**/dist
+**/.git
+
+# Local SQLite databases (never ship real data in the image).
+**/runtime/
+**/*.sqlite
+**/*.sqlite-shm
+**/*.sqlite-wal
+**/*.db
+
+# Tests and dev-only files — not needed in the build or runtime image.
+services/license-api/test
+**/*.test.ts
+**/vitest.config.*
+
+# Editor/OS cruft and secrets.
+**/.env
+**/.env.*
+**/*.pem
+**/.DS_Store

--- a/services/license-api/Dockerfile
+++ b/services/license-api/Dockerfile
@@ -1,0 +1,56 @@
+# syntax=docker/dockerfile:1
+
+# NeonDiff license-api (#327) — deploy image.
+#
+# Build context MUST be the monorepo root (not this directory), because the
+# service has zero runtime dependencies of its own and its `tsc` build tool
+# comes from the root devDependency (see ../../package.json). Build with:
+#   docker build -f services/license-api/Dockerfile -t neondiff-license .
+# from the repo root.
+#
+# Runtime is Node stdlib only (node:http, node:sqlite, node:fs, node:path) —
+# no npm dependencies are installed in the final image.
+
+ARG NODE_VERSION=26-slim
+
+# ---- build stage -----------------------------------------------------------
+FROM node:${NODE_VERSION} AS build
+WORKDIR /repo
+
+# Root manifest + lockfile first for layer caching.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Service source (package.json/tsconfig.json only needed for `tsc -p`).
+COPY services/license-api/package.json services/license-api/tsconfig.json services/license-api/
+COPY services/license-api/src services/license-api/src
+
+# Compile via the service's own build script, using the root-installed
+# TypeScript devDependency. Output: services/license-api/dist/*.js
+RUN npx --prefix . tsc -p services/license-api/tsconfig.json
+
+# ---- runtime stage ----------------------------------------------------------
+FROM node:${NODE_VERSION} AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+
+# Compiled output only — no node_modules, no source, no devDependencies.
+COPY --from=build /repo/services/license-api/dist ./dist
+COPY services/license-api/package.json ./package.json
+
+# SQLite lives on a mounted volume; the app creates the file (and any missing
+# parent directories) itself on startup via mkdirSync — see src/store.ts.
+# The mount point just needs to exist so the volume can attach to it.
+RUN mkdir -p /data
+VOLUME ["/data"]
+
+ENV LICENSE_DB_PATH=/data/license.sqlite
+ENV PORT=8080
+ENV HOST=0.0.0.0
+EXPOSE 8080
+
+# Runs unprivileged: node:*-slim images ship a non-root "node" user.
+USER node
+
+# Matches the service's own `"start": "node dist/server.js"` exactly.
+CMD ["node", "dist/server.js"]

--- a/services/license-api/README.md
+++ b/services/license-api/README.md
@@ -74,10 +74,13 @@ See [`docs/admin-runbook.md`](docs/admin-runbook.md) for the operator runbook.
 ## Deploy
 
 Deploy is a **separate, gated step** (not part of the PR that adds this
-service). The target is fly.io with SQLite on a mounted volume; the orchestrator
-drives `flyctl` (staging → owner confirm → production) and wires the prod URL
-into `docs/public-release-manifest.json`'s `licenseApi` slot once live. No
-secrets live in the repo.
+service). The target is fly.io with SQLite on a mounted volume; the owner
+drives `flyctl` (login → launch → volume → deploy → verify → promote) and
+wires the prod URL into `docs/public-release-manifest.json`'s `licenseApi`
+slot once live. No secrets live in the repo.
+
+Deploy-ready assets (`Dockerfile`, `fly.toml`, `.dockerignore`) and the exact
+command sequence live at [`docs/deploy.md`](docs/deploy.md).
 
 ## Tests
 

--- a/services/license-api/docs/admin-runbook.md
+++ b/services/license-api/docs/admin-runbook.md
@@ -4,6 +4,8 @@ Operator procedures for the NeonDiff license service
 ([#327](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327)).
 This runbook covers key issuance and lifecycle. It does **not** cover payment,
 billing, or deploy — deploy is a separate gated step driven by the orchestrator.
+See [`deploy.md`](deploy.md) for the fly.io deploy sequence (`Dockerfile`,
+`fly.toml`, volume/secrets setup, and rollback).
 
 All commands open the SQLite database at `LICENSE_DB_PATH`. In production this is
 the file on the mounted fly volume; run the CLI on the instance (or against a

--- a/services/license-api/docs/deploy.md
+++ b/services/license-api/docs/deploy.md
@@ -1,0 +1,167 @@
+# License API deploy runbook (fly.io)
+
+Deploy assets for `services/license-api` (#327): `Dockerfile`, `fly.toml`,
+`.dockerignore`. This document is the deploy sequence for the owner to run.
+**Nothing in this PR executes a deploy** — `flyctl` is unauthenticated on the
+machine that produced these assets; every command below is an owner step,
+run interactively after `flyctl auth login`.
+
+See also: [`admin-runbook.md`](admin-runbook.md) (key issuance/lifecycle —
+does not cover deploy) and the service [`README.md`](../README.md) (HTTP
+contract, env vars, local run).
+
+## Why this endpoint exists (scope reminder)
+
+License gating is **client-side and private-repo only**: public repos are
+free and never call this service (`publicReposFree: true` in
+`config.example.json`; see the client at `src/license.ts` and the contract
+description in `README.md`). This deploy stands up the backend that
+`activate` / `validate` / `deactivate` calls hit **only when a user has
+enabled license enforcement for a private repo**. There is no scenario where
+this service being down affects a public-repo user.
+
+## Prerequisites
+
+- `flyctl` installed (`brew install flyctl` or see fly.io docs) and
+  authenticated: `flyctl auth login`.
+- Repo root as the build context — the Dockerfile compiles the service using
+  the root `typescript` devDependency (the service itself has zero runtime
+  npm dependencies; see `Dockerfile` header comment). Run every `flyctl`
+  command below **from the repo root**, not from `services/license-api/`.
+
+## 1. Create the app (no deploy yet)
+
+```sh
+flyctl launch --no-deploy \
+  --config services/license-api/fly.toml \
+  --dockerfile services/license-api/Dockerfile \
+  --name neondiff-license   # placeholder in fly.toml — pick the real name here
+```
+
+`--no-deploy` creates the app and lets `flyctl` reconcile `fly.toml` without
+shipping a build yet. If the app already exists (re-running this later),
+use `flyctl apps create <name>` instead, or skip straight to volumes.
+
+## 2. Create the volume
+
+SQLite (`node:sqlite`, see `src/store.ts`) is a single-writer embedded file
+DB on local disk — it needs a Fly Volume, and the volume is machine-pinned
+(see the `fly.toml` comment block on `min_machines_running`). Create it in
+the **same region** as `primary_region` in `fly.toml`:
+
+```sh
+flyctl volumes create license_data --region iad --size 1 \
+  --app neondiff-license
+```
+
+- `1` GB is generous for a license SQLite file (activation rows are tiny);
+  resize later with `flyctl volumes extend` if ever needed.
+- The volume name (`license_data`) must match `[mounts].source` in
+  `fly.toml`.
+
+## 3. Secrets
+
+**None required for pass 1.** The service takes no API keys, auth tokens, or
+third-party credentials — it's a self-contained SQLite-backed HTTP service
+(`LICENSE_DB_PATH` / `PORT` / `HOST` are plain config, already set as
+`[env]` in `fly.toml`, not secrets). If a future pass adds e.g. an admin-CLI
+auth token for remote issuance, set it with:
+
+```sh
+flyctl secrets set SOME_KEY=value --app neondiff-license
+```
+
+## 4. Deploy
+
+```sh
+flyctl deploy \
+  --config services/license-api/fly.toml \
+  --dockerfile services/license-api/Dockerfile \
+  --app neondiff-license
+```
+
+Watch the health check pass (`GET /healthz` → `{ "status": "ok" }`, wired in
+`fly.toml` under `[http_service.checks.healthz]`). `flyctl status --app
+neondiff-license` shows machine + volume state; `flyctl logs --app
+neondiff-license` streams the `license-api listening on …` boot line from
+`src/server.ts`.
+
+## 5. Point a client config at the deployed URL
+
+**Use a copy of the client config, not the committed one** — this step is
+for verifying the deploy, not for flipping enforcement on for real users
+yet. Take `config.example.json`, copy it somewhere scratch, and set:
+
+```jsonc
+{
+  "license": {
+    "enabled": true,
+    "apiBaseUrl": "https://neondiff-license.fly.dev"  // your app's URL
+  }
+}
+```
+
+(`apiBaseUrl` is the exact field the client reads — see
+`src/license.ts`, `config.example.json`'s `_apiBaseUrlComment`.)
+
+## 6. Verify: contract + a live smoke check
+
+Two different things, both worth doing:
+
+- **Contract test (pre-deploy correctness, already covered):**
+  `npm test` at the repo root runs
+  `tests/license-service-contract.test.ts`, which drives the real client
+  (`src/license.ts`) against the real service in-process (mocked
+  request/response objects, no network) through
+  activate → validate → deactivate → reactivate-different-machine. This
+  proves the HTTP contract shape is correct *before* you ever deploy — it
+  does not hit a live URL, so it's not a substitute for step 2 below, but
+  there's no need to re-run it post-deploy unless the service code changed.
+- **Live smoke check against the real URL (do this post-deploy):** issue a
+  throwaway key on the deployed instance and drive the three endpoints
+  directly:
+
+  ```sh
+  # on the fly machine, or against a copy of the volume — see admin-runbook.md
+  flyctl ssh console --app neondiff-license -C \
+    "LICENSE_DB_PATH=/data/license.sqlite node dist/admin.js issue --plan yearly --scope private --seats 1"
+  # copy the printed key, then from your workstation:
+  curl -s https://neondiff-license.fly.dev/healthz
+  curl -s -X POST https://neondiff-license.fly.dev/v1/license/activate \
+    -H 'Content-Type: application/json' \
+    -d '{"licenseKey":"<key from above>","machineId":"smoke-test-1"}'
+  ```
+
+  Confirm `/healthz` returns `{"status":"ok"}` and `activate` returns a
+  `200` with an `entitlement` object. Revoke the throwaway key afterward
+  (`admin.js revoke --key … --reason "deploy smoke test"`) so it doesn't
+  linger as a live, unaccounted-for seat.
+
+## 7. Promote
+
+Only after the live smoke check passes: wire the real URL into
+`docs/public-release-manifest.json`'s `licenseApi` slot (currently
+`"state": "pending"`) and flip `license.enabled` / `apiBaseUrl` in the
+actual shipped config for the release that turns enforcement on. This is a
+separate, deliberate change — do not fold it into a deploy-assets PR.
+
+## Rollback
+
+- **Bad release, service still reachable:** `flyctl releases --app
+  neondiff-license` to list, then `flyctl deploy --image <previous image
+  ref>` (or `flyctl releases rollback` if available on your `flyctl`
+  version) to go back to the last good image. The SQLite volume is
+  untouched by an image rollback — activations/keys persist.
+- **Service unreachable / stuck:** `flyctl apps restart neondiff-license`.
+  If a bad migration or admin action corrupted data, restore from a Fly
+  volume snapshot (`flyctl volumes snapshots list` /
+  `flyctl volumes create --snapshot-id …` to a fresh volume, then swap the
+  mount) — there is no in-app migration system today, so data-level
+  recovery is volume-snapshot only.
+- **Emergency full stop:** `flyctl scale count 0 --app neondiff-license`
+  stops serving entirely. Since license checks fail closed only for
+  *private* repos with enforcement enabled, this is a safe last resort — it
+  does not affect public-repo users, and existing private-repo users just
+  see their entitlement checks start failing (client behavior on
+  `apiBaseUrl` unreachable is a server-classified failure, not a silent
+  allow — see `README.md`'s HTTP-code table) until service is restored.

--- a/services/license-api/fly.toml
+++ b/services/license-api/fly.toml
@@ -1,0 +1,73 @@
+# NeonDiff license-api (#327) — fly.io app config.
+#
+# Placeholder app name — the owner renames this at deploy time
+# (`flyctl launch` will prompt, or edit `app` below before `flyctl deploy`).
+app = "neondiff-license"
+primary_region = "iad"  # placeholder — set to wherever the fleet/owner is closest to.
+
+[build]
+  dockerfile = "Dockerfile"
+
+# Build context must be the repo root (the Dockerfile compiles the service
+# with the root TypeScript devDependency). Deploy from the repo root with:
+#   flyctl deploy --config services/license-api/fly.toml --dockerfile services/license-api/Dockerfile
+# or `cd` to repo root first so relative paths resolve; see docs/deploy.md.
+
+[env]
+  PORT = "8080"
+  HOST = "0.0.0.0"
+  LICENSE_DB_PATH = "/data/license.sqlite"
+
+# --- Storage -----------------------------------------------------------------
+# SQLite (node:sqlite, see src/store.ts) is a single-writer embedded file DB —
+# it lives on ONE machine's local volume, not shared/replicated storage. A Fly
+# Volume is machine-pinned, so this app must run as a single machine bound to
+# that volume (no horizontal scaling across machines without moving the DB to
+# a real network-attached store first).
+[mounts]
+  source = "license_data"
+  destination = "/data"
+
+# --- HTTP service --------------------------------------------------------------
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = false   # see min_machines_running note below
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [http_service.checks]
+    [http_service.checks.healthz]
+      grace_period = "10s"
+      interval = "15s"
+      method = "GET"
+      path = "/healthz"
+      protocol = "http"
+      timeout = "5s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"
+
+# --- Why min_machines_running = 1 (not 0) --------------------------------------
+# This is a licensing gate for PAID private-repo entitlements (see README.md /
+# docs/admin-runbook.md) — every `activate`/`validate` call on a private repo
+# blocks on this service being reachable. Two reasons to keep it warm instead
+# of scale-to-zero:
+#   1. UX: scale-to-zero means the first request after idle eats a cold-start
+#      (new machine boot + SQLite file open) before a customer's private-repo
+#      review can proceed — a bad place to add multi-second latency.
+#   2. Volume semantics: Fly volumes are machine-local. Scaling to zero and
+#      letting Fly schedule the next start on a DIFFERENT machine in the same
+#      region would detach it from this app's existing volume mount unless
+#      it's the same single machine/volume pairing Fly already tracks — safer
+#      to just keep the one machine (and its attached volume) continuously
+#      running than to lean on stop/start + reattach behavior for a database.
+# Public repos never call this service at all (license gating is client-side
+# and only fires for private repos — see README.md "Contract"), so traffic
+# here is inherently low-volume; the cost of staying warm on a single
+# shared-cpu-1x/256mb machine is small relative to the availability win.
+#
+# If cost becomes a real concern later: raise `auto_stop_machines` cautiously
+# only after confirming Fly's volume-reattach behavior for this app, and only
+# with a single machine (never > 1 with a single SQLite volume).


### PR DESCRIPTION
## Summary

Deploy assets for the merged license service (`services/license-api/`, #327) — this PR makes it **deploy-ready**, it does not deploy anything.

- `Dockerfile` — multi-stage build. Build context is the **repo root** (the service has zero runtime npm dependencies — pure `node:http`/`node:sqlite`/`node:fs`/`node:path` — and its `tsc` build tool comes from the root `typescript` devDependency, since there's no workspaces setup). Build stage: `npm ci` + `tsc -p services/license-api/tsconfig.json`. Runtime stage: `node:26-slim` (matches root `engines: {"node": ">=26"}`), only the compiled `dist/*.js` is copied in, runs as the non-root `node` user.
- `fly.toml` — app config: `[http_service]` on port 8080 with `/healthz` health checks, a mounted volume at `/data` for SQLite, `min_machines_running = 1` / `auto_stop_machines = false` (documented inline: this gates paid private-repo entitlements, and Fly volumes are machine-pinned so scale-to-zero risks a bad reattach story for a single-writer SQLite file — see the comment block in the file). Placeholder app name `neondiff-license`.
- `.dockerignore` — excludes `node_modules`, `dist`, tests, local `*.sqlite*`/`runtime/`, secrets/env files.
- `docs/deploy.md` (new) — the exact `flyctl` sequence: `auth login` → `launch --no-deploy` → `volumes create` → `secrets set` (none needed for pass 1 — the service takes no third-party credentials) → `deploy` → point a **copied** client config's `license.apiBaseUrl` at the app URL → verify (existing in-process contract test + a live curl-based smoke check against the deployed URL, since the current contract test doesn't hit real network) → promote (wire the URL into `docs/public-release-manifest.json`'s `licenseApi` slot). Includes a rollback section (image rollback, volume snapshot restore, emergency `scale count 0`). Cross-linked from `README.md` and `admin-runbook.md`.
- Explicit scope note in `docs/deploy.md`: public repos are free and client-side gated — this endpoint only ever serves private-repo key checks (`activate`/`validate`/`deactivate`).

## Entrypoint/port/env/volume mapping

| Service reality (`src/server.ts`, `package.json`) | Deploy asset |
| --- | --- |
| `"start": "node dist/server.js"` | Dockerfile `CMD ["node", "dist/server.js"]` |
| `tsc -p tsconfig.json` build script | Dockerfile build stage `RUN` line, same `-p` path |
| `PORT` env, default `8080` | `fly.toml` `[env] PORT = "8080"`, `internal_port = 8080` |
| `HOST` env, default `0.0.0.0` | `fly.toml` `[env] HOST = "0.0.0.0"` |
| `LICENSE_DB_PATH` env, SQLite file | `fly.toml` `[env] LICENSE_DB_PATH = "/data/license.sqlite"` + `[mounts] destination = "/data"` |
| `GET /healthz` → `{"status":"ok"}` | `fly.toml` `[http_service.checks.healthz]` path `/healthz` |
| `store.ts` `mkdirSync(dirname(dbPath), {recursive:true})` | Volume mount point just needs to exist — Dockerfile does `mkdir -p /data`, app creates the file itself |

## Validation

- Docker daemon isn't available on this machine (CLI installed, no Docker Desktop app, daemon unreachable) — **did not** `docker build`. Instead did a faithful outside-Docker simulation of both stages in a scratch dir: copied the exact files the Dockerfile `COPY`s, ran the exact `npm ci` + `tsc -p services/license-api/tsconfig.json` build-stage command (succeeded, produced `dist/server.js`), then ran the exact runtime `CMD` (`node dist/server.js`) with the exact env vars against the compiled output — confirmed `/healthz` returns `{"status":"ok"}` and the SQLite file auto-creates at the configured path. Every `COPY` source/dest path was cross-checked against the real repo layout.
- `services/license-api`'s own test suite: `npm run build` (tsc) + `node --import tsx --test test/*.test.ts` → **22/22 pass**.
- Root `npm run build` (`tsc -p tsconfig.json` + postbuild chmod) → green, confirming the added files don't touch or break the root build.
- `git status` after all edits: exactly the 4 new files + 2 doc cross-reference edits (`README.md`, `admin-runbook.md`), nothing else touched.

## Proof boundary

Deploy assets + runbook only. **No deploy was executed.** `flyctl` is unauthenticated on this machine by design — `flyctl auth login` and every command in `docs/deploy.md` (app creation, volume creation, deploy, promotion) is an owner step to run interactively, separately from this PR.