### PR TITLE
feat: curate OpenWiki repo-wiki packets

### DIFF
--- a/docs/repo-wiki-packet.md
+++ b/docs/repo-wiki-packet.md
@@ -132,3 +132,9 @@ This integration does not run OpenWiki during live review, mutate repository
 files, change GitHub comment posting behavior, alter checks, or make repo-wiki
 context authoritative. OpenWiki-generated files remain confined to
 `openwiki/**`; suggestions for other docs are report-only.
+
+The OpenWiki-derived packet builder is an offline/lab helper for producing the
+prebuilt packet consumed by this seam. Runtime wiring that invokes OpenWiki
+during a review is intentionally deferred to a later lab-enablement issue; live
+review workers should continue to read only a prepared packet from the PR
+worktree.

--- a/docs/repo-wiki-packet.md
+++ b/docs/repo-wiki-packet.md
@@ -60,9 +60,10 @@ secret-like environment variable names before packet construction.
 
 Freshness is source-backed: the packet is `fresh` only when
 `openwiki/.last-update.json` records the current head SHA and the worktree has no
-non-`openwiki/**` changes. Missing or mismatched metadata produces stale or
-missing degraded packets, which the runtime omits unless stale context is
-explicitly allowed.
+non-`openwiki/**` changes. The packet's own `.neondiff/**` output artifacts are
+excluded from this dirty-worktree check so reruns do not make themselves stale.
+Missing or mismatched metadata produces stale or missing degraded packets, which
+the runtime omits unless stale context is explicitly allowed.
 
 ## Budgets And Redaction
 

--- a/docs/repo-wiki-packet.md
+++ b/docs/repo-wiki-packet.md
@@ -50,6 +50,20 @@ Inputs are normalized deterministically:
 - source file lists are trimmed, de-duplicated, and sorted.
 - sections sort by `order`, then `id`.
 
+## OpenWiki-Derived Packets
+
+`src/openwiki-derived-packet.ts` curates an existing `openwiki/**` tree into the
+same deterministic packet model. It does not run OpenWiki or call a model. It
+reads Markdown pages under `openwiki/`, excludes `openwiki/_review/**`
+suggestions, extracts `## Source map` bullets as provenance, and redacts
+secret-like environment variable names before packet construction.
+
+Freshness is source-backed: the packet is `fresh` only when
+`openwiki/.last-update.json` records the current head SHA and the worktree has no
+non-`openwiki/**` changes. Missing or mismatched metadata produces stale or
+missing degraded packets, which the runtime omits unless stale context is
+explicitly allowed.
+
 ## Budgets And Redaction
 
 The builder caps section bodies by UTF-8 byte length without splitting a

--- a/src/openwiki-derived-packet.ts
+++ b/src/openwiki-derived-packet.ts
@@ -83,7 +83,7 @@ function resolveSourceFreshness(input: {
   if (input.sectionCount === 0) {
     return {
       ...base,
-      status: "missing",
+      status: input.skippedOversizedCount > 0 ? "stale" : "missing",
       staleReason: input.skippedOversizedCount > 0
         ? "OpenWiki Markdown files exceeded the safe read limit and were omitted."
         : "No OpenWiki Markdown files were found under openwiki/."
@@ -96,7 +96,7 @@ function resolveSourceFreshness(input: {
       staleReason: "Some OpenWiki Markdown files exceeded the safe read limit and were omitted."
     };
   }
-  const dirtyStatus = readDirtyNonOpenWikiPaths(input.worktreePath);
+  const dirtyStatus = readDirtyWorktreePaths(input.worktreePath);
   if (!dirtyStatus.ok) {
     return {
       ...base,
@@ -104,11 +104,18 @@ function resolveSourceFreshness(input: {
       staleReason: "Unable to read git worktree status; regenerate OpenWiki before building a packet."
     };
   }
-  if (dirtyStatus.paths.length > 0) {
+  if (dirtyStatus.nonOpenWikiPaths.length > 0) {
     return {
       ...base,
       status: "stale",
       staleReason: "Repository has non-openwiki worktree changes; regenerate OpenWiki before building a packet."
+    };
+  }
+  if (dirtyStatus.openWikiMarkdownPaths.length > 0) {
+    return {
+      ...base,
+      status: "stale",
+      staleReason: "OpenWiki Markdown files have uncommitted changes; regenerate OpenWiki before building a fresh packet."
     };
   }
   if (!input.metadata?.gitHead) {
@@ -214,14 +221,21 @@ function readOpenWikiMetadata(worktreePath: string): OpenWikiMetadata | undefine
   }
 }
 
-function readDirtyNonOpenWikiPaths(worktreePath: string): { ok: boolean; paths: string[] } {
+function readDirtyWorktreePaths(worktreePath: string): {
+  ok: boolean;
+  nonOpenWikiPaths: string[];
+  openWikiMarkdownPaths: string[];
+} {
   const status = readGitResult(worktreePath, ["status", "--porcelain=v1", "-z"]);
-  if (!status.ok) return { ok: false, paths: [] };
+  if (!status.ok) return { ok: false, nonOpenWikiPaths: [], openWikiMarkdownPaths: [] };
   const paths = parsePorcelainStatusPaths(status.stdout)
     .filter(Boolean)
-    .filter((changedPath) => changedPath !== ".neondiff" && !changedPath.startsWith(".neondiff/"))
-    .filter((changedPath) => changedPath !== OPENWIKI_DIR && !changedPath.startsWith(`${OPENWIKI_DIR}/`));
-  return { ok: true, paths };
+    .filter((changedPath) => changedPath !== ".neondiff" && !changedPath.startsWith(".neondiff/"));
+  return {
+    ok: true,
+    nonOpenWikiPaths: paths.filter((changedPath) => changedPath !== OPENWIKI_DIR && !changedPath.startsWith(`${OPENWIKI_DIR}/`)),
+    openWikiMarkdownPaths: paths.filter((changedPath) => changedPath.startsWith(`${OPENWIKI_DIR}/`) && changedPath.endsWith(".md"))
+  };
 }
 
 function parsePorcelainStatusPaths(status: string): string[] {

--- a/src/openwiki-derived-packet.ts
+++ b/src/openwiki-derived-packet.ts
@@ -14,10 +14,26 @@ const OPENWIKI_METADATA_PATH = "openwiki/.last-update.json";
 const DEFAULT_MAX_PACKET_BYTES = 12_000;
 const GIT_COMMAND_TIMEOUT_MS = 5_000;
 const REPO_PATH_EXTENSION_PATTERN = /\.(?:[cm]?[jt]sx?|mdx?|json|ya?ml|toml|lock|css|scss|html?|sh|bash|zsh|py|go|rs|swift|kt|java|rb|php|sql|txt)$/i;
-const SENSITIVE_ENV_ASSIGNMENT_PATTERN = /\b(?:(?:api[_-]?key|private[_-]?key|access[_-]?token|auth[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?cookie)|(?:[a-z][a-z0-9]*[_-]+)+(?:api[_-]?key|private[_-]?key|token|secret|password|cookie|session)(?:[_-]+[a-z0-9]+)*|(?:apiKey|privateKey|accessToken|authToken|refreshToken|idToken|sessionCookie|[a-z][A-Za-z0-9]*(?:ApiKey|PrivateKey|AccessToken|AuthToken|RefreshToken|IdToken|SessionCookie)))\b\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{8,}["']?/gi;
-const SENSITIVE_ENV_NAME_PATTERNS = [
-  /\b(?:(?:api[_-]?key|private[_-]?key|access[_-]?token|auth[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?cookie)|(?:[a-z][a-z0-9]*[_-]+)+(?:api[_-]?key|private[_-]?key|token|secret|password|cookie|session)(?:[_-]+[a-z0-9]+)*)\b/gi,
-  /\b(?:apiKey|privateKey|accessToken|authToken|refreshToken|idToken|sessionCookie|[a-z][A-Za-z0-9]*(?:ApiKey|PrivateKey|AccessToken|AuthToken|RefreshToken|IdToken|SessionCookie))\b/g
+const ENV_NAME_TOKEN_PATTERN = /\b[A-Za-z][A-Za-z0-9_-]{1,80}\b/g;
+const ENV_ASSIGNMENT_PATTERN = /\b([A-Za-z][A-Za-z0-9_-]{1,80})\b\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{8,}["']?/g;
+const SENSITIVE_SEGMENTS = new Set(["token", "secret", "password", "cookie", "session"]);
+const SENSITIVE_PAIR_SUFFIXES = new Set([
+  "api_key",
+  "private_key",
+  "access_token",
+  "auth_token",
+  "refresh_token",
+  "id_token",
+  "session_cookie"
+]);
+const SENSITIVE_CAMEL_SUFFIXES = [
+  "ApiKey",
+  "PrivateKey",
+  "AccessToken",
+  "AuthToken",
+  "RefreshToken",
+  "IdToken",
+  "SessionCookie"
 ];
 
 export interface BuildOpenWikiDerivedRepoWikiPacketInput {
@@ -111,11 +127,11 @@ function resolveSourceFreshness(input: {
       staleReason: "Repository has non-openwiki worktree changes; regenerate OpenWiki before building a packet."
     };
   }
-  if (dirtyStatus.openWikiMarkdownPaths.length > 0) {
+  if (dirtyStatus.openWikiPaths.length > 0) {
     return {
       ...base,
       status: "stale",
-      staleReason: "OpenWiki Markdown files have uncommitted changes; regenerate OpenWiki before building a fresh packet."
+      staleReason: "OpenWiki files have uncommitted changes; regenerate OpenWiki before building a fresh packet."
     };
   }
   if (!input.metadata?.gitHead) {
@@ -224,17 +240,17 @@ function readOpenWikiMetadata(worktreePath: string): OpenWikiMetadata | undefine
 function readDirtyWorktreePaths(worktreePath: string): {
   ok: boolean;
   nonOpenWikiPaths: string[];
-  openWikiMarkdownPaths: string[];
+  openWikiPaths: string[];
 } {
   const status = readGitResult(worktreePath, ["status", "--porcelain=v1", "-z"]);
-  if (!status.ok) return { ok: false, nonOpenWikiPaths: [], openWikiMarkdownPaths: [] };
+  if (!status.ok) return { ok: false, nonOpenWikiPaths: [], openWikiPaths: [] };
   const paths = parsePorcelainStatusPaths(status.stdout)
     .filter(Boolean)
     .filter((changedPath) => changedPath !== ".neondiff" && !changedPath.startsWith(".neondiff/"));
   return {
     ok: true,
     nonOpenWikiPaths: paths.filter((changedPath) => changedPath !== OPENWIKI_DIR && !changedPath.startsWith(`${OPENWIKI_DIR}/`)),
-    openWikiMarkdownPaths: paths.filter((changedPath) => changedPath.startsWith(`${OPENWIKI_DIR}/`) && changedPath.endsWith(".md"))
+    openWikiPaths: paths.filter((changedPath) => changedPath === OPENWIKI_DIR || changedPath.startsWith(`${OPENWIKI_DIR}/`))
   };
 }
 
@@ -286,23 +302,41 @@ function readFirstHeading(markdown: string): string | undefined {
 
 function redactSensitiveEnvNames(input: string): { text: string; replacementCount: number } {
   let replacementCount = 0;
-  const withAssignmentsRedacted = input.replace(SENSITIVE_ENV_ASSIGNMENT_PATTERN, () => {
+  const withAssignmentsRedacted = input.replace(ENV_ASSIGNMENT_PATTERN, (match, envName: string) => {
+    if (!isSensitiveEnvName(envName)) return match;
     replacementCount += 1;
     return "[redacted-secret]";
   });
-  const text = SENSITIVE_ENV_NAME_PATTERNS.reduce((current, pattern) => current.replace(pattern, () => {
-      replacementCount += 1;
-      return "[redacted-secret]";
-    }), withAssignmentsRedacted);
+  const text = withAssignmentsRedacted.replace(ENV_NAME_TOKEN_PATTERN, (match) => {
+    if (!isSensitiveEnvName(match)) return match;
+    replacementCount += 1;
+    return "[redacted-secret]";
+  });
   return {
     text,
     replacementCount
   };
 }
 
+function isSensitiveEnvName(name: string): boolean {
+  if (name.length > 80) return false;
+  if (SENSITIVE_CAMEL_SUFFIXES.some((suffix) => name === lowerFirst(suffix) || name.endsWith(suffix))) {
+    return true;
+  }
+  const parts = name.toLowerCase().replace(/-/g, "_").split("_").filter(Boolean);
+  if (parts.length < 2) return false;
+  if (SENSITIVE_PAIR_SUFFIXES.has(parts.slice(-2).join("_"))) return true;
+  return parts.some((part) => SENSITIVE_SEGMENTS.has(part));
+}
+
+function lowerFirst(input: string): string {
+  return `${input.slice(0, 1).toLowerCase()}${input.slice(1)}`;
+}
+
 function readDeclaredSectionOrder(markdown: string): number | undefined {
-  const frontMatter = markdown.match(/^---\n([\s\S]*?)\n---/);
-  const orderLine = frontMatter?.[1]?.match(/^order:\s*(-?\d+)\s*$/m) ?? markdown.match(/<!--\s*openwiki-order:\s*(-?\d+)\s*-->/i);
+  const normalized = markdown.replace(/\r\n?/g, "\n");
+  const frontMatter = normalized.match(/^---\n([\s\S]*?)\n---/);
+  const orderLine = frontMatter?.[1]?.match(/^order:\s*(-?\d+)\s*$/m) ?? normalized.match(/<!--\s*openwiki-order:\s*(-?\d+)\s*-->/i);
   if (!orderLine?.[1]) return undefined;
   const order = Number(orderLine[1]);
   return Number.isSafeInteger(order) ? order : undefined;

--- a/src/openwiki-derived-packet.ts
+++ b/src/openwiki-derived-packet.ts
@@ -13,8 +13,10 @@ const OPENWIKI_DIR = "openwiki";
 const OPENWIKI_METADATA_PATH = "openwiki/.last-update.json";
 const DEFAULT_MAX_PACKET_BYTES = 12_000;
 const GIT_COMMAND_TIMEOUT_MS = 5_000;
-const SENSITIVE_ENV_NAME_PATTERN =
-  /\b(?:(?:API_KEY|PRIVATE_KEY|ACCESS_TOKEN|AUTH_TOKEN|REFRESH_TOKEN|ID_TOKEN|SESSION_COOKIE)|(?:[A-Z][A-Z0-9]*_)+(?:API_KEY|PRIVATE_KEY|TOKEN|SECRET|PASSWORD|COOKIE|SESSION)(?:_[A-Z0-9]+)*)\b/g;
+const SENSITIVE_ENV_NAME_PATTERNS = [
+  /\b(?:(?:api[_-]?key|private[_-]?key|access[_-]?token|auth[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?cookie)|(?:[a-z][a-z0-9]*[_-]+)+(?:api[_-]?key|private[_-]?key|token|secret|password|cookie|session)(?:[_-]+[a-z0-9]+)*)\b/gi,
+  /\b[a-z][A-Za-z0-9]*(?:ApiKey|PrivateKey|AccessToken|AuthToken|RefreshToken|IdToken|SessionCookie|Token|Secret|Password|Cookie|Session)\b/g
+];
 
 export interface BuildOpenWikiDerivedRepoWikiPacketInput {
   repo: string;
@@ -34,14 +36,15 @@ export function buildOpenWikiDerivedRepoWikiPacket(input: BuildOpenWikiDerivedRe
   const generatedAt = input.generatedAt ?? new Date().toISOString();
   const headSha = input.headSha ?? readGit(input.worktreePath, ["rev-parse", "HEAD"]);
   const defaultBranch = input.defaultBranch ?? readDefaultBranch(input.worktreePath);
-  const sections = readOpenWikiSections(input.worktreePath);
+  const openWiki = readOpenWikiSections(input.worktreePath);
   const source = resolveSourceFreshness({
     worktreePath: input.worktreePath,
     generatedAt,
     headSha,
     defaultBranch,
     metadata: readOpenWikiMetadata(input.worktreePath),
-    sectionCount: sections.length
+    sectionCount: openWiki.sections.length,
+    skippedOversizedCount: openWiki.skippedOversizedCount
   });
   return buildRepoWikiPacket({
     repo: { fullName: input.repo, ...(defaultBranch ? { defaultBranch } : {}) },
@@ -51,7 +54,7 @@ export function buildOpenWikiDerivedRepoWikiPacket(input: BuildOpenWikiDerivedRe
       maxBytes: input.maxPacketBytes ?? DEFAULT_MAX_PACKET_BYTES,
       ...(input.maxSectionBytes ? { maxSectionBytes: input.maxSectionBytes } : {})
     },
-    sections
+    sections: openWiki.sections
   });
 }
 
@@ -62,6 +65,7 @@ function resolveSourceFreshness(input: {
   defaultBranch?: string;
   metadata: OpenWikiMetadata | undefined;
   sectionCount: number;
+  skippedOversizedCount: number;
 }): {
   ref: string;
   headSha?: string;
@@ -78,7 +82,16 @@ function resolveSourceFreshness(input: {
     return {
       ...base,
       status: "missing",
-      staleReason: "No OpenWiki Markdown files were found under openwiki/."
+      staleReason: input.skippedOversizedCount > 0
+        ? "OpenWiki Markdown files exceeded the safe read limit and were omitted."
+        : "No OpenWiki Markdown files were found under openwiki/."
+    };
+  }
+  if (input.skippedOversizedCount > 0) {
+    return {
+      ...base,
+      status: "stale",
+      staleReason: "Some OpenWiki Markdown files exceeded the safe read limit and were omitted."
     };
   }
   const dirtyStatus = readDirtyNonOpenWikiPaths(input.worktreePath);
@@ -113,37 +126,55 @@ function resolveSourceFreshness(input: {
   };
 }
 
-function readOpenWikiSections(worktreePath: string): RepoWikiSectionInput[] {
-  return listMarkdownFiles(join(worktreePath, OPENWIKI_DIR), worktreePath).map((sourcePath, index) => {
-    const raw = readFileSync(join(worktreePath, sourcePath), "utf8");
-    const body = redactSensitiveEnvNames(raw.trim());
-    return {
-      id: normalizeSectionId(sourcePath.replace(/^openwiki\//, "").replace(/\.md$/, "")),
-      title: readFirstHeading(body.text) ?? sourcePath,
-      body: body.text,
-      order: index,
-      sourceFiles: normalizeSourceFiles([sourcePath, ...readSourceMap(body.text)]),
-      sourceSha: sha256(body.text),
-      preRedactionReplacementCount: body.replacementCount
-    };
-  });
+function readOpenWikiSections(worktreePath: string): {
+  sections: RepoWikiSectionInput[];
+  skippedOversizedCount: number;
+} {
+  const listing = listMarkdownFiles(join(worktreePath, OPENWIKI_DIR), worktreePath);
+  return {
+    skippedOversizedCount: listing.skippedOversizedCount,
+    sections: listing.files.map((sourcePath, index) => {
+      const raw = readFileSync(join(worktreePath, sourcePath), "utf8");
+      const body = redactSensitiveEnvNames(raw.trim());
+      return {
+        id: normalizeSectionId(sourcePath.replace(/^openwiki\//, "").replace(/\.md$/, "")),
+        title: readFirstHeading(body.text) ?? sourcePath,
+        body: body.text,
+        order: index,
+        sourceFiles: normalizeSourceFiles([sourcePath, ...readSourceMap(body.text)]),
+        sourceSha: sha256(body.text),
+        preRedactionReplacementCount: body.replacementCount
+      };
+    })
+  };
 }
 
-function listMarkdownFiles(dir: string, worktreePath: string): string[] {
+function listMarkdownFiles(dir: string, worktreePath: string): { files: string[]; skippedOversizedCount: number } {
   try {
-    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-      if (entry.name.startsWith(".")) return [];
+    const files: string[] = [];
+    let skippedOversizedCount = 0;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith(".")) continue;
       const absolutePath = join(dir, entry.name);
       const sourcePath = relative(worktreePath, absolutePath).replace(/\\/g, "/");
-      if (sourcePath === "openwiki/_review" || sourcePath.startsWith("openwiki/_review/")) return [];
-      if (entry.isSymbolicLink()) return [];
-      if (entry.isDirectory()) return listMarkdownFiles(absolutePath, worktreePath);
-      if (!entry.isFile() || !entry.name.endsWith(".md")) return [];
-      if (statSync(absolutePath).size > 256_000) return [];
-      return [sourcePath];
-    }).sort(codeUnitCompare);
+      if (sourcePath === "openwiki/_review" || sourcePath.startsWith("openwiki/_review/")) continue;
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        const nested = listMarkdownFiles(absolutePath, worktreePath);
+        files.push(...nested.files);
+        skippedOversizedCount += nested.skippedOversizedCount;
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+      if (statSync(absolutePath).size > 256_000) {
+        skippedOversizedCount += 1;
+        continue;
+      }
+      files.push(sourcePath);
+    }
+    return { files: files.sort(codeUnitCompare), skippedOversizedCount };
   } catch {
-    return [];
+    return { files: [], skippedOversizedCount: 0 };
   }
 }
 
@@ -238,11 +269,12 @@ function readFirstHeading(markdown: string): string | undefined {
 
 function redactSensitiveEnvNames(input: string): { text: string; replacementCount: number } {
   let replacementCount = 0;
-  return {
-    text: input.replace(SENSITIVE_ENV_NAME_PATTERN, () => {
+  const text = SENSITIVE_ENV_NAME_PATTERNS.reduce((current, pattern) => current.replace(pattern, () => {
       replacementCount += 1;
       return "[redacted-secret]";
-    }),
+    }), input);
+  return {
+    text,
     replacementCount
   };
 }

--- a/src/openwiki-derived-packet.ts
+++ b/src/openwiki-derived-packet.ts
@@ -13,6 +13,7 @@ const OPENWIKI_DIR = "openwiki";
 const OPENWIKI_METADATA_PATH = "openwiki/.last-update.json";
 const DEFAULT_MAX_PACKET_BYTES = 12_000;
 const GIT_COMMAND_TIMEOUT_MS = 5_000;
+const REPO_PATH_EXTENSION_PATTERN = /\.(?:[cm]?[jt]sx?|mdx?|json|ya?ml|toml|lock|css|scss|html?|sh|bash|zsh|py|go|rs|swift|kt|java|rb|php|sql|txt)$/i;
 const SENSITIVE_ENV_NAME_PATTERNS = [
   /\b(?:(?:api[_-]?key|private[_-]?key|access[_-]?token|auth[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?cookie)|(?:[a-z][a-z0-9]*[_-]+)+(?:api[_-]?key|private[_-]?key|token|secret|password|cookie|session)(?:[_-]+[a-z0-9]+)*)\b/gi,
   /\b[a-z][A-Za-z0-9]*(?:ApiKey|PrivateKey|AccessToken|AuthToken|RefreshToken|IdToken|SessionCookie|Token|Secret|Password|Cookie|Session)\b/g
@@ -193,7 +194,7 @@ function readSourceMap(markdown: string): string[] {
     const item = match[1]?.trim() ?? "";
     if (/^Git evidence:/i.test(item)) continue;
     for (const candidate of item.split(/,\s*/)) {
-      const cleaned = candidate.replace(/[`"'<>]/g, "").trim();
+      const cleaned = candidate.replace(/[`"'<>]/g, "").replace(/[),.;:]+$/g, "").trim();
       if (isLikelyRepoPath(cleaned)) paths.push(cleaned);
     }
   }
@@ -227,11 +228,11 @@ function parsePorcelainStatusPaths(status: string): string[] {
   for (let index = 0; index < records.length; index += 1) {
     const record = records[index] ?? "";
     const statusCode = record.slice(0, 2);
-    const changedPath = record.slice(3).trim();
+    const changedPath = record.slice(3);
     if (changedPath) paths.push(changedPath);
     if (/[RC]/.test(statusCode) && records[index + 1]) {
       index += 1;
-      paths.push((records[index] ?? "").trim());
+      paths.push(records[index] ?? "");
     }
   }
   return paths;
@@ -292,7 +293,9 @@ function isLikelyRepoPath(value: string): boolean {
   if (!value || /\s/.test(value)) return false;
   if (/^[a-f0-9]{7,40}$/i.test(value)) return false;
   if (/^[a-z]+:\/\//i.test(value)) return false;
-  return value.includes("/") || value.includes(".");
+  if (/^v?\d+(?:\.\d+)+(?:[-+][A-Za-z0-9.-]+)?$/i.test(value)) return false;
+  if (value.includes("/")) return true;
+  return REPO_PATH_EXTENSION_PATTERN.test(value);
 }
 
 function sha256(input: string): string {

--- a/src/openwiki-derived-packet.ts
+++ b/src/openwiki-derived-packet.ts
@@ -12,8 +12,9 @@ import {
 const OPENWIKI_DIR = "openwiki";
 const OPENWIKI_METADATA_PATH = "openwiki/.last-update.json";
 const DEFAULT_MAX_PACKET_BYTES = 12_000;
+const GIT_COMMAND_TIMEOUT_MS = 5_000;
 const SENSITIVE_ENV_NAME_PATTERN =
-  /\b[A-Z][A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD|COOKIE|SESSION|PRIVATE_KEY)[A-Z0-9_]*\b/g;
+  /\b(?:[A-Z][A-Z0-9_]*_)?(?:API_KEY|TOKEN|SECRET|PASSWORD|COOKIE|SESSION|PRIVATE_KEY)(?:_[A-Z0-9]+)*\b/g;
 
 export interface BuildOpenWikiDerivedRepoWikiPacketInput {
   repo: string;
@@ -80,7 +81,15 @@ function resolveSourceFreshness(input: {
       staleReason: "No OpenWiki Markdown files were found under openwiki/."
     };
   }
-  if (readDirtyNonOpenWikiPaths(input.worktreePath).length > 0) {
+  const dirtyStatus = readDirtyNonOpenWikiPaths(input.worktreePath);
+  if (!dirtyStatus.ok) {
+    return {
+      ...base,
+      status: "stale",
+      staleReason: "Unable to read git worktree status; regenerate OpenWiki before building a packet."
+    };
+  }
+  if (dirtyStatus.paths.length > 0) {
     return {
       ...base,
       status: "stale",
@@ -170,15 +179,31 @@ function readOpenWikiMetadata(worktreePath: string): OpenWikiMetadata | undefine
   }
 }
 
-function readDirtyNonOpenWikiPaths(worktreePath: string): string[] {
-  const status = readGit(worktreePath, ["status", "--porcelain"]);
-  return status
-    .split(/\r?\n/)
-    .map((line) => line.slice(3).trim())
+function readDirtyNonOpenWikiPaths(worktreePath: string): { ok: boolean; paths: string[] } {
+  const status = readGitResult(worktreePath, ["status", "--porcelain=v1", "-z"]);
+  if (!status.ok) return { ok: false, paths: [] };
+  const paths = parsePorcelainStatusPaths(status.stdout)
     .filter(Boolean)
     .filter((changedPath) => changedPath !== ".neondiff" && !changedPath.startsWith(".neondiff/"))
     .filter((changedPath) => changedPath !== ".neondiff/repo-wiki-packet.json")
     .filter((changedPath) => changedPath !== OPENWIKI_DIR && !changedPath.startsWith(`${OPENWIKI_DIR}/`));
+  return { ok: true, paths };
+}
+
+function parsePorcelainStatusPaths(status: string): string[] {
+  const paths: string[] = [];
+  const records = status.split("\0").filter(Boolean);
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index] ?? "";
+    const statusCode = record.slice(0, 2);
+    const changedPath = record.slice(3).trim();
+    if (changedPath) paths.push(changedPath);
+    if (/[RC]/.test(statusCode) && records[index + 1]) {
+      index += 1;
+      paths.push((records[index] ?? "").trim());
+    }
+  }
+  return paths;
 }
 
 function readDefaultBranch(worktreePath: string): string | undefined {
@@ -188,11 +213,19 @@ function readDefaultBranch(worktreePath: string): string | undefined {
 }
 
 function readGit(worktreePath: string, args: string[]): string {
+  const result = readGitResult(worktreePath, args);
+  return result.ok ? result.stdout.trim() : "";
+}
+
+function readGitResult(worktreePath: string, args: string[]): { ok: boolean; stdout: string } {
   const result = spawnSync("git", args, {
     cwd: worktreePath,
-    encoding: "utf8"
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+    timeout: GIT_COMMAND_TIMEOUT_MS
   });
-  return result.status === 0 ? result.stdout.trim() : "";
+  if (result.error || result.status !== 0) return { ok: false, stdout: result.stdout ?? "" };
+  return { ok: true, stdout: result.stdout ?? "" };
 }
 
 function readFirstHeading(markdown: string): string | undefined {

--- a/src/openwiki-derived-packet.ts
+++ b/src/openwiki-derived-packet.ts
@@ -14,7 +14,7 @@ const OPENWIKI_METADATA_PATH = "openwiki/.last-update.json";
 const DEFAULT_MAX_PACKET_BYTES = 12_000;
 const GIT_COMMAND_TIMEOUT_MS = 5_000;
 const SENSITIVE_ENV_NAME_PATTERN =
-  /\b(?:[A-Z][A-Z0-9_]*_)?(?:API_KEY|TOKEN|SECRET|PASSWORD|COOKIE|SESSION|PRIVATE_KEY)(?:_[A-Z0-9]+)*\b/g;
+  /\b(?:(?:API_KEY|PRIVATE_KEY|ACCESS_TOKEN|AUTH_TOKEN|REFRESH_TOKEN|ID_TOKEN|SESSION_COOKIE)|(?:[A-Z][A-Z0-9]*_)+(?:API_KEY|PRIVATE_KEY|TOKEN|SECRET|PASSWORD|COOKIE|SESSION)(?:_[A-Z0-9]+)*)\b/g;
 
 export interface BuildOpenWikiDerivedRepoWikiPacketInput {
   repo: string;
@@ -119,11 +119,12 @@ function readOpenWikiSections(worktreePath: string): RepoWikiSectionInput[] {
     const body = redactSensitiveEnvNames(raw.trim());
     return {
       id: normalizeSectionId(sourcePath.replace(/^openwiki\//, "").replace(/\.md$/, "")),
-      title: readFirstHeading(body) ?? sourcePath,
-      body,
+      title: readFirstHeading(body.text) ?? sourcePath,
+      body: body.text,
       order: index,
-      sourceFiles: normalizeSourceFiles([sourcePath, ...readSourceMap(body)]),
-      sourceSha: sha256(body)
+      sourceFiles: normalizeSourceFiles([sourcePath, ...readSourceMap(body.text)]),
+      sourceSha: sha256(body.text),
+      preRedactionReplacementCount: body.replacementCount
     };
   });
 }
@@ -235,8 +236,15 @@ function readFirstHeading(markdown: string): string | undefined {
     .trim();
 }
 
-function redactSensitiveEnvNames(input: string): string {
-  return input.replace(SENSITIVE_ENV_NAME_PATTERN, "[redacted-secret]");
+function redactSensitiveEnvNames(input: string): { text: string; replacementCount: number } {
+  let replacementCount = 0;
+  return {
+    text: input.replace(SENSITIVE_ENV_NAME_PATTERN, () => {
+      replacementCount += 1;
+      return "[redacted-secret]";
+    }),
+    replacementCount
+  };
 }
 
 function normalizeSourceFiles(files: string[]): string[] {

--- a/src/openwiki-derived-packet.ts
+++ b/src/openwiki-derived-packet.ts
@@ -13,11 +13,15 @@ const OPENWIKI_DIR = "openwiki";
 const OPENWIKI_METADATA_PATH = "openwiki/.last-update.json";
 const DEFAULT_MAX_PACKET_BYTES = 12_000;
 const GIT_COMMAND_TIMEOUT_MS = 5_000;
+const MAX_OPENWIKI_SCAN_DEPTH = 8;
+const MAX_OPENWIKI_SCAN_ENTRIES = 500;
 const REPO_PATH_EXTENSION_PATTERN = /\.(?:[cm]?[jt]sx?|mdx?|json|ya?ml|toml|lock|css|scss|html?|sh|bash|zsh|py|go|rs|swift|kt|java|rb|php|sql|txt)$/i;
 const ENV_NAME_TOKEN_PATTERN = /\b[A-Za-z][A-Za-z0-9_-]{1,80}\b/g;
-const ENV_ASSIGNMENT_PATTERN = /\b([A-Za-z][A-Za-z0-9_-]{1,80})\b\s*[:=]\s*(?:"[^"\r\n]{0,256}"|'[^'\r\n]{0,256}'|[^\r\n]{1,256})/g;
+const LINE_ENV_ASSIGNMENT_PATTERN = /^(\s*)([A-Za-z][A-Za-z0-9_-]{1,80})\b\s*[:=]\s*(?:"[^"\r\n]{0,256}"|'[^'\r\n]{0,256}'|[^\r\n]{1,256})$/gm;
+const INLINE_ENV_ASSIGNMENT_PATTERN = /\b([A-Za-z][A-Za-z0-9_-]{1,80})\b\s*[:=]\s*(?:"[^"\r\n]{0,256}"|'[^'\r\n]{0,256}'|[^\s\r\n,;.)\]}]{1,256})/g;
 const REDACTION_SENTINEL = "\0OPENWIKI_REDACTED\0";
 const SENSITIVE_SEGMENTS = new Set(["token", "secret", "password", "cookie", "session"]);
+const SENSITIVE_ENV_ABBREVIATION_SEGMENTS = new Set(["pass", "key", "auth", "cred", "credential", "credentials"]);
 const SENSITIVE_PAIR_SUFFIXES = new Set([
   "api_key",
   "private_key",
@@ -186,18 +190,26 @@ function readOpenWikiSections(worktreePath: string): {
   };
 }
 
-function listMarkdownFiles(dir: string, worktreePath: string): { files: string[]; skippedOversizedCount: number } {
+function listMarkdownFiles(
+  dir: string,
+  worktreePath: string,
+  scanState: { entries: number } = { entries: 0 },
+  depth = 0
+): { files: string[]; skippedOversizedCount: number } {
   try {
     const files: string[] = [];
     let skippedOversizedCount = 0;
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (scanState.entries >= MAX_OPENWIKI_SCAN_ENTRIES) break;
+      scanState.entries += 1;
       if (entry.name.startsWith(".")) continue;
       const absolutePath = join(dir, entry.name);
       const sourcePath = relative(worktreePath, absolutePath).replace(/\\/g, "/");
       if (sourcePath === "openwiki/_review" || sourcePath.startsWith("openwiki/_review/")) continue;
       if (entry.isSymbolicLink()) continue;
       if (entry.isDirectory()) {
-        const nested = listMarkdownFiles(absolutePath, worktreePath);
+        if (depth >= MAX_OPENWIKI_SCAN_DEPTH) continue;
+        const nested = listMarkdownFiles(absolutePath, worktreePath, scanState, depth + 1);
         files.push(...nested.files);
         skippedOversizedCount += nested.skippedOversizedCount;
         continue;
@@ -313,7 +325,12 @@ function readFirstHeading(markdown: string): string | undefined {
 
 function redactSensitiveEnvNames(input: string): { text: string; replacementCount: number } {
   let replacementCount = 0;
-  const withAssignmentsRedacted = input.replace(ENV_ASSIGNMENT_PATTERN, (match, envName: string) => {
+  const withLineAssignmentsRedacted = input.replace(LINE_ENV_ASSIGNMENT_PATTERN, (match, indent: string, envName: string) => {
+    if (!isSensitiveEnvName(envName)) return match;
+    replacementCount += 1;
+    return `${indent}${REDACTION_SENTINEL}`;
+  });
+  const withAssignmentsRedacted = withLineAssignmentsRedacted.replace(INLINE_ENV_ASSIGNMENT_PATTERN, (match, envName: string) => {
     if (!isSensitiveEnvName(envName)) return match;
     replacementCount += 1;
     return REDACTION_SENTINEL;
@@ -337,7 +354,12 @@ function isSensitiveEnvName(name: string): boolean {
   const parts = name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase().replace(/-/g, "_").split("_").filter(Boolean);
   if (parts.length < 2) return false;
   if (SENSITIVE_PAIR_SUFFIXES.has(parts.slice(-2).join("_"))) return true;
+  if (isEnvStyleName(name) && parts.some((part) => SENSITIVE_ENV_ABBREVIATION_SEGMENTS.has(part))) return true;
   return parts.some((part) => SENSITIVE_SEGMENTS.has(part));
+}
+
+function isEnvStyleName(name: string): boolean {
+  return /[_-]/.test(name) || name === name.toUpperCase();
 }
 
 function lowerFirst(input: string): string {

--- a/src/openwiki-derived-packet.ts
+++ b/src/openwiki-derived-packet.ts
@@ -1,0 +1,232 @@
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  buildRepoWikiPacket,
+  type RepoWikiPacket,
+  type RepoWikiSectionInput,
+  type RepoWikiSourceStatus
+} from "./repo-wiki-packet.js";
+
+const OPENWIKI_DIR = "openwiki";
+const OPENWIKI_METADATA_PATH = "openwiki/.last-update.json";
+const DEFAULT_MAX_PACKET_BYTES = 12_000;
+const SENSITIVE_ENV_NAME_PATTERN =
+  /\b[A-Z][A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD|COOKIE|SESSION|PRIVATE_KEY)[A-Z0-9_]*\b/g;
+
+export interface BuildOpenWikiDerivedRepoWikiPacketInput {
+  repo: string;
+  worktreePath: string;
+  generatedAt?: string;
+  headSha?: string;
+  defaultBranch?: string;
+  maxPacketBytes?: number;
+  maxSectionBytes?: number;
+}
+
+interface OpenWikiMetadata {
+  gitHead?: string;
+}
+
+export function buildOpenWikiDerivedRepoWikiPacket(input: BuildOpenWikiDerivedRepoWikiPacketInput): RepoWikiPacket {
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+  const headSha = input.headSha ?? readGit(input.worktreePath, ["rev-parse", "HEAD"]);
+  const defaultBranch = input.defaultBranch ?? readDefaultBranch(input.worktreePath);
+  const sections = readOpenWikiSections(input.worktreePath);
+  const source = resolveSourceFreshness({
+    worktreePath: input.worktreePath,
+    generatedAt,
+    headSha,
+    defaultBranch,
+    metadata: readOpenWikiMetadata(input.worktreePath),
+    sectionCount: sections.length
+  });
+  return buildRepoWikiPacket({
+    repo: { fullName: input.repo, ...(defaultBranch ? { defaultBranch } : {}) },
+    source,
+    generatedAt,
+    budget: {
+      maxBytes: input.maxPacketBytes ?? DEFAULT_MAX_PACKET_BYTES,
+      ...(input.maxSectionBytes ? { maxSectionBytes: input.maxSectionBytes } : {})
+    },
+    sections
+  });
+}
+
+function resolveSourceFreshness(input: {
+  worktreePath: string;
+  generatedAt: string;
+  headSha?: string;
+  defaultBranch?: string;
+  metadata: OpenWikiMetadata | undefined;
+  sectionCount: number;
+}): {
+  ref: string;
+  headSha?: string;
+  checkedAt: string;
+  status: RepoWikiSourceStatus;
+  staleReason?: string;
+} {
+  const base = {
+    ref: input.defaultBranch ?? "HEAD",
+    ...(input.headSha ? { headSha: input.headSha } : {}),
+    checkedAt: input.generatedAt
+  };
+  if (input.sectionCount === 0) {
+    return {
+      ...base,
+      status: "missing",
+      staleReason: "No OpenWiki Markdown files were found under openwiki/."
+    };
+  }
+  if (readDirtyNonOpenWikiPaths(input.worktreePath).length > 0) {
+    return {
+      ...base,
+      status: "stale",
+      staleReason: "Repository has non-openwiki worktree changes; regenerate OpenWiki before building a packet."
+    };
+  }
+  if (!input.metadata?.gitHead) {
+    return {
+      ...base,
+      status: "stale",
+      staleReason: "openwiki/.last-update.json does not record a gitHead."
+    };
+  }
+  if (input.headSha && input.metadata.gitHead === input.headSha) {
+    return { ...base, status: "fresh" };
+  }
+  return {
+    ...base,
+    status: "stale",
+    staleReason: "OpenWiki metadata gitHead does not match the current repository head."
+  };
+}
+
+function readOpenWikiSections(worktreePath: string): RepoWikiSectionInput[] {
+  return listMarkdownFiles(join(worktreePath, OPENWIKI_DIR), worktreePath).map((sourcePath, index) => {
+    const raw = readFileSync(join(worktreePath, sourcePath), "utf8");
+    const body = redactSensitiveEnvNames(raw.trim());
+    return {
+      id: normalizeSectionId(sourcePath.replace(/^openwiki\//, "").replace(/\.md$/, "")),
+      title: readFirstHeading(body) ?? sourcePath,
+      body,
+      order: index,
+      sourceFiles: normalizeSourceFiles([sourcePath, ...readSourceMap(body)]),
+      sourceSha: sha256(raw)
+    };
+  });
+}
+
+function listMarkdownFiles(dir: string, worktreePath: string): string[] {
+  try {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      if (entry.name.startsWith(".")) return [];
+      const absolutePath = join(dir, entry.name);
+      const sourcePath = relative(worktreePath, absolutePath).replace(/\\/g, "/");
+      if (sourcePath === "openwiki/_review" || sourcePath.startsWith("openwiki/_review/")) return [];
+      if (entry.isSymbolicLink()) return [];
+      if (entry.isDirectory()) return listMarkdownFiles(absolutePath, worktreePath);
+      if (!entry.isFile() || !entry.name.endsWith(".md")) return [];
+      if (statSync(absolutePath).size > 256_000) return [];
+      return [sourcePath];
+    }).sort(codeUnitCompare);
+  } catch {
+    return [];
+  }
+}
+
+function readSourceMap(markdown: string): string[] {
+  const paths: string[] = [];
+  let inSourceMap = false;
+  for (const line of markdown.split(/\r?\n/)) {
+    if (/^##\s+Source map\s*$/i.test(line.trim())) {
+      inSourceMap = true;
+      continue;
+    }
+    if (inSourceMap && /^##\s+/.test(line.trim())) break;
+    if (!inSourceMap) continue;
+    const match = line.match(/^\s*-\s+(.+)$/);
+    if (!match) continue;
+    const item = match[1]?.trim() ?? "";
+    if (/^Git evidence:/i.test(item)) continue;
+    for (const candidate of item.split(/,\s*/)) {
+      const cleaned = candidate.replace(/[`"'<>]/g, "").trim();
+      if (isLikelyRepoPath(cleaned)) paths.push(cleaned);
+    }
+  }
+  return normalizeSourceFiles(paths);
+}
+
+function readOpenWikiMetadata(worktreePath: string): OpenWikiMetadata | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(join(worktreePath, OPENWIKI_METADATA_PATH), "utf8")) as unknown;
+    if (!parsed || typeof parsed !== "object") return undefined;
+    const gitHead = (parsed as { gitHead?: unknown }).gitHead;
+    return typeof gitHead === "string" ? { gitHead } : {};
+  } catch {
+    return undefined;
+  }
+}
+
+function readDirtyNonOpenWikiPaths(worktreePath: string): string[] {
+  const status = readGit(worktreePath, ["status", "--porcelain"]);
+  return status
+    .split(/\r?\n/)
+    .map((line) => line.slice(3).trim())
+    .filter(Boolean)
+    .filter((changedPath) => changedPath !== OPENWIKI_DIR && !changedPath.startsWith(`${OPENWIKI_DIR}/`));
+}
+
+function readDefaultBranch(worktreePath: string): string | undefined {
+  const originHead = readGit(worktreePath, ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"]);
+  if (originHead.startsWith("origin/")) return originHead.slice("origin/".length);
+  return readGit(worktreePath, ["branch", "--show-current"]) || undefined;
+}
+
+function readGit(worktreePath: string, args: string[]): string {
+  const result = spawnSync("git", args, {
+    cwd: worktreePath,
+    encoding: "utf8"
+  });
+  return result.status === 0 ? result.stdout.trim() : "";
+}
+
+function readFirstHeading(markdown: string): string | undefined {
+  return markdown
+    .split(/\r?\n/)
+    .find((line) => /^#\s+\S/.test(line))
+    ?.replace(/^#\s+/, "")
+    .trim();
+}
+
+function redactSensitiveEnvNames(input: string): string {
+  return input.replace(SENSITIVE_ENV_NAME_PATTERN, "[redacted-secret]");
+}
+
+function normalizeSourceFiles(files: string[]): string[] {
+  return [...new Set(files.map((file) => file.trim()).filter(Boolean))].sort(codeUnitCompare);
+}
+
+function normalizeSectionId(input: string): string {
+  const normalized = input.trim().toLowerCase().replace(/[^a-z0-9.-]+/g, "-").replace(/^-+|-+$/g, "");
+  return normalized || "section";
+}
+
+function isLikelyRepoPath(value: string): boolean {
+  if (!value || /\s/.test(value)) return false;
+  if (/^[a-f0-9]{7,40}$/i.test(value)) return false;
+  if (/^[a-z]+:\/\//i.test(value)) return false;
+  return value.includes("/") || value.includes(".");
+}
+
+function sha256(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function codeUnitCompare(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}

--- a/src/openwiki-derived-packet.ts
+++ b/src/openwiki-derived-packet.ts
@@ -15,7 +15,8 @@ const DEFAULT_MAX_PACKET_BYTES = 12_000;
 const GIT_COMMAND_TIMEOUT_MS = 5_000;
 const REPO_PATH_EXTENSION_PATTERN = /\.(?:[cm]?[jt]sx?|mdx?|json|ya?ml|toml|lock|css|scss|html?|sh|bash|zsh|py|go|rs|swift|kt|java|rb|php|sql|txt)$/i;
 const ENV_NAME_TOKEN_PATTERN = /\b[A-Za-z][A-Za-z0-9_-]{1,80}\b/g;
-const ENV_ASSIGNMENT_PATTERN = /\b([A-Za-z][A-Za-z0-9_-]{1,80})\b\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{8,}["']?/g;
+const ENV_ASSIGNMENT_PATTERN = /\b([A-Za-z][A-Za-z0-9_-]{1,80})\b\s*[:=]\s*(?:"[^"\r\n]{0,256}"|'[^'\r\n]{0,256}'|[^\r\n]{1,256})/g;
+const REDACTION_SENTINEL = "\0OPENWIKI_REDACTED\0";
 const SENSITIVE_SEGMENTS = new Set(["token", "secret", "password", "cookie", "session"]);
 const SENSITIVE_PAIR_SUFFIXES = new Set([
   "api_key",
@@ -52,13 +53,15 @@ interface OpenWikiMetadata {
 
 export function buildOpenWikiDerivedRepoWikiPacket(input: BuildOpenWikiDerivedRepoWikiPacketInput): RepoWikiPacket {
   const generatedAt = input.generatedAt ?? new Date().toISOString();
-  const headSha = input.headSha ?? readGit(input.worktreePath, ["rev-parse", "HEAD"]);
+  const headShaResult = input.headSha === undefined ? readGitResult(input.worktreePath, ["rev-parse", "HEAD"]) : undefined;
+  const headSha = input.headSha ?? (headShaResult?.ok ? headShaResult.stdout.trim() : undefined);
   const defaultBranch = input.defaultBranch ?? readDefaultBranch(input.worktreePath);
   const openWiki = readOpenWikiSections(input.worktreePath);
   const source = resolveSourceFreshness({
     worktreePath: input.worktreePath,
     generatedAt,
     headSha,
+    ...(headShaResult && !headShaResult.ok ? { headShaError: "Unable to read git HEAD; regenerate OpenWiki before building a packet." } : {}),
     defaultBranch,
     metadata: readOpenWikiMetadata(input.worktreePath),
     sectionCount: openWiki.sections.length,
@@ -80,6 +83,7 @@ function resolveSourceFreshness(input: {
   worktreePath: string;
   generatedAt: string;
   headSha?: string;
+  headShaError?: string;
   defaultBranch?: string;
   metadata: OpenWikiMetadata | undefined;
   sectionCount: number;
@@ -110,6 +114,13 @@ function resolveSourceFreshness(input: {
       ...base,
       status: "stale",
       staleReason: "Some OpenWiki Markdown files exceeded the safe read limit and were omitted."
+    };
+  }
+  if (input.headShaError) {
+    return {
+      ...base,
+      status: "stale",
+      staleReason: input.headShaError
     };
   }
   const dirtyStatus = readDirtyWorktreePaths(input.worktreePath);
@@ -305,13 +316,13 @@ function redactSensitiveEnvNames(input: string): { text: string; replacementCoun
   const withAssignmentsRedacted = input.replace(ENV_ASSIGNMENT_PATTERN, (match, envName: string) => {
     if (!isSensitiveEnvName(envName)) return match;
     replacementCount += 1;
-    return "[redacted-secret]";
+    return REDACTION_SENTINEL;
   });
   const text = withAssignmentsRedacted.replace(ENV_NAME_TOKEN_PATTERN, (match) => {
     if (!isSensitiveEnvName(match)) return match;
     replacementCount += 1;
-    return "[redacted-secret]";
-  });
+    return REDACTION_SENTINEL;
+  }).replaceAll(REDACTION_SENTINEL, "[redacted-secret]");
   return {
     text,
     replacementCount
@@ -323,7 +334,7 @@ function isSensitiveEnvName(name: string): boolean {
   if (SENSITIVE_CAMEL_SUFFIXES.some((suffix) => name === lowerFirst(suffix) || name.endsWith(suffix))) {
     return true;
   }
-  const parts = name.toLowerCase().replace(/-/g, "_").split("_").filter(Boolean);
+  const parts = name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase().replace(/-/g, "_").split("_").filter(Boolean);
   if (parts.length < 2) return false;
   if (SENSITIVE_PAIR_SUFFIXES.has(parts.slice(-2).join("_"))) return true;
   return parts.some((part) => SENSITIVE_SEGMENTS.has(part));

--- a/src/openwiki-derived-packet.ts
+++ b/src/openwiki-derived-packet.ts
@@ -123,7 +123,7 @@ function readOpenWikiSections(worktreePath: string): RepoWikiSectionInput[] {
       body,
       order: index,
       sourceFiles: normalizeSourceFiles([sourcePath, ...readSourceMap(body)]),
-      sourceSha: sha256(raw)
+      sourceSha: sha256(body)
     };
   });
 }
@@ -185,7 +185,6 @@ function readDirtyNonOpenWikiPaths(worktreePath: string): { ok: boolean; paths: 
   const paths = parsePorcelainStatusPaths(status.stdout)
     .filter(Boolean)
     .filter((changedPath) => changedPath !== ".neondiff" && !changedPath.startsWith(".neondiff/"))
-    .filter((changedPath) => changedPath !== ".neondiff/repo-wiki-packet.json")
     .filter((changedPath) => changedPath !== OPENWIKI_DIR && !changedPath.startsWith(`${OPENWIKI_DIR}/`));
   return { ok: true, paths };
 }

--- a/src/openwiki-derived-packet.ts
+++ b/src/openwiki-derived-packet.ts
@@ -176,6 +176,8 @@ function readDirtyNonOpenWikiPaths(worktreePath: string): string[] {
     .split(/\r?\n/)
     .map((line) => line.slice(3).trim())
     .filter(Boolean)
+    .filter((changedPath) => changedPath !== ".neondiff" && !changedPath.startsWith(".neondiff/"))
+    .filter((changedPath) => changedPath !== ".neondiff/repo-wiki-packet.json")
     .filter((changedPath) => changedPath !== OPENWIKI_DIR && !changedPath.startsWith(`${OPENWIKI_DIR}/`));
 }
 

--- a/src/openwiki-derived-packet.ts
+++ b/src/openwiki-derived-packet.ts
@@ -14,9 +14,10 @@ const OPENWIKI_METADATA_PATH = "openwiki/.last-update.json";
 const DEFAULT_MAX_PACKET_BYTES = 12_000;
 const GIT_COMMAND_TIMEOUT_MS = 5_000;
 const REPO_PATH_EXTENSION_PATTERN = /\.(?:[cm]?[jt]sx?|mdx?|json|ya?ml|toml|lock|css|scss|html?|sh|bash|zsh|py|go|rs|swift|kt|java|rb|php|sql|txt)$/i;
+const SENSITIVE_ENV_ASSIGNMENT_PATTERN = /\b(?:(?:api[_-]?key|private[_-]?key|access[_-]?token|auth[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?cookie)|(?:[a-z][a-z0-9]*[_-]+)+(?:api[_-]?key|private[_-]?key|token|secret|password|cookie|session)(?:[_-]+[a-z0-9]+)*|(?:apiKey|privateKey|accessToken|authToken|refreshToken|idToken|sessionCookie|[a-z][A-Za-z0-9]*(?:ApiKey|PrivateKey|AccessToken|AuthToken|RefreshToken|IdToken|SessionCookie)))\b\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{8,}["']?/gi;
 const SENSITIVE_ENV_NAME_PATTERNS = [
   /\b(?:(?:api[_-]?key|private[_-]?key|access[_-]?token|auth[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?cookie)|(?:[a-z][a-z0-9]*[_-]+)+(?:api[_-]?key|private[_-]?key|token|secret|password|cookie|session)(?:[_-]+[a-z0-9]+)*)\b/gi,
-  /\b[a-z][A-Za-z0-9]*(?:ApiKey|PrivateKey|AccessToken|AuthToken|RefreshToken|IdToken|SessionCookie|Token|Secret|Password|Cookie|Session)\b/g
+  /\b(?:apiKey|privateKey|accessToken|authToken|refreshToken|idToken|sessionCookie|[a-z][A-Za-z0-9]*(?:ApiKey|PrivateKey|AccessToken|AuthToken|RefreshToken|IdToken|SessionCookie))\b/g
 ];
 
 export interface BuildOpenWikiDerivedRepoWikiPacketInput {
@@ -136,14 +137,15 @@ function readOpenWikiSections(worktreePath: string): {
     skippedOversizedCount: listing.skippedOversizedCount,
     sections: listing.files.map((sourcePath, index) => {
       const raw = readFileSync(join(worktreePath, sourcePath), "utf8");
-      const body = redactSensitiveEnvNames(raw.trim());
+      const rawBody = raw.trim();
+      const body = redactSensitiveEnvNames(rawBody);
       return {
         id: normalizeSectionId(sourcePath.replace(/^openwiki\//, "").replace(/\.md$/, "")),
         title: readFirstHeading(body.text) ?? sourcePath,
         body: body.text,
-        order: index,
+        order: readDeclaredSectionOrder(body.text) ?? index,
         sourceFiles: normalizeSourceFiles([sourcePath, ...readSourceMap(body.text)]),
-        sourceSha: sha256(body.text),
+        sourceSha: sha256(rawBody),
         preRedactionReplacementCount: body.replacementCount
       };
     })
@@ -270,14 +272,26 @@ function readFirstHeading(markdown: string): string | undefined {
 
 function redactSensitiveEnvNames(input: string): { text: string; replacementCount: number } {
   let replacementCount = 0;
+  const withAssignmentsRedacted = input.replace(SENSITIVE_ENV_ASSIGNMENT_PATTERN, () => {
+    replacementCount += 1;
+    return "[redacted-secret]";
+  });
   const text = SENSITIVE_ENV_NAME_PATTERNS.reduce((current, pattern) => current.replace(pattern, () => {
       replacementCount += 1;
       return "[redacted-secret]";
-    }), input);
+    }), withAssignmentsRedacted);
   return {
     text,
     replacementCount
   };
+}
+
+function readDeclaredSectionOrder(markdown: string): number | undefined {
+  const frontMatter = markdown.match(/^---\n([\s\S]*?)\n---/);
+  const orderLine = frontMatter?.[1]?.match(/^order:\s*(-?\d+)\s*$/m) ?? markdown.match(/<!--\s*openwiki-order:\s*(-?\d+)\s*-->/i);
+  if (!orderLine?.[1]) return undefined;
+  const order = Number(orderLine[1]);
+  return Number.isSafeInteger(order) ? order : undefined;
 }
 
 function normalizeSourceFiles(files: string[]): string[] {

--- a/src/repo-wiki-packet.ts
+++ b/src/repo-wiki-packet.ts
@@ -217,21 +217,19 @@ export function buildRepoWikiPacket(input: BuildRepoWikiPacketInput): RepoWikiPa
     excluded.push({ id: "packet:sections", reason: "missing_source" });
   }
 
-  const redactionCounter = { count: 0 };
+  const baseRedactionCounter = { count: 0 };
+  const includedSectionRedactionCounts = new Map<string, number>();
   const includedSections: RepoWikiIncludedSection[] = [];
   for (const section of normalized.sections) {
     const preRedactionReplacementCount = section.preRedactionReplacementCount ?? 0;
-    redactionCounter.count += preRedactionReplacementCount;
-    const redactedTitle = redactAndCount(section.title, redactionCounter);
-    const redactedBody = redactAndCount(section.body, redactionCounter);
-    const redactedSourceFileResults = section.sourceFiles.map((file) => redactAndCount(file, redactionCounter));
+    const sectionRedactionCounter = { count: preRedactionReplacementCount };
+    const redactedTitle = redactAndCount(section.title, sectionRedactionCounter);
+    const redactedBody = redactAndCount(section.body, sectionRedactionCounter);
+    const redactedSourceFileResults = section.sourceFiles.map((file) => redactAndCount(file, sectionRedactionCounter));
     const redactedSourceFiles = normalizeSourceFiles(redactedSourceFileResults.map((file) => file.text));
-    const redactedSourceShaResult = section.sourceSha ? redactAndCount(section.sourceSha, redactionCounter) : undefined;
+    const redactedSourceShaResult = section.sourceSha ? redactAndCount(section.sourceSha, sectionRedactionCounter) : undefined;
     const redactedSourceSha = redactedSourceShaResult?.text;
     const cappedBody = truncateUtf8Bytes(redactedBody.text, maxSectionBytes);
-    const provenanceReplacementCount =
-      redactedSourceFileResults.reduce((count, file) => count + file.replacementCount, 0) +
-      (redactedSourceShaResult?.replacementCount ?? 0);
     const included: RepoWikiIncludedSection = {
       id: section.id,
       title: redactedTitle.text,
@@ -242,30 +240,31 @@ export function buildRepoWikiPacket(input: BuildRepoWikiPacketInput): RepoWikiPa
       byteLength: Buffer.byteLength(cappedBody, "utf8"),
       tokenEstimate: tokenEstimateForBytes(Buffer.byteLength(cappedBody, "utf8")),
       truncated: cappedBody !== redactedBody.text,
-      redacted: preRedactionReplacementCount + redactedTitle.replacementCount + redactedBody.replacementCount + provenanceReplacementCount > 0
+      redacted: sectionRedactionCounter.count > 0
     };
+    includedSectionRedactionCounts.set(included.id, sectionRedactionCounter.count);
     includedSections.push(included);
   }
 
   const packetBase = {
     packetVersion: input.packetVersion ?? REPO_WIKI_PACKET_VERSION,
-    repo: normalizeRepo(input.repo, redactionCounter),
-    source: normalizeSource(input.source, redactionCounter),
+    repo: normalizeRepo(input.repo, baseRedactionCounter),
+    source: normalizeSource(input.source, baseRedactionCounter),
     generatedAt,
     advisory: REPO_WIKI_ADVISORY_LINE,
     degraded: input.source.status !== "fresh",
     byteBudget: { maxBytes, usedBytes: 0 },
     tokenBudget: { maxTokens, usedTokens: 0 },
     redaction: {
-      status: redactionCounter.count > 0 ? "redacted" : "passed",
-      replacementCount: redactionCounter.count
+      status: baseRedactionCounter.count > 0 ? "redacted" : "passed",
+      replacementCount: baseRedactionCounter.count
     } satisfies RepoWikiRedactionResult
   };
 
   let acceptedSections = [...includedSections];
   let acceptedExcluded = [...excluded];
   while (acceptedSections.length > 0) {
-    const tentative = finalizePacket(packetBase, acceptedSections, acceptedExcluded);
+    const tentative = finalizePacket(packetBase, acceptedSections, acceptedExcluded, includedSectionRedactionCounts);
     if (tentative.byteBudget.usedBytes <= maxBytes && tentative.tokenBudget.usedTokens <= maxTokens) {
       return tentative;
     }
@@ -273,7 +272,7 @@ export function buildRepoWikiPacket(input: BuildRepoWikiPacketInput): RepoWikiPa
     if (dropped) acceptedExcluded = [{ id: dropped.id, reason: "packet_budget_exceeded" }, ...acceptedExcluded];
   }
 
-  const emptyPacket = finalizePacket(packetBase, acceptedSections, acceptedExcluded);
+  const emptyPacket = finalizePacket(packetBase, acceptedSections, acceptedExcluded, includedSectionRedactionCounts);
   if (emptyPacket.byteBudget.usedBytes > maxBytes || emptyPacket.tokenBudget.usedTokens > maxTokens) {
     throw new Error(
       `fixed packet header exceeds budget (${emptyPacket.byteBudget.usedBytes}/${maxBytes} bytes, ${emptyPacket.tokenBudget.usedTokens}/${maxTokens} token-ish)`
@@ -457,11 +456,18 @@ export function truncateUtf8Bytes(input: string, maxBytes: number): string {
 function finalizePacket(
   base: Omit<RepoWikiPacket, "includedSections" | "excludedSections" | "includedFiles" | "packetSha">,
   includedSections: RepoWikiIncludedSection[],
-  excludedSections: RepoWikiExcludedSection[]
+  excludedSections: RepoWikiExcludedSection[],
+  includedSectionRedactionCounts: Map<string, number>
 ): RepoWikiPacket {
   const includedFiles = buildIncludedFiles(includedSections);
+  const replacementCount = base.redaction.replacementCount +
+    includedSections.reduce((count, section) => count + (includedSectionRedactionCounts.get(section.id) ?? 0), 0);
   let withoutSha: Omit<RepoWikiPacket, "packetSha"> = {
     ...base,
+    redaction: {
+      status: replacementCount > 0 ? "redacted" : "passed",
+      replacementCount
+    },
     includedSections,
     excludedSections: [...excludedSections].sort(compareExcluded),
     includedFiles

--- a/src/repo-wiki-packet.ts
+++ b/src/repo-wiki-packet.ts
@@ -58,6 +58,7 @@ export interface RepoWikiIncludedSection {
   order: number;
   sourceFiles: string[];
   sourceSha?: string;
+  emittedBodySha?: string;
   byteLength: number;
   tokenEstimate: number;
   truncated: boolean;
@@ -227,15 +228,17 @@ export function buildRepoWikiPacket(input: BuildRepoWikiPacketInput): RepoWikiPa
     const redactedBody = redactAndCount(section.body, sectionRedactionCounter);
     const redactedSourceFileResults = section.sourceFiles.map((file) => redactAndCount(file, sectionRedactionCounter));
     const redactedSourceFiles = normalizeSourceFiles(redactedSourceFileResults.map((file) => file.text));
+    const redactedSourceSha = section.sourceSha ? redactAndCount(section.sourceSha, sectionRedactionCounter).text : undefined;
     const cappedBody = truncateUtf8Bytes(redactedBody.text, maxSectionBytes);
-    const emittedSourceSha = section.sourceSha ? sha256(cappedBody) : undefined;
+    const emittedBodySha = section.sourceSha ? sha256(cappedBody) : undefined;
     const included: RepoWikiIncludedSection = {
       id: section.id,
       title: redactedTitle.text,
       body: cappedBody,
       order: section.order,
       sourceFiles: redactedSourceFiles,
-      ...(emittedSourceSha ? { sourceSha: emittedSourceSha } : {}),
+      ...(redactedSourceSha ? { sourceSha: redactedSourceSha } : {}),
+      ...(emittedBodySha ? { emittedBodySha } : {}),
       byteLength: Buffer.byteLength(cappedBody, "utf8"),
       tokenEstimate: tokenEstimateForBytes(Buffer.byteLength(cappedBody, "utf8")),
       truncated: cappedBody !== redactedBody.text,
@@ -316,6 +319,7 @@ export function formatRepoWikiPacketMarkdown(packet: RepoWikiPacket): string {
           section.truncated ? "truncated=true" : "truncated=false",
           section.redacted ? "redacted=true" : "redacted=false",
           section.sourceSha ? `source_sha=${section.sourceSha}` : undefined,
+          section.emittedBodySha ? `emitted_body_sha=${section.emittedBodySha}` : undefined,
           section.sourceFiles.length ? `files=${section.sourceFiles.join(", ")}` : undefined
         ].filter(Boolean).join("; "),
         "",

--- a/src/repo-wiki-packet.ts
+++ b/src/repo-wiki-packet.ts
@@ -227,16 +227,15 @@ export function buildRepoWikiPacket(input: BuildRepoWikiPacketInput): RepoWikiPa
     const redactedBody = redactAndCount(section.body, sectionRedactionCounter);
     const redactedSourceFileResults = section.sourceFiles.map((file) => redactAndCount(file, sectionRedactionCounter));
     const redactedSourceFiles = normalizeSourceFiles(redactedSourceFileResults.map((file) => file.text));
-    const redactedSourceShaResult = section.sourceSha ? redactAndCount(section.sourceSha, sectionRedactionCounter) : undefined;
-    const redactedSourceSha = redactedSourceShaResult?.text;
     const cappedBody = truncateUtf8Bytes(redactedBody.text, maxSectionBytes);
+    const emittedSourceSha = section.sourceSha ? sha256(cappedBody) : undefined;
     const included: RepoWikiIncludedSection = {
       id: section.id,
       title: redactedTitle.text,
       body: cappedBody,
       order: section.order,
       sourceFiles: redactedSourceFiles,
-      ...(redactedSourceSha ? { sourceSha: redactedSourceSha } : {}),
+      ...(emittedSourceSha ? { sourceSha: emittedSourceSha } : {}),
       byteLength: Buffer.byteLength(cappedBody, "utf8"),
       tokenEstimate: tokenEstimateForBytes(Buffer.byteLength(cappedBody, "utf8")),
       truncated: cappedBody !== redactedBody.text,

--- a/src/repo-wiki-packet.ts
+++ b/src/repo-wiki-packet.ts
@@ -28,6 +28,7 @@ export interface RepoWikiSectionInput {
   order?: number;
   sourceFiles?: string[];
   sourceSha?: string;
+  preRedactionReplacementCount?: number;
 }
 
 export interface RepoWikiNormalizedSection {
@@ -37,6 +38,7 @@ export interface RepoWikiNormalizedSection {
   order: number;
   sourceFiles: string[];
   sourceSha?: string;
+  preRedactionReplacementCount?: number;
 }
 
 export type RepoWikiExcludedSectionReason =
@@ -178,6 +180,7 @@ export function normalizeRepoWikiSections(input: RepoWikiSectionInput[]): {
     .map((section) => {
       const baseId = normalizeSectionId(section.id);
       const body = normalizeText(section.body);
+      const preRedactionReplacementCount = readPreRedactionReplacementCount(section.preRedactionReplacementCount);
       if (!body) {
         excluded.push({ id: baseId, reason: "empty" });
         return undefined;
@@ -188,7 +191,8 @@ export function normalizeRepoWikiSections(input: RepoWikiSectionInput[]): {
         body,
         order: Number.isFinite(section.order) ? Number(section.order) : 0,
         sourceFiles: normalizeSourceFiles(section.sourceFiles ?? []),
-        ...(section.sourceSha ? { sourceSha: section.sourceSha } : {})
+        ...(section.sourceSha ? { sourceSha: section.sourceSha } : {}),
+        ...(preRedactionReplacementCount > 0 ? { preRedactionReplacementCount } : {})
       } satisfies RepoWikiNormalizedSection;
     })
     .filter((section): section is RepoWikiNormalizedSection => section !== undefined)
@@ -216,6 +220,8 @@ export function buildRepoWikiPacket(input: BuildRepoWikiPacketInput): RepoWikiPa
   const redactionCounter = { count: 0 };
   const includedSections: RepoWikiIncludedSection[] = [];
   for (const section of normalized.sections) {
+    const preRedactionReplacementCount = section.preRedactionReplacementCount ?? 0;
+    redactionCounter.count += preRedactionReplacementCount;
     const redactedTitle = redactAndCount(section.title, redactionCounter);
     const redactedBody = redactAndCount(section.body, redactionCounter);
     const redactedSourceFileResults = section.sourceFiles.map((file) => redactAndCount(file, redactionCounter));
@@ -236,7 +242,7 @@ export function buildRepoWikiPacket(input: BuildRepoWikiPacketInput): RepoWikiPa
       byteLength: Buffer.byteLength(cappedBody, "utf8"),
       tokenEstimate: tokenEstimateForBytes(Buffer.byteLength(cappedBody, "utf8")),
       truncated: cappedBody !== redactedBody.text,
-      redacted: redactedTitle.replacementCount + redactedBody.replacementCount + provenanceReplacementCount > 0
+      redacted: preRedactionReplacementCount + redactedTitle.replacementCount + redactedBody.replacementCount + provenanceReplacementCount > 0
     };
     includedSections.push(included);
   }
@@ -530,6 +536,11 @@ function redactAndCount(input: string, counter: { count: number }): { text: stri
   const result = redactRepoWikiText(input);
   counter.count += result.replacementCount;
   return result;
+}
+
+function readPreRedactionReplacementCount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return 0;
+  return Math.floor(value);
 }
 
 function normalizeSectionId(id: string): string {

--- a/tests/openwiki-derived-packet.test.ts
+++ b/tests/openwiki-derived-packet.test.ts
@@ -85,6 +85,26 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(packet.degraded).toBe(true);
   });
 
+  it("does not treat the standard packet artifact as stale source", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    mkdirSync(join(root, ".neondiff"), { recursive: true });
+    writeFileSync(join(root, ".neondiff", "repo-wiki-packet.json"), "{}\n", "utf8");
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.source).toMatchObject({
+      headSha: head,
+      status: "fresh"
+    });
+  });
+
   it("omits OpenWiki review suggestions from prompt packets", () => {
     const { head, root } = createRepoWithOpenWiki();
     roots.push(root);

--- a/tests/openwiki-derived-packet.test.ts
+++ b/tests/openwiki-derived-packet.test.ts
@@ -172,12 +172,12 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(body).not.toContain("ZAI_TOKEN");
     expect(body).not.toContain("api_key");
     expect(body).not.toContain("openrouter_api_key");
-    expect(body).toContain("zcodeToken");
+    expect(body).not.toContain("zcodeToken");
     expect(body).not.toContain("privateKey");
     expect(body).toContain("TOKEN, SECRET, PASSWORD, COOKIE, and SESSION should stay readable.");
     expect(packet.redaction).toMatchObject({
       status: "redacted",
-      replacementCount: 7
+      replacementCount: 8
     });
   });
 
@@ -241,6 +241,57 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(json).not.toContain(secret);
     expect(json).not.toContain(unprefixedSecret);
     expect(packet.redaction.status).toBe("redacted");
+  });
+
+  it("redacts assignment values with spaces without rescanning placeholders", () => {
+    const { head, root } = createRepoWithOpenWiki({
+      openWikiBody: [
+        "# Provider setup",
+        "",
+        "MY_DB_PASSWORD=plaintext value here",
+        "OPENWIKI_SESSION_COOKIE=plaintextvalue123456",
+        ""
+      ].join("\n")
+    });
+    roots.push(root);
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+    const body = packet.includedSections[0]?.body ?? "";
+
+    expect(body).toContain("[redacted-secret]");
+    expect(body).not.toContain("MY_DB_PASSWORD");
+    expect(body).not.toContain("plaintext value here");
+    expect(body).not.toContain("OPENWIKI_SESSION_COOKIE");
+    expect(body).not.toContain("plaintextvalue123456");
+    expect(body).not.toContain("[[redacted-secret]]");
+    expect(packet.redaction).toMatchObject({
+      status: "redacted",
+      replacementCount: 2
+    });
+  });
+
+  it("marks packets stale with explicit git HEAD reason when default head lookup fails", () => {
+    const { root } = createRepoWithOpenWiki();
+    roots.push(root);
+    rmSync(join(root, ".git"), { recursive: true, force: true });
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      defaultBranch: "main"
+    });
+
+    expect(packet.source).toMatchObject({
+      status: "stale",
+      staleReason: "Unable to read git HEAD; regenerate OpenWiki before building a packet."
+    });
   });
 
   it("preserves source provenance and separately hashes the emitted truncated section body", () => {

--- a/tests/openwiki-derived-packet.test.ts
+++ b/tests/openwiki-derived-packet.test.ts
@@ -46,6 +46,10 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(section?.body).toContain("[redacted-secret]");
     expect(section?.body).not.toContain("OPENROUTER_API_KEY");
     expect(section?.sourceSha).toBe(sha256(section?.body ?? ""));
+    expect(packet.redaction).toMatchObject({
+      status: "redacted",
+      replacementCount: 1
+    });
 
     mkdirSync(join(root, ".neondiff"), { recursive: true });
     writeFileSync(join(root, ".neondiff", "repo-wiki-packet.json"), formatRepoWikiPacketJson(packet));
@@ -130,7 +134,8 @@ describe("OpenWiki-derived repo-wiki packets", () => {
       openWikiBody: [
         "# Provider setup",
         "",
-        "Use API_KEY, TOKEN, SECRET, PASSWORD, PRIVATE_KEY, and SESSION_COOKIE only in GitHub secrets.",
+        "Use API_KEY, PRIVATE_KEY, SESSION_COOKIE, and ZAI_TOKEN only in GitHub secrets.",
+        "Bare prose words like TOKEN, SECRET, PASSWORD, COOKIE, and SESSION should stay readable.",
         ""
       ].join("\n")
     });
@@ -149,6 +154,12 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(body).not.toContain("API_KEY");
     expect(body).not.toContain("PRIVATE_KEY");
     expect(body).not.toContain("SESSION_COOKIE");
+    expect(body).not.toContain("ZAI_TOKEN");
+    expect(body).toContain("TOKEN, SECRET, PASSWORD, COOKIE, and SESSION should stay readable.");
+    expect(packet.redaction).toMatchObject({
+      status: "redacted",
+      replacementCount: 4
+    });
   });
 
   it("marks packets stale when dirty git status renames OpenWiki files into source docs", () => {
@@ -196,25 +207,21 @@ describe("OpenWiki-derived repo-wiki packets", () => {
   it("fails closed when git status cannot be read", () => {
     const { head, root } = createRepoWithOpenWiki();
     roots.push(root);
-    const originalPath = process.env.PATH;
-    process.env.PATH = "";
-    try {
-      const packet = buildOpenWikiDerivedRepoWikiPacket({
-        repo,
-        worktreePath: root,
-        generatedAt,
-        headSha: head,
-        defaultBranch: "main"
-      });
+    rmSync(join(root, ".git"), { recursive: true, force: true });
 
-      expect(packet.source).toMatchObject({
-        status: "stale",
-        staleReason: "Unable to read git worktree status; regenerate OpenWiki before building a packet."
-      });
-      expect(packet.degraded).toBe(true);
-    } finally {
-      process.env.PATH = originalPath;
-    }
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.source).toMatchObject({
+      status: "stale",
+      staleReason: "Unable to read git worktree status; regenerate OpenWiki before building a packet."
+    });
+    expect(packet.degraded).toBe(true);
   });
 
   it("marks packets missing when OpenWiki has no Markdown sections", () => {

--- a/tests/openwiki-derived-packet.test.ts
+++ b/tests/openwiki-derived-packet.test.ts
@@ -10,6 +10,18 @@ import { formatRepoWikiPacketJson } from "../src/repo-wiki-packet.js";
 
 const repo = "electricsheephq/evaos-code-review-bot-neondiff";
 const generatedAt = "2026-07-09T08:30:00.000Z";
+const defaultOpenWikiBody = [
+  "# Quickstart",
+  "",
+  "NeonDiff reviews pull requests. Configure provider credentials with OPENROUTER_API_KEY.",
+  "",
+  "## Source map",
+  "",
+  "- README.md",
+  "- src/worker.ts",
+  "- Git evidence: commits `abc1234`",
+  ""
+].join("\n");
 
 describe("OpenWiki-derived repo-wiki packets", () => {
   const roots: string[] = [];
@@ -45,8 +57,9 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     ]);
     expect(section?.body).toContain("[redacted-secret]");
     expect(section?.body).not.toContain("OPENROUTER_API_KEY");
-    expect(section?.sourceSha).toBe(sha256(section?.body ?? ""));
+    expect(section?.sourceSha).toBe(sha256(defaultOpenWikiBody.trim()));
     expect(section?.emittedBodySha).toBe(sha256(section?.body ?? ""));
+    expect(section?.sourceSha).not.toBe(section?.emittedBodySha);
     expect(packet.redaction).toMatchObject({
       status: "redacted",
       replacementCount: 1
@@ -159,22 +172,24 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(body).not.toContain("ZAI_TOKEN");
     expect(body).not.toContain("api_key");
     expect(body).not.toContain("openrouter_api_key");
-    expect(body).not.toContain("zcodeToken");
+    expect(body).toContain("zcodeToken");
     expect(body).not.toContain("privateKey");
     expect(body).toContain("TOKEN, SECRET, PASSWORD, COOKIE, and SESSION should stay readable.");
     expect(packet.redaction).toMatchObject({
       status: "redacted",
-      replacementCount: 8
+      replacementCount: 7
     });
   });
 
-  it("redacts secret-like values from OpenWiki section bodies and JSON output", () => {
+  it("redacts secret-like values and assignments from OpenWiki section bodies and JSON output", () => {
     const secret = "ghp_1234567890abcdef";
+    const unprefixedSecret = "Sup3rS3cr3tV4lue99";
     const { head, root } = createRepoWithOpenWiki({
       openWikiBody: [
         "# Provider setup",
         "",
         `Never paste ${secret} into OpenWiki docs.`,
+        `OPENROUTER_API_KEY=${unprefixedSecret}`,
         ""
       ].join("\n")
     });
@@ -192,7 +207,9 @@ describe("OpenWiki-derived repo-wiki packets", () => {
 
     expect(body).toContain("[redacted-secret]");
     expect(body).not.toContain(secret);
+    expect(body).not.toContain(unprefixedSecret);
     expect(json).not.toContain(secret);
+    expect(json).not.toContain(unprefixedSecret);
     expect(packet.redaction.status).toBe("redacted");
   });
 
@@ -259,6 +276,39 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(sourceFiles).not.toContain("v1.2");
     expect(sourceFiles).not.toContain("3.14");
     expect(sourceFiles).not.toContain("20.10.0");
+  });
+
+  it("honors declared OpenWiki section order before filename order", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    writeFileSync(join(root, "openwiki", "aaa-architecture.md"), [
+      "---",
+      "order: 50",
+      "---",
+      "# Architecture",
+      "",
+      "Architecture details."
+    ].join("\n"), "utf8");
+    writeFileSync(join(root, "openwiki", "zzz-runbook.md"), [
+      "<!-- openwiki-order: -5 -->",
+      "# Runbook",
+      "",
+      "Runbook details."
+    ].join("\n"), "utf8");
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.includedSections.map((section) => section.id)).toEqual([
+      "zzz-runbook",
+      "quickstart",
+      "aaa-architecture"
+    ]);
   });
 
   it("marks packets stale when dirty git status renames OpenWiki files into source docs", () => {
@@ -394,19 +444,7 @@ function createRepoWithOpenWiki(options: { metadataHead?: string; openWikiBody?:
   writeFileSync(join(root, "src", "worker.ts"), "export const worker = true;\n", "utf8");
   writeFileSync(
     join(root, "openwiki", "quickstart.md"),
-    options.openWikiBody ??
-      [
-        "# Quickstart",
-        "",
-        "NeonDiff reviews pull requests. Configure provider credentials with OPENROUTER_API_KEY.",
-        "",
-        "## Source map",
-        "",
-        "- README.md",
-        "- src/worker.ts",
-        "- Git evidence: commits `abc1234`",
-        ""
-      ].join("\n"),
+    options.openWikiBody ?? defaultOpenWikiBody,
     "utf8"
   );
   git(root, ["add", "."]);

--- a/tests/openwiki-derived-packet.test.ts
+++ b/tests/openwiki-derived-packet.test.ts
@@ -373,6 +373,25 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     });
   });
 
+  it("marks packets stale when OpenWiki Markdown has uncommitted changes", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    writeFileSync(join(root, "openwiki", "quickstart.md"), "# Quickstart\n\nUncommitted advisory docs.\n", "utf8");
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.source).toMatchObject({
+      status: "stale",
+      staleReason: "OpenWiki Markdown files have uncommitted changes; regenerate OpenWiki before building a fresh packet."
+    });
+  });
+
   it("fails closed when git status cannot be read", () => {
     const { head, root } = createRepoWithOpenWiki();
     roots.push(root);
@@ -428,6 +447,27 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(packet.source).toMatchObject({
       status: "stale",
       staleReason: "Some OpenWiki Markdown files exceeded the safe read limit and were omitted."
+    });
+    expect(packet.degraded).toBe(true);
+  });
+
+  it("marks packets stale when all OpenWiki Markdown files are oversized", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    rmSync(join(root, "openwiki", "quickstart.md"));
+    writeFileSync(join(root, "openwiki", "huge.md"), `# Huge\n\n${"x".repeat(256_001)}\n`, "utf8");
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.source).toMatchObject({
+      status: "stale",
+      staleReason: "OpenWiki Markdown files exceeded the safe read limit and were omitted."
     });
     expect(packet.degraded).toBe(true);
   });

--- a/tests/openwiki-derived-packet.test.ts
+++ b/tests/openwiki-derived-packet.test.ts
@@ -181,6 +181,36 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     });
   });
 
+  it("keeps secret-name redaction bounded to env-like tokens", () => {
+    const longToken = `not${"a".repeat(120)}token`;
+    const { head, root } = createRepoWithOpenWiki({
+      openWikiBody: [
+        "# Provider setup",
+        "",
+        `A long prose token ${longToken} should stay readable.`,
+        "The env-style ZAI_ACCESS_TOKEN should still be redacted.",
+        ""
+      ].join("\n")
+    });
+    roots.push(root);
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+    const body = packet.includedSections[0]?.body ?? "";
+
+    expect(body).toContain(longToken);
+    expect(body).not.toContain("ZAI_ACCESS_TOKEN");
+    expect(packet.redaction).toMatchObject({
+      status: "redacted",
+      replacementCount: 1
+    });
+  });
+
   it("redacts secret-like values and assignments from OpenWiki section bodies and JSON output", () => {
     const secret = "ghp_1234567890abcdef";
     const unprefixedSecret = "Sup3rS3cr3tV4lue99";
@@ -311,6 +341,32 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     ]);
   });
 
+  it("honors front-matter section order in CRLF OpenWiki files", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    writeFileSync(join(root, "openwiki", "zzz-runbook.md"), [
+      "---",
+      "order: -5",
+      "---",
+      "# Runbook",
+      "",
+      "Runbook details."
+    ].join("\r\n"), "utf8");
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.includedSections.map((section) => section.id).slice(0, 2)).toEqual([
+      "zzz-runbook",
+      "quickstart"
+    ]);
+  });
+
   it("marks packets stale when dirty git status renames OpenWiki files into source docs", () => {
     const { head, root } = createRepoWithOpenWiki();
     roots.push(root);
@@ -388,7 +444,36 @@ describe("OpenWiki-derived repo-wiki packets", () => {
 
     expect(packet.source).toMatchObject({
       status: "stale",
-      staleReason: "OpenWiki Markdown files have uncommitted changes; regenerate OpenWiki before building a fresh packet."
+      staleReason: "OpenWiki files have uncommitted changes; regenerate OpenWiki before building a fresh packet."
+    });
+  });
+
+  it("marks packets stale when OpenWiki metadata has uncommitted changes", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    writeFileSync(
+      join(root, "openwiki", ".last-update.json"),
+      `${JSON.stringify({
+        updatedAt: generatedAt,
+        command: "update",
+        gitHead: head,
+        model: "GLM-5.2",
+        note: "dirty metadata"
+      })}\n`,
+      "utf8"
+    );
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.source).toMatchObject({
+      status: "stale",
+      staleReason: "OpenWiki files have uncommitted changes; regenerate OpenWiki before building a fresh packet."
     });
   });
 
@@ -500,6 +585,8 @@ function createRepoWithOpenWiki(options: { metadataHead?: string; openWikiBody?:
     })}\n`,
     "utf8"
   );
+  git(root, ["add", "openwiki/.last-update.json"]);
+  git(root, ["commit", "-m", "add openwiki metadata"]);
   return { head, root };
 }
 

--- a/tests/openwiki-derived-packet.test.ts
+++ b/tests/openwiki-derived-packet.test.ts
@@ -46,6 +46,7 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(section?.body).toContain("[redacted-secret]");
     expect(section?.body).not.toContain("OPENROUTER_API_KEY");
     expect(section?.sourceSha).toBe(sha256(section?.body ?? ""));
+    expect(section?.emittedBodySha).toBe(sha256(section?.body ?? ""));
     expect(packet.redaction).toMatchObject({
       status: "redacted",
       replacementCount: 1
@@ -167,14 +168,43 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     });
   });
 
-  it("hashes the emitted truncated section body", () => {
+  it("redacts secret-like values from OpenWiki section bodies and JSON output", () => {
+    const secret = "ghp_1234567890abcdef";
     const { head, root } = createRepoWithOpenWiki({
       openWikiBody: [
-        "# Long Section",
+        "# Provider setup",
         "",
-        "abcdefghijklmnopqrstuvwxyz",
-        "0123456789"
+        `Never paste ${secret} into OpenWiki docs.`,
+        ""
       ].join("\n")
+    });
+    roots.push(root);
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+    const json = formatRepoWikiPacketJson(packet);
+    const body = packet.includedSections[0]?.body ?? "";
+
+    expect(body).toContain("[redacted-secret]");
+    expect(body).not.toContain(secret);
+    expect(json).not.toContain(secret);
+    expect(packet.redaction.status).toBe("redacted");
+  });
+
+  it("preserves source provenance and separately hashes the emitted truncated section body", () => {
+    const fullBody = [
+      "# Long Section",
+      "",
+      "abcdefghijklmnopqrstuvwxyz",
+      "0123456789"
+    ].join("\n");
+    const { head, root } = createRepoWithOpenWiki({
+      openWikiBody: fullBody
     });
     roots.push(root);
 
@@ -190,7 +220,45 @@ describe("OpenWiki-derived repo-wiki packets", () => {
 
     expect(section?.truncated).toBe(true);
     expect(section?.body.length).toBeLessThan("abcdefghijklmnopqrstuvwxyz0123456789".length);
-    expect(section?.sourceSha).toBe(sha256(section?.body ?? ""));
+    expect(section?.sourceSha).toBe(sha256(fullBody));
+    expect(section?.emittedBodySha).toBe(sha256(section?.body ?? ""));
+  });
+
+  it("does not treat version-like source-map bullets as source files", () => {
+    const { head, root } = createRepoWithOpenWiki({
+      openWikiBody: [
+        "# Quickstart",
+        "",
+        "NeonDiff reviews pull requests.",
+        "",
+        "## Source map",
+        "",
+        "- README.md, v1.2, 3.14, 20.10.0",
+        "- src/worker.ts",
+        "- docs/api",
+        ""
+      ].join("\n")
+    });
+    roots.push(root);
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+    const sourceFiles = packet.includedSections[0]?.sourceFiles ?? [];
+
+    expect(sourceFiles).toEqual([
+      "README.md",
+      "docs/api",
+      "openwiki/quickstart.md",
+      "src/worker.ts"
+    ]);
+    expect(sourceFiles).not.toContain("v1.2");
+    expect(sourceFiles).not.toContain("3.14");
+    expect(sourceFiles).not.toContain("20.10.0");
   });
 
   it("marks packets stale when dirty git status renames OpenWiki files into source docs", () => {
@@ -220,6 +288,26 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     roots.push(root);
     mkdirSync(join(root, "docs"), { recursive: true });
     writeFileSync(join(root, "docs", "new-guide.md"), "# New Guide\n", "utf8");
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.source).toMatchObject({
+      status: "stale",
+      staleReason: "Repository has non-openwiki worktree changes; regenerate OpenWiki before building a packet."
+    });
+  });
+
+  it("preserves leading path whitespace when checking dirty non-openwiki status", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    mkdirSync(join(root, " openwiki"), { recursive: true });
+    writeFileSync(join(root, " openwiki", "notes.md"), "# Shadow docs\n", "utf8");
 
     const packet = buildOpenWikiDerivedRepoWikiPacket({
       repo,

--- a/tests/openwiki-derived-packet.test.ts
+++ b/tests/openwiki-derived-packet.test.ts
@@ -135,6 +135,7 @@ describe("OpenWiki-derived repo-wiki packets", () => {
         "# Provider setup",
         "",
         "Use API_KEY, PRIVATE_KEY, SESSION_COOKIE, and ZAI_TOKEN only in GitHub secrets.",
+        "Also keep api_key, openrouter_api_key, zcodeToken, and privateKey out of docs.",
         "Bare prose words like TOKEN, SECRET, PASSWORD, COOKIE, and SESSION should stay readable.",
         ""
       ].join("\n")
@@ -155,11 +156,41 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(body).not.toContain("PRIVATE_KEY");
     expect(body).not.toContain("SESSION_COOKIE");
     expect(body).not.toContain("ZAI_TOKEN");
+    expect(body).not.toContain("api_key");
+    expect(body).not.toContain("openrouter_api_key");
+    expect(body).not.toContain("zcodeToken");
+    expect(body).not.toContain("privateKey");
     expect(body).toContain("TOKEN, SECRET, PASSWORD, COOKIE, and SESSION should stay readable.");
     expect(packet.redaction).toMatchObject({
       status: "redacted",
-      replacementCount: 4
+      replacementCount: 8
     });
+  });
+
+  it("hashes the emitted truncated section body", () => {
+    const { head, root } = createRepoWithOpenWiki({
+      openWikiBody: [
+        "# Long Section",
+        "",
+        "abcdefghijklmnopqrstuvwxyz",
+        "0123456789"
+      ].join("\n")
+    });
+    roots.push(root);
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main",
+      maxSectionBytes: 20
+    });
+    const section = packet.includedSections[0];
+
+    expect(section?.truncated).toBe(true);
+    expect(section?.body.length).toBeLessThan("abcdefghijklmnopqrstuvwxyz0123456789".length);
+    expect(section?.sourceSha).toBe(sha256(section?.body ?? ""));
   });
 
   it("marks packets stale when dirty git status renames OpenWiki files into source docs", () => {
@@ -241,6 +272,26 @@ describe("OpenWiki-derived repo-wiki packets", () => {
       status: "missing",
       staleReason: "No OpenWiki Markdown files were found under openwiki/."
     });
+  });
+
+  it("marks packets degraded when oversized OpenWiki Markdown files are omitted", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    writeFileSync(join(root, "openwiki", "huge.md"), `# Huge\n\n${"x".repeat(256_001)}\n`, "utf8");
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.source).toMatchObject({
+      status: "stale",
+      staleReason: "Some OpenWiki Markdown files exceeded the safe read limit and were omitted."
+    });
+    expect(packet.degraded).toBe(true);
   });
 });
 

--- a/tests/openwiki-derived-packet.test.ts
+++ b/tests/openwiki-derived-packet.test.ts
@@ -149,7 +149,9 @@ describe("OpenWiki-derived repo-wiki packets", () => {
         "# Provider setup",
         "",
         "Use API_KEY, PRIVATE_KEY, SESSION_COOKIE, and ZAI_TOKEN only in GitHub secrets.",
+        "Also redact DATABASE_PASS, SERVICE_AUTH, CLIENT_CRED, and CACHE_KEY from env-style examples.",
         "Also keep api_key, openrouter_api_key, zcodeToken, and privateKey out of docs.",
+        "The prose helper buildAuthFlow should stay readable.",
         "Bare prose words like TOKEN, SECRET, PASSWORD, COOKIE, and SESSION should stay readable.",
         ""
       ].join("\n")
@@ -170,14 +172,19 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(body).not.toContain("PRIVATE_KEY");
     expect(body).not.toContain("SESSION_COOKIE");
     expect(body).not.toContain("ZAI_TOKEN");
+    expect(body).not.toContain("DATABASE_PASS");
+    expect(body).not.toContain("SERVICE_AUTH");
+    expect(body).not.toContain("CLIENT_CRED");
+    expect(body).not.toContain("CACHE_KEY");
     expect(body).not.toContain("api_key");
     expect(body).not.toContain("openrouter_api_key");
     expect(body).not.toContain("zcodeToken");
     expect(body).not.toContain("privateKey");
+    expect(body).toContain("buildAuthFlow should stay readable.");
     expect(body).toContain("TOKEN, SECRET, PASSWORD, COOKIE, and SESSION should stay readable.");
     expect(packet.redaction).toMatchObject({
       status: "redacted",
-      replacementCount: 8
+      replacementCount: 12
     });
   });
 
@@ -250,6 +257,7 @@ describe("OpenWiki-derived repo-wiki packets", () => {
         "",
         "MY_DB_PASSWORD=plaintext value here",
         "OPENWIKI_SESSION_COOKIE=plaintextvalue123456",
+        "Use OPENWIKI_AUTH_TOKEN=abc123, then rotate it.",
         ""
       ].join("\n")
     });
@@ -269,10 +277,13 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(body).not.toContain("plaintext value here");
     expect(body).not.toContain("OPENWIKI_SESSION_COOKIE");
     expect(body).not.toContain("plaintextvalue123456");
+    expect(body).not.toContain("OPENWIKI_AUTH_TOKEN");
+    expect(body).not.toContain("abc123");
+    expect(body).toContain(", then rotate it.");
     expect(body).not.toContain("[[redacted-secret]]");
     expect(packet.redaction).toMatchObject({
       status: "redacted",
-      replacementCount: 2
+      replacementCount: 3
     });
   });
 
@@ -565,6 +576,28 @@ describe("OpenWiki-derived repo-wiki packets", () => {
       status: "missing",
       staleReason: "No OpenWiki Markdown files were found under openwiki/."
     });
+  });
+
+  it("bounds recursive OpenWiki Markdown scanning depth", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    let currentDir = join(root, "openwiki");
+    for (let index = 0; index < 10; index += 1) {
+      currentDir = join(currentDir, `level-${index}`);
+      mkdirSync(currentDir, { recursive: true });
+    }
+    writeFileSync(join(currentDir, "too-deep.md"), "# Too Deep\n\nShould not be scanned.\n", "utf8");
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.includedSections.map((section) => section.id)).toEqual(["quickstart"]);
+    expect(formatRepoWikiPacketJson(packet)).not.toContain("Too Deep");
   });
 
   it("marks packets degraded when oversized OpenWiki Markdown files are omitted", () => {

--- a/tests/openwiki-derived-packet.test.ts
+++ b/tests/openwiki-derived-packet.test.ts
@@ -122,9 +122,100 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(packet.includedSections.map((section) => section.id)).toEqual(["quickstart"]);
     expect(formatRepoWikiPacketJson(packet)).not.toContain("suggested-doc-edits");
   });
+
+  it("redacts sensitive env names that start with the sensitive keyword", () => {
+    const { head, root } = createRepoWithOpenWiki({
+      openWikiBody: [
+        "# Provider setup",
+        "",
+        "Use API_KEY, TOKEN, SECRET, PASSWORD, PRIVATE_KEY, and SESSION_COOKIE only in GitHub secrets.",
+        ""
+      ].join("\n")
+    });
+    roots.push(root);
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+    const body = packet.includedSections[0]?.body ?? "";
+
+    expect(body).toContain("[redacted-secret]");
+    expect(body).not.toContain("API_KEY");
+    expect(body).not.toContain("PRIVATE_KEY");
+    expect(body).not.toContain("SESSION_COOKIE");
+  });
+
+  it("marks packets stale when dirty git status renames OpenWiki files into source docs", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    mkdirSync(join(root, "docs"), { recursive: true });
+    git(root, ["mv", "openwiki/quickstart.md", "docs/quickstart.md"]);
+    writeFileSync(join(root, "openwiki", "replacement.md"), "# Replacement\n\nStill advisory.\n", "utf8");
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.source).toMatchObject({
+      status: "stale",
+      staleReason: "Repository has non-openwiki worktree changes; regenerate OpenWiki before building a packet."
+    });
+    expect(packet.degraded).toBe(true);
+  });
+
+  it("fails closed when git status cannot be read", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    const originalPath = process.env.PATH;
+    process.env.PATH = "";
+    try {
+      const packet = buildOpenWikiDerivedRepoWikiPacket({
+        repo,
+        worktreePath: root,
+        generatedAt,
+        headSha: head,
+        defaultBranch: "main"
+      });
+
+      expect(packet.source).toMatchObject({
+        status: "stale",
+        staleReason: "Unable to read git worktree status; regenerate OpenWiki before building a packet."
+      });
+      expect(packet.degraded).toBe(true);
+    } finally {
+      process.env.PATH = originalPath;
+    }
+  });
+
+  it("marks packets missing when OpenWiki has no Markdown sections", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    rmSync(join(root, "openwiki", "quickstart.md"));
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.source).toMatchObject({
+      status: "missing",
+      staleReason: "No OpenWiki Markdown files were found under openwiki/."
+    });
+  });
 });
 
-function createRepoWithOpenWiki(options: { metadataHead?: string } = {}): { head: string; root: string } {
+function createRepoWithOpenWiki(options: { metadataHead?: string; openWikiBody?: string } = {}): { head: string; root: string } {
   const root = mkdtempSync(join(tmpdir(), "neondiff-openwiki-derived-"));
   git(root, ["init"]);
   git(root, ["config", "user.email", "test@example.com"]);
@@ -135,18 +226,19 @@ function createRepoWithOpenWiki(options: { metadataHead?: string } = {}): { head
   writeFileSync(join(root, "src", "worker.ts"), "export const worker = true;\n", "utf8");
   writeFileSync(
     join(root, "openwiki", "quickstart.md"),
-    [
-      "# Quickstart",
-      "",
-      "NeonDiff reviews pull requests. Configure provider credentials with OPENROUTER_API_KEY.",
-      "",
-      "## Source map",
-      "",
-      "- README.md",
-      "- src/worker.ts",
-      "- Git evidence: commits `abc1234`",
-      ""
-    ].join("\n"),
+    options.openWikiBody ??
+      [
+        "# Quickstart",
+        "",
+        "NeonDiff reviews pull requests. Configure provider credentials with OPENROUTER_API_KEY.",
+        "",
+        "## Source map",
+        "",
+        "- README.md",
+        "- src/worker.ts",
+        "- Git evidence: commits `abc1234`",
+        ""
+      ].join("\n"),
     "utf8"
   );
   git(root, ["add", "."]);

--- a/tests/openwiki-derived-packet.test.ts
+++ b/tests/openwiki-derived-packet.test.ts
@@ -1,0 +1,150 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildOpenWikiDerivedRepoWikiPacket } from "../src/openwiki-derived-packet.js";
+import { buildRepoWikiContextPacket } from "../src/repo-wiki-context.js";
+import { formatRepoWikiPacketJson } from "../src/repo-wiki-packet.js";
+
+const repo = "electricsheephq/evaos-code-review-bot-neondiff";
+const generatedAt = "2026-07-09T08:30:00.000Z";
+
+describe("OpenWiki-derived repo-wiki packets", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("curates OpenWiki Markdown into the deterministic NeonDiff packet shape", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet).toMatchObject({
+      packetVersion: "repo-wiki-packet-v0.1",
+      repo: { fullName: repo, defaultBranch: "main" },
+      source: { headSha: head, status: "fresh" },
+      degraded: false
+    });
+    expect(packet.includedSections.map((section) => section.id)).toEqual(["quickstart"]);
+    expect(packet.includedSections[0]?.sourceFiles).toEqual([
+      "README.md",
+      "openwiki/quickstart.md",
+      "src/worker.ts"
+    ]);
+    expect(packet.includedSections[0]?.body).toContain("[redacted-secret]");
+    expect(packet.includedSections[0]?.body).not.toContain("OPENROUTER_API_KEY");
+    expect(packet.includedSections[0]?.sourceSha).toMatch(/^[a-f0-9]{64}$/);
+
+    mkdirSync(join(root, ".neondiff"), { recursive: true });
+    writeFileSync(join(root, ".neondiff", "repo-wiki-packet.json"), formatRepoWikiPacketJson(packet));
+    const contextPacket = buildRepoWikiContextPacket({
+      repo,
+      worktreePath: root,
+      config: {
+        enabled: true,
+        packetPath: ".neondiff/repo-wiki-packet.json",
+        maxPacketBytes: 12_000,
+        includeStaleContext: false
+      },
+      expectedHeadSha: head
+    });
+    expect(contextPacket.packet).toMatchObject({
+      repoWiki: {
+        freshness: "fresh",
+        degradedMode: false
+      }
+    });
+  });
+
+  it("marks OpenWiki packets stale when metadata is not source-backed", () => {
+    const { root } = createRepoWithOpenWiki({ metadataHead: "old-head" });
+    roots.push(root);
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: "current-head",
+      defaultBranch: "main"
+    });
+
+    expect(packet.source).toMatchObject({
+      status: "stale",
+      staleReason: "OpenWiki metadata gitHead does not match the current repository head."
+    });
+    expect(packet.degraded).toBe(true);
+  });
+
+  it("omits OpenWiki review suggestions from prompt packets", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    mkdirSync(join(root, "openwiki", "_review"), { recursive: true });
+    writeFileSync(join(root, "openwiki", "_review", "suggested-doc-edits.md"), "# Suggested edits\n", "utf8");
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.includedSections.map((section) => section.id)).toEqual(["quickstart"]);
+    expect(formatRepoWikiPacketJson(packet)).not.toContain("suggested-doc-edits");
+  });
+});
+
+function createRepoWithOpenWiki(options: { metadataHead?: string } = {}): { head: string; root: string } {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-openwiki-derived-"));
+  git(root, ["init"]);
+  git(root, ["config", "user.email", "test@example.com"]);
+  git(root, ["config", "user.name", "NeonDiff Test"]);
+  mkdirSync(join(root, "src"), { recursive: true });
+  mkdirSync(join(root, "openwiki"), { recursive: true });
+  writeFileSync(join(root, "README.md"), "# NeonDiff\n", "utf8");
+  writeFileSync(join(root, "src", "worker.ts"), "export const worker = true;\n", "utf8");
+  writeFileSync(
+    join(root, "openwiki", "quickstart.md"),
+    [
+      "# Quickstart",
+      "",
+      "NeonDiff reviews pull requests. Configure provider credentials with OPENROUTER_API_KEY.",
+      "",
+      "## Source map",
+      "",
+      "- README.md",
+      "- src/worker.ts",
+      "- Git evidence: commits `abc1234`",
+      ""
+    ].join("\n"),
+    "utf8"
+  );
+  git(root, ["add", "."]);
+  git(root, ["commit", "-m", "initial"]);
+  const head = git(root, ["rev-parse", "HEAD"]);
+  writeFileSync(
+    join(root, "openwiki", ".last-update.json"),
+    `${JSON.stringify({
+      updatedAt: generatedAt,
+      command: "update",
+      gitHead: options.metadataHead ?? head,
+      model: "GLM-5.2"
+    })}\n`,
+    "utf8"
+  );
+  return { head, root };
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}

--- a/tests/openwiki-derived-packet.test.ts
+++ b/tests/openwiki-derived-packet.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -36,14 +37,15 @@ describe("OpenWiki-derived repo-wiki packets", () => {
       degraded: false
     });
     expect(packet.includedSections.map((section) => section.id)).toEqual(["quickstart"]);
-    expect(packet.includedSections[0]?.sourceFiles).toEqual([
+    const section = packet.includedSections[0];
+    expect(section?.sourceFiles).toEqual([
       "README.md",
       "openwiki/quickstart.md",
       "src/worker.ts"
     ]);
-    expect(packet.includedSections[0]?.body).toContain("[redacted-secret]");
-    expect(packet.includedSections[0]?.body).not.toContain("OPENROUTER_API_KEY");
-    expect(packet.includedSections[0]?.sourceSha).toMatch(/^[a-f0-9]{64}$/);
+    expect(section?.body).toContain("[redacted-secret]");
+    expect(section?.body).not.toContain("OPENROUTER_API_KEY");
+    expect(section?.sourceSha).toBe(sha256(section?.body ?? ""));
 
     mkdirSync(join(root, ".neondiff"), { recursive: true });
     writeFileSync(join(root, ".neondiff", "repo-wiki-packet.json"), formatRepoWikiPacketJson(packet));
@@ -171,6 +173,26 @@ describe("OpenWiki-derived repo-wiki packets", () => {
     expect(packet.degraded).toBe(true);
   });
 
+  it("marks packets stale when untracked non-openwiki files exist", () => {
+    const { head, root } = createRepoWithOpenWiki();
+    roots.push(root);
+    mkdirSync(join(root, "docs"), { recursive: true });
+    writeFileSync(join(root, "docs", "new-guide.md"), "# New Guide\n", "utf8");
+
+    const packet = buildOpenWikiDerivedRepoWikiPacket({
+      repo,
+      worktreePath: root,
+      generatedAt,
+      headSha: head,
+      defaultBranch: "main"
+    });
+
+    expect(packet.source).toMatchObject({
+      status: "stale",
+      staleReason: "Repository has non-openwiki worktree changes; regenerate OpenWiki before building a packet."
+    });
+  });
+
   it("fails closed when git status cannot be read", () => {
     const { head, root } = createRepoWithOpenWiki();
     roots.push(root);
@@ -259,4 +281,8 @@ function createRepoWithOpenWiki(options: { metadataHead?: string; openWikiBody?:
 
 function git(cwd: string, args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function sha256(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
 }

--- a/tests/repo-wiki-packet.test.ts
+++ b/tests/repo-wiki-packet.test.ts
@@ -91,6 +91,38 @@ describe("repo wiki packets", () => {
     );
   });
 
+  it("counts redactions only from sections accepted after packet budgeting", () => {
+    const packet = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "feature/wiki", status: "fresh" },
+      generatedAt,
+      budget: { maxBytes: 700, maxTokens: 300, maxSectionBytes: 48 },
+      sections: [
+        section({
+          id: "kept",
+          title: "Kept notes",
+          order: 1,
+          body: "A".repeat(200)
+        }),
+        section({
+          id: "dropped",
+          title: "Dropped notes",
+          order: 2,
+          body: "B".repeat(200),
+          preRedactionReplacementCount: 5
+        })
+      ]
+    });
+
+    expect(packet.includedSections.map((included) => included.id)).toEqual(["kept"]);
+    expect(packet.excludedSections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "dropped", reason: "packet_budget_exceeded" })
+      ])
+    );
+    expect(packet.redaction).toEqual({ status: "passed", replacementCount: 0 });
+  });
+
   it("redacts token-like strings from markdown and JSON payloads", () => {
     const token = "ghp_fake_token";
     const packet = buildRepoWikiPacket({
@@ -570,13 +602,15 @@ function section(input: {
   body: string;
   order?: number;
   sourceFiles?: string[];
+  preRedactionReplacementCount?: number;
 }) {
   return {
     id: input.id,
     title: input.title,
     body: input.body,
     order: input.order,
-    sourceFiles: input.sourceFiles ?? ["README.md", "AGENTS.md", "src/worker.ts", "src/cli.ts", "tests/repo-wiki-packet.test.ts"]
+    sourceFiles: input.sourceFiles ?? ["README.md", "AGENTS.md", "src/worker.ts", "src/cli.ts", "tests/repo-wiki-packet.test.ts"],
+    preRedactionReplacementCount: input.preRedactionReplacementCount
   };
 }
 

--- a/tests/repo-wiki-packet.test.ts
+++ b/tests/repo-wiki-packet.test.ts
@@ -91,6 +91,31 @@ describe("repo wiki packets", () => {
     );
   });
 
+  it("preserves caller sourceSha and records emitted body hashes separately", () => {
+    const packet = buildRepoWikiPacket({
+      repo: { fullName: "electricsheephq/evaos-code-review-bot" },
+      source: { ref: "feature/wiki", status: "fresh" },
+      generatedAt,
+      budget: { maxBytes: 1_000, maxTokens: 300, maxSectionBytes: 12 },
+      sections: [
+        section({
+          id: "provenance",
+          title: "Provenance",
+          body: "Source file body that will be truncated.",
+          sourceSha: "source-file-sha"
+        })
+      ]
+    });
+    const included = packet.includedSections[0];
+    const markdown = formatRepoWikiPacketMarkdown(packet);
+
+    expect(included?.sourceSha).toBe("source-file-sha");
+    expect(included?.emittedBodySha).toBe(sha256(included?.body ?? ""));
+    expect(included?.emittedBodySha).not.toBe(included?.sourceSha);
+    expect(markdown).toContain("source_sha=source-file-sha");
+    expect(markdown).toContain(`emitted_body_sha=${included?.emittedBodySha}`);
+  });
+
   it("counts redactions only from sections accepted after packet budgeting", () => {
     const packet = buildRepoWikiPacket({
       repo: { fullName: "electricsheephq/evaos-code-review-bot" },
@@ -602,6 +627,7 @@ function section(input: {
   body: string;
   order?: number;
   sourceFiles?: string[];
+  sourceSha?: string;
   preRedactionReplacementCount?: number;
 }) {
   return {
@@ -610,6 +636,7 @@ function section(input: {
     body: input.body,
     order: input.order,
     sourceFiles: input.sourceFiles ?? ["README.md", "AGENTS.md", "src/worker.ts", "src/cli.ts", "tests/repo-wiki-packet.test.ts"],
+    sourceSha: input.sourceSha,
     preRedactionReplacementCount: input.preRedactionReplacementCount
   };
 }


### PR DESCRIPTION
## Summary

Refs #415. Refs #477. Stacked on #474.

Adds a NeonDiff-side curation helper for existing `openwiki/**` output. The helper converts OpenWiki Markdown into the existing deterministic `repo-wiki-packet-v0.1` shape without running OpenWiki, excludes `openwiki/_review/**`, extracts `## Source map` provenance, redacts secret-like environment variable names, and marks freshness from `openwiki/.last-update.json` plus the current worktree head.

This keeps raw OpenWiki Markdown out of prompts: the packet still flows through the #474 loader, freshness gate, budget gate, secret scan, and quoted advisory prompt boundary.

## Validation

- `npx vitest run tests/openwiki-derived-packet.test.ts tests/repo-wiki-context.test.ts`
- `npm run build`
- `npm run check:secrets`
- `git diff --check`

Note: `tests/public-docs.test.ts` was requested in the roadmap but is not present on this stacked branch, so that local gate was unavailable.

## Proof Boundary

This proves curated packet construction and loader compatibility for lab/manual evaluation only. It does not enable production daemon config, cron, auto-edits, or authoritative API docs.