### PR TITLE
chore: require live license API in release manifest

### DIFF
--- a/docs/evidence/v0.4.43-beta.1-license-api-healthz.json
+++ b/docs/evidence/v0.4.43-beta.1-license-api-healthz.json
@@ -1,0 +1,11 @@
+{
+  "evidenceKind": "license_api_healthz",
+  "releaseVersion": "v0.4.43-beta.1",
+  "observedAt": "2026-07-07T09:03:16Z",
+  "method": "GET",
+  "url": "https://neondiff-license.fly.dev/healthz",
+  "statusCode": 200,
+  "responseBody": "{\"status\":\"ok\"}",
+  "responseBodySha256": "a29ee2b15c494311c52521766e44af56a3ad2248e7a8ab465e5206463c13d288",
+  "redaction": "No license key, token, cookie, customer data, or private repo content was present in this health check."
+}

--- a/docs/evidence/v0.4.43-beta.1-license-api-healthz.json
+++ b/docs/evidence/v0.4.43-beta.1-license-api-healthz.json
@@ -7,5 +7,13 @@
   "statusCode": 200,
   "responseBody": "{\"status\":\"ok\"}",
   "responseBodySha256": "a29ee2b15c494311c52521766e44af56a3ad2248e7a8ab465e5206463c13d288",
+  "captureContext": {
+    "tool": "curl",
+    "transport": "https",
+    "resolverOverride": "neondiff-license.fly.dev:443:66.241.124.124",
+    "tlsValidation": "curl default CA validation",
+    "capturedFrom": "operator Mac",
+    "note": "Resolver override was used because the local macOS resolver cache lagged while public DNS already resolved neondiff-license.fly.dev to 66.241.124.124."
+  },
   "redaction": "No license key, token, cookie, customer data, or private repo content was present in this health check."
 }

--- a/docs/evidence/v0.4.43-beta.1-license-api-healthz.json
+++ b/docs/evidence/v0.4.43-beta.1-license-api-healthz.json
@@ -1,7 +1,7 @@
 {
   "evidenceKind": "license_api_healthz",
   "releaseVersion": "v0.4.43-beta.1",
-  "observedAt": "2026-07-07T09:03:16Z",
+  "observedAt": "2026-07-07T12:30:45Z",
   "method": "GET",
   "url": "https://neondiff-license.fly.dev/healthz",
   "statusCode": 200,
@@ -10,10 +10,10 @@
   "captureContext": {
     "tool": "curl",
     "transport": "https",
-    "resolverOverride": "neondiff-license.fly.dev:443:66.241.124.124",
     "tlsValidation": "curl default CA validation",
-    "capturedFrom": "operator Mac",
-    "note": "Resolver override was used because the local macOS resolver cache lagged while public DNS already resolved neondiff-license.fly.dev to 66.241.124.124."
+    "capturedFrom": "Codex Desktop macOS operator shell",
+    "dnsResolution": "neondiff-license.fly.dev -> 66.241.124.124 via system resolver",
+    "note": "Captured with normal system DNS resolution and curl default TLS validation."
   },
   "redaction": "No license key, token, cookie, customer data, or private repo content was present in this health check."
 }

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "v0.4.42-beta.1",
+  "version": "v0.4.43-beta.1",
   "releaseLevel": "source-beta",
   "packageArtifact": {
     "name": "neondiff",
@@ -24,38 +24,40 @@
       "v0.4.39-beta.1",
       "v0.4.40-beta.1",
       "v0.4.41-beta.1",
-      "v0.4.42-beta.1"
+      "v0.4.42-beta.1",
+      "v0.4.43-beta.1"
     ],
-    "note": "v0.4.25 through v0.4.29 and v0.4.31 through v0.4.42 were source/local-worker beta releases; v0.4.30-beta.1 remains the current public npm/site beta."
+    "note": "v0.4.25 through v0.4.29 and v0.4.31 through v0.4.43 were source/local-worker beta releases; v0.4.30-beta.1 remains the current public npm/site beta."
   },
   "source": {
     "shaState": "pending_tag_stamp",
-    "candidateHeadBeforeReleaseMetadata": "97aa93f4ce1231feb06ca68e6f592f14bf519ffe",
+    "candidateHeadBeforeReleaseMetadata": "10d897dc82e23acbe144d70d10cc83fcd3c52f8c",
     "proof": "after merge and tag, release:status --expected-head $(git rev-parse HEAD)"
   },
   "docs": {
-    "version": "v0.4.42-beta.1",
+    "version": "v0.4.43-beta.1",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v0.4.42-beta.1.md",
+    "releaseNotesPath": "docs/releases/v0.4.43-beta.1.md",
     "websiteRepo": "electricsheephq/neon-diff-agent"
   },
   "licenseApi": {
-    "requiredForThisRelease": false,
-    "state": "pending",
-    "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327"
+    "requiredForThisRelease": true,
+    "state": "healthy",
+    "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327",
+    "healthUrl": "https://neondiff-license.fly.dev/healthz"
   },
   "updateChannels": {
     "cli": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v0.4.42-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.41-beta.1"
+      "version": "v0.4.43-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.42-beta.1"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "launchd_prerelease",
-      "version": "v0.4.42-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.41-beta.1"
+      "version": "v0.4.43-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.42-beta.1"
     },
     "website": {
       "requiredForThisRelease": false,

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -44,7 +44,8 @@
     "requiredForThisRelease": true,
     "state": "healthy",
     "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327",
-    "healthUrl": "https://neondiff-license.fly.dev/healthz"
+    "healthUrl": "https://neondiff-license.fly.dev/healthz",
+    "healthProofPath": "docs/evidence/v0.4.43-beta.1-license-api-healthz.json"
   },
   "updateChannels": {
     "cli": {

--- a/docs/releases/v0.4.43-beta.1.md
+++ b/docs/releases/v0.4.43-beta.1.md
@@ -29,8 +29,7 @@ machine-checkable health proof for this beta.
   `services/license-api/fly.toml` and can deploy the service.
 - Deploy `neondiff-license` on Fly with SQLite backed by the existing
   `license_data` volume.
-- Verify the public health endpoint, with a resolver-pinned curl check while
-  the local macOS resolver cache was stale.
+- Verify the public health endpoint with a normal-DNS HTTPS curl check.
 - Smoke-test a throwaway private-scope license through issue, activate,
   validate, deactivate, revoke, and validate-after-revoke.
 - Update `docs/public-release-manifest.json` so `licenseApi` is

--- a/docs/releases/v0.4.43-beta.1.md
+++ b/docs/releases/v0.4.43-beta.1.md
@@ -68,7 +68,7 @@ machine-checkable health proof for this beta.
 
 - This release does not publish a new npm package; the public npm package
   remains `neondiff@0.4.30-beta.1`.
-- The committed license API health proof expires seven days after its
+- The committed license API health proof expires 30 days after its
   `observedAt` value. If this tag or the post-tag `release:status` promotion is
   delayed past that freshness window, re-capture `/healthz`, update
   `docs/evidence/v0.4.43-beta.1-license-api-healthz.json` with the new

--- a/docs/releases/v0.4.43-beta.1.md
+++ b/docs/releases/v0.4.43-beta.1.md
@@ -7,7 +7,8 @@
 - Promoted PRs: `#380`
 - Included implementation merge SHA:
   - `10d897dc82e23acbe144d70d10cc83fcd3c52f8c` (`#380`)
-- Operator evidence packet: `<EVIDENCE_ROOT>/neondiff-ga/2026-07-07/license-api-deploy/`
+- Committed health proof: `docs/evidence/v0.4.43-beta.1-license-api-healthz.json`
+- Operator-local smoke packet: `<EVIDENCE_ROOT>/neondiff-ga/2026-07-07/license-api-deploy/`
 - Rollback tag: `v0.4.42-beta.1`
 - Package artifact: `neondiff@0.4.30-beta.1` (held from previous public npm release)
 - Rollback baseline: `v0.4.42-beta.1`
@@ -44,9 +45,13 @@ healthy for this beta.
   checks passing.
 - Public `/healthz` returns `{"status":"ok"}` at
   `https://neondiff-license.fly.dev/healthz`.
+- The manifest points at a committed redacted health proof JSON under
+  `docs/evidence/`, and `release-status` requires that proof file when the
+  license API gate is `requiredForThisRelease: true` and `state: healthy`.
 - Redacted live smoke evidence exists for issue, activate, validate,
-  deactivate, revoke, and validate-after-revoke. No raw license key is included
-  in release notes, GitHub comments, or shared evidence.
+  deactivate, revoke, and validate-after-revoke in the operator-local evidence
+  packet. No raw license key is included in release notes, GitHub comments,
+  committed evidence, or shared evidence.
 - Release checkout validation: public-release readiness focused test,
   release-status focused test, `npm run build`, `git diff --check`, secret scan,
   and public claims scan.

--- a/docs/releases/v0.4.43-beta.1.md
+++ b/docs/releases/v0.4.43-beta.1.md
@@ -7,7 +7,7 @@
 - Promoted PRs: `#380`
 - Included implementation merge SHA:
   - `10d897dc82e23acbe144d70d10cc83fcd3c52f8c` (`#380`)
-- Local operator evidence path: `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-07/license-api-deploy/`
+- Operator evidence packet: `<EVIDENCE_ROOT>/neondiff-ga/2026-07-07/license-api-deploy/`
 - Rollback tag: `v0.4.42-beta.1`
 - Package artifact: `neondiff@0.4.30-beta.1` (held from previous public npm release)
 - Rollback baseline: `v0.4.42-beta.1`
@@ -72,13 +72,16 @@ healthy for this beta.
 ## Rollback
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
+: "${REPO_ROOT:?set REPO_ROOT to your local NeonDiff checkout}"
+: "${RELEASE_STATUS_CONFIG:?set RELEASE_STATUS_CONFIG to the live release-status config}"
+
+cd "$REPO_ROOT"
 git fetch origin --tags
 git checkout main
 git reset --hard refs/tags/v0.4.42-beta.1
 launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 npm run release:status -- \
-  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --config "$RELEASE_STATUS_CONFIG" \
   --expected-head "$(git rev-parse HEAD)" \
   --launchd-label com.electricsheephq.evaos-code-review-bot
 ```

--- a/docs/releases/v0.4.43-beta.1.md
+++ b/docs/releases/v0.4.43-beta.1.md
@@ -68,6 +68,12 @@ machine-checkable health proof for this beta.
 
 - This release does not publish a new npm package; the public npm package
   remains `neondiff@0.4.30-beta.1`.
+- The committed license API health proof expires seven days after its
+  `observedAt` value. If this tag or the post-tag `release:status` promotion is
+  delayed past that freshness window, re-capture `/healthz`, update
+  `docs/evidence/v0.4.43-beta.1-license-api-healthz.json` with the new
+  `observedAt`, `responseBody`, matching `responseBodySha256`, and
+  `captureContext`, then rerun the focused release-status tests before tagging.
 - This release does not cut stable `v1.0.0`, claim GA, or claim customer
   readiness beyond the live license API gate.
 - This release does not ship a signed, notarized desktop artifact or publish a

--- a/docs/releases/v0.4.43-beta.1.md
+++ b/docs/releases/v0.4.43-beta.1.md
@@ -73,6 +73,14 @@ machine-checkable health proof for this beta.
   `docs/evidence/v0.4.43-beta.1-license-api-healthz.json` with the new
   `observedAt`, `responseBody`, matching `responseBodySha256`, and
   `captureContext`, then rerun the focused release-status tests before tagging.
+- In source-beta manifests, machine-checkable license API health proof is
+  enforced only when `requiredForThisRelease: true` and `state: healthy`. A
+  non-required `healthy` source-beta gate is informational; this release sets
+  `requiredForThisRelease: true`.
+- The committed health proof is operator-captured evidence for a source-beta
+  release gate. It validates proof shape, timestamp freshness, response body
+  hash, and capture context, but it is not a server-signed or nonce-backed proof
+  that `/healthz` was reached at tag time.
 - This release does not cut stable `v1.0.0`, claim GA, or claim customer
   readiness beyond the live license API gate.
 - This release does not ship a signed, notarized desktop artifact or publish a

--- a/docs/releases/v0.4.43-beta.1.md
+++ b/docs/releases/v0.4.43-beta.1.md
@@ -1,0 +1,84 @@
+# v0.4.43-beta.1
+
+- Release type: source-only beta license API live gate promotion
+- Release source SHA: to be stamped by `refs/tags/v0.4.43-beta.1`
+- Previous prerelease: `v0.4.42-beta.1`
+- Tracking issues / source PRs: `#327`, `#380`
+- Promoted PRs: `#380`
+- Included implementation merge SHA:
+  - `10d897dc82e23acbe144d70d10cc83fcd3c52f8c` (`#380`)
+- Local operator evidence path: `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-07/license-api-deploy/`
+- Rollback tag: `v0.4.42-beta.1`
+- Package artifact: `neondiff@0.4.30-beta.1` (held from previous public npm release)
+- Rollback baseline: `v0.4.42-beta.1`
+
+## Purpose
+
+Promote the production license API from a pending, non-required source-beta gate
+to a live required gate in the public release manifest.
+
+The source code for the license service and deploy assets had already landed in
+the `v0.4.x` beta line. This release records the live Fly deployment proof and
+makes the release-status public manifest check fail if the license API is not
+healthy for this beta.
+
+## Included Changes
+
+- Fix the Fly health-check TOML shape so the current Fly CLI accepts
+  `services/license-api/fly.toml` and can deploy the service.
+- Deploy `neondiff-license` on Fly with SQLite backed by the existing
+  `license_data` volume.
+- Verify the public health endpoint, with a resolver-pinned curl check while
+  the local macOS resolver cache was stale.
+- Smoke-test a throwaway private-scope license through issue, activate,
+  validate, deactivate, revoke, and validate-after-revoke.
+- Update `docs/public-release-manifest.json` so `licenseApi` is
+  `requiredForThisRelease: true`, `state: healthy`, and points at the live
+  health URL.
+
+## Required Gates
+
+- PR `#380` merged to `main` after exact-head GitHub Actions, CodeQL, Socket,
+  CodeRabbit, evaOS review status, and unresolved review-thread checks passed.
+- Fly status shows machine `2861d25f04e698` started in `iad` with `1/1`
+  checks passing.
+- Public `/healthz` returns `{"status":"ok"}` at
+  `https://neondiff-license.fly.dev/healthz`.
+- Redacted live smoke evidence exists for issue, activate, validate,
+  deactivate, revoke, and validate-after-revoke. No raw license key is included
+  in release notes, GitHub comments, or shared evidence.
+- Release checkout validation: public-release readiness focused test,
+  release-status focused test, `npm run build`, `git diff --check`, secret scan,
+  and public claims scan.
+- Post-tag `Publish npm` workflow completes as a source-only skip, not a failed
+  npm publish attempt.
+- Post-tag `release:status` passes with:
+  - `--public-release-manifest docs/public-release-manifest.json`
+  - `--expected-public-version v0.4.43-beta.1`
+  - live launchd expected head equal to the promoted tag SHA.
+
+## Caveats
+
+- This release does not publish a new npm package; the public npm package
+  remains `neondiff@0.4.30-beta.1`.
+- This release does not cut stable `v1.0.0`, claim GA, or claim customer
+  readiness beyond the live license API gate.
+- This release does not ship a signed, notarized desktop artifact or publish a
+  production Sparkle appcast.
+- The license API uses the direct/admin key issuance lane. Marketplace billing,
+  team seats, enterprise policy, and public customer portal workflows remain
+  separate follow-on lanes.
+
+## Rollback
+
+```bash
+cd /Volumes/LEXAR/repos/evaos-code-review-bot
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v0.4.42-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```

--- a/docs/releases/v0.4.43-beta.1.md
+++ b/docs/releases/v0.4.43-beta.1.md
@@ -20,8 +20,8 @@ to a live required gate in the public release manifest.
 
 The source code for the license service and deploy assets had already landed in
 the `v0.4.x` beta line. This release records the live Fly deployment proof and
-makes the release-status public manifest check fail if the license API is not
-healthy for this beta.
+makes the release-status public manifest check fail unless the license API has a
+machine-checkable health proof for this beta.
 
 ## Included Changes
 
@@ -35,7 +35,7 @@ healthy for this beta.
   validate, deactivate, revoke, and validate-after-revoke.
 - Update `docs/public-release-manifest.json` so `licenseApi` is
   `requiredForThisRelease: true`, `state: healthy`, and points at the live
-  health URL.
+  health URL plus a committed machine-checkable health proof for this beta.
 
 ## Required Gates
 
@@ -46,8 +46,9 @@ healthy for this beta.
 - Public `/healthz` returns `{"status":"ok"}` at
   `https://neondiff-license.fly.dev/healthz`.
 - The manifest points at a committed redacted health proof JSON under
-  `docs/evidence/`, and `release-status` requires that proof file when the
-  license API gate is `requiredForThisRelease: true` and `state: healthy`.
+  `docs/evidence/`, and `release-status` validates proof kind, release version,
+  URL, method, status code, observed timestamp, and body hash when the license
+  API gate is `requiredForThisRelease: true` and `state: healthy`.
 - Redacted live smoke evidence exists for issue, activate, validate,
   deactivate, revoke, and validate-after-revoke in the operator-local evidence
   packet. No raw license key is included in release notes, GitHub comments,

--- a/docs/releases/v0.4.43-beta.1.md
+++ b/docs/releases/v0.4.43-beta.1.md
@@ -47,8 +47,9 @@ machine-checkable health proof for this beta.
   `https://neondiff-license.fly.dev/healthz`.
 - The manifest points at a committed redacted health proof JSON under
   `docs/evidence/`, and `release-status` validates proof kind, release version,
-  URL, method, status code, observed timestamp, and body hash when the license
-  API gate is `requiredForThisRelease: true` and `state: healthy`.
+  URL, method, status code, observed timestamp freshness, body hash, and capture
+  context when the license API gate is `requiredForThisRelease: true` and
+  `state: healthy`.
 - Redacted live smoke evidence exists for issue, activate, validate,
   deactivate, revoke, and validate-after-revoke in the operator-local evidence
   packet. No raw license key is included in release notes, GitHub comments,

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -870,10 +870,16 @@ function validateLicenseHealthProof(input: {
   const failures: string[] = [];
 
   if (evidenceKind !== "license_api_healthz") failures.push("evidenceKind must be license_api_healthz");
-  if (input.expectedReleaseVersion && releaseVersion !== input.expectedReleaseVersion) {
+  if (!input.expectedReleaseVersion) {
+    failures.push("expected releaseVersion must be present");
+  } else if (releaseVersion !== input.expectedReleaseVersion) {
     failures.push(`releaseVersion must match ${input.expectedReleaseVersion}`);
   }
-  if (input.expectedUrl && url !== input.expectedUrl) failures.push(`url must match ${input.expectedUrl}`);
+  if (!input.expectedUrl) {
+    failures.push("healthUrl must be present when validating health proof");
+  } else if (url !== input.expectedUrl) {
+    failures.push(`url must match ${input.expectedUrl}`);
+  }
   if (method !== "GET") failures.push("method must be GET");
   if (statusCode !== 200) failures.push("statusCode must be 200");
   const observedAtMs = observedAt ? Date.parse(observedAt) : NaN;

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -186,6 +186,8 @@ export interface ReleaseStatus {
 const REQUIRED_PUBLIC_UPDATE_CHANNELS = ["cli", "daemon"] as const;
 const PUBLIC_RELEASE_LEVELS = new Set(["beta", "source-beta", "stable"]);
 const MAX_PUBLIC_VERSION_TAG_LENGTH = 128;
+const LICENSE_HEALTH_PROOF_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1_000;
+const LICENSE_HEALTH_PROOF_MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
 const REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES = new Set(["source_checkout", "launchd_prerelease", "healthy", "published"]);
 const GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES = new Set([
   ...REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES,
@@ -438,7 +440,8 @@ export function collectReleaseStatus(input: {
             cwd: input.cwd,
             manifestPath: input.publicReleaseManifestPath,
             expectedVersion: input.expectedPublicVersion,
-            verifyRollbackRefs: input.verifyPublicRollbackRefs === true
+            verifyRollbackRefs: input.verifyPublicRollbackRefs === true,
+            now
           })
         }
       : {}),
@@ -469,6 +472,7 @@ export function readPublicReleaseManifestStatus(input: {
   manifestPath: string;
   expectedVersion?: string;
   verifyRollbackRefs?: boolean;
+  now?: Date;
 }): PublicReleaseStatus {
   const absolutePath = resolve(input.cwd, input.manifestPath);
   if (!existsSync(absolutePath)) {
@@ -544,7 +548,8 @@ export function readPublicReleaseManifestStatus(input: {
           cwd: input.cwd,
           proofPath: licenseHealthProofPath,
           expectedReleaseVersion: expectedVersion,
-          expectedUrl: readString(licenseApi.healthUrl)
+          expectedUrl: readString(licenseApi.healthUrl),
+          now: input.now
         })
       : { ok: true, detail: "" };
     const licenseHealthProofOk = licenseHealthProof.ok;
@@ -833,6 +838,7 @@ function validateLicenseHealthProof(input: {
   proofPath?: string;
   expectedReleaseVersion?: string;
   expectedUrl?: string;
+  now?: Date;
 }): { ok: boolean; detail: string } {
   if (!input.proofPath) return { ok: false, detail: "missing health proof (missing)" };
   const absolutePath = resolve(input.cwd, input.proofPath);
@@ -853,6 +859,11 @@ function validateLicenseHealthProof(input: {
   const statusCode = typeof proof.statusCode === "number" ? proof.statusCode : undefined;
   const responseBody = typeof proof.responseBody === "string" ? proof.responseBody : undefined;
   const responseBodySha256 = readString(proof.responseBodySha256);
+  const captureContext = asRecord(proof.captureContext);
+  const captureTool = readString(captureContext.tool);
+  const captureTransport = readString(captureContext.transport);
+  const captureTlsValidation = readString(captureContext.tlsValidation);
+  const captureHost = readString(captureContext.capturedFrom);
   const failures: string[] = [];
 
   if (evidenceKind !== "license_api_healthz") failures.push("evidenceKind must be license_api_healthz");
@@ -862,7 +873,18 @@ function validateLicenseHealthProof(input: {
   if (input.expectedUrl && url !== input.expectedUrl) failures.push(`url must match ${input.expectedUrl}`);
   if (method !== "GET") failures.push("method must be GET");
   if (statusCode !== 200) failures.push("statusCode must be 200");
-  if (!observedAt || Number.isNaN(Date.parse(observedAt))) failures.push("observedAt must be a valid ISO timestamp");
+  const observedAtMs = observedAt ? Date.parse(observedAt) : NaN;
+  if (!observedAt || Number.isNaN(observedAtMs)) {
+    failures.push("observedAt must be a valid ISO timestamp");
+  } else if (input.now) {
+    const nowMs = input.now.getTime();
+    if (observedAtMs > nowMs + LICENSE_HEALTH_PROOF_MAX_FUTURE_SKEW_MS) {
+      failures.push("observedAt must not be more than 5 minutes in the future");
+    }
+    if (nowMs - observedAtMs > LICENSE_HEALTH_PROOF_MAX_AGE_MS) {
+      failures.push("observedAt must be no older than 7 days");
+    }
+  }
   if (responseBody === undefined) {
     failures.push("responseBody must be present");
   }
@@ -871,6 +893,10 @@ function validateLicenseHealthProof(input: {
   } else if (responseBody !== undefined && createHash("sha256").update(responseBody).digest("hex") !== responseBodySha256) {
     failures.push("responseBodySha256 must match responseBody");
   }
+  if (!captureTool) failures.push("captureContext.tool must be present");
+  if (!captureTransport) failures.push("captureContext.transport must be present");
+  if (!captureTlsValidation) failures.push("captureContext.tlsValidation must be present");
+  if (!captureHost) failures.push("captureContext.capturedFrom must be present");
 
   return failures.length
     ? { ok: false, detail: `invalid health proof ${input.proofPath}: ${failures.join("; ")}` }

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -186,7 +186,8 @@ export interface ReleaseStatus {
 const REQUIRED_PUBLIC_UPDATE_CHANNELS = ["cli", "daemon"] as const;
 const PUBLIC_RELEASE_LEVELS = new Set(["beta", "source-beta", "stable"]);
 const MAX_PUBLIC_VERSION_TAG_LENGTH = 128;
-const LICENSE_HEALTH_PROOF_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1_000;
+const LICENSE_HEALTH_PROOF_MAX_AGE_DAYS = 30;
+const LICENSE_HEALTH_PROOF_MAX_AGE_MS = LICENSE_HEALTH_PROOF_MAX_AGE_DAYS * 24 * 60 * 60 * 1_000;
 const LICENSE_HEALTH_PROOF_MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
 const REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES = new Set(["source_checkout", "launchd_prerelease", "healthy", "published"]);
 const GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES = new Set([
@@ -878,13 +879,13 @@ function validateLicenseHealthProof(input: {
   const observedAtMs = observedAt ? Date.parse(observedAt) : NaN;
   if (!observedAt || Number.isNaN(observedAtMs)) {
     failures.push("observedAt must be a valid ISO timestamp");
-  } else if (input.now) {
-    const nowMs = input.now.getTime();
+  } else {
+    const nowMs = (input.now ?? new Date()).getTime();
     if (observedAtMs > nowMs + LICENSE_HEALTH_PROOF_MAX_FUTURE_SKEW_MS) {
       failures.push("observedAt must not be more than 5 minutes in the future");
     }
     if (nowMs - observedAtMs > LICENSE_HEALTH_PROOF_MAX_AGE_MS) {
-      failures.push("observedAt must be no older than 7 days");
+      failures.push(`observedAt must be no older than ${LICENSE_HEALTH_PROOF_MAX_AGE_DAYS} days`);
     }
   }
   if (responseBody === undefined) {
@@ -916,8 +917,14 @@ function resolveConfinedHealthProofPath(cwd: string, proofPath: string): { ok: t
   }
   if (!existsSync(absolutePath)) return { ok: true, absolutePath };
 
-  const realEvidenceRoot = realpathSync.native(evidenceRoot);
-  const realProofPath = realpathSync.native(absolutePath);
+  let realEvidenceRoot: string;
+  let realProofPath: string;
+  try {
+    realEvidenceRoot = realpathSync.native(evidenceRoot);
+    realProofPath = realpathSync.native(absolutePath);
+  } catch {
+    return { ok: false, detail: "healthProofPath could not be resolved within docs/evidence" };
+  }
   if (!isPathInsideOrEqual(realProofPath, realEvidenceRoot)) {
     return { ok: false, detail: "healthProofPath must be relative and stay within docs/evidence" };
   }

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -1,7 +1,7 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { loadConfig } from "./config.js";
 import { buildReviewBudgetStatus, type ReviewBudgetStatus } from "./review-budget.js";
@@ -841,7 +841,9 @@ function validateLicenseHealthProof(input: {
   now?: Date;
 }): { ok: boolean; detail: string } {
   if (!input.proofPath) return { ok: false, detail: "missing health proof (missing)" };
-  const absolutePath = resolve(input.cwd, input.proofPath);
+  const confinedPath = resolveConfinedHealthProofPath(input.cwd, input.proofPath);
+  if (!confinedPath.ok) return { ok: false, detail: `invalid health proof ${input.proofPath}: ${confinedPath.detail}` };
+  const absolutePath = confinedPath.absolutePath;
   if (!existsSync(absolutePath)) return { ok: false, detail: `missing health proof ${input.proofPath}` };
 
   let proof: Record<string, unknown>;
@@ -901,6 +903,30 @@ function validateLicenseHealthProof(input: {
   return failures.length
     ? { ok: false, detail: `invalid health proof ${input.proofPath}: ${failures.join("; ")}` }
     : { ok: true, detail: `validated health proof ${input.proofPath}` };
+}
+
+function resolveConfinedHealthProofPath(cwd: string, proofPath: string): { ok: true; absolutePath: string } | { ok: false; detail: string } {
+  if (isAbsolute(proofPath)) {
+    return { ok: false, detail: "healthProofPath must be relative and stay within docs/evidence" };
+  }
+  const evidenceRoot = resolve(cwd, "docs", "evidence");
+  const absolutePath = resolve(cwd, proofPath);
+  if (!isPathInsideOrEqual(absolutePath, evidenceRoot)) {
+    return { ok: false, detail: "healthProofPath must be relative and stay within docs/evidence" };
+  }
+  if (!existsSync(absolutePath)) return { ok: true, absolutePath };
+
+  const realEvidenceRoot = realpathSync.native(evidenceRoot);
+  const realProofPath = realpathSync.native(absolutePath);
+  if (!isPathInsideOrEqual(realProofPath, realEvidenceRoot)) {
+    return { ok: false, detail: "healthProofPath must be relative and stay within docs/evidence" };
+  }
+  return { ok: true, absolutePath };
+}
+
+function isPathInsideOrEqual(target: string, root: string): boolean {
+  const rel = relative(root, target);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
 function isUpdateChannelStateAcceptable(name: string, state: string, requiredForThisRelease: boolean): boolean {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -119,6 +119,7 @@ export interface PublicReleaseStatus {
     state: string;
     trackingIssue?: string;
     healthUrl?: string;
+    healthProofPath?: string;
   };
   updateChannels: {
     ok: boolean;
@@ -535,7 +536,11 @@ export function readPublicReleaseManifestStatus(input: {
     const licenseRequired = releaseLevel === "source-beta"
       ? (readBoolean(licenseApi.requiredForThisRelease) ?? true)
       : true;
-    const licenseOk = isLicenseApiStateAcceptable(licenseState, licenseRequired);
+    const licenseHealthProofPath = readString(licenseApi.healthProofPath);
+    const licenseNeedsHealthProof = licenseRequired && licenseState === "healthy";
+    const licenseHealthProofOk =
+      !licenseNeedsHealthProof || Boolean(licenseHealthProofPath && existsSync(resolve(input.cwd, licenseHealthProofPath)));
+    const licenseOk = isLicenseApiStateAcceptable(licenseState, licenseRequired) && licenseHealthProofOk;
     const declaredChannelNames = Object.keys(updateChannels);
     const channelNames = [
       ...REQUIRED_PUBLIC_UPDATE_CHANNELS,
@@ -597,9 +602,16 @@ export function readPublicReleaseManifestStatus(input: {
         state: licenseState,
         trackingIssue: readString(licenseApi.trackingIssue),
         healthUrl: readString(licenseApi.healthUrl),
+        healthProofPath: licenseHealthProofPath,
         detail: licenseOk
-          ? `license API state ${licenseState}; requiredForThisRelease=${licenseRequired}`
-          : `license API state ${licenseState} blocks this release; requiredForThisRelease=${licenseRequired}`
+          ? `license API state ${licenseState}; requiredForThisRelease=${licenseRequired}${
+              licenseHealthProofPath ? `; health proof ${licenseHealthProofPath}` : ""
+            }`
+          : `license API state ${licenseState} blocks this release; requiredForThisRelease=${licenseRequired}${
+              licenseNeedsHealthProof && !licenseHealthProofOk
+                ? `; missing health proof ${licenseHealthProofPath ?? "(missing)"}`
+                : ""
+            }`
       },
       updateChannels: {
         ok: channelsOk,

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -1,4 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -538,8 +539,15 @@ export function readPublicReleaseManifestStatus(input: {
       : true;
     const licenseHealthProofPath = readString(licenseApi.healthProofPath);
     const licenseNeedsHealthProof = licenseRequired && licenseState === "healthy";
-    const licenseHealthProofOk =
-      !licenseNeedsHealthProof || Boolean(licenseHealthProofPath && existsSync(resolve(input.cwd, licenseHealthProofPath)));
+    const licenseHealthProof = licenseNeedsHealthProof
+      ? validateLicenseHealthProof({
+          cwd: input.cwd,
+          proofPath: licenseHealthProofPath,
+          expectedReleaseVersion: expectedVersion,
+          expectedUrl: readString(licenseApi.healthUrl)
+        })
+      : { ok: true, detail: "" };
+    const licenseHealthProofOk = licenseHealthProof.ok;
     const licenseOk = isLicenseApiStateAcceptable(licenseState, licenseRequired) && licenseHealthProofOk;
     const declaredChannelNames = Object.keys(updateChannels);
     const channelNames = [
@@ -605,11 +613,11 @@ export function readPublicReleaseManifestStatus(input: {
         healthProofPath: licenseHealthProofPath,
         detail: licenseOk
           ? `license API state ${licenseState}; requiredForThisRelease=${licenseRequired}${
-              licenseHealthProofPath ? `; health proof ${licenseHealthProofPath}` : ""
+              licenseHealthProofPath ? `; ${licenseHealthProof.detail}` : ""
             }`
           : `license API state ${licenseState} blocks this release; requiredForThisRelease=${licenseRequired}${
               licenseNeedsHealthProof && !licenseHealthProofOk
-                ? `; missing health proof ${licenseHealthProofPath ?? "(missing)"}`
+                ? `; ${licenseHealthProof.detail}`
                 : ""
             }`
       },
@@ -818,6 +826,55 @@ function gitCommitishExists(cwd: string, target: string): boolean {
 function isLicenseApiStateAcceptable(state: string, requiredForThisRelease: boolean): boolean {
   if (requiredForThisRelease) return state === "healthy";
   return state === "healthy" || state === "not_applicable" || state === "disabled" || state === "pending";
+}
+
+function validateLicenseHealthProof(input: {
+  cwd: string;
+  proofPath?: string;
+  expectedReleaseVersion?: string;
+  expectedUrl?: string;
+}): { ok: boolean; detail: string } {
+  if (!input.proofPath) return { ok: false, detail: "missing health proof (missing)" };
+  const absolutePath = resolve(input.cwd, input.proofPath);
+  if (!existsSync(absolutePath)) return { ok: false, detail: `missing health proof ${input.proofPath}` };
+
+  let proof: Record<string, unknown>;
+  try {
+    proof = asRecord(JSON.parse(readFileSync(absolutePath, "utf8")));
+  } catch {
+    return { ok: false, detail: `invalid health proof ${input.proofPath}: proof JSON is invalid` };
+  }
+
+  const evidenceKind = readString(proof.evidenceKind);
+  const releaseVersion = readString(proof.releaseVersion);
+  const observedAt = readString(proof.observedAt);
+  const method = readString(proof.method);
+  const url = readString(proof.url);
+  const statusCode = typeof proof.statusCode === "number" ? proof.statusCode : undefined;
+  const responseBody = typeof proof.responseBody === "string" ? proof.responseBody : undefined;
+  const responseBodySha256 = readString(proof.responseBodySha256);
+  const failures: string[] = [];
+
+  if (evidenceKind !== "license_api_healthz") failures.push("evidenceKind must be license_api_healthz");
+  if (input.expectedReleaseVersion && releaseVersion !== input.expectedReleaseVersion) {
+    failures.push(`releaseVersion must match ${input.expectedReleaseVersion}`);
+  }
+  if (input.expectedUrl && url !== input.expectedUrl) failures.push(`url must match ${input.expectedUrl}`);
+  if (method !== "GET") failures.push("method must be GET");
+  if (statusCode !== 200) failures.push("statusCode must be 200");
+  if (!observedAt || Number.isNaN(Date.parse(observedAt))) failures.push("observedAt must be a valid ISO timestamp");
+  if (responseBody === undefined) {
+    failures.push("responseBody must be present");
+  }
+  if (!responseBodySha256) {
+    failures.push("responseBodySha256 must be present");
+  } else if (responseBody !== undefined && createHash("sha256").update(responseBody).digest("hex") !== responseBodySha256) {
+    failures.push("responseBodySha256 must match responseBody");
+  }
+
+  return failures.length
+    ? { ok: false, detail: `invalid health proof ${input.proofPath}: ${failures.join("; ")}` }
+    : { ok: true, detail: `validated health proof ${input.proofPath}` };
 }
 
 function isUpdateChannelStateAcceptable(name: string, state: string, requiredForThisRelease: boolean): boolean {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -543,18 +543,30 @@ export function readPublicReleaseManifestStatus(input: {
       ? (readBoolean(licenseApi.requiredForThisRelease) ?? true)
       : true;
     const licenseHealthProofPath = readString(licenseApi.healthProofPath);
+    const licenseHealthUrl = readString(licenseApi.healthUrl);
     const licenseNeedsHealthProof = licenseRequired && licenseState === "healthy";
+    const licenseMetadataFailures = validateLicenseHealthMetadata({
+      cwd: input.cwd,
+      healthUrl: licenseHealthUrl,
+      healthProofPath: licenseHealthProofPath,
+      proofRequired: licenseNeedsHealthProof
+    });
     const licenseHealthProof = licenseNeedsHealthProof
       ? validateLicenseHealthProof({
           cwd: input.cwd,
           proofPath: licenseHealthProofPath,
           expectedReleaseVersion: expectedVersion,
-          expectedUrl: readString(licenseApi.healthUrl),
+          expectedUrl: licenseHealthUrl,
           now: input.now
         })
       : { ok: true, detail: "" };
     const licenseHealthProofOk = licenseHealthProof.ok;
-    const licenseOk = isLicenseApiStateAcceptable(licenseState, licenseRequired) && licenseHealthProofOk;
+    const licenseMetadataOk = licenseMetadataFailures.length === 0;
+    const licenseOk = isLicenseApiStateAcceptable(licenseState, licenseRequired) && licenseMetadataOk && licenseHealthProofOk;
+    const licenseDetailParts = [
+      ...(licenseNeedsHealthProof ? [licenseHealthProof.detail] : []),
+      ...licenseMetadataFailures
+    ].filter(Boolean);
     const declaredChannelNames = Object.keys(updateChannels);
     const channelNames = [
       ...REQUIRED_PUBLIC_UPDATE_CHANNELS,
@@ -615,15 +627,15 @@ export function readPublicReleaseManifestStatus(input: {
         requiredForThisRelease: licenseRequired,
         state: licenseState,
         trackingIssue: readString(licenseApi.trackingIssue),
-        healthUrl: readString(licenseApi.healthUrl),
+        healthUrl: licenseHealthUrl,
         healthProofPath: licenseHealthProofPath,
         detail: licenseOk
           ? `license API state ${licenseState}; requiredForThisRelease=${licenseRequired}${
-              licenseNeedsHealthProof ? `; ${licenseHealthProof.detail}` : ""
+              licenseDetailParts.length ? `; ${licenseDetailParts.join("; ")}` : ""
             }`
           : `license API state ${licenseState} blocks this release; requiredForThisRelease=${licenseRequired}${
-              licenseNeedsHealthProof && !licenseHealthProofOk
-                ? `; ${licenseHealthProof.detail}`
+              licenseDetailParts.length
+                ? `; ${licenseDetailParts.join("; ")}`
                 : ""
             }`
       },
@@ -841,7 +853,7 @@ function validateLicenseHealthProof(input: {
   expectedUrl?: string;
   now?: Date;
 }): { ok: boolean; detail: string } {
-  if (!input.proofPath) return { ok: false, detail: "missing health proof (missing)" };
+  if (!input.proofPath) return { ok: false, detail: "missing health proof path (no healthProofPath declared)" };
   const confinedPath = resolveConfinedHealthProofPath(input.cwd, input.proofPath);
   if (!confinedPath.ok) return { ok: false, detail: `invalid health proof ${input.proofPath}: ${confinedPath.detail}` };
   const absolutePath = confinedPath.absolutePath;
@@ -910,6 +922,44 @@ function validateLicenseHealthProof(input: {
   return failures.length
     ? { ok: false, detail: `invalid health proof ${input.proofPath}: ${failures.join("; ")}` }
     : { ok: true, detail: `validated health proof ${input.proofPath}` };
+}
+
+function validateLicenseHealthMetadata(input: {
+  cwd: string;
+  healthUrl?: string;
+  healthProofPath?: string;
+  proofRequired: boolean;
+}): string[] {
+  const failures: string[] = [];
+  if (input.healthUrl) {
+    const healthUrlFailure = validateLicenseHealthUrl(input.healthUrl);
+    if (healthUrlFailure) failures.push(healthUrlFailure);
+  }
+  if (input.healthProofPath && !input.proofRequired) {
+    const confinedPath = resolveConfinedHealthProofPath(input.cwd, input.healthProofPath);
+    if (!confinedPath.ok) failures.push(`invalid health proof ${input.healthProofPath}: ${confinedPath.detail}`);
+  }
+  return failures;
+}
+
+function validateLicenseHealthUrl(healthUrl: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(healthUrl);
+  } catch {
+    return "healthUrl must be an https URL ending in /healthz with no credentials, query, or fragment";
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.pathname !== "/healthz" ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    return "healthUrl must be an https URL ending in /healthz with no credentials, query, or fragment";
+  }
+  return undefined;
 }
 
 function resolveConfinedHealthProofPath(cwd: string, proofPath: string): { ok: true; absolutePath: string } | { ok: false; detail: string } {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -613,7 +613,7 @@ export function readPublicReleaseManifestStatus(input: {
         healthProofPath: licenseHealthProofPath,
         detail: licenseOk
           ? `license API state ${licenseState}; requiredForThisRelease=${licenseRequired}${
-              licenseHealthProofPath ? `; ${licenseHealthProof.detail}` : ""
+              licenseNeedsHealthProof ? `; ${licenseHealthProof.detail}` : ""
             }`
           : `license API state ${licenseState} blocks this release; requiredForThisRelease=${licenseRequired}${
               licenseNeedsHealthProof && !licenseHealthProofOk

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -934,7 +934,7 @@ function resolveConfinedHealthProofPath(cwd: string, proofPath: string): { ok: t
   if (!isPathInsideOrEqual(realProofPath, realEvidenceRoot)) {
     return { ok: false, detail: "healthProofPath must be relative and stay within docs/evidence" };
   }
-  return { ok: true, absolutePath };
+  return { ok: true, absolutePath: realProofPath };
 }
 
 function isPathInsideOrEqual(target: string, root: string): boolean {

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -89,12 +89,31 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.40-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.41-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.42-beta.1");
+    expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.43-beta.1");
     expect(manifest.packageArtifact?.note).toMatch(/source\/local-worker/i);
     expect(manifest.source).toMatchObject({
       shaState: "pending_tag_stamp",
-      candidateHeadBeforeReleaseMetadata: "97aa93f4ce1231feb06ca68e6f592f14bf519ffe"
+      candidateHeadBeforeReleaseMetadata: "10d897dc82e23acbe144d70d10cc83fcd3c52f8c"
     });
     expect(manifest.source?.proof).toMatch(/after merge and tag/i);
+  });
+
+  it("requires the live production license API for this beta", () => {
+    const manifest = JSON.parse(read("docs/public-release-manifest.json")) as {
+      licenseApi?: {
+        requiredForThisRelease?: boolean;
+        state?: string;
+        trackingIssue?: string;
+        healthUrl?: string;
+      };
+    };
+
+    expect(manifest.licenseApi).toMatchObject({
+      requiredForThisRelease: true,
+      state: "healthy",
+      trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327",
+      healthUrl: "https://neondiff-license.fly.dev/healthz"
+    });
   });
 
   it("ships the canonical install script contract", () => {

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -111,9 +111,9 @@ describe("NeonDiff public release readiness", () => {
 
     expect(manifest.licenseApi).toMatchObject({
       requiredForThisRelease: true,
-      state: "healthy",
-      trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327"
+      state: "healthy"
     });
+    expect(manifest.licenseApi?.trackingIssue).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/);
     expect(manifest.licenseApi?.healthUrl).toMatch(/^https:\/\/[^/]+\/healthz$/);
     expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v0.4.43-beta.1-license-api-healthz.json");
 

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -105,14 +105,33 @@ describe("NeonDiff public release readiness", () => {
         state?: string;
         trackingIssue?: string;
         healthUrl?: string;
+        healthProofPath?: string;
       };
     };
 
     expect(manifest.licenseApi).toMatchObject({
       requiredForThisRelease: true,
       state: "healthy",
-      trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327",
-      healthUrl: "https://neondiff-license.fly.dev/healthz"
+      trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327"
+    });
+    expect(manifest.licenseApi?.healthUrl).toMatch(/^https:\/\/[^/]+\/healthz$/);
+    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v0.4.43-beta.1-license-api-healthz.json");
+
+    const proof = JSON.parse(read(manifest.licenseApi?.healthProofPath ?? "")) as {
+      evidenceKind?: string;
+      releaseVersion?: string;
+      url?: string;
+      statusCode?: number;
+      responseBody?: string;
+      responseBodySha256?: string;
+    };
+    expect(proof).toMatchObject({
+      evidenceKind: "license_api_healthz",
+      releaseVersion: "v0.4.43-beta.1",
+      url: manifest.licenseApi?.healthUrl,
+      statusCode: 200,
+      responseBody: "{\"status\":\"ok\"}",
+      responseBodySha256: "a29ee2b15c494311c52521766e44af56a3ad2248e7a8ab465e5206463c13d288"
     });
   });
 

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
@@ -130,9 +131,9 @@ describe("NeonDiff public release readiness", () => {
       releaseVersion: "v0.4.43-beta.1",
       url: manifest.licenseApi?.healthUrl,
       statusCode: 200,
-      responseBody: "{\"status\":\"ok\"}",
-      responseBodySha256: "a29ee2b15c494311c52521766e44af56a3ad2248e7a8ab465e5206463c13d288"
+      responseBody: "{\"status\":\"ok\"}"
     });
+    expect(createHash("sha256").update(proof.responseBody ?? "").digest("hex")).toBe(proof.responseBodySha256);
   });
 
   it("ships the canonical install script contract", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -193,16 +193,22 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.42-beta.1"
+      expectedVersion: "v0.4.43-beta.1"
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v0.4.42-beta.1",
+      version: "v0.4.43-beta.1",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v0.4.42-beta.1.md"
+        releaseNotesPath: "docs/releases/v0.4.43-beta.1.md"
+      },
+      licenseApi: {
+        ok: true,
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://neondiff-license.fly.dev/healthz"
       },
       updateChannels: {
         ok: true
@@ -213,12 +219,12 @@ describe("beta release status", () => {
         expect.objectContaining({
           name: "cli",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.41-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.42-beta.1"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.41-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.42-beta.1"
         })
       ])
     );
@@ -285,13 +291,13 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v0.4.42-beta.1",
+      expectedPublicVersion: "v0.4.43-beta.1",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot"
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v0.4.42-beta.1"
+      version: "v0.4.43-beta.1"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
@@ -303,7 +309,7 @@ describe("beta release status", () => {
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok
     });
-    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.41-beta.1");
+    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.42-beta.1");
     expect(redactedOutput).toContain("cli=published; daemon=launchd_prerelease");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
   });

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -228,7 +228,8 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.43-beta.1"
+      expectedVersion: "v0.4.43-beta.1",
+      now: new Date("2026-07-07T09:10:00.000Z")
     });
 
     expect(manifest).toMatchObject({

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -226,15 +226,10 @@ describe("beta release status", () => {
 
   it("validates the shipped public release manifest against the shipped release notes", () => {
     // Intentional shipped-manifest smoke: keep assertions scoped to publicRelease fields.
-    const shippedProof = JSON.parse(
-      readFileSync(join(repoRoot, "docs/evidence/v0.4.43-beta.1-license-api-healthz.json"), "utf8")
-    ) as { observedAt: string };
-    const proofObservedAt = Date.parse(shippedProof.observedAt);
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.43-beta.1",
-      now: new Date(proofObservedAt + 15_000)
+      expectedVersion: "v0.4.43-beta.1"
     });
 
     expect(manifest).toMatchObject({

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -714,6 +714,58 @@ describe("beta release status", () => {
     expect(manifest.ok).toBe(false);
   });
 
+  it("blocks required healthy license API gates without committed health proof", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-missing-health-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath: "docs/evidence/missing-health-proof.json"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi).toMatchObject({
+      ok: false,
+      requiredForThisRelease: true,
+      state: "healthy",
+      healthProofPath: "docs/evidence/missing-health-proof.json",
+      detail: "license API state healthy blocks this release; requiredForThisRelease=true; missing health proof docs/evidence/missing-health-proof.json"
+    });
+    expect(manifest.ok).toBe(false);
+  });
+
   it("blocks optional channel deferrals outside source-beta releases", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stable-channel-deferral-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -1006,6 +1006,61 @@ describe("beta release status", () => {
     expect(manifest.licenseApi.ok).toBe(false);
     expect(manifest.licenseApi.detail).toContain("healthUrl must be present when validating health proof");
     expect(manifest.ok).toBe(false);
+  });
+
+  it("accepts a symlinked health proof only after realpath confinement", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-symlink-health-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "evidence"), { recursive: true });
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeLicenseHealthProof(root, { path: "docs/evidence/license-healthz-target.json" });
+    symlinkSync("license-healthz-target.json", join(root, "docs", "evidence", "license-healthz-link.json"));
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath: "docs/evidence/license-healthz-link.json"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi).toMatchObject({
+      ok: true,
+      requiredForThisRelease: true,
+      state: "healthy",
+      healthProofPath: "docs/evidence/license-healthz-link.json",
+      detail: "license API state healthy; requiredForThisRelease=true; validated health proof docs/evidence/license-healthz-link.json"
+    });
+    expect(manifest.ok).toBe(true);
   });
 
   it("blocks required healthy license API gates when the proof file is not machine-checkable JSON", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -444,6 +444,57 @@ describe("beta release status", () => {
     expect(redactedOutput).toContain("[redacted-secret]");
   });
 
+  it("does not append empty health-proof detail when proof is not required", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-optional-proof-detail-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath: "docs/evidence/retained-health-proof.json"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi).toMatchObject({
+      ok: true,
+      requiredForThisRelease: false,
+      state: "pending",
+      healthProofPath: "docs/evidence/retained-health-proof.json",
+      detail: "license API state pending; requiredForThisRelease=false"
+    });
+  });
+
   it("preserves Date values when redacting JSON output", () => {
     const redactedOutput = stringifyRedactedJson({
       checkedAt: new Date("2026-07-04T00:00:00.000Z"),

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildReleaseStatus,
   collectReleaseStatus,
@@ -23,6 +23,7 @@ describe("beta release status", () => {
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
   afterEach(() => {
+    vi.useRealTimers();
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   });
 
@@ -44,7 +45,7 @@ describe("beta release status", () => {
     writeFileSync(join(root, proofPath), JSON.stringify({
       evidenceKind: options.evidenceKind ?? "license_api_healthz",
       releaseVersion: options.releaseVersion ?? "v1.0.0-beta.1",
-      observedAt: options.observedAt ?? "2026-07-07T00:00:00.000Z",
+      observedAt: options.observedAt ?? new Date().toISOString(),
       method: options.method ?? "GET",
       url: options.url ?? "https://license.example/healthz",
       statusCode: options.statusCode ?? 200,
@@ -1084,7 +1085,7 @@ describe("beta release status", () => {
     writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
     writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
     const healthProofPath = writeLicenseHealthProof(root, {
-      observedAt: "2026-06-29T23:59:59.000Z"
+      observedAt: "2026-06-06T23:59:59.000Z"
     });
     writeFileSync(join(root, "public-release.json"), JSON.stringify({
       version: "v1.0.0-beta.1",
@@ -1124,7 +1125,60 @@ describe("beta release status", () => {
     });
 
     expect(manifest.licenseApi.ok).toBe(false);
-    expect(manifest.licenseApi.detail).toContain("observedAt must be no older than 7 days");
+    expect(manifest.licenseApi.detail).toContain("observedAt must be no older than 30 days");
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("checks health proof freshness when callers omit now", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-07T00:00:00.000Z"));
+
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-default-now-health-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    const healthProofPath = writeLicenseHealthProof(root, {
+      observedAt: "2026-06-06T23:59:59.000Z"
+    });
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.ok).toBe(false);
+    expect(manifest.licenseApi.detail).toContain("observedAt must be no older than 30 days");
     expect(manifest.ok).toBe(false);
   });
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -27,22 +27,35 @@ describe("beta release status", () => {
   });
 
   function writeLicenseHealthProof(root: string, options: {
+    evidenceKind?: string;
     releaseVersion?: string;
+    observedAt?: string;
+    method?: string;
     url?: string;
+    statusCode?: number;
+    responseBody?: string;
+    responseBodySha256?: string;
+    captureContext?: Record<string, unknown>;
     path?: string;
   } = {}): string {
     const proofPath = options.path ?? "docs/evidence/license-healthz.json";
-    const responseBody = "{\"status\":\"ok\"}";
+    const responseBody = options.responseBody ?? "{\"status\":\"ok\"}";
     mkdirSync(dirname(join(root, proofPath)), { recursive: true });
     writeFileSync(join(root, proofPath), JSON.stringify({
-      evidenceKind: "license_api_healthz",
+      evidenceKind: options.evidenceKind ?? "license_api_healthz",
       releaseVersion: options.releaseVersion ?? "v1.0.0-beta.1",
-      observedAt: "2026-07-07T00:00:00.000Z",
-      method: "GET",
+      observedAt: options.observedAt ?? "2026-07-07T00:00:00.000Z",
+      method: options.method ?? "GET",
       url: options.url ?? "https://license.example/healthz",
-      statusCode: 200,
+      statusCode: options.statusCode ?? 200,
       responseBody,
-      responseBodySha256: createHash("sha256").update(responseBody).digest("hex")
+      responseBodySha256: options.responseBodySha256 ?? createHash("sha256").update(responseBody).digest("hex"),
+      captureContext: options.captureContext ?? {
+        tool: "curl",
+        transport: "https",
+        tlsValidation: "curl default CA validation",
+        capturedFrom: "test runner"
+      }
     }));
     return proofPath;
   }
@@ -888,6 +901,124 @@ describe("beta release status", () => {
       healthProofPath: "docs/releases/v1.0.0-beta.1.md",
       detail: "license API state healthy blocks this release; requiredForThisRelease=true; invalid health proof docs/releases/v1.0.0-beta.1.md: proof JSON is invalid"
     });
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("blocks required healthy license API gates when machine-checkable proof fields do not match", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-mismatched-health-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    const healthProofPath = writeLicenseHealthProof(root, {
+      evidenceKind: "not_license_api_healthz",
+      releaseVersion: "v1.0.0-beta.0",
+      observedAt: "not-a-date",
+      method: "POST",
+      url: "https://license.example/wrong",
+      statusCode: 503,
+      responseBodySha256: "not-the-body-hash",
+      captureContext: {}
+    });
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.ok).toBe(false);
+    expect(manifest.licenseApi.detail).toContain("evidenceKind must be license_api_healthz");
+    expect(manifest.licenseApi.detail).toContain("releaseVersion must match v1.0.0-beta.1");
+    expect(manifest.licenseApi.detail).toContain("url must match https://license.example/healthz");
+    expect(manifest.licenseApi.detail).toContain("method must be GET");
+    expect(manifest.licenseApi.detail).toContain("statusCode must be 200");
+    expect(manifest.licenseApi.detail).toContain("observedAt must be a valid ISO timestamp");
+    expect(manifest.licenseApi.detail).toContain("responseBodySha256 must match responseBody");
+    expect(manifest.licenseApi.detail).toContain("captureContext.tool must be present");
+    expect(manifest.licenseApi.detail).toContain("captureContext.transport must be present");
+    expect(manifest.licenseApi.detail).toContain("captureContext.tlsValidation must be present");
+    expect(manifest.licenseApi.detail).toContain("captureContext.capturedFrom must be present");
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("blocks stale or future health proofs when release-status supplies a run timestamp", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stale-health-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    const healthProofPath = writeLicenseHealthProof(root, {
+      observedAt: "2026-06-29T23:59:59.000Z"
+    });
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1",
+      now: new Date("2026-07-07T00:00:00.000Z")
+    });
+
+    expect(manifest.licenseApi.ok).toBe(false);
+    expect(manifest.licenseApi.detail).toContain("observedAt must be no older than 7 days");
     expect(manifest.ok).toBe(false);
   });
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -853,12 +853,13 @@ describe("beta release status", () => {
     expect(manifest.ok).toBe(false);
   });
 
-  it("blocks required healthy license API gates when the proof file is not machine-checkable JSON", () => {
-    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-invalid-health-proof-"));
+  it("blocks required healthy license API gates when healthProofPath leaves docs/evidence", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-outside-health-proof-"));
     roots.push(root);
     mkdirSync(join(root, "docs", "releases"), { recursive: true });
     writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
     writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    const healthProofPath = writeLicenseHealthProof(root, { path: "operator-local-proof.json" });
     writeFileSync(join(root, "public-release.json"), JSON.stringify({
       version: "v1.0.0-beta.1",
       releaseLevel: "source-beta",
@@ -871,7 +872,7 @@ describe("beta release status", () => {
         requiredForThisRelease: true,
         state: "healthy",
         healthUrl: "https://license.example/healthz",
-        healthProofPath: "docs/releases/v1.0.0-beta.1.md"
+        healthProofPath
       },
       updateChannels: {
         cli: {
@@ -899,8 +900,112 @@ describe("beta release status", () => {
       ok: false,
       requiredForThisRelease: true,
       state: "healthy",
-      healthProofPath: "docs/releases/v1.0.0-beta.1.md",
-      detail: "license API state healthy blocks this release; requiredForThisRelease=true; invalid health proof docs/releases/v1.0.0-beta.1.md: proof JSON is invalid"
+      healthProofPath,
+      detail: "license API state healthy blocks this release; requiredForThisRelease=true; invalid health proof operator-local-proof.json: healthProofPath must be relative and stay within docs/evidence"
+    });
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("blocks required healthy license API gates when healthProofPath is absolute", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-absolute-health-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeLicenseHealthProof(root);
+    const healthProofPath = join(root, "docs", "evidence", "license-healthz.json");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.ok).toBe(false);
+    expect(manifest.licenseApi.healthProofPath).toBe(healthProofPath);
+    expect(manifest.licenseApi.detail).toContain("healthProofPath must be relative and stay within docs/evidence");
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("blocks required healthy license API gates when the proof file is not machine-checkable JSON", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-invalid-health-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "evidence"), { recursive: true });
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "docs", "evidence", "not-json.json"), "# not json\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath: "docs/evidence/not-json.json"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi).toMatchObject({
+      ok: false,
+      requiredForThisRelease: true,
+      state: "healthy",
+      healthProofPath: "docs/evidence/not-json.json",
+      detail: "license API state healthy blocks this release; requiredForThisRelease=true; invalid health proof docs/evidence/not-json.json: proof JSON is invalid"
     });
     expect(manifest.ok).toBe(false);
   });

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -230,7 +230,7 @@ describe("beta release status", () => {
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
       expectedVersion: "v0.4.43-beta.1",
-      now: new Date("2026-07-07T09:10:00.000Z")
+      now: new Date("2026-07-07T12:31:00.000Z")
     });
 
     expect(manifest).toMatchObject({

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1023,6 +1023,57 @@ describe("beta release status", () => {
     expect(manifest.ok).toBe(false);
   });
 
+  it("blocks health proofs observed too far in the future", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-future-health-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    const healthProofPath = writeLicenseHealthProof(root, {
+      observedAt: "2026-07-07T00:06:00.000Z"
+    });
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1",
+      now: new Date("2026-07-07T00:00:00.000Z")
+    });
+
+    expect(manifest.licenseApi.ok).toBe(false);
+    expect(manifest.licenseApi.detail).toContain("observedAt must not be more than 5 minutes in the future");
+    expect(manifest.ok).toBe(false);
+  });
+
   it("blocks optional channel deferrals outside source-beta releases", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stable-channel-deferral-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -208,7 +208,8 @@ describe("beta release status", () => {
         ok: true,
         requiredForThisRelease: true,
         state: "healthy",
-        healthUrl: "https://neondiff-license.fly.dev/healthz"
+        healthUrl: "https://neondiff-license.fly.dev/healthz",
+        healthProofPath: "docs/evidence/v0.4.43-beta.1-license-api-healthz.json"
       },
       updateChannels: {
         ok: true
@@ -729,7 +730,8 @@ describe("beta release status", () => {
       },
       licenseApi: {
         requiredForThisRelease: true,
-        state: "healthy"
+        state: "healthy",
+        healthProofPath: "docs/releases/v1.0.0-beta.1.md"
       },
       updateChannels: {
         cli: {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -226,11 +226,15 @@ describe("beta release status", () => {
 
   it("validates the shipped public release manifest against the shipped release notes", () => {
     // Intentional shipped-manifest smoke: keep assertions scoped to publicRelease fields.
+    const shippedProof = JSON.parse(
+      readFileSync(join(repoRoot, "docs/evidence/v0.4.43-beta.1-license-api-healthz.json"), "utf8")
+    ) as { observedAt: string };
+    const proofObservedAt = Date.parse(shippedProof.observedAt);
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
       expectedVersion: "v0.4.43-beta.1",
-      now: new Date("2026-07-07T12:31:00.000Z")
+      now: new Date(proofObservedAt + 15_000)
     });
 
     expect(manifest).toMatchObject({

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -961,6 +961,53 @@ describe("beta release status", () => {
     expect(manifest.ok).toBe(false);
   });
 
+  it("blocks required healthy license API gates when healthUrl is missing", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-missing-health-url-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    const healthProofPath = writeLicenseHealthProof(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.ok).toBe(false);
+    expect(manifest.licenseApi.detail).toContain("healthUrl must be present when validating health proof");
+    expect(manifest.ok).toBe(false);
+  });
+
   it("blocks required healthy license API gates when the proof file is not machine-checkable JSON", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-invalid-health-proof-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -21,6 +21,7 @@ import { ReviewStateStore } from "../src/state.js";
 describe("beta release status", () => {
   const roots: string[] = [];
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const shippedReleaseValidationNow = new Date("2026-07-07T12:31:00Z");
 
   afterEach(() => {
     vi.useRealTimers();
@@ -229,7 +230,8 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.43-beta.1"
+      expectedVersion: "v0.4.43-beta.1",
+      now: shippedReleaseValidationNow
     });
 
     expect(manifest).toMatchObject({
@@ -265,6 +267,24 @@ describe("beta release status", () => {
         })
       ])
     );
+  });
+
+  it("documents the shipped public release health proof expiry mode", () => {
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: repoRoot,
+      manifestPath: "docs/public-release-manifest.json",
+      expectedVersion: "v0.4.43-beta.1",
+      now: new Date("2026-08-07T00:00:00Z")
+    });
+
+    expect(manifest.licenseApi).toMatchObject({
+      ok: false,
+      requiredForThisRelease: true,
+      state: "healthy",
+      healthProofPath: "docs/evidence/v0.4.43-beta.1-license-api-healthz.json"
+    });
+    expect(manifest.licenseApi.detail).toContain("observedAt must be no older than 30 days");
+    expect(manifest.ok).toBe(false);
   });
 
   it("fails closed when public release manifest flags are not paired", () => {
@@ -329,7 +349,8 @@ describe("beta release status", () => {
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
       expectedPublicVersion: "v0.4.43-beta.1",
-      launchdLabel: "com.electricsheephq.evaos-code-review-bot"
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: shippedReleaseValidationNow
     });
 
     expect(status.publicRelease).toMatchObject({
@@ -1000,6 +1021,54 @@ describe("beta release status", () => {
 
     expect(manifest.licenseApi.ok).toBe(false);
     expect(manifest.licenseApi.detail).toContain("healthUrl must be present when validating health proof");
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("validates optional license health metadata when fields are present", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-optional-invalid-health-metadata-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending",
+        healthUrl: "http://license.example/status?access_token=abcdefghijklmnopqrstuvwxyz",
+        healthProofPath: "../operator-local-proof.json"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.ok).toBe(false);
+    expect(manifest.licenseApi.detail).toContain("healthUrl must be an https URL ending in /healthz");
+    expect(manifest.licenseApi.detail).toContain("healthProofPath must be relative and stay within docs/evidence");
     expect(manifest.ok).toBe(false);
   });
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -24,6 +25,27 @@ describe("beta release status", () => {
   afterEach(() => {
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   });
+
+  function writeLicenseHealthProof(root: string, options: {
+    releaseVersion?: string;
+    url?: string;
+    path?: string;
+  } = {}): string {
+    const proofPath = options.path ?? "docs/evidence/license-healthz.json";
+    const responseBody = "{\"status\":\"ok\"}";
+    mkdirSync(dirname(join(root, proofPath)), { recursive: true });
+    writeFileSync(join(root, proofPath), JSON.stringify({
+      evidenceKind: "license_api_healthz",
+      releaseVersion: options.releaseVersion ?? "v1.0.0-beta.1",
+      observedAt: "2026-07-07T00:00:00.000Z",
+      method: "GET",
+      url: options.url ?? "https://license.example/healthz",
+      statusCode: 200,
+      responseBody,
+      responseBodySha256: createHash("sha256").update(responseBody).digest("hex")
+    }));
+    return proofPath;
+  }
 
   it("fails closed when the live checkout is dirty or not at the expected head", () => {
     const status = buildReleaseStatus({
@@ -766,12 +788,65 @@ describe("beta release status", () => {
     expect(manifest.ok).toBe(false);
   });
 
+  it("blocks required healthy license API gates when the proof file is not machine-checkable JSON", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-invalid-health-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi).toMatchObject({
+      ok: false,
+      requiredForThisRelease: true,
+      state: "healthy",
+      healthProofPath: "docs/releases/v1.0.0-beta.1.md",
+      detail: "license API state healthy blocks this release; requiredForThisRelease=true; invalid health proof docs/releases/v1.0.0-beta.1.md: proof JSON is invalid"
+    });
+    expect(manifest.ok).toBe(false);
+  });
+
   it("blocks optional channel deferrals outside source-beta releases", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stable-channel-deferral-"));
     roots.push(root);
     mkdirSync(join(root, "docs", "releases"), { recursive: true });
     writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
     writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    const healthProofPath = writeLicenseHealthProof(root);
     writeFileSync(join(root, "public-release.json"), JSON.stringify({
       version: "v1.0.0-beta.1",
       releaseLevel: "stable",
@@ -783,7 +858,8 @@ describe("beta release status", () => {
       licenseApi: {
         requiredForThisRelease: true,
         state: "healthy",
-        healthProofPath: "docs/releases/v1.0.0-beta.1.md"
+        healthUrl: "https://license.example/healthz",
+        healthProofPath
       },
       updateChannels: {
         cli: {


### PR DESCRIPTION
## Summary

- promote `docs/public-release-manifest.json` to `v0.4.43-beta.1`
- mark the production license API as `requiredForThisRelease: true` and `state: healthy` with the live health URL
- add `docs/releases/v0.4.43-beta.1.md` with the live Fly deploy and redacted smoke proof boundary
- update shipped-manifest tests so release-status guards the new beta version and license API gate

## Live proof

- Fly deploy succeeded for `neondiff-license`; machine `2861d25f04e698` is started in `iad` with `1/1` checks passing.
- Health proof: `https://neondiff-license.fly.dev/healthz` returned `{"status":"ok"}` via resolver-pinned curl while local macOS resolver cache was stale.
- Redacted smoke proof covered issue, activate, validate, deactivate, revoke, and validate-after-revoke. No raw throwaway license key is included in GitHub or shared evidence.

Evidence packet: `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-07/license-api-deploy/`

## Validation

- `npm test -- tests/public-release-readiness.test.ts tests/release-status.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- `node scripts/check-public-claims.mjs`
- `node scripts/check-secret-scan.mjs`
- `npm pack --dry-run --json`

## Proof boundary

This proves the source-beta public manifest now requires the live license API. It does not cut stable `v1.0.0`, publish a new npm package, claim customer readiness, or ship a signed desktop artifact.

Closes #327