### PR TITLE
[codex] Add checkout issuance smoke helper

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -386,6 +386,22 @@ npx tsx src/cli.ts review-head-gate \
   payload secrets, or raw response bodies. Public beta and source-beta releases
   may continue to use only the no-secret 401 gate unless authenticated checkout
   issuance is part of that release's scope.
+  Use the owner-run smoke helper to create the stable/GA proof after the shared
+  issuance secret is configured on both Fly and the server-side checkout webhook:
+
+  ```bash
+  npx tsx src/cli.ts checkout-issuance-smoke \
+    --url https://neondiff-license.fly.dev/v1/admin/licenses/issue \
+    --release-version <release-version> \
+    --checkout-lookup-key neondiff_monthly \
+    --secret-env LICENSE_ISSUANCE_SECRET \
+    --dry-run false \
+    --confirm-live-issuance true \
+    --output docs/evidence/license-checkout-issuance-authenticated.json
+  ```
+
+  Run the same command with `--dry-run true` first when preparing a release
+  packet; dry-run mode does not read the secret and does not send the POST.
   In `release:status` output, `checkoutIssuanceRequiredForThisRelease` is the
   computed effective gate; `checkoutIssuanceRequiredDeclaredForThisRelease`
   preserves the raw manifest declaration when present.

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -143,7 +143,11 @@ Before tagging:
    - for stable GA, a redacted authenticated checkout issuance success proof
      path (`checkoutIssuanceAuthenticatedProofPath`) with no raw bearer secret,
      license key, cookie, customer data, checkout payload secret, or raw response
-     body
+     body. Generate it with `npx tsx src/cli.ts checkout-issuance-smoke
+     --dry-run false --confirm-live-issuance true --secret-env
+     LICENSE_ISSUANCE_SECRET --output
+     docs/evidence/license-checkout-issuance-authenticated.json` after the
+     paired Fly and server-side checkout secrets are configured.
    - computed checkout issuance status and, when present, the raw manifest
      declaration that produced it
    - CLI, daemon, website, and desktop update-channel state

--- a/services/license-api/docs/deploy.md
+++ b/services/license-api/docs/deploy.md
@@ -105,6 +105,41 @@ issued license key. It must not store raw bearer headers,
 `LICENSE_ISSUANCE_SECRET`, raw `licenseKey`, cookies, customer data, checkout
 payload secrets, or raw response bodies.
 
+Use the repo-owned smoke helper for that owner-held success proof. Start with a
+dry run so the request shape is visible without reading the secret or sending a
+network request:
+
+```sh
+npx tsx src/cli.ts checkout-issuance-smoke \
+  --url https://neondiff-license.fly.dev/v1/admin/licenses/issue \
+  --release-version <release-version> \
+  --checkout-lookup-key neondiff_monthly \
+  --dry-run true
+```
+
+After the same issuance secret has been configured on the license API and the
+server-side checkout webhook, run the live proof capture from a clean checkout:
+
+```sh
+export LICENSE_ISSUANCE_SECRET="<owner-held-shared-secret>"
+npx tsx src/cli.ts checkout-issuance-smoke \
+  --url https://neondiff-license.fly.dev/v1/admin/licenses/issue \
+  --release-version <release-version> \
+  --checkout-lookup-key neondiff_monthly \
+  --secret-env LICENSE_ISSUANCE_SECRET \
+  --dry-run false \
+  --confirm-live-issuance true \
+  --output docs/evidence/license-checkout-issuance-authenticated.json
+```
+
+The command reads the bearer value only from `--secret-env`, never from argv,
+and writes only the strict redacted proof accepted by
+`checkoutIssuanceAuthenticatedProofPath`. It rejects non-HTTPS URLs before
+reading the secret. The smoke request uses a stable synthetic `idempotencyKey`
+as the replay key; `externalCheckoutId` mirrors that value only as smoke
+metadata, while the license API's idempotent issuance contract is keyed by
+`idempotencyKey`.
+
 ## 4. Deploy
 
 ```sh

--- a/src/checkout-issuance-smoke.ts
+++ b/src/checkout-issuance-smoke.ts
@@ -1,0 +1,407 @@
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { redactSecrets } from "./secrets.js";
+
+const CHECKOUT_LOOKUP_KEYS = new Set(["neondiff_monthly", "neondiff_yearly", "neondiff_org_yearly"]);
+const CHECKOUT_ISSUANCE_TIMEOUT_MS = 15_000;
+const MAX_RESPONSE_BODY_BYTES = 16 * 1024;
+const DEFAULT_CAPTURE_CONTEXT = {
+  tool: "neondiff checkout-issuance-smoke",
+  transport: "https",
+  tlsValidation: "node default CA validation",
+  capturedFrom: "operator CLI"
+} as const;
+
+export type CheckoutLookupKey = "neondiff_monthly" | "neondiff_yearly" | "neondiff_org_yearly";
+export type CheckoutIssuanceFetch = typeof fetch;
+
+export interface CheckoutIssuanceSmokeInput {
+  url: string;
+  releaseVersion: string;
+  checkoutLookupKey: string;
+  confirmLiveIssuance: boolean;
+  secretEnvName: string;
+  env?: Record<string, string | undefined>;
+  idempotencyKey?: string;
+  outputPath?: string;
+  cwd?: string;
+  now?: () => Date;
+  fetchImpl?: CheckoutIssuanceFetch;
+}
+
+export interface CheckoutIssuanceSmokeRequestPreview {
+  idempotencyKey: string;
+  checkoutLookupKey: CheckoutLookupKey;
+  externalCheckoutId: string;
+}
+
+export interface AuthenticatedCheckoutIssuanceProof {
+  evidenceKind: "license_api_checkout_issuance_authenticated";
+  releaseVersion: string;
+  observedAt: string;
+  method: "POST";
+  url: string;
+  statusCode: 200;
+  redactedResponse: {
+    status: "issued";
+    replayed: boolean;
+    checkoutLookupKey: CheckoutLookupKey;
+    issuedLicensePrefix: "nd_live_";
+    issuedLicenseFingerprint: string;
+  };
+  captureContext: typeof DEFAULT_CAPTURE_CONTEXT;
+}
+
+export type CheckoutIssuanceSmokeResult =
+  | {
+      ok: true;
+      command: "checkout-issuance-smoke";
+      proof: AuthenticatedCheckoutIssuanceProof;
+      proofPath?: string;
+      requestPreview: CheckoutIssuanceSmokeRequestPreview;
+      proofBoundary: string;
+    }
+  | {
+      ok: false;
+      command: "checkout-issuance-smoke";
+      errorCode:
+        | "confirm_live_issuance_required"
+        | "invalid_url"
+        | "invalid_checkout_lookup_key"
+        | "invalid_output_path"
+        | "missing_secret_env"
+        | "fetch_failed"
+        | "response_too_large"
+        | "invalid_json_response"
+        | "unexpected_status"
+        | "invalid_success_response";
+      detail: string;
+      secretEnvName?: string;
+      statusCode?: number;
+      requestPreview?: CheckoutIssuanceSmokeRequestPreview;
+      proofBoundary: string;
+    };
+
+export function buildCheckoutIssuanceSmokeRequestPreview(input: {
+  releaseVersion: string;
+  checkoutLookupKey: string;
+  idempotencyKey?: string;
+}): CheckoutIssuanceSmokeRequestPreview {
+  const checkoutLookupKey = normalizeCheckoutLookupKey(input.checkoutLookupKey);
+  const idempotencyKey = input.idempotencyKey ?? defaultIdempotencyKey(input.releaseVersion, checkoutLookupKey);
+  return {
+    idempotencyKey,
+    checkoutLookupKey,
+    externalCheckoutId: idempotencyKey
+  };
+}
+
+export function validateCheckoutIssuanceUrl(url: string): { ok: true } | { ok: false; detail: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, detail: "checkout issuance URL must be a valid HTTPS URL" };
+  }
+  if (parsed.protocol !== "https:") {
+    return { ok: false, detail: "checkout issuance URL must use https://" };
+  }
+  return { ok: true };
+}
+
+export async function runCheckoutIssuanceSmoke(input: CheckoutIssuanceSmokeInput): Promise<CheckoutIssuanceSmokeResult> {
+  let requestPreview: CheckoutIssuanceSmokeRequestPreview;
+  try {
+    requestPreview = buildCheckoutIssuanceSmokeRequestPreview(input);
+  } catch (error) {
+    return failure("invalid_checkout_lookup_key", error instanceof Error ? error.message : "invalid checkout lookup key");
+  }
+
+  const urlCheck = validateCheckoutIssuanceUrl(input.url);
+  if (!urlCheck.ok) return failure("invalid_url", urlCheck.detail, { requestPreview });
+
+  const outputPath = input.outputPath
+    ? resolveConfinedProofOutputPath(input.cwd ?? process.cwd(), input.outputPath)
+    : undefined;
+  if (outputPath && !outputPath.ok) {
+    return failure("invalid_output_path", outputPath.detail, { requestPreview });
+  }
+
+  if (!input.confirmLiveIssuance) {
+    return failure(
+      "confirm_live_issuance_required",
+      "checkout issuance smoke requires --confirm-live-issuance true before reading the owner-held secret or sending a live POST",
+      { requestPreview }
+    );
+  }
+
+  const env = input.env ?? process.env;
+  const secret = env[input.secretEnvName];
+  if (!secret) {
+    return failure(
+      "missing_secret_env",
+      "secret env var did not resolve to a non-empty value",
+      { secretEnvName: input.secretEnvName, requestPreview }
+    );
+  }
+
+  let response: Response;
+  const fetchImpl = input.fetchImpl ?? fetch;
+  try {
+    response = await fetchImpl(input.url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${secret}`
+      },
+      body: JSON.stringify(requestPreview),
+      signal: AbortSignal.timeout(CHECKOUT_ISSUANCE_TIMEOUT_MS)
+    });
+  } catch {
+    return failure(
+      "fetch_failed",
+      "checkout issuance request failed before receiving a response",
+      { requestPreview }
+    );
+  }
+
+  if (response.status !== 200) {
+    return failure("unexpected_status", `checkout issuance returned HTTP ${response.status}`, {
+      statusCode: response.status,
+      requestPreview
+    });
+  }
+
+  const bodyText = await readBoundedResponseText(response);
+  if (!bodyText.ok) {
+    return failure("response_too_large", bodyText.detail, {
+      statusCode: response.status,
+      requestPreview
+    });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(bodyText.text) as Record<string, unknown>;
+  } catch {
+    return failure("invalid_json_response", "checkout issuance response was not JSON", {
+      statusCode: response.status,
+      requestPreview
+    });
+  }
+
+  const proof = buildProofFromSuccess({
+    url: input.url,
+    releaseVersion: input.releaseVersion,
+    observedAt: (input.now ?? (() => new Date()))().toISOString(),
+    statusCode: response.status,
+    checkoutLookupKey: requestPreview.checkoutLookupKey,
+    body
+  });
+  if (!proof.ok) {
+    return failure("invalid_success_response", proof.detail, {
+      statusCode: response.status,
+      requestPreview
+    });
+  }
+
+  if (outputPath?.ok) {
+    mkdirSync(dirname(outputPath.absolutePath), { recursive: true });
+    writeFileSync(outputPath.absolutePath, `${JSON.stringify(proof.proof, null, 2)}\n`);
+  }
+
+  return {
+    ok: true,
+    command: "checkout-issuance-smoke",
+    proof: proof.proof,
+    ...(input.outputPath ? { proofPath: input.outputPath } : {}),
+    requestPreview,
+    proofBoundary: "Redacted authenticated checkout issuance proof only; raw license keys and bearer secrets are never written."
+  };
+}
+
+function buildProofFromSuccess(input: {
+  url: string;
+  releaseVersion: string;
+  observedAt: string;
+  statusCode: number;
+  checkoutLookupKey: CheckoutLookupKey;
+  body: Record<string, unknown>;
+}): { ok: true; proof: AuthenticatedCheckoutIssuanceProof } | { ok: false; detail: string } {
+  const status = input.body.status;
+  const replayed = input.body.replayed;
+  const licenseKey = input.body.licenseKey;
+  const responseCheckoutLookupKey = input.body.checkoutLookupKey;
+  if (status !== "issued") return { ok: false, detail: "checkout issuance response status was not issued" };
+  if (typeof replayed !== "boolean") return { ok: false, detail: "checkout issuance response replayed was not boolean" };
+  if (responseCheckoutLookupKey !== undefined && responseCheckoutLookupKey !== input.checkoutLookupKey) {
+    return { ok: false, detail: "checkout issuance response checkoutLookupKey did not match the request" };
+  }
+  if (typeof licenseKey !== "string" || !licenseKey.startsWith("nd_live_")) {
+    return { ok: false, detail: "checkout issuance response did not include an nd_live_ license key" };
+  }
+  return {
+    ok: true,
+    proof: {
+      evidenceKind: "license_api_checkout_issuance_authenticated",
+      releaseVersion: input.releaseVersion,
+      observedAt: input.observedAt,
+      method: "POST",
+      url: input.url,
+      statusCode: 200,
+      redactedResponse: {
+        status: "issued",
+        replayed,
+        checkoutLookupKey: input.checkoutLookupKey,
+        issuedLicensePrefix: "nd_live_",
+        issuedLicenseFingerprint: `sha256:${createHash("sha256").update(licenseKey).digest("hex")}`
+      },
+      captureContext: DEFAULT_CAPTURE_CONTEXT
+    }
+  };
+}
+
+function normalizeCheckoutLookupKey(input: string): CheckoutLookupKey {
+  if (CHECKOUT_LOOKUP_KEYS.has(input)) return input as CheckoutLookupKey;
+  throw new Error("checkoutLookupKey must be one of: neondiff_monthly, neondiff_yearly, neondiff_org_yearly");
+}
+
+function defaultIdempotencyKey(releaseVersion: string, checkoutLookupKey: CheckoutLookupKey): string {
+  return `neondiff-smoke-${releaseVersion}-${checkoutLookupKey}`;
+}
+
+function resolveConfinedProofOutputPath(
+  cwd: string,
+  outputPath: string
+): { ok: true; absolutePath: string } | { ok: false; detail: string } {
+  if (isAbsolute(outputPath)) {
+    return { ok: false, detail: "--output must be relative and stay within docs/evidence" };
+  }
+  const evidenceRoot = resolve(cwd, "docs", "evidence");
+  const absolutePath = resolve(cwd, outputPath);
+  const rel = relative(evidenceRoot, absolutePath);
+  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
+    return { ok: false, detail: "--output must be relative and stay within docs/evidence" };
+  }
+  if (existsSync(absolutePath) && lstatSync(absolutePath).isSymbolicLink()) {
+    return { ok: false, detail: "--output must not point at a symlink" };
+  }
+  if (hasSymlinkPathSegment(cwd, dirname(absolutePath))) {
+    return { ok: false, detail: "--output parent must resolve within docs/evidence" };
+  }
+  const realCwd = realpathSync.native(cwd);
+  const existingEvidenceBoundary = nearestExistingParent(evidenceRoot);
+  if (existingEvidenceBoundary) {
+    const realEvidenceBoundary = realpathSync.native(existingEvidenceBoundary);
+    if (!isPathInsideOrEqual(realEvidenceBoundary, realCwd)) {
+      return { ok: false, detail: "--output parent must resolve within docs/evidence" };
+    }
+  }
+  const existingParent = nearestExistingParent(dirname(absolutePath));
+  if (existingParent) {
+    const realParent = realpathSync.native(existingParent);
+    if (!isPathInsideOrEqual(realParent, realCwd)) {
+      return { ok: false, detail: "--output parent must resolve within docs/evidence" };
+    }
+    if (existsSync(evidenceRoot)) {
+      const realEvidenceRoot = realpathSync.native(evidenceRoot);
+      if (!isPathInsideOrEqual(realParent, realEvidenceRoot)) {
+        return { ok: false, detail: "--output parent must resolve within docs/evidence" };
+      }
+    }
+  }
+  return { ok: true, absolutePath };
+}
+
+async function readBoundedResponseText(response: Response): Promise<
+  { ok: true; text: string } | { ok: false; detail: string }
+> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BODY_BYTES) {
+    return { ok: false, detail: `checkout issuance response exceeded ${MAX_RESPONSE_BODY_BYTES} bytes` };
+  }
+  if (!response.body) return { ok: true, text: "" };
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      size += value.byteLength;
+      if (size > MAX_RESPONSE_BODY_BYTES) {
+        await reader.cancel();
+        return { ok: false, detail: `checkout issuance response exceeded ${MAX_RESPONSE_BODY_BYTES} bytes` };
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return { ok: true, text: Buffer.concat(chunks).toString("utf8") };
+}
+
+function nearestExistingParent(path: string): string | undefined {
+  let current = path;
+  while (!existsSync(current)) {
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+  return current;
+}
+
+function isPathInsideOrEqual(target: string, root: string): boolean {
+  const rel = relative(root, target);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function hasSymlinkPathSegment(root: string, target: string): boolean {
+  const rel = relative(root, target);
+  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) return false;
+  let current = root;
+  for (const segment of rel.split(/[\\/]+/)) {
+    if (!segment) continue;
+    current = resolve(current, segment);
+    if (!existsSync(current)) return false;
+    if (lstatSync(current).isSymbolicLink()) return true;
+  }
+  return false;
+}
+
+function failure(
+  errorCode: CheckoutIssuanceSmokeResult extends infer R
+    ? R extends { ok: false; errorCode: infer E }
+      ? E
+      : never
+      : never,
+  detail: string,
+  extra: Partial<Extract<CheckoutIssuanceSmokeResult, { ok: false }>> = {}
+): Extract<CheckoutIssuanceSmokeResult, { ok: false }> {
+  return {
+    ok: false,
+    command: "checkout-issuance-smoke",
+    errorCode,
+    detail: redactSecrets(detail),
+    proofBoundary: "No authenticated checkout issuance proof was produced.",
+    ...redactFailureExtra(extra)
+  };
+}
+
+function redactFailureExtra(
+  extra: Partial<Extract<CheckoutIssuanceSmokeResult, { ok: false }>>
+): Partial<Extract<CheckoutIssuanceSmokeResult, { ok: false }>> {
+  return {
+    ...extra,
+    ...(typeof extra.secretEnvName === "string"
+      ? { secretEnvName: isSafeEnvName(extra.secretEnvName) ? extra.secretEnvName : "[redacted-secret]" }
+      : {})
+  };
+}
+
+function isSafeEnvName(input: string): boolean {
+  return /^[A-Z_][A-Z0-9_]*$/.test(input);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,11 @@ import {
   writeOutcomeLedgerPacket
 } from "./outcome-ledger.js";
 import {
+  buildCheckoutIssuanceSmokeRequestPreview,
+  runCheckoutIssuanceSmoke,
+  validateCheckoutIssuanceUrl
+} from "./checkout-issuance-smoke.js";
+import {
   readOutcomeScorecardInput,
   writeOutcomeScorecardPacket
 } from "./outcome-scorecard.js";
@@ -167,6 +172,57 @@ async function main(): Promise<void> {
 
   if (command === "pricing") {
     console.log(stringifyRedactedJson(buildPricingOutput()));
+    return;
+  }
+
+  if (command === "checkout-issuance-smoke") {
+    const url = parseSingleArg(args.url ?? "https://neondiff-license.fly.dev/v1/admin/licenses/issue", "--url");
+    const releaseVersion = parseSingleArg(args["release-version"] ?? "v1.0.0", "--release-version");
+    const checkoutLookupKey = parseSingleArg(args["checkout-lookup-key"] ?? "neondiff_monthly", "--checkout-lookup-key");
+    const idempotencyKey = args["idempotency-key"] ? parseSingleArg(args["idempotency-key"], "--idempotency-key") : undefined;
+    const urlCheck = validateCheckoutIssuanceUrl(url);
+    if (!urlCheck.ok) {
+      console.log(stringifyRedactedJson({
+        ok: false,
+        command: "checkout-issuance-smoke",
+        errorCode: "invalid_url",
+        detail: urlCheck.detail,
+        proofBoundary: "No authenticated checkout issuance proof was produced."
+      }));
+      process.exitCode = 1;
+      return;
+    }
+    const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
+    if (dryRun) {
+      console.log(stringifyRedactedJson({
+        ok: true,
+        command: "checkout-issuance-smoke",
+        mode: "dry_run",
+        url,
+        releaseVersion,
+        requestPreview: buildCheckoutIssuanceSmokeRequestPreview({
+          releaseVersion,
+          checkoutLookupKey,
+          ...(idempotencyKey ? { idempotencyKey } : {})
+        }),
+        proofBoundary: "Dry-run request preview only; no owner-held secret was read and no network request was sent."
+      }));
+      return;
+    }
+    const secretEnvName = parseSingleArg(args["secret-env"] ?? "LICENSE_ISSUANCE_SECRET", "--secret-env");
+    const result = await runCheckoutIssuanceSmoke({
+      url,
+      releaseVersion,
+      checkoutLookupKey,
+      confirmLiveIssuance: args["confirm-live-issuance"] === undefined
+        ? false
+        : parseBooleanArg(args["confirm-live-issuance"], "--confirm-live-issuance"),
+      secretEnvName,
+      ...(idempotencyKey ? { idempotencyKey } : {}),
+      ...(args.output ? { outputPath: parseSingleArg(args.output, "--output") } : {})
+    });
+    console.log(stringifyRedactedJson(result));
+    if (!result.ok) process.exitCode = 1;
     return;
   }
 
@@ -3044,6 +3100,19 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--require-coverage", description: "true to fail release-status when active repo coverage has unreadable, unprocessed, or stale heads." },
       { name: "--public-release-manifest", description: "Public release manifest to validate for source-beta releases." },
       { name: "--expected-public-version", description: "Expected public release version/tag when validating a public manifest." }
+    ]
+  },
+  "checkout-issuance-smoke": {
+    description: "Dry-run or run the owner-held authenticated checkout issuance smoke and emit a redacted release-status proof.",
+    flags: [
+      { name: "--url", description: "Full /v1/admin/licenses/issue URL (default https://neondiff-license.fly.dev/v1/admin/licenses/issue)." },
+      { name: "--release-version", description: "Release version recorded in the proof (default v1.0.0)." },
+      { name: "--checkout-lookup-key", description: "Checkout lookup key to smoke: neondiff_monthly, neondiff_yearly, or neondiff_org_yearly." },
+      { name: "--idempotency-key", description: "Optional stable smoke idempotency key; defaults to release/version/lookup-key." },
+      { name: "--dry-run", description: "true by default; false sends the live POST." },
+      { name: "--confirm-live-issuance", description: "Must be true with --dry-run false before reading --secret-env and sending the POST." },
+      { name: "--secret-env", description: "Env var name holding the owner-held issuance bearer secret; raw secrets are never accepted on argv." },
+      { name: "--output", description: "Optional proof JSON path, normally docs/evidence/license-checkout-issuance-authenticated.json." }
     ]
   },
   "review-pr": {

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -31,6 +31,13 @@ const SAFE_ENV_VAR_NAMES = [
   "NEONDIFF_PROVIDER_API_KEY",
   "NEONDIFF_ALLOW_REMOTE_SMOKE"
 ];
+const SAFE_STRUCTURAL_VALUES = [
+  "missing_secret_env"
+];
+const SAFE_REDACTION_LITERALS = [
+  ...SAFE_ENV_VAR_NAMES,
+  ...SAFE_STRUCTURAL_VALUES
+];
 
 export function containsSecretLikeText(input: string): boolean {
   const safeInput = protectSafeEnvVarNames(input);
@@ -96,14 +103,14 @@ function readSensitiveCookieHeader(line: string): string | undefined {
 }
 
 function protectSafeEnvVarNames(input: string): string {
-  return SAFE_ENV_VAR_NAMES.reduce((text, name, index) => {
+  return SAFE_REDACTION_LITERALS.reduce((text, name, index) => {
     const pattern = new RegExp(`(?<![A-Za-z0-9_])${escapeRegExp(name)}(?![A-Za-z0-9_])`, "g");
     return text.replace(pattern, `__NEONDIFF_SAFE_ENV_${index}__`);
   }, input);
 }
 
 function restoreSafeEnvVarNames(input: string): string {
-  return SAFE_ENV_VAR_NAMES.reduce(
+  return SAFE_REDACTION_LITERALS.reduce(
     (text, name, index) => text.replaceAll(`__NEONDIFF_SAFE_ENV_${index}__`, name),
     input
   );

--- a/tests/checkout-issuance-smoke.test.ts
+++ b/tests/checkout-issuance-smoke.test.ts
@@ -1,0 +1,527 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildCheckoutIssuanceSmokeRequestPreview,
+  runCheckoutIssuanceSmoke,
+  type CheckoutIssuanceFetch
+} from "../src/checkout-issuance-smoke.js";
+
+const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
+const tsxCliPath = require.resolve("tsx/cli");
+
+describe("checkout issuance smoke", () => {
+  const tempRoots: string[] = [];
+
+  afterEach(() => {
+    for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function tempRoot(): string {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-checkout-issuance-smoke-"));
+    tempRoots.push(root);
+    return root;
+  }
+
+  it("requires explicit live confirmation before reading secrets or making a network request", async () => {
+    const calls: unknown[] = [];
+    const fetchImpl: CheckoutIssuanceFetch = async (...args) => {
+      calls.push(args);
+      throw new Error("fetch should not run");
+    };
+
+    const result = await runCheckoutIssuanceSmoke({
+      url: "https://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_monthly",
+      confirmLiveIssuance: false,
+      secretEnvName: "LICENSE_ISSUANCE_SECRET",
+      env: { LICENSE_ISSUANCE_SECRET: "owner-held-proof-key" },
+      fetchImpl
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected confirmation failure");
+    expect(result.errorCode).toBe("confirm_live_issuance_required");
+    expect(calls).toEqual([]);
+    expect(JSON.stringify(result)).not.toContain("owner-held-proof-key");
+  });
+
+  it("fails before the HTTP call when the requested secret env var is missing", async () => {
+    const calls: unknown[] = [];
+    const fetchImpl: CheckoutIssuanceFetch = async (...args) => {
+      calls.push(args);
+      throw new Error("fetch should not run");
+    };
+
+    const result = await runCheckoutIssuanceSmoke({
+      url: "https://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_monthly",
+      confirmLiveIssuance: true,
+      secretEnvName: "LICENSE_ISSUANCE_SECRET",
+      env: {},
+      fetchImpl
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected missing env failure");
+    expect(result.errorCode).toBe("missing_secret_env");
+    expect(result.secretEnvName).toBe("LICENSE_ISSUANCE_SECRET");
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects non-https URLs before reading the secret or making a network request", async () => {
+    const calls: unknown[] = [];
+    const fetchImpl: CheckoutIssuanceFetch = async (...args) => {
+      calls.push(args);
+      throw new Error("fetch should not run");
+    };
+
+    const result = await runCheckoutIssuanceSmoke({
+      url: "http://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_monthly",
+      confirmLiveIssuance: true,
+      secretEnvName: "LICENSE_ISSUANCE_SECRET",
+      env: { LICENSE_ISSUANCE_SECRET: "owner-held-proof-key" },
+      fetchImpl
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected invalid URL failure");
+    expect(result.errorCode).toBe("invalid_url");
+    expect(JSON.stringify(result)).not.toContain("owner-held-proof-key");
+    expect(calls).toEqual([]);
+  });
+
+  it("posts the supported checkout request and writes only redacted success proof", async () => {
+    const root = tempRoot();
+    const outputPath = "docs/evidence/license-checkout-issuance-authenticated.json";
+    const secretValue = "owner-held-proof-key";
+    const licenseKey = ["nd", "live", "abcdefghijklmnopqrstuvwxyz123456"].join("_");
+    let observedRequest: { url: string; init: RequestInit | undefined } | undefined;
+    const fetchImpl: CheckoutIssuanceFetch = async (url, init) => {
+      observedRequest = { url: String(url), init };
+      return jsonResponse(200, {
+        status: "issued",
+        replayed: false,
+        checkoutLookupKey: "neondiff_yearly",
+        licenseKey,
+        entitlement: { status: "active" }
+      });
+    };
+
+    const result = await runCheckoutIssuanceSmoke({
+      url: "https://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_yearly",
+      confirmLiveIssuance: true,
+      secretEnvName: "LICENSE_ISSUANCE_SECRET",
+      env: { LICENSE_ISSUANCE_SECRET: secretValue },
+      idempotencyKey: "neondiff-smoke-v1.0.0-neondiff_yearly",
+      outputPath,
+      cwd: root,
+      now: () => new Date("2026-07-08T12:00:00.000Z"),
+      fetchImpl
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected success proof");
+    expect(result.proofPath).toBe(outputPath);
+    expect(observedRequest?.url).toBe("https://license.example/v1/admin/licenses/issue");
+    expect(observedRequest?.init?.method).toBe("POST");
+    expect(observedRequest?.init?.signal).toBeInstanceOf(AbortSignal);
+    expect(observedRequest?.init?.headers).toMatchObject({
+      "content-type": "application/json",
+      authorization: `Bearer ${secretValue}`
+    });
+    expect(JSON.parse(String(observedRequest?.init?.body))).toEqual({
+      idempotencyKey: "neondiff-smoke-v1.0.0-neondiff_yearly",
+      checkoutLookupKey: "neondiff_yearly",
+      externalCheckoutId: "neondiff-smoke-v1.0.0-neondiff_yearly"
+    });
+
+    const proofText = readFileSync(join(root, outputPath), "utf8");
+    expect(proofText).not.toContain(secretValue);
+    expect(proofText).not.toContain(licenseKey);
+    expect(proofText).not.toContain("licenseKey");
+    expect(proofText).not.toContain("Authorization");
+    expect(JSON.parse(proofText)).toEqual({
+      evidenceKind: "license_api_checkout_issuance_authenticated",
+      releaseVersion: "v1.0.0",
+      observedAt: "2026-07-08T12:00:00.000Z",
+      method: "POST",
+      url: "https://license.example/v1/admin/licenses/issue",
+      statusCode: 200,
+      redactedResponse: {
+        status: "issued",
+        replayed: false,
+        checkoutLookupKey: "neondiff_yearly",
+        issuedLicensePrefix: "nd_live_",
+        issuedLicenseFingerprint: `sha256:${createHash("sha256").update(licenseKey).digest("hex")}`
+      },
+      captureContext: {
+        tool: "neondiff checkout-issuance-smoke",
+        transport: "https",
+        tlsValidation: "node default CA validation",
+        capturedFrom: "operator CLI"
+      }
+    });
+  });
+
+  it("rejects symlinked proof output targets inside docs/evidence", async () => {
+    const root = tempRoot();
+    mkdirSync(join(root, "docs/evidence"), { recursive: true });
+    const outsidePath = join(root, "outside-proof.json");
+    writeFileSync(outsidePath, "outside");
+    symlinkSync(outsidePath, join(root, "docs/evidence/license-checkout-issuance-authenticated.json"));
+    const secretValue = "owner-held-proof-key";
+    const licenseKey = ["nd", "live", "abcdefghijklmnopqrstuvwxyz123456"].join("_");
+    const fetchImpl: CheckoutIssuanceFetch = async () => jsonResponse(200, {
+      status: "issued",
+      replayed: false,
+      licenseKey
+    });
+
+    const result = await runCheckoutIssuanceSmoke({
+      url: "https://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_monthly",
+      confirmLiveIssuance: true,
+      secretEnvName: "LICENSE_ISSUANCE_SECRET",
+      env: { LICENSE_ISSUANCE_SECRET: secretValue },
+      outputPath: "docs/evidence/license-checkout-issuance-authenticated.json",
+      cwd: root,
+      fetchImpl
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected invalid output path");
+    expect(result.errorCode).toBe("invalid_output_path");
+    expect(readFileSync(outsidePath, "utf8")).toBe("outside");
+  });
+
+  it("rejects proof output when an existing parent path escapes docs/evidence through a symlink", async () => {
+    const root = tempRoot();
+    const outsideDocs = join(root, "outside-docs");
+    mkdirSync(outsideDocs, { recursive: true });
+    symlinkSync(outsideDocs, join(root, "docs"));
+    const secretValue = "owner-held-proof-key";
+    const licenseKey = ["nd", "live", "abcdefghijklmnopqrstuvwxyz123456"].join("_");
+    const fetchImpl: CheckoutIssuanceFetch = async () => jsonResponse(200, {
+      status: "issued",
+      replayed: false,
+      licenseKey
+    });
+
+    const result = await runCheckoutIssuanceSmoke({
+      url: "https://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_monthly",
+      confirmLiveIssuance: true,
+      secretEnvName: "LICENSE_ISSUANCE_SECRET",
+      env: { LICENSE_ISSUANCE_SECRET: secretValue },
+      outputPath: "docs/evidence/license-checkout-issuance-authenticated.json",
+      cwd: root,
+      fetchImpl
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected invalid output path");
+    expect(result.errorCode).toBe("invalid_output_path");
+  });
+
+  it("rejects output paths outside docs/evidence before writing proof files", async () => {
+    const root = tempRoot();
+    const secretValue = "owner-held-proof-key";
+    const licenseKey = ["nd", "live", "abcdefghijklmnopqrstuvwxyz123456"].join("_");
+    const fetchImpl: CheckoutIssuanceFetch = async () => jsonResponse(200, {
+      status: "issued",
+      replayed: false,
+      licenseKey
+    });
+
+    const result = await runCheckoutIssuanceSmoke({
+      url: "https://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_monthly",
+      confirmLiveIssuance: true,
+      secretEnvName: "LICENSE_ISSUANCE_SECRET",
+      env: { LICENSE_ISSUANCE_SECRET: secretValue },
+      outputPath: "../license-checkout-issuance-authenticated.json",
+      cwd: root,
+      fetchImpl
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected invalid output path");
+    expect(result.errorCode).toBe("invalid_output_path");
+    expect(JSON.stringify(result)).not.toContain(licenseKey);
+  });
+
+  it("fails if the server echoes a different checkout lookup key than requested", async () => {
+    const secretValue = "owner-held-proof-key";
+    const licenseKey = ["nd", "live", "abcdefghijklmnopqrstuvwxyz123456"].join("_");
+    const fetchImpl: CheckoutIssuanceFetch = async () => jsonResponse(200, {
+      status: "issued",
+      replayed: false,
+      checkoutLookupKey: "neondiff_yearly",
+      licenseKey
+    });
+
+    const result = await runCheckoutIssuanceSmoke({
+      url: "https://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_monthly",
+      confirmLiveIssuance: true,
+      secretEnvName: "LICENSE_ISSUANCE_SECRET",
+      env: { LICENSE_ISSUANCE_SECRET: secretValue },
+      fetchImpl
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected invalid success response");
+    expect(result.errorCode).toBe("invalid_success_response");
+    expect(JSON.stringify(result)).not.toContain(licenseKey);
+  });
+
+  it("omits provider failure bodies and never writes a success proof for non-200 responses", async () => {
+    const root = tempRoot();
+    const outputPath = "docs/evidence/license-checkout-issuance-authenticated.json";
+    const secretValue = "owner-held-proof-key";
+    const rawKey = "plain-license-key-that-does-not-match-token-patterns";
+    const customerEmail = "buyer@example.com";
+    const fetchImpl: CheckoutIssuanceFetch = async () => jsonResponse(503, {
+      status: "server",
+      detail: `bad upstream key ${rawKey}`,
+      licenseKey: rawKey,
+      customerEmail,
+      checkoutMetadata: {
+        pastedSecret: "owner shared proof phrase"
+      }
+    });
+
+    const result = await runCheckoutIssuanceSmoke({
+      url: "https://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_monthly",
+      confirmLiveIssuance: true,
+      secretEnvName: "LICENSE_ISSUANCE_SECRET",
+      env: { LICENSE_ISSUANCE_SECRET: secretValue },
+      outputPath,
+      cwd: root,
+      fetchImpl
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected provider failure");
+    expect(result.errorCode).toBe("unexpected_status");
+    expect(JSON.stringify(result)).not.toContain(secretValue);
+    expect(JSON.stringify(result)).not.toContain(rawKey);
+    expect(JSON.stringify(result)).not.toContain(customerEmail);
+    expect(JSON.stringify(result)).not.toContain("owner shared proof phrase");
+    expect("redactedResponseBody" in result).toBe(false);
+    expect("proofPath" in result).toBe(false);
+  });
+
+  it("classifies non-200 non-JSON responses as unexpected status without parsing the body", async () => {
+    const secretValue = "owner-held-proof-key";
+    const fetchImpl: CheckoutIssuanceFetch = async () => new Response("<html>Private Buyer</html>", {
+      status: 503,
+      headers: { "content-type": "text/html" }
+    });
+
+    const result = await runCheckoutIssuanceSmoke({
+      url: "https://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_monthly",
+      confirmLiveIssuance: true,
+      secretEnvName: "LICENSE_ISSUANCE_SECRET",
+      env: { LICENSE_ISSUANCE_SECRET: secretValue },
+      fetchImpl
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected provider failure");
+    expect(result.errorCode).toBe("unexpected_status");
+    expect(JSON.stringify(result)).not.toContain("Private Buyer");
+  });
+
+  it("rejects oversized success responses before parsing proof bodies", async () => {
+    const secretValue = "owner-held-proof-key";
+    const licenseKey = ["nd", "live", "abcdefghijklmnopqrstuvwxyz123456"].join("_");
+    const fetchImpl: CheckoutIssuanceFetch = async () => jsonResponse(200, {
+      status: "issued",
+      replayed: false,
+      licenseKey,
+      padding: "x".repeat(20_000)
+    });
+
+    const result = await runCheckoutIssuanceSmoke({
+      url: "https://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_monthly",
+      confirmLiveIssuance: true,
+      secretEnvName: "LICENSE_ISSUANCE_SECRET",
+      env: { LICENSE_ISSUANCE_SECRET: secretValue },
+      fetchImpl
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected oversized response failure");
+    expect(result.errorCode).toBe("response_too_large");
+    expect(JSON.stringify(result)).not.toContain(licenseKey);
+  });
+
+  it("omits malformed success bodies that include customer data or arbitrary keys", async () => {
+    const secretValue = "owner-held-proof-key";
+    const rawKey = "plain-license-key-that-does-not-match-token-patterns";
+    const fetchImpl: CheckoutIssuanceFetch = async () => jsonResponse(200, {
+      status: "issued",
+      replayed: false,
+      licenseKey: rawKey,
+      customerName: "Private Buyer",
+      authorization: `Bearer ${secretValue}`
+    });
+
+    const result = await runCheckoutIssuanceSmoke({
+      url: "https://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_monthly",
+      confirmLiveIssuance: true,
+      secretEnvName: "LICENSE_ISSUANCE_SECRET",
+      env: { LICENSE_ISSUANCE_SECRET: secretValue },
+      fetchImpl
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected invalid success response");
+    expect(result.errorCode).toBe("invalid_success_response");
+    expect(JSON.stringify(result)).not.toContain(secretValue);
+    expect(JSON.stringify(result)).not.toContain(rawKey);
+    expect(JSON.stringify(result)).not.toContain("Private Buyer");
+    expect("redactedResponseBody" in result).toBe(false);
+  });
+
+  it("redacts exported failure extra fields before callers stringify results directly", async () => {
+    const mistakenSecretEnvName = "owner shared proof phrase";
+
+    const result = await runCheckoutIssuanceSmoke({
+      url: "https://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_monthly",
+      confirmLiveIssuance: true,
+      secretEnvName: mistakenSecretEnvName,
+      env: {},
+      fetchImpl: async () => {
+        throw new Error("fetch should not run");
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    expect(JSON.stringify(result)).not.toContain(mistakenSecretEnvName);
+  });
+
+  it("supports dry-run request preview without a secret or network call", () => {
+    const preview = buildCheckoutIssuanceSmokeRequestPreview({
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_org_yearly"
+    });
+
+    expect(preview).toEqual({
+      idempotencyKey: "neondiff-smoke-v1.0.0-neondiff_org_yearly",
+      checkoutLookupKey: "neondiff_org_yearly",
+      externalCheckoutId: "neondiff-smoke-v1.0.0-neondiff_org_yearly"
+    });
+  });
+
+  it("exposes a dry-run CLI preview that does not require the owner-held secret", async () => {
+    const output = await runCli([
+      "checkout-issuance-smoke",
+      "--url",
+      "https://license.example/v1/admin/licenses/issue",
+      "--release-version",
+      "v1.0.0",
+      "--checkout-lookup-key",
+      "neondiff_org_yearly",
+      "--secret-env",
+      "LICENSE_ISSUANCE_SECRET",
+      "--dry-run",
+      "true"
+    ]);
+
+    expect(output.ok).toBe(true);
+    expect(output.command).toBe("checkout-issuance-smoke");
+    expect(output.mode).toBe("dry_run");
+    expect(output.requestPreview).toEqual({
+      idempotencyKey: "neondiff-smoke-v1.0.0-neondiff_org_yearly",
+      checkoutLookupKey: "neondiff_org_yearly",
+      externalCheckoutId: "neondiff-smoke-v1.0.0-neondiff_org_yearly"
+    });
+    expect(JSON.stringify(output)).not.toContain("LICENSE_ISSUANCE_SECRET");
+  });
+
+  it("rejects plaintext URLs in CLI dry-run before presenting a request preview", async () => {
+    await expect(runCli([
+      "checkout-issuance-smoke",
+      "--url",
+      "http://license.example/v1/admin/licenses/issue",
+      "--release-version",
+      "v1.0.0",
+      "--checkout-lookup-key",
+      "neondiff_monthly",
+      "--dry-run",
+      "true"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("\"errorCode\": \"invalid_url\"")
+    });
+  });
+
+  it("exposes a CLI guard for missing secret env vars without printing secret values", async () => {
+    await expect(runCli([
+      "checkout-issuance-smoke",
+      "--url",
+      "https://license.example/v1/admin/licenses/issue",
+      "--release-version",
+      "v1.0.0",
+      "--checkout-lookup-key",
+      "neondiff_monthly",
+      "--secret-env",
+      "NEONDIFF_TEST_ISSUANCE_KEY",
+      "--dry-run",
+      "false",
+      "--confirm-live-issuance",
+      "true"
+    ])).rejects.toMatchObject({
+      stdout: expect.stringContaining("\"errorCode\": \"missing_secret_env\"")
+    });
+  });
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+}
+
+async function runCli(args: string[]): Promise<Record<string, unknown>> {
+  const { stdout } = await execFileAsync(process.execPath, [tsxCliPath, "src/cli.ts", ...args], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      NODE_OPTIONS: "--experimental-sqlite",
+      LICENSE_ISSUANCE_SECRET: "",
+      NEONDIFF_TEST_ISSUANCE_KEY: ""
+    },
+    maxBuffer: 1024 * 1024
+  });
+  return JSON.parse(stdout) as Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- add `checkout-issuance-smoke` for dry-run request preview and confirmed live authenticated checkout issuance proof capture
- write only the strict redacted proof shape accepted by `checkoutIssuanceAuthenticatedProofPath`
- document the owner-run command in the license deploy and release runbooks

Closes #421 after the live paired Fly/Lovable secret configuration and authenticated proof are completed. This PR does not transmit or store a new secret.

## Validation
- `npm test -- --run tests/checkout-issuance-smoke.test.ts tests/secrets.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `npx tsx src/cli.ts checkout-issuance-smoke --url https://neondiff-license.fly.dev/v1/admin/licenses/issue --release-version v1.0.0 --checkout-lookup-key neondiff_monthly --dry-run true`
- `node scripts/check-secret-scan.mjs`
- `node scripts/check-public-claims.mjs`
- `git diff --check`

## Proof Boundary
This adds the repeatable, redacted owner-run proof helper. It does not prove the live purchase path until the owner confirms paired secret configuration and the live command produces a `statusCode: 200` proof under `docs/evidence/`.
