### PR TITLE
[codex] Add browser-first dashboard MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ version is:
 
 ```bash
 neondiff init --config config.local.json
+neondiff dashboard --config config.local.json
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 neondiff doctor github --config config.local.json --json

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -215,6 +215,7 @@ Check:
 Then run full doctor with the config you intend to use:
 
 ```bash
+neondiff dashboard --config config.local.json
 neondiff providers list --config config.local.json --json
 neondiff providers doctor --config config.local.json --json
 neondiff doctor --config config.local.json --json
@@ -257,7 +258,7 @@ Before touching launchd, use JSON status commands:
 ```bash
 neondiff status --json --config config.local.json
 neondiff queue --config config.local.json
-neondiff dashboard --config config.local.json --limit 10
+neondiff dashboard --operator true --config config.local.json --limit 10
 ```
 
 Launchd controls are explicit and JSON-first. Dry-run them before changing a

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -40,7 +40,7 @@ evaos-review-bot status --config config.local.json
   every PR head is covered but a durable queue row is failed or ready to retry.
   Durable queue summaries include the oldest waiting repo/head age so burst
   backlogs can be diagnosed without hand-querying SQLite.
-- `dashboard`: read-only PR review dashboard over coverage, durable queue,
+- `dashboard --operator true`: read-only PR review dashboard over coverage, durable queue,
   readiness lifecycle rows, GitHub PR links, and local evidence-path hints.
   Filter with `--repo`, `--status`, `--priority`, `--stale-head-reason`, and
   `--limit`. By default the dashboard hides stale-only historical rows so the
@@ -48,8 +48,10 @@ evaos-review-bot status --config config.local.json
   explicit stale status filter when investigating historical rows. Use
   `--job-limit` to cap durable-queue/readiness rows read from SQLite before
   merging; `--limit` caps the final merged item list. JSON is the default; use
-  `--human` for a compact operator view. The command exits nonzero when visible
-  rows are blocked; healthy active rows are counted but do not fail the gate by
+  `--human` for a compact operator view. Bare `dashboard` now starts the
+  user-facing local HTML first-run dashboard; include `--operator true` for this
+  JSON-first operator surface. The command exits nonzero when visible rows are
+  blocked; healthy active rows are counted but do not fail the gate by
   themselves.
 - `budget-status`: read-only scheduler budget projection. Shows active counts,
   queued counts, would-lease jobs, delayed jobs, and deterministic delay reasons

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,6 +52,7 @@ import {
   type IssueEnrichmentRepoReadCheck
 } from "./issue-enrichment.js";
 import { activateLicense, deactivateLicense, getLicenseStatus, type LicenseConfig } from "./license.js";
+import { startLocalDashboardServer } from "./local-dashboard.js";
 import {
   assertOutcomeLedgerOutputDirEmpty,
   readOutcomeLedgerInput,
@@ -653,31 +654,56 @@ async function main(): Promise<void> {
   }
 
   if (command === "dashboard") {
-    const config = loadConfig(args.config);
-    const report = await collectCoverageReport(args, config);
-    const statePath = args["state-path"] ?? config.statePath;
-    const dashboard = buildOperatorDashboard({
-      coverage: report,
-      durableQueue: collectOperatorReviewQueue(statePath, {
-        repo: args.repo,
-        limit: args["job-limit"] ? parsePositiveInteger(args["job-limit"], "--job-limit") : undefined
-      }),
-      readiness: collectOperatorReviewReadiness(statePath, {
-        repo: args.repo,
-        limit: args["job-limit"] ? parsePositiveInteger(args["job-limit"], "--job-limit") : undefined
-      }),
-      evidenceDir: config.evidenceDir,
-      filters: {
-        ...(args.repo ? { repo: args.repo } : {}),
-        ...(args.status ?? args.state ? { status: args.status ?? args.state } : {}),
-        ...(args.priority ? { priority: parseNonNegativeInteger(args.priority, "--priority") } : {}),
-        ...(args["stale-head-reason"] ? { staleHeadReason: args["stale-head-reason"] } : {}),
-        ...(args["include-history"] === "true" ? { includeHistory: true } : {}),
-        ...(args.limit ? { limit: parsePositiveInteger(args.limit, "--limit") } : {})
-      }
+    if (shouldUseOperatorDashboard(args)) {
+      const config = loadConfig(args.config);
+      const report = await collectCoverageReport(args, config);
+      const statePath = args["state-path"] ?? config.statePath;
+      const dashboard = buildOperatorDashboard({
+        coverage: report,
+        durableQueue: collectOperatorReviewQueue(statePath, {
+          repo: args.repo,
+          limit: args["job-limit"] ? parsePositiveInteger(args["job-limit"], "--job-limit") : undefined
+        }),
+        readiness: collectOperatorReviewReadiness(statePath, {
+          repo: args.repo,
+          limit: args["job-limit"] ? parsePositiveInteger(args["job-limit"], "--job-limit") : undefined
+        }),
+        evidenceDir: config.evidenceDir,
+        filters: {
+          ...(args.repo ? { repo: args.repo } : {}),
+          ...(args.status ?? args.state ? { status: args.status ?? args.state } : {}),
+          ...(args.priority ? { priority: parseNonNegativeInteger(args.priority, "--priority") } : {}),
+          ...(args["stale-head-reason"] ? { staleHeadReason: args["stale-head-reason"] } : {}),
+          ...(args["include-history"] === "true" ? { includeHistory: true } : {}),
+          ...(args.limit ? { limit: parsePositiveInteger(args.limit, "--limit") } : {})
+        }
+      });
+      console.log(args.human === "true" ? formatOperatorDashboardHuman(dashboard) : stringifyRedactedJson(dashboard));
+      if (!dashboard.ok) process.exitCode = 1;
+      return;
+    }
+    const configPath = resolve(parseSingleArg(args.config ?? "config.local.json", "--config"));
+    const config = loadConfig(configPath);
+    const handle = await startLocalDashboardServer({
+      config,
+      configPath,
+      configExists: existsSync(configPath),
+      host: args.host ? parseSingleArg(args.host, "--host") : "127.0.0.1",
+      port: args.port ? parseNonNegativeInteger(parseSingleArg(args.port, "--port"), "--port") : 0,
+      launchdLabel: args["launchd-label"] ? parseSingleArg(args["launchd-label"], "--launchd-label") : undefined,
+      openBrowser: args.open === undefined ? true : parseBooleanArg(args.open, "--open"),
+      allowRemoteSmoke: args["allow-remote-smoke"] === undefined ? false : parseBooleanArg(args["allow-remote-smoke"], "--allow-remote-smoke")
     });
-    console.log(args.human === "true" ? formatOperatorDashboardHuman(dashboard) : stringifyRedactedJson(dashboard));
-    if (!dashboard.ok) process.exitCode = 1;
+    console.log(stringifyRedactedJson({
+      ok: true,
+      command: "dashboard",
+      mode: "local_html",
+      url: handle.url,
+      openAttempted: handle.openAttempted,
+      openOk: handle.openOk,
+      status: handle.status,
+      proofBoundary: "Starts a local HTML dashboard only; it does not prove signed desktop release, appcast, notarization, or live review quality."
+    }));
     return;
   }
 
@@ -3037,6 +3063,17 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--smoke", description: "true to run a live smoke check in providers doctor." }
     ]
   },
+  dashboard: {
+    description: "Start and open the local first-run HTML dashboard; use --operator true for the JSON operator dashboard.",
+    flags: [
+      { name: "--config", description: "Path to the config file (default config.local.json)." },
+      { name: "--host", description: "Dashboard bind host (default 127.0.0.1)." },
+      { name: "--port", description: "Dashboard port (default 0, choose an available port)." },
+      { name: "--open", description: "true (default) to open the dashboard in the browser." },
+      { name: "--allow-remote-smoke", description: "true to allow hosted provider API-key verification." },
+      { name: "--operator", description: "true to use the legacy operator JSON/human dashboard." }
+    ]
+  },
   license: {
     description: "Manage the license: `license activate|status|deactivate`.",
     flags: [
@@ -3061,6 +3098,7 @@ function buildHelp(command?: string) {
         "config patch",
         "pricing",
         "badge",
+        "dashboard",
         "providers list",
         "providers doctor",
         "doctor",
@@ -3128,6 +3166,7 @@ function buildHelp(command?: string) {
       "desktop-patch.json uses nested object shape, e.g. {\"zcode\":{\"cliPath\":\"/path/to/neondiff\"}}",
       "neondiff pricing",
       "neondiff badge --config config.local.json --output docs/badges/precision.json",
+      "neondiff dashboard --config config.local.json",
       "neondiff providers list --config config.local.json --json",
       "neondiff providers doctor --config config.local.json --json",
       "neondiff providers doctor --config config.local.json --provider ollama-local --smoke true --json",
@@ -3149,8 +3188,8 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts agents --config /path/to/live.json",
       "npx tsx src/cli.ts queue --config /path/to/live.json",
       "npx tsx src/cli.ts queue --config /path/to/live.json --state provider_deferred",
-      "npx tsx src/cli.ts dashboard --config /path/to/live.json --status blocked_on_proof",
-      "npx tsx src/cli.ts dashboard --config /path/to/live.json --human",
+      "npx tsx src/cli.ts dashboard --operator true --config /path/to/live.json --status blocked_on_proof",
+      "npx tsx src/cli.ts dashboard --operator true --config /path/to/live.json --human",
       "npx tsx src/cli.ts budget-status --config /path/to/live.json",
       "npx tsx src/cli.ts provider-throttle-report --config /path/to/live.json --since 7d --timezone Asia/Singapore",
       "provider-throttle-report peak-window flags use inclusive local-hour buckets, e.g. --peak-start-hour 14 --peak-end-hour 18 includes 14:00 through 18:00",
@@ -3258,6 +3297,23 @@ function redactProviderOutput(input: unknown, key?: string): unknown {
 function isHelpRequested(args: ParsedArgs): boolean {
   if (args.help === "true") return true;
   return args._.slice(1).some((arg) => arg === "help" || arg === "-h" || arg === "--help");
+}
+
+function shouldUseOperatorDashboard(args: ParsedArgs): boolean {
+  if (args.operator !== undefined && parseBooleanArg(args.operator, "--operator")) return true;
+  return [
+    "human",
+    "json",
+    "repo",
+    "status",
+    "state",
+    "state-path",
+    "job-limit",
+    "priority",
+    "stale-head-reason",
+    "include-history",
+    "limit"
+  ].some((key) => args[key] !== undefined);
 }
 
 function parseArgs(argv: string[]): ParsedArgs {

--- a/src/local-dashboard.ts
+++ b/src/local-dashboard.ts
@@ -1,0 +1,886 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { createHash } from "node:crypto";
+import type { AddressInfo } from "node:net";
+import type { BotConfig } from "./config.js";
+import { getLicenseStatus, type LicenseStatusResult } from "./license.js";
+import {
+  doctorProviderRegistry,
+  type ProviderDoctorCheck,
+  type ProviderRegistryConfig
+} from "./providers.js";
+import { redactSecrets, stringifyRedactedJson } from "./secrets.js";
+
+export type LocalDashboardReadinessState =
+  | "not_configured"
+  | "configured_unverified"
+  | "healthy"
+  | "degraded"
+  | "blocked";
+
+export interface LocalDashboardStatusItem {
+  id: "license" | "githubApp" | "daemon" | "provider";
+  label: string;
+  state: LocalDashboardReadinessState;
+  detail: string;
+  checkedAt: string;
+  redacted: true;
+  actions: string[];
+  metadata?: Record<string, string | number | boolean | null>;
+}
+
+export interface LocalDashboardProviderOption {
+  id: string;
+  label: string;
+  adapter: string;
+  authMode: string;
+  apiKeyEnv?: string;
+  default: boolean;
+}
+
+export interface LocalDashboardStatusContract {
+  ok: boolean;
+  command: "dashboard status";
+  schemaVersion: "local-dashboard-status-v0.1";
+  checkedAt: string;
+  config: {
+    path: string;
+    exists: boolean;
+    source: "file" | "defaults";
+  };
+  items: {
+    license: LocalDashboardStatusItem;
+    githubApp: LocalDashboardStatusItem;
+    daemon: LocalDashboardStatusItem;
+    provider: LocalDashboardStatusItem;
+  };
+  providers: {
+    defaultProviderId: string;
+    options: LocalDashboardProviderOption[];
+  };
+  firstReviewPreview: {
+    available: boolean;
+    detail: string;
+    command: string;
+  };
+  proofBoundary: string;
+}
+
+export interface LocalDashboardServerHandle {
+  server: Server;
+  url: string;
+  status: LocalDashboardStatusContract;
+  openAttempted: boolean;
+  openOk: boolean;
+}
+
+export interface ProviderApiKeyVerificationInput {
+  config: BotConfig;
+  providerId?: string;
+  apiKey?: string;
+  allowRemoteSmoke?: boolean;
+  env?: Record<string, string | undefined>;
+}
+
+export interface ProviderApiKeyVerificationResult {
+  ok: boolean;
+  command: "dashboard verify-provider";
+  checkedAt: string;
+  providerId: string;
+  state: LocalDashboardReadinessState;
+  mode: "metadata_only" | "openai_compatible_models";
+  detail: string;
+  redacted: true;
+  keyFingerprint?: string;
+  check?: Omit<ProviderDoctorCheck, "error"> & { error?: string };
+  troubleshooting: string[];
+}
+
+export async function buildLocalDashboardStatus(input: {
+  config: BotConfig;
+  configPath: string;
+  configExists: boolean;
+  launchdLabel?: string;
+  providerVerification?: ProviderApiKeyVerificationResult;
+  now?: Date;
+}): Promise<LocalDashboardStatusContract> {
+  const now = input.now ?? new Date();
+  const checkedAt = now.toISOString();
+  const license = await buildLicenseStatusItem(input.config, checkedAt);
+  const githubApp = buildGitHubAppStatusItem(input.config, checkedAt);
+  const daemon = buildDaemonStatusItem(input.config, checkedAt, input.launchdLabel);
+  const provider = input.providerVerification
+    ? providerStatusItemFromVerification(input.providerVerification, checkedAt)
+    : buildProviderStatusItem(input.config.providers!, checkedAt);
+  const items = { license, githubApp, daemon, provider };
+  const ok = Object.values(items).every((item) => item.state === "healthy" || item.state === "degraded");
+
+  return redactedStatus({
+    ok,
+    command: "dashboard status",
+    schemaVersion: "local-dashboard-status-v0.1",
+    checkedAt,
+    config: {
+      path: input.configPath,
+      exists: input.configExists,
+      source: input.configExists ? "file" : "defaults"
+    },
+    items,
+    providers: {
+      defaultProviderId: input.config.providers!.defaultProviderId,
+      options: buildProviderOptions(input.config.providers!)
+    },
+    firstReviewPreview: {
+      available: ok,
+      detail: ok
+        ? "Configuration looks ready for a dry-run PR review."
+        : "Complete blocked setup items before running a review.",
+      command: "neondiff review-pr --config config.local.json --repo owner/repo --pr 123 --dry-run true"
+    },
+    proofBoundary: "Local dashboard readiness only; this does not prove signed desktop release, appcast, notarization, or live review quality."
+  });
+}
+
+export async function verifyProviderApiKey(input: ProviderApiKeyVerificationInput): Promise<ProviderApiKeyVerificationResult> {
+  const checkedAt = new Date().toISOString();
+  const registry = input.config.providers!;
+  const providerId = input.providerId ?? registry.defaultProviderId;
+  const provider = registry.providers[providerId];
+  if (!provider) {
+    return redactedVerification({
+      ok: false,
+      command: "dashboard verify-provider",
+      checkedAt,
+      providerId,
+      state: "blocked",
+      mode: "metadata_only",
+      detail: `Provider ${providerId} is not configured.`,
+      redacted: true,
+      troubleshooting: ["Choose a configured provider id from config.providers.providers."]
+    });
+  }
+
+  if (provider.adapter !== "openai-compatible" || provider.authMode !== "api-key-env") {
+    const result = await doctorProviderRegistry({
+      registry,
+      providerId,
+      smoke: false,
+      env: input.env
+    });
+    const check = result.checks[0];
+    return redactedVerification({
+      ok: Boolean(check?.ok),
+      command: "dashboard verify-provider",
+      checkedAt,
+      providerId,
+      state: check?.ok ? "configured_unverified" : "blocked",
+      mode: "metadata_only",
+      detail: check?.ok
+        ? `${displayProviderName(providerId, registry)} passed metadata checks; API-key verification is not applicable for ${provider.authMode}.`
+        : check?.error ?? "Provider metadata check failed.",
+      redacted: true,
+      ...(check ? { check: redactProviderCheck(check) } : {}),
+      troubleshooting: result.troubleshooting
+    });
+  }
+
+  const apiKey = input.apiKey?.trim();
+  const env = { ...(input.env ?? process.env) };
+  if (apiKey && provider.apiKeyEnv) env[provider.apiKeyEnv] = apiKey;
+  const keyFingerprint = apiKey ? fingerprintSecret(apiKey) : provider.apiKeyEnv && env[provider.apiKeyEnv] ? "env-present" : undefined;
+  if (provider.apiKeyEnv && !env[provider.apiKeyEnv]) {
+    return redactedVerification({
+      ok: false,
+      command: "dashboard verify-provider",
+      checkedAt,
+      providerId,
+      state: "blocked",
+      mode: "metadata_only",
+      detail: `Missing API key source ${provider.apiKeyEnv}.`,
+      redacted: true,
+      troubleshooting: [`Set ${provider.apiKeyEnv} or paste a key into the local dashboard verify form.`]
+    });
+  }
+
+  const allowRemoteSmoke = input.allowRemoteSmoke === true;
+  const shouldSmoke = isLoopbackProvider(provider.baseUrl) || allowRemoteSmoke;
+  if (!shouldSmoke) {
+    const result = await doctorProviderRegistry({
+      registry,
+      providerId,
+      smoke: false,
+      env
+    });
+    const check = result.checks[0];
+    return redactedVerification({
+      ok: false,
+      command: "dashboard verify-provider",
+      checkedAt,
+      providerId,
+      state: check?.ok ? "configured_unverified" : "blocked",
+      mode: "metadata_only",
+      detail: check?.ok
+        ? "API key source is present, but hosted provider smoke was not run. Start dashboard with --allow-remote-smoke true to perform a live /models check."
+        : check?.error ?? "Provider metadata check failed.",
+      redacted: true,
+      ...(keyFingerprint ? { keyFingerprint } : {}),
+      ...(check ? { check: redactProviderCheck(check) } : {}),
+      troubleshooting: [
+        ...result.troubleshooting,
+        "Remote provider verification is opt-in to avoid surprising hosted-provider calls."
+      ]
+    });
+  }
+
+  const result = await doctorProviderRegistry({
+    registry,
+    providerId,
+    smoke: true,
+    allowRemoteSmoke,
+    env
+  });
+  const check = result.checks[0];
+  return redactedVerification({
+    ok: Boolean(check?.ok),
+    command: "dashboard verify-provider",
+    checkedAt,
+    providerId,
+    state: check?.ok ? "healthy" : "blocked",
+    mode: "openai_compatible_models",
+    detail: check?.ok
+      ? `Verified ${displayProviderName(providerId, registry)} with a redacted /models check.`
+      : check?.error ?? "Provider verification failed.",
+    redacted: true,
+    ...(keyFingerprint ? { keyFingerprint } : {}),
+    ...(check ? { check: redactProviderCheck(check) } : {}),
+    troubleshooting: result.troubleshooting
+  });
+}
+
+export function renderLocalDashboardHtml(status: LocalDashboardStatusContract): string {
+  const safeStatusJson = stringifyRedactedJson(status).replaceAll("</", "<\\/");
+  const items = Object.values(status.items).map((item) => renderStatusItem(item)).join("\n");
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>NeonDiff Dashboard</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #171a1f;
+      --muted: #5b6470;
+      --line: #d8dee8;
+      --panel: #ffffff;
+      --wash: #f5f7fb;
+      --ok: #16724b;
+      --warn: #9a5b00;
+      --bad: #b3261e;
+      --accent: #155eef;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink);
+      background: var(--wash);
+    }
+    main {
+      width: min(1120px, calc(100vw - 40px));
+      margin: 0 auto;
+      padding: 32px 0 44px;
+    }
+    header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 24px;
+      padding-bottom: 22px;
+      border-bottom: 1px solid var(--line);
+    }
+    h1 {
+      margin: 0 0 8px;
+      font-size: 34px;
+      line-height: 1.1;
+      letter-spacing: 0;
+    }
+    p { margin: 0; color: var(--muted); line-height: 1.45; }
+    .command {
+      flex: none;
+      padding: 8px 10px;
+      border: 1px solid var(--line);
+      background: var(--panel);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 13px;
+      border-radius: 6px;
+      color: #2e3440;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin: 22px 0;
+    }
+    .status-card, .setup-panel, .preview-panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+    }
+    .status-card {
+      min-height: 184px;
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .label {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      font-size: 14px;
+      font-weight: 700;
+    }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 3px 7px;
+      border-radius: 999px;
+      font-size: 11px;
+      border: 1px solid currentColor;
+      text-transform: uppercase;
+    }
+    .healthy { color: var(--ok); }
+    .degraded, .configured_unverified { color: var(--warn); }
+    .blocked, .not_configured { color: var(--bad); }
+    .detail { font-size: 13px; color: var(--muted); }
+    .actions {
+      margin: auto 0 0;
+      padding: 0;
+      list-style: none;
+      display: grid;
+      gap: 5px;
+      font-size: 12px;
+      color: #384250;
+    }
+    .setup-panel {
+      display: grid;
+      grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+      gap: 20px;
+      padding: 18px;
+      margin-bottom: 16px;
+    }
+    .form-row { display: grid; gap: 7px; margin-top: 12px; }
+    label { font-size: 13px; font-weight: 700; }
+    input, select {
+      width: 100%;
+      min-height: 38px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 8px 10px;
+      background: #fff;
+      color: var(--ink);
+      font: inherit;
+    }
+    .check-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 10px;
+      font-size: 13px;
+      color: var(--muted);
+    }
+    .check-row input { width: auto; min-height: 0; }
+    button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 38px;
+      margin-top: 12px;
+      padding: 8px 12px;
+      border: 1px solid #0f45bf;
+      border-radius: 6px;
+      background: var(--accent);
+      color: #fff;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    button:disabled { opacity: 0.58; cursor: progress; }
+    pre {
+      margin: 0;
+      white-space: pre-wrap;
+      word-break: break-word;
+      padding: 12px;
+      border-radius: 6px;
+      background: #111827;
+      color: #e5e7eb;
+      min-height: 132px;
+      font-size: 12px;
+    }
+    .preview-panel { padding: 16px 18px; }
+    .preview-panel code {
+      display: block;
+      margin-top: 8px;
+      padding: 10px;
+      border-radius: 6px;
+      border: 1px solid var(--line);
+      background: #f9fafb;
+      overflow-wrap: anywhere;
+    }
+    @media (max-width: 860px) {
+      header, .setup-panel { display: grid; }
+      .command { width: 100%; overflow-wrap: anywhere; }
+      .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+    @media (max-width: 540px) {
+      main { width: min(100vw - 24px, 1120px); padding-top: 20px; }
+      .grid { grid-template-columns: 1fr; }
+      h1 { font-size: 28px; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>NeonDiff Dashboard</h1>
+        <p>First-run setup and readiness for the local PR reviewer. Output is redacted before it reaches the browser.</p>
+      </div>
+      <div class="command">neondiff dashboard</div>
+    </header>
+    <section class="grid" aria-label="Readiness status">
+      ${items}
+    </section>
+    <section class="setup-panel" aria-label="Provider API key verification">
+      <div>
+        <h2>Provider Setup</h2>
+        <p>Verify the provider key source before launching review work. Hosted provider smoke checks are opt-in.</p>
+        <div class="form-row">
+          <label for="provider-id">Provider</label>
+          <select id="provider-id">
+            ${renderProviderOptions(status)}
+          </select>
+        </div>
+        <div class="form-row">
+          <label for="api-key">API key</label>
+          <input id="api-key" type="password" autocomplete="off" placeholder="Paste key for local verification; it is not echoed back">
+        </div>
+        <label class="check-row" for="allow-remote-smoke">
+          <input id="allow-remote-smoke" type="checkbox">
+          Allow hosted provider /models smoke check
+        </label>
+        <button id="verify-api-key" type="button">Verify API Key</button>
+      </div>
+      <div>
+        <h2>Verification Result</h2>
+        <pre id="verification-output">No provider verification has run in this browser session.</pre>
+      </div>
+    </section>
+    <section class="preview-panel" aria-label="First review dry-run preview">
+      <h2>First Review Dry Run</h2>
+      <p>${escapeHtml(status.firstReviewPreview.detail)}</p>
+      <code>${escapeHtml(status.firstReviewPreview.command)}</code>
+    </section>
+  </main>
+  <script type="application/json" id="dashboard-status">${safeStatusJson}</script>
+  <script>
+    const button = document.getElementById("verify-api-key");
+    const output = document.getElementById("verification-output");
+    button.addEventListener("click", async () => {
+      button.disabled = true;
+      output.textContent = "Verifying provider readiness...";
+      try {
+        const response = await fetch("/api/provider/verify", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            providerId: document.getElementById("provider-id").value,
+            apiKey: document.getElementById("api-key").value,
+            allowRemoteSmoke: document.getElementById("allow-remote-smoke").checked
+          })
+        });
+        const json = await response.json();
+        output.textContent = JSON.stringify(json, null, 2);
+      } catch (error) {
+        output.textContent = JSON.stringify({ ok: false, error: String(error) }, null, 2);
+      } finally {
+        document.getElementById("api-key").value = "";
+        button.disabled = false;
+      }
+    });
+  </script>
+</body>
+</html>`;
+}
+
+export async function startLocalDashboardServer(input: {
+  config: BotConfig;
+  configPath: string;
+  configExists: boolean;
+  host?: string;
+  port?: number;
+  launchdLabel?: string;
+  openBrowser?: boolean;
+  allowRemoteSmoke?: boolean;
+}): Promise<LocalDashboardServerHandle> {
+  let latestVerification: ProviderApiKeyVerificationResult | undefined;
+  let status = await buildLocalDashboardStatus({
+    config: input.config,
+    configPath: input.configPath,
+    configExists: input.configExists,
+    launchdLabel: input.launchdLabel,
+    providerVerification: latestVerification
+  });
+  const server = createServer(async (request, response) => {
+    try {
+      const url = new URL(request.url ?? "/", `http://${input.host ?? "127.0.0.1"}`);
+      if (request.method === "GET" && url.pathname === "/") {
+        status = await buildLocalDashboardStatus({
+          config: input.config,
+          configPath: input.configPath,
+          configExists: input.configExists,
+          launchdLabel: input.launchdLabel,
+          providerVerification: latestVerification
+        });
+        writeResponse(response, 200, "text/html; charset=utf-8", renderLocalDashboardHtml(status));
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/api/status") {
+        status = await buildLocalDashboardStatus({
+          config: input.config,
+          configPath: input.configPath,
+          configExists: input.configExists,
+          launchdLabel: input.launchdLabel,
+          providerVerification: latestVerification
+        });
+        writeResponse(response, 200, "application/json; charset=utf-8", stringifyRedactedJson(status));
+        return;
+      }
+      if (request.method === "POST" && url.pathname === "/api/provider/verify") {
+        const body = await readJsonBody(request);
+        latestVerification = await verifyProviderApiKey({
+          config: input.config,
+          providerId: readOptionalString(body, "providerId"),
+          apiKey: readOptionalString(body, "apiKey"),
+          allowRemoteSmoke: readOptionalBoolean(body, "allowRemoteSmoke") || input.allowRemoteSmoke === true
+        });
+        writeResponse(response, latestVerification.ok ? 200 : 422, "application/json; charset=utf-8", stringifyRedactedJson(latestVerification));
+        return;
+      }
+      writeResponse(response, 404, "application/json; charset=utf-8", stringifyRedactedJson({ ok: false, error: "not found" }));
+    } catch (error) {
+      writeResponse(response, 500, "application/json; charset=utf-8", stringifyRedactedJson({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error)
+      }));
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(input.port ?? 0, input.host ?? "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  const url = `http://${address.address === "::" ? "localhost" : address.address}:${address.port}/`;
+  const openAttempted = input.openBrowser !== false;
+  const openOk = openAttempted ? openLocalUrl(url) : false;
+  return { server, url, status, openAttempted, openOk };
+}
+
+async function buildLicenseStatusItem(config: BotConfig, checkedAt: string): Promise<LocalDashboardStatusItem> {
+  if (!config.license?.enabled) {
+    return {
+      id: "license",
+      label: "License",
+      state: config.license?.publicReposFree ? "degraded" : "not_configured",
+      detail: config.license?.publicReposFree
+        ? "License enforcement is not enabled; public repository mode may work, private activation is still pending."
+        : "License configuration is missing.",
+      checkedAt,
+      redacted: true,
+      actions: ["Set license.apiBaseUrl and activate a license before private-repo launch."]
+    };
+  }
+  const status = await getLicenseStatus({ config: config.license, refresh: false });
+  return licenseStatusItemFromResult(status, checkedAt);
+}
+
+function licenseStatusItemFromResult(status: LicenseStatusResult, checkedAt: string): LocalDashboardStatusItem {
+  return {
+    id: "license",
+    label: "License",
+    state: status.ok ? (status.stale ? "degraded" : "healthy") : status.status === "missing" ? "not_configured" : "blocked",
+    detail: status.detail,
+    checkedAt,
+    redacted: true,
+    actions: status.ok ? ["License status is ready for the configured scope."] : ["Run neondiff license activate with a key stored outside shell history."],
+    metadata: {
+      status: status.status,
+      source: status.source,
+      stale: status.stale === true,
+      plan: status.entitlement?.plan ?? null,
+      licenseFingerprint: status.entitlement?.licenseFingerprint ?? null
+    }
+  };
+}
+
+function buildGitHubAppStatusItem(config: BotConfig, checkedAt: string): LocalDashboardStatusItem {
+  const hasApp = Boolean(config.github.appId && config.github.privateKeyPath);
+  const hasReadableKeyPath = Boolean(config.github.privateKeyPath && existsSync(config.github.privateKeyPath));
+  const hasFallbackToken = Boolean(config.github.token);
+  if (hasApp && hasReadableKeyPath) {
+    return {
+      id: "githubApp",
+      label: "GitHub App",
+      state: "configured_unverified",
+      detail: "GitHub App credentials are configured locally; run doctor github for installation-scope proof.",
+      checkedAt,
+      redacted: true,
+      actions: ["Run neondiff doctor github --config config.local.json --json."],
+      metadata: {
+        readMode: "app_installation",
+        appIdConfigured: true,
+        privateKeyPathPresent: true
+      }
+    };
+  }
+  if (hasFallbackToken) {
+    return {
+      id: "githubApp",
+      label: "GitHub App",
+      state: "degraded",
+      detail: "Fallback GitHub token is present, but GitHub App installation proof is not configured.",
+      checkedAt,
+      redacted: true,
+      actions: ["Create/install the GitHub App and set NEONDIFF_GITHUB_APP_ID plus NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH."],
+      metadata: { readMode: "fallback_token" }
+    };
+  }
+  return {
+    id: "githubApp",
+    label: "GitHub App",
+    state: "not_configured",
+    detail: "No GitHub App credentials or fallback token are configured.",
+    checkedAt,
+    redacted: true,
+    actions: ["Create/install the GitHub App before expecting PR reviews."]
+  };
+}
+
+function buildDaemonStatusItem(config: BotConfig, checkedAt: string, launchdLabel?: string): LocalDashboardStatusItem {
+  if (!launchdLabel) {
+    return {
+      id: "daemon",
+      label: "Daemon",
+      state: "not_configured",
+      detail: "No launchd label was supplied to this dashboard session.",
+      checkedAt,
+      redacted: true,
+      actions: ["Start with --launchd-label or use daemon start/status after setup."],
+      metadata: {
+        pollIntervalMs: config.pollIntervalMs
+      }
+    };
+  }
+  return {
+    id: "daemon",
+    label: "Daemon",
+    state: "configured_unverified",
+    detail: "Daemon label is configured for display; launchd status proof is a separate operator check.",
+    checkedAt,
+    redacted: true,
+    actions: ["Run neondiff daemon status --config config.local.json --launchd-label <label>."],
+    metadata: { launchdLabel }
+  };
+}
+
+function buildProviderStatusItem(registry: ProviderRegistryConfig, checkedAt: string): LocalDashboardStatusItem {
+  const providerId = registry.defaultProviderId;
+  const provider = registry.providers[providerId];
+  if (!provider) {
+    return {
+      id: "provider",
+      label: "Provider",
+      state: "blocked",
+      detail: `Default provider ${providerId} is not configured.`,
+      checkedAt,
+      redacted: true,
+      actions: ["Choose an existing provider id in providers.defaultProviderId."]
+    };
+  }
+  const authReady = provider.authMode !== "api-key-env" || Boolean(provider.apiKeyEnv && process.env[provider.apiKeyEnv]);
+  const state: LocalDashboardReadinessState = !provider.enabled
+    ? "not_configured"
+    : provider.authMode === "api-key-env" && !authReady
+      ? "not_configured"
+      : provider.capabilities.review && provider.capabilities.jsonOutput
+        ? "configured_unverified"
+        : "blocked";
+  return {
+    id: "provider",
+    label: "Provider",
+    state,
+    detail: providerStatusDetail(providerId, registry, state),
+    checkedAt,
+    redacted: true,
+    actions: provider.authMode === "api-key-env"
+      ? ["Use Verify API Key to run a redacted readiness check."]
+      : ["Run provider doctor or a review dry-run to verify runtime auth."],
+    metadata: {
+      providerId,
+      adapter: provider.adapter,
+      authMode: provider.authMode,
+      apiKeyEnv: provider.apiKeyEnv ?? null,
+      model: provider.model
+    }
+  };
+}
+
+function providerStatusDetail(providerId: string, registry: ProviderRegistryConfig, state: LocalDashboardReadinessState): string {
+  const provider = registry.providers[providerId]!;
+  if (!provider.enabled) return `${displayProviderName(providerId, registry)} is disabled.`;
+  if (provider.authMode === "api-key-env" && provider.apiKeyEnv && !process.env[provider.apiKeyEnv]) {
+    return `${displayProviderName(providerId, registry)} needs API key source ${provider.apiKeyEnv}.`;
+  }
+  if (!provider.capabilities.review || !provider.capabilities.jsonOutput) {
+    return `${displayProviderName(providerId, registry)} is not ready for JSON PR reviews.`;
+  }
+  if (state === "configured_unverified") {
+    return `${displayProviderName(providerId, registry)} is configured but has not been verified in this dashboard session.`;
+  }
+  return `${displayProviderName(providerId, registry)} status is ${state}.`;
+}
+
+function providerStatusItemFromVerification(result: ProviderApiKeyVerificationResult, checkedAt: string): LocalDashboardStatusItem {
+  return {
+    id: "provider",
+    label: "Provider",
+    state: result.state,
+    detail: result.detail,
+    checkedAt,
+    redacted: true,
+    actions: result.ok ? ["Provider readiness check passed."] : result.troubleshooting,
+    metadata: {
+      providerId: result.providerId,
+      mode: result.mode,
+      keyFingerprint: result.keyFingerprint ?? null
+    }
+  };
+}
+
+function displayProviderName(providerId: string, registry: ProviderRegistryConfig): string {
+  return registry.providers[providerId]?.displayName ?? providerId;
+}
+
+function isLoopbackProvider(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false;
+  try {
+    const parsed = new URL(baseUrl);
+    return parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1" || parsed.hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function redactProviderCheck(check: ProviderDoctorCheck): ProviderDoctorCheck {
+  return JSON.parse(stringifyRedactedJson(check)) as ProviderDoctorCheck;
+}
+
+function redactedStatus(status: LocalDashboardStatusContract): LocalDashboardStatusContract {
+  return JSON.parse(stringifyRedactedJson(status)) as LocalDashboardStatusContract;
+}
+
+function redactedVerification(result: ProviderApiKeyVerificationResult): ProviderApiKeyVerificationResult {
+  return JSON.parse(stringifyRedactedJson(result)) as ProviderApiKeyVerificationResult;
+}
+
+function fingerprintSecret(secret: string): string {
+  const hash = createHash("sha256").update(secret).digest("hex").slice(0, 12);
+  return `sha256:${hash}`;
+}
+
+function renderStatusItem(item: LocalDashboardStatusItem): string {
+  return `<article class="status-card" data-status-id="${escapeHtml(item.id)}">
+    <div class="label">
+      <span>${escapeHtml(item.label)}</span>
+      <span class="pill ${escapeHtml(item.state)}">${escapeHtml(item.state)}</span>
+    </div>
+    <p class="detail">${escapeHtml(item.detail)}</p>
+    <ul class="actions">
+      ${item.actions.map((action) => `<li>${escapeHtml(action)}</li>`).join("")}
+    </ul>
+  </article>`;
+}
+
+function renderProviderOptions(status: LocalDashboardStatusContract): string {
+  return status.providers.options.map((option) => {
+    const label = `${option.label} (${option.authMode})`;
+    return `<option value="${escapeHtml(option.id)}"${option.default ? " selected" : ""}>${escapeHtml(label)}</option>`;
+  }).join("\n");
+}
+
+function buildProviderOptions(registry: ProviderRegistryConfig): LocalDashboardProviderOption[] {
+  return Object.entries(registry.providers).map(([id, provider]) => ({
+    id,
+    label: provider.displayName ?? id,
+    adapter: provider.adapter,
+    authMode: provider.authMode,
+    ...(provider.apiKeyEnv ? { apiKeyEnv: provider.apiKeyEnv } : {}),
+    default: id === registry.defaultProviderId
+  }));
+}
+
+function escapeHtml(value: string): string {
+  return redactSecrets(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function openLocalUrl(url: string): boolean {
+  try {
+    const child = spawn("open", [url], {
+      detached: true,
+      stdio: "ignore"
+    });
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    if (Buffer.concat(chunks).length > 16 * 1024) throw new Error("request body is too large");
+  }
+  if (chunks.length === 0) return {};
+  const parsed = JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {};
+}
+
+function readOptionalString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function readOptionalBoolean(record: Record<string, unknown>, key: string): boolean {
+  return record[key] === true;
+}
+
+function writeResponse(response: ServerResponse, statusCode: number, contentType: string, body: string): void {
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", contentType);
+  response.setHeader("Cache-Control", "no-store");
+  response.end(body);
+}

--- a/src/local-dashboard.ts
+++ b/src/local-dashboard.ts
@@ -1,7 +1,6 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { createHash } from "node:crypto";
 import type { AddressInfo } from "node:net";
 import type { BotConfig } from "./config.js";
 import { getLicenseStatus, type LicenseStatusResult } from "./license.js";
@@ -92,7 +91,7 @@ export interface ProviderApiKeyVerificationResult {
   mode: "metadata_only" | "openai_compatible_models";
   detail: string;
   redacted: true;
-  keyFingerprint?: string;
+  keySource?: "submitted" | "env";
   check?: Omit<ProviderDoctorCheck, "error"> & { error?: string };
   troubleshooting: string[];
 }
@@ -188,7 +187,7 @@ export async function verifyProviderApiKey(input: ProviderApiKeyVerificationInpu
   const apiKey = input.apiKey?.trim();
   const env = { ...(input.env ?? process.env) };
   if (apiKey && provider.apiKeyEnv) env[provider.apiKeyEnv] = apiKey;
-  const keyFingerprint = apiKey ? fingerprintSecret(apiKey) : provider.apiKeyEnv && env[provider.apiKeyEnv] ? "env-present" : undefined;
+  const keySource = apiKey ? "submitted" : provider.apiKeyEnv && env[provider.apiKeyEnv] ? "env" : undefined;
   if (provider.apiKeyEnv && !env[provider.apiKeyEnv]) {
     return redactedVerification({
       ok: false,
@@ -224,7 +223,7 @@ export async function verifyProviderApiKey(input: ProviderApiKeyVerificationInpu
         ? "API key source is present, but hosted provider smoke was not run. Start dashboard with --allow-remote-smoke true to perform a live /models check."
         : check?.error ?? "Provider metadata check failed.",
       redacted: true,
-      ...(keyFingerprint ? { keyFingerprint } : {}),
+      ...(keySource ? { keySource } : {}),
       ...(check ? { check: redactProviderCheck(check) } : {}),
       troubleshooting: [
         ...result.troubleshooting,
@@ -252,7 +251,7 @@ export async function verifyProviderApiKey(input: ProviderApiKeyVerificationInpu
       ? `Verified ${displayProviderName(providerId, registry)} with a redacted /models check.`
       : check?.error ?? "Provider verification failed.",
     redacted: true,
-    ...(keyFingerprint ? { keyFingerprint } : {}),
+    ...(keySource ? { keySource } : {}),
     ...(check ? { check: redactProviderCheck(check) } : {}),
     troubleshooting: result.troubleshooting
   });
@@ -574,7 +573,7 @@ export async function startLocalDashboardServer(input: {
     } catch (error) {
       writeResponse(response, 500, "application/json; charset=utf-8", stringifyRedactedJson({
         ok: false,
-        error: error instanceof Error ? error.message : String(error)
+        error: "dashboard request failed"
       }));
     }
   });
@@ -769,7 +768,7 @@ function providerStatusItemFromVerification(result: ProviderApiKeyVerificationRe
     metadata: {
       providerId: result.providerId,
       mode: result.mode,
-      keyFingerprint: result.keyFingerprint ?? null
+      keySource: result.keySource ?? null
     }
   };
 }
@@ -798,11 +797,6 @@ function redactedStatus(status: LocalDashboardStatusContract): LocalDashboardSta
 
 function redactedVerification(result: ProviderApiKeyVerificationResult): ProviderApiKeyVerificationResult {
   return JSON.parse(stringifyRedactedJson(result)) as ProviderApiKeyVerificationResult;
-}
-
-function fingerprintSecret(secret: string): string {
-  const hash = createHash("sha256").update(secret).digest("hex").slice(0, 12);
-  return `sha256:${hash}`;
 }
 
 function renderStatusItem(item: LocalDashboardStatusItem): string {

--- a/tests/local-dashboard.test.ts
+++ b/tests/local-dashboard.test.ts
@@ -88,7 +88,7 @@ describe("local HTML dashboard", () => {
       state: "configured_unverified",
       mode: "metadata_only",
       redacted: true,
-      keyFingerprint: expect.stringMatching(/^sha256:[a-f0-9]{12}$/)
+      keySource: "submitted"
     });
     const serialized = JSON.stringify(result);
     expect(serialized).not.toContain(fakeKey);

--- a/tests/local-dashboard.test.ts
+++ b/tests/local-dashboard.test.ts
@@ -1,0 +1,212 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadConfigFromObject } from "../src/config.js";
+import {
+  buildLocalDashboardStatus,
+  renderLocalDashboardHtml,
+  startLocalDashboardServer,
+  verifyProviderApiKey
+} from "../src/local-dashboard.js";
+
+describe("local HTML dashboard", () => {
+  const servers: Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map((server) => closeServer(server)));
+  });
+
+  it("builds a redacted first-run status contract for an empty config", async () => {
+    const config = loadConfigFromObject({});
+    const status = await buildLocalDashboardStatus({
+      config,
+      configPath: "/Volumes/LEXAR/Codex/neondiff/config.local.json",
+      configExists: false,
+      now: new Date("2026-07-08T12:00:00.000Z")
+    });
+
+    expect(status).toMatchObject({
+      ok: false,
+      command: "dashboard status",
+      schemaVersion: "local-dashboard-status-v0.1",
+      config: {
+        exists: false,
+        source: "defaults"
+      },
+      items: {
+        license: expect.objectContaining({ id: "license", redacted: true }),
+        githubApp: expect.objectContaining({ id: "githubApp", state: "not_configured", redacted: true }),
+        daemon: expect.objectContaining({ id: "daemon", state: "not_configured", redacted: true }),
+        provider: expect.objectContaining({ id: "provider", state: "configured_unverified", redacted: true })
+      },
+      providers: {
+        defaultProviderId: "zcode-glm",
+        options: expect.arrayContaining([
+          expect.objectContaining({ id: "zcode-glm", default: true }),
+          expect.objectContaining({ id: "openai-compatible", authMode: "api-key-env" })
+        ])
+      }
+    });
+
+    const html = renderLocalDashboardHtml(status);
+    expect(html).toContain("NeonDiff Dashboard");
+    expect(html).toContain("Verify API Key");
+    expect(html).toContain("License");
+    expect(html).toContain("GitHub App");
+    expect(html).toContain("Daemon");
+    expect(html).toContain("Provider");
+    expect(html).toContain("openai-compatible");
+  });
+
+  it("verifies provider API key input without echoing the submitted key", async () => {
+    const fakeKey = ["sk", "dashboard-secret-value-1234567890"].join("-");
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model"
+          }
+        }
+      }
+    });
+
+    const result = await verifyProviderApiKey({
+      config,
+      providerId: "openai-compatible",
+      apiKey: fakeKey,
+      allowRemoteSmoke: false,
+      env: {}
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      command: "dashboard verify-provider",
+      providerId: "openai-compatible",
+      state: "configured_unverified",
+      mode: "metadata_only",
+      redacted: true,
+      keyFingerprint: expect.stringMatching(/^sha256:[a-f0-9]{12}$/)
+    });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(fakeKey);
+    expect(serialized).not.toContain("dashboard-secret-value");
+    expect(serialized).not.toMatch(/Bearer\s+/i);
+  });
+
+  it("performs a real loopback /models smoke check when provider verification is local", async () => {
+    const modelServer = createServer((request, response) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      response.setHeader("Content-Type", "application/json");
+      if (request.method === "GET" && url.pathname === "/v1/models") {
+        response.end(JSON.stringify({ data: [{ id: "local-review-model" }] }));
+        return;
+      }
+      response.statusCode = 404;
+      response.end(JSON.stringify({ message: "not found" }));
+    });
+    servers.push(modelServer);
+    await listen(modelServer);
+    const address = modelServer.address() as AddressInfo;
+    const fakeKey = ["sk", "local-dashboard-loopback-1234567890"].join("-");
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            baseUrl: `http://127.0.0.1:${address.port}/v1`,
+            model: "local-review-model",
+            capabilities: {
+              local: true
+            }
+          }
+        }
+      }
+    });
+
+    const result = await verifyProviderApiKey({
+      config,
+      providerId: "openai-compatible",
+      apiKey: fakeKey,
+      env: {}
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      state: "healthy",
+      mode: "openai_compatible_models",
+      check: expect.objectContaining({
+        smokeAttempted: true,
+        readMode: "openai_compatible_models",
+        modelCount: 1
+      })
+    });
+    expect(JSON.stringify(result)).not.toContain(fakeKey);
+  });
+
+  it("serves HTML status and redacted provider verification routes", async () => {
+    const fakeKey = ["sk", "dashboard-route-1234567890"].join("-");
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model"
+          }
+        }
+      }
+    });
+    const handle = await startLocalDashboardServer({
+      config,
+      configPath: "/Volumes/LEXAR/Codex/neondiff/config.local.json",
+      configExists: true,
+      openBrowser: false,
+      port: 0
+    });
+    servers.push(handle.server);
+
+    const html = await (await fetch(handle.url)).text();
+    expect(html).toContain("Verify API Key");
+    expect(html).toContain("dashboard-status");
+
+    const response = await fetch(new URL("/api/provider/verify", handle.url), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        providerId: "openai-compatible",
+        apiKey: fakeKey,
+        allowRemoteSmoke: false
+      })
+    });
+    const resultText = await response.text();
+    expect(response.status).toBe(422);
+    expect(resultText).toContain("configured_unverified");
+    expect(resultText).not.toContain(fakeKey);
+    expect(resultText).not.toContain("dashboard-route");
+  });
+});
+
+async function listen(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -41,6 +41,7 @@ describe("public NeonDiff CLI surface", () => {
       "config patch",
       "pricing",
       "badge",
+      "dashboard",
       "providers list",
       "providers doctor",
       "doctor",
@@ -57,6 +58,7 @@ describe("public NeonDiff CLI surface", () => {
     expect(output.examples).toContain("neondiff init --config config.local.json");
     expect(output.examples).toContain("neondiff pricing");
     expect(output.examples).toContain("neondiff badge --config config.local.json --output docs/badges/precision.json");
+    expect(output.examples).toContain("neondiff dashboard --config config.local.json");
     expect(output.examples).toContain("neondiff providers list --config config.local.json --json");
     expect(output.examples).toContain("neondiff providers doctor --config config.local.json --json");
     expect(output.examples).toContain("neondiff providers doctor --config config.local.json --provider ollama-local --smoke true --json");


### PR DESCRIPTION
## Summary

- adds the local HTML `neondiff dashboard` entrypoint for first-run setup/status
- adds a redacted dashboard status bridge for license, GitHub App, daemon, and provider readiness
- adds a visible provider selector plus `Verify API Key` flow with opt-in hosted smoke and no raw-key echoing
- preserves the legacy operator dashboard behind `--operator true` / existing operator filters

Closes #443
Closes #444
Closes #445

## Validation

- `npm test -- --run tests/local-dashboard.test.ts tests/public-cli.test.ts`
- `npm run build`
- `git diff --check`
- Browser smoke via headless Chrome against local dashboard URL

## Evidence

- Screenshot: `/Volumes/LEXAR/Codex/evidence/neondiff/browser-first-dashboard/dashboard-443-444-445.png`
- Redacted provider verify response: `/Volumes/LEXAR/Codex/evidence/neondiff/browser-first-dashboard/provider-verify-redacted.json`
- Notes: `/Volumes/LEXAR/Codex/session-notes/2026-07-08/neondiff-ga-dashboard/implementation-notes.html`

## Proof Boundary

This proves the browser-first dashboard MVP, local status bridge, and API-key verification UI/route. It does not prove signed desktop app readiness, appcast, updater, notarization, GA cutover, live review quality, or paid/private license issuance.
