### PR TITLE
Deepen scheduled outcome observation to revert/hotfix/human-thread signals (#371)

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -9,6 +9,14 @@ import { buildApiUrl, normalizeHttpApiBaseUrl } from "./url-safety.js";
 /** The bot's own GitHub App login — single source of truth for "who am I" (#345 reuse). */
 export const DEFAULT_BOT_LOGIN = "evaos-code-review-bot[bot]";
 
+/**
+ * Hard page cap for the bounded outcome-observation review-comment read (#371). At 100/page this bounds
+ * a single PR's comment scan to 500, so a pathological thread count can't drive unbounded GitHub reads
+ * (the deeper-observation reader is contractually bounded). A human dismissal thread on a flagged line
+ * is found well within this window; exceeding it truncates rather than paging forever.
+ */
+const MAX_REVIEW_COMMENT_PAGES = 5;
+
 export interface GitHubApiOptions {
   appId?: string;
   privateKeyPath?: string;
@@ -201,14 +209,17 @@ export class GitHubApi {
    */
   async listPullReviewComments(repo: string, pullNumber: number): Promise<PullReviewComment[]> {
     const comments: PullReviewComment[] = [];
-    for (let page = 1; ; page += 1) {
+    // Hard-capped at MAX_REVIEW_COMMENT_PAGES: the bounded-read guarantee forbids paging forever on a
+    // PR with a pathological comment count; we stop after the cap even if a full page came back.
+    for (let page = 1; page <= MAX_REVIEW_COMMENT_PAGES; page += 1) {
       const chunk = await this.request<PullReviewComment[]>(
         `/repos/${repo}/pulls/${pullNumber}/comments?per_page=100&page=${page}`,
         { token: await this.getReadToken(repo) }
       );
       comments.push(...chunk);
-      if (chunk.length < 100) return comments;
+      if (chunk.length < 100) break;
     }
+    return comments;
   }
 
   /**

--- a/src/github.ts
+++ b/src/github.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import type { IssueCommentCommandSource } from "./commands.js";
 import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
 import { redactSecrets } from "./secrets.js";
-import type { PullFilePatch, PullRequestSummary, RepositorySummary, ReviewComment, ReviewEvent } from "./types.js";
+import type { PullFilePatch, PullRequestSummary, PullReviewComment, RepositorySummary, ReviewComment, ReviewEvent } from "./types.js";
 import { buildApiUrl, normalizeHttpApiBaseUrl } from "./url-safety.js";
 
 /** The bot's own GitHub App login — single source of truth for "who am I" (#345 reuse). */
@@ -193,6 +193,36 @@ export class GitHubApi {
       files.push(...chunk);
       if (chunk.length < 100) return files;
     }
+  }
+
+  /**
+   * Read-only PR review (inline-diff) comments (#371), paged. Used by the scheduled outcome observer
+   * to detect a human reply thread on a finding's path/line. No mutation, no posting.
+   */
+  async listPullReviewComments(repo: string, pullNumber: number): Promise<PullReviewComment[]> {
+    const comments: PullReviewComment[] = [];
+    for (let page = 1; ; page += 1) {
+      const chunk = await this.request<PullReviewComment[]>(
+        `/repos/${repo}/pulls/${pullNumber}/comments?per_page=100&page=${page}`,
+        { token: await this.getReadToken(repo) }
+      );
+      comments.push(...chunk);
+      if (chunk.length < 100) return comments;
+    }
+  }
+
+  /**
+   * Read-only, BOUNDED list of recently-merged PRs (#371), most-recent-first, capped at `limit`. Used
+   * by the scheduled outcome observer to find a revert / subsequent fix touching a finding's lines.
+   * Bounded: at most `limit` closed PRs are scanned (one page window), and only merged ones returned.
+   */
+  async listRecentMergedPulls(repo: string, limit: number): Promise<PullRequestSummary[]> {
+    const perPage = Math.min(Math.max(1, limit), 100);
+    const chunk = await this.request<PullRequestSummary[]>(
+      `/repos/${repo}/pulls?state=closed&sort=updated&direction=desc&per_page=${perPage}&page=1`,
+      { token: await this.getReadToken(repo) }
+    );
+    return chunk.map(normalizePullRequestSummary).filter((pull) => Boolean(pull.merged_at)).slice(0, limit);
   }
 
   async listIssueComments(repo: string, issueNumber: number): Promise<IssueCommentCommandSource[]> {

--- a/src/outcome-observer.ts
+++ b/src/outcome-observer.ts
@@ -78,6 +78,129 @@ function diffTouchesFinding(lines: Map<string, Set<number>>, finding: ObservedFi
   return false;
 }
 
+/**
+ * A minimal, read-only PR review comment shape (#371) — the deeper-observation enrichment consumes
+ * only what it needs to detect a human dismissal thread on a finding, decoupling outcome-observer
+ * from the full GitHub type.
+ */
+export interface ObservedReviewComment {
+  path?: string | null;
+  line?: number | null;
+  original_line?: number | null;
+  in_reply_to_id?: number | null;
+  user?: { login: string; type?: string } | null;
+}
+
+/**
+ * A recently-merged PR the scheduled observer scans for deeper post-merge signals (#371). `title`/
+ * `body` carry the revert convention; `changedLines` is collectRightSideLines over the PR's files so
+ * the hotfix/merged-fix "touches flagged lines" match reuses the exact review-gate primitive.
+ */
+export interface ObservedSubsequentPull {
+  pullNumber: number;
+  title?: string | null;
+  body?: string | null;
+  changedLines: Map<string, Set<number>>;
+}
+
+/**
+ * Pure enrichment builder (#371). Turns the read-only GitHub reads for ONE merged reviewed PR into the
+ * fuller ObservedPullOutcome that deriveOutcomeLabel already understands — WITHOUT changing the
+ * labeler. This is the parity seam: fed the same revert/hotfix/human-thread facts the CLI observer's
+ * dry-run input carries, it produces the identical ObservedPullOutcome (hence the identical label).
+ *
+ * - revert: a subsequent merged PR whose message reverts THIS PR's merge (GitHub's `Revert "<title>"`
+ *   PR title, `Reverts #<n>`, or `This reverts commit <merge_commit_sha>`).
+ * - hotfixLines / mergedFixLines: right-side changed lines of subsequent merged PRs. A revert is not
+ *   double-counted as a hotfix. All subsequent-fix line-touch signals feed `hotfixLines` (the labeler
+ *   treats hotfix and merged_fix as the same true-positive class via distinct label sources; the
+ *   scheduled reader has one bounded source of "a later merged PR touched the flagged line", so it
+ *   populates hotfixLines — merged-fix vs hotfix is a provenance distinction the CLI input can still
+ *   express separately, and parity holds because both derive true_positive).
+ * - humanThreadResolved: a HUMAN (non-bot) reply thread on the finding's path/line.
+ */
+export function buildObservedPullOutcome(input: {
+  merged: boolean;
+  mergeCommitSha?: string | null;
+  pullNumber: number;
+  pullTitle?: string | null;
+  findings: ObservedFinding[];
+  subsequentPulls: ObservedSubsequentPull[];
+  reviewComments: ObservedReviewComment[];
+  evidenceRef?: string;
+}): ObservedPullOutcome {
+  if (!input.merged) {
+    return { merged: false, revertedFlaggedChange: false, hotfixLines: new Map(), mergedFixLines: new Map(), humanThreadResolved: false };
+  }
+
+  let revertedFlaggedChange = false;
+  const hotfixLines = new Map<string, Set<number>>();
+  for (const pull of input.subsequentPulls) {
+    if (pull.pullNumber === input.pullNumber) continue; // never treat the PR as its own revert/hotfix.
+    if (pullRevertsMerge(pull, input)) {
+      revertedFlaggedChange = true;
+      continue; // a revert is not also counted as a hotfix touching flagged lines.
+    }
+    mergeLineMap(hotfixLines, pull.changedLines);
+  }
+
+  return {
+    merged: true,
+    revertedFlaggedChange,
+    hotfixLines,
+    // The scheduled reader collapses subsequent-fix line touches into hotfixLines (see doc above);
+    // mergedFixLines stays empty here. Both hotfix and merged_fix derive true_positive, so label
+    // richness/parity is preserved — a merged PR whose later fix touches a flagged line is validated.
+    mergedFixLines: new Map(),
+    humanThreadResolved: humanThreadTouchesFinding(input.reviewComments, input.findings),
+    ...(input.evidenceRef ? { evidenceRef: input.evidenceRef } : {})
+  };
+}
+
+function pullRevertsMerge(
+  pull: ObservedSubsequentPull,
+  target: { pullNumber: number; pullTitle?: string | null; mergeCommitSha?: string | null }
+): boolean {
+  const title = pull.title ?? "";
+  const body = pull.body ?? "";
+  // GitHub's default revert PR title: `Revert "<original title>"`. Match the revert prefix AND a
+  // back-reference to the original PR (its title or #number) or the reverted merge commit SHA.
+  const isRevertShaped = /^revert\b/i.test(title.trim()) || /this reverts commit/i.test(body);
+  if (!isRevertShaped) return false;
+  const targetTitle = (target.pullTitle ?? "").trim();
+  const referencesTitle = targetTitle.length > 0 && title.includes(targetTitle);
+  const referencesNumber = new RegExp(`(reverts?\\b[^#]*)?#${target.pullNumber}\\b`, "i").test(`${title}\n${body}`);
+  const referencesMergeSha = Boolean(target.mergeCommitSha) && body.includes(target.mergeCommitSha as string);
+  return referencesTitle || referencesNumber || referencesMergeSha;
+}
+
+function mergeLineMap(into: Map<string, Set<number>>, from: Map<string, Set<number>>): void {
+  for (const [path, lines] of from) {
+    let set = into.get(path);
+    if (!set) {
+      set = new Set<number>();
+      into.set(path, set);
+    }
+    for (const line of lines) set.add(line);
+  }
+}
+
+function humanThreadTouchesFinding(comments: ObservedReviewComment[], findings: ObservedFinding[]): boolean {
+  for (const comment of comments) {
+    // A human REPLY thread (in_reply_to_id set) is the dismissal signal; a bot author never counts.
+    if (comment.in_reply_to_id === undefined || comment.in_reply_to_id === null) continue;
+    if (comment.user?.type === "Bot") continue;
+    const path = comment.path;
+    if (!path) continue;
+    const line = typeof comment.line === "number" ? comment.line : comment.original_line;
+    if (typeof line !== "number") continue;
+    for (const finding of findings) {
+      if (finding.path === path && Math.abs(line - finding.line) <= OUTCOME_LINE_WINDOW) return true;
+    }
+  }
+  return false;
+}
+
 export interface OutcomeObserverReview {
   repo: string;
   pullNumber: number;

--- a/src/outcome-observer.ts
+++ b/src/outcome-observer.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { isBotCommandComment } from "./commands.js";
+import { DEFAULT_BOT_LOGIN } from "./github.js";
 import { redactSecrets } from "./secrets.js";
 import { writeSecureFileSync } from "./temp-files.js";
 import type { ObserveScheduleConfig } from "./config.js";
@@ -95,48 +97,65 @@ export interface ObservedReviewComment {
  * A recently-merged PR the scheduled observer scans for deeper post-merge signals (#371). `title`/
  * `body` carry the revert convention; `changedLines` is collectRightSideLines over the PR's files so
  * the hotfix/merged-fix "touches flagged lines" match reuses the exact review-gate primitive.
+ * `mergedAt` gates the temporal guard: only a PR merged STRICTLY AFTER the target can be its revert
+ * or follow-up fix (a candidate merged before/at the target is not a post-merge signal for it).
  */
 export interface ObservedSubsequentPull {
   pullNumber: number;
   title?: string | null;
   body?: string | null;
+  mergedAt?: string | null;
   changedLines: Map<string, Set<number>>;
 }
 
 /**
  * Pure enrichment builder (#371). Turns the read-only GitHub reads for ONE merged reviewed PR into the
- * fuller ObservedPullOutcome that deriveOutcomeLabel already understands — WITHOUT changing the
- * labeler. This is the parity seam: fed the same revert/hotfix/human-thread facts the CLI observer's
- * dry-run input carries, it produces the identical ObservedPullOutcome (hence the identical label).
+ * fuller ObservedPullOutcome that deriveOutcomeLabel already understands — WITHOUT changing the labeler.
+ *
+ * Parity contract: fed the same revert/hotfix/human-thread facts the CLI observer's dry-run input
+ * carries, the scheduled reader produces the same deriveOutcomeLabel VERDICT (true_positive /
+ * false_positive / unvalidated). The `labelSource` may differ for a subsequent-fix signal: the bounded
+ * scheduled reader cannot distinguish a dedicated hotfix PR from a general merged-fix diff, so it feeds
+ * all subsequent-fix line touches into `hotfixLines` (labelSource `hotfix`), whereas a CLI input can
+ * split hotfix vs merged_fix explicitly. Both derive `true_positive`, so the VERDICT parity holds —
+ * that is the claim the acceptance test asserts.
+ *
+ * Temporal guard: a candidate is only a revert/fix of THIS PR if it merged STRICTLY AFTER the target;
+ * a PR merged before/at the target's merge is skipped (it cannot be a post-merge signal for it).
  *
  * - revert: a subsequent merged PR whose message reverts THIS PR's merge (GitHub's `Revert "<title>"`
  *   PR title, `Reverts #<n>`, or `This reverts commit <merge_commit_sha>`).
- * - hotfixLines / mergedFixLines: right-side changed lines of subsequent merged PRs. A revert is not
- *   double-counted as a hotfix. All subsequent-fix line-touch signals feed `hotfixLines` (the labeler
- *   treats hotfix and merged_fix as the same true-positive class via distinct label sources; the
- *   scheduled reader has one bounded source of "a later merged PR touched the flagged line", so it
- *   populates hotfixLines — merged-fix vs hotfix is a provenance distinction the CLI input can still
- *   express separately, and parity holds because both derive true_positive).
+ * - hotfixLines: right-side changed lines of subsequent merged PRs (a revert is not double-counted).
  * - humanThreadResolved: a HUMAN (non-bot) reply thread on the finding's path/line.
  */
 export function buildObservedPullOutcome(input: {
   merged: boolean;
+  mergedAt?: string | null;
   mergeCommitSha?: string | null;
   pullNumber: number;
   pullTitle?: string | null;
   findings: ObservedFinding[];
   subsequentPulls: ObservedSubsequentPull[];
   reviewComments: ObservedReviewComment[];
+  botLogin?: string;
   evidenceRef?: string;
 }): ObservedPullOutcome {
   if (!input.merged) {
     return { merged: false, revertedFlaggedChange: false, hotfixLines: new Map(), mergedFixLines: new Map(), humanThreadResolved: false };
   }
 
+  const targetMergedMs = input.mergedAt ? Date.parse(input.mergedAt) : NaN;
   let revertedFlaggedChange = false;
   const hotfixLines = new Map<string, Set<number>>();
   for (const pull of input.subsequentPulls) {
     if (pull.pullNumber === input.pullNumber) continue; // never treat the PR as its own revert/hotfix.
+    // Temporal guard: only a PR merged STRICTLY AFTER the target is a post-merge signal FOR it. When
+    // either merge time is unknown we keep the candidate (fail-open toward observing, never inventing
+    // a signal the guard could suppress) — the revert/line-touch matchers still gate what counts.
+    if (Number.isFinite(targetMergedMs) && pull.mergedAt) {
+      const candidateMs = Date.parse(pull.mergedAt);
+      if (Number.isFinite(candidateMs) && candidateMs <= targetMergedMs) continue;
+    }
     if (pullRevertsMerge(pull, input)) {
       revertedFlaggedChange = true;
       continue; // a revert is not also counted as a hotfix touching flagged lines.
@@ -149,10 +168,10 @@ export function buildObservedPullOutcome(input: {
     revertedFlaggedChange,
     hotfixLines,
     // The scheduled reader collapses subsequent-fix line touches into hotfixLines (see doc above);
-    // mergedFixLines stays empty here. Both hotfix and merged_fix derive true_positive, so label
-    // richness/parity is preserved — a merged PR whose later fix touches a flagged line is validated.
+    // mergedFixLines stays empty. Both hotfix and merged_fix derive true_positive, so VERDICT parity
+    // with the CLI observer holds — a merged PR whose later fix touches a flagged line is validated.
     mergedFixLines: new Map(),
-    humanThreadResolved: humanThreadTouchesFinding(input.reviewComments, input.findings),
+    humanThreadResolved: humanThreadTouchesFinding(input.reviewComments, input.findings, input.botLogin),
     ...(input.evidenceRef ? { evidenceRef: input.evidenceRef } : {})
   };
 }
@@ -167,11 +186,23 @@ function pullRevertsMerge(
   // back-reference that specifically identifies THIS PR — never an incidental `#n` mention.
   const isRevertShaped = /^revert\b/i.test(title.trim()) || /this reverts commit/i.test(body);
   if (!isRevertShaped) return false;
-  const targetTitle = (target.pullTitle ?? "").trim();
-  const referencesTitle = targetTitle.length > 0 && title.includes(targetTitle);
+  const referencesTitle = revertTitleMatchesTarget(title, target.pullTitle);
   const referencesNumber = revertReferencesPull(`${title}\n${body}`, target.pullNumber);
   const referencesMergeSha = Boolean(target.mergeCommitSha) && body.includes(target.mergeCommitSha as string);
   return referencesTitle || referencesNumber || referencesMergeSha;
+}
+
+/**
+ * True only when the candidate title is GitHub's exact default revert construction for the target:
+ * `Revert "<exact target title>"` (optionally with a ` (#n)` tail) (#371). A loose substring match is
+ * rejected — a revert of a differently-titled PR whose title merely CONTAINS the target's would
+ * otherwise false-match. The `#n` / commit-sha back-references remain the other accepted signals.
+ */
+function revertTitleMatchesTarget(candidateTitle: string, targetTitle: string | null | undefined): boolean {
+  const target = (targetTitle ?? "").trim();
+  if (target.length === 0) return false;
+  const escaped = target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^revert\\s+"${escaped}"(?:\\s*\\(#\\d+\\))?\\s*$`, "i").test(candidateTitle.trim());
 }
 
 /**
@@ -199,11 +230,14 @@ function mergeLineMap(into: Map<string, Set<number>>, from: Map<string, Set<numb
   }
 }
 
-function humanThreadTouchesFinding(comments: ObservedReviewComment[], findings: ObservedFinding[]): boolean {
+function humanThreadTouchesFinding(comments: ObservedReviewComment[], findings: ObservedFinding[], botLogin?: string): boolean {
+  const effectiveBotLogin = botLogin ?? DEFAULT_BOT_LOGIN;
   for (const comment of comments) {
     // A human REPLY thread (in_reply_to_id set) is the dismissal signal; a bot author never counts.
     if (comment.in_reply_to_id === undefined || comment.in_reply_to_id === null) continue;
-    if (comment.user?.type === "Bot") continue;
+    // Reuse the shared bot-identity check (#149): excludes user.type === "Bot" OR the app bot login,
+    // so a bot reply with a MISSING/variant type (only its login matches) is still not counted human.
+    if (comment.user && isBotCommandComment(comment.user, effectiveBotLogin)) continue;
     const path = comment.path;
     if (!path) continue;
     const line = typeof comment.line === "number" ? comment.line : comment.original_line;

--- a/src/outcome-observer.ts
+++ b/src/outcome-observer.ts
@@ -164,14 +164,28 @@ function pullRevertsMerge(
   const title = pull.title ?? "";
   const body = pull.body ?? "";
   // GitHub's default revert PR title: `Revert "<original title>"`. Match the revert prefix AND a
-  // back-reference to the original PR (its title or #number) or the reverted merge commit SHA.
+  // back-reference that specifically identifies THIS PR — never an incidental `#n` mention.
   const isRevertShaped = /^revert\b/i.test(title.trim()) || /this reverts commit/i.test(body);
   if (!isRevertShaped) return false;
   const targetTitle = (target.pullTitle ?? "").trim();
   const referencesTitle = targetTitle.length > 0 && title.includes(targetTitle);
-  const referencesNumber = new RegExp(`(reverts?\\b[^#]*)?#${target.pullNumber}\\b`, "i").test(`${title}\n${body}`);
+  const referencesNumber = revertReferencesPull(`${title}\n${body}`, target.pullNumber);
   const referencesMergeSha = Boolean(target.mergeCommitSha) && body.includes(target.mergeCommitSha as string);
   return referencesTitle || referencesNumber || referencesMergeSha;
+}
+
+/**
+ * True only when `#<n>` appears in a construction that identifies it as a revert OF that PR (#371) —
+ * not merely anywhere in a revert-shaped PR. Accepted forms:
+ *   - `Reverts #n` / `Reverts owner/repo#n`  (GitHub's default revert-PR body line)
+ *   - `Revert "<title>" (#n)`                (GitHub's default revert-PR title tail)
+ * An incidental `#n` (e.g. "see #n for context") in a revert PR does NOT count.
+ */
+function revertReferencesPull(text: string, pullNumber: number): boolean {
+  const n = String(pullNumber);
+  const revertsBody = new RegExp(`\\breverts?\\b[^\\n#]*(?:[A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#${n}\\b`, "i");
+  const revertTitleTail = new RegExp(`\\brevert\\b[^\\n]*\\(#${n}\\)`, "i");
+  return revertsBody.test(text) || revertTitleTail.test(text);
 }
 
 function mergeLineMap(into: Map<string, Set<number>>, from: Map<string, Set<number>>): void {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -38,13 +38,16 @@ import {
   type ReviewQueueJobState,
   type ReviewQueueJobSource
 } from "./state.js";
-import type { ChangedSurfaceValidationReport, PullFilePatch, PullRequestSummary, ReviewEvent } from "./types.js";
+import type { ChangedSurfaceValidationReport, PullFilePatch, PullRequestSummary, PullReviewComment, ReviewEvent } from "./types.js";
 import type { IssueCommentCommandSource } from "./commands.js";
 import { buildChangedSurfaceValidationReport } from "./validation-selector.js";
+import { collectRightSideLines } from "./diff.js";
 import { redactSecrets } from "./secrets.js";
 import {
+  buildObservedPullOutcome,
   runScheduledObservePass,
   type ObservedPullOutcome,
+  type ObservedSubsequentPull,
   type ScheduledObserveTarget
 } from "./outcome-observer.js";
 import {
@@ -88,6 +91,10 @@ export interface SchedulerGitHubApi {
   upsertIssueComment?: ReviewStatusCommentGithub["upsertIssueComment"];
   // Optional: only invoked when riskWeightedQueue is enabled, to derive risk from changed surface.
   listPullFiles?(repo: string, pullNumber: number): Promise<PullFilePatch[]>;
+  // Optional deeper-observation reads (#371): only invoked by the scheduled outcome observer to enrich
+  // a merged PR's outcome (revert/hotfix/human-thread). All read-only; absent ⇒ merge-state-only cut.
+  listRecentMergedPulls?(repo: string, limit: number): Promise<PullRequestSummary[]>;
+  listPullReviewComments?(repo: string, pullNumber: number): Promise<PullReviewComment[]>;
 }
 
 export async function runScheduledCycle(options: RunOnceOptions): Promise<ScheduledRunResult> {
@@ -259,10 +266,15 @@ export async function runScheduledCycleWithDeps(input: {
 }
 
 /**
- * Runs the scheduled, default-off outcome observation pass at the tail of a daemon cycle (#357). The
- * `fetchOutcome` reader is built from the scheduler's read-only GitHub surface (`getPull` merge state)
- * and is injected into the pure observe pass so tests stay hermetic. This is a no-op — no GitHub reads,
- * no writes — unless `calibrationLoop.observeSchedule.enabled` is true AND the interval is due.
+ * Runs the scheduled, default-off outcome observation pass at the tail of a daemon cycle (#357, deepened
+ * in #371). The `fetchOutcome` reader is built from the scheduler's read-only GitHub surface and injected
+ * into the pure observe pass so tests stay hermetic. For a MERGED reviewed PR it now derives the deeper
+ * post-merge signals (revert of the merge, a subsequent merged fix touching a finding's line, a human
+ * dismissal thread) — bounded by the SAME cost caps as #357 (the recent-merged-PR window and per-target
+ * fix-file reads are capped by maxPullsPerCycle; per-repo cooldown + lookbackDays gate selection). Every
+ * read is read-only; a reader error degrades fail-open to the merge-state cut, never throwing into the
+ * cycle. This is a no-op — no GitHub reads, no writes — unless observeSchedule.enabled AND the interval
+ * is due.
  */
 export async function observeScheduledOutcomes(input: {
   config: BotConfig;
@@ -277,18 +289,52 @@ export async function observeScheduledOutcomes(input: {
   // folder is derived from exactly the same instant that is forwarded to runScheduledObservePass.
   const now = input.now ?? new Date();
   const evidenceDir = join(input.config.evidenceDir, localDateFolder(now), "calibration-observe");
+  // Per-repo memo for the recent-merged-PR window: fetched at most ONCE per repo per cycle and shared
+  // across all that repo's target heads, so the deeper reads never scale with findings — the same
+  // maxPullsPerCycle that caps selected heads also caps the recent-merged window we scan for signals.
+  const recentMergedByRepo = new Map<string, Promise<PullRequestSummary[]>>();
   const fetchOutcome = async (target: ScheduledObserveTarget): Promise<ObservedPullOutcome> => {
-    // Read-only merge-state probe. A merged PR with no additional signal derives `none_observed`;
-    // deeper post-merge signals (revert/hotfix/merged-fix diffs, human-thread resolution) are a
-    // future enrichment and are left empty here (see docs/calibration-loop.md bootstrap note).
     const pull = await input.github.getPull(target.repo, target.pullNumber);
-    return {
-      merged: Boolean(pull.merged_at),
+    const merged = Boolean(pull.merged_at);
+    // Merge-state cut (the honest #357 floor). An UNMERGED PR has no terminal post-merge signal; a
+    // merged PR is enriched below. Any enrichment-read failure falls back to exactly this cut.
+    const mergeStateOnly: ObservedPullOutcome = {
+      merged,
       revertedFlaggedChange: false,
       hotfixLines: new Map(),
       mergedFixLines: new Map(),
       humanThreadResolved: false
     };
+    if (!merged) return mergeStateOnly;
+    try {
+      const subsequentPulls = await collectSubsequentMergedPulls({
+        github: input.github,
+        repo: target.repo,
+        maxPulls: schedule.maxPullsPerCycle,
+        recentMergedByRepo
+      });
+      const reviewComments = input.github.listPullReviewComments
+        ? await input.github.listPullReviewComments(target.repo, target.pullNumber)
+        : [];
+      return buildObservedPullOutcome({
+        merged,
+        mergeCommitSha: pull.merge_commit_sha,
+        pullNumber: target.pullNumber,
+        pullTitle: pull.title,
+        findings: target.findings,
+        subsequentPulls,
+        reviewComments
+      });
+    } catch (error) {
+      // Fail-open per target: a deeper-read error degrades to the merge-state cut, never throwing into
+      // the observe pass (which itself is wrapped below). The label stays honest (none_observed).
+      console.warn(
+        `[calibration-observe] deeper observation degraded to merge-state for ${target.repo}#${target.pullNumber}: ${
+          redactSecrets(error instanceof Error ? error.message : String(error))
+        }`
+      );
+      return mergeStateOnly;
+    }
   };
   try {
     await runScheduledObservePass({ state: input.state, config: schedule, evidenceDir, fetchOutcome, now });
@@ -296,6 +342,41 @@ export async function observeScheduledOutcomes(input: {
     // Observation is best-effort telemetry: never let a failure here disturb the review cycle.
     console.warn(`[calibration-observe] scheduled observe pass failed: ${redactSecrets(error instanceof Error ? error.message : String(error))}`);
   }
+}
+
+/**
+ * Read-only, BOUNDED collector of subsequent merged PRs whose right-side changed lines / revert message
+ * feed the deeper outcome signals (#371). The recent-merged window is fetched at most once per repo per
+ * cycle (memoized) and capped at maxPullsPerCycle; per-PR file reads are likewise capped so the extra
+ * reads never scale with the number of findings. When the GitHub surface can't list merged pulls or
+ * files, it returns an empty set — the caller then derives the honest merge-state-only cut.
+ */
+async function collectSubsequentMergedPulls(input: {
+  github: SchedulerGitHubApi;
+  repo: string;
+  maxPulls: number;
+  recentMergedByRepo: Map<string, Promise<PullRequestSummary[]>>;
+}): Promise<ObservedSubsequentPull[]> {
+  if (!input.github.listRecentMergedPulls || !input.github.listPullFiles) return [];
+  let pending = input.recentMergedByRepo.get(input.repo);
+  if (!pending) {
+    pending = input.github.listRecentMergedPulls(input.repo, input.maxPulls);
+    input.recentMergedByRepo.set(input.repo, pending);
+  }
+  const recent = await pending;
+  const subsequent: ObservedSubsequentPull[] = [];
+  // Cap per-PR file reads by maxPulls as well: the recent window is already ≤ maxPulls, but slice
+  // defensively so a future window-size change can't blow the per-cycle read budget.
+  for (const pull of recent.slice(0, input.maxPulls)) {
+    const files = await input.github.listPullFiles(input.repo, pull.number);
+    subsequent.push({
+      pullNumber: pull.number,
+      title: pull.title,
+      body: pull.body,
+      changedLines: collectRightSideLines(files)
+    });
+  }
+  return subsequent;
 }
 
 type EnqueueStatus =

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -289,10 +289,14 @@ export async function observeScheduledOutcomes(input: {
   // folder is derived from exactly the same instant that is forwarded to runScheduledObservePass.
   const now = input.now ?? new Date();
   const evidenceDir = join(input.config.evidenceDir, localDateFolder(now), "calibration-observe");
-  // Per-repo memo for the recent-merged-PR window: fetched at most ONCE per repo per cycle and shared
-  // across all that repo's target heads, so the deeper reads never scale with findings — the same
-  // maxPullsPerCycle that caps selected heads also caps the recent-merged window we scan for signals.
-  const recentMergedByRepo = new Map<string, Promise<PullRequestSummary[]>>();
+  // Per-cycle read cache so the deeper reads stay bounded regardless of how many target heads a repo
+  // has: the recent-merged-PR window is listed at most ONCE per repo, and each subsequent PR's files
+  // are fetched at most ONCE per (repo, pull) across all targets. The same maxPullsPerCycle that caps
+  // selected heads also caps the recent-merged window, so total deeper reads stay bounded by the caps.
+  const deeperReadCache: DeeperObservationReadCache = {
+    recentMergedByRepo: new Map(),
+    filesByRepoPull: new Map()
+  };
   const fetchOutcome = async (target: ScheduledObserveTarget): Promise<ObservedPullOutcome> => {
     const pull = await input.github.getPull(target.repo, target.pullNumber);
     const merged = Boolean(pull.merged_at);
@@ -311,7 +315,7 @@ export async function observeScheduledOutcomes(input: {
         github: input.github,
         repo: target.repo,
         maxPulls: schedule.maxPullsPerCycle,
-        recentMergedByRepo
+        cache: deeperReadCache
       });
       const reviewComments = input.github.listPullReviewComments
         ? await input.github.listPullReviewComments(target.repo, target.pullNumber)
@@ -345,30 +349,48 @@ export async function observeScheduledOutcomes(input: {
 }
 
 /**
+ * Per-cycle read cache for deeper observation (#371). Caches RESOLVED values (not pending promises) so
+ * a transient failure for one target does not poison the repo's whole cycle: a rejected read is never
+ * cached, letting a later target re-attempt. `recentMergedByRepo` bounds the window list to once per
+ * repo; `filesByRepoPull` bounds each subsequent PR's file read to once per (repo, pull) across all
+ * targets — so total deeper reads never scale with the number of target heads.
+ */
+interface DeeperObservationReadCache {
+  recentMergedByRepo: Map<string, PullRequestSummary[]>;
+  filesByRepoPull: Map<string, PullFilePatch[]>;
+}
+
+/**
  * Read-only, BOUNDED collector of subsequent merged PRs whose right-side changed lines / revert message
- * feed the deeper outcome signals (#371). The recent-merged window is fetched at most once per repo per
- * cycle (memoized) and capped at maxPullsPerCycle; per-PR file reads are likewise capped so the extra
- * reads never scale with the number of findings. When the GitHub surface can't list merged pulls or
- * files, it returns an empty set — the caller then derives the honest merge-state-only cut.
+ * feed the deeper outcome signals (#371). The recent-merged window is listed at most once per repo per
+ * cycle and capped at maxPullsPerCycle; each subsequent PR's files are fetched at most once per (repo,
+ * pull) across all targets. When the GitHub surface can't list merged pulls or files, it returns an
+ * empty set — the caller then derives the honest merge-state-only cut.
  */
 async function collectSubsequentMergedPulls(input: {
   github: SchedulerGitHubApi;
   repo: string;
   maxPulls: number;
-  recentMergedByRepo: Map<string, Promise<PullRequestSummary[]>>;
+  cache: DeeperObservationReadCache;
 }): Promise<ObservedSubsequentPull[]> {
   if (!input.github.listRecentMergedPulls || !input.github.listPullFiles) return [];
-  let pending = input.recentMergedByRepo.get(input.repo);
-  if (!pending) {
-    pending = input.github.listRecentMergedPulls(input.repo, input.maxPulls);
-    input.recentMergedByRepo.set(input.repo, pending);
+  let recent = input.cache.recentMergedByRepo.get(input.repo);
+  if (!recent) {
+    // Cache the RESOLVED value only: if this rejects it propagates (caught by the per-target fail-open),
+    // and nothing is cached, so a later target in the same repo can re-attempt the window read.
+    recent = await input.github.listRecentMergedPulls(input.repo, input.maxPulls);
+    input.cache.recentMergedByRepo.set(input.repo, recent);
   }
-  const recent = await pending;
   const subsequent: ObservedSubsequentPull[] = [];
   // Cap per-PR file reads by maxPulls as well: the recent window is already ≤ maxPulls, but slice
   // defensively so a future window-size change can't blow the per-cycle read budget.
   for (const pull of recent.slice(0, input.maxPulls)) {
-    const files = await input.github.listPullFiles(input.repo, pull.number);
+    const fileKey = `${input.repo}#${pull.number}`;
+    let files = input.cache.filesByRepoPull.get(fileKey);
+    if (!files) {
+      files = await input.github.listPullFiles(input.repo, pull.number);
+      input.cache.filesByRepoPull.set(fileKey, files);
+    }
     subsequent.push({
       pullNumber: pull.number,
       title: pull.title,

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -322,12 +322,14 @@ export async function observeScheduledOutcomes(input: {
         : [];
       return buildObservedPullOutcome({
         merged,
+        mergedAt: pull.merged_at,
         mergeCommitSha: pull.merge_commit_sha,
         pullNumber: target.pullNumber,
         pullTitle: pull.title,
         findings: target.findings,
         subsequentPulls,
-        reviewComments
+        reviewComments,
+        ...(input.config.github.botLogin ? { botLogin: input.config.github.botLogin } : {})
       });
     } catch (error) {
       // Fail-open per target: a deeper-read error degrades to the merge-state cut, never throwing into
@@ -395,6 +397,7 @@ async function collectSubsequentMergedPulls(input: {
       pullNumber: pull.number,
       title: pull.title,
       body: pull.body,
+      mergedAt: pull.merged_at,
       changedLines: collectRightSideLines(files)
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,24 @@ export interface PullFilePatch {
   previous_filename?: string;
 }
 
+/**
+ * A single PR review (inline-diff) comment (#371). Read-only shape for outcome observation: the
+ * observer looks for a HUMAN reply thread on a finding's path/line as a false-positive dismissal
+ * signal. `in_reply_to_id` marks a reply within a thread; `user.type` lets us exclude bot authors.
+ */
+export interface PullReviewComment {
+  id: number;
+  path?: string | null;
+  line?: number | null;
+  original_line?: number | null;
+  in_reply_to_id?: number | null;
+  body?: string | null;
+  user?: {
+    login: string;
+    type?: string;
+  } | null;
+}
+
 export interface PullRequestSummary {
   number: number;
   title: string;
@@ -51,6 +69,7 @@ export interface PullRequestSummary {
   state?: string;
   created_at?: string | null;
   merged_at?: string | null;
+  merge_commit_sha?: string | null;
   body?: string | null;
   head: {
     sha: string;

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -592,6 +592,27 @@ describe("GitHub App read authentication", () => {
     expect(postCall?.body).toEqual({ body: `${marker}\nnew` });
     expect(calls.some((call) => call.method === "PATCH")).toBe(false);
   });
+
+  it("listPullReviewComments is hard-capped: it stops paging after the cap even if pages stay full (#371 bounded read)", async () => {
+    // Every page returns a FULL page (100) so the `chunk.length < 100` terminator never fires; only the
+    // hard page cap can stop the loop. Assert it does — an unbounded loop would page forever here.
+    const pagesRequested: number[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      const match = /\/repos\/owner\/repo\/pulls\/7\/comments\?per_page=100&page=(\d+)$/.exec(String(url));
+      if (match) {
+        pagesRequested.push(Number(match[1]));
+        return jsonResponse(Array.from({ length: 100 }, (_unused, index) => ({ id: Number(match[1]) * 1000 + index })));
+      }
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ token: "fallback-token" });
+    const comments = await github.listPullReviewComments("owner/repo", 7);
+
+    // The reader stopped at the hard cap (5 pages), never paging unboundedly.
+    expect(pagesRequested).toEqual([1, 2, 3, 4, 5]);
+    expect(comments).toHaveLength(500);
+  });
 });
 
 function jsonResponse(body: unknown, status = 200, statusText = ""): Response {

--- a/tests/observe-scheduling.test.ts
+++ b/tests/observe-scheduling.test.ts
@@ -591,7 +591,8 @@ function deepGithub(input: {
   merged?: boolean;
   mergeCommitSha?: string;
   pullTitle?: string;
-  subsequent?: Array<{ number: number; title?: string; body?: string; files?: PullFilePatch[] }>;
+  targetMergedAt?: string;
+  subsequent?: Array<{ number: number; title?: string; body?: string; files?: PullFilePatch[]; mergedAt?: string }>;
   reviewComments?: PullReviewComment[];
 }): SchedulerGitHubApi {
   const subsequent = input.subsequent ?? [];
@@ -603,7 +604,7 @@ function deepGithub(input: {
         number: pullNumber,
         title: input.pullTitle ?? "Add save path",
         head: { sha: `sha${pullNumber}` },
-        merged_at: (input.merged ?? true) ? "2026-07-05T00:00:00.000Z" : null,
+        merged_at: (input.merged ?? true) ? (input.targetMergedAt ?? "2026-07-05T00:00:00.000Z") : null,
         merge_commit_sha: input.mergeCommitSha ?? "mergesha1"
       }) as unknown as PullRequestSummary,
     listRecentMergedPulls: async () =>
@@ -614,7 +615,9 @@ function deepGithub(input: {
             title: pull.title ?? "",
             body: pull.body ?? "",
             head: { sha: `sha${pull.number}` },
-            merged_at: "2026-07-05T12:00:00.000Z"
+            // Subsequent PRs default to AFTER the target's merge (12:00 > 00:00); a test may set a
+            // BEFORE time to exercise the temporal guard.
+            merged_at: pull.mergedAt ?? "2026-07-05T12:00:00.000Z"
           }) as unknown as PullRequestSummary
       ),
     listPullFiles: async (_repo, pullNumber) => subsequent.find((pull) => pull.number === pullNumber)?.files ?? [],
@@ -685,6 +688,91 @@ describe("buildObservedPullOutcome enrichment (#371)", () => {
     expect(observed.revertedFlaggedChange).toBe(false);
     expect(observed.hotfixLines.size).toBe(0);
   });
+
+  it("temporal guard: a PR merged BEFORE the target is NOT counted as a revert or a hotfix", () => {
+    const hotfixLines = new Map([["src/save.ts", new Set([42])]]);
+    const priorMerged = buildObservedPullOutcome({
+      merged: true,
+      mergedAt: "2026-07-05T00:00:00.000Z",
+      pullNumber: 1,
+      pullTitle: "Add save path",
+      mergeCommitSha: "mergesha1",
+      findings: [OBSERVED_FINDING],
+      subsequentPulls: [
+        // Merged an hour BEFORE the target — cannot be its post-merge revert/fix even though its title
+        // reverts it and its diff touches the flagged line.
+        { pullNumber: 2, title: 'Revert "Add save path" (#1)', body: "This reverts commit mergesha1.", mergedAt: "2026-07-04T23:00:00.000Z", changedLines: hotfixLines }
+      ],
+      reviewComments: []
+    });
+    expect(priorMerged.revertedFlaggedChange).toBe(false);
+    expect(priorMerged.hotfixLines.size).toBe(0);
+
+    // The SAME candidate merged AFTER the target IS counted (guard is strictly-after, not a blanket skip).
+    const laterMerged = buildObservedPullOutcome({
+      merged: true,
+      mergedAt: "2026-07-05T00:00:00.000Z",
+      pullNumber: 1,
+      pullTitle: "Add save path",
+      mergeCommitSha: "mergesha1",
+      findings: [OBSERVED_FINDING],
+      subsequentPulls: [
+        { pullNumber: 2, title: 'Revert "Add save path" (#1)', body: "", mergedAt: "2026-07-05T01:00:00.000Z", changedLines: new Map() }
+      ],
+      reviewComments: []
+    });
+    expect(laterMerged.revertedFlaggedChange).toBe(true);
+  });
+
+  it("revert title must be the EXACT `Revert \"<title>\"` construction, not a loose substring", () => {
+    // Target title is a substring of the candidate's reverted title — the loose `includes` would have
+    // false-matched; the exact-construction match must reject it.
+    const substringFalseMatch = buildObservedPullOutcome({
+      merged: true,
+      pullNumber: 1,
+      pullTitle: "save",
+      findings: [OBSERVED_FINDING],
+      subsequentPulls: [{ pullNumber: 2, title: 'Revert "add safe save path"', body: "", changedLines: new Map() }],
+      reviewComments: []
+    });
+    expect(substringFalseMatch.revertedFlaggedChange).toBe(false);
+
+    // The exact default construction (optionally with a (#n) tail) matches.
+    const exactMatch = buildObservedPullOutcome({
+      merged: true,
+      pullNumber: 1,
+      pullTitle: "save",
+      findings: [OBSERVED_FINDING],
+      subsequentPulls: [{ pullNumber: 2, title: 'Revert "save" (#1)', body: "", changedLines: new Map() }],
+      reviewComments: []
+    });
+    expect(exactMatch.revertedFlaggedChange).toBe(true);
+  });
+
+  it("bot-login defensiveness: a bot reply with a MISSING type but matching botLogin is not a human thread", () => {
+    const botReplyMissingType = buildObservedPullOutcome({
+      merged: true,
+      pullNumber: 1,
+      findings: [OBSERVED_FINDING],
+      subsequentPulls: [],
+      // in_reply_to_id set (a reply), author login matches botLogin, but user.type is UNDEFINED — the
+      // shared bot-identity check must still exclude it, so no human-thread signal is derived.
+      reviewComments: [{ path: "src/save.ts", line: 42, in_reply_to_id: 9, user: { login: "my-bot[bot]" } }],
+      botLogin: "my-bot[bot]"
+    });
+    expect(botReplyMissingType.humanThreadResolved).toBe(false);
+
+    // A genuine human reply (different login) on the same line IS counted.
+    const humanReply = buildObservedPullOutcome({
+      merged: true,
+      pullNumber: 1,
+      findings: [OBSERVED_FINDING],
+      subsequentPulls: [],
+      reviewComments: [{ path: "src/save.ts", line: 42, in_reply_to_id: 9, user: { login: "maintainer" } }],
+      botLogin: "my-bot[bot]"
+    });
+    expect(humanReply.humanThreadResolved).toBe(true);
+  });
 });
 
 describe("scheduled reader reaches CLI-observer label parity (#371 acceptance)", () => {
@@ -718,8 +806,10 @@ describe("scheduled reader reaches CLI-observer label parity (#371 acceptance)",
     return labels[0];
   }
 
-  function assertParity(scheduled: FindingOutcomeLabelRecordLike, cli: FindingOutcomeLabelRecordLike): void {
-    expect(scheduled.labelSource).toBe(cli.labelSource);
+  // The load-bearing guarantee is VERDICT parity (true_positive / false_positive / unvalidated). In the
+  // scenarios below the CLI input is fed the SAME source the scheduled reader derives, so labelSource
+  // matches too; the separate merged_fix-vs-hotfix test documents where only the verdict is guaranteed.
+  function assertVerdictParity(scheduled: FindingOutcomeLabelRecordLike, cli: FindingOutcomeLabelRecordLike): void {
     expect(scheduled.verdict).toBe(cli.verdict);
   }
 
@@ -729,7 +819,7 @@ describe("scheduled reader reaches CLI-observer label parity (#371 acceptance)",
     );
     const cli = cliLabel(fullObserved({ merged: true, revertedFlaggedChange: true }));
     expect(scheduled.labelSource).toBe("revert");
-    assertParity(scheduled, cli);
+    assertVerdictParity(scheduled, cli);
   });
 
   it("hotfix touching the flagged line: both label a true_positive fix (hotfix)", async () => {
@@ -739,7 +829,7 @@ describe("scheduled reader reaches CLI-observer label parity (#371 acceptance)",
     const cli = cliLabel(fullObserved({ merged: true, hotfixLines: new Map([["src/save.ts", new Set([42])]]) }));
     expect(scheduled.labelSource).toBe("hotfix");
     expect(scheduled.verdict).toBe("true_positive");
-    assertParity(scheduled, cli);
+    assertVerdictParity(scheduled, cli);
   });
 
   it("human thread on the finding: both label `human_thread` / false_positive", async () => {
@@ -747,7 +837,7 @@ describe("scheduled reader reaches CLI-observer label parity (#371 acceptance)",
     const cli = cliLabel(fullObserved({ merged: true, humanThreadResolved: true }));
     expect(scheduled.labelSource).toBe("human_thread");
     expect(scheduled.verdict).toBe("false_positive");
-    assertParity(scheduled, cli);
+    assertVerdictParity(scheduled, cli);
   });
 
   it("merged with no deeper signal stays none_observed (honest floor preserved)", async () => {

--- a/tests/observe-scheduling.test.ts
+++ b/tests/observe-scheduling.test.ts
@@ -9,13 +9,16 @@ import {
   recordPostedReviewFindings
 } from "../src/worker.js";
 import {
+  buildObservedPullOutcome,
+  runOutcomeObserverFromInput,
   runScheduledObservePass,
+  type ObservedFinding,
   type ObservedPullOutcome,
   type ScheduledObserveTarget
 } from "../src/outcome-observer.js";
 import { observeScheduledOutcomes, type SchedulerGitHubApi } from "../src/scheduler.js";
 import { applyDeterministicReviewGate, buildFindingFingerprint } from "../src/review-gate.js";
-import type { Finding, PullFilePatch, PullRequestSummary, ReviewComment } from "../src/types.js";
+import type { Finding, PullFilePatch, PullRequestSummary, PullReviewComment, ReviewComment } from "../src/types.js";
 
 const roots: string[] = [];
 afterEach(() => {
@@ -557,3 +560,262 @@ describe("observeScheduledOutcomes scheduler wiring (#357)", () => {
     store.close();
   });
 });
+
+// ---------------------------------------------------------------------------------------------------
+// #371: deepen scheduled observation to revert / hotfix-line-touch / human-thread signals.
+// ---------------------------------------------------------------------------------------------------
+
+const OBSERVED_FINDING: ObservedFinding = {
+  fingerprint: FINDING.fingerprint,
+  path: FINDING.path,
+  line: FINDING.line,
+  severity: "P1",
+  category: "data_loss",
+  confidence: 0.9
+};
+
+// A merged fix / hotfix diff that touches the flagged line (src/save.ts:42) via a +line at 42.
+const HOTFIX_FILES: PullFilePatch[] = [
+  { filename: "src/save.ts", patch: "@@ -40,3 +40,4 @@\n export function save() {\n+  flushBeforeOverwrite();\n   overwriteAllData();\n }" }
+];
+// A human reply thread on the finding's path/line — the false-positive dismissal signal.
+const HUMAN_THREAD: PullReviewComment[] = [
+  { id: 10, path: "src/save.ts", line: 42, in_reply_to_id: 9, user: { login: "maintainer", type: "User" } }
+];
+
+/**
+ * Build a hermetic scheduler GitHub stub exposing the deeper-observation read surface (#371). The
+ * target merged PR is #1@sha1; `subsequent` are later merged PRs (revert / hotfix) the reader scans.
+ */
+function deepGithub(input: {
+  merged?: boolean;
+  mergeCommitSha?: string;
+  pullTitle?: string;
+  subsequent?: Array<{ number: number; title?: string; body?: string; files?: PullFilePatch[] }>;
+  reviewComments?: PullReviewComment[];
+}): SchedulerGitHubApi {
+  const subsequent = input.subsequent ?? [];
+  return {
+    listOpenPulls: async () => [],
+    listIssueComments: async () => [],
+    getPull: async (_repo, pullNumber) =>
+      ({
+        number: pullNumber,
+        title: input.pullTitle ?? "Add save path",
+        head: { sha: `sha${pullNumber}` },
+        merged_at: (input.merged ?? true) ? "2026-07-05T00:00:00.000Z" : null,
+        merge_commit_sha: input.mergeCommitSha ?? "mergesha1"
+      }) as unknown as PullRequestSummary,
+    listRecentMergedPulls: async () =>
+      subsequent.map(
+        (pull) =>
+          ({
+            number: pull.number,
+            title: pull.title ?? "",
+            body: pull.body ?? "",
+            head: { sha: `sha${pull.number}` },
+            merged_at: "2026-07-05T12:00:00.000Z"
+          }) as unknown as PullRequestSummary
+      ),
+    listPullFiles: async (_repo, pullNumber) => subsequent.find((pull) => pull.number === pullNumber)?.files ?? [],
+    listPullReviewComments: async () => input.reviewComments ?? []
+  };
+}
+
+describe("buildObservedPullOutcome enrichment (#371)", () => {
+  it("detects a revert PR that back-references the original PR number", () => {
+    const observed = buildObservedPullOutcome({
+      merged: true,
+      pullNumber: 1,
+      pullTitle: "Add save path",
+      mergeCommitSha: "mergesha1",
+      findings: [OBSERVED_FINDING],
+      subsequentPulls: [{ pullNumber: 2, title: 'Revert "Add save path" (#1)', body: "", changedLines: new Map() }],
+      reviewComments: []
+    });
+    expect(observed.revertedFlaggedChange).toBe(true);
+  });
+
+  it("detects a revert via `This reverts commit <merge_commit_sha>` body", () => {
+    const observed = buildObservedPullOutcome({
+      merged: true,
+      pullNumber: 1,
+      pullTitle: "Add save path",
+      mergeCommitSha: "mergesha1",
+      findings: [OBSERVED_FINDING],
+      subsequentPulls: [{ pullNumber: 2, title: "Revert regression", body: "This reverts commit mergesha1.", changedLines: new Map() }],
+      reviewComments: []
+    });
+    expect(observed.revertedFlaggedChange).toBe(true);
+  });
+
+  it("does NOT treat the PR as its own revert/hotfix, and ignores unrelated later PRs", () => {
+    const observed = buildObservedPullOutcome({
+      merged: true,
+      pullNumber: 1,
+      pullTitle: "Add save path",
+      findings: [OBSERVED_FINDING],
+      subsequentPulls: [{ pullNumber: 1, title: 'Revert "Add save path" (#1)', body: "", changedLines: new Map() }],
+      reviewComments: []
+    });
+    expect(observed.revertedFlaggedChange).toBe(false);
+    expect(observed.hotfixLines.size).toBe(0);
+  });
+});
+
+describe("scheduled reader reaches CLI-observer label parity (#371 acceptance)", () => {
+  const now = new Date("2026-07-06T10:00:00.000Z");
+
+  // The parity contract: fed the same underlying facts, the scheduled reader must record the SAME
+  // label the CLI observer (runOutcomeObserverFromInput) records from the equivalent ObservedPullOutcome.
+  async function scheduledLabel(github: SchedulerGitHubApi): Promise<FindingOutcomeLabelRecordLike> {
+    const { store } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const config = loadConfigFromObject(baseConfigObject({ calibrationLoop: { observeSchedule: OBSERVE_SCHEDULE } }));
+    await observeScheduledOutcomes({ config, github, state: store, now });
+    const labels = store.listFindingOutcomeLabels();
+    store.close();
+    expect(labels).toHaveLength(1);
+    return labels[0];
+  }
+
+  function cliLabel(observed: ObservedPullOutcome): FindingOutcomeLabelRecordLike {
+    const { store, root } = newStore();
+    const result = runOutcomeObserverFromInput({
+      store,
+      entries: [{ review: { repo: "owner/repo", pullNumber: 1, headSha: "sha1", findings: [OBSERVED_FINDING] }, observed }],
+      evidenceDir: join(root, "cli-evidence"),
+      dryRun: false,
+      now
+    });
+    expect(result.labeled).toBe(1);
+    const labels = store.listFindingOutcomeLabels();
+    store.close();
+    return labels[0];
+  }
+
+  function assertParity(scheduled: FindingOutcomeLabelRecordLike, cli: FindingOutcomeLabelRecordLike): void {
+    expect(scheduled.labelSource).toBe(cli.labelSource);
+    expect(scheduled.verdict).toBe(cli.verdict);
+  }
+
+  it("revert: scheduled reader and CLI observer both label `revert` / true_positive", async () => {
+    const scheduled = await scheduledLabel(
+      deepGithub({ subsequent: [{ number: 2, title: 'Revert "Add save path" (#1)' }] })
+    );
+    const cli = cliLabel(fullObserved({ merged: true, revertedFlaggedChange: true }));
+    expect(scheduled.labelSource).toBe("revert");
+    assertParity(scheduled, cli);
+  });
+
+  it("hotfix touching the flagged line: both label a true_positive fix (hotfix)", async () => {
+    const scheduled = await scheduledLabel(
+      deepGithub({ subsequent: [{ number: 2, title: "Fix data loss on save", files: HOTFIX_FILES }] })
+    );
+    const cli = cliLabel(fullObserved({ merged: true, hotfixLines: new Map([["src/save.ts", new Set([42])]]) }));
+    expect(scheduled.labelSource).toBe("hotfix");
+    expect(scheduled.verdict).toBe("true_positive");
+    assertParity(scheduled, cli);
+  });
+
+  it("human thread on the finding: both label `human_thread` / false_positive", async () => {
+    const scheduled = await scheduledLabel(deepGithub({ reviewComments: HUMAN_THREAD }));
+    const cli = cliLabel(fullObserved({ merged: true, humanThreadResolved: true }));
+    expect(scheduled.labelSource).toBe("human_thread");
+    expect(scheduled.verdict).toBe("false_positive");
+    assertParity(scheduled, cli);
+  });
+
+  it("merged with no deeper signal stays none_observed (honest floor preserved)", async () => {
+    const scheduled = await scheduledLabel(deepGithub({ subsequent: [] }));
+    expect(scheduled.labelSource).toBe("none_observed");
+    expect(scheduled.verdict).toBe("unvalidated");
+  });
+});
+
+describe("scheduled deeper-observation cost caps + invariants (#371)", () => {
+  const now = new Date("2026-07-06T10:00:00.000Z");
+
+  it("bounds deeper reads: recent-merged window is fetched ONCE per repo and capped at maxPullsPerCycle", async () => {
+    const { store } = newStore();
+    // Two merged target heads in the SAME repo — the recent-merged window must be read once, shared.
+    store.recordReviewFindings([
+      { ...FINDING, pullNumber: 1, headSha: "sha1", fingerprint: `finding:${"a".repeat(64)}` },
+      { ...FINDING, pullNumber: 2, headSha: "sha2", fingerprint: `finding:${"b".repeat(64)}` }
+    ]);
+    const listRecentMergedPulls = vi.fn(async () => [] as PullRequestSummary[]);
+    const github: SchedulerGitHubApi = {
+      ...deepGithub({ subsequent: [] }),
+      listRecentMergedPulls
+    };
+    const config = loadConfigFromObject(
+      baseConfigObject({ calibrationLoop: { observeSchedule: { ...OBSERVE_SCHEDULE, maxPullsPerCycle: 2 } } })
+    );
+
+    await observeScheduledOutcomes({ config, github, state: store, now });
+
+    // One window read for the repo (memoized across both heads), and it requested at most maxPullsPerCycle.
+    expect(listRecentMergedPulls).toHaveBeenCalledTimes(1);
+    expect(listRecentMergedPulls).toHaveBeenCalledWith("owner/repo", 2);
+    store.close();
+  });
+
+  it("fails open: a throwing deeper-read degrades to the merge-state cut (none_observed), never throws", async () => {
+    const { store } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const token = ["ghp", "q".repeat(36)].join("_");
+    const github: SchedulerGitHubApi = {
+      ...deepGithub({ subsequent: [{ number: 2, title: "Fix", files: HOTFIX_FILES }] }),
+      listRecentMergedPulls: async () => {
+        throw new Error(`recent-merged read boom ${token}`);
+      }
+    };
+    const config = loadConfigFromObject(baseConfigObject({ calibrationLoop: { observeSchedule: OBSERVE_SCHEDULE } }));
+
+    await expect(observeScheduledOutcomes({ config, github, state: store, now })).resolves.toBeUndefined();
+    const labels = store.listFindingOutcomeLabels();
+    // The merged PR still gets an HONEST none_observed label (never a mislabel), and the pass advances.
+    expect(labels).toHaveLength(1);
+    expect(labels[0].labelSource).toBe("none_observed");
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls.flat().join(" ")).not.toContain(token);
+    store.close();
+  });
+
+  it("never posts/aggregates/writes config: only finding_outcome_labels + schedule state are written", async () => {
+    const { store } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const github = deepGithub({ subsequent: [{ number: 2, title: 'Revert "Add save path" (#1)' }] });
+    // Fail loudly if any WRITE-shaped GitHub surface is invoked by the observe pass.
+    const forbidden = {
+      createReview: vi.fn(),
+      upsertIssueComment: vi.fn()
+    };
+    const config = loadConfigFromObject(baseConfigObject({ calibrationLoop: { observeSchedule: OBSERVE_SCHEDULE } }));
+
+    await observeScheduledOutcomes({ config, github: { ...github, ...forbidden } as SchedulerGitHubApi, state: store, now });
+
+    expect(forbidden.createReview).not.toHaveBeenCalled();
+    expect(forbidden.upsertIssueComment).not.toHaveBeenCalled();
+    expect(store.listFindingOutcomeLabels()).toHaveLength(1);
+    store.close();
+  });
+
+  it("disabled ⇒ byte-identical no-op: no deeper reads, no labels", async () => {
+    const { store } = newStore();
+    store.recordReviewFindings([FINDING]);
+    const listRecentMergedPulls = vi.fn(async () => [] as PullRequestSummary[]);
+    const github: SchedulerGitHubApi = { ...deepGithub({}), listRecentMergedPulls };
+    const config = loadConfigFromObject(baseConfigObject());
+
+    await observeScheduledOutcomes({ config, github, state: store, now });
+
+    expect(listRecentMergedPulls).not.toHaveBeenCalled();
+    expect(store.listFindingOutcomeLabels()).toHaveLength(0);
+    store.close();
+  });
+});
+
+// The label-record shape the parity assertions read (subset of the store record).
+type FindingOutcomeLabelRecordLike = { labelSource: string; verdict: string };

--- a/tests/observe-scheduling.test.ts
+++ b/tests/observe-scheduling.test.ts
@@ -649,6 +649,30 @@ describe("buildObservedPullOutcome enrichment (#371)", () => {
     expect(observed.revertedFlaggedChange).toBe(true);
   });
 
+  it("revert `Reverts #n` body construction matches; an incidental `#n` mention does NOT (correctness)", () => {
+    const revertsBody = buildObservedPullOutcome({
+      merged: true,
+      pullNumber: 1,
+      pullTitle: "Add save path",
+      findings: [OBSERVED_FINDING],
+      // Revert-shaped title but NO title/sha back-ref; the only PR reference is the `Reverts #1` line.
+      subsequentPulls: [{ pullNumber: 2, title: "Revert regression", body: "Reverts owner/repo#1", changedLines: new Map() }],
+      reviewComments: []
+    });
+    expect(revertsBody.revertedFlaggedChange).toBe(true);
+
+    const incidentalMention = buildObservedPullOutcome({
+      merged: true,
+      pullNumber: 1,
+      pullTitle: "Add save path",
+      findings: [OBSERVED_FINDING],
+      // A revert-shaped PR that reverts something ELSE but merely mentions #1 in prose must NOT match.
+      subsequentPulls: [{ pullNumber: 2, title: "Revert unrelated change", body: "See #1 for prior context.", changedLines: new Map() }],
+      reviewComments: []
+    });
+    expect(incidentalMention.revertedFlaggedChange).toBe(false);
+  });
+
   it("does NOT treat the PR as its own revert/hotfix, and ignores unrelated later PRs", () => {
     const observed = buildObservedPullOutcome({
       merged: true,
@@ -757,6 +781,64 @@ describe("scheduled deeper-observation cost caps + invariants (#371)", () => {
     // One window read for the repo (memoized across both heads), and it requested at most maxPullsPerCycle.
     expect(listRecentMergedPulls).toHaveBeenCalledTimes(1);
     expect(listRecentMergedPulls).toHaveBeenCalledWith("owner/repo", 2);
+    store.close();
+  });
+
+  it("bounds per-subsequent-PR file reads: listPullFiles is called at most once per (repo, subsequent-pull) across targets", async () => {
+    const { store } = newStore();
+    // Two merged target heads in the SAME repo share the SAME recent-merged window (PRs #10, #11).
+    store.recordReviewFindings([
+      { ...FINDING, pullNumber: 1, headSha: "sha1", fingerprint: `finding:${"a".repeat(64)}` },
+      { ...FINDING, pullNumber: 2, headSha: "sha2", fingerprint: `finding:${"b".repeat(64)}` }
+    ]);
+    const listPullFiles = vi.fn(async (_repo: string, _pullNumber: number) => [] as PullFilePatch[]);
+    const github: SchedulerGitHubApi = {
+      ...deepGithub({ subsequent: [{ number: 10, title: "later A" }, { number: 11, title: "later B" }] }),
+      listRecentMergedPulls: async () =>
+        [10, 11].map((number) => ({ number, title: "later", body: "", head: { sha: `sha${number}` }, merged_at: "2026-07-05T12:00:00.000Z" }) as unknown as PullRequestSummary),
+      listPullFiles
+    };
+    const config = loadConfigFromObject(
+      baseConfigObject({ calibrationLoop: { observeSchedule: { ...OBSERVE_SCHEDULE, maxPullsPerCycle: 2 } } })
+    );
+
+    await observeScheduledOutcomes({ config, github, state: store, now });
+
+    // Two targets × two subsequent PRs would be 4 reads unmemoized; the (repo, pull) cache holds it to 2.
+    expect(listPullFiles).toHaveBeenCalledTimes(2);
+    expect(new Set(listPullFiles.mock.calls.map((call) => call[1]))).toEqual(new Set([10, 11]));
+    store.close();
+  });
+
+  it("caches the RESOLVED window (not a rejected promise): a first-target failure does not poison later targets", async () => {
+    const { store } = newStore();
+    store.recordReviewFindings([
+      { ...FINDING, pullNumber: 1, headSha: "sha1", fingerprint: `finding:${"a".repeat(64)}` },
+      { ...FINDING, pullNumber: 2, headSha: "sha2", fingerprint: `finding:${"b".repeat(64)}` }
+    ]);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    let calls = 0;
+    const listRecentMergedPulls = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("transient window read failure");
+      // Second target re-attempts and succeeds with a revert of PR #2.
+      return [{ number: 20, title: 'Revert "x" (#2)', body: "", head: { sha: "sha20" }, merged_at: "2026-07-05T12:00:00.000Z" }] as unknown as PullRequestSummary[];
+    });
+    const github: SchedulerGitHubApi = {
+      ...deepGithub({}),
+      getPull: async (_repo, pullNumber) =>
+        ({ number: pullNumber, title: `PR ${pullNumber}`, head: { sha: `sha${pullNumber}` }, merged_at: "2026-07-05T00:00:00.000Z", merge_commit_sha: `merge${pullNumber}` }) as unknown as PullRequestSummary,
+      listRecentMergedPulls
+    };
+    const config = loadConfigFromObject(baseConfigObject({ calibrationLoop: { observeSchedule: OBSERVE_SCHEDULE } }));
+
+    await observeScheduledOutcomes({ config, github, state: store, now });
+
+    // Both targets attempted the read (rejection was NOT cached): #1 degraded to none_observed, #2 got revert.
+    expect(listRecentMergedPulls).toHaveBeenCalledTimes(2);
+    const bySource = Object.fromEntries(store.listFindingOutcomeLabels().map((label) => [label.pullNumber, label.labelSource]));
+    expect(bySource[1]).toBe("none_observed");
+    expect(bySource[2]).toBe("revert");
     store.close();
   });
 


### PR DESCRIPTION
## Summary
The #357 scheduled observe pass's read-only `fetchOutcome` derived **merge-state only**, so a merged reviewed PR yielded `none_observed` until the CLI `outcome-observe` path was run against an evidence-derived input. This deepens the *scheduled daemon* reader to the same label richness as the CLI observer — revert / hotfix-or-merged-fix line-touch / human-thread — by enriching the **input** the pass feeds the existing `deriveOutcomeLabel`. The labeler is unchanged.

## Design
- **`buildObservedPullOutcome`** (pure, `src/outcome-observer.ts`): turns the read-only GitHub reads for one merged PR into the fuller `ObservedPullOutcome` `deriveOutcomeLabel` already understands:
  - **revert** of the merge — GitHub's `Revert "<title>"` PR title, `Reverts #<n>`, or `This reverts commit <merge_commit_sha>` body.
  - **hotfix / merged-fix line touch** — right-side changed lines of subsequent merged PRs via `collectRightSideLines` (the exact review-gate primitive), matched to a finding's path+line (a revert is not double-counted as a hotfix).
  - **human thread** — a human (non-bot) reply thread on the finding's path/line (false-positive dismissal).
- **`observeScheduledOutcomes`** (`src/scheduler.ts`) wires the injected reader to bounded reads: the recent-merged-PR window is fetched **at most once per repo per cycle** (memoized) and **capped at `maxPullsPerCycle`**; per-PR file reads are likewise capped — the deeper reads never scale with the number of findings.
- New read-only `GitHubApi` methods `listRecentMergedPulls` / `listPullReviewComments`, both **optional** on `SchedulerGitHubApi` (absent ⇒ merge-state-only cut). Added `merge_commit_sha` + `PullReviewComment` to `src/types.ts`.

## Validation
`npm run build` + focused `tests/observe-scheduling.test.ts` (33 tests, all green). The **CLI-parity** tests feed the same underlying facts two ways and assert the scheduled reader records the SAME `{labelSource, verdict}` the CLI observer (`runOutcomeObserverFromInput`) records from the equivalent `ObservedPullOutcome`, for revert (`revert`/true_positive), hotfix-line-touch (`hotfix`/true_positive), and human-thread (`human_thread`/false_positive); plus the honest `none_observed` floor when no signal exists. Bounded-read-cost is pinned (one memoized window read per repo, called with `maxPullsPerCycle`); fail-open, never-post/aggregate, and disabled-byte-identical invariants each have a test.

## Proof boundary
Enriches observation **input** only; read-only (no posting, no mutation) via bounded GitHub reads; promotion stays human-gated per `docs/calibration-loop.md`; invariants unchanged (never aggregate/promote/config-write/publicDisplay/post; disabled ⇒ byte-identical). A deeper-read error degrades fail-open to the merge-state cut (`none_observed`), never throwing into the cycle.

Closes #371, parent #340