### PR TITLE
[codex] Add minimal Mac dashboard launcher

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopApp.swift
@@ -16,6 +16,11 @@ struct NeonDiffDesktopApp: App {
         }
         .commands {
             CommandMenu("NeonDiff") {
+                Button("Open Local Dashboard") {
+                    model.openDashboard()
+                }
+                .keyboardShortcut("d", modifiers: [.command])
+
                 Button("Refresh Status") {
                     model.refreshStatus()
                 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
@@ -15,6 +15,8 @@ final class NeonDiffDesktopModel: ObservableObject {
     @Published var logText = "No logs loaded."
     @Published var lastError: String?
     @Published var lastCommandLine = ""
+    @Published var dashboardLaunchStatus = "not opened"
+    @Published var dashboardProcessIdentifier: Int32?
     @Published var pendingProviderKey = ""
     @Published var pendingLicenseKey = ""
     @Published var onboardingFlow = OnboardingFlow()
@@ -22,6 +24,7 @@ final class NeonDiffDesktopModel: ObservableObject {
 
     private let userDefaults: UserDefaults
     private let keychain: DesktopSecretStoring
+    private var didAutoOpenDashboard = false
 
     init(
         userDefaults: UserDefaults = .standard,
@@ -42,6 +45,10 @@ final class NeonDiffDesktopModel: ObservableObject {
 
     var statusCommand: DesktopCommand {
         NeonDiffCommandBuilder.daemonStatus(cliPath: cliPath, configPath: configPath, launchdLabel: launchdLabel)
+    }
+
+    var dashboardCommand: DesktopCommand {
+        NeonDiffCommandBuilder.dashboard(cliPath: cliPath, configPath: configPath, launchdLabel: launchdLabel)
     }
 
     var startDaemonDryRunCommand: DesktopCommand {
@@ -81,6 +88,43 @@ final class NeonDiffDesktopModel: ObservableObject {
     func refreshStatus() {
         persistLocalSettings()
         runCLI(arguments: ["daemon", "status", "--config", configPath, "--launchd-label", launchdLabel], displayCommand: statusCommand)
+    }
+
+    func openDashboardOnLaunch() {
+        guard !didAutoOpenDashboard else { return }
+        didAutoOpenDashboard = true
+        openDashboard()
+    }
+
+    func openDashboard() {
+        persistLocalSettings()
+        lastCommandLine = dashboardCommand.commandLine
+        dashboardLaunchStatus = "starting"
+        let executablePath = cliPath
+        let arguments = ["dashboard", "--config", configPath, "--launchd-label", launchdLabel, "--open", "true"]
+
+        Task.detached {
+            let client = NeonDiffCLIClient(
+                executablePath: executablePath,
+                workingDirectory: NeonDiffCLIResolver.defaultWorkingDirectory()
+            )
+            do {
+                let result = try client.launchDetached(arguments: arguments)
+                await MainActor.run {
+                    self.dashboardProcessIdentifier = result.processIdentifier
+                    self.dashboardLaunchStatus = "launched pid \(result.processIdentifier); browser opens the local HTML dashboard"
+                    self.lastError = nil
+                    self.logText = "Started NeonDiff local dashboard from the desktop launcher. The dashboard process opens the browser and serves the same HTML experience as `neondiff dashboard`."
+                }
+            } catch {
+                await MainActor.run {
+                    self.dashboardProcessIdentifier = nil
+                    self.dashboardLaunchStatus = "failed"
+                    self.lastError = NeonDiffRedactor.redact(error.localizedDescription)
+                    self.logText = self.lastError ?? "Unknown dashboard launch error"
+                }
+            }
+        }
     }
 
     func previewStartDaemon() {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
@@ -34,6 +34,9 @@ struct ContentView: View {
         .tint(NeonDiffTheme.accent)
         .buttonStyle(OperatorButtonStyle())
         .preferredColorScheme(.dark)
+        .onAppear {
+            model.openDashboardOnLaunch()
+        }
         .sheet(isPresented: $model.isOnboardingPresented) {
             OnboardingWizardView(model: model)
                 .frame(minWidth: 760, minHeight: 560)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -12,9 +12,30 @@ struct OverviewView: View {
                     StatusTile(title: "Runtime", value: model.status.healthState, systemImage: "bolt.horizontal.circle")
                     StatusTile(title: "Repos", value: "\(model.status.monitoredRepos.count)", systemImage: "folder")
                     StatusTile(title: "Keys", value: model.providers.providerKeyStored ? "stored" : "missing", systemImage: "key")
+                    StatusTile(title: "Dashboard", value: model.dashboardProcessIdentifier == nil ? model.dashboardLaunchStatus : "launched", systemImage: "macwindow")
+                }
+
+                OperatorSection("Local Dashboard Launcher") {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("The Mac launcher opens the same local HTML dashboard as the CLI. Provider, license, GitHub App, and daemon readiness remain redacted in the browser dashboard.")
+                            .operatorBodyText()
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        HStack(spacing: 10) {
+                            Button { model.openDashboard() } label: {
+                                Label("Open Dashboard", systemImage: "safari")
+                            }
+                            Button { model.copyCommand(model.dashboardCommand) } label: {
+                                Label("Copy Dashboard Command", systemImage: "doc.on.doc")
+                            }
+                        }
+
+                        OperatorCommandText(text: model.dashboardCommand.commandLine, lineLimit: 3)
+                    }
                 }
 
                 CommandPanel(commands: [
+                    model.dashboardCommand,
                     model.statusCommand,
                     model.startDaemonDryRunCommand,
                     model.stopDaemonDryRunCommand,
@@ -22,6 +43,9 @@ struct OverviewView: View {
                 ], copy: model.copyCommand)
 
                 HStack(spacing: 10) {
+                    Button { model.openDashboard() } label: {
+                        Label("Dashboard", systemImage: "macwindow")
+                    }
                     Button { model.refreshStatus() } label: {
                         Label("Refresh", systemImage: "arrow.clockwise")
                     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/SettingsPane.swift
@@ -17,8 +17,12 @@ struct SettingsPane: View {
                 }
 
                 OperatorSection("Commands") {
+                    OperatorCommandText(text: model.dashboardCommand.commandLine, lineLimit: 5)
                     OperatorCommandText(text: model.statusCommand.commandLine, lineLimit: 5)
                     HStack(spacing: 10) {
+                        Button { model.openDashboard() } label: {
+                            Label("Open Dashboard", systemImage: "safari")
+                        }
                         Button { model.copyCommand(model.statusCommand) } label: {
                             Label("Copy Status Command", systemImage: "doc.on.doc")
                         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/CommandBuilders.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/CommandBuilders.swift
@@ -23,6 +23,18 @@ public enum NeonDiffCommandBuilder {
         )
     }
 
+    public static func dashboard(
+        cliPath: String,
+        configPath: String,
+        launchdLabel: String,
+        openBrowser: Bool = true
+    ) -> DesktopCommand {
+        DesktopCommand(
+            title: "Open local dashboard",
+            commandLine: "\(shellQuote(cliPath)) dashboard --config \(shellQuote(configPath)) --launchd-label \(shellQuote(launchdLabel)) --open \(openBrowser ? "true" : "false")"
+        )
+    }
+
     public static func daemonControl(
         action: String,
         cliPath: String,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
@@ -9,6 +9,18 @@ public struct CLIRunResult: Equatable {
     public var redactedStderr: String { NeonDiffRedactor.redact(stderr) }
 }
 
+public struct CLILaunchResult: Equatable {
+    public var processIdentifier: Int32
+    public var executablePath: String
+    public var arguments: [String]
+
+    public init(processIdentifier: Int32, executablePath: String, arguments: [String]) {
+        self.processIdentifier = processIdentifier
+        self.executablePath = executablePath
+        self.arguments = arguments
+    }
+}
+
 public enum NeonDiffCLIError: Error, LocalizedError {
     case timedOut
     case launchFailed(String)
@@ -23,6 +35,7 @@ public enum NeonDiffCLIError: Error, LocalizedError {
 
 public protocol NeonDiffCLIClienting {
     func run(arguments: [String], timeout: TimeInterval) throws -> CLIRunResult
+    func launchDetached(arguments: [String]) throws -> CLILaunchResult
 }
 
 public final class NeonDiffCLIClient: NeonDiffCLIClienting {
@@ -100,6 +113,37 @@ public final class NeonDiffCLIClient: NeonDiffCLIClienting {
         let stdoutText = String(data: stdoutSnapshot, encoding: .utf8) ?? ""
         let stderrText = String(data: stderrSnapshot, encoding: .utf8) ?? ""
         return CLIRunResult(exitCode: process.terminationStatus, stdout: stdoutText, stderr: stderrText)
+    }
+
+    public func launchDetached(arguments: [String]) throws -> CLILaunchResult {
+        let process = Process()
+        guard let resolvedExecutable = NeonDiffCLIResolver.resolveExecutablePath(executablePath, workingDirectory: workingDirectory) else {
+            throw NeonDiffCLIError.launchFailed("Could not find executable NeonDiff CLI at \(executablePath). Set an absolute CLI path or install the `neondiff` command in a GUI-visible bin directory.")
+        }
+        process.executableURL = resolvedExecutable
+        process.arguments = arguments
+        process.environment = guiSafeEnvironment()
+        if let workingDirectory {
+            process.currentDirectoryURL = workingDirectory
+        }
+
+        let nullOutput = FileHandle(forWritingAtPath: "/dev/null")
+        process.standardOutput = nullOutput
+        process.standardError = nullOutput
+
+        do {
+            try process.run()
+        } catch {
+            nullOutput?.closeFile()
+            throw NeonDiffCLIError.launchFailed("Failed to launch NeonDiff CLI at \(executablePath): \(error.localizedDescription)")
+        }
+        nullOutput?.closeFile()
+
+        return CLILaunchResult(
+            processIdentifier: process.processIdentifier,
+            executablePath: process.executableURL?.path ?? executablePath,
+            arguments: process.arguments ?? arguments
+        )
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
@@ -66,4 +66,23 @@ check(
     "local package CLI is preferred over GUI PATH fallback"
 )
 
+let launchMarker = tempRoot.appendingPathComponent("dashboard-launch-marker.txt")
+let launchScript = tempRoot.appendingPathComponent("dashboard-launcher")
+try """
+#!/usr/bin/env bash
+printf '%s\\n' "$*" > \(launchMarker.path)
+""".write(to: launchScript, atomically: true, encoding: .utf8)
+try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: launchScript.path)
+
+let launchClient = NeonDiffCLIClient(executablePath: launchScript.path, workingDirectory: tempRoot)
+let launchResult = try launchClient.launchDetached(arguments: ["dashboard", "--config", "config.local.json", "--open", "true"])
+check(launchResult.processIdentifier > 0, "dashboard launcher returns a child process identifier")
+let markerDeadline = Date().addingTimeInterval(3)
+while !FileManager.default.fileExists(atPath: launchMarker.path), Date() < markerDeadline {
+    Thread.sleep(forTimeInterval: 0.05)
+}
+check(FileManager.default.fileExists(atPath: launchMarker.path), "dashboard launcher writes its marker file")
+let markerContents = try String(contentsOf: launchMarker, encoding: .utf8)
+check(markerContents.contains("dashboard --config config.local.json --open true"), "dashboard launcher passes expected CLI arguments")
+
 print("NeonDiffDesktopCoreChecks passed")

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
@@ -29,6 +29,19 @@ do {
         throw NSError(domain: "NeonDiffDesktopSmoke", code: 3, userInfo: [NSLocalizedDescriptionKey: "daemon command is not dry-run safe"])
     }
 
+    let dashboardCommand = NeonDiffCommandBuilder.dashboard(
+        cliPath: "neondiff",
+        configPath: "/tmp/config.local.json",
+        launchdLabel: "com.example.neondiff"
+    )
+    guard dashboardCommand.commandLine.contains("dashboard"),
+          dashboardCommand.commandLine.contains("--open true"),
+          dashboardCommand.commandLine.contains("--launchd-label"),
+          !dashboardCommand.commandLine.contains("--operator true")
+    else {
+        throw NSError(domain: "NeonDiffDesktopSmoke", code: 10, userInfo: [NSLocalizedDescriptionKey: "dashboard command does not launch the local HTML dashboard"])
+    }
+
     let fakeStatusJSON = """
     {
       "ok": false,
@@ -117,7 +130,7 @@ do {
 
     try store.deleteSecret(account: providerAccount)
     try store.deleteSecret(account: licenseAccount)
-    print(#"{"ok":true,"keychainRoundTrip":true,"daemonDryRun":true,"fakeStatusParse":true,"fakeConfigParse":true,"repoProfilesFallback":true,"redaction":true}"#)
+    print(#"{"ok":true,"keychainRoundTrip":true,"daemonDryRun":true,"dashboardCommand":true,"fakeStatusParse":true,"fakeConfigParse":true,"repoProfilesFallback":true,"redaction":true}"#)
 } catch {
     try? store.deleteSecret(account: providerAccount)
     try? store.deleteSecret(account: licenseAccount)

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -1,11 +1,16 @@
 # NeonDiff Desktop Dev MVP
 
 NeonDiff Desktop is a SwiftPM macOS app scaffold for issue #115. It is a thin local control panel over the NeonDiff CLI and daemon contracts.
+For the 1.0 launch bar, the Mac app is intentionally a minimal launcher:
+opening the app starts `neondiff dashboard` and opens the same local HTML
+dashboard used by the CLI.
 
 ## Boundaries
 
 - No review engine runs in the desktop app.
 - No UI path posts GitHub reviews directly.
+- The Mac launcher does not implement a separate native setup flow; the local
+  HTML dashboard remains the first-run/provider/license/status surface.
 - No signing, notarization, Sparkle appcast, downloadable artifact, TCC, Mac-control, or customer-control proof is claimed here.
 - Provider and license keys are stored in macOS Keychain under a NeonDiff-specific service and are never written to config files.
 
@@ -34,9 +39,23 @@ neondiff config patch --config config.local.json --input desktop-patch.json --dr
 neondiff daemon status --config config.local.json --launchd-label com.example.neondiff
 neondiff daemon start --config config.local.json --launchd-label com.example.neondiff --dry-run true
 neondiff daemon stop --config config.local.json --launchd-label com.example.neondiff --dry-run true
+neondiff dashboard --config config.local.json --launchd-label com.example.neondiff --open true
 ```
 
 `config patch` writes only whitelisted non-secret fields, defaults to dry-run, and requires `--confirm true` for live writes.
 Patch inputs use nested JSON object shape for editable paths. For example, the advertised `zcode.cliPath` path is supplied as `{ "zcode": { "cliPath": "/path/to/neondiff" } }`; flat dotted keys such as `{ "zcode.cliPath": "/path/to/neondiff" }` are rejected to avoid ambiguous profile keys.
 
 The ZCode defaults in `config.example.json` are developer-machine paths. On any non-author workstation or packaged desktop install, set explicit local values for `zcode.cliPath`, `zcode.appConfigPath`, and `zcode.model` before relying on daemon controls.
+
+## Local Dashboard Launcher
+
+Opening the dev app starts the same local dashboard server as:
+
+```bash
+neondiff dashboard --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --open true
+```
+
+The dashboard owns first-run setup and readiness display for provider API key
+verification, license status, GitHub App status, daemon status, and provider
+readiness. The Swift app only launches that browser-first surface and shows the
+redacted command/status locally.


### PR DESCRIPTION
## Summary

Closes #447.
Closes #448.

Adds the GA-minimum Mac desktop launcher path for the browser-first dashboard:

- launches the same local HTML dashboard as `neondiff dashboard` when the app opens
- adds an explicit Open Dashboard button and `Cmd+D` menu command
- tracks launcher state in the overview without adding native provider logic
- adds focused Swift checks for the dashboard command and detached launcher path
- documents the 1.0 boundary: minimal launcher only, no signing/appcast/autoupdate/native polish claims

## Verification

- `npm run build`
- `npm test -- --run tests/local-dashboard.test.ts tests/public-cli.test.ts`
- `cd apps/neondiff-desktop && swift run NeonDiffDesktopCoreChecks`
- `cd apps/neondiff-desktop && swift run NeonDiffDesktopCoreSmoke`
- `cd apps/neondiff-desktop && script/build_and_run.sh build`
- `cd apps/neondiff-desktop && script/build_and_run.sh bundle-check`
- Visible dev smoke evidence: `/Volumes/LEXAR/Codex/evidence/neondiff/mac-launcher-447-448/README.md`

## Proof Boundary

This proves the local unsigned Mac launcher opens the browser-first dashboard and that dashboard setup/verification controls render and click. It does not prove signed desktop artifacts, notarization, appcast hosting, auto-update, installer UX, or production desktop distribution.
