### PR TITLE
[codex] Reconcile reviewer sessions covered by queue retries

### DIFF
--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -101,6 +101,7 @@ export interface RuntimeInventory {
     providerDeferredHeads: number;
     staleHeads: number;
     readFailures: number;
+    retryCoveredReviewerSessions: number;
     expiredProviderCooldowns: number;
     retryableExpiredProviderCooldowns: number;
     coveredExpiredProviderCooldowns: number;
@@ -592,6 +593,7 @@ export function buildRuntimeInventory(input: {
   const retryableExpiredProviderCooldowns =
     input.release.database.retryableExpiredProviderCooldownCount ??
     Math.max(0, expiredProviderCooldowns - coveredExpiredProviderCooldowns);
+  const retryCoveredReviewerSessions = input.release.database.retryCoveredReviewerSessionCount ?? 0;
   const failedQueueJobs = durableQueue?.summary.failed ?? 0;
   const zcodeTimeoutQueue = zcodeTimeoutQueueCounts(input.release, durableQueue);
   const zcodeTimeoutRetryActions = zcodeTimeoutRecommendedActions(input.release, durableQueue);
@@ -662,6 +664,13 @@ export function buildRuntimeInventory(input: {
         (coveredExpiredProviderCooldowns > 0
           ? `; ${coveredExpiredProviderCooldowns} covered by active provider/repo cooldown`
           : "")
+    },
+    {
+      name: "runtime_reviewer_sessions_retry_covered",
+      ok: true,
+      detail:
+        `${retryCoveredReviewerSessions} reviewer session(s) with terminal/stale row state ` +
+        "covered by active queue retry"
     },
     {
       name: "runtime_process_inventory_available",
@@ -749,6 +758,7 @@ export function buildRuntimeInventory(input: {
       providerDeferredHeads,
       staleHeads,
       readFailures,
+      retryCoveredReviewerSessions,
       expiredProviderCooldowns,
       retryableExpiredProviderCooldowns,
       coveredExpiredProviderCooldowns,
@@ -858,7 +868,8 @@ export function formatRuntimeInventoryHuman(inventory: RuntimeInventory): string
       ` failed=${inventory.issueEnrichmentRuntime?.summary.failed ?? 0}` +
       ` deferred=${inventory.issueEnrichmentRuntime?.summary.deferred ?? 0}`,
     `processes: botOwned=${inventory.summary.botProcesses}`,
-    `leases: active=${inventory.summary.activeLeases} stale=${inventory.summary.staleLeases}`
+    `leases: active=${inventory.summary.activeLeases} stale=${inventory.summary.staleLeases}`,
+    `reviewerSessions: retryCovered=${inventory.summary.retryCoveredReviewerSessions}`
   ];
 
   const failingGates = inventory.gates.filter((gate) => !gate.ok);

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -34,6 +34,7 @@ export interface ReleaseDatabaseStatus {
   reviewerSessionCount?: number;
   activeReviewerSessionCount?: number;
   expiredReviewerSessionCount?: number;
+  retryCoveredReviewerSessionCount?: number;
   reviewerSessionsByRepo?: ReviewerSessionRepoStatus[];
   providerCooldownCount?: number;
   activeProviderCooldownCount?: number;
@@ -64,6 +65,7 @@ export interface ReviewerSessionRepoStatus {
   total: number;
   active: number;
   expired: number;
+  retryCovered?: number;
 }
 
 export interface ReviewQueueRepoStatus {
@@ -1763,7 +1765,7 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       : retryableExpiredProviderCooldownCount > 0
         ? "expired_retryable"
         : "none";
-    const reviewerSessions = readReviewerSessionCounts(db, now);
+    const reviewerSessions = readReviewerSessionCounts(db, now, leaseTtlMs);
     const reviewQueue = readReviewQueueCounts(db, now);
     const reviewRunLeases = readReviewRunLeaseCounts(db, now);
     const staleActiveReviewQueueJobCount = readStaleActiveReviewQueueJobCount(db, now, leaseTtlMs);
@@ -1773,6 +1775,7 @@ function readDatabaseStatus(statePath: string, now: Date, leaseTtlMs = 15 * 60_0
       reviewerSessionCount: reviewerSessions.total,
       activeReviewerSessionCount: reviewerSessions.active,
       expiredReviewerSessionCount: reviewerSessions.expired,
+      retryCoveredReviewerSessionCount: reviewerSessions.retryCovered,
       reviewerSessionsByRepo: reviewerSessions.byRepo,
       providerCooldownCount: row.providerCooldownCount ?? 0,
       activeProviderCooldownCount,
@@ -1960,35 +1963,55 @@ function readStaleActiveReviewQueueJobCount(db: DatabaseSync, now: Date, leaseTt
 
 function readReviewerSessionCounts(
   db: DatabaseSync,
-  now: Date
-): { total: number; active: number; expired: number; byRepo: ReviewerSessionRepoStatus[] } {
+  now: Date,
+  leaseTtlMs: number
+): { total: number; active: number; expired: number; retryCovered: number; byRepo: ReviewerSessionRepoStatus[] } {
   const hasTable = db
     .prepare("select 1 from sqlite_master where type = 'table' and name = 'reviewer_sessions' limit 1")
     .get();
-  if (!hasTable) return { total: 0, active: 0, expired: 0, byRepo: [] };
+  if (!hasTable) return { total: 0, active: 0, expired: 0, retryCovered: 0, byRepo: [] };
   const rows = db
     .prepare(
-      `select repo, state, expires_at, head_count_used, head_count_limit, worker_pid
+      `select session_id, repo, state, expires_at, head_count_used, head_count_limit, worker_pid
        from reviewer_sessions`
     )
     .all() as unknown as ReviewerSessionCountRow[];
+  const retryCoveredSessionIds = readRetryCoveredReviewerSessionIds(db, now, leaseTtlMs);
   const byRepo = new Map<string, ReviewerSessionRepoStatus>();
+  let active = 0;
+  let expired = 0;
+  let retryCoveredCount = 0;
   for (const row of rows) {
     const repoStatus = byRepo.get(row.repo) ?? { repo: row.repo, total: 0, active: 0, expired: 0 };
+    const rowActive = isReviewerSessionActiveForStatus(row, now);
+    const retryCovered = !rowActive && retryCoveredSessionIds.has(row.session_id);
+    const rowExpired = !retryCovered && isReviewerSessionExpiredForStatus(row, now);
     repoStatus.total += 1;
-    if (isReviewerSessionActiveForStatus(row, now)) repoStatus.active += 1;
-    if (isReviewerSessionExpiredForStatus(row, now)) repoStatus.expired += 1;
+    if (rowActive || retryCovered) {
+      active += 1;
+      repoStatus.active += 1;
+    }
+    if (rowExpired) {
+      expired += 1;
+      repoStatus.expired += 1;
+    }
+    if (retryCovered) {
+      retryCoveredCount += 1;
+      repoStatus.retryCovered = (repoStatus.retryCovered ?? 0) + 1;
+    }
     byRepo.set(row.repo, repoStatus);
   }
   return {
     total: rows.length,
-    active: rows.filter((row) => isReviewerSessionActiveForStatus(row, now)).length,
-    expired: rows.filter((row) => isReviewerSessionExpiredForStatus(row, now)).length,
+    active,
+    expired,
+    retryCovered: retryCoveredCount,
     byRepo: [...byRepo.values()].sort((left, right) => left.repo.localeCompare(right.repo))
   };
 }
 
 interface ReviewerSessionCountRow {
+  session_id: string;
   repo: string;
   state: string;
   expires_at: string | null;
@@ -2007,6 +2030,60 @@ function isReviewerSessionActiveForStatus(row: ReviewerSessionCountRow, now: Dat
 function isReviewerSessionExpiredForStatus(row: ReviewerSessionCountRow, now: Date): boolean {
   const expiresAtMs = row.expires_at ? Date.parse(row.expires_at) : Number.NaN;
   return row.state === "expired" || !Number.isFinite(expiresAtMs) || expiresAtMs <= now.getTime() || row.head_count_used >= row.head_count_limit;
+}
+
+function readRetryCoveredReviewerSessionIds(db: DatabaseSync, now: Date, leaseTtlMs: number): Set<string> {
+  const hasRequiredTables = ["reviewer_session_jobs", "review_queue_jobs"].every((tableName) =>
+    Boolean(
+      db
+        .prepare("select 1 from sqlite_master where type = 'table' and name = ? limit 1")
+        .get(tableName)
+    )
+  );
+  if (!hasRequiredTables) return new Set();
+
+  const queueColumns = new Set(
+    (db.prepare("pragma table_info(review_queue_jobs)").all() as unknown as Array<{ name: string }>)
+      .map((column) => column.name)
+  );
+  const sessionJobColumns = new Set(
+    (db.prepare("pragma table_info(reviewer_session_jobs)").all() as unknown as Array<{ name: string }>)
+      .map((column) => column.name)
+  );
+  const requiredQueueColumns = ["session_id", "repo", "pull_number", "head_sha", "state", "updated_at"];
+  const requiredSessionJobColumns = ["session_id", "repo", "pull_number", "head_sha"];
+  if (
+    requiredQueueColumns.some((column) => !queueColumns.has(column)) ||
+    requiredSessionJobColumns.some((column) => !sessionJobColumns.has(column))
+  ) {
+    return new Set();
+  }
+
+  const hasLeaseExpiresAt = queueColumns.has("lease_expires_at");
+  const activeLeaseClause = hasLeaseExpiresAt
+    ? `and (
+         (q.lease_expires_at is not null and datetime(q.lease_expires_at) > datetime(?))
+         or (q.lease_expires_at is null and datetime(q.updated_at) > datetime(?))
+       )`
+    : "and datetime(q.updated_at) > datetime(?)";
+  const rows = db
+    .prepare(
+      `select distinct sj.session_id as session_id
+       from reviewer_session_jobs sj
+       join review_queue_jobs q
+         on q.session_id = sj.session_id
+        and q.repo = sj.repo
+        and q.pull_number = sj.pull_number
+        and q.head_sha = sj.head_sha
+       where q.state in ('leased', 'running')
+       ${activeLeaseClause}`
+    )
+    .all(
+      ...(hasLeaseExpiresAt
+        ? [now.toISOString(), new Date(now.getTime() - leaseTtlMs).toISOString()]
+        : [new Date(now.getTime() - leaseTtlMs).toISOString()])
+    ) as unknown as Array<{ session_id: string | null }>;
+  return new Set(rows.map((row) => row.session_id).filter((sessionId): sessionId is string => Boolean(sessionId)));
 }
 
 interface ProviderCooldownCandidate {

--- a/tests/operator-cli.test.ts
+++ b/tests/operator-cli.test.ts
@@ -829,6 +829,51 @@ describe("operator CLI summaries", () => {
     expect(JSON.stringify(inventory)).not.toMatch(/ghp_|BEGIN RSA|PRIVATE KEY/);
   });
 
+  it("surfaces reviewer sessions covered by active queue retries in runtime inventory", () => {
+    const inventory = buildRuntimeInventory({
+      release: releaseStatus({
+        ok: true,
+        database: {
+          activeReviewerSessionCount: 1,
+          expiredReviewerSessionCount: 0,
+          retryCoveredReviewerSessionCount: 1
+        }
+      }),
+      coverage: coverageReport({ ok: true }),
+      agents: agentInventory({ ok: true }),
+      durableQueue: durableQueueSnapshot({
+        ok: true,
+        summary: {
+          ...cleanDurableQueueSummary(),
+          total: 1,
+          running: 1
+        },
+        jobs: [
+          durableJob({
+            repo: "electricsheephq/evaos-code-review-bot-neondiff",
+            pullNumber: 451,
+            headSha: "active-head",
+            state: "running",
+            sessionId: "covered-failed-session"
+          })
+        ]
+      }),
+      providerCooldowns: [],
+      repoProviderCooldowns: [],
+      checkedAt: "2026-07-08T07:51:35.481Z"
+    });
+
+    expect(inventory.ok).toBe(true);
+    expect(inventory.runtimeState).toBe("healthy_active");
+    expect(inventory.summary.retryCoveredReviewerSessions).toBe(1);
+    expect(inventory.gates).toContainEqual({
+      name: "runtime_reviewer_sessions_retry_covered",
+      ok: true,
+      detail: "1 reviewer session(s) with terminal/stale row state covered by active queue retry"
+    });
+    expect(inventory.recommendedActions).toContain("monitor active review work; avoid restarting a healthy in-flight run");
+  });
+
   it("flags uncovered pending heads as blocked runtime inventory", () => {
     const inventory = buildRuntimeInventory({
       release: releaseStatus({ ok: true }),

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -4881,6 +4881,7 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
     expect(status.database.reviewerSessionCount).toBe(5);
     expect(status.database.activeReviewerSessionCount).toBe(1);
     expect(status.database.expiredReviewerSessionCount).toBe(3);
+    expect(status.database.retryCoveredReviewerSessionCount).toBe(0);
     expect(status.database.reviewerSessionsByRepo).toHaveLength(4);
     expect(status.database.reviewerSessionsByRepo).toEqual(
       expect.arrayContaining([
@@ -4890,6 +4891,432 @@ gui/502/com.electricsheephq.evaos-code-review-bot = {
         { repo: "electricsheephq/evaos-code-review-bot", total: 2, active: 0, expired: 1 }
       ])
     );
+  });
+
+  function createReviewerSessionRetryFixture(options: {
+    rootPrefix: string;
+    includeLeaseExpiresAt?: boolean;
+    queueLeaseExpiresAt?: string | null;
+    queueUpdatedAt?: string;
+    queueState?: string;
+    sessionId?: string;
+    sessionState?: string;
+    sessionHeadSha?: string;
+    queueHeadSha?: string;
+    includeSessionJob?: boolean;
+    includeQueueJob?: boolean;
+  }): string {
+    const root = mkdtempSync(join(tmpdir(), options.rootPrefix));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    const includeLeaseExpiresAt = options.includeLeaseExpiresAt ?? true;
+    const sessionId = options.sessionId ?? "covered-failed-session";
+    const repo = "electricsheephq/evaos-code-review-bot-neondiff";
+    const sessionHeadSha = options.sessionHeadSha ?? "active-head";
+    const queueHeadSha = options.queueHeadSha ?? sessionHeadSha;
+    const queueUpdatedAt = options.queueUpdatedAt ?? "2026-07-08T07:50:35.197Z";
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table reviewer_sessions (
+          session_id text primary key,
+          repo text not null,
+          repo_family text,
+          state text not null,
+          started_at text not null,
+          last_used_at text not null,
+          expires_at text not null,
+          head_count_used integer not null,
+          head_count_limit integer not null,
+          worker_pid integer,
+          model text,
+          provider text,
+          zcode_cli_version text,
+          memory_packet_sha text,
+          gitnexus_packet_sha text,
+          last_error text
+        );
+
+        create table reviewer_session_jobs (
+          session_id text not null,
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          job_state text not null,
+          assignment_reason text not null,
+          created_at text not null,
+          started_at text,
+          finished_at text,
+          processed_review_status text,
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          ${includeLeaseExpiresAt ? "lease_expires_at text," : ""}
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      db.prepare(
+        `insert into reviewer_sessions
+          (session_id, repo, state, started_at, last_used_at, expires_at,
+           head_count_used, head_count_limit, worker_pid, last_error)
+         values (?, ?, ?, ?, ?, ?, 1, 10, null, ?)`
+      ).run(
+        sessionId,
+        repo,
+        options.sessionState ?? "failed",
+        "2026-07-08T07:27:13.504Z",
+        "2026-07-08T07:34:41.973Z",
+        "2026-07-08T08:30:00.000Z",
+        "owner_pid_not_alive:1594"
+      );
+      if (options.includeSessionJob ?? true) {
+        db.prepare(
+          `insert into reviewer_session_jobs
+            (session_id, repo, pull_number, head_sha, job_state, assignment_reason, created_at, started_at)
+           values (?, ?, ?, ?, 'running', 'same_repo_active_session', ?, ?)`
+        ).run(
+          sessionId,
+          repo,
+          451,
+          sessionHeadSha,
+          "2026-07-08T07:27:13.504Z",
+          "2026-07-08T07:34:41.973Z"
+        );
+      }
+      if (options.includeQueueJob ?? true) {
+        if (includeLeaseExpiresAt) {
+          db.prepare(
+            `insert into review_queue_jobs
+              (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+               priority, state, lease_id, lease_expires_at, session_id, created_at, updated_at, started_at)
+             values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, ?, ?, ?, ?, ?, ?, ?)`
+          ).run(
+            "running-active-head",
+            `automatic:${repo}#451@${queueHeadSha}`,
+            repo,
+            "electricsheephq",
+            451,
+            queueHeadSha,
+            options.queueState ?? "running",
+            "lease-active",
+            options.queueLeaseExpiresAt === undefined ? "2026-07-08T08:05:35.197Z" : options.queueLeaseExpiresAt,
+            sessionId,
+            "2026-07-08T07:27:13.504Z",
+            queueUpdatedAt,
+            "2026-07-08T07:34:41.973Z"
+          );
+        } else {
+          db.prepare(
+            `insert into review_queue_jobs
+              (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+               priority, state, lease_id, session_id, created_at, updated_at, started_at)
+             values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, ?, ?, ?, ?, ?, ?)`
+          ).run(
+            "running-active-head",
+            `automatic:${repo}#451@${queueHeadSha}`,
+            repo,
+            "electricsheephq",
+            451,
+            queueHeadSha,
+            options.queueState ?? "running",
+            "lease-active",
+            sessionId,
+            "2026-07-08T07:27:13.504Z",
+            queueUpdatedAt,
+            "2026-07-08T07:34:41.973Z"
+          );
+        }
+      }
+    } finally {
+      db.close();
+    }
+    return dbPath;
+  }
+
+  it("counts failed reviewer sessions covered by active durable queue jobs as active retry-covered work", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-status-reviewer-session-covered-failure-"));
+    roots.push(root);
+    const dbPath = join(root, "reviews.sqlite");
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table processed_reviews (
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          status text not null,
+          event text,
+          review_url text,
+          error text,
+          created_at text not null default (datetime('now')),
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table reviewer_sessions (
+          session_id text primary key,
+          repo text not null,
+          repo_family text,
+          state text not null,
+          started_at text not null,
+          last_used_at text not null,
+          expires_at text not null,
+          head_count_used integer not null,
+          head_count_limit integer not null,
+          worker_pid integer,
+          model text,
+          provider text,
+          zcode_cli_version text,
+          memory_packet_sha text,
+          gitnexus_packet_sha text,
+          last_error text
+        );
+
+        create table reviewer_session_jobs (
+          session_id text not null,
+          repo text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          job_state text not null,
+          assignment_reason text not null,
+          created_at text not null,
+          started_at text,
+          finished_at text,
+          processed_review_status text,
+          primary key (repo, pull_number, head_sha)
+        );
+
+        create table review_queue_jobs (
+          job_id text primary key,
+          attempt_id text not null unique,
+          source text not null,
+          lane text not null,
+          repo text not null,
+          org text not null,
+          pull_number integer not null,
+          head_sha text not null,
+          base_sha text,
+          provider_id text,
+          priority integer not null,
+          state text not null,
+          next_eligible_at text,
+          lease_id text,
+          lease_expires_at text,
+          session_id text,
+          comment_id integer,
+          review_url text,
+          last_error text,
+          created_at text not null,
+          updated_at text not null,
+          started_at text,
+          finished_at text
+        );
+      `);
+      db.prepare(
+        `insert into reviewer_sessions
+          (session_id, repo, state, started_at, last_used_at, expires_at,
+           head_count_used, head_count_limit, worker_pid, last_error)
+         values (?, ?, 'failed', ?, ?, ?, 1, 10, ?, ?)`
+      ).run(
+        "covered-failed-session",
+        "electricsheephq/evaos-code-review-bot-neondiff",
+        "2026-07-08T07:27:13.504Z",
+        "2026-07-08T07:34:41.973Z",
+        "2026-07-08T08:30:00.000Z",
+        1_594,
+        "owner_pid_not_alive:1594"
+      );
+      db.prepare(
+        `insert into reviewer_session_jobs
+          (session_id, repo, pull_number, head_sha, job_state, assignment_reason, created_at, started_at)
+         values (?, ?, ?, ?, 'running', 'same_repo_active_session', ?, ?)`
+      ).run(
+        "covered-failed-session",
+        "electricsheephq/evaos-code-review-bot-neondiff",
+        451,
+        "active-head",
+        "2026-07-08T07:27:13.504Z",
+        "2026-07-08T07:34:41.973Z"
+      );
+      db.prepare(
+        `insert into review_queue_jobs
+          (job_id, attempt_id, source, lane, repo, org, pull_number, head_sha,
+           priority, state, lease_id, lease_expires_at, session_id, created_at, updated_at, started_at)
+         values (?, ?, 'automatic', 'background', ?, ?, ?, ?, 50, 'running', ?, ?, ?, ?, ?, ?)`
+      ).run(
+        "running-active-head",
+        "automatic:electricsheephq/evaos-code-review-bot-neondiff#451@active-head",
+        "electricsheephq/evaos-code-review-bot-neondiff",
+        "electricsheephq",
+        451,
+        "active-head",
+        "lease-active",
+        "2026-07-08T08:05:35.197Z",
+        "covered-failed-session",
+        "2026-07-08T07:27:13.504Z",
+        "2026-07-08T07:34:41.973Z",
+        "2026-07-08T07:34:41.973Z"
+      );
+    } finally {
+      db.close();
+    }
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-08T07:51:35.481Z")
+    });
+
+    expect(status.database.reviewerSessionCount).toBe(1);
+    expect(status.database.activeReviewerSessionCount).toBe(1);
+    expect(status.database.expiredReviewerSessionCount).toBe(0);
+    expect(status.database.retryCoveredReviewerSessionCount).toBe(1);
+    expect(status.database.reviewerSessionsByRepo).toEqual([
+      {
+        repo: "electricsheephq/evaos-code-review-bot-neondiff",
+        total: 1,
+        active: 1,
+        expired: 0,
+        retryCovered: 1
+      }
+    ]);
+  });
+
+  it("counts failed reviewer sessions covered by legacy active durable queue jobs without lease expiry columns", () => {
+    const dbPath = createReviewerSessionRetryFixture({
+      rootPrefix: "release-status-reviewer-session-legacy-retry-",
+      includeLeaseExpiresAt: false
+    });
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-08T07:51:35.481Z")
+    });
+
+    expect(status.database.activeReviewerSessionCount).toBe(1);
+    expect(status.database.expiredReviewerSessionCount).toBe(0);
+    expect(status.database.retryCoveredReviewerSessionCount).toBe(1);
+    expect(status.database.reviewerSessionsByRepo).toEqual([
+      {
+        repo: "electricsheephq/evaos-code-review-bot-neondiff",
+        total: 1,
+        active: 1,
+        expired: 0,
+        retryCovered: 1
+      }
+    ]);
+  });
+
+  it("counts failed reviewer sessions covered by active queue jobs with null lease expiry and recent updates", () => {
+    const dbPath = createReviewerSessionRetryFixture({
+      rootPrefix: "release-status-reviewer-session-null-lease-retry-",
+      queueLeaseExpiresAt: null
+    });
+
+    const status = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: dbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-08T07:51:35.481Z")
+    });
+
+    expect(status.database.activeReviewerSessionCount).toBe(1);
+    expect(status.database.expiredReviewerSessionCount).toBe(0);
+    expect(status.database.retryCoveredReviewerSessionCount).toBe(1);
+  });
+
+  it("does not retry-cover unmatched sessions, expired queue leases, or already-active sessions", () => {
+    const unmatchedDbPath = createReviewerSessionRetryFixture({
+      rootPrefix: "release-status-reviewer-session-unmatched-retry-",
+      queueHeadSha: "different-head"
+    });
+    const unmatchedStatus = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: unmatchedDbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-08T07:51:35.481Z")
+    });
+
+    expect(unmatchedStatus.database.activeReviewerSessionCount).toBe(0);
+    expect(unmatchedStatus.database.retryCoveredReviewerSessionCount).toBe(0);
+
+    const expiredLeaseDbPath = createReviewerSessionRetryFixture({
+      rootPrefix: "release-status-reviewer-session-expired-lease-retry-",
+      queueLeaseExpiresAt: "2026-07-08T07:05:35.197Z"
+    });
+    const expiredLeaseStatus = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: expiredLeaseDbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-08T07:51:35.481Z")
+    });
+
+    expect(expiredLeaseStatus.database.activeReviewerSessionCount).toBe(0);
+    expect(expiredLeaseStatus.database.retryCoveredReviewerSessionCount).toBe(0);
+
+    const activeSessionDbPath = createReviewerSessionRetryFixture({
+      rootPrefix: "release-status-reviewer-session-active-no-double-count-",
+      sessionState: "active"
+    });
+    const activeSessionStatus = collectReleaseStatus({
+      cwd: process.cwd(),
+      statePath: activeSessionDbPath,
+      configPath: undefined,
+      launchdLabel: "com.electricsheephq.evaos-code-review-bot",
+      now: new Date("2026-07-08T07:51:35.481Z")
+    });
+
+    expect(activeSessionStatus.database.activeReviewerSessionCount).toBe(1);
+    expect(activeSessionStatus.database.retryCoveredReviewerSessionCount).toBe(0);
+    expect(activeSessionStatus.database.reviewerSessionsByRepo).toEqual([
+      {
+        repo: "electricsheephq/evaos-code-review-bot-neondiff",
+        total: 1,
+        active: 1,
+        expired: 0
+      }
+    ]);
   });
 
   it("reports durable review queue counts and fails retryable deferred or failed jobs", () => {


### PR DESCRIPTION
## Summary
- Treat terminal/stale reviewer session rows as active retry-covered work when an active durable queue job is carrying the same `{repo, pr, head_sha}`.
- Expose `retryCoveredReviewerSessionCount` in release status and `retryCoveredReviewerSessions` in runtime inventory.
- Add focused SQLite/operator fixtures for the #452 failure mode.

Closes #452

## Validation
- `npm test -- --run tests/release-status.test.ts tests/operator-cli.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `node scripts/check-secret-scan.mjs`
- `node scripts/check-public-claims.mjs`
- `git diff --check`

## Proof Boundary
This is observability/reconciliation only. It does not change review timeout, concurrency, provider retry, launchd restart, or queue leasing behavior.