### PR TITLE
[codex] Align pricing with website canonical tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ with your GitHub installation, your provider keys, your repo policy, and
 public-safe evidence for every live posting decision.
 
 Public open-source repos are free. Private and commercial repos require a paid
-NeonDiff support license: $1/month, $10/year, or $100 lifetime. NeonDiff is a
-source-available beta, not an open-source or GA release.
+NeonDiff support license: $1/month or $10/year for individuals, or $100/year for
+organizations. Individual plans include a 7-day trial, organization plans include
+a 30-day trial, and legacy lifetime licenses remain honored but are no longer
+sold. NeonDiff is a source-available beta, not an open-source or GA release.
 
 [Website](https://www.neondiff.com) · [Setup](docs/SETUP.md) ·
 [GitHub App Install](docs/github-app-setup.md) · [Contributing](CONTRIBUTING.md) ·

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -16,11 +16,13 @@ for the support-tier pricing contract.
 - optional NeonDiff license key for private or commercial repo use
 
 Public open-source repos are free. Private and commercial repos require a paid
-support license: $1/month, $10/year, or $100 lifetime. Paid support includes
-private repo review, commercial usage, and auto-updates. Provider/model costs
-remain external through your own provider key or local model; NeonDiff does not
-include hosted model credits, unlimited SaaS inference, or bundled provider
-tokens.
+support license: $1/month or $10/year for individuals, or $100/year for
+organizations. Individual plans include a 7-day trial, organization plans include
+a 30-day trial, and legacy lifetime licenses remain honored for existing holders
+but are no longer sold. Paid support includes private repo review, commercial
+usage, and auto-updates. Provider/model costs remain external through your own
+provider key or local model; NeonDiff does not include hosted model credits,
+unlimited SaaS inference, or bundled provider tokens.
 
 ## 1. Install NeonDiff
 
@@ -111,9 +113,10 @@ OpenAI-compatible endpoint examples. The provider registry stores metadata such
 as provider id, base URL, model id, timeout, retry policy, and an API-key
 environment variable name; it must not store the API key itself.
 
-If you are reviewing private or commercial repos, set your license key through
-the configured local secret path or environment used by your operator wrapper.
-Do not paste license keys into tracked config.
+If you are reviewing private or commercial repos, set the `NEONDIFF_LICENSE_KEY`
+environment variable to your `nd_live_...` license key value, or store that same
+value in the configured local secret path used by your operator wrapper. Do not
+paste license keys into tracked config.
 
 The public license path is explicit and local-first. By default, license
 enforcement is disabled in the example config so internal beta workers do not

--- a/docs/license-boundary.md
+++ b/docs/license-boundary.md
@@ -12,9 +12,12 @@ proprietary, hosted, marketplace, binary redistribution, and auto-updates requir
 an active paid NeonDiff license.
 
 Public open-source repositories are free. Private and commercial repository
-review requires a paid NeonDiff support license: $1/month, $10/year, or $100
-lifetime. NeonDiff support tiers do not include hosted model credits, unlimited
-SaaS inference, or bundled provider tokens.
+review requires a paid NeonDiff support license: $1/month or $10/year for
+individuals, or $100/year for organizations. Individual plans include a 7-day
+trial, organization plans include a 30-day trial, and legacy lifetime licenses
+remain honored for existing holders but are no longer sold. NeonDiff support
+tiers do not include hosted model credits, unlimited SaaS inference, or bundled
+provider tokens.
 
 ## Allowed Without A Paid License
 
@@ -75,7 +78,10 @@ Use:
 - "source-available beta"
 - "free for public open-source repositories"
 - "private and commercial repository review requires a paid NeonDiff license"
-- "$1/month, $10/year, or $100 lifetime support license"
+- "$1/month or $10/year individual support license"
+- "$100/year organization support license"
+- "7-day individual trial and 30-day organization trial"
+- "legacy lifetime licenses remain honored but are no longer sold"
 - "bring your own provider key or local model"
 - "local worker; current-head, secret-redacted review evidence"
 
@@ -108,8 +114,10 @@ CLI setup/help copy should say:
 
 > NeonDiff is source-available beta software. Public open-source repository
 > review is free. Private, internal, and commercial repository review requires
-> an active paid NeonDiff license. Support tiers are $1/month, $10/year, or
-> $100 lifetime; provider/model costs stay external through BYOK or local
+> an active paid NeonDiff license. Individual support tiers are $1/month or
+> $10/year, organization support is $100/year, trials are 7 days for individuals
+> and 30 days for organizations, and legacy lifetime licenses remain honored but
+> are no longer sold; provider/model costs stay external through BYOK or local
 > providers.
 
 Private-repo failure copy should say:

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -13,9 +13,10 @@ credits, unlimited SaaS inference, or bundled provider tokens.
 | Tier | Price | Best For | Private Repos | Commercial Use | Auto-Updates | Provider Credits |
 | --- | ---: | --- | --- | --- | --- | --- |
 | Free OSS | $0 | Public open-source projects | No | No | No | Not included |
-| Monthly Support | $1/mo | Low-friction private or commercial use | Yes | Yes | Yes | Not included |
-| Yearly Support | $10/yr | Annual support license | Yes | Yes | Yes | Not included |
-| Lifetime Support | $100 lifetime | One-time support license | Yes | Yes | Yes | Not included |
+| Individual Monthly | $1/mo | Single-user private or commercial use; 7-day free trial | Yes | Yes | Yes | Not included |
+| Individual Yearly | $10/yr | Single-user yearly license; 7-day free trial | Yes | Yes | Yes | Not included |
+| Organization Yearly | $100/yr | Flat organization license; 30-day free trial | Yes | Yes | Yes | Not included |
+| Legacy Lifetime Support | no longer sold | Existing lifetime license holders only | Yes | Yes | Yes | Not included |
 
 ## CLI Contract
 
@@ -29,7 +30,11 @@ neondiff pricing
 The pricing command emits JSON by default and does not call the network. It reports:
 
 - public open-source repositories are free
-- paid support tiers are `$1/mo`, `$10/yr`, and `$100 lifetime`
+- active paid support tiers are `$1/mo`, `$10/yr`, and `$100/yr`
+- individual paid plans include a 7-day trial; organization plans include a
+  30-day trial
+- legacy lifetime licenses remain honored for existing holders but are no
+  longer sold
 - paid support includes private repo review, commercial usage, and auto-updates
 - provider/model costs stay external through BYOK or local providers
 - hosted model credits and unlimited SaaS inference are not included
@@ -42,7 +47,13 @@ usage, and auto-updates:
 
 - `monthly_support`
 - `yearly_support`
+- `org_yearly_support`
 - `lifetime_support`
+
+`monthly_support`, `yearly_support`, and `org_yearly_support` are active
+checkout plans. `lifetime_support` is a legacy entitlement id kept for existing
+lifetime holders only; it is read-only for compatibility and not offered for new
+checkout.
 
 Runtime license enforcement is outside this pricing command. This document only
 defines the pricing and entitlement vocabulary that enforcement code and setup

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -13,13 +13,22 @@ const paths = [
 const required = [
   /source-available beta/i,
   /public open-source repositor(?:y|ies).*free/i,
-  /private.*commercial.*paid|paid.*private.*commercial/i
+  /private.*commercial.*paid|paid.*private.*commercial/i,
+  /\$100\/(?:year|yr)/i,
+  /7-day trial/i,
+  /30-day trial/i,
+  /legacy lifetime licenses? remain honored/i,
+  /org_yearly_support/i,
+  /NEONDIFF_LICENSE_KEY/,
+  /nd_live_/
 ];
 
 const forbiddenClaims = [
   /\bMIT licensed\b/i,
   /\bApache licensed\b/i,
   /\bopen-source software\b/i,
+  /\$100\s+lifetime/i,
+  /NEONDIFF_API_KEY/,
   /\bproduction-ready\b/i,
   /\benterprise-ready\b/i,
   /\bCodeRabbit parity\b/i,

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,18 +1,33 @@
-export type NeonDiffPricingPlanId = "free_oss" | "monthly_support" | "yearly_support" | "lifetime_support";
+export type NeonDiffPricingPlanId =
+  | "free_oss"
+  | "monthly_support"
+  | "yearly_support"
+  | "org_yearly_support"
+  | "lifetime_support";
+
+export type NeonDiffActiveCheckoutLookupKey =
+  | "neondiff_monthly"
+  | "neondiff_yearly"
+  | "neondiff_org_yearly";
 
 export interface NeonDiffPricingPlan {
   id: NeonDiffPricingPlanId;
   name: string;
   priceUsd: number;
   displayPrice: string;
-  cadence: "public open-source repositories" | "month" | "year" | "lifetime";
+  cadence: "public open-source repositories" | "month" | "year" | "legacy";
   summary: string;
   requiresPaidLicense: boolean;
   repoVisibilityScope: "public" | "private";
   commercialUse: boolean;
   autoUpdates: boolean;
   providerCreditsIncluded: false;
-  entitlementPlan?: "monthly_support" | "yearly_support" | "lifetime_support";
+  buyerSegment: "public" | "individual" | "organization" | "legacy";
+  availableForNewPurchase: boolean;
+  trialDays?: 7 | 30;
+  checkoutLookupKey?: NeonDiffActiveCheckoutLookupKey;
+  entitlementPlan?: Exclude<NeonDiffPricingPlanId, "free_oss">;
+  legacyNote?: string;
 }
 
 export const NEONDIFF_PRICING_PLANS: readonly NeonDiffPricingPlan[] = [
@@ -27,49 +42,80 @@ export const NEONDIFF_PRICING_PLANS: readonly NeonDiffPricingPlan[] = [
     repoVisibilityScope: "public",
     commercialUse: false,
     autoUpdates: false,
-    providerCreditsIncluded: false
+    providerCreditsIncluded: false,
+    buyerSegment: "public",
+    availableForNewPurchase: true
   },
   {
     id: "monthly_support",
-    name: "Monthly Support",
+    name: "Individual Monthly",
     priceUsd: 1,
     displayPrice: "$1/mo",
     cadence: "month",
-    summary: "Paid support tier for private repo review, commercial use, and auto-updates.",
+    summary: "Single-user monthly support tier for private repo review, commercial use, and auto-updates.",
     requiresPaidLicense: true,
     repoVisibilityScope: "private",
     commercialUse: true,
     autoUpdates: true,
     providerCreditsIncluded: false,
+    buyerSegment: "individual",
+    availableForNewPurchase: true,
+    trialDays: 7,
+    checkoutLookupKey: "neondiff_monthly",
     entitlementPlan: "monthly_support"
   },
   {
     id: "yearly_support",
-    name: "Yearly Support",
+    name: "Individual Yearly",
     priceUsd: 10,
     displayPrice: "$10/yr",
     cadence: "year",
-    summary: "Annual paid support tier for private repo review, commercial use, and auto-updates.",
+    summary: "Single-user yearly support tier for private repo review, commercial use, and auto-updates.",
     requiresPaidLicense: true,
     repoVisibilityScope: "private",
     commercialUse: true,
     autoUpdates: true,
     providerCreditsIncluded: false,
+    buyerSegment: "individual",
+    availableForNewPurchase: true,
+    trialDays: 7,
+    checkoutLookupKey: "neondiff_yearly",
     entitlementPlan: "yearly_support"
   },
   {
-    id: "lifetime_support",
-    name: "Lifetime Support",
+    id: "org_yearly_support",
+    name: "Organization Yearly",
     priceUsd: 100,
-    displayPrice: "$100 lifetime",
-    cadence: "lifetime",
-    summary: "Lifetime paid support tier for private repo review, commercial use, and auto-updates.",
+    displayPrice: "$100/yr",
+    cadence: "year",
+    summary: "Flat organization yearly support tier for private and commercial repositories.",
     requiresPaidLicense: true,
     repoVisibilityScope: "private",
     commercialUse: true,
     autoUpdates: true,
     providerCreditsIncluded: false,
-    entitlementPlan: "lifetime_support"
+    buyerSegment: "organization",
+    availableForNewPurchase: true,
+    trialDays: 30,
+    checkoutLookupKey: "neondiff_org_yearly",
+    entitlementPlan: "org_yearly_support"
+  },
+  {
+    id: "lifetime_support",
+    name: "Legacy Lifetime Support",
+    priceUsd: 100,
+    displayPrice: "legacy; no longer sold",
+    cadence: "legacy",
+    summary: "Legacy lifetime licenses remain honored for existing holders but are no longer sold.",
+    requiresPaidLicense: true,
+    repoVisibilityScope: "private",
+    commercialUse: true,
+    autoUpdates: true,
+    providerCreditsIncluded: false,
+    buyerSegment: "legacy",
+    availableForNewPurchase: false,
+    entitlementPlan: "lifetime_support",
+    legacyNote: "Existing lifetime license holders remain entitled; new lifetime checkout is disabled."
   }
 ] as const;
 
@@ -105,13 +151,21 @@ export function buildPricingOutput() {
         requiresPaidLicense: true,
         commercialUse: true,
         autoUpdates: true,
-        acceptedPlanIds: ["monthly_support", "yearly_support", "lifetime_support"]
+        activeCheckoutPlanIds: ["monthly_support", "yearly_support", "org_yearly_support"],
+        legacyAcceptedPlanIds: ["lifetime_support"],
+        acceptedPlanIds: ["monthly_support", "yearly_support", "org_yearly_support", "lifetime_support"],
+        checkoutLookupKeys: ["neondiff_monthly", "neondiff_yearly", "neondiff_org_yearly"],
+        trialDays: {
+          individual: 7,
+          organization: 30
+        }
       }
     },
     sourceOfTruth: {
-      roadmap: "https://github.com/electricsheephq/evaos-code-review-bot/issues/103",
-      licenseBoundary: "https://github.com/electricsheephq/evaos-code-review-bot/issues/104",
-      pricingImplementation: "https://github.com/electricsheephq/evaos-code-review-bot/issues/105"
+      roadmap: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103",
+      licenseBoundary: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/104",
+      pricingImplementation: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/105",
+      pricingParityGate: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
     },
     forbiddenClaims: [
       "hosted model credits included",

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -420,7 +420,14 @@ exit 1
           requiresPaidLicense: true,
           commercialUse: true,
           autoUpdates: true,
-          acceptedPlanIds: ["monthly_support", "yearly_support", "lifetime_support"]
+          activeCheckoutPlanIds: ["monthly_support", "yearly_support", "org_yearly_support"],
+          legacyAcceptedPlanIds: ["lifetime_support"],
+          acceptedPlanIds: ["monthly_support", "yearly_support", "org_yearly_support", "lifetime_support"],
+          checkoutLookupKeys: ["neondiff_monthly", "neondiff_yearly", "neondiff_org_yearly"],
+          trialDays: {
+            individual: 7,
+            organization: 30
+          }
         }
       }
     });
@@ -434,6 +441,9 @@ exit 1
       expect.objectContaining({
         id: "monthly_support",
         displayPrice: "$1/mo",
+        availableForNewPurchase: true,
+        trialDays: 7,
+        checkoutLookupKey: "neondiff_monthly",
         requiresPaidLicense: true,
         commercialUse: true,
         autoUpdates: true,
@@ -442,6 +452,20 @@ exit 1
       expect.objectContaining({
         id: "yearly_support",
         displayPrice: "$10/yr",
+        availableForNewPurchase: true,
+        trialDays: 7,
+        checkoutLookupKey: "neondiff_yearly",
+        requiresPaidLicense: true,
+        commercialUse: true,
+        autoUpdates: true,
+        providerCreditsIncluded: false
+      }),
+      expect.objectContaining({
+        id: "org_yearly_support",
+        displayPrice: "$100/yr",
+        availableForNewPurchase: true,
+        trialDays: 30,
+        checkoutLookupKey: "neondiff_org_yearly",
         requiresPaidLicense: true,
         commercialUse: true,
         autoUpdates: true,
@@ -449,7 +473,9 @@ exit 1
       }),
       expect.objectContaining({
         id: "lifetime_support",
-        displayPrice: "$100 lifetime",
+        displayPrice: "legacy; no longer sold",
+        availableForNewPurchase: false,
+        legacyNote: expect.stringMatching(/existing lifetime/i),
         requiresPaidLicense: true,
         commercialUse: true,
         autoUpdates: true,

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -25,7 +25,10 @@ describe("NeonDiff public community funnel", () => {
       /public open-source repos.*free/i,
       /\$1\/month/i,
       /\$10\/year/i,
-      /\$100 lifetime/i,
+      /\$100\/year/i,
+      /7-day trial/i,
+      /30-day trial/i,
+      /legacy lifetime licenses remain honored/i,
       /private.*commercial.*paid/i,
       /source-available beta/i,
       /GitHub App/i,
@@ -86,7 +89,10 @@ describe("NeonDiff public community funnel", () => {
       expect(text).toMatch(/public open-source/i);
       expect(text).toMatch(/\$1\/mo|\$1\/month/i);
       expect(text).toMatch(/\$10\/yr|\$10\/year/i);
-      expect(text).toMatch(/\$100 lifetime/i);
+      expect(text).toMatch(/\$100\/yr|\$100\/year/i);
+      expect(text).toMatch(/7-day.*trial/i);
+      expect(text).toMatch(/30-day.*trial/i);
+      expect(text).toMatch(/legacy lifetime licenses? remain honored/i);
       expect(text).toMatch(/private repo review|private.*repo/i);
       expect(text).toMatch(/commercial/i);
       expect(text).toMatch(/auto-updates/i);
@@ -100,7 +106,9 @@ describe("NeonDiff public community funnel", () => {
     expect(pricing).toMatch(/neondiff pricing/i);
     expect(pricing).toMatch(/monthly_support/i);
     expect(pricing).toMatch(/yearly_support/i);
+    expect(pricing).toMatch(/org_yearly_support/i);
     expect(pricing).toMatch(/lifetime_support/i);
+    expect(pricing).toMatch(/no longer sold/i);
     expect(issueTemplate).toMatch(/docs\/pricing\.md/i);
   });
 


### PR DESCRIPTION
Refs #421.

## Summary
- align product pricing JSON/docs with the website-canonical tiers: individual monthly/yearly, organization yearly, trials, and legacy lifetime honored but no longer sold
- add `org_yearly_support` and `neondiff_org_yearly` to the `neondiff pricing` output while preserving `lifetime_support` as a legacy accepted entitlement
- harden public-claims checks so product docs require `NEONDIFF_LICENSE_KEY` / `nd_live_...`, require org-yearly/trial/lifetime-legacy wording, and reject stale `$100 lifetime` offer copy

## Proof Boundary
This PR only reconciles repo pricing/docs/CLI claims to the owner ruling in #421. It does **not** bridge website checkout to the Fly license API, mint production license keys, publish the website, or prove paid activation. #421 remains open for that purchase-path work.

## Validation
- `npm test -- tests/public-cli.test.ts tests/public-community-funnel.test.ts --pool=forks --maxWorkers=1`
- `node scripts/check-public-claims.mjs`
- `npm run build`
- `git diff --check`
- `npm test -- tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1`