### PR TITLE
[codex] Add checkout license issuance endpoint

### DIFF
--- a/services/license-api/README.md
+++ b/services/license-api/README.md
@@ -4,8 +4,10 @@ Self-contained license service for NeonDiff private-repo entitlements
 ([#327](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327)).
 It implements the exact HTTP contract the shipped client (`src/license.ts`)
 already calls — activate / validate / deactivate — backed by SQLite, with an
-admin CLI that mints keys. **Payment rails are out of scope**: keys are issued by
-an operator via the CLI.
+admin CLI that mints keys. Checkout fulfillment may also use the guarded
+server-to-server issuance endpoint below; Stripe/Lovable publish wiring remains
+outside this package and must call the endpoint with an owner-held shared
+secret.
 
 The service is a separate package boundary; it does **not** import the review
 worker and can be deployed on its own (SQLite on a mounted volume).
@@ -19,6 +21,7 @@ Three `POST` endpoints, JSON in / JSON out (`Content-Type: application/json`):
 | `/v1/license/activate` | `{ licenseKey, repo?, machineId }` | `{ entitlement: { status:"active", repoVisibilityScope, … } }` | 404 invalid · 403 revoked · 402 expired · **409 scope_mismatch** (seat exhausted) |
 | `/v1/license/validate` | `{ licenseKey, repo?, machineId }` | active entitlement | 404 invalid · 403 revoked · 402 expired · 409 scope_mismatch (never activated on this machine) |
 | `/v1/license/deactivate` | `{ licenseKey, repo?, machineId }` | `{ status:"active", … }` (idempotent) | 404 invalid |
+| `/v1/admin/licenses/issue` | `{ idempotencyKey, checkoutLookupKey, ... }` + `Authorization: Bearer <LICENSE_ISSUANCE_SECRET>` | `{ status:"issued", licenseKey:"nd_live_...", entitlement, replayed }` | 401 unauthorized · 400 malformed/unsupported plan · 409 idempotency conflict |
 
 Cross-cutting: 429 rate_limited (per-key throttle) · 400 malformed · 5xx server.
 `machineId` is the single-activation binding — one machine per seat (default
@@ -29,6 +32,36 @@ The HTTP-code → client-classification map is fixed by the client
 (`402→expired · 429→rate_limited · 426→unsupported_client · 409→scope_mismatch ·
 403/410→revoked · 401/404→invalid · 5xx→server`); the service returns codes that
 match it.
+
+### Checkout issuance
+
+`POST /v1/admin/licenses/issue` is for the website/payment webhook only. It is
+disabled unless `LICENSE_ISSUANCE_SECRET` is configured, and it requires:
+
+```json
+{
+  "idempotencyKey": "stripe-checkout-session-or-event-id",
+  "checkoutLookupKey": "neondiff_monthly",
+  "customerEmail": "buyer@example.com",
+  "externalCustomerId": "cus_...",
+  "externalCheckoutId": "cs_...",
+  "seats": 1,
+  "expiresAt": "2027-07-08T00:00:00.000Z"
+}
+```
+
+Supported active checkout lookup keys are `neondiff_monthly`,
+`neondiff_yearly`, and `neondiff_org_yearly`; they map to
+`monthly_support`, `yearly_support`, and `org_yearly_support`. The endpoint
+issues private-repo entitlements with `updateEntitlement=true` and returns the
+raw `nd_live_...` license key to the caller for one-shot customer fulfillment.
+
+Idempotency is keyed by `idempotencyKey`. Retries with identical request data
+return the same `licenseKey` and `replayed=true` without minting a duplicate
+license. Reusing an idempotency key with different checkout data returns `409
+conflict`. SQLite stores only the license hash plus issuance metadata; the raw
+key is deterministically derived from `LICENSE_ISSUANCE_SECRET` and the
+idempotency key so webhook retries can be safe without storing raw key material.
 
 ## Run
 
@@ -45,6 +78,9 @@ Environment:
   at a mounted volume in deploy).
 - `PORT` / `HOST` — listen address (default `8080` / `0.0.0.0`). TLS is
   terminated upstream (fly), so the process serves plain HTTP internally.
+- `LICENSE_ISSUANCE_SECRET` — optional server-to-server bearer secret that
+  enables `POST /v1/admin/licenses/issue`. Keep it shared only with the
+  checkout webhook server; do not expose it to browsers or clients.
 
 ## Admin issuance CLI
 

--- a/services/license-api/docs/deploy.md
+++ b/services/license-api/docs/deploy.md
@@ -63,10 +63,11 @@ flyctl volumes create license_data --region iad --size 1 \
 ## 3. Secrets
 
 Production DR now requires an owner-held Litestream replica URL, provider
-credentials, and production `LICENSE_LITESTREAM_REQUIRED=true`. Do not commit
-secret values. Set the replica URL and provider credentials through Fly secrets
+credentials, production `LICENSE_LITESTREAM_REQUIRED=true`, and checkout
+issuance requires `LICENSE_ISSUANCE_SECRET`. Do not commit secret values. Set
+the replica URL, provider credentials, and issuance secret through Fly secrets
 before deploying with the required flag enabled; otherwise the container
-refuses to start. `LICENSE_DB_PATH` / `PORT` / `HOST` /
+refuses to start or checkout issuance stays disabled. `LICENSE_DB_PATH` / `PORT` / `HOST` /
 `LITESTREAM_CONFIG` / `LITESTREAM_SYNC_INTERVAL` /
 `LICENSE_LITESTREAM_REQUIRED` are plain config in `fly.toml`, not secrets.
 
@@ -75,12 +76,18 @@ flyctl secrets set \
   LICENSE_REPLICA_URL="<object-store-url-for-license.sqlite>" \
   AWS_ACCESS_KEY_ID="<provider-access-key-id>" \
   AWS_SECRET_ACCESS_KEY="<provider-secret-access-key>" \
+  LICENSE_ISSUANCE_SECRET="<shared-secret-used-by-website-webhook>" \
   --app neondiff-license
 ```
 
 Use the provider-specific variables for non-S3-compatible storage. See
 [`disaster-recovery.md`](disaster-recovery.md) for the owner-only setup and
 restore drill proof boundary.
+
+`LICENSE_ISSUANCE_SECRET` enables `POST /v1/admin/licenses/issue` for the
+website payment webhook. Keep the same value configured only on the license API
+and the server-side checkout webhook; never expose it to browser code, public
+docs, logs, or generated release packets.
 
 ## 4. Deploy
 

--- a/services/license-api/src/http.ts
+++ b/services/license-api/src/http.ts
@@ -1,6 +1,12 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { LicenseStore } from "./store.js";
 import {
+  issueCheckoutLicense,
+  malformedIssuanceResult,
+  parseIssuanceRequest,
+  validateBearerSecret
+} from "./issuance.js";
+import {
   activate,
   deactivate,
   malformedResult,
@@ -16,6 +22,7 @@ const MAX_BODY_BYTES = 16 * 1024;
 export interface LicenseHttpOptions {
   store: LicenseStore;
   rateLimiter?: RateLimiter;
+  issuanceSecret?: string;
   /** Injectable clock for deterministic tests. */
   now?: () => Date;
 }
@@ -42,7 +49,12 @@ export function createLicenseRequestListener(options: LicenseHttpOptions) {
     if (req.method === "GET" && req.url === "/healthz") {
       return writeJson(res, 200, { status: "ok" });
     }
-    const route = req.url ? ROUTES[req.url.split("?")[0]] : undefined;
+    const path = req.url?.split("?")[0];
+    if (req.method === "POST" && path === "/v1/admin/licenses/issue") {
+      return handleIssuanceRequest(options, req, res);
+    }
+
+    const route = path ? ROUTES[path] : undefined;
     if (req.method !== "POST" || !route) {
       return writeResult(res, malformedResult("unknown route"), 404);
     }
@@ -66,6 +78,29 @@ export function createLicenseRequestListener(options: LicenseHttpOptions) {
       return writeJson(res, 500, { status: "server", detail: "internal error" });
     }
   };
+}
+
+async function handleIssuanceRequest(
+  options: LicenseHttpOptions,
+  req: IncomingMessage,
+  res: ServerResponse
+): Promise<void> {
+  if (!options.issuanceSecret) {
+    return writeJson(res, 503, { status: "server", detail: "license issuance is not configured" });
+  }
+  if (!validateBearerSecret(req.headers.authorization, options.issuanceSecret)) {
+    return writeJson(res, 401, { status: "unauthorized", detail: "license issuance authorization failed" });
+  }
+
+  try {
+    const parsed = parseIssuanceRequest(await readBody(req));
+    return writeResult(res, issueCheckoutLicense(options.store, parsed, options.issuanceSecret));
+  } catch (error) {
+    return writeResult(
+      res,
+      malformedIssuanceResult(error instanceof Error ? error.message : "malformed request body")
+    );
+  }
 }
 
 export function startLicenseServer(options: LicenseHttpOptions & { port?: number; host?: string }): Promise<{ server: Server; url: string }> {

--- a/services/license-api/src/issuance.ts
+++ b/services/license-api/src/issuance.ts
@@ -1,0 +1,195 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import {
+  type IssueLicenseInput,
+  type LicenseRecord,
+  type LicenseStore,
+  type RepoVisibilityScope
+} from "./store.js";
+import { malformedResult, type ServiceResult } from "./service.js";
+
+const ACTIVE_CHECKOUT_LOOKUP_KEYS = {
+  neondiff_monthly: "monthly_support",
+  neondiff_yearly: "yearly_support",
+  neondiff_org_yearly: "org_yearly_support"
+} as const;
+
+type CheckoutLookupKey = keyof typeof ACTIVE_CHECKOUT_LOOKUP_KEYS;
+
+export interface LicenseIssuanceRequest {
+  idempotencyKey: string;
+  checkoutLookupKey: CheckoutLookupKey;
+  customerEmail?: string;
+  externalCustomerId?: string;
+  externalCheckoutId?: string;
+  seats?: number;
+  expiresAt?: string;
+}
+
+export interface LicenseIssuanceInput extends IssueLicenseInput {
+  idempotencyKey: string;
+  requestHash: string;
+  source?: string;
+  externalRef?: string;
+}
+
+export interface LicenseIssuanceResult {
+  rawKey: string;
+  record: LicenseRecord;
+  replayed: boolean;
+}
+
+export function checkoutLookupKeys(): readonly string[] {
+  return Object.keys(ACTIVE_CHECKOUT_LOOKUP_KEYS);
+}
+
+export function parseIssuanceRequest(raw: string): LicenseIssuanceRequest {
+  const parsed = raw ? (JSON.parse(raw) as unknown) : {};
+  if (typeof parsed !== "object" || parsed === null) throw new Error("request body must be a JSON object");
+  const body = parsed as Record<string, unknown>;
+
+  const idempotencyKey = readBoundedString(body, "idempotencyKey", { required: true, max: 200 });
+  if (!/^[A-Za-z0-9._:-]+$/.test(idempotencyKey)) {
+    throw new Error("idempotencyKey contains unsupported characters");
+  }
+
+  const checkoutLookupKey = readBoundedString(body, "checkoutLookupKey", { required: true, max: 80 });
+  if (!isCheckoutLookupKey(checkoutLookupKey)) {
+    throw new Error(`checkoutLookupKey must be one of: ${checkoutLookupKeys().join(", ")}`);
+  }
+
+  const seatsRaw = body.seats;
+  const seats = seatsRaw === undefined ? undefined : Number(seatsRaw);
+  if (seats !== undefined && (!Number.isInteger(seats) || seats < 1 || seats > 500)) {
+    throw new Error("seats must be a positive integer <= 500");
+  }
+
+  const expiresAt = readBoundedString(body, "expiresAt", { required: false, max: 80 });
+  if (expiresAt && !Number.isFinite(Date.parse(expiresAt))) {
+    throw new Error("expiresAt must be an ISO timestamp");
+  }
+  const customerEmail = readBoundedString(body, "customerEmail", { required: false, max: 320 });
+  const externalCustomerId = readBoundedString(body, "externalCustomerId", { required: false, max: 160 });
+  const externalCheckoutId = readBoundedString(body, "externalCheckoutId", { required: false, max: 160 });
+
+  return {
+    idempotencyKey,
+    checkoutLookupKey,
+    ...(customerEmail ? { customerEmail } : {}),
+    ...(externalCustomerId ? { externalCustomerId } : {}),
+    ...(externalCheckoutId ? { externalCheckoutId } : {}),
+    ...(seats !== undefined ? { seats } : {}),
+    ...(expiresAt ? { expiresAt } : {})
+  };
+}
+
+export function issueCheckoutLicense(
+  store: LicenseStore,
+  req: LicenseIssuanceRequest,
+  issuanceSecret: string
+): ServiceResult {
+  const plan = ACTIVE_CHECKOUT_LOOKUP_KEYS[req.checkoutLookupKey];
+  const issueInput: LicenseIssuanceInput = {
+    idempotencyKey: req.idempotencyKey,
+    requestHash: issuanceRequestHash(req),
+    source: "checkout",
+    externalRef: req.externalCheckoutId ?? req.externalCustomerId,
+    plan,
+    repoVisibilityScope: "private",
+    privateRepoAllowed: true,
+    updateEntitlement: true,
+    ...(req.seats !== undefined ? { seats: req.seats } : {}),
+    ...(req.expiresAt ? { expiresAt: req.expiresAt } : {})
+  };
+  const rawKey = deriveCheckoutLicenseKey(issuanceSecret, req.idempotencyKey);
+
+  try {
+    const issued = store.issueIdempotentLicense(rawKey, issueInput);
+    return {
+      httpStatus: 200,
+      body: {
+        status: "issued",
+        replayed: issued.replayed,
+        idempotencyKey: req.idempotencyKey,
+        licenseKey: issued.rawKey,
+        licenseKeyHash: issued.record.licenseKeyHash,
+        entitlement: entitlementFromRecord(issued.record)
+      }
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : "license issuance failed";
+    if (detail.includes("idempotency key")) {
+      return { httpStatus: 409, body: { status: "conflict", detail } };
+    }
+    return { httpStatus: 500, body: { status: "server", detail: "license issuance failed" } };
+  }
+}
+
+export function malformedIssuanceResult(detail: string): ServiceResult {
+  return malformedResult(detail);
+}
+
+export function validateBearerSecret(header: string | string[] | undefined, expected: string): boolean {
+  const value = Array.isArray(header) ? header[0] : header;
+  const prefix = "Bearer ";
+  if (!value?.startsWith(prefix)) return false;
+  const supplied = value.slice(prefix.length);
+  return timingSafeEqualDigest(supplied, expected);
+}
+
+function deriveCheckoutLicenseKey(secret: string, idempotencyKey: string): string {
+  const digest = createHmac("sha256", secret).update(`checkout-license:${idempotencyKey}`).digest();
+  return ["nd", "live", digest.subarray(0, 24).toString("base64url")].join("_");
+}
+
+function issuanceRequestHash(req: LicenseIssuanceRequest): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        checkoutLookupKey: req.checkoutLookupKey,
+        customerEmail: req.customerEmail ?? null,
+        externalCustomerId: req.externalCustomerId ?? null,
+        externalCheckoutId: req.externalCheckoutId ?? null,
+        seats: req.seats ?? null,
+        expiresAt: req.expiresAt ?? null
+      })
+    )
+    .digest("hex");
+}
+
+function entitlementFromRecord(record: LicenseRecord): Record<string, unknown> {
+  return {
+    status: "active",
+    repoVisibilityScope: record.repoVisibilityScope,
+    privateRepoAllowed: record.privateRepoAllowed,
+    updateEntitlement: record.updateEntitlement,
+    plan: record.plan,
+    seats: record.seats,
+    ...(record.expiresAt ? { expiresAt: record.expiresAt } : {})
+  };
+}
+
+function isCheckoutLookupKey(value: string): value is CheckoutLookupKey {
+  return Object.prototype.hasOwnProperty.call(ACTIVE_CHECKOUT_LOOKUP_KEYS, value);
+}
+
+function readBoundedString(
+  body: Record<string, unknown>,
+  key: string,
+  options: { required: true; max: number } | { required: false; max: number }
+): string {
+  const value = body[key];
+  if (typeof value !== "string") {
+    if (options.required) throw new Error(`${key} is required`);
+    return "";
+  }
+  const trimmed = value.trim();
+  if (!trimmed && options.required) throw new Error(`${key} is required`);
+  if (trimmed.length > options.max) throw new Error(`${key} is too long`);
+  return trimmed;
+}
+
+function timingSafeEqualDigest(a: string, b: string): boolean {
+  const aDigest = createHash("sha256").update(a).digest();
+  const bDigest = createHash("sha256").update(b).digest();
+  return timingSafeEqual(aDigest, bDigest);
+}

--- a/services/license-api/src/server.ts
+++ b/services/license-api/src/server.ts
@@ -11,7 +11,12 @@ async function main(): Promise<void> {
   const port = Number(process.env.PORT ?? 8080);
   const host = process.env.HOST ?? "0.0.0.0";
   const store = new LicenseStore(dbPath);
-  const { url } = await startLicenseServer({ store, port, host });
+  const { url } = await startLicenseServer({
+    store,
+    port,
+    host,
+    issuanceSecret: process.env.LICENSE_ISSUANCE_SECRET
+  });
   // eslint-disable-next-line no-console
   console.log(`license-api listening on ${url} (db=${dbPath})`);
 }

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -48,6 +48,15 @@ interface ActivationRow {
   last_seen_at: string;
 }
 
+interface LicenseIssuanceRow {
+  idempotency_key: string;
+  license_key_hash: string;
+  request_hash: string;
+  source: string | null;
+  external_ref: string | null;
+  created_at: string;
+}
+
 /**
  * Deterministic at-rest identifier for a license key. Only the hash is ever
  * stored or logged; the raw key is printed once by the admin CLI at issuance
@@ -74,6 +83,13 @@ export interface IssueLicenseInput {
   updateEntitlement?: boolean;
   seats?: number;
   expiresAt?: string;
+}
+
+export interface IssueIdempotentLicenseInput extends IssueLicenseInput {
+  idempotencyKey: string;
+  requestHash: string;
+  source?: string;
+  externalRef?: string;
 }
 
 export class LicenseStore {
@@ -109,6 +125,16 @@ export class LicenseStore {
         last_seen_at text not null default (datetime('now')),
         primary key (license_key_hash, machine_id)
       );
+
+      create table if not exists license_issuance_events (
+        idempotency_key text primary key,
+        license_key_hash text not null,
+        request_hash text not null,
+        source text,
+        external_ref text,
+        created_at text not null default (datetime('now')),
+        foreign key (license_key_hash) references licenses(license_key_hash)
+      );
     `);
   }
 
@@ -119,6 +145,57 @@ export class LicenseStore {
   /** Issue a new license: generates a raw key, stores only its hash. */
   issueLicense(input: IssueLicenseInput): { rawKey: string; record: LicenseRecord } {
     const rawKey = generateLicenseKey();
+    return this.insertLicense(rawKey, input);
+  }
+
+  /**
+   * Issue a checkout-backed license idempotently. The caller supplies a raw key
+   * derived from its idempotency secret, so retries can return the same key
+   * without storing raw license material in SQLite.
+   */
+  issueIdempotentLicense(
+    rawKey: string,
+    input: IssueIdempotentLicenseInput
+  ): { rawKey: string; record: LicenseRecord; replayed: boolean } {
+    const existing = this.getIssuanceEvent(input.idempotencyKey);
+    if (existing) {
+      if (existing.request_hash !== input.requestHash) {
+        throw new Error("idempotency key was already used with different request data");
+      }
+      const licenseKeyHash = hashLicenseKey(rawKey);
+      if (licenseKeyHash !== existing.license_key_hash) {
+        throw new Error("idempotency key was issued with a different key derivation secret");
+      }
+      const record = this.getLicenseByHash(existing.license_key_hash);
+      if (!record) throw new Error("idempotency key points to a missing license record");
+      return { rawKey, record, replayed: true };
+    }
+
+    this.db.exec("begin immediate");
+    try {
+      const { record } = this.insertLicense(rawKey, input);
+      this.db
+        .prepare(
+          `insert into license_issuance_events (
+            idempotency_key, license_key_hash, request_hash, source, external_ref
+          ) values (?, ?, ?, ?, ?)`
+        )
+        .run(
+          input.idempotencyKey,
+          record.licenseKeyHash,
+          input.requestHash,
+          input.source ?? null,
+          input.externalRef ?? null
+        );
+      this.db.exec("commit");
+      return { rawKey, record, replayed: false };
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
+  private insertLicense(rawKey: string, input: IssueLicenseInput): { rawKey: string; record: LicenseRecord } {
     const licenseKeyHash = hashLicenseKey(rawKey);
     const seats = input.seats ?? 1;
     if (!Number.isInteger(seats) || seats < 1) throw new Error("seats must be a positive integer");
@@ -143,6 +220,12 @@ export class LicenseStore {
     const record = this.getLicenseByHash(licenseKeyHash);
     if (!record) throw new Error("license insert did not persist");
     return { rawKey, record };
+  }
+
+  private getIssuanceEvent(idempotencyKey: string): LicenseIssuanceRow | undefined {
+    return this.db
+      .prepare("select * from license_issuance_events where idempotency_key = ?")
+      .get(idempotencyKey) as LicenseIssuanceRow | undefined;
   }
 
   getLicenseByHash(licenseKeyHash: string): LicenseRecord | undefined {

--- a/services/license-api/test/http.test.ts
+++ b/services/license-api/test/http.test.ts
@@ -7,10 +7,15 @@ import { RateLimiter } from "../src/service.ts";
 
 const fakeKey = (tag: string): string => ["nd", "live", `${tag}${"x".repeat(24 - tag.length)}`].join("_");
 
-async function post(url: string, path: string, body: unknown): Promise<{ status: number; json: any }> {
+async function post(
+  url: string,
+  path: string,
+  body: unknown,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; json: any }> {
   const res = await fetch(`${url}${path}`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...headers },
     body: typeof body === "string" ? body : JSON.stringify(body)
   });
   const text = await res.text();
@@ -72,5 +77,126 @@ describe("license http transport", () => {
     const throttled = await post(url, "/v1/license/validate", { licenseKey: key, machineId: "m" });
     assert.equal(throttled.status, 429);
     assert.equal(throttled.json.status, "rate_limited");
+  });
+});
+
+describe("license issuance transport", () => {
+  let store: LicenseStore;
+  let server: Server;
+  let url: string;
+  const issuanceSecret = ["test", "issuance", "secret", "0123456789"].join("_");
+  const auth = { Authorization: `Bearer ${issuanceSecret}` };
+
+  before(async () => {
+    store = new LicenseStore(":memory:");
+    const started = await startLicenseServer({
+      store,
+      issuanceSecret,
+      rateLimiter: new RateLimiter({ maxPerWindow: 100, windowMs: 60_000 }),
+      now: () => new Date("2026-07-08T00:00:00.000Z")
+    });
+    server = started.server;
+    url = started.url;
+  });
+
+  after(() => {
+    server.close();
+    store.close();
+  });
+
+  it("rejects issuance without the shared secret", async () => {
+    const res = await post(url, "/v1/admin/licenses/issue", {
+      idempotencyKey: "checkout-session-unauthorized",
+      checkoutLookupKey: "neondiff_monthly"
+    });
+    assert.equal(res.status, 401);
+    assert.equal(store.listLicenses().length, 0);
+  });
+
+  it("issues a product-native license key for checkout fulfillment", async () => {
+    const issued = await post(
+      url,
+      "/v1/admin/licenses/issue",
+      {
+        idempotencyKey: "checkout-session-123",
+        checkoutLookupKey: "neondiff_org_yearly",
+        customerEmail: "buyer@example.com",
+        externalCustomerId: "cus_123",
+        externalCheckoutId: "cs_123",
+        seats: 3,
+        expiresAt: "2027-07-08T00:00:00.000Z"
+      },
+      auth
+    );
+    assert.equal(issued.status, 200);
+    assert.equal(issued.json.status, "issued");
+    assert.equal(issued.json.replayed, false);
+    assert.match(issued.json.licenseKey, /^nd_live_[A-Za-z0-9_-]+$/);
+    assert.equal(issued.json.entitlement.plan, "org_yearly_support");
+    assert.equal(issued.json.entitlement.repoVisibilityScope, "private");
+    assert.equal(issued.json.entitlement.updateEntitlement, true);
+    assert.equal(issued.json.entitlement.seats, 3);
+
+    const record = store.getLicenseByKey(issued.json.licenseKey);
+    assert.ok(record);
+    assert.equal(record.plan, "org_yearly_support");
+    assert.equal(record.repoVisibilityScope, "private");
+    assert.equal(record.updateEntitlement, true);
+    assert.equal(record.seats, 3);
+
+    const activated = await post(url, "/v1/license/activate", {
+      licenseKey: issued.json.licenseKey,
+      machineId: "machine-a"
+    });
+    assert.equal(activated.status, 200);
+    assert.equal(activated.json.entitlement.status, "active");
+    assert.ok(!JSON.stringify(activated.json).includes(issued.json.licenseKey));
+  });
+
+  it("replays the same idempotency key without minting a duplicate license", async () => {
+    const body = {
+      idempotencyKey: "checkout-session-repeat",
+      checkoutLookupKey: "neondiff_yearly",
+      externalCheckoutId: "cs_repeat"
+    };
+    const first = await post(url, "/v1/admin/licenses/issue", body, auth);
+    const second = await post(url, "/v1/admin/licenses/issue", body, auth);
+    assert.equal(first.status, 200);
+    assert.equal(second.status, 200);
+    assert.equal(second.json.replayed, true);
+    assert.equal(second.json.licenseKey, first.json.licenseKey);
+    assert.equal(
+      store.listLicenses().filter((record) => record.plan === "yearly_support").length,
+      1
+    );
+  });
+
+  it("fails closed when an idempotency key is reused with different checkout data", async () => {
+    const first = await post(
+      url,
+      "/v1/admin/licenses/issue",
+      { idempotencyKey: "checkout-session-conflict", checkoutLookupKey: "neondiff_monthly" },
+      auth
+    );
+    assert.equal(first.status, 200);
+    const conflict = await post(
+      url,
+      "/v1/admin/licenses/issue",
+      { idempotencyKey: "checkout-session-conflict", checkoutLookupKey: "neondiff_org_yearly" },
+      auth
+    );
+    assert.equal(conflict.status, 409);
+    assert.equal(conflict.json.status, "conflict");
+  });
+
+  it("rejects unsupported checkout lookup keys before issuing", async () => {
+    const res = await post(
+      url,
+      "/v1/admin/licenses/issue",
+      { idempotencyKey: "checkout-session-bad-plan", checkoutLookupKey: "neondiff_lifetime" },
+      auth
+    );
+    assert.equal(res.status, 400);
+    assert.equal(res.json.status, "invalid");
   });
 });


### PR DESCRIPTION
## Summary

Closes part of #421 by adding the product-side source contract for checkout-backed license issuance:

- adds guarded `POST /v1/admin/licenses/issue` to the license API
- maps active website checkout lookup keys to product entitlement plans
- issues product-native `nd_live_...` keys into the license API SQLite store
- adds idempotency so checkout/webhook retries do not mint duplicate licenses
- keeps raw license keys out of SQLite by storing only hashes plus issuance metadata
- documents `LICENSE_ISSUANCE_SECRET`, request shape, deploy secret setup, and owner-gated website/Fly/Lovable boundaries

## Proof Boundary

This PR proves the license API can mint checkout-backed keys that activate through the existing product license endpoint. It does not wire the website webhook, publish Lovable, configure Fly secrets, or prove a real paid activation. Those remain #421 follow-up gates.

## Validation

- `node --import /Volumes/LEXAR/Codex/repos/neondiff/node_modules/tsx/dist/loader.mjs --test services/license-api/test/*.test.ts`
- `npm run build`
- `git diff --check`
- `./node_modules/.bin/vitest run tests/license-service-contract.test.ts`
- `node scripts/check-public-claims.mjs`
