### PR TITLE
Sparkle appcast channel model + fixtures + dry-run generator (#323)

### DIFF
--- a/apps/neondiff-desktop/Package.swift
+++ b/apps/neondiff-desktop/Package.swift
@@ -36,6 +36,14 @@ let package = Package(
         .executableTarget(
             name: "NeonDiffDesktopCoreChecks",
             dependencies: ["NeonDiffDesktopCore"]
+        ),
+        .executableTarget(
+            name: "NeonDiffDesktopAppcastChecks",
+            dependencies: ["NeonDiffDesktopCore"]
+        ),
+        .executableTarget(
+            name: "NeonDiffDesktopAppcastDryRun",
+            dependencies: ["NeonDiffDesktopCore"]
         )
     ]
 )

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppcastChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppcastChecks/main.swift
@@ -16,12 +16,14 @@ let fixtures = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
 let stable = try AppcastManifest.load(from: fixtures.appendingPathComponent("stable.json"))
 check(stable.channel == .stable, "stable fixture channel")
 check(stable.latestRelease()?.version == "1.0.0", "stable latest release")
+check(stable.expectedStatus == .updateAvailable, "stable expected status metadata")
 let stableXML = try AppcastSerializer.serialize(stable)
 check(stableXML.contains("xmlns:sparkle=\"http://www.andymatuschak.org/xml-namespaces/sparkle\""), "sparkle namespace")
 check(stableXML.contains("sparkle:shortVersionString=\"1.0.0\""), "stable short version")
 
 let beta = try AppcastManifest.load(from: fixtures.appendingPathComponent("beta.json"))
 check(beta.channel == .beta, "beta fixture channel")
+check(beta.expectedStatus == .updateAvailable, "beta expected status metadata")
 let betaXML = try AppcastSerializer.serialize(beta)
 check(betaXML.contains("<sparkle:channel>beta</sparkle:channel>"), "beta channel tag")
 check(!betaXML.contains("sparkle:edSignature=\"\""), "dry-run does not emit empty signatures")
@@ -68,6 +70,94 @@ check(licenseBlocked.dryRunStatus(currentBuild: "90", licenseAllowsPrivateArtifa
 check(stable.dryRunStatus(currentBuild: "90", networkAvailable: false) == .networkError, "network outage status is network_error")
 check(stable.dryRunStatus(currentBuild: "90", allowedChannels: [.beta]) == .unsupportedChannel, "channel filter status is unsupported_channel")
 check(emptyFeed.dryRunStatus(currentBuild: "90") == .feedInvalid, "empty feed status is feed_invalid")
+
+let mixedChannel = AppcastManifest(
+    channel: .stable,
+    title: "Mixed channel fixture",
+    feedURL: "https://updates.neondiff.com/stable/appcast.xml",
+    releases: [
+        AppcastRelease(
+            version: "1.0.0",
+            build: "100",
+            title: "Stable",
+            pubDate: "Tue, 07 Jul 2026 00:00:00 +0000",
+            artifactURL: "https://updates.neondiff.com/stable/NeonDiffDesktop-1.0.0.zip",
+            artifactLength: 123,
+            minimumSystemVersion: "14.0",
+            channel: .stable
+        ),
+        AppcastRelease(
+            version: "1.1.0-beta.1",
+            build: "1101",
+            title: "Beta",
+            pubDate: "Tue, 07 Jul 2026 00:00:00 +0000",
+            artifactURL: "https://updates.neondiff.com/beta/NeonDiffDesktop-1.1.0-beta.1.zip",
+            artifactLength: 123,
+            minimumSystemVersion: "14.0",
+            channel: .beta
+        )
+    ]
+)
+let mixedChannelXML = try AppcastSerializer.serialize(mixedChannel)
+check(!mixedChannelXML.contains("1.1.0-beta.1.zip"), "stable appcast excludes beta-channel release")
+
+let finalBeatsPrerelease = AppcastManifest(
+    channel: .stable,
+    title: "Prerelease ordering fixture",
+    feedURL: "https://updates.neondiff.com/stable/appcast.xml",
+    releases: [
+        AppcastRelease(
+            version: "1.1.0-beta.1",
+            build: "1101",
+            title: "Beta",
+            pubDate: "Tue, 07 Jul 2026 00:00:00 +0000",
+            artifactURL: "https://updates.neondiff.com/stable/NeonDiffDesktop-1.1.0-beta.1.zip",
+            artifactLength: 123,
+            minimumSystemVersion: "14.0",
+            channel: .stable
+        ),
+        AppcastRelease(
+            version: "1.1.0",
+            build: "1100",
+            title: "Final",
+            pubDate: "Tue, 07 Jul 2026 00:00:00 +0000",
+            artifactURL: "https://updates.neondiff.com/stable/NeonDiffDesktop-1.1.0.zip",
+            artifactLength: 123,
+            minimumSystemVersion: "14.0",
+            channel: .stable
+        )
+    ]
+)
+check(finalBeatsPrerelease.latestRelease()?.version == "1.1.0", "final release outranks matching prerelease")
+
+let numericBuild = AppcastManifest(
+    channel: .stable,
+    title: "Build ordering fixture",
+    feedURL: "https://updates.neondiff.com/stable/appcast.xml",
+    releases: [
+        AppcastRelease(
+            version: "1.0.1",
+            build: "9",
+            title: "Build 9",
+            pubDate: "Tue, 07 Jul 2026 00:00:00 +0000",
+            artifactURL: "https://updates.neondiff.com/stable/NeonDiffDesktop-1.0.1-9.zip",
+            artifactLength: 123,
+            minimumSystemVersion: "14.0",
+            channel: .stable
+        ),
+        AppcastRelease(
+            version: "1.0.1",
+            build: "10",
+            title: "Build 10",
+            pubDate: "Tue, 07 Jul 2026 00:00:00 +0000",
+            artifactURL: "https://updates.neondiff.com/stable/NeonDiffDesktop-1.0.1-10.zip",
+            artifactLength: 123,
+            minimumSystemVersion: "14.0",
+            channel: .stable
+        )
+    ]
+)
+check(numericBuild.latestRelease()?.build == "10", "numeric build ordering")
 
 let dryRun = AppcastDryRun(fixture: fixtures.appendingPathComponent("beta.json"), output: nil)
 let output = try dryRun.run()

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppcastChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppcastChecks/main.swift
@@ -28,6 +28,8 @@ check(!betaXML.contains("sparkle:edSignature=\"\""), "dry-run does not emit empt
 
 let rollback = try AppcastManifest.load(from: fixtures.appendingPathComponent("rollback.json"))
 check(rollback.latestRelease()?.version == "1.0.0", "rollback pins prior stable")
+let rollbackXML = try AppcastSerializer.serialize(rollback)
+check(!rollbackXML.contains("NeonDiffDesktop-1.1.0.zip"), "rollback appcast excludes superseded build")
 
 let signatureFailure = try AppcastManifest.load(from: fixtures.appendingPathComponent("signature-failure.json"))
 check(signatureFailure.releases.contains { $0.signatureState == .invalidFixture }, "signature failure fixture is marked invalid")
@@ -47,6 +49,25 @@ for fixtureName in ["beta", "stable", "rollback", "signature-failure"] {
         .trimmingCharacters(in: .whitespacesAndNewlines)
     check(actualXML == expectedXML, "\(fixtureName) matches committed appcast XML fixture")
 }
+
+let stale = try AppcastManifest.load(from: fixtures.appendingPathComponent("stale-version.json"))
+let licenseBlocked = try AppcastManifest.load(from: fixtures.appendingPathComponent("license-blocked.json"))
+let emptyFeed = AppcastManifest(
+    channel: .stable,
+    title: "Empty feed fixture",
+    feedURL: "https://updates.neondiff.com/stable/appcast.xml",
+    releases: []
+)
+check(AppcastUpdateStatus.allCases.map(\.rawValue).contains("signature_error"), "status taxonomy includes signature_error")
+check(beta.dryRunStatus(currentBuild: "100") == .updateAvailable, "beta fixture status is update_available")
+check(stable.dryRunStatus(currentBuild: "90") == .updateAvailable, "stable fixture status is update_available")
+check(rollback.dryRunStatus(currentBuild: "90") == .updateAvailable, "rollback fixture status is update_available")
+check(signatureFailure.dryRunStatus(currentBuild: "90") == .signatureError, "signature fixture status is signature_error")
+check(stale.dryRunStatus(currentBuild: "100") == .noUpdate, "stale fixture status is no_update")
+check(licenseBlocked.dryRunStatus(currentBuild: "90", licenseAllowsPrivateArtifacts: false) == .blockedByLicense, "license fixture status is blocked_by_license")
+check(stable.dryRunStatus(currentBuild: "90", networkAvailable: false) == .networkError, "network outage status is network_error")
+check(stable.dryRunStatus(currentBuild: "90", allowedChannels: [.beta]) == .unsupportedChannel, "channel filter status is unsupported_channel")
+check(emptyFeed.dryRunStatus(currentBuild: "90") == .feedInvalid, "empty feed status is feed_invalid")
 
 let dryRun = AppcastDryRun(fixture: fixtures.appendingPathComponent("beta.json"), output: nil)
 let output = try dryRun.run()

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppcastChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppcastChecks/main.swift
@@ -1,0 +1,56 @@
+import Foundation
+import NeonDiffDesktopCore
+
+@discardableResult
+func check(_ condition: @autoclosure () -> Bool, _ message: String) -> Bool {
+    if condition() {
+        return true
+    }
+    fputs("check failed: \(message)\n", stderr)
+    exit(1)
+}
+
+let fixtures = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    .appendingPathComponent("fixtures/appcast")
+
+let stable = try AppcastManifest.load(from: fixtures.appendingPathComponent("stable.json"))
+check(stable.channel == .stable, "stable fixture channel")
+check(stable.latestRelease()?.version == "1.0.0", "stable latest release")
+let stableXML = try AppcastSerializer.serialize(stable)
+check(stableXML.contains("xmlns:sparkle=\"http://www.andymatuschak.org/xml-namespaces/sparkle\""), "sparkle namespace")
+check(stableXML.contains("sparkle:shortVersionString=\"1.0.0\""), "stable short version")
+
+let beta = try AppcastManifest.load(from: fixtures.appendingPathComponent("beta.json"))
+check(beta.channel == .beta, "beta fixture channel")
+let betaXML = try AppcastSerializer.serialize(beta)
+check(betaXML.contains("<sparkle:channel>beta</sparkle:channel>"), "beta channel tag")
+check(!betaXML.contains("sparkle:edSignature=\"\""), "dry-run does not emit empty signatures")
+
+let rollback = try AppcastManifest.load(from: fixtures.appendingPathComponent("rollback.json"))
+check(rollback.latestRelease()?.version == "1.0.0", "rollback pins prior stable")
+
+let signatureFailure = try AppcastManifest.load(from: fixtures.appendingPathComponent("signature-failure.json"))
+check(signatureFailure.releases.contains { $0.signatureState == .invalidFixture }, "signature failure fixture is marked invalid")
+
+for fixtureName in ["beta", "stable", "rollback", "signature-failure", "stale-version", "license-blocked"] {
+    let manifest = try AppcastManifest.load(from: fixtures.appendingPathComponent("\(fixtureName).json"))
+    let xml = try AppcastSerializer.serialize(manifest)
+    check(xml.contains("<rss"), "\(fixtureName) serializes to rss")
+    check(xml.contains("<enclosure"), "\(fixtureName) serializes enclosure")
+}
+
+for fixtureName in ["beta", "stable", "rollback", "signature-failure"] {
+    let manifest = try AppcastManifest.load(from: fixtures.appendingPathComponent("\(fixtureName).json"))
+    let actualXML = try AppcastSerializer.serialize(manifest).trimmingCharacters(in: .whitespacesAndNewlines)
+    let expectedURL = fixtures.appendingPathComponent("expected/\(fixtureName).xml")
+    let expectedXML = try String(contentsOf: expectedURL, encoding: .utf8)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    check(actualXML == expectedXML, "\(fixtureName) matches committed appcast XML fixture")
+}
+
+let dryRun = AppcastDryRun(fixture: fixtures.appendingPathComponent("beta.json"), output: nil)
+let output = try dryRun.run()
+check(output.contains("<rss"), "dry-run emits rss")
+check(!output.contains("NEONDIFF_SPARKLE_PRIVATE_KEY"), "dry-run does not mention private key material")
+
+print("NeonDiffDesktopAppcastChecks passed")

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppcastDryRun/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppcastDryRun/main.swift
@@ -1,0 +1,56 @@
+import Foundation
+import NeonDiffDesktopCore
+
+struct AppcastDryRunArguments {
+    var fixture: URL?
+    var output: URL?
+
+    init(_ arguments: [String]) throws {
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--fixture":
+                index += 1
+                guard index < arguments.count else { throw ArgumentError.missingValue("--fixture") }
+                fixture = URL(fileURLWithPath: arguments[index])
+            case "--output":
+                index += 1
+                guard index < arguments.count else { throw ArgumentError.missingValue("--output") }
+                output = URL(fileURLWithPath: arguments[index])
+            case "--dry-run":
+                break
+            default:
+                throw ArgumentError.unknown(argument)
+            }
+            index += 1
+        }
+    }
+}
+
+enum ArgumentError: Error, LocalizedError {
+    case missingValue(String)
+    case missingFixture
+    case unknown(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingValue(let flag): "\(flag) requires a value"
+        case .missingFixture: "--fixture is required"
+        case .unknown(let argument): "unknown argument: \(argument)"
+        }
+    }
+}
+
+do {
+    let parsed = try AppcastDryRunArguments(Array(CommandLine.arguments.dropFirst()))
+    guard let fixture = parsed.fixture else { throw ArgumentError.missingFixture }
+    let xml = try AppcastDryRun(fixture: fixture, output: parsed.output).run()
+    if parsed.output == nil {
+        print(xml)
+    }
+} catch {
+    fputs("NeonDiffDesktopAppcastDryRun: \(error.localizedDescription)\n", stderr)
+    fputs("usage: NeonDiffDesktopAppcastDryRun --fixture <manifest.json> [--output <appcast.xml>] [--dry-run]\n", stderr)
+    exit(2)
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/AppcastModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/AppcastModels.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+public enum AppcastChannel: String, Codable, CaseIterable, Hashable {
+    case beta
+    case stable
+}
+
+public enum AppcastSignatureState: String, Codable, Hashable {
+    case absent
+    case present
+    case invalidFixture
+}
+
+public struct AppcastRelease: Codable, Equatable, Hashable {
+    public var version: String
+    public var build: String
+    public var title: String
+    public var pubDate: String
+    public var artifactURL: String
+    public var artifactLength: Int
+    public var minimumSystemVersion: String
+    public var channel: AppcastChannel
+    public var edSignature: String?
+    public var signatureState: AppcastSignatureState
+    public var rollbackTo: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case build
+        case title
+        case pubDate = "pub_date"
+        case artifactURL = "artifact_url"
+        case artifactLength = "artifact_length"
+        case minimumSystemVersion = "minimum_system_version"
+        case channel
+        case edSignature = "ed_signature"
+        case signatureState = "signature_state"
+        case rollbackTo = "rollback_to"
+    }
+
+    public init(
+        version: String,
+        build: String,
+        title: String,
+        pubDate: String,
+        artifactURL: String,
+        artifactLength: Int,
+        minimumSystemVersion: String,
+        channel: AppcastChannel,
+        edSignature: String? = nil,
+        signatureState: AppcastSignatureState = .absent,
+        rollbackTo: String? = nil
+    ) {
+        self.version = version
+        self.build = build
+        self.title = title
+        self.pubDate = pubDate
+        self.artifactURL = artifactURL
+        self.artifactLength = artifactLength
+        self.minimumSystemVersion = minimumSystemVersion
+        self.channel = channel
+        self.edSignature = edSignature
+        self.signatureState = signatureState
+        self.rollbackTo = rollbackTo
+    }
+}
+
+public struct AppcastManifest: Codable, Equatable {
+    public var channel: AppcastChannel
+    public var title: String
+    public var feedURL: String
+    public var releases: [AppcastRelease]
+
+    private enum CodingKeys: String, CodingKey {
+        case channel
+        case title
+        case feedURL = "feed_url"
+        case releases
+    }
+
+    public init(channel: AppcastChannel, title: String, feedURL: String, releases: [AppcastRelease]) {
+        self.channel = channel
+        self.title = title
+        self.feedURL = feedURL
+        self.releases = releases
+    }
+
+    public static func load(from url: URL) throws -> AppcastManifest {
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        return try decoder.decode(AppcastManifest.self, from: data)
+    }
+
+    public func latestRelease() -> AppcastRelease? {
+        let channelReleases = releases.filter { $0.channel == channel }
+        if let rollbackTarget = channelReleases.compactMap(\.rollbackTo).last,
+           let pinned = channelReleases.first(where: { $0.version == rollbackTarget }) {
+            return pinned
+        }
+        return channelReleases.sorted(by: compareVersionsDescending).first
+    }
+
+    public func releasesForAppcast() -> [AppcastRelease] {
+        guard let latest = latestRelease() else { return [] }
+        let remaining = releases.filter { $0 != latest }.sorted(by: compareVersionsDescending)
+        return [latest] + remaining
+    }
+}
+
+private func compareVersionsDescending(_ lhs: AppcastRelease, _ rhs: AppcastRelease) -> Bool {
+    let lhsParts = versionParts(lhs.version)
+    let rhsParts = versionParts(rhs.version)
+    for index in 0..<max(lhsParts.count, rhsParts.count) {
+        let left = index < lhsParts.count ? lhsParts[index] : 0
+        let right = index < rhsParts.count ? rhsParts[index] : 0
+        if left != right { return left > right }
+    }
+    return lhs.build > rhs.build
+}
+
+private func versionParts(_ value: String) -> [Int] {
+    value
+        .split { !$0.isNumber }
+        .map { Int($0) ?? 0 }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/AppcastModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/AppcastModels.swift
@@ -112,8 +112,7 @@ public struct AppcastManifest: Codable, Equatable {
 
     public func latestRelease() -> AppcastRelease? {
         let channelReleases = releases.filter { $0.channel == channel }
-        if let rollbackTarget = channelReleases.compactMap(\.rollbackTo).last,
-           let pinned = channelReleases.first(where: { $0.version == rollbackTarget }) {
+        if let pinned = rollbackPinnedRelease(in: channelReleases) {
             return pinned
         }
         return channelReleases.sorted(by: compareVersionsDescending).first
@@ -121,8 +120,7 @@ public struct AppcastManifest: Codable, Equatable {
 
     public func releasesForAppcast() -> [AppcastRelease] {
         let channelReleases = releases.filter { $0.channel == channel }
-        if let rollbackTarget = channelReleases.compactMap(\.rollbackTo).last,
-           let pinned = channelReleases.first(where: { $0.version == rollbackTarget }) {
+        if let pinned = rollbackPinnedRelease(in: channelReleases) {
             return channelReleases
                 .filter { release in
                     release.rollbackTo == nil && !compareVersionsDescending(release, pinned)
@@ -130,7 +128,7 @@ public struct AppcastManifest: Codable, Equatable {
                 .sorted(by: compareVersionsDescending)
         }
         guard let latest = latestRelease() else { return [] }
-        let remaining = releases.filter { $0 != latest }.sorted(by: compareVersionsDescending)
+        let remaining = channelReleases.filter { $0 != latest }.sorted(by: compareVersionsDescending)
         return [latest] + remaining
     }
 
@@ -154,21 +152,81 @@ public struct AppcastManifest: Codable, Equatable {
     }
 }
 
+private struct ParsedAppcastVersion {
+    var core: [Int]
+    var prerelease: [String]?
+}
+
+private func rollbackPinnedRelease(in releases: [AppcastRelease]) -> AppcastRelease? {
+    let rollbackSources = releases
+        .filter { $0.rollbackTo != nil }
+        .sorted(by: compareVersionsDescending)
+    guard let rollbackTarget = rollbackSources.first?.rollbackTo else { return nil }
+    return releases.first(where: { $0.version == rollbackTarget })
+}
+
 private func compareVersionsDescending(_ lhs: AppcastRelease, _ rhs: AppcastRelease) -> Bool {
-    let lhsParts = versionParts(lhs.version)
-    let rhsParts = versionParts(rhs.version)
-    for index in 0..<max(lhsParts.count, rhsParts.count) {
-        let left = index < lhsParts.count ? lhsParts[index] : 0
-        let right = index < rhsParts.count ? rhsParts[index] : 0
-        if left != right { return left > right }
+    let versionComparison = compareVersions(lhs.version, rhs.version)
+    if versionComparison != .orderedSame {
+        return versionComparison == .orderedDescending
     }
     return compareBuilds(lhs.build, rhs.build) == .orderedDescending
 }
 
-private func versionParts(_ value: String) -> [Int] {
-    value
-        .split { !$0.isNumber }
-        .map { Int($0) ?? 0 }
+private func compareVersions(_ lhs: String, _ rhs: String) -> ComparisonResult {
+    let left = parseVersion(lhs)
+    let right = parseVersion(rhs)
+    for index in 0..<max(left.core.count, right.core.count) {
+        let leftPart = index < left.core.count ? left.core[index] : 0
+        let rightPart = index < right.core.count ? right.core[index] : 0
+        if leftPart == rightPart { continue }
+        return leftPart > rightPart ? .orderedDescending : .orderedAscending
+    }
+    switch (left.prerelease, right.prerelease) {
+    case (nil, nil):
+        return .orderedSame
+    case (nil, _?):
+        return .orderedDescending
+    case (_?, nil):
+        return .orderedAscending
+    case let (leftIdentifiers?, rightIdentifiers?):
+        return comparePrerelease(leftIdentifiers, rightIdentifiers)
+    }
+}
+
+private func parseVersion(_ value: String) -> ParsedAppcastVersion {
+    let version = value.split(separator: "+", maxSplits: 1, omittingEmptySubsequences: false).first ?? ""
+    let parts = version.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+    let core = parts.first?
+        .split(separator: ".")
+        .map { Int($0) ?? 0 } ?? []
+    let prerelease = parts.count > 1
+        ? parts[1].split(separator: ".").map(String.init)
+        : nil
+    return ParsedAppcastVersion(core: core, prerelease: prerelease)
+}
+
+private func comparePrerelease(_ lhs: [String], _ rhs: [String]) -> ComparisonResult {
+    for index in 0..<max(lhs.count, rhs.count) {
+        guard index < lhs.count else { return .orderedAscending }
+        guard index < rhs.count else { return .orderedDescending }
+        let leftIdentifier = lhs[index]
+        let rightIdentifier = rhs[index]
+        if leftIdentifier == rightIdentifier { continue }
+        let leftNumeric = Int(leftIdentifier)
+        let rightNumeric = Int(rightIdentifier)
+        switch (leftNumeric, rightNumeric) {
+        case let (left?, right?):
+            return left > right ? .orderedDescending : .orderedAscending
+        case (_?, nil):
+            return .orderedAscending
+        case (nil, _?):
+            return .orderedDescending
+        case (nil, nil):
+            return leftIdentifier > rightIdentifier ? .orderedDescending : .orderedAscending
+        }
+    }
+    return .orderedSame
 }
 
 private func compareBuilds(_ lhs: String, _ rhs: String) -> ComparisonResult {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/AppcastModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/AppcastModels.swift
@@ -11,6 +11,16 @@ public enum AppcastSignatureState: String, Codable, Hashable {
     case invalidFixture
 }
 
+public enum AppcastUpdateStatus: String, Codable, CaseIterable, Hashable {
+    case noUpdate = "no_update"
+    case updateAvailable = "update_available"
+    case blockedByLicense = "blocked_by_license"
+    case networkError = "network_error"
+    case signatureError = "signature_error"
+    case feedInvalid = "feed_invalid"
+    case unsupportedChannel = "unsupported_channel"
+}
+
 public struct AppcastRelease: Codable, Equatable, Hashable {
     public var version: String
     public var build: String
@@ -69,19 +79,28 @@ public struct AppcastManifest: Codable, Equatable {
     public var channel: AppcastChannel
     public var title: String
     public var feedURL: String
+    public var expectedStatus: AppcastUpdateStatus?
     public var releases: [AppcastRelease]
 
     private enum CodingKeys: String, CodingKey {
         case channel
         case title
         case feedURL = "feed_url"
+        case expectedStatus = "expected_status"
         case releases
     }
 
-    public init(channel: AppcastChannel, title: String, feedURL: String, releases: [AppcastRelease]) {
+    public init(
+        channel: AppcastChannel,
+        title: String,
+        feedURL: String,
+        expectedStatus: AppcastUpdateStatus? = nil,
+        releases: [AppcastRelease]
+    ) {
         self.channel = channel
         self.title = title
         self.feedURL = feedURL
+        self.expectedStatus = expectedStatus
         self.releases = releases
     }
 
@@ -101,9 +120,37 @@ public struct AppcastManifest: Codable, Equatable {
     }
 
     public func releasesForAppcast() -> [AppcastRelease] {
+        let channelReleases = releases.filter { $0.channel == channel }
+        if let rollbackTarget = channelReleases.compactMap(\.rollbackTo).last,
+           let pinned = channelReleases.first(where: { $0.version == rollbackTarget }) {
+            return channelReleases
+                .filter { release in
+                    release.rollbackTo == nil && !compareVersionsDescending(release, pinned)
+                }
+                .sorted(by: compareVersionsDescending)
+        }
         guard let latest = latestRelease() else { return [] }
         let remaining = releases.filter { $0 != latest }.sorted(by: compareVersionsDescending)
         return [latest] + remaining
+    }
+
+    public func dryRunStatus(
+        currentBuild: String,
+        allowedChannels: Set<AppcastChannel> = Set(AppcastChannel.allCases),
+        licenseAllowsPrivateArtifacts: Bool = true,
+        networkAvailable: Bool = true
+    ) -> AppcastUpdateStatus {
+        guard networkAvailable else { return .networkError }
+        guard !releases.isEmpty else { return .feedInvalid }
+        guard allowedChannels.contains(channel) else { return .unsupportedChannel }
+        guard let latest = latestRelease() else { return .feedInvalid }
+        if !licenseAllowsPrivateArtifacts && latest.artifactURL.contains("/private/") {
+            return .blockedByLicense
+        }
+        if latest.signatureState == .invalidFixture {
+            return .signatureError
+        }
+        return compareBuilds(latest.build, currentBuild) == .orderedDescending ? .updateAvailable : .noUpdate
     }
 }
 
@@ -115,11 +162,19 @@ private func compareVersionsDescending(_ lhs: AppcastRelease, _ rhs: AppcastRele
         let right = index < rhsParts.count ? rhsParts[index] : 0
         if left != right { return left > right }
     }
-    return lhs.build > rhs.build
+    return compareBuilds(lhs.build, rhs.build) == .orderedDescending
 }
 
 private func versionParts(_ value: String) -> [Int] {
     value
         .split { !$0.isNumber }
         .map { Int($0) ?? 0 }
+}
+
+private func compareBuilds(_ lhs: String, _ rhs: String) -> ComparisonResult {
+    if let left = Int(lhs), let right = Int(rhs) {
+        if left == right { return .orderedSame }
+        return left > right ? .orderedDescending : .orderedAscending
+    }
+    return lhs.compare(rhs, options: [.numeric])
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/AppcastDryRun.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/AppcastDryRun.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct AppcastDryRun {
+    public var fixture: URL
+    public var output: URL?
+
+    public init(fixture: URL, output: URL?) {
+        self.fixture = fixture
+        self.output = output
+    }
+
+    public func run() throws -> String {
+        let manifest = try AppcastManifest.load(from: fixture)
+        let xml = try AppcastSerializer.serialize(manifest)
+        if let output {
+            let directory = output.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try xml.write(to: output, atomically: true, encoding: .utf8)
+        }
+        return xml
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/AppcastSerializer.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/AppcastSerializer.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+public enum AppcastSerializer {
+    public static func serialize(_ manifest: AppcastManifest) throws -> String {
+        let items = manifest.releasesForAppcast().map(serializeItem).joined(separator: "\n")
+        return """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <title>\(xmlText(manifest.title))</title>
+            <link>\(xmlText(manifest.feedURL))</link>
+            <description>NeonDiff Desktop \(xmlText(manifest.channel.rawValue)) appcast</description>
+        \(items)
+          </channel>
+        </rss>
+        """
+    }
+
+    private static func serializeItem(_ release: AppcastRelease) -> String {
+        let signatureAttribute = release.edSignature.map { " sparkle:edSignature=\"\(xmlAttribute($0))\"" } ?? ""
+        let channelElement = release.channel == .beta ? "\n      <sparkle:channel>beta</sparkle:channel>" : ""
+        return """
+            <item>
+              <title>\(xmlText(release.title))</title>
+              <pubDate>\(xmlText(release.pubDate))</pubDate>\(channelElement)
+              <sparkle:minimumSystemVersion>\(xmlText(release.minimumSystemVersion))</sparkle:minimumSystemVersion>
+              <enclosure url="\(xmlAttribute(release.artifactURL))" length="\(release.artifactLength)" type="application/octet-stream" sparkle:version="\(xmlAttribute(release.build))" sparkle:shortVersionString="\(xmlAttribute(release.version))" sparkle:minimumSystemVersion="\(xmlAttribute(release.minimumSystemVersion))"\(signatureAttribute) />
+            </item>
+        """
+    }
+}
+
+private func xmlText(_ value: String) -> String {
+    xmlAttribute(value)
+}
+
+private func xmlAttribute(_ value: String) -> String {
+    value
+        .replacingOccurrences(of: "&", with: "&amp;")
+        .replacingOccurrences(of: "\"", with: "&quot;")
+        .replacingOccurrences(of: "'", with: "&apos;")
+        .replacingOccurrences(of: "<", with: "&lt;")
+        .replacingOccurrences(of: ">", with: "&gt;")
+}

--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -1,0 +1,66 @@
+# NeonDiff Desktop Appcast Channels
+
+This document covers the buildable appcast generation lane for NeonDiff Desktop.
+It does not prove hosted feeds, notarized artifacts, or real EdDSA signing.
+
+## Channels
+
+- `beta`: early desktop builds for opted-in testers.
+- `stable`: signed release builds after the Mac release runbook has passed.
+- Rollback is represented by a stable feed whose newest marker pins the channel
+  latest to an earlier stable version via `rollback_to`.
+
+## Dry-Run Generator
+
+Generate a local appcast from a committed fixture:
+
+```sh
+apps/neondiff-desktop/script/generate-appcast.sh \
+  --fixture fixtures/appcast/beta.json \
+  --output /tmp/neondiff-beta-appcast.xml \
+  --dry-run
+```
+
+Dry-run mode never signs, uploads, notarizes, or fabricates a real signature.
+The `sparkle:edSignature` attribute appears only when the manifest explicitly
+contains an `ed_signature`, such as the signature-failure fixture.
+
+The generated XML follows Sparkle 2's appcast publishing model: beta releases
+use the item-level `sparkle:channel` element, and EdDSA signatures live on the
+download enclosure as `sparkle:edSignature`.
+
+## Fixtures
+
+Fixtures live under `apps/neondiff-desktop/fixtures/appcast/`:
+
+- `beta.json`: beta-channel appcast.
+- `stable.json`: stable-channel appcast.
+- `rollback.json`: stable rollback feed that pins latest to a prior version.
+- `signature-failure.json`: intentionally invalid signature metadata for the
+  client-side failure story.
+- `stale-version.json`: stale-version fixture for release checks.
+- `license-blocked.json`: private/update entitlement fixture for later license
+  service integration.
+
+## Signing Seam
+
+Real appcast signing is parked until the signed/notarized artifact and owner
+credentials are available. The future signing step should fill `ed_signature`
+from Sparkle's `sign_update` output using owner-custodied private key material.
+Private key values must never be committed, logged, or written to evidence.
+
+The public key and feed URL are build-time inputs documented in
+`signing-credentials.md`; the current generator only creates local XML from
+manifest metadata.
+
+## References
+
+- Sparkle publishing guide: `https://sparkle-project.org/documentation/publishing/`
+- Sparkle updater delegate channel API: `https://sparkle-project.org/documentation/api-reference/Protocols/SPUUpdaterDelegate.html`
+
+## Proof Boundary
+
+This lane proves channel modeling, rollback ordering, fixtures, and local
+appcast XML generation only. It does not prove Sparkle client update success,
+signature verification, hosting, notarization, public download readiness, or GA
+readiness.

--- a/apps/neondiff-desktop/docs/appcast-channels.md
+++ b/apps/neondiff-desktop/docs/appcast-channels.md
@@ -8,7 +8,8 @@ It does not prove hosted feeds, notarized artifacts, or real EdDSA signing.
 - `beta`: early desktop builds for opted-in testers.
 - `stable`: signed release builds after the Mac release runbook has passed.
 - Rollback is represented by a stable feed whose newest marker pins the channel
-  latest to an earlier stable version via `rollback_to`.
+  latest to an earlier stable version via `rollback_to`; the generated appcast
+  excludes the superseded newer build so Sparkle cannot select it.
 
 ## Dry-Run Generator
 
@@ -17,7 +18,7 @@ Generate a local appcast from a committed fixture:
 ```sh
 apps/neondiff-desktop/script/generate-appcast.sh \
   --fixture fixtures/appcast/beta.json \
-  --output /tmp/neondiff-beta-appcast.xml \
+  --output /Volumes/LEXAR/Codex/evidence/neondiff-desktop/neondiff-beta-appcast.xml \
   --dry-run
 ```
 
@@ -28,6 +29,23 @@ contains an `ed_signature`, such as the signature-failure fixture.
 The generated XML follows Sparkle 2's appcast publishing model: beta releases
 use the item-level `sparkle:channel` element, and EdDSA signatures live on the
 download enclosure as `sparkle:edSignature`.
+
+## Dry-Run Status Taxonomy
+
+The appcast core models these update outcomes for fixtures and release evidence:
+
+- `no_update`
+- `update_available`
+- `blocked_by_license`
+- `network_error`
+- `signature_error`
+- `feed_invalid`
+- `unsupported_channel`
+
+These statuses are evidence taxonomy for dry-run planning and tests. Mapping
+real Sparkle delegate errors into the desktop UI requires signed/notarized
+artifacts and hosted appcasts, so that runtime proof remains in the owner/Codex
+release lane.
 
 ## Fixtures
 

--- a/apps/neondiff-desktop/docs/signing-credentials.md
+++ b/apps/neondiff-desktop/docs/signing-credentials.md
@@ -91,6 +91,9 @@ against the `SUPublicEDKey` baked into the app.
   `SUPublicEDKey` / `SUFeedURL` into `Info.plist`. Absent → the app ships with
   Sparkle **off** (a valid dev-build state; the private-key check remains the hard
   gate, the public-key check is advisory/non-required).
+- **Appcast generation:** channel fixtures, rollback behavior, and dry-run XML
+  generation are documented in `appcast-channels.md`. Real signing and hosting
+  remain a separate owner/Codex release step.
 
 ---
 

--- a/apps/neondiff-desktop/fixtures/appcast/beta.json
+++ b/apps/neondiff-desktop/fixtures/appcast/beta.json
@@ -1,0 +1,18 @@
+{
+  "channel": "beta",
+  "title": "NeonDiff Desktop Beta",
+  "feed_url": "https://updates.neondiff.com/beta/appcast.xml",
+  "releases": [
+    {
+      "version": "1.1.0-beta.1",
+      "build": "1101",
+      "title": "NeonDiff Desktop 1.1.0 Beta 1",
+      "pub_date": "Tue, 07 Jul 2026 00:00:00 +0000",
+      "artifact_url": "https://updates.neondiff.com/beta/NeonDiffDesktop-1.1.0-beta.1.zip",
+      "artifact_length": 13345678,
+      "minimum_system_version": "14.0",
+      "channel": "beta",
+      "signature_state": "absent"
+    }
+  ]
+}

--- a/apps/neondiff-desktop/fixtures/appcast/beta.json
+++ b/apps/neondiff-desktop/fixtures/appcast/beta.json
@@ -2,6 +2,7 @@
   "channel": "beta",
   "title": "NeonDiff Desktop Beta",
   "feed_url": "https://updates.neondiff.com/beta/appcast.xml",
+  "expected_status": "update_available",
   "releases": [
     {
       "version": "1.1.0-beta.1",

--- a/apps/neondiff-desktop/fixtures/appcast/expected/beta.xml
+++ b/apps/neondiff-desktop/fixtures/appcast/expected/beta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>NeonDiff Desktop Beta</title>
+    <link>https://updates.neondiff.com/beta/appcast.xml</link>
+    <description>NeonDiff Desktop beta appcast</description>
+    <item>
+      <title>NeonDiff Desktop 1.1.0 Beta 1</title>
+      <pubDate>Tue, 07 Jul 2026 00:00:00 +0000</pubDate>
+      <sparkle:channel>beta</sparkle:channel>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <enclosure url="https://updates.neondiff.com/beta/NeonDiffDesktop-1.1.0-beta.1.zip" length="13345678" type="application/octet-stream" sparkle:version="1101" sparkle:shortVersionString="1.1.0-beta.1" sparkle:minimumSystemVersion="14.0" />
+    </item>
+  </channel>
+</rss>

--- a/apps/neondiff-desktop/fixtures/appcast/expected/rollback.xml
+++ b/apps/neondiff-desktop/fixtures/appcast/expected/rollback.xml
@@ -10,11 +10,5 @@
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
       <enclosure url="https://updates.neondiff.com/stable/NeonDiffDesktop-1.0.0.zip" length="12345678" type="application/octet-stream" sparkle:version="100" sparkle:shortVersionString="1.0.0" sparkle:minimumSystemVersion="14.0" />
     </item>
-    <item>
-      <title>NeonDiff Desktop 1.1.0 rollback marker</title>
-      <pubDate>Tue, 07 Jul 2026 01:00:00 +0000</pubDate>
-      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-      <enclosure url="https://updates.neondiff.com/stable/NeonDiffDesktop-1.1.0.zip" length="14345678" type="application/octet-stream" sparkle:version="110" sparkle:shortVersionString="1.1.0" sparkle:minimumSystemVersion="14.0" />
-    </item>
   </channel>
 </rss>

--- a/apps/neondiff-desktop/fixtures/appcast/expected/rollback.xml
+++ b/apps/neondiff-desktop/fixtures/appcast/expected/rollback.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>NeonDiff Desktop Stable Rollback</title>
+    <link>https://updates.neondiff.com/stable/appcast.xml</link>
+    <description>NeonDiff Desktop stable appcast</description>
+    <item>
+      <title>NeonDiff Desktop 1.0.0</title>
+      <pubDate>Tue, 07 Jul 2026 00:00:00 +0000</pubDate>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <enclosure url="https://updates.neondiff.com/stable/NeonDiffDesktop-1.0.0.zip" length="12345678" type="application/octet-stream" sparkle:version="100" sparkle:shortVersionString="1.0.0" sparkle:minimumSystemVersion="14.0" />
+    </item>
+    <item>
+      <title>NeonDiff Desktop 1.1.0 rollback marker</title>
+      <pubDate>Tue, 07 Jul 2026 01:00:00 +0000</pubDate>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <enclosure url="https://updates.neondiff.com/stable/NeonDiffDesktop-1.1.0.zip" length="14345678" type="application/octet-stream" sparkle:version="110" sparkle:shortVersionString="1.1.0" sparkle:minimumSystemVersion="14.0" />
+    </item>
+  </channel>
+</rss>

--- a/apps/neondiff-desktop/fixtures/appcast/expected/signature-failure.xml
+++ b/apps/neondiff-desktop/fixtures/appcast/expected/signature-failure.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>NeonDiff Desktop Signature Failure Fixture</title>
+    <link>https://updates.neondiff.com/stable/appcast.xml</link>
+    <description>NeonDiff Desktop stable appcast</description>
+    <item>
+      <title>NeonDiff Desktop invalid signature fixture</title>
+      <pubDate>Tue, 07 Jul 2026 00:00:00 +0000</pubDate>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <enclosure url="https://updates.neondiff.com/stable/NeonDiffDesktop-1.0.0.zip" length="12345678" type="application/octet-stream" sparkle:version="100" sparkle:shortVersionString="1.0.0" sparkle:minimumSystemVersion="14.0" sparkle:edSignature="invalid-fixture-signature" />
+    </item>
+  </channel>
+</rss>

--- a/apps/neondiff-desktop/fixtures/appcast/expected/stable.xml
+++ b/apps/neondiff-desktop/fixtures/appcast/expected/stable.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>NeonDiff Desktop Stable</title>
+    <link>https://updates.neondiff.com/stable/appcast.xml</link>
+    <description>NeonDiff Desktop stable appcast</description>
+    <item>
+      <title>NeonDiff Desktop 1.0.0</title>
+      <pubDate>Tue, 07 Jul 2026 00:00:00 +0000</pubDate>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <enclosure url="https://updates.neondiff.com/stable/NeonDiffDesktop-1.0.0.zip" length="12345678" type="application/octet-stream" sparkle:version="100" sparkle:shortVersionString="1.0.0" sparkle:minimumSystemVersion="14.0" />
+    </item>
+    <item>
+      <title>NeonDiff Desktop 0.9.0</title>
+      <pubDate>Mon, 06 Jul 2026 00:00:00 +0000</pubDate>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <enclosure url="https://updates.neondiff.com/stable/NeonDiffDesktop-0.9.0.zip" length="11345678" type="application/octet-stream" sparkle:version="90" sparkle:shortVersionString="0.9.0" sparkle:minimumSystemVersion="14.0" />
+    </item>
+  </channel>
+</rss>

--- a/apps/neondiff-desktop/fixtures/appcast/license-blocked.json
+++ b/apps/neondiff-desktop/fixtures/appcast/license-blocked.json
@@ -2,6 +2,7 @@
   "channel": "stable",
   "title": "NeonDiff Desktop License Blocked Fixture",
   "feed_url": "https://updates.neondiff.com/stable/appcast.xml",
+  "expected_status": "blocked_by_license",
   "releases": [
     {
       "version": "1.0.0",

--- a/apps/neondiff-desktop/fixtures/appcast/license-blocked.json
+++ b/apps/neondiff-desktop/fixtures/appcast/license-blocked.json
@@ -1,0 +1,18 @@
+{
+  "channel": "stable",
+  "title": "NeonDiff Desktop License Blocked Fixture",
+  "feed_url": "https://updates.neondiff.com/stable/appcast.xml",
+  "releases": [
+    {
+      "version": "1.0.0",
+      "build": "100",
+      "title": "NeonDiff Desktop license blocked fixture",
+      "pub_date": "Tue, 07 Jul 2026 00:00:00 +0000",
+      "artifact_url": "https://updates.neondiff.com/private/NeonDiffDesktop-1.0.0.zip",
+      "artifact_length": 12345678,
+      "minimum_system_version": "14.0",
+      "channel": "stable",
+      "signature_state": "absent"
+    }
+  ]
+}

--- a/apps/neondiff-desktop/fixtures/appcast/rollback.json
+++ b/apps/neondiff-desktop/fixtures/appcast/rollback.json
@@ -2,6 +2,7 @@
   "channel": "stable",
   "title": "NeonDiff Desktop Stable Rollback",
   "feed_url": "https://updates.neondiff.com/stable/appcast.xml",
+  "expected_status": "update_available",
   "releases": [
     {
       "version": "1.1.0",

--- a/apps/neondiff-desktop/fixtures/appcast/rollback.json
+++ b/apps/neondiff-desktop/fixtures/appcast/rollback.json
@@ -1,0 +1,30 @@
+{
+  "channel": "stable",
+  "title": "NeonDiff Desktop Stable Rollback",
+  "feed_url": "https://updates.neondiff.com/stable/appcast.xml",
+  "releases": [
+    {
+      "version": "1.1.0",
+      "build": "110",
+      "title": "NeonDiff Desktop 1.1.0 rollback marker",
+      "pub_date": "Tue, 07 Jul 2026 01:00:00 +0000",
+      "artifact_url": "https://updates.neondiff.com/stable/NeonDiffDesktop-1.1.0.zip",
+      "artifact_length": 14345678,
+      "minimum_system_version": "14.0",
+      "channel": "stable",
+      "signature_state": "absent",
+      "rollback_to": "1.0.0"
+    },
+    {
+      "version": "1.0.0",
+      "build": "100",
+      "title": "NeonDiff Desktop 1.0.0",
+      "pub_date": "Tue, 07 Jul 2026 00:00:00 +0000",
+      "artifact_url": "https://updates.neondiff.com/stable/NeonDiffDesktop-1.0.0.zip",
+      "artifact_length": 12345678,
+      "minimum_system_version": "14.0",
+      "channel": "stable",
+      "signature_state": "absent"
+    }
+  ]
+}

--- a/apps/neondiff-desktop/fixtures/appcast/signature-failure.json
+++ b/apps/neondiff-desktop/fixtures/appcast/signature-failure.json
@@ -1,0 +1,19 @@
+{
+  "channel": "stable",
+  "title": "NeonDiff Desktop Signature Failure Fixture",
+  "feed_url": "https://updates.neondiff.com/stable/appcast.xml",
+  "releases": [
+    {
+      "version": "1.0.0",
+      "build": "100",
+      "title": "NeonDiff Desktop invalid signature fixture",
+      "pub_date": "Tue, 07 Jul 2026 00:00:00 +0000",
+      "artifact_url": "https://updates.neondiff.com/stable/NeonDiffDesktop-1.0.0.zip",
+      "artifact_length": 12345678,
+      "minimum_system_version": "14.0",
+      "channel": "stable",
+      "ed_signature": "invalid-fixture-signature",
+      "signature_state": "invalidFixture"
+    }
+  ]
+}

--- a/apps/neondiff-desktop/fixtures/appcast/signature-failure.json
+++ b/apps/neondiff-desktop/fixtures/appcast/signature-failure.json
@@ -2,6 +2,7 @@
   "channel": "stable",
   "title": "NeonDiff Desktop Signature Failure Fixture",
   "feed_url": "https://updates.neondiff.com/stable/appcast.xml",
+  "expected_status": "signature_error",
   "releases": [
     {
       "version": "1.0.0",

--- a/apps/neondiff-desktop/fixtures/appcast/stable.json
+++ b/apps/neondiff-desktop/fixtures/appcast/stable.json
@@ -2,6 +2,7 @@
   "channel": "stable",
   "title": "NeonDiff Desktop Stable",
   "feed_url": "https://updates.neondiff.com/stable/appcast.xml",
+  "expected_status": "update_available",
   "releases": [
     {
       "version": "1.0.0",

--- a/apps/neondiff-desktop/fixtures/appcast/stable.json
+++ b/apps/neondiff-desktop/fixtures/appcast/stable.json
@@ -1,0 +1,29 @@
+{
+  "channel": "stable",
+  "title": "NeonDiff Desktop Stable",
+  "feed_url": "https://updates.neondiff.com/stable/appcast.xml",
+  "releases": [
+    {
+      "version": "1.0.0",
+      "build": "100",
+      "title": "NeonDiff Desktop 1.0.0",
+      "pub_date": "Tue, 07 Jul 2026 00:00:00 +0000",
+      "artifact_url": "https://updates.neondiff.com/stable/NeonDiffDesktop-1.0.0.zip",
+      "artifact_length": 12345678,
+      "minimum_system_version": "14.0",
+      "channel": "stable",
+      "signature_state": "absent"
+    },
+    {
+      "version": "0.9.0",
+      "build": "90",
+      "title": "NeonDiff Desktop 0.9.0",
+      "pub_date": "Mon, 06 Jul 2026 00:00:00 +0000",
+      "artifact_url": "https://updates.neondiff.com/stable/NeonDiffDesktop-0.9.0.zip",
+      "artifact_length": 11345678,
+      "minimum_system_version": "14.0",
+      "channel": "stable",
+      "signature_state": "absent"
+    }
+  ]
+}

--- a/apps/neondiff-desktop/fixtures/appcast/stale-version.json
+++ b/apps/neondiff-desktop/fixtures/appcast/stale-version.json
@@ -2,6 +2,7 @@
   "channel": "stable",
   "title": "NeonDiff Desktop Stale Version Fixture",
   "feed_url": "https://updates.neondiff.com/stable/appcast.xml",
+  "expected_status": "no_update",
   "releases": [
     {
       "version": "0.8.0",

--- a/apps/neondiff-desktop/fixtures/appcast/stale-version.json
+++ b/apps/neondiff-desktop/fixtures/appcast/stale-version.json
@@ -1,0 +1,18 @@
+{
+  "channel": "stable",
+  "title": "NeonDiff Desktop Stale Version Fixture",
+  "feed_url": "https://updates.neondiff.com/stable/appcast.xml",
+  "releases": [
+    {
+      "version": "0.8.0",
+      "build": "80",
+      "title": "NeonDiff Desktop stale version",
+      "pub_date": "Sun, 05 Jul 2026 00:00:00 +0000",
+      "artifact_url": "https://updates.neondiff.com/stable/NeonDiffDesktop-0.8.0.zip",
+      "artifact_length": 10345678,
+      "minimum_system_version": "14.0",
+      "channel": "stable",
+      "signature_state": "absent"
+    }
+  ]
+}

--- a/apps/neondiff-desktop/script/generate-appcast.sh
+++ b/apps/neondiff-desktop/script/generate-appcast.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$ROOT_DIR"
+exec swift run NeonDiffDesktopAppcastDryRun "$@"


### PR DESCRIPTION
## Summary
- add a NeonDiff Desktop appcast manifest model for beta/stable channels and rollback pinning
- add Sparkle RSS XML serialization, golden appcast fixtures, and a dry-run generator CLI/script
- document appcast channel policy and the parked signing/hosting seam next to existing signing docs

## Validation
- `swift run NeonDiffDesktopAppcastChecks`
- `swift run NeonDiffDesktopAppcastDryRun --fixture fixtures/appcast/beta.json --dry-run`
- `script/generate-appcast.sh --fixture fixtures/appcast/rollback.json --output /Volumes/LEXAR/Codex/evidence/neondiff-desktop/2026-07-07/sparkle-appcast/neondiff-rollback-appcast.xml --dry-run`
- `swift run NeonDiffDesktopCoreChecks`
- `swift run NeonDiffDesktopCoreSmoke`
- `swift build --product NeonDiffDesktop`
- `bash -n script/generate-appcast.sh`
- `git diff --check`
- `node scripts/check-secret-scan.mjs`
- `NODE_OPTIONS="--experimental-sqlite --use-system-ca" npm run build`

## Proof boundary
This proves appcast generation, committed fixtures, rollback ordering, and dry-run XML only. Real EdDSA signing, hosted appcast publication, notarized artifacts, and client-side signature-failure proof remain the owner/Codex release lane under the parent desktop signing work.

Closes #323
Parent: #116
Roadmap handoff: #374
