### PR TITLE
Weighted relevance scoring for related-context references (#119, R8)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -875,6 +875,29 @@ function validateGitHubRelatedContextConfig(value: unknown, label: string): void
   if (typeof value.maxTitleChars === "number" && value.maxTitleChars < 20) {
     throw new Error(`${label}.maxTitleChars must be at least 20`);
   }
+  if (value.relevanceScoring !== undefined) {
+    validateRelevanceScoringConfig(value.relevanceScoring, `${label}.relevanceScoring`);
+  }
+}
+
+function validateRelevanceScoringConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  for (const key of Object.keys(value)) {
+    if (key !== "enabled" && key !== "weights") {
+      throw new Error(`${label} has unknown key "${key}"; expected only enabled or weights`);
+    }
+  }
+  validateBoolean(value.enabled, `${label}.enabled`);
+  if (value.weights !== undefined) {
+    if (!isRecord(value.weights)) throw new Error(`${label}.weights must be an object`);
+    const allowed = new Set(["kind", "pathOverlap", "lexical", "recency", "state"]);
+    for (const [key, weight] of Object.entries(value.weights)) {
+      if (!allowed.has(key)) throw new Error(`${label}.weights has unknown key "${key}"`);
+      if (typeof weight !== "number" || !Number.isFinite(weight) || weight < 0 || weight > 1) {
+        throw new Error(`${label}.weights.${key} must be a number from 0 to 1`);
+      }
+    }
+  }
 }
 
 function validateSkillPacksConfig(value: unknown, label: string): void {

--- a/src/github-related-context.ts
+++ b/src/github-related-context.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
-import type { PullRequestSummary } from "./types.js";
+import type { PullFilePatch, PullRequestSummary } from "./types.js";
 
 export const GITHUB_RELATED_CONTEXT_PACKET_VERSION = "github-related-context-packet-v0.1";
 export const GITHUB_RELATED_CONTEXT_ADVISORY_LINE =
@@ -15,6 +15,38 @@ export interface GitHubRelatedContextConfig {
   maxPacketBytes: number;
   requestTimeoutMs: number;
   includeCrossRepoRefs: boolean;
+  /** Weighted relevance ranking (#119 R8, default off). Absent/disabled ⇒ byte-identical ordering. */
+  relevanceScoring?: RelevanceScoringConfig;
+}
+
+export interface RelevanceScoringConfig {
+  enabled: boolean;
+  weights?: Partial<RelevanceWeights>;
+}
+
+export interface RelevanceWeights {
+  kind: number;
+  pathOverlap: number;
+  lexical: number;
+  recency: number;
+  state: number;
+}
+
+/** Default component weights: `kind` dominates (preserving today's closing-ref-first ordering). */
+export const DEFAULT_RELEVANCE_WEIGHTS: RelevanceWeights = {
+  kind: 1,
+  pathOverlap: 0.6,
+  lexical: 0.4,
+  recency: 0.2,
+  state: 0.3
+};
+
+export interface RelevanceComponents {
+  kind: number;
+  pathOverlap: number;
+  lexical: number;
+  recency: number;
+  state: number;
 }
 
 export type GitHubReferenceSource = "title" | "body";
@@ -93,11 +125,19 @@ export interface GitHubRelatedContextPacket {
   redactionReportSha256: string;
 }
 
+export interface RelevanceBreakdownEntry {
+  id: string;
+  score: number;
+  components: RelevanceComponents;
+}
+
 export type GitHubRelatedContextBuildResult =
   | {
       ok: true;
       packet: GitHubRelatedContextPacket;
       redactionReport: GitHubRelatedContextRedactionReport;
+      /** Per-reference relevance breakdown (#119 R8); present only when relevanceScoring is enabled. */
+      relevanceBreakdown?: RelevanceBreakdownEntry[];
     }
   | {
       ok: false;
@@ -111,6 +151,9 @@ export async function buildGitHubRelatedContextPacket(input: {
   pull: PullRequestSummary;
   config: GitHubRelatedContextConfig;
   reader: GitHubRelatedContextReader;
+  /** Changed files (already fetched for the review). Feeds pathOverlap/lexical when relevanceScoring
+   * is enabled; ignored (and the ordering byte-identical) when disabled. */
+  files?: PullFilePatch[];
   generatedAt?: string;
 }): Promise<GitHubRelatedContextBuildResult> {
   validateConfig(input.config);
@@ -144,6 +187,8 @@ export async function buildGitHubRelatedContextPacket(input: {
   }
 
   const fetched: GitHubRelatedReference[] = [];
+  // Internal-only: updated_at per fetched ref feeds recency/state scoring; never rendered into the packet.
+  const updatedAtById = new Map<string, string | null | undefined>();
   const redactionSources: Array<{ id: string; text: string }> = [];
   for (let index = 0; index < boundedRefs.length; index += 1) {
     const ref = boundedRefs[index]!;
@@ -165,6 +210,7 @@ export async function buildGitHubRelatedContextPacket(input: {
       const milestone = item.milestone?.title ? truncateChars(redactSecrets(item.milestone.title), input.config.maxTitleChars) : undefined;
       const bodyExcerpt = item.body ? truncateBytes(redactSecrets(item.body), input.config.maxBodyBytes) : undefined;
       redactionSources.push({ id, text: `${item.title ?? ""}\n${item.html_url ?? ""}\n${item.body ?? ""}` });
+      updatedAtById.set(id, item.updated_at);
       fetched.push({
         repo: ref.repo,
         number: ref.number,
@@ -199,6 +245,18 @@ export async function buildGitHubRelatedContextPacket(input: {
     }
   }
 
+  // Relevance re-ordering (#119 R8) operates ONLY on the already-fetched, already-capped references —
+  // packet bounds, redaction, and omitted-reference reporting are untouched. Disabled/absent ⇒ the
+  // exact existing compareReferences order (byte-identical).
+  const ordered = orderReferencesByRelevance({
+    references: fetched,
+    config: input.config,
+    prTitle: input.pull.title,
+    files: input.files ?? [],
+    updatedAtById,
+    now: new Date(generatedAt)
+  });
+
   const base = {
     repo: input.repo,
     pullNumber: input.pull.number,
@@ -207,7 +265,7 @@ export async function buildGitHubRelatedContextPacket(input: {
     packetVersion: input.config.packetVersion,
     generatedAt,
     advisory: GITHUB_RELATED_CONTEXT_ADVISORY_LINE,
-    references: fetched.sort(compareReferences),
+    references: ordered.references,
     omittedReferences: omittedReferences.sort(compareOmitted)
   };
   const budgeted = renderWithinBudget(base, input.config.maxPacketBytes);
@@ -249,7 +307,7 @@ export async function buildGitHubRelatedContextPacket(input: {
     tokenEstimate: Math.max(1, Math.ceil(Buffer.byteLength(budgeted.markdown, "utf8") / 4)),
     redactionReportSha256: sha256(JSON.stringify(redactionReport))
   };
-  return { ok: true, packet, redactionReport };
+  return { ok: true, packet, redactionReport, ...(ordered.breakdown ? { relevanceBreakdown: ordered.breakdown } : {}) };
 }
 
 export function extractGitHubReferences(input: { repo: string; title?: string | null; body?: string | null }): ExtractedGitHubReference[] {
@@ -328,7 +386,9 @@ function renderWithinBudget(input: {
   references: GitHubRelatedReference[];
   omittedReferences: GitHubRelatedOmittedReference[];
 } {
-  const references = [...input.references].sort(compareReferences);
+  // Preserve the caller's ordering (already sorted upstream: compareReferences when relevance is
+  // disabled, or the relevance ranking when enabled). Budget drops trim from the low-priority tail.
+  const references = [...input.references];
   const omittedReferences = [...input.omittedReferences].sort(compareOmitted);
   for (;;) {
     const markdown = renderMarkdown({ ...input, references, omittedReferences });
@@ -418,6 +478,151 @@ function rankReference(ref: ExtractedGitHubReference): number {
   return (ref.relationship === "closing" ? 0 : 10) + (ref.source === "body" ? 0 : 1);
 }
 
+const RECENCY_HALF_LIFE_MS = 30 * 24 * 60 * 60_000; // 30-day half-life decay
+const RECENTLY_CLOSED_MS = 30 * 24 * 60 * 60_000; // a closed ref updated within 30d is "recently closed"
+const RELEVANCE_STOPWORDS = new Set([
+  "the", "a", "an", "and", "or", "of", "to", "in", "on", "for", "with", "is", "are", "be", "fix", "fixes",
+  "add", "adds", "update", "updates", "issue", "pr", "bug", "when", "that", "this", "from", "into", "via"
+]);
+
+/**
+ * Pure, deterministic, hermetic relevance score for a related-context reference (#119 R8, pass 1).
+ * Computed only from data the packet builder already has — no API calls, no embeddings, no graph
+ * distance (graph distance is an explicit pass-2 candidate, gated on #344). score = Σ wᵢ·componentᵢ;
+ * each component is in [0,1]. `kind` preserves today's closing-ref-first dominance under default
+ * weights. The component breakdown is returned so the ranking is replayable and evidence-inspectable.
+ */
+export function scoreReferenceRelevance(input: {
+  reference: {
+    relationship: GitHubReferenceRelationship;
+    source: GitHubReferenceSource;
+    state: string;
+    title: string;
+    bodyExcerpt?: string;
+    updatedAt?: string | null;
+  };
+  prTitle: string;
+  changedPaths: string[];
+  hunkHeaders: string[];
+  weights: RelevanceWeights;
+  now: Date;
+}): { score: number; components: RelevanceComponents } {
+  const ref = input.reference;
+  const components: RelevanceComponents = {
+    kind: ref.relationship === "closing" ? 1 : ref.source === "title" ? 0.5 : 0,
+    pathOverlap: pathOverlapComponent(`${ref.title} ${ref.bodyExcerpt ?? ""}`, input.changedPaths),
+    lexical: lexicalComponent(ref.title, `${input.prTitle} ${input.hunkHeaders.join(" ")}`),
+    recency: recencyComponent(ref.updatedAt, input.now),
+    state: stateComponent(ref.state, ref.updatedAt, input.now)
+  };
+  const w = input.weights;
+  const score =
+    w.kind * components.kind +
+    w.pathOverlap * components.pathOverlap +
+    w.lexical * components.lexical +
+    w.recency * components.recency +
+    w.state * components.state;
+  return { score, components };
+}
+
+function orderReferencesByRelevance(input: {
+  references: GitHubRelatedReference[];
+  config: GitHubRelatedContextConfig;
+  prTitle: string;
+  files: PullFilePatch[];
+  updatedAtById: Map<string, string | null | undefined>;
+  now: Date;
+}): { references: GitHubRelatedReference[]; breakdown?: RelevanceBreakdownEntry[] } {
+  const relevance = input.config.relevanceScoring;
+  if (!relevance?.enabled) {
+    // Disabled/absent ⇒ byte-identical to today.
+    return { references: [...input.references].sort(compareReferences) };
+  }
+  const weights: RelevanceWeights = { ...DEFAULT_RELEVANCE_WEIGHTS, ...(relevance.weights ?? {}) };
+  const changedPaths = input.files.map((file) => file.filename);
+  const hunkHeaders = input.files.flatMap((file) => extractHunkHeaders(file.patch ?? ""));
+  const scored = input.references.map((reference) => {
+    const id = `${reference.repo}#${reference.number}`;
+    const { score, components } = scoreReferenceRelevance({
+      reference: {
+        relationship: reference.relationship,
+        source: reference.source,
+        state: reference.state,
+        title: reference.title,
+        ...(reference.bodyExcerpt ? { bodyExcerpt: reference.bodyExcerpt } : {}),
+        updatedAt: input.updatedAtById.get(id)
+      },
+      prTitle: input.prTitle,
+      changedPaths,
+      hunkHeaders,
+      weights,
+      now: input.now
+    });
+    return { reference, id, score, components };
+  });
+  // Highest score first; deterministic tie-break via the existing compareReferences so the order is
+  // stable and replayable.
+  scored.sort((left, right) => right.score - left.score || compareReferences(left.reference, right.reference));
+  return {
+    references: scored.map((entry) => entry.reference),
+    breakdown: scored.map((entry) => ({ id: entry.id, score: entry.score, components: entry.components }))
+  };
+}
+
+function extractHunkHeaders(patch: string): string[] {
+  return patch.split("\n").filter((line) => line.startsWith("@@"));
+}
+
+function pathSegments(paths: string[]): Set<string> {
+  const segments = new Set<string>();
+  for (const path of paths) {
+    for (const segment of path.toLowerCase().split(/[\/.]+/)) {
+      if (segment.length >= 3) segments.add(segment);
+    }
+  }
+  return segments;
+}
+
+function pathOverlapComponent(refText: string, changedPaths: string[]): number {
+  const changed = pathSegments(changedPaths);
+  if (changed.size === 0) return 0;
+  const refTokens = new Set(refText.toLowerCase().split(/[^a-z0-9]+/).filter((token) => token.length >= 3));
+  if (refTokens.size === 0) return 0;
+  let hits = 0;
+  for (const segment of changed) if (refTokens.has(segment)) hits += 1;
+  return hits / changed.size;
+}
+
+function relevanceTokens(text: string): Set<string> {
+  return new Set(
+    text.toLowerCase().split(/[^a-z0-9]+/).filter((token) => token.length >= 3 && !RELEVANCE_STOPWORDS.has(token))
+  );
+}
+
+function lexicalComponent(refTitle: string, prText: string): number {
+  const a = relevanceTokens(refTitle);
+  const b = relevanceTokens(prText);
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const token of a) if (b.has(token)) intersection += 1;
+  return intersection / (a.size + b.size - intersection); // Jaccard
+}
+
+function recencyComponent(updatedAt: string | null | undefined, now: Date): number {
+  if (!updatedAt) return 0;
+  const updatedMs = Date.parse(updatedAt);
+  if (!Number.isFinite(updatedMs)) return 0;
+  const ageMs = Math.max(0, now.getTime() - updatedMs);
+  return 2 ** (-ageMs / RECENCY_HALF_LIFE_MS); // exponential decay, 1.0 fresh → 0 old
+}
+
+function stateComponent(state: string, updatedAt: string | null | undefined, now: Date): number {
+  if (state.toLowerCase() === "open") return 1;
+  const updatedMs = updatedAt ? Date.parse(updatedAt) : NaN;
+  if (Number.isFinite(updatedMs) && now.getTime() - updatedMs <= RECENTLY_CLOSED_MS) return 0.5;
+  return 0;
+}
+
 function compareExtractedReferences(left: ExtractedGitHubReference, right: ExtractedGitHubReference): number {
   return left.repo.localeCompare(right.repo) ||
     left.number - right.number ||
@@ -453,6 +658,16 @@ function validateConfig(config: GitHubRelatedContextConfig): void {
   if (!Number.isInteger(config.maxBodyBytes) || config.maxBodyBytes < 0) throw new Error("githubRelatedContext.maxBodyBytes must be a non-negative integer");
   if (!Number.isInteger(config.requestTimeoutMs) || config.requestTimeoutMs < 1) throw new Error("githubRelatedContext.requestTimeoutMs must be a positive integer");
   if (!Number.isInteger(config.maxPacketBytes) || config.maxPacketBytes < 500) throw new Error("githubRelatedContext.maxPacketBytes must be at least 500");
+  const relevance = config.relevanceScoring;
+  if (relevance !== undefined) {
+    if (typeof relevance.enabled !== "boolean") throw new Error("githubRelatedContext.relevanceScoring.enabled must be a boolean");
+    for (const [key, weight] of Object.entries(relevance.weights ?? {})) {
+      if (!(key in DEFAULT_RELEVANCE_WEIGHTS)) throw new Error(`githubRelatedContext.relevanceScoring.weights has unknown key "${key}"`);
+      if (typeof weight !== "number" || !Number.isFinite(weight) || weight < 0 || weight > 1) {
+        throw new Error(`githubRelatedContext.relevanceScoring.weights.${key} must be a number from 0 to 1`);
+      }
+    }
+  }
 }
 
 function parseRepo(repo: string): [string, string] {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1434,6 +1434,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       github: createGitHubRelatedContextReader(config, github),
       repo,
       pull,
+      files: reviewFiles,
       evidenceDir
     });
 
@@ -2212,6 +2213,7 @@ export async function buildGitHubRelatedContext(input: {
   github: GitHubRelatedContextReader;
   repo: string;
   pull: PullRequestSummary;
+  files?: PullFilePatch[];
   evidenceDir: string;
 }): Promise<{ packet?: GitHubRelatedContextPacket }> {
   const relatedConfig = input.config.githubRelatedContext;
@@ -2221,7 +2223,8 @@ export async function buildGitHubRelatedContext(input: {
     repo: input.repo,
     pull: input.pull,
     config: relatedConfig,
-    reader: input.github
+    reader: input.github,
+    ...(input.files ? { files: input.files } : {})
   });
 
   if (!packetResult.ok) {
@@ -2231,6 +2234,10 @@ export async function buildGitHubRelatedContext(input: {
 
   writeRedactedJson(join(input.evidenceDir, "github-related-context-packet.json"), packetResult);
   writeRedactedText(join(input.evidenceDir, "github-related-context-packet.md"), packetResult.packet.markdown);
+  // Evidence: the relevance component breakdown (#119 R8) makes the ranking replayable/inspectable.
+  if (packetResult.relevanceBreakdown) {
+    writeRedactedJson(join(input.evidenceDir, "github-related-context-relevance.json"), packetResult.relevanceBreakdown);
+  }
   return { packet: packetResult.packet };
 }
 

--- a/tests/github-related-context.test.ts
+++ b/tests/github-related-context.test.ts
@@ -3,9 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadConfig } from "../src/config.js";
+import { loadConfigFromObject } from "../src/config.js";
 import {
   buildGitHubRelatedContextPacket,
+  DEFAULT_RELEVANCE_WEIGHTS,
   extractGitHubReferences,
+  scoreReferenceRelevance,
   type GitHubRelatedContextConfig,
   type GitHubRelatedContextReader
 } from "../src/github-related-context.js";
@@ -335,3 +338,134 @@ function readerFor(items: Record<string, Awaited<ReturnType<GitHubRelatedContext
     }
   };
 }
+
+describe("relevance scoring components (#119 R8)", () => {
+  const NOW = new Date("2026-07-07T00:00:00.000Z");
+  function ref(overrides: Partial<Parameters<typeof scoreReferenceRelevance>[0]["reference"]> = {}) {
+    return {
+      relationship: "mentioned" as const,
+      source: "body" as const,
+      state: "open",
+      title: "unrelated title",
+      ...overrides
+    };
+  }
+  function score(input: Partial<Parameters<typeof scoreReferenceRelevance>[0]> = {}) {
+    return scoreReferenceRelevance({
+      reference: ref(input.reference),
+      prTitle: input.prTitle ?? "",
+      changedPaths: input.changedPaths ?? [],
+      hunkHeaders: input.hunkHeaders ?? [],
+      weights: input.weights ?? DEFAULT_RELEVANCE_WEIGHTS,
+      now: input.now ?? NOW
+    });
+  }
+
+  it("scores pathOverlap higher when the reference names a changed path segment", () => {
+    const hit = score({ reference: ref({ title: "Fix the auth session handler" }), changedPaths: ["src/auth/session.ts"] });
+    const miss = score({ reference: ref({ title: "Fix the auth session handler" }), changedPaths: ["docs/readme.md"] });
+    expect(hit.components.pathOverlap).toBeGreaterThan(miss.components.pathOverlap);
+    expect(miss.components.pathOverlap).toBe(0);
+  });
+
+  it("scores lexical overlap between reference title and PR title + hunk headers", () => {
+    const hit = score({ reference: ref({ title: "retry backoff regression" }), prTitle: "fix retry backoff", hunkHeaders: ["@@ retry backoff loop @@"] });
+    const miss = score({ reference: ref({ title: "unrelated docs typo" }), prTitle: "fix retry backoff" });
+    expect(hit.components.lexical).toBeGreaterThan(miss.components.lexical);
+  });
+
+  it("decays recency so a newer reference outranks an older one", () => {
+    const fresh = score({ reference: ref({ updatedAt: "2026-07-06T00:00:00.000Z" }) });
+    const stale = score({ reference: ref({ updatedAt: "2024-01-01T00:00:00.000Z" }) });
+    expect(fresh.components.recency).toBeGreaterThan(stale.components.recency);
+  });
+
+  it("ranks state open > recently-closed > long-closed", () => {
+    const open = score({ reference: ref({ state: "open" }) }).components.state;
+    const recentlyClosed = score({ reference: ref({ state: "closed", updatedAt: "2026-07-05T00:00:00.000Z" }) }).components.state;
+    const longClosed = score({ reference: ref({ state: "closed", updatedAt: "2023-01-01T00:00:00.000Z" }) }).components.state;
+    expect(open).toBeGreaterThan(recentlyClosed);
+    expect(recentlyClosed).toBeGreaterThan(longClosed);
+  });
+
+  it("keeps kind (closing) the dominant prior under default weights", () => {
+    // A closing ref with no other signal still outscores a mentioned ref that has some lexical/path signal.
+    const closing = score({ reference: ref({ relationship: "closing", source: "title", title: "" }) });
+    const mentioned = score({ reference: ref({ relationship: "mentioned", source: "body", title: "auth session" }), changedPaths: ["src/auth/session.ts"] });
+    expect(closing.components.kind).toBeGreaterThan(mentioned.components.kind);
+    expect(closing.score).toBeGreaterThan(mentioned.score);
+  });
+
+  it("returns a total score equal to the weighted sum of its components", () => {
+    const result = score({ reference: ref({ relationship: "closing", source: "title", state: "open", updatedAt: NOW.toISOString(), title: "auth session" }), prTitle: "auth session", changedPaths: ["src/auth/session.ts"], hunkHeaders: ["@@ auth session @@"] });
+    const c = result.components;
+    const w = DEFAULT_RELEVANCE_WEIGHTS;
+    const expected = w.kind * c.kind + w.pathOverlap * c.pathOverlap + w.lexical * c.lexical + w.recency * c.recency + w.state * c.state;
+    expect(result.score).toBeCloseTo(expected, 10);
+  });
+});
+
+describe("relevance re-ordering in the packet (#119 R8)", () => {
+  const reader = readerFor({
+    // Closing ref: stale, unrelated to the diff.
+    "owner/repo#12": { number: 12, title: "old unrelated milestone note", state: "closed", updated_at: "2023-01-01T00:00:00.000Z", html_url: "https://github.test/owner/repo/issues/12" },
+    // Mentioned ref: open, directly overlaps the changed auth/session path + PR title.
+    "owner/repo#20": { number: 20, title: "auth session token regression", state: "open", updated_at: "2026-07-06T00:00:00.000Z", html_url: "https://github.test/owner/repo/issues/20" }
+  });
+  const prBody = "Closes #12 and relates to #20.";
+  const files: PullFilePatch[] = [{ filename: "src/auth/session.ts", patch: "@@ -1,2 +1,3 @@ auth session token\n+  refreshToken();\n" }];
+
+  async function build(relevanceEnabled: boolean) {
+    return buildGitHubRelatedContextPacket({
+      repo: "owner/repo",
+      pull: pull({ title: "fix auth session token refresh", body: prBody }),
+      config: config(relevanceEnabled ? { relevanceScoring: { enabled: true } } : {}),
+      reader,
+      files,
+      generatedAt: "2026-07-07T00:00:00.000Z"
+    });
+  }
+
+  it("keeps the existing closing-ref-first order when relevanceScoring is disabled (byte-identical)", async () => {
+    const result = await build(false);
+    if (!result.ok) throw new Error("expected ok");
+    // Disabled ⇒ compareReferences: closing (#12) before mentioned (#20).
+    expect(result.packet.references.map((ref) => ref.number)).toEqual([12, 20]);
+    expect(result.relevanceBreakdown).toBeUndefined();
+  });
+
+  it("re-orders by relevance when enabled — the diff-overlapping open ref outranks the stale closing ref", async () => {
+    const result = await build(true);
+    if (!result.ok) throw new Error("expected ok");
+    // Enabled ⇒ #20 (open, path+lexical+recency hits) outscores #12 (stale long-closed).
+    expect(result.packet.references.map((ref) => ref.number)).toEqual([20, 12]);
+    // Same reference set (bounds untouched) — only the order changed.
+    expect(result.packet.references.map((ref) => ref.number).sort()).toEqual([12, 20]);
+    // Evidence breakdown present and replayable.
+    expect(result.relevanceBreakdown).toHaveLength(2);
+    const top = result.relevanceBreakdown!.find((entry) => entry.id === "owner/repo#20")!;
+    expect(top.components.pathOverlap).toBeGreaterThan(0);
+    expect(top.components.state).toBe(1);
+  });
+});
+
+describe("relevance scoring config (#119 R8)", () => {
+  const base = { githubRelatedContext: { enabled: true } };
+
+  it("defaults relevanceScoring unset (byte-identical ordering) and accepts a valid config", () => {
+    expect(loadConfigFromObject({ ...base }).githubRelatedContext?.relevanceScoring).toBeUndefined();
+    const config = loadConfigFromObject({
+      githubRelatedContext: { enabled: true, relevanceScoring: { enabled: true, weights: { kind: 1, pathOverlap: 0.8, lexical: 0.5, recency: 0.2, state: 0.3 } } }
+    });
+    expect(config.githubRelatedContext?.relevanceScoring).toMatchObject({ enabled: true, weights: { kind: 1, pathOverlap: 0.8 } });
+  });
+
+  it("fails closed on out-of-range weights and unknown keys", () => {
+    const rs = (relevanceScoring: unknown) => () => loadConfigFromObject({ githubRelatedContext: { enabled: true, relevanceScoring } });
+    expect(rs({ enabled: "yes" })).toThrow(/relevanceScoring\.enabled must be a boolean/);
+    expect(rs({ enabled: true, weights: { kind: 1.5 } })).toThrow(/relevanceScoring\.weights\.kind must be a number from 0 to 1/);
+    expect(rs({ enabled: true, weights: { kind: -0.1 } })).toThrow(/relevanceScoring\.weights\.kind must be a number from 0 to 1/);
+    expect(rs({ enabled: true, weights: { bogus: 0.5 } })).toThrow(/relevanceScoring\.weights has unknown key "bogus"/);
+    expect(rs({ enabled: true, bogus: 1 })).toThrow(/relevanceScoring has unknown key "bogus"/);
+  });
+});


### PR DESCRIPTION
**Part of #119** (NOT Closes — the umbrella stays open for its other halves). The R8 substrate fix from the original review; the re-scoped relevance-scoring half of old #261. Additive, **default-off**.

## Summary
Replaces the constant `rankReference` bucket (`(closing?0:10)+(body?0:1)`) in `github-related-context.ts` with a weighted, pure-lexical **relevance score** that re-orders related-context references. Absent/disabled ⇒ byte-identical current ordering.

## Design (link: `.dispatch/119-relevance-scoring-spec.md`)
- **Pass 1 = pure-lexical, deterministic, hermetic** — computed only from data the packet builder already has: no new API calls, no embeddings, no model calls. New pure `scoreReferenceRelevance` → `{ score, components }`, five `[0,1]` components: **kind** (closing > title-ref > body-ref, the strongest prior), **pathOverlap** (ref title/body tokens vs changed-file path segments), **lexical** (stopworded token Jaccard of ref title vs PR title + hunk headers), **recency** (30-day half-life decay on `updated_at`), **state** (open > recently-closed > long-closed). `score = Σ wᵢ·componentᵢ`, config-resident weights (default kind-dominant so today's closing-first order is preserved *ceteris paribus*, yet a stale long-closed closing ref can lose to a strongly-relevant open ref).
- **Config:** `githubRelatedContext.relevanceScoring { enabled: false, weights? {kind,pathOverlap,lexical,recency,state} }`, fail-closed (unknown keys rejected, weights 0..1). The #344 context-activation lab evaluates it on real packets; **this PR never flips it**.
- **Wiring:** scored post-fetch on the already-fetched, already-capped references. The worker threads the changed files it already fetched (`listPullFiles`) — no new API call. `renderWithinBudget` now preserves the caller's ordering instead of re-sorting.

## Bounds invariant (untouched)
Relevance only **re-orders** within the existing reference cap. Packet size bounds, byte/token estimates, redaction, and omitted-reference reporting are unchanged. `updated_at` is captured internally for scoring only (never rendered). Per-reference component breakdown is written to evidence (`github-related-context-relevance.json`) so the ranking is replayable/inspectable.

## Out of scope
**gitnexus graph distance is explicitly OUT of pass 1** (nondeterministic vs index freshness) — a pass-2 candidate gated on #344's findings.

## Validation
TDD: component table (pathOverlap hit/miss, lexical, recency decay, state ordering, kind dominance, `score = weighted sum`); enabled re-orders / disabled byte-identical / breakdown-in-evidence; config validation matrix. Focused vitest (22 in-file + config-schema/worker-failure regressions = 119 green) + `npm run build`, all under `set -o pipefail`. Fake tokens via `join("_")`.

## Proof boundary
Default-off ordering improvement inside existing packet bounds; no posting-surface change; enabling stays a #344 lab decision.