### PR TITLE
[codex] Add dashboard preview smoke gate

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -206,6 +206,21 @@ Recommended local order:
    smoke first and record the URL, route, screenshots, and settled behavior in
    the evidence packet. Browser proof is fast product evidence; it is not a
    substitute for desktop signing, appcast, or Swift release gates.
+   For the built-in local dashboard, use the one-shot smoke command before the
+   first push:
+
+   ```bash
+   npx tsx src/cli.ts dashboard \
+     --config config.local.json \
+     --preview-smoke true \
+     --output-dir runtime/dashboard-preview-smoke
+   ```
+
+   The packet writes `dashboard.html`, `dashboard-status.json`,
+   `provider-verify.json`, and `preview-smoke.json` with the route, source SHA,
+   settled UI-state booleans, redacted provider output, and optional
+   `--screenshot-path` when a Browser/Playwright screenshot is captured in the
+   same loop.
 3. For NeonDiff Desktop Swift changes, run
    `swift run NeonDiffDesktopCoreSmoke`, then `swift build`, then
    `script/build_and_run.sh build` plus `script/build_and_run.sh bundle-check`

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -53,6 +53,12 @@ evaos-review-bot status --config config.local.json
   JSON-first operator surface. The command exits nonzero when visible rows are
   blocked; healthy active rows are counted but do not fail the gate by
   themselves.
+- `dashboard --preview-smoke true`: one-shot local HTML dashboard route smoke.
+  Starts the same local dashboard without opening a browser, requests `/`,
+  `/api/status`, and `/api/provider/verify`, then writes a public-safe evidence
+  packet with `dashboard.html`, `dashboard-status.json`, `provider-verify.json`,
+  and `preview-smoke.json`. Add `--screenshot-path` to attach a Browser,
+  Playwright, or Computer Use screenshot captured during the same smoke loop.
 - `budget-status`: read-only scheduler budget projection. Shows active counts,
   queued counts, would-lease jobs, delayed jobs, and deterministic delay reasons
   such as `provider_cooldown`, `provider_capacity`, `org_capacity`,
@@ -246,6 +252,15 @@ Show the review dashboard:
 
 ```bash
 npx tsx src/cli.ts dashboard --config config.local.json
+```
+
+Run a fast local HTML dashboard preview smoke before browser/dashboard PRs:
+
+```bash
+npx tsx src/cli.ts dashboard \
+  --config config.local.json \
+  --preview-smoke true \
+  --output-dir runtime/dashboard-preview-smoke
 ```
 
 Show dashboard rows blocked on proof:

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "doctor": "tsx src/cli.ts doctor",
+    "dashboard:preview-smoke": "tsx src/cli.ts dashboard --config config.example.json --preview-smoke true --output-dir runtime/dashboard-preview-smoke",
     "eval:offline": "tsx src/cli.ts eval-offline",
     "eval:suite": "tsx src/cli.ts eval-suite",
     "eval:sticky-vs-cold": "tsx src/cli.ts eval-sticky-vs-cold",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ import {
   type IssueEnrichmentRepoReadCheck
 } from "./issue-enrichment.js";
 import { activateLicense, deactivateLicense, getLicenseStatus, type LicenseConfig } from "./license.js";
-import { startLocalDashboardServer } from "./local-dashboard.js";
+import { runLocalDashboardPreviewSmoke, startLocalDashboardServer } from "./local-dashboard.js";
 import {
   assertOutcomeLedgerOutputDirEmpty,
   readOutcomeLedgerInput,
@@ -684,6 +684,25 @@ async function main(): Promise<void> {
     }
     const configPath = resolve(parseSingleArg(args.config ?? "config.local.json", "--config"));
     const config = loadConfig(configPath);
+    if (args["preview-smoke"] !== undefined && parseBooleanArg(args["preview-smoke"], "--preview-smoke")) {
+      const outputDir = resolve(parseSingleArg(args["output-dir"] ?? "runtime/dashboard-preview-smoke", "--output-dir"));
+      const smoke = await runLocalDashboardPreviewSmoke({
+        config,
+        configPath,
+        configExists: existsSync(configPath),
+        outputDir,
+        host: args.host ? parseSingleArg(args.host, "--host") : "127.0.0.1",
+        port: args.port ? parseNonNegativeInteger(parseSingleArg(args.port, "--port"), "--port") : 0,
+        launchdLabel: args["launchd-label"] ? parseSingleArg(args["launchd-label"], "--launchd-label") : undefined,
+        providerId: args.provider ? parseSingleArg(args.provider, "--provider") : undefined,
+        allowRemoteSmoke: args["allow-remote-smoke"] === undefined ? false : parseBooleanArg(args["allow-remote-smoke"], "--allow-remote-smoke"),
+        screenshotPath: args["screenshot-path"] ? resolve(parseSingleArg(args["screenshot-path"], "--screenshot-path")) : undefined,
+        sourceSha: args["source-sha"] ? parseSingleArg(args["source-sha"], "--source-sha") : readCurrentGitHead(process.cwd())
+      });
+      console.log(stringifyRedactedJson(smoke));
+      if (!smoke.ok) process.exitCode = 1;
+      return;
+    }
     const handle = await startLocalDashboardServer({
       config,
       configPath,
@@ -3070,6 +3089,10 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--host", description: "Dashboard bind host (default 127.0.0.1)." },
       { name: "--port", description: "Dashboard port (default 0, choose an available port)." },
       { name: "--open", description: "true (default) to open the dashboard in the browser." },
+      { name: "--preview-smoke", description: "true to run a one-shot local HTML dashboard route smoke and write an evidence packet." },
+      { name: "--output-dir", description: "Evidence directory for --preview-smoke (default runtime/dashboard-preview-smoke)." },
+      { name: "--screenshot-path", description: "Optional browser/Playwright screenshot path to record in preview-smoke evidence." },
+      { name: "--source-sha", description: "Source SHA to record in preview-smoke evidence (defaults to git rev-parse HEAD)." },
       { name: "--allow-remote-smoke", description: "true to allow hosted provider API-key verification." },
       { name: "--operator", description: "true to use the legacy operator JSON/human dashboard." }
     ]
@@ -3167,6 +3190,7 @@ function buildHelp(command?: string) {
       "neondiff pricing",
       "neondiff badge --config config.local.json --output docs/badges/precision.json",
       "neondiff dashboard --config config.local.json",
+      "neondiff dashboard --preview-smoke true --config config.local.json --output-dir runtime/dashboard-preview-smoke",
       "neondiff providers list --config config.local.json --json",
       "neondiff providers doctor --config config.local.json --json",
       "neondiff providers doctor --config config.local.json --provider ollama-local --smoke true --json",
@@ -3456,6 +3480,17 @@ function issueEnrichmentRunLiveExitReason(
 function parseSingleArg(value: string | string[], label: string): string {
   if (Array.isArray(value)) throw new Error(`${label} must be provided once`);
   return value;
+}
+
+function readCurrentGitHead(cwd: string): string | undefined {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"]
+  });
+  if (result.status !== 0) return undefined;
+  const head = result.stdout.trim();
+  return /^[0-9a-f]{40}$/i.test(head) ? head : undefined;
 }
 
 function parseCanonicalIsoTimestamp(value: string, label: string): Date {

--- a/src/local-dashboard.ts
+++ b/src/local-dashboard.ts
@@ -1,7 +1,8 @@
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
+import { join, resolve } from "node:path";
 import type { BotConfig } from "./config.js";
 import { getLicenseStatus, type LicenseStatusResult } from "./license.js";
 import {
@@ -94,6 +95,30 @@ export interface ProviderApiKeyVerificationResult {
   keySource?: "submitted" | "env";
   check?: Omit<ProviderDoctorCheck, "error"> & { error?: string };
   troubleshooting: string[];
+}
+
+export interface LocalDashboardPreviewSmokeResult {
+  ok: boolean;
+  command: "dashboard preview-smoke";
+  route: "/";
+  url: string;
+  sourceSha?: string;
+  outputDir: string;
+  htmlPath: string;
+  statusPath: string;
+  providerVerifyPath: string;
+  packetPath: string;
+  screenshotPath?: string;
+  screenshotCaptured: boolean;
+  settledUiState: {
+    htmlLoaded: boolean;
+    statusApiLoaded: boolean;
+    providerVerifyRouteLoaded: boolean;
+    controlsRendered: boolean;
+    statusScriptRendered: boolean;
+    providerVerifyStatus: number;
+  };
+  proofBoundary: string;
 }
 
 export async function buildLocalDashboardStatus(input: {
@@ -515,6 +540,97 @@ export function renderLocalDashboardHtml(status: LocalDashboardStatusContract): 
 </html>`;
 }
 
+export async function runLocalDashboardPreviewSmoke(input: {
+  config: BotConfig;
+  configPath: string;
+  configExists: boolean;
+  outputDir: string;
+  host?: string;
+  port?: number;
+  launchdLabel?: string;
+  providerId?: string;
+  apiKey?: string;
+  allowRemoteSmoke?: boolean;
+  screenshotPath?: string;
+  sourceSha?: string;
+}): Promise<LocalDashboardPreviewSmokeResult> {
+  const outputDir = resolve(input.outputDir);
+  mkdirSync(outputDir, { recursive: true });
+  const handle = await startLocalDashboardServer({
+    config: input.config,
+    configPath: input.configPath,
+    configExists: input.configExists,
+    host: input.host,
+    port: input.port,
+    launchdLabel: input.launchdLabel,
+    openBrowser: false,
+    allowRemoteSmoke: input.allowRemoteSmoke
+  });
+
+  try {
+    const htmlResponse = await fetch(handle.url);
+    const html = await htmlResponse.text();
+    const statusResponse = await fetch(new URL("/api/status", handle.url));
+    const statusText = await statusResponse.text();
+    const providerVerifyResponse = await fetch(new URL("/api/provider/verify", handle.url), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...(input.providerId ? { providerId: input.providerId } : {}),
+        ...(input.apiKey ? { apiKey: input.apiKey } : {}),
+        allowRemoteSmoke: input.allowRemoteSmoke === true
+      })
+    });
+    const providerVerifyText = await providerVerifyResponse.text();
+
+    const htmlPath = join(outputDir, "dashboard.html");
+    const statusPath = join(outputDir, "dashboard-status.json");
+    const providerVerifyPath = join(outputDir, "provider-verify.json");
+    const packetPath = join(outputDir, "preview-smoke.json");
+    writeFileSync(htmlPath, redactSecrets(html));
+    writeFileSync(statusPath, stringifyRedactedJson(JSON.parse(statusText)));
+    writeFileSync(providerVerifyPath, stringifyRedactedJson(JSON.parse(providerVerifyText)));
+
+    const statusScriptRendered = html.includes('id="dashboard-status"');
+    const controlsRendered =
+      html.includes('id="provider-id"') &&
+      html.includes('id="api-key"') &&
+      html.includes('id="verify-api-key"') &&
+      html.includes("Verify API Key");
+    const settledUiState = {
+      htmlLoaded: htmlResponse.ok && html.includes("NeonDiff Dashboard"),
+      statusApiLoaded: statusResponse.ok,
+      providerVerifyRouteLoaded: providerVerifyResponse.status === 200 || providerVerifyResponse.status === 422,
+      controlsRendered,
+      statusScriptRendered,
+      providerVerifyStatus: providerVerifyResponse.status
+    };
+    const ok = Object.values(settledUiState)
+      .filter((value): value is boolean => typeof value === "boolean")
+      .every(Boolean);
+    const result: LocalDashboardPreviewSmokeResult = {
+      ok,
+      command: "dashboard preview-smoke",
+      route: "/",
+      url: handle.url,
+      ...(input.sourceSha ? { sourceSha: input.sourceSha } : {}),
+      outputDir,
+      htmlPath,
+      statusPath,
+      providerVerifyPath,
+      packetPath,
+      ...(input.screenshotPath ? { screenshotPath: input.screenshotPath } : {}),
+      screenshotCaptured: Boolean(input.screenshotPath && existsSync(input.screenshotPath)),
+      settledUiState,
+      proofBoundary: "Preview/browser smoke proves the local HTML dashboard routes and controls only; it does not prove signed Mac app behavior, updater, TCC, customer readiness, or GA."
+    };
+    writeFileSync(packetPath, stringifyRedactedJson(result));
+    return JSON.parse(stringifyRedactedJson(result)) as LocalDashboardPreviewSmokeResult;
+  } finally {
+    await closeServer(handle.server);
+  }
+}
+
 export async function startLocalDashboardServer(input: {
   config: BotConfig;
   configPath: string;
@@ -590,6 +706,16 @@ export async function startLocalDashboardServer(input: {
   const openAttempted = input.openBrowser !== false;
   const openOk = openAttempted ? openLocalUrl(url) : false;
   return { server, url, status, openAttempted, openOk };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => {
+      if (error) rejectClose(error);
+      else resolveClose();
+    });
+  });
 }
 
 async function buildLicenseStatusItem(config: BotConfig, checkedAt: string): Promise<LocalDashboardStatusItem> {

--- a/src/local-dashboard.ts
+++ b/src/local-dashboard.ts
@@ -1,10 +1,11 @@
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { join, resolve } from "node:path";
 import type { BotConfig } from "./config.js";
 import { getLicenseStatus, type LicenseStatusResult } from "./license.js";
+import { writeSecureFileSync } from "./temp-files.js";
 import {
   doctorProviderRegistry,
   type ProviderDoctorCheck,
@@ -587,9 +588,9 @@ export async function runLocalDashboardPreviewSmoke(input: {
     const statusPath = join(outputDir, "dashboard-status.json");
     const providerVerifyPath = join(outputDir, "provider-verify.json");
     const packetPath = join(outputDir, "preview-smoke.json");
-    writeFileSync(htmlPath, redactSecrets(html));
-    writeFileSync(statusPath, stringifyRedactedJson(JSON.parse(statusText)));
-    writeFileSync(providerVerifyPath, stringifyRedactedJson(JSON.parse(providerVerifyText)));
+    writeSecureFileSync(htmlPath, redactSecrets(html));
+    writeSecureFileSync(statusPath, stringifyRedactedJson(JSON.parse(statusText)));
+    writeSecureFileSync(providerVerifyPath, stringifyRedactedJson(JSON.parse(providerVerifyText)));
 
     const statusScriptRendered = html.includes('id="dashboard-status"');
     const controlsRendered =
@@ -624,7 +625,7 @@ export async function runLocalDashboardPreviewSmoke(input: {
       settledUiState,
       proofBoundary: "Preview/browser smoke proves the local HTML dashboard routes and controls only; it does not prove signed Mac app behavior, updater, TCC, customer readiness, or GA."
     };
-    writeFileSync(packetPath, stringifyRedactedJson(result));
+    writeSecureFileSync(packetPath, stringifyRedactedJson(result));
     return JSON.parse(stringifyRedactedJson(result)) as LocalDashboardPreviewSmokeResult;
   } finally {
     await closeServer(handle.server);

--- a/tests/local-dashboard.test.ts
+++ b/tests/local-dashboard.test.ts
@@ -1,10 +1,14 @@
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadConfigFromObject } from "../src/config.js";
 import {
   buildLocalDashboardStatus,
   renderLocalDashboardHtml,
+  runLocalDashboardPreviewSmoke,
   startLocalDashboardServer,
   verifyProviderApiKey
 } from "../src/local-dashboard.js";
@@ -188,6 +192,58 @@ describe("local HTML dashboard", () => {
     expect(resultText).toContain("configured_unverified");
     expect(resultText).not.toContain(fakeKey);
     expect(resultText).not.toContain("dashboard-route");
+  });
+
+  it("writes a preview-smoke evidence packet for browser-first dashboard validation", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-dashboard-preview-smoke-"));
+    const fakeKey = ["sk", "preview-smoke-route-1234567890"].join("-");
+    const screenshotPath = join(outputDir, "dashboard.png");
+    const config = loadConfigFromObject({
+      providers: {
+        defaultProviderId: "openai-compatible",
+        providers: {
+          "openai-compatible": {
+            enabled: true,
+            baseUrl: "https://gateway.example.test/v1",
+            model: "review-model"
+          }
+        }
+      }
+    });
+
+    const smoke = await runLocalDashboardPreviewSmoke({
+      config,
+      configPath: "/Volumes/LEXAR/Codex/neondiff/config.local.json",
+      configExists: true,
+      outputDir,
+      providerId: "openai-compatible",
+      apiKey: fakeKey,
+      allowRemoteSmoke: false,
+      screenshotPath,
+      sourceSha: "0123456789abcdef0123456789abcdef01234567"
+    });
+
+    expect(smoke).toMatchObject({
+      ok: true,
+      command: "dashboard preview-smoke",
+      route: "/",
+      sourceSha: "0123456789abcdef0123456789abcdef01234567",
+      screenshotPath,
+      settledUiState: {
+        htmlLoaded: true,
+        statusApiLoaded: true,
+        providerVerifyRouteLoaded: true,
+        controlsRendered: true
+      }
+    });
+    expect(existsSync(smoke.htmlPath)).toBe(true);
+    expect(existsSync(smoke.statusPath)).toBe(true);
+    expect(existsSync(smoke.providerVerifyPath)).toBe(true);
+    expect(existsSync(smoke.packetPath)).toBe(true);
+    expect(readFileSync(smoke.htmlPath, "utf8")).toContain("Verify API Key");
+    const serialized = JSON.stringify(smoke) + readFileSync(smoke.packetPath, "utf8");
+    expect(serialized).not.toContain(fakeKey);
+    expect(serialized).not.toContain("preview-smoke-route");
   });
 });
 

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -59,6 +59,7 @@ describe("public NeonDiff CLI surface", () => {
     expect(output.examples).toContain("neondiff pricing");
     expect(output.examples).toContain("neondiff badge --config config.local.json --output docs/badges/precision.json");
     expect(output.examples).toContain("neondiff dashboard --config config.local.json");
+    expect(output.examples).toContain("neondiff dashboard --preview-smoke true --config config.local.json --output-dir runtime/dashboard-preview-smoke");
     expect(output.examples).toContain("neondiff providers list --config config.local.json --json");
     expect(output.examples).toContain("neondiff providers doctor --config config.local.json --json");
     expect(output.examples).toContain("neondiff providers doctor --config config.local.json --provider ollama-local --smoke true --json");


### PR DESCRIPTION
Closes #446

## Summary
- add `neondiff dashboard --preview-smoke true` plus `npm run dashboard:preview-smoke` for one-shot local HTML dashboard route validation
- write redacted preview evidence packets with dashboard HTML, status JSON, provider verification JSON, source SHA, route, settled UI state, and optional screenshot path
- document the preview-first validation loop in the operator CLI docs and beta release runbook

## Validation
- `npm test -- --run tests/local-dashboard.test.ts tests/public-cli.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- `npx tsx src/cli.ts dashboard --config config.example.json --preview-smoke true --output-dir /Volumes/LEXAR/Codex/evidence/neondiff/preview-smoke-446 --source-sha a33095036aa9dc64ac42a218df13c594e1cc6b7b --screenshot-path /Volumes/LEXAR/Codex/evidence/neondiff/preview-smoke-446/dashboard.png`

## Evidence
- `/Volumes/LEXAR/Codex/evidence/neondiff/preview-smoke-446/preview-smoke.json`
- `/Volumes/LEXAR/Codex/evidence/neondiff/preview-smoke-446/dashboard.png`

## Proof boundary
Preview/browser smoke proves the local HTML dashboard routes and controls only. It does not prove signed Mac app behavior, updater/appcast behavior, TCC prompts, customer readiness, or GA release readiness.