### PR TITLE
Lifecycle markers + fixer-handoff metadata (#263)

### DIFF
--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -2,6 +2,12 @@ import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { sanitizePublicConfidenceText, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
 import { redactSecrets } from "./secrets.js";
+import {
+  buildIssueHash,
+  renderMarkerLifecycleFields,
+  type IssueLifecycleState,
+  type MarkerLifecycleFields
+} from "./marker-lifecycle.js";
 import { writeSecureFileSync } from "./temp-files.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
 import type {
@@ -171,6 +177,8 @@ export function buildIssueEnrichmentComment(input: {
   maxSuggestions?: number;
   postIssueComment?: boolean;
   publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
+  /** Optional lifecycle/handoff metadata (#263). Rides the diagnostic issue state marker only. */
+  lifecycle?: IssueEnrichmentLifecycleInput;
 }): EnrichmentComment {
   validateRepoIssue({ repo: input.repo, issueNumber: input.issue.number });
   const eligibility = getIssueEnrichmentEligibility(input.issue);
@@ -261,7 +269,10 @@ export function buildIssueEnrichmentComment(input: {
     repo: input.repo,
     issueNumber: input.issue.number,
     state,
-    bodyHash
+    bodyHash,
+    // Opt-in only: absent lifecycle input ⇒ no new tokens ⇒ byte-identical marker text.
+    ...(input.lifecycle?.state ? { lifecycleState: input.lifecycle.state } : {}),
+    ...(input.lifecycle ? { lifecycle: buildIssueLifecycleFields(input.repo, input.issue.number, input.lifecycle) } : {})
   });
 
   return {
@@ -269,6 +280,34 @@ export function buildIssueEnrichmentComment(input: {
     body: [marker, stateMarker, redactedVisibleBody].join("\n"),
     bodyHash,
     postIssueComment: input.postIssueComment ?? false
+  };
+}
+
+/**
+ * Optional #263 lifecycle/handoff inputs for an issue enrichment marker. `state` is the mapped
+ * issue-side lifecycle state (a renaming of the existing enrichment decision); the rest are
+ * optional passthroughs. All ride the diagnostic issue state marker only.
+ */
+export interface IssueEnrichmentLifecycleInput {
+  state?: IssueLifecycleState;
+  runId?: string;
+  handoffTarget?: string;
+}
+
+function buildIssueLifecycleFields(
+  repo: string,
+  issueNumber: number,
+  lifecycle: IssueEnrichmentLifecycleInput | undefined
+): MarkerLifecycleFields {
+  // Role is fixed for the enricher surface; issueHash correlates repo+issue. outcome=enriched only
+  // when the mapped lifecycle state is `enriched` (a terminal enrich decision). runId/handoffTarget
+  // are optional passthroughs.
+  return {
+    role: "enricher",
+    issueHash: buildIssueHash({ repo, issueNumber }),
+    ...(lifecycle?.state === "enriched" ? { outcome: "enriched" as const } : {}),
+    ...(lifecycle?.runId ? { runId: lifecycle.runId } : {}),
+    ...(lifecycle?.handoffTarget ? { handoffTarget: lifecycle.handoffTarget } : {})
   };
 }
 
@@ -357,11 +396,22 @@ function buildStateMarker(input: { repo: string; pullNumber: number; headSha: st
   return `${ENRICHMENT_STATE_MARKER_PREFIX} version=${ENRICHMENT_SCHEMA_VERSION} repo=${input.repo} pr=${input.pullNumber} sha=${input.headSha} hash=${input.bodyHash} -->`;
 }
 
-function buildIssueStateMarker(input: { repo: string; issueNumber: number; state: string; bodyHash: string }): string {
+function buildIssueStateMarker(input: {
+  repo: string;
+  issueNumber: number;
+  state: string;
+  bodyHash: string;
+  lifecycle?: MarkerLifecycleFields;
+  lifecycleState?: IssueLifecycleState;
+}): string {
   validateRepoIssue(input);
   if (!/^[0-9a-f]{64}$/i.test(input.bodyHash)) throw new Error(`Invalid enrichment body hash: ${input.bodyHash}`);
   const state = normalizeIssueState({ state: input.state, number: input.issueNumber });
-  return `${ENRICHMENT_STATE_MARKER_PREFIX} version=${ENRICHMENT_SCHEMA_VERSION} repo=${input.repo} issue=${input.issueNumber} state=${state} hash=${input.bodyHash} -->`;
+  // `lifecycle=` is the #263 issue-side lifecycle state; distinct from the `state=` identity token
+  // (open|closed|unknown) so both round-trip. Absent ⇒ token omitted ⇒ byte-identical marker.
+  const lifecycleState = input.lifecycleState ? ` lifecycle=${input.lifecycleState}` : "";
+  const lifecycle = renderMarkerLifecycleFields(input.lifecycle);
+  return `${ENRICHMENT_STATE_MARKER_PREFIX} version=${ENRICHMENT_SCHEMA_VERSION} repo=${input.repo} issue=${input.issueNumber} state=${state}${lifecycleState} hash=${input.bodyHash}${lifecycle} -->`;
 }
 
 function validateIdentity(input: { repo: string; pullNumber: number; headSha: string }): void {

--- a/src/issue-enrichment.ts
+++ b/src/issue-enrichment.ts
@@ -3,7 +3,8 @@ import {
   buildIssueEnrichmentDryRunOutput,
   postEnrichmentComment,
   type EnrichmentComment,
-  type EnrichmentCommentGithub
+  type EnrichmentCommentGithub,
+  type IssueEnrichmentLifecycleInput
 } from "./enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
 import { redactSecrets } from "./secrets.js";
@@ -772,8 +773,10 @@ export async function runIssueEnrichmentCycle(input: {
 
       try {
         if (!issue) throw new Error(`Issue metadata missing for ${item.repo}#${item.issueNumber}`);
-        const plannedEnrichment = plannedEnrichmentForItem(item);
-        const enrichment = plannedEnrichment ?? buildIssueEnrichmentForCycle(config, item.repo, issue);
+        // #263: attach the mapped lifecycle state (`enriched`) to the marker at post time. This is a
+        // renaming of the decision already made (status=posted) and rides the diagnostic state marker
+        // only; bodyHash excludes the marker, so idempotency is unaffected.
+        const enrichment = buildIssueEnrichmentForCycle(config, item.repo, issue, { state: "enriched" });
         const postBodyHash = plannedBodyHashForItem(item) ?? enrichment.bodyHash;
         const post = await postEnrichmentComment({
           enabled: true,
@@ -1188,7 +1191,8 @@ function isIssueEnrichmentCommentAction(action: IssueEnrichmentScanAction): bool
 function buildIssueEnrichmentForCycle(
   config: IssueEnrichmentConfig,
   repo: string,
-  issue: GitHubRelatedIssueOrPull
+  issue: GitHubRelatedIssueOrPull,
+  lifecycle?: IssueEnrichmentLifecycleInput
 ): EnrichmentComment {
   const policy = resolveIssueEnrichmentRepoPolicy(config, repo);
   const allowlists = issueSuggestionAllowlists(policy.suggestions);
@@ -1197,7 +1201,8 @@ function buildIssueEnrichmentForCycle(
     issue,
     allowedLabels: allowlists.allowedLabels,
     allowedOwners: allowlists.allowedOwners,
-    postIssueComment: true
+    postIssueComment: true,
+    ...(lifecycle ? { lifecycle } : {})
   });
 }
 

--- a/src/marker-lifecycle.ts
+++ b/src/marker-lifecycle.ts
@@ -1,0 +1,163 @@
+import { createHash } from "node:crypto";
+import { redactSecrets } from "./secrets.js";
+
+/**
+ * Additive, backward-compatible lifecycle + fixer-handoff metadata for the bot-owned markers
+ * (#263). These fields ride the DIAGNOSTIC state marker only — never the public identity marker
+ * that keys sticky-comment upsert — so the dedup key stays byte-stable and posting behavior is
+ * unchanged. Every field is optional: when absent, the marker is byte-identical to today.
+ *
+ * All values are derived from decisions the run already made (see mapReviewOutcome / mapReviewRole
+ * / mapIssueLifecycleState); nothing here computes new behavior or posts new comments.
+ */
+
+/** Actor role for a marker-posting surface. */
+export type MarkerRole = "reviewer" | "enricher" | "observer";
+
+/** Terminal review outcome, mapped from the existing review-status decision. */
+export type MarkerOutcome = "reviewed" | "enriched" | "skipped" | "deferred" | "stale";
+
+/** Issue-side lifecycle state, mapped from the existing issue-enrichment decision path. */
+export type IssueLifecycleState =
+  | "enriched"
+  | "needs-human-routing"
+  | "needs-repro"
+  | "ready-for-fix-proposal"
+  | "stale-head"
+  | "deferred-by-throttle";
+
+/** Optional lifecycle/handoff metadata appended to a diagnostic state marker. */
+export interface MarkerLifecycleFields {
+  runId?: string;
+  role?: MarkerRole;
+  outcome?: MarkerOutcome;
+  /** Free-form downstream-fixer pointer (agent/label). Diagnostic-only; redacted. */
+  handoffTarget?: string;
+  /** Stable hash of the reviewed subject; never raw subject text. */
+  issueHash?: string;
+}
+
+/** Parsed lifecycle fields plus the issue-side `lifecycle=` state token, for round-trip checks. */
+export interface ParsedMarkerLifecycleFields extends MarkerLifecycleFields {
+  issueLifecycleState?: IssueLifecycleState;
+}
+
+const MARKER_FIELD_ORDER = ["runId", "role", "outcome", "handoffTarget", "issueHash"] as const;
+// Marker tokens are space-delimited `key=value` pairs closed by ` -->`; values may not contain
+// whitespace or the comment terminator, so we sanitize to a token-safe charset.
+const TOKEN_UNSAFE_PATTERN = /[\s>]|--/g;
+
+/**
+ * Stable, hashed subject identifier for cross-run correlation. Hashes the identity tuple
+ * (repo+pr+head or repo+issue) — never the raw subject text — and truncates to 16 hex chars.
+ */
+export function buildIssueHash(input:
+  | { repo: string; pullNumber: number; headSha: string }
+  | { repo: string; issueNumber: number }
+): string {
+  const subject = "pullNumber" in input
+    ? `${input.repo}#pr-${input.pullNumber}@${input.headSha}`
+    : `${input.repo}#issue-${input.issueNumber}`;
+  return createHash("sha256").update(subject, "utf8").digest("hex").slice(0, 16);
+}
+
+/**
+ * Renders the optional lifecycle fields as ` key=value` tokens in a fixed order. Returns "" when
+ * no fields are present so callers append byte-identical marker text to today's output. Values are
+ * redacted and stripped of marker-breaking characters; handoffTarget in particular is treated as
+ * untrusted free-form text.
+ */
+export function renderMarkerLifecycleFields(fields: MarkerLifecycleFields | undefined): string {
+  if (!fields) return "";
+  const parts: string[] = [];
+  for (const key of MARKER_FIELD_ORDER) {
+    const value = fields[key];
+    if (value === undefined) continue;
+    const token = sanitizeMarkerToken(value);
+    if (!token) continue;
+    parts.push(`${key}=${token}`);
+  }
+  return parts.length ? ` ${parts.join(" ")}` : "";
+}
+
+/**
+ * Parses lifecycle fields back out of a marker string, ignoring the identity tokens
+ * (repo/pr/sha/issue/state/status/version/hash/updated_at). Round-trips markers WITHOUT these
+ * fields to an empty object (never fail-closed on absence), which is what preserves back-compat.
+ */
+export function parseMarkerLifecycleFields(marker: string): ParsedMarkerLifecycleFields {
+  const fields: ParsedMarkerLifecycleFields = {};
+  for (const match of marker.matchAll(/(\w+)=(\S+)/g)) {
+    const key = match[1]!;
+    const value = match[2]!;
+    if (key === "role" && isMarkerRole(value)) fields.role = value;
+    else if (key === "outcome" && isMarkerOutcome(value)) fields.outcome = value;
+    else if (key === "runId") fields.runId = value;
+    else if (key === "handoffTarget") fields.handoffTarget = value;
+    else if (key === "issueHash") fields.issueHash = value;
+    else if (key === "lifecycle" && isIssueLifecycleState(value)) fields.issueLifecycleState = value;
+  }
+  return fields;
+}
+
+/** Maps the existing review-status decision to a terminal outcome. Undefined for non-terminal states. */
+export function mapReviewOutcome(state: string): MarkerOutcome | undefined {
+  switch (state) {
+    case "completed":
+      return "reviewed";
+    case "skipped":
+      return "skipped";
+    case "provider_deferred":
+      return "deferred";
+    case "stale_head":
+    case "closed_or_merged_before_review":
+      return "stale";
+    default:
+      // queued / in_progress / failed have no terminal handoff outcome yet.
+      return undefined;
+  }
+}
+
+/**
+ * Maps the existing issue-enrichment record status (+ optional skip/defer reason) to an issue-side
+ * lifecycle state. These are renamings/exposures of decisions the enricher already made — not new
+ * behavior. Undefined for statuses with no lifecycle exposure (e.g. dry_run/failed).
+ */
+export function mapIssueLifecycleState(input: {
+  status: string;
+  reason?: string;
+}): IssueLifecycleState | undefined {
+  switch (input.status) {
+    case "posted":
+      return "enriched";
+    case "deferred":
+      // The enricher already decided WHY it deferred; expose throttle vs stale separately.
+      if (input.reason === "stale_issue_closed") return "stale-head";
+      return "deferred-by-throttle";
+    case "skipped":
+      if (input.reason === "stale_issue_closed") return "stale-head";
+      if (input.reason === "issue_is_pull_request") return "needs-human-routing";
+      return undefined;
+    default:
+      // dry_run / failed carry no public lifecycle exposure.
+      return undefined;
+  }
+}
+
+function sanitizeMarkerToken(value: string): string {
+  return redactSecrets(value).replace(TOKEN_UNSAFE_PATTERN, "").trim();
+}
+
+function isMarkerRole(value: string): value is MarkerRole {
+  return value === "reviewer" || value === "enricher" || value === "observer";
+}
+
+function isMarkerOutcome(value: string): value is MarkerOutcome {
+  return value === "reviewed" || value === "enriched" || value === "skipped" ||
+    value === "deferred" || value === "stale";
+}
+
+function isIssueLifecycleState(value: string): value is IssueLifecycleState {
+  return value === "enriched" || value === "needs-human-routing" || value === "needs-repro" ||
+    value === "ready-for-fix-proposal" || value === "stale-head" || value === "deferred-by-throttle";
+}

--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -1,5 +1,11 @@
 import { redactSecrets } from "./secrets.js";
 import { sanitizePublicConfidenceText, type PublicConfidenceDisplayPolicy } from "./public-confidence.js";
+import {
+  buildIssueHash,
+  mapReviewOutcome,
+  renderMarkerLifecycleFields,
+  type MarkerLifecycleFields
+} from "./marker-lifecycle.js";
 
 export type ReviewStatusCommentState =
   | "queued"
@@ -36,6 +42,14 @@ export interface BuildReviewStatusCommentInput {
   details?: string;
   now?: Date;
   publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
+  /**
+   * Optional run id for correlating this marker with the review run (#263). Reuses the run's
+   * existing id (e.g. queue jobId) — this surface does not mint a new one. Absent ⇒ byte-identical
+   * marker.
+   */
+  runId?: string;
+  /** Optional downstream-fixer pointer (#263). Diagnostic-only; rides the state marker. */
+  handoffTarget?: string;
 }
 
 export const REVIEW_STATUS_MARKER_PREFIX = "<!-- evaos-code-review-bot:review-status";
@@ -59,13 +73,18 @@ export function buildReviewStatusComment(input: BuildReviewStatusCommentInput): 
 } {
   const marker = buildReviewStatusMarker(input);
   const updatedAt = (input.now ?? new Date()).toISOString();
+  // Opt-in only: a caller threads a runId/handoffTarget to attach lifecycle metadata. Without an
+  // opt-in the state marker stays byte-identical to today (no role/outcome/issueHash tokens).
+  const lifecycle = hasReviewLifecycleOptIn(input)
+    ? renderMarkerLifecycleFields(buildReviewLifecycleFields(input))
+    : "";
   const title = formatInlinePublicText(input.pullTitle, input.publicConfidencePolicy);
   const details = sanitizePublicText(input.details, input.publicConfidencePolicy);
   const pullUrl = sanitizePublicUrlText(input.pullUrl);
   const reviewUrl = sanitizePublicUrlText(input.reviewUrl);
   const lines = [
     marker,
-    `${REVIEW_STATUS_STATE_MARKER_PREFIX} status=${input.state} updated_at=${updatedAt} -->`,
+    `${REVIEW_STATUS_STATE_MARKER_PREFIX} status=${input.state} updated_at=${updatedAt}${lifecycle} -->`,
     "",
     `## evaOS review status: ${formatStatus(input.state)}`,
     "",
@@ -101,6 +120,8 @@ export async function postReviewStatusComment(input: {
   details?: string;
   now?: Date;
   publicConfidencePolicy?: PublicConfidenceDisplayPolicy;
+  runId?: string;
+  handoffTarget?: string;
 }): Promise<ReviewStatusCommentPostResult> {
   if (!input.enabled) return { posted: false, reason: "disabled", state: input.state };
   if (input.dryRun) return { posted: false, reason: "dry_run", state: input.state };
@@ -134,6 +155,23 @@ export async function postReviewStatusComment(input: {
       error: redactSecrets(error instanceof Error ? error.message : String(error))
     };
   }
+}
+
+function hasReviewLifecycleOptIn(input: BuildReviewStatusCommentInput): boolean {
+  return input.runId !== undefined || input.handoffTarget !== undefined;
+}
+
+function buildReviewLifecycleFields(input: BuildReviewStatusCommentInput): MarkerLifecycleFields {
+  // Role is fixed for the review-status surface; outcome is a mapping of the existing decision
+  // (undefined for non-terminal states); issueHash correlates repo+pr+head. runId/handoffTarget
+  // are optional passthroughs. All ride the diagnostic state marker only.
+  return {
+    role: "reviewer",
+    issueHash: buildIssueHash({ repo: input.repo, pullNumber: input.pullNumber, headSha: input.headSha }),
+    ...(mapReviewOutcome(input.state) ? { outcome: mapReviewOutcome(input.state) } : {}),
+    ...(input.runId ? { runId: input.runId } : {}),
+    ...(input.handoffTarget ? { handoffTarget: input.handoffTarget } : {})
+  };
 }
 
 function formatStatus(state: ReviewStatusCommentState): string {

--- a/tests/enrichment.test.ts
+++ b/tests/enrichment.test.ts
@@ -14,6 +14,7 @@ import {
   postEnrichmentComment
 } from "../src/enrichment.js";
 import type { GitHubRelatedIssueOrPull } from "../src/github-related-context.js";
+import { parseMarkerLifecycleFields } from "../src/marker-lifecycle.js";
 import { buildIssueEnrichmentStatus, collectIssueEnrichmentScan, resolveIssueEnrichmentRepoPolicy, runIssueEnrichmentCycle } from "../src/issue-enrichment.js";
 import { ReviewStateStore } from "../src/state.js";
 import type { PullFilePatch, PullRequestSummary } from "../src/types.js";
@@ -2343,7 +2344,10 @@ describe("sticky enrichment comments", () => {
           commentUrl: "https://github.test/comment/1",
           bodyHash: firstRecord?.bodyHash
         });
-        expect(posts[0]!.body).toContain(`hash=${firstRecord?.bodyHash} -->`);
+        // #263: live-posted markers now carry the mapped `enriched` lifecycle state + fields after
+        // the hash token, so the hash is no longer the final token. The hash token itself is stable.
+        expect(posts[0]!.body).toContain(`hash=${firstRecord?.bodyHash}`);
+        expect(posts[0]!.body).toContain("lifecycle=enriched");
         expect(refreshedRecord).toMatchObject({
           status: "posted",
           issueUpdatedAt: "2026-07-03T02:07:00.000Z",
@@ -2358,7 +2362,8 @@ describe("sticky enrichment comments", () => {
         });
         expect(changedRecord?.bodyHash).toMatch(/^[a-f0-9]{64}$/);
         expect(changedRecord?.bodyHash).not.toBe(firstRecord?.bodyHash);
-        expect(posts[1]!.body).toContain(`hash=${changedRecord?.bodyHash} -->`);
+        expect(posts[1]!.body).toContain(`hash=${changedRecord?.bodyHash}`);
+        expect(posts[1]!.body).toContain("lifecycle=enriched");
       } finally {
         state.close();
       }
@@ -2682,6 +2687,71 @@ describe("sticky enrichment comments", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("issue enrichment lifecycle markers (#263)", () => {
+  const issue: GitHubRelatedIssueOrPull = {
+    number: 263,
+    title: "Lifecycle markers",
+    state: "open",
+    html_url: "https://github.test/electricsheephq/evaos-code-review-bot/issues/263",
+    body: "Add lifecycle metadata.",
+    user: { login: "issue-author" }
+  };
+
+  it("keeps the issue state marker byte-identical when no lifecycle input is supplied (back-compat)", () => {
+    const comment = buildIssueEnrichmentComment({ repo: "owner/repo", issue, postIssueComment: true });
+    const stateLine = comment.body.split("\n").find((line) => line.includes("enrichment-state"))!;
+    expect(stateLine).toMatch(/^<!-- evaos-code-review-bot:enrichment-state version=1 repo=owner\/repo issue=263 state=open hash=[0-9a-f]{64} -->$/);
+    expect(stateLine).not.toContain("lifecycle=");
+    expect(stateLine).not.toContain("role=");
+    expect(stateLine).not.toContain("issueHash=");
+  });
+
+  it("attaches the issue lifecycle state, role, and hashed issueHash to the diagnostic state marker only", () => {
+    const comment = buildIssueEnrichmentComment({
+      repo: "owner/repo",
+      issue,
+      postIssueComment: true,
+      lifecycle: { state: "enriched", runId: "owner__repo-issue-263" }
+    });
+    const parsed = parseMarkerLifecycleFields(comment.body.split("\n").find((line) => line.includes("enrichment-state"))!);
+    expect(parsed.issueLifecycleState).toBe("enriched");
+    expect(parsed.role).toBe("enricher");
+    expect(parsed.outcome).toBe("enriched");
+    expect(parsed.runId).toBe("owner__repo-issue-263");
+    expect(parsed.issueHash).toMatch(/^[0-9a-f]{16}$/);
+    // Diagnostic fields never leak into the public identity marker (the upsert dedup key).
+    expect(comment.marker).toBe("<!-- evaos-code-review-bot:enrichment repo=owner/repo issue=263 -->");
+    expect(comment.marker).not.toContain("lifecycle=");
+    expect(comment.marker).not.toContain("issueHash=");
+    expect(comment.marker).not.toContain("role=");
+  });
+
+  it("does not change bodyHash when lifecycle fields are attached (idempotency preserved)", () => {
+    const withoutLifecycle = buildIssueEnrichmentComment({ repo: "owner/repo", issue, postIssueComment: true });
+    const withLifecycle = buildIssueEnrichmentComment({
+      repo: "owner/repo",
+      issue,
+      postIssueComment: true,
+      lifecycle: { state: "deferred-by-throttle", handoffTarget: "throttle-queue" }
+    });
+    expect(withLifecycle.bodyHash).toBe(withoutLifecycle.bodyHash);
+  });
+
+  it("redacts and token-strips handoffTarget on the issue state marker", () => {
+    const token = ["ghp", "z".repeat(36)].join("_");
+    const comment = buildIssueEnrichmentComment({
+      repo: "owner/repo",
+      issue,
+      postIssueComment: true,
+      lifecycle: { state: "needs-human-routing", handoffTarget: `route ${token}` }
+    });
+    expect(comment.body).not.toContain(token);
+    const stateLine = comment.body.split("\n").find((line) => line.includes("enrichment-state"))!;
+    expect(stateLine).toContain("handoffTarget=route");
+    expect(comment.marker).not.toContain("handoffTarget=");
   });
 });
 

--- a/tests/marker-lifecycle.test.ts
+++ b/tests/marker-lifecycle.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildIssueHash,
+  mapIssueLifecycleState,
+  mapReviewOutcome,
+  parseMarkerLifecycleFields,
+  renderMarkerLifecycleFields
+} from "../src/marker-lifecycle.js";
+
+const FAKE_TOKEN = ["ghp", "x".repeat(36)].join("_");
+const HEAD = "a".repeat(40);
+
+describe("marker lifecycle fields", () => {
+  it("renders nothing when no fields are present (back-compat)", () => {
+    expect(renderMarkerLifecycleFields(undefined)).toBe("");
+    expect(renderMarkerLifecycleFields({})).toBe("");
+  });
+
+  it("renders fields in a stable order with a leading space", () => {
+    const rendered = renderMarkerLifecycleFields({
+      runId: "repo__x-pr-1-abc",
+      role: "reviewer",
+      outcome: "reviewed",
+      handoffTarget: "fixer-agent",
+      issueHash: "0123456789abcdef"
+    });
+    expect(rendered).toBe(" runId=repo__x-pr-1-abc role=reviewer outcome=reviewed handoffTarget=fixer-agent issueHash=0123456789abcdef");
+  });
+
+  it("round-trips every field with and without each present", () => {
+    const full = { runId: "r1", role: "enricher" as const, outcome: "enriched" as const, handoffTarget: "team-x", issueHash: "deadbeefdeadbeef" };
+    const marker = `<!-- x version=1 repo=owner/repo issue=5${renderMarkerLifecycleFields(full)} -->`;
+    expect(parseMarkerLifecycleFields(marker)).toMatchObject(full);
+
+    const partial = { role: "reviewer" as const };
+    const partialMarker = `<!-- x repo=owner/repo pr=1${renderMarkerLifecycleFields(partial)} -->`;
+    const parsed = parseMarkerLifecycleFields(partialMarker);
+    expect(parsed.role).toBe("reviewer");
+    expect(parsed.runId).toBeUndefined();
+    expect(parsed.outcome).toBeUndefined();
+    expect(parsed.handoffTarget).toBeUndefined();
+    expect(parsed.issueHash).toBeUndefined();
+  });
+
+  it("round-trips a marker WITHOUT any lifecycle fields to an empty object", () => {
+    const legacy = "<!-- evaos-code-review-bot:review-status-state status=queued updated_at=2026-07-02T00:00:00.000Z -->";
+    expect(parseMarkerLifecycleFields(legacy)).toEqual({});
+  });
+
+  it("round-trips the issue lifecycle state token", () => {
+    const marker = "<!-- x version=1 repo=owner/repo issue=5 state=open lifecycle=deferred-by-throttle hash=abc -->";
+    expect(parseMarkerLifecycleFields(marker).issueLifecycleState).toBe("deferred-by-throttle");
+  });
+
+  it("redacts secret-like handoff targets and strips marker-breaking characters", () => {
+    const rendered = renderMarkerLifecycleFields({ handoffTarget: `route-to ${FAKE_TOKEN} --> evil` });
+    expect(rendered).not.toContain(FAKE_TOKEN);
+    expect(rendered).not.toContain("-->");
+    expect(rendered).not.toContain(" evil");
+  });
+
+  it("hashes the subject stably and never exposes raw subject text", () => {
+    const a = buildIssueHash({ repo: "owner/repo", pullNumber: 7, headSha: HEAD });
+    const b = buildIssueHash({ repo: "owner/repo", pullNumber: 7, headSha: HEAD });
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
+    expect(a).not.toContain("owner/repo");
+    // Different subjects hash differently.
+    expect(buildIssueHash({ repo: "owner/repo", issueNumber: 7 })).not.toBe(a);
+  });
+});
+
+describe("review outcome mapping", () => {
+  it("derives outcome from the existing review-status decision", () => {
+    expect(mapReviewOutcome("completed")).toBe("reviewed");
+    expect(mapReviewOutcome("skipped")).toBe("skipped");
+    expect(mapReviewOutcome("provider_deferred")).toBe("deferred");
+    expect(mapReviewOutcome("stale_head")).toBe("stale");
+    expect(mapReviewOutcome("closed_or_merged_before_review")).toBe("stale");
+    expect(mapReviewOutcome("queued")).toBeUndefined();
+    expect(mapReviewOutcome("in_progress")).toBeUndefined();
+    expect(mapReviewOutcome("failed")).toBeUndefined();
+  });
+});
+
+describe("issue lifecycle state mapping", () => {
+  it("maps from the existing issue-enrichment decision path", () => {
+    expect(mapIssueLifecycleState({ status: "posted" })).toBe("enriched");
+    expect(mapIssueLifecycleState({ status: "deferred", reason: "repo_max_comments_per_cycle" })).toBe("deferred-by-throttle");
+    expect(mapIssueLifecycleState({ status: "deferred", reason: "stale_issue_closed" })).toBe("stale-head");
+    expect(mapIssueLifecycleState({ status: "skipped", reason: "stale_issue_closed" })).toBe("stale-head");
+    expect(mapIssueLifecycleState({ status: "skipped", reason: "issue_is_pull_request" })).toBe("needs-human-routing");
+    expect(mapIssueLifecycleState({ status: "dry_run" })).toBeUndefined();
+    expect(mapIssueLifecycleState({ status: "failed" })).toBeUndefined();
+  });
+});

--- a/tests/review-status-comment.test.ts
+++ b/tests/review-status-comment.test.ts
@@ -217,6 +217,59 @@ describe("review status comment", () => {
     expect(comment.body).not.toContain("repo=evil/repo");
   });
 
+  it("keeps the state marker byte-identical when no lifecycle fields are supplied (back-compat)", () => {
+    const comment = buildReviewStatusComment({
+      repo: "owner/repo",
+      pullNumber: 274,
+      headSha: HEAD_A,
+      state: "queued",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+    // No opt-in ⇒ the state marker is byte-identical to today (no role/outcome/issueHash tokens).
+    expect(comment.body).toContain(
+      "<!-- evaos-code-review-bot:review-status-state status=queued updated_at=2026-07-02T00:00:00.000Z -->"
+    );
+    expect(comment.body).not.toContain("role=");
+    expect(comment.body).not.toContain("issueHash=");
+  });
+
+  it("adds role, derived outcome, and issueHash to the diagnostic state marker (not the identity marker)", () => {
+    const comment = buildReviewStatusComment({
+      repo: "owner/repo",
+      pullNumber: 274,
+      headSha: HEAD_A,
+      state: "completed",
+      runId: "owner__repo-pr-274-abc123",
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+    const stateLine = comment.body.split("\n").find((line) => line.includes("review-status-state"))!;
+    expect(stateLine).toContain("role=reviewer");
+    expect(stateLine).toContain("outcome=reviewed");
+    expect(stateLine).toContain("runId=owner__repo-pr-274-abc123");
+    expect(stateLine).toMatch(/issueHash=[0-9a-f]{16}/);
+    // Diagnostic fields must NOT leak into the public identity marker (the upsert dedup key).
+    expect(comment.marker).toBe(`<!-- evaos-code-review-bot:review-status repo=owner/repo pr=274 sha=${HEAD_A} -->`);
+    expect(comment.marker).not.toContain("role=");
+    expect(comment.marker).not.toContain("outcome=");
+    expect(comment.marker).not.toContain("issueHash=");
+    expect(comment.marker).not.toContain("runId=");
+  });
+
+  it("keeps handoffTarget diagnostic-only and redacted", () => {
+    const token = ["ghp", "y".repeat(36)].join("_");
+    const comment = buildReviewStatusComment({
+      repo: "owner/repo",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      state: "failed",
+      handoffTarget: `fixer ${token}`
+    });
+    const stateLine = comment.body.split("\n").find((line) => line.includes("review-status-state"))!;
+    expect(stateLine).toContain("handoffTarget=fixer");
+    expect(comment.body).not.toContain(token);
+    expect(comment.marker).not.toContain("handoffTarget=");
+  });
+
   it("rejects invalid marker identity values", () => {
     expect(() => buildReviewStatusMarker({ repo: "owner/repo with space", pullNumber: 1, headSha: HEAD_A }))
       .toThrow("Invalid review status repo slug");


### PR DESCRIPTION
## Summary
Additive lifecycle + fixer-handoff metadata on the bot-owned markers, plus issue-side lifecycle states. Metadata only — zero behavior change: no new posting, no gate change, no posting-surface change.

- **New `src/marker-lifecycle.ts`** — optional `runId` / `role` (reviewer|enricher|observer) / `outcome` (reviewed|enriched|skipped|deferred|stale) / `handoffTarget` / `issueHash` fields, rendered as space-delimited tokens on the **diagnostic state marker only**. Renderer returns `""` when no fields are present (byte-identical to today); parser round-trips markers with **and without** the fields. `issueHash` = truncated sha256 of the identity tuple (`repo+pr+head` | `repo+issue`), never raw subject text. `mapReviewOutcome` / `mapIssueLifecycleState` derive from the existing decisions.
- **`review-status-comment.ts`** — opt-in (`runId`/`handoffTarget`) lifecycle on the review-status state marker; `role=reviewer`, outcome mapped from the existing `ReviewStatusCommentState`, `issueHash` from repo+pr+head. Without opt-in the marker is byte-identical.
- **`enrichment.ts`** — optional lifecycle on the issue state marker; a distinct `lifecycle=` token carries the issue-side state alongside the existing `state=open|closed` identity token; `role=enricher`, hashed `issueHash`. `bodyHash` excludes the marker so sticky-comment idempotency is unaffected.
- **`issue-enrichment.ts`** — wires the mapped `enriched` state onto live-posted issue markers (a renaming of the existing `status=posted` decision).

## Design
Decided spec: `.dispatch/263-lifecycle-markers-spec.md` (parent trackers #260 / #269). Markers have a public/diagnostic split: line 1 = public **identity** marker (the sticky-comment upsert dedup key — kept byte-stable), line 2 = **state** marker (mutable diagnostic). All new fields ride the **state** marker so the dedup key and posting behavior never change.

## Validation
`npx vitest run tests/marker-lifecycle.test.ts tests/review-status-comment.test.ts tests/enrichment.test.ts tests/issue-enrichment-policy.test.ts tests/enrichment-cli.test.ts` → **120 passed**; `tests/scheduler.test.ts` (74) + `tests/worker-failure.test.ts` (64) green; `npm run build` clean. Covers: round-trip with/without each field (back-compat); each outcome/role/issue-state derives from the correct existing decision; `issueHash` stable + hashed + no raw subject; public/private split for issue markers specifically; opt-in absent ⇒ byte-identical existing marker text; `handoffTarget` redacted + token-stripped; `bodyHash` unchanged when lifecycle attached (idempotency).

## Proof boundary
Additive marker metadata + issue lifecycle states; **no posting/gate/behavior change**; redaction + public-split preserved. New fields are optional and, on the review path, opt-in; when absent the existing marker text is byte-identical.

Closes #263
Parent trackers #260 / #269