### PR TITLE
docs: prepare v0.4.42 beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ for the semver/GA-line and npm dist-tag policy.
 
 No unreleased changes tracked yet.
 
+## [0.4.42-beta.1] - docs/releases/v0.4.42-beta.1.md
+
+### Added
+- Add the completed buildable NeonDiff roadmap batch: desktop onboarding wizard, Sparkle appcast channel model/dry-run generator, and signed Mac release runbook documentation
+- Keep the public npm package held at `neondiff@0.4.30-beta.1` while promoting the source-only beta release surface to the current merged head
+
 ## [0.4.41-beta.1] - docs/releases/v0.4.41-beta.1.md
 
 ### Added

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "v0.4.41-beta.1",
+  "version": "v0.4.42-beta.1",
   "releaseLevel": "source-beta",
   "packageArtifact": {
     "name": "neondiff",
@@ -23,37 +23,39 @@
       "v0.4.38-beta.1",
       "v0.4.39-beta.1",
       "v0.4.40-beta.1",
-      "v0.4.41-beta.1"
+      "v0.4.41-beta.1",
+      "v0.4.42-beta.1"
     ],
-    "note": "v0.4.25 through v0.4.29 and v0.4.31 through v0.4.41 were source/local-worker beta releases; v0.4.30-beta.1 remains the current public npm/site beta."
+    "note": "v0.4.25 through v0.4.29 and v0.4.31 through v0.4.42 were source/local-worker beta releases; v0.4.30-beta.1 remains the current public npm/site beta."
   },
   "source": {
-    "shaState": "66ef93ca4e8a37511df95fb75164db254d6d7e42",
-    "proof": "release:status --expected-head $(git rev-parse HEAD)"
+    "shaState": "pending_tag_stamp",
+    "candidateHeadBeforeReleaseMetadata": "97aa93f4ce1231feb06ca68e6f592f14bf519ffe",
+    "proof": "after merge and tag, release:status --expected-head $(git rev-parse HEAD)"
   },
   "docs": {
-    "version": "v0.4.41-beta.1",
+    "version": "v0.4.42-beta.1",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v0.4.41-beta.1.md",
+    "releaseNotesPath": "docs/releases/v0.4.42-beta.1.md",
     "websiteRepo": "electricsheephq/neon-diff-agent"
   },
   "licenseApi": {
     "requiredForThisRelease": false,
     "state": "pending",
-    "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/111"
+    "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327"
   },
   "updateChannels": {
     "cli": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v0.4.41-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.40-beta.1"
+      "version": "v0.4.42-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.41-beta.1"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "launchd_prerelease",
-      "version": "v0.4.41-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.40-beta.1"
+      "version": "v0.4.42-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.41-beta.1"
     },
     "website": {
       "requiredForThisRelease": false,

--- a/docs/releases/v0.4.42-beta.1.md
+++ b/docs/releases/v0.4.42-beta.1.md
@@ -1,0 +1,80 @@
+# v0.4.42-beta.1
+
+- Release type: source-only beta completed-buildable-roadmap alignment
+- Release source SHA: to be stamped by `refs/tags/v0.4.42-beta.1`
+- Previous prerelease: `v0.4.41-beta.1`
+- Tracking issues / source PRs: `#322`, `#323`, `#325`, `#374`, `#378`
+- Promoted PRs: `#375`, `#376`, `#377`
+- Included implementation merge SHAs:
+  - `6e98ea3cc831d0dabecb4170c749295819c3251f` (`#375`)
+  - `d82d83e1b83443e63f4e6bd8fe1b288e90700ae0` (`#376`)
+  - `97aa93f4ce1231feb06ca68e6f592f14bf519ffe` (`#377`)
+- Local operator evidence path: `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-07/v0.4.42-beta.1/`
+- Rollback tag: `v0.4.41-beta.1`
+- Package artifact: `neondiff@0.4.30-beta.1` (held from previous public npm release)
+- Rollback baseline: `v0.4.41-beta.1`
+
+## Purpose
+
+Promote the buildable NeonDiff roadmap items that landed after
+`v0.4.41-beta.1` as a named source-only beta instead of leaving the release
+surface on stale untagged `main`.
+
+This release aligns the changelog, public release manifest, and release packet
+with the merged desktop onboarding, Sparkle appcast, and signed Mac release
+runbook work. It intentionally keeps owner-gated GA work tracked separately.
+
+## Included Changes
+
+- Add the Desktop onboarding wizard for provider setup and daemon bootstrap,
+  with the license-service step left as an explicit integration point until
+  the production license service is deployed.
+- Add the Sparkle appcast channel model, fixtures, and dry-run generator for
+  future desktop update-channel publication.
+- Add the signed Mac release runbook that an owner plus a Codex agent can use
+  for Apple signing, notarization, stapling, Gatekeeper, appcast, rollback, and
+  evidence proof.
+- Record the remaining NeonDiff roadmap handoff in `#374`, with only
+  owner-gated or post-GA work left outside this source-beta alignment.
+
+## Required Gates
+
+- PRs `#375`, `#376`, and `#377` merged to `main`.
+- GitHub Actions on current `main` passed for the promoted head.
+- Release checkout validation: public-release readiness focused test,
+  release-status focused test, `npm run build`, `git diff --check`, packlist
+  dry-run, secret scan, and public claims scan.
+- Post-tag `Publish npm` workflow completes as a source-only skip, not a failed
+  npm publish attempt.
+- Post-tag `release:status` after launchd restart at the promoted tag SHA.
+- Post-promotion `coverage-audit`, runtime inventory, `doctor github`, and
+  expired provider cooldown audit where applicable to the local-worker lane.
+
+## Caveats
+
+- This release does not publish a new npm package; the public npm package
+  remains `neondiff@0.4.30-beta.1`.
+- This release does not deploy the production license service, cut GA, or claim
+  `v1.0.0` readiness.
+- This release does not ship a signed, notarized desktop artifact or publish a
+  production Sparkle appcast.
+- The Mac release runbook is execution guidance for a future signed artifact
+  lane; it is not itself signed desktop release proof.
+- This release does not change monitored repos, GitHub App permissions, live
+  review concurrency, issue-enrichment allowlists, provider selection, model
+  selection, native ZCode skills, MCP tools, memory, shell tools,
+  auto-approval behavior, or target-repo mutation.
+
+## Rollback
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v0.4.41-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -33,6 +33,11 @@ describe("NeonDiff public release readiness", () => {
         skippedPublicPackageVersions?: string[];
         note?: string;
       };
+      source?: {
+        shaState?: string;
+        candidateHeadBeforeReleaseMetadata?: string;
+        proof?: string;
+      };
     };
 
     expect(pkg.name).toBe("neondiff");
@@ -83,7 +88,13 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.39-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.40-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.41-beta.1");
+    expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.42-beta.1");
     expect(manifest.packageArtifact?.note).toMatch(/source\/local-worker/i);
+    expect(manifest.source).toMatchObject({
+      shaState: "pending_tag_stamp",
+      candidateHeadBeforeReleaseMetadata: "97aa93f4ce1231feb06ca68e6f592f14bf519ffe"
+    });
+    expect(manifest.source?.proof).toMatch(/after merge and tag/i);
   });
 
   it("ships the canonical install script contract", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -193,16 +193,16 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.41-beta.1"
+      expectedVersion: "v0.4.42-beta.1"
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v0.4.41-beta.1",
+      version: "v0.4.42-beta.1",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v0.4.41-beta.1.md"
+        releaseNotesPath: "docs/releases/v0.4.42-beta.1.md"
       },
       updateChannels: {
         ok: true
@@ -213,12 +213,12 @@ describe("beta release status", () => {
         expect.objectContaining({
           name: "cli",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.40-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.41-beta.1"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.40-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.41-beta.1"
         })
       ])
     );
@@ -285,13 +285,13 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v0.4.41-beta.1",
+      expectedPublicVersion: "v0.4.42-beta.1",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot"
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v0.4.41-beta.1"
+      version: "v0.4.42-beta.1"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
@@ -303,9 +303,9 @@ describe("beta release status", () => {
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok
     });
-    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.40-beta.1");
+    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.41-beta.1");
     expect(redactedOutput).toContain("cli=published; daemon=launchd_prerelease");
-    expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/111");
+    expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
   });
 
   it("fails closed without throwing when collectReleaseStatus receives a missing public manifest path", () => {


### PR DESCRIPTION
## Summary

Prepare the source-only `v0.4.42-beta.1` release metadata for the merged buildable NeonDiff roadmap batch:

- #375 desktop onboarding wizard
- #376 Sparkle appcast channel model and dry-run generator
- #377 signed Mac release runbook

This keeps the public npm package held at `neondiff@0.4.30-beta.1`, updates the public release manifest to the current source SHA, and points the deferred license-service gate at the live GA blocker #327.

Closes #378.

## Validation

- `npm test -- tests/release-status.test.ts tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- `npm pack --dry-run --json > /Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-07/v0.4.42-beta.1/pack.json && node scripts/check-packlist.mjs /Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-07/v0.4.42-beta.1/pack.json`
- `node scripts/check-public-claims.mjs`
- `node scripts/check-secret-scan.mjs`

## Promotion Notes

Do not tag/promote until the current-main CodeQL run has finished and release-status is green. The pre-PR release-status manifest check passed its public-release portion, but overall release-status was red because live runtime state had unrelated queue/cooldown blockers:

- `failedQueueJobs: 1`
- `expiredProviderCooldowns: 2`

Evidence: `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-07/v0.4.42-beta.1/`.

## Non-Goals

- No npm publish or package version bump.
- No desktop signing/notarization or Sparkle feed publication.
- No production license service deployment.
- No GA `v1.0.0` claim.
- No live runtime config or launchd mutation.
