### PR TITLE
[codex] Add path-aware Swift desktop gates

### DIFF
--- a/.github/workflows/codeql-swift-path-aware.yml
+++ b/.github/workflows/codeql-swift-path-aware.yml
@@ -20,7 +20,6 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 concurrency:
   group: swift-codeql-${{ github.event.pull_request.number || github.ref }}
@@ -30,12 +29,18 @@ jobs:
   analyze-swift:
     name: Analyze Swift (path-aware)
     runs-on: macos-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
         with:
           languages: swift
           build-mode: manual
@@ -46,6 +51,6 @@ jobs:
         run: swift build --product NeonDiffDesktop
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
         with:
           category: "/language:swift"

--- a/.github/workflows/codeql-swift-path-aware.yml
+++ b/.github/workflows/codeql-swift-path-aware.yml
@@ -38,10 +38,12 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: swift
+          build-mode: manual
           queries: security-extended
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+      - name: Manual SwiftPM build
+        working-directory: apps/neondiff-desktop
+        run: swift build --product NeonDiffDesktop --arch arm64
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-swift-path-aware.yml
+++ b/.github/workflows/codeql-swift-path-aware.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     paths:
       - apps/neondiff-desktop/**
-      - Package.swift
-      - Package.resolved
       - .github/workflows/codeql-swift-path-aware.yml
       - .github/workflows/swift-desktop-gate.yml
   push:
@@ -13,8 +11,6 @@ on:
       - main
     paths:
       - apps/neondiff-desktop/**
-      - Package.swift
-      - Package.resolved
       - .github/workflows/codeql-swift-path-aware.yml
       - .github/workflows/swift-desktop-gate.yml
   workflow_dispatch:

--- a/.github/workflows/codeql-swift-path-aware.yml
+++ b/.github/workflows/codeql-swift-path-aware.yml
@@ -1,0 +1,53 @@
+name: Swift CodeQL Path-Aware
+
+on:
+  pull_request:
+    paths:
+      - apps/neondiff-desktop/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/codeql-swift-path-aware.yml
+      - .github/workflows/swift-desktop-gate.yml
+  push:
+    branches:
+      - main
+    paths:
+      - apps/neondiff-desktop/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/codeql-swift-path-aware.yml
+      - .github/workflows/swift-desktop-gate.yml
+  workflow_dispatch:
+  schedule:
+    - cron: "37 9 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: swift-codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze-swift:
+    name: Analyze Swift (path-aware)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: swift
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:swift"

--- a/.github/workflows/codeql-swift-path-aware.yml
+++ b/.github/workflows/codeql-swift-path-aware.yml
@@ -3,12 +3,16 @@ name: Swift CodeQL Path-Aware
 on:
   pull_request:
     paths:
-      - apps/neondiff-desktop/**
+      - apps/neondiff-desktop/Package.swift
+      - apps/neondiff-desktop/Package.resolved
+      - apps/neondiff-desktop/Sources/**
   push:
     branches:
       - main
     paths:
-      - apps/neondiff-desktop/**
+      - apps/neondiff-desktop/Package.swift
+      - apps/neondiff-desktop/Package.resolved
+      - apps/neondiff-desktop/Sources/**
   workflow_dispatch:
   schedule:
     - cron: "37 9 * * 1"

--- a/.github/workflows/codeql-swift-path-aware.yml
+++ b/.github/workflows/codeql-swift-path-aware.yml
@@ -4,15 +4,11 @@ on:
   pull_request:
     paths:
       - apps/neondiff-desktop/**
-      - .github/workflows/codeql-swift-path-aware.yml
-      - .github/workflows/swift-desktop-gate.yml
   push:
     branches:
       - main
     paths:
       - apps/neondiff-desktop/**
-      - .github/workflows/codeql-swift-path-aware.yml
-      - .github/workflows/swift-desktop-gate.yml
   workflow_dispatch:
   schedule:
     - cron: "37 9 * * 1"

--- a/.github/workflows/codeql-swift-path-aware.yml
+++ b/.github/workflows/codeql-swift-path-aware.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Manual SwiftPM build
         working-directory: apps/neondiff-desktop
-        run: swift build --product NeonDiffDesktop --arch arm64
+        run: swift build --product NeonDiffDesktop
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -40,11 +40,15 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo '{"affected":true,"matched":["manual dispatch"],"files":["manual dispatch"]}' > swift-impact.json
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch --no-tags origin "${{ github.base_ref }}"
-            node scripts/swift-affected.mjs \
-              --base "origin/${{ github.base_ref }}" \
-              --head "${{ github.event.pull_request.head.sha }}" \
-              > swift-impact.json
+            git fetch --no-tags origin "${{ github.base_ref }}" || true
+            if git cat-file -e "origin/${{ github.base_ref }}^{commit}" 2>/dev/null; then
+              node scripts/swift-affected.mjs \
+                --base "origin/${{ github.base_ref }}" \
+                --head "${{ github.event.pull_request.head.sha }}" \
+                > swift-impact.json
+            else
+              echo '{"affected":true,"matched":["base ref unavailable; fail open"],"files":["base ref unavailable; fail open"]}' > swift-impact.json
+            fi
           else
             BEFORE="${{ github.event.before }}"
             if [ -z "$BEFORE" ] || printf '%s' "$BEFORE" | grep -Eq '^0+$'; then

--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -88,10 +88,10 @@ jobs:
         if: steps.impact.outputs.affected != 'true'
         run: echo "No Swift desktop files changed; stable gate passes without Swift build."
 
-      - name: Swift core smoke
+      - name: Swift core checks
         if: steps.impact.outputs.affected == 'true'
         working-directory: apps/neondiff-desktop
-        run: swift run NeonDiffDesktopCoreSmoke
+        run: swift run NeonDiffDesktopCoreChecks
 
       - name: Swift build
         if: steps.impact.outputs.affected == 'true'

--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -1,0 +1,93 @@
+name: Swift Desktop Gate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: swift-desktop-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  swift-desktop-gate:
+    name: Swift desktop gate
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 26
+
+      - name: Detect Swift desktop impact
+        id: impact
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo '{"affected":true,"matched":["manual dispatch"],"files":["manual dispatch"]}' > swift-impact.json
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --no-tags origin "${{ github.base_ref }}"
+            node scripts/swift-affected.mjs \
+              --base "origin/${{ github.base_ref }}" \
+              --head "${{ github.event.pull_request.head.sha }}" \
+              > swift-impact.json
+          else
+            BEFORE="${{ github.event.before }}"
+            if [ -z "$BEFORE" ] || printf '%s' "$BEFORE" | grep -Eq '^0+$'; then
+              git diff-tree --no-commit-id --name-only -r "${{ github.sha }}" \
+                | node scripts/swift-affected.mjs --stdin > swift-impact.json
+            else
+              git fetch --no-tags origin "$BEFORE" || true
+              node scripts/swift-affected.mjs \
+                --base "$BEFORE" \
+                --head "${{ github.sha }}" \
+                > swift-impact.json
+            fi
+          fi
+          cat swift-impact.json
+          AFFECTED="$(node -e "console.log(JSON.parse(require('fs').readFileSync('swift-impact.json', 'utf8')).affected ? 'true' : 'false')")"
+          echo "affected=$AFFECTED" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Swift desktop impact"
+            echo
+            echo "\`affected=$AFFECTED\`"
+            echo
+            echo "\`\`\`json"
+            cat swift-impact.json
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Skip Swift smoke for non-desktop changes
+        if: steps.impact.outputs.affected != 'true'
+        run: echo "No Swift desktop files changed; stable gate passes without Swift build."
+
+      - name: Swift core smoke
+        if: steps.impact.outputs.affected == 'true'
+        working-directory: apps/neondiff-desktop
+        run: swift run NeonDiffDesktopCoreSmoke
+
+      - name: Swift build
+        if: steps.impact.outputs.affected == 'true'
+        working-directory: apps/neondiff-desktop
+        run: swift build
+
+      - name: Build app bundle
+        if: steps.impact.outputs.affected == 'true'
+        working-directory: apps/neondiff-desktop
+        run: script/build_and_run.sh build
+
+      - name: Bundle check
+        if: steps.impact.outputs.affected == 'true'
+        working-directory: apps/neondiff-desktop
+        run: script/build_and_run.sh bundle-check

--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -2,7 +2,8 @@ name: Swift Desktop Gate
 
 on:
   # This gate intentionally has no PR/push path filter. It must report on every
-  # PR/main push, then skip Swift work internally when desktop files are clean.
+  # current PR/main head, then skip Swift work internally when desktop files are clean.
+  # Superseded runs may be cancelled when a newer head takes over the same check.
   pull_request:
   push:
     branches:
@@ -62,7 +63,16 @@ jobs:
             fi
           fi
           cat swift-impact.json
-          AFFECTED="$(node -e "console.log(JSON.parse(require('fs').readFileSync('swift-impact.json', 'utf8')).affected ? 'true' : 'false')")"
+          AFFECTED="$(node <<'NODE'
+          const fs = require('fs');
+          try {
+            const payload = JSON.parse(fs.readFileSync('swift-impact.json', 'utf8'));
+            console.log(payload && payload.affected === true ? 'true' : 'false');
+          } catch {
+            console.log('false');
+          }
+          NODE
+          )"
           echo "affected=$AFFECTED" >> "$GITHUB_OUTPUT"
           {
             echo "## Swift desktop impact"

--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -23,43 +23,50 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 26
 
       - name: Detect Swift desktop impact
         id: impact
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          PULL_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CURRENT_SHA: ${{ github.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo '{"affected":true,"matched":["manual dispatch"],"files":["manual dispatch"]}' > swift-impact.json
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch --no-tags origin "${{ github.base_ref }}" || true
-            if git cat-file -e "origin/${{ github.base_ref }}^{commit}" 2>/dev/null; then
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags origin "$BASE_REF" || true
+            if [ -n "$BASE_REF" ] && git cat-file -e "origin/$BASE_REF^{commit}" 2>/dev/null; then
               node scripts/swift-affected.mjs \
-                --base "origin/${{ github.base_ref }}" \
-                --head "${{ github.event.pull_request.head.sha }}" \
+                --base "origin/$BASE_REF" \
+                --head "$PULL_HEAD_SHA" \
                 > swift-impact.json
             else
               echo '{"affected":true,"matched":["base ref unavailable; fail open"],"files":["base ref unavailable; fail open"]}' > swift-impact.json
             fi
           else
-            BEFORE="${{ github.event.before }}"
+            BEFORE="$BEFORE_SHA"
             if [ -z "$BEFORE" ] || printf '%s' "$BEFORE" | grep -Eq '^0+$'; then
-              git diff-tree --no-commit-id --name-only -r "${{ github.sha }}" \
+              git diff-tree --no-commit-id --name-only -r "$CURRENT_SHA" \
                 | node scripts/swift-affected.mjs --stdin > swift-impact.json
             else
               git fetch --no-tags origin "$BEFORE" || true
               if git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
                 node scripts/swift-affected.mjs \
                   --base "$BEFORE" \
-                  --head "${{ github.sha }}" \
+                  --head "$CURRENT_SHA" \
                   > swift-impact.json
               else
                 echo '{"affected":true,"matched":["before ref unavailable; fail open"],"files":["before ref unavailable; fail open"]}' > swift-impact.json

--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -1,6 +1,8 @@
 name: Swift Desktop Gate
 
 on:
+  # This gate intentionally has no PR/push path filter. It must report on every
+  # PR/main push, then skip Swift work internally when desktop files are clean.
   pull_request:
   push:
     branches:
@@ -49,10 +51,14 @@ jobs:
                 | node scripts/swift-affected.mjs --stdin > swift-impact.json
             else
               git fetch --no-tags origin "$BEFORE" || true
-              node scripts/swift-affected.mjs \
-                --base "$BEFORE" \
-                --head "${{ github.sha }}" \
-                > swift-impact.json
+              if git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+                node scripts/swift-affected.mjs \
+                  --base "$BEFORE" \
+                  --head "${{ github.sha }}" \
+                  > swift-impact.json
+              else
+                echo '{"affected":true,"matched":["before ref unavailable; fail open"],"files":["before ref unavailable; fail open"]}' > swift-impact.json
+              fi
             fi
           fi
           cat swift-impact.json

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -27,6 +27,29 @@ state is complete.
 | TCC proof | A final signed/notarized artifact is used for any Accessibility, Screen Recording, microphone, or other TCC acceptance proof. | Stop if proof comes from an unsigned/ad-hoc app or a different signing identity. |
 | Customer readiness | Owner-approved release notes, license/update policy, hosting, rollback, and support handoff are recorded. | Stop if #327 or any customer-facing entitlement/update policy is unresolved for the chosen channel. |
 
+## Fast Desktop Iteration Before Release
+
+Use the fastest proof loop that covers the changed behavior before entering the
+release lane.
+
+- Swift model, parser, command-builder, daemon-status, onboarding, or license
+  setup changes: run `swift run NeonDiffDesktopCoreSmoke`.
+- SwiftUI or app wiring changes: run the core smoke, `swift build`,
+  `script/build_and_run.sh build`, and `script/build_and_run.sh bundle-check`.
+- Browser, website, renderer, public docs, or config-only changes: use a
+  preview server/browser smoke or focused Node tests first; do not run Swift
+  locally unless the changed contract crosses into `apps/neondiff-desktop/`.
+- Review-response commits that only change docs, release notes, or GitHub
+  metadata should not restart local Swift work. Preserve the running remote gate
+  and batch remaining feedback before the next push.
+
+The CI `Swift desktop gate` is intentionally always-reporting. It should say
+`not affected` for non-desktop PRs, and it should run the Swift core smoke,
+Swift build, app bundle build, and bundle check for desktop-affecting PRs. The
+path-aware Swift CodeQL workflow is a release/security scan. It should run for
+desktop/signing/appcast/release paths, scheduled scans, manual dispatch, and
+`main`; it should not be the inner product iteration loop.
+
 ## Preconditions
 
 Run every command from a fresh checkout of

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -44,7 +44,7 @@ release lane.
   and batch remaining feedback before the next push.
 
 The CI `Swift desktop gate` is intentionally always-reporting. It should say
-`not affected` for non-desktop PRs, and it should run the Swift core smoke,
+`not affected` for non-desktop PRs, and it should run the Swift core checks,
 Swift build, app bundle build, and bundle check for desktop-affecting PRs. The
 path-aware Swift CodeQL workflow is a release/security scan. It should run for
 desktop/signing/appcast/release paths, scheduled scans, manual dispatch, and

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -214,11 +214,12 @@ Recommended local order:
 
 Remote CI should keep a stable, always-reporting `Swift desktop gate` check.
 That check passes quickly with an explicit `not affected` result on non-desktop
-changes, and runs the non-Keychain Swift core checks/build/bundle check only
-when Swift desktop paths changed or when manually dispatched. Keep
-`NeonDiffDesktopCoreSmoke` in the local/release-smoke lane unless a runner has a
-known-good Keychain session; hosted macOS runners can kill Keychain round-trip
-smoke executables after a successful build.
+changes, and runs `swift run NeonDiffDesktopCoreChecks`, `swift build`, app
+bundle build, and bundle check only when Swift desktop paths changed or when
+manually dispatched. Keep `NeonDiffDesktopCoreSmoke` in the local/release-smoke
+lane because it exercises the Keychain-backed smoke path; hosted macOS runners
+can kill Keychain round-trip smoke executables after a successful build unless
+the runner has a known-good Keychain session.
 
 Swift CodeQL is a release/security gate. Use the checked-in path-aware Swift
 CodeQL workflow for desktop/signing/appcast/release surfaces, scheduled scans,

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -224,6 +224,17 @@ GitHub CodeQL default setup or disable repo-wide default setup for Swift. If
 default setup keeps `swift` enabled, GitHub will continue running
 `Analyze (swift)` on every PR head regardless of path filters.
 
+Verify the setting after merge with:
+
+```bash
+gh api repos/electricsheephq/evaos-code-review-bot-neondiff/code-scanning/default-setup \
+  --jq '.languages'
+```
+
+The returned languages must not contain `swift`. For this repo, the intended
+default setup languages are `actions` and `javascript-typescript`; Swift is
+owned by `.github/workflows/codeql-swift-path-aware.yml`.
+
 Every public release packet should state which proof loop was used:
 
 - `preview/browser`: URL or local route, command, screenshots or DOM assertion,

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -214,8 +214,11 @@ Recommended local order:
 
 Remote CI should keep a stable, always-reporting `Swift desktop gate` check.
 That check passes quickly with an explicit `not affected` result on non-desktop
-changes, and runs the Swift core smoke/build/bundle check only when Swift desktop
-paths changed or when manually dispatched.
+changes, and runs the non-Keychain Swift core checks/build/bundle check only
+when Swift desktop paths changed or when manually dispatched. Keep
+`NeonDiffDesktopCoreSmoke` in the local/release-smoke lane unless a runner has a
+known-good Keychain session; hosted macOS runners can kill Keychain round-trip
+smoke executables after a successful build.
 
 Swift CodeQL is a release/security gate. Use the checked-in path-aware Swift
 CodeQL workflow for desktop/signing/appcast/release surfaces, scheduled scans,

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -189,6 +189,51 @@ Do not use `--allow-dimension-change true` during routine post-merge refreshes;
 that flag is only for a separate embedding migration issue with its own evidence
 packet.
 
+## Fast Iteration And Batched Release Validation
+
+Do not spend a Swift release-gate cycle on every review-fix commit. Batch as much
+validation as possible before the first push, then let one remote CI cycle prove
+the current head.
+
+Recommended local order:
+
+1. For docs, TypeScript release tooling, manifest, license-service, or review
+   wording changes, run the focused Node tests/build/scans that cover the changed
+   surface once before push.
+2. For browser, website, renderer, or config flows, use a preview server/browser
+   smoke first and record the URL, route, screenshots, and settled behavior in
+   the evidence packet. Browser proof is fast product evidence; it is not a
+   substitute for desktop signing, appcast, or Swift release gates.
+3. For NeonDiff Desktop Swift changes, run
+   `swift run NeonDiffDesktopCoreSmoke`, then `swift build`, then
+   `script/build_and_run.sh build` plus `script/build_and_run.sh bundle-check`
+   from `apps/neondiff-desktop/` before the first PR push.
+4. For signed desktop release candidates, use the Mac release runbook after the
+   desktop smoke passes. Do not use notarization, appcast generation, or Swift
+   CodeQL to debug product behavior.
+
+Remote CI should keep a stable, always-reporting `Swift desktop gate` check.
+That check passes quickly with an explicit `not affected` result on non-desktop
+changes, and runs the Swift core smoke/build/bundle check only when Swift desktop
+paths changed or when manually dispatched.
+
+Swift CodeQL is a release/security gate. Use the checked-in path-aware Swift
+CodeQL workflow for desktop/signing/appcast/release surfaces, scheduled scans,
+manual dispatch, and `main`. After that workflow is merged, remove Swift from
+GitHub CodeQL default setup or disable repo-wide default setup for Swift. If
+default setup keeps `swift` enabled, GitHub will continue running
+`Analyze (swift)` on every PR head regardless of path filters.
+
+Every public release packet should state which proof loop was used:
+
+- `preview/browser`: URL or local route, command, screenshots or DOM assertion,
+  and why it covers the changed behavior.
+- `node/source`: focused tests/build/scans, command log, and source SHA.
+- `desktop-smoke`: Swift core smoke, Swift build, app bundle build, bundle
+  check, source SHA, and app bundle path.
+- `desktop-release`: signed/notarized/stapled artifact, appcast, Gatekeeper, and
+  installed-app visual/UI proof from the exact candidate.
+
 ## Required Gates
 
 - GitHub PR merged to `main` with checks green and no current-head actionable

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -15,10 +15,14 @@ NeonDiff Desktop is a SwiftPM macOS app scaffold for issue #115. It is a thin lo
 cd apps/neondiff-desktop
 swift run NeonDiffDesktopCoreSmoke
 swift build
-./script/build_and_run.sh --verify
+./script/build_and_run.sh build
+./script/build_and_run.sh bundle-check
 ```
 
 `./script/build_and_run.sh` stages a local unsigned `.app` bundle under `apps/neondiff-desktop/dist/` for development only.
+Use that unsigned bundle for dev smoke and bundle-resource proof only. Signed,
+notarized, appcast, and installed-app visual proof belong to the Mac release
+runbook after source behavior is already proven.
 
 ## CLI Contract
 

--- a/scripts/swift-affected.mjs
+++ b/scripts/swift-affected.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const SWIFT_PATH_PREFIXES = [
+  "apps/neondiff-desktop/",
+  ".github/workflows/"
+];
+
+const SWIFT_ROOT_FILES = new Set([
+  "Package.swift",
+  "Package.resolved"
+]);
+
+export function isSwiftRelevantPath(file) {
+  const normalized = file.replaceAll("\\", "/").replace(/^\.\/+/, "").trim();
+  if (!normalized) return false;
+  if (SWIFT_ROOT_FILES.has(normalized)) return true;
+  return SWIFT_PATH_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+export function summarizeSwiftAffected(files) {
+  const normalizedFiles = files
+    .map((file) => file.replaceAll("\\", "/").replace(/^\.\/+/, "").trim())
+    .filter(Boolean);
+  const matched = normalizedFiles.filter(isSwiftRelevantPath);
+  return {
+    affected: matched.length > 0,
+    matched,
+    files: normalizedFiles
+  };
+}
+
+function parseArgs(argv) {
+  const args = [...argv];
+  const parsed = {
+    files: [],
+    stdin: false,
+    base: undefined,
+    head: undefined
+  };
+  while (args.length) {
+    const arg = args.shift();
+    if (arg === "--stdin") {
+      parsed.stdin = true;
+    } else if (arg === "--files") {
+      while (args.length && !args[0].startsWith("--")) parsed.files.push(args.shift());
+    } else if (arg === "--base") {
+      parsed.base = args.shift();
+    } else if (arg === "--head") {
+      parsed.head = args.shift();
+    } else if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    } else if (arg) {
+      parsed.files.push(arg);
+    }
+  }
+  return parsed;
+}
+
+function readGitDiffFiles(base, head) {
+  if (!base || !head) return [];
+  try {
+    return execFileSync("git", ["diff", "--name-only", `${base}...${head}`], { encoding: "utf8" }).split(/\r?\n/);
+  } catch {
+    return execFileSync("git", ["diff", "--name-only", base, head], { encoding: "utf8" }).split(/\r?\n/);
+  }
+}
+
+function printUsage() {
+  console.log(`usage:
+  node scripts/swift-affected.mjs --files <path...>
+  node scripts/swift-affected.mjs --stdin < changed-files.txt
+  node scripts/swift-affected.mjs --base <git-ref> --head <git-ref>`);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : "";
+if (import.meta.url === invokedPath) {
+  const args = parseArgs(process.argv.slice(2));
+  const stdinFiles = args.stdin ? readFileSync(0, "utf8").split(/\r?\n/) : [];
+  const gitFiles = args.base && args.head ? readGitDiffFiles(args.base, args.head) : [];
+  const summary = summarizeSwiftAffected([...args.files, ...stdinFiles, ...gitFiles]);
+  console.log(JSON.stringify(summary, null, 2));
+}

--- a/scripts/swift-affected.mjs
+++ b/scripts/swift-affected.mjs
@@ -73,7 +73,11 @@ function readGitDiffFiles(base, head) {
   try {
     return execFileSync("git", ["diff", "--name-only", `${base}...${head}`], { encoding: "utf8" }).split(/\r?\n/);
   } catch {
-    return execFileSync("git", ["diff", "--name-only", base, head], { encoding: "utf8" }).split(/\r?\n/);
+    try {
+      return execFileSync("git", ["diff", "--name-only", base, head], { encoding: "utf8" }).split(/\r?\n/);
+    } catch {
+      return [];
+    }
   }
 }
 

--- a/scripts/swift-affected.mjs
+++ b/scripts/swift-affected.mjs
@@ -45,7 +45,7 @@ function parseArgs(argv) {
     if (arg === "--stdin") {
       parsed.stdin = true;
     } else if (arg === "--files") {
-      while (args.length && !args[0].startsWith("--")) parsed.files.push(args.shift());
+      parsed.files.push(...args.splice(0));
     } else if (arg === "--base") {
       parsed.base = args.shift();
     } else if (arg === "--head") {

--- a/scripts/swift-affected.mjs
+++ b/scripts/swift-affected.mjs
@@ -4,12 +4,15 @@ import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const SWIFT_PATH_PREFIXES = [
-  "apps/neondiff-desktop/"
+  "apps/neondiff-desktop/Sources/"
 ];
 
 const SWIFT_ROOT_FILES = new Set([
   "Package.swift",
-  "Package.resolved"
+  "Package.resolved",
+  "apps/neondiff-desktop/Package.swift",
+  "apps/neondiff-desktop/Package.resolved",
+  "apps/neondiff-desktop/script/build_and_run.sh"
 ]);
 
 const SWIFT_WORKFLOW_FILES = new Set([

--- a/scripts/swift-affected.mjs
+++ b/scripts/swift-affected.mjs
@@ -4,8 +4,7 @@ import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const SWIFT_PATH_PREFIXES = [
-  "apps/neondiff-desktop/",
-  ".github/workflows/"
+  "apps/neondiff-desktop/"
 ];
 
 const SWIFT_ROOT_FILES = new Set([
@@ -13,10 +12,16 @@ const SWIFT_ROOT_FILES = new Set([
   "Package.resolved"
 ]);
 
+const SWIFT_WORKFLOW_FILES = new Set([
+  ".github/workflows/codeql-swift-path-aware.yml",
+  ".github/workflows/swift-desktop-gate.yml"
+]);
+
 export function isSwiftRelevantPath(file) {
   const normalized = file.replaceAll("\\", "/").replace(/^\.\/+/, "").trim();
   if (!normalized) return false;
   if (SWIFT_ROOT_FILES.has(normalized)) return true;
+  if (SWIFT_WORKFLOW_FILES.has(normalized)) return true;
   return SWIFT_PATH_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 }
 
@@ -71,7 +76,7 @@ function readGitDiffFiles(base, head) {
 
 function printUsage() {
   console.log(`usage:
-  node scripts/swift-affected.mjs --files <path...>
+  node scripts/swift-affected.mjs --files <path...>  # --files is terminal and consumes the remaining argv
   node scripts/swift-affected.mjs --stdin < changed-files.txt
   node scripts/swift-affected.mjs --base <git-ref> --head <git-ref>`);
 }

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -52,11 +52,26 @@ describe("Swift CI velocity policy", () => {
 
     expect(codeql).toMatch(/name:\s*Swift CodeQL Path-Aware/);
     expect(codeql).toMatch(/apps\/neondiff-desktop\/\*\*/);
+    expect(codeql).not.toMatch(/-\s*Package\.swift/);
+    expect(codeql).not.toMatch(/-\s*Package\.resolved/);
     expect(codeql).toMatch(/languages:\s*swift/);
     expect(codeql).toMatch(/github\/codeql-action\/autobuild@v3/);
     expect(codeql).toMatch(/schedule:/);
     expect(codeql).toMatch(/workflow_dispatch:/);
     expect(codeql).toMatch(/cancel-in-progress:\s*true/);
+    expect(gate).toMatch(/no PR\/push path filter/);
+    expect(gate).toMatch(/before ref unavailable; fail open/);
+  });
+
+  it("keeps all --files operands as filenames, including option-like paths", () => {
+    expect(swiftAffected([
+      "--base",
+      "apps/neondiff-desktop/Package.swift"
+    ])).toMatchObject({
+      affected: true,
+      matched: ["apps/neondiff-desktop/Package.swift"],
+      files: ["--base", "apps/neondiff-desktop/Package.swift"]
+    });
   });
 
   it("documents the fast preview/smoke loop and the release proof boundary", () => {

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -49,6 +49,10 @@ describe("Swift CI velocity policy", () => {
     expect(gate).toMatch(/script\/build_and_run\.sh build/);
     expect(gate).toMatch(/script\/build_and_run\.sh bundle-check/);
     expect(gate).toMatch(/cancel-in-progress:\s*true/);
+    expect(gate).toMatch(/current PR\/main head/);
+    expect(gate).toMatch(/Superseded runs may be cancelled/);
+    expect(gate).toMatch(/payload && payload\.affected === true/);
+    expect(gate).toMatch(/console\.log\('false'\)/);
 
     expect(codeql).toMatch(/name:\s*Swift CodeQL Path-Aware/);
     expect(codeql).toMatch(/apps\/neondiff-desktop\/\*\*/);
@@ -65,7 +69,7 @@ describe("Swift CI velocity policy", () => {
     expect(gate).toMatch(/before ref unavailable; fail open/);
   });
 
-  it("keeps all --files operands as filenames, including option-like paths", () => {
+  it("keeps every operand after --files as a filename, including option-like paths", () => {
     expect(swiftAffected([
       "--base",
       "apps/neondiff-desktop/Package.swift"
@@ -85,6 +89,8 @@ describe("Swift CI velocity policy", () => {
     expect(betaRunbook).toMatch(/preview server\/browser\s+smoke/);
     expect(betaRunbook).toMatch(/Swift desktop gate/);
     expect(betaRunbook).toMatch(/remove Swift from\s+GitHub CodeQL default setup/i);
+    expect(betaRunbook).toMatch(/code-scanning\/default-setup/);
+    expect(betaRunbook).toMatch(/languages must not contain `swift`/);
     expect(betaRunbook).toMatch(/desktop-smoke/);
     expect(betaRunbook).toMatch(/desktop-release/);
 

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -53,6 +53,10 @@ describe("Swift CI velocity policy", () => {
     expect(gate).toMatch(/cancel-in-progress:\s*true/);
     expect(gate).toMatch(/current PR\/main head/);
     expect(gate).toMatch(/Superseded runs may be cancelled/);
+    expect(gate).toMatch(/persist-credentials:\s*false/);
+    expect(gate).toMatch(/EVENT_NAME:/);
+    expect(gate).toMatch(/BASE_REF:/);
+    expect(gate).toMatch(/PULL_HEAD_SHA:/);
     expect(gate).toMatch(/payload && payload\.affected === true/);
     expect(gate).toMatch(/console\.log\('false'\)/);
     expect(gate).toMatch(/base ref unavailable; fail open/);
@@ -68,6 +72,11 @@ describe("Swift CI velocity policy", () => {
     expect(codeql).toMatch(/languages:\s*swift/);
     expect(codeql).toMatch(/build-mode:\s*manual/);
     expect(codeql).toMatch(/swift build --product NeonDiffDesktop/);
+    expect(codeql).toMatch(/security-events:\s*write/);
+    expect(codeql).toMatch(/persist-credentials:\s*false/);
+    expect(codeql).not.toMatch(/actions\/checkout@v4/);
+    expect(codeql).not.toMatch(/github\/codeql-action\/init@v3/);
+    expect(codeql).not.toMatch(/github\/codeql-action\/analyze@v3/);
     expect(codeql).not.toMatch(/--arch arm64/);
     expect(codeql).not.toMatch(/github\/codeql-action\/autobuild/);
     expect(codeql).toMatch(/schedule:/);
@@ -94,6 +103,22 @@ describe("Swift CI velocity policy", () => {
     expect(help).toMatch(/--files is terminal/);
   });
 
+  it("degrades safely when git diff refs are unavailable", () => {
+    const output = execFileSync("node", [
+      "scripts/swift-affected.mjs",
+      "--base",
+      "refs/does-not-exist",
+      "--head",
+      "also-missing"
+    ], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+
+    expect(JSON.parse(output)).toMatchObject({
+      affected: false,
+      matched: [],
+      files: []
+    });
+  });
+
   it("documents the fast preview/smoke loop and the release proof boundary", () => {
     const betaRunbook = read("docs/beta-release-runbook.md");
     const macRunbook = read("apps/neondiff-desktop/docs/mac-release-runbook.md");
@@ -110,6 +135,7 @@ describe("Swift CI velocity policy", () => {
 
     expect(macRunbook).toMatch(/Fast Desktop Iteration Before Release/);
     expect(macRunbook).toMatch(/swift run NeonDiffDesktopCoreSmoke/);
+    expect(macRunbook).toMatch(/Swift core checks/);
     expect(macRunbook).toMatch(/script\/build_and_run\.sh bundle-check/);
     expect(macRunbook).toMatch(/path-aware Swift CodeQL workflow is a release\/security scan/);
 

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -16,7 +16,8 @@ describe("Swift CI velocity policy", () => {
       "docs/releases/v0.4.43-beta.1.md",
       "src/release-status.ts",
       "tests/release-status.test.ts",
-      ".github/workflows/ci.yml"
+      ".github/workflows/ci.yml",
+      "apps/neondiff-desktop/docs/mac-release-runbook.md"
     ])).toMatchObject({
       affected: false,
       matched: []
@@ -57,7 +58,9 @@ describe("Swift CI velocity policy", () => {
     expect(gate).toMatch(/base ref unavailable; fail open/);
 
     expect(codeql).toMatch(/name:\s*Swift CodeQL Path-Aware/);
-    expect(codeql).toMatch(/apps\/neondiff-desktop\/\*\*/);
+    expect(codeql).toMatch(/apps\/neondiff-desktop\/Sources\/\*\*/);
+    expect(codeql).toMatch(/apps\/neondiff-desktop\/Package\.swift/);
+    expect(codeql).toMatch(/apps\/neondiff-desktop\/Package\.resolved/);
     expect(codeql).not.toMatch(/\.github\/workflows\/swift-desktop-gate\.yml/);
     expect(codeql).not.toMatch(/\.github\/workflows\/codeql-swift-path-aware\.yml/);
     expect(codeql).not.toMatch(/-\s*Package\.swift/);

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -56,6 +56,8 @@ describe("Swift CI velocity policy", () => {
 
     expect(codeql).toMatch(/name:\s*Swift CodeQL Path-Aware/);
     expect(codeql).toMatch(/apps\/neondiff-desktop\/\*\*/);
+    expect(codeql).not.toMatch(/\.github\/workflows\/swift-desktop-gate\.yml/);
+    expect(codeql).not.toMatch(/\.github\/workflows\/codeql-swift-path-aware\.yml/);
     expect(codeql).not.toMatch(/-\s*Package\.swift/);
     expect(codeql).not.toMatch(/-\s*Package\.resolved/);
     expect(codeql).toMatch(/languages:\s*swift/);

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+function swiftAffected(files: string[]): { affected: boolean; matched: string[]; files: string[] } {
+  return JSON.parse(execFileSync("node", ["scripts/swift-affected.mjs", "--files", ...files], { encoding: "utf8" }));
+}
+
+describe("Swift CI velocity policy", () => {
+  it("classifies desktop and Swift workflow paths without flagging docs or TypeScript release tooling", () => {
+    expect(swiftAffected([
+      "docs/releases/v0.4.43-beta.1.md",
+      "src/release-status.ts",
+      "tests/release-status.test.ts"
+    ])).toMatchObject({
+      affected: false,
+      matched: []
+    });
+
+    expect(swiftAffected([
+      "apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift",
+      ".github/workflows/swift-desktop-gate.yml"
+    ])).toMatchObject({
+      affected: true,
+      matched: [
+        "apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift",
+        ".github/workflows/swift-desktop-gate.yml"
+      ]
+    });
+  });
+
+  it("ships an always-reporting Swift desktop gate and a path-aware Swift CodeQL workflow", () => {
+    expect(existsSync(".github/workflows/swift-desktop-gate.yml")).toBe(true);
+    expect(existsSync(".github/workflows/codeql-swift-path-aware.yml")).toBe(true);
+
+    const gate = read(".github/workflows/swift-desktop-gate.yml");
+    const codeql = read(".github/workflows/codeql-swift-path-aware.yml");
+
+    expect(gate).toMatch(/name:\s*Swift Desktop Gate/);
+    expect(gate).toMatch(/Swift desktop gate/);
+    expect(gate).toMatch(/scripts\/swift-affected\.mjs/);
+    expect(gate).toMatch(/No Swift desktop files changed/);
+    expect(gate).toMatch(/swift run NeonDiffDesktopCoreSmoke/);
+    expect(gate).toMatch(/swift build/);
+    expect(gate).toMatch(/script\/build_and_run\.sh build/);
+    expect(gate).toMatch(/script\/build_and_run\.sh bundle-check/);
+    expect(gate).toMatch(/cancel-in-progress:\s*true/);
+
+    expect(codeql).toMatch(/name:\s*Swift CodeQL Path-Aware/);
+    expect(codeql).toMatch(/apps\/neondiff-desktop\/\*\*/);
+    expect(codeql).toMatch(/languages:\s*swift/);
+    expect(codeql).toMatch(/github\/codeql-action\/autobuild@v3/);
+    expect(codeql).toMatch(/schedule:/);
+    expect(codeql).toMatch(/workflow_dispatch:/);
+    expect(codeql).toMatch(/cancel-in-progress:\s*true/);
+  });
+
+  it("documents the fast preview/smoke loop and the release proof boundary", () => {
+    const betaRunbook = read("docs/beta-release-runbook.md");
+    const macRunbook = read("apps/neondiff-desktop/docs/mac-release-runbook.md");
+    const desktopDocs = read("docs/neondiff-desktop.md");
+
+    expect(betaRunbook).toMatch(/Fast Iteration And Batched Release Validation/);
+    expect(betaRunbook).toMatch(/preview server\/browser\s+smoke/);
+    expect(betaRunbook).toMatch(/Swift desktop gate/);
+    expect(betaRunbook).toMatch(/remove Swift from\s+GitHub CodeQL default setup/i);
+    expect(betaRunbook).toMatch(/desktop-smoke/);
+    expect(betaRunbook).toMatch(/desktop-release/);
+
+    expect(macRunbook).toMatch(/Fast Desktop Iteration Before Release/);
+    expect(macRunbook).toMatch(/swift run NeonDiffDesktopCoreSmoke/);
+    expect(macRunbook).toMatch(/script\/build_and_run\.sh bundle-check/);
+    expect(macRunbook).toMatch(/path-aware Swift CodeQL workflow is a release\/security scan/);
+
+    expect(desktopDocs).toMatch(/script\/build_and_run\.sh build/);
+    expect(desktopDocs).toMatch(/script\/build_and_run\.sh bundle-check/);
+    expect(desktopDocs).toMatch(/Signed,\s*notarized,\s*appcast,\s*and installed-app visual proof belong to the Mac release\s+runbook/);
+  });
+});

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -15,7 +15,8 @@ describe("Swift CI velocity policy", () => {
     expect(swiftAffected([
       "docs/releases/v0.4.43-beta.1.md",
       "src/release-status.ts",
-      "tests/release-status.test.ts"
+      "tests/release-status.test.ts",
+      ".github/workflows/ci.yml"
     ])).toMatchObject({
       affected: false,
       matched: []
@@ -53,6 +54,7 @@ describe("Swift CI velocity policy", () => {
     expect(gate).toMatch(/Superseded runs may be cancelled/);
     expect(gate).toMatch(/payload && payload\.affected === true/);
     expect(gate).toMatch(/console\.log\('false'\)/);
+    expect(gate).toMatch(/base ref unavailable; fail open/);
 
     expect(codeql).toMatch(/name:\s*Swift CodeQL Path-Aware/);
     expect(codeql).toMatch(/apps\/neondiff-desktop\/\*\*/);
@@ -62,7 +64,8 @@ describe("Swift CI velocity policy", () => {
     expect(codeql).not.toMatch(/-\s*Package\.resolved/);
     expect(codeql).toMatch(/languages:\s*swift/);
     expect(codeql).toMatch(/build-mode:\s*manual/);
-    expect(codeql).toMatch(/swift build --product NeonDiffDesktop --arch arm64/);
+    expect(codeql).toMatch(/swift build --product NeonDiffDesktop/);
+    expect(codeql).not.toMatch(/--arch arm64/);
     expect(codeql).not.toMatch(/github\/codeql-action\/autobuild/);
     expect(codeql).toMatch(/schedule:/);
     expect(codeql).toMatch(/workflow_dispatch:/);
@@ -80,6 +83,12 @@ describe("Swift CI velocity policy", () => {
       matched: ["apps/neondiff-desktop/Package.swift"],
       files: ["--base", "apps/neondiff-desktop/Package.swift"]
     });
+  });
+
+  it("documents that --files is terminal", () => {
+    const help = execFileSync("node", ["scripts/swift-affected.mjs", "--help"], { encoding: "utf8" });
+
+    expect(help).toMatch(/--files is terminal/);
   });
 
   it("documents the fast preview/smoke loop and the release proof boundary", () => {

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -44,7 +44,7 @@ describe("Swift CI velocity policy", () => {
     expect(gate).toMatch(/Swift desktop gate/);
     expect(gate).toMatch(/scripts\/swift-affected\.mjs/);
     expect(gate).toMatch(/No Swift desktop files changed/);
-    expect(gate).toMatch(/swift run NeonDiffDesktopCoreSmoke/);
+    expect(gate).toMatch(/swift run NeonDiffDesktopCoreChecks/);
     expect(gate).toMatch(/swift build/);
     expect(gate).toMatch(/script\/build_and_run\.sh build/);
     expect(gate).toMatch(/script\/build_and_run\.sh bundle-check/);

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -55,7 +55,9 @@ describe("Swift CI velocity policy", () => {
     expect(codeql).not.toMatch(/-\s*Package\.swift/);
     expect(codeql).not.toMatch(/-\s*Package\.resolved/);
     expect(codeql).toMatch(/languages:\s*swift/);
-    expect(codeql).toMatch(/github\/codeql-action\/autobuild@v3/);
+    expect(codeql).toMatch(/build-mode:\s*manual/);
+    expect(codeql).toMatch(/swift build --product NeonDiffDesktop --arch arm64/);
+    expect(codeql).not.toMatch(/github\/codeql-action\/autobuild/);
     expect(codeql).toMatch(/schedule:/);
     expect(codeql).toMatch(/workflow_dispatch:/);
     expect(codeql).toMatch(/cancel-in-progress:\s*true/);


### PR DESCRIPTION
## Summary
- add an always-reporting Swift desktop gate that skips fast for non-desktop changes and runs CoreSmoke/build/bundle-check for desktop-affecting changes
- add path-aware Swift CodeQL for desktop/signing/appcast/release paths, scheduled scans, and manual dispatch
- document the fast preview/browser/source/desktop-smoke/release proof loops in the beta and Mac release runbooks
- add regression coverage for Swift path detection, workflows, and runbook drift

Closes #383.

## Validation
- npm test -- tests/swift-ci-velocity.test.ts tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1
- npm run build
- git diff --check
- node scripts/check-public-claims.mjs
- node scripts/check-secret-scan.mjs

## Notes
After this merges, repo admins still need to remove Swift from GitHub CodeQL default setup or disable default setup for Swift. Until then, GitHub can continue running the old repo-wide Analyze (swift) job in addition to these path-aware gates.