### PR TITLE
[codex] Tighten GA dashboard launch setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Recommended package install for the current beta:
 npm install -g neondiff@0.4.30-beta.1
 ```
 
+GA/latest package install path after the `v1.0.0` dist-tag cutover:
+
+```bash
+npm install -g neondiff
+```
+
 Installer script path:
 
 ```bash
@@ -114,6 +120,10 @@ neondiff providers list --config config.local.json --json
 neondiff providers doctor --config config.local.json --json
 neondiff doctor --config config.local.json --json
 ```
+
+The local HTML dashboard is the first-run setup surface. It shows license status,
+GitHub App status, daemon status, and provider readiness, and its provider card
+includes a `Verify API Key` control that reports redacted pass/fail output.
 
 Create or install the GitHub App before expecting PR reviews to run. The App
 must be installed on the same selected repositories listed in `pilotRepos`; see

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -32,6 +32,12 @@ Recommended package install:
 npm install -g neondiff@0.4.30-beta.1
 ```
 
+GA/latest package install path after the `v1.0.0` dist-tag cutover:
+
+```bash
+npm install -g neondiff
+```
+
 Installer script:
 
 ```bash
@@ -220,6 +226,12 @@ neondiff providers list --config config.local.json --json
 neondiff providers doctor --config config.local.json --json
 neondiff doctor --config config.local.json --json
 ```
+
+The local HTML dashboard is the human first-run surface. It shows license
+status, GitHub App status, daemon status, and provider readiness with redacted
+output. Use the provider card's `Verify API Key` button before launch/use; the
+button checks the selected provider path and reports pass/fail without printing
+the submitted key.
 
 The full doctor output is JSON. Check:
 

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -224,6 +224,10 @@ describe("NeonDiff public release readiness", () => {
 
     expect(docs).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff");
     expect(docs).toMatch(/npm install -g neondiff@0\.4\.30-beta\.1/i);
+    expect(docs).toMatch(/npm install -g neondiff(?!@)/i);
+    expect(docs).toMatch(/neondiff dashboard --config config\.local\.json/i);
+    expect(docs).toMatch(/Verify API Key/i);
+    expect(docs).toMatch(/license\s+status,\s+GitHub App status,\s+daemon status,\s+and provider readiness/i);
     expect(docs).toMatch(/curl -fsSL https:\/\/www\.neondiff\.com\/install/i);
     expect(docs).toContain("git clone https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git");
     expect(legacyRepoReferences).toEqual([]);


### PR DESCRIPTION
## Summary
- document the post-cutover GA install path with 
added 1 package in 963ms
- make README/setup docs point users at {
  "ok": true,
  "checkedAt": "2026-07-08T12:11:34.544Z",
  "filters": {},
  "summary": {
    "totalItems": 7,
    "blockedItems": 0,
    "activeReviews": 1,
    "commandTriggered": 0,
    "staleHeads": 0,
    "proofGaps": 0,
    "checkBlocks": 0,
    "failed": 0,
    "providerDeferred": 0,
    "hiddenHistoricalStale": 0
  },
  "items": [
    {
      "repo": "electricsheephq/WorldOS",
      "pullNumber": 1298,
      "headSha": "e69f3d5d5bebdf73020d547089f91a945040c0ed",
      "title": "renderer: day-state plate selection (#1291)",
      "url": "https://github.com/electricsheephq/WorldOS/pull/1298",
      "status": "pending_review",
      "coverageState": "pending_review",
      "latestVerdict": "pending_review",
      "proofStatus": "pending_review",
      "checkStatus": "not_collected",
      "nextAction": "wait for daemon cycle or run scoped run-once",
      "evidencePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/electricsheephq__WorldOS/pr-1298/e69f3d5d5bebdf73020d547089f91a945040c0ed"
    },
    {
      "repo": "100yenadmin/evaOS-GUI",
      "pullNumber": 618,
      "headSha": "c59a8cd7fae93bf3ef100f6046d428c083d65913",
      "title": "[codex] Spike AionCore v0.1.43 runtime pin",
      "url": "https://github.com/100yenadmin/evaOS-GUI/pull/618",
      "status": "skipped",
      "coverageState": "skipped",
      "latestVerdict": "skipped",
      "proofStatus": "skipped",
      "checkStatus": "not_collected",
      "reason": "draft",
      "nextAction": "none",
      "evidencePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-08/100yenadmin__evaOS-GUI/pr-618/c59a8cd7fae93bf3ef100f6046d428c083d65913"
    },
    {
      "repo": "electricsheephq/WorldOS",
      "pullNumber": 573,
      "headSha": "76810f04d94e804ef083f5620b3e2df3331c63d2",
      "title": "qa: structured run names + INDEX.jsonl + backfill + find_run helper",
      "url": "https://github.com/electricsheephq/WorldOS/pull/573",
      "status": "skipped",
      "coverageState": "skipped",
      "latestVerdict": "skipped",
      "proofStatus": "skipped",
      "checkStatus": "not_collected",
      "reason": "draft",
      "nextAction": "none",
      "evidencePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-08/electricsheephq__WorldOS/pr-573/76810f04d94e804ef083f5620b3e2df3331c63d2"
    },
    {
      "repo": "electricsheephq/WorldOS",
      "pullNumber": 1012,
      "headSha": "35e862460ea8f47a4d804455c6282404f22c525c",
      "title": "feat(engine): per-tool tool-schema tiering + tier-aware guard (slab Phases 1-2) [A/B-gated]",
      "url": "https://github.com/electricsheephq/WorldOS/pull/1012",
      "status": "skipped",
      "coverageState": "skipped",
      "latestVerdict": "skipped",
      "proofStatus": "skipped",
      "checkStatus": "not_collected",
      "reason": "draft",
      "nextAction": "none",
      "evidencePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-08/electricsheephq__WorldOS/pr-1012/35e862460ea8f47a4d804455c6282404f22c525c"
    },
    {
      "repo": "electricsheephq/WorldOS",
      "pullNumber": 1102,
      "headSha": "e432fdf5502e219fccc8a918c0f419320bc178bb",
      "title": "ci(release): auto-tag on milestone close — dry-run default, RELEASE-gated (Track 4)",
      "url": "https://github.com/electricsheephq/WorldOS/pull/1102",
      "status": "skipped",
      "coverageState": "skipped",
      "latestVerdict": "skipped",
      "proofStatus": "skipped",
      "checkStatus": "not_collected",
      "reason": "draft",
      "nextAction": "none",
      "evidencePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-08/electricsheephq__WorldOS/pr-1102/e432fdf5502e219fccc8a918c0f419320bc178bb"
    },
    {
      "repo": "electricsheephq/WorldOS",
      "pullNumber": 1128,
      "headSha": "f88ae0ee9af3621f1a8017e45de4f89cf6cbcf8b",
      "title": "chore(deps-dev): bump soundfile from 0.13.1 to 0.14.0 in /servers/voice",
      "url": "https://github.com/electricsheephq/WorldOS/pull/1128",
      "status": "skipped",
      "coverageState": "skipped",
      "latestVerdict": "skipped",
      "proofStatus": "skipped",
      "checkStatus": "not_collected",
      "reason": "activation_baseline_existing_pr",
      "nextAction": "none",
      "evidencePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/electricsheephq__WorldOS/pr-1128/f88ae0ee9af3621f1a8017e45de4f89cf6cbcf8b"
    },
    {
      "repo": "electricsheephq/WorldOS",
      "pullNumber": 1161,
      "headSha": "0cb56091f926fe951aad6a78ddc779a0c2472d3a",
      "title": "feat(viewer): 4 sat→7 web-viewer UX/correctness fixes (battle-log sanitize, dice-header strip, roll context, drop-confirm)",
      "url": "https://github.com/electricsheephq/WorldOS/pull/1161",
      "status": "skipped",
      "coverageState": "skipped",
      "latestVerdict": "skipped",
      "proofStatus": "skipped",
      "checkStatus": "not_collected",
      "reason": "activation_baseline_existing_pr",
      "nextAction": "none",
      "evidencePath": "/Volumes/LEXAR/Codex/evaos-code-review-bot/evidence/2026-07-06/electricsheephq__WorldOS/pr-1161/0cb56091f926fe951aad6a78ddc779a0c2472d3a"
    }
  ]
} as the first-run local HTML setup surface
- call out redacted license, GitHub App, daemon, and provider/API-key readiness in public setup docs

Closes #397

## Validation
- 
> neondiff@0.4.30-beta.1 test
> vitest run --run tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1


 RUN  v3.2.6 /Volumes/LEXAR/repos/worktrees/evaos-code-review-bot-neondiff/397-ga-docs-pass

 ✓ tests/public-release-readiness.test.ts (5 tests) 6ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  19:11:36
   Duration  134ms (transform 19ms, setup 0ms, collect 15ms, tests 6ms, environment 0ms, prepare 33ms)
- 
> neondiff@0.4.30-beta.1 build
> tsc -p tsconfig.json


> neondiff@0.4.30-beta.1 postbuild
> chmod +x dist/src/cli.js
- 
- forbidden public claims scan ok
- secret scan ok: 417 tracked files