### PR TITLE
[codex] Add redacted checkout issuance smoke gate

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -375,13 +375,17 @@ npx tsx src/cli.ts review-head-gate \
   `checkoutIssuanceRequiredForThisRelease: false`. When checkout issuance proof
   is required and a state is declared, `checkoutIssuanceState` must be `ready`.
   This manifest proof is a negative fail-closed boundary only; it proves the
-  public endpoint rejects unauthenticated callers. It does not prove a valid
-  owner-held checkout secret can issue a license, write the DB, or complete the
-  paid/trial fulfillment path. Authenticated issuance success must be captured
-  in the deploy runbook's redacted owner-held evidence lane before claiming
-  checkout issuance works end to end; the first-class release-status smoke gate
-  for that positive path is tracked in
-  `https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/456`.
+  public endpoint rejects unauthenticated callers. Stable/GA releases must also
+  declare `checkoutIssuanceAuthenticatedProofPath`, pointing to a redacted
+  owner-held success proof with
+  `evidenceKind: "license_api_checkout_issuance_authenticated"`,
+  `statusCode: 200`, and a `redactedResponse` containing only issuance status,
+  replay flag, checkout lookup key, `issuedLicensePrefix: "nd_live_"`, and a
+  `sha256:<64-hex>` license fingerprint. Do not commit raw bearer headers,
+  `LICENSE_ISSUANCE_SECRET`, raw `licenseKey`, cookies, customer data, checkout
+  payload secrets, or raw response bodies. Public beta and source-beta releases
+  may continue to use only the no-secret 401 gate unless authenticated checkout
+  issuance is part of that release's scope.
   In `release:status` output, `checkoutIssuanceRequiredForThisRelease` is the
   computed effective gate; `checkoutIssuanceRequiredDeclaredForThisRelease`
   preserves the raw manifest declaration when present.
@@ -519,7 +523,9 @@ For each beta promotion, record:
 - public release manifest state for docs, license API, CLI update channel,
   daemon update channel, website/download channel, and desktop update channel.
 - checkout issuance evidence or the explicit deferred state and tracking issue
-  when the paid/trial purchase path is not in scope for the beta.
+  when the paid/trial purchase path is not in scope for the beta; stable/GA
+  release packets must include both the unauthenticated rejection proof and the
+  redacted authenticated issuance success proof.
 - rollback SHA and command.
 - rollback note for provider config, GitHub App settings, website deploy, and
   desktop update channel when those surfaces are in scope; otherwise record the

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -133,13 +133,17 @@ Before tagging:
    - live config path
    - rollback command
    - known provider cooldown or runtime caveats
-6. For public source-beta or public beta releases,
+6. For public source-beta, public beta, or stable GA releases,
    `docs/public-release-manifest.json` exists and declares:
    - docs version and release-notes path
    - license API state and whether it is required for this release
    - license API health proof, plus unauthenticated checkout issuance rejection
      proof unless a source-beta release explicitly defers it with a tracking
      issue
+   - for stable GA, a redacted authenticated checkout issuance success proof
+     path (`checkoutIssuanceAuthenticatedProofPath`) with no raw bearer secret,
+     license key, cookie, customer data, checkout payload secret, or raw response
+     body
    - computed checkout issuance status and, when present, the raw manifest
      declaration that produced it
    - CLI, daemon, website, and desktop update-channel state
@@ -249,12 +253,13 @@ The release is green only when:
 - daemon heartbeat is fresh
 - no blocking DB error rows exist
 - public docs, license API state, unauthenticated checkout issuance rejection
-  state, and update channels are either healthy/proven or explicitly deferred
-  as non-required for the release in `docs/public-release-manifest.json`
-- authenticated checkout issuance success, DB writes, and paid/trial
-  fulfillment are proven only by owner-held deploy-runbook evidence or a future
-  release-status smoke gate; a green manifest gate alone must not be described
-  as end-to-end checkout issuance proof
+  state, authenticated checkout issuance success when stable/GA, and update
+  channels are either healthy/proven or explicitly deferred as non-required for
+  the release in `docs/public-release-manifest.json`
+- authenticated checkout issuance success is proven only by the redacted
+  owner-held proof packet; a green source-beta or public-beta 401 manifest gate
+  alone must not be described as paid/trial fulfillment or end-to-end checkout
+  activation proof
 - coverage audit has zero unprocessed eligible heads
 - provider cooldowns are either absent or active and named in release notes
 - durable queue jobs have zero failed rows and zero retryable provider-deferred

--- a/services/license-api/docs/deploy.md
+++ b/services/license-api/docs/deploy.md
@@ -96,10 +96,14 @@ return `401` with `{"status":"unauthorized"}`. A `503` response with
 `LICENSE_ISSUANCE_SECRET` and is not ready for paid/trial checkout activation.
 This release-status proof intentionally verifies only the fail-closed public
 boundary. It does not prove that a valid server-side checkout webhook can issue
-a license or write the DB. Capture positive authenticated issuance smoke in an
-owner-held, redacted evidence packet outside tracked manifest JSON; the
-first-class release-status gate for that path is tracked in
-`https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/456`.
+a license or write the DB. Stable/GA manifests must also point
+`checkoutIssuanceAuthenticatedProofPath` at an owner-held redacted success proof
+under `docs/evidence/`. That proof may record `statusCode: 200`,
+`status: "issued"`, `replayed`, the checkout lookup key,
+`issuedLicensePrefix: "nd_live_"`, and a `sha256:<64-hex>` fingerprint of the
+issued license key. It must not store raw bearer headers,
+`LICENSE_ISSUANCE_SECRET`, raw `licenseKey`, cookies, customer data, checkout
+payload secrets, or raw response bodies.
 
 ## 4. Deploy
 

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -5,6 +5,7 @@ import { isAbsolute, relative, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { loadConfig } from "./config.js";
 import { buildReviewBudgetStatus, type ReviewBudgetStatus } from "./review-budget.js";
+import { containsSecretLikeText } from "./secrets.js";
 import { parseProviderCooldownError, PROVIDER_COOLDOWN_ERROR_PREFIX } from "./state.js";
 import { buildZCodeTimeoutInspectCommand, summarizeZCodeTimeoutErrors, ZCODE_TIMEOUT_ERROR_PREFIX } from "./zcode-timeout.js";
 import type { BotConfig } from "./config.js";
@@ -128,6 +129,7 @@ export interface PublicReleaseStatus {
     checkoutIssuanceRequiredDeclaredForThisRelease?: boolean;
     checkoutIssuanceUrl?: string;
     checkoutIssuanceProofPath?: string;
+    checkoutIssuanceAuthenticatedProofPath?: string;
     checkoutIssuanceState?: string;
     checkoutIssuanceTrackingIssue?: string;
   };
@@ -204,6 +206,28 @@ const CHECKOUT_ISSUANCE_DEFERRED_STATES = new Set(["deferred", "pending_secret_a
 const CHECKOUT_ISSUANCE_STATES = new Set([
   CHECKOUT_ISSUANCE_READY_STATE,
   ...CHECKOUT_ISSUANCE_DEFERRED_STATES
+]);
+const CHECKOUT_ISSUANCE_LOOKUP_KEYS = new Set([
+  "neondiff_monthly",
+  "neondiff_yearly",
+  "neondiff_org_yearly"
+]);
+const AUTHENTICATED_CHECKOUT_PROOF_FIELDS = new Set([
+  "evidenceKind",
+  "releaseVersion",
+  "observedAt",
+  "method",
+  "url",
+  "statusCode",
+  "redactedResponse",
+  "captureContext"
+]);
+const AUTHENTICATED_CHECKOUT_REDACTED_RESPONSE_FIELDS = new Set([
+  "status",
+  "replayed",
+  "checkoutLookupKey",
+  "issuedLicensePrefix",
+  "issuedLicenseFingerprint"
 ]);
 const GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES = new Set([
   ...REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES,
@@ -598,6 +622,7 @@ export function readPublicReleaseManifestStatus(input: {
       releaseRequiresCheckoutIssuance && !sourceBetaExplicitlyDefersCheckoutIssuance;
     const licenseIssuanceUrl = readString(licenseApi.checkoutIssuanceUrl);
     const licenseIssuanceProofPath = readString(licenseApi.checkoutIssuanceProofPath);
+    const licenseIssuanceAuthenticatedProofPath = readString(licenseApi.checkoutIssuanceAuthenticatedProofPath);
     const licenseIssuanceState = readString(licenseApi.checkoutIssuanceState);
     const licenseIssuanceTrackingIssue = readString(licenseApi.checkoutIssuanceTrackingIssue);
     const licenseNeedsHealthProof = licenseRequired && licenseState === "healthy";
@@ -640,16 +665,31 @@ export function readPublicReleaseManifestStatus(input: {
         })
       : { ok: true, detail: "" };
     const licenseIssuanceProofOk = licenseIssuanceProof.ok;
+    const licenseNeedsAuthenticatedIssuanceProof = licenseNeedsIssuanceProof && releaseLevel === "stable";
+    const licenseShouldValidateAuthenticatedIssuanceProof =
+      licenseNeedsAuthenticatedIssuanceProof || licenseIssuanceAuthenticatedProofPath !== undefined;
+    const licenseIssuanceAuthenticatedProof = licenseShouldValidateAuthenticatedIssuanceProof
+      ? validateAuthenticatedLicenseIssuanceProof({
+          cwd: input.cwd,
+          proofPath: licenseIssuanceAuthenticatedProofPath,
+          expectedReleaseVersion: expectedVersion,
+          expectedUrl: licenseIssuanceUrl,
+          now: input.now
+        })
+      : { ok: true, detail: "" };
+    const licenseIssuanceAuthenticatedProofOk = licenseIssuanceAuthenticatedProof.ok;
     const licenseMetadataFailures = licenseHealthMetadataFailures.concat(licenseIssuanceMetadataFailures);
     const licenseMetadataOk = licenseMetadataFailures.length === 0;
     const licenseOk =
       isLicenseApiStateAcceptable(licenseState, licenseRequired) &&
       licenseMetadataOk &&
       licenseHealthProofOk &&
-      licenseIssuanceProofOk;
+      licenseIssuanceProofOk &&
+      licenseIssuanceAuthenticatedProofOk;
     const licenseDetailParts = [
       ...(licenseNeedsHealthProof ? [licenseHealthProof.detail] : []),
       ...(licenseNeedsIssuanceProof ? [licenseIssuanceProof.detail] : []),
+      ...(licenseShouldValidateAuthenticatedIssuanceProof ? [licenseIssuanceAuthenticatedProof.detail] : []),
       ...licenseMetadataFailures
     ].filter(Boolean);
     const declaredChannelNames = Object.keys(updateChannels);
@@ -732,6 +772,7 @@ export function readPublicReleaseManifestStatus(input: {
         checkoutIssuanceRequiredDeclaredForThisRelease: explicitLicenseIssuanceRequired,
         checkoutIssuanceUrl: licenseIssuanceUrl,
         checkoutIssuanceProofPath: licenseIssuanceProofPath,
+        checkoutIssuanceAuthenticatedProofPath: licenseIssuanceAuthenticatedProofPath,
         checkoutIssuanceState: licenseIssuanceState,
         checkoutIssuanceTrackingIssue: licenseIssuanceTrackingIssue,
         detail: licenseOk
@@ -1112,6 +1153,118 @@ function validateLicenseIssuanceProof(input: {
     : { ok: true, detail: `validated checkout issuance proof ${input.proofPath}` };
 }
 
+function validateAuthenticatedLicenseIssuanceProof(input: {
+  cwd: string;
+  proofPath?: string;
+  expectedReleaseVersion?: string;
+  expectedUrl?: string;
+  now?: Date;
+}): { ok: boolean; detail: string } {
+  if (!input.proofPath) {
+    return {
+      ok: false,
+      detail: "missing authenticated checkout issuance proof path (no checkoutIssuanceAuthenticatedProofPath declared)"
+    };
+  }
+  if (containsSecretLikeText(input.proofPath)) {
+    return {
+      ok: false,
+      detail: "invalid authenticated checkout issuance proof path: checkoutIssuanceAuthenticatedProofPath must not contain secret-like text"
+    };
+  }
+  const confinedPath = resolveConfinedEvidenceProofPath(input.cwd, input.proofPath, "checkoutIssuanceAuthenticatedProofPath");
+  if (!confinedPath.ok) {
+    return { ok: false, detail: `invalid authenticated checkout issuance proof ${input.proofPath}: ${confinedPath.detail}` };
+  }
+  const absolutePath = confinedPath.absolutePath;
+  if (!existsSync(absolutePath)) return { ok: false, detail: `missing authenticated checkout issuance proof ${input.proofPath}` };
+
+  let proof: Record<string, unknown>;
+  try {
+    proof = asRecord(JSON.parse(readFileSync(absolutePath, "utf8")));
+  } catch {
+    return { ok: false, detail: `invalid authenticated checkout issuance proof ${input.proofPath}: proof JSON is invalid` };
+  }
+
+  const evidenceKind = readString(proof.evidenceKind);
+  const releaseVersion = readString(proof.releaseVersion);
+  const observedAt = readString(proof.observedAt);
+  const method = readString(proof.method);
+  const url = readString(proof.url);
+  const statusCode = typeof proof.statusCode === "number" ? proof.statusCode : undefined;
+  const redactedResponse = asRecord(proof.redactedResponse);
+  const responseStatus = readString(redactedResponse.status);
+  const replayed = typeof redactedResponse.replayed === "boolean" ? redactedResponse.replayed : undefined;
+  const checkoutLookupKey = readString(redactedResponse.checkoutLookupKey);
+  const issuedLicensePrefix = readString(redactedResponse.issuedLicensePrefix);
+  const issuedLicenseFingerprint = readString(redactedResponse.issuedLicenseFingerprint);
+  const captureContext = asRecord(proof.captureContext);
+  const captureTool = readString(captureContext.tool);
+  const captureTransport = readString(captureContext.transport);
+  const captureTlsValidation = readString(captureContext.tlsValidation);
+  const captureHost = readString(captureContext.capturedFrom);
+  const failures: string[] = [];
+  const unexpectedProofKeys = collectUnexpectedKeys(proof, AUTHENTICATED_CHECKOUT_PROOF_FIELDS);
+  const unexpectedRedactedResponseKeys = collectUnexpectedKeys(
+    redactedResponse,
+    AUTHENTICATED_CHECKOUT_REDACTED_RESPONSE_FIELDS
+  );
+
+  if (evidenceKind !== "license_api_checkout_issuance_authenticated") {
+    failures.push("evidenceKind must be license_api_checkout_issuance_authenticated");
+  }
+  if (unexpectedProofKeys.length > 0) failures.push("proof must contain only allowed top-level fields");
+  if (unexpectedRedactedResponseKeys.length > 0) failures.push("redactedResponse must contain only allowed fields");
+  if (!input.expectedReleaseVersion) {
+    failures.push("expected releaseVersion must be present");
+  } else if (releaseVersion !== input.expectedReleaseVersion) {
+    failures.push(`releaseVersion must match ${input.expectedReleaseVersion}`);
+  }
+  if (!input.expectedUrl) {
+    failures.push("checkoutIssuanceUrl must be present when validating authenticated checkout issuance proof");
+  } else if (url !== input.expectedUrl) {
+    failures.push(`url must match ${input.expectedUrl}`);
+  }
+  if (method !== "POST") failures.push("method must be POST");
+  if (statusCode !== 200) failures.push("statusCode must be 200");
+  failures.push(...validateLicenseProofObservedAt(observedAt, input.now));
+  if (!isPlainRecord(proof.redactedResponse)) failures.push("redactedResponse must be present");
+  if (responseStatus !== "issued") failures.push("redactedResponse.status must be issued");
+  if (replayed === undefined) failures.push("redactedResponse.replayed must be boolean");
+  if (!checkoutLookupKey || !CHECKOUT_ISSUANCE_LOOKUP_KEYS.has(checkoutLookupKey)) {
+    failures.push(`redactedResponse.checkoutLookupKey must be one of ${Array.from(CHECKOUT_ISSUANCE_LOOKUP_KEYS).join(", ")}`);
+  }
+  if (issuedLicensePrefix !== "nd_live_") failures.push("redactedResponse.issuedLicensePrefix must be nd_live_");
+  if (!issuedLicenseFingerprint || !/^sha256:[a-f0-9]{64}$/.test(issuedLicenseFingerprint)) {
+    failures.push("redactedResponse.issuedLicenseFingerprint must be sha256:<64 lowercase hex chars>");
+  }
+  if (Object.prototype.hasOwnProperty.call(proof, "responseBody")) {
+    failures.push("responseBody must be omitted from authenticated proof");
+  }
+  if (Object.prototype.hasOwnProperty.call(proof, "responseBodySha256")) {
+    failures.push("responseBodySha256 must be omitted from authenticated proof");
+  }
+  const forbiddenKeys = collectForbiddenAuthenticatedProofKeys(proof);
+  if (forbiddenKeys.length > 0) {
+    failures.push("proof must omit sensitive field names");
+  }
+  const serializedProof = JSON.stringify(proof);
+  if (/LICENSE_ISSUANCE_SECRET/i.test(serializedProof)) {
+    failures.push("proof must not mention owner-held issuance secret names");
+  }
+  if (/\bBearer\s+[A-Za-z0-9._~+/=-]+/i.test(serializedProof) || containsSecretLikeText(serializedProof)) {
+    failures.push("proof must not contain secret-like text");
+  }
+  if (!captureTool) failures.push("captureContext.tool must be present");
+  if (!captureTransport) failures.push("captureContext.transport must be present");
+  if (!captureTlsValidation) failures.push("captureContext.tlsValidation must be present");
+  if (!captureHost) failures.push("captureContext.capturedFrom must be present");
+
+  return failures.length
+    ? { ok: false, detail: `invalid authenticated checkout issuance proof ${input.proofPath}: ${failures.join("; ")}` }
+    : { ok: true, detail: `validated authenticated checkout issuance proof ${input.proofPath}` };
+}
+
 function validateLicenseHealthMetadata(input: {
   cwd: string;
   healthUrl?: string;
@@ -1276,7 +1429,7 @@ function resolveConfinedHealthProofPath(cwd: string, proofPath: string): { ok: t
 function resolveConfinedEvidenceProofPath(
   cwd: string,
   proofPath: string,
-  fieldName: "healthProofPath" | "checkoutIssuanceProofPath"
+  fieldName: "healthProofPath" | "checkoutIssuanceProofPath" | "checkoutIssuanceAuthenticatedProofPath"
 ): { ok: true; absolutePath: string } | { ok: false; detail: string } {
   if (isAbsolute(proofPath)) {
     return { ok: false, detail: `${fieldName} must be relative and stay within docs/evidence` };
@@ -1307,14 +1460,47 @@ function isPathInsideOrEqual(target: string, root: string): boolean {
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
+function collectUnexpectedKeys(value: Record<string, unknown>, allowedKeys: Set<string>): string[] {
+  return Object.keys(value).filter((key) => !allowedKeys.has(key)).sort();
+}
+
+function collectForbiddenAuthenticatedProofKeys(value: unknown, path = ""): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => collectForbiddenAuthenticatedProofKeys(item, `${path}[${index}]`));
+  }
+  if (!isPlainRecord(value)) return [];
+  const forbidden: string[] = [];
+  for (const [key, child] of Object.entries(value)) {
+    const keyPath = path ? `${path}.${key}` : key;
+    const normalized = key.toLowerCase();
+    if (
+      normalized === "licensekey" ||
+      normalized === "responsebody" ||
+      normalized === "rawresponse" ||
+      normalized === "authorization" ||
+      normalized === "authorizationheader" ||
+      normalized === "cookie" ||
+      normalized.includes("secret")
+    ) {
+      forbidden.push(keyPath);
+    }
+    forbidden.push(...collectForbiddenAuthenticatedProofKeys(child, keyPath));
+  }
+  return Array.from(new Set(forbidden)).sort();
+}
+
 function isUpdateChannelStateAcceptable(name: string, state: string, requiredForThisRelease: boolean): boolean {
   return requiredForThisRelease
     ? REQUIRED_PUBLIC_UPDATE_CHANNEL_STATES.has(state)
     : (OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATE_OVERRIDES.get(name) ?? GENERAL_OPTIONAL_PUBLIC_UPDATE_CHANNEL_STATES).has(state);
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 function asRecord(value: unknown): Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
+  return isPlainRecord(value)
     ? value as Record<string, unknown>
     : {};
 }

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -12,6 +12,7 @@ const SECRET_PATTERNS: RegExp[] = [
   /\b(?:customer|client)[_-]?phone\b\s*[:=]\s*["']?\+?\d[\d ().-]{7,}\d\b/gi,
   /\b(?:api[_-]?key|token|secret|password|cookie|session)\b\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{16,}/gi,
   /\b(?:NEONDIFF|NDL|LIC)_[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/gi,
+  /\bnd_live_[A-Za-z0-9_-]{8,}\b/gi,
   /(?<![A-Za-z0-9_./-])(?:[Nn][Ee][Oo][Nn][Dd][Ii][Ff][Ff]|[Nn][Dd][Ll]|[Ll][Ii][Cc])-(?=[A-Za-z0-9_-]*[A-Z0-9])[A-Za-z0-9][A-Za-z0-9_-]{11,}\b/g,
   /\b[A-Za-z0-9]{3,}[-_](?:secret|token|password|cookie)[-_][A-Za-z0-9_-]{3,}\b/gi,
   /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -86,6 +86,46 @@ describe("beta release status", () => {
       statusCode: options.statusCode ?? 401,
       responseBody,
       responseBodySha256: options.responseBodySha256 ?? createHash("sha256").update(responseBody).digest("hex"),
+      captureContext: options.captureContext ?? {
+        tool: "curl",
+        transport: "https",
+        tlsValidation: "curl default CA validation",
+        capturedFrom: "test runner"
+      }
+    }));
+    return proofPath;
+  }
+
+  function writeAuthenticatedLicenseIssuanceProof(root: string, options: {
+    evidenceKind?: string;
+    releaseVersion?: string;
+    observedAt?: string;
+    method?: string;
+    url?: string;
+    statusCode?: number;
+    checkoutLookupKey?: string;
+    redactedResponse?: Record<string, unknown>;
+    responseBody?: string;
+    captureContext?: Record<string, unknown>;
+    path?: string;
+  } = {}): string {
+    const proofPath = options.path ?? "docs/evidence/license-checkout-issuance-authenticated.json";
+    mkdirSync(dirname(join(root, proofPath)), { recursive: true });
+    writeFileSync(join(root, proofPath), JSON.stringify({
+      evidenceKind: options.evidenceKind ?? "license_api_checkout_issuance_authenticated",
+      releaseVersion: options.releaseVersion ?? "v1.0.0",
+      observedAt: options.observedAt ?? new Date().toISOString(),
+      method: options.method ?? "POST",
+      url: options.url ?? "https://license.example/v1/admin/licenses/issue",
+      statusCode: options.statusCode ?? 200,
+      redactedResponse: options.redactedResponse ?? {
+        status: "issued",
+        replayed: false,
+        checkoutLookupKey: options.checkoutLookupKey ?? "neondiff_monthly",
+        issuedLicensePrefix: "nd_live_",
+        issuedLicenseFingerprint: `sha256:${"a".repeat(64)}`
+      },
+      ...(options.responseBody !== undefined ? { responseBody: options.responseBody } : {}),
       captureContext: options.captureContext ?? {
         tool: "curl",
         transport: "https",
@@ -1755,6 +1795,12 @@ describe("beta release status", () => {
         releaseVersion,
         url: "https://license.example/v1/admin/licenses/issue"
       });
+      const checkoutIssuanceAuthenticatedProofPath = releaseLevel === "stable"
+        ? writeAuthenticatedLicenseIssuanceProof(root, {
+            releaseVersion,
+            url: "https://license.example/v1/admin/licenses/issue"
+          })
+        : undefined;
       writeFileSync(join(root, "public-release.json"), JSON.stringify({
         version: releaseVersion,
         releaseLevel,
@@ -1771,7 +1817,8 @@ describe("beta release status", () => {
           checkoutIssuanceRequiredForThisRelease: true,
           checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue",
           checkoutIssuanceState: "ready",
-          checkoutIssuanceProofPath
+          checkoutIssuanceProofPath,
+          ...(checkoutIssuanceAuthenticatedProofPath ? { checkoutIssuanceAuthenticatedProofPath } : {})
         },
         updateChannels: {
           cli: {
@@ -1799,6 +1846,278 @@ describe("beta release status", () => {
       expect(manifest.licenseApi.detail).toContain(`validated checkout issuance proof ${checkoutIssuanceProofPath}`);
       expect(manifest.ok).toBe(true);
     }
+  });
+
+  it("blocks stable checkout issuance without redacted authenticated success proof", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stable-missing-auth-issuance-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0.md"), "# v1.0.0\n");
+    writeChangelogHead(root, "1.0.0", "docs/releases/v1.0.0.md");
+    const healthProofPath = writeLicenseHealthProof(root, {
+      releaseVersion: "v1.0.0",
+      url: "https://license.example/healthz"
+    });
+    const checkoutIssuanceProofPath = writeLicenseIssuanceProof(root, {
+      releaseVersion: "v1.0.0",
+      url: "https://license.example/v1/admin/licenses/issue"
+    });
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0",
+      releaseLevel: "stable",
+      docs: {
+        version: "v1.0.0",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue",
+        checkoutIssuanceState: "ready",
+        checkoutIssuanceProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "published",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0"
+    });
+
+    expect(manifest.licenseApi.detail).toContain(
+      "missing authenticated checkout issuance proof path (no checkoutIssuanceAuthenticatedProofPath declared)"
+    );
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("accepts stable checkout issuance with redacted authenticated success proof", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stable-auth-issuance-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0.md"), "# v1.0.0\n");
+    writeChangelogHead(root, "1.0.0", "docs/releases/v1.0.0.md");
+    const healthProofPath = writeLicenseHealthProof(root, {
+      releaseVersion: "v1.0.0",
+      url: "https://license.example/healthz"
+    });
+    const checkoutIssuanceProofPath = writeLicenseIssuanceProof(root, {
+      releaseVersion: "v1.0.0",
+      url: "https://license.example/v1/admin/licenses/issue"
+    });
+    const checkoutIssuanceAuthenticatedProofPath = writeAuthenticatedLicenseIssuanceProof(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0",
+      releaseLevel: "stable",
+      docs: {
+        version: "v1.0.0",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue",
+        checkoutIssuanceState: "ready",
+        checkoutIssuanceProofPath,
+        checkoutIssuanceAuthenticatedProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "published",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0"
+    });
+
+    expect(manifest.licenseApi).toMatchObject({
+      ok: true,
+      checkoutIssuanceAuthenticatedProofPath
+    });
+    expect(manifest.licenseApi.detail).toContain(
+      `validated authenticated checkout issuance proof ${checkoutIssuanceAuthenticatedProofPath}`
+    );
+    expect(JSON.stringify(manifest)).not.toMatch(/nd_live_[A-Za-z0-9_-]{8,}|LICENSE_ISSUANCE_SECRET|Bearer /);
+    expect(manifest.ok).toBe(true);
+  });
+
+  it("blocks authenticated checkout issuance proofs that include raw response material", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stable-raw-auth-issuance-proof-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0.md"), "# v1.0.0\n");
+    writeChangelogHead(root, "1.0.0", "docs/releases/v1.0.0.md");
+    const healthProofPath = writeLicenseHealthProof(root, {
+      releaseVersion: "v1.0.0",
+      url: "https://license.example/healthz"
+    });
+    const checkoutIssuanceProofPath = writeLicenseIssuanceProof(root, {
+      releaseVersion: "v1.0.0",
+      url: "https://license.example/v1/admin/licenses/issue"
+    });
+    const checkoutIssuanceAuthenticatedProofPath = writeAuthenticatedLicenseIssuanceProof(root, {
+      responseBody: "{\"status\":\"issued\",\"licenseKey\":\"nd_live_rawleaksecret\"}"
+    });
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0",
+      releaseLevel: "stable",
+      docs: {
+        version: "v1.0.0",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue",
+        checkoutIssuanceState: "ready",
+        checkoutIssuanceProofPath,
+        checkoutIssuanceAuthenticatedProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "published",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0"
+    });
+
+    expect(manifest.licenseApi.detail).toContain(
+      `invalid authenticated checkout issuance proof ${checkoutIssuanceAuthenticatedProofPath}`
+    );
+    expect(manifest.licenseApi.detail).toContain("responseBody must be omitted from authenticated proof");
+    expect(JSON.stringify(manifest)).not.toMatch(/nd_live_[A-Za-z0-9_-]{8,}|LICENSE_ISSUANCE_SECRET|Bearer /);
+    expect(manifest.ok).toBe(false);
+  });
+
+  it("blocks authenticated checkout issuance proofs that carry extra payload fields", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-stable-extra-auth-issuance-fields-"));
+    roots.push(root);
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0.md"), "# v1.0.0\n");
+    writeChangelogHead(root, "1.0.0", "docs/releases/v1.0.0.md");
+    const healthProofPath = writeLicenseHealthProof(root, {
+      releaseVersion: "v1.0.0",
+      url: "https://license.example/healthz"
+    });
+    const checkoutIssuanceProofPath = writeLicenseIssuanceProof(root, {
+      releaseVersion: "v1.0.0",
+      url: "https://license.example/v1/admin/licenses/issue"
+    });
+    const checkoutIssuanceAuthenticatedProofPath = writeAuthenticatedLicenseIssuanceProof(root, {
+      redactedResponse: {
+        status: "issued",
+        replayed: false,
+        checkoutLookupKey: "neondiff_monthly",
+        issuedLicensePrefix: "nd_live_",
+        issuedLicenseFingerprint: `sha256:${"a".repeat(64)}`,
+        body: "{\"status\":\"issued\"}",
+        checkoutPayload: { lookupKey: "neondiff_monthly" }
+      }
+    });
+    const proof = JSON.parse(readFileSync(join(root, checkoutIssuanceAuthenticatedProofPath), "utf8")) as Record<string, unknown>;
+    proof.response = { status: "issued" };
+    proof.customerData = { fixture: "synthetic customer context" };
+    writeFileSync(join(root, checkoutIssuanceAuthenticatedProofPath), JSON.stringify(proof));
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0",
+      releaseLevel: "stable",
+      docs: {
+        version: "v1.0.0",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: true,
+        state: "healthy",
+        healthUrl: "https://license.example/healthz",
+        healthProofPath,
+        checkoutIssuanceRequiredForThisRelease: true,
+        checkoutIssuanceUrl: "https://license.example/v1/admin/licenses/issue",
+        checkoutIssuanceState: "ready",
+        checkoutIssuanceProofPath,
+        checkoutIssuanceAuthenticatedProofPath
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "published",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        },
+        daemon: {
+          requiredForThisRelease: true,
+          state: "launchd_prerelease",
+          version: "v1.0.0",
+          rollback: "git reset --hard refs/tags/v0.4.9-beta.1"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0"
+    });
+
+    expect(manifest.licenseApi.detail).toContain("proof must contain only allowed top-level fields");
+    expect(manifest.licenseApi.detail).toContain("redactedResponse must contain only allowed fields");
+    expect(manifest.ok).toBe(false);
   });
 
   it("blocks deferred checkout issuance state when proof is required", () => {

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -24,6 +24,13 @@ describe("secret redaction", () => {
     expect(redactSecrets(`license=${license}`)).toBe("license=[redacted-secret]");
   });
 
+  it("redacts lowercase live license keys from checkout issuance responses", () => {
+    const license = "nd_live_abcdefgh12345678";
+
+    expect(containsSecretLikeText(license)).toBe(true);
+    expect(redactSecrets(`licenseKey=${license}`)).toBe("licenseKey=[redacted-secret]");
+  });
+
   it("does not redact documented NeonDiff environment variable names", () => {
     const text = "Set NEONDIFF_GITHUB_APP_ID and NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH before doctor github.";
 


### PR DESCRIPTION
## Summary
- require stable/GA public-release manifests to include a redacted authenticated checkout issuance proof path
- validate the proof shape without live POSTs, raw response bodies, bearer secrets, raw license keys, cookies, customer data, or checkout payload fields
- redact lowercase `nd_live_*` license keys and update release/deploy docs for the GA proof boundary

Closes #456.
Tracks #421 / #396.

## Validation
- `npm test -- --run tests/secrets.test.ts tests/release-status.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `node scripts/check-secret-scan.mjs`
- `node scripts/check-public-claims.mjs`
- `git diff --check`

## Proof Boundary
This adds static release-status proof validation. It does not configure owner-held production secrets, run the live authenticated issuance POST, or prove paid checkout activation end to end.