### PR TITLE
Desktop credential preflight doctor + CI secret-naming policy (#324)

### DIFF
--- a/apps/neondiff-desktop/docs/signing-credentials.md
+++ b/apps/neondiff-desktop/docs/signing-credentials.md
@@ -1,0 +1,119 @@
+# NeonDiff Desktop — signing & notarization credential policy
+
+Canonical names, custody, and CI-injection rules for every credential the desktop
+signing/notarization/auto-update chain needs. **This file contains no secret
+values and no real fingerprints — only names and policy.**
+
+Two invariants govern everything below:
+
+1. **Public keys are committed; private keys never touch the repo.** The Sparkle
+   *public* EdDSA key ships in the app's `Info.plist` (`SUPublicEDKey`) and may be
+   committed/published freely. Every *private* key, certificate, password, and API
+   key is owner-custody or CI-injected — it is never committed, printed, or logged.
+2. **Presence is checked, values are not disclosed.** `script/preflight-credentials.sh`
+   reports each credential as `present` / `missing` / `invalid` and never prints a
+   secret value (fingerprint tails only where useful). It signs and notarizes
+   nothing — that is issue #322.
+
+Run the doctor anytime (it mutates nothing):
+
+```sh
+apps/neondiff-desktop/script/preflight-credentials.sh          # human table
+apps/neondiff-desktop/script/preflight-credentials.sh --json   # machine-readable
+```
+
+Exit `0` = all required credentials present; non-zero lists exactly what is missing.
+
+---
+
+## Credential classes
+
+### 1. Developer ID Application certificate (code signing)
+
+Signs the `.app` bundle with the team's Developer ID so Gatekeeper trusts it.
+
+| GitHub Actions secret               | What it is                                                        | Custody        |
+| ----------------------------------- | ----------------------------------------------------------------- | -------------- |
+| `APPLE_DEVELOPER_ID_CERT_P12_BASE64`| Base64 of the exported Developer ID Application cert + private key (`.p12`) | CI-injected    |
+| `APPLE_DEVELOPER_ID_CERT_PASSWORD`  | Password protecting that `.p12` export                            | CI-injected    |
+
+- **CI import:** decode the base64 to a `.p12`, then
+  `security import` it into a throwaway CI keychain unlocked for the signing step.
+- **Local/owner:** the cert lives in the login keychain; the doctor probes it with
+  `security find-identity -v -p codesigning` and reports the identity **name** only
+  (e.g. `Developer ID Application: <Team> (<TEAMID>)`) — never the private key.
+- **Required:** yes. Missing → doctor exits non-zero (`developer_id_application`).
+
+### 2. Notarization credentials
+
+Submits the signed bundle to Apple's notary service (`xcrun notarytool`). Two
+supported paths — either satisfies the check:
+
+**(a) App Store Connect API key — the CI path.**
+
+| GitHub Actions secret          | What it is                                              | Custody     |
+| ------------------------------ | ------------------------------------------------------ | ----------- |
+| `APPLE_NOTARY_API_KEY_ID`      | ASC API key ID (the `-p8` key's short id)              | CI-injected |
+| `APPLE_NOTARY_API_ISSUER_ID`   | ASC API issuer id (the team's issuer UUID)             | CI-injected |
+| `APPLE_NOTARY_API_KEY_BASE64`  | Base64 of the `AuthKey_<id>.p8` private key file       | CI-injected |
+
+  The doctor reads the equivalent env at runtime as
+  `NEONDIFF_NOTARY_API_KEY_ID`, `NEONDIFF_NOTARY_API_ISSUER_ID`, and one of
+  `NEONDIFF_NOTARY_API_KEY_PATH` / `NEONDIFF_NOTARY_API_KEY_BASE64` — map the CI
+  secrets onto these in the workflow `env:`.
+
+**(b) notarytool keychain profile — the local/owner path.**
+
+  Created once with `xcrun notarytool store-credentials <profile-name>`. The doctor
+  probes the profile named by `NEONDIFF_NOTARY_KEYCHAIN_PROFILE` (default
+  `neondiff-notary`) via a read-only `notarytool history` call — it submits nothing.
+
+- **Required:** yes. Missing both paths → doctor exits non-zero (`notarization`).
+  A stored-but-unauthenticated profile is reported `invalid` (rotate/re-store).
+
+### 3. Sparkle EdDSA appcast-signing keys (auto-update)
+
+Sparkle signs each appcast/update with an EdDSA key so clients verify authenticity
+against the `SUPublicEDKey` baked into the app.
+
+| Name                              | What it is                                          | Custody              | Committed? |
+| --------------------------------- | --------------------------------------------------- | -------------------- | ---------- |
+| `SPARKLE_ED_PRIVATE_KEY`          | EdDSA **private** key that signs appcasts (`sign_update`) | Owner-custody / CI-injected | **Never** |
+| `SUPublicEDKey` (Info.plist)      | EdDSA **public** key clients verify against         | in-repo build config | **Yes**    |
+| `NEONDIFF_SPARKLE_PUBLIC_ED_KEY`  | Build-time env the build script injects as `SUPublicEDKey` | build config       | value is public |
+| `NEONDIFF_SPARKLE_FEED_URL`       | Appcast feed URL injected as `SUFeedURL`            | build config         | value is public |
+
+- **Private key custody:** generated once by Sparkle's `generate_keys` (stored in
+  the login keychain) or supplied to CI via `SPARKLE_ED_PRIVATE_KEY`. The doctor
+  reports only whether it is *reachable* — never the key.
+- **Public key / feed:** injected by `script/build_and_run.sh`, which already reads
+  `NEONDIFF_SPARKLE_PUBLIC_ED_KEY` and `NEONDIFF_SPARKLE_FEED_URL` and writes
+  `SUPublicEDKey` / `SUFeedURL` into `Info.plist`. Absent → the app ships with
+  Sparkle **off** (a valid dev-build state; the private-key check remains the hard
+  gate, the public-key check is advisory/non-required).
+
+---
+
+## Rotation
+
+Rotate on any suspected exposure and on the team's regular cadence:
+
+- **Developer ID cert:** re-issue in the Apple Developer portal, re-export the
+  `.p12`, and update `APPLE_DEVELOPER_ID_CERT_P12_BASE64` / `_PASSWORD`.
+- **ASC API key:** revoke the old key in App Store Connect, mint a new one, and
+  update `APPLE_NOTARY_API_KEY_ID` / `_ISSUER_ID` / `_KEY_BASE64`.
+- **Sparkle EdDSA key:** rotating the **private** key means the **public**
+  `SUPublicEDKey` must be updated in `Info.plist` in the *same* release, or clients
+  will reject the newly-signed appcast. Ship both together.
+
+After any rotation, run `preflight-credentials.sh` in the target environment to
+confirm the new credential resolves before relying on it.
+
+---
+
+## Boundary
+
+This doc and the doctor **report credential presence only**. They do not sign,
+notarize, upload, or fetch anything, print no secret values, and touch no
+review-pipeline surface. Actual signing/notarization wiring is tracked separately
+(#322); the auto-update parent is #116.

--- a/apps/neondiff-desktop/script/build_and_run.sh
+++ b/apps/neondiff-desktop/script/build_and_run.sh
@@ -6,7 +6,16 @@ APP_NAME="NeonDiffDesktop"
 BUNDLE_ID="com.electricsheephq.NeonDiffDesktop"
 MIN_SYSTEM_VERSION="14.0"
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# preflight: run the credential doctor (reports signing/notarization/Sparkle
+# credential presence) and exit before any build. Additive, read-only mode —
+# it mutates nothing and does not touch the default run/build behavior below.
+if [ "$MODE" = "preflight" ] || [ "$MODE" = "--preflight" ]; then
+  exec "$SCRIPT_DIR/preflight-credentials.sh" "${@:2}"
+fi
+
 DIST_DIR="$ROOT_DIR/dist"
 APP_BUNDLE="$DIST_DIR/$APP_NAME.app"
 APP_CONTENTS="$APP_BUNDLE/Contents"
@@ -127,7 +136,7 @@ case "$MODE" in
     fi
     ;;
   *)
-    echo "usage: $0 [run|--debug|--logs|--telemetry|--verify|--bundle-check]" >&2
+    echo "usage: $0 [run|--debug|--logs|--telemetry|--verify|--bundle-check|preflight]" >&2
     exit 2
     ;;
 esac

--- a/apps/neondiff-desktop/script/preflight-credentials.sh
+++ b/apps/neondiff-desktop/script/preflight-credentials.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# preflight-credentials.sh — desktop signing/notarization/Sparkle credential DOCTOR.
+#
+# Reports which signing/notarization/appcast-signing credentials are PRESENT,
+# MISSING, or INVALID on this machine (or in a CI environment). It is a doctor:
+# it mutates nothing, submits nothing, signs nothing, and NEVER prints a secret
+# value (only fingerprint tails / identity names where useful for humans).
+#
+# Exit 0 when every REQUIRED credential is present; non-zero otherwise, listing
+# exactly what is missing and the doc pointer to obtain it.
+#
+# Usage:
+#   preflight-credentials.sh            human-readable table (default)
+#   preflight-credentials.sh --json     machine-readable JSON
+#   preflight-credentials.sh --help
+#
+# Credential naming/custody policy: apps/neondiff-desktop/docs/signing-credentials.md
+
+# ---------------------------------------------------------------------------
+# Configuration — canonical env var / profile names (see signing-credentials.md).
+# Overridable so CI can point the doctor at whatever names it injects.
+# ---------------------------------------------------------------------------
+NOTARY_KEYCHAIN_PROFILE="${NEONDIFF_NOTARY_KEYCHAIN_PROFILE:-neondiff-notary}"
+DOCS_POINTER="apps/neondiff-desktop/docs/signing-credentials.md"
+
+MODE="human"
+case "${1:-}" in
+  --json) MODE="json" ;;
+  --help|-h)
+    sed -n '3,26p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  "") ;;
+  *)
+    echo "usage: $0 [--json|--help]" >&2
+    exit 2
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Result accumulation. Each check appends four parallel arrays:
+#   id / status (present|missing|invalid|skipped) / required (true|false) / detail
+# ---------------------------------------------------------------------------
+IDS=()
+STATUSES=()
+REQUIREDS=()
+DETAILS=()
+
+record() {
+  IDS+=("$1")
+  STATUSES+=("$2")
+  REQUIREDS+=("$3")
+  DETAILS+=("$4")
+}
+
+# Redact a fingerprint/hash to a short tail so humans can eyeball a match without
+# the value being disclosed. "ABCD1234EF..." -> "…34EF".
+tail_only() {
+  local v="$1"
+  local n=${#v}
+  if [ "$n" -le 4 ]; then
+    printf '…%s' "$v"
+  else
+    printf '…%s' "${v:$((n-4))}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. Developer ID Application certificate (code signing).
+# ---------------------------------------------------------------------------
+check_developer_id_cert() {
+  if ! command -v security >/dev/null 2>&1; then
+    record "developer_id_application" "skipped" "true" \
+      "'security' tool unavailable (not macOS?); cannot probe codesigning identities"
+    return
+  fi
+  local identities count name
+  identities="$(security find-identity -v -p codesigning 2>/dev/null || true)"
+  # Match "Developer ID Application: Team Name (TEAMID)" lines only.
+  count="$(printf '%s\n' "$identities" | grep -c 'Developer ID Application' || true)"
+  if [ "${count:-0}" -gt 0 ]; then
+    # Extract the identity name (inside quotes) of the first match; never the key.
+    name="$(printf '%s\n' "$identities" | grep 'Developer ID Application' | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')"
+    record "developer_id_application" "present" "true" \
+      "$count Developer ID Application identity/identities (e.g. \"$name\")"
+  else
+    record "developer_id_application" "missing" "true" \
+      "no 'Developer ID Application' identity in keychain — import the Developer ID cert (see $DOCS_POINTER)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 2. Notarization credentials — a notarytool keychain profile OR an ASC API key.
+#    We PROBE only; we never submit or fetch history (a dry, read-only check).
+# ---------------------------------------------------------------------------
+check_notarization() {
+  # 2a. App Store Connect API key via env (CI-injected path).
+  if [ -n "${NEONDIFF_NOTARY_API_KEY_ID:-}" ] \
+     && [ -n "${NEONDIFF_NOTARY_API_ISSUER_ID:-}" ] \
+     && [ -n "${NEONDIFF_NOTARY_API_KEY_PATH:-}${NEONDIFF_NOTARY_API_KEY_BASE64:-}" ]; then
+    record "notarization" "present" "true" \
+      "App Store Connect API key configured via env (key id …$(tail_only "${NEONDIFF_NOTARY_API_KEY_ID}"))"
+    return
+  fi
+
+  # 2b. notarytool keychain profile (local/owner path).
+  if ! command -v xcrun >/dev/null 2>&1; then
+    record "notarization" "missing" "true" \
+      "no ASC API key env and 'xcrun' unavailable — configure notarytool profile '$NOTARY_KEYCHAIN_PROFILE' or ASC API key (see $DOCS_POINTER)"
+    return
+  fi
+
+  # `notarytool history` against a profile is read-only and requires no submission.
+  # It reaches the network; a stored-but-invalid profile surfaces as an auth error.
+  local out rc
+  # Guard the assignment: a failing probe must not trip `set -e` before we read $?.
+  out="$(xcrun notarytool history --keychain-profile "$NOTARY_KEYCHAIN_PROFILE" 2>&1)" && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    record "notarization" "present" "true" \
+      "notarytool keychain profile '$NOTARY_KEYCHAIN_PROFILE' is usable"
+  elif printf '%s' "$out" | grep -qiE 'could not find|no such|not been found|unable to find|no keychain (item|password item)'; then
+    record "notarization" "missing" "true" \
+      "no notarytool profile '$NOTARY_KEYCHAIN_PROFILE' and no ASC API key env — create one with 'xcrun notarytool store-credentials' (see $DOCS_POINTER)"
+  elif printf '%s' "$out" | grep -qiE 'network|timed out|could not connect|offline'; then
+    record "notarization" "skipped" "true" \
+      "notarytool profile '$NOTARY_KEYCHAIN_PROFILE' present but could not be verified offline (network probe failed)"
+  else
+    record "notarization" "invalid" "true" \
+      "notarytool profile '$NOTARY_KEYCHAIN_PROFILE' exists but failed to authenticate — rotate/re-store credentials (see $DOCS_POINTER)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 3. Sparkle EdDSA appcast-signing keys.
+#    PRIVATE key: custody for signing appcasts (never printed, never committed).
+#    PUBLIC key:  goes into Info.plist as SUPublicEDKey (safe to commit/publish).
+# ---------------------------------------------------------------------------
+check_sparkle_private_key() {
+  # Private key custody: env (CI) or Sparkle's generate_keys keychain item (owner).
+  if [ -n "${SPARKLE_ED_PRIVATE_KEY:-}" ]; then
+    record "sparkle_private_key" "present" "true" \
+      "appcast signing private key reachable via SPARKLE_ED_PRIVATE_KEY env (value not shown)"
+    return
+  fi
+  # Sparkle stores the generated private key in the login keychain under this name.
+  if command -v security >/dev/null 2>&1 \
+     && security find-generic-password -s "https://sparkle-project.org" >/dev/null 2>&1; then
+    record "sparkle_private_key" "present" "true" \
+      "appcast signing private key found in login keychain (Sparkle generate_keys; value not shown)"
+    return
+  fi
+  record "sparkle_private_key" "missing" "true" \
+    "no appcast-signing private key (SPARKLE_ED_PRIVATE_KEY env or Sparkle keychain item) — run Sparkle's generate_keys in custody (see $DOCS_POINTER)"
+}
+
+check_sparkle_public_key() {
+  # Public key config path: the build injects NEONDIFF_SPARKLE_PUBLIC_ED_KEY into
+  # Info.plist as SUPublicEDKey (see build_and_run.sh). Safe to disclose, so we
+  # only report presence + a redacted tail for eyeballing.
+  local pub="${NEONDIFF_SPARKLE_PUBLIC_ED_KEY:-}"
+  if [ -n "$pub" ]; then
+    record "sparkle_public_key" "present" "false" \
+      "SUPublicEDKey configured via NEONDIFF_SPARKLE_PUBLIC_ED_KEY (tail $(tail_only "$pub"))"
+  else
+    record "sparkle_public_key" "missing" "false" \
+      "NEONDIFF_SPARKLE_PUBLIC_ED_KEY unset — the build ships without SUPublicEDKey (Sparkle stays OFF; safe for dev builds; see $DOCS_POINTER)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Run all checks.
+# ---------------------------------------------------------------------------
+check_developer_id_cert
+check_notarization
+check_sparkle_private_key
+check_sparkle_public_key
+
+# ---------------------------------------------------------------------------
+# Compute overall verdict: fail if any REQUIRED credential is missing/invalid.
+# ('skipped' does not fail the run — the probe could not be performed here.)
+# ---------------------------------------------------------------------------
+exit_code=0
+missing_ids=()
+for i in "${!IDS[@]}"; do
+  if [ "${REQUIREDS[$i]}" = "true" ]; then
+    case "${STATUSES[$i]}" in
+      missing|invalid)
+        exit_code=1
+        missing_ids+=("${IDS[$i]}")
+        ;;
+    esac
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Emit report.
+# ---------------------------------------------------------------------------
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\n'/\\n}"
+  printf '%s' "$s"
+}
+
+if [ "$MODE" = "json" ]; then
+  printf '{\n'
+  printf '  "ok": %s,\n' "$([ "$exit_code" -eq 0 ] && echo true || echo false)"
+  printf '  "checks": [\n'
+  for i in "${!IDS[@]}"; do
+    printf '    {"id": "%s", "status": "%s", "required": %s, "detail": "%s"}' \
+      "$(json_escape "${IDS[$i]}")" \
+      "$(json_escape "${STATUSES[$i]}")" \
+      "${REQUIREDS[$i]}" \
+      "$(json_escape "${DETAILS[$i]}")"
+    if [ "$i" -lt $(( ${#IDS[@]} - 1 )) ]; then printf ','; fi
+    printf '\n'
+  done
+  printf '  ],\n'
+  printf '  "missing_required": ['
+  for j in "${!missing_ids[@]}"; do
+    printf '"%s"' "$(json_escape "${missing_ids[$j]}")"
+    if [ "$j" -lt $(( ${#missing_ids[@]} - 1 )) ]; then printf ', '; fi
+  done
+  printf ']\n'
+  printf '}\n'
+else
+  printf 'NeonDiff Desktop — credential preflight doctor\n'
+  printf '(reports presence only; signs/notarizes nothing; no secret values printed)\n\n'
+  printf '%-26s %-9s %-9s %s\n' "CREDENTIAL" "STATUS" "REQUIRED" "DETAIL"
+  printf '%-26s %-9s %-9s %s\n' "--------------------------" "-------" "--------" "------"
+  for i in "${!IDS[@]}"; do
+    printf '%-26s %-9s %-9s %s\n' \
+      "${IDS[$i]}" "${STATUSES[$i]}" "${REQUIREDS[$i]}" "${DETAILS[$i]}"
+  done
+  printf '\n'
+  if [ "$exit_code" -eq 0 ]; then
+    printf 'RESULT: all required credentials present.\n'
+  else
+    printf 'RESULT: missing required credential(s): %s\n' "${missing_ids[*]}"
+    printf 'See %s for how to obtain/inject each.\n' "$DOCS_POINTER"
+  fi
+fi
+
+exit "$exit_code"


### PR DESCRIPTION
## Summary

The cred-INDEPENDENT slice of the desktop signing chain (parent #116): a read-only
**preflight doctor** that reports which signing/notarization/Sparkle credentials are
present/missing/invalid, plus a **CI secret-naming/custody policy** doc. It signs and
notarizes nothing (that's #322) and needs no real credentials to run — it reports what's
missing. New files under `apps/neondiff-desktop/`; disjoint from the review pipeline.

## What the doctor checks

`apps/neondiff-desktop/script/preflight-credentials.sh` (`set -euo pipefail`, `--json`
+ human-table modes; exit 0 when all required present, non-zero listing what's missing):

- **Developer ID Application cert** — `security find-identity -v -p codesigning`; reports
  count + identity name, never the private key.
- **Notarization** — an ASC API key via env OR a `notarytool` keychain profile probed
  read-only with `notarytool history` (submits nothing); reports present/missing/invalid.
- **Sparkle EdDSA keys** — private appcast-signing key reachability (env or Sparkle
  keychain item) and public `SUPublicEDKey` config; never prints either.

It is a DOCTOR: mutates nothing, safe anytime. Fingerprint/tails only where useful; no
secret values ever printed.

## Secret policy

`apps/neondiff-desktop/docs/signing-credentials.md` — canonical GitHub Actions secret
NAMES (`APPLE_DEVELOPER_ID_CERT_P12_BASE64` + `_PASSWORD`, `APPLE_NOTARY_API_KEY_ID` /
`_ISSUER_ID` / `_KEY_BASE64`, `SPARKLE_ED_PRIVATE_KEY`), what each is, owner-custody vs
CI-injected, rotation notes, and the invariants: **public keys committed
(`SUPublicEDKey`), private keys never touch the repo**. Cross-links `build_and_run.sh`'s
existing env vars. No values, no real fingerprints.

`build_and_run.sh` gains an additive `preflight` mode (`build_and_run.sh preflight`) that
execs the doctor before any build; the default run/build path is unchanged.

## Validation (this machine, redacted)

- `shellcheck` clean on both scripts; `bash -n build_and_run.sh` OK.
- Doctor run (human + `--json`) on this machine:
  - `developer_id_application`: **present** (identity name only, no key)
  - `notarization`: **missing** (no notarytool profile / ASC API key env)
  - `sparkle_private_key`: **present** (login-keychain item; value not shown)
  - `sparkle_public_key`: **missing** (non-required; `NEONDIFF_SPARKLE_PUBLIC_ED_KEY` unset → Sparkle off)
  - Overall exit **1** (driven by required `notarization`) — a valid, expected first-run/CI result.
- `build_and_run.sh preflight` and `preflight --json` correctly exec the doctor with no build.

## Proof boundary

Reports credential presence only; signs/notarizes nothing; no secret values printed; no
review-pipeline surface touched. Actual signing/notarization wiring is #322.

Closes #324, parent #116.
