### PR TITLE
[codex] Repair settled review status comments

### DIFF
--- a/src/review-status-comment.ts
+++ b/src/review-status-comment.ts
@@ -57,6 +57,7 @@ const REVIEW_STATUS_STATE_MARKER_PREFIX = "<!-- evaos-code-review-bot:review-sta
 const REPO_SLUG_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const HEAD_SHA_PATTERN = /^[0-9a-f]{40}$/i;
 const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/g;
+const REVIEW_STATUS_STATE_PATTERN = /<!--\s*evaos-code-review-bot:review-status-state\b[^>]*\bstatus=([A-Za-z_]+)\b[^>]*-->/;
 
 export function buildReviewStatusMarker(input: {
   repo: string;
@@ -104,6 +105,16 @@ export function buildReviewStatusComment(input: BuildReviewStatusCommentInput): 
     marker,
     body: lines.join("\n")
   };
+}
+
+export function parseReviewStatusCommentState(body: string | null | undefined): ReviewStatusCommentState | undefined {
+  const match = body?.match(REVIEW_STATUS_STATE_PATTERN);
+  if (!match?.[1]) return undefined;
+  return isReviewStatusCommentState(match[1]) ? match[1] : undefined;
+}
+
+export function isRepairableReviewStatusCommentState(state: ReviewStatusCommentState | undefined): boolean {
+  return state === "queued" || state === "in_progress" || state === "provider_deferred";
 }
 
 export async function postReviewStatusComment(input: {
@@ -155,6 +166,19 @@ export async function postReviewStatusComment(input: {
       error: redactSecrets(error instanceof Error ? error.message : String(error))
     };
   }
+}
+
+function isReviewStatusCommentState(value: string): value is ReviewStatusCommentState {
+  return (
+    value === "queued" ||
+    value === "in_progress" ||
+    value === "completed" ||
+    value === "provider_deferred" ||
+    value === "stale_head" ||
+    value === "closed_or_merged_before_review" ||
+    value === "skipped" ||
+    value === "failed"
+  );
 }
 
 function hasReviewLifecycleOptIn(input: BuildReviewStatusCommentInput): boolean {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -14,6 +14,9 @@ import { isFinishingTouchActionEnabled } from "./finishing-touches.js";
 import { DEFAULT_BOT_LOGIN, GitHubApi } from "./github.js";
 import { listReposToScan, resolveRepoProfile } from "./repo-policy.js";
 import {
+  buildReviewStatusMarker,
+  isRepairableReviewStatusCommentState,
+  parseReviewStatusCommentState,
   postReviewStatusComment,
   type ReviewStatusCommentGithub,
   type ReviewStatusCommentPostResult,
@@ -536,6 +539,7 @@ async function enqueuePullIfEligible(input: {
   await retireSupersededQueueJobsForPull(input);
   if (processed || input.state.hasProcessed(input.repo, input.pull.number, input.pull.head.sha)) {
     backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
+    await repairProcessedHeadStatusCommentIfNeeded({ ...input, processed });
     return "skipped_processed";
   }
   const activeQueueJob = getActiveQueueJobForHead(input.state, input.repo, input.pull.number, input.pull.head.sha);
@@ -1438,6 +1442,60 @@ function isStatusCommentFailure(result: ReviewStatusCommentPostResult): boolean 
     result.reason === "build_failed" ||
     result.reason === "upsert_failed"
   );
+}
+
+async function repairProcessedHeadStatusCommentIfNeeded(input: {
+  config: BotConfig;
+  github: SchedulerGitHubApi;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  dryRun: boolean;
+  processed?: { status: ProcessedStatus; reviewUrl?: string };
+  onStatusCommentFailure?: () => void;
+  now?: Date;
+}): Promise<void> {
+  if (!input.config.reviewStatusComment?.enabled || input.dryRun || !isReviewStatusCommentGithub(input.github)) return;
+  const processed = input.processed ?? input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha);
+  if (processed?.status !== "posted") return;
+  const postedJob = input.state
+    .listReviewQueueJobsForPull({ repo: input.repo, pullNumber: input.pull.number, state: "posted" })
+    .find((job) => job.headSha === input.pull.head.sha);
+  const reviewUrl = processed.reviewUrl ?? postedJob?.reviewUrl;
+  if (!reviewUrl) return;
+
+  let comments: IssueCommentCommandSource[];
+  try {
+    comments = await input.github.listIssueComments(input.repo, input.pull.number);
+  } catch {
+    input.onStatusCommentFailure?.();
+    return;
+  }
+
+  const marker = buildReviewStatusMarker({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha
+  });
+  const botLogin = input.config.github.botLogin ?? DEFAULT_BOT_LOGIN;
+  const existing = comments.find((comment) =>
+    comment.body?.includes(marker) &&
+    comment.user?.type === "Bot" &&
+    comment.user.login === botLogin
+  );
+  if (!isRepairableReviewStatusCommentState(parseReviewStatusCommentState(existing?.body))) return;
+
+  await syncReviewStatusComment({
+    config: input.config,
+    github: input.github,
+    dryRun: input.dryRun,
+    repo: input.repo,
+    pull: input.pull,
+    state: "completed",
+    reviewUrl,
+    onStatusCommentFailure: input.onStatusCommentFailure,
+    now: input.now
+  });
 }
 
 async function syncReviewStatusCommentForReviewResult(input: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1742,6 +1742,14 @@ export async function reconcileProcessedHeadAfterDirectReview(input: {
 
   const now = input.now ?? new Date();
   if (activeJobs.length === 0) {
+    recordDirectReviewReadinessIfRepairable({
+      state: input.state,
+      repo: input.repo,
+      pull: input.pull,
+      processed,
+      existingReadiness: input.state.getReviewReadiness(input.repo, input.pull.number, input.pull.head.sha),
+      now
+    });
     return {
       activeQueueJobs: 0,
       settledQueueJobs: 0,
@@ -1835,6 +1843,37 @@ function directReviewReconcileReadinessReason(previous?: ReviewReadinessRecord):
     return DIRECT_REVIEW_RECONCILED_REASON;
   }
   return `${DIRECT_REVIEW_RECONCILED_REASON}; previous_reason=${redactSecrets(previousReason).slice(0, 200)}`;
+}
+
+function recordDirectReviewReadinessIfRepairable(input: {
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  processed: { event?: ReviewEvent; reviewUrl?: string };
+  existingReadiness?: ReviewReadinessRecord;
+  now: Date;
+}): void {
+  if (!shouldRepairDirectReviewReadiness(input.existingReadiness)) return;
+  input.state.recordReviewReadiness({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    state: readinessStateForDirectProcessedReview(input.processed.event),
+    reason: directReviewReconcileReadinessReason(input.existingReadiness),
+    ...(input.processed.event ? { event: input.processed.event } : {}),
+    ...(input.processed.reviewUrl ? { reviewUrl: input.processed.reviewUrl } : {}),
+    now: input.now
+  });
+}
+
+function shouldRepairDirectReviewReadiness(readiness?: ReviewReadinessRecord): boolean {
+  return (
+    !readiness ||
+    readiness.state === "queued" ||
+    readiness.state === "reviewing" ||
+    readiness.state === "awaiting_re_review" ||
+    readiness.state === "provider_deferred"
+  );
 }
 
 function readinessStateForDirectProcessedReview(event?: ReviewEvent): ReviewReadinessState {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1728,6 +1728,7 @@ export async function reconcileProcessedHeadAfterDirectReview(input: {
   now?: Date;
 }): Promise<{ activeQueueJobs: number; settledQueueJobs: number; statusCommentPosted: boolean }> {
   if (input.dryRun) return { activeQueueJobs: 0, settledQueueJobs: 0, statusCommentPosted: false };
+  const processed = input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha);
   const activeJobs = input.state
     .listReviewQueueJobsForPull({
       repo: input.repo,
@@ -1735,16 +1736,19 @@ export async function reconcileProcessedHeadAfterDirectReview(input: {
       states: DIRECT_REVIEW_RECONCILE_QUEUE_STATES
     })
     .filter((job) => job.headSha === input.pull.head.sha);
-  if (activeJobs.length === 0) {
-    return { activeQueueJobs: 0, settledQueueJobs: 0, statusCommentPosted: false };
-  }
-
-  const processed = input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha);
   if (processed?.status !== "posted") {
     return { activeQueueJobs: activeJobs.length, settledQueueJobs: 0, statusCommentPosted: false };
   }
 
   const now = input.now ?? new Date();
+  if (activeJobs.length === 0) {
+    return {
+      activeQueueJobs: 0,
+      settledQueueJobs: 0,
+      statusCommentPosted: await postDirectReviewCompletedStatusComment({ ...input, processed, now })
+    };
+  }
+
   const manualCommandJob =
     activeJobs.find((job) => job.source === "manual_command" && job.commentId) ??
     activeJobs.find((job) => job.source === "manual_command");
@@ -1782,30 +1786,38 @@ export async function reconcileProcessedHeadAfterDirectReview(input: {
     now
   });
 
-  let statusCommentPosted = false;
-  if (isReviewStatusCommentGithub(input.github)) {
-    const result = await postReviewStatusComment({
-      enabled: input.config.reviewStatusComment?.enabled ?? false,
-      dryRun: input.dryRun,
-      github: input.github,
-      repo: input.repo,
-      pullNumber: input.pull.number,
-      headSha: input.pull.head.sha,
-      state: "completed",
-      pullTitle: input.pull.title,
-      pullUrl: input.pull.html_url,
-      ...(processed.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
-      now,
-      publicConfidencePolicy: input.config.confidenceCalibration?.publicDisplay
-    });
-    statusCommentPosted = result.posted;
-  }
-
   return {
     activeQueueJobs: activeJobs.length,
     settledQueueJobs: activeJobs.length,
-    statusCommentPosted
+    statusCommentPosted: await postDirectReviewCompletedStatusComment({ ...input, processed, now })
   };
+}
+
+async function postDirectReviewCompletedStatusComment(input: {
+  config: BotConfig;
+  github: GitHubApi;
+  repo: string;
+  pull: PullRequestSummary;
+  dryRun: boolean;
+  processed: { reviewUrl?: string };
+  now: Date;
+}): Promise<boolean> {
+  if (!isReviewStatusCommentGithub(input.github)) return false;
+  const result = await postReviewStatusComment({
+    enabled: input.config.reviewStatusComment?.enabled ?? false,
+    dryRun: input.dryRun,
+    github: input.github,
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    state: "completed",
+    pullTitle: input.pull.title,
+    pullUrl: input.pull.html_url,
+    ...(input.processed.reviewUrl ? { reviewUrl: input.processed.reviewUrl } : {}),
+    now: input.now,
+    publicConfidencePolicy: input.config.confidenceCalibration?.publicDisplay
+  });
+  return result.posted;
 }
 
 const DIRECT_REVIEW_RECONCILED_ERROR = "direct_review_reconciled_processed_head=posted";

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -305,6 +305,93 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("repairs stale duplicate processed-head scheduler status comments without updating settled markers", async () => {
+    const scenarios = [
+      { existingStatus: "in_progress", expectedStatusCalls: ["completed"] },
+      { existingStatus: "completed", expectedStatusCalls: [] }
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const root = mkdtempSync(join(tmpdir(), `evaos-scheduler-status-repair-${scenario.existingStatus}-`));
+      roots.push(root);
+      const config = schedulerConfig(root, ["org/repo-a"]);
+      config.reviewStatusComment!.enabled = true;
+      const state = new ReviewStateStore(config.statePath);
+      const reviewUrl = `https://github.com/org/repo-a/pull/1#pullrequestreview-${scenario.existingStatus}`;
+      const statusCalls: StatusCommentCall[] = [];
+      const comments = new Map([
+        [`org/repo-a#1`, [
+          {
+            id: 9001,
+            body: reviewStatusBody("org/repo-a", 1, HEAD_A, scenario.existingStatus),
+            html_url: "https://github.test/comment/9001",
+            user: {
+              login: "evaos-code-review-bot[bot]",
+              type: "Bot"
+            }
+          }
+        ]]
+      ]);
+      state.recordProcessed({
+        repo: "org/repo-a",
+        pullNumber: 1,
+        headSha: HEAD_A,
+        status: "posted",
+        event: "COMMENT",
+        reviewUrl
+      });
+      const job = state.enqueueReviewQueueJob({
+        repo: "org/repo-a",
+        pullNumber: 1,
+        headSha: HEAD_A,
+        baseSha: "base"
+      }).job;
+      state.updateReviewQueueJobState({
+        jobId: job.jobId,
+        state: "posted",
+        reviewUrl,
+        lastError: "reviewed"
+      });
+      state.recordReviewReadiness({
+        repo: "org/repo-a",
+        pullNumber: 1,
+        headSha: HEAD_A,
+        state: "reviewing",
+        reason: "queue_job_running",
+        now: new Date("2026-07-02T00:00:00.000Z")
+      });
+
+      const result = await runScheduledCycleWithDeps({
+        config,
+        github: githubFromMap(new Map([
+          ["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]
+        ]), comments, statusCalls),
+        state,
+        options: { dryRun: false, useZCode: false },
+        reviewPullImpl: async () => {
+          throw new Error("duplicate processed heads must not run review work");
+        },
+        now: new Date("2026-07-02T00:05:00.000Z")
+      });
+
+      expect(result.skippedProcessed).toBe(1);
+      expect(statusCalls.map(statusFromBody)).toEqual(scenario.expectedStatusCalls);
+      expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+        state: "ready_for_human",
+        reason: "processed_head_already_posted",
+        event: "COMMENT",
+        reviewUrl
+      });
+      expect(state.getReviewQueueJob(job.jobId)).toMatchObject({
+        state: "posted",
+        reviewUrl,
+        lastError: "reviewed"
+      });
+      if (statusCalls.length > 0) expect(statusCalls[0]?.body).toContain(reviewUrl);
+      state.close();
+    }
+  });
+
   it("marks older readiness rows stale when a newer PR head is scanned", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-readiness-superseded-"));
     roots.push(root);
@@ -3838,6 +3925,13 @@ function statusFromBody(call: StatusCommentCall): string {
   const match = call.body.match(/review-status-state status=([^ ]+)/);
   if (!match?.[1]) throw new Error(`missing status marker in ${call.body}`);
   return match[1];
+}
+
+function reviewStatusBody(repo: string, pullNumber: number, headSha: string, status: string): string {
+  return [
+    `<!-- evaos-code-review-bot:review-status repo=${repo} pr=${pullNumber} sha=${headSha} -->`,
+    `<!-- evaos-code-review-bot:review-status-state status=${status} updated_at=2026-07-02T00:00:00.000Z -->`
+  ].join("\n");
 }
 
 function pull(

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -2249,6 +2249,81 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("repairs an already-settled direct-review status comment without an active queue row", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-direct-review-settled-status-repair-"));
+    roots.push(root);
+    const config = {
+      ...minimalConfig(root),
+      reviewStatusComment: { enabled: true }
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const headSha = "abababababababababababababababababababab";
+    const pull = pullSummary(1242, headSha);
+    const reviewUrl = "https://github.com/electricsheephq/WorldOS/pull/1242#pullrequestreview-10";
+    const statusCalls: Array<{ marker: string; body: string }> = [];
+    const github = {
+      canPostAsApp: () => true,
+      upsertIssueComment: async (input: { marker: string; body: string }) => {
+        statusCalls.push(input);
+        return { action: "updated" as const, id: 12348, html_url: "https://github.test/status-comment" };
+      }
+    } as unknown as GitHubApi;
+    const queueJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      baseSha: pull.base.sha
+    }).job;
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl
+    });
+    state.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "posted",
+      reviewUrl,
+      lastError: "reviewed"
+    });
+    state.recordReviewReadiness({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      state: "ready_for_human",
+      reason: "comment_review_posted",
+      event: "COMMENT",
+      reviewUrl,
+      now: new Date("2026-07-05T00:00:00.000Z")
+    });
+
+    const result = await reconcileProcessedHeadAfterDirectReview({
+      config,
+      github,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      now: new Date("2026-07-05T00:03:00.000Z")
+    });
+
+    expect(result).toEqual({ activeQueueJobs: 0, settledQueueJobs: 0, statusCommentPosted: true });
+    expect(state.getReviewQueueJob(queueJob.jobId)).toMatchObject({
+      state: "posted",
+      reviewUrl,
+      lastError: "reviewed"
+    });
+    expect(statusCalls).toHaveLength(1);
+    expect(statusCalls[0]?.marker).toBe(
+      `<!-- evaos-code-review-bot:review-status repo=electricsheephq/WorldOS pr=1242 sha=${headSha} -->`
+    );
+    expect(statusCalls[0]?.body).toContain("review-status-state status=completed");
+    expect(statusCalls[0]?.body).toContain(reviewUrl);
+    state.close();
+  });
+
   it("does not settle direct-review queue rows for dry-runs or non-posted processed heads", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-direct-review-no-settle-"));
     roots.push(root);

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -2324,6 +2324,74 @@ describe("worker review failures", () => {
     state.close();
   });
 
+  it("repairs missing direct-review readiness from processed truth without an active queue row", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-worker-direct-review-settled-readiness-repair-"));
+    roots.push(root);
+    const config = {
+      ...minimalConfig(root),
+      reviewStatusComment: { enabled: true }
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const headSha = "babababababababababababababababababababa";
+    const pull = pullSummary(1243, headSha);
+    const reviewUrl = "https://github.com/electricsheephq/WorldOS/pull/1243#pullrequestreview-11";
+    const statusCalls: Array<{ marker: string; body: string }> = [];
+    const github = {
+      canPostAsApp: () => true,
+      upsertIssueComment: async (input: { marker: string; body: string }) => {
+        statusCalls.push(input);
+        return { action: "updated" as const, id: 12349, html_url: "https://github.test/status-comment" };
+      }
+    } as unknown as GitHubApi;
+    const queueJob = state.enqueueReviewQueueJob({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      baseSha: pull.base.sha
+    }).job;
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl
+    });
+    state.updateReviewQueueJobState({
+      jobId: queueJob.jobId,
+      state: "posted",
+      reviewUrl,
+      lastError: "reviewed"
+    });
+
+    const result = await reconcileProcessedHeadAfterDirectReview({
+      config,
+      github,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      now: new Date("2026-07-05T00:04:00.000Z")
+    });
+
+    expect(result).toEqual({ activeQueueJobs: 0, settledQueueJobs: 0, statusCommentPosted: true });
+    expect(state.getReviewReadiness("electricsheephq/WorldOS", pull.number, headSha)).toMatchObject({
+      state: "needs_fix",
+      reason: "direct_review_reconciled_processed_head",
+      event: "REQUEST_CHANGES",
+      reviewUrl
+    });
+    expect(state.getReviewQueueJob(queueJob.jobId)).toMatchObject({
+      state: "posted",
+      reviewUrl,
+      lastError: "reviewed"
+    });
+    expect(statusCalls).toHaveLength(1);
+    expect(statusCalls[0]?.body).toContain("review-status-state status=completed");
+    expect(statusCalls[0]?.body).toContain(reviewUrl);
+    state.close();
+  });
+
   it("does not settle direct-review queue rows for dry-runs or non-posted processed heads", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-direct-review-no-settle-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- repair direct-review reconciliation so already-settled posted heads still upsert the sticky review-status comment to `completed`
- repair scheduler duplicate processed-head cycles when an existing bot status marker is stranded in a non-terminal state
- restore missing/non-terminal readiness from processed truth during settled-head direct repair while preserving already-settled readiness
- preserve no-spam behavior for already-terminal markers and keep terminal queue rows unchanged when no active queue row exists
- add regressions for the #436 stranded `in_progress` marker shapes

Closes #436.

## Validation
- `npm test -- --pool=forks --maxWorkers=1 tests/worker-failure.test.ts -t "repairs an already-settled direct-review status comment"`
- `npm test -- --pool=forks --maxWorkers=1 tests/worker-failure.test.ts`
- `npm test -- --pool=forks --maxWorkers=1 tests/scheduler.test.ts tests/worker-failure.test.ts`
- `npm test -- --pool=forks --maxWorkers=1 tests/review-status-comment.test.ts`
- `npm test -- --pool=forks --maxWorkers=1 tests/scheduler.test.ts tests/worker-failure.test.ts tests/review-status-comment.test.ts`
- `npm run build`
- `git diff --check`