### PR TITLE
[codex] Enforce changelog release lockstep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ for the semver/GA-line and npm dist-tag policy.
 
 No unreleased changes tracked yet.
 
+## [0.4.43-beta.1] - docs/releases/v0.4.43-beta.1.md
+
+### Added
+- Promote the production license API to a required healthy source-beta gate with committed `/healthz` proof, live Fly deployment evidence, and release-status validation for the license API health artifact
+- Keep the public npm package held at `neondiff@0.4.30-beta.1` while advancing the source-beta release surface to `v0.4.43-beta.1`
+
 ## [0.4.42-beta.1] - docs/releases/v0.4.42-beta.1.md
 
 ### Added

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -310,7 +310,8 @@ npx tsx src/cli.ts review-head-gate \
 - Release checkout is clean and exactly at the intended source SHA.
 - Root `CHANGELOG.md` has a dated section for this version (moved out of
   `[Unreleased]` if it was tracked there) linking to
-  `docs/releases/<version>.md`.
+  `docs/releases/<version>.md`. Public source-beta `release:status` checks this
+  head changelog entry against the manifest version and release notes path.
 - `npm test` and `npm run build` pass from the release checkout.
 - `release:status` records exact source SHA, branch, config path, launchd job,
   launchd dry-run mode, state DB row count, and error count.

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -114,6 +114,9 @@ export interface PublicReleaseStatus {
     setupPath?: string;
     releaseNotesPath?: string;
     websiteRepo?: string;
+    changelogPath?: string;
+    changelogHeadVersion?: string;
+    changelogReleaseNotesPath?: string;
   };
   licenseApi: PublicReleaseGateStatus & {
     requiredForThisRelease: boolean;
@@ -519,6 +522,7 @@ export function readPublicReleaseManifestStatus(input: {
     const docsVersion = readString(docs.version) ?? "(missing)";
     const setupPath = readString(docs.setupPath);
     const releaseNotesPath = readString(docs.releaseNotesPath);
+    const changelog = readChangelogHead(input.cwd);
     const docsPathChecks = [
       setupPath
         ? { label: "setup", path: setupPath, exists: existsSync(resolve(input.cwd, setupPath)) }
@@ -532,11 +536,20 @@ export function readPublicReleaseManifestStatus(input: {
     const docsVersionOk = expectedVersionOk && docsVersion === expectedVersion;
     const expectedReleaseNotesPath = expectedVersionOk ? `docs/releases/${expectedVersion}.md` : undefined;
     const releaseNotesPathOk = expectedReleaseNotesPath !== undefined && releaseNotesPath === expectedReleaseNotesPath;
+    const expectedChangelogVersion = expectedVersionOk ? stripLeadingV(expectedVersion) : undefined;
+    const changelogVersionOk =
+      expectedChangelogVersion !== undefined &&
+      changelog.version === expectedChangelogVersion;
+    const changelogReleaseNotesPathOk =
+      expectedReleaseNotesPath !== undefined &&
+      changelog.releaseNotesPath === expectedReleaseNotesPath;
     const docsOk =
       expectedVersionOk &&
       manifestVersionOk &&
       docsVersionOk &&
       releaseNotesPathOk &&
+      changelogVersionOk &&
+      changelogReleaseNotesPathOk &&
       missingDocsPaths.length === 0;
     const licenseState = readString(licenseApi.state) ?? "missing";
     const licenseRequired = releaseLevel === "source-beta"
@@ -598,9 +611,12 @@ export function readPublicReleaseManifestStatus(input: {
         actualVersion: docsVersion,
         setupPath,
         releaseNotesPath,
+        changelogPath: changelog.path,
+        changelogHeadVersion: changelog.version,
+        changelogReleaseNotesPath: changelog.releaseNotesPath,
         websiteRepo: readString(docs.websiteRepo),
         detail: docsOk
-          ? `manifest version ${version} and docs version ${docsVersion} match ${expectedVersion}; checked setup and release notes paths`
+          ? `manifest version ${version}, docs version ${docsVersion}, and CHANGELOG head ${changelog.version} match ${expectedVersion}; checked setup, release notes, and changelog paths`
           : [
               expectedVersion
                 ? manifestVersionOk
@@ -619,6 +635,17 @@ export function readPublicReleaseManifestStatus(input: {
               ...(releaseNotesPath && expectedReleaseNotesPath && !releaseNotesPathOk
                 ? [`release notes path ${releaseNotesPath} does not match ${expectedReleaseNotesPath}`]
                 : []),
+              ...(expectedVersion
+                ? [
+                    changelogVersionOk
+                      ? `CHANGELOG head ${changelog.version} matches ${expectedChangelogVersion}`
+                      : `CHANGELOG head ${changelog.version ?? "(missing)"} does not match ${expectedChangelogVersion}`
+                  ]
+                : []),
+              ...(changelog.releaseNotesPath && expectedReleaseNotesPath && !changelogReleaseNotesPathOk
+                ? [`CHANGELOG release notes path ${changelog.releaseNotesPath} does not match ${expectedReleaseNotesPath}`]
+                : []),
+              ...(!changelog.exists ? [`CHANGELOG missing at ${changelog.path}`] : []),
               ...missingDocsPaths.map((pathCheck) => `${pathCheck.label} missing at ${pathCheck.path}`)
             ].join("; ")
       },
@@ -1765,6 +1792,37 @@ function describeHeartbeat(heartbeat: ReleaseHeartbeatStatus): string {
     ? ""
     : `; active age ${heartbeat.activeAgeMs}ms; active max ${heartbeat.activeMaxAgeMs ?? heartbeat.maxAgeMs}ms; active cycle ${heartbeat.activeCycle ?? "unknown"}`;
   return `${heartbeat.status}; age ${age}; max ${heartbeat.maxAgeMs}ms; event ${heartbeat.event ?? "unknown"}; cycle ${heartbeat.cycle ?? "unknown"}${activeSuffix}`;
+}
+
+interface ChangelogHeadStatus {
+  path: string;
+  exists: boolean;
+  version?: string;
+  releaseNotesPath?: string;
+}
+
+function readChangelogHead(cwd: string): ChangelogHeadStatus {
+  const path = "CHANGELOG.md";
+  const absolutePath = resolve(cwd, path);
+  if (!existsSync(absolutePath)) return { path, exists: false };
+
+  const lines = readFileSync(absolutePath, "utf8").split(/\r?\n/);
+  for (const line of lines) {
+    const match = /^## \[([^\]]+)\](?:\s*-\s*(\S+))?/.exec(line.trim());
+    if (!match || match[1] === "Unreleased") continue;
+    return {
+      path,
+      exists: true,
+      version: match[1],
+      ...(match[2] ? { releaseNotesPath: match[2] } : {})
+    };
+  }
+
+  return { path, exists: true };
+}
+
+function stripLeadingV(version: string): string {
+  return version.startsWith("v") ? version.slice(1) : version;
 }
 
 function git(cwd: string, args: string[]): string {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -62,6 +62,22 @@ describe("beta release status", () => {
     return proofPath;
   }
 
+  function writeChangelogHead(root: string, version = "1.0.0-beta.1", releaseNotesPath = `docs/releases/v${version}.md`): void {
+    writeFileSync(join(root, "CHANGELOG.md"), [
+      "# Changelog",
+      "",
+      "## [Unreleased]",
+      "",
+      "No unreleased changes tracked yet.",
+      "",
+      `## [${version}] - ${releaseNotesPath}`,
+      "",
+      "### Added",
+      "- Fixture release entry.",
+      ""
+    ].join("\n"));
+  }
+
   it("fails closed when the live checkout is dirty or not at the expected head", () => {
     const status = buildReleaseStatus({
       repo: {
@@ -136,6 +152,7 @@ describe("beta release status", () => {
     mkdirSync(join(root, "docs", "releases"), { recursive: true });
     writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
     writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
     writeFileSync(join(root, "public-release.json"), JSON.stringify({
       version: "v1.0.0-beta.1",
       releaseLevel: "source-beta",
@@ -211,7 +228,7 @@ describe("beta release status", () => {
     expect(status.gates).toContainEqual({
       name: "public_docs_version",
       ok: true,
-      detail: "manifest version v1.0.0-beta.1 and docs version v1.0.0-beta.1 match v1.0.0-beta.1; checked setup and release notes paths"
+      detail: "manifest version v1.0.0-beta.1, docs version v1.0.0-beta.1, and CHANGELOG head 1.0.0-beta.1 match v1.0.0-beta.1; checked setup, release notes, and changelog paths"
     });
     expect(status.gates).toContainEqual({
       name: "public_license_api_state",
@@ -240,7 +257,10 @@ describe("beta release status", () => {
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v0.4.43-beta.1.md"
+        releaseNotesPath: "docs/releases/v0.4.43-beta.1.md",
+        changelogPath: "CHANGELOG.md",
+        changelogHeadVersion: "0.4.43-beta.1",
+        changelogReleaseNotesPath: "docs/releases/v0.4.43-beta.1.md"
       },
       licenseApi: {
         ok: true,
@@ -285,6 +305,55 @@ describe("beta release status", () => {
     });
     expect(manifest.licenseApi.detail).toContain("observedAt must be no older than 30 days");
     expect(manifest.ok).toBe(false);
+  });
+
+  it("fails the public docs gate when CHANGELOG head lags the manifest version", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-changelog-drift-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v0.4.43-beta.1.md"), "# v0.4.43-beta.1\n");
+    writeChangelogHead(root, "0.4.42-beta.1", "docs/releases/v0.4.42-beta.1.md");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v0.4.43-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v0.4.43-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v0.4.43-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          rollback: "git reset --hard refs/tags/v0.4.42-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          rollback: "git reset --hard refs/tags/v0.4.42-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v0.4.43-beta.1"
+    });
+
+    expect(manifest.ok).toBe(false);
+    expect(manifest.docs).toMatchObject({
+      ok: false,
+      changelogHeadVersion: "0.4.42-beta.1",
+      changelogReleaseNotesPath: "docs/releases/v0.4.42-beta.1.md"
+    });
+    expect(manifest.docs.detail).toContain("CHANGELOG head 0.4.42-beta.1 does not match 0.4.43-beta.1");
+    expect(manifest.docs.detail).toContain("CHANGELOG release notes path docs/releases/v0.4.42-beta.1.md does not match docs/releases/v0.4.43-beta.1.md");
   });
 
   it("fails closed when public release manifest flags are not paired", () => {
@@ -435,6 +504,7 @@ describe("beta release status", () => {
     mkdirSync(join(root, "docs", "releases"), { recursive: true });
     writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
     writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
     writeFileSync(join(root, "public-release.json"), JSON.stringify({
       version: "v1.0.0-beta.1",
       releaseLevel: "source-beta",
@@ -485,6 +555,7 @@ describe("beta release status", () => {
     mkdirSync(join(root, "docs", "releases"), { recursive: true });
     writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
     writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
     writeFileSync(join(root, "public-release.json"), JSON.stringify({
       version: "v1.0.0-beta.1",
       releaseLevel: "source-beta",
@@ -549,6 +620,7 @@ describe("beta release status", () => {
     mkdirSync(join(root, "docs", "releases"), { recursive: true });
     writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
     writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
     writeFileSync(join(root, "public-release.json"), JSON.stringify({
       version: "v1.0.0-beta.1",
       releaseLevel: "source-beta",
@@ -584,6 +656,7 @@ describe("beta release status", () => {
   it("fails public docs gate when required docs paths are omitted", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-no-doc-paths-"));
     roots.push(root);
+    writeChangelogHead(root);
     writeFileSync(join(root, "public-release.json"), JSON.stringify({
       version: "v1.0.0-beta.1",
       releaseLevel: "source-beta",
@@ -610,7 +683,7 @@ describe("beta release status", () => {
 
     expect(manifest.ok).toBe(false);
     expect(manifest.docs.detail).toBe(
-      "manifest version v1.0.0-beta.1 matches v1.0.0-beta.1; docs version v1.0.0-beta.1 matches v1.0.0-beta.1; setupPath missing at (missing); releaseNotesPath missing at (missing)"
+      "manifest version v1.0.0-beta.1 matches v1.0.0-beta.1; docs version v1.0.0-beta.1 matches v1.0.0-beta.1; CHANGELOG head 1.0.0-beta.1 matches 1.0.0-beta.1; setupPath missing at (missing); releaseNotesPath missing at (missing)"
     );
   });
 
@@ -1079,6 +1152,7 @@ describe("beta release status", () => {
     mkdirSync(join(root, "docs", "releases"), { recursive: true });
     writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
     writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
     writeLicenseHealthProof(root, { path: "docs/evidence/license-healthz-target.json" });
     symlinkSync("license-healthz-target.json", join(root, "docs", "evidence", "license-healthz-link.json"));
     writeFileSync(join(root, "public-release.json"), JSON.stringify({
@@ -2212,6 +2286,7 @@ describe("beta release status", () => {
     roots.push(root);
     mkdirSync(join(root, "docs"), { recursive: true });
     writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeChangelogHead(root);
     writeFileSync(join(root, "public-release.json"), JSON.stringify({
       version: "v1.0.0-beta.1",
       releaseLevel: "public-beta",
@@ -2271,7 +2346,7 @@ describe("beta release status", () => {
     expect(status.gates).toContainEqual({
       name: "public_docs_version",
       ok: false,
-      detail: "manifest version v1.0.0-beta.1 matches v1.0.0-beta.1; docs version v0.9.0-beta.1 does not match v1.0.0-beta.1; release notes missing at docs/releases/v1.0.0-beta.1.md"
+      detail: "manifest version v1.0.0-beta.1 matches v1.0.0-beta.1; docs version v0.9.0-beta.1 does not match v1.0.0-beta.1; CHANGELOG head 1.0.0-beta.1 matches 1.0.0-beta.1; release notes missing at docs/releases/v1.0.0-beta.1.md"
     });
     expect(status.gates).toContainEqual({
       name: "public_license_api_state",


### PR DESCRIPTION
Closes #395.

## Summary
- catch up `CHANGELOG.md` with `v0.4.43-beta.1` and its release packet
- make public source-beta release-status require the root CHANGELOG head to match the public manifest version and `docs/releases/<version>.md` path
- document the lockstep release gate in the beta release runbook

## Validation
- `npm test -- tests/release-status.test.ts --pool=forks --maxWorkers=1`
- `npm test -- tests/public-release-readiness.test.ts tests/release-status.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`

## Visible App Proof Note
No SwiftUI/app behavior changed in this PR, so I did not spend another Swift build cycle here. The runbook now explicitly treats build-only Swift passes as insufficient for UI behavior; the previous desktop lane included a visible Computer Use smoke on `dist/NeonDiffDesktop.app` for the onboarding flow.