### PR TITLE
fix: use valid Fly health check config

### DIFF
--- a/services/license-api/docs/deploy.md
+++ b/services/license-api/docs/deploy.md
@@ -81,7 +81,7 @@ flyctl deploy \
 ```
 
 Watch the health check pass (`GET /healthz` → `{ "status": "ok" }`, wired in
-`fly.toml` under `[http_service.checks.healthz]`). `flyctl status --app
+`fly.toml` under `[[http_service.checks]]`). `flyctl status --app
 neondiff-license` shows machine + volume state; `flyctl logs --app
 neondiff-license` streams the `license-api listening on …` boot line from
 `src/server.ts`.

--- a/services/license-api/fly.toml
+++ b/services/license-api/fly.toml
@@ -36,14 +36,13 @@ primary_region = "iad"  # placeholder — set to wherever the fleet/owner is clo
   auto_start_machines = true
   min_machines_running = 1
 
-  [http_service.checks]
-    [http_service.checks.healthz]
-      grace_period = "10s"
-      interval = "15s"
-      method = "GET"
-      path = "/healthz"
-      protocol = "http"
-      timeout = "5s"
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "15s"
+    method = "GET"
+    path = "/healthz"
+    protocol = "http"
+    timeout = "5s"
 
 [[vm]]
   size = "shared-cpu-1x"


### PR DESCRIPTION
## Summary

Fixes the license-api Fly health-check config so Fly can validate and deploy the #327 service.

## What changed

- Changes `services/license-api/fly.toml` from the old nested `[http_service.checks.healthz]` object to Fly's valid `[[http_service.checks]]` array form.
- Updates the deploy runbook wording to point at `[[http_service.checks]]`.

## Validation

- `flyctl config validate --config services/license-api/fly.toml --app neondiff-license --strict`
- `npm test -- tests/license-service-contract.test.ts tests/license.test.ts --pool=forks --maxWorkers=1`
- `(cd services/license-api && npm test)`
- `npm run build`
- `git diff --check`
- `node scripts/check-public-claims.mjs`
- `node scripts/check-secret-scan.mjs`

## Deploy evidence

Before this patch, `flyctl deploy --config services/license-api/fly.toml --dockerfile services/license-api/Dockerfile --app neondiff-license --remote-only` failed during config validation with:

```text
json: cannot unmarshal object into Go struct field HTTPService.http_service.checks of type []*appconfig.ServiceHTTPCheck
```

Evidence path: `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-07/license-api-deploy/`

Closes #327 only after the follow-up deploy/live smoke evidence lands; this PR is the deploy-config blocker fix.
