### PR TITLE
[codex] Add bounded schema feedback retry

### DIFF
--- a/docs/neondiff-config.md
+++ b/docs/neondiff-config.md
@@ -121,7 +121,11 @@ review call as one total wall-clock budget across all attempts, records
 `schemaRetries` and redacted `schemaRetryErrors` in adapter evidence, and falls
 back to the existing model-output/provider-deferred path after the bounded
 attempts are exhausted. Set the value to `0` to disable this adapter-level
-recovery behavior.
+recovery behavior. Truncated review output, including `finish_reason: "length"`
+or JSON-looking findings output with unclosed delimiters, is excluded from
+schema-feedback retries and fails immediately as a truncation model-output error;
+that failure usually needs a smaller prompt, larger output budget, or stronger
+provider-side structured output rather than another identical reprompt.
 
 ## Safety Defaults
 

--- a/docs/neondiff-config.md
+++ b/docs/neondiff-config.md
@@ -112,6 +112,16 @@ mode evidence is stamped as `constrained:<mode>`; `none` and plain
 `json-object` remain the recovery path because they do not enforce the findings
 schema.
 
+OpenAI-compatible provider entries may also set `retrySchemaFeedbackMax`
+(`integer`, `0..3`, default `2`). When a provider returns malformed review JSON
+or JSON that fails the canonical findings schema, NeonDiff can reprompt the same
+chat-completions conversation with only the exact schema error and the canonical
+findings schema. The retry loop uses the same provider timeout as the original
+review call, records `schemaRetries` and redacted `schemaRetryErrors` in adapter
+evidence, and falls back to the existing model-output/provider-deferred path
+after the bounded attempts are exhausted. Set the value to `0` to disable this
+adapter-level recovery behavior.
+
 ## Safety Defaults
 
 Mutation, finishing touches, issue enrichment, and public confidence percentages are default-off in this draft. A future runtime loader should fail before review starts when a repo config tries to enable unsupported unsafe behavior.

--- a/docs/neondiff-config.md
+++ b/docs/neondiff-config.md
@@ -117,10 +117,11 @@ OpenAI-compatible provider entries may also set `retrySchemaFeedbackMax`
 or JSON that fails the canonical findings schema, NeonDiff can reprompt the same
 chat-completions conversation with only the exact schema error and the canonical
 findings schema. The retry loop uses the same provider timeout as the original
-review call, records `schemaRetries` and redacted `schemaRetryErrors` in adapter
-evidence, and falls back to the existing model-output/provider-deferred path
-after the bounded attempts are exhausted. Set the value to `0` to disable this
-adapter-level recovery behavior.
+review call as one total wall-clock budget across all attempts, records
+`schemaRetries` and redacted `schemaRetryErrors` in adapter evidence, and falls
+back to the existing model-output/provider-deferred path after the bounded
+attempts are exhausted. Set the value to `0` to disable this adapter-level
+recovery behavior.
 
 ## Safety Defaults
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -180,7 +180,10 @@ default is `2`; valid values are `0..3`. Each retry appends a compact corrective
 user message containing the schema validation error and canonical findings JSON
 Schema, never the raw rejected model output. Retries share the original provider
 timeout as one total wall-clock budget across all attempts, and record
-`schemaRetries` plus redacted `schemaRetryErrors` in evidence.
+`schemaRetries` plus redacted `schemaRetryErrors` in evidence. Truncated output
+is not retried: `finish_reason: "length"` and JSON-looking findings output with
+unclosed delimiters fail immediately as truncation model-output errors because
+an identical schema reprompt does not add output budget or shrink context.
 
 | Mode | Request shape | Intended backend |
 | --- | --- | --- |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -174,6 +174,13 @@ default-compatible: unsupported providers can keep the recovery path, while
 schema-capable providers record `structuredOutputMode: "constrained:<mode>"` in
 adapter evidence.
 
+For OpenAI-compatible review adapters, `retrySchemaFeedbackMax` controls bounded
+schema-feedback recovery after malformed or schema-invalid findings JSON. The
+default is `2`; valid values are `0..3`. Each retry appends a compact corrective
+user message containing the schema validation error and canonical findings JSON
+Schema, never the raw rejected model output. Retries share the original provider
+timeout and record `schemaRetries` plus redacted `schemaRetryErrors` in evidence.
+
 | Mode | Request shape | Intended backend |
 | --- | --- | --- |
 | `none` | no provider-side JSON/structured-output field | recovery-only providers |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -179,7 +179,8 @@ schema-feedback recovery after malformed or schema-invalid findings JSON. The
 default is `2`; valid values are `0..3`. Each retry appends a compact corrective
 user message containing the schema validation error and canonical findings JSON
 Schema, never the raw rejected model output. Retries share the original provider
-timeout and record `schemaRetries` plus redacted `schemaRetryErrors` in evidence.
+timeout as one total wall-clock budget across all attempts, and record
+`schemaRetries` plus redacted `schemaRetryErrors` in evidence.
 
 | Mode | Request shape | Intended backend |
 | --- | --- | --- |

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -59,7 +59,7 @@ const REPO_PROFILE_NESTED_PATTERN =
   new RegExp(`^repoProfiles\\.repos\\.(${CONFIG_NAME_SEGMENT_PATTERN}\\/${CONFIG_NAME_SEGMENT_PATTERN})\\.(?:autoReview\\.(?:baseBranches|labels)|preMergeChecks\\.(?:title|description|linkedIssue|testEvidence|docs|docstrings)\\.(?:mode|instructions|threshold)|finishingTouches\\.(?:docs|docstrings|unitTests|simplifySuggestion|changelogDraft|riskExplanation|reviewReady|stackedPr)\\.(?:enabled|instructions))$`);
 
 const PROVIDER_SAFE_FIELD_PATTERN =
-  new RegExp(`^providers\\.providers\\.(${CONFIG_NAME_SEGMENT_PATTERN})\\.(?:enabled|adapter|displayName|baseUrl|model|authMode|apiKeyEnv|contextWindowTokens|timeoutMs|retryMaxRetries|structuredOutputMode)$`);
+  new RegExp(`^providers\\.providers\\.(${CONFIG_NAME_SEGMENT_PATTERN})\\.(?:enabled|adapter|displayName|baseUrl|model|authMode|apiKeyEnv|contextWindowTokens|timeoutMs|retryMaxRetries|retrySchemaFeedbackMax|structuredOutputMode)$`);
 
 const PROVIDER_CAPABILITY_PATTERN =
   new RegExp(`^providers\\.providers\\.(${CONFIG_NAME_SEGMENT_PATTERN})\\.capabilities\\.(?:review|jsonOutput|local|streaming)$`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ import {
   PUBLIC_CONFIDENCE_MIN_WILSON_LOWER_BOUND,
   type PublicConfidenceDisplayPolicy
 } from "./public-confidence.js";
-import { isApiKeyEnvName, isProviderId, isProviderStructuredOutputMode, PROVIDER_STRUCTURED_OUTPUT_MODES, type ProviderRegistryConfig } from "./providers.js";
+import { isApiKeyEnvName, isProviderId, isProviderStructuredOutputMode, PROVIDER_STRUCTURED_OUTPUT_MODES, SCHEMA_FEEDBACK_RETRY_MAX, type ProviderRegistryConfig } from "./providers.js";
 import { REGRESSION_CATEGORIES, type CategoryPrecisionFloors, type RequestChangesConfidenceFloors } from "./regression-taxonomy.js";
 import type { ReviewMode, ReviewModeDefinition, ReviewModesConfig } from "./review-mode-types.js";
 import { containsSecretLikeText } from "./secrets.js";
@@ -1337,7 +1337,7 @@ function validateProviderRegistryEntry(value: unknown, label: string): void {
     if (adapter !== "openai-compatible") {
       throw new Error(`${label}.retrySchemaFeedbackMax is only supported for openai-compatible providers`);
     }
-    validateIntegerRange(value.retrySchemaFeedbackMax, `${label}.retrySchemaFeedbackMax`, 0, 3);
+    validateIntegerRange(value.retrySchemaFeedbackMax, `${label}.retrySchemaFeedbackMax`, 0, SCHEMA_FEEDBACK_RETRY_MAX);
   }
   if (value.structuredOutputMode !== undefined && !isProviderStructuredOutputMode(value.structuredOutputMode)) {
     throw new Error(`${label}.structuredOutputMode must be one of ${PROVIDER_STRUCTURED_OUTPUT_MODES.join(", ")}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1333,7 +1333,12 @@ function validateProviderRegistryEntry(value: unknown, label: string): void {
   if (value.contextWindowTokens !== undefined) validatePositiveInteger(value.contextWindowTokens, `${label}.contextWindowTokens`);
   if (value.timeoutMs !== undefined) validatePositiveInteger(value.timeoutMs, `${label}.timeoutMs`);
   if (value.retryMaxRetries !== undefined) validateNonNegativeInteger(value.retryMaxRetries, `${label}.retryMaxRetries`);
-  if (value.retrySchemaFeedbackMax !== undefined) validateIntegerRange(value.retrySchemaFeedbackMax, `${label}.retrySchemaFeedbackMax`, 0, 3);
+  if (value.retrySchemaFeedbackMax !== undefined) {
+    if (adapter !== "openai-compatible") {
+      throw new Error(`${label}.retrySchemaFeedbackMax is only supported for openai-compatible providers`);
+    }
+    validateIntegerRange(value.retrySchemaFeedbackMax, `${label}.retrySchemaFeedbackMax`, 0, 3);
+  }
   if (value.structuredOutputMode !== undefined && !isProviderStructuredOutputMode(value.structuredOutputMode)) {
     throw new Error(`${label}.structuredOutputMode must be one of ${PROVIDER_STRUCTURED_OUTPUT_MODES.join(", ")}`);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -440,6 +440,7 @@ const DEFAULT_CONFIG: BotConfig = {
         contextWindowTokens: 32_000,
         timeoutMs: 180_000,
         retryMaxRetries: 1,
+        retrySchemaFeedbackMax: 2,
         capabilities: {
           review: true,
           jsonOutput: true,
@@ -458,6 +459,7 @@ const DEFAULT_CONFIG: BotConfig = {
         contextWindowTokens: 128_000,
         timeoutMs: 180_000,
         retryMaxRetries: 1,
+        retrySchemaFeedbackMax: 2,
         capabilities: {
           review: true,
           jsonOutput: true,
@@ -1331,6 +1333,7 @@ function validateProviderRegistryEntry(value: unknown, label: string): void {
   if (value.contextWindowTokens !== undefined) validatePositiveInteger(value.contextWindowTokens, `${label}.contextWindowTokens`);
   if (value.timeoutMs !== undefined) validatePositiveInteger(value.timeoutMs, `${label}.timeoutMs`);
   if (value.retryMaxRetries !== undefined) validateNonNegativeInteger(value.retryMaxRetries, `${label}.retryMaxRetries`);
+  if (value.retrySchemaFeedbackMax !== undefined) validateIntegerRange(value.retrySchemaFeedbackMax, `${label}.retrySchemaFeedbackMax`, 0, 3);
   if (value.structuredOutputMode !== undefined && !isProviderStructuredOutputMode(value.structuredOutputMode)) {
     throw new Error(`${label}.structuredOutputMode must be one of ${PROVIDER_STRUCTURED_OUTPUT_MODES.join(", ")}`);
   }
@@ -1556,6 +1559,12 @@ function validatePositiveInteger(value: unknown, label: string): void {
 
 function validateNonNegativeInteger(value: unknown, label: string): void {
   if (!Number.isInteger(value) || Number(value) < 0) throw new Error(`${label} must be a non-negative integer`);
+}
+
+function validateIntegerRange(value: unknown, label: string, min: number, max: number): void {
+  if (!Number.isInteger(value) || Number(value) < min || Number(value) > max) {
+    throw new Error(`${label} must be an integer from ${min} to ${max}`);
+  }
 }
 
 function validateProbability(value: unknown, label: string): void {

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -16,6 +16,7 @@ const EVIDENCE_PREVIEW_TRUNCATED_SENTINEL = "...[truncated]";
 const DEFAULT_OPENAI_COMPATIBLE_REVIEW_TIMEOUT_MS = 180_000;
 const DEFAULT_SCHEMA_FEEDBACK_RETRY_MAX = 2;
 const MAX_SCHEMA_FEEDBACK_RETRY_MAX = 3;
+const TRUNCATED_REVIEW_JSON_ERROR = "OpenAI-compatible review output was truncated before a parseable JSON review object (finish_reason=length).";
 const REDACTION_TOKENS = [
   "[redacted-private-evidence]",
   "[redacted-private-field]",
@@ -200,56 +201,65 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
       const schemaRetryErrors: string[] = [];
       try {
         for (let attempt = 0; attempt <= schemaFeedbackMax; attempt += 1) {
-          const response = await fetchImpl(buildOpenAIChatCompletionsUrl(baseUrl), {
-            method: "POST",
-            signal: timeout.signal,
-            headers: {
-              Accept: "application/json",
-              "Content-Type": "application/json",
-              ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
-            },
-            body: JSON.stringify(buildOpenAICompatibleReviewRequestBody({
-              provider,
-              model: input.model,
-              prompt: input.prompt,
-              structuredOutput,
-              schemaRetryErrors
-            }))
-          });
+          try {
+            const response = await fetchImpl(buildOpenAIChatCompletionsUrl(baseUrl), {
+              method: "POST",
+              signal: timeout.signal,
+              headers: {
+                Accept: "application/json",
+                "Content-Type": "application/json",
+                ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
+              },
+              body: JSON.stringify(buildOpenAICompatibleReviewRequestBody({
+                provider,
+                model: input.model,
+                prompt: input.prompt,
+                structuredOutput,
+                schemaRetryErrors
+              }))
+            });
 
-          if (!response.ok) {
-            const responseErrorText = await readResponseTextWithAbort(response, timeout.signal);
-            throw new Error(openAICompatibleStatusErrorMessage(response.status, responseErrorText));
-          }
-
-          const responseText = await readResponseTextWithAbort(response, timeout.signal);
-          const parsed = parseOpenAICompatibleResponse(responseText);
-          const content = extractOpenAICompatibleMessageContent(parsed);
-          const reviewOutput = normalizeReviewJsonOutput(content);
-          if (!reviewOutput.ok) {
-            const schemaError = openAICompatibleReviewSchemaError(reviewOutput.error, parsed);
-            if (schemaRetryErrors.length >= schemaFeedbackMax) throw new Error(schemaError);
-            schemaRetryErrors.push(schemaError);
-            continue;
-          }
-
-          return {
-            text: reviewOutput.text,
-            reviewJsonValidated: true,
-            rawEvidence: {
-              providerId: options.providerId,
-              adapterId: input.adapterId,
-              model: input.model,
-              baseUrl,
-              structuredOutputMode: structuredOutput.evidenceMode,
-              schemaRetries: schemaRetryErrors.length,
-              ...(schemaRetryErrors.length > 0 ? { schemaRetryErrors } : {}),
-              status: response.status,
-              ...(typeof parsed.id === "string" ? { responseId: parsed.id } : {}),
-              ...extractOpenAICompatibleChoiceEvidence(parsed),
-              ...extractOpenAICompatibleUsageEvidence(parsed)
+            if (!response.ok) {
+              const responseErrorText = await readResponseTextWithAbort(response, timeout.signal);
+              throw new Error(openAICompatibleStatusErrorMessage(response.status, responseErrorText));
             }
-          };
+
+            const responseText = await readResponseTextWithAbort(response, timeout.signal);
+            const parsed = parseOpenAICompatibleResponse(responseText);
+            const content = extractOpenAICompatibleMessageContent(parsed);
+            const reviewOutput = normalizeReviewJsonOutput(content);
+            if (!reviewOutput.ok) {
+              const schemaError = openAICompatibleReviewSchemaError(reviewOutput.error, parsed);
+              if (schemaError === TRUNCATED_REVIEW_JSON_ERROR || schemaRetryErrors.length >= schemaFeedbackMax) {
+                throw new Error(schemaError);
+              }
+              schemaRetryErrors.push(schemaError);
+              continue;
+            }
+
+            return {
+              text: reviewOutput.text,
+              reviewJsonValidated: true,
+              rawEvidence: {
+                providerId: options.providerId,
+                adapterId: input.adapterId,
+                model: input.model,
+                baseUrl,
+                structuredOutputMode: structuredOutput.evidenceMode,
+                schemaRetries: schemaRetryErrors.length,
+                ...(schemaRetryErrors.length > 0 ? { schemaRetryErrors } : {}),
+                status: response.status,
+                ...(typeof parsed.id === "string" ? { responseId: parsed.id } : {}),
+                ...extractOpenAICompatibleChoiceEvidence(parsed),
+                ...extractOpenAICompatibleUsageEvidence(parsed)
+              }
+            };
+          } catch (error) {
+            if (schemaRetryErrors.length > 0 && isSharedRetryTimeoutError(error)) {
+              throw new Error(schemaRetryErrors[schemaRetryErrors.length - 1]);
+            }
+            throw error;
+          }
         }
 
         throw new Error("OpenAI-compatible review output did not produce valid review JSON after schema feedback retries.");
@@ -301,8 +311,13 @@ function buildSchemaFeedbackRetryPrompt(schemaError: string): string {
 
 function openAICompatibleReviewSchemaError(error: string, parsed: Record<string, unknown>): string {
   return extractOpenAICompatibleFinishReason(parsed) === "length"
-    ? "OpenAI-compatible review output was truncated before a parseable JSON review object (finish_reason=length)."
+    ? TRUNCATED_REVIEW_JSON_ERROR
     : error;
+}
+
+function isSharedRetryTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return error.name === "AbortError" || /\b(deadline exceeded|aborted|timed?[ _-]?out|timeout)\b/i.test(error.message);
 }
 
 function resolveSchemaFeedbackRetryMax(provider: ProviderRegistryEntry): number {

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -231,7 +231,8 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
               model: input.model,
               prompt: input.prompt,
               structuredOutput,
-              schemaFeedbackErrors
+              schemaFeedbackErrors,
+              schemaFeedbackErrorLimit: schemaFeedbackMax
             }))
           });
 
@@ -294,6 +295,7 @@ function buildOpenAICompatibleReviewRequestBody(input: {
   prompt: string;
   structuredOutput: { requestFields: Record<string, unknown> };
   schemaFeedbackErrors: readonly string[];
+  schemaFeedbackErrorLimit: number;
 }): Record<string, unknown> {
   return {
     model: input.model,
@@ -311,14 +313,15 @@ function buildOpenAICompatibleReviewRequestBody(input: {
       },
       ...(input.schemaFeedbackErrors.length === 0 ? [] : [{
         role: "user",
-        content: buildSchemaFeedbackRetryPrompt(input.schemaFeedbackErrors)
+        content: buildSchemaFeedbackRetryPrompt(input.schemaFeedbackErrors, input.schemaFeedbackErrorLimit)
       }])
     ]
   };
 }
 
-function buildSchemaFeedbackRetryPrompt(schemaErrors: readonly string[]): string {
-  const recentDistinctErrors = [...new Set(schemaErrors)].slice(-SCHEMA_FEEDBACK_RETRY_MAX);
+function buildSchemaFeedbackRetryPrompt(schemaErrors: readonly string[], maxSchemaErrors: number): string {
+  const schemaErrorLimit = Math.max(1, Math.min(maxSchemaErrors, SCHEMA_FEEDBACK_RETRY_MAX));
+  const recentDistinctErrors = [...new Set(schemaErrors)].slice(-schemaErrorLimit);
   return [
     "The previous response could not be accepted as NeonDiff review JSON.",
     "Recent schema errors:",
@@ -344,13 +347,14 @@ function openAICompatibleReviewSchemaError(error: string, parsed: Record<string,
 function isLikelyTruncatedReviewJsonContent(content: string): boolean {
   const trimmed = content.trim();
   if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return false;
-  if (!/"findings"\s*:/.test(trimmed.slice(0, REVIEW_JSON_EXTRACTION_CHAR_LIMIT))) return false;
+  const boundedText = trimmed.slice(0, REVIEW_JSON_EXTRACTION_CHAR_LIMIT);
+  if (!/"findings"\s*:/.test(boundedText)) return false;
   try {
-    JSON.parse(trimmed);
+    JSON.parse(boundedText);
     return false;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return /\b(unexpected end|unterminated)\b/i.test(message) || hasUnclosedJsonDelimiters(trimmed);
+    return /\b(unexpected end|unterminated)\b/i.test(message) || hasUnclosedJsonDelimiters(boundedText);
   }
 }
 

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -16,6 +16,7 @@ const EVIDENCE_PREVIEW_TRUNCATED_SENTINEL = "...[truncated]";
 const DEFAULT_OPENAI_COMPATIBLE_REVIEW_TIMEOUT_MS = 180_000;
 const DEFAULT_SCHEMA_FEEDBACK_RETRY_MAX = 2;
 const TRUNCATED_REVIEW_JSON_ERROR = "OpenAI-compatible review output was truncated before a parseable JSON review object.";
+const FINISH_REASON_LENGTH_TRUNCATED_REVIEW_JSON_ERROR = `${TRUNCATED_REVIEW_JSON_ERROR} (finish_reason=length)`;
 const REDACTION_TOKENS = [
   "[redacted-private-evidence]",
   "[redacted-private-field]",
@@ -249,7 +250,7 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
             const schemaError = openAICompatibleReviewSchemaError(reviewOutput.error, parsed, content);
             const schemaFeedbackError = buildSchemaFeedbackErrorForPrompt(schemaError, input.prompt);
             const schemaEvidenceError = redactPrivateEvidenceText(schemaError, input.prompt);
-            if (schemaError === TRUNCATED_REVIEW_JSON_ERROR || attempt >= schemaFeedbackMax) {
+            if (isTruncatedReviewJsonSchemaError(schemaError) || attempt >= schemaFeedbackMax) {
               throw new ProviderAdapterEvidenceError(schemaError, buildOpenAICompatibleSchemaRetryEvidence({
                 providerId: options.providerId,
                 adapterId: input.adapterId,
@@ -339,9 +340,13 @@ function buildSchemaFeedbackErrorForPrompt(schemaError: string, prompt: string):
 }
 
 function openAICompatibleReviewSchemaError(error: string, parsed: Record<string, unknown>, content: string): string {
-  return extractOpenAICompatibleFinishReason(parsed) === "length" || isLikelyTruncatedReviewJsonContent(content)
-    ? TRUNCATED_REVIEW_JSON_ERROR
-    : error;
+  if (extractOpenAICompatibleFinishReason(parsed) === "length") return FINISH_REASON_LENGTH_TRUNCATED_REVIEW_JSON_ERROR;
+  if (isLikelyTruncatedReviewJsonContent(content)) return TRUNCATED_REVIEW_JSON_ERROR;
+  return error;
+}
+
+function isTruncatedReviewJsonSchemaError(schemaError: string): boolean {
+  return schemaError === TRUNCATED_REVIEW_JSON_ERROR || schemaError === FINISH_REASON_LENGTH_TRUNCATED_REVIEW_JSON_ERROR;
 }
 
 function isLikelyTruncatedReviewJsonContent(content: string): boolean {

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -214,7 +214,8 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
       const timeout = createAbortSignal(provider.timeoutMs);
       const structuredOutput = buildStructuredOutputRequestFields(provider);
       const schemaFeedbackMax = resolveSchemaFeedbackRetryMax(provider);
-      const schemaRetryErrors: string[] = [];
+      const schemaFeedbackErrors: string[] = [];
+      const schemaEvidenceErrors: string[] = [];
       try {
         for (let attempt = 0; ; attempt += 1) {
           const response = await fetchImpl(buildOpenAIChatCompletionsUrl(baseUrl), {
@@ -230,7 +231,7 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
               model: input.model,
               prompt: input.prompt,
               structuredOutput,
-              schemaRetryErrors
+              schemaFeedbackErrors
             }))
           });
 
@@ -244,7 +245,9 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
           const content = extractOpenAICompatibleMessageContent(parsed);
           const reviewOutput = normalizeReviewJsonOutput(content);
           if (!reviewOutput.ok) {
-            const schemaError = redactPrivateEvidenceText(openAICompatibleReviewSchemaError(reviewOutput.error, parsed, content), input.prompt);
+            const schemaError = openAICompatibleReviewSchemaError(reviewOutput.error, parsed, content);
+            const schemaFeedbackError = buildSchemaFeedbackErrorForPrompt(schemaError, input.prompt);
+            const schemaEvidenceError = redactPrivateEvidenceText(schemaError, input.prompt);
             if (schemaError === TRUNCATED_REVIEW_JSON_ERROR || attempt >= schemaFeedbackMax) {
               throw new ProviderAdapterEvidenceError(schemaError, buildOpenAICompatibleSchemaRetryEvidence({
                 providerId: options.providerId,
@@ -254,11 +257,12 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
                 structuredOutputMode: structuredOutput.evidenceMode,
                 status: response.status,
                 parsed,
-                schemaRetries: schemaRetryErrors.length,
-                schemaRetryErrors: [...schemaRetryErrors, schemaError]
+                schemaRetries: schemaFeedbackErrors.length,
+                schemaRetryErrors: [...schemaEvidenceErrors, schemaEvidenceError]
               }));
             }
-            schemaRetryErrors.push(schemaError);
+            schemaFeedbackErrors.push(schemaFeedbackError);
+            schemaEvidenceErrors.push(schemaEvidenceError);
             continue;
           }
 
@@ -271,8 +275,8 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
               model: input.model,
               baseUrl,
               structuredOutputMode: structuredOutput.evidenceMode,
-              schemaRetries: schemaRetryErrors.length,
-              ...(schemaRetryErrors.length > 0 ? { schemaRetryErrors } : {}),
+              schemaRetries: schemaFeedbackErrors.length,
+              ...(schemaEvidenceErrors.length > 0 ? { schemaRetryErrors: schemaEvidenceErrors } : {}),
               ...buildOpenAICompatibleResponseEvidence(response.status, parsed)
             }
           };
@@ -289,7 +293,7 @@ function buildOpenAICompatibleReviewRequestBody(input: {
   model: string;
   prompt: string;
   structuredOutput: { requestFields: Record<string, unknown> };
-  schemaRetryErrors: readonly string[];
+  schemaFeedbackErrors: readonly string[];
 }): Record<string, unknown> {
   return {
     model: input.model,
@@ -305,22 +309,30 @@ function buildOpenAICompatibleReviewRequestBody(input: {
         role: "user",
         content: input.prompt
       },
-      ...(input.schemaRetryErrors.length === 0 ? [] : [{
+      ...(input.schemaFeedbackErrors.length === 0 ? [] : [{
         role: "user",
-        content: buildSchemaFeedbackRetryPrompt(input.schemaRetryErrors[input.schemaRetryErrors.length - 1])
+        content: buildSchemaFeedbackRetryPrompt(input.schemaFeedbackErrors)
       }])
     ]
   };
 }
 
-function buildSchemaFeedbackRetryPrompt(schemaError: string): string {
+function buildSchemaFeedbackRetryPrompt(schemaErrors: readonly string[]): string {
+  const recentDistinctErrors = [...new Set(schemaErrors)].slice(-SCHEMA_FEEDBACK_RETRY_MAX);
   return [
     "The previous response could not be accepted as NeonDiff review JSON.",
-    `Schema error: ${schemaError}`,
+    "Recent schema errors:",
+    ...recentDistinctErrors.map((schemaError) => `- ${schemaError}`),
     `Return only a JSON object matching ${REVIEW_FINDINGS_JSON_SCHEMA_NAME}.`,
     "Canonical schema:",
     JSON.stringify(REVIEW_FINDINGS_JSON_SCHEMA)
   ].join("\n");
+}
+
+function buildSchemaFeedbackErrorForPrompt(schemaError: string, prompt: string): string {
+  const redactedError = redactPrivateEvidenceText(schemaError, prompt);
+  if (redactedError === schemaError) return schemaError;
+  return "Adapter output failed NeonDiff review JSON schema validation.";
 }
 
 function openAICompatibleReviewSchemaError(error: string, parsed: Record<string, unknown>, content: string): string {
@@ -332,7 +344,7 @@ function openAICompatibleReviewSchemaError(error: string, parsed: Record<string,
 function isLikelyTruncatedReviewJsonContent(content: string): boolean {
   const trimmed = content.trim();
   if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return false;
-  if (!/"findings"\s*:/.test(trimmed.slice(0, 2_048))) return false;
+  if (!/"findings"\s*:/.test(trimmed.slice(0, REVIEW_JSON_EXTRACTION_CHAR_LIMIT))) return false;
   try {
     JSON.parse(trimmed);
     return false;

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -16,7 +16,7 @@ const EVIDENCE_PREVIEW_TRUNCATED_SENTINEL = "...[truncated]";
 const DEFAULT_OPENAI_COMPATIBLE_REVIEW_TIMEOUT_MS = 180_000;
 const DEFAULT_SCHEMA_FEEDBACK_RETRY_MAX = 2;
 const MAX_SCHEMA_FEEDBACK_RETRY_MAX = 3;
-const TRUNCATED_REVIEW_JSON_ERROR = "OpenAI-compatible review output was truncated before a parseable JSON review object (finish_reason=length).";
+const TRUNCATED_REVIEW_JSON_ERROR = "OpenAI-compatible review output was truncated before a parseable JSON review object.";
 const REDACTION_TOKENS = [
   "[redacted-private-evidence]",
   "[redacted-private-field]",
@@ -200,69 +200,60 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
       const schemaFeedbackMax = resolveSchemaFeedbackRetryMax(provider);
       const schemaRetryErrors: string[] = [];
       try {
-        for (let attempt = 0; attempt <= schemaFeedbackMax; attempt += 1) {
-          try {
-            const response = await fetchImpl(buildOpenAIChatCompletionsUrl(baseUrl), {
-              method: "POST",
-              signal: timeout.signal,
-              headers: {
-                Accept: "application/json",
-                "Content-Type": "application/json",
-                ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
-              },
-              body: JSON.stringify(buildOpenAICompatibleReviewRequestBody({
-                provider,
-                model: input.model,
-                prompt: input.prompt,
-                structuredOutput,
-                schemaRetryErrors
-              }))
-            });
+        for (let attempt = 0; ; attempt += 1) {
+          const response = await fetchImpl(buildOpenAIChatCompletionsUrl(baseUrl), {
+            method: "POST",
+            signal: timeout.signal,
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/json",
+              ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
+            },
+            body: JSON.stringify(buildOpenAICompatibleReviewRequestBody({
+              provider,
+              model: input.model,
+              prompt: input.prompt,
+              structuredOutput,
+              schemaRetryErrors
+            }))
+          });
 
-            if (!response.ok) {
-              const responseErrorText = await readResponseTextWithAbort(response, timeout.signal);
-              throw new Error(openAICompatibleStatusErrorMessage(response.status, responseErrorText));
-            }
-
-            const responseText = await readResponseTextWithAbort(response, timeout.signal);
-            const parsed = parseOpenAICompatibleResponse(responseText);
-            const content = extractOpenAICompatibleMessageContent(parsed);
-            const reviewOutput = normalizeReviewJsonOutput(content);
-            if (!reviewOutput.ok) {
-              const schemaError = openAICompatibleReviewSchemaError(reviewOutput.error, parsed);
-              if (schemaError === TRUNCATED_REVIEW_JSON_ERROR || schemaRetryErrors.length >= schemaFeedbackMax) {
-                throw new Error(schemaError);
-              }
-              schemaRetryErrors.push(schemaError);
-              continue;
-            }
-
-            return {
-              text: reviewOutput.text,
-              reviewJsonValidated: true,
-              rawEvidence: {
-                providerId: options.providerId,
-                adapterId: input.adapterId,
-                model: input.model,
-                baseUrl,
-                structuredOutputMode: structuredOutput.evidenceMode,
-                schemaRetries: schemaRetryErrors.length,
-                ...(schemaRetryErrors.length > 0 ? { schemaRetryErrors } : {}),
-                status: response.status,
-                ...(typeof parsed.id === "string" ? { responseId: parsed.id } : {}),
-                ...extractOpenAICompatibleChoiceEvidence(parsed),
-                ...extractOpenAICompatibleUsageEvidence(parsed)
-              }
-            };
-          } catch (error) {
-            if (schemaRetryErrors.length > 0 && isSharedRetryTimeoutError(error)) {
-              throw new Error(schemaRetryErrors[schemaRetryErrors.length - 1]);
-            }
-            throw error;
+          if (!response.ok) {
+            const responseErrorText = await readResponseTextWithAbort(response, timeout.signal);
+            throw new Error(openAICompatibleStatusErrorMessage(response.status, responseErrorText));
           }
-        }
 
-        throw new Error("OpenAI-compatible review output did not produce valid review JSON after schema feedback retries.");
+          const responseText = await readResponseTextWithAbort(response, timeout.signal);
+          const parsed = parseOpenAICompatibleResponse(responseText);
+          const content = extractOpenAICompatibleMessageContent(parsed);
+          const reviewOutput = normalizeReviewJsonOutput(content);
+          if (!reviewOutput.ok) {
+            const schemaError = openAICompatibleReviewSchemaError(reviewOutput.error, parsed, content);
+            if (schemaError === TRUNCATED_REVIEW_JSON_ERROR || attempt >= schemaFeedbackMax) {
+              throw new Error(schemaError);
+            }
+            schemaRetryErrors.push(schemaError);
+            continue;
+          }
+
+          return {
+            text: reviewOutput.text,
+            reviewJsonValidated: true,
+            rawEvidence: {
+              providerId: options.providerId,
+              adapterId: input.adapterId,
+              model: input.model,
+              baseUrl,
+              structuredOutputMode: structuredOutput.evidenceMode,
+              schemaRetries: schemaRetryErrors.length,
+              ...(schemaRetryErrors.length > 0 ? { schemaRetryErrors } : {}),
+              status: response.status,
+              ...(typeof parsed.id === "string" ? { responseId: parsed.id } : {}),
+              ...extractOpenAICompatibleChoiceEvidence(parsed),
+              ...extractOpenAICompatibleUsageEvidence(parsed)
+            }
+          };
+        }
       } finally {
         timeout.dispose();
       }
@@ -309,15 +300,54 @@ function buildSchemaFeedbackRetryPrompt(schemaError: string): string {
   ].join("\n");
 }
 
-function openAICompatibleReviewSchemaError(error: string, parsed: Record<string, unknown>): string {
-  return extractOpenAICompatibleFinishReason(parsed) === "length"
+function openAICompatibleReviewSchemaError(error: string, parsed: Record<string, unknown>, content: string): string {
+  return extractOpenAICompatibleFinishReason(parsed) === "length" || isLikelyTruncatedReviewJsonContent(content)
     ? TRUNCATED_REVIEW_JSON_ERROR
     : error;
 }
 
-function isSharedRetryTimeoutError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  return error.name === "AbortError" || /\b(deadline exceeded|aborted|timed?[ _-]?out|timeout)\b/i.test(error.message);
+function isLikelyTruncatedReviewJsonContent(content: string): boolean {
+  const trimmed = content.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return false;
+  if (!/"findings"\s*:/.test(trimmed.slice(0, 2_048))) return false;
+  try {
+    JSON.parse(trimmed);
+    return false;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return /\b(unexpected end|unterminated)\b/i.test(message) || hasUnclosedJsonDelimiters(trimmed);
+  }
+}
+
+function hasUnclosedJsonDelimiters(value: string): boolean {
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+  for (const character of value) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = inString;
+      continue;
+    }
+    if (character === "\"") {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (character === "{" || character === "[") {
+      stack.push(character);
+      continue;
+    }
+    if (character === "}") {
+      if (stack.pop() !== "{") return false;
+      continue;
+    }
+    if (character === "]" && stack.pop() !== "[") return false;
+  }
+  return inString || stack.length > 0;
 }
 
 function resolveSchemaFeedbackRetryMax(provider: ProviderRegistryEntry): number {

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -14,6 +14,8 @@ const REVIEW_JSON_EXTRACTION_CHAR_LIMIT = 200_000;
 const REVIEW_JSON_NESTED_OBJECT_MAX_DEPTH = 32;
 const EVIDENCE_PREVIEW_TRUNCATED_SENTINEL = "...[truncated]";
 const DEFAULT_OPENAI_COMPATIBLE_REVIEW_TIMEOUT_MS = 180_000;
+const DEFAULT_SCHEMA_FEEDBACK_RETRY_MAX = 2;
+const MAX_SCHEMA_FEEDBACK_RETRY_MAX = 3;
 const REDACTION_TOKENS = [
   "[redacted-private-evidence]",
   "[redacted-private-field]",
@@ -194,71 +196,121 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
       const apiKey = resolveOpenAICompatibleApiKey(provider, env);
       const timeout = createAbortSignal(provider.timeoutMs);
       const structuredOutput = buildStructuredOutputRequestFields(provider);
-      const requestBody = {
-        model: input.model,
-        stream: false,
-        ...(provider.temperature === undefined ? {} : { temperature: provider.temperature }),
-        ...structuredOutput.requestFields,
-        messages: [
-          {
-            role: "system",
-            content: "Return only the NeonDiff review JSON object. Do not include markdown, prose, tool calls, or raw diff excerpts."
-          },
-          {
-            role: "user",
-            content: input.prompt
-          }
-        ]
-      };
+      const schemaFeedbackMax = resolveSchemaFeedbackRetryMax(provider);
+      const schemaRetryErrors: string[] = [];
       try {
-        const response = await fetchImpl(buildOpenAIChatCompletionsUrl(baseUrl), {
-          method: "POST",
-          signal: timeout.signal,
-          headers: {
-            Accept: "application/json",
-            "Content-Type": "application/json",
-            ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
-          },
-          body: JSON.stringify(requestBody)
-        });
+        for (let attempt = 0; attempt <= schemaFeedbackMax; attempt += 1) {
+          const response = await fetchImpl(buildOpenAIChatCompletionsUrl(baseUrl), {
+            method: "POST",
+            signal: timeout.signal,
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/json",
+              ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {})
+            },
+            body: JSON.stringify(buildOpenAICompatibleReviewRequestBody({
+              provider,
+              model: input.model,
+              prompt: input.prompt,
+              structuredOutput,
+              schemaRetryErrors
+            }))
+          });
 
-        if (!response.ok) {
-          const responseErrorText = await readResponseTextWithAbort(response, timeout.signal);
-          throw new Error(openAICompatibleStatusErrorMessage(response.status, responseErrorText));
+          if (!response.ok) {
+            const responseErrorText = await readResponseTextWithAbort(response, timeout.signal);
+            throw new Error(openAICompatibleStatusErrorMessage(response.status, responseErrorText));
+          }
+
+          const responseText = await readResponseTextWithAbort(response, timeout.signal);
+          const parsed = parseOpenAICompatibleResponse(responseText);
+          const content = extractOpenAICompatibleMessageContent(parsed);
+          const reviewOutput = normalizeReviewJsonOutput(content);
+          if (!reviewOutput.ok) {
+            const schemaError = openAICompatibleReviewSchemaError(reviewOutput.error, parsed);
+            if (schemaRetryErrors.length >= schemaFeedbackMax) throw new Error(schemaError);
+            schemaRetryErrors.push(schemaError);
+            continue;
+          }
+
+          return {
+            text: reviewOutput.text,
+            reviewJsonValidated: true,
+            rawEvidence: {
+              providerId: options.providerId,
+              adapterId: input.adapterId,
+              model: input.model,
+              baseUrl,
+              structuredOutputMode: structuredOutput.evidenceMode,
+              schemaRetries: schemaRetryErrors.length,
+              ...(schemaRetryErrors.length > 0 ? { schemaRetryErrors } : {}),
+              status: response.status,
+              ...(typeof parsed.id === "string" ? { responseId: parsed.id } : {}),
+              ...extractOpenAICompatibleChoiceEvidence(parsed),
+              ...extractOpenAICompatibleUsageEvidence(parsed)
+            }
+          };
         }
 
-        const responseText = await readResponseTextWithAbort(response, timeout.signal);
-        const parsed = parseOpenAICompatibleResponse(responseText);
-        const content = extractOpenAICompatibleMessageContent(parsed);
-        const reviewOutput = normalizeReviewJsonOutput(content);
-        if (!reviewOutput.ok) {
-          const finishReason = extractOpenAICompatibleFinishReason(parsed);
-          if (finishReason === "length") {
-            throw new Error("OpenAI-compatible review output was truncated before a parseable JSON review object (finish_reason=length).");
-          }
-          throw new Error(reviewOutput.error);
-        }
-
-        return {
-          text: reviewOutput.text,
-          reviewJsonValidated: true,
-          rawEvidence: {
-            providerId: options.providerId,
-            adapterId: input.adapterId,
-            model: input.model,
-            baseUrl,
-            structuredOutputMode: structuredOutput.evidenceMode,
-            status: response.status,
-            ...(typeof parsed.id === "string" ? { responseId: parsed.id } : {}),
-            ...extractOpenAICompatibleChoiceEvidence(parsed),
-            ...extractOpenAICompatibleUsageEvidence(parsed)
-          }
-        };
+        throw new Error("OpenAI-compatible review output did not produce valid review JSON after schema feedback retries.");
       } finally {
         timeout.dispose();
       }
     }
   };
+}
+
+function buildOpenAICompatibleReviewRequestBody(input: {
+  provider: ProviderRegistryEntry;
+  model: string;
+  prompt: string;
+  structuredOutput: { requestFields: Record<string, unknown> };
+  schemaRetryErrors: readonly string[];
+}): Record<string, unknown> {
+  return {
+    model: input.model,
+    stream: false,
+    ...(input.provider.temperature === undefined ? {} : { temperature: input.provider.temperature }),
+    ...input.structuredOutput.requestFields,
+    messages: [
+      {
+        role: "system",
+        content: "Return only the NeonDiff review JSON object. Do not include markdown, prose, tool calls, or raw diff excerpts."
+      },
+      {
+        role: "user",
+        content: input.prompt
+      },
+      ...input.schemaRetryErrors.map((schemaError) => ({
+        role: "user",
+        content: buildSchemaFeedbackRetryPrompt(schemaError)
+      }))
+    ]
+  };
+}
+
+function buildSchemaFeedbackRetryPrompt(schemaError: string): string {
+  return [
+    "The previous response could not be accepted as NeonDiff review JSON.",
+    `Schema error: ${schemaError}`,
+    `Return only a JSON object matching ${REVIEW_FINDINGS_JSON_SCHEMA_NAME}.`,
+    "Canonical schema:",
+    JSON.stringify(REVIEW_FINDINGS_JSON_SCHEMA)
+  ].join("\n");
+}
+
+function openAICompatibleReviewSchemaError(error: string, parsed: Record<string, unknown>): string {
+  return extractOpenAICompatibleFinishReason(parsed) === "length"
+    ? "OpenAI-compatible review output was truncated before a parseable JSON review object (finish_reason=length)."
+    : error;
+}
+
+function resolveSchemaFeedbackRetryMax(provider: ProviderRegistryEntry): number {
+  if (provider.retrySchemaFeedbackMax === undefined) return DEFAULT_SCHEMA_FEEDBACK_RETRY_MAX;
+  if (!Number.isInteger(provider.retrySchemaFeedbackMax) || provider.retrySchemaFeedbackMax < 0 || provider.retrySchemaFeedbackMax > MAX_SCHEMA_FEEDBACK_RETRY_MAX) {
+    throw new Error(`retrySchemaFeedbackMax must be an integer from 0 to ${MAX_SCHEMA_FEEDBACK_RETRY_MAX}.`);
+  }
+  return provider.retrySchemaFeedbackMax;
 }
 
 function buildStructuredOutputRequestFields(provider: ProviderRegistryEntry): {

--- a/src/provider-adapters.ts
+++ b/src/provider-adapters.ts
@@ -6,7 +6,7 @@ import {
   REVIEW_FINDINGS_JSON_SCHEMA_STRICT
 } from "./findings-schema.js";
 import { parseFindings } from "./findings.js";
-import { openAICompatibleProviderTargetError, type ProviderRegistryEntry, type ProviderStructuredOutputMode } from "./providers.js";
+import { openAICompatibleProviderTargetError, SCHEMA_FEEDBACK_RETRY_MAX, type ProviderRegistryEntry, type ProviderStructuredOutputMode } from "./providers.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 const EVIDENCE_PREVIEW_LIMIT = 500;
@@ -15,7 +15,6 @@ const REVIEW_JSON_NESTED_OBJECT_MAX_DEPTH = 32;
 const EVIDENCE_PREVIEW_TRUNCATED_SENTINEL = "...[truncated]";
 const DEFAULT_OPENAI_COMPATIBLE_REVIEW_TIMEOUT_MS = 180_000;
 const DEFAULT_SCHEMA_FEEDBACK_RETRY_MAX = 2;
-const MAX_SCHEMA_FEEDBACK_RETRY_MAX = 3;
 const TRUNCATED_REVIEW_JSON_ERROR = "OpenAI-compatible review output was truncated before a parseable JSON review object.";
 const REDACTION_TOKENS = [
   "[redacted-private-evidence]",
@@ -89,6 +88,16 @@ export interface ProviderAdapterFixtureError {
   message: string;
 }
 
+class ProviderAdapterEvidenceError extends Error {
+  readonly rawEvidence: unknown;
+
+  constructor(message: string, rawEvidence: unknown) {
+    super(message);
+    this.name = "ProviderAdapterEvidenceError";
+    this.rawEvidence = rawEvidence;
+  }
+}
+
 export interface ProviderAdapterFixtureResultBase {
   fixtureId: string;
   providerId: string;
@@ -156,9 +165,16 @@ export async function runProviderAdapterFixture(input: {
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    const rawEvidence = error instanceof ProviderAdapterEvidenceError ? error.rawEvidence : undefined;
     return {
       ok: false,
       ...baseResult,
+      evidence: rawEvidence === undefined
+        ? baseResult.evidence
+        : {
+          ...baseResult.evidence,
+          rawEvidencePreview: previewEvidenceText(stableStringify(redactPrivateEvidenceValue(rawEvidence, fixture.prompt)))
+        },
       error: {
         class: classifyProviderAdapterError(message),
         message: redactPrivateEvidenceText(message, fixture.prompt)
@@ -228,9 +244,19 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
           const content = extractOpenAICompatibleMessageContent(parsed);
           const reviewOutput = normalizeReviewJsonOutput(content);
           if (!reviewOutput.ok) {
-            const schemaError = openAICompatibleReviewSchemaError(reviewOutput.error, parsed, content);
+            const schemaError = redactPrivateEvidenceText(openAICompatibleReviewSchemaError(reviewOutput.error, parsed, content), input.prompt);
             if (schemaError === TRUNCATED_REVIEW_JSON_ERROR || attempt >= schemaFeedbackMax) {
-              throw new Error(schemaError);
+              throw new ProviderAdapterEvidenceError(schemaError, buildOpenAICompatibleSchemaRetryEvidence({
+                providerId: options.providerId,
+                adapterId: input.adapterId,
+                model: input.model,
+                baseUrl,
+                structuredOutputMode: structuredOutput.evidenceMode,
+                status: response.status,
+                parsed,
+                schemaRetries: schemaRetryErrors.length,
+                schemaRetryErrors: [...schemaRetryErrors, schemaError]
+              }));
             }
             schemaRetryErrors.push(schemaError);
             continue;
@@ -247,10 +273,7 @@ export function createOpenAICompatibleReviewAdapter(options: OpenAICompatibleRev
               structuredOutputMode: structuredOutput.evidenceMode,
               schemaRetries: schemaRetryErrors.length,
               ...(schemaRetryErrors.length > 0 ? { schemaRetryErrors } : {}),
-              status: response.status,
-              ...(typeof parsed.id === "string" ? { responseId: parsed.id } : {}),
-              ...extractOpenAICompatibleChoiceEvidence(parsed),
-              ...extractOpenAICompatibleUsageEvidence(parsed)
+              ...buildOpenAICompatibleResponseEvidence(response.status, parsed)
             }
           };
         }
@@ -282,10 +305,10 @@ function buildOpenAICompatibleReviewRequestBody(input: {
         role: "user",
         content: input.prompt
       },
-      ...input.schemaRetryErrors.map((schemaError) => ({
+      ...(input.schemaRetryErrors.length === 0 ? [] : [{
         role: "user",
-        content: buildSchemaFeedbackRetryPrompt(schemaError)
-      }))
+        content: buildSchemaFeedbackRetryPrompt(input.schemaRetryErrors[input.schemaRetryErrors.length - 1])
+      }])
     ]
   };
 }
@@ -352,10 +375,42 @@ function hasUnclosedJsonDelimiters(value: string): boolean {
 
 function resolveSchemaFeedbackRetryMax(provider: ProviderRegistryEntry): number {
   if (provider.retrySchemaFeedbackMax === undefined) return DEFAULT_SCHEMA_FEEDBACK_RETRY_MAX;
-  if (!Number.isInteger(provider.retrySchemaFeedbackMax) || provider.retrySchemaFeedbackMax < 0 || provider.retrySchemaFeedbackMax > MAX_SCHEMA_FEEDBACK_RETRY_MAX) {
-    throw new Error(`retrySchemaFeedbackMax must be an integer from 0 to ${MAX_SCHEMA_FEEDBACK_RETRY_MAX}.`);
+  if (!Number.isInteger(provider.retrySchemaFeedbackMax) || provider.retrySchemaFeedbackMax < 0 || provider.retrySchemaFeedbackMax > SCHEMA_FEEDBACK_RETRY_MAX) {
+    throw new Error(`retrySchemaFeedbackMax must be an integer from 0 to ${SCHEMA_FEEDBACK_RETRY_MAX}.`);
   }
   return provider.retrySchemaFeedbackMax;
+}
+
+function buildOpenAICompatibleSchemaRetryEvidence(input: {
+  providerId: string;
+  adapterId: string;
+  model: string;
+  baseUrl: string;
+  structuredOutputMode: string;
+  status: number;
+  parsed: Record<string, unknown>;
+  schemaRetries: number;
+  schemaRetryErrors: readonly string[];
+}): Record<string, unknown> {
+  return {
+    providerId: input.providerId,
+    adapterId: input.adapterId,
+    model: input.model,
+    baseUrl: input.baseUrl,
+    structuredOutputMode: input.structuredOutputMode,
+    schemaRetries: input.schemaRetries,
+    ...(input.schemaRetryErrors.length > 0 ? { schemaRetryErrors: [...input.schemaRetryErrors] } : {}),
+    ...buildOpenAICompatibleResponseEvidence(input.status, input.parsed)
+  };
+}
+
+function buildOpenAICompatibleResponseEvidence(status: number, parsed: Record<string, unknown>): Record<string, unknown> {
+  return {
+    status,
+    ...(typeof parsed.id === "string" ? { responseId: parsed.id } : {}),
+    ...extractOpenAICompatibleChoiceEvidence(parsed),
+    ...extractOpenAICompatibleUsageEvidence(parsed)
+  };
 }
 
 function buildStructuredOutputRequestFields(provider: ProviderRegistryEntry): {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -76,6 +76,7 @@ export interface ProviderRegistryEntry {
   contextWindowTokens?: number;
   timeoutMs?: number;
   retryMaxRetries?: number;
+  retrySchemaFeedbackMax?: number;
   temperature?: number;
   jsonObjectResponseFormat?: boolean;
   structuredOutputMode?: ProviderStructuredOutputMode;
@@ -109,6 +110,7 @@ export interface ProviderRegistrySummaryEntry {
   contextWindowTokens?: number;
   timeoutMs?: number;
   retryMaxRetries?: number;
+  retrySchemaFeedbackMax?: number;
   structuredOutputMode?: ProviderStructuredOutputMode;
   capabilities: ProviderCapabilityFlags;
   currentRuntime?: boolean;
@@ -160,6 +162,7 @@ export function buildProviderRegistrySummary(input: {
       ...(provider.contextWindowTokens ? { contextWindowTokens: provider.contextWindowTokens } : {}),
       ...(provider.timeoutMs ? { timeoutMs: provider.timeoutMs } : {}),
       ...(provider.retryMaxRetries !== undefined ? { retryMaxRetries: provider.retryMaxRetries } : {}),
+      ...(provider.retrySchemaFeedbackMax !== undefined ? { retrySchemaFeedbackMax: provider.retrySchemaFeedbackMax } : {}),
       ...(provider.structuredOutputMode ? { structuredOutputMode: provider.structuredOutputMode } : {}),
       capabilities: provider.capabilities,
       currentRuntime: provider.adapter === "zcode" && (

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -45,6 +45,7 @@ export type ProviderSmokeRequestImpl = (
 
 export type ProviderAdapter = "zcode" | "openai-compatible" | "anthropic" | "openai" | "gemini";
 export type ProviderAuthMode = "zcode-app-config" | "api-key-env" | "none";
+export const SCHEMA_FEEDBACK_RETRY_MAX = 3;
 export const PROVIDER_STRUCTURED_OUTPUT_MODES = [
   "none",
   "json-object",

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -162,6 +162,7 @@ describe("desktop config CLI", () => {
             baseUrl: "http://localhost:11434/v1",
             model: "qwen2.5-coder:14b",
             authMode: "none",
+            retrySchemaFeedbackMax: 1,
             structuredOutputMode: "ollama-format-json-schema",
             capabilities: {
               review: true,
@@ -205,6 +206,7 @@ describe("desktop config CLI", () => {
         "providers.providers.ollama-local.baseUrl",
         "providers.providers.ollama-local.model",
         "providers.providers.ollama-local.authMode",
+        "providers.providers.ollama-local.retrySchemaFeedbackMax",
         "providers.providers.ollama-local.structuredOutputMode",
         "providers.providers.ollama-local.capabilities.review",
         "providers.providers.ollama-local.capabilities.jsonOutput",

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -1047,6 +1047,47 @@ describe("provider adapter fixtures", () => {
     expect(calls).toBe(1);
   });
 
+  it("treats finish_reason length as truncation even when the body is not JSON-looking", async () => {
+    let calls = 0;
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "length-finish-reason-non-json-local-model",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://localhost:8080/v1",
+          retrySchemaFeedbackMax: 2
+        }),
+        fetchImpl: async () => {
+          calls += 1;
+          return jsonResponse({
+            choices: [
+              {
+                finish_reason: "length",
+                message: {
+                  content: "partial prose response"
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "length-finish-reason-non-json-local-model-fixture",
+        providerId: "length-finish-reason-non-json-local-model",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "model-output",
+        message: "OpenAI-compatible review output was truncated before a parseable JSON review object."
+      }
+    });
+    expect(calls).toBe(1);
+  });
+
   it("does not schema-retry JSON-looking truncated review output without finish_reason length", async () => {
     let calls = 0;
     const result = await runProviderAdapterFixture({

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -527,6 +527,104 @@ describe("provider adapter fixtures", () => {
     expect(result.evidence.rawEvidencePreview).toContain('"structuredOutputMode":"recovery"');
   });
 
+  it("retries malformed OpenAI-compatible review JSON with schema feedback and records retry evidence", async () => {
+    const calls: unknown[] = [];
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "schema-feedback-local",
+        provider: makeOpenAICompatibleProvider({
+          retrySchemaFeedbackMax: 2,
+          structuredOutputMode: "none"
+        }),
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as {
+            messages?: Array<{ role?: string; content?: string }>;
+          };
+          calls.push(body);
+          if (calls.length === 1) {
+            return jsonResponse({
+              id: "malformed-first",
+              choices: [
+                {
+                  message: {
+                    content: "not json"
+                  }
+                }
+              ]
+            });
+          }
+          expect(body.messages).toHaveLength(3);
+          expect(body.messages?.at(-1)?.role).toBe("user");
+          expect(body.messages?.at(-1)?.content).toContain("Adapter output was not a parseable JSON review object.");
+          expect(body.messages?.at(-1)?.content).toContain(REVIEW_FINDINGS_JSON_SCHEMA_NAME);
+          expect(body.messages?.at(-1)?.content).toContain('"findings"');
+          return jsonResponse({
+            id: "valid-second",
+            choices: [
+              {
+                message: {
+                  content: '{"findings":[],"summary":"Recovered after schema feedback."}'
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "schema-feedback-fixture",
+        providerId: "schema-feedback-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(2);
+    expect(result.evidence.rawEvidencePreview).toContain('"schemaRetries":1');
+    expect(result.evidence.rawEvidencePreview).toContain('"schemaRetryErrors":["Adapter output was not a parseable JSON review object."]');
+  });
+
+  it("exhausts bounded schema-feedback retries without changing the model-output error class", async () => {
+    let calls = 0;
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "schema-feedback-exhausted-local",
+        provider: makeOpenAICompatibleProvider({
+          retrySchemaFeedbackMax: 1,
+          structuredOutputMode: "none"
+        }),
+        fetchImpl: async () => {
+          calls += 1;
+          return jsonResponse({
+            id: `malformed-${calls}`,
+            choices: [
+              {
+                message: {
+                  content: calls === 1 ? "not json" : "{\"notFindings\":[]}"
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "schema-feedback-exhausted-fixture",
+        providerId: "schema-feedback-exhausted-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(calls).toBe(2);
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "model-output",
+        message: "Adapter output did not contain a review findings array."
+      }
+    });
+  });
+
   it("times out OpenAI-compatible responses that stall after headers", async () => {
     let bodyCancelled = false;
     const result = await runProviderAdapterFixture({

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -530,6 +530,7 @@ describe("provider adapter fixtures", () => {
   it("retries malformed OpenAI-compatible review JSON with schema feedback and records retry evidence", async () => {
     const calls: unknown[] = [];
     const signals: AbortSignal[] = [];
+    const fakeSecret = ["ghp", "schemaFeedbackFixtureToken1234567890"].join("_");
     const result = await runProviderAdapterFixture({
       adapter: createOpenAICompatibleReviewAdapter({
         providerId: "schema-feedback-local",
@@ -549,7 +550,7 @@ describe("provider adapter fixtures", () => {
               choices: [
                 {
                   message: {
-                    content: "not json"
+                    content: `not json ${fakeSecret}`
                   }
                 }
               ]
@@ -560,6 +561,7 @@ describe("provider adapter fixtures", () => {
           expect(body.messages?.at(-1)?.content).toContain("Adapter output was not a parseable JSON review object.");
           expect(body.messages?.at(-1)?.content).toContain(REVIEW_FINDINGS_JSON_SCHEMA_NAME);
           expect(body.messages?.at(-1)?.content).toContain('"findings"');
+          expect(body.messages?.at(-1)?.content).not.toContain(fakeSecret);
           return jsonResponse({
             id: "valid-second",
             choices: [
@@ -586,6 +588,7 @@ describe("provider adapter fixtures", () => {
     expect(signals[1]).toBe(signals[0]);
     expect(result.evidence.rawEvidencePreview).toContain('"schemaRetries":1');
     expect(result.evidence.rawEvidencePreview).toContain('"schemaRetryErrors":["Adapter output was not a parseable JSON review object."]');
+    expect(result.evidence.rawEvidencePreview).not.toContain(fakeSecret);
   });
 
   it("does not retry malformed review JSON when schema feedback is disabled", async () => {
@@ -635,6 +638,7 @@ describe("provider adapter fixtures", () => {
 
   it("exhausts bounded schema-feedback retries without changing the model-output error class", async () => {
     let calls = 0;
+    const requestBodies: Array<{ messages?: Array<{ role?: string; content?: string }> }> = [];
     const result = await runProviderAdapterFixture({
       adapter: createOpenAICompatibleReviewAdapter({
         providerId: "schema-feedback-exhausted-local",
@@ -642,8 +646,9 @@ describe("provider adapter fixtures", () => {
           retrySchemaFeedbackMax: 1,
           structuredOutputMode: "none"
         }),
-        fetchImpl: async () => {
+        fetchImpl: async (_url, init) => {
           calls += 1;
+          requestBodies.push(JSON.parse(String(init?.body)) as { messages?: Array<{ role?: string; content?: string }> });
           return jsonResponse({
             id: `malformed-${calls}`,
             choices: [
@@ -665,11 +670,57 @@ describe("provider adapter fixtures", () => {
     });
 
     expect(calls).toBe(2);
+    expect(requestBodies[1]?.messages).toHaveLength(3);
+    expect(requestBodies[1]?.messages?.filter((message) => message.content?.includes(REVIEW_FINDINGS_JSON_SCHEMA_NAME))).toHaveLength(1);
     expect(result).toMatchObject({
       ok: false,
       error: {
         class: "model-output",
         message: "Adapter output did not contain a review findings array."
+      }
+    });
+    expect(result.evidence.rawEvidencePreview).toContain('"schemaRetries":1');
+    expect(result.evidence.rawEvidencePreview).toContain('"schemaRetryErrors":["Adapter output was not a parseable JSON review object.","Adapter output did not contain a review findings array."]');
+  });
+
+  it.each([
+    ["out-of-range", 5],
+    ["non-integer", 1.5]
+  ])("rejects %s adapter-level schema-feedback retry limits before fetching", async (_label, retrySchemaFeedbackMax) => {
+    let calls = 0;
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "invalid-schema-feedback-local",
+        provider: makeOpenAICompatibleProvider({
+          retrySchemaFeedbackMax,
+          structuredOutputMode: "none"
+        }),
+        fetchImpl: async () => {
+          calls += 1;
+          return jsonResponse({
+            choices: [
+              {
+                message: {
+                  content: '{"findings":[]}'
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: `invalid-schema-feedback-${_label}-fixture`,
+        providerId: "invalid-schema-feedback-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(calls).toBe(0);
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        message: "retrySchemaFeedbackMax must be an integer from 0 to 3."
       }
     });
   });

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -1041,7 +1041,7 @@ describe("provider adapter fixtures", () => {
       ok: false,
       error: {
         class: "model-output",
-        message: "OpenAI-compatible review output was truncated before a parseable JSON review object."
+        message: "OpenAI-compatible review output was truncated before a parseable JSON review object. (finish_reason=length)"
       }
     });
     expect(calls).toBe(1);
@@ -1082,7 +1082,7 @@ describe("provider adapter fixtures", () => {
       ok: false,
       error: {
         class: "model-output",
-        message: "OpenAI-compatible review output was truncated before a parseable JSON review object."
+        message: "OpenAI-compatible review output was truncated before a parseable JSON review object. (finish_reason=length)"
       }
     });
     expect(calls).toBe(1);

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -674,6 +674,50 @@ describe("provider adapter fixtures", () => {
     });
   });
 
+  it("preserves schema-output classification when the shared retry timeout expires", async () => {
+    let calls = 0;
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "schema-feedback-timeout-local",
+        provider: makeOpenAICompatibleProvider({
+          retrySchemaFeedbackMax: 1,
+          structuredOutputMode: "none"
+        }),
+        fetchImpl: async () => {
+          calls += 1;
+          if (calls === 1) {
+            return jsonResponse({
+              id: "malformed-before-timeout",
+              choices: [
+                {
+                  message: {
+                    content: "not json"
+                  }
+                }
+              ]
+            });
+          }
+          throw new Error("deadline exceeded");
+        }
+      }),
+      fixture: makeFixture({
+        id: "schema-feedback-timeout-fixture",
+        providerId: "schema-feedback-timeout-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(calls).toBe(2);
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "model-output",
+        message: "Adapter output was not a parseable JSON review object."
+      }
+    });
+  });
+
   it("times out OpenAI-compatible responses that stall after headers", async () => {
     let bodyCancelled = false;
     const result = await runProviderAdapterFixture({
@@ -862,22 +906,26 @@ describe("provider adapter fixtures", () => {
   });
 
   it("preserves finish_reason length when OpenAI-compatible review JSON is truncated", async () => {
+    let calls = 0;
     const result = await runProviderAdapterFixture({
       adapter: createOpenAICompatibleReviewAdapter({
         providerId: "truncated-local-model",
         provider: makeOpenAICompatibleProvider({
           baseUrl: "http://localhost:8080/v1"
         }),
-        fetchImpl: async () => jsonResponse({
-          choices: [
-            {
-              finish_reason: "length",
-              message: {
-                content: '{"findings":[{"severity":"P1"'
+        fetchImpl: async () => {
+          calls += 1;
+          return jsonResponse({
+            choices: [
+              {
+                finish_reason: "length",
+                message: {
+                  content: '{"findings":[{"severity":"P1"'
+                }
               }
-            }
-          ]
-        })
+            ]
+          });
+        }
       }),
       fixture: makeFixture({
         id: "truncated-local-model-fixture",
@@ -894,6 +942,7 @@ describe("provider adapter fixtures", () => {
         message: "OpenAI-compatible review output was truncated before a parseable JSON review object (finish_reason=length)."
       }
     });
+    expect(calls).toBe(1);
   });
 
   it("extracts trailing review JSON after deeply nested non-review braces", async () => {

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -674,7 +674,7 @@ describe("provider adapter fixtures", () => {
     });
   });
 
-  it("preserves schema-output classification when the shared retry timeout expires", async () => {
+  it("classifies a shared schema-feedback retry deadline as timeout", async () => {
     let calls = 0;
     const result = await runProviderAdapterFixture({
       adapter: createOpenAICompatibleReviewAdapter({
@@ -712,8 +712,8 @@ describe("provider adapter fixtures", () => {
     expect(result).toMatchObject({
       ok: false,
       error: {
-        class: "model-output",
-        message: "Adapter output was not a parseable JSON review object."
+        class: "timeout",
+        message: "deadline exceeded"
       }
     });
   });
@@ -939,7 +939,46 @@ describe("provider adapter fixtures", () => {
       ok: false,
       error: {
         class: "model-output",
-        message: "OpenAI-compatible review output was truncated before a parseable JSON review object (finish_reason=length)."
+        message: "OpenAI-compatible review output was truncated before a parseable JSON review object."
+      }
+    });
+    expect(calls).toBe(1);
+  });
+
+  it("does not schema-retry JSON-looking truncated review output without finish_reason length", async () => {
+    let calls = 0;
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "truncated-without-finish-reason-local-model",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://localhost:8080/v1"
+        }),
+        fetchImpl: async () => {
+          calls += 1;
+          return jsonResponse({
+            choices: [
+              {
+                message: {
+                  content: '{"findings":[{"severity":"P1"'
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "truncated-without-finish-reason-local-model-fixture",
+        providerId: "truncated-without-finish-reason-local-model",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "model-output",
+        message: "OpenAI-compatible review output was truncated before a parseable JSON review object."
       }
     });
     expect(calls).toBe(1);

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -591,6 +591,57 @@ describe("provider adapter fixtures", () => {
     expect(result.evidence.rawEvidencePreview).not.toContain(fakeSecret);
   });
 
+  it("includes recent distinct schema errors in one bounded schema-feedback prompt", async () => {
+    let calls = 0;
+    const requestBodies: Array<{ messages?: Array<{ role?: string; content?: string }> }> = [];
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "schema-feedback-multi-error-local",
+        provider: makeOpenAICompatibleProvider({
+          retrySchemaFeedbackMax: 2,
+          structuredOutputMode: "none"
+        }),
+        fetchImpl: async (_url, init) => {
+          calls += 1;
+          const body = JSON.parse(String(init?.body)) as { messages?: Array<{ role?: string; content?: string }> };
+          requestBodies.push(body);
+          return jsonResponse({
+            id: `schema-feedback-multi-error-${calls}`,
+            choices: [
+              {
+                message: {
+                  content: calls === 1
+                    ? "not json"
+                    : calls === 2
+                      ? "{\"notFindings\":[]}"
+                      : '{"findings":[],"summary":"Recovered after two schema errors."}'
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "schema-feedback-multi-error-fixture",
+        providerId: "schema-feedback-multi-error-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(calls).toBe(3);
+    expect(requestBodies[2]?.messages).toHaveLength(3);
+    const feedbackPrompt = requestBodies[2]?.messages?.at(-1)?.content ?? "";
+    expect(feedbackPrompt).toContain("Recent schema errors:");
+    expect(feedbackPrompt).toContain("- Adapter output was not a parseable JSON review object.");
+    expect(feedbackPrompt).toContain("- Adapter output did not contain a review findings array.");
+    expect(feedbackPrompt.match(/Canonical schema:/g)).toHaveLength(1);
+    expect(feedbackPrompt).toContain(REVIEW_FINDINGS_JSON_SCHEMA_NAME);
+    expect(result.evidence.rawEvidencePreview).toContain('"schemaRetries":2');
+    expect(result.evidence.rawEvidencePreview).toContain('"schemaRetryErrors":["Adapter output was not a parseable JSON review object.","Adapter output did not contain a review findings array."]');
+  });
+
   it("does not retry malformed review JSON when schema feedback is disabled", async () => {
     const calls: unknown[] = [];
     const result = await runProviderAdapterFixture({
@@ -1020,6 +1071,45 @@ describe("provider adapter fixtures", () => {
       fixture: makeFixture({
         id: "truncated-without-finish-reason-local-model-fixture",
         providerId: "truncated-without-finish-reason-local-model",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "model-output",
+        message: "OpenAI-compatible review output was truncated before a parseable JSON review object."
+      }
+    });
+    expect(calls).toBe(1);
+  });
+
+  it("detects truncated review JSON when findings appears after the old short scan window", async () => {
+    let calls = 0;
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "delayed-findings-truncated-local-model",
+        provider: makeOpenAICompatibleProvider({
+          baseUrl: "http://localhost:8080/v1"
+        }),
+        fetchImpl: async () => {
+          calls += 1;
+          return jsonResponse({
+            choices: [
+              {
+                message: {
+                  content: `{"preamble":"${"x".repeat(3_000)}","findings":[{"severity":"P1"`
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "delayed-findings-truncated-local-model-fixture",
+        providerId: "delayed-findings-truncated-local-model",
         adapterId: "openai-compatible",
         expectReviewJson: true
       })

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -529,6 +529,7 @@ describe("provider adapter fixtures", () => {
 
   it("retries malformed OpenAI-compatible review JSON with schema feedback and records retry evidence", async () => {
     const calls: unknown[] = [];
+    const signals: AbortSignal[] = [];
     const result = await runProviderAdapterFixture({
       adapter: createOpenAICompatibleReviewAdapter({
         providerId: "schema-feedback-local",
@@ -537,6 +538,7 @@ describe("provider adapter fixtures", () => {
           structuredOutputMode: "none"
         }),
         fetchImpl: async (_url, init) => {
+          signals.push(init?.signal as AbortSignal);
           const body = JSON.parse(String(init?.body)) as {
             messages?: Array<{ role?: string; content?: string }>;
           };
@@ -580,8 +582,55 @@ describe("provider adapter fixtures", () => {
 
     expect(result.ok).toBe(true);
     expect(calls).toHaveLength(2);
+    expect(signals).toHaveLength(2);
+    expect(signals[1]).toBe(signals[0]);
     expect(result.evidence.rawEvidencePreview).toContain('"schemaRetries":1');
     expect(result.evidence.rawEvidencePreview).toContain('"schemaRetryErrors":["Adapter output was not a parseable JSON review object."]');
+  });
+
+  it("does not retry malformed review JSON when schema feedback is disabled", async () => {
+    const calls: unknown[] = [];
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "schema-feedback-disabled-local",
+        provider: makeOpenAICompatibleProvider({
+          retrySchemaFeedbackMax: 0,
+          structuredOutputMode: "none"
+        }),
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as {
+            messages?: Array<{ role?: string; content?: string }>;
+          };
+          calls.push(body);
+          expect(body.messages).toHaveLength(2);
+          return jsonResponse({
+            id: "malformed-disabled",
+            choices: [
+              {
+                message: {
+                  content: "not json"
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "schema-feedback-disabled-fixture",
+        providerId: "schema-feedback-disabled-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        class: "model-output",
+        message: "Adapter output was not a parseable JSON review object."
+      }
+    });
   });
 
   it("exhausts bounded schema-feedback retries without changing the model-output error class", async () => {

--- a/tests/provider-adapters.test.ts
+++ b/tests/provider-adapters.test.ts
@@ -642,6 +642,47 @@ describe("provider adapter fixtures", () => {
     expect(result.evidence.rawEvidencePreview).toContain('"schemaRetryErrors":["Adapter output was not a parseable JSON review object.","Adapter output did not contain a review findings array."]');
   });
 
+  it("retries parseable findings JSON that fails canonical schema validation", async () => {
+    const requestBodies: Array<{ messages?: Array<{ role?: string; content?: string }> }> = [];
+    const result = await runProviderAdapterFixture({
+      adapter: createOpenAICompatibleReviewAdapter({
+        providerId: "schema-feedback-invalid-finding-local",
+        provider: makeOpenAICompatibleProvider({
+          retrySchemaFeedbackMax: 1,
+          structuredOutputMode: "none"
+        }),
+        fetchImpl: async (_url, init) => {
+          const body = JSON.parse(String(init?.body)) as { messages?: Array<{ role?: string; content?: string }> };
+          requestBodies.push(body);
+          return jsonResponse({
+            id: `schema-feedback-invalid-finding-${requestBodies.length}`,
+            choices: [
+              {
+                message: {
+                  content: requestBodies.length === 1
+                    ? '{"findings":[{"severity":"P1","path":"src/app.ts","line":12,"title":"Bug","body":"Fix it.","confidence":1.0000001}]}'
+                    : '{"findings":[],"summary":"Recovered after invalid finding schema."}'
+                }
+              }
+            ]
+          });
+        }
+      }),
+      fixture: makeFixture({
+        id: "schema-feedback-invalid-finding-fixture",
+        providerId: "schema-feedback-invalid-finding-local",
+        adapterId: "openai-compatible",
+        expectReviewJson: true
+      })
+    });
+
+    expect(result.ok).toBe(true);
+    expect(requestBodies).toHaveLength(2);
+    expect(requestBodies[1]?.messages?.at(-1)?.content).toContain("Adapter output contained invalid review findings.");
+    expect(result.evidence.rawEvidencePreview).toContain('"schemaRetries":1');
+    expect(result.evidence.rawEvidencePreview).toContain('"schemaRetryErrors":["Adapter output contained invalid review findings."]');
+  });
+
   it("does not retry malformed review JSON when schema feedback is disabled", async () => {
     const calls: unknown[] = [];
     const result = await runProviderAdapterFixture({

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -119,7 +119,8 @@ describe("provider registry", () => {
     });
     expect(summary.providers.find((provider) => provider.id === "openai-compatible")).toMatchObject({
       authMode: "api-key-env",
-      apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY"
+      apiKeyEnv: "NEONDIFF_PROVIDER_API_KEY",
+      retrySchemaFeedbackMax: 2
     });
     const secondZCode = buildProviderRegistrySummary({
       registry: {
@@ -2248,5 +2249,27 @@ describe("provider registry", () => {
         }
       }
     })).toThrow(/structuredOutputMode must be/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "bad-schema-feedback-retry",
+        providers: {
+          "bad-schema-feedback-retry": {
+            enabled: true,
+            adapter: "openai-compatible",
+            baseUrl: "http://localhost:11434/v1",
+            model: "review-model",
+            authMode: "none",
+            retrySchemaFeedbackMax: 4,
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: true,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/retrySchemaFeedbackMax must be an integer from 0 to 3/);
   });
 });

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -2271,5 +2271,26 @@ describe("provider registry", () => {
         }
       }
     })).toThrow(/retrySchemaFeedbackMax must be an integer from 0 to 3/);
+
+    expect(() => loadConfigFromObject({
+      providers: {
+        defaultProviderId: "zcode-with-schema-feedback-retry",
+        providers: {
+          "zcode-with-schema-feedback-retry": {
+            enabled: true,
+            adapter: "zcode",
+            model: "GLM-5.2",
+            authMode: "zcode-app-config",
+            retrySchemaFeedbackMax: 1,
+            capabilities: {
+              review: true,
+              jsonOutput: true,
+              local: false,
+              streaming: false
+            }
+          }
+        }
+      }
+    })).toThrow(/retrySchemaFeedbackMax is only supported for openai-compatible providers/);
   });
 });


### PR DESCRIPTION
Closes #400

## Summary
- add retrySchemaFeedbackMax to provider config, summary output, and desktop-safe config patching
- retry OpenAI-compatible review JSON parse/schema failures with compact schema-feedback reprompts
- stamp schemaRetries and redacted schemaRetryErrors in adapter evidence
- document the bounded retry knob for provider/operator config

## Recovery-path eval
- RED baseline: malformed-then-valid OpenAI-compatible fixture failed after one provider call; exhausted retry fixture also called once
- GREEN result: malformed-then-valid fixture recovered 1/1 with schemaRetries=1, so the local recovery-path delta is 0/1 -> 1/1 for the seeded malformed-output case
- Exhaustion remains fail-closed as model-output after the bounded retry count

## Validation
- npm test -- --run tests/provider-adapters.test.ts tests/provider-registry.test.ts tests/config-cli.test.ts --pool=forks --maxWorkers=1
- npm run build
- git diff --check
- npm run check:public-claims
- npm run check:secrets

## Safety boundary
- OpenAI-compatible adapter-level recovery only
- no scheduler, queue, posting, stale-head, provider cooldown, provider auto-detection, ZCode, or live runtime config changes
- retry prompt includes schema errors and the canonical schema only; it does not echo raw rejected model output