### PR TITLE
[codex] Add precision badge endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ review loop without handing every diff to a hosted review SaaS.**
 
 ![NeonDiff cyberpunk wordmark in toxic green inside a black HUD frame](assets/readme/neondiff-cyberpunk-hero.png)
 
+[![NeonDiff precision](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Felectricsheephq%2Fevaos-code-review-bot-neondiff%2Fmain%2Fdocs%2Fbadges%2Fprecision.json)](docs/precision-badge.md)
+
 Use it when you want a GitHub App to review pull requests from a local worker,
 with your GitHub installation, your provider keys, your repo policy, and
 public-safe evidence for every live posting decision.
@@ -22,6 +24,7 @@ sold. NeonDiff is a source-available beta, not an open-source or GA release.
 [License Boundary](docs/license-boundary.md) · [Pricing](docs/pricing.md) ·
 [Providers](docs/providers.md) ·
 [Known Limitations](docs/known-limitations-and-provider-status.md) ·
+[Precision Badge](docs/precision-badge.md) ·
 [Roadmap](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103) ·
 [Repository](https://github.com/electricsheephq/evaos-code-review-bot-neondiff)
 
@@ -223,6 +226,26 @@ Not claimed:
   [docs/calibration-loop.md](docs/calibration-loop.md) passes and a human
   flips it)
 - desktop client readiness
+
+### Precision Badge
+
+NeonDiff's precision badge is public-safe by default: the generated Shields
+endpoint at `docs/badges/precision.json` shows a gray `calibrating (n=...)`
+state until the calibration aggregate passes the existing public-confidence
+gate and a human flips `confidenceCalibration.publicDisplay.mode` to
+`"calibrated"`. Below that gate, no public percentage is displayed.
+
+Copy-paste README badge snippet, replacing the branch if you publish from
+somewhere other than `main`:
+
+```md
+[![NeonDiff precision](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Felectricsheephq%2Fevaos-code-review-bot-neondiff%2Fmain%2Fdocs%2Fbadges%2Fprecision.json)](docs/precision-badge.md)
+```
+
+The badge JSON is generated from NeonDiff's own aggregate evidence; the tool
+does not accept a public-percent override and does not flip calibrated display
+mode. See [docs/precision-badge.md](docs/precision-badge.md) for the review
+rules behind that contract.
 
 ## Roadmap Vs Shipped
 

--- a/docs/badges/precision.json
+++ b/docs/badges/precision.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "NeonDiff precision",
+  "message": "calibrating (n=0)",
+  "color": "lightgrey"
+}

--- a/docs/calibration-loop.md
+++ b/docs/calibration-loop.md
@@ -22,13 +22,16 @@ review posts findings
 2. calibration-aggregate  — labels → per-bin precision + Wilson lower bounds
         │
         ▼
+2b. precision badge       — aggregate → Shields endpoint JSON, gray until gated
+        │
+        ▼
 3. calibration-promote    — evidence numbers → reviewable config patch (human-gated)
         │
         ▼
 4. manual human edit      — flipping publicDisplay.mode is never automated
 ```
 
-Steps 1–3 are CLI commands. Step 4 is deliberately not.
+Steps 1–3 and badge regeneration are CLI commands. Step 4 is deliberately not.
 
 ## 1. Observe Outcomes: `neondiff outcome-observe`
 
@@ -109,6 +112,33 @@ neondiff calibration-aggregate \
 This step is read-only with respect to behavior: it evaluates the
 public-confidence floors and reports eligibility, but never mutates config and
 never switches the public display.
+
+### Regenerating The Precision Badge Endpoint
+
+After each aggregate run, regenerate the static Shields endpoint JSON:
+
+```bash
+mkdir -p docs/badges
+neondiff badge \
+  --config config.local.json \
+  --output docs/badges/precision.json
+```
+
+The badge command is safe to run before calibration is earned. When the
+aggregate is empty, below the public-confidence gate, or still paired with
+`confidenceCalibration.publicDisplay.mode: "uncalibrated"`, the endpoint must
+remain gray with a `calibrating (n=...)` message. A public percentage can appear
+only when the aggregate passes the same floors listed below and a human has
+manually flipped public display mode to `"calibrated"`.
+
+The generated JSON is self-attested evidence, not a third-party benchmark: it
+reports what NeonDiff's own calibration aggregate currently proves. The
+generator is deliberately un-inflatable by tooling: it does not accept a
+percentage override, does not write public display mode, and must fall back to
+gray when the proof boundary is not met. Treat manual edits that add or raise a
+percentage as invalid; regenerate from the aggregate instead. See
+[precision-badge.md](precision-badge.md) for the public README snippet and
+review rules.
 
 ## 3. Promote Evidence: `neondiff calibration-promote`
 

--- a/docs/precision-badge.md
+++ b/docs/precision-badge.md
@@ -9,12 +9,16 @@ public-confidence gate passes and a human flips public display mode.
 
 | State | Badge message | Public meaning |
 | --- | --- | --- |
-| Calibrating | `calibrating (n=<labeled findings>)` | NeonDiff is collecting and aggregating outcome labels. No public precision percentage has been earned yet. |
-| Calibrated | `<precision>% (n=<labeled findings>)` | The aggregate passed the public-confidence gate and a human set `confidenceCalibration.publicDisplay.mode` to `"calibrated"`. |
+| Calibrating | `calibrating (n=<validated findings>)` | NeonDiff is collecting and aggregating outcome labels. No public precision percentage has been earned yet. |
+| Calibrated | `<precision>% (n=<validated findings>)` | The aggregate passed the public-confidence gate and a human set `confidenceCalibration.publicDisplay.mode` to `"calibrated"`. |
 
 The calibrating state is the default, public-safe state. It is intentionally a
 gray badge: useful enough to show that NeonDiff measures itself, but conservative
 enough not to imply calibrated accuracy.
+
+The `n` denominator counts validated findings only. It excludes explicit-control
+and unvalidated outcome labels so the public badge denominator matches the
+calibration aggregate used for the precision gate.
 
 ## Public Percentage Gate
 

--- a/docs/precision-badge.md
+++ b/docs/precision-badge.md
@@ -1,0 +1,91 @@
+# Precision Badge
+
+The precision badge is NeonDiff's public proof object for calibration without
+overclaiming. It can be published while the system is still learning, but it
+must stay gray and say `calibrating (n=...)` until the existing
+public-confidence gate passes and a human flips public display mode.
+
+## Public States
+
+| State | Badge message | Public meaning |
+| --- | --- | --- |
+| Calibrating | `calibrating (n=<labeled findings>)` | NeonDiff is collecting and aggregating outcome labels. No public precision percentage has been earned yet. |
+| Calibrated | `<precision>% (n=<labeled findings>)` | The aggregate passed the public-confidence gate and a human set `confidenceCalibration.publicDisplay.mode` to `"calibrated"`. |
+
+The calibrating state is the default, public-safe state. It is intentionally a
+gray badge: useful enough to show that NeonDiff measures itself, but conservative
+enough not to imply calibrated accuracy.
+
+## Public Percentage Gate
+
+No public percentage may appear in `docs/badges/precision.json` unless all of
+these are true:
+
+- `neondiff calibration-aggregate` produced a current aggregate.
+- The aggregate passes the public-confidence floors in
+  [calibration-loop.md](calibration-loop.md): at least 100 labeled findings, 30
+  P0/P1 labels, 10 explicit negative-control scenarios, and a Wilson lower bound
+  of at least 0.95.
+- A human reviewed the evidence and set
+  `confidenceCalibration.publicDisplay.mode` to `"calibrated"`.
+- Config validation accepts the same evidence at load time.
+
+If any condition is missing, stale, malformed, or below threshold, the badge
+falls back to gray `calibrating (n=...)`. The tool must not expose raw confidence
+values, model self-ratings, or a best-case estimate as a public precision claim.
+
+## Generate The Endpoint JSON
+
+Regenerate the badge after each aggregate run:
+
+```bash
+mkdir -p docs/badges
+neondiff badge \
+  --config config.local.json \
+  --output docs/badges/precision.json
+```
+
+The generated file is a Shields endpoint payload. The below-gate shape is:
+
+```json
+{
+  "schemaVersion": 1,
+  "label": "NeonDiff precision",
+  "message": "calibrating (n=42)",
+  "color": "lightgrey"
+}
+```
+
+When the gate and human flip both pass, the tool may emit a percentage in the
+same endpoint shape. Do not hand-edit the JSON to add or raise a percentage.
+Regenerate it from the aggregate so the badge remains tied to evidence.
+
+## README Badge Snippet
+
+Use the generated JSON through Shields' endpoint badge:
+
+```md
+[![NeonDiff precision](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Felectricsheephq%2Fevaos-code-review-bot-neondiff%2Fmain%2Fdocs%2Fbadges%2Fprecision.json)](docs/precision-badge.md)
+```
+
+If a fork, prerelease branch, or docs site publishes the JSON from another raw
+URL, keep the same `docs/badges/precision.json` path and change only the encoded
+endpoint URL.
+
+## Self-Attestation Contract
+
+The badge is self-attested: it reports NeonDiff's own measured aggregate, not a
+vendor benchmark or a claim of parity with another reviewer.
+
+The generator is un-inflatable by tool design:
+
+- no flag accepts a public precision percentage;
+- no flag flips `confidenceCalibration.publicDisplay.mode`;
+- below-gate or uncalibrated input always renders gray;
+- the public file contains only badge display fields, not raw labels, secrets,
+  or review text.
+
+This does not make arbitrary hand edits impossible. The review rule is simple:
+percentage changes to `docs/badges/precision.json` are valid only when they come
+from regenerating the file after a passing aggregate and the human calibrated
+mode flip.

--- a/docs/precision-badge.md
+++ b/docs/precision-badge.md
@@ -20,6 +20,10 @@ The `n` denominator counts validated findings only. It excludes explicit-control
 and unvalidated outcome labels so the public badge denominator matches the
 calibration aggregate used for the precision gate.
 
+When calibrated display is enabled, the percentage is the aggregate-wide Wilson
+lower bound over the same validated findings counted by `n`, floored to a whole
+percent for display.
+
 ## Public Percentage Gate
 
 No public percentage may appear in `docs/badges/precision.json` unless all of
@@ -37,6 +41,10 @@ these are true:
 If any condition is missing, stale, malformed, or below threshold, the badge
 falls back to gray `calibrating (n=...)`. The tool must not expose raw confidence
 values, model self-ratings, or a best-case estimate as a public precision claim.
+
+The checked-in `docs/badges/precision.json` starts as a below-gate placeholder
+with `n=0`. After main has a real aggregate packet available, regenerate and
+commit the file from the outcome-label store rather than hand-editing the count.
 
 ## Generate The Endpoint JSON
 

--- a/docs/precision-badge.md
+++ b/docs/precision-badge.md
@@ -20,9 +20,10 @@ The `n` denominator counts validated findings only. It excludes explicit-control
 and unvalidated outcome labels so the public badge denominator matches the
 calibration aggregate used for the precision gate.
 
-When calibrated display is enabled, the percentage is the aggregate-wide Wilson
-lower bound over the same validated findings counted by `n`, floored to a whole
-percent for display.
+When calibrated display is enabled, the percentage is the strongest calibrated
+confidence-bin Wilson lower bound used by the public-confidence gate, floored to
+a whole percent for display. It is not an all-findings precision claim. The `n`
+value remains the total validated finding count behind the aggregate packet.
 
 ## Public Percentage Gate
 
@@ -32,8 +33,8 @@ these are true:
 - `neondiff calibration-aggregate` produced a current aggregate.
 - The aggregate passes the public-confidence floors in
   [calibration-loop.md](calibration-loop.md): at least 100 labeled findings, 30
-  P0/P1 labels, 10 explicit negative-control scenarios, and a Wilson lower bound
-  of at least 0.95.
+  P0/P1 labels, 10 explicit negative-control scenarios, and the strongest
+  calibrated confidence-bin Wilson lower bound of at least 0.95.
 - A human reviewed the evidence and set
   `confidenceCalibration.publicDisplay.mode` to `"calibrated"`.
 - Config validation accepts the same evidence at load time.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -104,8 +104,9 @@ import {
   type ReviewQueueJobState
 } from "./state.js";
 import { readOutcomeObserverInput, recordNegativeControlLabels, runOutcomeObserverFromInput } from "./outcome-observer.js";
-import { writeCalibrationAggregatePacket } from "./calibration-aggregate.js";
+import { aggregateCalibrationLabels, writeCalibrationAggregatePacket } from "./calibration-aggregate.js";
 import { runCalibrationPromotion } from "./calibration-promote.js";
+import { writePrecisionBadgeEndpoint } from "./precision-badge.js";
 import { buildChangedSurfaceValidationReport, evaluateProofRequirements } from "./validation-selector.js";
 import { isSuccessfulRetryStatus, retryFailedHead, retryProviderCooldowns } from "./worker.js";
 import { resolveZCodeProviderEnv } from "./zcode-env.js";
@@ -1656,6 +1657,35 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "badge") {
+    if (args.output === undefined || (Array.isArray(args.output) && args.output.length === 0)) {
+      throw new Error("--output is required for badge");
+    }
+    const config = loadConfig(args.config ? parseSingleArg(args.config, "--config") : undefined);
+    const repo = args.repo ? parseSingleArg(args.repo, "--repo") : undefined;
+    const store = new ReviewStateStore(config.statePath);
+    try {
+      const labels = store.listFindingOutcomeLabels(repo ? { repo } : {});
+      const aggregate = aggregateCalibrationLabels(labels);
+      const result = writePrecisionBadgeEndpoint({
+        aggregate,
+        publicDisplay: config.confidenceCalibration?.publicDisplay,
+        outputPath: parseSingleArg(args.output, "--output")
+      });
+      console.log(stringifyRedactedJson({
+        command: "badge",
+        ...result,
+        message: result.badge.message,
+        color: result.badge.color,
+        ...(repo ? { repo } : {})
+      }));
+      if (!result.ok) process.exitCode = 1;
+    } finally {
+      store.close();
+    }
+    return;
+  }
+
   if (command === "run-once" || command === "review-pr") {
     if (command === "review-pr" && (!args.repo || !args.pr)) {
       console.log(JSON.stringify({
@@ -2924,6 +2954,14 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
     description: "Print the redacted local pricing/cost model output.",
     flags: []
   },
+  badge: {
+    description: "Write a Shields endpoint JSON precision badge from the calibration aggregate gate.",
+    flags: [
+      { name: "--config", description: "Path to the config file (default config.local.json)." },
+      { name: "--repo", description: "Optional repo scope for outcome labels, owner/name." },
+      { name: "--output", description: "Path to write the Shields endpoint JSON (required)." }
+    ]
+  },
   doctor: {
     description: "Check repo read access, provider env, and issue-enrichment readiness (add `github` for GitHub-only checks).",
     flags: [
@@ -3013,6 +3051,7 @@ function buildHelp(command?: string) {
         "config inspect",
         "config patch",
         "pricing",
+        "badge",
         "providers list",
         "providers doctor",
         "doctor",
@@ -3069,7 +3108,8 @@ function buildHelp(command?: string) {
         "review-mode",
         "outcome-observe",
         "calibration-aggregate",
-        "calibration-promote"
+        "calibration-promote",
+        "badge"
       ]
     },
     examples: [
@@ -3078,6 +3118,7 @@ function buildHelp(command?: string) {
       "neondiff config patch --config config.local.json --input desktop-patch.json --dry-run true",
       "desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}",
       "neondiff pricing",
+      "neondiff badge --config config.local.json --output docs/badges/precision.json",
       "neondiff providers list --config config.local.json --json",
       "neondiff providers doctor --config config.local.json --json",
       "neondiff providers doctor --config config.local.json --provider ollama-local --smoke true --json",
@@ -3123,6 +3164,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts outcome-observe --config /path/to/live.json --input /path/to/outcome-observer-input.json --dry-run true --output-dir /path/to/evidence/outcome-observe-run",
       "npx tsx src/cli.ts calibration-aggregate --config /path/to/live.json --output-dir /path/to/evidence/calibration-aggregate-run",
       "npx tsx src/cli.ts calibration-promote --input /path/to/evidence/calibration-aggregate-run/aggregate-calibration.json --output-dir /path/to/evidence/calibration-promote-run --confirm true",
+      "npx tsx src/cli.ts badge --config /path/to/live.json --repo owner/repo --output docs/badges/precision.json",
       "npx tsx src/cli.ts finishing-touch-dry-run --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD --current-head HEAD --comment-id 456 --author maintainer --trusted-authors maintainer --body '@evaos-code-review-bot explain risk'",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1674,7 +1674,17 @@ async function main(): Promise<void> {
       });
       console.log(stringifyRedactedJson({
         command: "badge",
-        ...result,
+        ok: result.ok,
+        outputPath: result.outputPath,
+        publicMode: result.publicMode,
+        allowed: result.allowed,
+        missingThresholds: result.missingThresholds,
+        labeledFindings: result.labeledFindings,
+        wilsonLowerBound: result.wilsonLowerBound,
+        displayWilsonLowerBound: result.displayWilsonLowerBound,
+        proofBoundary: result.proofBoundary,
+        schemaVersion: result.badge.schemaVersion,
+        label: result.badge.label,
         message: result.badge.message,
         color: result.badge.color,
         ...(repo ? { repo } : {})

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1679,7 +1679,6 @@ async function main(): Promise<void> {
         color: result.badge.color,
         ...(repo ? { repo } : {})
       }));
-      if (!result.ok) process.exitCode = 1;
     } finally {
       store.close();
     }

--- a/src/precision-badge.ts
+++ b/src/precision-badge.ts
@@ -32,7 +32,14 @@ export function buildPrecisionBadgeEndpoint(input: {
   publicDisplay?: PublicConfidenceDisplayPolicy;
 }): ShieldsEndpointBadge {
   const evaluation = evaluatePrecisionBadgePolicy(input);
-  const n = input.aggregate.labeledFindings;
+  return badgeForEvaluation(input.aggregate, evaluation);
+}
+
+function badgeForEvaluation(
+  aggregate: CalibrationAggregate,
+  evaluation: PublicConfidencePolicyEvaluation
+): ShieldsEndpointBadge {
+  const n = aggregate.labeledFindings;
   if (!evaluation.allowed) {
     return {
       schemaVersion: 1,
@@ -45,7 +52,7 @@ export function buildPrecisionBadgeEndpoint(input: {
   return {
     schemaVersion: 1,
     label: "NeonDiff precision",
-    message: `${formatConservativePercent(input.aggregate.bestWilsonLowerBound)}% (n=${n})`,
+    message: `${formatConservativePercent(aggregate.bestWilsonLowerBound)}% (n=${n})`,
     color: "green"
   };
 }
@@ -56,7 +63,7 @@ export function writePrecisionBadgeEndpoint(input: {
   outputPath: string;
 }): PrecisionBadgeResult {
   const evaluation = evaluatePrecisionBadgePolicy(input);
-  const badge = buildPrecisionBadgeEndpoint(input);
+  const badge = badgeForEvaluation(input.aggregate, evaluation);
   mkdirSync(dirname(input.outputPath), { recursive: true });
   writeFileSync(input.outputPath, `${JSON.stringify(badge, null, 2)}\n`);
   return {

--- a/src/precision-badge.ts
+++ b/src/precision-badge.ts
@@ -53,7 +53,7 @@ function badgeForEvaluation(
   return {
     schemaVersion: 1,
     label: "NeonDiff precision",
-    message: `${formatConservativePercent(aggregateWilsonLowerBound(aggregate))}% (n=${n})`,
+    message: `${formatConservativePercent(aggregate.bestWilsonLowerBound)}% (n=${n})`,
     color: "green"
   };
 }
@@ -76,8 +76,8 @@ export function writePrecisionBadgeEndpoint(input: {
     missingThresholds: evaluation.missingThresholds,
     labeledFindings: input.aggregate.labeledFindings,
     wilsonLowerBound: input.aggregate.bestWilsonLowerBound,
-    displayWilsonLowerBound: aggregateWilsonLowerBound(input.aggregate),
-    proofBoundary: "Shields endpoint badge only. Percentages render only when the existing public-confidence gate passes and publicDisplay.mode is human-flipped to calibrated. The displayed percentage is the aggregate-wide Wilson lower bound over validated findings."
+    displayWilsonLowerBound: input.aggregate.bestWilsonLowerBound,
+    proofBoundary: "Shields endpoint badge only. Percentages render only when the existing public-confidence gate passes and publicDisplay.mode is human-flipped to calibrated. The displayed percentage is the strongest calibrated-bin Wilson lower bound used by the public-confidence gate, not an all-findings precision claim."
   };
 }
 
@@ -97,20 +97,4 @@ function evaluatePrecisionBadgePolicy(input: {
 function formatConservativePercent(value: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.max(0, Math.min(100, Math.floor(value * 100)));
-}
-
-function aggregateWilsonLowerBound(aggregate: CalibrationAggregate): number {
-  const findings = aggregate.bins.reduce((sum, bin) => sum + bin.findings, 0);
-  const matched = aggregate.bins.reduce((sum, bin) => sum + bin.matched, 0);
-  return wilsonLowerBound95(matched, findings);
-}
-
-function wilsonLowerBound95(successes: number, total: number): number {
-  if (!Number.isFinite(successes) || !Number.isFinite(total) || total <= 0 || successes < 0 || successes > total) return 0;
-  const z = 1.96;
-  const p = successes / total;
-  const denominator = 1 + z ** 2 / total;
-  const centre = p + z ** 2 / (2 * total);
-  const margin = z * Math.sqrt((p * (1 - p) + z ** 2 / (4 * total)) / total);
-  return Math.max(0, (centre - margin) / denominator);
 }

--- a/src/precision-badge.ts
+++ b/src/precision-badge.ts
@@ -24,6 +24,7 @@ export interface PrecisionBadgeResult {
   missingThresholds: PublicConfidencePolicyEvaluation["missingThresholds"];
   labeledFindings: number;
   wilsonLowerBound: number;
+  displayWilsonLowerBound: number;
   proofBoundary: string;
 }
 
@@ -52,7 +53,7 @@ function badgeForEvaluation(
   return {
     schemaVersion: 1,
     label: "NeonDiff precision",
-    message: `${formatConservativePercent(aggregate.bestWilsonLowerBound)}% (n=${n})`,
+    message: `${formatConservativePercent(aggregateWilsonLowerBound(aggregate))}% (n=${n})`,
     color: "green"
   };
 }
@@ -75,7 +76,8 @@ export function writePrecisionBadgeEndpoint(input: {
     missingThresholds: evaluation.missingThresholds,
     labeledFindings: input.aggregate.labeledFindings,
     wilsonLowerBound: input.aggregate.bestWilsonLowerBound,
-    proofBoundary: "Shields endpoint badge only. Percentages render only when the existing public-confidence gate passes and publicDisplay.mode is human-flipped to calibrated."
+    displayWilsonLowerBound: aggregateWilsonLowerBound(input.aggregate),
+    proofBoundary: "Shields endpoint badge only. Percentages render only when the existing public-confidence gate passes and publicDisplay.mode is human-flipped to calibrated. The displayed percentage is the aggregate-wide Wilson lower bound over validated findings."
   };
 }
 
@@ -95,4 +97,20 @@ function evaluatePrecisionBadgePolicy(input: {
 function formatConservativePercent(value: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.max(0, Math.min(100, Math.floor(value * 100)));
+}
+
+function aggregateWilsonLowerBound(aggregate: CalibrationAggregate): number {
+  const findings = aggregate.bins.reduce((sum, bin) => sum + bin.findings, 0);
+  const matched = aggregate.bins.reduce((sum, bin) => sum + bin.matched, 0);
+  return wilsonLowerBound95(matched, findings);
+}
+
+function wilsonLowerBound95(successes: number, total: number): number {
+  if (!Number.isFinite(successes) || !Number.isFinite(total) || total <= 0 || successes < 0 || successes > total) return 0;
+  const z = 1.96;
+  const p = successes / total;
+  const denominator = 1 + z ** 2 / total;
+  const centre = p + z ** 2 / (2 * total);
+  const margin = z * Math.sqrt((p * (1 - p) + z ** 2 / (4 * total)) / total);
+  return Math.max(0, (centre - margin) / denominator);
 }

--- a/src/precision-badge.ts
+++ b/src/precision-badge.ts
@@ -1,0 +1,91 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { CalibrationAggregate } from "./calibration-aggregate.js";
+import {
+  buildPublicConfidencePolicy,
+  evaluatePublicConfidencePolicy,
+  type PublicConfidenceDisplayPolicy,
+  type PublicConfidencePolicyEvaluation
+} from "./public-confidence.js";
+
+export interface ShieldsEndpointBadge {
+  schemaVersion: 1;
+  label: "NeonDiff precision";
+  message: string;
+  color: "green" | "lightgrey";
+}
+
+export interface PrecisionBadgeResult {
+  ok: boolean;
+  badge: ShieldsEndpointBadge;
+  outputPath?: string;
+  publicMode: PublicConfidencePolicyEvaluation["publicMode"];
+  allowed: boolean;
+  missingThresholds: PublicConfidencePolicyEvaluation["missingThresholds"];
+  labeledFindings: number;
+  wilsonLowerBound: number;
+  proofBoundary: string;
+}
+
+export function buildPrecisionBadgeEndpoint(input: {
+  aggregate: CalibrationAggregate;
+  publicDisplay?: PublicConfidenceDisplayPolicy;
+}): ShieldsEndpointBadge {
+  const evaluation = evaluatePrecisionBadgePolicy(input);
+  const n = input.aggregate.labeledFindings;
+  if (!evaluation.allowed) {
+    return {
+      schemaVersion: 1,
+      label: "NeonDiff precision",
+      message: `calibrating (n=${n})`,
+      color: "lightgrey"
+    };
+  }
+
+  return {
+    schemaVersion: 1,
+    label: "NeonDiff precision",
+    message: `${formatConservativePercent(input.aggregate.bestWilsonLowerBound)}% (n=${n})`,
+    color: "green"
+  };
+}
+
+export function writePrecisionBadgeEndpoint(input: {
+  aggregate: CalibrationAggregate;
+  publicDisplay?: PublicConfidenceDisplayPolicy;
+  outputPath: string;
+}): PrecisionBadgeResult {
+  const evaluation = evaluatePrecisionBadgePolicy(input);
+  const badge = buildPrecisionBadgeEndpoint(input);
+  mkdirSync(dirname(input.outputPath), { recursive: true });
+  writeFileSync(input.outputPath, `${JSON.stringify(badge, null, 2)}\n`);
+  return {
+    ok: true,
+    badge,
+    outputPath: input.outputPath,
+    publicMode: evaluation.publicMode,
+    allowed: evaluation.allowed,
+    missingThresholds: evaluation.missingThresholds,
+    labeledFindings: input.aggregate.labeledFindings,
+    wilsonLowerBound: input.aggregate.bestWilsonLowerBound,
+    proofBoundary: "Shields endpoint badge only. Percentages render only when the existing public-confidence gate passes and publicDisplay.mode is human-flipped to calibrated."
+  };
+}
+
+function evaluatePrecisionBadgePolicy(input: {
+  aggregate: CalibrationAggregate;
+  publicDisplay?: PublicConfidenceDisplayPolicy;
+}): PublicConfidencePolicyEvaluation {
+  return evaluatePublicConfidencePolicy(buildPublicConfidencePolicy({
+    ...input.publicDisplay,
+    labeledFindings: input.aggregate.labeledFindings,
+    p0p1Labels: input.aggregate.p0p1Labels,
+    negativeControlScenarios: input.aggregate.negativeControlScenarios,
+    wilsonLowerBound: input.aggregate.bestWilsonLowerBound
+  }));
+}
+
+function formatConservativePercent(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, Math.floor(value * 100)));
+}

--- a/tests/precision-badge.test.ts
+++ b/tests/precision-badge.test.ts
@@ -1,0 +1,162 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildPrecisionBadgeEndpoint, writePrecisionBadgeEndpoint } from "../src/precision-badge.js";
+import { ReviewStateStore, type FindingOutcomeLabelRecord } from "../src/state.js";
+
+const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
+
+let seq = 0;
+function label(overrides: Partial<FindingOutcomeLabelRecord> & Pick<FindingOutcomeLabelRecord, "confidence" | "verdict">): FindingOutcomeLabelRecord {
+  seq += 1;
+  return {
+    fingerprint: `finding:${String(seq).padStart(64, "0")}`,
+    repo: "owner/repo",
+    pullNumber: seq,
+    headSha: `sha${seq}`,
+    severity: "P1",
+    category: "data_loss",
+    labelSource: "merged_fix",
+    observedAt: "2026-07-08T00:00:00.000Z",
+    ...overrides
+  };
+}
+
+const PASSING_AGGREGATE = {
+  labeledFindings: 120,
+  p0p1Labels: 35,
+  negativeControlScenarios: 12,
+  bins: [],
+  bestWilsonLowerBound: 0.956,
+  categoryPrecision: [],
+  thresholds: {
+    minLabeledFindings: 100,
+    minP0P1Labels: 30,
+    minNegativeControlScenarios: 10,
+    minWilsonLowerBound: 0.95
+  },
+  eligible: true,
+  reason: "eligible"
+};
+
+const CALIBRATED_POLICY = {
+  mode: "calibrated" as const,
+  evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/123",
+  datasetId: "neondiff-calibration-v1",
+  minLabeledFindings: 100,
+  labeledFindings: 120,
+  minP0P1Labels: 30,
+  p0p1Labels: 35,
+  minNegativeControlScenarios: 10,
+  negativeControlScenarios: 12,
+  minWilsonLowerBound: 0.95,
+  wilsonLowerBound: 0.956
+};
+
+describe("precision badge endpoint (#425)", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("renders gray calibrating with n when the human publicDisplay flip is still off", () => {
+    const badge = buildPrecisionBadgeEndpoint({
+      aggregate: PASSING_AGGREGATE,
+      publicDisplay: { ...CALIBRATED_POLICY, mode: "uncalibrated" }
+    });
+
+    expect(badge).toMatchObject({
+      schemaVersion: 1,
+      label: "NeonDiff precision",
+      message: "calibrating (n=120)",
+      color: "lightgrey"
+    });
+    expect(badge.message).not.toMatch(/\d+%/);
+  });
+
+  it("renders gray calibrating with n when aggregate evidence is below any public gate", () => {
+    const badge = buildPrecisionBadgeEndpoint({
+      aggregate: { ...PASSING_AGGREGATE, labeledFindings: 99, reason: "insufficient_labeled_findings" },
+      publicDisplay: CALIBRATED_POLICY
+    });
+
+    expect(badge.message).toBe("calibrating (n=99)");
+    expect(badge.color).toBe("lightgrey");
+    expect(badge.message).not.toMatch(/\d+%/);
+  });
+
+  it("renders a floored percentage with n only after the existing public-confidence gate allows display", () => {
+    const badge = buildPrecisionBadgeEndpoint({
+      aggregate: PASSING_AGGREGATE,
+      publicDisplay: CALIBRATED_POLICY
+    });
+
+    expect(badge).toMatchObject({
+      schemaVersion: 1,
+      label: "NeonDiff precision",
+      message: "95% (n=120)",
+      color: "green"
+    });
+  });
+
+  it("writes a Shields endpoint JSON file without leaking non-schema metadata", () => {
+    const dir = mkdtempSync(join(tmpdir(), "neondiff-badge-write-"));
+    roots.push(dir);
+    const output = join(dir, "precision.json");
+
+    const result = writePrecisionBadgeEndpoint({
+      aggregate: PASSING_AGGREGATE,
+      publicDisplay: { ...CALIBRATED_POLICY, mode: "uncalibrated" },
+      outputPath: output
+    });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(output)).toBe(true);
+    const parsed = JSON.parse(readFileSync(output, "utf8"));
+    expect(parsed).toEqual({
+      schemaVersion: 1,
+      label: "NeonDiff precision",
+      message: "calibrating (n=120)",
+      color: "lightgrey"
+    });
+  });
+
+  it("exposes a CLI that reads the real outcome-label store and writes the badge endpoint", () => {
+    const dir = mkdtempSync(join(tmpdir(), "neondiff-badge-cli-"));
+    roots.push(dir);
+    const configPath = join(dir, "config.json");
+    const outputPath = join(dir, "public", "precision.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(dir, "runtime"),
+      statePath: join(dir, "state.sqlite"),
+      evidenceDir: join(dir, "evidence")
+    })}\n`);
+    const store = new ReviewStateStore(join(dir, "state.sqlite"));
+    store.recordFindingOutcomeLabel(label({ confidence: 0.9, verdict: "true_positive" }));
+    store.close();
+
+    const output = execFileSync(process.execPath, [
+      tsxCli, "src/cli.ts", "badge", "--config", configPath, "--repo", "owner/repo", "--output", outputPath
+    ], { cwd: process.cwd(), encoding: "utf8" });
+
+    const parsed = JSON.parse(output);
+    expect(parsed).toMatchObject({
+      command: "badge",
+      ok: true,
+      outputPath,
+      repo: "owner/repo",
+      message: "calibrating (n=1)",
+      publicMode: "uncalibrated"
+    });
+    expect(JSON.parse(readFileSync(outputPath, "utf8"))).toMatchObject({
+      schemaVersion: 1,
+      label: "NeonDiff precision",
+      message: "calibrating (n=1)",
+      color: "lightgrey"
+    });
+  });
+});

--- a/tests/precision-badge.test.ts
+++ b/tests/precision-badge.test.ts
@@ -29,8 +29,17 @@ const PASSING_AGGREGATE = {
   labeledFindings: 120,
   p0p1Labels: 35,
   negativeControlScenarios: 12,
-  bins: [],
-  bestWilsonLowerBound: 0.956,
+  bins: [
+    {
+      minConfidence: 0.8,
+      maxConfidence: 1,
+      findings: 120,
+      matched: 119,
+      empiricalPrecision: 119 / 120,
+      rawWilsonLowerBound: 0.9543025846256779
+    }
+  ],
+  bestWilsonLowerBound: 0.9543025846256779,
   categoryPrecision: [],
   thresholds: {
     minLabeledFindings: 100,
@@ -53,7 +62,7 @@ const CALIBRATED_POLICY = {
   minNegativeControlScenarios: 10,
   negativeControlScenarios: 12,
   minWilsonLowerBound: 0.95,
-  wilsonLowerBound: 0.956
+  wilsonLowerBound: 0.9543025846256779
 };
 
 describe("precision badge endpoint (#425)", () => {
@@ -136,7 +145,8 @@ describe("precision badge endpoint (#425)", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.wilsonLowerBound).toBe(0.956);
+    expect(result.wilsonLowerBound).toBe(0.9543025846256779);
+    expect(result.displayWilsonLowerBound).toBe(0.9543025846256779);
     expect(existsSync(output)).toBe(true);
     const parsed = JSON.parse(readFileSync(output, "utf8"));
     expect(parsed).toEqual({
@@ -177,6 +187,7 @@ describe("precision badge endpoint (#425)", () => {
       message: "calibrating (n=1)",
       publicMode: "uncalibrated"
     });
+    expect(parsed).not.toHaveProperty("badge");
     expect(JSON.parse(readFileSync(outputPath, "utf8"))).toMatchObject({
       schemaVersion: 1,
       label: "NeonDiff precision",
@@ -184,4 +195,59 @@ describe("precision badge endpoint (#425)", () => {
       color: "lightgrey"
     });
   });
+
+  it("exposes a CLI calibrated path that writes the green percentage badge from config publicDisplay", () => {
+    const dir = mkdtempSync(join(tmpdir(), "neondiff-badge-cli-calibrated-"));
+    roots.push(dir);
+    const configPath = join(dir, "config.json");
+    const outputPath = join(dir, "public", "precision.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["owner/repo"],
+      workRoot: join(dir, "runtime"),
+      statePath: join(dir, "state.sqlite"),
+      evidenceDir: join(dir, "evidence"),
+      confidenceCalibration: {
+        publicDisplay: CALIBRATED_POLICY
+      }
+    })}\n`);
+    const store = new ReviewStateStore(join(dir, "state.sqlite"));
+    for (let i = 0; i < 119; i += 1) {
+      store.recordFindingOutcomeLabel(label({ confidence: 0.9, verdict: "true_positive" }));
+    }
+    store.recordFindingOutcomeLabel(label({ confidence: 0.9, verdict: "false_positive" }));
+    for (let i = 0; i < 12; i += 1) {
+      store.recordFindingOutcomeLabel(label({
+        confidence: 0,
+        verdict: "unvalidated",
+        labelSource: "explicit_control"
+      }));
+    }
+    store.close();
+
+    const output = execFileSync(process.execPath, [
+      tsxCli, "src/cli.ts", "badge", "--config", configPath, "--repo", "owner/repo", "--output", outputPath
+    ], { cwd: process.cwd(), encoding: "utf8" });
+
+    const parsed = JSON.parse(output);
+    expect(parsed).toMatchObject({
+      command: "badge",
+      ok: true,
+      outputPath,
+      repo: "owner/repo",
+      label: "NeonDiff precision",
+      schemaVersion: 1,
+      message: "95% (n=120)",
+      color: "green",
+      publicMode: "calibrated",
+      allowed: true,
+      labeledFindings: 120
+    });
+    expect(parsed).not.toHaveProperty("badge");
+    expect(JSON.parse(readFileSync(outputPath, "utf8"))).toEqual({
+      schemaVersion: 1,
+      label: "NeonDiff precision",
+      message: "95% (n=120)",
+      color: "green"
+    });
+  }, 15_000);
 });

--- a/tests/precision-badge.test.ts
+++ b/tests/precision-badge.test.ts
@@ -51,6 +51,23 @@ const PASSING_AGGREGATE = {
   reason: "eligible"
 };
 
+const PASSING_MULTI_BIN_AGGREGATE = {
+  ...PASSING_AGGREGATE,
+  labeledFindings: 160,
+  bins: [
+    ...PASSING_AGGREGATE.bins,
+    {
+      minConfidence: 0.5,
+      maxConfidence: 0.8,
+      findings: 40,
+      matched: 20,
+      empiricalPrecision: 0.5,
+      rawWilsonLowerBound: 0.35198494879084225
+    }
+  ],
+  categoryPrecision: []
+};
+
 const CALIBRATED_POLICY = {
   mode: "calibrated" as const,
   evidenceUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/123",
@@ -111,6 +128,20 @@ describe("precision badge endpoint (#425)", () => {
     });
   });
 
+  it("renders the same Wilson metric used by the public gate even when bins diverge", () => {
+    const badge = buildPrecisionBadgeEndpoint({
+      aggregate: PASSING_MULTI_BIN_AGGREGATE,
+      publicDisplay: CALIBRATED_POLICY
+    });
+
+    expect(badge).toMatchObject({
+      schemaVersion: 1,
+      label: "NeonDiff precision",
+      message: "95% (n=160)",
+      color: "green"
+    });
+  });
+
   it("writes a Shields endpoint JSON file without leaking non-schema metadata", () => {
     const dir = mkdtempSync(join(tmpdir(), "neondiff-badge-write-"));
     roots.push(dir);
@@ -146,7 +177,7 @@ describe("precision badge endpoint (#425)", () => {
 
     expect(result.ok).toBe(true);
     expect(result.wilsonLowerBound).toBe(0.9543025846256779);
-    expect(result.displayWilsonLowerBound).toBe(0.9543025846256779);
+    expect(result.displayWilsonLowerBound).toBe(result.wilsonLowerBound);
     expect(existsSync(output)).toBe(true);
     const parsed = JSON.parse(readFileSync(output, "utf8"));
     expect(parsed).toEqual({

--- a/tests/precision-badge.test.ts
+++ b/tests/precision-badge.test.ts
@@ -124,6 +124,31 @@ describe("precision badge endpoint (#425)", () => {
     });
   });
 
+  it("writes the calibrated Shields endpoint JSON file without leaking result metadata", () => {
+    const dir = mkdtempSync(join(tmpdir(), "neondiff-badge-write-calibrated-"));
+    roots.push(dir);
+    const output = join(dir, "precision.json");
+
+    const result = writePrecisionBadgeEndpoint({
+      aggregate: PASSING_AGGREGATE,
+      publicDisplay: CALIBRATED_POLICY,
+      outputPath: output
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.wilsonLowerBound).toBe(0.956);
+    expect(existsSync(output)).toBe(true);
+    const parsed = JSON.parse(readFileSync(output, "utf8"));
+    expect(parsed).toEqual({
+      schemaVersion: 1,
+      label: "NeonDiff precision",
+      message: "95% (n=120)",
+      color: "green"
+    });
+    expect(parsed).not.toHaveProperty("wilsonLowerBound");
+    expect(parsed).not.toHaveProperty("missingThresholds");
+  });
+
   it("exposes a CLI that reads the real outcome-label store and writes the badge endpoint", () => {
     const dir = mkdtempSync(join(tmpdir(), "neondiff-badge-cli-"));
     roots.push(dir);

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -40,6 +40,7 @@ describe("public NeonDiff CLI surface", () => {
       "config inspect",
       "config patch",
       "pricing",
+      "badge",
       "providers list",
       "providers doctor",
       "doctor",
@@ -55,6 +56,7 @@ describe("public NeonDiff CLI surface", () => {
     ]);
     expect(output.examples).toContain("neondiff init --config config.local.json");
     expect(output.examples).toContain("neondiff pricing");
+    expect(output.examples).toContain("neondiff badge --config config.local.json --output docs/badges/precision.json");
     expect(output.examples).toContain("neondiff providers list --config config.local.json --json");
     expect(output.examples).toContain("neondiff providers doctor --config config.local.json --json");
     expect(output.examples).toContain("neondiff providers doctor --config config.local.json --provider ollama-local --smoke true --json");


### PR DESCRIPTION
Closes #425.

## Summary
- Add `neondiff badge` to generate a Shields endpoint JSON from the existing calibration aggregate/public-confidence gate.
- Check in `docs/badges/precision.json` as the honest gray `calibrating (n=0)` state generated from the current live state for this repo.
- Add README badge/docs explaining the self-attested, tool-un-inflatable boundary and the human-gated calibrated percentage path.

## Safety / proof boundary
- No runtime config mutation.
- No public percentage renders unless the existing public-confidence gate passes and `confidenceCalibration.publicDisplay.mode` is human-flipped to `calibrated`.
- The badge output contains only Shields display fields: schemaVersion, label, message, color.

## Validation
- `npm test -- --pool=forks --maxWorkers=1 tests/precision-badge.test.ts`
- `npm test -- --pool=forks --maxWorkers=1 tests/precision-badge.test.ts tests/public-confidence.test.ts tests/calibration-aggregate.test.ts`
- `npm run build`
- `git diff --check`
- `tsx src/cli.ts badge --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --repo electricsheephq/evaos-code-review-bot-neondiff --output docs/badges/precision.json`

Evidence packet: `/Volumes/LEXAR/Codex/evidence/neondiff/2026-07-08/425-precision-badge/`