### PR TITLE
Schedule the calibration loop (daemon-integrated outcome observation)

### DIFF
--- a/docs/calibration-loop.md
+++ b/docs/calibration-loop.md
@@ -50,6 +50,48 @@ neondiff outcome-observe \
   writes. Negative controls are never inferred from missing labels; a clean
   run only counts when you explicitly mark it.
 
+### Scheduling the loop (daemon-integrated observation)
+
+The observe step above is a manual CLI. To run it hands-off, the review daemon
+can perform a bounded, read-only observe pass at the tail of each scheduled
+cycle. It is **additive and default-off** — enable it under `calibrationLoop`:
+
+```jsonc
+{
+  "calibrationLoop": {
+    "observeSchedule": {
+      "enabled": true,          // default false ⇒ zero observer work, zero extra GitHub reads
+      "intervalMinutes": 720,   // minimum spacing between observe passes (global gate)
+      "maxPullsPerCycle": 25,   // upper bound on heads observed per cycle
+      "perRepoCooldownMinutes": 720, // skip a repo observed within this window
+      "lookbackDays": 14        // only consider findings recorded within this window
+    }
+  }
+}
+```
+
+When enabled and due, the pass selects recently-recorded review findings within
+`lookbackDays`, groups them by `(repo, pull, head)`, skips repos still inside
+`perRepoCooldownMinutes`, caps the batch at `maxPullsPerCycle`, reads each PR's
+merge state read-only, derives outcome labels via the same precedence resolver
+as the CLI, and records them into `finding_outcome_labels`. It writes a redacted
+`calibration-observe.json` evidence packet. It **never** aggregates, promotes,
+mutates config, switches the public display, or posts to GitHub — those stay
+manual, human-gated steps. A failure in the pass never disturbs the review
+cycle.
+
+**Observation source — the findings ledger.** Reconstructing an outcome needs
+each finding's path and line. Every posted review therefore records its findings
+into a `review_findings` ledger (fingerprint, repo, pull, head, path, line,
+severity, category, confidence — **never title or body text**, all fields already
+public in the posted review). This write is **best-effort and fail-open**: if it
+throws, the review still posts — observation bookkeeping never gates a review.
+
+**Bootstrap note.** The scheduled pass can only observe findings recorded into
+`review_findings` *after this ships*. PRs reviewed before the ledger existed are
+invisible to the scheduled pass; use the manual `outcome-observe` CLI to backfill
+them if needed.
+
 ## 2. Aggregate Labels: `neondiff calibration-aggregate`
 
 Reads accumulated outcome labels from the state DB and produces

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,7 @@ export interface BotConfig {
   riskWeightedQueue?: RiskWeightedQueueConfig;
   /** Review mode router (#266, default off / absent). Absent ⇒ byte-identical + zero evidence. */
   reviewModes?: ReviewModesConfig;
+  calibrationLoop?: CalibrationLoopConfig;
   providerCooldown: {
     enabled: boolean;
     durationMs: number;
@@ -247,6 +248,25 @@ export interface QueueAgingConfig {
   enabled: boolean;
   /** A queued job waiting longer than this is aged UP to baseline at lease time (never demoted). */
   maxWaitMinutes: number;
+}
+
+export interface CalibrationLoopConfig {
+  /** Daemon-scheduled outcome observation (#357, default off). Records outcome labels + evidence
+   * only — never aggregates, promotes, writes config, or posts to GitHub. */
+  observeSchedule?: ObserveScheduleConfig;
+}
+
+export interface ObserveScheduleConfig {
+  /** When false (default/unset), zero observer calls / zero observation GitHub reads — byte-identical. */
+  enabled: boolean;
+  /** Minimum minutes between observe passes (schedule is "due" when now − lastObserveAt ≥ this). */
+  intervalMinutes: number;
+  /** Hard bound on GitHub reads per observe pass. */
+  maxPullsPerCycle: number;
+  /** Do not re-observe the same repo more often than this. */
+  perRepoCooldownMinutes: number;
+  /** Only revisit findings/PRs recorded within this window. */
+  lookbackDays: number;
 }
 
 export interface RepoMemoryConfig {
@@ -573,6 +593,7 @@ function validateConfig(config: BotConfig): void {
   if (config.reviewModes !== undefined) {
     validateReviewModesConfig(config.reviewModes, "config.reviewModes", config);
   }
+  if (config.calibrationLoop !== undefined) validateCalibrationLoopConfig(config.calibrationLoop, "config.calibrationLoop");
   validateBoolean(config.providerCooldown.enabled, "config.providerCooldown.enabled");
   validatePositiveInteger(config.providerCooldown.durationMs, "config.providerCooldown.durationMs");
   validatePositiveInteger(config.providerCooldown.requestRateLimitDurationMs, "config.providerCooldown.requestRateLimitDurationMs");
@@ -792,6 +813,27 @@ function validateSelfConsistencyConfig(value: unknown, label: string): void {
   if (value.maxFindingsPerReview !== undefined) {
     validatePositiveInteger(value.maxFindingsPerReview, `${label}.maxFindingsPerReview`);
   }
+}
+
+function validateCalibrationLoopConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  for (const key of Object.keys(value)) {
+    if (key !== "observeSchedule") throw new Error(`${label} has unknown key "${key}"; expected only observeSchedule`);
+  }
+  if (value.observeSchedule !== undefined) validateObserveScheduleConfig(value.observeSchedule, `${label}.observeSchedule`);
+}
+
+function validateObserveScheduleConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  const allowed = new Set(["enabled", "intervalMinutes", "maxPullsPerCycle", "perRepoCooldownMinutes", "lookbackDays"]);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) throw new Error(`${label} has unknown key "${key}"; expected only enabled, intervalMinutes, maxPullsPerCycle, perRepoCooldownMinutes, lookbackDays`);
+  }
+  validateBoolean(value.enabled, `${label}.enabled`);
+  validatePositiveInteger(value.intervalMinutes, `${label}.intervalMinutes`);
+  validatePositiveInteger(value.maxPullsPerCycle, `${label}.maxPullsPerCycle`);
+  validatePositiveInteger(value.perRepoCooldownMinutes, `${label}.perRepoCooldownMinutes`);
+  validatePositiveInteger(value.lookbackDays, `${label}.lookbackDays`);
 }
 
 function validateRiskWeightedQueueConfig(value: unknown, label: string, backgroundPriority: number): void {

--- a/src/findings.ts
+++ b/src/findings.ts
@@ -1,7 +1,30 @@
+import { createHash } from "node:crypto";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 import { categoryLabel, isRegressionCategory, isRequestChangesEligible, normalizeFindingCategory, type CategoryPrecisionFloors, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import { sanitizePublicConfidenceText, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import type { DroppedFinding, Finding, ReviewComment, ReviewEvent, Severity } from "./types.js";
+
+/**
+ * Deterministic per-finding fingerprint (sha256 over the canonical finding identity). Computed over
+ * the ORIGINAL Finding — including why_this_matters and raw (pre-sanitization) title/body — so the
+ * deterministic gate, the finding_outcome_labels store, and the review_findings ledger (#357) all key
+ * a given finding under the SAME fingerprint. Lives here (a leaf) rather than review-gate.ts so the
+ * comment builder can stamp it without a review-gate → findings import cycle; review-gate re-exports.
+ */
+export function buildFindingFingerprint(
+  finding: Pick<Finding, "severity" | "path" | "line" | "title" | "body" | "category" | "why_this_matters">
+): string {
+  const canonical = JSON.stringify({
+    severity: finding.severity,
+    path: finding.path,
+    line: finding.line,
+    title: finding.title.trim().toLowerCase(),
+    body: finding.body.trim().toLowerCase(),
+    why_this_matters: finding.why_this_matters?.trim().toLowerCase() ?? "",
+    category: finding.category ?? "unknown"
+  });
+  return `finding:${createHash("sha256").update(canonical).digest("hex")}`;
+}
 
 const SEVERITY_RANK: Record<Severity, number> = {
   P0: 0,
@@ -127,6 +150,11 @@ export function normalizeFindingsForReview(
         category,
         // Internal gating/evidence metadata; never rendered into the public body/title.
         confidence: finding.confidence,
+        // Fingerprint over the ORIGINAL finding (raw title/body + why_this_matters, and the
+        // pre-normalized category the gate hashes) — NOT the sanitized publicTitle/publicBody or
+        // the normalized `category` above — so it matches the gate/finding_outcome_labels fingerprint
+        // and the #357 observe→label join stays intact.
+        fingerprint: buildFindingFingerprint(finding),
         title: publicTitle,
         body: formatReviewComment(
           { ...finding, category, title: publicTitle, body: publicBody, ...(publicWhy ? { why_this_matters: publicWhy } : {}) },

--- a/src/outcome-observer.ts
+++ b/src/outcome-observer.ts
@@ -2,11 +2,13 @@ import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { redactSecrets } from "./secrets.js";
+import type { ObserveScheduleConfig } from "./config.js";
 import type { OutcomeLedgerPostMergeStatus } from "./outcome-ledger.js";
 import type {
   FindingOutcomeLabelRecord,
   FindingOutcomeLabelSource,
   FindingOutcomeVerdict,
+  ReviewFindingRecord,
   ReviewStateStore
 } from "./state.js";
 import type { Severity } from "./types.js";
@@ -323,4 +325,155 @@ function escalatePostMergeStatus(current: OutcomeLedgerPostMergeStatus, next: Ou
     reverted: 4
   };
   return rank[next] > rank[current] ? next : current;
+}
+
+const GLOBAL_OBSERVE_SCOPE = "__global__";
+
+export interface ScheduledObserveTarget {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  findings: ObservedFinding[];
+}
+
+export interface ScheduledObservePassResult {
+  ran: boolean;
+  reason: "disabled" | "not_due" | "observed";
+  targets: number;
+  labeled: number;
+}
+
+/**
+ * Daemon-scheduled outcome observation (#357). Bounded, read-only, default-off. When enabled AND due
+ * (now − lastObserveAt ≥ intervalMinutes), it selects recorded review findings within lookbackDays
+ * whose repo is not in per-repo cooldown, capped at maxPullsPerCycle heads, reconstructs
+ * ObservedFinding from the public findings ledger, derives labels via the existing deriveOutcomeLabel,
+ * and records them via the atomic recordFindingOutcomeLabels batch (#286 Part C). It writes a redacted
+ * evidence packet and updates the schedule state. It NEVER aggregates, promotes, writes config,
+ * touches publicDisplay.mode, or posts to GitHub — the `fetchOutcome` reader is injected and read-only.
+ * Disabled/absent config ⇒ zero observer work, zero GitHub reads.
+ */
+export async function runScheduledObservePass(input: {
+  state: ReviewStateStore;
+  config: ObserveScheduleConfig | undefined;
+  evidenceDir: string;
+  fetchOutcome: (target: ScheduledObserveTarget) => ObservedPullOutcome | Promise<ObservedPullOutcome>;
+  now?: Date;
+}): Promise<ScheduledObservePassResult> {
+  const schedule = input.config;
+  if (!schedule?.enabled) return { ran: false, reason: "disabled", targets: 0, labeled: 0 };
+  const now = input.now ?? new Date();
+  const lastGlobal = input.state.getCalibrationObserveAt(GLOBAL_OBSERVE_SCOPE);
+  if (!isScheduleDue(lastGlobal, now, schedule.intervalMinutes)) {
+    return { ran: false, reason: "not_due", targets: 0, labeled: 0 };
+  }
+
+  const since = new Date(now.getTime() - schedule.lookbackDays * 24 * 60 * 60_000).toISOString();
+  const targets = selectObserveTargets(input.state, since, schedule, now);
+
+  const observedAt = now.toISOString();
+  const records: FindingOutcomeLabelRecord[] = [];
+  const observations: Array<{ repo: string; pullNumber: number; headSha: string; postMergeStatus: OutcomeLedgerPostMergeStatus; labeled: number }> = [];
+  const observedRepos = new Set<string>();
+  for (const target of targets) {
+    const outcome = await input.fetchOutcome(target);
+    let labeled = 0;
+    let postMergeStatus: OutcomeLedgerPostMergeStatus = outcome.merged ? "no_incident_seen" : "not_merged";
+    if (outcome.merged) {
+      for (const finding of target.findings) {
+        const derived = deriveOutcomeLabel({ finding, observed: outcome });
+        postMergeStatus = escalatePostMergeStatus(postMergeStatus, derived.postMergeStatus);
+        records.push({
+          fingerprint: finding.fingerprint,
+          repo: target.repo,
+          pullNumber: target.pullNumber,
+          headSha: target.headSha,
+          severity: finding.severity,
+          category: finding.category,
+          confidence: finding.confidence,
+          labelSource: derived.labelSource,
+          verdict: derived.verdict,
+          observedAt,
+          ...(outcome.evidenceRef ? { evidenceRef: outcome.evidenceRef } : {})
+        });
+        labeled += 1;
+      }
+    }
+    observedRepos.add(target.repo);
+    observations.push({ repo: target.repo, pullNumber: target.pullNumber, headSha: target.headSha, postMergeStatus, labeled });
+  }
+
+  // Record all derived labels atomically (#286 Part C batch). This is the ONLY write to the label
+  // store — no aggregate, no promote, no config write, no GitHub mutation.
+  input.state.recordFindingOutcomeLabels(records);
+
+  // Schedule bookkeeping: advance the global interval clock and each observed repo's cooldown.
+  input.state.recordCalibrationObserveAt(GLOBAL_OBSERVE_SCOPE, observedAt);
+  for (const repo of observedRepos) input.state.recordCalibrationObserveAt(repo, observedAt);
+
+  const packet = {
+    ok: true,
+    observedAt,
+    intervalMinutes: schedule.intervalMinutes,
+    maxPullsPerCycle: schedule.maxPullsPerCycle,
+    perRepoCooldownMinutes: schedule.perRepoCooldownMinutes,
+    lookbackDays: schedule.lookbackDays,
+    targets: targets.length,
+    labeled: records.length,
+    observations
+  };
+  mkdirSync(input.evidenceDir, { recursive: true });
+  writeFileSync(join(input.evidenceDir, "calibration-observe.json"), `${redactSecrets(JSON.stringify(packet, null, 2))}\n`);
+
+  return { ran: true, reason: "observed", targets: targets.length, labeled: records.length };
+}
+
+function isScheduleDue(lastObserveAt: string | undefined, now: Date, intervalMinutes: number): boolean {
+  if (!lastObserveAt) return true;
+  const lastMs = Date.parse(lastObserveAt);
+  if (!Number.isFinite(lastMs)) return true;
+  return now.getTime() - lastMs >= intervalMinutes * 60_000;
+}
+
+function selectObserveTargets(
+  state: ReviewStateStore,
+  since: string,
+  schedule: ObserveScheduleConfig,
+  now: Date
+): ScheduledObserveTarget[] {
+  // Group recorded findings within the lookback window by (repo, pull, head).
+  const byHead = new Map<string, ScheduledObserveTarget>();
+  for (const finding of state.listReviewFindings({ since })) {
+    const key = `${finding.repo}#${finding.pullNumber}@${finding.headSha}`;
+    let target = byHead.get(key);
+    if (!target) {
+      target = { repo: finding.repo, pullNumber: finding.pullNumber, headSha: finding.headSha, findings: [] };
+      byHead.set(key, target);
+    }
+    target.findings.push({
+      fingerprint: finding.fingerprint,
+      path: finding.path,
+      line: finding.line,
+      severity: finding.severity as Severity,
+      category: finding.category,
+      confidence: finding.confidence
+    });
+  }
+
+  const cooldownMs = schedule.perRepoCooldownMinutes * 60_000;
+  const repoInCooldown = new Map<string, boolean>();
+  const selected: ScheduledObserveTarget[] = [];
+  for (const target of byHead.values()) {
+    if (selected.length >= schedule.maxPullsPerCycle) break;
+    let inCooldown = repoInCooldown.get(target.repo);
+    if (inCooldown === undefined) {
+      const last = state.getCalibrationObserveAt(target.repo);
+      const lastMs = last ? Date.parse(last) : NaN;
+      inCooldown = Number.isFinite(lastMs) && now.getTime() - lastMs < cooldownMs;
+      repoInCooldown.set(target.repo, inCooldown);
+    }
+    if (inCooldown) continue;
+    selected.push(target);
+  }
+  return selected;
 }

--- a/src/outcome-observer.ts
+++ b/src/outcome-observer.ts
@@ -399,8 +399,12 @@ export async function runScheduledObservePass(input: {
         });
         labeled += 1;
       }
+      // Only a MERGED PR is actually observed (its outcome is terminal for this head), so only then
+      // do we advance the repo's cooldown. An unmerged/not-yet-observable target must NOT cool the
+      // repo down — otherwise we'd wrongly delay re-observing it until it finally merges. The cooldown
+      // exists to space out re-observation of a repo we DID observe, not one we merely selected.
+      observedRepos.add(target.repo);
     }
-    observedRepos.add(target.repo);
     // evidenceRef may carry free text from the outcome reader; the packet-level redactSecrets wrapper
     // below strips any secret-shaped content before it is written.
     observations.push({ repo: target.repo, pullNumber: target.pullNumber, headSha: target.headSha, postMergeStatus, labeled, ...(outcome.evidenceRef ? { evidenceRef: outcome.evidenceRef } : {}) });
@@ -471,6 +475,9 @@ function selectObserveTargets(
   const repoInCooldown = new Map<string, boolean>();
   const selected: ScheduledObserveTarget[] = [];
   for (const target of byHead.values()) {
+    // Cap counts only ACTUALLY-selected (non-cooldown) heads: it is checked against `selected.length`,
+    // and a cooldown head `continue`s below WITHOUT pushing — so a cooled head never consumes a slot,
+    // and non-cooldown repos that sort later are still reached until the cap fills with real work.
     if (selected.length >= schedule.maxPullsPerCycle) break;
     let inCooldown = repoInCooldown.get(target.repo);
     if (inCooldown === undefined) {

--- a/src/outcome-observer.ts
+++ b/src/outcome-observer.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { redactSecrets } from "./secrets.js";
+import { writeSecureFileSync } from "./temp-files.js";
 import type { ObserveScheduleConfig } from "./config.js";
 import type { OutcomeLedgerPostMergeStatus } from "./outcome-ledger.js";
 import type {
@@ -423,7 +424,7 @@ export async function runScheduledObservePass(input: {
     observations
   };
   mkdirSync(input.evidenceDir, { recursive: true });
-  writeFileSync(join(input.evidenceDir, "calibration-observe.json"), `${redactSecrets(JSON.stringify(packet, null, 2))}\n`);
+  writeSecureFileSync(join(input.evidenceDir, "calibration-observe.json"), `${redactSecrets(JSON.stringify(packet, null, 2))}\n`);
 
   return { ran: true, reason: "observed", targets: targets.length, labeled: records.length };
 }

--- a/src/outcome-observer.ts
+++ b/src/outcome-observer.ts
@@ -374,7 +374,7 @@ export async function runScheduledObservePass(input: {
 
   const observedAt = now.toISOString();
   const records: FindingOutcomeLabelRecord[] = [];
-  const observations: Array<{ repo: string; pullNumber: number; headSha: string; postMergeStatus: OutcomeLedgerPostMergeStatus; labeled: number }> = [];
+  const observations: Array<{ repo: string; pullNumber: number; headSha: string; postMergeStatus: OutcomeLedgerPostMergeStatus; labeled: number; evidenceRef?: string }> = [];
   const observedRepos = new Set<string>();
   for (const target of targets) {
     const outcome = await input.fetchOutcome(target);
@@ -401,7 +401,9 @@ export async function runScheduledObservePass(input: {
       }
     }
     observedRepos.add(target.repo);
-    observations.push({ repo: target.repo, pullNumber: target.pullNumber, headSha: target.headSha, postMergeStatus, labeled });
+    // evidenceRef may carry free text from the outcome reader; the packet-level redactSecrets wrapper
+    // below strips any secret-shaped content before it is written.
+    observations.push({ repo: target.repo, pullNumber: target.pullNumber, headSha: target.headSha, postMergeStatus, labeled, ...(outcome.evidenceRef ? { evidenceRef: outcome.evidenceRef } : {}) });
   }
 
   // Record all derived labels atomically (#286 Part C batch). This is the ONLY write to the label
@@ -409,6 +411,10 @@ export async function runScheduledObservePass(input: {
   input.state.recordFindingOutcomeLabels(records);
 
   // Schedule bookkeeping: advance the global interval clock and each observed repo's cooldown.
+  // intervalMinutes is a CHECK cadence, not a work cadence: we advance the global clock on EVERY due
+  // pass, including a zero-target one (all repos in cooldown / nothing inside lookback). A no-op due
+  // pass therefore waits a full interval before re-checking — intended, so a barren cycle can't spin
+  // the selection query every tick. (This is not a bug: do not switch to advance-only-on-work.)
   input.state.recordCalibrationObserveAt(GLOBAL_OBSERVE_SCOPE, observedAt);
   for (const repo of observedRepos) input.state.recordCalibrationObserveAt(repo, observedAt);
 

--- a/src/review-gate.ts
+++ b/src/review-gate.ts
@@ -1,6 +1,6 @@
-import { createHash } from "node:crypto";
 import { validateFindingLocations } from "./diff.js";
 import {
+  buildFindingFingerprint,
   decideReviewEvent,
   normalizeFindingsForReview,
   normalizeTitleForDedup,
@@ -94,20 +94,10 @@ export function applyDeterministicReviewGate(input: {
   };
 }
 
-export function buildFindingFingerprint(
-  finding: Pick<Finding, "severity" | "path" | "line" | "title" | "body" | "category" | "why_this_matters">
-): string {
-  const canonical = JSON.stringify({
-    severity: finding.severity,
-    path: finding.path,
-    line: finding.line,
-    title: finding.title.trim().toLowerCase(),
-    body: finding.body.trim().toLowerCase(),
-    why_this_matters: finding.why_this_matters?.trim().toLowerCase() ?? "",
-    category: finding.category ?? "unknown"
-  });
-  return `finding:${createHash("sha256").update(canonical).digest("hex")}`;
-}
+// Re-exported from findings.ts (the leaf owner) to preserve the historical review-gate import path
+// for existing callers. Definition moved to break the review-gate → findings cycle the comment
+// builder would otherwise create (#357).
+export { buildFindingFingerprint } from "./findings.js";
 
 function applyRepoMemoryFalsePositiveSuppressions(
   findings: Finding[],

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -272,7 +272,11 @@ export async function observeScheduledOutcomes(input: {
 }): Promise<void> {
   const schedule = input.config.calibrationLoop?.observeSchedule;
   if (!schedule?.enabled) return;
-  const evidenceDir = join(input.config.evidenceDir, localDateFolder(input.now), "calibration-observe");
+  // Bind ONE `now` for this pass so the evidence-folder date and the observe-pass timestamp
+  // (observedAt / schedule bookkeeping) can never drift apart across a future refactor: the date
+  // folder is derived from exactly the same instant that is forwarded to runScheduledObservePass.
+  const now = input.now ?? new Date();
+  const evidenceDir = join(input.config.evidenceDir, localDateFolder(now), "calibration-observe");
   const fetchOutcome = async (target: ScheduledObserveTarget): Promise<ObservedPullOutcome> => {
     // Read-only merge-state probe. A merged PR with no additional signal derives `none_observed`;
     // deeper post-merge signals (revert/hotfix/merged-fix diffs, human-thread resolution) are a
@@ -287,7 +291,7 @@ export async function observeScheduledOutcomes(input: {
     };
   };
   try {
-    await runScheduledObservePass({ state: input.state, config: schedule, evidenceDir, fetchOutcome, now: input.now });
+    await runScheduledObservePass({ state: input.state, config: schedule, evidenceDir, fetchOutcome, now });
   } catch (error) {
     // Observation is best-effort telemetry: never let a failure here disturb the review cycle.
     console.warn(`[calibration-observe] scheduled observe pass failed: ${redactSecrets(error instanceof Error ? error.message : String(error))}`);

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { isPreActivationExistingPull } from "./activation-policy.js";
 import { loadConfig, type BotConfig, type RepoReviewSchedulerConfig } from "./config.js";
 import {
@@ -42,6 +43,11 @@ import type { IssueCommentCommandSource } from "./commands.js";
 import { buildChangedSurfaceValidationReport } from "./validation-selector.js";
 import { redactSecrets } from "./secrets.js";
 import {
+  runScheduledObservePass,
+  type ObservedPullOutcome,
+  type ScheduledObserveTarget
+} from "./outcome-observer.js";
+import {
   activateRepoForNewOnlyReview,
   isCanaryAllowed,
   recordFailedReview,
@@ -49,6 +55,7 @@ import {
   recordProviderRateLimitCooldownIfNeeded,
   providerCooldownDurationMs,
   reviewPull,
+  localDateFolder,
   type ReviewPullInput,
   type ReviewPullResult,
   type RunOnceOptions,
@@ -241,7 +248,50 @@ export async function runScheduledCycleWithDeps(input: {
   }
 
   result.queue.remainingQueued = input.state.listReviewQueueJobs({ states: ["queued", "provider_deferred", "blocked_on_proof"] }).length;
+
+  // Scheduled outcome observation (#357). Additive, default-off, bounded, READ-ONLY: gated by
+  // calibrationLoop.observeSchedule.enabled. Disabled/absent ⇒ zero observer work and zero GitHub
+  // reads. It records outcome labels only; it never aggregates, promotes, writes config, touches
+  // publicDisplay.mode, or posts to GitHub. Failures here never affect the review cycle result.
+  await observeScheduledOutcomes({ config, github: input.github, state: input.state, now });
+
   return result;
+}
+
+/**
+ * Runs the scheduled, default-off outcome observation pass at the tail of a daemon cycle (#357). The
+ * `fetchOutcome` reader is built from the scheduler's read-only GitHub surface (`getPull` merge state)
+ * and is injected into the pure observe pass so tests stay hermetic. This is a no-op — no GitHub reads,
+ * no writes — unless `calibrationLoop.observeSchedule.enabled` is true AND the interval is due.
+ */
+export async function observeScheduledOutcomes(input: {
+  config: BotConfig;
+  github: SchedulerGitHubApi;
+  state: ReviewStateStore;
+  now?: Date;
+}): Promise<void> {
+  const schedule = input.config.calibrationLoop?.observeSchedule;
+  if (!schedule?.enabled) return;
+  const evidenceDir = join(input.config.evidenceDir, localDateFolder(input.now), "calibration-observe");
+  const fetchOutcome = async (target: ScheduledObserveTarget): Promise<ObservedPullOutcome> => {
+    // Read-only merge-state probe. A merged PR with no additional signal derives `none_observed`;
+    // deeper post-merge signals (revert/hotfix/merged-fix diffs, human-thread resolution) are a
+    // future enrichment and are left empty here (see docs/calibration-loop.md bootstrap note).
+    const pull = await input.github.getPull(target.repo, target.pullNumber);
+    return {
+      merged: Boolean(pull.merged_at),
+      revertedFlaggedChange: false,
+      hotfixLines: new Map(),
+      mergedFixLines: new Map(),
+      humanThreadResolved: false
+    };
+  };
+  try {
+    await runScheduledObservePass({ state: input.state, config: schedule, evidenceDir, fetchOutcome, now: input.now });
+  } catch (error) {
+    // Observation is best-effort telemetry: never let a failure here disturb the review cycle.
+    console.warn(`[calibration-observe] scheduled observe pass failed: ${redactSecrets(error instanceof Error ? error.message : String(error))}`);
+  }
 }
 
 type EnqueueStatus =

--- a/src/state.ts
+++ b/src/state.ts
@@ -95,6 +95,20 @@ export interface FindingOutcomeLabelRecord {
   evidenceRef?: string;
 }
 
+/** Public-safe posted-finding coordinates (#357) — reconstructable into an ObservedFinding. */
+export interface ReviewFindingRecord {
+  fingerprint: string;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  path: string;
+  line: number;
+  severity: string;
+  category: string;
+  confidence: number;
+  recordedAt: string;
+}
+
 export interface RepoActivationRecord {
   repo: string;
   activatedAt: string;
@@ -494,6 +508,30 @@ export class ReviewStateStore {
         primary key (fingerprint, repo, pull_number, head_sha)
       );
 
+      -- Public-safe findings ledger (#357): records the coordinates the bot ALREADY posted publicly
+      -- (fingerprint/path/line/severity/category/confidence — deliberately NO title/body), so the
+      -- daemon observe pass can reconstruct ObservedFinding and re-derive outcome labels later.
+      create table if not exists review_findings (
+        fingerprint text not null,
+        repo text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        path text not null,
+        line integer not null,
+        severity text not null,
+        category text not null,
+        confidence real not null,
+        recorded_at text not null,
+        primary key (fingerprint, repo, pull_number, head_sha)
+      );
+
+      -- Calibration observe-pass schedule state (#357): one global row (scope='__global__') tracks
+      -- lastObserveAt for the interval gate; per-repo rows (scope=repo) track per-repo cooldown.
+      create table if not exists calibration_observe_runs (
+        scope text primary key,
+        observed_at text not null
+      );
+
       create table if not exists repo_activation_watermarks (
         repo text primary key,
         activated_at text not null,
@@ -877,6 +915,89 @@ export class ReviewStateStore {
           )
           .all()) as unknown as FindingOutcomeLabelRow[];
     return rows.map(mapFindingOutcomeLabelRow);
+  }
+
+  /**
+   * Best-effort atomic write of posted-finding coordinates (#357). All rows land or none do (one
+   * BEGIN IMMEDIATE txn). Callers at the review-post seam MUST wrap this so a throw never blocks the
+   * review — this is benign posting bookkeeping, never a gate on posting.
+   */
+  recordReviewFindings(records: ReviewFindingRecord[]): void {
+    if (records.length === 0) return;
+    this.db.exec("begin immediate");
+    try {
+      for (const record of records) this.writeReviewFinding(record);
+      this.db.exec("commit");
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
+  private writeReviewFinding(record: ReviewFindingRecord): void {
+    validateRepoName(record.repo, "repo");
+    if (!/^finding:[a-f0-9]{64}$/.test(record.fingerprint)) {
+      throw new Error("review finding fingerprint must match finding:<64-hex>");
+    }
+    if (!Number.isInteger(record.pullNumber) || record.pullNumber < 1) throw new Error("pullNumber must be a positive integer");
+    if (!Number.isInteger(record.line) || record.line < 1) throw new Error("line must be a positive integer");
+    if (!Number.isFinite(record.confidence) || record.confidence < 0 || record.confidence > 1) {
+      throw new Error("confidence must be a number from 0 to 1");
+    }
+    // Idempotent: re-posting the same head UPSERTs. path is public (already posted); redact defensively.
+    this.db
+      .prepare(
+        `insert or replace into review_findings
+          (fingerprint, repo, pull_number, head_sha, path, line, severity, category, confidence, recorded_at)
+         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        record.fingerprint,
+        record.repo,
+        record.pullNumber,
+        record.headSha,
+        redactSecrets(record.path).trim(),
+        record.line,
+        record.severity,
+        record.category,
+        record.confidence,
+        record.recordedAt
+      );
+  }
+
+  /**
+   * List recorded review findings (#357), newest first, optionally scoped by repo and to those
+   * recorded on/after `since` (the lookback window). Used by the daemon observe pass to reconstruct
+   * ObservedFinding candidates.
+   */
+  listReviewFindings(input: { repo?: string; since?: string } = {}): ReviewFindingRecord[] {
+    const predicates: string[] = [];
+    const params: Array<string> = [];
+    if (input.repo) { predicates.push("repo = ?"); params.push(input.repo); }
+    if (input.since) { predicates.push("datetime(recorded_at) >= datetime(?)"); params.push(input.since); }
+    const where = predicates.length ? `where ${predicates.join(" and ")}` : "";
+    const rows = this.db
+      .prepare(
+        `select fingerprint, repo, pull_number, head_sha, path, line, severity, category, confidence, recorded_at
+         from review_findings ${where} order by datetime(recorded_at) desc`
+      )
+      .all(...params) as unknown as ReviewFindingRow[];
+    return rows.map(mapReviewFindingRow);
+  }
+
+  /** Last calibration observe-pass timestamp for a scope (#357): "__global__" for the interval gate,
+   * a repo slug for per-repo cooldown. Undefined ⇒ never observed. */
+  getCalibrationObserveAt(scope: string): string | undefined {
+    const row = this.db
+      .prepare("select observed_at from calibration_observe_runs where scope = ? limit 1")
+      .get(scope) as { observed_at: string } | undefined;
+    return row?.observed_at;
+  }
+
+  recordCalibrationObserveAt(scope: string, observedAt: string): void {
+    this.db
+      .prepare("insert or replace into calibration_observe_runs (scope, observed_at) values (?, ?)")
+      .run(scope, observedAt);
   }
 
   getReviewReadiness(repo: string, pullNumber: number, headSha: string): ReviewReadinessRecord | undefined {
@@ -3170,6 +3291,19 @@ interface FindingOutcomeLabelRow {
   evidence_ref: string | null;
 }
 
+interface ReviewFindingRow {
+  fingerprint: string;
+  repo: string;
+  pull_number: number;
+  head_sha: string;
+  path: string;
+  line: number;
+  severity: string;
+  category: string;
+  confidence: number;
+  recorded_at: string;
+}
+
 interface RepoActivationRow {
   repo: string;
   activated_at: string;
@@ -3359,6 +3493,21 @@ function mapFindingOutcomeLabelRow(row: FindingOutcomeLabelRow): FindingOutcomeL
     verdict: row.verdict,
     observedAt: row.observed_at,
     ...(row.evidence_ref ? { evidenceRef: row.evidence_ref } : {})
+  };
+}
+
+function mapReviewFindingRow(row: ReviewFindingRow): ReviewFindingRecord {
+  return {
+    fingerprint: row.fingerprint,
+    repo: row.repo,
+    pullNumber: row.pull_number,
+    headSha: row.head_sha,
+    path: row.path,
+    line: row.line,
+    severity: row.severity,
+    category: row.category,
+    confidence: row.confidence,
+    recordedAt: row.recorded_at
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,14 @@ export interface ReviewComment {
   /** Model confidence (0..1); internal gating/evidence metadata, never rendered publicly. */
   confidence: number;
   title: string;
+  /**
+   * Deterministic finding fingerprint computed at the gate over the ORIGINAL Finding (including
+   * why_this_matters and raw title/body), so it matches the fingerprint used by the deterministic
+   * gate and the finding_outcome_labels store. Never recompute this from the public/sanitized
+   * comment fields — that would drop why_this_matters and hash the redacted text, breaking the
+   * observe→label→calibration-aggregate join (#357).
+   */
+  fingerprint: string;
 }
 
 export interface ReviewPlan {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -38,7 +38,7 @@ import {
   listReposToScan,
   resolveRepoProfile
 } from "./repo-policy.js";
-import { applyDeterministicReviewGate, type RepoMemoryFalsePositiveEntry } from "./review-gate.js";
+import { applyDeterministicReviewGate, buildFindingFingerprint, type RepoMemoryFalsePositiveEntry } from "./review-gate.js";
 import {
   buildOutcomeLedger,
   buildOutcomeLedgerInputFromReviewPlan,
@@ -65,6 +65,7 @@ import {
   type ProcessedStatus,
   type ReviewQueueJobState,
   type ReviewHeadClaim,
+  type ReviewFindingRecord,
   type ReviewReadinessRecord,
   type ReviewReadinessState,
   type ReviewerSessionJobState,
@@ -78,7 +79,7 @@ import { buildReviewPrompt, extractJsonObject, extractZCodeResponse, isZCodeSche
 import { runSelfConsistencyRecheck, type SelfConsistencySecondDrawResult } from "./self-consistency.js";
 import type { DeterministicReviewGateResult } from "./review-gate.js";
 import { formatZCodeTimeoutFailureError } from "./zcode-timeout.js";
-import type { Finding, PullFilePatch, PullRequestSummary, RepositorySummary, ReviewEvent, ReviewPlan, ReviewProviderMetadata } from "./types.js";
+import type { Finding, PullFilePatch, PullRequestSummary, RepositorySummary, ReviewComment, ReviewEvent, ReviewPlan, ReviewProviderMetadata } from "./types.js";
 
 const LICENSE_GATE_REPO_VISIBILITY_CACHE_TTL_MS = 10 * 60_000;
 const LICENSE_GATE_UNKNOWN_REPO_VISIBILITY_CACHE_TTL_MS = 2 * 60_000;
@@ -1665,6 +1666,10 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       event,
       reviewUrl: review.html_url
     });
+    // Public-safe findings ledger (#357): record the coordinates we just posted publicly so the
+    // daemon calibration-observe pass can re-derive outcome labels later. BEST-EFFORT / FAIL-OPEN —
+    // the review is already durable; observation bookkeeping must never block or fail the review.
+    recordPostedReviewFindings({ state, repo, pull, comments });
     releaseReviewCapacity();
     if (input.processedHeadPolicy !== "retry_failed_head") {
       await reconcileProcessedHeadAfterDirectReviewSafely({
@@ -2330,6 +2335,51 @@ function recordStaleHeadSkip(input: {
     status: "skipped",
     error: `${input.stale.reason}: live=${input.stale.liveHeadSha}`
   });
+}
+
+/**
+ * Best-effort, FAIL-OPEN recording of the posted findings' public coordinates (#357). The fingerprint
+ * is derived from the same fields as the gate so it matches label-store rows; title/body are used only
+ * to compute the fingerprint and are NEVER stored. Any failure is swallowed — the review is already
+ * posted and durable, so observation bookkeeping must never block or fail it.
+ */
+export function recordPostedReviewFindings(input: {
+  state: Pick<ReviewStateStore, "recordReviewFindings">;
+  repo: string;
+  pull: PullRequestSummary;
+  comments: ReviewComment[];
+  now?: Date;
+}): void {
+  try {
+    if (input.comments.length === 0) return;
+    const recordedAt = (input.now ?? new Date()).toISOString();
+    const records: ReviewFindingRecord[] = input.comments.map((comment) => ({
+      fingerprint: buildFindingFingerprint({
+        severity: comment.severity,
+        path: comment.path,
+        line: comment.line,
+        title: comment.title,
+        body: comment.body,
+        category: comment.category
+      }),
+      repo: input.repo,
+      pullNumber: input.pull.number,
+      headSha: input.pull.head.sha,
+      path: comment.path,
+      line: comment.line,
+      severity: comment.severity,
+      category: comment.category,
+      confidence: comment.confidence,
+      recordedAt
+    }));
+    input.state.recordReviewFindings(records);
+  } catch (error) {
+    console.warn(
+      `[findings-ledger] best-effort review-findings record failed repo=${input.repo} pr=${input.pull.number}: ${
+        redactSecrets(error instanceof Error ? error.message : String(error))
+      }`
+    );
+  }
 }
 
 export function recordConcurrentClaimSkip(input: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -38,7 +38,7 @@ import {
   listReposToScan,
   resolveRepoProfile
 } from "./repo-policy.js";
-import { applyDeterministicReviewGate, buildFindingFingerprint, type RepoMemoryFalsePositiveEntry } from "./review-gate.js";
+import { applyDeterministicReviewGate, type RepoMemoryFalsePositiveEntry } from "./review-gate.js";
 import {
   buildOutcomeLedger,
   buildOutcomeLedgerInputFromReviewPlan,
@@ -2354,14 +2354,11 @@ export function recordPostedReviewFindings(input: {
     if (input.comments.length === 0) return;
     const recordedAt = (input.now ?? new Date()).toISOString();
     const records: ReviewFindingRecord[] = input.comments.map((comment) => ({
-      fingerprint: buildFindingFingerprint({
-        severity: comment.severity,
-        path: comment.path,
-        line: comment.line,
-        title: comment.title,
-        body: comment.body,
-        category: comment.category
-      }),
+      // Use the gate-computed fingerprint threaded onto the comment (over the ORIGINAL finding,
+      // incl. why_this_matters + raw title/body). Recomputing here from the sanitized comment would
+      // hash a DIFFERENT identity (why_this_matters="", redacted title/body) and key the ledger under
+      // a fingerprint that finding_outcome_labels never uses — silently breaking the #357 join.
+      fingerprint: comment.fingerprint,
       repo: input.repo,
       pullNumber: input.pull.number,
       headSha: input.pull.head.sha,

--- a/tests/observe-scheduling.test.ts
+++ b/tests/observe-scheduling.test.ts
@@ -1,0 +1,316 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadConfigFromObject } from "../src/config.js";
+import { ReviewStateStore, type ReviewFindingRecord } from "../src/state.js";
+import {
+  recordPostedReviewFindings
+} from "../src/worker.js";
+import {
+  runScheduledObservePass,
+  type ObservedPullOutcome,
+  type ScheduledObserveTarget
+} from "../src/outcome-observer.js";
+import { observeScheduledOutcomes, type SchedulerGitHubApi } from "../src/scheduler.js";
+import type { PullRequestSummary, ReviewComment } from "../src/types.js";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function newStore(): { store: ReviewStateStore; root: string } {
+  const root = mkdtempSync(join(tmpdir(), "evaos-observe-sched-"));
+  roots.push(root);
+  return { store: new ReviewStateStore(join(root, "state.sqlite")), root };
+}
+
+function baseConfigObject(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    pilotRepos: ["owner/repo"],
+    workRoot: "/tmp/runtime",
+    statePath: "/tmp/state.sqlite",
+    evidenceDir: "/tmp/evidence",
+    ...overrides
+  };
+}
+
+const OBSERVE_SCHEDULE = {
+  enabled: true,
+  intervalMinutes: 60,
+  maxPullsPerCycle: 2,
+  perRepoCooldownMinutes: 720,
+  lookbackDays: 30
+};
+
+const FINDING: ReviewFindingRecord = {
+  fingerprint: `finding:${"a".repeat(64)}`,
+  repo: "owner/repo",
+  pullNumber: 1,
+  headSha: "sha1",
+  path: "src/save.ts",
+  line: 42,
+  severity: "P1",
+  category: "data_loss",
+  confidence: 0.9,
+  recordedAt: "2026-07-06T00:00:00.000Z"
+};
+
+function fullObserved(overrides: Partial<ObservedPullOutcome>): ObservedPullOutcome {
+  return {
+    merged: true,
+    revertedFlaggedChange: false,
+    hotfixLines: new Map(),
+    mergedFixLines: new Map(),
+    humanThreadResolved: false,
+    ...overrides
+  };
+}
+
+describe("calibrationLoop.observeSchedule config validation (#357)", () => {
+  it("is absent by default and validates a fully-specified block", () => {
+    expect(loadConfigFromObject(baseConfigObject()).calibrationLoop).toBeUndefined();
+    const config = loadConfigFromObject(baseConfigObject({ calibrationLoop: { observeSchedule: OBSERVE_SCHEDULE } }));
+    expect(config.calibrationLoop?.observeSchedule).toMatchObject({ enabled: true, intervalMinutes: 60 });
+  });
+
+  it("rejects unknown keys (fail-closed) on both the loop and the schedule", () => {
+    expect(() => loadConfigFromObject(baseConfigObject({ calibrationLoop: { promote: true } }))).toThrow(/unknown key "promote"/);
+    expect(() =>
+      loadConfigFromObject(baseConfigObject({ calibrationLoop: { observeSchedule: { ...OBSERVE_SCHEDULE, autoPromote: true } } }))
+    ).toThrow(/unknown key "autoPromote"/);
+  });
+
+  it("rejects a non-boolean enabled and non-positive integers", () => {
+    expect(() =>
+      loadConfigFromObject(baseConfigObject({ calibrationLoop: { observeSchedule: { ...OBSERVE_SCHEDULE, enabled: "yes" } } }))
+    ).toThrow(/enabled/);
+    expect(() =>
+      loadConfigFromObject(baseConfigObject({ calibrationLoop: { observeSchedule: { ...OBSERVE_SCHEDULE, intervalMinutes: 0 } } }))
+    ).toThrow(/intervalMinutes/);
+    expect(() =>
+      loadConfigFromObject(baseConfigObject({ calibrationLoop: { observeSchedule: { ...OBSERVE_SCHEDULE, lookbackDays: -1 } } }))
+    ).toThrow(/lookbackDays/);
+  });
+});
+
+describe("findings-ledger recording is fail-open (#357)", () => {
+  const pull = { number: 1, head: { sha: "sha1" } } as PullRequestSummary;
+  const comment: ReviewComment = {
+    path: "src/save.ts",
+    line: 42,
+    side: "RIGHT",
+    body: "loses data",
+    severity: "P1",
+    category: "data_loss",
+    confidence: 0.9,
+    title: "Data loss on save"
+  };
+
+  it("records posted findings into review_findings", () => {
+    const { store } = newStore();
+    recordPostedReviewFindings({ state: store, repo: "owner/repo", pull, comments: [comment] });
+    const rows = store.listReviewFindings({});
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ repo: "owner/repo", pullNumber: 1, headSha: "sha1", path: "src/save.ts", line: 42 });
+    // Public-safe: no title/body text is persisted (only the fingerprint that encodes them).
+    expect(JSON.stringify(rows[0])).not.toContain("Data loss on save");
+    expect(JSON.stringify(rows[0])).not.toContain("loses data");
+    store.close();
+  });
+
+  it("does NOT throw when the store's recordReviewFindings throws (review path is never blocked)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const throwingStore = {
+      recordReviewFindings: () => {
+        throw new Error("db is locked");
+      }
+    };
+    expect(() =>
+      recordPostedReviewFindings({ state: throwingStore, repo: "owner/repo", pull, comments: [comment] })
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe("runScheduledObservePass gating + selection (#357)", () => {
+  it("disabled ⇒ byte-identical no-op: never calls the observer, records nothing, writes no evidence", async () => {
+    const { store, root } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const fetchOutcome = vi.fn<(target: ScheduledObserveTarget) => ObservedPullOutcome>();
+
+    const result = await runScheduledObservePass({
+      state: store,
+      config: undefined,
+      evidenceDir: join(root, "evidence"),
+      fetchOutcome
+    });
+
+    expect(result).toMatchObject({ ran: false, reason: "disabled" });
+    expect(fetchOutcome).not.toHaveBeenCalled();
+    expect(store.listFindingOutcomeLabels()).toHaveLength(0);
+    expect(store.getCalibrationObserveAt("__global__")).toBeUndefined();
+    store.close();
+  });
+
+  it("not-due ⇒ no observer calls when within the interval", async () => {
+    const { store, root } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const now = new Date("2026-07-06T02:00:00.000Z");
+    store.recordCalibrationObserveAt("__global__", "2026-07-06T01:30:00.000Z"); // 30 min ago; interval 60
+    const fetchOutcome = vi.fn<(target: ScheduledObserveTarget) => ObservedPullOutcome>();
+
+    const result = await runScheduledObservePass({
+      state: store,
+      config: OBSERVE_SCHEDULE,
+      evidenceDir: join(root, "evidence"),
+      fetchOutcome,
+      now
+    });
+
+    expect(result).toMatchObject({ ran: false, reason: "not_due" });
+    expect(fetchOutcome).not.toHaveBeenCalled();
+    store.close();
+  });
+
+  it("records outcome labels for a merged candidate and advances schedule state", async () => {
+    const { store, root } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const now = new Date("2026-07-06T10:00:00.000Z");
+
+    const result = await runScheduledObservePass({
+      state: store,
+      config: OBSERVE_SCHEDULE,
+      evidenceDir: join(root, "evidence"),
+      fetchOutcome: () => fullObserved({ merged: true, revertedFlaggedChange: true }),
+      now
+    });
+
+    expect(result).toMatchObject({ ran: true, reason: "observed", targets: 1, labeled: 1 });
+    const labels = store.listFindingOutcomeLabels();
+    expect(labels).toHaveLength(1);
+    expect(labels[0]).toMatchObject({ labelSource: "revert", verdict: "true_positive", fingerprint: FINDING.fingerprint });
+    // Schedule bookkeeping updated for both the global interval and the observed repo cooldown.
+    expect(store.getCalibrationObserveAt("__global__")).toBe(now.toISOString());
+    expect(store.getCalibrationObserveAt("owner/repo")).toBe(now.toISOString());
+    const packet = JSON.parse(readFileSync(join(root, "evidence", "calibration-observe.json"), "utf8"));
+    expect(packet.observations[0]).toMatchObject({ repo: "owner/repo", pullNumber: 1, postMergeStatus: "reverted" });
+    store.close();
+  });
+
+  it("caps at maxPullsPerCycle heads", async () => {
+    const { store, root } = newStore();
+    store.recordReviewFindings([
+      { ...FINDING, pullNumber: 1, headSha: "sha1", fingerprint: `finding:${"a".repeat(64)}` },
+      { ...FINDING, pullNumber: 2, headSha: "sha2", fingerprint: `finding:${"b".repeat(64)}` },
+      { ...FINDING, pullNumber: 3, headSha: "sha3", fingerprint: `finding:${"c".repeat(64)}` }
+    ]);
+    const seen: number[] = [];
+
+    const result = await runScheduledObservePass({
+      state: store,
+      config: { ...OBSERVE_SCHEDULE, maxPullsPerCycle: 2 },
+      evidenceDir: join(root, "evidence"),
+      fetchOutcome: (target) => {
+        seen.push(target.pullNumber);
+        return fullObserved({ merged: false });
+      },
+      now: new Date("2026-07-06T10:00:00.000Z")
+    });
+
+    expect(result.targets).toBe(2);
+    expect(seen).toHaveLength(2);
+    store.close();
+  });
+
+  it("skips a repo within per-repo cooldown", async () => {
+    const { store, root } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const now = new Date("2026-07-06T10:00:00.000Z");
+    // owner/repo observed 1h ago; cooldown is 720min ⇒ still cooling.
+    store.recordCalibrationObserveAt("owner/repo", "2026-07-06T09:00:00.000Z");
+    const fetchOutcome = vi.fn(() => fullObserved({ merged: false }));
+
+    const result = await runScheduledObservePass({
+      state: store,
+      config: OBSERVE_SCHEDULE,
+      evidenceDir: join(root, "evidence"),
+      fetchOutcome,
+      now
+    });
+
+    expect(result.targets).toBe(0);
+    expect(fetchOutcome).not.toHaveBeenCalled();
+    store.close();
+  });
+
+  it("respects the lookback window (findings older than lookback are excluded)", async () => {
+    const { store, root } = newStore();
+    store.recordReviewFindings([{ ...FINDING, recordedAt: "2026-01-01T00:00:00.000Z" }]);
+    const fetchOutcome = vi.fn(() => fullObserved({ merged: false }));
+
+    const result = await runScheduledObservePass({
+      state: store,
+      config: { ...OBSERVE_SCHEDULE, lookbackDays: 7 },
+      evidenceDir: join(root, "evidence"),
+      fetchOutcome,
+      now: new Date("2026-07-06T10:00:00.000Z")
+    });
+
+    expect(result.targets).toBe(0);
+    expect(fetchOutcome).not.toHaveBeenCalled();
+    store.close();
+  });
+});
+
+describe("observeScheduledOutcomes scheduler wiring (#357)", () => {
+  function stubGithub(): SchedulerGitHubApi & { getPull: ReturnType<typeof vi.fn> } {
+    const getPull = vi.fn(async (repo: string, pullNumber: number) => ({
+      number: pullNumber,
+      head: { sha: `sha${pullNumber}` },
+      merged_at: null
+    }) as unknown as PullRequestSummary);
+    return {
+      listOpenPulls: async () => [],
+      getPull,
+      listIssueComments: async () => []
+    };
+  }
+
+  it("disabled ⇒ zero GitHub reads (byte-identical daemon cycle)", async () => {
+    const { store } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const github = stubGithub();
+    const config = loadConfigFromObject(baseConfigObject());
+
+    await observeScheduledOutcomes({ config, github, state: store, now: new Date("2026-07-06T10:00:00.000Z") });
+
+    expect(github.getPull).not.toHaveBeenCalled();
+    expect(store.listFindingOutcomeLabels()).toHaveLength(0);
+    store.close();
+  });
+
+  it("enabled ⇒ reads merge state read-only and records; never aggregates/promotes/writes config", async () => {
+    const { store } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const github = stubGithub();
+    github.getPull.mockResolvedValueOnce({
+      number: 1,
+      head: { sha: "sha1" },
+      merged_at: "2026-07-05T00:00:00.000Z"
+    } as unknown as PullRequestSummary);
+    const config = loadConfigFromObject(
+      baseConfigObject({ calibrationLoop: { observeSchedule: OBSERVE_SCHEDULE } })
+    );
+
+    await observeScheduledOutcomes({ config, github, state: store, now: new Date("2026-07-06T10:00:00.000Z") });
+
+    expect(github.getPull).toHaveBeenCalledWith("owner/repo", 1);
+    // A merged PR with no additional signal derives none_observed (bounded reader).
+    expect(store.listFindingOutcomeLabels()).toHaveLength(1);
+    expect(store.getCalibrationObserveAt("__global__")).toBeDefined();
+    store.close();
+  });
+});

--- a/tests/observe-scheduling.test.ts
+++ b/tests/observe-scheduling.test.ts
@@ -13,7 +13,8 @@ import {
   type ScheduledObserveTarget
 } from "../src/outcome-observer.js";
 import { observeScheduledOutcomes, type SchedulerGitHubApi } from "../src/scheduler.js";
-import type { PullRequestSummary, ReviewComment } from "../src/types.js";
+import { applyDeterministicReviewGate, buildFindingFingerprint } from "../src/review-gate.js";
+import type { Finding, PullFilePatch, PullRequestSummary, ReviewComment } from "../src/types.js";
 
 const roots: string[] = [];
 afterEach(() => {
@@ -106,7 +107,8 @@ describe("findings-ledger recording is fail-open (#357)", () => {
     severity: "P1",
     category: "data_loss",
     confidence: 0.9,
-    title: "Data loss on save"
+    title: "Data loss on save",
+    fingerprint: `finding:${"a".repeat(64)}`
   };
 
   it("records posted findings into review_findings", () => {
@@ -118,6 +120,52 @@ describe("findings-ledger recording is fail-open (#357)", () => {
     // Public-safe: no title/body text is persisted (only the fingerprint that encodes them).
     expect(JSON.stringify(rows[0])).not.toContain("Data loss on save");
     expect(JSON.stringify(rows[0])).not.toContain("loses data");
+    store.close();
+  });
+
+  it("ledger fingerprint EQUALS the gate/finding_outcome_labels fingerprint (end-to-end join works)", () => {
+    // A finding whose why_this_matters is load-bearing for the fingerprint: recomputing the hash from
+    // the sanitized ReviewComment (no why_this_matters, public title/body) would produce a DIFFERENT
+    // key. This test pins that the ledger stores the SAME fingerprint the observe→label path uses.
+    const finding: Finding = {
+      severity: "P1",
+      path: "src/save.ts",
+      line: 42,
+      title: "Data loss on save",
+      body: "overwriteAllData() clobbers the file before the retry lands",
+      confidence: 0.9,
+      category: "data_loss",
+      why_this_matters: "silent, unrecoverable user data loss on the common save path"
+    };
+    const files: PullFilePatch[] = [
+      { filename: "src/save.ts", patch: "@@ -40,2 +40,3 @@\n export function save() {\n+  overwriteAllData();\n }" }
+    ];
+    const gate = applyDeterministicReviewGate({ findings: [finding], files });
+    expect(gate.comments).toHaveLength(1);
+
+    const { store } = newStore();
+    recordPostedReviewFindings({
+      state: store,
+      repo: "owner/repo",
+      pull: { number: 1, head: { sha: "sha1" } } as PullRequestSummary,
+      comments: gate.comments
+    });
+
+    const expected = buildFindingFingerprint(finding); // the key finding_outcome_labels uses
+    const ledgerFingerprint = store.listReviewFindings({})[0]?.fingerprint;
+    expect(ledgerFingerprint).toBe(expected);
+
+    // Guard against regression to the lossy recompute: hashing the sanitized comment (no
+    // why_this_matters) yields a DIFFERENT fingerprint, which is exactly what we must NOT store.
+    const lossy = buildFindingFingerprint({
+      severity: gate.comments[0].severity,
+      path: gate.comments[0].path,
+      line: gate.comments[0].line,
+      title: gate.comments[0].title,
+      body: gate.comments[0].body,
+      category: gate.comments[0].category
+    });
+    expect(ledgerFingerprint).not.toBe(lossy);
     store.close();
   });
 
@@ -261,6 +309,78 @@ describe("runScheduledObservePass gating + selection (#357)", () => {
 
     expect(result.targets).toBe(0);
     expect(fetchOutcome).not.toHaveBeenCalled();
+    store.close();
+  });
+
+  it("cap interacts with multi-repo cooldown: cooled heads are skipped WITHOUT consuming a slot, cap applies across the post-cooldown set", async () => {
+    const { store, root } = newStore();
+    const now = new Date("2026-07-06T10:00:00.000Z");
+    // repoA is in cooldown (observed 1h ago, 720min cooldown); repoB and repoC are eligible.
+    // Order the ledger so the cooled repoA head is encountered FIRST — it must not eat a slot, and
+    // with maxPullsPerCycle=2 both eligible heads (B and C) must still be selected.
+    store.recordCalibrationObserveAt("owner/repoA", "2026-07-06T09:00:00.000Z");
+    store.recordReviewFindings([
+      { ...FINDING, repo: "owner/repoA", pullNumber: 1, headSha: "shaA", fingerprint: `finding:${"a".repeat(64)}`, recordedAt: "2026-07-06T09:59:59.000Z" },
+      { ...FINDING, repo: "owner/repoB", pullNumber: 2, headSha: "shaB", fingerprint: `finding:${"b".repeat(64)}`, recordedAt: "2026-07-06T09:59:58.000Z" },
+      { ...FINDING, repo: "owner/repoC", pullNumber: 3, headSha: "shaC", fingerprint: `finding:${"c".repeat(64)}`, recordedAt: "2026-07-06T09:59:57.000Z" }
+    ]);
+    const observedRepos: string[] = [];
+
+    const result = await runScheduledObservePass({
+      state: store,
+      config: { ...OBSERVE_SCHEDULE, maxPullsPerCycle: 2 },
+      evidenceDir: join(root, "evidence"),
+      fetchOutcome: (target) => {
+        observedRepos.push(target.repo);
+        return fullObserved({ merged: false });
+      },
+      now
+    });
+
+    expect(result.targets).toBe(2);
+    // The cooled repoA is absent; the two eligible repos consumed the two slots.
+    expect(observedRepos.sort()).toEqual(["owner/repoB", "owner/repoC"]);
+    store.close();
+  });
+
+  it("advances the global interval clock on a ZERO-target due pass (intervalMinutes is a check cadence)", async () => {
+    const { store, root } = newStore();
+    // A due pass with nothing to observe (no findings at all). The clock must still advance so a
+    // barren cycle waits a full interval before re-checking rather than re-querying every tick.
+    const now = new Date("2026-07-06T10:00:00.000Z");
+    expect(store.getCalibrationObserveAt("__global__")).toBeUndefined();
+
+    const result = await runScheduledObservePass({
+      state: store,
+      config: OBSERVE_SCHEDULE,
+      evidenceDir: join(root, "evidence"),
+      fetchOutcome: () => fullObserved({ merged: false }),
+      now
+    });
+
+    expect(result).toMatchObject({ ran: true, targets: 0, labeled: 0 });
+    expect(store.getCalibrationObserveAt("__global__")).toBe(now.toISOString());
+    store.close();
+  });
+
+  it("redacts secret-shaped CONTENT in the written evidence packet, not just its structure", async () => {
+    const { store, root } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const token = ["ghp", "x".repeat(36)].join("_");
+
+    await runScheduledObservePass({
+      state: store,
+      config: OBSERVE_SCHEDULE,
+      evidenceDir: join(root, "evidence"),
+      fetchOutcome: () => fullObserved({ merged: true, revertedFlaggedChange: true, evidenceRef: `revert ${token}` }),
+      now: new Date("2026-07-06T10:00:00.000Z")
+    });
+
+    const raw = readFileSync(join(root, "evidence", "calibration-observe.json"), "utf8");
+    expect(raw).toContain("revert"); // the observation surfaced
+    expect(raw).not.toContain(token); // ...but the secret-shaped token was redacted
+    // And the token never reached the persisted label evidenceRef either.
+    expect(JSON.stringify(store.listFindingOutcomeLabels())).not.toContain(token);
     store.close();
   });
 });

--- a/tests/observe-scheduling.test.ts
+++ b/tests/observe-scheduling.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadConfigFromObject } from "../src/config.js";
 import { ReviewStateStore, type ReviewFindingRecord } from "../src/state.js";
 import {
+  localDateFolder,
   recordPostedReviewFindings
 } from "../src/worker.js";
 import {
@@ -312,6 +313,46 @@ describe("runScheduledObservePass gating + selection (#357)", () => {
     store.close();
   });
 
+  it("does NOT advance a repo's cooldown for a selected-but-UNMERGED target (re-observable next cycle)", async () => {
+    const { store, root } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const now = new Date("2026-07-06T10:00:00.000Z");
+
+    const result = await runScheduledObservePass({
+      state: store,
+      config: OBSERVE_SCHEDULE,
+      evidenceDir: join(root, "evidence"),
+      fetchOutcome: () => fullObserved({ merged: false }), // selected, read, but not yet merged
+      now
+    });
+
+    // The target was selected + read (so the global check-clock advances) but produced NO label,
+    // so the repo cooldown must NOT advance — otherwise we'd delay re-observing until it merges.
+    expect(result).toMatchObject({ ran: true, targets: 1, labeled: 0 });
+    expect(store.listFindingOutcomeLabels()).toHaveLength(0);
+    expect(store.getCalibrationObserveAt("__global__")).toBe(now.toISOString());
+    expect(store.getCalibrationObserveAt("owner/repo")).toBeUndefined();
+    store.close();
+  });
+
+  it("DOES advance a repo's cooldown for a merged+observed target (a label was recorded)", async () => {
+    const { store, root } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const now = new Date("2026-07-06T10:00:00.000Z");
+
+    const result = await runScheduledObservePass({
+      state: store,
+      config: OBSERVE_SCHEDULE,
+      evidenceDir: join(root, "evidence"),
+      fetchOutcome: () => fullObserved({ merged: true, revertedFlaggedChange: true }),
+      now
+    });
+
+    expect(result).toMatchObject({ ran: true, targets: 1, labeled: 1 });
+    expect(store.getCalibrationObserveAt("owner/repo")).toBe(now.toISOString());
+    store.close();
+  });
+
   it("cap interacts with multi-repo cooldown: cooled heads are skipped WITHOUT consuming a slot, cap applies across the post-cooldown set", async () => {
     const { store, root } = newStore();
     const now = new Date("2026-07-06T10:00:00.000Z");
@@ -431,6 +472,88 @@ describe("observeScheduledOutcomes scheduler wiring (#357)", () => {
     // A merged PR with no additional signal derives none_observed (bounded reader).
     expect(store.listFindingOutcomeLabels()).toHaveLength(1);
     expect(store.getCalibrationObserveAt("__global__")).toBeDefined();
+    store.close();
+  });
+
+  it("is fail-open: a throwing observe pass never propagates out of the daemon cycle", async () => {
+    const { store } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // getPull throws INSIDE runScheduledObservePass (at the fetchOutcome boundary) with a secret-shaped
+    // token in the message; observeScheduledOutcomes must swallow it (never disturb the review cycle)
+    // and redact the token in the warning.
+    const token = ["ghp", "z".repeat(36)].join("_");
+    const github: SchedulerGitHubApi = {
+      listOpenPulls: async () => [],
+      getPull: async () => {
+        throw new Error(`boom ${token}`);
+      },
+      listIssueComments: async () => []
+    };
+    const config = loadConfigFromObject(
+      baseConfigObject({ calibrationLoop: { observeSchedule: OBSERVE_SCHEDULE } })
+    );
+
+    await expect(
+      observeScheduledOutcomes({ config, github, state: store, now: new Date("2026-07-06T10:00:00.000Z") })
+    ).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls.flat().join(" ")).not.toContain(token);
+    store.close();
+  });
+
+  it("exercises the PRODUCTION deriveOutcomeLabel path end-to-end (merged getPull ⇒ recorded label)", async () => {
+    const { store } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const github = stubGithub();
+    // Real merged PR shape flowing through the production fetchOutcome ⇒ deriveOutcomeLabel. The
+    // bounded reader supplies no revert/hotfix/merged-fix signal, so the honest derived label is
+    // none_observed / unvalidated (a merged PR with no post-merge evidence).
+    github.getPull.mockResolvedValueOnce({
+      number: 1,
+      head: { sha: "sha1" },
+      merged_at: "2026-07-05T00:00:00.000Z"
+    } as unknown as PullRequestSummary);
+    const config = loadConfigFromObject(
+      baseConfigObject({ calibrationLoop: { observeSchedule: OBSERVE_SCHEDULE } })
+    );
+
+    await observeScheduledOutcomes({ config, github, state: store, now: new Date("2026-07-06T10:00:00.000Z") });
+
+    const labels = store.listFindingOutcomeLabels();
+    expect(labels).toHaveLength(1);
+    expect(labels[0]).toMatchObject({
+      fingerprint: FINDING.fingerprint,
+      labelSource: "none_observed",
+      verdict: "unvalidated"
+    });
+    store.close();
+  });
+
+  it("writes the evidence packet under the SAME date the observe pass timestamps (single now)", async () => {
+    const { store, root } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const github = stubGithub();
+    github.getPull.mockResolvedValueOnce({
+      number: 1,
+      head: { sha: "sha1" },
+      merged_at: "2026-07-05T00:00:00.000Z"
+    } as unknown as PullRequestSummary);
+    // evidenceDir is config.evidenceDir/<localDateFolder(now)>/calibration-observe. Use a fixed now
+    // and assert the folder and the packet's observedAt derive from that same instant.
+    const now = new Date("2026-07-06T10:00:00.000Z");
+    const config = loadConfigFromObject(
+      baseConfigObject({ evidenceDir: join(root, "evidence"), calibrationLoop: { observeSchedule: OBSERVE_SCHEDULE } })
+    );
+
+    await observeScheduledOutcomes({ config, github, state: store, now });
+
+    const dateFolder = localDateFolder(now);
+    const packetPath = join(root, "evidence", dateFolder, "calibration-observe", "calibration-observe.json");
+    const packet = JSON.parse(readFileSync(packetPath, "utf8"));
+    // The packet's observedAt is the same instant that named the date folder.
+    expect(localDateFolder(new Date(packet.observedAt))).toBe(dateFolder);
+    expect(packet.observedAt).toBe(now.toISOString());
     store.close();
   });
 });

--- a/tests/outcome-ledger.test.ts
+++ b/tests/outcome-ledger.test.ts
@@ -558,7 +558,8 @@ function sampleReviewPlan(): ReviewPlan {
         severity: "P1",
         category: "runtime_correctness",
         confidence: 0.9,
-        title: "Preserve provider state"
+        title: "Preserve provider state",
+        fingerprint: `finding:${"0".repeat(64)}`
       }
     ],
     dropped: [],

--- a/tests/self-consistency.test.ts
+++ b/tests/self-consistency.test.ts
@@ -8,6 +8,7 @@ function comment(overrides: Partial<ReviewComment> & Pick<ReviewComment, "severi
     side: "RIGHT",
     body: "A concrete review comment.",
     category: "data_loss",
+    fingerprint: `finding:${"0".repeat(64)}`,
     ...overrides
   };
 }

--- a/tests/walkthrough.test.ts
+++ b/tests/walkthrough.test.ts
@@ -72,7 +72,8 @@ describe("walkthrough comment rendering", () => {
         category: "data_loss",
         confidence: 0.9,
         title: "Rollback can overwrite fresh saves",
-        body: "The rollback path can clobber newer save data."
+        body: "The rollback path can clobber newer save data.",
+        fingerprint: `finding:${"0".repeat(64)}`
       }
     ];
 
@@ -480,7 +481,8 @@ describe("walkthrough comment rendering", () => {
           category: "security_boundary",
           confidence: 0.91,
           title: "Confidence: 95% should never be quoted",
-          body: "The model says 0.91 reliability in raw finding prose."
+          body: "The model says 0.91 reliability in raw finding prose.",
+          fingerprint: `finding:${"0".repeat(64)}`
         }
       ],
       dropped: [],
@@ -607,7 +609,8 @@ describe("walkthrough comment rendering", () => {
           category: "runtime_correctness",
           confidence: 0.88,
           title: "Model says 88% confidence",
-          body: "Confidence: 88%. The model is 0.88 confident."
+          body: "Confidence: 88%. The model is 0.88 confident.",
+          fingerprint: `finding:${"0".repeat(64)}`
         }
       ],
       dropped: [],
@@ -656,7 +659,8 @@ describe("walkthrough comment rendering", () => {
           category: "runtime_correctness",
           confidence: 0.91,
           title: "Regression with 99% confidence",
-          body: "Model body says `0.91` likely."
+          body: "Model body says `0.91` likely.",
+          fingerprint: `finding:${"0".repeat(64)}`
         }
       ],
       dropped: [],


### PR DESCRIPTION
Closes #357, parent #340.

## What

Adds an additive, **default-off** `calibrationLoop.observeSchedule` that runs a bounded, read-only outcome-observation pass at the tail of each scheduled daemon cycle (`runScheduledCycleWithDeps`).

When enabled and due, the pass:
- selects recently-recorded review findings within `lookbackDays`, grouped by `(repo, pull, head)`
- skips repos inside `perRepoCooldownMinutes`, caps the batch at `maxPullsPerCycle`
- reads each PR's merge state **read-only**, derives outcome labels via the existing `deriveOutcomeLabel` precedence, and records them through the atomic `recordFindingOutcomeLabels` batch
- writes a redacted `calibration-observe.json` evidence packet and advances schedule state

## Load-bearing invariants (tested)

- Never aggregates, promotes, mutates config, touches `publicDisplay.mode`, or posts to GitHub.
- Disabled / absent config ⇒ **byte-identical no-op**: zero observer calls, zero extra GitHub reads.
- A failure in the pass never disturbs the review cycle.

## Observation source — reuse-first finding

Reconstructing an outcome needs each finding's path and line. The existing `outcome-ledger` is a **file packet** (`writeFileSync`), not a queryable table, and its risk-claim input carries no per-finding path/line — so it could not be reused. Added a minimal **public-safe** `review_findings` ledger (fingerprint, repo, pull, head, path, line, severity, category, confidence — **never title/body text**; all fields already public in the posted review), written at the review-post seam adjacent to `recordProcessed`.

This write is **best-effort and fail-open**: if it throws, the review still posts (covered by a dedicated test — a throwing store still lets `recordPostedReviewFindings` complete without throwing).

**Bootstrap note** (documented, not solved): the scheduled pass only sees findings recorded into `review_findings` after this ships; use the manual `outcome-observe` CLI to backfill older PRs.

## Tests / build

- New `tests/observe-scheduling.test.ts` (13 tests): config validation (fail-closed, unknown keys), fail-open findings recording, gating (disabled/not-due), candidate selection (cap, per-repo cooldown, lookback), label recording + schedule-state advance, and scheduler-wiring (disabled ⇒ zero GitHub reads).
- `npm run build` green; full `vitest run` green (1331 tests, 75 files).