### PR TITLE
Add Linux daemon operator path

### DIFF
--- a/.github/workflows/linux-daemon-smoke.yml
+++ b/.github/workflows/linux-daemon-smoke.yml
@@ -32,14 +32,20 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: linux-daemon-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
     env:
       NEONDIFF_TEST_PLATFORM: linux
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 26
           cache: npm

--- a/.github/workflows/linux-daemon-smoke.yml
+++ b/.github/workflows/linux-daemon-smoke.yml
@@ -45,7 +45,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npx vitest run tests/linux-packaging.test.ts tests/public-cli.test.ts --pool=forks --maxWorkers=1
+      - run: npx vitest run tests/linux-packaging.test.ts --pool=forks --maxWorkers=1
       - name: Verify Linux daemon command guidance
         run: |
           set -euo pipefail

--- a/.github/workflows/linux-daemon-smoke.yml
+++ b/.github/workflows/linux-daemon-smoke.yml
@@ -50,4 +50,4 @@ jobs:
         run: |
           set -euo pipefail
           node dist/src/cli.js daemon status > linux-daemon-status.json || true
-          node -e 'const fs=require("fs"); const out=JSON.parse(fs.readFileSync("linux-daemon-status.json","utf8")); if (out.ok !== false || out.serviceManager !== "systemd") process.exit(1);'
+          node -e 'const fs=require("fs"); const out=JSON.parse(fs.readFileSync("linux-daemon-status.json","utf8")); if (out.ok !== false || out.command !== "daemon status" || out.serviceManager !== "systemd" || typeof out.error !== "string") process.exit(1);'

--- a/.github/workflows/linux-daemon-smoke.yml
+++ b/.github/workflows/linux-daemon-smoke.yml
@@ -50,4 +50,4 @@ jobs:
         run: |
           set -euo pipefail
           node dist/src/cli.js daemon status > linux-daemon-status.json || true
-          node -e 'const fs=require("fs"); const out=JSON.parse(fs.readFileSync("linux-daemon-status.json","utf8")); if (out.ok !== false || out.command !== "daemon status" || out.serviceManager !== "systemd" || typeof out.error !== "string") process.exit(1);'
+          node -e 'const fs=require("fs"); const out=JSON.parse(fs.readFileSync("linux-daemon-status.json","utf8")); if (out.ok !== false || out.command !== "daemon status" || out.platform !== "linux" || out.serviceManager !== "systemd" || out.docs !== "docs/systemd.md" || typeof out.error !== "string") process.exit(1);'

--- a/.github/workflows/linux-daemon-smoke.yml
+++ b/.github/workflows/linux-daemon-smoke.yml
@@ -1,0 +1,53 @@
+name: Linux Daemon Smoke
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/linux-daemon-smoke.yml"
+      - "Dockerfile"
+      - "docker-compose.example.yml"
+      - "docs/systemd.md"
+      - "docs/docker.md"
+      - "docs/ci-runner.md"
+      - "systemd/**"
+      - "src/cli.ts"
+      - "tests/linux-packaging.test.ts"
+      - "tests/public-cli.test.ts"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/linux-daemon-smoke.yml"
+      - "Dockerfile"
+      - "docker-compose.example.yml"
+      - "docs/systemd.md"
+      - "docs/docker.md"
+      - "docs/ci-runner.md"
+      - "systemd/**"
+      - "src/cli.ts"
+      - "tests/linux-packaging.test.ts"
+      - "tests/public-cli.test.ts"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      NEONDIFF_TEST_PLATFORM: linux
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 26
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npx vitest run tests/linux-packaging.test.ts tests/public-cli.test.ts --pool=forks --maxWorkers=1
+      - name: Verify Linux daemon command guidance
+        run: |
+          set -euo pipefail
+          node dist/src/cli.js daemon status > linux-daemon-status.json || true
+          node -e 'const fs=require("fs"); const out=JSON.parse(fs.readFileSync("linux-daemon-status.json","utf8")); if (out.ok !== false || out.serviceManager !== "systemd") process.exit(1);'

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ VOLUME ["/config", "/state", "/evidence", "/work"]
 USER node
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-  CMD neondiff help >/dev/null || exit 1
+  CMD node -e 'const fs = require("node:fs"); const cmd = fs.readFileSync("/proc/1/cmdline", "utf8").replace(/\0/g, " "); if (!/\bdaemon\b/.test(cmd)) process.exit(1);'
 
 ENTRYPOINT ["neondiff"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:26-bookworm-slim AS build
+
+WORKDIR /app
+COPY package.json package-lock.json tsconfig.json ./
+RUN npm ci
+COPY src ./src
+COPY docs ./docs
+COPY config.example.json LICENSE.md README.md SECURITY.md CODE_OF_CONDUCT.md ./
+RUN npm run build
+RUN npm prune --omit=dev
+
+FROM node:26-bookworm-slim
+
+ENV NODE_ENV=production
+ENV NEONDIFF_CONFIG=/config/config.local.json
+
+WORKDIR /app
+COPY --from=build /app /app
+RUN npm link
+
+VOLUME ["/config", "/state", "/evidence", "/work"]
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD neondiff providers list --config "$NEONDIFF_CONFIG" --json >/dev/null || exit 1
+
+# Equivalent operator command: neondiff daemon --config /config/config.local.json
+CMD ["neondiff", "daemon", "--config", "/config/config.local.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Node 26 is intentional: package.json requires node >=26 for this beta CLI.
 FROM node:26-bookworm-slim AS build
 
 WORKDIR /app
@@ -9,6 +10,7 @@ COPY config.example.json LICENSE.md README.md SECURITY.md CODE_OF_CONDUCT.md ./
 RUN npm run build
 RUN npm prune --omit=dev
 
+# Keep runtime on Node 26 so Docker matches the published package engine.
 FROM node:26-bookworm-slim
 
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,18 @@ ENV NEONDIFF_CONFIG=/config/config.local.json
 
 WORKDIR /app
 COPY --from=build /app /app
-RUN npm link
+RUN npm link \
+  && mkdir -p /config /state /evidence /work \
+  && chown -R node:node /app /config /state /evidence /work
 
 VOLUME ["/config", "/state", "/evidence", "/work"]
+
+USER node
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD neondiff providers list --config "$NEONDIFF_CONFIG" --json >/dev/null || exit 1
 
-# Equivalent operator command: neondiff daemon --config /config/config.local.json
-CMD ["neondiff", "daemon", "--config", "/config/config.local.json"]
+ENTRYPOINT ["neondiff"]
+
+# Equivalent operator command: neondiff daemon --config /config/config.local.json --dry-run true
+CMD ["daemon", "--config", "/config/config.local.json", "--dry-run", "true"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ VOLUME ["/config", "/state", "/evidence", "/work"]
 USER node
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-  CMD neondiff providers list --config "$NEONDIFF_CONFIG" --json >/dev/null || exit 1
+  CMD neondiff help >/dev/null || exit 1
 
 ENTRYPOINT ["neondiff"]
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ sold. NeonDiff is a source-available beta, not an open-source or GA release.
 [Code of Conduct](CODE_OF_CONDUCT.md) · [License](LICENSE.md) ·
 [License Boundary](docs/license-boundary.md) · [Pricing](docs/pricing.md) ·
 [Providers](docs/providers.md) ·
+[systemd](docs/systemd.md) · [Docker](docs/docker.md) · [CI Runner](docs/ci-runner.md) ·
 [Known Limitations](docs/known-limitations-and-provider-status.md) ·
 [Precision Badge](docs/precision-badge.md) ·
 [Roadmap](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103) ·
@@ -133,6 +134,16 @@ selected-repo install path.
 Do not store the GitHub App private key, provider API key, license key, tokens,
 or customer data in this repository. Keep local config, secrets, state DBs, and
 evidence outside git.
+
+Platform operator paths:
+
+| Platform | Daemon path | Status |
+| --- | --- | --- |
+| macOS | launchd with [docs/launchd.md](docs/launchd.md) | Tested beta operator path |
+| Linux | systemd with [docs/systemd.md](docs/systemd.md) | Packaged and covered by Ubuntu smoke tests |
+| Docker | Compose recipe with [docs/docker.md](docs/docker.md) | Packaged for local/self-hosted workers |
+| CI runners | One-shot review or dry-run with [docs/ci-runner.md](docs/ci-runner.md) | Documented for Ubuntu-style runners |
+| Windows | CLI-only source/package usage | Untested; no supervised daemon claim |
 
 ## Provider Resources And Compatibility
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -16,7 +16,8 @@ services:
       - neondiff-evidence:/evidence
       - neondiff-work:/work
     depends_on:
-      - ollama
+      ollama:
+        condition: service_healthy
     restart: unless-stopped
 
   ollama:
@@ -26,6 +27,11 @@ services:
     volumes:
       - ollama:/root/.ollama
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
 
 volumes:
   neondiff-state:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -8,6 +8,7 @@ services:
     environment:
       - NEONDIFF_CONFIG=/config/config.local.json
       - OLLAMA_BASE_URL=http://ollama:11434
+    command: ["daemon", "--config", "/config/config.local.json", "--dry-run", "true"]
     volumes:
       - ./config.local.json:/config/config.local.json:ro
       - ./secrets:/config/secrets:ro

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,33 @@
+services:
+  neondiff:
+    build:
+      context: .
+    image: neondiff:local
+    env_file:
+      - .env
+    environment:
+      - NEONDIFF_CONFIG=/config/config.local.json
+      - OLLAMA_BASE_URL=http://ollama:11434
+    volumes:
+      - ./config.local.json:/config/config.local.json:ro
+      - ./secrets:/config/secrets:ro
+      - neondiff-state:/state
+      - neondiff-evidence:/evidence
+      - neondiff-work:/work
+    depends_on:
+      - ollama
+    restart: unless-stopped
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama:/root/.ollama
+    restart: unless-stopped
+
+volumes:
+  neondiff-state:
+  neondiff-evidence:
+  neondiff-work:
+  ollama:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -307,6 +307,21 @@ Launchd and live beta promotion are advanced operator tasks. Use
 [docs/beta-release-runbook.md](beta-release-runbook.md) only after dry-run proof
 passes.
 
+On Linux, `neondiff daemon start|stop|status` intentionally does not call
+`launchctl`. It returns JSON with `serviceManager: "systemd"` and points to the
+Linux service guide. Use [docs/systemd.md](systemd.md) for user/system services,
+[docs/docker.md](docker.md) for the Compose recipe, and
+[docs/ci-runner.md](ci-runner.md) for one-shot Ubuntu runner checks.
+
+Platform support at this beta stage:
+
+| Platform | Supervision path | Launch-readiness truth |
+| --- | --- | --- |
+| macOS | launchd | Tested live beta operator path |
+| Linux | systemd or Docker | Packaged and guarded by Ubuntu smoke tests; provider setup still varies by host |
+| CI runners | One-shot dry-run/review commands | Documented for Ubuntu-style runners |
+| Windows | CLI-only | Untested; no supervised daemon claim |
+
 Public source-beta promotion additionally uses
 [docs/public-release-manifest.json](public-release-manifest.json). The manifest
 declares the current public beta version, setup/release-notes alignment, license

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -1,0 +1,63 @@
+# CI Runner Guide
+
+NeonDiff can run one-shot dry-run checks on Linux CI runners when you want PR
+review evidence without a long-lived daemon. This guide covers GitHub Actions
+and generic CI hosts. It does not grant extra GitHub permissions or bypass the
+normal current-head checks.
+
+## GitHub Actions
+
+Use an Ubuntu runner, install Node.js 26, and run a dry-run review or setup
+smoke with credentials supplied by the repository or organization secret store.
+
+```yaml
+name: NeonDiff dry-run
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+
+jobs:
+  neondiff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 26
+          cache: npm
+      - run: npm install -g neondiff
+      - name: Write GitHub App key
+        run: |
+          install -m 600 /dev/null "$RUNNER_TEMP/neondiff.private-key.pem"
+          printf '%s' "${NEONDIFF_GITHUB_APP_PRIVATE_KEY}" > "$RUNNER_TEMP/neondiff.private-key.pem"
+        env:
+          NEONDIFF_GITHUB_APP_PRIVATE_KEY: ${{ secrets.NEONDIFF_GITHUB_APP_PRIVATE_KEY }}
+      - run: neondiff doctor github --config config.local.json --json
+        env:
+          NEONDIFF_GITHUB_APP_ID: ${{ secrets.NEONDIFF_GITHUB_APP_ID }}
+          NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH: ${{ runner.temp }}/neondiff.private-key.pem
+```
+
+For CI-hosted dry-run review, write the App private key to
+`$RUNNER_TEMP/neondiff.private-key.pem` with restricted permissions as shown
+above, run `neondiff review-pr --dry-run true`, and upload only redacted
+evidence.
+
+## Generic CI
+
+The generic shape is:
+
+```bash
+node --version
+npm install -g neondiff
+neondiff doctor github --config config.local.json --json
+neondiff providers list --config config.local.json --json
+neondiff review-pr --config config.local.json --repo owner/name --pr "$PR_NUMBER" --dry-run true
+```
+
+Use CI for one-shot checks. Use [docs/systemd.md](systemd.md) or
+[docs/docker.md](docker.md) for a supervised long-running Linux worker.

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -47,6 +47,12 @@ For CI-hosted dry-run review, write the App private key to
 above, run `neondiff review-pr --dry-run true`, and upload only redacted
 evidence.
 
+`--dry-run true` never posts GitHub comments. Live CI posting still inherits the
+normal NeonDiff gates: the target head must be current, duplicate suppression
+must allow the head, and the public alias must be invoked with
+`--dry-run false --confirm true` after the repo, PR, head SHA, and config path
+are approved.
+
 ## Generic CI
 
 The generic shape is:

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -30,13 +30,15 @@ jobs:
           node-version: 26
           cache: npm
       - run: npm install -g neondiff
+      - name: Prepare dry-run config
+        run: cp config.example.json "$RUNNER_TEMP/config.local.json"
       - name: Write GitHub App key
         run: |
           install -m 600 /dev/null "$RUNNER_TEMP/neondiff.private-key.pem"
           printf '%s' "${NEONDIFF_GITHUB_APP_PRIVATE_KEY}" > "$RUNNER_TEMP/neondiff.private-key.pem"
         env:
           NEONDIFF_GITHUB_APP_PRIVATE_KEY: ${{ secrets.NEONDIFF_GITHUB_APP_PRIVATE_KEY }}
-      - run: neondiff doctor github --config config.local.json --json
+      - run: neondiff doctor github --config "$RUNNER_TEMP/config.local.json" --json
         env:
           NEONDIFF_GITHUB_APP_ID: ${{ secrets.NEONDIFF_GITHUB_APP_ID }}
           NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH: ${{ runner.temp }}/neondiff.private-key.pem
@@ -60,9 +62,10 @@ The generic shape is:
 ```bash
 node --version
 npm install -g neondiff
-neondiff doctor github --config config.local.json --json
-neondiff providers list --config config.local.json --json
-neondiff review-pr --config config.local.json --repo owner/name --pr "$PR_NUMBER" --dry-run true
+cp config.example.json "$RUNNER_TEMP/config.local.json"
+neondiff doctor github --config "$RUNNER_TEMP/config.local.json" --json
+neondiff providers list --config "$RUNNER_TEMP/config.local.json" --json
+neondiff review-pr --config "$RUNNER_TEMP/config.local.json" --repo owner/name --pr "$PR_NUMBER" --dry-run true
 ```
 
 Use CI for one-shot checks. Use [docs/systemd.md](systemd.md) or

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -24,8 +24,8 @@ jobs:
   neondiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 26
           cache: npm

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,15 +39,16 @@ command: ["daemon", "--config", "/config/config.local.json", "--dry-run", "false
 Only make that change after `doctor`, provider readiness, repo allowlist,
 current-head proof, duplicate suppression, and issue/PR approval are recorded.
 
-## Healthcheck
+## Healthcheck And Readiness
 
-The image healthcheck runs a config/provider-list command against
-`NEONDIFF_CONFIG`. A healthy container means the CLI can start and parse the
-configured provider registry; it is not a guarantee of review quality or live
-posting readiness, and it does not distinguish dry-run from live posting mode.
-Pair it with:
+The image healthcheck runs `neondiff help` as a cheap process/CLI liveness
+check. It intentionally does not read the mounted config, call a provider, or
+distinguish dry-run from live posting mode. Treat it as container liveness only.
+Use explicit readiness checks before live review:
 
 ```bash
+docker compose -f docker-compose.local.yml exec neondiff \
+  neondiff providers list --config /config/config.local.json --json
 docker compose -f docker-compose.local.yml exec neondiff \
   neondiff doctor --config /config/config.local.json --json
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -36,8 +36,11 @@ reviews from Docker, change the compose command to:
 command: ["daemon", "--config", "/config/config.local.json", "--dry-run", "false"]
 ```
 
-Only make that change after `doctor`, provider readiness, repo allowlist,
-current-head proof, duplicate suppression, and issue/PR approval are recorded.
+The long-running daemon worker uses `--dry-run` as its posting boundary; it does
+not implement the `--confirm true` gate used by one-shot `review-pr` live posting
+and launchd mutation commands. Only switch Docker to `--dry-run false` after
+`doctor`, provider readiness, repo allowlist, current-head proof, duplicate
+suppression, and issue/PR approval are recorded.
 
 ## Healthcheck And Readiness
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,54 @@
+# Docker Operator Guide
+
+The Docker recipe is for local or self-hosted workers where config, state,
+evidence, and checkout work directories are mounted as volumes. It is not a
+hosted NeonDiff SaaS path and does not bundle model credits.
+
+## Compose Quick Start
+
+Copy the example and provide secrets through an untracked `.env` file:
+
+```bash
+cp docker-compose.example.yml docker-compose.local.yml
+cat > .env <<'EOF'
+NEONDIFF_GITHUB_APP_ID=123456
+NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH=/config/neondiff.private-key.pem
+EOF
+```
+
+Mount your config at `/config/config.local.json` and keep keys outside git:
+
+```bash
+docker compose -f docker-compose.local.yml build neondiff
+docker compose -f docker-compose.local.yml up -d neondiff
+docker compose -f docker-compose.local.yml logs -f neondiff
+```
+
+The example also includes an `ollama` service for local OpenAI-compatible
+provider experiments. It is optional; remove it if your provider runs elsewhere.
+
+## Healthcheck
+
+The image healthcheck runs a config/provider-list command against
+`NEONDIFF_CONFIG`. A healthy container means the CLI can start and parse the
+configured provider registry; it is not a guarantee of review quality or live
+posting readiness. Pair it with:
+
+```bash
+docker compose -f docker-compose.local.yml exec neondiff \
+  neondiff doctor --config /config/config.local.json --json
+```
+
+## Volumes
+
+Recommended mounts:
+
+| Mount | Purpose |
+| --- | --- |
+| `/config` | Local config, GitHub App private key path, and untracked env inputs |
+| `/state` | SQLite state DBs and license cache files |
+| `/evidence` | Redacted review evidence packets |
+| `/work` | Bare mirrors and per-PR worktrees |
+
+Do not bake GitHub App keys, provider API keys, license keys, customer data, or
+raw review evidence into the image.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -44,10 +44,11 @@ suppression, and issue/PR approval are recorded.
 
 ## Healthcheck And Readiness
 
-The image healthcheck runs `neondiff help` as a cheap process/CLI liveness
-check. It intentionally does not read the mounted config, call a provider, or
-distinguish dry-run from live posting mode. Treat it as container liveness only.
-Use explicit readiness checks before live review:
+The image healthcheck verifies that PID 1 was launched as the `neondiff daemon`
+command. It intentionally does not read the mounted config, call a provider,
+or distinguish dry-run from live posting mode. Treat it as container liveness
+only, not evidence that reviews are draining or providers are ready. Use
+explicit readiness checks before live review:
 
 ```bash
 docker compose -f docker-compose.local.yml exec neondiff \

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -27,12 +27,25 @@ docker compose -f docker-compose.local.yml logs -f neondiff
 The example also includes an `ollama` service for local OpenAI-compatible
 provider experiments. It is optional; remove it if your provider runs elsewhere.
 
+The image runs as the bundled non-root `node` user. The example daemon command
+is deliberately explicit about `--dry-run true`, so a first deploy can prove the
+worker loop and evidence path without posting GitHub comments. To post live
+reviews from Docker, change the compose command to:
+
+```yaml
+command: ["daemon", "--config", "/config/config.local.json", "--dry-run", "false"]
+```
+
+Only make that change after `doctor`, provider readiness, repo allowlist,
+current-head proof, duplicate suppression, and issue/PR approval are recorded.
+
 ## Healthcheck
 
 The image healthcheck runs a config/provider-list command against
 `NEONDIFF_CONFIG`. A healthy container means the CLI can start and parse the
 configured provider registry; it is not a guarantee of review quality or live
-posting readiness. Pair it with:
+posting readiness, and it does not distinguish dry-run from live posting mode.
+Pair it with:
 
 ```bash
 docker compose -f docker-compose.local.yml exec neondiff \

--- a/docs/known-limitations-and-provider-status.md
+++ b/docs/known-limitations-and-provider-status.md
@@ -38,7 +38,7 @@ provider registry.
 | CLI/source checkout | Node.js 26 and npm are required. Source checkout remains the contributor fallback. This document does not prove every Linux distribution or shell environment. |
 | npm package | Use the version named in README/setup docs. Dist-tag and package truth must be checked before public announcements. |
 | GitHub App review posting | Live posting is gated by configured repos, current-head checks, duplicate suppression, provider readiness, and dry-run evidence. NeonDiff does not approve PRs, merge, push repairs, or silently expand permissions. |
-| Daemon/launchd | The live beta operator path is macOS launchd-oriented. Linux service packaging is not claimed here. |
+| Daemon supervision | The live beta operator path is macOS launchd-oriented. Linux systemd, Docker, and CI-runner assets are packaged and guarded by an Ubuntu smoke workflow, but provider-specific Linux review quality and every distribution shape are not claimed. |
 | Desktop app | macOS dev MVP only. No signed/notarized/appcast/TCC/customer-control readiness is claimed. |
 | License activation | Public repos are free. Private/commercial repos require a paid support license. The beta file backend is the active CLI path; Keychain activation is intentionally not a headless write path. |
 | Security | Security policy exists, but this is not an enterprise/customer-ready security certification. Use private GitHub vulnerability reporting for secrets or private data. |
@@ -59,7 +59,7 @@ provider registry.
 - CodeRabbit parity.
 - Calibrated review accuracy.
 - Enterprise or customer-ready security.
-- Linux service packaging.
+- Broad Linux distribution coverage beyond the packaged systemd/Docker/Ubuntu-smoke path.
 - Signed/notarized desktop release.
 - Universal provider compatibility.
 - Hosted review SaaS with bundled model credits.

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -157,7 +157,10 @@ evaos-review-bot status --config config.local.json
   the existing scoped `run-once` review command. Live posting through this
   public alias requires `--dry-run false --confirm true` after the exact repo,
   PR, head SHA, and config path are approved.
-- `daemon start|stop|status`: JSON-first launchd controls. All daemon
+- `daemon start|stop|status`: JSON-first macOS launchd controls. On Linux and
+  other non-Darwin platforms these subcommands fail closed with
+  `serviceManager: "systemd"` and a pointer to [docs/systemd.md](systemd.md)
+  instead of trying to run `launchctl`. All macOS daemon
   subcommands require `--launchd-label`; `start` and `stop` default to dry-run planning; live mutation
   requires both `--dry-run false` and `--confirm true`.
   When `start` uses `--plist <path>`, `stop` can either pass the same `--plist`

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -6,6 +6,20 @@ not change review behavior: the worker still reviews only configured repos,
 uses current-head duplicate suppression, redacts secrets, and writes evidence
 under the configured paths.
 
+## Install The CLI
+
+Install NeonDiff into a path visible to systemd before enabling either unit.
+The example units use `/usr/bin/env neondiff`, so `command -v neondiff` should
+resolve to a systemd-visible path such as `/usr/local/bin/neondiff` or
+`/usr/bin/neondiff`. If your npm global prefix is account-local, edit
+`ExecStart` in the copied unit file to the absolute path returned by
+`command -v neondiff`.
+
+```bash
+npm install -g neondiff
+command -v neondiff
+```
+
 ## User Service
 
 Use the user unit for a single operator account that owns the config, state, and

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -12,7 +12,7 @@ Use the user unit for a single operator account that owns the config, state, and
 repo work directories.
 
 ```bash
-mkdir -p ~/.config/neondiff ~/.config/systemd/user ~/.local/share/neondiff
+mkdir -p ~/.config/neondiff ~/.config/systemd/user ~/.local/share/neondiff/state
 cp systemd/neondiff.user.service.example ~/.config/systemd/user/neondiff.service
 ```
 
@@ -25,6 +25,16 @@ NEONDIFF_GITHUB_APP_ID=123456
 NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH=/home/neondiff/.config/neondiff/neondiff.private-key.pem
 EOF
 chmod 600 ~/.config/neondiff/neondiff.env
+```
+
+Set `statePath` in `~/.config/neondiff/config.local.json` so SQLite state,
+leases, duplicate suppression, and license cache defaults stay under the
+operator-owned writable state directory:
+
+```json
+{
+  "statePath": "/home/neondiff/.local/share/neondiff/state/reviews.sqlite"
+}
 ```
 
 Then enable the service:
@@ -49,9 +59,10 @@ Use the system unit when NeonDiff should run as a dedicated service account.
 
 ```bash
 sudo useradd --system --home-dir /var/lib/neondiff --create-home --shell /usr/sbin/nologin neondiff
-sudo mkdir -p /etc/neondiff
+sudo mkdir -p /etc/neondiff /var/lib/neondiff/state
 sudo cp systemd/neondiff.service.example /etc/systemd/system/neondiff.service
 sudo install -m 600 -o root -g neondiff /dev/null /etc/neondiff/neondiff.env
+sudo chown -R neondiff:neondiff /var/lib/neondiff
 ```
 
 Populate `/etc/neondiff/neondiff.env` with redacted-safe variable names, not raw
@@ -61,6 +72,16 @@ secrets in tracked files:
 NEONDIFF_CONFIG=/etc/neondiff/config.local.json
 NEONDIFF_GITHUB_APP_ID=123456
 NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH=/etc/neondiff/neondiff.private-key.pem
+```
+
+Set `statePath` in `/etc/neondiff/config.local.json` so the hardened system
+unit writes all SQLite state and leases under the service account's writable
+state directory:
+
+```json
+{
+  "statePath": "/var/lib/neondiff/state/reviews.sqlite"
+}
 ```
 
 Then start the daemon:

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -95,9 +95,15 @@ sudo journalctl -u neondiff -f
 
 ## Status And Doctor
 
-Run setup checks before enabling the service:
+Run setup checks before enabling the service. Load the same env file into the
+current shell first so `NEONDIFF_CONFIG` and credential paths are exported for
+the `neondiff` commands:
 
 ```bash
+set -a
+source ~/.config/neondiff/neondiff.env # or /etc/neondiff/neondiff.env for the system unit
+set +a
+
 neondiff doctor github --config "$NEONDIFF_CONFIG" --json
 neondiff providers list --config "$NEONDIFF_CONFIG" --json
 neondiff providers doctor --config "$NEONDIFF_CONFIG" --json

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -1,0 +1,111 @@
+# Linux systemd Operator Guide
+
+This guide is the Linux supervised-daemon path for NeonDiff. It mirrors the
+macOS launchd guide, but uses systemd, `EnvironmentFile`, and journald. It does
+not change review behavior: the worker still reviews only configured repos,
+uses current-head duplicate suppression, redacts secrets, and writes evidence
+under the configured paths.
+
+## User Service
+
+Use the user unit for a single operator account that owns the config, state, and
+repo work directories.
+
+```bash
+mkdir -p ~/.config/neondiff ~/.config/systemd/user ~/.local/share/neondiff
+cp systemd/neondiff.user.service.example ~/.config/systemd/user/neondiff.service
+```
+
+Create an environment file outside the repository:
+
+```bash
+cat > ~/.config/neondiff/neondiff.env <<'EOF'
+NEONDIFF_CONFIG=/home/neondiff/.config/neondiff/config.local.json
+NEONDIFF_GITHUB_APP_ID=123456
+NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH=/home/neondiff/.config/neondiff/neondiff.private-key.pem
+EOF
+chmod 600 ~/.config/neondiff/neondiff.env
+```
+
+Then enable the service:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now neondiff
+systemctl --user status neondiff
+journalctl --user -u neondiff -f
+```
+
+If the service should keep running after the SSH session ends, enable lingering
+for the operator user:
+
+```bash
+sudo loginctl enable-linger "$USER"
+```
+
+## System Service
+
+Use the system unit when NeonDiff should run as a dedicated service account.
+
+```bash
+sudo useradd --system --home-dir /var/lib/neondiff --create-home --shell /usr/sbin/nologin neondiff
+sudo mkdir -p /etc/neondiff
+sudo cp systemd/neondiff.service.example /etc/systemd/system/neondiff.service
+sudo install -m 600 -o root -g neondiff /dev/null /etc/neondiff/neondiff.env
+```
+
+Populate `/etc/neondiff/neondiff.env` with redacted-safe variable names, not raw
+secrets in tracked files:
+
+```bash
+NEONDIFF_CONFIG=/etc/neondiff/config.local.json
+NEONDIFF_GITHUB_APP_ID=123456
+NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH=/etc/neondiff/neondiff.private-key.pem
+```
+
+Then start the daemon:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now neondiff
+sudo systemctl status neondiff
+sudo journalctl -u neondiff -f
+```
+
+## Status And Doctor
+
+Run setup checks before enabling the service:
+
+```bash
+neondiff doctor github --config "$NEONDIFF_CONFIG" --json
+neondiff providers list --config "$NEONDIFF_CONFIG" --json
+neondiff providers doctor --config "$NEONDIFF_CONFIG" --json
+neondiff doctor --config "$NEONDIFF_CONFIG" --json
+```
+
+Linux does not use `neondiff daemon start|stop|status`; those subcommands are
+launchd controls and intentionally fail closed off macOS with a JSON pointer to
+this guide. Use `systemctl --user status neondiff` or
+`systemctl status neondiff`, then use NeonDiff's JSON operator commands for
+review health:
+
+```bash
+neondiff status --config "$NEONDIFF_CONFIG" --json
+neondiff queue --config "$NEONDIFF_CONFIG"
+neondiff dashboard --operator true --config "$NEONDIFF_CONFIG"
+```
+
+## Journald Troubleshooting
+
+```bash
+journalctl --user -u neondiff --since "30 minutes ago"
+sudo journalctl -u neondiff --since "30 minutes ago"
+```
+
+Common failures:
+
+- `status=203/EXEC`: the `neondiff` binary is not on the service user's PATH.
+- Config load failure: verify `NEONDIFF_CONFIG` points to readable JSON.
+- GitHub read failure: verify App ID, private key path, and selected repo install.
+- Provider failure: verify local provider config and use redacted provider output
+  from `providers doctor`.

--- a/package.json
+++ b/package.json
@@ -20,11 +20,18 @@
     "CODE_OF_CONDUCT.md",
     "config.example.json",
     "docs/SETUP.md",
+    "docs/ci-runner.md",
+    "docs/docker.md",
     "docs/github-app-setup.md",
     "docs/providers.md",
     "docs/license-boundary.md",
     "docs/pricing.md",
-    "docs/schema/neondiff-config.schema.json"
+    "docs/schema/neondiff-config.schema.json",
+    "docs/systemd.md",
+    "systemd/neondiff.service.example",
+    "systemd/neondiff.user.service.example",
+    "Dockerfile",
+    "docker-compose.example.yml"
   ],
   "engines": {
     "node": ">=26"

--- a/scripts/check-packlist.mjs
+++ b/scripts/check-packlist.mjs
@@ -29,11 +29,18 @@ for (const required of [
   "CODE_OF_CONDUCT.md",
   "config.example.json",
   "docs/SETUP.md",
+  "docs/ci-runner.md",
+  "docs/docker.md",
   "docs/github-app-setup.md",
   "docs/providers.md",
   "docs/license-boundary.md",
   "docs/pricing.md",
-  "docs/schema/neondiff-config.schema.json"
+  "docs/schema/neondiff-config.schema.json",
+  "docs/systemd.md",
+  "systemd/neondiff.service.example",
+  "systemd/neondiff.user.service.example",
+  "Dockerfile",
+  "docker-compose.example.yml"
 ]) {
   if (!files.has(required)) {
     console.error(`Missing required package file: ${required}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2500,15 +2500,17 @@ function unsupportedNonDarwinDaemonControl(
   action: "start" | "stop" | "status",
   platform: string
 ): DaemonControlResult {
+  const isLinux = platform === "linux";
   return {
     ok: false,
     command: `daemon ${action}`,
     platform,
-    serviceManager: "systemd",
-    docs: "docs/systemd.md",
+    ...(isLinux ? { serviceManager: "systemd" as const, docs: "docs/systemd.md" } : { docs: "docs/docker.md" }),
     error:
       `launchd daemon controls are only supported on macOS; detected ${platform}. ` +
-      "On Linux, use systemd with docs/systemd.md or Docker with docs/docker.md."
+      (isLinux
+        ? "On Linux, use systemd with docs/systemd.md or Docker with docs/docker.md."
+        : "Use Docker with docs/docker.md, or run this on Linux with docs/systemd.md.")
   };
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2330,6 +2330,9 @@ function writeFileAtomic(path: string, contents: string): void {
 type DaemonControlResult = {
   ok: boolean;
   command: "daemon start" | "daemon stop" | "daemon status";
+  platform?: string;
+  serviceManager?: "launchd" | "systemd";
+  docs?: string;
   dryRun?: boolean;
   launchdLabel?: string;
   launchdTarget?: string;
@@ -2361,6 +2364,9 @@ function runDaemonControlCommand(
   action: "start" | "stop" | "status",
   args: ParsedArgs
 ): DaemonControlResult {
+  const platform = currentDaemonPlatform();
+  if (platform !== "darwin") return unsupportedNonDarwinDaemonControl(action, platform);
+
   if (action === "status") {
     if (!args["launchd-label"]) {
       return {
@@ -2483,6 +2489,26 @@ function runDaemonControlCommand(
     ...(plistPath ? { plistPath } : {}),
     ...(warning ? { warning } : {}),
     results
+  };
+}
+
+function currentDaemonPlatform(): string {
+  return process.env.NEONDIFF_TEST_PLATFORM || process.platform;
+}
+
+function unsupportedNonDarwinDaemonControl(
+  action: "start" | "stop" | "status",
+  platform: string
+): DaemonControlResult {
+  return {
+    ok: false,
+    command: `daemon ${action}`,
+    platform,
+    serviceManager: "systemd",
+    docs: "docs/systemd.md",
+    error:
+      `launchd daemon controls are only supported on macOS; detected ${platform}. ` +
+      "On Linux, use systemd with docs/systemd.md or Docker with docs/docker.md."
   };
 }
 

--- a/systemd/neondiff.service.example
+++ b/systemd/neondiff.service.example
@@ -1,0 +1,25 @@
+[Unit]
+Description=NeonDiff local review daemon
+Documentation=https://github.com/electricsheephq/evaos-code-review-bot-neondiff/blob/main/docs/systemd.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=neondiff
+Group=neondiff
+EnvironmentFile=/etc/neondiff/neondiff.env
+WorkingDirectory=/var/lib/neondiff
+StateDirectory=neondiff
+CacheDirectory=neondiff
+LogsDirectory=neondiff
+ExecStart=/usr/bin/env neondiff daemon --config ${NEONDIFF_CONFIG}
+Restart=on-failure
+RestartSec=10
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ReadWritePaths=/var/lib/neondiff /var/cache/neondiff /var/log/neondiff /etc/neondiff
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/neondiff.service.example
+++ b/systemd/neondiff.service.example
@@ -19,7 +19,7 @@ RestartSec=10
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-ReadWritePaths=/var/lib/neondiff /var/cache/neondiff /var/log/neondiff /etc/neondiff
+ReadWritePaths=/var/lib/neondiff /var/cache/neondiff /var/log/neondiff
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/neondiff.user.service.example
+++ b/systemd/neondiff.user.service.example
@@ -1,0 +1,18 @@
+[Unit]
+Description=NeonDiff local review daemon
+Documentation=https://github.com/electricsheephq/evaos-code-review-bot-neondiff/blob/main/docs/systemd.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=%h/.config/neondiff/neondiff.env
+WorkingDirectory=%h/.local/share/neondiff
+ExecStart=/usr/bin/env neondiff daemon --config ${NEONDIFF_CONFIG}
+Restart=on-failure
+RestartSec=10
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=default.target

--- a/tests/linux-packaging.test.ts
+++ b/tests/linux-packaging.test.ts
@@ -29,7 +29,8 @@ describe("Linux daemon packaging", () => {
 
     expect(dockerfile).toContain("FROM node:26");
     expect(dockerfile).toContain("HEALTHCHECK");
-    expect(dockerfile).toContain("neondiff help");
+    expect(dockerfile).toContain("/proc/1/cmdline");
+    expect(dockerfile).toContain("\\bdaemon\\b");
     expect(dockerfile).toContain("neondiff daemon");
     expect(dockerfile).toContain("USER node");
     expect(dockerfile).toContain("\"--dry-run\", \"true\"");

--- a/tests/linux-packaging.test.ts
+++ b/tests/linux-packaging.test.ts
@@ -37,6 +37,7 @@ describe("Linux daemon packaging", () => {
     expect(linuxSmokeWorkflow).toContain("ubuntu-latest");
     expect(linuxSmokeWorkflow).toContain("NEONDIFF_TEST_PLATFORM: linux");
     expect(linuxSmokeWorkflow).toContain("tests/linux-packaging.test.ts");
+    expect(linuxSmokeWorkflow).toContain("node dist/src/cli.js daemon status");
   });
 
   it("includes Linux operator assets in the npm package allowlist", () => {

--- a/tests/linux-packaging.test.ts
+++ b/tests/linux-packaging.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("Linux daemon packaging", () => {
+  it("ships systemd, Docker, and CI-runner operator assets", () => {
+    const systemdDocs = readFileSync("docs/systemd.md", "utf8");
+    const dockerDocs = readFileSync("docs/docker.md", "utf8");
+    const ciDocs = readFileSync("docs/ci-runner.md", "utf8");
+    const userUnit = readFileSync("systemd/neondiff.user.service.example", "utf8");
+    const systemUnit = readFileSync("systemd/neondiff.service.example", "utf8");
+    const dockerfile = readFileSync("Dockerfile", "utf8");
+    const compose = readFileSync("docker-compose.example.yml", "utf8");
+    const linuxSmokeWorkflow = readFileSync(".github/workflows/linux-daemon-smoke.yml", "utf8");
+
+    expect(systemdDocs).toContain("systemctl --user");
+    expect(systemdDocs).toContain("EnvironmentFile");
+    expect(systemdDocs).toContain("journalctl --user -u neondiff");
+    expect(dockerDocs).toContain("docker compose");
+    expect(dockerDocs).toContain("ollama");
+    expect(ciDocs).toContain("GitHub Actions");
+    expect(ciDocs).toContain("ubuntu-latest");
+
+    expect(userUnit).toContain("ExecStart=/usr/bin/env neondiff daemon");
+    expect(userUnit).toContain("EnvironmentFile=%h/.config/neondiff/neondiff.env");
+    expect(userUnit).toContain("Restart=on-failure");
+    expect(systemUnit).toContain("User=neondiff");
+    expect(systemUnit).toContain("EnvironmentFile=/etc/neondiff/neondiff.env");
+    expect(systemUnit).toContain("Restart=on-failure");
+
+    expect(dockerfile).toContain("FROM node:26");
+    expect(dockerfile).toContain("HEALTHCHECK");
+    expect(dockerfile).toContain("neondiff daemon");
+    expect(compose).toContain("neondiff:");
+    expect(compose).toContain("ollama:");
+    expect(compose).toContain("NEONDIFF_CONFIG=/config/config.local.json");
+
+    expect(linuxSmokeWorkflow).toContain("ubuntu-latest");
+    expect(linuxSmokeWorkflow).toContain("NEONDIFF_TEST_PLATFORM: linux");
+    expect(linuxSmokeWorkflow).toContain("tests/linux-packaging.test.ts");
+  });
+
+  it("includes Linux operator assets in the npm package allowlist", () => {
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+    const packlistGuard = readFileSync("scripts/check-packlist.mjs", "utf8");
+    const requiredFiles = [
+      "docs/systemd.md",
+      "docs/docker.md",
+      "docs/ci-runner.md",
+      "systemd/neondiff.user.service.example",
+      "systemd/neondiff.service.example",
+      "Dockerfile",
+      "docker-compose.example.yml"
+    ];
+
+    for (const file of requiredFiles) {
+      expect(packageJson.files).toContain(file);
+      expect(packlistGuard).toContain(file);
+    }
+  });
+});

--- a/tests/linux-packaging.test.ts
+++ b/tests/linux-packaging.test.ts
@@ -30,14 +30,23 @@ describe("Linux daemon packaging", () => {
     expect(dockerfile).toContain("FROM node:26");
     expect(dockerfile).toContain("HEALTHCHECK");
     expect(dockerfile).toContain("neondiff daemon");
+    expect(dockerfile).toContain("USER node");
+    expect(dockerfile).toContain("\"--dry-run\", \"true\"");
     expect(compose).toContain("neondiff:");
     expect(compose).toContain("ollama:");
     expect(compose).toContain("NEONDIFF_CONFIG=/config/config.local.json");
+    expect(compose).toContain("[\"daemon\", \"--config\", \"/config/config.local.json\", \"--dry-run\", \"true\"]");
+    expect(dockerDocs).toContain("--dry-run true");
+    expect(dockerDocs).toContain("--dry-run\", \"false");
+    expect(ciDocs).toContain("actions/checkout@v4");
+    expect(ciDocs).toContain("actions/setup-node@v4");
 
     expect(linuxSmokeWorkflow).toContain("ubuntu-latest");
     expect(linuxSmokeWorkflow).toContain("NEONDIFF_TEST_PLATFORM: linux");
     expect(linuxSmokeWorkflow).toContain("tests/linux-packaging.test.ts");
     expect(linuxSmokeWorkflow).toContain("node dist/src/cli.js daemon status");
+    expect(linuxSmokeWorkflow).toContain("out.command !== \"daemon status\"");
+    expect(linuxSmokeWorkflow).toContain("typeof out.error !== \"string\"");
   });
 
   it("includes Linux operator assets in the npm package allowlist", () => {

--- a/tests/linux-packaging.test.ts
+++ b/tests/linux-packaging.test.ts
@@ -29,6 +29,7 @@ describe("Linux daemon packaging", () => {
 
     expect(dockerfile).toContain("FROM node:26");
     expect(dockerfile).toContain("HEALTHCHECK");
+    expect(dockerfile).toContain("neondiff help");
     expect(dockerfile).toContain("neondiff daemon");
     expect(dockerfile).toContain("USER node");
     expect(dockerfile).toContain("\"--dry-run\", \"true\"");

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -2846,6 +2846,38 @@ exit 1
     });
   });
 
+  it("degrades launchd daemon controls on Linux with systemd guidance", async () => {
+    const startError = await runCli([
+      "daemon",
+      "start",
+      "--launchd-label",
+      "com.example.neondiff"
+    ], { env: { NEONDIFF_TEST_PLATFORM: "linux" } }).catch((error: { stdout: string }) => error);
+    const statusError = await runCli([
+      "daemon",
+      "status"
+    ], { env: { NEONDIFF_TEST_PLATFORM: "linux" } }).catch((error: { stdout: string }) => error);
+
+    expect(JSON.parse(startError.stdout)).toMatchObject({
+      ok: false,
+      command: "daemon start",
+      platform: "linux",
+      serviceManager: "systemd",
+      docs: "docs/systemd.md",
+      error: expect.stringContaining("launchd daemon controls are only supported on macOS")
+    });
+    expect(JSON.parse(startError.stdout).error).toContain("use systemd");
+    expect(JSON.parse(startError.stdout).plannedCommands).toBeUndefined();
+    expect(JSON.parse(statusError.stdout)).toMatchObject({
+      ok: false,
+      command: "daemon status",
+      platform: "linux",
+      serviceManager: "systemd",
+      docs: "docs/systemd.md",
+      error: expect.stringContaining("use systemd")
+    });
+  });
+
   it("validates launchd labels and plist labels before planning daemon commands", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-launchd-plist-"));
     roots.push(root);

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -2879,6 +2879,23 @@ exit 1
     });
   });
 
+  it("degrades launchd daemon controls on non-Linux platforms with Docker guidance", async () => {
+    const statusError = await runCli([
+      "daemon",
+      "status"
+    ], { env: { NEONDIFF_TEST_PLATFORM: "win32" } }).catch((error: { stdout: string }) => error);
+
+    const output = JSON.parse(statusError.stdout);
+    expect(output).toMatchObject({
+      ok: false,
+      command: "daemon status",
+      platform: "win32",
+      docs: "docs/docker.md",
+      error: expect.stringContaining("Use Docker")
+    });
+    expect(output.serviceManager).toBeUndefined();
+  });
+
   it("validates launchd labels and plist labels before planning daemon commands", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-launchd-plist-"));
     roots.push(root);

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -15,6 +15,7 @@ const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
 const tsxCliPath = require.resolve("tsx/cli");
 const repoRoot = process.cwd();
+const darwinDaemonEnv = { NEONDIFF_TEST_PLATFORM: "darwin" };
 
 describe("public NeonDiff CLI surface", () => {
   const roots: string[] = [];
@@ -109,7 +110,7 @@ describe("public NeonDiff CLI surface", () => {
         statePath,
         "--launchd-label",
         "com.example.neondiff"
-      ]);
+      ], { env: darwinDaemonEnv });
     } catch (error) {
       failure = error;
     }
@@ -2809,13 +2810,13 @@ exit 1
       "start",
       "--launchd-label",
       "com.example.neondiff"
-    ]);
+    ], { env: darwinDaemonEnv });
     const { stdout: stopStdout } = await runCli([
       "daemon",
       "stop",
       "--launchd-label",
       "com.example.neondiff"
-    ]);
+    ], { env: darwinDaemonEnv });
 
     expect(JSON.parse(startStdout)).toMatchObject({
       ok: true,
@@ -2841,7 +2842,7 @@ exit 1
       "status",
       "--launchd-label",
       "com.example.neondiff"
-    ])).rejects.toMatchObject({
+    ], { env: darwinDaemonEnv })).rejects.toMatchObject({
       stdout: expect.stringContaining("--config is required for daemon status")
     });
   });
@@ -2891,7 +2892,7 @@ exit 1
       "com.example.neondiff",
       "--plist",
       plistPath
-    ]);
+    ], { env: darwinDaemonEnv });
 
     expect(JSON.parse(stdout)).toMatchObject({
       ok: true,
@@ -2912,7 +2913,7 @@ exit 1
       "bad label",
       "--plist",
       plistPath
-    ])).rejects.toMatchObject({
+    ], { env: darwinDaemonEnv })).rejects.toMatchObject({
       stdout: expect.stringContaining("must be a launchd label")
     });
   });
@@ -2930,7 +2931,7 @@ exit 1
       "com.example.neondiff",
       "--plist",
       plistPath
-    ])).rejects.toMatchObject({
+    ], { env: darwinDaemonEnv })).rejects.toMatchObject({
       stdout: expect.stringContaining("must match --launchd-label")
     });
   });
@@ -2943,7 +2944,7 @@ exit 1
       "com.example.neondiff",
       "--dry-run",
       "false"
-    ])).rejects.toMatchObject({
+    ], { env: darwinDaemonEnv })).rejects.toMatchObject({
       stdout: expect.stringContaining("requires --confirm true")
     });
   });
@@ -2965,7 +2966,7 @@ exit 1
       "false",
       "--confirm",
       "true"
-    ])).rejects.toMatchObject({
+    ], { env: darwinDaemonEnv })).rejects.toMatchObject({
       stdout: expect.stringContaining("requires --allow-external-plist true")
     });
   });

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -74,11 +74,18 @@ describe("NeonDiff public release readiness", () => {
       "CODE_OF_CONDUCT.md",
       "config.example.json",
       "docs/SETUP.md",
+      "docs/ci-runner.md",
+      "docs/docker.md",
       "docs/github-app-setup.md",
       "docs/providers.md",
       "docs/license-boundary.md",
       "docs/pricing.md",
-      "docs/schema/neondiff-config.schema.json"
+      "docs/schema/neondiff-config.schema.json",
+      "docs/systemd.md",
+      "systemd/neondiff.service.example",
+      "systemd/neondiff.user.service.example",
+      "Dockerfile",
+      "docker-compose.example.yml"
     ]);
 
     expect(lock.name).toBe("neondiff");


### PR DESCRIPTION
## Summary
- add first-class Linux systemd operator docs and user/system unit examples
- add Dockerfile, Compose recipe with Ollama sidecar, and CI-runner docs
- gate launchd daemon controls off Darwin with JSON systemd guidance
- include Linux operator assets in npm package allowlist and packlist checks

## Validation
- npm test -- --run tests/public-cli.test.ts tests/linux-packaging.test.ts --pool=forks --maxWorkers=1
- npm run build
- node scripts/check-secret-scan.mjs
- node scripts/check-public-claims.mjs
- git diff --check
- npm pack --dry-run --json > /Volumes/LEXAR/Codex/neondiff-424-pack.json
- node scripts/check-packlist.mjs /Volumes/LEXAR/Codex/neondiff-424-pack.json
- npm test -- --run tests/linux-packaging.test.ts --pool=forks --maxWorkers=1

## Proof Boundary
This proves packaging, docs, platform guard behavior, and Ubuntu smoke coverage for Linux supervision. It does not claim provider quality, broad distribution coverage, or review behavior changes.

Closes #424