### PR TITLE
[codex] Add desktop release-smoke gate

### DIFF
--- a/.github/workflows/desktop-release-smoke.yml
+++ b/.github/workflows/desktop-release-smoke.yml
@@ -1,0 +1,76 @@
+name: Desktop release smoke
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: desktop-release-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unsigned-desktop-release-smoke:
+    name: Unsigned desktop release smoke
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: apps/neondiff-desktop
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run desktop core checks
+        run: swift run NeonDiffDesktopCoreChecks
+
+      - name: Run desktop appcast checks
+        run: swift run NeonDiffDesktopAppcastChecks
+
+      - name: Build unsigned app bundle
+        run: script/build_and_run.sh build
+
+      - name: Check unsigned app bundle
+        run: script/build_and_run.sh bundle-check
+
+      - name: Package unsigned app bundle and metadata
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_REF: ${{ github.ref }}
+        run: |
+          mkdir -p dist/release-smoke
+          ditto -c -k --keepParent dist/NeonDiffDesktop.app dist/release-smoke/NeonDiffDesktop.app.zip
+          cat > dist/release-smoke/desktop-release-smoke-metadata.json <<JSON
+          {
+            "workflow": "desktop-release-smoke",
+            "artifact": "NeonDiffDesktop.app.zip",
+            "artifact_classification": "unsigned-desktop-release-smoke",
+            "source_sha": "$SOURCE_SHA",
+            "source_ref": "$SOURCE_REF",
+            "release_ready": false,
+            "customer_ready": false,
+            "ui_launch": false,
+            "proof_boundary": "non-release app bundle build, hosted-runner-safe core checks, appcast checks, and bundle structure check only"
+          }
+          JSON
+
+      - name: Upload unsigned app bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: neondiff-desktop-unsigned-app
+          path: apps/neondiff-desktop/dist/release-smoke/NeonDiffDesktop.app.zip
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload release-smoke metadata
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: neondiff-desktop-release-smoke-metadata
+          path: apps/neondiff-desktop/dist/release-smoke/desktop-release-smoke-metadata.json
+          if-no-files-found: error
+          retention-days: 14

--- a/apps/neondiff-desktop/docs/desktop-release-smoke.md
+++ b/apps/neondiff-desktop/docs/desktop-release-smoke.md
@@ -1,0 +1,7 @@
+# Desktop Release Smoke
+
+`.github/workflows/desktop-release-smoke.yml` is the unsigned macOS app-bundle smoke lane for NeonDiff Desktop. It is manual and tag-oriented, runs the hosted-runner-safe `NeonDiffDesktopCoreChecks` and appcast checks, builds the `.app`, validates bundle structure, and uploads the zipped bundle with metadata.
+
+The uploaded bundle is non-release proof. Its metadata marks `release_ready: false`, `customer_ready: false`, and `artifact_classification: unsigned-desktop-release-smoke`, so it is customer-not-ready by design.
+
+The Keychain-backed `NeonDiffDesktopCoreSmoke` executable remains a local or release-smoke proof on a runner with known-good Keychain behavior. Hosted CI does not run that target because the unsigned release-smoke lane is meant to prove build, package, and app-bundle shape without touching credentials or local Keychain state.

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+describe("NeonDiff desktop release-smoke pipeline", () => {
+  it("defines an unsigned macOS release-smoke workflow with the required desktop gates", () => {
+    const workflowPath = ".github/workflows/desktop-release-smoke.yml";
+
+    expect(existsSync(workflowPath)).toBe(true);
+
+    const workflow = read(workflowPath);
+    const parsed = YAML.parse(workflow) as {
+      on?: {
+        workflow_dispatch?: unknown;
+        push?: { tags?: string[] };
+      };
+      concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+      permissions?: { contents?: string };
+      jobs?: Record<
+        string,
+        {
+          "runs-on"?: string;
+          defaults?: { run?: { "working-directory"?: string } };
+          steps?: Array<{ name?: string; uses?: string; run?: string; with?: Record<string, string> }>;
+        }
+      >;
+    };
+
+    expect(Object.prototype.hasOwnProperty.call(parsed.on ?? {}, "workflow_dispatch")).toBe(true);
+    expect(parsed.on?.push?.tags).toContain("v*");
+    expect(parsed.concurrency?.group).toContain("desktop-release-smoke");
+    expect(parsed.concurrency?.["cancel-in-progress"]).toBe(true);
+    expect(parsed.permissions).toEqual({ contents: "read" });
+
+    const job = parsed.jobs?.["unsigned-desktop-release-smoke"];
+    expect(job?.["runs-on"]).toBe("macos-latest");
+    expect(job?.defaults?.run?.["working-directory"]).toBe("apps/neondiff-desktop");
+
+    for (const command of [
+      "swift run NeonDiffDesktopCoreChecks",
+      "swift run NeonDiffDesktopAppcastChecks",
+      "script/build_and_run.sh build",
+      "script/build_and_run.sh bundle-check"
+    ]) {
+      expect(workflow).toContain(command);
+    }
+
+    expect(workflow).not.toContain("NeonDiffDesktopCoreSmoke");
+    expect(workflow).toContain("release_ready");
+    expect(workflow).toContain("customer_ready");
+    expect(workflow).toContain("unsigned");
+    expect(workflow).toMatch(/hosted-runner-safe core checks/);
+    expect(workflow).toMatch(/persist-credentials:\s*false/);
+    expect(workflow).toMatch(/SOURCE_SHA:/);
+    expect(workflow).toMatch(/SOURCE_REF:/);
+    expect(workflow).toMatch(/actions\/upload-artifact@[0-9a-f]{40}/);
+    expect(workflow).not.toMatch(/actions\/checkout@v4/);
+    expect(workflow).not.toMatch(/actions\/upload-artifact@v4/);
+    expect(workflow).toMatch(/NeonDiffDesktop\.app\.zip/);
+    expect(workflow).toMatch(/desktop-release-smoke-metadata\.json/);
+
+    expect(workflow).not.toMatch(/\$\{\{\s*secrets\./);
+    expect(workflow).not.toMatch(/\b(codesign|notarytool|stapler|spctl)\b/);
+    expect(workflow).not.toMatch(/\bopen\s+-n\b/);
+  });
+
+  it("documents the desktop smoke artifact as non-release proof", () => {
+    const docPath = "apps/neondiff-desktop/docs/desktop-release-smoke.md";
+
+    expect(existsSync(docPath)).toBe(true);
+
+    const docs = read(docPath);
+    expect(docs).toMatch(/desktop-release-smoke\.yml/);
+    expect(docs).toMatch(/unsigned/i);
+    expect(docs).toMatch(/non-release proof/i);
+    expect(docs).toMatch(/customer-not-ready/i);
+    expect(docs).toMatch(/NeonDiffDesktopCoreChecks/);
+    expect(docs).toMatch(/Keychain/i);
+    expect(docs).not.toMatch(/\b(codesign|notarytool|stapler|spctl)\b/);
+  });
+});


### PR DESCRIPTION
Closes #386.

## Summary

Adds the first NeonDiff Desktop release-smoke pipeline:

- `desktop-release-smoke.yml` for manual/tag-oriented unsigned macOS app-bundle smoke runs
- hosted-runner-safe desktop checks: `NeonDiffDesktopCoreChecks`, appcast checks, app bundle build, and bundle-check
- uploaded unsigned `.app` zip plus metadata marked `release_ready: false` and `customer_ready: false`
- docs for the release-smoke proof boundary and Keychain/CoreSmoke split
- tests that pin the workflow contract, action hardening, and non-release proof wording

## Proof Boundary

This is release-pipeline proof, not a signed release. It does not codesign, notarize, staple, open the app UI, touch Keychain credentials, or claim customer readiness. `NeonDiffDesktopCoreSmoke` remains a local/release-smoke proof on a runner with known-good Keychain behavior.

## Validation

Local focused validation from `/Volumes/LEXAR/repos/worktrees/evaos-code-review-bot-neondiff/386-desktop-release-smoke`:

- `npm test -- tests/desktop-release-pipeline.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- `node scripts/check-public-claims.mjs`
- `node scripts/check-secret-scan.mjs`
