### PR TITLE
Desktop onboarding wizard: provider setup, daemon bootstrap, license step (#325)

### DIFF
--- a/apps/neondiff-desktop/Package.swift
+++ b/apps/neondiff-desktop/Package.swift
@@ -32,6 +32,10 @@ let package = Package(
         .executableTarget(
             name: "NeonDiffDesktopCoreSmoke",
             dependencies: ["NeonDiffDesktopCore"]
+        ),
+        .executableTarget(
+            name: "NeonDiffDesktopCoreChecks",
+            dependencies: ["NeonDiffDesktopCore"]
         )
     ]
 )

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
@@ -17,21 +17,26 @@ final class NeonDiffDesktopModel: ObservableObject {
     @Published var lastCommandLine = ""
     @Published var pendingProviderKey = ""
     @Published var pendingLicenseKey = ""
+    @Published var onboardingFlow = OnboardingFlow()
+    @Published var isOnboardingPresented = false
 
     private let userDefaults: UserDefaults
-    private let keychain: KeychainSecretStore
+    private let keychain: DesktopSecretStoring
 
     init(
         userDefaults: UserDefaults = .standard,
-        keychain: KeychainSecretStore = KeychainSecretStore()
+        keychain: DesktopSecretStoring = KeychainSecretStore()
     ) {
         self.userDefaults = userDefaults
         self.keychain = keychain
         self.configPath = userDefaults.string(forKey: "neondiff.configPath") ?? "config.local.json"
         self.cliPath = userDefaults.string(forKey: "neondiff.cliPath") ?? "neondiff"
         self.launchdLabel = userDefaults.string(forKey: "neondiff.launchdLabel") ?? "com.electricsheephq.evaos-code-review-bot"
-        self.providers.providerKeyStored = keychain.containsSecret(account: providerKeyAccount)
+        let providerKeyStored = keychain.containsSecret(account: providerKeyAccount)
+        self.providers.providerKeyStored = providerKeyStored
         self.license.keyStored = keychain.containsSecret(account: licenseKeyAccount)
+        self.onboardingFlow = OnboardingFlow(providerKeyStored: providerKeyStored)
+        self.isOnboardingPresented = !userDefaults.bool(forKey: onboardingCompletedKey)
         self.lastCommandLine = statusCommand.commandLine
     }
 
@@ -45,6 +50,14 @@ final class NeonDiffDesktopModel: ObservableObject {
 
     var stopDaemonDryRunCommand: DesktopCommand {
         NeonDiffCommandBuilder.daemonControl(action: "stop", cliPath: cliPath, configPath: configPath, launchdLabel: launchdLabel)
+    }
+
+    var startDaemonCommand: DesktopCommand {
+        NeonDiffCommandBuilder.daemonControl(action: "start", cliPath: cliPath, configPath: configPath, launchdLabel: launchdLabel, dryRun: false)
+    }
+
+    var stopDaemonCommand: DesktopCommand {
+        NeonDiffCommandBuilder.daemonControl(action: "stop", cliPath: cliPath, configPath: configPath, launchdLabel: launchdLabel, dryRun: false)
     }
 
     var configInspectCommand: DesktopCommand {
@@ -78,6 +91,22 @@ final class NeonDiffDesktopModel: ObservableObject {
         runCLI(arguments: ["daemon", "stop", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "true"], displayCommand: stopDaemonDryRunCommand)
     }
 
+    func startDaemon() {
+        persistLocalSettings()
+        runCLI(
+            arguments: ["daemon", "start", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "false", "--confirm", "true"],
+            displayCommand: startDaemonCommand
+        )
+    }
+
+    func stopDaemon() {
+        persistLocalSettings()
+        runCLI(
+            arguments: ["daemon", "stop", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "false", "--confirm", "true"],
+            displayCommand: stopDaemonCommand
+        )
+    }
+
     func inspectConfig() {
         runCLI(arguments: ["config", "inspect", "--config", configPath], displayCommand: configInspectCommand)
     }
@@ -95,6 +124,7 @@ final class NeonDiffDesktopModel: ObservableObject {
             try keychain.setSecret(pendingProviderKey, account: providerKeyAccount)
             pendingProviderKey = ""
             providers.providerKeyStored = true
+            onboardingFlow.providerKeyStored = true
             lastError = nil
         } catch {
             lastError = NeonDiffRedactor.redact(error.localizedDescription)
@@ -110,6 +140,39 @@ final class NeonDiffDesktopModel: ObservableObject {
         } catch {
             lastError = NeonDiffRedactor.redact(error.localizedDescription)
         }
+    }
+
+    func activateLicenseForOnboarding() {
+        if !pendingLicenseKey.isEmpty {
+            storeLicenseKey()
+        }
+        onboardingFlow.licenseActivation = .servicePending
+        license.entitlement = "service pending"
+        lastError = nil
+        logText = "License activation is pending the hosted license service deployment."
+    }
+
+    func advanceOnboarding() {
+        onboardingFlow.providerKeyStored = providers.providerKeyStored
+        if onboardingFlow.currentStep == .done {
+            completeOnboarding()
+            return
+        }
+        onboardingFlow.advance()
+    }
+
+    func goBackOnboarding() {
+        onboardingFlow.goBack()
+    }
+
+    func completeOnboarding() {
+        userDefaults.set(true, forKey: onboardingCompletedKey)
+        isOnboardingPresented = false
+    }
+
+    func reopenOnboarding() {
+        onboardingFlow.providerKeyStored = providers.providerKeyStored
+        isOnboardingPresented = true
     }
 
     func copyCommand(_ command: DesktopCommand) {
@@ -207,6 +270,7 @@ final class NeonDiffDesktopModel: ObservableObject {
 
         if let parsed = DaemonStatusParser.parse(result.stdout, launchdLabel: launchdLabel, fallbackCommand: fallbackCommand) {
             status = parsed.0
+            onboardingFlow.daemonBootstrapChecked = true
             if !parsed.1.isEmpty {
                 repos = parsed.1
             }
@@ -226,3 +290,4 @@ final class NeonDiffDesktopModel: ObservableObject {
 
 private let providerKeyAccount = "provider/glm/api-key"
 private let licenseKeyAccount = "license/default"
+private let onboardingCompletedKey = "neondiff.hasCompletedOnboarding"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
@@ -34,6 +34,14 @@ struct ContentView: View {
         .tint(NeonDiffTheme.accent)
         .buttonStyle(OperatorButtonStyle())
         .preferredColorScheme(.dark)
+        .sheet(isPresented: $model.isOnboardingPresented) {
+            OnboardingWizardView(model: model)
+                .frame(minWidth: 760, minHeight: 560)
+                .buttonStyle(OperatorButtonStyle())
+                .tint(NeonDiffTheme.accent)
+                .preferredColorScheme(.dark)
+                .interactiveDismissDisabled(model.onboardingFlow.currentStep != .done)
+        }
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LicenseView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LicenseView.swift
@@ -26,7 +26,7 @@ struct LicenseView: View {
                 }
 
                 OperatorSection("Boundary") {
-                    Text("This MVP stores a fake/local license key only. Activation, signed updater behavior, and downloadable app readiness remain separate release work.")
+                    Text("This MVP can store a local license key while hosted activation remains pending #327. Signed updater behavior and downloadable app readiness remain separate release work.")
                         .operatorBodyText()
                 }
             }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -1,0 +1,287 @@
+import SwiftUI
+import NeonDiffDesktopCore
+
+struct OnboardingWizardView: View {
+    @ObservedObject var model: NeonDiffDesktopModel
+
+    var body: some View {
+        ZStack {
+            OperatorBackdrop()
+
+            VStack(spacing: 0) {
+                header
+                    .padding([.horizontal, .top], 22)
+                    .padding(.bottom, 12)
+
+                HStack(spacing: 0) {
+                    stepList
+                        .frame(width: 190)
+                        .padding(.leading, 22)
+                        .padding(.bottom, 22)
+
+                    Divider()
+                        .overlay(NeonDiffTheme.stroke.opacity(0.54))
+                        .padding(.vertical, 4)
+
+                    stepContent
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                        .padding(22)
+                }
+
+                footer
+                    .padding(.horizontal, 22)
+                    .padding(.bottom, 22)
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: model.onboardingFlow.currentStep.systemImage)
+                .font(.system(size: 22, weight: .bold))
+                .foregroundStyle(NeonDiffTheme.accent)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("NeonDiff Onboarding")
+                    .font(NeonDiffTheme.headlineFont)
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+                Text(model.onboardingFlow.currentStep.title)
+                    .font(NeonDiffTheme.badgeFont)
+                    .foregroundStyle(NeonDiffTheme.textSecondary)
+            }
+
+            Spacer()
+
+            OperatorBadge(
+                text: model.onboardingFlow.mode == .publicReposOnly ? "Public" : "Private",
+                color: model.onboardingFlow.mode == .publicReposOnly ? NeonDiffTheme.accent : NeonDiffTheme.cyan
+            )
+        }
+        .operatorPanel(active: true)
+    }
+
+    private var stepList: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(OnboardingStep.allCases) { step in
+                HStack(spacing: 9) {
+                    Image(systemName: step.systemImage)
+                        .frame(width: 18)
+                    Text(step.title)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.76)
+                }
+                .font(NeonDiffTheme.badgeFont)
+                .foregroundStyle(step == model.onboardingFlow.currentStep ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background {
+                    AngularRectangle(corner: 8)
+                        .fill(step == model.onboardingFlow.currentStep ? NeonDiffTheme.panelActive : Color.black.opacity(0.20))
+                }
+            }
+
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private var stepContent: some View {
+        switch model.onboardingFlow.currentStep {
+        case .welcome:
+            welcomeStep
+        case .provider:
+            providerStep
+        case .daemon:
+            daemonStep
+        case .license:
+            licenseStep
+        case .done:
+            doneStep
+        }
+    }
+
+    private var welcomeStep: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            OperatorSection("Mode") {
+                Picker("Review Mode", selection: $model.onboardingFlow.mode) {
+                    ForEach(OnboardingMode.allCases) { mode in
+                        Text(mode.title).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Text("Public repositories can be reviewed without a NeonDiff license. Private repositories stay locked until the hosted license service is deployed and activation succeeds.")
+                    .operatorBodyText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            OperatorSection("Authority") {
+                Text("Desktop configures local state and starts CLI-backed checks. GitHub reviews still go through the daemon and its current-head safety gates.")
+                    .operatorBodyText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var providerStep: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                OperatorSection("Provider") {
+                    OperatorTextField(title: "Model", text: $model.providers.zcodeModel)
+                    OperatorTextField(title: "CLI Path", text: $model.providers.zcodeCliPath)
+                    OperatorTextField(title: "App Config Path", text: $model.providers.zcodeAppConfigPath)
+                    OperatorTextField(title: "OpenAI-Compatible Endpoint", text: $model.providers.openAICompatibleEndpoint)
+                    OperatorTextField(title: "Provider API Key", text: $model.pendingProviderKey, secure: true)
+
+                    HStack(spacing: 10) {
+                        Button { model.storeProviderKey() } label: {
+                            Label("Store Key", systemImage: "key.fill")
+                        }
+                        OperatorBadge(
+                            text: model.providers.providerKeyStored ? "Stored in Keychain" : "Key Required",
+                            color: model.providers.providerKeyStored ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                        )
+                    }
+                }
+
+                OperatorSection("Config Patch") {
+                    OperatorCommandText(text: model.providerPatchPreviewCommand.commandLine, lineLimit: 4)
+                    HStack(spacing: 10) {
+                        Button { model.previewProviderConfigPatch() } label: {
+                            Label("Preview", systemImage: "eye")
+                        }
+                        Button { model.copyCommand(model.providerPatchPreviewCommand) } label: {
+                            Label("Copy", systemImage: "doc.on.doc")
+                        }
+                    }
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+    }
+
+    private var daemonStep: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            OperatorSection("Daemon") {
+                LabeledContent("Heartbeat", value: model.status.healthState)
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+                LabeledContent("Config", value: model.configPath)
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+                LabeledContent("Launchd Label", value: model.launchdLabel)
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+
+                OperatorCommandText(text: model.statusCommand.commandLine, lineLimit: 4)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(spacing: 10) {
+                        Button { model.refreshStatus() } label: {
+                            Label("Check Status", systemImage: "arrow.clockwise")
+                        }
+                        Button { model.startDaemon() } label: {
+                            Label("Start/Restart", systemImage: "play.circle")
+                        }
+                        Button { model.stopDaemon() } label: {
+                            Label("Stop", systemImage: "stop.circle")
+                        }
+                    }
+
+                    HStack(spacing: 10) {
+                        Button { model.previewStartDaemon() } label: {
+                            Label("Preview Start", systemImage: "eye")
+                        }
+                        Button { model.copyCommand(model.statusCommand) } label: {
+                            Label("Copy Status", systemImage: "doc.on.doc")
+                        }
+                    }
+                }
+
+                OperatorBadge(
+                    text: model.onboardingFlow.daemonBootstrapChecked ? "Checked" : "Check Required",
+                    color: model.onboardingFlow.daemonBootstrapChecked ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                )
+            }
+
+            if !model.repos.isEmpty {
+                OperatorSection("Monitored Repos") {
+                    Text(model.repos.map(\.name).prefix(6).joined(separator: "\n"))
+                        .font(NeonDiffTheme.commandFont)
+                        .foregroundStyle(NeonDiffTheme.textSecondary)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+
+    private var licenseStep: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            OperatorSection("License") {
+                OperatorTextField(title: "License Key", text: $model.pendingLicenseKey, secure: true)
+
+                HStack(spacing: 10) {
+                    Button { model.activateLicenseForOnboarding() } label: {
+                        Label("Store / Check", systemImage: "key")
+                    }
+                    Button {
+                        model.onboardingFlow.mode = .publicReposOnly
+                    } label: {
+                        Label("Use Public Repos", systemImage: "lock.open")
+                    }
+                    OperatorBadge(
+                        text: model.onboardingFlow.licenseActivation == .activated ? "Activated" : "Service Pending",
+                        color: model.onboardingFlow.licenseActivation == .activated ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary
+                    )
+                }
+
+                Text("Private repository activation is parked until the hosted license service from #327 is deployed. The wizard does not fake activation; public-repo setup can finish now.")
+                    .operatorBodyText()
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var doneStep: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            OperatorSection("Ready") {
+                LabeledContent("Provider key", value: model.providers.providerKeyStored ? "stored" : "missing")
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+                LabeledContent("Daemon check", value: model.onboardingFlow.daemonBootstrapChecked ? "checked" : "not checked")
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+                LabeledContent("Mode", value: model.onboardingFlow.mode.title)
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+                LabeledContent("License", value: model.onboardingFlow.licenseActivation == .activated ? "activated" : "service pending")
+                    .foregroundStyle(NeonDiffTheme.textPrimary)
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            Button { model.goBackOnboarding() } label: {
+                Label("Back", systemImage: "chevron.left")
+            }
+            .disabled(!model.onboardingFlow.canGoBack)
+
+            Spacer()
+
+            if let lastError = model.lastError, !lastError.isEmpty {
+                Text(lastError)
+                    .font(.caption)
+                    .foregroundStyle(NeonDiffTheme.warning)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.8)
+            }
+
+            Button {
+                if model.onboardingFlow.currentStep == .done {
+                    model.completeOnboarding()
+                } else {
+                    model.advanceOnboarding()
+                }
+            } label: {
+                Label(model.onboardingFlow.nextActionTitle, systemImage: model.onboardingFlow.currentStep == .done ? "checkmark" : "chevron.right")
+            }
+            .buttonStyle(OperatorButtonStyle(solid: true))
+            .disabled(!model.onboardingFlow.canAdvance)
+        }
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
@@ -18,8 +18,13 @@ struct SettingsPane: View {
 
                 OperatorSection("Commands") {
                     OperatorCommandText(text: model.statusCommand.commandLine, lineLimit: 5)
-                    Button { model.copyCommand(model.statusCommand) } label: {
-                        Label("Copy Status Command", systemImage: "doc.on.doc")
+                    HStack(spacing: 10) {
+                        Button { model.copyCommand(model.statusCommand) } label: {
+                            Label("Copy Status Command", systemImage: "doc.on.doc")
+                        }
+                        Button { model.reopenOnboarding() } label: {
+                            Label("Open Onboarding", systemImage: "sparkles")
+                        }
                     }
                 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/OnboardingModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/OnboardingModels.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+public enum OnboardingMode: String, CaseIterable, Identifiable, Hashable {
+    case publicReposOnly
+    case privateRepos
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .publicReposOnly: "Public Repos"
+        case .privateRepos: "Private Repos"
+        }
+    }
+}
+
+public enum OnboardingStep: String, CaseIterable, Identifiable, Hashable {
+    case welcome
+    case provider
+    case daemon
+    case license
+    case done
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .welcome: "Welcome"
+        case .provider: "Provider"
+        case .daemon: "Daemon"
+        case .license: "License"
+        case .done: "Done"
+        }
+    }
+
+    public var systemImage: String {
+        switch self {
+        case .welcome: "sparkles"
+        case .provider: "cpu"
+        case .daemon: "bolt.horizontal.circle"
+        case .license: "key"
+        case .done: "checkmark.seal"
+        }
+    }
+}
+
+public enum OnboardingLicenseActivation: String, Hashable {
+    case notStarted
+    case servicePending
+    case activated
+}
+
+public struct OnboardingFlow: Equatable {
+    public var currentStep: OnboardingStep
+    public var mode: OnboardingMode
+    public var providerKeyStored: Bool
+    public var daemonBootstrapChecked: Bool
+    public var licenseActivation: OnboardingLicenseActivation
+
+    public init(
+        currentStep: OnboardingStep = .welcome,
+        mode: OnboardingMode = .publicReposOnly,
+        providerKeyStored: Bool = false,
+        daemonBootstrapChecked: Bool = false,
+        licenseActivation: OnboardingLicenseActivation = .servicePending
+    ) {
+        self.currentStep = currentStep
+        self.mode = mode
+        self.providerKeyStored = providerKeyStored
+        self.daemonBootstrapChecked = daemonBootstrapChecked
+        self.licenseActivation = licenseActivation
+    }
+
+    public var canGoBack: Bool {
+        currentStep != .welcome
+    }
+
+    public var canAdvance: Bool {
+        switch currentStep {
+        case .welcome:
+            return true
+        case .provider:
+            return providerKeyStored
+        case .daemon:
+            return daemonBootstrapChecked
+        case .license:
+            return mode == .publicReposOnly || licenseActivation == .activated
+        case .done:
+            return true
+        }
+    }
+
+    public var nextActionTitle: String {
+        switch currentStep {
+        case .done:
+            return "Finish"
+        case .license where mode == .publicReposOnly:
+            return "Continue Public Setup"
+        default:
+            return "Continue"
+        }
+    }
+
+    public mutating func advance() {
+        guard canAdvance else { return }
+        switch currentStep {
+        case .welcome:
+            currentStep = .provider
+        case .provider:
+            currentStep = .daemon
+        case .daemon:
+            currentStep = .license
+        case .license:
+            currentStep = .done
+        case .done:
+            break
+        }
+    }
+
+    public mutating func goBack() {
+        switch currentStep {
+        case .welcome:
+            break
+        case .provider:
+            currentStep = .welcome
+        case .daemon:
+            currentStep = .provider
+        case .license:
+            currentStep = .daemon
+        case .done:
+            currentStep = .license
+        }
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/KeychainSecretStore.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/KeychainSecretStore.swift
@@ -1,6 +1,13 @@
 import Foundation
 import Security
 
+public protocol DesktopSecretStoring {
+    func setSecret(_ secret: String, account: String) throws
+    func readSecret(account: String) throws -> String?
+    func containsSecret(account: String) -> Bool
+    func deleteSecret(account: String) throws
+}
+
 public enum KeychainSecretError: Error, LocalizedError {
     case unexpectedStatus(OSStatus)
     case invalidData
@@ -13,7 +20,7 @@ public enum KeychainSecretError: Error, LocalizedError {
     }
 }
 
-public final class KeychainSecretStore {
+public final class KeychainSecretStore: DesktopSecretStoring {
     public let service: String
 
     public init(service: String = "com.electricsheephq.NeonDiffDesktop.secrets") {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
@@ -1,0 +1,42 @@
+import Foundation
+import NeonDiffDesktopCore
+
+@discardableResult
+func check(_ condition: @autoclosure () -> Bool, _ message: String) -> Bool {
+    if condition() {
+        return true
+    }
+    fputs("check failed: \(message)\n", stderr)
+    exit(1)
+}
+
+var providerFlow = OnboardingFlow()
+check(providerFlow.currentStep == .welcome, "flow starts at welcome")
+providerFlow.advance()
+check(providerFlow.currentStep == .provider, "welcome advances to provider")
+check(!providerFlow.canAdvance, "provider step requires a stored provider key")
+providerFlow.providerKeyStored = true
+check(providerFlow.canAdvance, "provider step advances after key storage")
+
+var publicFlow = OnboardingFlow(providerKeyStored: true)
+publicFlow.currentStep = .license
+publicFlow.mode = .publicReposOnly
+publicFlow.licenseActivation = .servicePending
+check(publicFlow.canAdvance, "public repo path can finish while license service is pending")
+publicFlow.advance()
+check(publicFlow.currentStep == .done, "public repo path finishes from license step")
+
+var privateFlow = OnboardingFlow(providerKeyStored: true)
+privateFlow.currentStep = .license
+privateFlow.mode = .privateRepos
+privateFlow.licenseActivation = .servicePending
+check(!privateFlow.canAdvance, "private repo path cannot fake activation while service is pending")
+check(privateFlow.licenseActivation != .activated, "pending service is not activated")
+
+var daemonFlow = OnboardingFlow(providerKeyStored: true)
+daemonFlow.currentStep = .daemon
+check(!daemonFlow.canAdvance, "daemon step requires bootstrap/status check")
+daemonFlow.daemonBootstrapChecked = true
+check(daemonFlow.canAdvance, "daemon step advances after bootstrap/status check")
+
+print("NeonDiffDesktopCoreChecks passed")

--- a/apps/neondiff-desktop/script/build_and_run.sh
+++ b/apps/neondiff-desktop/script/build_and_run.sh
@@ -108,6 +108,8 @@ open_app() {
 }
 
 case "$MODE" in
+  build)
+    ;;
   run)
     open_app
     ;;
@@ -136,7 +138,7 @@ case "$MODE" in
     fi
     ;;
   *)
-    echo "usage: $0 [run|--debug|--logs|--telemetry|--verify|--bundle-check|preflight]" >&2
+    echo "usage: $0 [build|run|--debug|--logs|--telemetry|--verify|--bundle-check|preflight]" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
## Summary
- Add a first-run NeonDiff Desktop onboarding wizard with Welcome, Provider, Daemon, License, and Done steps.
- Reuse the existing provider/keychain/config-patch and daemon CLI client paths instead of adding a direct review or launchd bypass path.
- Keep license activation honest: public-repo setup can finish now, while private-repo activation remains a parked #327 integration point.
- Add a Core check executable for onboarding flow gating and align `build_and_run.sh build` with the issue validation command.

## Validation
- `swift run NeonDiffDesktopCoreChecks`
- `swift run NeonDiffDesktopCoreSmoke`
- `bash -n script/build_and_run.sh`
- `./script/build_and_run.sh build`
- `./script/build_and_run.sh bundle-check`
- `NODE_OPTIONS="--experimental-sqlite --use-system-ca" npm run build`
- `node scripts/check-secret-scan.mjs`
- `git diff --cached --check`

Evidence packet: `/Volumes/LEXAR/Codex/evidence/neondiff-desktop/2026-07-07/desktop-onboarding-proof/`

## Proof Boundary
This proves first-run wizard code, provider setup/key storage, daemon CLI-backed bootstrap controls, and the parked license-service integration point. It does not prove hosted license activation, signing/notarization, public download readiness, Sparkle appcast hosting/signing, or GA readiness.

Closes #325
Parent: #116
