### PR TITLE
Add launch-influx readiness docs and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,6 +17,58 @@ body:
       description: Package version, tag, or commit SHA.
     validations:
       required: true
+  - type: dropdown
+    id: provider
+    attributes:
+      label: Provider or model path
+      description: Pick the path involved, even if you are not sure yet.
+      options:
+        - GLM/Z.AI through ZCode
+        - Ollama localhost
+        - Local OpenAI-compatible endpoint
+        - Hosted OpenAI-compatible BYOK endpoint
+        - Provider-independent bug
+        - Unknown or not configured
+    validations:
+      required: true
+  - type: checkboxes
+    id: backend_matrix
+    attributes:
+      label: Backend or surface involved
+      description: Check every surface that appears relevant.
+      options:
+        - label: CLI command
+        - label: Daemon or launchd worker
+        - label: GitHub App read/posting path
+        - label: Provider registry, doctor, or smoke check
+        - label: Review output, inline comments, duplicate suppression, or stale-head handling
+        - label: License or entitlement gate
+        - label: Desktop macOS app
+        - label: Install, setup, or docs
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS
+        - Linux
+        - GitHub Actions or CI
+        - Other or unknown
+    validations:
+      required: true
+  - type: dropdown
+    id: review_mode
+    attributes:
+      label: Mode
+      options:
+        - Dry-run review
+        - Live GitHub posting
+        - Provider/list/doctor/smoke command
+        - Setup or install
+        - Not review-related
+        - Unknown
+    validations:
+      required: true
   - type: textarea
     id: repro
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security report
-    url: https://github.com/electricsheephq/evaos-code-review-bot/security
+    url: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/security/policy
     about: Report vulnerabilities, secrets, credentials, or private repo data privately.
+  - name: Support contact
+    url: mailto:support@electricsheephq.com
+    about: Non-security support alias listed for launch readiness; owner must verify monitoring before public launch.
   - name: NeonDiff roadmap
-    url: https://github.com/electricsheephq/evaos-code-review-bot/issues/103
+    url: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103
     about: Public product roadmap and proof boundaries.

--- a/.github/ISSUE_TEMPLATE/provider_request.yml
+++ b/.github/ISSUE_TEMPLATE/provider_request.yml
@@ -10,11 +10,60 @@ body:
       placeholder: Ollama, OpenAI-compatible endpoint, Anthropic, Gemini...
     validations:
       required: true
+  - type: dropdown
+    id: provider_class
+    attributes:
+      label: Provider class
+      description: Pick the closest fit. Provider catalogs alone are not NeonDiff compatibility proof.
+      options:
+        - Local model runtime on localhost
+        - Self-hosted OpenAI-compatible endpoint
+        - Hosted OpenAI-compatible BYOK endpoint
+        - Hosted provider with custom API
+        - Agent runtime adapter
+        - Free/trial provider catalog entry
+        - Other or unknown
+    validations:
+      required: true
+  - type: checkboxes
+    id: backend_matrix
+    attributes:
+      label: Backend matrix
+      description: Which NeonDiff surfaces would this need before live review promotion?
+      options:
+        - label: Provider registry metadata
+        - label: "`providers doctor` without network smoke"
+        - label: "Single-provider smoke such as `/models`"
+        - label: Mocked adapter fixture tests
+        - label: Dry-run PR review proof
+        - label: Live GitHub posting proof
+        - label: macOS operator path
+        - label: Linux operator path
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: API shape and model behavior
+      description: Describe API compatibility, model id, JSON output behavior, timeout/rate limits, and any known output-schema risks.
+    validations:
+      required: true
   - type: textarea
     id: auth
     attributes:
       label: Auth and data boundary
       description: Explain key handling, local/cloud behavior, and what code or diff data would leave the machine.
+    validations:
+      required: true
+  - type: dropdown
+    id: requested_status
+    attributes:
+      label: Requested status
+      description: Be honest about the proof you are asking for.
+      options:
+        - Resource only / discovery
+        - Compatible by interface
+        - Provider doctor or smoke support
+        - Dry-run review support
+        - Live review promotion
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,41 @@
+name: Question
+description: Ask a public-safe NeonDiff setup, provider, license, or workflow question.
+title: "[question]: "
+labels: ["question"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What are you trying to understand or decide?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Install or setup
+        - GitHub App permissions
+        - Provider or model path
+        - Dry-run or live review workflow
+        - License or pricing boundary
+        - Desktop macOS app
+        - Roadmap or shipped status
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Public-safe context
+      description: Include docs read, commands tried, and the decision you need. Redact secrets, tokens, private repo names, private diffs, and customer data.
+    validations:
+      required: true
+  - type: checkboxes
+    id: boundary
+    attributes:
+      label: Boundary check
+      options:
+        - label: I removed private keys, provider tokens, license keys, credentials, raw private diffs, and customer data.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,16 @@ Describe the user, maintainer, or agent workflow this improves.
 - [ ] `npm run build`:
 - [ ] GitHub CI/review-bot follow-up:
 
+## Proof Boundary
+
+This PR proves:
+
+- Describe the narrow behavior, document, or policy surface proven by this PR.
+
+This PR does not prove:
+
+- List launch, provider, runtime, customer, or release claims intentionally not proven here.
+
 ## Safety Boundary
 
 - [ ] No GitHub App permission expansion.
@@ -25,6 +35,11 @@ Describe the user, maintainer, or agent workflow this improves.
 - [ ] No package publish, GitHub Release, or repo visibility change.
 - [ ] No secrets, tokens, credentials, raw private diffs, or customer data in the PR.
 - [ ] Claims stay within the source-available beta boundary.
+- [ ] Provider status claims distinguish tested, compatible-by-interface, planned, and untested/resource-only states.
+
+## Restricted Actions Not Performed
+
+- List any merge, tag, publish, release, live-config, launchd, credential, or owner-only actions intentionally not performed.
 
 ## Evidence
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@ contributions are focused, test-backed, and careful about public claims.
 ## Quick Links
 
 - [Setup guide](docs/SETUP.md)
+- [Known limitations and provider status](docs/known-limitations-and-provider-status.md)
+- [Triage policy](docs/triage-policy.md)
 - [Repository agent instructions](AGENTS.md)
 - [Operator CLI](docs/operator-cli.md)
 - [GitHub App setup](docs/github-app-setup.md)
@@ -25,6 +27,7 @@ Use the GitHub issue forms and keep one problem per issue.
 | Missing, stale, or contradictory docs | Docs bug report | Affected path, current wording, expected wording, setup impact |
 | New capability or product improvement | Feature request | User story, proposed behavior, alternatives, safety boundary |
 | Provider, model, or runtime adapter | Provider request | Provider/runtime, auth shape, data sent, failure modes, proof available |
+| Setup, provider, license, roadmap, or workflow question | Question | Public-safe context, docs read, commands tried, decision needed |
 | License, public/private repo, or setup confusion | License/setup confusion | Question, current doc path, expected answer, no secrets |
 | Unsafe review behavior | Unsafe review report | Repo/PR/head SHA, whether dry-run happened, posted/suppressed behavior, redacted evidence |
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ sold. NeonDiff is a source-available beta, not an open-source or GA release.
 [Code of Conduct](CODE_OF_CONDUCT.md) · [License](LICENSE.md) ·
 [License Boundary](docs/license-boundary.md) · [Pricing](docs/pricing.md) ·
 [Providers](docs/providers.md) ·
+[Known Limitations](docs/known-limitations-and-provider-status.md) ·
 [Roadmap](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103) ·
 [Repository](https://github.com/electricsheephq/evaos-code-review-bot-neondiff)
 
@@ -144,6 +145,9 @@ Small NeonDiff compatibility matrix:
 | Hosted OpenAI-compatible BYOK gateways | Compatible by interface; remote smoke and live review proof required | Hosted provider receives prompts and diffs |
 | Free-provider catalogs | Resource only; untested by NeonDiff unless a provider has its own proof issue | Usually hosted; check each provider |
 
+For the blunt launch-facing matrix, including macOS/Linux and backend limits,
+see [docs/known-limitations-and-provider-status.md](docs/known-limitations-and-provider-status.md).
+
 ## First Dry-Run Review
 
 Run a dry-run review before any live posting. Replace `--repo owner/name` and
@@ -174,6 +178,9 @@ If you are contributing as an AI coding agent:
 4. Keep the PR linked to the issue with `Closes #<issue>` or `Related: #<issue>`.
 5. Record validation and evidence without raw secrets, raw customer data, or
    private logs.
+
+For public issue intake and launch-influx handling, use
+[docs/triage-policy.md](docs/triage-policy.md).
 
 Useful public-product issues:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,6 +15,15 @@ GitHub issues.
 Do not open a public issue for vulnerabilities, secrets, credential exposure,
 private PR content, or customer data.
 
+Use the GitHub private vulnerability reporting flow for this repository:
+https://github.com/electricsheephq/evaos-code-review-bot-neondiff/security/policy.
+
+For non-security support, `support@electricsheephq.com` is listed as the launch
+support alias, but this repository currently has no explicit evidence that the
+alias is monitored. The owner must verify that alias before treating it as a
+public launch support channel. Do not use the support alias as the only security
+route while that verification is pending.
+
 Report privately to the maintainers with:
 
 - affected commit, tag, or branch

--- a/docs/known-limitations-and-provider-status.md
+++ b/docs/known-limitations-and-provider-status.md
@@ -1,0 +1,65 @@
+# Known Limitations And Provider Status
+
+Pinned discussion title: `Known limitations and provider status before GA`
+
+This page is intentionally blunt. It is safe to link from a launch issue,
+discussion, or PR, but it is not proof that launch is complete. The owner can
+copy this content into a GitHub Discussion and pin it; this PR only adds the
+repo-owned source document and does not pin GitHub UI state.
+
+## Status Terms
+
+| Term | Meaning |
+| --- | --- |
+| `tested by NeonDiff` | Repo evidence has covered this path with fixture, doctor, smoke, dry-run, or live-route proof. It is not a quality-parity claim. |
+| `compatible by interface` | The API shape can be described or checked, but live review promotion still needs NeonDiff proof. |
+| `planned` | Tracked work exists, but users should not rely on it as shipped. |
+| `resource only` | Useful for discovery, not compatibility proof. |
+| `not claimed` | Do not market or depend on this behavior until a specific issue and PR prove it. |
+
+## Provider Status
+
+| Provider or runtime | Current status | macOS status | Linux status | Egress posture | What is still missing |
+| --- | --- | --- | --- | --- | --- |
+| GLM/Z.AI through ZCode (`zcode-glm`) | `tested by NeonDiff` as the default beta route | Used by the current local beta operator path | Expected only where the local ZCode/provider setup is available; not a broad Linux launch claim | Hosted provider receives prompts and diff context | Does not prove CodeRabbit parity, calibrated accuracy, or every repo shape |
+| Ollama on `http://localhost:11434/v1` | `compatible by interface` | Provider doctor/smoke path only until adapter proof promotes live review | Provider doctor/smoke path only until adapter proof promotes live review | No-egress only when the endpoint and model are local | Live review promotion, quality evidence, redaction proof, duplicate-suppression proof |
+| LM Studio, vLLM, or local OpenAI-compatible gateway | `compatible by interface` | Describable as local/self-hosted OpenAI-compatible endpoints | Describable as local/self-hosted OpenAI-compatible endpoints | No-egress only for local/self-hosted endpoints | Fixture and dry-run review proof before live usage |
+| Hosted OpenAI-compatible BYOK gateway | `compatible by interface` | Remote smoke requires explicit opt-in | Remote smoke requires explicit opt-in | Hosted provider receives prompts and diffs | Remote smoke, live review proof, and provider-specific privacy/terms review |
+| Free/trial provider catalogs | `resource only` | Discovery only | Discovery only | Usually hosted; each provider differs | Provider-specific issue, auth boundary, terms review, and NeonDiff proof |
+| Agent runtimes such as Codex CLI, Claude Code, or OpenCode | `planned` / discovery-stage | Not a live provider adapter | Not a live provider adapter | Depends on each runtime and its provider chain | Bounded no-write runtime contract, output schema, timeout handling, current-head behavior |
+
+See [docs/providers.md](providers.md) for setup examples and the longer
+provider registry.
+
+## Backend And Platform Limitations
+
+| Surface | Current launch-readiness truth |
+| --- | --- |
+| CLI/source checkout | Node.js 26 and npm are required. Source checkout remains the contributor fallback. This document does not prove every Linux distribution or shell environment. |
+| npm package | Use the version named in README/setup docs. Dist-tag and package truth must be checked before public announcements. |
+| GitHub App review posting | Live posting is gated by configured repos, current-head checks, duplicate suppression, provider readiness, and dry-run evidence. NeonDiff does not approve PRs, merge, push repairs, or silently expand permissions. |
+| Daemon/launchd | The live beta operator path is macOS launchd-oriented. Linux service packaging is not claimed here. |
+| Desktop app | macOS dev MVP only. No signed/notarized/appcast/TCC/customer-control readiness is claimed. |
+| License activation | Public repos are free. Private/commercial repos require a paid support license. The beta file backend is the active CLI path; Keychain activation is intentionally not a headless write path. |
+| Security | Security policy exists, but this is not an enterprise/customer-ready security certification. Use private GitHub vulnerability reporting for secrets or private data. |
+| Support alias | `support@electricsheephq.com` is listed as a launch support contact that requires owner verification before public launch. This repo has no evidence that the alias is monitored. |
+
+## What Visitors Should Self-Triage Before Filing
+
+1. Check whether the issue is provider-specific, backend-specific, platform-specific, or docs/setup-only.
+2. Use the bug template when behavior is wrong, and fill the provider/backend matrix.
+3. Use the provider request template for a new model/runtime/provider path.
+4. Use the question template when the right route or proof boundary is unclear.
+5. Use private security reporting, not a public issue, for secrets, credentials, private diffs, private repo data, or customer data.
+
+## Not Claimed Before GA
+
+- Public launch completion.
+- Final legal/license adequacy.
+- CodeRabbit parity.
+- Calibrated review accuracy.
+- Enterprise or customer-ready security.
+- Linux service packaging.
+- Signed/notarized desktop release.
+- Universal provider compatibility.
+- Hosted review SaaS with bundled model credits.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -11,6 +11,10 @@ The current live review engine remains ZCode-backed. The provider registry is
 the public setup and operator surface for declaring available providers before
 alternate adapter execution is promoted.
 
+For launch-facing caveats, including tested-vs-interface-compatible status,
+macOS/Linux backend limits, and the owner-pinning note for public visitors, see
+[docs/known-limitations-and-provider-status.md](known-limitations-and-provider-status.md).
+
 ## Resource Links
 
 Official/provider-owned docs:

--- a/docs/triage-policy.md
+++ b/docs/triage-policy.md
@@ -1,0 +1,95 @@
+# NeonDiff Triage Policy
+
+This policy is a public intake contract for a single-maintainer,
+agent-assisted repository. It describes intent, not a guaranteed service-level
+agreement. Security reports, customer data, credentials, private diffs, and
+license keys do not belong in public issues.
+
+## Intake Routes
+
+| Route | Use it for | Do not use it for |
+| --- | --- | --- |
+| Bug report | Product bugs, crashes, wrong review output, setup failures, provider/backend regressions | Secrets, private repo diffs, customer data |
+| Provider request | New providers, local runtimes, hosted BYOK gateways, adapter/runtime work | Claiming a provider is tested without NeonDiff proof |
+| Question | Public-safe setup, provider, license, roadmap, or workflow questions | Vulnerabilities or private account data |
+| Docs bug report | Missing, stale, contradictory, or unsafe docs | Product behavior bugs |
+| License/setup confusion | Public/private repo boundary, install, update entitlement, or pricing confusion | Billing account data or license keys |
+| Unsafe review report | Public-safe unsafe review behavior, stale-head behavior, posting, or redaction gaps | Raw private diffs, credentials, or secrets |
+| Private security report | Vulnerabilities, secrets, credentials, private repo content, customer data | General product questions |
+
+Private security route: [SECURITY.md](../SECURITY.md).
+
+Non-security support alias: `support@electricsheephq.com`. This alias is listed
+for launch readiness but requires owner verification before public launch; this
+repo currently has no explicit evidence that it is monitored.
+
+## Label Policy
+
+Use existing labels before creating new ones.
+
+| Label family | Intended use |
+| --- | --- |
+| `bug` | Reproducible wrong behavior, crashes, bad output, broken setup |
+| `docs` / `documentation` | Documentation updates, examples, schemas, docs-site surfaces |
+| `question` | Public-safe questions that do not yet require product work |
+| `enhancement` | New capabilities or product improvements |
+| `provider-registry` | Provider/model/runtime metadata, adapter, smoke, BYOK, or provider-proof work |
+| `review-policy` | Review behavior, filters, severity routing, posting policy |
+| `repo-profile` | Repository-specific review profile, path policy, or proof expectations |
+| `license` / `pricing` | Entitlement, activation, support-tier, package, or commercial-boundary work |
+| `release-governance` | Release cadence, update channels, rollback, signing, public beta gates |
+| `public-product` / `website` | Public productization, website, buyer-facing docs |
+| `ga-blocker` / `v1-mvp` | Work that blocks or belongs to the public v1.0 MVP |
+| `owner-gated` | Requires owner credential, account action, install, approval, or external verification |
+| `decision-needed` | Human product, licensing, pricing, or architecture decision needed |
+| `sprint:active`, `sprint:next`, `sprint:blocked` | Current sprint routing and explicit blockers |
+| `post-1.0` / `deferred-spike` | Intentionally deferred work or exploration outside the current release scope |
+
+If a report involves credentials, private diffs, private repo names, customer
+data, or a vulnerability, do not label it publicly. Move it to the private
+security route first.
+
+## Response-Time Intent
+
+These are triage goals for launch-influx handling, not promises.
+
+| Class | Intent |
+| --- | --- |
+| Private security report | Acknowledge as soon as owner availability permits; keep discussion private. |
+| `ga-blocker`, release regression, data-loss, posting safety, or credential exposure | Same or next maintainer cycle when evidence is public-safe. |
+| Reproducible `bug` with provider/backend matrix and evidence | First triage within a few maintainer cycles. |
+| Provider request with public API docs and proof notes | Batch review during provider-registry planning. |
+| Docs bug, question, setup confusion | Batch review when launch support bandwidth permits. |
+| Resource-only catalog suggestions | Defer unless a provider-specific proof issue exists. |
+
+## Agent-Driven Triage Behavior
+
+NeonDiff's own bot reviews PRs. Agent-authored triage and PR work is allowed
+when it stays inside the repo's proof boundary:
+
+- Agents may suggest labels, routes, missing evidence, and safer issue forms.
+- Agents may open PRs linked to issues when scoped by a maintainer or an issue.
+- Agents must not auto-close issues, merge PRs, tag releases, publish packages,
+  restart live workers, mutate live config, expand permissions, or claim public
+  launch readiness without the matching proof gates.
+- Agents must keep public comments free of secrets, raw private diffs,
+  customer data, license keys, provider tokens, cookies, and connector URLs.
+- Agents should distinguish `tested by NeonDiff`, `compatible by interface`,
+  `planned`, and `resource only` provider states.
+- Agents should update the issue before handoff or pause when they changed
+  code, docs, labels, roadmap state, or operating evidence.
+
+## Escalation And Security Routing
+
+Escalate privately when a report includes any of:
+
+- GitHub App private key, token, cookie, or connector URL.
+- Provider API key, license key, or billing/account data.
+- Raw private PR diff, private repo name, customer logs, or customer identity.
+- Vulnerability that could expose private code, credentials, comments, or local
+  evidence.
+- Reported behavior that posted secrets or private data publicly.
+
+Use GitHub private vulnerability reporting first. Use
+`support@electricsheephq.com` only for non-security support until the owner
+verifies alias monitoring.

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -22,6 +22,7 @@ describe("NeonDiff public community funnel", () => {
       /docs\/license-boundary\.md/i,
       /docs\/pricing\.md/i,
       /docs\/providers\.md/i,
+      /docs\/known-limitations-and-provider-status\.md/i,
       /public open-source repos.*free/i,
       /\$1\/month/i,
       /\$10\/year/i,
@@ -190,6 +191,8 @@ describe("NeonDiff public community funnel", () => {
       /Issue Routing/i,
       /Before You Open A PR/i,
       /Agent-Authored Contributions/i,
+      /docs\/known-limitations-and-provider-status\.md/i,
+      /docs\/triage-policy\.md/i,
       /Validation/i,
       /Evidence/i,
       /Review Threads/i,
@@ -234,6 +237,7 @@ describe("NeonDiff public community funnel", () => {
       ".github/ISSUE_TEMPLATE/bug_report.yml",
       ".github/ISSUE_TEMPLATE/docs_bug_report.yml",
       ".github/ISSUE_TEMPLATE/feature_request.yml",
+      ".github/ISSUE_TEMPLATE/question.yml",
       ".github/ISSUE_TEMPLATE/provider_request.yml",
       ".github/ISSUE_TEMPLATE/license_setup_confusion.yml",
       ".github/ISSUE_TEMPLATE/unsafe_review_report.yml"
@@ -245,6 +249,7 @@ describe("NeonDiff public community funnel", () => {
       read(".github/ISSUE_TEMPLATE/bug_report.yml"),
       read(".github/ISSUE_TEMPLATE/docs_bug_report.yml"),
       read(".github/ISSUE_TEMPLATE/feature_request.yml"),
+      read(".github/ISSUE_TEMPLATE/question.yml"),
       read(".github/ISSUE_TEMPLATE/provider_request.yml"),
       read(".github/ISSUE_TEMPLATE/license_setup_confusion.yml"),
       read(".github/ISSUE_TEMPLATE/unsafe_review_report.yml")
@@ -261,6 +266,7 @@ describe("NeonDiff public community funnel", () => {
       /What Problem This Solves/i,
       /User Impact/i,
       /Validation/i,
+      /Proof Boundary/i,
       /Safety Boundary/i,
       /Evidence/i,
       /Closes #<issue>/i,
@@ -288,5 +294,37 @@ describe("NeonDiff public community funnel", () => {
     expect(JSON.stringify(scorecard.pass_criteria)).toMatch(/AGENTS/i);
     expect(JSON.stringify(scorecard.pass_criteria)).toMatch(/issue templates/i);
     expect(String(scorecard.proof_boundary)).toMatch(/does not prove public launch/i);
+  });
+
+  it("launch-influx docs separate provider proof, triage, security, and support boundaries", () => {
+    const limitations = read("docs/known-limitations-and-provider-status.md");
+    const triage = read("docs/triage-policy.md");
+    const providers = read("docs/providers.md");
+    const security = read("SECURITY.md");
+
+    for (const text of [limitations, providers]) {
+      expect(text).toMatch(/tested by NeonDiff/i);
+      expect(text).toMatch(/compatible by interface/i);
+      expect(text).toMatch(/resource only/i);
+      expect(text).toMatch(/GLM\/Z\.AI|GLM\/Z\.ai/i);
+      expect(text).toMatch(/Ollama/i);
+      expect(text).toMatch(/Hosted OpenAI-compatible BYOK/i);
+    }
+
+    for (const text of [limitations, triage, security]) {
+      expect(text).toMatch(/support@electricsheephq\.com/i);
+      expect(text).toMatch(/owner.*verify|requires owner verification|owner must verify/i);
+      expect(text).toMatch(/private.*security|security.*private/i);
+      expect(text).not.toMatch(/support@electricsheephq\.com.*verified/i);
+    }
+
+    expect(limitations).toMatch(/Pinned discussion title/i);
+    expect(limitations).toMatch(/does not pin GitHub UI state/i);
+    expect(limitations).toMatch(/macOS/i);
+    expect(limitations).toMatch(/Linux/i);
+    expect(triage).toMatch(/Agent-Driven Triage Behavior/i);
+    expect(triage).toMatch(/Response-Time Intent/i);
+    expect(triage).toMatch(/ga-blocker/i);
+    expect(triage).toMatch(/owner-gated/i);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Refs #427. This PR implements the repo-owned launch-influx readiness surfaces, but intentionally does not close #427 because the actual GitHub pinning step and `support@electricsheephq.com` monitoring verification remain owner-gated.

## User Impact

Launch-influx visitors get a clearer intake path before public promotion: bugs collect provider/backend/platform context, provider requests separate interface compatibility from proof, questions have a public-safe route, and PRs require explicit validation/proof-boundary language.

## Implementation Notes

- Expanded the bug report and provider request issue forms with provider/backend matrix fields.
- Added a public-safe question issue form.
- Updated the PR template with proof-boundary and restricted-actions sections.
- Added `docs/known-limitations-and-provider-status.md` as a pinned-discussion-ready limitations/status document.
- Added `docs/triage-policy.md` for label policy, response-time intent, agent triage behavior, private security routing, and support-contact caveats.
- Updated `SECURITY.md` and issue-template contact links to route private reports to this repo's security policy.
- Linked the new launch-influx docs from README, providers docs, and CONTRIBUTING.

## Validation

- [x] Failing test, smoke, or eval was added/updated first: extended `tests/public-community-funnel.test.ts` for question form, limitations doc, triage policy, proof boundary, support alias caveat, and provider status wording.
- [x] Focused validation: `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/provider_request.yml .github/ISSUE_TEMPLATE/question.yml .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/docs_bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/license_setup_confusion.yml .github/ISSUE_TEMPLATE/unsafe_review_report.yml`
- [x] Focused validation: `node scripts/check-public-claims.mjs`
- [x] Focused validation: `./node_modules/.bin/vitest run tests/public-community-funnel.test.ts --pool=forks --maxWorkers=1` after temporarily symlinking the canonical Lexar `node_modules`, then removing the symlink.
- [x] Focused validation: `git diff --check`
- [x] GitHub CI: Build, test, and package green on current head `01a4c5b295f028659316a25d49ba07a64b2d5992`.
- [x] GitHub CI: CodeQL actions and javascript-typescript green; Swift desktop impact/gate green; Swift desktop smoke skipped because no Swift desktop paths changed; Socket green.
- [x] evaOS review-bot follow-up: current-head review completed with no validated inline findings.
- [ ] `npm test`: not run locally; this PR only touches docs/templates plus one focused docs/template test, so broader validation is delegated to GitHub CI.
- [ ] `npm run build`: not run locally; no runtime TypeScript source or build-checked docs/templates changed, and the hosted Build/test/package check is green.

## Proof Boundary

This PR proves:

- The repo has launch-influx issue templates, PR proof-boundary prompts, a triage policy, and a public limitations/provider-status document wired into the public community funnel test.
- The new and existing issue-form YAML parses.
- The limitations doc is ready for an owner to copy/link into a GitHub Discussion and pin.

This PR does not prove:

- Public launch completion, GA readiness, CodeRabbit parity, calibrated review accuracy, or enterprise/customer-ready security.
- Any provider beyond the statuses explicitly named as tested, compatible-by-interface, planned, or resource-only.
- That `support@electricsheephq.com` is monitored. The docs list it as a support alias requiring owner verification before public launch.
- That a GitHub Discussion was created or pinned.

## Remaining #427 Owner Gates

- Create or copy the limitations matrix into the intended GitHub Discussion or issue and pin/link it as the launch-facing surface.
- Verify that `support@electricsheephq.com` is monitored before outward announcement.

## Safety Boundary

- [x] No GitHub App permission expansion.
- [x] No live worker restart, launchd mutation, or beta promotion.
- [x] No package publish, GitHub Release, or repo visibility change.
- [x] No secrets, tokens, credentials, raw private diffs, or customer data in the PR.
- [x] Claims stay within the source-available beta boundary.
- [x] Provider status claims distinguish tested, compatible-by-interface, planned, and untested/resource-only states.

## Restricted Actions Not Performed

- Did not merge, tag, publish, mutate live config, restart launchd, create/pin a GitHub Discussion, verify external support inbox ownership, or close trackers.

## Evidence

- Worktree: `/Volumes/LEXAR/repos/worktrees/evaos-code-review-bot-neondiff/427-launch-influx-readiness`
- Scratch notes: `/Volumes/LEXAR/Codex/session-notes/2026-07-08/neondiff-427-launch-influx-readiness/implementation-notes.html`
- Current head: `01a4c5b295f028659316a25d49ba07a64b2d5992`

## Agent-Authored PR

- [x] This PR was authored or materially edited by an AI agent.
- [x] The agent listed restricted actions not performed and kept validation public-safe.
