### PR TITLE
Add NeonDiff GitHub App env aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,10 @@ If you are a coding agent working in this repository:
 8. Do not restart launchd, promote a live beta, expand GitHub App permissions,
    flip repo visibility, publish packages, or create GitHub Releases unless the
    issue explicitly scopes that action.
-9. Update the issue before handoff, merge, pause, or external-review wait.
+9. For setup or GitHub App setup changes, update README.md,
+   docs/SETUP.md, docs/github-app-setup.md, and the website onboarding copy in
+   the current website repo before claiming the first-run path is fixed.
+10. Update the issue before handoff, merge, pause, or external-review wait.
 
 ## Source-Available Product Boundary
 
@@ -41,7 +44,9 @@ CodeRabbit parity, enterprise readiness, or legal adequacy from this file.
 - The NeonDiff public product roadmap is #103.
 - Public CLI/package setup is #107 and release-readiness packaging is #232.
 - Agent-first docs are #113.
-- Website changes live in `electricsheephq/neon-diff-agent`, not this repo.
+- Website changes currently live in `electricsheephq/neon-diff-agent-website`,
+  not this repo. Verify the active website repo before editing because older
+  marketing clones may still exist locally.
 - Before merge, release, or readiness claims, query current-head review threads
   and separate resolvable review threads from top-level bot comments and check
   annotations.

--- a/README.md
+++ b/README.md
@@ -106,13 +106,18 @@ version is:
 
 ```bash
 neondiff init --config config.local.json
-export EVAOS_REVIEW_BOT_APP_ID="<github-app-id>"
-export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
+export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
+export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 neondiff doctor github --config config.local.json --json
 neondiff providers list --config config.local.json --json
 neondiff providers doctor --config config.local.json --json
 neondiff doctor --config config.local.json --json
 ```
+
+Create or install the GitHub App before expecting PR reviews to run. The App
+must be installed on the same selected repositories listed in `pilotRepos`; see
+[docs/github-app-setup.md](docs/github-app-setup.md) for the permission set and
+selected-repo install path.
 
 Do not store the GitHub App private key, provider API key, license key, tokens,
 or customer data in this repository. Keep local config, secrets, state DBs, and

--- a/config.active-profiles.example.json
+++ b/config.active-profiles.example.json
@@ -64,7 +64,7 @@
   "commands": {
     "enabled": false,
     "botMentions": [
-      "@evaos-code-review-bot"
+      "@neondiff"
     ],
     "trustedAuthors": [
       "100yenadmin"

--- a/config.example.json
+++ b/config.example.json
@@ -165,7 +165,7 @@
   },
   "commands": {
     "enabled": false,
-    "botMentions": ["@evaos-code-review-bot"],
+    "botMentions": ["@neondiff"],
     "trustedAuthors": ["100yenadmin"],
     "acknowledge": false
   },
@@ -305,8 +305,8 @@
     "retryMaxRetries": 0
   },
   "github": {
-    "appId": "set via EVAOS_REVIEW_BOT_APP_ID",
-    "privateKeyPath": "set via EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH",
+    "appId": "set via NEONDIFF_GITHUB_APP_ID",
+    "privateKeyPath": "set via NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH",
     "token": "optional fallback token for local development only"
   }
 }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -91,8 +91,8 @@ be enabled just because a repo is monitored:
 Save the generated private key outside the repository.
 
 ```bash
-export EVAOS_REVIEW_BOT_APP_ID="<github-app-id>"
-export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
+export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
+export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 ```
 
 ## 3. Configure Provider And License
@@ -310,10 +310,10 @@ set.
 
 | Variable | Read by | Overrides config value | Notes |
 | --- | --- | --- | --- |
-| `EVAOS_REVIEW_BOT_APP_ID` | `loadConfig`/`loadConfigFromObject` (`src/config.ts`) | `github.appId` | Set once per step 2; unset falls back to the config-file value. |
-| `EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH` | `loadConfig`/`loadConfigFromObject` (`src/config.ts`) | `github.privateKeyPath` | Path to the GitHub App private key; keep the key itself outside the repo. |
+| `NEONDIFF_GITHUB_APP_ID` | `loadConfig`/`loadConfigFromObject` (`src/config.ts`) | `github.appId` | Set once per step 2; unset falls back to the config-file value. Legacy `EVAOS_REVIEW_BOT_APP_ID` remains supported for existing internal deployments. |
+| `NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH` | `loadConfig`/`loadConfigFromObject` (`src/config.ts`) | `github.privateKeyPath` | Path to the GitHub App private key; keep the key itself outside the repo. Legacy `EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH` remains supported for existing internal deployments. |
 | `GITHUB_TOKEN` | `loadConfig`/`loadConfigFromObject` (`src/config.ts`) | `github.token` | Local-development fallback token only; App auth is required for App-authored posting. |
-| `EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT` | `getProtectedCheckoutRoots` (`src/path-safety.ts`) | Adds to the built-in checkout-isolation boundary | Advanced use only: an additional path `config.workRoot` must stay outside of, alongside the current package checkout. Unset by default. |
+| `NEONDIFF_PROTECTED_CHECKOUT_ROOT` | `getProtectedCheckoutRoots` (`src/path-safety.ts`) | Adds to the built-in checkout-isolation boundary | Advanced use only: an additional path `config.workRoot` must stay outside of, alongside the current package checkout. Legacy `EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT` remains supported for existing internal deployments. |
 | `NEONDIFF_ALLOW_REMOTE_SMOKE` | `providers doctor` remote smoke path (`src/providers.ts`) | N/A (opt-in gate, not a config override) | Required before a hosted (non-loopback) provider smoke check is allowed to run. See [docs/providers.md](providers.md). |
 | A provider's configured `apiKeyEnv` name (e.g. `ANTHROPIC_API_KEY`, `NEONDIFF_PROVIDER_API_KEY`) | Provider adapters for any `authMode: "api-key-env"` provider (`src/providers.ts`, `src/provider-adapters.ts`) | N/A (the config only stores the variable *name*, never the key) | Applies to `anthropic`, `openai`, and `openai-compatible` adapters. See [docs/providers.md](providers.md) for the per-provider list. |
 

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -14,7 +14,7 @@ The beta release unit is:
 - evidence root: `/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/`
 
 Packaged or non-source deployments must set
-`EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT` to the live operator checkout so
+`NEONDIFF_PROTECTED_CHECKOUT_ROOT` to the live operator checkout so
 review mirrors and worktrees cannot be planned inside or above that checkout.
 
 The beta release unit does not include expanding monitored repos, GitHub App

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -57,8 +57,8 @@ because milestone or planning days can create large issue bursts.
 Keep the private key and local config out of git. A typical shell setup is:
 
 ```bash
-export EVAOS_REVIEW_BOT_APP_ID="<github-app-id>"
-export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
+export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
+export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 ```
 
 ## Verify Installation
@@ -155,8 +155,10 @@ To remove NeonDiff from a user or organization:
 ## Troubleshooting
 
 - `doctor github` reports `readMode: "unconfigured"`: set
-  `EVAOS_REVIEW_BOT_APP_ID` and `EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH`, or set
+  `NEONDIFF_GITHUB_APP_ID` and `NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH`, or set
   `github.appId` and `github.privateKeyPath` in an untracked local config.
+  Legacy `EVAOS_REVIEW_BOT_*` aliases remain supported for existing internal
+  deployments, but new public setup should use the NeonDiff names.
 - `doctor github` reports `fallback_token`: the worker can use a token for
   local reads, but it cannot prove App-authored review posting.
 - A repo read fails with 404 or "Resource not accessible by integration":

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -5,18 +5,18 @@ Launchd should stay disabled until GitHub App installation is complete and a rea
 Recommended first live command:
 
 ```bash
-cd /Volumes/LEXAR/repos/evaos-code-review-bot
-export EVAOS_REVIEW_BOT_APP_ID=4184532
-export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH=/Volumes/LEXAR/Codex/evaos-code-review-bot/secrets/evaos-code-review-bot.private-key.pem
-npm run run-once -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-dry-run.json --dry-run true --repo electricsheephq/WorldOS --pr 1161
+cd /path/to/neondiff
+export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
+export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
+npm run run-once -- --config /absolute/path/to/config.local.json --dry-run true --repo owner/repo --pr 123
 ```
 
 After the GitHub App is installed, use app credentials and keep `--dry-run true` for the first observation window:
 
 ```bash
-export EVAOS_REVIEW_BOT_APP_ID=4184532
-export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH=/Volumes/LEXAR/Codex/evaos-code-review-bot/secrets/evaos-code-review-bot.private-key.pem
-npm run daemon -- --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/canary-dry-run.json --dry-run true
+export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
+export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
+npm run daemon -- --config /absolute/path/to/config.local.json --dry-run true
 ```
 
 When installed as a LaunchAgent, write stdout/stderr to `~/Library/Logs/evaos-code-review-bot/`. On this Mac, launchd failed with `EX_CONFIG` when those paths pointed directly at the Lexar volume; copy the local launch logs into the Lexar evidence packet after each proof window.
@@ -32,10 +32,10 @@ Minimum LaunchAgent environment block:
 ```xml
 <key>EnvironmentVariables</key>
 <dict>
-  <key>EVAOS_REVIEW_BOT_APP_ID</key>
+  <key>NEONDIFF_GITHUB_APP_ID</key>
   <string>&lt;github-app-id&gt;</string>
-  <key>EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH</key>
-  <string>/absolute/path/to/evaos-code-review-bot.private-key.pem</string>
+  <key>NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH</key>
+  <string>/absolute/path/to/neondiff.private-key.pem</string>
   <key>NODE_OPTIONS</key>
   <string>--use-system-ca</string>
 </dict>

--- a/docs/maintainer-commands.md
+++ b/docs/maintainer-commands.md
@@ -11,7 +11,7 @@ Commands are disabled by default:
 {
   "commands": {
     "enabled": false,
-    "botMentions": ["@evaos-code-review-bot"],
+    "botMentions": ["@neondiff"],
     "trustedAuthors": ["100yenadmin"],
     "acknowledge": false
   }
@@ -25,25 +25,24 @@ comment-volume behavior are verified.
 
 Each command must appear as its own trimmed line in a PR comment:
 
-- `@evaos-code-review-bot review`
-- `@evaos-code-review-bot re-review`
-- `@evaos-code-review-bot explain`
-- `@evaos-code-review-bot stop`
-- `@evaos-code-review-bot generate tests`
-- `@evaos-code-review-bot draft tests`
-- `@evaos-code-review-bot generate docs`
-- `@evaos-code-review-bot draft docs`
-- `@evaos-code-review-bot generate docstrings`
-- `@evaos-code-review-bot simplify suggestion`
-- `@evaos-code-review-bot changelog draft`
-- `@evaos-code-review-bot draft changelog`
-- `@evaos-code-review-bot explain risk`
-- `@evaos-code-review-bot make review-ready`
+- `@neondiff review`
+- `@neondiff re-review`
+- `@neondiff explain`
+- `@neondiff stop`
+- `@neondiff generate tests`
+- `@neondiff draft tests`
+- `@neondiff generate docs`
+- `@neondiff draft docs`
+- `@neondiff generate docstrings`
+- `@neondiff simplify suggestion`
+- `@neondiff changelog draft`
+- `@neondiff draft changelog`
+- `@neondiff explain risk`
+- `@neondiff make review-ready`
 
-The public `@neondiff` mention uses the same parser when it is present in
-`commands.botMentions`, including `@neondiff review`, `@neondiff draft tests`,
-`@neondiff draft docs`, `@neondiff draft changelog`, and
-`@neondiff explain risk`.
+Existing internal deployments may keep their current bot mention in
+`commands.botMentions`; new public setup should use the NeonDiff mention or the
+actual GitHub App slug chosen during installation.
 
 `review` and `re-review` route into the same ZCode review pipeline used by
 polling. They still use the current PR head SHA, current RIGHT-side diff-line

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -198,8 +198,8 @@ launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
 Run the status gate with App credentials set in the shell:
 
 ```bash
-export EVAOS_REVIEW_BOT_APP_ID=4184532
-export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH=/Volumes/LEXAR/Codex/evaos-code-review-bot/secrets/evaos-code-review-bot.private-key.pem
+export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
+export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 npm run release:status -- \
   --config /Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json \
   --expected-head <source-sha> \

--- a/docs/repo-profiles.md
+++ b/docs/repo-profiles.md
@@ -240,8 +240,8 @@ The template intentionally keeps:
 Before copying any part of the template into the active live config, run:
 
 ```sh
-EVAOS_REVIEW_BOT_APP_ID=4184532 \
-EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH=/Volumes/LEXAR/Codex/evaos-code-review-bot/secrets/evaos-code-review-bot.private-key.pem \
+NEONDIFF_GITHUB_APP_ID="<github-app-id>" \
+NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem" \
 npx tsx src/cli.ts doctor --config /path/to/candidate-live-config.json
 ```
 

--- a/docs/skills/release-operator.md
+++ b/docs/skills/release-operator.md
@@ -33,8 +33,8 @@ exception in the tracker issue and open a backfill issue before ending.
 ## Required Commands
 
 ```bash
-export EVAOS_REVIEW_BOT_APP_ID=4184532
-export EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH=/Volumes/LEXAR/Codex/evaos-code-review-bot/secrets/evaos-code-review-bot.private-key.pem
+export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
+export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 
 git fetch origin main --tags
 git checkout main

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2799,7 +2799,7 @@ async function buildDoctorGithubReport(config: BotConfig) {
     github: {
       canPostAsApp: appCredentialsConfigured,
       readMode: appCredentialsConfigured ? "app_installation" : hasFallbackReadToken ? "fallback_token" : "unconfigured",
-      botLogin: config.github.botLogin ?? "evaos-code-review-bot[bot]",
+      botLogin: config.github.botLogin ?? "configured GitHub App bot",
       apiBaseUrl: config.github.apiBaseUrl ?? "https://api.github.com",
       readChecks
     },
@@ -2827,7 +2827,7 @@ async function buildDoctorGithubReport(config: BotConfig) {
       "neondiff daemon status --config config.local.json --launchd-label com.example.neondiff"
     ],
     troubleshooting: [
-      ...(appCredentialsConfigured ? [] : ["Set EVAOS_REVIEW_BOT_APP_ID and EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH, or configure github.appId/privateKeyPath outside git."]),
+      ...(appCredentialsConfigured ? [] : ["Set NEONDIFF_GITHUB_APP_ID and NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH, or configure github.appId/privateKeyPath outside git. Legacy EVAOS_REVIEW_BOT_* aliases remain supported for existing internal deployments."]),
       ...(activeRepoChecks > 0 ? [] : ["Add at least one enabled repo to pilotRepos or repoProfiles before using this as an install proof."]),
       ...(readChecks.some((check) => !check.ok) ? ["Confirm the GitHub App is installed on selected repositories with the required repository permissions."] : [])
     ]
@@ -3174,7 +3174,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts calibration-aggregate --config /path/to/live.json --output-dir /path/to/evidence/calibration-aggregate-run",
       "npx tsx src/cli.ts calibration-promote --input /path/to/evidence/calibration-aggregate-run/aggregate-calibration.json --output-dir /path/to/evidence/calibration-promote-run --confirm true",
       "npx tsx src/cli.ts badge --config /path/to/live.json --repo owner/repo --output docs/badges/precision.json",
-      "npx tsx src/cli.ts finishing-touch-dry-run --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD --current-head HEAD --comment-id 456 --author maintainer --trusted-authors maintainer --body '@evaos-code-review-bot explain risk'",
+      "npx tsx src/cli.ts finishing-touch-dry-run --config /path/to/live.json --repo owner/repo --pr 123 --head-sha HEAD --current-head HEAD --comment-id 456 --author maintainer --trusted-authors maintainer --body '@neondiff explain risk'",
       "npx tsx src/cli.ts cooldowns --config /path/to/live.json --expired-only true"
     ],
     outcomeLedger: {
@@ -3460,10 +3460,10 @@ function resolveFinishingTouchAction(input: {
   const botMentions = parseCsv(input.botMentions);
   const parsed = parseFinishingTouchCommand({
     body,
-    botMentions: botMentions.length > 0 ? botMentions : ["@evaos-code-review-bot"]
+    botMentions: botMentions.length > 0 ? botMentions : ["@neondiff"]
   });
   if (!parsed) {
-    throw new Error(`--body must contain one of the finishing-touch commands for mentions ${botMentions.join(", ") || "@evaos-code-review-bot"}`);
+    throw new Error(`--body must contain one of the finishing-touch commands for mentions ${botMentions.join(", ") || "@neondiff"}`);
   }
   return parsed.action;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import type { EnrichmentConfig } from "./enrichment.js";
 import type { GitNexusContextConfig } from "./gitnexus-context.js";
 import type { GitHubRelatedContextConfig } from "./github-related-context.js";
 import { DEFAULT_ISSUE_ENRICHMENT_CONFIG, type IssueEnrichmentConfig } from "./issue-enrichment.js";
+import { resolveEnvAlias } from "./env-alias.js";
 import type { LicenseConfig } from "./license.js";
 import { assertPathOutsideProtectedRoot, getProtectedCheckoutRoots } from "./path-safety.js";
 import {
@@ -519,7 +520,7 @@ const DEFAULT_CONFIG: BotConfig = {
   },
   commands: {
     enabled: false,
-    botMentions: ["@evaos-code-review-bot"],
+    botMentions: ["@neondiff"],
     trustedAuthors: [],
     acknowledge: false
   },
@@ -542,8 +543,16 @@ export function loadConfig(configPath?: string): BotConfig {
 export function loadConfigFromObject(fromFile: unknown): BotConfig {
   const merged = deepMerge(DEFAULT_CONFIG, fromFile) as BotConfig;
 
-  merged.github.appId = process.env.EVAOS_REVIEW_BOT_APP_ID ?? merged.github.appId;
-  merged.github.privateKeyPath = process.env.EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH ?? merged.github.privateKeyPath;
+  merged.github.appId = resolveEnvAlias({
+    primaryName: "NEONDIFF_GITHUB_APP_ID",
+    legacyName: "EVAOS_REVIEW_BOT_APP_ID",
+    valueLabel: "github.appId"
+  }) ?? merged.github.appId;
+  merged.github.privateKeyPath = resolveEnvAlias({
+    primaryName: "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH",
+    legacyName: "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH",
+    valueLabel: "github.privateKeyPath"
+  }) ?? merged.github.privateKeyPath;
   merged.github.token = process.env.GITHUB_TOKEN ?? merged.github.token;
   validateConfig(merged);
 

--- a/src/env-alias.ts
+++ b/src/env-alias.ts
@@ -1,0 +1,24 @@
+export interface EnvAliasInput {
+  primaryName: string;
+  legacyName: string;
+  valueLabel: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export function resolveEnvAlias(input: EnvAliasInput): string | undefined {
+  const env = input.env ?? process.env;
+  const primaryValue = normalizeEnvValue(env[input.primaryName]);
+  const legacyValue = normalizeEnvValue(env[input.legacyName]);
+  if (primaryValue !== undefined && legacyValue !== undefined && primaryValue !== legacyValue) {
+    throw new Error(
+      `${input.primaryName} and ${input.legacyName} are both set with different values for ${input.valueLabel}; unset one or set them to the same value.`
+    );
+  }
+  return primaryValue ?? legacyValue;
+}
+
+function normalizeEnvValue(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  if (value.trim().length === 0) return undefined;
+  return value;
+}

--- a/src/path-safety.ts
+++ b/src/path-safety.ts
@@ -1,6 +1,7 @@
 import { existsSync, realpathSync } from "node:fs";
 import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveEnvAlias } from "./env-alias.js";
 
 export interface PathBoundary {
   path: string;
@@ -19,7 +20,11 @@ interface SinglePathBoundary {
 
 export function getProtectedCheckoutRoots(): string[] {
   return uniqueDefinedPaths([
-    process.env.EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT,
+    resolveEnvAlias({
+      primaryName: "NEONDIFF_PROTECTED_CHECKOUT_ROOT",
+      legacyName: "EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT",
+      valueLabel: "protected checkout root"
+    }),
     findPackageRoot(process.cwd()),
     getInstalledPackageRoot()
   ]);

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -22,19 +22,30 @@ const SECRET_PATTERNS: RegExp[] = [
 const COOKIE_HEADER_PREFIX = "cookie:";
 const SENSITIVE_COOKIE_NAME_PATTERN = /(?:session|token|auth|secret|cookie)/i;
 const MAX_COOKIE_ATTRIBUTE_SCAN = 1_000;
+const SAFE_ENV_VAR_NAMES = [
+  "NEONDIFF_GITHUB_APP_ID",
+  "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH",
+  "NEONDIFF_PROTECTED_CHECKOUT_ROOT",
+  "NEONDIFF_LICENSE_KEY",
+  "NEONDIFF_PROVIDER_API_KEY",
+  "NEONDIFF_ALLOW_REMOTE_SMOKE"
+];
 
 export function containsSecretLikeText(input: string): boolean {
-  return containsSensitiveCookieHeader(input) || SECRET_PATTERNS.some((pattern) => {
+  const safeInput = protectSafeEnvVarNames(input);
+  return containsSensitiveCookieHeader(safeInput) || SECRET_PATTERNS.some((pattern) => {
     pattern.lastIndex = 0;
-    return pattern.test(input);
+    return pattern.test(safeInput);
   });
 }
 
 export function redactSecrets(input: string): string {
-  return SECRET_PATTERNS.reduce(
+  const protectedInput = protectSafeEnvVarNames(input);
+  const redacted = SECRET_PATTERNS.reduce(
     (text, pattern) => text.replace(pattern, "[redacted-secret]"),
-    redactSensitiveCookieHeaders(input)
+    redactSensitiveCookieHeaders(protectedInput)
   );
+  return restoreSafeEnvVarNames(redacted);
 }
 
 export function stringifyRedactedJson(input: unknown): string {
@@ -81,4 +92,22 @@ function readSensitiveCookieHeader(line: string): string | undefined {
     if (value.length > 0 && SENSITIVE_COOKIE_NAME_PATTERN.test(name)) return line;
   }
   return undefined;
+}
+
+function protectSafeEnvVarNames(input: string): string {
+  return SAFE_ENV_VAR_NAMES.reduce((text, name, index) => {
+    const pattern = new RegExp(`(?<![A-Za-z0-9_])${escapeRegExp(name)}(?![A-Za-z0-9_])`, "g");
+    return text.replace(pattern, `__NEONDIFF_SAFE_ENV_${index}__`);
+  }, input);
+}
+
+function restoreSafeEnvVarNames(input: string): string {
+  return SAFE_ENV_VAR_NAMES.reduce(
+    (text, name, index) => text.replaceAll(`__NEONDIFF_SAFE_ENV_${index}__`, name),
+    input
+  );
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -610,6 +610,8 @@ describe("desktop config CLI", () => {
 
   async function runConfigRaw(args: string[]): Promise<{ stdout: string; stderr: string }> {
     const {
+      NEONDIFF_GITHUB_APP_ID,
+      NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH,
       EVAOS_REVIEW_BOT_APP_ID,
       EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH,
       GITHUB_TOKEN,

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -293,7 +293,7 @@ exit 1
       "--trusted-authors",
       "100yenadmin",
       "--body",
-      "@evaos-code-review-bot changelog draft",
+      "@neondiff changelog draft",
       "--generated-at",
       "2026-07-03T00:00:00.000Z"
     ]);
@@ -722,8 +722,8 @@ exit 1
 
       const { stdout } = await runCli(["doctor", "github", "--config", configPath], {
         env: {
-          EVAOS_REVIEW_BOT_APP_ID: "12345",
-          EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: privateKeyPath
+          NEONDIFF_GITHUB_APP_ID: "12345",
+          NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH: privateKeyPath
         }
       });
       const output = JSON.parse(stdout);
@@ -770,6 +770,7 @@ exit 1
       expect(output.requiredRepositoryPermissions).toContain("Pull requests: read/write");
       expect(output.optionalPermissions.join(" ")).toMatch(/issue-enrichment/i);
       expect(output.licenseBoundary.privateRepoDataStaysLocal).toBe(true);
+      expect(output.github.botLogin).toBe("configured GitHub App bot");
       expect(stdout).not.toContain(privateKeyPem);
       expect(stdout).not.toContain(privateKeyPath);
       expect(stdout).not.toContain(installationToken);
@@ -923,6 +924,32 @@ exit 1
     } finally {
       await closeServer(server);
     }
+  });
+
+  it("doctor github points missing App credentials at NeonDiff env names", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-doctor-github-missing-env-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, `${JSON.stringify({
+      pilotRepos: ["acme/demo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    })}\n`);
+
+    let stdout = "";
+    try {
+      await runCli(["doctor", "github", "--config", configPath]);
+    } catch (error) {
+      stdout = (error as { stdout?: string }).stdout ?? "";
+    }
+    const output = JSON.parse(stdout);
+
+    expect(output.ok).toBe(false);
+    expect(output.github.readMode).toBe("unconfigured");
+    expect(output.troubleshooting.join("\n")).toContain("NEONDIFF_GITHUB_APP_ID");
+    expect(output.troubleshooting.join("\n")).toContain("NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH");
+    expect(output.troubleshooting.join("\n")).not.toContain("Set EVAOS_REVIEW_BOT_APP_ID");
   });
 
   it("rejects non-boolean public rollback ref verification values", async () => {
@@ -2944,6 +2971,8 @@ async function runCli(args: string[], options: { cwd?: string; timeout?: number;
     encoding: "utf8",
     env: {
       ...process.env,
+      NEONDIFF_GITHUB_APP_ID: "",
+      NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH: "",
       EVAOS_REVIEW_BOT_APP_ID: "",
       EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH: "",
       GITHUB_TOKEN: "",

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -123,6 +123,8 @@ describe("NeonDiff public community funnel", () => {
       /Requirements/i,
       /GitHub App/i,
       /github-app-setup\.md/i,
+      /NEONDIFF_GITHUB_APP_ID/i,
+      /NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH/i,
       /Contents: read/i,
       /Pull requests: read\/write/i,
       /doctor github/i,
@@ -161,6 +163,8 @@ describe("NeonDiff public community funnel", () => {
       /Pull requests: read\/write/i,
       /Checks: read/i,
       /Actions: read/i,
+      /NEONDIFF_GITHUB_APP_ID/i,
+      /NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH/i,
       /issue-enrichment permissions are separate from PR review/i,
       /issueEnrichment\.allowlist/i,
       /neondiff doctor github --config config\.local\.json --json/i,
@@ -178,6 +182,8 @@ describe("NeonDiff public community funnel", () => {
     ]) {
       expect(githubApp).toMatch(required);
     }
+    expect(setup).not.toMatch(/export EVAOS_REVIEW_BOT_APP_ID/);
+    expect(githubApp).not.toMatch(/export EVAOS_REVIEW_BOT_APP_ID/);
     expect(githubApp).not.toMatch(/BEGIN (RSA|OPENSSH|PRIVATE) KEY|ghp_|github_pat_|sk-[A-Za-z0-9]/);
   });
 
@@ -219,6 +225,8 @@ describe("NeonDiff public community funnel", () => {
       /Write or update a failing test/i,
       /Do not commit.*tokens/i,
       /Do not restart launchd/i,
+      /GitHub App setup/i,
+      /website onboarding/i,
       /source-available/i,
       /Update the issue before handoff/i
     ]) {

--- a/tests/review-scheduler-config.test.ts
+++ b/tests/review-scheduler-config.test.ts
@@ -124,6 +124,73 @@ describe("review scheduler config", () => {
     expect(() => loadConfig(writeConfig({ github: { requestTimeoutMs: 0 } }))).toThrow(/config\.github\.requestTimeoutMs/);
   });
 
+  it("prefers NeonDiff GitHub App environment aliases over config-file values", () => {
+    const oldPrimaryAppId = process.env.NEONDIFF_GITHUB_APP_ID;
+    const oldPrimaryPrivateKeyPath = process.env.NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH;
+    const oldLegacyAppId = process.env.EVAOS_REVIEW_BOT_APP_ID;
+    const oldLegacyPrivateKeyPath = process.env.EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH;
+    process.env.NEONDIFF_GITHUB_APP_ID = "primary-app-id";
+    process.env.NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH = "/safe/neondiff.private-key.pem";
+    delete process.env.EVAOS_REVIEW_BOT_APP_ID;
+    delete process.env.EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH;
+
+    try {
+      const config = loadConfig(writeConfig({
+        github: {
+          appId: "from-config",
+          privateKeyPath: "/safe/from-config.pem"
+        }
+      }));
+
+      expect(config.github.appId).toBe("primary-app-id");
+      expect(config.github.privateKeyPath).toBe("/safe/neondiff.private-key.pem");
+    } finally {
+      restoreEnv("NEONDIFF_GITHUB_APP_ID", oldPrimaryAppId);
+      restoreEnv("NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH", oldPrimaryPrivateKeyPath);
+      restoreEnv("EVAOS_REVIEW_BOT_APP_ID", oldLegacyAppId);
+      restoreEnv("EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH", oldLegacyPrivateKeyPath);
+    }
+  });
+
+  it("keeps legacy evaOS GitHub App environment aliases as fallback", () => {
+    const oldPrimaryAppId = process.env.NEONDIFF_GITHUB_APP_ID;
+    const oldPrimaryPrivateKeyPath = process.env.NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH;
+    const oldLegacyAppId = process.env.EVAOS_REVIEW_BOT_APP_ID;
+    const oldLegacyPrivateKeyPath = process.env.EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH;
+    delete process.env.NEONDIFF_GITHUB_APP_ID;
+    delete process.env.NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH;
+    process.env.EVAOS_REVIEW_BOT_APP_ID = "legacy-app-id";
+    process.env.EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH = "/safe/legacy.private-key.pem";
+
+    try {
+      const config = loadConfig(writeConfig({}));
+
+      expect(config.github.appId).toBe("legacy-app-id");
+      expect(config.github.privateKeyPath).toBe("/safe/legacy.private-key.pem");
+    } finally {
+      restoreEnv("NEONDIFF_GITHUB_APP_ID", oldPrimaryAppId);
+      restoreEnv("NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH", oldPrimaryPrivateKeyPath);
+      restoreEnv("EVAOS_REVIEW_BOT_APP_ID", oldLegacyAppId);
+      restoreEnv("EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH", oldLegacyPrivateKeyPath);
+    }
+  });
+
+  it("rejects conflicting NeonDiff and legacy GitHub App environment aliases", () => {
+    const oldPrimaryAppId = process.env.NEONDIFF_GITHUB_APP_ID;
+    const oldLegacyAppId = process.env.EVAOS_REVIEW_BOT_APP_ID;
+    process.env.NEONDIFF_GITHUB_APP_ID = "primary-app-id";
+    process.env.EVAOS_REVIEW_BOT_APP_ID = "legacy-app-id";
+
+    try {
+      expect(() => loadConfig(writeConfig({}))).toThrow(
+        /NEONDIFF_GITHUB_APP_ID and EVAOS_REVIEW_BOT_APP_ID are both set with different values/
+      );
+    } finally {
+      restoreEnv("NEONDIFF_GITHUB_APP_ID", oldPrimaryAppId);
+      restoreEnv("EVAOS_REVIEW_BOT_APP_ID", oldLegacyAppId);
+    }
+  });
+
   it("rejects a review workRoot inside the live repository checkout", () => {
     expect(() => loadConfig(writeConfig({
       workRoot: join(process.cwd(), "runtime")
@@ -161,6 +228,25 @@ describe("review scheduler config", () => {
     }
   });
 
+  it("supports NeonDiff protected checkout root environment alias", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-scheduler-protected-"));
+    roots.push(root);
+    const protectedRoot = join(root, "operator-checkout");
+    const oldPrimaryProtectedRoot = process.env.NEONDIFF_PROTECTED_CHECKOUT_ROOT;
+    const oldLegacyProtectedRoot = process.env.EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT;
+    process.env.NEONDIFF_PROTECTED_CHECKOUT_ROOT = protectedRoot;
+    delete process.env.EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT;
+
+    try {
+      expect(() => loadConfig(writeConfig({
+        workRoot: join(protectedRoot, "runtime")
+      }))).toThrow(/config\.workRoot must be outside the current repository checkout/);
+    } finally {
+      restoreEnv("NEONDIFF_PROTECTED_CHECKOUT_ROOT", oldPrimaryProtectedRoot);
+      restoreEnv("EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT", oldLegacyProtectedRoot);
+    }
+  });
+
   it("allows reviews when workRoot is outside the live repository checkout", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-scheduler-runtime-"));
     roots.push(root);
@@ -178,5 +264,13 @@ describe("review scheduler config", () => {
     const path = join(root, "config.json");
     writeFileSync(path, `${JSON.stringify(overlay)}\n`);
     return path;
+  }
+
+  function restoreEnv(name: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[name];
+      return;
+    }
+    process.env[name] = value;
   }
 });

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -24,6 +24,13 @@ describe("secret redaction", () => {
     expect(redactSecrets(`license=${license}`)).toBe("license=[redacted-secret]");
   });
 
+  it("does not redact documented NeonDiff environment variable names", () => {
+    const text = "Set NEONDIFF_GITHUB_APP_ID and NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH before doctor github.";
+
+    expect(containsSecretLikeText(text)).toBe(false);
+    expect(redactSecrets(text)).toBe(text);
+  });
+
   it("redacts hyphenated license-shaped values case-insensitively", () => {
     const license = "neondiff-revocation-reason-test-123456";
     const digitPoorLicense = "NDL-XQKM-RPYB-SUTE";


### PR DESCRIPTION
## Summary
- adds primary NeonDiff GitHub App env vars while preserving legacy evaOS aliases
- fails closed when primary and legacy aliases conflict
- updates public/default setup docs, examples, doctor troubleshooting, and command mention defaults
- keeps documented env-var names visible through redaction while still redacting actual NeonDiff key-shaped values

Refs #453

## Validation
- `npm test -- --pool=forks --maxWorkers=1 tests/review-scheduler-config.test.ts`
- `npm test -- --pool=forks --maxWorkers=1 tests/public-community-funnel.test.ts`
- `npm test -- --pool=forks --maxWorkers=1 tests/secrets.test.ts`
- `npm test -- --pool=forks --maxWorkers=1 tests/public-cli.test.ts`
- `npm run build`
- `git diff --check`
- grep proof: no public/default `export EVAOS_REVIEW_BOT_APP_ID`, `set via EVAOS_REVIEW_BOT`, or `@evaos-code-review-bot` in active setup/example surfaces

## Notes
- No live daemon config, launchd job, GitHub App permissions, repo/package name, or historical release notes changed.
- Legacy `EVAOS_REVIEW_BOT_*` names remain supported for existing internal deployments.
