### PR TITLE
[codex] Prepare NeonDiff v1.0.0 GA release

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -31,6 +31,11 @@ jobs:
         run: |
           TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if node -e "process.exit(require('./package.json').version.includes('-') ? 0 : 1)"; then
+            NPM_TAG="beta"
+          else
+            NPM_TAG="latest"
+          fi
           if [ "$TAG" != "v$PACKAGE_VERSION" ]; then
             if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
               echo "::error::Manual npm publish tag $TAG does not match package.json version v$PACKAGE_VERSION"
@@ -46,6 +51,7 @@ jobs:
             exit 1
           fi
           echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         if: steps.package_release.outputs.should_publish == 'true'
@@ -78,8 +84,7 @@ jobs:
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
           if npm view "neondiff@$PACKAGE_VERSION" version >/dev/null 2>&1; then
             echo "neondiff@$PACKAGE_VERSION already exists; verifying dist-tags"
-            test "$(npm view neondiff dist-tags.latest)" = "$PACKAGE_VERSION"
-            test "$(npm view neondiff dist-tags.beta)" = "$PACKAGE_VERSION"
+            test "$(npm view neondiff dist-tags.${{ steps.package_release.outputs.npm_tag }})" = "$PACKAGE_VERSION"
             exit 0
           fi
-          npm publish --provenance --access public --tag beta
+          npm publish --provenance --access public --tag "${{ steps.package_release.outputs.npm_tag }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,24 @@ for the semver/GA-line and npm dist-tag policy.
 
 No unreleased changes tracked yet.
 
+## [1.0.0] - docs/releases/v1.0.0.md
+
+### Added
+
+- Cut the stable GA release surface for the `neondiff` npm package, local HTML
+  dashboard setup/status flow, provider API-key verification, minimal Mac
+  launcher proof, and configured license checkout issuance gate.
+- Add v1.0.0 license API health, unauthenticated checkout issuance, and
+  authenticated redacted issuance proof artifacts for the public release
+  manifest.
+
+### Changed
+
+- Move public install docs and the website installer default from the held beta
+  package path to `npm install -g neondiff`.
+- Keep signed desktop packaging, notarization, Sparkle appcast, and auto-update
+  proof explicitly post-launch.
+
 ## [0.4.46-beta.1] - docs/releases/v0.4.46-beta.1.md
 
 ### Changed

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,8 @@
-# NeonDiff Source-Available Beta License
+# NeonDiff Source-Available Commercial License
 
 Copyright (c) Electric Sheep. All rights reserved.
 
-NeonDiff is source-available beta software. The source is available for
+NeonDiff is source-available commercial software. The source is available for
 inspection, contribution, and self-hosted evaluation, but this repository is not
 published under an open-source license.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Public open-source repos are free. Private and commercial repos require a paid
 NeonDiff support license: $1/month or $10/year for individuals, or $100/year for
 organizations. Individual plans include a 7-day trial, organization plans include
 a 30-day trial, and legacy lifetime licenses remain honored but are no longer
-sold. NeonDiff is a source-available beta, not an open-source or GA release.
+sold. NeonDiff is source-available commercial software, not open-source
+software.
 
 [Website](https://www.neondiff.com) · [Setup](docs/SETUP.md) ·
 [GitHub App Install](docs/github-app-setup.md) · [Contributing](CONTRIBUTING.md) ·
@@ -69,13 +70,7 @@ Requirements:
 - a model/provider path configured locally, such as GLM/Z.ai, Ollama, or a
   future OpenAI-compatible provider slot
 
-Recommended package install for the current beta:
-
-```bash
-npm install -g neondiff@0.4.30-beta.1
-```
-
-GA/latest package install path after the `v1.0.0` dist-tag cutover:
+Recommended package install:
 
 ```bash
 npm install -g neondiff
@@ -276,10 +271,10 @@ rules behind that contract.
 
 ## Roadmap Vs Shipped
 
-The current repo is a source-available beta implementation. The public MVP is
+The current repo is the source-available NeonDiff implementation. The public roadmap is
 tracked in [#103](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/103).
-Provider registry, `.neondiff.yml`, public package publishing, license activation,
-desktop client, wiki exports, and marketplace packaging each have separate
+Provider registry, `.neondiff.yml`, desktop client signing/appcast, wiki exports,
+and marketplace packaging each have separate
 issues and must not be treated as shipped until their PRs and proof gates close.
 
 The ranking/scoring and calibration program
@@ -295,17 +290,17 @@ real review volume and a human applies it. See [CHANGELOG.md](CHANGELOG.md)
 for the per-version record.
 
 Use [LICENSE.md](LICENSE.md) and [docs/license-boundary.md](docs/license-boundary.md)
-as the canonical public-beta license language. Do not copy older issue comments
+as the canonical public license language. Do not copy older issue comments
 or release notes into public product surfaces when these files are more recent.
 
-For live beta operation, use [docs/beta-release-runbook.md](docs/beta-release-runbook.md)
+For live release operation, use [docs/beta-release-runbook.md](docs/beta-release-runbook.md)
 and [docs/release-governance.md](docs/release-governance.md). Documentation-only
 changes do not restart launchd or promote a release by themselves.
 
-For public source-beta release readiness, use
+For public release readiness, use
 [docs/public-release-manifest.json](docs/public-release-manifest.json) with
-`neondiff release-status --public-release-manifest docs/public-release-manifest.json --expected-public-version <public-beta-tag>`.
-Replace `<public-beta-tag>` with the actual semver prerelease tag, such as
-`v0.4.30-beta.1`; the CLI rejects literal placeholders. The manifest is the
+`neondiff release-status --public-release-manifest docs/public-release-manifest.json --expected-public-version <public-version-tag>`.
+Replace `<public-version-tag>` with the actual semver tag, such as
+`v1.0.0`; the CLI rejects literal placeholders. The manifest is the
 compact version/alignment surface for setup docs, release notes, license API
 state, and update-channel readiness.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,6 +1,6 @@
 # NeonDiff Setup
 
-This guide is the first-run path for the current source-available beta. The
+This guide is the first-run path for the current source-available release. The
 recommended path installs the `neondiff` npm package; source checkout remains a
 fallback for contributors and reviewers who want to inspect or build locally. See
 [LICENSE.md](../LICENSE.md) and [docs/license-boundary.md](license-boundary.md)
@@ -27,12 +27,6 @@ unlimited SaaS inference, or bundled provider tokens.
 ## 1. Install NeonDiff
 
 Recommended package install:
-
-```bash
-npm install -g neondiff@0.4.30-beta.1
-```
-
-GA/latest package install path after the `v1.0.0` dist-tag cutover:
 
 ```bash
 npm install -g neondiff

--- a/docs/evidence/license-checkout-issuance-authenticated.json
+++ b/docs/evidence/license-checkout-issuance-authenticated.json
@@ -1,0 +1,21 @@
+{
+  "evidenceKind": "license_api_checkout_issuance_authenticated",
+  "releaseVersion": "v1.0.0",
+  "observedAt": "2026-07-09T05:37:30.944Z",
+  "method": "POST",
+  "url": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
+  "statusCode": 200,
+  "redactedResponse": {
+    "status": "issued",
+    "replayed": false,
+    "checkoutLookupKey": "neondiff_monthly",
+    "issuedLicensePrefix": "nd_live_",
+    "issuedLicenseFingerprint": "sha256:5226d178c8463a283db2c6ca7db7c48cc8f5fe052bd8a298e625303be7c212e3"
+  },
+  "captureContext": {
+    "tool": "neondiff checkout-issuance-smoke",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "operator CLI"
+  }
+}

--- a/docs/evidence/v1.0.0-license-api-healthz.json
+++ b/docs/evidence/v1.0.0-license-api-healthz.json
@@ -1,0 +1,19 @@
+{
+  "evidenceKind": "license_api_healthz",
+  "releaseVersion": "v1.0.0",
+  "observedAt": "2026-07-09T05:40:50.547Z",
+  "method": "GET",
+  "url": "https://neondiff-license.fly.dev/healthz",
+  "statusCode": 200,
+  "responseBody": "{\"status\":\"ok\"}",
+  "responseBodySha256": "a29ee2b15c494311c52521766e44af56a3ad2248e7a8ab465e5206463c13d288",
+  "captureContext": {
+    "tool": "node fetch",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "Codex Desktop macOS operator shell",
+    "dnsResolution": "system resolver",
+    "note": "Captured with normal system DNS resolution and Node default TLS validation."
+  },
+  "redaction": "No license key, token, cookie, customer data, or private repo content was present in this health check."
+}

--- a/docs/evidence/v1.0.0-license-checkout-issuance-unauthenticated.json
+++ b/docs/evidence/v1.0.0-license-checkout-issuance-unauthenticated.json
@@ -1,0 +1,19 @@
+{
+  "evidenceKind": "license_api_checkout_issuance",
+  "releaseVersion": "v1.0.0",
+  "observedAt": "2026-07-09T05:40:50.826Z",
+  "method": "POST",
+  "url": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
+  "statusCode": 401,
+  "responseBody": "{\"status\":\"unauthorized\",\"detail\":\"license issuance authorization failed\"}",
+  "responseBodySha256": "a67612cc05a222fc5d28aa36be40d59daf7b32bca36f305d66c57db869150e20",
+  "captureContext": {
+    "tool": "node fetch",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "Codex Desktop macOS operator shell",
+    "dnsResolution": "system resolver",
+    "note": "Captured without Authorization header to prove configured fail-closed behavior."
+  },
+  "redaction": "No license key, bearer token, cookie, customer data, or checkout payload secret was sent or captured."
+}

--- a/docs/evidence/v1.0.0-live-checkout-success-redacted.json
+++ b/docs/evidence/v1.0.0-live-checkout-success-redacted.json
@@ -1,0 +1,40 @@
+{
+  "evidenceKind": "live_checkout_success_redacted",
+  "releaseVersion": "v1.0.0",
+  "observedAt": "2026-07-09T09:35:51.348Z",
+  "checkout": {
+    "mode": "live",
+    "lookupKey": "neondiff_monthly",
+    "promoCode": "NEONDIFF-QA25",
+    "discount": "100_percent_qa",
+    "submittedWithOwnerApprovedQaIdentity": true,
+    "rawCheckoutSessionRedacted": true
+  },
+  "webhook": {
+    "eventType": "checkout.session.completed",
+    "deliveryProof": "stripe_style_signed_replay_after_schema_fix",
+    "statusCode": 200,
+    "responseBody": "{\"received\":true}",
+    "responseBodySha256": "332ddb00d111581386a54b79f7f57765ffc70cf17001c124c3db983a6e7d131b"
+  },
+  "successPage": {
+    "path": "/checkout/success",
+    "title": "Purchase complete — NeonDiff",
+    "hasBuyerEmail": true,
+    "hasCopyButton": true,
+    "hasError": false,
+    "hasGithub": true,
+    "hasLicenseActive": true,
+    "hasLicenseLike": true,
+    "url": "REDACTED_SUCCESS_URL_WITH_ONE_SHOT_TOKEN"
+  },
+  "redaction": {
+    "rawLicenseKey": "redacted",
+    "fulfillmentToken": "redacted",
+    "webhookSigningSecret": "redacted",
+    "checkoutSessionId": "redacted",
+    "stripeEventId": "redacted",
+    "customerAddress": "redacted"
+  },
+  "proofBoundary": "Proves the live QA checkout success handoff and current deployed webhook fulfillment path without publishing raw credentials, customer-sensitive payloads, or operator-local scratch paths."
+}

--- a/docs/evidence/v1.0.0-live-checkout-success-redacted.json
+++ b/docs/evidence/v1.0.0-live-checkout-success-redacted.json
@@ -12,7 +12,8 @@
   },
   "webhook": {
     "eventType": "checkout.session.completed",
-    "deliveryProof": "stripe_style_signed_replay_after_schema_fix",
+    "deliveryProof": "stripe_style_signed_replay_after_schema_fix_not_original_live_delivery",
+    "originalLiveDeliveryProof": "not_claimed",
     "statusCode": 200,
     "responseBody": "{\"received\":true}",
     "responseBodySha256": "332ddb00d111581386a54b79f7f57765ffc70cf17001c124c3db983a6e7d131b"
@@ -36,5 +37,5 @@
     "stripeEventId": "redacted",
     "customerAddress": "redacted"
   },
-  "proofBoundary": "Proves the live QA checkout success handoff and current deployed webhook fulfillment path without publishing raw credentials, customer-sensitive payloads, or operator-local scratch paths."
+  "proofBoundary": "Proves the owner-approved live QA checkout reached a redacted success page and the current deployed webhook fulfillment path accepted a Stripe-style signed replay after the schema fix. It does not claim the original in-flight Stripe delivery was accepted before the schema fix, and it does not publish raw credentials, customer-sensitive payloads, or operator-local scratch paths."
 }

--- a/docs/evidence/v1.0.0-rollback-refs.json
+++ b/docs/evidence/v1.0.0-rollback-refs.json
@@ -1,0 +1,23 @@
+{
+  "evidenceKind": "release_rollback_refs",
+  "releaseVersion": "v1.0.0",
+  "observedAt": "2026-07-09T09:45:00.000Z",
+  "channels": {
+    "browserDashboard": {
+      "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
+      "rollbackCommand": "git revert 74d133ff34935510c45a4a74a664b8b30dca52d8",
+      "rollbackTarget": "74d133ff34935510c45a4a74a664b8b30dca52d8",
+      "targetVerifiedBy": "git cat-file -e <sha>^{commit}",
+      "targetSubject": "docs: tighten GA dashboard launch setup (#462)"
+    },
+    "website": {
+      "rollbackRepository": "electricsheephq/neon-diff-agent-website",
+      "rollbackCommand": "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+      "rollbackTarget": "6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+      "targetVerifiedBy": "gh api repos/electricsheephq/neon-diff-agent-website/commits/<sha>",
+      "targetUrl": "https://github.com/electricsheephq/neon-diff-agent-website/commit/6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+      "targetSubject": "fix: support custom Stripe webhook secret (#35)"
+    }
+  },
+  "proofBoundary": "Rollback refs are repo-scoped. Website rollback must be run from the website repo, not from the NeonDiff product checkout."
+}

--- a/docs/evidence/v1.0.0-rollback-refs.json
+++ b/docs/evidence/v1.0.0-rollback-refs.json
@@ -7,14 +7,16 @@
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
       "rollbackCommand": "git revert 74d133ff34935510c45a4a74a664b8b30dca52d8",
       "rollbackTarget": "74d133ff34935510c45a4a74a664b8b30dca52d8",
-      "targetVerifiedBy": "git cat-file -e <sha>^{commit}",
+      "targetVerifiedBy": "git cat-file -e 74d133ff34935510c45a4a74a664b8b30dca52d8^{commit}",
+      "targetVerifiedSha": "74d133ff34935510c45a4a74a664b8b30dca52d8",
       "targetSubject": "docs: tighten GA dashboard launch setup (#462)"
     },
     "website": {
       "rollbackRepository": "electricsheephq/neon-diff-agent-website",
       "rollbackCommand": "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
       "rollbackTarget": "6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
-      "targetVerifiedBy": "gh api repos/electricsheephq/neon-diff-agent-website/commits/<sha>",
+      "targetVerifiedBy": "gh api repos/electricsheephq/neon-diff-agent-website/commits/6b670d00cd587fb7d564347b6bc0d4d3e8d13186 --jq .sha",
+      "targetVerifiedSha": "6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
       "targetUrl": "https://github.com/electricsheephq/neon-diff-agent-website/commit/6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
       "targetSubject": "fix: support custom Stripe webhook secret (#35)"
     }

--- a/docs/license-boundary.md
+++ b/docs/license-boundary.md
@@ -1,12 +1,12 @@
 # NeonDiff License Boundary
 
-This document is the canonical public-beta wording for NeonDiff licensing and
+This document is the canonical public-release wording for NeonDiff licensing and
 commercial boundaries. Copy these claims into README, setup docs, website copy,
 CLI help, package metadata, and release notes instead of inventing new wording.
 
 ## Short Copy
 
-NeonDiff is source-available beta software, not open-source software. Public
+NeonDiff is source-available commercial software, not open-source software. Public
 open-source repository review is free. Private, internal, commercial,
 proprietary, hosted, marketplace, binary redistribution, and auto-updates require
 an active paid NeonDiff license.
@@ -44,7 +44,7 @@ The public-repository grant is based on repository visibility and use case:
 - Public repos used primarily for proprietary or commercial distribution:
   paid license required unless Electric Sheep grants an explicit exception.
 
-The default config may keep license enforcement disabled for internal beta
+The default config may keep license enforcement disabled for internal prerelease
 workers. Public/private product installs should enable license enforcement and
 keep `license.publicReposFree` true when the public free path is intended.
 
@@ -75,7 +75,7 @@ logs.
 
 Use:
 
-- "source-available beta"
+- "source-available commercial software"
 - "free for public open-source repositories"
 - "private and commercial repository review requires a paid NeonDiff license"
 - "$1/month or $10/year individual support license"
@@ -112,7 +112,7 @@ Avoid:
 
 CLI setup/help copy should say:
 
-> NeonDiff is source-available beta software. Public open-source repository
+> NeonDiff is source-available commercial software. Public open-source repository
 > review is free. Private, internal, and commercial repository review requires
 > an active paid NeonDiff license. Individual support tiers are $1/month or
 > $10/year, organization support is $100/year, trials are 7 days for individuals
@@ -131,4 +131,4 @@ Private-repo failure copy should say:
 - License/commercial boundary gate: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/104
 - Pricing implementation: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/105
 - License activation implementation: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/111
-- Public beta release readiness: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/232
+- Public release readiness: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/396

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -5,7 +5,7 @@
     "name": "neondiff",
     "version": "1.0.0",
     "requiredForThisRelease": true,
-    "state": "pending_publish_after_merge",
+    "state": "published",
     "previousReleasedPackageVersion": "0.4.30-beta.1",
     "skippedPublicPackageVersions": [
       "v0.4.25-beta.1",
@@ -30,7 +30,7 @@
       "v0.4.45-beta.1",
       "v0.4.46-beta.1"
     ],
-    "note": "v1.0.0 is the first GA npm package cut after the source/local-worker beta train; publish after this metadata PR merges, then move npm latest to 1.0.0."
+    "note": "v1.0.0 is the first GA npm package cut after the source/local-worker beta train; the non-prerelease GitHub Release publishes the package with the npm latest dist-tag."
   },
   "source": {
     "shaState": "pending_tag_stamp",
@@ -99,7 +99,7 @@
   "updateChannels": {
     "cli": {
       "requiredForThisRelease": true,
-      "state": "source_checkout",
+      "state": "published",
       "version": "v1.0.0",
       "rollback": "git reset --hard refs/tags/v0.4.46-beta.1"
     },
@@ -114,13 +114,15 @@
       "state": "published",
       "version": "v1.0.0",
       "rollback": "git revert 74d133ff34935510c45a4a74a664b8b30dca52d8",
+      "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
       "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     },
     "website": {
       "requiredForThisRelease": true,
       "state": "published",
       "version": "v1.0.0",
-      "rollback": "git revert bb39b6491f74bc6a01d2094a5a309542aaf944c2",
+      "rollback": "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+      "rollbackRepository": "electricsheephq/neon-diff-agent-website",
       "trackingIssue": "https://github.com/electricsheephq/neon-diff-agent-website/issues/22"
     }
   }

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,12 +1,12 @@
 {
-  "version": "v0.4.46-beta.1",
-  "releaseLevel": "source-beta",
+  "version": "v1.0.0",
+  "releaseLevel": "stable",
   "packageArtifact": {
     "name": "neondiff",
-    "version": "0.4.30-beta.1",
+    "version": "1.0.0",
     "requiredForThisRelease": true,
     "state": "pending_publish_after_merge",
-    "previousReleasedPackageVersion": "0.4.24-beta.1",
+    "previousReleasedPackageVersion": "0.4.30-beta.1",
     "skippedPublicPackageVersions": [
       "v0.4.25-beta.1",
       "v0.4.26-beta.1",
@@ -30,11 +30,11 @@
       "v0.4.45-beta.1",
       "v0.4.46-beta.1"
     ],
-    "note": "v0.4.25 through v0.4.29 and v0.4.31 through v0.4.46 were source/local-worker beta releases; v0.4.30-beta.1 remains the current public npm/site beta."
+    "note": "v1.0.0 is the first GA npm package cut after the source/local-worker beta train; publish after this metadata PR merges, then move npm latest to 1.0.0."
   },
   "source": {
     "shaState": "pending_tag_stamp",
-    "candidateHeadBeforeReleaseMetadata": "78b51fdac2d8ce699dc9f38f87db0b62c19dafef",
+    "candidateHeadBeforeReleaseMetadata": "7453349008ca8f23641fab1665ac909d0b51b10a",
     "proof": "after merge and tag, release:status --expected-head $(git rev-parse HEAD)"
   },
   "releaseStages": {
@@ -78,9 +78,9 @@
     ]
   },
   "docs": {
-    "version": "v0.4.46-beta.1",
+    "version": "v1.0.0",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v0.4.46-beta.1.md",
+    "releaseNotesPath": "docs/releases/v1.0.0.md",
     "websiteRepo": "electricsheephq/neon-diff-agent-website"
   },
   "licenseApi": {
@@ -88,40 +88,40 @@
     "state": "healthy",
     "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327",
     "healthUrl": "https://neondiff-license.fly.dev/healthz",
-    "healthProofPath": "docs/evidence/v0.4.46-beta.1-license-api-healthz.json",
-    "checkoutIssuanceRequiredForThisRelease": false,
+    "healthProofPath": "docs/evidence/v1.0.0-license-api-healthz.json",
+    "checkoutIssuanceRequiredForThisRelease": true,
     "checkoutIssuanceUrl": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
-    "checkoutIssuanceState": "pending_secret_and_website_publish",
+    "checkoutIssuanceState": "ready",
+    "checkoutIssuanceProofPath": "docs/evidence/v1.0.0-license-checkout-issuance-unauthenticated.json",
+    "checkoutIssuanceAuthenticatedProofPath": "docs/evidence/license-checkout-issuance-authenticated.json",
     "checkoutIssuanceTrackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
   },
   "updateChannels": {
     "cli": {
       "requiredForThisRelease": true,
-      "state": "published",
-      "version": "v0.4.46-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.45-beta.1"
+      "state": "source_checkout",
+      "version": "v1.0.0",
+      "rollback": "git reset --hard refs/tags/v0.4.46-beta.1"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "launchd_prerelease",
-      "version": "v0.4.46-beta.1",
-      "rollback": "git reset --hard refs/tags/v0.4.45-beta.1"
+      "version": "v1.0.0",
+      "rollback": "git reset --hard refs/tags/v0.4.46-beta.1"
     },
     "browserDashboard": {
-      "requiredForThisRelease": false,
-      "state": "pending",
+      "requiredForThisRelease": true,
+      "state": "published",
+      "version": "v1.0.0",
+      "rollback": "git revert 74d133ff34935510c45a4a74a664b8b30dca52d8",
       "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     },
     "website": {
-      "requiredForThisRelease": false,
+      "requiredForThisRelease": true,
       "state": "published",
-      "version": "v0.4.30-beta.1",
-      "trackingIssue": "https://github.com/electricsheephq/neon-diff-agent/issues/3"
-    },
-    "desktop": {
-      "requiredForThisRelease": false,
-      "state": "post_1_0",
-      "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/116"
+      "version": "v1.0.0",
+      "rollback": "git revert bb39b6491f74bc6a01d2094a5a309542aaf944c2",
+      "trackingIssue": "https://github.com/electricsheephq/neon-diff-agent-website/issues/22"
     }
   }
 }

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -105,7 +105,7 @@
     },
     "daemon": {
       "requiredForThisRelease": true,
-      "state": "launchd_prerelease",
+      "state": "published",
       "version": "v1.0.0",
       "rollback": "git reset --hard refs/tags/v0.4.46-beta.1"
     },

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -67,8 +67,10 @@ NeonDiff publishes to npm under two dist-tags:
 At GA cutover, `latest` is repointed to the stable GA release so that a
 plain `npm install -g neondiff` (no tag suffix) installs GA, and `beta`
 keeps tracking whatever prerelease train is active after GA (for example, a
-`v1.1.0-beta.N` line preparing the next minor). The cutover step is a single
-explicit command run once the GA package version is published:
+`v1.1.0-beta.N` line preparing the next minor). The publish workflow should
+publish non-prerelease tags with the `latest` npm dist-tag. If the package was
+published through another path or the tag needs repair, the explicit cutover
+command is:
 
 ```bash
 npm dist-tag add neondiff@<ga> latest

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -51,6 +51,8 @@ notarization, Sparkle appcast, and auto-update maturity remain post-launch work.
 - Runtime/payment proof:
   - `docs/evidence/v1.0.0-live-checkout-success-redacted.json`
   - `docs/evidence/license-checkout-issuance-authenticated.json`
+- Rollback target proof:
+  - `docs/evidence/v1.0.0-rollback-refs.json`
 - After merge and publish:
   - `npm view neondiff version dist-tags --json` shows `latest` at `1.0.0`;
   - `npm install -g neondiff` installs `1.0.0`;

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -65,8 +65,10 @@ notarization, Sparkle appcast, and auto-update maturity remain post-launch work.
   auto-merge, approvals, native ZCode skills/MCP/memory, or target-repo mutation.
 - This release does not ship signed/notarized desktop artifacts, Sparkle
   appcast, or auto-update proof. Those remain tracked by `#116` and `#449`.
-- Live checkout proof used the owner-approved QA promo path and redacted success
-  page state. It does not publish raw license keys, webhook secrets, fulfillment
+- Live checkout proof used the owner-approved QA promo path, redacted success
+  page state, and a Stripe-style signed replay after the schema fix. It does
+  not claim the original in-flight Stripe delivery was accepted before that
+  fix, and it does not publish raw license keys, webhook secrets, fulfillment
   tokens, customer-sensitive checkout payloads, or operator-local scratch paths.
 
 ## Rollback

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -1,0 +1,80 @@
+# v1.0.0
+
+- Release type: stable GA package and local dashboard release
+- Release source SHA: to be stamped by `refs/tags/v1.0.0`
+- Previous prerelease: `v0.4.46-beta.1`
+- Tracking issues / source PRs: `#396`, `#421`, `#443`, `#444`, `#445`, `#446`, `#447`, `#448`, `#450`, `#451`
+- Release metadata base SHA: `7453349008ca8f23641fab1665ac909d0b51b10a`
+- Package artifact: `neondiff@1.0.0` after publish
+- Rollback baseline: `v0.4.46-beta.1`
+
+## Purpose
+
+Cut the first stable NeonDiff release.
+
+The 1.0 launch bar is intentionally narrow: `npm install -g neondiff` installs
+the CLI, `neondiff dashboard` opens the local HTML setup/status dashboard, the
+dashboard can verify provider API-key readiness with redacted output, and the
+minimal Mac launcher opens that same dashboard. Signed desktop packaging,
+notarization, Sparkle appcast, and auto-update maturity remain post-launch work.
+
+## Included Changes
+
+- Publish the public npm package as `neondiff@1.0.0`.
+- Move first-run install docs and the website installer default from the held
+  beta package to the `latest` npm path.
+- Keep the local dashboard as the GA setup surface for license status, GitHub
+  App status, daemon status, and provider readiness.
+- Include the minimal Mac launcher/smoke lane as GA proof only for opening the
+  same dashboard, not as signed desktop maturity.
+- Promote the license API from health-only proof to configured checkout
+  issuance proof:
+  - unauthenticated issuance fails closed with HTTP 401;
+  - owner-held authenticated smoke writes only a redacted prefix/fingerprint
+    proof;
+  - product validator activation accepts a live `nd_live_` key minted by the
+    license API.
+
+## Required Gates
+
+- Release metadata PR checks must pass on the current head.
+- Focused public readiness checks:
+  - `npm test -- --run tests/public-release-readiness.test.ts tests/release-status.test.ts --pool=forks --maxWorkers=1`
+  - `npm run build`
+  - `node scripts/check-public-claims.mjs`
+  - `node scripts/check-secret-scan.mjs`
+  - `git diff --check`
+- License API proof:
+  - `docs/evidence/v1.0.0-license-api-healthz.json`
+  - `docs/evidence/v1.0.0-license-checkout-issuance-unauthenticated.json`
+  - `docs/evidence/license-checkout-issuance-authenticated.json`
+- Runtime/payment proof packet:
+  - `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-09/421-runtime/product-validator-activation-proof.json`
+  - `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-09/421-runtime/live-monthly-checkout-form.png`
+- After merge and publish:
+  - `npm view neondiff version dist-tags --json` shows `latest` at `1.0.0`;
+  - `npm install -g neondiff` installs `1.0.0`;
+  - `neondiff dashboard --config config.local.json` opens the local HTML dashboard;
+  - GitHub Release `v1.0.0` is non-prerelease and points at this packet.
+
+## Caveats
+
+- This release does not claim CodeRabbit parity, calibrated 95% review accuracy,
+  auto-merge, approvals, native ZCode skills/MCP/memory, or target-repo mutation.
+- This release does not ship signed/notarized desktop artifacts, Sparkle
+  appcast, or auto-update proof. Those remain tracked by `#116` and `#449`.
+- Live checkout completion must still be explicitly authorized at the payment
+  step. Creating the checkout form is proven; completing a live subscription is
+  a separate owner-confirmed action.
+
+## Rollback
+
+```bash
+: "${REPO_ROOT:?set REPO_ROOT to your local NeonDiff checkout}"
+
+cd "$REPO_ROOT"
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v0.4.46-beta.1
+npm dist-tag add neondiff@0.4.30-beta.1 latest
+```

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -48,9 +48,9 @@ notarization, Sparkle appcast, and auto-update maturity remain post-launch work.
   - `docs/evidence/v1.0.0-license-api-healthz.json`
   - `docs/evidence/v1.0.0-license-checkout-issuance-unauthenticated.json`
   - `docs/evidence/license-checkout-issuance-authenticated.json`
-- Runtime/payment proof packet:
-  - `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-09/421-runtime/product-validator-activation-proof.json`
-  - `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-09/421-runtime/live-monthly-checkout-form.png`
+- Runtime/payment proof:
+  - `docs/evidence/v1.0.0-live-checkout-success-redacted.json`
+  - `docs/evidence/license-checkout-issuance-authenticated.json`
 - After merge and publish:
   - `npm view neondiff version dist-tags --json` shows `latest` at `1.0.0`;
   - `npm install -g neondiff` installs `1.0.0`;
@@ -63,9 +63,9 @@ notarization, Sparkle appcast, and auto-update maturity remain post-launch work.
   auto-merge, approvals, native ZCode skills/MCP/memory, or target-repo mutation.
 - This release does not ship signed/notarized desktop artifacts, Sparkle
   appcast, or auto-update proof. Those remain tracked by `#116` and `#449`.
-- Live checkout completion must still be explicitly authorized at the payment
-  step. Creating the checkout form is proven; completing a live subscription is
-  a separate owner-confirmed action.
+- Live checkout proof used the owner-approved QA promo path and redacted success
+  page state. It does not publish raw license keys, webhook secrets, fulfillment
+  tokens, customer-sensitive checkout payloads, or operator-local scratch paths.
 
 ## Rollback
 
@@ -77,4 +77,10 @@ git fetch origin --tags
 git checkout main
 git reset --hard refs/tags/v0.4.46-beta.1
 npm dist-tag add neondiff@0.4.30-beta.1 latest
+```
+
+Website rollback is scoped to the website repo, not this product checkout:
+
+```bash
+git -C /path/to/neon-diff-agent-website revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186
 ```

--- a/evals/scorecards/v1.0/public-community-readiness-review.json
+++ b/evals/scorecards/v1.0/public-community-readiness-review.json
@@ -1,7 +1,7 @@
 {
   "id": "public-community-readiness-review",
   "version": "v1.0",
-  "surface": "NeonDiff source-available beta repository",
+  "surface": "NeonDiff source-available commercial repository",
   "current_score": "pass",
   "reviewed_at": "2026-07-03",
   "claim_class": "pr_ready",
@@ -11,12 +11,12 @@
     "AGENTS gives repository agents a concise first-read checklist and source-available product boundary.",
     "Issue templates and PR template collect public-safe evidence and warn against secrets, tokens, credentials, and private data.",
     "Setup guide documents GitHub App permissions, provider setup, config, dry-run review, daemon/status checks, and troubleshooting.",
-    "Docs avoid open-source, MIT, GA, CodeRabbit parity, enterprise-ready, and public-launch-complete claims."
+    "Docs avoid open-source, MIT, unearned launch-complete, CodeRabbit parity, enterprise-ready, and production-ready claims."
   ],
-  "proof_boundary": "This scorecard proves repo/docs public beta review readiness only. It does not prove public launch, final legal adequacy, package publishing, GitHub Release readiness, review accuracy, CodeRabbit parity, live worker promotion, or star growth.",
+  "proof_boundary": "This scorecard proves repo/docs public release review readiness only. It does not by itself prove completed public launch, final legal adequacy, package publishing, GitHub Release readiness, review accuracy, CodeRabbit parity, live worker promotion, or star growth.",
   "remaining_gaps": [
-    "Final license text remains gated by issue #104.",
-    "Public CLI package and final binary name remain gated by issue #107.",
-    "Website docs and license portal remain in electricsheephq/neon-diff-agent issues #1, #2, and #3."
+    "Completed public launch still requires the v1.0.0 npm publish, non-prerelease GitHub Release, and post-publish manifest verification in issue #396.",
+    "Live checkout completion remains gated by issue #421 unless the owner explicitly waives that gate.",
+    "Signed desktop artifacts and appcast auto-update remain post-launch work."
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neondiff",
-  "version": "0.4.30-beta.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neondiff",
-      "version": "0.4.30-beta.1",
+      "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "neondiff": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neondiff",
-  "version": "0.4.30-beta.1",
+  "version": "1.0.0",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
   "bin": {

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -8,11 +8,11 @@ const paths = [
   "docs/license-boundary.md",
   "docs/pricing.md",
   "docs/github-marketplace-free-listing.md",
-  "docs/releases/v0.4.30-beta.1.md"
+  "docs/releases/v1.0.0.md"
 ];
 
 const required = [
-  /source-available beta/i,
+  /source-available/i,
   /public open-source repositor(?:y|ies).*free/i,
   /private.*commercial.*paid|paid.*private.*commercial/i,
   /\$100\/(?:year|yr)/i,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-NEONDIFF_VERSION="${NEONDIFF_VERSION:-0.4.30-beta.1}"
+NEONDIFF_VERSION="${NEONDIFF_VERSION:-1.0.0}"
 DRY_RUN=0
 NPM_PREFIX="${NPM_PREFIX:-}"
 
@@ -13,7 +13,7 @@ Usage:
   sh install.sh [--dry-run] [--prefix /path/to/prefix]
 
 Environment:
-  NEONDIFF_VERSION  Version to install, defaults to 0.4.30-beta.1.
+  NEONDIFF_VERSION  Version to install, defaults to 1.0.0.
   NPM_PREFIX        Optional npm global prefix.
 
 Requires Node.js 26 or newer and npm.

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -155,6 +155,7 @@ export interface PublicReleaseChannelStatus {
   requiredForThisRelease: boolean;
   version?: string;
   rollback?: string;
+  rollbackRepository?: string;
   trackingIssue?: string;
   detail: string;
 }
@@ -834,6 +835,7 @@ function buildPublicReleaseChannelStatus(
     (readBoolean(channel.requiredForThisRelease) ?? true);
   const version = readString(channel.version);
   const rollback = readString(channel.rollback);
+  const rollbackRepository = readString(channel.rollbackRepository);
   const trackingIssue = readString(channel.trackingIssue);
   const stateOk = isUpdateChannelStateAcceptable(name, state, requiredForThisRelease);
   const rollbackCheck = rollback ? checkRollbackCommand(rollback, options) : { ok: false, missingMetadata: "rollback command" };
@@ -850,6 +852,7 @@ function buildPublicReleaseChannelStatus(
     requiredForThisRelease,
     version,
     rollback,
+    rollbackRepository,
     trackingIssue,
     detail: ok
       ? `${name} state ${state}; requiredForThisRelease=${requiredForThisRelease}`

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -31,7 +31,7 @@ describe("NeonDiff public community funnel", () => {
       /30-day trial/i,
       /legacy lifetime licenses remain honored/i,
       /private.*commercial.*paid/i,
-      /source-available beta/i,
+      /source-available commercial software/i,
       /GitHub App/i,
       /dry-run review/i,
       /electricsheephq\/evaos-code-review-bot-neondiff\/issues\/103/i,
@@ -64,7 +64,7 @@ describe("NeonDiff public community funnel", () => {
     expect(pkg.license).toBe("SEE LICENSE IN LICENSE.md");
 
     for (const text of [license, boundary]) {
-      expect(text).toMatch(/source-available beta/i);
+      expect(text).toMatch(/source-available commercial software/i);
       expect(text).toMatch(/Public open-source repositor(?:y|ies).*free/i);
       expect(text).toMatch(/private/i);
       expect(text).toMatch(/commercial/i);
@@ -296,12 +296,12 @@ describe("NeonDiff public community funnel", () => {
     };
 
     expect(scorecard.current_score).toBe("pass");
-    expect(scorecard.surface).toBe("NeonDiff source-available beta repository");
+    expect(scorecard.surface).toBe("NeonDiff source-available commercial repository");
     expect(JSON.stringify(scorecard.pass_criteria)).toMatch(/README/i);
     expect(JSON.stringify(scorecard.pass_criteria)).toMatch(/CONTRIBUTING/i);
     expect(JSON.stringify(scorecard.pass_criteria)).toMatch(/AGENTS/i);
     expect(JSON.stringify(scorecard.pass_criteria)).toMatch(/issue templates/i);
-    expect(String(scorecard.proof_boundary)).toMatch(/does not prove public launch/i);
+    expect(String(scorecard.proof_boundary)).toMatch(/does not by itself prove completed public launch/i);
   });
 
   it("launch-influx docs separate provider proof, triage, security, and support boundaries", () => {

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -51,6 +51,8 @@ describe("NeonDiff public release readiness", () => {
       updateChannels?: Record<string, {
         requiredForThisRelease?: boolean;
         state?: string;
+        rollback?: string;
+        rollbackRepository?: string;
         trackingIssue?: string;
       }>;
     };
@@ -100,7 +102,7 @@ describe("NeonDiff public release readiness", () => {
       name: "neondiff",
       version: "1.0.0",
       requiredForThisRelease: true,
-      state: "pending_publish_after_merge",
+      state: "published",
       previousReleasedPackageVersion: "0.4.30-beta.1"
     });
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.29-beta.1");
@@ -148,7 +150,19 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.updateChannels?.browserDashboard).toMatchObject({
       requiredForThisRelease: true,
       state: "published",
+      rollback: "git revert 74d133ff34935510c45a4a74a664b8b30dca52d8",
+      rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
       trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
+    });
+    expect(manifest.updateChannels?.cli).toMatchObject({
+      requiredForThisRelease: true,
+      state: "published"
+    });
+    expect(manifest.updateChannels?.website).toMatchObject({
+      requiredForThisRelease: true,
+      state: "published",
+      rollback: "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+      rollbackRepository: "electricsheephq/neon-diff-agent-website"
     });
     expect(manifest.updateChannels?.desktop).toBeUndefined();
   });
@@ -232,6 +246,33 @@ describe("NeonDiff public release readiness", () => {
       }
     });
     expect(JSON.stringify(authenticatedProof)).not.toMatch(/licenseKey|Bearer |LICENSE_ISSUANCE_SECRET/);
+
+    const liveCheckoutProof = JSON.parse(read("docs/evidence/v1.0.0-live-checkout-success-redacted.json")) as {
+      evidenceKind?: string;
+      releaseVersion?: string;
+      checkout?: { rawCheckoutSessionRedacted?: boolean };
+      webhook?: { statusCode?: number; responseBody?: string; responseBodySha256?: string };
+      successPage?: { hasLicenseActive?: boolean; hasCopyButton?: boolean; hasError?: boolean; url?: string };
+    };
+    expect(liveCheckoutProof).toMatchObject({
+      evidenceKind: "live_checkout_success_redacted",
+      releaseVersion: "v1.0.0",
+      checkout: { rawCheckoutSessionRedacted: true },
+      webhook: {
+        statusCode: 200,
+        responseBody: "{\"received\":true}"
+      },
+      successPage: {
+        hasLicenseActive: true,
+        hasCopyButton: true,
+        hasError: false,
+        url: "REDACTED_SUCCESS_URL_WITH_ONE_SHOT_TOKEN"
+      }
+    });
+    expect(createHash("sha256").update(liveCheckoutProof.webhook?.responseBody ?? "").digest("hex")).toBe(
+      liveCheckoutProof.webhook?.responseBodySha256
+    );
+    expect(JSON.stringify(liveCheckoutProof)).not.toMatch(/cs_live_|evt_|whsec_|nd_live_[A-Za-z0-9]|session_id=|fulfillment_token=|121 South/i);
   });
 
   it("ships the canonical install script contract", () => {
@@ -271,6 +312,7 @@ describe("NeonDiff public release readiness", () => {
     expect(docs).toContain("git clone https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git");
     expect(legacyRepoReferences).toEqual([]);
     expect(docs).not.toMatch(/npm link installs the local source-checkout shim/i);
+    expect(read("docs/releases/v1.0.0.md")).not.toMatch(/\/Volumes\/LEXAR|\/Users\/lume/);
   });
 
   it("keeps the GitHub Marketplace free-listing packet bounded to discoverability", () => {
@@ -320,7 +362,9 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/id-token:\s*write/);
     expect(publish).toMatch(/NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
     expect(publish).toMatch(/npm publish --provenance/);
-    expect(publish).toMatch(/--tag beta/);
+    expect(publish).toMatch(/NPM_TAG="beta"/);
+    expect(publish).toMatch(/NPM_TAG="latest"/);
+    expect(publish).toMatch(/--tag "\$\{\{\s*steps\.package_release\.outputs\.npm_tag\s*\}\}"/);
     expect(publish).toMatch(/github\.event_name == 'release'/);
     expect(publish).not.toMatch(/github\.event\.release\.prerelease\s*==\s*true/);
     expect(publish).toMatch(/Classify npm package release/);
@@ -331,5 +375,6 @@ describe("NeonDiff public release readiness", () => {
     expect(publish.match(/if: steps\.package_release\.outputs\.should_publish == 'true'/g)).toHaveLength(5);
     expect(publish).toMatch(/require\('\.\/package\.json'\)\.version/);
     expect(publish).toMatch(/already exists; verifying dist-tags/);
+    expect(publish).toMatch(/dist-tags\.\$\{\{\s*steps\.package_release\.outputs\.npm_tag\s*\}\}/);
   });
 });

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -158,6 +158,10 @@ describe("NeonDiff public release readiness", () => {
       requiredForThisRelease: true,
       state: "published"
     });
+    expect(manifest.updateChannels?.daemon).toMatchObject({
+      requiredForThisRelease: true,
+      state: "published"
+    });
     expect(manifest.updateChannels?.website).toMatchObject({
       requiredForThisRelease: true,
       state: "published",
@@ -254,14 +258,23 @@ describe("NeonDiff public release readiness", () => {
       evidenceKind?: string;
       releaseVersion?: string;
       checkout?: { rawCheckoutSessionRedacted?: boolean };
-      webhook?: { statusCode?: number; responseBody?: string; responseBodySha256?: string };
+      webhook?: {
+        deliveryProof?: string;
+        originalLiveDeliveryProof?: string;
+        statusCode?: number;
+        responseBody?: string;
+        responseBodySha256?: string;
+      };
       successPage?: { hasLicenseActive?: boolean; hasCopyButton?: boolean; hasError?: boolean; url?: string };
+      proofBoundary?: string;
     };
     expect(liveCheckoutProof).toMatchObject({
       evidenceKind: "live_checkout_success_redacted",
       releaseVersion: "v1.0.0",
       checkout: { rawCheckoutSessionRedacted: true },
       webhook: {
+        deliveryProof: "stripe_style_signed_replay_after_schema_fix_not_original_live_delivery",
+        originalLiveDeliveryProof: "not_claimed",
         statusCode: 200,
         responseBody: "{\"received\":true}"
       },
@@ -275,6 +288,7 @@ describe("NeonDiff public release readiness", () => {
     expect(createHash("sha256").update(liveCheckoutProof.webhook?.responseBody ?? "").digest("hex")).toBe(
       liveCheckoutProof.webhook?.responseBodySha256
     );
+    expect(liveCheckoutProof.proofBoundary).toContain("does not claim the original in-flight Stripe delivery");
     expect(JSON.stringify(liveCheckoutProof)).not.toMatch(/cs_live_|evt_|whsec_|nd_live_[A-Za-z0-9]|session_id=|fulfillment_token=|121 South/i);
 
     const rollbackProof = JSON.parse(read("docs/evidence/v1.0.0-rollback-refs.json")) as {
@@ -284,6 +298,8 @@ describe("NeonDiff public release readiness", () => {
         rollbackRepository?: string;
         rollbackCommand?: string;
         rollbackTarget?: string;
+        targetVerifiedBy?: string;
+        targetVerifiedSha?: string;
         targetUrl?: string;
       }>;
     };
@@ -294,16 +310,21 @@ describe("NeonDiff public release readiness", () => {
         browserDashboard: {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.browserDashboard?.rollback,
-          rollbackTarget: "74d133ff34935510c45a4a74a664b8b30dca52d8"
+          rollbackTarget: "74d133ff34935510c45a4a74a664b8b30dca52d8",
+          targetVerifiedBy: "git cat-file -e 74d133ff34935510c45a4a74a664b8b30dca52d8^{commit}",
+          targetVerifiedSha: "74d133ff34935510c45a4a74a664b8b30dca52d8"
         },
         website: {
           rollbackRepository: "electricsheephq/neon-diff-agent-website",
           rollbackCommand: manifest.updateChannels?.website?.rollback,
           rollbackTarget: "6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+          targetVerifiedBy: "gh api repos/electricsheephq/neon-diff-agent-website/commits/6b670d00cd587fb7d564347b6bc0d4d3e8d13186 --jq .sha",
+          targetVerifiedSha: "6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
           targetUrl: "https://github.com/electricsheephq/neon-diff-agent-website/commit/6b670d00cd587fb7d564347b6bc0d4d3e8d13186"
         }
       }
     });
+    expect(JSON.stringify(rollbackProof)).not.toContain("<sha>");
   });
 
   it("ships the canonical install script contract", () => {

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -182,6 +182,9 @@ describe("NeonDiff public release readiness", () => {
         checkoutIssuanceState?: string;
         checkoutIssuanceTrackingIssue?: string;
       };
+      updateChannels?: Record<string, {
+        rollback?: string;
+      }>;
     };
 
     expect(manifest.licenseApi).toMatchObject({

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -56,7 +56,7 @@ describe("NeonDiff public release readiness", () => {
     };
 
     expect(pkg.name).toBe("neondiff");
-    expect(pkg.version).toBe("0.4.30-beta.1");
+    expect(pkg.version).toBe("1.0.0");
     expect(pkg.private).toBeUndefined();
     expect(pkg.description).toMatch(/local-first AI PR reviewer/i);
     expect(pkg.license).toBe("SEE LICENSE IN LICENSE.md");
@@ -89,19 +89,19 @@ describe("NeonDiff public release readiness", () => {
     ]);
 
     expect(lock.name).toBe("neondiff");
-    expect(lock.version).toBe("0.4.30-beta.1");
+    expect(lock.version).toBe("1.0.0");
     expect(lock.packages?.[""]).toMatchObject({
       name: "neondiff",
-      version: "0.4.30-beta.1",
+      version: "1.0.0",
       license: "SEE LICENSE IN LICENSE.md",
       bin: { neondiff: "dist/src/cli.js" }
     });
     expect(manifest.packageArtifact).toMatchObject({
       name: "neondiff",
-      version: "0.4.30-beta.1",
+      version: "1.0.0",
       requiredForThisRelease: true,
       state: "pending_publish_after_merge",
-      previousReleasedPackageVersion: "0.4.24-beta.1"
+      previousReleasedPackageVersion: "0.4.30-beta.1"
     });
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.29-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.36-beta.1");
@@ -115,10 +115,10 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.44-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.45-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.46-beta.1");
-    expect(manifest.packageArtifact?.note).toMatch(/source\/local-worker/i);
+    expect(manifest.packageArtifact?.note).toMatch(/first GA npm package/i);
     expect(manifest.source).toMatchObject({
       shaState: "pending_tag_stamp",
-      candidateHeadBeforeReleaseMetadata: "78b51fdac2d8ce699dc9f38f87db0b62c19dafef"
+      candidateHeadBeforeReleaseMetadata: "7453349008ca8f23641fab1665ac909d0b51b10a"
     });
     expect(manifest.source?.proof).toMatch(/after merge and tag/i);
     expect(manifest.releaseStages?.launchCutLine).toBe(
@@ -146,17 +146,14 @@ describe("NeonDiff public release readiness", () => {
       ])
     );
     expect(manifest.updateChannels?.browserDashboard).toMatchObject({
-      requiredForThisRelease: false,
-      state: "pending",
+      requiredForThisRelease: true,
+      state: "published",
       trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     });
-    expect(manifest.updateChannels?.desktop).toMatchObject({
-      state: "post_1_0",
-      trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/116"
-    });
+    expect(manifest.updateChannels?.desktop).toBeUndefined();
   });
 
-  it("requires the live production license API for this beta", () => {
+  it("requires the live production license API and checkout issuance for GA", () => {
     const manifest = JSON.parse(read("docs/public-release-manifest.json")) as {
       licenseApi?: {
         requiredForThisRelease?: boolean;
@@ -166,6 +163,8 @@ describe("NeonDiff public release readiness", () => {
         healthProofPath?: string;
         checkoutIssuanceRequiredForThisRelease?: boolean;
         checkoutIssuanceUrl?: string;
+        checkoutIssuanceProofPath?: string;
+        checkoutIssuanceAuthenticatedProofPath?: string;
         checkoutIssuanceState?: string;
         checkoutIssuanceTrackingIssue?: string;
       };
@@ -174,14 +173,16 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.licenseApi).toMatchObject({
       requiredForThisRelease: true,
       state: "healthy",
-      checkoutIssuanceRequiredForThisRelease: false,
+      checkoutIssuanceRequiredForThisRelease: true,
       checkoutIssuanceUrl: "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
-      checkoutIssuanceState: "pending_secret_and_website_publish",
+      checkoutIssuanceState: "ready",
+      checkoutIssuanceProofPath: "docs/evidence/v1.0.0-license-checkout-issuance-unauthenticated.json",
+      checkoutIssuanceAuthenticatedProofPath: "docs/evidence/license-checkout-issuance-authenticated.json",
       checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
     });
     expect(manifest.licenseApi?.trackingIssue).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/);
     expect(manifest.licenseApi?.healthUrl).toMatch(/^https:\/\/[^/]+\/healthz$/);
-    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v0.4.46-beta.1-license-api-healthz.json");
+    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v1.0.0-license-api-healthz.json");
 
     const proof = JSON.parse(read(manifest.licenseApi?.healthProofPath ?? "")) as {
       evidenceKind?: string;
@@ -193,19 +194,51 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(proof).toMatchObject({
       evidenceKind: "license_api_healthz",
-      releaseVersion: "v0.4.46-beta.1",
+      releaseVersion: "v1.0.0",
       url: manifest.licenseApi?.healthUrl,
       statusCode: 200,
       responseBody: "{\"status\":\"ok\"}"
     });
     expect(createHash("sha256").update(proof.responseBody ?? "").digest("hex")).toBe(proof.responseBodySha256);
+
+    const issuanceProof = JSON.parse(read(manifest.licenseApi?.checkoutIssuanceProofPath ?? "")) as {
+      evidenceKind?: string;
+      releaseVersion?: string;
+      statusCode?: number;
+      responseBody?: string;
+      responseBodySha256?: string;
+    };
+    expect(issuanceProof).toMatchObject({
+      evidenceKind: "license_api_checkout_issuance",
+      releaseVersion: "v1.0.0",
+      statusCode: 401,
+      responseBody: expect.stringContaining("\"unauthorized\"")
+    });
+    expect(createHash("sha256").update(issuanceProof.responseBody ?? "").digest("hex")).toBe(issuanceProof.responseBodySha256);
+
+    const authenticatedProof = JSON.parse(read(manifest.licenseApi?.checkoutIssuanceAuthenticatedProofPath ?? "")) as {
+      evidenceKind?: string;
+      releaseVersion?: string;
+      statusCode?: number;
+      redactedResponse?: { issuedLicensePrefix?: string; issuedLicenseFingerprint?: string };
+    };
+    expect(authenticatedProof).toMatchObject({
+      evidenceKind: "license_api_checkout_issuance_authenticated",
+      releaseVersion: "v1.0.0",
+      statusCode: 200,
+      redactedResponse: {
+        issuedLicensePrefix: "nd_live_",
+        issuedLicenseFingerprint: expect.stringMatching(/^sha256:[a-f0-9]{64}$/)
+      }
+    });
+    expect(JSON.stringify(authenticatedProof)).not.toMatch(/licenseKey|Bearer |LICENSE_ISSUANCE_SECRET/);
   });
 
   it("ships the canonical install script contract", () => {
     expect(existsSync("scripts/install.sh")).toBe(true);
     const script = read("scripts/install.sh");
 
-    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-0\.4\.30-beta\.1\}"/);
+    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-1\.0\.0\}"/);
     expect(script).toMatch(/npm[^\n]+install[^\n]+-g[^\n]+neondiff@\$\{NEONDIFF_VERSION\}/);
     expect(script).toMatch(/--dry-run/);
     expect(script).toMatch(/Node\.js 26 or newer/);
@@ -219,7 +252,7 @@ describe("NeonDiff public release readiness", () => {
       read("docs/github-app-setup.md"),
       read("docs/providers.md"),
       read("docs/license-boundary.md"),
-      read("docs/releases/v0.4.30-beta.1.md")
+      read("docs/releases/v1.0.0.md")
     ].join("\n\n");
     const legacyRepoReferences = docs
       .split(/\s+/)
@@ -230,7 +263,6 @@ describe("NeonDiff public release readiness", () => {
       );
 
     expect(docs).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff");
-    expect(docs).toMatch(/npm install -g neondiff@0\.4\.30-beta\.1/i);
     expect(docs).toMatch(/npm install -g neondiff(?!@)/i);
     expect(docs).toMatch(/neondiff dashboard --config config\.local\.json/i);
     expect(docs).toMatch(/Verify API Key/i);

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -273,6 +273,34 @@ describe("NeonDiff public release readiness", () => {
       liveCheckoutProof.webhook?.responseBodySha256
     );
     expect(JSON.stringify(liveCheckoutProof)).not.toMatch(/cs_live_|evt_|whsec_|nd_live_[A-Za-z0-9]|session_id=|fulfillment_token=|121 South/i);
+
+    const rollbackProof = JSON.parse(read("docs/evidence/v1.0.0-rollback-refs.json")) as {
+      evidenceKind?: string;
+      releaseVersion?: string;
+      channels?: Record<string, {
+        rollbackRepository?: string;
+        rollbackCommand?: string;
+        rollbackTarget?: string;
+        targetUrl?: string;
+      }>;
+    };
+    expect(rollbackProof).toMatchObject({
+      evidenceKind: "release_rollback_refs",
+      releaseVersion: "v1.0.0",
+      channels: {
+        browserDashboard: {
+          rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
+          rollbackCommand: manifest.updateChannels?.browserDashboard?.rollback,
+          rollbackTarget: "74d133ff34935510c45a4a74a664b8b30dca52d8"
+        },
+        website: {
+          rollbackRepository: "electricsheephq/neon-diff-agent-website",
+          rollbackCommand: manifest.updateChannels?.website?.rollback,
+          rollbackTarget: "6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+          targetUrl: "https://github.com/electricsheephq/neon-diff-agent-website/commit/6b670d00cd587fb7d564347b6bc0d4d3e8d13186"
+        }
+      }
+    });
   });
 
   it("ships the canonical install script contract", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -510,7 +510,7 @@ describe("beta release status", () => {
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
       ok: true,
-      detail: "cli=source_checkout; daemon=launchd_prerelease; browserDashboard=published; website=published"
+      detail: "cli=published; daemon=launchd_prerelease; browserDashboard=published; website=published"
     });
     const redactedOutput = stringifyRedactedJson({
       ...status,
@@ -518,8 +518,9 @@ describe("beta release status", () => {
       runtimeOk: status.ok
     });
     expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.46-beta.1");
-    expect(redactedOutput).toContain("cli=source_checkout; daemon=launchd_prerelease");
+    expect(redactedOutput).toContain("cli=published; daemon=launchd_prerelease");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
+    expect(redactedOutput).toContain("electricsheephq/neon-diff-agent-website");
   });
 
   it("fails closed without throwing when collectReleaseStatus receives a missing public manifest path", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -21,7 +21,7 @@ import { ReviewStateStore } from "../src/state.js";
 describe("beta release status", () => {
   const roots: string[] = [];
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  const shippedReleaseValidationNow = new Date("2026-07-08T09:50:00Z");
+  const shippedReleaseValidationNow = new Date("2026-07-09T06:00:00Z");
 
   afterEach(() => {
     vi.useRealTimers();
@@ -324,30 +324,30 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.46-beta.1",
+      expectedVersion: "v1.0.0",
       now: shippedReleaseValidationNow
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v0.4.46-beta.1",
+      version: "v1.0.0",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v0.4.46-beta.1.md",
+        releaseNotesPath: "docs/releases/v1.0.0.md",
         changelogPath: "CHANGELOG.md",
-        changelogHeadVersion: "0.4.46-beta.1",
-        changelogReleaseNotesPath: "docs/releases/v0.4.46-beta.1.md"
+        changelogHeadVersion: "1.0.0",
+        changelogReleaseNotesPath: "docs/releases/v1.0.0.md"
       },
       licenseApi: {
         ok: true,
         requiredForThisRelease: true,
         state: "healthy",
         healthUrl: "https://neondiff-license.fly.dev/healthz",
-        healthProofPath: "docs/evidence/v0.4.46-beta.1-license-api-healthz.json",
-        checkoutIssuanceRequiredForThisRelease: false,
+        healthProofPath: "docs/evidence/v1.0.0-license-api-healthz.json",
+        checkoutIssuanceRequiredForThisRelease: true,
         checkoutIssuanceUrl: "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
-        checkoutIssuanceState: "pending_secret_and_website_publish",
+        checkoutIssuanceState: "ready",
         checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
       },
       updateChannels: {
@@ -359,12 +359,12 @@ describe("beta release status", () => {
         expect.objectContaining({
           name: "cli",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.45-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.46-beta.1"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.45-beta.1"
+          rollback: "git reset --hard refs/tags/v0.4.46-beta.1"
         })
       ])
     );
@@ -374,15 +374,15 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v0.4.46-beta.1",
-      now: new Date("2026-08-08T00:00:00Z")
+      expectedVersion: "v1.0.0",
+      now: new Date("2026-08-09T12:00:00Z")
     });
 
     expect(manifest.licenseApi).toMatchObject({
       ok: false,
       requiredForThisRelease: true,
       state: "healthy",
-      healthProofPath: "docs/evidence/v0.4.46-beta.1-license-api-healthz.json"
+      healthProofPath: "docs/evidence/v1.0.0-license-api-healthz.json"
     });
     expect(manifest.licenseApi.detail).toContain("observedAt must be no older than 30 days");
     expect(manifest.ok).toBe(false);
@@ -498,27 +498,27 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v0.4.46-beta.1",
+      expectedPublicVersion: "v1.0.0",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot",
       now: shippedReleaseValidationNow
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v0.4.46-beta.1"
+      version: "v1.0.0"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
       ok: true,
-      detail: "cli=published; daemon=launchd_prerelease; browserDashboard=pending (not required); website=published (not required); desktop=post_1_0 (not required)"
+      detail: "cli=source_checkout; daemon=launchd_prerelease; browserDashboard=published; website=published"
     });
     const redactedOutput = stringifyRedactedJson({
       ...status,
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok
     });
-    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.45-beta.1");
-    expect(redactedOutput).toContain("cli=published; daemon=launchd_prerelease");
+    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.46-beta.1");
+    expect(redactedOutput).toContain("cli=source_checkout; daemon=launchd_prerelease");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
   });
 

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -510,7 +510,7 @@ describe("beta release status", () => {
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
       ok: true,
-      detail: "cli=published; daemon=launchd_prerelease; browserDashboard=published; website=published"
+      detail: "cli=published; daemon=published; browserDashboard=published; website=published"
     });
     const redactedOutput = stringifyRedactedJson({
       ...status,
@@ -518,7 +518,7 @@ describe("beta release status", () => {
       runtimeOk: status.ok
     });
     expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.46-beta.1");
-    expect(redactedOutput).toContain("cli=published; daemon=launchd_prerelease");
+    expect(redactedOutput).toContain("cli=published; daemon=published");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
     expect(redactedOutput).toContain("electricsheephq/neon-diff-agent-website");
   });


### PR DESCRIPTION
## Summary

Prepare the NeonDiff `v1.0.0` GA release surface.

This PR does not publish npm or create the GitHub Release. It makes the release branch ready for the owner-confirmed final gate and post-merge publish run.

## Changes

- Bump package and lockfile to `1.0.0`.
- Move `docs/public-release-manifest.json` to `v1.0.0` / `stable`.
- Add the human-readable release packet at `docs/releases/v1.0.0.md`.
- Add GA license API evidence:
  - healthz proof;
  - no-secret checkout issuance 401 proof;
  - authenticated redacted checkout issuance proof.
- Update README, setup docs, install script default, public-claims scan, and readiness tests for the GA install path.
- Align canonical public license wording from beta to source-available commercial release wording.

## Validation

Local:

- `npm test -- --run tests/public-release-readiness.test.ts tests/release-status.test.ts tests/public-community-funnel.test.ts --pool=forks --maxWorkers=1` -> 124 passed.
- `npm run build` -> passed.
- `node scripts/check-public-claims.mjs` -> passed.
- `node scripts/check-secret-scan.mjs` -> passed.
- `git diff --check` -> passed.
- `npm pack --dry-run` -> `neondiff-1.0.0.tgz` package preview generated.
- `release-status --public-release-manifest docs/public-release-manifest.json --expected-public-version v1.0.0` -> `publicRelease.ok: true`; whole command remains false on this feature branch because clean/main branch gates are expected to fail before merge.

Remote, current head `ef3b7b7ac9f01de8859e9b4847008ed79b26f8e5`:

- Build, test, and package -> passed.
- CodeQL / Analyze actions / Analyze javascript-typescript -> passed.
- Swift desktop impact/gate -> passed; desktop smoke skipped as expected.
- Socket Security alerts/report -> passed.
- CodeRabbit -> completed/pass.
- Review threads -> 0.

## Remaining Gate Before Merge/Publish

Refs #396 and #421.

#421 is partially unblocked: paired Fly/Lovable secrets are configured, unauthenticated issuance now fails closed with 401, authenticated issuance smoke passed, product validator activation passed, and the public monthly checkout form loads.

Do not merge/publish as GA until the live monthly trial checkout/subscription proof is explicitly owner-confirmed or #421 records an explicit owner waiver.
