### PR TITLE
[codex] Document staged 1.0 release governance

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -26,6 +26,21 @@ Public source-beta releases also include a compact manifest at
 for docs version alignment, license API readiness or explicit deferral, and
 update-channel readiness for CLI, daemon, website, and desktop surfaces.
 
+The 1.0 cut line is intentionally narrower than full desktop maturity:
+`1.0 is a usable local HTML installer/dashboard plus minimal Mac launcher, not
+full signed desktop maturity.` Keep release notes aligned to these public
+surface stages:
+
+| Stage | Required For 1.0 | Allowed Claims | Forbidden Claims |
+| --- | --- | --- | --- |
+| CLI/dashboard GA | Yes | `npm install -g neondiff`; `neondiff dashboard` starts and opens a local HTML dashboard; dashboard supports first-run setup/status and redacted provider API-key verification. | Signed desktop artifacts, Sparkle appcast/auto-update readiness, native Swift desktop maturity. |
+| Minimal Mac launcher GA | Yes | A minimal Mac icon/app launcher opens the same local HTML dashboard. | Full native app maturity, signing/notarization, appcast, auto-update, or TCC readiness. |
+| Signed/appcast desktop | Post-launch unless owner-promoted | Signed/notarized desktop, Sparkle/appcast, updater, and native Swift polish only after #449/#116 proof. | Treating browser preview or unsigned launcher smoke as signed desktop release proof. |
+
+Represent browser dashboard readiness separately from desktop readiness in
+`docs/public-release-manifest.json` when the distinction matters. The dashboard
+may be ready while signed desktop/appcast remains explicitly post-launch.
+
 ## Cadence
 
 - Cut at most one normal beta promotion per focused sprint lane unless a safety

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -37,6 +37,46 @@
     "candidateHeadBeforeReleaseMetadata": "78b51fdac2d8ce699dc9f38f87db0b62c19dafef",
     "proof": "after merge and tag, release:status --expected-head $(git rev-parse HEAD)"
   },
+  "releaseStages": {
+    "launchCutLine": "1.0 is a usable local HTML installer/dashboard plus minimal Mac launcher, not full signed desktop maturity.",
+    "stages": [
+      {
+        "id": "cli-dashboard-ga",
+        "requiredForV1": true,
+        "allowedClaims": [
+          "npm install -g neondiff",
+          "neondiff dashboard opens a local HTML dashboard",
+          "dashboard supports first-run setup/status and redacted provider API-key verification"
+        ],
+        "forbiddenClaims": [
+          "signed desktop artifact",
+          "Sparkle appcast or auto-update readiness",
+          "native Swift desktop maturity"
+        ]
+      },
+      {
+        "id": "minimal-mac-launcher-ga",
+        "requiredForV1": true,
+        "allowedClaims": [
+          "minimal Mac icon/app launcher opens the same local dashboard"
+        ],
+        "forbiddenClaims": [
+          "full native Swift desktop maturity",
+          "signed, notarized, or auto-updating desktop release"
+        ]
+      },
+      {
+        "id": "signed-appcast-desktop-post-launch",
+        "requiredForV1": false,
+        "allowedClaims": [
+          "signed/notarized desktop and appcast only after #449/#116 proof"
+        ],
+        "forbiddenClaims": [
+          "treating browser preview or unsigned launcher smoke as signed desktop release proof"
+        ]
+      }
+    ]
+  },
   "docs": {
     "version": "v0.4.46-beta.1",
     "setupPath": "docs/SETUP.md",
@@ -66,6 +106,11 @@
       "state": "launchd_prerelease",
       "version": "v0.4.46-beta.1",
       "rollback": "git reset --hard refs/tags/v0.4.45-beta.1"
+    },
+    "browserDashboard": {
+      "requiredForThisRelease": false,
+      "state": "pending",
+      "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     },
     "website": {
       "requiredForThisRelease": false,

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -39,6 +39,20 @@ describe("NeonDiff public release readiness", () => {
         candidateHeadBeforeReleaseMetadata?: string;
         proof?: string;
       };
+      releaseStages?: {
+        launchCutLine?: string;
+        stages?: Array<{
+          id?: string;
+          requiredForV1?: boolean;
+          allowedClaims?: string[];
+          forbiddenClaims?: string[];
+        }>;
+      };
+      updateChannels?: Record<string, {
+        requiredForThisRelease?: boolean;
+        state?: string;
+        trackingIssue?: string;
+      }>;
     };
 
     expect(pkg.name).toBe("neondiff");
@@ -100,6 +114,39 @@ describe("NeonDiff public release readiness", () => {
       candidateHeadBeforeReleaseMetadata: "78b51fdac2d8ce699dc9f38f87db0b62c19dafef"
     });
     expect(manifest.source?.proof).toMatch(/after merge and tag/i);
+    expect(manifest.releaseStages?.launchCutLine).toBe(
+      "1.0 is a usable local HTML installer/dashboard plus minimal Mac launcher, not full signed desktop maturity."
+    );
+    expect(manifest.releaseStages?.stages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "cli-dashboard-ga",
+          requiredForV1: true,
+          allowedClaims: expect.arrayContaining(["npm install -g neondiff", "neondiff dashboard opens a local HTML dashboard"]),
+          forbiddenClaims: expect.arrayContaining(["signed desktop artifact", "Sparkle appcast or auto-update readiness"])
+        }),
+        expect.objectContaining({
+          id: "minimal-mac-launcher-ga",
+          requiredForV1: true,
+          allowedClaims: expect.arrayContaining(["minimal Mac icon/app launcher opens the same local dashboard"]),
+          forbiddenClaims: expect.arrayContaining(["full native Swift desktop maturity"])
+        }),
+        expect.objectContaining({
+          id: "signed-appcast-desktop-post-launch",
+          requiredForV1: false,
+          allowedClaims: expect.arrayContaining(["signed/notarized desktop and appcast only after #449/#116 proof"])
+        })
+      ])
+    );
+    expect(manifest.updateChannels?.browserDashboard).toMatchObject({
+      requiredForThisRelease: false,
+      state: "pending",
+      trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
+    });
+    expect(manifest.updateChannels?.desktop).toMatchObject({
+      state: "post_1_0",
+      trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/116"
+    });
   });
 
   it("requires the live production license API for this beta", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -470,7 +470,7 @@ describe("beta release status", () => {
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
       ok: true,
-      detail: "cli=published; daemon=launchd_prerelease; website=published (not required); desktop=post_1_0 (not required)"
+      detail: "cli=published; daemon=launchd_prerelease; browserDashboard=pending (not required); website=published (not required); desktop=post_1_0 (not required)"
     });
     const redactedOutput = stringifyRedactedJson({
       ...status,


### PR DESCRIPTION
Closes #450

## Summary
- add the official 1.0 launch cut line to the beta release runbook
- add release-stage metadata to `docs/public-release-manifest.json` for CLI/dashboard GA, minimal Mac launcher GA, and post-launch signed/appcast desktop
- represent `browserDashboard` as its own optional manifest update channel, separate from `desktop`
- lock the cut line and channel language with release-readiness tests

## Validation
- `npm test -- --run tests/public-release-readiness.test.ts tests/release-status.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- `node scripts/check-public-claims.mjs`
- `node scripts/check-secret-scan.mjs`

## Proof boundary
This is release-governance clarity only. It does not publish, sign, notarize, promote, or deploy a release.