### PR TITLE
[codex] Add checkout issuance release gate

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -344,6 +344,14 @@ npx tsx src/cli.ts review-head-gate \
   `pending_secret_and_website_publish`), and
   `checkoutIssuanceRequiredForThisRelease: false`. When checkout issuance proof
   is required and a state is declared, `checkoutIssuanceState` must be `ready`.
+  This manifest proof is a negative fail-closed boundary only; it proves the
+  public endpoint rejects unauthenticated callers. It does not prove a valid
+  owner-held checkout secret can issue a license, write the DB, or complete the
+  paid/trial fulfillment path. Authenticated issuance success must be captured
+  in the deploy runbook's redacted owner-held evidence lane before claiming
+  checkout issuance works end to end; the first-class release-status smoke gate
+  for that positive path is tracked in
+  `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/456`.
   In `release:status` output, `checkoutIssuanceRequiredForThisRelease` is the
   computed effective gate; `checkoutIssuanceRequiredDeclaredForThisRelease`
   preserves the raw manifest declaration when present.

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -340,8 +340,11 @@ npx tsx src/cli.ts review-head-gate \
   `{"status":"unauthorized"}`. Stable/GA releases require this checkout
   issuance proof by default. Public beta and source-beta releases also require
   this proof by default; source-beta releases may defer it explicitly only with a
-  tracking issue and `checkoutIssuanceRequiredForThisRelease: false`. In
-  `release:status` output, `checkoutIssuanceRequiredForThisRelease` is the
+  tracking issue, a deferred `checkoutIssuanceState` (`deferred` or
+  `pending_secret_and_website_publish`), and
+  `checkoutIssuanceRequiredForThisRelease: false`. When checkout issuance proof
+  is required and a state is declared, `checkoutIssuanceState` must be `ready`.
+  In `release:status` output, `checkoutIssuanceRequiredForThisRelease` is the
   computed effective gate; `checkoutIssuanceRequiredDeclaredForThisRelease`
   preserves the raw manifest declaration when present.
 - launchd emits a fresh heartbeat after restart.

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -340,7 +340,10 @@ npx tsx src/cli.ts review-head-gate \
   `{"status":"unauthorized"}`. Stable/GA releases require this checkout
   issuance proof by default. Public beta and source-beta releases also require
   this proof by default; source-beta releases may defer it explicitly only with a
-  tracking issue and `checkoutIssuanceRequiredForThisRelease: false`.
+  tracking issue and `checkoutIssuanceRequiredForThisRelease: false`. In
+  `release:status` output, `checkoutIssuanceRequiredForThisRelease` is the
+  computed effective gate; `checkoutIssuanceRequiredDeclaredForThisRelease`
+  preserves the raw manifest declaration when present.
 - launchd emits a fresh heartbeat after restart.
 - live DB has no unexpected error rows.
 - active provider cooldown rows are allowed only when they are explicit

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -333,6 +333,13 @@ npx tsx src/cli.ts review-head-gate \
 - Public release manifests may mark license API, website, or desktop channels
   as pending only when `requiredForThisRelease` is `false`; required channels
   must not be pending.
+- The license API health gate proves only `GET /healthz`. When checkout
+  issuance is part of the release, the manifest must also require
+  `checkoutIssuanceRequiredForThisRelease` and point at an evidence file showing
+  an unauthenticated `POST /v1/admin/licenses/issue` returned `401` with
+  `{"status":"unauthorized"}`. Stable/GA releases require this checkout
+  issuance proof by default; source-beta releases may defer it explicitly only
+  with a tracking issue and `checkoutIssuanceRequiredForThisRelease: false`.
 - launchd emits a fresh heartbeat after restart.
 - live DB has no unexpected error rows.
 - active provider cooldown rows are allowed only when they are explicit
@@ -466,6 +473,8 @@ For each beta promotion, record:
   expiry, active/expired count, retry command, and retry result.
 - public release manifest state for docs, license API, CLI update channel,
   daemon update channel, website/download channel, and desktop update channel.
+- checkout issuance evidence or the explicit deferred state and tracking issue
+  when the paid/trial purchase path is not in scope for the beta.
 - rollback SHA and command.
 - rollback note for provider config, GitHub App settings, website deploy, and
   desktop update channel when those surfaces are in scope; otherwise record the

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -338,8 +338,9 @@ npx tsx src/cli.ts review-head-gate \
   `checkoutIssuanceRequiredForThisRelease` and point at an evidence file showing
   an unauthenticated `POST /v1/admin/licenses/issue` returned `401` with
   `{"status":"unauthorized"}`. Stable/GA releases require this checkout
-  issuance proof by default; source-beta releases may defer it explicitly only
-  with a tracking issue and `checkoutIssuanceRequiredForThisRelease: false`.
+  issuance proof by default. Public beta and source-beta releases also require
+  this proof by default; source-beta releases may defer it explicitly only with a
+  tracking issue and `checkoutIssuanceRequiredForThisRelease: false`.
 - launchd emits a fresh heartbeat after restart.
 - live DB has no unexpected error rows.
 - active provider cooldown rows are allowed only when they are explicit

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -47,7 +47,11 @@
     "state": "healthy",
     "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327",
     "healthUrl": "https://neondiff-license.fly.dev/healthz",
-    "healthProofPath": "docs/evidence/v0.4.45-beta.1-license-api-healthz.json"
+    "healthProofPath": "docs/evidence/v0.4.45-beta.1-license-api-healthz.json",
+    "checkoutIssuanceRequiredForThisRelease": false,
+    "checkoutIssuanceUrl": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
+    "checkoutIssuanceState": "pending_secret_and_website_publish",
+    "checkoutIssuanceTrackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
   },
   "updateChannels": {
     "cli": {

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -137,6 +137,8 @@ Before tagging:
    `docs/public-release-manifest.json` exists and declares:
    - docs version and release-notes path
    - license API state and whether it is required for this release
+   - license API health proof, plus checkout issuance proof when checkout or GA
+     activation is in scope
    - CLI, daemon, website, and desktop update-channel state
    - rollback command or tracking issue for each required channel
    - required-channel rollback fields with one source revert command such as
@@ -243,8 +245,8 @@ The release is green only when:
 - launchd is running with the active live config
 - daemon heartbeat is fresh
 - no blocking DB error rows exist
-- public docs, license API state, and update channels are either healthy or
-  explicitly deferred as non-required for the release in
+- public docs, license API state, checkout issuance state, and update channels
+  are either healthy/proven or explicitly deferred as non-required for the release in
   `docs/public-release-manifest.json`
 - coverage audit has zero unprocessed eligible heads
 - provider cooldowns are either absent or active and named in release notes

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -139,6 +139,8 @@ Before tagging:
    - license API state and whether it is required for this release
    - license API health proof, plus checkout issuance proof unless a source-beta
      release explicitly defers it with a tracking issue
+   - computed checkout issuance status and, when present, the raw manifest
+     declaration that produced it
    - CLI, daemon, website, and desktop update-channel state
    - rollback command or tracking issue for each required channel
    - required-channel rollback fields with one source revert command such as

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -137,8 +137,9 @@ Before tagging:
    `docs/public-release-manifest.json` exists and declares:
    - docs version and release-notes path
    - license API state and whether it is required for this release
-   - license API health proof, plus checkout issuance proof unless a source-beta
-     release explicitly defers it with a tracking issue
+   - license API health proof, plus unauthenticated checkout issuance rejection
+     proof unless a source-beta release explicitly defers it with a tracking
+     issue
    - computed checkout issuance status and, when present, the raw manifest
      declaration that produced it
    - CLI, daemon, website, and desktop update-channel state
@@ -247,9 +248,13 @@ The release is green only when:
 - launchd is running with the active live config
 - daemon heartbeat is fresh
 - no blocking DB error rows exist
-- public docs, license API state, checkout issuance state, and update channels
-  are either healthy/proven or explicitly deferred as non-required for the release in
-  `docs/public-release-manifest.json`
+- public docs, license API state, unauthenticated checkout issuance rejection
+  state, and update channels are either healthy/proven or explicitly deferred
+  as non-required for the release in `docs/public-release-manifest.json`
+- authenticated checkout issuance success, DB writes, and paid/trial
+  fulfillment are proven only by owner-held deploy-runbook evidence or a future
+  release-status smoke gate; a green manifest gate alone must not be described
+  as end-to-end checkout issuance proof
 - coverage audit has zero unprocessed eligible heads
 - provider cooldowns are either absent or active and named in release notes
 - durable queue jobs have zero failed rows and zero retryable provider-deferred

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -137,8 +137,8 @@ Before tagging:
    `docs/public-release-manifest.json` exists and declares:
    - docs version and release-notes path
    - license API state and whether it is required for this release
-   - license API health proof, plus checkout issuance proof when checkout or GA
-     activation is in scope
+   - license API health proof, plus checkout issuance proof unless a source-beta
+     release explicitly defers it with a tracking issue
    - CLI, daemon, website, and desktop update-channel state
    - rollback command or tracking issue for each required channel
    - required-channel rollback fields with one source revert command such as

--- a/services/license-api/docs/deploy.md
+++ b/services/license-api/docs/deploy.md
@@ -94,6 +94,12 @@ release-status: an unauthenticated request to the checkout issuance endpoint mus
 return `401` with `{"status":"unauthorized"}`. A `503` response with
 `license issuance is not configured` means the Fly app is still missing
 `LICENSE_ISSUANCE_SECRET` and is not ready for paid/trial checkout activation.
+This release-status proof intentionally verifies only the fail-closed public
+boundary. It does not prove that a valid server-side checkout webhook can issue
+a license or write the DB. Capture positive authenticated issuance smoke in an
+owner-held, redacted evidence packet outside tracked manifest JSON; the
+first-class release-status gate for that path is tracked in
+`https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/456`.
 
 ## 4. Deploy
 

--- a/services/license-api/docs/deploy.md
+++ b/services/license-api/docs/deploy.md
@@ -89,6 +89,12 @@ website payment webhook. Keep the same value configured only on the license API
 and the server-side checkout webhook; never expose it to browser code, public
 docs, logs, or generated release packets.
 
+After setting the secret and deploying, capture a non-secret readiness proof for
+release-status: an unauthenticated request to the checkout issuance endpoint must
+return `401` with `{"status":"unauthorized"}`. A `503` response with
+`license issuance is not configured` means the Fly app is still missing
+`LICENSE_ISSUANCE_SECRET` and is not ready for paid/trial checkout activation.
+
 ## 4. Deploy
 
 ```sh
@@ -103,6 +109,12 @@ Watch the health check pass (`GET /healthz` → `{ "status": "ok" }`, wired in
 neondiff-license` shows machine + volume state; `flyctl logs --app
 neondiff-license` streams the Litestream restore/replication logs plus the
 `license-api listening on …` boot line from `src/server.ts`.
+
+```sh
+curl -s -i -X POST https://neondiff-license.fly.dev/v1/admin/licenses/issue \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
 
 ## 5. Point a client config at the deployed URL
 

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -124,6 +124,11 @@ export interface PublicReleaseStatus {
     trackingIssue?: string;
     healthUrl?: string;
     healthProofPath?: string;
+    checkoutIssuanceRequiredForThisRelease?: boolean;
+    checkoutIssuanceUrl?: string;
+    checkoutIssuanceProofPath?: string;
+    checkoutIssuanceState?: string;
+    checkoutIssuanceTrackingIssue?: string;
   };
   updateChannels: {
     ok: boolean;
@@ -574,13 +579,25 @@ export function readPublicReleaseManifestStatus(input: {
       : true;
     const licenseHealthProofPath = readString(licenseApi.healthProofPath);
     const licenseHealthUrl = readString(licenseApi.healthUrl);
+    const licenseIssuanceRequired =
+      readBoolean(licenseApi.checkoutIssuanceRequiredForThisRelease) ?? (releaseLevel === "stable" && licenseRequired);
+    const licenseIssuanceUrl = readString(licenseApi.checkoutIssuanceUrl);
+    const licenseIssuanceProofPath = readString(licenseApi.checkoutIssuanceProofPath);
+    const licenseIssuanceState = readString(licenseApi.checkoutIssuanceState);
+    const licenseIssuanceTrackingIssue = readString(licenseApi.checkoutIssuanceTrackingIssue);
     const licenseNeedsHealthProof = licenseRequired && licenseState === "healthy";
+    const licenseNeedsIssuanceProof = licenseNeedsHealthProof && licenseIssuanceRequired;
     const licenseMetadataFailures = validateLicenseHealthMetadata({
       cwd: input.cwd,
       healthUrl: licenseHealthUrl,
       healthProofPath: licenseHealthProofPath,
       proofRequired: licenseNeedsHealthProof
-    });
+    }).concat(validateLicenseIssuanceMetadata({
+      cwd: input.cwd,
+      issuanceUrl: licenseIssuanceUrl,
+      issuanceProofPath: licenseIssuanceProofPath,
+      proofRequired: licenseNeedsIssuanceProof
+    }));
     const licenseHealthProof = licenseNeedsHealthProof
       ? validateLicenseHealthProof({
           cwd: input.cwd,
@@ -590,11 +607,26 @@ export function readPublicReleaseManifestStatus(input: {
           now: input.now
         })
       : { ok: true, detail: "" };
+    const licenseIssuanceProof = licenseNeedsIssuanceProof
+      ? validateLicenseIssuanceProof({
+          cwd: input.cwd,
+          proofPath: licenseIssuanceProofPath,
+          expectedReleaseVersion: expectedVersion,
+          expectedUrl: licenseIssuanceUrl,
+          now: input.now
+        })
+      : { ok: true, detail: "" };
     const licenseHealthProofOk = licenseHealthProof.ok;
+    const licenseIssuanceProofOk = licenseIssuanceProof.ok;
     const licenseMetadataOk = licenseMetadataFailures.length === 0;
-    const licenseOk = isLicenseApiStateAcceptable(licenseState, licenseRequired) && licenseMetadataOk && licenseHealthProofOk;
+    const licenseOk =
+      isLicenseApiStateAcceptable(licenseState, licenseRequired) &&
+      licenseMetadataOk &&
+      licenseHealthProofOk &&
+      licenseIssuanceProofOk;
     const licenseDetailParts = [
       ...(licenseNeedsHealthProof ? [licenseHealthProof.detail] : []),
+      ...(licenseNeedsIssuanceProof ? [licenseIssuanceProof.detail] : []),
       ...licenseMetadataFailures
     ].filter(Boolean);
     const declaredChannelNames = Object.keys(updateChannels);
@@ -673,6 +705,11 @@ export function readPublicReleaseManifestStatus(input: {
         trackingIssue: readString(licenseApi.trackingIssue),
         healthUrl: licenseHealthUrl,
         healthProofPath: licenseHealthProofPath,
+        checkoutIssuanceRequiredForThisRelease: licenseIssuanceRequired,
+        checkoutIssuanceUrl: licenseIssuanceUrl,
+        checkoutIssuanceProofPath: licenseIssuanceProofPath,
+        checkoutIssuanceState: licenseIssuanceState,
+        checkoutIssuanceTrackingIssue: licenseIssuanceTrackingIssue,
         detail: licenseOk
           ? `license API state ${licenseState}; requiredForThisRelease=${licenseRequired}${
               licenseDetailParts.length ? `; ${licenseDetailParts.join("; ")}` : ""
@@ -968,6 +1005,92 @@ function validateLicenseHealthProof(input: {
     : { ok: true, detail: `validated health proof ${input.proofPath}` };
 }
 
+function validateLicenseIssuanceProof(input: {
+  cwd: string;
+  proofPath?: string;
+  expectedReleaseVersion?: string;
+  expectedUrl?: string;
+  now?: Date;
+}): { ok: boolean; detail: string } {
+  if (!input.proofPath) return { ok: false, detail: "missing checkout issuance proof path (no checkoutIssuanceProofPath declared)" };
+  const confinedPath = resolveConfinedEvidenceProofPath(input.cwd, input.proofPath, "checkoutIssuanceProofPath");
+  if (!confinedPath.ok) return { ok: false, detail: `invalid checkout issuance proof ${input.proofPath}: ${confinedPath.detail}` };
+  const absolutePath = confinedPath.absolutePath;
+  if (!existsSync(absolutePath)) return { ok: false, detail: `missing checkout issuance proof ${input.proofPath}` };
+
+  let proof: Record<string, unknown>;
+  try {
+    proof = asRecord(JSON.parse(readFileSync(absolutePath, "utf8")));
+  } catch {
+    return { ok: false, detail: `invalid checkout issuance proof ${input.proofPath}: proof JSON is invalid` };
+  }
+
+  const evidenceKind = readString(proof.evidenceKind);
+  const releaseVersion = readString(proof.releaseVersion);
+  const observedAt = readString(proof.observedAt);
+  const method = readString(proof.method);
+  const url = readString(proof.url);
+  const statusCode = typeof proof.statusCode === "number" ? proof.statusCode : undefined;
+  const responseBody = typeof proof.responseBody === "string" ? proof.responseBody : undefined;
+  const responseBodySha256 = readString(proof.responseBodySha256);
+  const captureContext = asRecord(proof.captureContext);
+  const captureTool = readString(captureContext.tool);
+  const captureTransport = readString(captureContext.transport);
+  const captureTlsValidation = readString(captureContext.tlsValidation);
+  const captureHost = readString(captureContext.capturedFrom);
+  const failures: string[] = [];
+
+  if (evidenceKind !== "license_api_checkout_issuance") failures.push("evidenceKind must be license_api_checkout_issuance");
+  if (!input.expectedReleaseVersion) {
+    failures.push("expected releaseVersion must be present");
+  } else if (releaseVersion !== input.expectedReleaseVersion) {
+    failures.push(`releaseVersion must match ${input.expectedReleaseVersion}`);
+  }
+  if (!input.expectedUrl) {
+    failures.push("checkoutIssuanceUrl must be present when validating checkout issuance proof");
+  } else if (url !== input.expectedUrl) {
+    failures.push(`url must match ${input.expectedUrl}`);
+  }
+  if (method !== "POST") failures.push("method must be POST");
+  if (statusCode !== 401) failures.push("statusCode must be 401");
+  const observedAtMs = observedAt ? Date.parse(observedAt) : NaN;
+  if (!observedAt || Number.isNaN(observedAtMs)) {
+    failures.push("observedAt must be a valid ISO timestamp");
+  } else {
+    const nowMs = (input.now ?? new Date()).getTime();
+    if (observedAtMs > nowMs + LICENSE_HEALTH_PROOF_MAX_FUTURE_SKEW_MS) {
+      failures.push("observedAt must not be more than 5 minutes in the future");
+    }
+    if (nowMs - observedAtMs > LICENSE_HEALTH_PROOF_MAX_AGE_MS) {
+      failures.push(`observedAt must be no older than ${LICENSE_HEALTH_PROOF_MAX_AGE_DAYS} days`);
+    }
+  }
+  if (responseBody === undefined) {
+    failures.push("responseBody must be present");
+  }
+  if (!responseBodySha256) {
+    failures.push("responseBodySha256 must be present");
+  } else if (responseBody !== undefined && createHash("sha256").update(responseBody).digest("hex") !== responseBodySha256) {
+    failures.push("responseBodySha256 must match responseBody");
+  }
+  if (responseBody !== undefined) {
+    try {
+      const body = asRecord(JSON.parse(responseBody));
+      if (readString(body.status) !== "unauthorized") failures.push("responseBody.status must be unauthorized");
+    } catch {
+      failures.push("responseBody must be JSON");
+    }
+  }
+  if (!captureTool) failures.push("captureContext.tool must be present");
+  if (!captureTransport) failures.push("captureContext.transport must be present");
+  if (!captureTlsValidation) failures.push("captureContext.tlsValidation must be present");
+  if (!captureHost) failures.push("captureContext.capturedFrom must be present");
+
+  return failures.length
+    ? { ok: false, detail: `invalid checkout issuance proof ${input.proofPath}: ${failures.join("; ")}` }
+    : { ok: true, detail: `validated checkout issuance proof ${input.proofPath}` };
+}
+
 function validateLicenseHealthMetadata(input: {
   cwd: string;
   healthUrl?: string;
@@ -982,6 +1105,27 @@ function validateLicenseHealthMetadata(input: {
   if (input.healthProofPath && !input.proofRequired) {
     const confinedPath = resolveConfinedHealthProofPath(input.cwd, input.healthProofPath);
     if (!confinedPath.ok) failures.push(`invalid health proof ${input.healthProofPath}: ${confinedPath.detail}`);
+  }
+  return failures;
+}
+
+function validateLicenseIssuanceMetadata(input: {
+  cwd: string;
+  issuanceUrl?: string;
+  issuanceProofPath?: string;
+  proofRequired: boolean;
+}): string[] {
+  const failures: string[] = [];
+  if (input.proofRequired && !input.issuanceUrl) {
+    failures.push("checkoutIssuanceUrl must be present when validating checkout issuance proof");
+  }
+  if (input.issuanceUrl) {
+    const issuanceUrlFailure = validateLicenseIssuanceUrl(input.issuanceUrl);
+    if (issuanceUrlFailure) failures.push(issuanceUrlFailure);
+  }
+  if (input.issuanceProofPath && !input.proofRequired) {
+    const confinedPath = resolveConfinedEvidenceProofPath(input.cwd, input.issuanceProofPath, "checkoutIssuanceProofPath");
+    if (!confinedPath.ok) failures.push(`invalid checkout issuance proof ${input.issuanceProofPath}: ${confinedPath.detail}`);
   }
   return failures;
 }
@@ -1006,14 +1150,42 @@ function validateLicenseHealthUrl(healthUrl: string): string | undefined {
   return undefined;
 }
 
+function validateLicenseIssuanceUrl(issuanceUrl: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(issuanceUrl);
+  } catch {
+    return "checkoutIssuanceUrl must be an https URL ending in /v1/admin/licenses/issue with no credentials, query, or fragment";
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.pathname !== "/v1/admin/licenses/issue" ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    return "checkoutIssuanceUrl must be an https URL ending in /v1/admin/licenses/issue with no credentials, query, or fragment";
+  }
+  return undefined;
+}
+
 function resolveConfinedHealthProofPath(cwd: string, proofPath: string): { ok: true; absolutePath: string } | { ok: false; detail: string } {
+  return resolveConfinedEvidenceProofPath(cwd, proofPath, "healthProofPath");
+}
+
+function resolveConfinedEvidenceProofPath(
+  cwd: string,
+  proofPath: string,
+  fieldName: "healthProofPath" | "checkoutIssuanceProofPath"
+): { ok: true; absolutePath: string } | { ok: false; detail: string } {
   if (isAbsolute(proofPath)) {
-    return { ok: false, detail: "healthProofPath must be relative and stay within docs/evidence" };
+    return { ok: false, detail: `${fieldName} must be relative and stay within docs/evidence` };
   }
   const evidenceRoot = resolve(cwd, "docs", "evidence");
   const absolutePath = resolve(cwd, proofPath);
   if (!isPathInsideOrEqual(absolutePath, evidenceRoot)) {
-    return { ok: false, detail: "healthProofPath must be relative and stay within docs/evidence" };
+    return { ok: false, detail: `${fieldName} must be relative and stay within docs/evidence` };
   }
   if (!existsSync(absolutePath)) return { ok: true, absolutePath };
 
@@ -1023,10 +1195,10 @@ function resolveConfinedHealthProofPath(cwd: string, proofPath: string): { ok: t
     realEvidenceRoot = realpathSync.native(evidenceRoot);
     realProofPath = realpathSync.native(absolutePath);
   } catch {
-    return { ok: false, detail: "healthProofPath could not be resolved within docs/evidence" };
+    return { ok: false, detail: `${fieldName} could not be resolved within docs/evidence` };
   }
   if (!isPathInsideOrEqual(realProofPath, realEvidenceRoot)) {
-    return { ok: false, detail: "healthProofPath must be relative and stay within docs/evidence" };
+    return { ok: false, detail: `${fieldName} must be relative and stay within docs/evidence` };
   }
   return { ok: true, absolutePath: realProofPath };
 }

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -580,9 +580,10 @@ export function readPublicReleaseManifestStatus(input: {
     const licenseHealthProofPath = readString(licenseApi.healthProofPath);
     const licenseHealthUrl = readString(licenseApi.healthUrl);
     const explicitLicenseIssuanceRequired = readBoolean(licenseApi.checkoutIssuanceRequiredForThisRelease);
+    const releaseRequiresCheckoutIssuance =
+      (releaseLevel === "stable" || releaseLevel === "beta" || releaseLevel === "source-beta") && licenseRequired;
     const licenseIssuanceRequired =
-      explicitLicenseIssuanceRequired ??
-      ((releaseLevel === "stable" || releaseLevel === "beta" || releaseLevel === "source-beta") && licenseRequired);
+      releaseRequiresCheckoutIssuance && !(explicitLicenseIssuanceRequired === false && releaseLevel === "source-beta");
     const licenseIssuanceUrl = readString(licenseApi.checkoutIssuanceUrl);
     const licenseIssuanceProofPath = readString(licenseApi.checkoutIssuanceProofPath);
     const licenseIssuanceState = readString(licenseApi.checkoutIssuanceState);
@@ -613,7 +614,9 @@ export function readPublicReleaseManifestStatus(input: {
       issuanceTrackingIssue: licenseIssuanceTrackingIssue,
       proofRequired: licenseNeedsIssuanceProof,
       healthProofRequired: licenseNeedsHealthProof && licenseHealthGateOk,
-      issuanceRequiredExplicit: explicitLicenseIssuanceRequired
+      issuanceRequiredExplicit: explicitLicenseIssuanceRequired,
+      releaseLevel,
+      expectedHost: extractUrlHost(licenseHealthUrl)
     });
     const licenseIssuanceProof = licenseNeedsIssuanceProof
       ? validateLicenseIssuanceProof({
@@ -1125,13 +1128,19 @@ function validateLicenseIssuanceMetadata(input: {
   proofRequired: boolean;
   healthProofRequired: boolean;
   issuanceRequiredExplicit?: boolean;
+  releaseLevel: string;
+  expectedHost?: string;
 }): string[] {
   const failures: string[] = [];
   if (input.proofRequired && !input.issuanceUrl) {
     failures.push("checkoutIssuanceUrl must be present when validating checkout issuance proof");
   }
-  if (input.healthProofRequired && input.issuanceRequiredExplicit === false && !input.issuanceTrackingIssue) {
-    failures.push("checkoutIssuanceTrackingIssue must be present when checkout issuance proof is deferred");
+  if (input.healthProofRequired && input.issuanceRequiredExplicit === false) {
+    if (input.releaseLevel !== "source-beta") {
+      failures.push("checkoutIssuanceRequiredForThisRelease:false is only allowed for source-beta releases");
+    } else if (!input.issuanceTrackingIssue) {
+      failures.push("checkoutIssuanceTrackingIssue must be present when checkout issuance proof is deferred");
+    }
   }
   if (input.issuanceTrackingIssue) {
     const trackingIssueFailure = validateGithubIssueUrl(
@@ -1141,7 +1150,7 @@ function validateLicenseIssuanceMetadata(input: {
     if (trackingIssueFailure) failures.push(trackingIssueFailure);
   }
   if (input.issuanceUrl) {
-    const issuanceUrlFailure = validateLicenseIssuanceUrl(input.issuanceUrl);
+    const issuanceUrlFailure = validateLicenseIssuanceUrl(input.issuanceUrl, input.expectedHost);
     if (issuanceUrlFailure) failures.push(issuanceUrlFailure);
   }
   if (input.issuanceProofPath && !input.proofRequired) {
@@ -1192,7 +1201,16 @@ function validateLicenseHealthUrl(healthUrl: string): string | undefined {
   return undefined;
 }
 
-function validateLicenseIssuanceUrl(issuanceUrl: string): string | undefined {
+function extractUrlHost(url?: string): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+function validateLicenseIssuanceUrl(issuanceUrl: string, expectedHost?: string): string | undefined {
   let parsed: URL;
   try {
     parsed = new URL(issuanceUrl);
@@ -1208,6 +1226,9 @@ function validateLicenseIssuanceUrl(issuanceUrl: string): string | undefined {
     parsed.hash
   ) {
     return "checkoutIssuanceUrl must be an https URL ending in /v1/admin/licenses/issue with no credentials, query, or fragment";
+  }
+  if (expectedHost && parsed.hostname !== expectedHost) {
+    return `checkoutIssuanceUrl host must match healthUrl host ${expectedHost}`;
   }
   return undefined;
 }

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -617,7 +617,7 @@ export function readPublicReleaseManifestStatus(input: {
       deferralPolicyApplies: licenseNeedsHealthProof,
       issuanceRequiredExplicit: explicitLicenseIssuanceRequired,
       releaseLevel,
-      expectedHost: extractUrlHost(licenseHealthUrl)
+      healthUrl: licenseHealthUrl
     });
     const licenseIssuanceProof = licenseNeedsIssuanceProof
       ? validateLicenseIssuanceProof({
@@ -1131,7 +1131,7 @@ function validateLicenseIssuanceMetadata(input: {
   deferralPolicyApplies: boolean;
   issuanceRequiredExplicit?: boolean;
   releaseLevel: string;
-  expectedHost?: string;
+  healthUrl?: string;
 }): string[] {
   const failures: string[] = [];
   if (input.proofRequired && !input.issuanceUrl) {
@@ -1152,8 +1152,12 @@ function validateLicenseIssuanceMetadata(input: {
     if (trackingIssueFailure) failures.push(trackingIssueFailure);
   }
   if (input.issuanceUrl) {
-    const issuanceUrlFailure = validateLicenseIssuanceUrl(input.issuanceUrl, input.expectedHost);
+    const expectedHost = extractValidHealthUrlHost(input.healthUrl);
+    const issuanceUrlFailure = validateLicenseIssuanceUrl(input.issuanceUrl, expectedHost);
     if (issuanceUrlFailure) failures.push(issuanceUrlFailure);
+    if (!expectedHost) {
+      failures.push("checkoutIssuanceUrl host cannot be validated because healthUrl is missing or invalid");
+    }
   }
   if (input.issuanceProofPath && !input.proofRequired) {
     const confinedPath = resolveConfinedEvidenceProofPath(input.cwd, input.issuanceProofPath, "checkoutIssuanceProofPath");
@@ -1210,6 +1214,11 @@ function extractUrlHost(url?: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function extractValidHealthUrlHost(healthUrl?: string): string | undefined {
+  if (!healthUrl || validateLicenseHealthUrl(healthUrl)) return undefined;
+  return extractUrlHost(healthUrl);
 }
 
 function validateLicenseIssuanceUrl(issuanceUrl: string, expectedHost?: string): string | undefined {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -587,16 +587,16 @@ export function readPublicReleaseManifestStatus(input: {
     const licenseHealthProofPath = readString(licenseApi.healthProofPath);
     const licenseHealthUrl = readString(licenseApi.healthUrl);
     const explicitLicenseIssuanceRequired = readBoolean(licenseApi.checkoutIssuanceRequiredForThisRelease);
+    const releaseLevelSupportsCheckoutIssuance =
+      releaseLevel === "stable" || releaseLevel === "beta" || releaseLevel === "source-beta";
     const releaseRequiresCheckoutIssuance =
-      (releaseLevel === "stable" || releaseLevel === "beta" || releaseLevel === "source-beta") && licenseRequired;
+      releaseLevelSupportsCheckoutIssuance && (licenseRequired || explicitLicenseIssuanceRequired === true);
     const licenseIssuanceRequired =
       releaseRequiresCheckoutIssuance && !(explicitLicenseIssuanceRequired === false && releaseLevel === "source-beta");
     const licenseIssuanceUrl = readString(licenseApi.checkoutIssuanceUrl);
     const licenseIssuanceProofPath = readString(licenseApi.checkoutIssuanceProofPath);
     const licenseIssuanceState = readString(licenseApi.checkoutIssuanceState);
     const licenseIssuanceTrackingIssue = readString(licenseApi.checkoutIssuanceTrackingIssue);
-    const releaseLevelSupportsCheckoutIssuance =
-      releaseLevel === "stable" || releaseLevel === "beta" || releaseLevel === "source-beta";
     const licenseNeedsHealthProof = licenseRequired && licenseState === "healthy";
     const licenseHealthMetadataFailures = validateLicenseHealthMetadata({
       cwd: input.cwd,
@@ -614,8 +614,7 @@ export function readPublicReleaseManifestStatus(input: {
         })
       : { ok: true, detail: "" };
     const licenseHealthProofOk = licenseHealthProof.ok;
-    const licenseHealthGateOk = licenseHealthMetadataFailures.length === 0 && licenseHealthProofOk;
-    const licenseNeedsIssuanceProof = licenseNeedsHealthProof && licenseHealthGateOk && licenseIssuanceRequired;
+    const licenseNeedsIssuanceProof = licenseIssuanceRequired;
     const licenseIssuanceMetadataFailures = validateLicenseIssuanceMetadata({
       cwd: input.cwd,
       issuanceUrl: licenseIssuanceUrl,

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -1174,11 +1174,17 @@ function validateLicenseIssuanceMetadata(input: {
     if (trackingIssueFailure) failures.push(trackingIssueFailure);
   }
   if (input.issuanceUrl) {
+    // Pin checkout issuance to the health host when a valid health URL exists.
+    // Source-beta can still prove the fail-closed issuance endpoint while
+    // health is deferred; that posture relies on URL shape plus proof content,
+    // and must not be described as end-to-end checkout fulfillment.
     const expectedHost = extractValidHealthUrlHost(input.healthUrl);
     const issuanceUrlFailure = validateLicenseIssuanceUrl(input.issuanceUrl, expectedHost);
     if (issuanceUrlFailure) failures.push(issuanceUrlFailure);
   }
   if (input.issuanceProofPath && !input.proofRequired) {
+    // Required-proof path confinement is enforced inside
+    // validateLicenseIssuanceProof before the proof file is read.
     const confinedPath = resolveConfinedEvidenceProofPath(input.cwd, input.issuanceProofPath, "checkoutIssuanceProofPath");
     if (!confinedPath.ok) failures.push(`invalid checkout issuance proof ${input.issuanceProofPath}: ${confinedPath.detail}`);
   }

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -1075,6 +1075,9 @@ function validateLicenseIssuanceProof(input: {
     failures.push(`url must match ${input.expectedUrl}`);
   }
   if (method !== "POST") failures.push("method must be POST");
+  // This manifest proof is the no-secret release gate: unauthenticated issuance
+  // must fail closed. Authenticated issuance smoke uses owner-held secrets and
+  // belongs in the deploy runbook/evidence lane, not committed manifest JSON.
   if (statusCode !== 401) failures.push("statusCode must be 401");
   const observedAtMs = observedAt ? Date.parse(observedAt) : NaN;
   if (!observedAt || Number.isNaN(observedAtMs)) {
@@ -1156,11 +1159,13 @@ function validateLicenseIssuanceMetadata(input: {
   if (input.deferralPolicyApplies && input.issuanceRequiredExplicit === false) {
     if (input.releaseLevel !== "source-beta") {
       failures.push("checkoutIssuanceRequiredForThisRelease:false is only allowed for source-beta releases");
-    } else if (!input.issuanceTrackingIssue) {
-      failures.push("checkoutIssuanceTrackingIssue must be present when checkout issuance proof is deferred");
-    }
-    if (!input.issuanceState || !CHECKOUT_ISSUANCE_DEFERRED_STATES.has(input.issuanceState)) {
-      failures.push("checkoutIssuanceState must be a deferred state when checkout issuance proof is deferred");
+    } else {
+      if (!input.issuanceTrackingIssue) {
+        failures.push("checkoutIssuanceTrackingIssue must be present when checkout issuance proof is deferred");
+      }
+      if (!input.issuanceState || !CHECKOUT_ISSUANCE_DEFERRED_STATES.has(input.issuanceState)) {
+        failures.push("checkoutIssuanceState must be a deferred state when checkout issuance proof is deferred");
+      }
     }
   }
   if (input.proofRequired && input.issuanceState && CHECKOUT_ISSUANCE_DEFERRED_STATES.has(input.issuanceState)) {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -198,6 +198,9 @@ const MAX_PUBLIC_VERSION_TAG_LENGTH = 128;
 const LICENSE_HEALTH_PROOF_MAX_AGE_DAYS = 30;
 const LICENSE_HEALTH_PROOF_MAX_AGE_MS = LICENSE_HEALTH_PROOF_MAX_AGE_DAYS * 24 * 60 * 60 * 1_000;
 const LICENSE_HEALTH_PROOF_MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
+const LICENSE_ISSUANCE_PROOF_MAX_AGE_DAYS = 30;
+const LICENSE_ISSUANCE_PROOF_MAX_AGE_MS = LICENSE_ISSUANCE_PROOF_MAX_AGE_DAYS * 24 * 60 * 60 * 1_000;
+const LICENSE_ISSUANCE_PROOF_MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
 const REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES = new Set(["source_checkout", "launchd_prerelease", "healthy", "published"]);
 const CHECKOUT_ISSUANCE_READY_STATE = "ready";
 const CHECKOUT_ISSUANCE_DEFERRED_STATES = new Set(["deferred", "pending_secret_and_website_publish"]);
@@ -589,8 +592,7 @@ export function readPublicReleaseManifestStatus(input: {
     const explicitLicenseIssuanceRequired = readBoolean(licenseApi.checkoutIssuanceRequiredForThisRelease);
     const releaseLevelSupportsCheckoutIssuance =
       releaseLevel === "stable" || releaseLevel === "beta" || releaseLevel === "source-beta";
-    const releaseRequiresCheckoutIssuance =
-      releaseLevelSupportsCheckoutIssuance && (licenseRequired || explicitLicenseIssuanceRequired === true);
+    const releaseRequiresCheckoutIssuance = releaseLevelSupportsCheckoutIssuance;
     const licenseIssuanceRequired =
       releaseRequiresCheckoutIssuance && !(explicitLicenseIssuanceRequired === false && releaseLevel === "source-beta");
     const licenseIssuanceUrl = readString(licenseApi.checkoutIssuanceUrl);
@@ -1079,11 +1081,11 @@ function validateLicenseIssuanceProof(input: {
     failures.push("observedAt must be a valid ISO timestamp");
   } else {
     const nowMs = (input.now ?? new Date()).getTime();
-    if (observedAtMs > nowMs + LICENSE_HEALTH_PROOF_MAX_FUTURE_SKEW_MS) {
+    if (observedAtMs > nowMs + LICENSE_ISSUANCE_PROOF_MAX_FUTURE_SKEW_MS) {
       failures.push("observedAt must not be more than 5 minutes in the future");
     }
-    if (nowMs - observedAtMs > LICENSE_HEALTH_PROOF_MAX_AGE_MS) {
-      failures.push(`observedAt must be no older than ${LICENSE_HEALTH_PROOF_MAX_AGE_DAYS} days`);
+    if (nowMs - observedAtMs > LICENSE_ISSUANCE_PROOF_MAX_AGE_MS) {
+      failures.push(`observedAt must be no older than ${LICENSE_ISSUANCE_PROOF_MAX_AGE_DAYS} days`);
     }
   }
   if (responseBody === undefined) {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -195,12 +195,9 @@ export interface ReleaseStatus {
 const REQUIRED_PUBLIC_UPDATE_CHANNELS = ["cli", "daemon"] as const;
 const PUBLIC_RELEASE_LEVELS = new Set(["beta", "source-beta", "stable"]);
 const MAX_PUBLIC_VERSION_TAG_LENGTH = 128;
-const LICENSE_HEALTH_PROOF_MAX_AGE_DAYS = 30;
-const LICENSE_HEALTH_PROOF_MAX_AGE_MS = LICENSE_HEALTH_PROOF_MAX_AGE_DAYS * 24 * 60 * 60 * 1_000;
-const LICENSE_HEALTH_PROOF_MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
-const LICENSE_ISSUANCE_PROOF_MAX_AGE_DAYS = 30;
-const LICENSE_ISSUANCE_PROOF_MAX_AGE_MS = LICENSE_ISSUANCE_PROOF_MAX_AGE_DAYS * 24 * 60 * 60 * 1_000;
-const LICENSE_ISSUANCE_PROOF_MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
+const LICENSE_PROOF_MAX_AGE_DAYS = 30;
+const LICENSE_PROOF_MAX_AGE_MS = LICENSE_PROOF_MAX_AGE_DAYS * 24 * 60 * 60 * 1_000;
+const LICENSE_PROOF_MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
 const REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES = new Set(["source_checkout", "launchd_prerelease", "healthy", "published"]);
 const CHECKOUT_ISSUANCE_READY_STATE = "ready";
 const CHECKOUT_ISSUANCE_DEFERRED_STATES = new Set(["deferred", "pending_secret_and_website_publish"]);
@@ -950,6 +947,22 @@ function isLicenseApiStateAcceptable(state: string, requiredForThisRelease: bool
   return state === "healthy" || state === "not_applicable" || state === "disabled" || state === "pending";
 }
 
+function validateLicenseProofObservedAt(observedAt: string | undefined, now?: Date): string[] {
+  if (!observedAt) return ["observedAt must be a valid ISO timestamp"];
+  const observedAtMs = Date.parse(observedAt);
+  if (Number.isNaN(observedAtMs)) return ["observedAt must be a valid ISO timestamp"];
+
+  const failures: string[] = [];
+  const nowMs = (now ?? new Date()).getTime();
+  if (observedAtMs > nowMs + LICENSE_PROOF_MAX_FUTURE_SKEW_MS) {
+    failures.push("observedAt must not be more than 5 minutes in the future");
+  }
+  if (nowMs - observedAtMs > LICENSE_PROOF_MAX_AGE_MS) {
+    failures.push(`observedAt must be no older than ${LICENSE_PROOF_MAX_AGE_DAYS} days`);
+  }
+  return failures;
+}
+
 function validateLicenseHealthProof(input: {
   cwd: string;
   proofPath?: string;
@@ -998,18 +1011,7 @@ function validateLicenseHealthProof(input: {
   }
   if (method !== "GET") failures.push("method must be GET");
   if (statusCode !== 200) failures.push("statusCode must be 200");
-  const observedAtMs = observedAt ? Date.parse(observedAt) : NaN;
-  if (!observedAt || Number.isNaN(observedAtMs)) {
-    failures.push("observedAt must be a valid ISO timestamp");
-  } else {
-    const nowMs = (input.now ?? new Date()).getTime();
-    if (observedAtMs > nowMs + LICENSE_HEALTH_PROOF_MAX_FUTURE_SKEW_MS) {
-      failures.push("observedAt must not be more than 5 minutes in the future");
-    }
-    if (nowMs - observedAtMs > LICENSE_HEALTH_PROOF_MAX_AGE_MS) {
-      failures.push(`observedAt must be no older than ${LICENSE_HEALTH_PROOF_MAX_AGE_DAYS} days`);
-    }
-  }
+  failures.push(...validateLicenseProofObservedAt(observedAt, input.now));
   if (responseBody === undefined) {
     failures.push("responseBody must be present");
   }
@@ -1079,18 +1081,7 @@ function validateLicenseIssuanceProof(input: {
   // must fail closed. Authenticated issuance smoke uses owner-held secrets and
   // belongs in the deploy runbook/evidence lane, not committed manifest JSON.
   if (statusCode !== 401) failures.push("statusCode must be 401");
-  const observedAtMs = observedAt ? Date.parse(observedAt) : NaN;
-  if (!observedAt || Number.isNaN(observedAtMs)) {
-    failures.push("observedAt must be a valid ISO timestamp");
-  } else {
-    const nowMs = (input.now ?? new Date()).getTime();
-    if (observedAtMs > nowMs + LICENSE_ISSUANCE_PROOF_MAX_FUTURE_SKEW_MS) {
-      failures.push("observedAt must not be more than 5 minutes in the future");
-    }
-    if (nowMs - observedAtMs > LICENSE_ISSUANCE_PROOF_MAX_AGE_MS) {
-      failures.push(`observedAt must be no older than ${LICENSE_ISSUANCE_PROOF_MAX_AGE_DAYS} days`);
-    }
-  }
+  failures.push(...validateLicenseProofObservedAt(observedAt, input.now));
   if (responseBody === undefined) {
     failures.push("responseBody must be present");
   }

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -590,8 +590,12 @@ export function readPublicReleaseManifestStatus(input: {
     const releaseLevelSupportsCheckoutIssuance =
       releaseLevel === "stable" || releaseLevel === "beta" || releaseLevel === "source-beta";
     const releaseRequiresCheckoutIssuance = releaseLevelSupportsCheckoutIssuance;
+    // Only source-beta can explicitly defer checkout issuance. Stable and beta
+    // releases force this gate on regardless of a false manifest declaration.
+    const sourceBetaExplicitlyDefersCheckoutIssuance =
+      explicitLicenseIssuanceRequired === false && releaseLevel === "source-beta";
     const licenseIssuanceRequired =
-      releaseRequiresCheckoutIssuance && !(explicitLicenseIssuanceRequired === false && releaseLevel === "source-beta");
+      releaseRequiresCheckoutIssuance && !sourceBetaExplicitlyDefersCheckoutIssuance;
     const licenseIssuanceUrl = readString(licenseApi.checkoutIssuanceUrl);
     const licenseIssuanceProofPath = readString(licenseApi.checkoutIssuanceProofPath);
     const licenseIssuanceState = readString(licenseApi.checkoutIssuanceState);
@@ -1173,9 +1177,6 @@ function validateLicenseIssuanceMetadata(input: {
     const expectedHost = extractValidHealthUrlHost(input.healthUrl);
     const issuanceUrlFailure = validateLicenseIssuanceUrl(input.issuanceUrl, expectedHost);
     if (issuanceUrlFailure) failures.push(issuanceUrlFailure);
-    if (!expectedHost) {
-      failures.push("checkoutIssuanceUrl host cannot be validated because healthUrl is missing or invalid");
-    }
   }
   if (input.issuanceProofPath && !input.proofRequired) {
     const confinedPath = resolveConfinedEvidenceProofPath(input.cwd, input.issuanceProofPath, "checkoutIssuanceProofPath");

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -125,6 +125,7 @@ export interface PublicReleaseStatus {
     healthUrl?: string;
     healthProofPath?: string;
     checkoutIssuanceRequiredForThisRelease?: boolean;
+    checkoutIssuanceRequiredDeclaredForThisRelease?: boolean;
     checkoutIssuanceUrl?: string;
     checkoutIssuanceProofPath?: string;
     checkoutIssuanceState?: string;
@@ -613,7 +614,7 @@ export function readPublicReleaseManifestStatus(input: {
       issuanceProofPath: licenseIssuanceProofPath,
       issuanceTrackingIssue: licenseIssuanceTrackingIssue,
       proofRequired: licenseNeedsIssuanceProof,
-      healthProofRequired: licenseNeedsHealthProof && licenseHealthGateOk,
+      deferralPolicyApplies: licenseNeedsHealthProof,
       issuanceRequiredExplicit: explicitLicenseIssuanceRequired,
       releaseLevel,
       expectedHost: extractUrlHost(licenseHealthUrl)
@@ -717,6 +718,7 @@ export function readPublicReleaseManifestStatus(input: {
         healthUrl: licenseHealthUrl,
         healthProofPath: licenseHealthProofPath,
         checkoutIssuanceRequiredForThisRelease: licenseIssuanceRequired,
+        checkoutIssuanceRequiredDeclaredForThisRelease: explicitLicenseIssuanceRequired,
         checkoutIssuanceUrl: licenseIssuanceUrl,
         checkoutIssuanceProofPath: licenseIssuanceProofPath,
         checkoutIssuanceState: licenseIssuanceState,
@@ -1126,7 +1128,7 @@ function validateLicenseIssuanceMetadata(input: {
   issuanceProofPath?: string;
   issuanceTrackingIssue?: string;
   proofRequired: boolean;
-  healthProofRequired: boolean;
+  deferralPolicyApplies: boolean;
   issuanceRequiredExplicit?: boolean;
   releaseLevel: string;
   expectedHost?: string;
@@ -1135,7 +1137,7 @@ function validateLicenseIssuanceMetadata(input: {
   if (input.proofRequired && !input.issuanceUrl) {
     failures.push("checkoutIssuanceUrl must be present when validating checkout issuance proof");
   }
-  if (input.healthProofRequired && input.issuanceRequiredExplicit === false) {
+  if (input.deferralPolicyApplies && input.issuanceRequiredExplicit === false) {
     if (input.releaseLevel !== "source-beta") {
       failures.push("checkoutIssuanceRequiredForThisRelease:false is only allowed for source-beta releases");
     } else if (!input.issuanceTrackingIssue) {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -614,7 +614,7 @@ export function readPublicReleaseManifestStatus(input: {
       issuanceProofPath: licenseIssuanceProofPath,
       issuanceTrackingIssue: licenseIssuanceTrackingIssue,
       proofRequired: licenseNeedsIssuanceProof,
-      deferralPolicyApplies: licenseNeedsHealthProof,
+      deferralPolicyApplies: releaseRequiresCheckoutIssuance,
       issuanceRequiredExplicit: explicitLicenseIssuanceRequired,
       releaseLevel,
       healthUrl: licenseHealthUrl

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -199,6 +199,12 @@ const LICENSE_HEALTH_PROOF_MAX_AGE_DAYS = 30;
 const LICENSE_HEALTH_PROOF_MAX_AGE_MS = LICENSE_HEALTH_PROOF_MAX_AGE_DAYS * 24 * 60 * 60 * 1_000;
 const LICENSE_HEALTH_PROOF_MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
 const REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES = new Set(["source_checkout", "launchd_prerelease", "healthy", "published"]);
+const CHECKOUT_ISSUANCE_READY_STATE = "ready";
+const CHECKOUT_ISSUANCE_DEFERRED_STATES = new Set(["deferred", "pending_secret_and_website_publish"]);
+const CHECKOUT_ISSUANCE_STATES = new Set([
+  CHECKOUT_ISSUANCE_READY_STATE,
+  ...CHECKOUT_ISSUANCE_DEFERRED_STATES
+]);
 const GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES = new Set([
   ...REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES,
   "deferred",
@@ -589,6 +595,8 @@ export function readPublicReleaseManifestStatus(input: {
     const licenseIssuanceProofPath = readString(licenseApi.checkoutIssuanceProofPath);
     const licenseIssuanceState = readString(licenseApi.checkoutIssuanceState);
     const licenseIssuanceTrackingIssue = readString(licenseApi.checkoutIssuanceTrackingIssue);
+    const releaseLevelSupportsCheckoutIssuance =
+      releaseLevel === "stable" || releaseLevel === "beta" || releaseLevel === "source-beta";
     const licenseNeedsHealthProof = licenseRequired && licenseState === "healthy";
     const licenseHealthMetadataFailures = validateLicenseHealthMetadata({
       cwd: input.cwd,
@@ -612,9 +620,10 @@ export function readPublicReleaseManifestStatus(input: {
       cwd: input.cwd,
       issuanceUrl: licenseIssuanceUrl,
       issuanceProofPath: licenseIssuanceProofPath,
+      issuanceState: licenseIssuanceState,
       issuanceTrackingIssue: licenseIssuanceTrackingIssue,
       proofRequired: licenseNeedsIssuanceProof,
-      deferralPolicyApplies: releaseRequiresCheckoutIssuance,
+      deferralPolicyApplies: releaseLevelSupportsCheckoutIssuance,
       issuanceRequiredExplicit: explicitLicenseIssuanceRequired,
       releaseLevel,
       healthUrl: licenseHealthUrl
@@ -1126,6 +1135,7 @@ function validateLicenseIssuanceMetadata(input: {
   cwd: string;
   issuanceUrl?: string;
   issuanceProofPath?: string;
+  issuanceState?: string;
   issuanceTrackingIssue?: string;
   proofRequired: boolean;
   deferralPolicyApplies: boolean;
@@ -1137,12 +1147,23 @@ function validateLicenseIssuanceMetadata(input: {
   if (input.proofRequired && !input.issuanceUrl) {
     failures.push("checkoutIssuanceUrl must be present when validating checkout issuance proof");
   }
+  if (input.issuanceState && !CHECKOUT_ISSUANCE_STATES.has(input.issuanceState)) {
+    failures.push(
+      `checkoutIssuanceState must be one of ${Array.from(CHECKOUT_ISSUANCE_STATES).sort().join(", ")}`
+    );
+  }
   if (input.deferralPolicyApplies && input.issuanceRequiredExplicit === false) {
     if (input.releaseLevel !== "source-beta") {
       failures.push("checkoutIssuanceRequiredForThisRelease:false is only allowed for source-beta releases");
     } else if (!input.issuanceTrackingIssue) {
       failures.push("checkoutIssuanceTrackingIssue must be present when checkout issuance proof is deferred");
     }
+    if (!input.issuanceState || !CHECKOUT_ISSUANCE_DEFERRED_STATES.has(input.issuanceState)) {
+      failures.push("checkoutIssuanceState must be a deferred state when checkout issuance proof is deferred");
+    }
+  }
+  if (input.proofRequired && input.issuanceState && CHECKOUT_ISSUANCE_DEFERRED_STATES.has(input.issuanceState)) {
+    failures.push("checkoutIssuanceState must be ready when checkout issuance proof is required");
   }
   if (input.issuanceTrackingIssue) {
     const trackingIssueFailure = validateGithubIssueUrl(

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -579,25 +579,21 @@ export function readPublicReleaseManifestStatus(input: {
       : true;
     const licenseHealthProofPath = readString(licenseApi.healthProofPath);
     const licenseHealthUrl = readString(licenseApi.healthUrl);
+    const explicitLicenseIssuanceRequired = readBoolean(licenseApi.checkoutIssuanceRequiredForThisRelease);
     const licenseIssuanceRequired =
-      readBoolean(licenseApi.checkoutIssuanceRequiredForThisRelease) ?? (releaseLevel === "stable" && licenseRequired);
+      explicitLicenseIssuanceRequired ??
+      ((releaseLevel === "stable" || releaseLevel === "beta" || releaseLevel === "source-beta") && licenseRequired);
     const licenseIssuanceUrl = readString(licenseApi.checkoutIssuanceUrl);
     const licenseIssuanceProofPath = readString(licenseApi.checkoutIssuanceProofPath);
     const licenseIssuanceState = readString(licenseApi.checkoutIssuanceState);
     const licenseIssuanceTrackingIssue = readString(licenseApi.checkoutIssuanceTrackingIssue);
     const licenseNeedsHealthProof = licenseRequired && licenseState === "healthy";
-    const licenseNeedsIssuanceProof = licenseNeedsHealthProof && licenseIssuanceRequired;
-    const licenseMetadataFailures = validateLicenseHealthMetadata({
+    const licenseHealthMetadataFailures = validateLicenseHealthMetadata({
       cwd: input.cwd,
       healthUrl: licenseHealthUrl,
       healthProofPath: licenseHealthProofPath,
       proofRequired: licenseNeedsHealthProof
-    }).concat(validateLicenseIssuanceMetadata({
-      cwd: input.cwd,
-      issuanceUrl: licenseIssuanceUrl,
-      issuanceProofPath: licenseIssuanceProofPath,
-      proofRequired: licenseNeedsIssuanceProof
-    }));
+    });
     const licenseHealthProof = licenseNeedsHealthProof
       ? validateLicenseHealthProof({
           cwd: input.cwd,
@@ -607,6 +603,18 @@ export function readPublicReleaseManifestStatus(input: {
           now: input.now
         })
       : { ok: true, detail: "" };
+    const licenseHealthProofOk = licenseHealthProof.ok;
+    const licenseHealthGateOk = licenseHealthMetadataFailures.length === 0 && licenseHealthProofOk;
+    const licenseNeedsIssuanceProof = licenseNeedsHealthProof && licenseHealthGateOk && licenseIssuanceRequired;
+    const licenseIssuanceMetadataFailures = validateLicenseIssuanceMetadata({
+      cwd: input.cwd,
+      issuanceUrl: licenseIssuanceUrl,
+      issuanceProofPath: licenseIssuanceProofPath,
+      issuanceTrackingIssue: licenseIssuanceTrackingIssue,
+      proofRequired: licenseNeedsIssuanceProof,
+      healthProofRequired: licenseNeedsHealthProof && licenseHealthGateOk,
+      issuanceRequiredExplicit: explicitLicenseIssuanceRequired
+    });
     const licenseIssuanceProof = licenseNeedsIssuanceProof
       ? validateLicenseIssuanceProof({
           cwd: input.cwd,
@@ -616,8 +624,8 @@ export function readPublicReleaseManifestStatus(input: {
           now: input.now
         })
       : { ok: true, detail: "" };
-    const licenseHealthProofOk = licenseHealthProof.ok;
     const licenseIssuanceProofOk = licenseIssuanceProof.ok;
+    const licenseMetadataFailures = licenseHealthMetadataFailures.concat(licenseIssuanceMetadataFailures);
     const licenseMetadataOk = licenseMetadataFailures.length === 0;
     const licenseOk =
       isLicenseApiStateAcceptable(licenseState, licenseRequired) &&
@@ -1113,11 +1121,24 @@ function validateLicenseIssuanceMetadata(input: {
   cwd: string;
   issuanceUrl?: string;
   issuanceProofPath?: string;
+  issuanceTrackingIssue?: string;
   proofRequired: boolean;
+  healthProofRequired: boolean;
+  issuanceRequiredExplicit?: boolean;
 }): string[] {
   const failures: string[] = [];
   if (input.proofRequired && !input.issuanceUrl) {
     failures.push("checkoutIssuanceUrl must be present when validating checkout issuance proof");
+  }
+  if (input.healthProofRequired && input.issuanceRequiredExplicit === false && !input.issuanceTrackingIssue) {
+    failures.push("checkoutIssuanceTrackingIssue must be present when checkout issuance proof is deferred");
+  }
+  if (input.issuanceTrackingIssue) {
+    const trackingIssueFailure = validateGithubIssueUrl(
+      input.issuanceTrackingIssue,
+      "checkoutIssuanceTrackingIssue"
+    );
+    if (trackingIssueFailure) failures.push(trackingIssueFailure);
   }
   if (input.issuanceUrl) {
     const issuanceUrlFailure = validateLicenseIssuanceUrl(input.issuanceUrl);
@@ -1128,6 +1149,27 @@ function validateLicenseIssuanceMetadata(input: {
     if (!confinedPath.ok) failures.push(`invalid checkout issuance proof ${input.issuanceProofPath}: ${confinedPath.detail}`);
   }
   return failures;
+}
+
+function validateGithubIssueUrl(issueUrl: string, fieldName: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(issueUrl);
+  } catch {
+    return `${fieldName} must be an https GitHub issue URL with no credentials, query, or fragment`;
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.hostname !== "github.com" ||
+    !/^\/[^/]+\/[^/]+\/issues\/\d+$/.test(parsed.pathname) ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    return `${fieldName} must be an https GitHub issue URL with no credentials, query, or fragment`;
+  }
+  return undefined;
 }
 
 function validateLicenseHealthUrl(healthUrl: string): string | undefined {

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -109,12 +109,20 @@ describe("NeonDiff public release readiness", () => {
         trackingIssue?: string;
         healthUrl?: string;
         healthProofPath?: string;
+        checkoutIssuanceRequiredForThisRelease?: boolean;
+        checkoutIssuanceUrl?: string;
+        checkoutIssuanceState?: string;
+        checkoutIssuanceTrackingIssue?: string;
       };
     };
 
     expect(manifest.licenseApi).toMatchObject({
       requiredForThisRelease: true,
-      state: "healthy"
+      state: "healthy",
+      checkoutIssuanceRequiredForThisRelease: false,
+      checkoutIssuanceUrl: "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
+      checkoutIssuanceState: "pending_secret_and_website_publish",
+      checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
     });
     expect(manifest.licenseApi?.trackingIssue).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/);
     expect(manifest.licenseApi?.healthUrl).toMatch(/^https:\/\/[^/]+\/healthz$/);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1042,6 +1042,159 @@ describe("beta release status", () => {
     expect(manifest.ok).toBe(false);
   });
 
+  it("requires checkout issuance proof by default for source-beta releases", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-source-beta-issuance-default-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    const healthProofPath = writeLicenseHealthProof(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.checkoutIssuanceRequiredForThisRelease).toBe(true);
+    expect(manifest.licenseApi.detail).toContain("missing checkout issuance proof path");
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("requires a tracking issue when source-beta checkout issuance proof is deferred", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-source-beta-issuance-deferral-no-issue-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    const healthProofPath = writeLicenseHealthProof(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceRequiredForThisRelease: false,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.checkoutIssuanceRequiredForThisRelease).toBe(false);
+    expect(manifest.licenseApi.detail).toContain(
+      "checkoutIssuanceTrackingIssue must be present when checkout issuance proof is deferred"
+    );
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("requires checkout issuance proof by default for public beta releases", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-beta-issuance-default-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    const healthProofPath = writeLicenseHealthProof(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.checkoutIssuanceRequiredForThisRelease).toBe(true);
+    expect(manifest.licenseApi.detail).toContain("missing checkout issuance proof path");
+    expect(manifest.ok).toBe(false);
+  });
+
   it("requires checkout issuance proof by default for stable releases", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stable-issuance-default-"));
     roots.push(root);
@@ -1373,7 +1526,9 @@ describe("beta release status", () => {
         requiredForThisRelease: true,
         state: "healthy",
         healthUrl: "https://license.example/healthz",
-        healthProofPath: "docs/evidence/license-healthz-link.json"
+        healthProofPath: "docs/evidence/license-healthz-link.json",
+        checkoutIssuanceRequiredForThisRelease: false,
+        checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
       },
       updateChannels: {
         cli: {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -2088,7 +2088,7 @@ describe("beta release status", () => {
     expect(manifest.ok).toBe(false);
   });
 
-  it("blocks checkout issuance host validation when healthUrl is invalid", () => {
+  it("reports invalid healthUrl without blocking checkout issuance self-validation", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-issuance-invalid-health-url-"));
     roots.push(root);
     mkdirSync(join(root, "docs", "releases"), { recursive: true });
@@ -2133,10 +2133,60 @@ describe("beta release status", () => {
     });
 
     expect(manifest.licenseApi.detail).toContain("healthUrl must be an https URL ending in /healthz");
-    expect(manifest.licenseApi.detail).toContain(
-      "checkoutIssuanceUrl host cannot be validated because healthUrl is missing or invalid"
-    );
+    expect(manifest.licenseApi.detail).not.toContain("checkoutIssuanceUrl host cannot be validated");
     expect(manifest.ok).toBe(false);
+  });
+
+  it("accepts checkout issuance proof when source-beta license API health is deferred", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-issuance-proof-deferred-health-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    const checkoutIssuanceProofPath = writeLicenseIssuanceProof(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending",
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue",
+        checkoutIssuanceState: "ready",
+        checkoutIssuanceProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.ok).toBe(true);
+    expect(manifest.licenseApi.detail).toContain(`validated checkout issuance proof ${checkoutIssuanceProofPath}`);
+    expect(manifest.licenseApi.detail).not.toContain("checkoutIssuanceUrl host cannot be validated");
+    expect(manifest.ok).toBe(true);
   });
 
   it("blocks required healthy license API gates when healthProofPath leaves docs/evidence", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1139,6 +1139,7 @@ describe("beta release status", () => {
     });
 
     expect(manifest.licenseApi.checkoutIssuanceRequiredForThisRelease).toBe(false);
+    expect(manifest.licenseApi.checkoutIssuanceRequiredDeclaredForThisRelease).toBe(false);
     expect(manifest.licenseApi.detail).toContain(
       "checkoutIssuanceTrackingIssue must be present when checkout issuance proof is deferred"
     );
@@ -1248,11 +1249,65 @@ describe("beta release status", () => {
       });
 
       expect(manifest.licenseApi.checkoutIssuanceRequiredForThisRelease).toBe(true);
+      expect(manifest.licenseApi.checkoutIssuanceRequiredDeclaredForThisRelease).toBe(false);
       expect(manifest.licenseApi.detail).toContain(
         "checkoutIssuanceRequiredForThisRelease:false is only allowed for source-beta releases"
       );
       expect(manifest.ok).toBe(false);
     }
+  });
+
+  it("keeps checkout issuance deferral diagnostics visible when health proof is invalid", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-issuance-deferral-invalid-health-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0.md"), "# v1.0.0\n");
+    writeChangelogHead(root, "1.0.0", "docs/releases/v1.0.0.md");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0",
+      releaseLevel: "stable",
+      docs: {
+        version: "v1.0.0",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        checkoutIssuanceRequiredForThisRelease: false,
+        checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "published",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0"
+    });
+
+    expect(manifest.licenseApi.checkoutIssuanceRequiredForThisRelease).toBe(true);
+    expect(manifest.licenseApi.checkoutIssuanceRequiredDeclaredForThisRelease).toBe(false);
+    expect(manifest.licenseApi.detail).toContain("missing health proof path");
+    expect(manifest.licenseApi.detail).toContain(
+      "checkoutIssuanceRequiredForThisRelease:false is only allowed for source-beta releases"
+    );
+    expect(manifest.ok).toBe(false);
   });
 
   it("requires checkout issuance proof by default for stable releases", () => {
@@ -1359,6 +1414,7 @@ describe("beta release status", () => {
     expect(manifest.licenseApi).toMatchObject({
       ok: true,
       checkoutIssuanceRequiredForThisRelease: true,
+      checkoutIssuanceRequiredDeclaredForThisRelease: true,
       checkoutIssuanceProofPath
     });
     expect(manifest.licenseApi.detail).toContain(`validated checkout issuance proof ${checkoutIssuanceProofPath}`);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -927,9 +927,10 @@ describe("beta release status", () => {
     expect(manifest.licenseApi).toMatchObject({
       ok: false,
       requiredForThisRelease: true,
-      state: "pending",
-      detail: "license API state pending blocks this release; requiredForThisRelease=true"
+      state: "pending"
     });
+    expect(manifest.licenseApi.detail).toContain("license API state pending blocks this release");
+    expect(manifest.licenseApi.detail).toContain("missing checkout issuance proof path");
     expect(manifest.ok).toBe(false);
   });
 
@@ -979,9 +980,10 @@ describe("beta release status", () => {
       ok: false,
       requiredForThisRelease: true,
       state: "healthy",
-      healthProofPath: "docs/evidence/missing-health-proof.json",
-      detail: "license API state healthy blocks this release; requiredForThisRelease=true; missing health proof docs/evidence/missing-health-proof.json"
+      healthProofPath: "docs/evidence/missing-health-proof.json"
     });
+    expect(manifest.licenseApi.detail).toContain("missing health proof docs/evidence/missing-health-proof.json");
+    expect(manifest.licenseApi.detail).toContain("missing checkout issuance proof path");
     expect(manifest.ok).toBe(false);
   });
 
@@ -1250,6 +1252,55 @@ describe("beta release status", () => {
     expect(manifest.ok).toBe(false);
   });
 
+  it("honors explicit source-beta checkout issuance requirement when the license API is deferred", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-source-beta-license-deferred-issuance-required-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending",
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.checkoutIssuanceRequiredForThisRelease).toBe(true);
+    expect(manifest.licenseApi.checkoutIssuanceRequiredDeclaredForThisRelease).toBe(true);
+    expect(manifest.licenseApi.detail).toContain("missing checkout issuance proof path");
+    expect(manifest.ok).toBe(false);
+  });
+
   it("requires checkout issuance proof by default for public beta releases", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-beta-issuance-default-"));
     roots.push(root);
@@ -1411,6 +1462,55 @@ describe("beta release status", () => {
     expect(manifest.licenseApi.detail).toContain(
       "checkoutIssuanceRequiredForThisRelease:false is only allowed for source-beta releases"
     );
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("keeps required checkout issuance proof diagnostics visible when health proof is invalid", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-issuance-required-invalid-health-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "not-a-healthz-url",
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.detail).toContain("healthUrl must be an https URL ending in /healthz");
+    expect(manifest.licenseApi.detail).toContain("missing checkout issuance proof path");
     expect(manifest.ok).toBe(false);
   });
 
@@ -1965,9 +2065,12 @@ describe("beta release status", () => {
       ok: false,
       requiredForThisRelease: true,
       state: "healthy",
-      healthProofPath,
-      detail: "license API state healthy blocks this release; requiredForThisRelease=true; invalid health proof operator-local-proof.json: healthProofPath must be relative and stay within docs/evidence"
+      healthProofPath
     });
+    expect(manifest.licenseApi.detail).toContain(
+      "invalid health proof operator-local-proof.json: healthProofPath must be relative and stay within docs/evidence"
+    );
+    expect(manifest.licenseApi.detail).toContain("missing checkout issuance proof path");
     expect(manifest.ok).toBe(false);
   });
 
@@ -2223,9 +2326,12 @@ describe("beta release status", () => {
       ok: false,
       requiredForThisRelease: true,
       state: "healthy",
-      healthProofPath: "docs/evidence/not-json.json",
-      detail: "license API state healthy blocks this release; requiredForThisRelease=true; invalid health proof docs/evidence/not-json.json: proof JSON is invalid"
+      healthProofPath: "docs/evidence/not-json.json"
     });
+    expect(manifest.licenseApi.detail).toContain(
+      "invalid health proof docs/evidence/not-json.json: proof JSON is invalid"
+    );
+    expect(manifest.licenseApi.detail).toContain("missing checkout issuance proof path");
     expect(manifest.ok).toBe(false);
   });
 
@@ -2569,11 +2675,10 @@ describe("beta release status", () => {
     });
 
     expect(status.ok).toBe(false);
-    expect(status.gates).toContainEqual({
-      name: "public_license_api_state",
-      ok: false,
-      detail: "license API state unknown blocks this release; requiredForThisRelease=true"
-    });
+    const licenseGate = status.gates.find((gate) => gate.name === "public_license_api_state");
+    expect(licenseGate).toMatchObject({ name: "public_license_api_state", ok: false });
+    expect(licenseGate?.detail).toContain("license API state unknown blocks this release");
+    expect(licenseGate?.detail).toContain("missing checkout issuance proof path");
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
       ok: false,

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1472,6 +1472,57 @@ describe("beta release status", () => {
     expect(manifest.ok).toBe(false);
   });
 
+  it("blocks checkout issuance host validation when healthUrl is invalid", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-issuance-invalid-health-url-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "pending",
+        healthUrl: "not-a-healthz-url",
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.detail).toContain("healthUrl must be an https URL ending in /healthz");
+    expect(manifest.licenseApi.detail).toContain(
+      "checkoutIssuanceUrl host cannot be validated because healthUrl is missing or invalid"
+    );
+    expect(manifest.ok).toBe(false);
+  });
+
   it("blocks required healthy license API gates when healthProofPath leaves docs/evidence", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-outside-health-proof-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -199,7 +199,10 @@ describe("beta release status", () => {
       licenseApi: {
         requiredForThisRelease: false,
         state: "pending",
-        trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot/issues/111"
+        trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot/issues/111",
+        checkoutIssuanceRequiredForThisRelease: false,
+        checkoutIssuanceState: "pending_secret_and_website_publish",
+        checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot/issues/111"
       },
       updateChannels: {
         cli: {
@@ -606,7 +609,10 @@ describe("beta release status", () => {
         requiredForThisRelease: false,
         state: "pending",
         healthUrl: "https://license.example/healthz",
-        healthProofPath: "docs/evidence/retained-health-proof.json"
+        healthProofPath: "docs/evidence/retained-health-proof.json",
+        checkoutIssuanceRequiredForThisRelease: false,
+        checkoutIssuanceState: "pending_secret_and_website_publish",
+        checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
       },
       updateChannels: {
         cli: {
@@ -1196,6 +1202,54 @@ describe("beta release status", () => {
     expect(manifest.licenseApi.detail).toContain(
       "checkoutIssuanceTrackingIssue must be present when checkout issuance proof is deferred"
     );
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("requires checkout issuance proof by default when source-beta license API is deferred and issuance declaration is omitted", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-source-beta-license-deferred-issuance-default-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.checkoutIssuanceRequiredForThisRelease).toBe(true);
+    expect(manifest.licenseApi.checkoutIssuanceRequiredDeclaredForThisRelease).toBeUndefined();
+    expect(manifest.licenseApi.detail).toContain("missing checkout issuance proof path");
+    expect(manifest.licenseApi.detail).toContain("checkoutIssuanceUrl must be present");
     expect(manifest.ok).toBe(false);
   });
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1310,6 +1310,58 @@ describe("beta release status", () => {
     expect(manifest.ok).toBe(false);
   });
 
+  it("keeps checkout issuance deferral diagnostics visible when license state is pending", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-issuance-deferral-pending-state-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0.md"), "# v1.0.0\n");
+    writeChangelogHead(root, "1.0.0", "docs/releases/v1.0.0.md");
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0",
+      releaseLevel: "stable",
+      docs: {
+        version: "v1.0.0",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "pending",
+        healthUrl: "https://license.example/healthz",
+        checkoutIssuanceRequiredForThisRelease: false,
+        checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "published",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0"
+    });
+
+    expect(manifest.licenseApi.checkoutIssuanceRequiredForThisRelease).toBe(true);
+    expect(manifest.licenseApi.checkoutIssuanceRequiredDeclaredForThisRelease).toBe(false);
+    expect(manifest.licenseApi.detail).toContain(
+      "checkoutIssuanceRequiredForThisRelease:false is only allowed for source-beta releases"
+    );
+    expect(manifest.ok).toBe(false);
+  });
+
   it("requires checkout issuance proof by default for stable releases", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stable-issuance-default-"));
     roots.push(root);
@@ -1420,6 +1472,188 @@ describe("beta release status", () => {
     expect(manifest.licenseApi.detail).toContain(`validated checkout issuance proof ${checkoutIssuanceProofPath}`);
     expect(JSON.stringify(manifest)).not.toMatch(/nd_live_|LICENSE_ISSUANCE_SECRET|Bearer /);
     expect(manifest.ok).toBe(true);
+  });
+
+  it("blocks stale or future checkout issuance proofs when release-status supplies a run timestamp", () => {
+    for (const scenario of [
+      {
+        suffix: "stale",
+        observedAt: "2026-06-06T23:59:59.000Z",
+        expectedDetail: "observedAt must be no older than 30 days"
+      },
+      {
+        suffix: "future",
+        observedAt: "2026-07-07T00:06:00.000Z",
+        expectedDetail: "observedAt must not be more than 5 minutes in the future"
+      }
+    ]) {
+      const root = mkdtempSync(join(tmpdir(), `public-release-manifest-${scenario.suffix}-issuance-proof-`));
+      roots.push(root);
+      mkdirSync(join(root, "docs", "releases"), { recursive: true });
+      writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+      writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+      writeChangelogHead(root);
+      const healthProofPath = writeLicenseHealthProof(root, {
+        observedAt: "2026-07-07T00:00:00.000Z"
+      });
+      const checkoutIssuanceProofPath = writeLicenseIssuanceProof(root, {
+        observedAt: scenario.observedAt
+      });
+      writeFileSync(join(root, "public-release.json"), JSON.stringify({
+        version: "v1.0.0-beta.1",
+        releaseLevel: "source-beta",
+        docs: {
+          version: "v1.0.0-beta.1",
+          setupPath: "docs/SETUP.md",
+          releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+        },
+        licenseApi: {
+          requiredForThisRelease: true,
+          state: "healthy",
+          healthUrl: "https://license.example/healthz",
+          healthProofPath,
+          checkoutIssuanceRequiredForThisRelease: true,
+          checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue",
+          checkoutIssuanceProofPath
+        },
+        updateChannels: {
+          cli: {
+            requiredForThisRelease: true,
+            state: "source_checkout",
+            version: "v1.0.0-beta.1",
+            rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+          },
+          daemon: {
+            requiredForThisRelease: true,
+            state: "launchd_prerelease",
+            version: "v1.0.0-beta.1",
+            rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+          }
+        }
+      }));
+
+      const manifest = readPublicReleaseManifestStatus({
+        cwd: root,
+        manifestPath: "public-release.json",
+        expectedVersion: "v1.0.0-beta.1",
+        now: new Date("2026-07-07T00:00:00.000Z")
+      });
+
+      expect(manifest.licenseApi.detail).toContain(scenario.expectedDetail);
+      expect(manifest.ok).toBe(false);
+    }
+  });
+
+  it("blocks checkout issuance proof paths that leave docs/evidence", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-outside-issuance-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    const healthProofPath = writeLicenseHealthProof(root);
+    const checkoutIssuanceProofPath = writeLicenseIssuanceProof(root, {
+      path: "operator-local-proof.json"
+    });
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue",
+        checkoutIssuanceProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.detail).toContain(
+      "invalid checkout issuance proof operator-local-proof.json: checkoutIssuanceProofPath must be relative and stay within docs/evidence"
+    );
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("blocks tampered checkout issuance proof bodies", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-tampered-issuance-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    const healthProofPath = writeLicenseHealthProof(root);
+    const checkoutIssuanceProofPath = writeLicenseIssuanceProof(root, {
+      responseBody: "{\"status\":\"forbidden\"}",
+      responseBodySha256: "not-the-body-hash"
+    });
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue",
+        checkoutIssuanceProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.detail).toContain("responseBodySha256 must match responseBody");
+    expect(manifest.licenseApi.detail).toContain("responseBody.status must be unauthorized");
+    expect(manifest.ok).toBe(false);
   });
 
   it("blocks checkout issuance URLs that do not match the license health host", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -62,6 +62,40 @@ describe("beta release status", () => {
     return proofPath;
   }
 
+  function writeLicenseIssuanceProof(root: string, options: {
+    evidenceKind?: string;
+    releaseVersion?: string;
+    observedAt?: string;
+    method?: string;
+    url?: string;
+    statusCode?: number;
+    responseBody?: string;
+    responseBodySha256?: string;
+    captureContext?: Record<string, unknown>;
+    path?: string;
+  } = {}): string {
+    const proofPath = options.path ?? "docs/evidence/license-checkout-issuance.json";
+    const responseBody = options.responseBody ?? "{\"status\":\"unauthorized\",\"detail\":\"license issuance authorization failed\"}";
+    mkdirSync(dirname(join(root, proofPath)), { recursive: true });
+    writeFileSync(join(root, proofPath), JSON.stringify({
+      evidenceKind: options.evidenceKind ?? "license_api_checkout_issuance",
+      releaseVersion: options.releaseVersion ?? "v1.0.0-beta.1",
+      observedAt: options.observedAt ?? new Date().toISOString(),
+      method: options.method ?? "POST",
+      url: options.url ?? "https://license.example/v1/admin/licenses/issue",
+      statusCode: options.statusCode ?? 401,
+      responseBody,
+      responseBodySha256: options.responseBodySha256 ?? createHash("sha256").update(responseBody).digest("hex"),
+      captureContext: options.captureContext ?? {
+        tool: "curl",
+        transport: "https",
+        tlsValidation: "curl default CA validation",
+        capturedFrom: "test runner"
+      }
+    }));
+    return proofPath;
+  }
+
   function writeChangelogHead(root: string, version = "1.0.0-beta.1", releaseNotesPath = `docs/releases/v${version}.md`): void {
     writeFileSync(join(root, "CHANGELOG.md"), [
       "# Changelog",
@@ -267,7 +301,11 @@ describe("beta release status", () => {
         requiredForThisRelease: true,
         state: "healthy",
         healthUrl: "https://neondiff-license.fly.dev/healthz",
-        healthProofPath: "docs/evidence/v0.4.45-beta.1-license-api-healthz.json"
+        healthProofPath: "docs/evidence/v0.4.45-beta.1-license-api-healthz.json",
+        checkoutIssuanceRequiredForThisRelease: false,
+        checkoutIssuanceUrl: "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
+        checkoutIssuanceState: "pending_secret_and_website_publish",
+        checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
       },
       updateChannels: {
         ok: true
@@ -945,6 +983,174 @@ describe("beta release status", () => {
       detail: "license API state healthy blocks this release; requiredForThisRelease=true; missing health proof docs/evidence/missing-health-proof.json"
     });
     expect(manifest.ok).toBe(false);
+  });
+
+  it("blocks checkout issuance gates when required but no proof is committed", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-missing-issuance-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    const healthProofPath = writeLicenseHealthProof(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi).toMatchObject({
+      ok: false,
+      requiredForThisRelease: true,
+      state: "healthy",
+      checkoutIssuanceRequiredForThisRelease: true,
+      checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue"
+    });
+    expect(manifest.licenseApi.detail).toContain("missing checkout issuance proof path");
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("requires checkout issuance proof by default for stable releases", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stable-issuance-default-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0.md"), "# v1.0.0\n");
+    writeChangelogHead(root, "1.0.0", "docs/releases/v1.0.0.md");
+    const healthProofPath = writeLicenseHealthProof(root, {
+      releaseVersion: "v1.0.0",
+      url: "https://license.example/healthz"
+    });
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0",
+      releaseLevel: "stable",
+      docs: {
+        version: "v1.0.0",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "published",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.45-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.45-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0"
+    });
+
+    expect(manifest.licenseApi.checkoutIssuanceRequiredForThisRelease).toBe(true);
+    expect(manifest.licenseApi.detail).toContain("missing checkout issuance proof path");
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("accepts required checkout issuance proof without exposing a raw license key", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-valid-issuance-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    const healthProofPath = writeLicenseHealthProof(root);
+    const checkoutIssuanceProofPath = writeLicenseIssuanceProof(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue",
+        checkoutIssuanceProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi).toMatchObject({
+      ok: true,
+      checkoutIssuanceRequiredForThisRelease: true,
+      checkoutIssuanceProofPath
+    });
+    expect(manifest.licenseApi.detail).toContain(`validated checkout issuance proof ${checkoutIssuanceProofPath}`);
+    expect(JSON.stringify(manifest)).not.toMatch(/nd_live_|LICENSE_ISSUANCE_SECRET|Bearer /);
+    expect(manifest.ok).toBe(true);
   });
 
   it("blocks required healthy license API gates when healthProofPath leaves docs/evidence", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1737,6 +1737,70 @@ describe("beta release status", () => {
     expect(manifest.ok).toBe(true);
   });
 
+  it("accepts valid checkout issuance proof for stable and beta releases", () => {
+    for (const releaseLevel of ["stable", "beta"]) {
+      const releaseVersion = releaseLevel === "stable" ? "v1.0.0" : "v1.0.0-beta.1";
+      const changelogVersion = releaseVersion.replace(/^v/, "");
+      const root = mkdtempSync(join(tmpdir(), `public-release-manifest-${releaseLevel}-valid-issuance-proof-`));
+      roots.push(root);
+      mkdirSync(join(root, "docs", "releases"), { recursive: true });
+      writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+      writeFileSync(join(root, "docs", "releases", `${releaseVersion}.md`), `# ${releaseVersion}\n`);
+      writeChangelogHead(root, changelogVersion, `docs/releases/${releaseVersion}.md`);
+      const healthProofPath = writeLicenseHealthProof(root, {
+        releaseVersion,
+        url: "https://license.example/healthz"
+      });
+      const checkoutIssuanceProofPath = writeLicenseIssuanceProof(root, {
+        releaseVersion,
+        url: "https://license.example/v1/admin/licenses/issue"
+      });
+      writeFileSync(join(root, "public-release.json"), JSON.stringify({
+        version: releaseVersion,
+        releaseLevel,
+        docs: {
+          version: releaseVersion,
+          setupPath: "docs/SETUP.md",
+          releaseNotesPath: `docs/releases/${releaseVersion}.md`
+        },
+        licenseApi: {
+          requiredForThisRelease: true,
+          state: "healthy",
+          healthUrl: "https://license.example/healthz",
+          healthProofPath,
+          checkoutIssuanceRequiredForThisRelease: true,
+          checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue",
+          checkoutIssuanceState: "ready",
+          checkoutIssuanceProofPath
+        },
+        updateChannels: {
+          cli: {
+            requiredForThisRelease: true,
+            state: releaseLevel === "stable" ? "published" : "source_checkout",
+            version: releaseVersion,
+            rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+          },
+          daemon: {
+            requiredForThisRelease: true,
+            state: "launchd_prerelease",
+            version: releaseVersion,
+            rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+          }
+        }
+      }));
+
+      const manifest = readPublicReleaseManifestStatus({
+        cwd: root,
+        manifestPath: "public-release.json",
+        expectedVersion: releaseVersion
+      });
+
+      expect(manifest.licenseApi.ok).toBe(true);
+      expect(manifest.licenseApi.detail).toContain(`validated checkout issuance proof ${checkoutIssuanceProofPath}`);
+      expect(manifest.ok).toBe(true);
+    }
+  });
+
   it("blocks deferred checkout issuance state when proof is required", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-required-issuance-deferred-state-"));
     roots.push(root);

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1146,6 +1146,110 @@ describe("beta release status", () => {
     expect(manifest.ok).toBe(false);
   });
 
+  it("requires a tracking issue when source-beta license and checkout issuance are both deferred", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-source-beta-license-issuance-deferred-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending",
+        checkoutIssuanceRequiredForThisRelease: false,
+        checkoutIssuanceState: "pending_secret_and_website_publish"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.checkoutIssuanceRequiredForThisRelease).toBe(false);
+    expect(manifest.licenseApi.checkoutIssuanceRequiredDeclaredForThisRelease).toBe(false);
+    expect(manifest.licenseApi.detail).toContain(
+      "checkoutIssuanceTrackingIssue must be present when checkout issuance proof is deferred"
+    );
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("requires checkout issuance state to match explicit source-beta deferral", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-source-beta-issuance-deferral-ready-state-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    const healthProofPath = writeLicenseHealthProof(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceRequiredForThisRelease: false,
+        checkoutIssuanceState: "ready",
+        checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.detail).toContain(
+      "checkoutIssuanceState must be a deferred state when checkout issuance proof is deferred"
+    );
+    expect(manifest.ok).toBe(false);
+  });
+
   it("requires checkout issuance proof by default for public beta releases", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-beta-issuance-default-"));
     roots.push(root);
@@ -1439,6 +1543,7 @@ describe("beta release status", () => {
         healthProofPath,
         checkoutIssuanceRequiredForThisRelease: true,
         checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue",
+        checkoutIssuanceState: "ready",
         checkoutIssuanceProofPath
       },
       updateChannels: {
@@ -1467,11 +1572,67 @@ describe("beta release status", () => {
       ok: true,
       checkoutIssuanceRequiredForThisRelease: true,
       checkoutIssuanceRequiredDeclaredForThisRelease: true,
+      checkoutIssuanceState: "ready",
       checkoutIssuanceProofPath
     });
     expect(manifest.licenseApi.detail).toContain(`validated checkout issuance proof ${checkoutIssuanceProofPath}`);
     expect(JSON.stringify(manifest)).not.toMatch(/nd_live_|LICENSE_ISSUANCE_SECRET|Bearer /);
     expect(manifest.ok).toBe(true);
+  });
+
+  it("blocks deferred checkout issuance state when proof is required", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-required-issuance-deferred-state-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    const healthProofPath = writeLicenseHealthProof(root);
+    const checkoutIssuanceProofPath = writeLicenseIssuanceProof(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue",
+        checkoutIssuanceState: "pending_secret_and_website_publish",
+        checkoutIssuanceProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.detail).toContain(
+      "checkoutIssuanceState must be ready when checkout issuance proof is required"
+    );
+    expect(manifest.ok).toBe(false);
   });
 
   it("blocks stale or future checkout issuance proofs when release-status supplies a run timestamp", () => {
@@ -1979,6 +2140,7 @@ describe("beta release status", () => {
         healthUrl: "https://license.example/healthz",
         healthProofPath: "docs/evidence/license-healthz-link.json",
         checkoutIssuanceRequiredForThisRelease: false,
+        checkoutIssuanceState: "pending_secret_and_website_publish",
         checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
       },
       updateChannels: {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1195,6 +1195,66 @@ describe("beta release status", () => {
     expect(manifest.ok).toBe(false);
   });
 
+  it("blocks stable and beta releases from deferring checkout issuance with only a tracking issue", () => {
+    for (const releaseLevel of ["stable", "beta"]) {
+      const releaseVersion = releaseLevel === "stable" ? "v1.0.0" : "v1.0.0-beta.1";
+      const changelogVersion = releaseVersion.replace(/^v/, "");
+      const root = mkdtempSync(join(tmpdir(), `public-release-manifest-${releaseLevel}-issuance-deferral-`));
+      roots.push(root);
+      mkdirSync(join(root, "docs", "releases"), { recursive: true });
+      writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+      writeFileSync(join(root, "docs", "releases", `${releaseVersion}.md`), `# ${releaseVersion}\n`);
+      writeChangelogHead(root, changelogVersion, `docs/releases/${releaseVersion}.md`);
+      const healthProofPath = writeLicenseHealthProof(root, {
+        releaseVersion,
+        url: "https://license.example/healthz"
+      });
+      writeFileSync(join(root, "public-release.json"), JSON.stringify({
+        version: releaseVersion,
+        releaseLevel,
+        docs: {
+          version: releaseVersion,
+          setupPath: "docs/SETUP.md",
+          releaseNotesPath: `docs/releases/${releaseVersion}.md`
+        },
+        licenseApi: {
+          requiredForThisRelease: true,
+          state: "healthy",
+          healthUrl: "https://license.example/healthz",
+          healthProofPath,
+          checkoutIssuanceRequiredForThisRelease: false,
+          checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
+        },
+        updateChannels: {
+          cli: {
+            requiredForThisRelease: true,
+            state: releaseLevel === "stable" ? "published" : "source_checkout",
+            version: releaseVersion,
+            rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+          },
+          daemon: {
+            requiredForThisRelease: true,
+            state: "launchd_prerelease",
+            version: releaseVersion,
+            rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+          }
+        }
+      }));
+
+      const manifest = readPublicReleaseManifestStatus({
+        cwd: root,
+        manifestPath: "public-release.json",
+        expectedVersion: releaseVersion
+      });
+
+      expect(manifest.licenseApi.checkoutIssuanceRequiredForThisRelease).toBe(true);
+      expect(manifest.licenseApi.detail).toContain(
+        "checkoutIssuanceRequiredForThisRelease:false is only allowed for source-beta releases"
+      );
+      expect(manifest.ok).toBe(false);
+    }
+  });
+
   it("requires checkout issuance proof by default for stable releases", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stable-issuance-default-"));
     roots.push(root);
@@ -1304,6 +1364,56 @@ describe("beta release status", () => {
     expect(manifest.licenseApi.detail).toContain(`validated checkout issuance proof ${checkoutIssuanceProofPath}`);
     expect(JSON.stringify(manifest)).not.toMatch(/nd_live_|LICENSE_ISSUANCE_SECRET|Bearer /);
     expect(manifest.ok).toBe(true);
+  });
+
+  it("blocks checkout issuance URLs that do not match the license health host", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-issuance-host-mismatch-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    const healthProofPath = writeLicenseHealthProof(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://other-license.example/v1/admin/licenses/issue"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1"
+    });
+
+    expect(manifest.licenseApi.detail).toContain("checkoutIssuanceUrl host must match healthUrl host license.example");
+    expect(manifest.ok).toBe(false);
   });
 
   it("blocks required healthy license API gates when healthProofPath leaves docs/evidence", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1462,6 +1462,9 @@ describe("beta release status", () => {
       expect(manifest.licenseApi.detail).toContain(
         "checkoutIssuanceRequiredForThisRelease:false is only allowed for source-beta releases"
       );
+      expect(manifest.licenseApi.detail).not.toContain(
+        "checkoutIssuanceState must be a deferred state when checkout issuance proof is deferred"
+      );
       expect(manifest.ok).toBe(false);
     }
   });


### PR DESCRIPTION
## Summary
- Add release-status validation for checkout issuance readiness separate from license API healthz
- Require checkout issuance proof by default for stable/GA releases while allowing source-beta releases to explicitly defer it
- Update the public release manifest and runbooks to record #421 as the deferred paid/trial activation proof lane

## Why
`GET /healthz` can be green while `POST /v1/admin/licenses/issue` is still unconfigured. This adds a release gate so future GA/purchase-path releases need non-secret checkout issuance proof instead of treating healthz as enough.

## Validation
- `npm test -- --pool=forks --maxWorkers=1 tests/release-status.test.ts tests/public-release-readiness.test.ts`
- `npm run build`
- `git diff --check`
- Direct manifest read: `readPublicReleaseManifestStatus(...)` reports `checkoutIssuanceRequiredForThisRelease: false` and `checkoutIssuanceTrackingIssue: #421` for current `v0.4.45-beta.1`

Refs #421