### PR TITLE
Add v0.4.46 beta release packet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ for the semver/GA-line and npm dist-tag policy.
 
 No unreleased changes tracked yet.
 
+## [0.4.46-beta.1] - docs/releases/v0.4.46-beta.1.md
+
+### Changed
+
+- Add NeonDiff-branded GitHub App credential env aliases and fail-closed alias conflict handling while preserving the legacy internal `EVAOS_REVIEW_BOT_*` aliases
+- Refresh first-run GitHub App setup docs, agent guidance, launchd examples, and doctor troubleshooting so public setup requires App creation/installation before daemon reviews
+- Update public website onboarding to add the GitHub App setup step and fix website source metadata to `electricsheephq/neon-diff-agent-website`
+- Keep the public npm package held at `neondiff@0.4.30-beta.1` while advancing the source-beta release surface to the current merged setup fix
+
 ## [0.4.45-beta.1] - docs/releases/v0.4.45-beta.1.md
 
 ### Added

--- a/docs/evidence/v0.4.46-beta.1-license-api-healthz.json
+++ b/docs/evidence/v0.4.46-beta.1-license-api-healthz.json
@@ -1,0 +1,19 @@
+{
+  "evidenceKind": "license_api_healthz",
+  "releaseVersion": "v0.4.46-beta.1",
+  "observedAt": "2026-07-08T09:48:00Z",
+  "method": "GET",
+  "url": "https://neondiff-license.fly.dev/healthz",
+  "statusCode": 200,
+  "responseBody": "{\"status\":\"ok\"}",
+  "responseBodySha256": "a29ee2b15c494311c52521766e44af56a3ad2248e7a8ab465e5206463c13d288",
+  "captureContext": {
+    "tool": "curl",
+    "transport": "https",
+    "tlsValidation": "curl default CA validation",
+    "capturedFrom": "Codex Desktop macOS operator shell",
+    "dnsResolution": "system resolver",
+    "note": "Captured with normal system DNS resolution and curl default TLS validation."
+  },
+  "redaction": "No license key, token, cookie, customer data, or private repo content was present in this health check."
+}

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "v0.4.45-beta.1",
+  "version": "v0.4.46-beta.1",
   "releaseLevel": "source-beta",
   "packageArtifact": {
     "name": "neondiff",
@@ -27,27 +27,28 @@
       "v0.4.42-beta.1",
       "v0.4.43-beta.1",
       "v0.4.44-beta.1",
-      "v0.4.45-beta.1"
+      "v0.4.45-beta.1",
+      "v0.4.46-beta.1"
     ],
-    "note": "v0.4.25 through v0.4.29 and v0.4.31 through v0.4.45 were source/local-worker beta releases; v0.4.30-beta.1 remains the current public npm/site beta."
+    "note": "v0.4.25 through v0.4.29 and v0.4.31 through v0.4.46 were source/local-worker beta releases; v0.4.30-beta.1 remains the current public npm/site beta."
   },
   "source": {
     "shaState": "pending_tag_stamp",
-    "candidateHeadBeforeReleaseMetadata": "4cd081ca581c24f2f054106b4c4cc8e6453c9dce",
+    "candidateHeadBeforeReleaseMetadata": "78b51fdac2d8ce699dc9f38f87db0b62c19dafef",
     "proof": "after merge and tag, release:status --expected-head $(git rev-parse HEAD)"
   },
   "docs": {
-    "version": "v0.4.45-beta.1",
+    "version": "v0.4.46-beta.1",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v0.4.45-beta.1.md",
-    "websiteRepo": "electricsheephq/neon-diff-agent"
+    "releaseNotesPath": "docs/releases/v0.4.46-beta.1.md",
+    "websiteRepo": "electricsheephq/neon-diff-agent-website"
   },
   "licenseApi": {
     "requiredForThisRelease": true,
     "state": "healthy",
     "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327",
     "healthUrl": "https://neondiff-license.fly.dev/healthz",
-    "healthProofPath": "docs/evidence/v0.4.45-beta.1-license-api-healthz.json",
+    "healthProofPath": "docs/evidence/v0.4.46-beta.1-license-api-healthz.json",
     "checkoutIssuanceRequiredForThisRelease": false,
     "checkoutIssuanceUrl": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
     "checkoutIssuanceState": "pending_secret_and_website_publish",
@@ -57,14 +58,14 @@
     "cli": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v0.4.45-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.44-beta.1"
+      "version": "v0.4.46-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.45-beta.1"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "launchd_prerelease",
-      "version": "v0.4.45-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.44-beta.1"
+      "version": "v0.4.46-beta.1",
+      "rollback": "git reset --hard refs/tags/v0.4.45-beta.1"
     },
     "website": {
       "requiredForThisRelease": false,

--- a/docs/releases/v0.4.46-beta.1.md
+++ b/docs/releases/v0.4.46-beta.1.md
@@ -1,0 +1,107 @@
+# v0.4.46-beta.1
+
+- Release type: source-only beta setup/onboarding promotion
+- Release source SHA: to be stamped by `refs/tags/v0.4.46-beta.1`
+- Previous prerelease: `v0.4.45-beta.1`
+- Tracking issues / source PRs: `#453`, `#454`, `neon-diff-agent-website#24`, `neon-diff-agent-website#25`
+- Promoted PRs: `#454`, `neon-diff-agent-website#25`
+- Included implementation merge SHA:
+  - `78b51fdac2d8ce699dc9f38f87db0b62c19dafef` (`#454`)
+- Rollback tag: `v0.4.45-beta.1`
+- Package artifact: `neondiff@0.4.30-beta.1` (held from previous public npm release)
+- Rollback baseline: `v0.4.45-beta.1`
+
+## Purpose
+
+Promote the first-user GitHub App onboarding repair for NeonDiff.
+
+This release makes GitHub App creation and installation an explicit first-run
+requirement, changes public/default credential prompts to NeonDiff-branded env
+vars, preserves existing internal evaOS aliases as compatibility fallbacks, and
+records the matching website onboarding update.
+
+## Included Changes
+
+- Add primary GitHub App credential env vars:
+  `NEONDIFF_GITHUB_APP_ID` and
+  `NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH`.
+- Preserve legacy internal aliases:
+  `EVAOS_REVIEW_BOT_APP_ID` and
+  `EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH`.
+- Fail config load closed when primary and legacy aliases are both set to
+  different values, without printing secret values.
+- Refresh README, setup docs, GitHub App setup docs, launchd/operator examples,
+  repo profile docs, config examples, and agent guidance so new users create and
+  install a GitHub App before daemon reviews.
+- Update `doctor github` troubleshooting to prefer NeonDiff env names and keep
+  evaOS names only as compatibility aliases.
+- Replace public/default bot mention examples with NeonDiff placeholders instead
+  of `@evaos-code-review-bot`.
+- Update the website checkout/onboarding path with a GitHub App setup step,
+  required permissions, local env var names, and `neondiff doctor github`.
+- Correct website repo metadata to
+  `electricsheephq/neon-diff-agent-website`.
+
+## Required Gates
+
+- Product PR `#454` merged to `main` at
+  `78b51fdac2d8ce699dc9f38f87db0b62c19dafef`.
+- Website PR `neon-diff-agent-website#25` merged to its `main` branch.
+- Current-head GitHub checks passed on product PR `#454`:
+  - Build, test, and package
+  - CodeQL / Analyze actions
+  - CodeQL / Analyze javascript-typescript
+  - Swift desktop impact/gate path-aware checks
+  - Socket Security project and PR checks
+  - CodeRabbit
+- Product review threads on `#454` were empty before admin merge.
+- Focused local validation before product merge:
+  - `npm test -- --pool=forks --maxWorkers=1 tests/review-scheduler-config.test.ts`
+  - `npm test -- --pool=forks --maxWorkers=1 tests/public-community-funnel.test.ts`
+  - `npm test -- --pool=forks --maxWorkers=1 tests/secrets.test.ts`
+  - `npm test -- --pool=forks --maxWorkers=1 tests/public-cli.test.ts`
+  - `npm run build`
+  - `git diff --check`
+- Website validation before website merge:
+  - `npm run check:public-claims`
+  - `npm run build`
+  - `git diff --check`
+- Release metadata PR must pass the same GitHub required checks before tagging.
+- Post-tag `release:status` must pass with:
+  - `--public-release-manifest docs/public-release-manifest.json`
+  - `--expected-public-version v0.4.46-beta.1`
+  - live launchd expected head equal to the promoted tag SHA only if this source
+    beta is separately promoted into the local worker checkout.
+
+## Caveats
+
+- This release does not publish a new npm package; the public npm package
+  remains `neondiff@0.4.30-beta.1`.
+- This release does not mutate the live daemon checkout or active launchd
+  config by itself.
+- This release does not collect private keys in the website UI. Private keys
+  remain local-only on the machine running NeonDiff.
+- This release does not expand GitHub App permissions. Required permissions
+  remain Metadata read, Contents read, Pull requests read/write, Checks read,
+  and Actions read.
+- This release does not enable issue enrichment, native ZCode skills, MCP,
+  memory, auto-merge, approvals, or target-repo mutation.
+- Website source was merged separately; public website deploy/publish proof is a
+  separate lane from this product source-beta release.
+
+## Rollback
+
+```bash
+: "${REPO_ROOT:?set REPO_ROOT to your local NeonDiff checkout}"
+: "${RELEASE_STATUS_CONFIG:?set RELEASE_STATUS_CONFIG to the live release-status config}"
+
+cd "$REPO_ROOT"
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v0.4.45-beta.1
+launchctl kickstart -k gui/$(id -u)/com.electricsheephq.evaos-code-review-bot
+npm run release:status -- \
+  --config "$RELEASE_STATUS_CONFIG" \
+  --expected-head "$(git rev-parse HEAD)" \
+  --launchd-label com.electricsheephq.evaos-code-review-bot
+```

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -93,10 +93,11 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.43-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.44-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.45-beta.1");
+    expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.46-beta.1");
     expect(manifest.packageArtifact?.note).toMatch(/source\/local-worker/i);
     expect(manifest.source).toMatchObject({
       shaState: "pending_tag_stamp",
-      candidateHeadBeforeReleaseMetadata: "4cd081ca581c24f2f054106b4c4cc8e6453c9dce"
+      candidateHeadBeforeReleaseMetadata: "78b51fdac2d8ce699dc9f38f87db0b62c19dafef"
     });
     expect(manifest.source?.proof).toMatch(/after merge and tag/i);
   });
@@ -126,7 +127,7 @@ describe("NeonDiff public release readiness", () => {
     });
     expect(manifest.licenseApi?.trackingIssue).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/);
     expect(manifest.licenseApi?.healthUrl).toMatch(/^https:\/\/[^/]+\/healthz$/);
-    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v0.4.45-beta.1-license-api-healthz.json");
+    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v0.4.46-beta.1-license-api-healthz.json");
 
     const proof = JSON.parse(read(manifest.licenseApi?.healthProofPath ?? "")) as {
       evidenceKind?: string;
@@ -138,7 +139,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(proof).toMatchObject({
       evidenceKind: "license_api_healthz",
-      releaseVersion: "v0.4.45-beta.1",
+      releaseVersion: "v0.4.46-beta.1",
       url: manifest.licenseApi?.healthUrl,
       statusCode: 200,
       responseBody: "{\"status\":\"ok\"}"

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -21,7 +21,7 @@ import { ReviewStateStore } from "../src/state.js";
 describe("beta release status", () => {
   const roots: string[] = [];
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  const shippedReleaseValidationNow = new Date("2026-07-08T06:50:00Z");
+  const shippedReleaseValidationNow = new Date("2026-07-08T09:50:00Z");
 
   afterEach(() => {
     vi.useRealTimers();
@@ -284,27 +284,27 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.45-beta.1",
+      expectedVersion: "v0.4.46-beta.1",
       now: shippedReleaseValidationNow
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v0.4.45-beta.1",
+      version: "v0.4.46-beta.1",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v0.4.45-beta.1.md",
+        releaseNotesPath: "docs/releases/v0.4.46-beta.1.md",
         changelogPath: "CHANGELOG.md",
-        changelogHeadVersion: "0.4.45-beta.1",
-        changelogReleaseNotesPath: "docs/releases/v0.4.45-beta.1.md"
+        changelogHeadVersion: "0.4.46-beta.1",
+        changelogReleaseNotesPath: "docs/releases/v0.4.46-beta.1.md"
       },
       licenseApi: {
         ok: true,
         requiredForThisRelease: true,
         state: "healthy",
         healthUrl: "https://neondiff-license.fly.dev/healthz",
-        healthProofPath: "docs/evidence/v0.4.45-beta.1-license-api-healthz.json",
+        healthProofPath: "docs/evidence/v0.4.46-beta.1-license-api-healthz.json",
         checkoutIssuanceRequiredForThisRelease: false,
         checkoutIssuanceUrl: "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
         checkoutIssuanceState: "pending_secret_and_website_publish",
@@ -319,12 +319,12 @@ describe("beta release status", () => {
         expect.objectContaining({
           name: "cli",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.44-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.45-beta.1"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.44-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.45-beta.1"
         })
       ])
     );
@@ -334,7 +334,7 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.45-beta.1",
+      expectedVersion: "v0.4.46-beta.1",
       now: new Date("2026-08-08T00:00:00Z")
     });
 
@@ -342,7 +342,7 @@ describe("beta release status", () => {
       ok: false,
       requiredForThisRelease: true,
       state: "healthy",
-      healthProofPath: "docs/evidence/v0.4.45-beta.1-license-api-healthz.json"
+      healthProofPath: "docs/evidence/v0.4.46-beta.1-license-api-healthz.json"
     });
     expect(manifest.licenseApi.detail).toContain("observedAt must be no older than 30 days");
     expect(manifest.ok).toBe(false);
@@ -458,14 +458,14 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v0.4.45-beta.1",
+      expectedPublicVersion: "v0.4.46-beta.1",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot",
       now: shippedReleaseValidationNow
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v0.4.45-beta.1"
+      version: "v0.4.46-beta.1"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
@@ -477,7 +477,7 @@ describe("beta release status", () => {
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok
     });
-    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.44-beta.1");
+    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.45-beta.1");
     expect(redactedOutput).toContain("cli=published; daemon=launchd_prerelease");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
   });


### PR DESCRIPTION
## Summary
- Adds the `v0.4.46-beta.1` source-beta release packet for the GitHub App onboarding/env alias cleanup.
- Updates `CHANGELOG.md` and `docs/public-release-manifest.json` to the new version.
- Captures fresh license API health evidence, preserves the checkout issuance release gate from #451, and fixes the manifest website repo to `electricsheephq/neon-diff-agent-website`.

Refs #453.

## Validation
- `npx vitest run tests/public-release-readiness.test.ts tests/release-status.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- Public manifest gate: `readPublicReleaseManifestStatus(... expectedVersion: "v0.4.46-beta.1", now: "2026-07-08T09:50:00Z")` returned `ok: true` with docs, license API health proof, checkout issuance deferral, and update channels valid.
- GitHub Actions on final head `f1d1a81343b5551eef3534060cd2190d6eb71d0c`: Build/test/package, CodeQL, Swift desktop gate, Socket Security, and CodeRabbit all green.
- evaOS bot current-head status completed for `f1d1a81343b5551eef3534060cd2190d6eb71d0c`; review event COMMENT, no validated inline findings.

## Rollback
- Source rollback baseline: `git reset --hard refs/tags/v0.4.45-beta.1`.
- No live daemon config or launchd promotion is performed by this PR.