### PR TITLE
[codex] Document Swift CodeQL release policy

### DIFF
--- a/.github/workflows/codeql-swift-path-aware.yml
+++ b/.github/workflows/codeql-swift-path-aware.yml
@@ -17,6 +17,7 @@ jobs:
   analyze-swift:
     name: Analyze Swift (path-aware)
     runs-on: macos-latest
+    timeout-minutes: 35
     permissions:
       actions: read
       contents: read
@@ -53,6 +54,7 @@ jobs:
             echo
             echo "This workflow runs Swift CodeQL extraction and queries, but does not upload SARIF."
             echo
+            echo "Policy: Swift CodeQL is scheduled/manual release-security evidence, not a required PR velocity gate."
             echo "Reason: GitHub rejected advanced CodeQL SARIF uploads while repository default setup is enabled."
-            echo "Track the long-term default-vs-advanced CodeQL decision in #393."
+            echo "See docs/swift-codeql-policy.md and #393 for the long-term default-vs-advanced CodeQL decision."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/neondiff-desktop/docs/mac-release-runbook.md
+++ b/apps/neondiff-desktop/docs/mac-release-runbook.md
@@ -50,8 +50,10 @@ desktop-affecting PRs. Execute `NeonDiffDesktopCoreChecks`, run
 `NeonDiffDesktopCoreSmoke`, and click through the visible UI in the local or
 release-smoke lane where an interactive session exists. The path-aware Swift
 CodeQL workflow is a release/security scan. It should run for
-desktop/signing/appcast/release paths, scheduled scans, manual dispatch, and
-`main`; it should not be the inner product iteration loop.
+desktop/signing/appcast/release paths through weekly schedule or manual dispatch
+against the intended release ref; it should not be the inner product iteration
+loop. The durable trigger, upload, timeout, and release-ref policy is
+`docs/swift-codeql-policy.md`.
 
 ### Visible Desktop UI Smoke
 

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -255,12 +255,11 @@ manually dispatched. Keep `NeonDiffDesktopCoreChecks` execution,
 lane because hosted macOS runners can kill smoke executables after a successful
 build unless the runner has a known-good interactive session.
 
-Swift CodeQL is a release/security gate. Use the checked-in path-aware Swift
-CodeQL workflow for desktop/signing/appcast/release surfaces, scheduled scans,
-manual dispatch, and `main`. After that workflow is merged, remove Swift from
-GitHub CodeQL default setup or disable repo-wide default setup for Swift. If
-default setup keeps `swift` enabled, GitHub will continue running
-`Analyze (swift)` on every PR head regardless of path filters.
+Swift CodeQL is a release/security gate, not the PR iteration loop. The durable
+policy lives in `docs/swift-codeql-policy.md`: the checked-in path-aware Swift
+CodeQL workflow runs only by `workflow_dispatch` and weekly schedule, keeps SARIF
+upload disabled while default setup is enabled, and must be recorded in the
+release packet before signed desktop release or GA.
 
 Verify the setting after merge with:
 
@@ -270,8 +269,11 @@ gh api repos/electricsheephq/evaos-code-review-bot-neondiff/code-scanning/defaul
 ```
 
 The returned languages must not contain `swift`. For this repo, the intended
-default setup languages are `actions` and `javascript-typescript`; Swift is
-owned by `.github/workflows/codeql-swift-path-aware.yml`.
+read-only verification output currently includes `actions`, `javascript`,
+`javascript-typescript`, and `typescript`; Swift is owned by
+`.github/workflows/codeql-swift-path-aware.yml` as scheduled/manual advisory
+release-security evidence. This is a GET verification check, not a PATCH payload
+for changing GitHub default setup.
 
 Every public release packet should state which proof loop was used:
 

--- a/docs/swift-codeql-policy.md
+++ b/docs/swift-codeql-policy.md
@@ -1,0 +1,87 @@
+# Swift CodeQL Policy
+
+Swift CodeQL is release/security evidence for NeonDiff Desktop. It is not the
+inner PR iteration loop.
+
+## Durable Decision
+
+- Required PR velocity gate: `.github/workflows/swift-desktop-gate.yml`.
+- Swift security-analysis workflow: `.github/workflows/codeql-swift-path-aware.yml`.
+- Trigger policy: `workflow_dispatch` and weekly schedule only.
+- PR/push policy: no `pull_request` or `push` trigger in the Swift CodeQL
+  workflow.
+- Upload policy: keep `upload: false`, `upload-database: false`, and
+  `wait-for-processing: false` while the repository uses GitHub CodeQL default
+  setup for non-Swift languages.
+- Default setup policy: GitHub default setup may remain configured for actions
+  and JavaScript/TypeScript, but it must not list Swift.
+
+This keeps Swift CodeQL from blocking every Swift-source PR while preserving a
+manual/scheduled security proof lane before signed release or GA.
+
+## Current Measurements
+
+- Swift CodeQL PR run
+  [28882286388](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/28882286388)
+  took 25m58s and failed after the manual SwiftPM build spent about 23m11s.
+  The failure was SARIF upload rejection while repository default CodeQL setup
+  was enabled.
+- Earlier Swift CodeQL PR runs on 2026-07-07 ranged from roughly 18m26s to
+  49m25s including canceled runs.
+- The split Swift Desktop Gate on #419 completed the current-head impact,
+  macOS smoke, and final gate in about 10s, 44s, and 4s respectively.
+
+- Current main/manual measurement
+  [28886926047](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/28886926047)
+  on `5840b2d4bd6d6ef4cce6f99f149f5aa4c4f22e1f` completed successfully in
+  about 25m48s. The job ran from 17:48:10Z to 18:13:52Z on 2026-07-07; manual
+  SwiftPM build ran from 17:49:41Z to 18:12:11Z, about 22m30s. CodeQL analysis
+  itself ran for about 1m16s. The run was dispatched against `main` before this
+  policy was merged, so it is current budget evidence, not immutable release-tag
+  evidence.
+
+## Required Release Check
+
+Before a signed desktop release or GA cut:
+
+1. Verify default setup does not list Swift:
+
+   ```bash
+   gh api repos/electricsheephq/evaos-code-review-bot-neondiff/code-scanning/default-setup \
+     --jq '{state,languages,query_suite,updated_at}'
+   ```
+
+2. Run the Swift CodeQL workflow on the immutable release tag:
+
+   ```bash
+   gh workflow run codeql-swift-path-aware.yml \
+     -R electricsheephq/evaos-code-review-bot-neondiff \
+     --ref <immutable-release-tag>
+   ```
+
+3. Verify the workflow run `headSha` equals the exact source SHA in the release
+   record before using it as release evidence. If the tag does not exist yet and
+   the workflow is dispatched against a branch for preflight only, record that as
+   provisional evidence and rerun against the immutable tag before GA or signed
+   distribution.
+
+4. Record the run URL, conclusion, duration, `headSha`, and proof boundary in
+   the release packet.
+
+5. Stop the release only when the run finds an actual security issue, fails to
+   initialize/build/analyze the release source, or the repo has no replacement
+   Swift security-analysis evidence. Do not block ordinary PRs on advisory
+   upload limitations.
+
+## Budget
+
+The workflow has a 35-minute job timeout. If a manual/scheduled run exceeds that
+budget, treat it as a release-security investigation item, not a PR velocity
+blocker. Keep the Swift Desktop Gate responsible for fast PR feedback.
+
+## Future Conversion
+
+Only enable Swift CodeQL SARIF upload after a tracked decision converts the repo
+from default setup to compatible advanced CodeQL configuration, or after GitHub
+supports the intended mixed default/advanced shape for this repository. That
+change needs its own issue, PR, release evidence, and code-scanning proof.

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -38,9 +38,11 @@ describe("Swift CI velocity policy", () => {
   it("ships an always-reporting Swift desktop gate and a scheduled/manual Swift CodeQL workflow", () => {
     expect(existsSync(".github/workflows/swift-desktop-gate.yml")).toBe(true);
     expect(existsSync(".github/workflows/codeql-swift-path-aware.yml")).toBe(true);
+    expect(existsSync("docs/swift-codeql-policy.md")).toBe(true);
 
     const gate = read(".github/workflows/swift-desktop-gate.yml");
     const codeql = read(".github/workflows/codeql-swift-path-aware.yml");
+    const swiftCodeQLPolicy = read("docs/swift-codeql-policy.md");
 
     expect(gate).toMatch(/name:\s*Swift Desktop Gate/);
     expect(gate).toMatch(/swift-desktop-impact:/);
@@ -91,8 +93,10 @@ describe("Swift CI velocity policy", () => {
     expect(codeql).toMatch(/upload:\s*false/);
     expect(codeql).toMatch(/upload-database:\s*false/);
     expect(codeql).toMatch(/wait-for-processing:\s*false/);
+    expect(codeql).toMatch(/timeout-minutes:\s*35/);
     expect(codeql).toMatch(/default setup is enabled/);
     expect(codeql).toMatch(/#393/);
+    expect(codeql).toMatch(/docs\/swift-codeql-policy\.md/);
     expect(codeql).not.toMatch(/security-events:\s*write/);
     expect(codeql).toMatch(/persist-credentials:\s*false/);
     expect(codeql).not.toMatch(/actions\/checkout@v4/);
@@ -103,6 +107,19 @@ describe("Swift CI velocity policy", () => {
     expect(codeql).toMatch(/schedule:/);
     expect(codeql).toMatch(/workflow_dispatch:/);
     expect(codeql).toMatch(/cancel-in-progress:\s*true/);
+    expect(swiftCodeQLPolicy).toMatch(/not the\s+inner PR iteration loop/);
+    expect(swiftCodeQLPolicy).toMatch(/no `pull_request` or `push` trigger/);
+    expect(swiftCodeQLPolicy).toMatch(/upload: false/);
+    expect(swiftCodeQLPolicy).toMatch(/default setup may remain configured/);
+    expect(swiftCodeQLPolicy).toMatch(/must not list Swift/);
+    expect(swiftCodeQLPolicy).toMatch(/35-minute job timeout/);
+    expect(swiftCodeQLPolicy).toMatch(/--ref <immutable-release-tag>/);
+    expect(swiftCodeQLPolicy).toMatch(/headSha.*equals the exact source SHA/);
+    expect(swiftCodeQLPolicy).toMatch(/provisional evidence/);
+    expect(swiftCodeQLPolicy).toMatch(/28882286388/);
+    expect(swiftCodeQLPolicy).toMatch(/28886926047/);
+    expect(swiftCodeQLPolicy).toMatch(/about 25m48s/);
+    expect(swiftCodeQLPolicy).toMatch(/about 22m30s/);
     expect(gate).toMatch(/no PR\/push path filter/);
     expect(gate).toMatch(/before ref unavailable; fail open/);
   });
@@ -149,9 +166,11 @@ describe("Swift CI velocity policy", () => {
     expect(betaRunbook).toMatch(/preview server\/browser\s+smoke/);
     expect(betaRunbook).toMatch(/Swift desktop gate/);
     expect(betaRunbook).toMatch(/compiles `NeonDiffDesktopCoreChecks`/);
-    expect(betaRunbook).toMatch(/remove Swift from\s+GitHub CodeQL default setup/i);
+    expect(betaRunbook).toMatch(/docs\/swift-codeql-policy\.md/);
+    expect(betaRunbook).toMatch(/must not contain `swift`/);
     expect(betaRunbook).toMatch(/code-scanning\/default-setup/);
-    expect(betaRunbook).toMatch(/languages must not contain `swift`/);
+    expect(betaRunbook).toMatch(/read-only verification output currently includes `actions`, `javascript`,\s+`javascript-typescript`, and `typescript`/);
+    expect(betaRunbook).toMatch(/not a PATCH payload/);
     expect(betaRunbook).toMatch(/desktop-smoke/);
     expect(betaRunbook).toMatch(/desktop-release/);
     expect(betaRunbook).toMatch(/Visible Desktop UI Smoke/);
@@ -168,6 +187,8 @@ describe("Swift CI velocity policy", () => {
     expect(macRunbook).toMatch(/Execute `NeonDiffDesktopCoreChecks`/);
     expect(macRunbook).toMatch(/script\/build_and_run\.sh bundle-check/);
     expect(macRunbook).toMatch(/path-aware Swift\s+CodeQL workflow is a release\/security scan/);
+    expect(macRunbook).toMatch(/weekly schedule or manual dispatch\s+against the intended release ref/);
+    expect(macRunbook).toMatch(/docs\/swift-codeql-policy\.md/);
     expect(macRunbook).toMatch(/Visible Desktop UI Smoke/);
     expect(macRunbook).toMatch(/Computer Use/);
     expect(macRunbook).toMatch(/CI artifact smoke/);


### PR DESCRIPTION
## Summary

Closes #393.

This makes the Swift CodeQL decision durable:

- Swift CodeQL is scheduled/manual release-security evidence, not a required PR velocity gate.
- The Swift CodeQL workflow keeps `pull_request`/`push` disabled and adds a 35-minute job timeout.
- SARIF/database upload stays disabled while repository CodeQL default setup remains enabled for non-Swift languages.
- Release runbooks point to `docs/swift-codeql-policy.md` for trigger, upload, timeout, and release-packet requirements.

## Validation

- `gh api repos/electricsheephq/evaos-code-review-bot-neondiff/code-scanning/default-setup --jq '{state,languages,query_suite,updated_at}'`
  - observed default setup: `actions`, `javascript`, `javascript-typescript`, `typescript`; no Swift.
- `npm test -- tests/swift-ci-velocity.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`

## Swift CodeQL Measurement

Historical PR measurement:

- Run https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/28882286388 took 25m58s and failed after the manual SwiftPM build spent about 23m11s; failure was advanced CodeQL SARIF upload rejection while default setup was enabled.

Current main/manual measurement:

- Run https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/28886926047 is in progress on `5840b2d4bd6d6ef4cce6f99f149f5aa4c4f22e1f`; this PR should update the policy doc with its conclusion before merge.

## Proof Boundary

This PR sets the durable CI/security policy and budget. It does not convert the repo to advanced CodeQL upload, prove signed release security, or cut GA.
