### PR TITLE
release v0.4.45 beta metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ for the semver/GA-line and npm dist-tag policy.
 
 No unreleased changes tracked yet.
 
+## [0.4.45-beta.1] - docs/releases/v0.4.45-beta.1.md
+
+### Added
+
+- Add the public precision badge endpoint and `neondiff badge` command with an honest gray calibrating default, human-gated calibrated percentage path, README/docs wiring, and focused badge/CLI coverage while keeping the public npm package held at `neondiff@0.4.30-beta.1`
+
 ## [0.4.44-beta.1] - docs/releases/v0.4.44-beta.1.md
 
 ### Fixed

--- a/docs/evidence/v0.4.45-beta.1-license-api-healthz.json
+++ b/docs/evidence/v0.4.45-beta.1-license-api-healthz.json
@@ -1,0 +1,19 @@
+{
+  "evidenceKind": "license_api_healthz",
+  "releaseVersion": "v0.4.45-beta.1",
+  "observedAt": "2026-07-08T06:49:06Z",
+  "method": "GET",
+  "url": "https://neondiff-license.fly.dev/healthz",
+  "statusCode": 200,
+  "responseBody": "{\"status\":\"ok\"}",
+  "responseBodySha256": "a29ee2b15c494311c52521766e44af56a3ad2248e7a8ab465e5206463c13d288",
+  "captureContext": {
+    "tool": "curl",
+    "transport": "https",
+    "tlsValidation": "curl default CA validation",
+    "capturedFrom": "Codex Desktop macOS operator shell",
+    "dnsResolution": "neondiff-license.fly.dev -> 66.241.124.124 via system resolver",
+    "note": "Captured with normal system DNS resolution and curl default TLS validation."
+  },
+  "redaction": "No license key, token, cookie, customer data, or private repo content was present in this health check."
+}

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "v0.4.44-beta.1",
+  "version": "v0.4.45-beta.1",
   "releaseLevel": "source-beta",
   "packageArtifact": {
     "name": "neondiff",
@@ -26,19 +26,20 @@
       "v0.4.41-beta.1",
       "v0.4.42-beta.1",
       "v0.4.43-beta.1",
-      "v0.4.44-beta.1"
+      "v0.4.44-beta.1",
+      "v0.4.45-beta.1"
     ],
-    "note": "v0.4.25 through v0.4.29 and v0.4.31 through v0.4.44 were source/local-worker beta releases; v0.4.30-beta.1 remains the current public npm/site beta."
+    "note": "v0.4.25 through v0.4.29 and v0.4.31 through v0.4.45 were source/local-worker beta releases; v0.4.30-beta.1 remains the current public npm/site beta."
   },
   "source": {
     "shaState": "pending_tag_stamp",
-    "candidateHeadBeforeReleaseMetadata": "cfce597b9bdb0211f313f1b1879341c47736ac14",
+    "candidateHeadBeforeReleaseMetadata": "4cd081ca581c24f2f054106b4c4cc8e6453c9dce",
     "proof": "after merge and tag, release:status --expected-head $(git rev-parse HEAD)"
   },
   "docs": {
-    "version": "v0.4.44-beta.1",
+    "version": "v0.4.45-beta.1",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v0.4.44-beta.1.md",
+    "releaseNotesPath": "docs/releases/v0.4.45-beta.1.md",
     "websiteRepo": "electricsheephq/neon-diff-agent"
   },
   "licenseApi": {
@@ -46,20 +47,20 @@
     "state": "healthy",
     "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327",
     "healthUrl": "https://neondiff-license.fly.dev/healthz",
-    "healthProofPath": "docs/evidence/v0.4.44-beta.1-license-api-healthz.json"
+    "healthProofPath": "docs/evidence/v0.4.45-beta.1-license-api-healthz.json"
   },
   "updateChannels": {
     "cli": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v0.4.44-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.43-beta.1"
+      "version": "v0.4.45-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.44-beta.1"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "launchd_prerelease",
-      "version": "v0.4.44-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.43-beta.1"
+      "version": "v0.4.45-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.44-beta.1"
     },
     "website": {
       "requiredForThisRelease": false,

--- a/docs/releases/v0.4.45-beta.1.md
+++ b/docs/releases/v0.4.45-beta.1.md
@@ -1,0 +1,90 @@
+# v0.4.45-beta.1
+
+- Release type: source-only beta precision badge promotion
+- Release source SHA: to be stamped by `refs/tags/v0.4.45-beta.1`
+- Previous prerelease: `v0.4.44-beta.1`
+- Tracking issues / source PRs: `#425`, `#439`
+- Promoted PRs: `#439`
+- Included implementation merge SHA:
+  - `4cd081ca581c24f2f054106b4c4cc8e6453c9dce` (`#439`)
+- Rollback tag: `v0.4.44-beta.1`
+- Package artifact: `neondiff@0.4.30-beta.1` (held from previous public npm release)
+- Rollback baseline: `v0.4.44-beta.1`
+
+## Purpose
+
+Promote the public precision badge slice for NeonDiff before the announcement
+path depends on calibrated public percentages.
+
+This release adds an honest Shields endpoint badge that defaults to gray
+`calibrating (n=0)` and only renders a percentage when the existing
+public-confidence gate passes and a human flips
+`confidenceCalibration.publicDisplay.mode` to `calibrated`.
+
+## Included Changes
+
+- Add `neondiff badge --output <path>` for generating a Shields endpoint JSON
+  from the existing calibration aggregate and public-confidence gate.
+- Check in `docs/badges/precision.json` as the initial gray below-gate badge.
+- Add README and `docs/precision-badge.md` documentation explaining the badge
+  states, validated-finding denominator, human-gated calibrated path, and proof
+  boundary.
+- Add focused unit and CLI coverage for gray, green, write-to-file,
+  multi-confidence-bin, and no-extra-metadata badge behavior.
+
+## Required Gates
+
+- PR `#439` merged to `main` at
+  `4cd081ca581c24f2f054106b4c4cc8e6453c9dce`.
+- Current-head GitHub checks passed on the implementation PR:
+  - Build, test, and package
+  - CodeQL / Analyze actions
+  - CodeQL / Analyze javascript-typescript
+  - Swift desktop impact/gate path-aware checks
+  - Socket Security project and PR checks
+  - CodeRabbit
+- evaOS exact-head gate passed on
+  `3f979451c87b1975474ff0088712b892772b4c9c` with a nonblocking COMMENT review:
+  `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/439#pullrequestreview-4651569265`.
+- Review threads on `#439` were resolved before merge.
+- Focused local validation before merge:
+  - `npm test -- --pool=forks --maxWorkers=1 tests/precision-badge.test.ts`
+  - `npm test -- --pool=forks --maxWorkers=1 --testTimeout=15000 tests/public-cli.test.ts`
+  - `npm run build`
+  - `git diff --check`
+- Release metadata PR must pass the same GitHub required checks before tagging.
+- Post-tag `release:status` must pass with:
+  - `--public-release-manifest docs/public-release-manifest.json`
+  - `--expected-public-version v0.4.45-beta.1`
+  - live launchd expected head equal to the promoted tag SHA when this source
+    beta is promoted into the local worker checkout.
+
+## Caveats
+
+- This release does not publish a new npm package; the public npm package
+  remains `neondiff@0.4.30-beta.1`.
+- This release does not claim a calibrated public precision percentage. The
+  shipped badge is intentionally gray until the measured gate and human flip
+  both pass.
+- This release does not change provider policy, model prompts, review posting
+  policy, issue-enrichment allowlists, monitored repos, or GitHub App
+  permissions.
+- This release does not cut stable `v1.0.0`, claim GA, or claim human-review
+  replacement.
+
+## Rollback
+
+```bash
+: "${REPO_ROOT:?set REPO_ROOT to your local NeonDiff checkout}"
+: "${RELEASE_STATUS_CONFIG:?set RELEASE_STATUS_CONFIG to the live release-status config}"
+
+cd "$REPO_ROOT"
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v0.4.44-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config "$RELEASE_STATUS_CONFIG" \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -92,10 +92,11 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.42-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.43-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.44-beta.1");
+    expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.45-beta.1");
     expect(manifest.packageArtifact?.note).toMatch(/source\/local-worker/i);
     expect(manifest.source).toMatchObject({
       shaState: "pending_tag_stamp",
-      candidateHeadBeforeReleaseMetadata: "cfce597b9bdb0211f313f1b1879341c47736ac14"
+      candidateHeadBeforeReleaseMetadata: "4cd081ca581c24f2f054106b4c4cc8e6453c9dce"
     });
     expect(manifest.source?.proof).toMatch(/after merge and tag/i);
   });
@@ -117,7 +118,7 @@ describe("NeonDiff public release readiness", () => {
     });
     expect(manifest.licenseApi?.trackingIssue).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/);
     expect(manifest.licenseApi?.healthUrl).toMatch(/^https:\/\/[^/]+\/healthz$/);
-    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v0.4.44-beta.1-license-api-healthz.json");
+    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v0.4.45-beta.1-license-api-healthz.json");
 
     const proof = JSON.parse(read(manifest.licenseApi?.healthProofPath ?? "")) as {
       evidenceKind?: string;
@@ -129,7 +130,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(proof).toMatchObject({
       evidenceKind: "license_api_healthz",
-      releaseVersion: "v0.4.44-beta.1",
+      releaseVersion: "v0.4.45-beta.1",
       url: manifest.licenseApi?.healthUrl,
       statusCode: 200,
       responseBody: "{\"status\":\"ok\"}"

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -21,7 +21,7 @@ import { ReviewStateStore } from "../src/state.js";
 describe("beta release status", () => {
   const roots: string[] = [];
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  const shippedReleaseValidationNow = new Date("2026-07-08T04:59:00Z");
+  const shippedReleaseValidationNow = new Date("2026-07-08T06:50:00Z");
 
   afterEach(() => {
     vi.useRealTimers();
@@ -247,27 +247,27 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.44-beta.1",
+      expectedVersion: "v0.4.45-beta.1",
       now: shippedReleaseValidationNow
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v0.4.44-beta.1",
+      version: "v0.4.45-beta.1",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v0.4.44-beta.1.md",
+        releaseNotesPath: "docs/releases/v0.4.45-beta.1.md",
         changelogPath: "CHANGELOG.md",
-        changelogHeadVersion: "0.4.44-beta.1",
-        changelogReleaseNotesPath: "docs/releases/v0.4.44-beta.1.md"
+        changelogHeadVersion: "0.4.45-beta.1",
+        changelogReleaseNotesPath: "docs/releases/v0.4.45-beta.1.md"
       },
       licenseApi: {
         ok: true,
         requiredForThisRelease: true,
         state: "healthy",
         healthUrl: "https://neondiff-license.fly.dev/healthz",
-        healthProofPath: "docs/evidence/v0.4.44-beta.1-license-api-healthz.json"
+        healthProofPath: "docs/evidence/v0.4.45-beta.1-license-api-healthz.json"
       },
       updateChannels: {
         ok: true
@@ -278,12 +278,12 @@ describe("beta release status", () => {
         expect.objectContaining({
           name: "cli",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.43-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.44-beta.1"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.43-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.44-beta.1"
         })
       ])
     );
@@ -293,7 +293,7 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.44-beta.1",
+      expectedVersion: "v0.4.45-beta.1",
       now: new Date("2026-08-08T00:00:00Z")
     });
 
@@ -301,7 +301,7 @@ describe("beta release status", () => {
       ok: false,
       requiredForThisRelease: true,
       state: "healthy",
-      healthProofPath: "docs/evidence/v0.4.44-beta.1-license-api-healthz.json"
+      healthProofPath: "docs/evidence/v0.4.45-beta.1-license-api-healthz.json"
     });
     expect(manifest.licenseApi.detail).toContain("observedAt must be no older than 30 days");
     expect(manifest.ok).toBe(false);
@@ -417,14 +417,14 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v0.4.44-beta.1",
+      expectedPublicVersion: "v0.4.45-beta.1",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot",
       now: shippedReleaseValidationNow
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v0.4.44-beta.1"
+      version: "v0.4.45-beta.1"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
@@ -436,7 +436,7 @@ describe("beta release status", () => {
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok
     });
-    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.43-beta.1");
+    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.44-beta.1");
     expect(redactedOutput).toContain("cli=published; daemon=launchd_prerelease");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
   });


### PR DESCRIPTION
## Summary
- Add the `v0.4.45-beta.1` source-beta release packet for the precision badge promotion from #439 / #425.
- Update `docs/public-release-manifest.json`, `CHANGELOG.md`, and release-status/readiness pins to `v0.4.45-beta.1`.
- Capture fresh production license API `/healthz` evidence for the required license gate.

## Proof boundary
- Source-only beta metadata release; no npm package publish. Public package remains `neondiff@0.4.30-beta.1`.
- No runtime config mutation, monitored repo expansion, provider policy change, issue-enrichment allowlist change, desktop signing/appcast release, or GA claim.
- Release/status manifest gates are expected to be fully green only after this metadata lands on `main` and the tag/GitHub prerelease is created.

## Validation
- `npm test -- --pool=forks --maxWorkers=1 tests/public-release-readiness.test.ts tests/release-status.test.ts`
- `npm run build`
- `git diff --check`
- Live manifest smoke before commit: `npx tsx src/cli.ts release-status --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json --expected-head 4cd081ca581c24f2f054106b4c4cc8e6453c9dce --public-release-manifest docs/public-release-manifest.json --expected-public-version v0.4.45-beta.1 --launchd-label com.electricsheephq.evaos-code-review-bot` passed public manifest/license/update-channel gates; expected pre-merge branch/dirty gates were red.

Refs #425.