### PR TITLE
[codex] Add structured findings JSON provider modes

### DIFF
--- a/docs/neondiff-config.md
+++ b/docs/neondiff-config.md
@@ -91,6 +91,27 @@ repo:
 
 `providers.byok.apiKeyEnv` names an environment variable; it is not a value slot for a raw key. Local provider hints are limited to HTTP loopback version roots such as `http://localhost:11434/v1`; HTTPS loopback and arbitrary path suffixes are intentionally rejected in this draft. Committed config should still avoid machine-specific secrets and credentials. Machine-specific provider settings belong in local overrides once runtime support exists.
 
+The live `BotConfig.providers.providers.<provider-id>.structuredOutputMode`
+field is separate from the public `.neondiff.yml` draft above. It is a
+machine/operator config knob for provider adapters, not a repo-owned policy
+field. Supported values are:
+
+| Value | Behavior |
+| --- | --- |
+| `none` | No provider-side JSON/structured-output field; NeonDiff uses its recovery parser only. |
+| `json-object` | Legacy `response_format: { "type": "json_object" }`; valid JSON object hint, not schema-constrained findings. |
+| `openai-json-schema` | OpenAI/LM Studio style `response_format` with the canonical findings JSON Schema. |
+| `llama-cpp-json-schema` | llama.cpp-compatible `response_format` with a direct `schema` field. |
+| `vllm-structured-outputs` | Current vLLM `structured_outputs: { "json": ... }` shape. |
+| `vllm-guided-json` | Legacy vLLM `guided_json` shape for older deployments. |
+| `ollama-format-json-schema` | Ollama-style `format` field with the findings schema. |
+| `sglang-json-schema` | SGLang OpenAI-compatible `response_format: { "type": "json_schema", ... }` shape. |
+
+Unknown values fail config validation rather than silently downgrading. Schema
+mode evidence is stamped as `constrained:<mode>`; `none` and plain
+`json-object` remain the recovery path because they do not enforce the findings
+schema.
+
 ## Safety Defaults
 
 Mutation, finishing touches, issue enrichment, and public confidence percentages are default-off in this draft. A future runtime loader should fail before review starts when a repo config tries to enable unsupported unsafe behavior.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -24,6 +24,11 @@ Official/provider-owned docs:
 - [Z.AI OpenAI SDK compatibility](https://docs.z.ai/guides/develop/openai/python)
 - [Z.AI current GLM coding model guidance](https://docs.z.ai/devpack/latest-model)
 - [Ollama OpenAI compatibility](https://docs.ollama.com/api/openai-compatibility)
+- [Ollama structured outputs](https://docs.ollama.com/capabilities/structured-outputs)
+- [LM Studio structured output](https://lmstudio.ai/docs/developer/openai-compat/structured-output)
+- [vLLM structured outputs](https://docs.vllm.ai/en/latest/features/structured_outputs/)
+- [llama.cpp server OpenAI-compatible endpoint](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md)
+- [SGLang structured outputs](https://docs.sglang.io/docs/advanced_features/structured_outputs)
 
 Discovery/resource catalogs:
 
@@ -52,8 +57,8 @@ Status definitions:
 | Provider, runtime, or resource | Status | How to verify | Egress posture | Tracking |
 | --- | --- | --- | --- | --- |
 | GLM/Z.AI through ZCode (`zcode-glm`) | `default beta path`; `tested by NeonDiff` as the current live review route | `neondiff providers doctor --config config.local.json --json`, then a dry-run review before live posting | Hosted Z.AI/GLM path through ZCode can receive prompts and diffs | Provider sprint [#238](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/238) |
-| Ollama on `http://localhost:11434/v1` | `compatible by interface`; provider doctor/smoke only until adapter proof promotes live review | Enable the local provider and run `neondiff providers doctor --config config.local.json --provider ollama-local --smoke true --json` | No-egress only when endpoint is loopback or self-hosted and the model runs locally | OpenAI-compatible adapter [#240](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/240) |
-| LM Studio, vLLM, or local OpenAI-compatible gateway | `compatible by interface`; `tracked/planned` for live adapter proof | Use an explicit provider id and local `/v1` base URL; promote only after fixture and dry-run review proof | No-egress only for local/self-hosted endpoints; hosted gateways are remote egress | OpenAI-compatible adapter [#240](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/240) |
+| Ollama on `http://localhost:11434/v1` | `compatible by interface`; `ollama-format-json-schema` request construction shipped behind explicit config | Enable the local provider and run `neondiff providers doctor --config config.local.json --provider ollama-local --smoke true --json`, then a review fixture/dry-run | No-egress only when endpoint is loopback or self-hosted and the model runs locally | OpenAI-compatible adapter [#240](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/240), schema mode [#399](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/399) |
+| LM Studio, vLLM, llama.cpp, SGLang, or local OpenAI-compatible gateway | `compatible by interface`; schema-constrained request construction shipped behind explicit config | Use an explicit provider id and local `/v1` base URL; promote only after fixture and dry-run review proof | No-egress only for local/self-hosted endpoints; hosted gateways are remote egress | OpenAI-compatible adapter [#240](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/240), schema mode [#399](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/399) |
 | Hosted OpenAI-compatible BYOK gateway | `compatible by interface`; remote smoke and live review proof required | Store only `apiKeyEnv`, run a single-provider smoke, then record redacted evidence before live review | Hosted provider receives prompts and diffs | Hosted BYOK coverage [#241](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/241) |
 | Free/trial provider catalogs such as `cheahjs/free-llm-api-resources` | `resource only / untested` unless a provider has a NeonDiff proof issue | Verify provider terms, model availability, OpenAI compatibility, quota, and NeonDiff proof separately | Usually hosted egress; read each provider's terms and privacy posture | This resource issue [#242](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/242) |
 | Agent runtimes such as Codex CLI, Claude Code, and OpenCode | `tracked/planned`; discovery only | Do not configure as a live review provider until the runtime contract is documented and proven | Depends on each runtime/provider chain; no general no-egress claim | Agent runtime discovery [#243](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/243) |
@@ -147,6 +152,52 @@ does not need an API key:
         "baseUrl": "http://localhost:11434/v1",
         "model": "qwen2.5-coder:7b",
         "authMode": "none",
+        "capabilities": {
+          "review": true,
+          "jsonOutput": true,
+          "local": true,
+          "streaming": false
+        }
+      }
+    }
+  }
+}
+```
+
+## Structured Findings JSON Modes
+
+NeonDiff always validates model output with the canonical findings parser before
+posting comments. `structuredOutputMode` is an optional provider request hint
+that asks compatible local backends to constrain decoding to the same findings
+JSON Schema before the response reaches NeonDiff. It is additive and
+default-compatible: unsupported providers can keep the recovery path, while
+schema-capable providers record `structuredOutputMode: "constrained:<mode>"` in
+adapter evidence.
+
+| Mode | Request shape | Intended backend |
+| --- | --- | --- |
+| `none` | no provider-side JSON/structured-output field | recovery-only providers |
+| `json-object` | `response_format: { "type": "json_object" }` | legacy OpenAI-compatible JSON mode |
+| `openai-json-schema` | `response_format: { "type": "json_schema", "json_schema": { "name", "strict", "schema" } }` | LM Studio and OpenAI-style structured-output gateways |
+| `llama-cpp-json-schema` | `response_format: { "type": "json_schema", "schema": <findings schema> }` | llama.cpp server variants |
+| `vllm-structured-outputs` | `structured_outputs: { "json": <findings schema> }` | current vLLM OpenAI-compatible serving |
+| `vllm-guided-json` | `guided_json: <findings schema>` | older vLLM deployments that still accept the legacy field |
+| `ollama-format-json-schema` | `format: <findings schema>` | Ollama structured-output compatible endpoints |
+| `sglang-json-schema` | OpenAI-style `response_format: { "type": "json_schema", ... }` | SGLang OpenAI-compatible serving |
+
+Example local Ollama-style schema mode:
+
+```json
+{
+  "providers": {
+    "providers": {
+      "ollama-local": {
+        "enabled": true,
+        "adapter": "openai-compatible",
+        "baseUrl": "http://localhost:11434/v1",
+        "model": "qwen2.5-coder:7b",
+        "authMode": "none",
+        "structuredOutputMode": "ollama-format-json-schema",
         "capabilities": {
           "review": true,
           "jsonOutput": true,

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -59,7 +59,7 @@ const REPO_PROFILE_NESTED_PATTERN =
   new RegExp(`^repoProfiles\\.repos\\.(${CONFIG_NAME_SEGMENT_PATTERN}\\/${CONFIG_NAME_SEGMENT_PATTERN})\\.(?:autoReview\\.(?:baseBranches|labels)|preMergeChecks\\.(?:title|description|linkedIssue|testEvidence|docs|docstrings)\\.(?:mode|instructions|threshold)|finishingTouches\\.(?:docs|docstrings|unitTests|simplifySuggestion|changelogDraft|riskExplanation|reviewReady|stackedPr)\\.(?:enabled|instructions))$`);
 
 const PROVIDER_SAFE_FIELD_PATTERN =
-  new RegExp(`^providers\\.providers\\.(${CONFIG_NAME_SEGMENT_PATTERN})\\.(?:enabled|adapter|displayName|baseUrl|model|authMode|apiKeyEnv|contextWindowTokens|timeoutMs|retryMaxRetries)$`);
+  new RegExp(`^providers\\.providers\\.(${CONFIG_NAME_SEGMENT_PATTERN})\\.(?:enabled|adapter|displayName|baseUrl|model|authMode|apiKeyEnv|contextWindowTokens|timeoutMs|retryMaxRetries|structuredOutputMode)$`);
 
 const PROVIDER_CAPABILITY_PATTERN =
   new RegExp(`^providers\\.providers\\.(${CONFIG_NAME_SEGMENT_PATTERN})\\.capabilities\\.(?:review|jsonOutput|local|streaming)$`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ import {
   PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND,
   type PublicConfidenceDisplayPolicy
 } from "./public-confidence.js";
-import { isApiKeyEnvName, isProviderId, type ProviderRegistryConfig } from "./providers.js";
+import { isApiKeyEnvName, isProviderId, isProviderStructuredOutputMode, PROVIDER_STRUCTURED_OUTPUT_MODES, type ProviderRegistryConfig } from "./providers.js";
 import { REGRESSION_CATEGORIES, type CategoryPrecisionFloors, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import type { ReviewMode, ReviewModeDefinition, ReviewModesConfig } from "./review-mode-types.js";
 import { containsSecretLikeText } from "./secrets.js";
@@ -1331,6 +1331,9 @@ function validateProviderRegistryEntry(value: unknown, label: string): void {
   if (value.contextWindowTokens !== undefined) validatePositiveInteger(value.contextWindowTokens, `${label}.contextWindowTokens`);
   if (value.timeoutMs !== undefined) validatePositiveInteger(value.timeoutMs, `${label}.timeoutMs`);
   if (value.retryMaxRetries !== undefined) validateNonNegativeInteger(value.retryMaxRetries, `${label}.retryMaxRetries`);
+  if (value.structuredOutputMode !== undefined && !isProviderStructuredOutputMode(value.structuredOutputMode)) {
+    throw new Error(`${label}.structuredOutputMode must be one of ${PROVIDER_STRUCTURED_OUTPUT_MODES.join(", ")}`);
+  }
   if (!isRecord(value.capabilities)) throw new Error(`${label}.capabilities must be an object`);
   for (const capability of ["review", "jsonOutput", "local", "streaming"] as const) {
     validateBoolean(value.capabilities[capability], `${label}.capabilities.${capability}`);

--- a/src/findings-schema.ts
+++ b/src/findings-schema.ts
@@ -1,0 +1,56 @@
+import { REGRESSION_CATEGORIES } from "./regression-taxonomy.js";
+
+export const REVIEW_FINDINGS_JSON_SCHEMA_NAME = "neondiff_review_findings";
+export const REVIEW_FINDINGS_JSON_SCHEMA_STRICT = true;
+
+export interface ReviewFindingsJsonSchema {
+  type: "object";
+  additionalProperties: false;
+  required: ["findings"];
+  properties: {
+    findings: {
+      type: "array";
+      items: {
+        type: "object";
+        additionalProperties: false;
+        required: ["severity", "path", "line", "title", "body", "confidence"];
+        properties: {
+          severity: { type: "string"; enum: ["P0", "P1", "P2", "P3"] };
+          path: { type: "string"; minLength: 1 };
+          line: { type: "integer"; minimum: 1 };
+          title: { type: "string"; minLength: 1 };
+          body: { type: "string"; minLength: 1 };
+          confidence: { type: "number"; minimum: 0; maximum: 1 };
+          category: { type: "string"; enum: typeof REGRESSION_CATEGORIES };
+          why_this_matters: { type: "string"; minLength: 1 };
+        };
+      };
+    };
+  };
+}
+
+export const REVIEW_FINDINGS_JSON_SCHEMA: ReviewFindingsJsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["findings"],
+  properties: {
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["severity", "path", "line", "title", "body", "confidence"],
+        properties: {
+          severity: { type: "string", enum: ["P0", "P1", "P2", "P3"] },
+          path: { type: "string", minLength: 1 },
+          line: { type: "integer", minimum: 1 },
+          title: { type: "string", minLength: 1 },
+          body: { type: "string", minLength: 1 },
+          confidence: { type: "number", minimum: 0, maximum: 1 },
+          category: { type: "string", enum: REGRESSION_CATEGORIES },
+          why_this_matters: { type: "string", minLength: 1 }
+        }
+      }
+    }
+  }
+};

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -1,7 +1,12 @@
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
+import {
+  REVIEW_FINDINGS_JSON_SCHEMA,
+  REVIEW_FINDINGS_JSON_SCHEMA_NAME,
+  REVIEW_FINDINGS_JSON_SCHEMA_STRICT
+} from "./findings-schema.js";
 import { parseFindings } from "./findings.js";
-import { openAICompatibleProviderTargetError, type ProviderRegistryEntry } from "./providers.js";
+import { openAICompatibleProviderTargetError, type ProviderRegistryEntry, type ProviderStructuredOutputMode } from "./providers.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 const EVIDENCE_PREVIEW_LIMIT = 500;
@@ -16,6 +21,14 @@ const REDACTION_TOKENS = [
   "[redacted-sensitive-field]",
   "[redacted-unserializable-evidence]"
 ] as const;
+const SCHEMA_CONSTRAINED_OUTPUT_MODES = new Set<ProviderStructuredOutputMode>([
+  "openai-json-schema",
+  "llama-cpp-json-schema",
+  "vllm-structured-outputs",
+  "vllm-guided-json",
+  "ollama-format-json-schema",
+  "sglang-json-schema"
+]);
 
 export type ProviderAdapterErrorClass =
   | "auth"
@@ -180,11 +193,12 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
 
       const apiKey = resolveOpenAICompatibleApiKey(provider, env);
       const timeout = createAbortSignal(provider.timeoutMs);
+      const structuredOutput = buildStructuredOutputRequestFields(provider);
       const requestBody = {
         model: input.model,
         stream: false,
         ...(provider.temperature === undefined ? {} : { temperature: provider.temperature }),
-        ...(provider.capabilities.jsonOutput && provider.jsonObjectResponseFormat !== false ? { response_format: { type: "json_object" } } : {}),
+        ...structuredOutput.requestFields,
         messages: [
           {
             role: "system",
@@ -233,6 +247,7 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
             adapterId: input.adapterId,
             model: input.model,
             baseUrl,
+            structuredOutputMode: structuredOutput.evidenceMode,
             status: response.status,
             ...(typeof parsed.id === "string" ? { responseId: parsed.id } : {}),
             ...extractOpenAICompatibleChoiceEvidence(parsed),
@@ -244,6 +259,77 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
       }
     }
   };
+}
+
+function buildStructuredOutputRequestFields(provider: ProviderRegistryEntry): {
+  requestFields: Record<string, unknown>;
+  evidenceMode: string;
+} {
+  const mode = resolveStructuredOutputMode(provider);
+  const evidenceMode = SCHEMA_CONSTRAINED_OUTPUT_MODES.has(mode)
+    ? `constrained:${mode}`
+    : "recovery";
+
+  switch (mode) {
+    case "none":
+      return { requestFields: {}, evidenceMode };
+    case "json-object":
+      return { requestFields: { response_format: { type: "json_object" } }, evidenceMode };
+    case "openai-json-schema":
+    case "sglang-json-schema":
+      return {
+        requestFields: {
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: REVIEW_FINDINGS_JSON_SCHEMA_NAME,
+              strict: REVIEW_FINDINGS_JSON_SCHEMA_STRICT,
+              schema: REVIEW_FINDINGS_JSON_SCHEMA
+            }
+          }
+        },
+        evidenceMode
+      };
+    case "llama-cpp-json-schema":
+      return {
+        requestFields: {
+          response_format: {
+            type: "json_schema",
+            schema: REVIEW_FINDINGS_JSON_SCHEMA
+          }
+        },
+        evidenceMode
+      };
+    case "vllm-structured-outputs":
+      return {
+        requestFields: {
+          structured_outputs: {
+            json: REVIEW_FINDINGS_JSON_SCHEMA
+          }
+        },
+        evidenceMode
+      };
+    case "vllm-guided-json":
+      return {
+        requestFields: {
+          guided_json: REVIEW_FINDINGS_JSON_SCHEMA
+        },
+        evidenceMode
+      };
+    case "ollama-format-json-schema":
+      return {
+        requestFields: {
+          format: REVIEW_FINDINGS_JSON_SCHEMA
+        },
+        evidenceMode
+      };
+  }
+}
+
+function resolveStructuredOutputMode(provider: ProviderRegistryEntry): ProviderStructuredOutputMode {
+  if (provider.structuredOutputMode) return provider.structuredOutputMode;
+  if (provider.capabilities.jsonOutput && provider.jsonObjectResponseFormat !== false) return "json-object";
+  return "none";
 }
 
 export function buildOpenAIChatCompletionsUrl(baseUrl: string): string {

--- a/src/provider-registry.ts
+++ b/src/provider-registry.ts
@@ -1,4 +1,5 @@
 import { redactSecrets } from "./secrets.js";
+import type { ProviderStructuredOutputMode } from "./providers.js";
 
 export type ProviderFamilyId =
   | "glm"
@@ -33,6 +34,7 @@ export interface ProviderFamily {
   authHints: readonly ProviderAuthHint[];
   locality: ProviderLocality;
   supportsJsonMode: ProviderSupport;
+  structuredOutputModes: readonly ProviderStructuredOutputMode[];
   supportsToolUse: ProviderSupport;
   riskNotes: readonly string[];
   byok: {
@@ -79,6 +81,7 @@ export const PROVIDER_FAMILY_CATALOG = [
     ],
     locality: "remote",
     supportsJsonMode: true,
+    structuredOutputModes: ["json-object"],
     supportsToolUse: "unknown",
     riskNotes: [
       "Hosted provider; review prompts and repository excerpts can leave the local machine.",
@@ -92,7 +95,19 @@ export const PROVIDER_FAMILY_CATALOG = [
   {
     id: "openai-compatible",
     displayName: "OpenAI-Compatible API",
-    aliases: ["openai-compatible-api", "openai-compatible-endpoint", "openrouter", "vllm", "lm-studio", "internal-gateway"],
+    aliases: [
+      "openai-compatible-api",
+      "openai-compatible-endpoint",
+      "openrouter",
+      "vllm",
+      "lm-studio",
+      "lms",
+      "llama.cpp",
+      "llama-cpp",
+      "llama-server",
+      "sglang",
+      "internal-gateway"
+    ],
     transport: "openai-compatible-chat-completions",
     apiShape: "OpenAI-style /v1/chat/completions and /v1/models endpoints.",
     authHints: [
@@ -103,6 +118,14 @@ export const PROVIDER_FAMILY_CATALOG = [
     ],
     locality: "local-or-remote",
     supportsJsonMode: "unknown",
+    structuredOutputModes: [
+      "json-object",
+      "openai-json-schema",
+      "llama-cpp-json-schema",
+      "vllm-structured-outputs",
+      "vllm-guided-json",
+      "sglang-json-schema"
+    ],
     supportsToolUse: "unknown",
     riskNotes: [
       "Compatibility varies by gateway and model; validate JSON output and context behavior before promotion.",
@@ -126,6 +149,7 @@ export const PROVIDER_FAMILY_CATALOG = [
     ],
     locality: "local",
     supportsJsonMode: "unknown",
+    structuredOutputModes: ["json-object", "ollama-format-json-schema"],
     supportsToolUse: "unknown",
     riskNotes: [
       "No-egress posture depends on using a loopback endpoint and a local model.",
@@ -150,6 +174,7 @@ export const PROVIDER_FAMILY_CATALOG = [
     ],
     locality: "remote",
     supportsJsonMode: false,
+    structuredOutputModes: [],
     supportsToolUse: true,
     riskNotes: [
       "Hosted provider; review prompts and repository excerpts can leave the local machine.",
@@ -174,6 +199,7 @@ export const PROVIDER_FAMILY_CATALOG = [
     ],
     locality: "remote",
     supportsJsonMode: true,
+    structuredOutputModes: ["json-object", "openai-json-schema"],
     supportsToolUse: true,
     riskNotes: [
       "Hosted provider; review prompts and repository excerpts can leave the local machine.",
@@ -202,6 +228,7 @@ export const PROVIDER_FAMILY_CATALOG = [
     ],
     locality: "remote",
     supportsJsonMode: true,
+    structuredOutputModes: ["json-object"],
     supportsToolUse: true,
     riskNotes: [
       "Hosted provider; review prompts and repository excerpts can leave the local machine.",
@@ -274,6 +301,7 @@ export function toPublicProviderFamily(provider: ProviderFamily): PublicProvider
     })),
     locality: provider.locality,
     supportsJsonMode: provider.supportsJsonMode,
+    structuredOutputModes: [...provider.structuredOutputModes],
     supportsToolUse: provider.supportsToolUse,
     riskNotes: provider.riskNotes.map((note) => redactProviderPublicText(note)),
     byok: {
@@ -301,6 +329,7 @@ function cloneProviderFamily(provider: ProviderFamily): ProviderFamily {
   return {
     ...provider,
     aliases: [...provider.aliases],
+    structuredOutputModes: [...provider.structuredOutputModes],
     authHints: provider.authHints.map((hint) => ({ ...hint })),
     riskNotes: [...provider.riskNotes],
     byok: { ...provider.byok }

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -45,6 +45,18 @@ export type ProviderSmokeRequestImpl = (
 
 export type ProviderAdapter = "zcode" | "openai-compatible" | "anthropic" | "openai" | "gemini";
 export type ProviderAuthMode = "zcode-app-config" | "api-key-env" | "none";
+export const PROVIDER_STRUCTURED_OUTPUT_MODES = [
+  "none",
+  "json-object",
+  "openai-json-schema",
+  "llama-cpp-json-schema",
+  "vllm-structured-outputs",
+  "vllm-guided-json",
+  "ollama-format-json-schema",
+  "sglang-json-schema"
+] as const;
+
+export type ProviderStructuredOutputMode = typeof PROVIDER_STRUCTURED_OUTPUT_MODES[number];
 
 export interface ProviderCapabilityFlags {
   review: boolean;
@@ -66,6 +78,7 @@ export interface ProviderRegistryEntry {
   retryMaxRetries?: number;
   temperature?: number;
   jsonObjectResponseFormat?: boolean;
+  structuredOutputMode?: ProviderStructuredOutputMode;
   capabilities: ProviderCapabilityFlags;
 }
 
@@ -96,6 +109,7 @@ export interface ProviderRegistrySummaryEntry {
   contextWindowTokens?: number;
   timeoutMs?: number;
   retryMaxRetries?: number;
+  structuredOutputMode?: ProviderStructuredOutputMode;
   capabilities: ProviderCapabilityFlags;
   currentRuntime?: boolean;
 }
@@ -146,6 +160,7 @@ export function buildProviderRegistrySummary(input: {
       ...(provider.contextWindowTokens ? { contextWindowTokens: provider.contextWindowTokens } : {}),
       ...(provider.timeoutMs ? { timeoutMs: provider.timeoutMs } : {}),
       ...(provider.retryMaxRetries !== undefined ? { retryMaxRetries: provider.retryMaxRetries } : {}),
+      ...(provider.structuredOutputMode ? { structuredOutputMode: provider.structuredOutputMode } : {}),
       capabilities: provider.capabilities,
       currentRuntime: provider.adapter === "zcode" && (
         currentZCodeProviderId
@@ -154,6 +169,10 @@ export function buildProviderRegistrySummary(input: {
       )
     }))
   };
+}
+
+export function isProviderStructuredOutputMode(value: unknown): value is ProviderStructuredOutputMode {
+  return typeof value === "string" && (PROVIDER_STRUCTURED_OUTPUT_MODES as readonly string[]).includes(value);
 }
 
 export async function doctorProviderRegistry(input: {

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -162,6 +162,7 @@ describe("desktop config CLI", () => {
             baseUrl: "http://localhost:11434/v1",
             model: "qwen2.5-coder:14b",
             authMode: "none",
+            structuredOutputMode: "ollama-format-json-schema",
             capabilities: {
               review: true,
               jsonOutput: true
@@ -204,6 +205,7 @@ describe("desktop config CLI", () => {
         "providers.providers.ollama-local.baseUrl",
         "providers.providers.ollama-local.model",
         "providers.providers.ollama-local.authMode",
+        "providers.providers.ollama-local.structuredOutputMode",
         "providers.providers.ollama-local.capabilities.review",
         "providers.providers.ollama-local.capabilities.jsonOutput",
         "providers.providers.openai-compatible.apiKeyEnv"

--- a/tests/findings.test.ts
+++ b/tests/findings.test.ts
@@ -1,9 +1,56 @@
 import { describe, expect, it } from "vitest";
+import { REVIEW_FINDINGS_JSON_SCHEMA } from "../src/findings-schema.js";
 import { decideReviewEvent, formatReviewComment, normalizeFindingsForReview, parseFindings, suppressSameRunNearDuplicates } from "../src/findings.js";
 import type { PublicConfidenceDisplayPolicy } from "../src/public-confidence.js";
 import type { Finding } from "../src/types.js";
 
 describe("finding normalization and review policy", () => {
+  it("exports a canonical JSON schema matching the parseFindings envelope", () => {
+    expect(REVIEW_FINDINGS_JSON_SCHEMA).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+      required: ["findings"],
+      properties: {
+        findings: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["severity", "path", "line", "title", "body", "confidence"],
+            properties: {
+              severity: { type: "string", enum: ["P0", "P1", "P2", "P3"] },
+              path: { type: "string", minLength: 1 },
+              line: { type: "integer", minimum: 1 },
+              title: { type: "string", minLength: 1 },
+              body: { type: "string", minLength: 1 },
+              confidence: { type: "number", minimum: 0, maximum: 1 },
+              category: {
+                type: "string",
+                enum: [
+                  "data_loss",
+                  "auth",
+                  "ci_build",
+                  "unity_scene_prefab",
+                  "security_boundary",
+                  "migration",
+                  "api_compatibility",
+                  "release_regression",
+                  "flaky_test_risk",
+                  "proof_gap",
+                  "runtime_correctness",
+                  "dependency",
+                  "docs_only",
+                  "unknown"
+                ]
+              },
+              why_this_matters: { type: "string", minLength: 1 }
+            }
+          }
+        }
+      }
+    });
+  });
+
   it("orders same-severity findings by confidence and caps the lowest-confidence first", () => {
     const findings: Finding[] = [
       {

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -1,6 +1,12 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
+  REVIEW_FINDINGS_JSON_SCHEMA,
+  REVIEW_FINDINGS_JSON_SCHEMA_NAME,
+  REVIEW_FINDINGS_JSON_SCHEMA_STRICT,
+  type ReviewFindingsJsonSchema
+} from "../src/findings-schema.js";
+import {
   buildOpenAIChatCompletionsUrl,
   classifyProviderAdapterError,
   createOpenAICompatibleReviewAdapter,
@@ -351,6 +357,174 @@ describe("provider adapter fixtures", () => {
     });
 
     expect(result.ok).toBe(true);
+  });
+
+  it("sends the canonical findings schema for OpenAI-style structured output providers", async () => {
+    const seenBodies: unknown[] = [];
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "lm-studio-local",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://127.0.0.1:1234/v1",
+          structuredOutputMode: "openai-json-schema"
+        }),
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as {
+            response_format?: {
+              type?: string;
+              json_schema?: {
+                name?: string;
+                strict?: boolean;
+                schema?: ReviewFindingsJsonSchema;
+              };
+            };
+          };
+          seenBodies.push(body);
+          expect(body.response_format).toEqual({
+            type: "json_schema",
+            json_schema: {
+              name: REVIEW_FINDINGS_JSON_SCHEMA_NAME,
+              strict: REVIEW_FINDINGS_JSON_SCHEMA_STRICT,
+              schema: REVIEW_FINDINGS_JSON_SCHEMA
+            }
+          });
+          return jsonResponse({
+            choices: [
+              {
+                message: {
+                  content: '{"findings":[],"summary":"Structured JSON schema request parsed."}'
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "openai-json-schema-fixture",
+        providerId: "lm-studio-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(seenBodies).toHaveLength(1);
+    expect(result.evidence.rawEvidencePreview).toContain('"structuredOutputMode":"constrained:openai-json-schema"');
+  });
+
+  it("maps backend-specific structured output modes to their provider request fields", async () => {
+    const cases = [
+      {
+        mode: "llama-cpp-json-schema",
+        expected: {
+          response_format: {
+            type: "json_schema",
+            schema: REVIEW_FINDINGS_JSON_SCHEMA
+          }
+        }
+      },
+      {
+        mode: "vllm-structured-outputs",
+        expected: {
+          structured_outputs: {
+            json: REVIEW_FINDINGS_JSON_SCHEMA
+          }
+        }
+      },
+      {
+        mode: "vllm-guided-json",
+        expected: {
+          guided_json: REVIEW_FINDINGS_JSON_SCHEMA
+        }
+      },
+      {
+        mode: "ollama-format-json-schema",
+        expected: {
+          format: REVIEW_FINDINGS_JSON_SCHEMA
+        }
+      },
+      {
+        mode: "sglang-json-schema",
+        expected: {
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: REVIEW_FINDINGS_JSON_SCHEMA_NAME,
+              strict: REVIEW_FINDINGS_JSON_SCHEMA_STRICT,
+              schema: REVIEW_FINDINGS_JSON_SCHEMA
+            }
+          }
+        }
+      }
+    ] as const;
+
+    for (const testCase of cases) {
+      const result = await runProviderAdapterFixture({
+        adapter: createOpenAICompatibleReviewAdapter({
+          providerId: `provider-${testCase.mode}`,
+          provider: makeOpenAICompatibleProvider({
+            structuredOutputMode: testCase.mode
+          }),
+          fetchImpl: async (_url, init) => {
+            const body = JSON.parse(String(init?.body)) as unknown;
+            expect(body).toMatchObject(testCase.expected);
+            return jsonResponse({
+              choices: [
+                {
+                  message: {
+                    content: '{"findings":[],"summary":"Backend structured mode parsed."}'
+                  }
+                }
+              ]
+            });
+          }
+        }),
+        fixture: makeFixture({
+          id: `${testCase.mode}-fixture`,
+          providerId: `provider-${testCase.mode}`,
+          adapterId: "openai-compatible",
+          expectReviewJson: true
+        })
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.evidence.rawEvidencePreview).toContain(`"structuredOutputMode":"constrained:${testCase.mode}"`);
+    }
+  });
+
+  it("keeps unsupported providers on the recovery path when structured output is explicitly disabled", async () => {
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "schema-disabled-local",
+        provider: makeOpenAICompatibleProvider({
+          structuredOutputMode: "none"
+        }),
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as { response_format?: unknown; guided_json?: unknown; format?: unknown };
+          expect(body).not.toHaveProperty("response_format");
+          expect(body).not.toHaveProperty("guided_json");
+          expect(body).not.toHaveProperty("format");
+          return jsonResponse({
+            choices: [
+              {
+                message: {
+                  content: '{"findings":[],"summary":"Recovery-only path parsed."}'
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "schema-disabled-fixture",
+        providerId: "schema-disabled-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.evidence.rawEvidencePreview).toContain('"structuredOutputMode":"recovery"');
   });
 
   it("times out OpenAI-compatible responses that stall after headers", async () => {

--- a/tests/provider-registry-catalog.test.ts
+++ b/tests/provider-registry-catalog.test.ts
@@ -26,6 +26,8 @@ describe("provider family catalog", () => {
     expect(findProviderFamily("z.ai")?.id).toBe("glm");
     expect(findProviderFamily("ZCODE")?.id).toBe("glm");
     expect(findProviderFamily("openai-compatible-api")?.id).toBe("openai-compatible");
+    expect(findProviderFamily("llama.cpp")?.id).toBe("openai-compatible");
+    expect(findProviderFamily("sglang")?.id).toBe("openai-compatible");
     expect(findProviderFamily("ollama-local")?.id).toBe("ollama");
     expect(findProviderFamily("claude")?.id).toBe("anthropic");
     expect(findProviderFamily("google-ai")?.id).toBe("gemini");
@@ -65,6 +67,16 @@ describe("provider family catalog", () => {
       firstProviderId: "glm",
       duplicateProviderId: "glm"
     });
+  });
+
+  it("publishes structured-output capability modes for grammar-capable local backends", () => {
+    expect(findProviderFamily("lm-studio")?.structuredOutputModes).toEqual(
+      expect.arrayContaining(["openai-json-schema", "llama-cpp-json-schema", "vllm-structured-outputs", "sglang-json-schema"])
+    );
+    expect(findProviderFamily("ollama-local")?.structuredOutputModes).toEqual(
+      expect.arrayContaining(["json-object", "ollama-format-json-schema"])
+    );
+    expect(findProviderFamily("zcode-glm")?.structuredOutputModes).toEqual(["json-object"]);
   });
 
   it("keeps public metadata free of secret-looking auth values", () => {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -149,6 +149,21 @@ describe("provider registry", () => {
     });
     expect(zcodeRuntimeWithAlternateDefault.providers.find((provider) => provider.id === "zcode-glm")).toMatchObject({ currentRuntime: true });
     expect(zcodeRuntimeWithAlternateDefault.providers.find((provider) => provider.id === "ollama-local")).toMatchObject({ currentRuntime: false });
+    const explicitStructuredMode = buildProviderRegistrySummary({
+      registry: {
+        ...config.providers!,
+        providers: {
+          ...config.providers!.providers,
+          "openai-compatible": {
+            ...config.providers!.providers["openai-compatible"],
+            structuredOutputMode: "openai-json-schema"
+          }
+        }
+      }
+    });
+    expect(explicitStructuredMode.providers.find((provider) => provider.id === "openai-compatible")).toMatchObject({
+      structuredOutputMode: "openai-json-schema"
+    });
 
     const doctor = await doctorProviderRegistry({ registry: config.providers! });
     expect(doctor).toMatchObject({
@@ -2211,5 +2226,27 @@ describe("provider registry", () => {
         }
       }
     })).toThrow(/authMode none is not supported for zcode provider/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "bad-structured-mode",
+        providers: {
+          "bad-structured-mode": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "http://localhost:11434/v1",
+            model: "review-model",
+            authMode: "none",
+            structuredOutputMode: "typo-json-schema",
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: true,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/structuredOutputMode must be/);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a canonical NeonDiff findings JSON Schema export for provider-side structured output hints.
- Adds explicit opt-in `structuredOutputMode` request mappings for OpenAI/LM Studio, llama.cpp, vLLM, Ollama, and SGLang-compatible backends.
- Records constrained-mode evidence, fails closed on unknown config values, and documents the operator mode matrix.

Closes #399.

## Validation
- `npm test -- --run tests/provider-adapters.test.ts tests/provider-registry.test.ts tests/provider-registry-catalog.test.ts tests/findings.test.ts tests/config-cli.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- `npm run check:public-claims`
- `npm run check:secrets`

## Proof boundary
Request construction, config validation, provider metadata, evidence stamping, and docs only. Ranking, gating, posting, and provider promotion behavior are unchanged.
