### PR TITLE
[codex] Add release-status active repo coverage gate

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -323,6 +323,8 @@ npx tsx src/cli.ts review-head-gate \
 - Release promotions run `release:status --require-coverage true` so the same
   packet fails when an active PR-review repo is configured but unreadable by
   the GitHub App, or when eligible heads are unprocessed/stale.
+  `release:status --coverage true` is advisory-only and keeps top-level gates
+  runtime-scoped; do not use it as the promotion gate.
 - Public source-beta promotions pass `release:status` with
   `--public-release-manifest docs/public-release-manifest.json` and the release
   tag as `--expected-public-version`.

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -91,7 +91,8 @@ sleep 5
 npm run release:status -- \
   --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
   --expected-head "$(git rev-parse HEAD)" \
-  --launchd-label com.electricsheephq.evaos-code-review-bot
+  --launchd-label com.electricsheephq.evaos-code-review-bot \
+  --require-coverage true
 ```
 
 For public source-beta releases, run the same gate with manifest checks:
@@ -103,7 +104,8 @@ npx tsx src/cli.ts release-status \
   --expected-head "$(git rev-parse HEAD)" \
   --public-release-manifest docs/public-release-manifest.json \
   --expected-public-version "$PUBLIC_BETA_TAG" \
-  --launchd-label com.electricsheephq.evaos-code-review-bot
+  --launchd-label com.electricsheephq.evaos-code-review-bot \
+  --require-coverage true
 ```
 
 Set `PUBLIC_BETA_TAG` to the actual public beta tag before running the command.
@@ -318,6 +320,9 @@ npx tsx src/cli.ts review-head-gate \
 - `release:status` verifies the loaded LaunchAgent includes
   `NODE_OPTIONS=--use-system-ca` so Node uses the macOS system trust store for
   GitHub App installation fetches.
+- Release promotions run `release:status --require-coverage true` so the same
+  packet fails when an active PR-review repo is configured but unreadable by
+  the GitHub App, or when eligible heads are unprocessed/stale.
 - Public source-beta promotions pass `release:status` with
   `--public-release-manifest docs/public-release-manifest.json` and the release
   tag as `--expected-public-version`.

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -324,7 +324,9 @@ npx tsx src/cli.ts review-head-gate \
   packet fails when an active PR-review repo is configured but unreadable by
   the GitHub App, or when eligible heads are unprocessed/stale.
   `release:status --coverage true` is advisory-only and keeps top-level gates
-  runtime-scoped; do not use it as the promotion gate.
+  runtime-scoped; both coverage flags still perform live GitHub App reads
+  across active repos, so do not use advisory mode as an offline or promotion
+  gate.
 - Public source-beta promotions pass `release:status` with
   `--public-release-manifest docs/public-release-manifest.json` and the release
   tag as `--expected-public-version`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,7 @@ import {
   buildOperatorQueue,
   buildOperatorStatus,
   buildReleaseMonitoringCoverage,
+  buildReleaseStatusCommandOutput,
   collectBotProcessInventory,
   collectOperatorIssueEnrichmentRuntime,
   collectOperatorLeases,
@@ -351,27 +352,13 @@ async function main(): Promise<void> {
       required: requireCoverage,
       recommendedCommand: buildReleaseCoverageCommand(args)
     });
-    const gates = requireCoverage ? [...status.gates, ...monitoringCoverage.gates] : status.gates;
-    const ok = status.ok && (!requireCoverage || monitoringCoverage.ok === true);
-    const recommendedActions = [
-      ...status.recommendedActions,
-      ...(requireCoverage && monitoringCoverage.ok === false ? monitoringCoverage.recommendedActions : [])
-    ];
-    console.log(stringifyRedactedJson({
-      ...status,
-      ok,
-      recommendedActions,
-      gates,
-      healthState: ok
-        ? "runtime_ok"
-        : status.ok
-          ? "coverage_blocked"
-          : "runtime_blocked",
-      runtimeOk: status.ok,
+    const output = buildReleaseStatusCommandOutput({
+      status,
       monitoringCoverage,
-      failedGates: failedGates(gates)
-    }));
-    if (!ok) process.exitCode = 1;
+      requireCoverage
+    });
+    console.log(stringifyRedactedJson(output));
+    if (!output.ok) process.exitCode = 1;
     return;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,6 +70,7 @@ import {
   buildRuntimeInventory,
   buildOperatorQueue,
   buildOperatorStatus,
+  buildReleaseMonitoringCoverage,
   collectBotProcessInventory,
   collectOperatorIssueEnrichmentRuntime,
   collectOperatorLeases,
@@ -321,6 +322,11 @@ async function main(): Promise<void> {
     const budgetJobLimit = args["budget-job-limit"]
       ? parsePositiveInteger(args["budget-job-limit"], "--budget-job-limit")
       : undefined;
+    const requireCoverage = args["require-coverage"] === undefined
+      ? false
+      : parseBooleanArg(args["require-coverage"], "--require-coverage");
+    const collectCoverage = requireCoverage ||
+      (args.coverage === undefined ? false : parseBooleanArg(args.coverage, "--coverage"));
     const status = collectReleaseStatus({
       cwd: process.cwd(),
       configPath: args.config,
@@ -336,13 +342,35 @@ async function main(): Promise<void> {
       ...(budgetDetailLimit !== undefined ? { budgetDetailLimit } : {}),
       ...(budgetJobLimit !== undefined ? { budgetJobLimit } : {})
     });
+    const coverageReport = collectCoverage
+      ? await collectCoverageReport(args, loadConfig(args.config))
+      : undefined;
+    const monitoringCoverage = buildReleaseMonitoringCoverage({
+      report: coverageReport,
+      required: requireCoverage,
+      recommendedCommand: buildReleaseCoverageCommand(args)
+    });
+    const gates = requireCoverage ? [...status.gates, ...monitoringCoverage.gates] : status.gates;
+    const ok = status.ok && (!requireCoverage || monitoringCoverage.ok === true);
+    const recommendedActions = [
+      ...status.recommendedActions,
+      ...(requireCoverage && monitoringCoverage.ok === false ? monitoringCoverage.recommendedActions : [])
+    ];
     console.log(stringifyRedactedJson({
       ...status,
-      healthState: status.ok ? "runtime_ok" : "runtime_blocked",
+      ok,
+      recommendedActions,
+      gates,
+      healthState: ok
+        ? "runtime_ok"
+        : status.ok
+          ? "coverage_blocked"
+          : "runtime_blocked",
       runtimeOk: status.ok,
-      failedGates: failedGates(status.gates)
+      monitoringCoverage,
+      failedGates: failedGates(gates)
     }));
-    if (!status.ok) process.exitCode = 1;
+    if (!ok) process.exitCode = 1;
     return;
   }
 
@@ -2502,6 +2530,32 @@ function collectBudgetJobsForSelection(
   return [...jobsById.values()];
 }
 
+function buildReleaseCoverageCommand(args: ParsedArgs): string {
+  const parts = ["npx", "tsx", "src/cli.ts", "release-status"];
+  appendCommandArg(parts, "--config", args.config);
+  appendCommandArg(parts, "--expected-head", args["expected-head"]);
+  appendCommandArg(parts, "--public-release-manifest", args["public-release-manifest"]);
+  appendCommandArg(parts, "--expected-public-version", args["expected-public-version"]);
+  appendCommandArg(parts, "--verify-public-rollback-refs", args["verify-public-rollback-refs"]);
+  appendCommandArg(parts, "--launchd-label", args["launchd-label"]);
+  appendCommandArg(parts, "--state-path", args["state-path"]);
+  appendCommandArg(parts, "--repo", args.repo);
+  appendCommandArg(parts, "--pr", args.pr);
+  parts.push("--require-coverage", "true");
+  return parts.map(shellQuoteCommandArg).join(" ");
+}
+
+function appendCommandArg(parts: string[], name: string, value: string | string[] | undefined): void {
+  if (value === undefined) return;
+  parts.push(name, parseSingleArg(value, name));
+}
+
+function shellQuoteCommandArg(value: string): string {
+  return /^[A-Za-z0-9_./:=@%+-]+$/.test(value)
+    ? value
+    : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 function failedGates(gates: Array<{ name: string; ok: boolean; detail: string }>): Array<{ name: string; ok: boolean; detail: string }> {
   return gates.filter((gate) => !gate.ok);
 }
@@ -2896,6 +2950,19 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--expected-head", description: "Expected release head SHA to verify against." },
       { name: "--launchd-label", description: "launchd label to inspect for daemon liveness." },
       { name: "--state-path", description: "Override the SQLite state path (defaults to config.statePath)." }
+    ]
+  },
+  "release-status": {
+    description: "Report release/runtime health; add --require-coverage true to also gate active repo App-read coverage.",
+    flags: [
+      { name: "--config", description: "Path to the config file." },
+      { name: "--expected-head", description: "Expected release head SHA to verify against." },
+      { name: "--launchd-label", description: "launchd label to inspect for daemon liveness." },
+      { name: "--state-path", description: "Override the SQLite state path (defaults to config.statePath)." },
+      { name: "--coverage", description: "true to attach active repo coverage as advisory output." },
+      { name: "--require-coverage", description: "true to fail release-status when active repo coverage has unreadable, unprocessed, or stale heads." },
+      { name: "--public-release-manifest", description: "Public release manifest to validate for source-beta releases." },
+      { name: "--expected-public-version", description: "Expected public release version/tag when validating a public manifest." }
     ]
   },
   "review-pr": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,7 +87,7 @@ import {
 } from "./operator-cli.js";
 import { buildPricingOutput } from "./pricing.js";
 import { buildProviderRegistrySummary, doctorProviderRegistry, isProviderId } from "./providers.js";
-import { collectReleaseStatus, type ReleaseStatus } from "./release-status.js";
+import { collectReleaseStatus, collectReleaseStatusWithConfig, type ReleaseStatus } from "./release-status.js";
 import { buildReviewHeadGate } from "./review-head-gate.js";
 import { buildRepoMemoryPacket, readRepoMemoryMarkdown } from "./repo-memory.js";
 import { buildRepoPolicySnapshot, listReposToScan, resolveRepoProfile } from "./repo-policy.js";
@@ -327,7 +327,8 @@ async function main(): Promise<void> {
       : parseBooleanArg(args["require-coverage"], "--require-coverage");
     const collectCoverage = requireCoverage ||
       (args.coverage === undefined ? false : parseBooleanArg(args.coverage, "--coverage"));
-    const status = collectReleaseStatus({
+    const config = loadConfig(args.config);
+    const status = collectReleaseStatusWithConfig({
       cwd: process.cwd(),
       configPath: args.config,
       expectedHead: args["expected-head"],
@@ -341,9 +342,9 @@ async function main(): Promise<void> {
       budgetDetails: args["budget-details"] === "true",
       ...(budgetDetailLimit !== undefined ? { budgetDetailLimit } : {}),
       ...(budgetJobLimit !== undefined ? { budgetJobLimit } : {})
-    });
+    }, config);
     const coverageReport = collectCoverage
-      ? await collectCoverageReport(args, loadConfig(args.config))
+      ? await collectCoverageReport(args, config)
       : undefined;
     const monitoringCoverage = buildReleaseMonitoringCoverage({
       report: coverageReport,
@@ -2959,7 +2960,7 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--expected-head", description: "Expected release head SHA to verify against." },
       { name: "--launchd-label", description: "launchd label to inspect for daemon liveness." },
       { name: "--state-path", description: "Override the SQLite state path (defaults to config.statePath)." },
-      { name: "--coverage", description: "true to attach active repo coverage as advisory output." },
+      { name: "--coverage", description: "true to attach active repo coverage as advisory output; top-level gates remain runtime-only unless --require-coverage true is set." },
       { name: "--require-coverage", description: "true to fail release-status when active repo coverage has unreadable, unprocessed, or stale heads." },
       { name: "--public-release-manifest", description: "Public release manifest to validate for source-beta releases." },
       { name: "--expected-public-version", description: "Expected public release version/tag when validating a public manifest." }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -317,6 +317,9 @@ async function main(): Promise<void> {
   }
 
   if (command === "release-status") {
+    if (args.repo !== undefined || args.pr !== undefined) {
+      throw new Error("release-status does not support --repo/--pr; use coverage-audit for scoped coverage checks");
+    }
     const budgetDetailLimit = args["budget-detail-limit"]
       ? parsePositiveInteger(args["budget-detail-limit"], "--budget-detail-limit")
       : undefined;
@@ -2527,8 +2530,6 @@ function buildReleaseCoverageCommand(args: ParsedArgs): string {
   appendCommandArg(parts, "--verify-public-rollback-refs", args["verify-public-rollback-refs"]);
   appendCommandArg(parts, "--launchd-label", args["launchd-label"]);
   appendCommandArg(parts, "--state-path", args["state-path"]);
-  appendCommandArg(parts, "--repo", args.repo);
-  appendCommandArg(parts, "--pr", args.pr);
   parts.push("--require-coverage", "true");
   return parts.map(shellQuoteCommandArg).join(" ");
 }

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -274,6 +274,13 @@ export interface ReleaseMonitoringCoverageStatus {
   staleHeads?: OperatorQueueEntry[];
 }
 
+export interface ReleaseStatusCommandOutput extends ReleaseStatus {
+  healthState: "runtime_ok" | "runtime_blocked" | "coverage_blocked";
+  runtimeOk: boolean;
+  monitoringCoverage: ReleaseMonitoringCoverageStatus;
+  failedGates: OperatorGate[];
+}
+
 export interface OperatorDashboardFilters {
   repo?: string;
   status?: string;
@@ -1233,6 +1240,37 @@ export function buildReleaseMonitoringCoverage(input: {
     unprocessed: queue.pending,
     staleHeads: queue.staleHeads,
     ...(input.recommendedCommand ? { recommendedCommand: input.recommendedCommand } : {})
+  };
+}
+
+export function buildReleaseStatusCommandOutput(input: {
+  status: ReleaseStatus;
+  monitoringCoverage: ReleaseMonitoringCoverageStatus;
+  requireCoverage: boolean;
+}): ReleaseStatusCommandOutput {
+  const gates = input.requireCoverage
+    ? [...input.status.gates, ...input.monitoringCoverage.gates]
+    : input.status.gates;
+  const ok = input.status.ok && (!input.requireCoverage || input.monitoringCoverage.ok === true);
+  const recommendedActions = [
+    ...input.status.recommendedActions,
+    ...(input.requireCoverage && input.monitoringCoverage.ok === false
+      ? input.monitoringCoverage.recommendedActions
+      : [])
+  ];
+  return {
+    ...input.status,
+    ok,
+    recommendedActions,
+    gates,
+    healthState: ok
+      ? "runtime_ok"
+      : input.status.ok
+        ? "coverage_blocked"
+        : "runtime_blocked",
+    runtimeOk: input.status.ok,
+    monitoringCoverage: input.monitoringCoverage,
+    failedGates: gates.filter((gate) => !gate.ok)
   };
 }
 

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1170,14 +1170,14 @@ export function buildReleaseMonitoringCoverage(input: {
         ? [{
             name: "active_repo_coverage_collected",
             ok: false,
-            detail: "coverage not collected"
+            detail: "coverage was required but no coverage report was supplied"
           }]
         : [],
       failedGates: input.required
         ? [{
             name: "active_repo_coverage_collected",
             ok: false,
-            detail: "coverage not collected"
+            detail: "coverage was required but no coverage report was supplied"
           }]
         : [],
       recommendedActions: [

--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -248,6 +248,32 @@ export interface OperatorQueueSnapshot {
   readFailures: Array<{ repo: string; error: string; nextAction: string }>;
 }
 
+export type ReleaseMonitoringCoverageState = "not_collected" | "coverage_ok" | "coverage_blocked";
+
+export interface ReleaseMonitoringCoverageStatus {
+  collected: boolean;
+  required: boolean;
+  ok: boolean | null;
+  healthState: ReleaseMonitoringCoverageState;
+  proofBoundary: string;
+  summary?: {
+    reposScanned: number;
+    pullsSeen: number;
+    processed: number;
+    queued: number;
+    unprocessed: number;
+    staleHeads: number;
+    readFailures: number;
+  };
+  gates: OperatorGate[];
+  failedGates: OperatorGate[];
+  recommendedActions: string[];
+  recommendedCommand?: string;
+  readFailures?: Array<{ repo: string; error: string; nextAction: string }>;
+  unprocessed?: OperatorQueueEntry[];
+  staleHeads?: OperatorQueueEntry[];
+}
+
 export interface OperatorDashboardFilters {
   repo?: string;
   status?: string;
@@ -1125,6 +1151,88 @@ export function buildOperatorQueue(report: CoverageAuditReport): OperatorQueueSn
       ...failure,
       nextAction: "inspect GitHub App installation/read permissions or network failure"
     }))
+  };
+}
+
+export function buildReleaseMonitoringCoverage(input: {
+  report?: CoverageAuditReport;
+  required: boolean;
+  recommendedCommand?: string;
+}): ReleaseMonitoringCoverageStatus {
+  if (!input.report) {
+    return {
+      collected: false,
+      required: input.required,
+      ok: input.required ? false : null,
+      healthState: "not_collected",
+      proofBoundary: "release-status runtime health only; active repo GitHub App readability was not collected",
+      gates: input.required
+        ? [{
+            name: "active_repo_coverage_collected",
+            ok: false,
+            detail: "coverage not collected"
+          }]
+        : [],
+      failedGates: input.required
+        ? [{
+            name: "active_repo_coverage_collected",
+            ok: false,
+            detail: "coverage not collected"
+          }]
+        : [],
+      recommendedActions: [
+        "run release-status with --require-coverage true before claiming full active-repo monitoring coverage"
+      ],
+      ...(input.recommendedCommand ? { recommendedCommand: input.recommendedCommand } : {})
+    };
+  }
+
+  const queue = buildOperatorQueue(input.report);
+  const gates: OperatorGate[] = [
+    {
+      name: "active_repo_coverage_no_unprocessed_heads",
+      ok: input.report.summary.unprocessed === 0,
+      detail: `${input.report.summary.unprocessed} unprocessed eligible head(s)`
+    },
+    {
+      name: "active_repo_coverage_no_read_failures",
+      ok: input.report.summary.readFailures === 0,
+      detail: `${input.report.summary.readFailures} read failure(s)`
+    },
+    {
+      name: "active_repo_coverage_no_stale_heads",
+      ok: input.report.summary.staleHeads === 0,
+      detail: `${input.report.summary.staleHeads} stale head(s)`
+    }
+  ];
+  const failed = gates.filter((gate) => !gate.ok);
+  const ok = failed.length === 0;
+  return {
+    collected: true,
+    required: input.required,
+    ok,
+    healthState: ok ? "coverage_ok" : "coverage_blocked",
+    proofBoundary: "active repo coverage checks currently open eligible PR heads and GitHub App read access; it does not replace exact-head review proof",
+    summary: {
+      reposScanned: input.report.summary.reposScanned,
+      pullsSeen: input.report.summary.pullsSeen,
+      processed: input.report.summary.processed,
+      queued: input.report.summary.queued,
+      unprocessed: input.report.summary.unprocessed,
+      staleHeads: input.report.summary.staleHeads,
+      readFailures: input.report.summary.readFailures
+    },
+    gates,
+    failedGates: failed,
+    recommendedActions: [
+      ...(input.report.summary.unprocessed > 0 ? ["wait for daemon cycle or run scoped run-once for unprocessed heads"] : []),
+      ...(input.report.summary.readFailures > 0 ? ["run doctor and inspect GitHub App installation/read permissions"] : []),
+      ...(input.report.summary.staleHeads > 0 ? ["wait for next daemon cycle or run scoped coverage audit"] : [])
+    ],
+    readFailures: queue.readFailures,
+    unprocessed: queue.pending,
+    staleHeads: queue.staleHeads,
+    ...(input.recommendedCommand ? { recommendedCommand: input.recommendedCommand } : {})
   };
 }
 

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -416,8 +416,25 @@ export function collectReleaseStatus(input: {
   budgetJobLimit?: number;
   now?: Date;
 }): ReleaseStatus {
-  validatePublicReleaseManifestInputs(input);
   const config = loadConfig(input.configPath);
+  return collectReleaseStatusWithConfig(input, config);
+}
+
+export function collectReleaseStatusWithConfig(input: {
+  cwd: string;
+  configPath?: string;
+  expectedHead?: string;
+  publicReleaseManifestPath?: string;
+  expectedPublicVersion?: string;
+  verifyPublicRollbackRefs?: boolean;
+  launchdLabel?: string;
+  statePath?: string;
+  budgetDetails?: boolean;
+  budgetDetailLimit?: number;
+  budgetJobLimit?: number;
+  now?: Date;
+}, config: BotConfig): ReleaseStatus {
+  validatePublicReleaseManifestInputs(input);
   const configPath = input.configPath ?? "(default config)";
   const now = input.now ?? new Date();
   const statePath = input.statePath ?? config.statePath;

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -9,6 +9,7 @@ import {
   buildRuntimeInventory,
   buildOperatorQueue,
   buildOperatorStatus,
+  buildReleaseMonitoringCoverage,
   collectOperatorIssueEnrichmentRuntime,
   collectOperatorLeases,
   collectOperatorRepoProviderCooldowns,
@@ -96,6 +97,59 @@ describe("operator CLI summaries", () => {
     expect(status.recommendedActions).toContain("inspect operator queue failed jobs before promotion");
     expect(status.recommendedActions).toContain("retry or requeue provider-deferred jobs whose nextEligibleAt has expired");
     expect(JSON.stringify(status)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
+  });
+
+  it("marks release monitoring coverage as not collected unless the release gate requests it", () => {
+    const coverage = buildReleaseMonitoringCoverage({
+      required: false,
+      recommendedCommand: "npx tsx src/cli.ts release-status --require-coverage true"
+    });
+
+    expect(coverage).toMatchObject({
+      collected: false,
+      required: false,
+      ok: null,
+      healthState: "not_collected",
+      failedGates: []
+    });
+    expect(coverage.recommendedActions).toContain(
+      "run release-status with --require-coverage true before claiming full active-repo monitoring coverage"
+    );
+  });
+
+  it("fails required release monitoring coverage on active repo read failures", () => {
+    const coverage = buildReleaseMonitoringCoverage({
+      required: true,
+      recommendedCommand: "npx tsx src/cli.ts release-status --require-coverage true",
+      report: coverageReport({
+        processed: [processedEntry(101, "head-ok", "posted")],
+        readFailures: [{ repo: "owner/unreadable", error: "GitHub API 404" }]
+      })
+    });
+
+    expect(coverage).toMatchObject({
+      collected: true,
+      required: true,
+      ok: false,
+      healthState: "coverage_blocked",
+      summary: {
+        processed: 1,
+        readFailures: 1
+      }
+    });
+    expect(coverage.failedGates).toContainEqual({
+      name: "active_repo_coverage_no_read_failures",
+      ok: false,
+      detail: "1 read failure(s)"
+    });
+    expect(coverage.readFailures).toEqual([
+      {
+        repo: "owner/unreadable",
+        error: "GitHub API 404",
+        nextAction: "inspect GitHub App installation/read permissions or network failure"
+      }
+    ]);
+    expect(coverage.recommendedActions).toContain("run doctor and inspect GitHub App installation/read permissions");
   });
 
   it("uses review budget readiness instead of raw provider-deferred retry counts for gates", () => {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -115,6 +115,88 @@ describe("operator CLI summaries", () => {
     expect(coverage.recommendedActions).toContain(
       "run release-status with --require-coverage true before claiming full active-repo monitoring coverage"
     );
+
+    const requiredWithoutReport = buildReleaseMonitoringCoverage({ required: true });
+    expect(requiredWithoutReport.failedGates).toContainEqual({
+      name: "active_repo_coverage_collected",
+      ok: false,
+      detail: "coverage was required but no coverage report was supplied"
+    });
+  });
+
+  it("passes required release monitoring coverage when all coverage gates are green", () => {
+    const coverage = buildReleaseMonitoringCoverage({
+      required: true,
+      report: coverageReport({
+        processed: [processedEntry(101, "head-ok", "posted")]
+      })
+    });
+
+    expect(coverage).toMatchObject({
+      collected: true,
+      required: true,
+      ok: true,
+      healthState: "coverage_ok",
+      failedGates: [],
+      recommendedActions: [],
+      summary: {
+        processed: 1,
+        unprocessed: 0,
+        staleHeads: 0,
+        readFailures: 0
+      }
+    });
+  });
+
+  it("fails required release monitoring coverage on unprocessed heads", () => {
+    const coverage = buildReleaseMonitoringCoverage({
+      required: true,
+      report: coverageReport({
+        unprocessed: [pullEntry(102, "head-pending")]
+      })
+    });
+
+    expect(coverage).toMatchObject({
+      collected: true,
+      required: true,
+      ok: false,
+      healthState: "coverage_blocked"
+    });
+    expect(coverage.failedGates).toContainEqual({
+      name: "active_repo_coverage_no_unprocessed_heads",
+      ok: false,
+      detail: "1 unprocessed eligible head(s)"
+    });
+    expect(coverage.recommendedActions).toContain("wait for daemon cycle or run scoped run-once for unprocessed heads");
+  });
+
+  it("fails required release monitoring coverage on stale heads", () => {
+    const coverage = buildReleaseMonitoringCoverage({
+      required: true,
+      report: coverageReport({
+        staleHeads: [{
+          repo: "owner/repo",
+          pullNumber: 103,
+          expectedHeadSha: "old-head",
+          liveHeadSha: "new-head",
+          title: "stale",
+          url: "https://github.com/owner/repo/pull/103"
+        }]
+      })
+    });
+
+    expect(coverage).toMatchObject({
+      collected: true,
+      required: true,
+      ok: false,
+      healthState: "coverage_blocked"
+    });
+    expect(coverage.failedGates).toContainEqual({
+      name: "active_repo_coverage_no_stale_heads",
+      ok: false,
+      detail: "1 stale head(s)"
+    });
+    expect(coverage.recommendedActions).toContain("wait for next daemon cycle or run scoped coverage audit");
   });
 
   it("fails required release monitoring coverage on active repo read failures", () => {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -10,6 +10,7 @@ import {
   buildOperatorQueue,
   buildOperatorStatus,
   buildReleaseMonitoringCoverage,
+  buildReleaseStatusCommandOutput,
   collectOperatorIssueEnrichmentRuntime,
   collectOperatorLeases,
   collectOperatorRepoProviderCooldowns,
@@ -232,6 +233,92 @@ describe("operator CLI summaries", () => {
       }
     ]);
     expect(coverage.recommendedActions).toContain("run doctor and inspect GitHub App installation/read permissions");
+  });
+
+  it("merges release-status coverage output only when required by the command", () => {
+    const runtime = releaseStatus({ ok: true });
+    const blockedCoverage = buildReleaseMonitoringCoverage({
+      required: false,
+      report: coverageReport({
+        readFailures: [{ repo: "owner/unreadable", error: "GitHub API 404" }]
+      })
+    });
+    const requiredBlockedCoverage = buildReleaseMonitoringCoverage({
+      required: true,
+      report: coverageReport({
+        readFailures: [{ repo: "owner/unreadable", error: "GitHub API 404" }]
+      })
+    });
+
+    const defaultOutput = buildReleaseStatusCommandOutput({
+      status: runtime,
+      monitoringCoverage: buildReleaseMonitoringCoverage({ required: false }),
+      requireCoverage: false
+    });
+    expect(defaultOutput).toMatchObject({
+      ok: true,
+      runtimeOk: true,
+      healthState: "runtime_ok",
+      failedGates: []
+    });
+    expect(defaultOutput.gates).toEqual(runtime.gates);
+
+    const advisoryOutput = buildReleaseStatusCommandOutput({
+      status: runtime,
+      monitoringCoverage: blockedCoverage,
+      requireCoverage: false
+    });
+    expect(advisoryOutput).toMatchObject({
+      ok: true,
+      runtimeOk: true,
+      healthState: "runtime_ok",
+      monitoringCoverage: {
+        ok: false,
+        healthState: "coverage_blocked"
+      },
+      failedGates: []
+    });
+    expect(advisoryOutput.gates).toEqual(runtime.gates);
+
+    const requiredBlockedOutput = buildReleaseStatusCommandOutput({
+      status: runtime,
+      monitoringCoverage: requiredBlockedCoverage,
+      requireCoverage: true
+    });
+    expect(requiredBlockedOutput).toMatchObject({
+      ok: false,
+      runtimeOk: true,
+      healthState: "coverage_blocked"
+    });
+    expect(requiredBlockedOutput.failedGates).toContainEqual({
+      name: "active_repo_coverage_no_read_failures",
+      ok: false,
+      detail: "1 read failure(s)"
+    });
+    expect(requiredBlockedOutput.recommendedActions).toContain(
+      "run doctor and inspect GitHub App installation/read permissions"
+    );
+
+    const requiredCleanOutput = buildReleaseStatusCommandOutput({
+      status: runtime,
+      monitoringCoverage: buildReleaseMonitoringCoverage({
+        required: true,
+        report: coverageReport({ processed: [processedEntry(101, "head-ok", "posted")] })
+      }),
+      requireCoverage: true
+    });
+    expect(requiredCleanOutput).toMatchObject({
+      ok: true,
+      runtimeOk: true,
+      healthState: "runtime_ok",
+      failedGates: []
+    });
+    expect(requiredCleanOutput.gates.map((gate) => gate.name)).toEqual([
+      "provider_cooldown_backlog",
+      "active_repo_coverage_no_unprocessed_heads",
+      "active_repo_coverage_no_read_failures",
+      "active_repo_coverage_no_stale_heads"
+    ]);
   });
 
   it("uses review budget readiness instead of raw provider-deferred retry counts for gates", () => {

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -946,6 +946,31 @@ exit 1
     });
   });
 
+  it("rejects scoped release-status coverage gates", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-release-status-scope-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: [],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      pollIntervalMs: 60_000
+    })}\n`);
+
+    await expect(runCli([
+      "release-status",
+      "--config",
+      configPath,
+      "--require-coverage",
+      "true",
+      "--repo",
+      "owner/repo"
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining("release-status does not support --repo/--pr")
+    });
+  });
+
   it("prints command help without executing run-once, review-pr, or daemon paths", async () => {
     for (const args of [["run-once", "--help"], ["review-pr", "help"], ["daemon", "start", "-h"]]) {
       const { stdout } = await runCli(args);


### PR DESCRIPTION
## Summary

Closes #433.

Adds an explicit release-status coverage attachment so release operators can distinguish local runtime health from active PR-review repo readability. `release-status` remains fast/local by default, but `--require-coverage true` collects active coverage and fails when eligible heads are unprocessed, stale, or unreadable by the GitHub App.

## Changes

- Add `buildReleaseMonitoringCoverage` for release-facing active-repo coverage summaries.
- Add `release-status --coverage true` advisory output and `--require-coverage true` hard gate.
- Update release-status help output.
- Update the beta release runbook to require coverage for promotion gates.

## Validation

- `/Volumes/LEXAR/Codex/repos/neondiff/node_modules/.bin/vitest run tests/operator-cli.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `npx tsx src/cli.ts release-status --help` smoke for `--require-coverage`
- `git diff --check`

## Proof Boundary

This does not solve the underlying GitHub App installation/read-permission gaps for every configured repo. It makes those gaps visible and blocking when operators run the release gate with `--require-coverage true`; deeper repo-state classification can follow as a separate hardening slice.