### PR TITLE
[codex] Require visible desktop UI smoke in runbooks

### DIFF
--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -50,6 +50,36 @@ path-aware Swift CodeQL workflow is a release/security scan. It should run for
 desktop/signing/appcast/release paths, scheduled scans, manual dispatch, and
 `main`; it should not be the inner product iteration loop.
 
+### Visible Desktop UI Smoke
+
+Use a visible local smoke whenever the changed behavior is in onboarding,
+provider setup, daemon controls, license entry, update-channel selection, or
+other SwiftUI/AppKit wiring. This is a separate proof lane:
+
+- CI artifact smoke: hosted runner builds an unsigned app bundle and metadata;
+  it does not open the UI.
+- Local visible smoke: launch the built `.app`, inspect the window with
+  Computer Use or equivalent UI evidence, click the changed flow, and record the
+  observed state.
+- Signed/notarized release proof: owner-gated release credentials, signing,
+  notarization, stapling, Gatekeeper, updater, and installed-app checks on the
+  exact candidate artifact.
+
+Minimum local visible-smoke checklist:
+
+1. Record the source SHA and built app path.
+2. Record `Welcome visible`: the Welcome screen is present in the launched app.
+3. Navigate to the changed step.
+4. Record `changed button/action clicked`: click the changed button/action.
+5. Capture the expected disabled, error, or success state.
+6. Name `credential-gated steps` that were not exercised because a provider
+   key, license key, signing credential, or owner approval was absent.
+7. Link the evidence from the PR or issue before merge.
+
+Prefer one local build/run per logical batch. Do not spend a Swift build cycle
+after every small review-response edit when the current built app already covers
+the changed behavior.
+
 ## Preconditions
 
 Run every command from a fresh checkout of

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -212,6 +212,31 @@ Recommended local order:
    desktop smoke passes. Do not use notarization, appcast generation, or Swift
    CodeQL to debug product behavior.
 
+### Visible Desktop UI Smoke
+
+Desktop onboarding, provider, daemon, license, and update-channel UI changes
+need a visible local app smoke before anyone claims the flow works. CI artifact
+smoke proves the hosted runner built an unsigned bundle; it does not prove a
+human-visible window opened or that the changed control works.
+
+Run the local smoke once per logical batch, not after every tiny review-fix
+commit:
+
+1. Build and launch the current app bundle with the desktop run script.
+2. Inspect the app with Computer Use or equivalent accessibility/UI evidence.
+3. Record `Welcome visible`: the Welcome screen is present in the launched app.
+4. Navigate to the changed step.
+5. Record `changed button/action clicked`: click the changed button/action and
+   capture the observed disabled, error, or success state.
+6. Call out `credential-gated steps` that were not tested because keys,
+   licenses, signing credentials, or owner approvals were absent.
+7. Post the visible smoke evidence on the PR or linked issue before merge.
+
+Keep the proof boundary explicit: local visible UI smoke is product-behavior
+evidence for the named local build only. It is not signed/notarized release
+proof, TCC proof, appcast proof, customer readiness, or final installed-app
+behavior.
+
 Remote CI should keep a stable, always-reporting `Swift desktop gate` check.
 That check passes quickly with an explicit `not affected` result on non-desktop
 changes, and runs `swift run NeonDiffDesktopCoreChecks`, `swift build`, app

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -139,12 +139,20 @@ describe("Swift CI velocity policy", () => {
     expect(betaRunbook).toMatch(/languages must not contain `swift`/);
     expect(betaRunbook).toMatch(/desktop-smoke/);
     expect(betaRunbook).toMatch(/desktop-release/);
+    expect(betaRunbook).toMatch(/Visible Desktop UI Smoke/);
+    expect(betaRunbook).toMatch(/Welcome visible/);
+    expect(betaRunbook).toMatch(/changed button\/action clicked/);
+    expect(betaRunbook).toMatch(/credential-gated steps/);
 
     expect(macRunbook).toMatch(/Fast Desktop Iteration Before Release/);
     expect(macRunbook).toMatch(/swift run NeonDiffDesktopCoreSmoke/);
     expect(macRunbook).toMatch(/Swift core checks/);
     expect(macRunbook).toMatch(/script\/build_and_run\.sh bundle-check/);
     expect(macRunbook).toMatch(/path-aware Swift CodeQL workflow is a release\/security scan/);
+    expect(macRunbook).toMatch(/Visible Desktop UI Smoke/);
+    expect(macRunbook).toMatch(/Computer Use/);
+    expect(macRunbook).toMatch(/CI artifact smoke/);
+    expect(macRunbook).toMatch(/Signed\/notarized release proof/);
 
     expect(desktopDocs).toMatch(/script\/build_and_run\.sh build/);
     expect(desktopDocs).toMatch(/script\/build_and_run\.sh bundle-check/);


### PR DESCRIPTION
## Summary

Closes #392.

Adds a durable runbook checklist for visible desktop UI smoke on onboarding/provider/daemon/license/update-channel UI changes, explicitly separating:

- CI artifact smoke
- local visible UI smoke
- signed/notarized release proof

The checklist requires Welcome visible, navigation to the changed step, changed button/action clicked, expected state captured, credential-gated steps called out, and PR/issue evidence before merge.

## Validation

- `npm test -- tests/swift-ci-velocity.test.ts --pool=forks --maxWorkers=1`
- `git diff --check`

## Proof Boundary

Docs/test PR only. It does not claim a new signed desktop release, provider-key storage proof, daemon bootstrap proof, or GA readiness.