### PR TITLE
feat: add OpenWiki eval gates

### DIFF
--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -42,7 +42,10 @@ npx tsx src/cli.ts eval-openwiki-docs-drift \
 ```
 
 Both OpenWiki gates are offline evidence generators. They do not call a model,
-post GitHub comments, enable the daemon, add cron, or edit production docs.
+post GitHub comments, enable the daemon, add cron, or edit production docs. The
+docs-drift gate may write a `suggested-doc-edits.md` evidence artifact under the
+chosen `--output-root`; treat that file as a review packet, not as a repository
+documentation change.
 
 The suite command exits non-zero when any scenario fails, when two scenarios use
 the same `runId`, when a `runId` is not a safe path segment, or when any required

--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -24,6 +24,26 @@ npm run eval:sticky-vs-cold -- \
   --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold-seeded-quality
 ```
 
+Run the repo-wiki context A/B gate with a fixture that contains baseline,
+deterministic repo-wiki, and curated OpenWiki-derived findings:
+
+```bash
+npx tsx src/cli.ts eval-repo-wiki-context-ab \
+  --input /path/to/repo-wiki-context-ab.json \
+  --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/ab
+```
+
+Run the suggest-only OpenWiki docs-drift gate:
+
+```bash
+npx tsx src/cli.ts eval-openwiki-docs-drift \
+  --input /path/to/docs-drift.json \
+  --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/docs-drift
+```
+
+Both OpenWiki gates are offline evidence generators. They do not call a model,
+post GitHub comments, enable the daemon, add cron, or edit production docs.
+
 The suite command exits non-zero when any scenario fails, when two scenarios use
 the same `runId`, when a `runId` is not a safe path segment, or when any required
 suite is missing from the input directory.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@ import {
   runOfflineEval,
   runStickyVsColdEval
 } from "./eval-harness.js";
+import { runDocsDriftEval, runRepoWikiContextAbEval } from "./openwiki-eval-gates.js";
 import { inspectConfigForDesktop, patchConfigForDesktop } from "./config-cli.js";
 import { buildEnrichmentComment, buildIssueEnrichmentDryRunOutput } from "./enrichment.js";
 import {
@@ -1581,6 +1582,28 @@ async function main(): Promise<void> {
     const result = runStickyVsColdEval(input, {
       outputRoot: args["output-root"]
     });
+    console.log(JSON.stringify(result.summary, null, 2));
+    if (!result.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "eval-repo-wiki-context-ab") {
+    if (!args.input) throw new Error("--input is required for eval-repo-wiki-context-ab");
+    if (!args["output-root"]) throw new Error("--output-root is required for eval-repo-wiki-context-ab");
+    const outputRoot = assertEvalOutputDirSafe(parseSingleArg(args["output-root"], "--output-root"));
+    const input = readJsonInput(parseSingleArg(args.input, "--input"), "--input") as Parameters<typeof runRepoWikiContextAbEval>[0];
+    const result = runRepoWikiContextAbEval(input, { outputRoot });
+    console.log(JSON.stringify(result.summary, null, 2));
+    if (!result.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "eval-openwiki-docs-drift") {
+    if (!args.input) throw new Error("--input is required for eval-openwiki-docs-drift");
+    if (!args["output-root"]) throw new Error("--output-root is required for eval-openwiki-docs-drift");
+    const outputRoot = assertEvalOutputDirSafe(parseSingleArg(args["output-root"], "--output-root"));
+    const input = readJsonInput(parseSingleArg(args.input, "--input"), "--input") as Parameters<typeof runDocsDriftEval>[0];
+    const result = runDocsDriftEval(input, { outputRoot });
     console.log(JSON.stringify(result.summary, null, 2));
     if (!result.ok) process.exitCode = 1;
     return;
@@ -3270,6 +3293,8 @@ function buildHelp(command?: string) {
         "eval-offline",
         "eval-suite",
         "eval-sticky-vs-cold",
+        "eval-repo-wiki-context-ab",
+        "eval-openwiki-docs-drift",
         "outcome-ledger",
         "outcome-scorecard",
         "review-mode",
@@ -3328,6 +3353,8 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts clear-issue-enrichment-leases --config /path/to/live.json --dry-run true --expired-only true",
       "npx tsx src/cli.ts clear-review-queue-leases --config /path/to/live.json --dry-run true --expired-only true",
       "npx tsx src/cli.ts eval-sticky-vs-cold --input /path/to/sticky-vs-cold.json --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold",
+      "npx tsx src/cli.ts eval-repo-wiki-context-ab --input /path/to/repo-wiki-ab.json --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/ab",
+      "npx tsx src/cli.ts eval-openwiki-docs-drift --input /path/to/docs-drift.json --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/$(date +%F)/eval-gates/docs-drift",
       "npx tsx src/cli.ts outcome-ledger --input /path/to/outcome-ledger-input.json --dry-run true --output-dir /path/to/evidence/outcome-ledger-run",
       "npx tsx src/cli.ts outcome-scorecard --input /path/to/outcome-scorecard-input.json --dry-run true --output-dir /path/to/evidence/outcome-scorecard-run",
       "npx tsx src/cli.ts outcome-observe --config /path/to/live.json --input /path/to/outcome-observer-input.json --dry-run true --output-dir /path/to/evidence/outcome-observe-run",

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -312,6 +312,16 @@ const DEFAULT_THRESHOLDS: EvalThresholds = {
   maxDuplicateFindings: 0
 };
 
+export function buildEvalThresholds(
+  thresholds: Partial<EvalThresholds> | undefined,
+  mode: "gating" | "exploratory" = "gating"
+): EvalThresholds {
+  const merged = { ...DEFAULT_THRESHOLDS, ...(thresholds ?? {}) };
+  validateThresholds(merged);
+  validateThresholdPolicy(mode, thresholds ?? {});
+  return merged;
+}
+
 export const PUBLIC_CONFIDENCE_POLICY: EvalPublicDisplayPolicy = {
   defaultLabel: "uncalibrated",
   minWilsonLowerBound: 0.95,
@@ -352,9 +362,7 @@ const DEFAULT_STICKY_VS_COLD_THRESHOLDS: StickyVsColdThresholds = {
 
 export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions = {}): EvalRunResult {
   validateEvalInput(input);
-  const thresholds = { ...DEFAULT_THRESHOLDS, ...(input.thresholds ?? {}) };
-  validateThresholds(thresholds);
-  validateThresholdPolicy(input.mode ?? "gating", input.thresholds ?? {});
+  const thresholds = buildEvalThresholds(input.thresholds, input.mode ?? "gating");
 
   const evalName = input.evalName ?? "evaos-zcode-review-bot-comparison-v0.1";
   const outputDir = options.outputDir ?? defaultEvalOutputDir(input, options.now ?? new Date());
@@ -1615,10 +1623,8 @@ function validateStickyVsColdInput(input: StickyVsColdScenarioInput): void {
 }
 
 function validateEvalScenarioThresholdPolicy(input: EvalScenarioInput, labelPath: string): void {
-  const thresholds = { ...DEFAULT_THRESHOLDS, ...(input.thresholds ?? {}) };
   try {
-    validateThresholds(thresholds);
-    validateThresholdPolicy(input.mode ?? "gating", input.thresholds ?? {});
+    buildEvalThresholds(input.thresholds, input.mode ?? "gating");
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     throw new Error(`${labelPath}.${detail}`);

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -1521,14 +1521,14 @@ function guardOutputDir(outputDir: string): void {
   assertEvalOutputDirSafe(outputDir);
 }
 
-function guardEmptyOutputRoot(outputRoot: string): void {
+export function guardEmptyOutputRoot(outputRoot: string, evalLabel = "sticky-vs-cold eval"): void {
   if (!existsSync(outputRoot)) return;
   const stat = statSync(outputRoot);
   if (!stat.isDirectory()) {
     throw new Error("outputRoot must be a directory when it already exists");
   }
   if (readdirSync(outputRoot).length > 0) {
-    throw new Error("outputRoot must be empty before running sticky-vs-cold eval; choose a fresh output root to avoid stale artifacts");
+    throw new Error(`outputRoot must be empty before running ${evalLabel}; choose a fresh output root to avoid stale artifacts`);
   }
 }
 

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { parseFindings } from "./findings.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
@@ -420,7 +420,7 @@ export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions
   writeJson(artifacts["merged-fixes.json"]!, mergedFixes);
   writeJson(artifacts["redaction-report.json"]!, redactionReport);
   writeJson(artifacts["duplicate-report.json"]!, duplicateReport);
-  writeFileSync(artifacts["comparison.csv"]!, buildComparisonCsv(botFindings, labels, matches));
+  writeEvalArtifactFile(artifacts["comparison.csv"]!, buildComparisonCsv(botFindings, labels, matches));
   writeJson(artifacts["labels.json"]!, labels);
   writeJson(artifacts["calibration-report.json"]!, buildCalibrationReport(botFindings, labels, matches, input.negativeControl === true));
   writeJson(artifacts["scorecard.json"]!, scorecard);
@@ -494,7 +494,7 @@ export function runStickyVsColdEval(
     thresholds,
     now
   });
-  writeFileSync(reportPath, buildStickyVsColdReport(summary));
+  writeEvalArtifactFile(reportPath, buildStickyVsColdReport(summary));
   const artifactInventory = [
     { name: "sticky-vs-cold-report.md", sha256: sha256File(reportPath) },
     { name: "cold/scorecard.json", sha256: sha256File(cold.artifacts["scorecard.json"]!) },
@@ -1501,7 +1501,17 @@ function sanitizePathSegment(value: string): string {
 }
 
 function writeJson(path: string, value: unknown): void {
-  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+  writeEvalArtifactFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function writeEvalArtifactFile(path: string, contents: string): void {
+  // Eval output roots are operator-controlled; exclusive creation avoids clobbering raced files or symlinks.
+  const fd = openSync(path, "wx", 0o600);
+  try {
+    writeFileSync(fd, contents, "utf8");
+  } finally {
+    closeSync(fd);
+  }
 }
 
 function sha256File(path: string): string {

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -448,6 +448,23 @@ export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions
   };
 }
 
+export function countEvalFalsePositiveSeverities(
+  botFindingsInput: unknown,
+  labelsInput: EvalLabelInput[]
+): Record<Severity, number> {
+  const parsedBot = parseFindings(botFindingsInput);
+  const botFindings = parsedBot.findings.map((finding, index) => normalizeFinding(finding, "bot", `bot-${index + 1}`));
+  const labels = labelsInput
+    .filter((label) => label.expected !== false)
+    .map((label, index) => normalizeFinding(label, label.source, `label-${index + 1}`));
+  const matchedBotIds = new Set(matchFindings(botFindings, labels).map((match) => match.botFindingId));
+  const counts: Record<Severity, number> = { P0: 0, P1: 0, P2: 0, P3: 0 };
+  for (const finding of botFindings) {
+    if (!matchedBotIds.has(finding.id)) counts[finding.severity] += 1;
+  }
+  return counts;
+}
+
 export function runStickyVsColdEval(
   input: StickyVsColdScenarioInput,
   options: { outputRoot?: string; now?: Date } = {}

--- a/src/eval-harness.ts
+++ b/src/eval-harness.ts
@@ -243,6 +243,7 @@ export interface EvalScorecard {
     seededRecall: number;
     maxWilsonLowerBound: number;
   };
+  falsePositiveSeverities: Record<Severity, number>;
   matchedLabelKeys: string[];
   thresholds: EvalThresholds;
   gates: Array<{ name: string; ok: boolean; detail: string }>;
@@ -448,21 +449,8 @@ export function runOfflineEval(input: EvalScenarioInput, options: EvalRunOptions
   };
 }
 
-export function countEvalFalsePositiveSeverities(
-  botFindingsInput: unknown,
-  labelsInput: EvalLabelInput[]
-): Record<Severity, number> {
-  const parsedBot = parseFindings(botFindingsInput);
-  const botFindings = parsedBot.findings.map((finding, index) => normalizeFinding(finding, "bot", `bot-${index + 1}`));
-  const labels = labelsInput
-    .filter((label) => label.expected !== false)
-    .map((label, index) => normalizeFinding(label, label.source, `label-${index + 1}`));
-  const matchedBotIds = new Set(matchFindings(botFindings, labels).map((match) => match.botFindingId));
-  const counts: Record<Severity, number> = { P0: 0, P1: 0, P2: 0, P3: 0 };
-  for (const finding of botFindings) {
-    if (!matchedBotIds.has(finding.id)) counts[finding.severity] += 1;
-  }
-  return counts;
+export function countEvalFalsePositiveSeverities(scorecard: EvalScorecard): Record<Severity, number> {
+  return { ...scorecard.falsePositiveSeverities };
 }
 
 export function runStickyVsColdEval(
@@ -921,6 +909,7 @@ function buildScorecard(input: {
   const truePositive = matchedBotIds.size;
   const falsePositive = input.botFindings.length - truePositive;
   const falseNegative = input.labels.length - matchedLabelIds.size;
+  const falsePositiveSeverities = countFindingSeverities(input.botFindings.filter((finding) => !matchedBotIds.has(finding.id)));
   const labelById = new Map(input.labels.map((label) => [label.id, label]));
   const matchedLabelKeys = [...matchedLabelIds]
     .map((labelId) => labelById.get(labelId))
@@ -979,6 +968,7 @@ function buildScorecard(input: {
       seededRecall: roundMetric(seededRecall),
       maxWilsonLowerBound
     },
+    falsePositiveSeverities,
     matchedLabelKeys,
     thresholds: input.thresholds,
     gates: [
@@ -1019,6 +1009,12 @@ function buildScorecard(input: {
       }
     ]
   };
+}
+
+function countFindingSeverities(findings: NormalizedEvalFinding[]): Record<Severity, number> {
+  const counts: Record<Severity, number> = { P0: 0, P1: 0, P2: 0, P3: 0 };
+  for (const finding of findings) counts[finding.severity] += 1;
+  return counts;
 }
 
 function evaluateSuiteRequirements(input: {

--- a/src/openwiki-eval-gates.ts
+++ b/src/openwiki-eval-gates.ts
@@ -1,8 +1,8 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { basename, dirname, join, relative, resolve } from "node:path";
-import { parseFindings } from "./findings.js";
+import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
+  countEvalFalsePositiveSeverities,
   runOfflineEval,
   type EvalLabelInput,
   type EvalRunResult,
@@ -11,7 +11,7 @@ import {
   type EvalSuiteName
 } from "./eval-harness.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
-import type { Finding, Severity } from "./types.js";
+import type { Severity } from "./types.js";
 import type { RepoWikiPacket } from "./repo-wiki-packet.js";
 
 export type RepoWikiEvalMode = "baseline" | "deterministic" | "openwiki";
@@ -412,53 +412,7 @@ function buildAbGates(input: {
 }
 
 function countFalsePositiveSeverities(botFindings: unknown, labels: EvalLabelInput[]): Record<Severity, number> {
-  const findings = parseFindings(botFindings).findings;
-  const matchedFindingIndexes = new Set<number>();
-  const usedLabelIndexes = new Set<number>();
-  const candidates = labels.flatMap((label, labelIndex) => findings
-    .map((finding, findingIndex) => ({ finding, findingIndex, label, labelIndex, kind: classifyMatch(finding, label) }))
-    .filter((candidate) => candidate.kind !== undefined));
-  candidates.sort((a, b) =>
-    matchRank(a.kind!) - matchRank(b.kind!) ||
-    Math.abs(a.finding.line - a.label.line) - Math.abs(b.finding.line - b.label.line) ||
-    b.finding.confidence - a.finding.confidence
-  );
-  for (const candidate of candidates) {
-    if (matchedFindingIndexes.has(candidate.findingIndex) || usedLabelIndexes.has(candidate.labelIndex)) continue;
-    matchedFindingIndexes.add(candidate.findingIndex);
-    usedLabelIndexes.add(candidate.labelIndex);
-  }
-  const counts: Record<Severity, number> = { P0: 0, P1: 0, P2: 0, P3: 0 };
-  findings.forEach((finding, index) => {
-    if (!matchedFindingIndexes.has(index)) counts[finding.severity] += 1;
-  });
-  return counts;
-}
-
-function classifyMatch(finding: Finding, label: EvalLabelInput): "exact_line" | "nearby_line" | "semantic" | undefined {
-  if (finding.severity !== label.severity || finding.path !== label.path) return undefined;
-  const overlap = tokenOverlap(finding, label);
-  if (finding.line === label.line && overlap >= 0.25) return "exact_line";
-  if (Math.abs(finding.line - label.line) <= 3 && overlap >= 0.35) return "nearby_line";
-  if (overlap >= 0.55) return "semantic";
-  return undefined;
-}
-
-function matchRank(kind: "exact_line" | "nearby_line" | "semantic"): number {
-  if (kind === "exact_line") return 0;
-  if (kind === "nearby_line") return 1;
-  return 2;
-}
-
-function tokenOverlap(a: Pick<Finding | EvalLabelInput, "title" | "body">, b: Pick<Finding | EvalLabelInput, "title" | "body">): number {
-  const aTokens = tokenize(`${a.title} ${a.body}`);
-  const bTokens = tokenize(`${b.title} ${b.body}`);
-  if (aTokens.size === 0 || bTokens.size === 0) return 0;
-  return [...aTokens].filter((token) => bTokens.has(token)).length / Math.min(aTokens.size, bTokens.size);
-}
-
-function tokenize(text: string): Set<string> {
-  return new Set(text.toLowerCase().split(/[^a-z0-9]+/).filter((token) => token.length >= 4));
+  return countEvalFalsePositiveSeverities(botFindings, labels);
 }
 
 function readRepoWikiPacket(input: DocsDriftEvalInput): {
@@ -469,14 +423,11 @@ function readRepoWikiPacket(input: DocsDriftEvalInput): {
   includedSourceFiles: string[];
   sectionIdsBySourcePath: Map<string, string[]>;
 } {
-  const absolutePath = resolve(input.worktreePath, input.packetPath);
-  if (!isInside(input.worktreePath, absolutePath)) {
-    return { ok: false, error: "packetPath must resolve inside worktreePath", includedSourceFiles: [], sectionIdsBySourcePath: new Map() };
+  const packetPath = resolveExistingFileInside(input.worktreePath, input.packetPath, "packetPath");
+  if (!packetPath.ok) {
+    return { ok: false, error: packetPath.error, includedSourceFiles: [], sectionIdsBySourcePath: new Map() };
   }
-  if (!existsSync(absolutePath)) {
-    return { ok: false, error: "packetPath does not exist", includedSourceFiles: [], sectionIdsBySourcePath: new Map() };
-  }
-  const raw = readFileSync(absolutePath, "utf8");
+  const raw = readFileSync(packetPath.path, "utf8");
   if (containsSecretLikeText(raw)) {
     return { ok: false, error: "packet contains secret-like text", includedSourceFiles: [], sectionIdsBySourcePath: new Map() };
   }
@@ -548,15 +499,15 @@ function evaluateDocsDriftClaim(input: {
       ? {
           suggestion: {
             claimId: input.claim.id,
-            docPath: input.claim.docPath,
+            docPath: redactSecrets(input.claim.docPath),
             line: input.claim.line,
-            currentClaim: input.claim.claim,
-            suggestedText: input.claim.suggestion,
+            currentClaim: redactSecrets(input.claim.claim),
+            suggestedText: redactSecrets(input.claim.suggestion),
             sourceCitation: {
-              path: input.claim.sourcePath,
-              text: input.claim.currentText
+              path: redactSecrets(input.claim.sourcePath),
+              text: redactSecrets(input.claim.currentText)
             },
-            packetSectionIds
+            packetSectionIds: packetSectionIds.map(redactSecrets)
           }
         }
       : {})
@@ -564,10 +515,10 @@ function evaluateDocsDriftClaim(input: {
 }
 
 function readWorktreeFile(worktreePath: string, relativePath: string): string {
-  const absolutePath = resolve(worktreePath, relativePath);
-  if (!isInside(worktreePath, absolutePath)) return "";
+  const filePath = resolveExistingFileInside(worktreePath, relativePath, "path");
+  if (!filePath.ok) return "";
   try {
-    return readFileSync(absolutePath, "utf8");
+    return readFileSync(filePath.path, "utf8");
   } catch {
     return "";
   }
@@ -667,11 +618,34 @@ function roundMetric(value: number): number {
   return Math.round(value * 1000) / 1000;
 }
 
-function isInside(rootPath: string, candidatePath: string): boolean {
-  const root = resolve(rootPath);
-  const candidate = resolve(candidatePath);
-  const rel = relative(root, candidate);
-  return rel === "" || (!rel.startsWith("..") && !rel.startsWith(`/`) && basename(rel) !== "");
+function resolveExistingFileInside(
+  rootPath: string,
+  candidatePath: string,
+  label: string
+): { ok: true; path: string } | { ok: false; error: string } {
+  const resolvedRoot = resolve(rootPath);
+  const resolvedCandidate = resolve(resolvedRoot, candidatePath);
+  const lexicalRelation = relative(resolvedRoot, resolvedCandidate);
+  if (lexicalRelation === "" || lexicalRelation.startsWith("..") || isAbsolute(lexicalRelation)) {
+    return { ok: false, error: `${label} must resolve inside worktreePath` };
+  }
+  if (!existsSync(resolvedCandidate)) {
+    return { ok: false, error: `${label} does not exist` };
+  }
+  try {
+    const realRoot = realpathSync(resolvedRoot);
+    const realCandidate = realpathSync(resolvedCandidate);
+    const realRelation = relative(realRoot, realCandidate);
+    if (realRelation === "" || realRelation.startsWith("..") || isAbsolute(realRelation)) {
+      return { ok: false, error: `${label} must resolve inside worktreePath` };
+    }
+    if (!statSync(realCandidate).isFile()) {
+      return { ok: false, error: `${label} must point to a file` };
+    }
+    return { ok: true, path: realCandidate };
+  } catch (error) {
+    return { ok: false, error: `${label} could not be resolved safely: ${error instanceof Error ? error.message : String(error)}` };
+  }
 }
 
 function codeUnitCompare(left: string, right: string): number {

--- a/src/openwiki-eval-gates.ts
+++ b/src/openwiki-eval-gates.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
   assertEvalOutputDirSafe,
@@ -7,6 +7,7 @@ import {
   countEvalFalsePositiveSeverities,
   guardEmptyOutputRoot,
   runOfflineEval,
+  writeEvalArtifactFile,
   type EvalLabelInput,
   type EvalRunResult,
   type EvalScenarioInput,
@@ -368,7 +369,7 @@ export function runDocsDriftEval(
   assertNoSecretLikeText(suggestionsText, "docs-drift suggestions");
   assertNoSecretLikeText(reportText, "docs-drift report");
   mkdirSync(outputRoot, { recursive: true });
-  writeFileSync(suggestionsPath, suggestionsText, "utf8");
+  writeEvalArtifactFile(suggestionsPath, suggestionsText);
   writeJson(reportPath, reportText);
   const artifactInventory = buildArtifactInventory(outputRoot, [
     "suggested-doc-edits.md",
@@ -748,7 +749,7 @@ function buildArtifactInventory(root: string, names: string[]): Array<{ name: st
 
 function writeJson(path: string, value: unknown): void {
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${typeof value === "string" ? value : JSON.stringify(value, null, 2)}\n`, "utf8");
+  writeEvalArtifactFile(path, `${typeof value === "string" ? value : JSON.stringify(value, null, 2)}\n`);
 }
 
 function assertNoSecretLikeText(value: unknown, label: string): void {

--- a/src/openwiki-eval-gates.ts
+++ b/src/openwiki-eval-gates.ts
@@ -292,7 +292,6 @@ export function runDocsDriftEval(
   const thresholds = validateDocsDriftThresholds(input.thresholds);
   const outputRoot = assertEvalOutputDirSafe(options.outputRoot);
   guardEmptyOutputRoot(outputRoot, "OpenWiki docs-drift eval");
-  mkdirSync(outputRoot, { recursive: true });
   const packet = readRepoWikiPacket(input);
   const suggestions: DocsDriftSuggestion[] = [];
   const claims = input.claims.map((claim) => {
@@ -363,6 +362,7 @@ export function runDocsDriftEval(
   const reportText = buildDocsDriftReport(summaryWithoutInventory);
   assertNoSecretLikeText(suggestionsText, "docs-drift suggestions");
   assertNoSecretLikeText(reportText, "docs-drift report");
+  mkdirSync(outputRoot, { recursive: true });
   writeFileSync(suggestionsPath, suggestionsText, "utf8");
   writeJson(reportPath, reportText);
   const artifactInventory = buildArtifactInventory(outputRoot, [
@@ -491,7 +491,16 @@ function readRepoWikiPacket(input: DocsDriftEvalInput): {
     return { ok: false, error: "packet contains secret-like text", includedSourceFiles: [], sectionIdsBySourcePath: new Map() };
   }
   try {
-    const repoWiki = JSON.parse(raw) as RepoWikiPacket;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRepoWikiPacket(parsed)) {
+      return {
+        ok: false,
+        error: "packet JSON did not match repo-wiki packet shape",
+        includedSourceFiles: [],
+        sectionIdsBySourcePath: new Map()
+      };
+    }
+    const repoWiki = parsed;
     const sectionIdsBySourcePath = new Map<string, string[]>();
     for (const section of repoWiki.includedSections ?? []) {
       for (const sourceFile of section.sourceFiles ?? []) {
@@ -516,6 +525,47 @@ function readRepoWikiPacket(input: DocsDriftEvalInput): {
       sectionIdsBySourcePath: new Map()
     };
   }
+}
+
+function isRepoWikiPacket(value: unknown): value is RepoWikiPacket {
+  if (!isRecord(value)) return false;
+  if (typeof value.packetVersion !== "string") return false;
+  if (!isRecord(value.repo) || typeof value.repo.fullName !== "string") return false;
+  if (!isRecord(value.source) || !isRepoWikiSourceStatus(value.source.status)) return false;
+  if (typeof value.generatedAt !== "string") return false;
+  if (typeof value.advisory !== "string") return false;
+  if (typeof value.degraded !== "boolean") return false;
+  if (!isRecord(value.byteBudget) || typeof value.byteBudget.maxBytes !== "number" || typeof value.byteBudget.usedBytes !== "number") {
+    return false;
+  }
+  if (!isRecord(value.tokenBudget) || typeof value.tokenBudget.maxTokens !== "number" || typeof value.tokenBudget.usedTokens !== "number") {
+    return false;
+  }
+  if (!isRecord(value.redaction) || typeof value.redaction.status !== "string" || typeof value.redaction.replacementCount !== "number") {
+    return false;
+  }
+  if (!Array.isArray(value.includedSections) || !value.includedSections.every(isRepoWikiIncludedSection)) return false;
+  if (!Array.isArray(value.excludedSections)) return false;
+  if (!Array.isArray(value.includedFiles)) return false;
+  return typeof value.packetSha === "string";
+}
+
+function isRepoWikiIncludedSection(value: unknown): value is RepoWikiPacket["includedSections"][number] {
+  return isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.title === "string" &&
+    typeof value.body === "string" &&
+    typeof value.order === "number" &&
+    Array.isArray(value.sourceFiles) &&
+    value.sourceFiles.every((sourceFile) => typeof sourceFile === "string") &&
+    typeof value.byteLength === "number" &&
+    typeof value.tokenEstimate === "number" &&
+    typeof value.truncated === "boolean" &&
+    typeof value.redacted === "boolean";
+}
+
+function isRepoWikiSourceStatus(value: unknown): value is RepoWikiPacket["source"]["status"] {
+  return value === "fresh" || value === "stale" || value === "missing";
 }
 
 function evaluateDocsDriftClaim(input: {

--- a/src/openwiki-eval-gates.ts
+++ b/src/openwiki-eval-gates.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
+  assertEvalOutputDirSafe,
   countEvalFalsePositiveSeverities,
   runOfflineEval,
   type EvalLabelInput,
@@ -179,7 +180,8 @@ export function runRepoWikiContextAbEval(
 ): RepoWikiContextAbEvalResult {
   const now = options.now ?? new Date();
   const evalName = input.evalName ?? "neondiff-openwiki-context-ab-v0.1";
-  mkdirSync(options.outputRoot, { recursive: true });
+  const outputRoot = assertEvalOutputDirSafe(options.outputRoot);
+  mkdirSync(outputRoot, { recursive: true });
   const modes = Object.fromEntries(
     (["baseline", "deterministic", "openwiki"] as const).map((mode) => {
       const modeInput = input.modes[mode];
@@ -195,7 +197,7 @@ export function runRepoWikiContextAbEval(
         botFindings: modeInput.botFindings,
         rawOutput: modeInput.rawOutput ?? modeInput.botFindings
       }, {
-        outputDir: join(options.outputRoot, mode),
+        outputDir: join(outputRoot, mode),
         now
       });
       return [mode, summarizeMode({ modeInput, result, labels: input.labels })];
@@ -212,8 +214,8 @@ export function runRepoWikiContextAbEval(
     ...(input.providerProof?.notes ? { notes: redactSecrets(input.providerProof.notes) } : {})
   };
   const gates = buildAbGates({ modes, comparisons, providerProof });
-  const summaryPath = join(options.outputRoot, "repo-wiki-context-ab-summary.json");
-  const reportPath = join(options.outputRoot, "repo-wiki-context-ab-report.md");
+  const summaryPath = join(outputRoot, "repo-wiki-context-ab-summary.json");
+  const reportPath = join(outputRoot, "repo-wiki-context-ab-report.md");
   const summaryWithoutInventory: Omit<RepoWikiContextAbEvalSummary, "artifactInventory"> = {
     evalName,
     artifactVersion: "0.1",
@@ -231,7 +233,7 @@ export function runRepoWikiContextAbEval(
     gates
   };
   writeJson(reportPath, buildAbReport(summaryWithoutInventory));
-  const artifactInventory = buildArtifactInventory(options.outputRoot, [
+  const artifactInventory = buildArtifactInventory(outputRoot, [
     "baseline/scorecard.json",
     "deterministic/scorecard.json",
     "openwiki/scorecard.json",
@@ -241,7 +243,7 @@ export function runRepoWikiContextAbEval(
   writeJson(summaryPath, summary);
   return {
     ok: summary.ok,
-    outputRoot: options.outputRoot,
+    outputRoot,
     summary,
     artifacts: {
       "repo-wiki-context-ab-summary.json": summaryPath,
@@ -256,7 +258,8 @@ export function runDocsDriftEval(
 ): DocsDriftEvalResult {
   const now = options.now ?? new Date();
   const evalName = input.evalName ?? "neondiff-openwiki-docs-drift-v0.1";
-  mkdirSync(options.outputRoot, { recursive: true });
+  const outputRoot = assertEvalOutputDirSafe(options.outputRoot);
+  mkdirSync(outputRoot, { recursive: true });
   const packet = readRepoWikiPacket(input);
   const suggestions: DocsDriftSuggestion[] = [];
   const claims = input.claims.map((claim) => {
@@ -294,9 +297,9 @@ export function runDocsDriftEval(
       detail: `${suggestions.length} suggestion(s) checked`
     }
   ];
-  const suggestionsPath = join(options.outputRoot, "suggested-doc-edits.md");
-  const summaryPath = join(options.outputRoot, "docs-drift-summary.json");
-  const reportPath = join(options.outputRoot, "docs-drift-report.md");
+  const suggestionsPath = join(outputRoot, "suggested-doc-edits.md");
+  const summaryPath = join(outputRoot, "docs-drift-summary.json");
+  const reportPath = join(outputRoot, "docs-drift-report.md");
   writeFileSync(suggestionsPath, formatDocsDriftSuggestions(suggestions), "utf8");
   const summaryWithoutInventory: Omit<DocsDriftEvalSummary, "artifactInventory"> = {
     evalName,
@@ -327,7 +330,7 @@ export function runDocsDriftEval(
     proofBoundary: "suggest-only docs-drift eval artifact; no docs, source, config, workflow, daemon, or GitHub comments are modified"
   };
   writeJson(reportPath, buildDocsDriftReport(summaryWithoutInventory));
-  const artifactInventory = buildArtifactInventory(options.outputRoot, [
+  const artifactInventory = buildArtifactInventory(outputRoot, [
     "suggested-doc-edits.md",
     "docs-drift-report.md"
   ]);
@@ -335,7 +338,7 @@ export function runDocsDriftEval(
   writeJson(summaryPath, summary);
   return {
     ok: summary.ok,
-    outputRoot: options.outputRoot,
+    outputRoot,
     summary,
     artifacts: {
       "docs-drift-summary.json": summaryPath,
@@ -389,6 +392,11 @@ function buildAbGates(input: {
         name: `${mode}_precision_neutral_or_better`,
         ok: input.comparisons[mode].precisionDelta >= 0,
         detail: `${input.comparisons[mode].precisionDelta} >= 0`
+      },
+      {
+        name: `${mode}_recall_neutral_or_better`,
+        ok: input.comparisons[mode].recallDelta >= 0,
+        detail: `${input.comparisons[mode].recallDelta} >= 0`
       },
       {
         name: `${mode}_no_p0_p1_false_positive_regression`,
@@ -476,8 +484,7 @@ function evaluateDocsDriftClaim(input: {
   const shouldSuggest = docContainsClaim &&
     sourceBacked &&
     input.claim.claim.trim() !== input.claim.currentText.trim();
-  const falsePositive = input.claim.expected === "true" && shouldSuggest;
-  const ok = input.claim.expected === "stale" ? shouldSuggest : !falsePositive;
+  const ok = input.claim.expected === "stale" ? shouldSuggest : !shouldSuggest;
   const detail = !docContainsClaim
     ? "doc claim text not found"
     : !sourceContainsCurrentText
@@ -485,7 +492,9 @@ function evaluateDocsDriftClaim(input: {
       : packetSectionIds.length === 0
         ? "source path not present in curated packet"
         : shouldSuggest
-          ? "stale claim suggested with source citation"
+          ? input.claim.expected === "true"
+            ? "true trap would be rewritten; counted as material false positive"
+            : "stale claim suggested with source citation"
           : "claim left unchanged";
   return {
     claimSummary: {

--- a/src/openwiki-eval-gates.ts
+++ b/src/openwiki-eval-gates.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileS
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
   assertEvalOutputDirSafe,
+  buildEvalThresholds,
   countEvalFalsePositiveSeverities,
   guardEmptyOutputRoot,
   runOfflineEval,
@@ -184,6 +185,7 @@ export function runRepoWikiContextAbEval(
   const now = options.now ?? new Date();
   const evalName = input.evalName ?? "neondiff-openwiki-context-ab-v0.1";
   const modeInputs = validateRepoWikiContextAbModes(input.modes);
+  validateRepoWikiContextAbThresholds(input.thresholds);
   const outputRoot = assertEvalOutputDirSafe(options.outputRoot);
   guardEmptyOutputRoot(outputRoot, "repo-wiki context A/B eval");
   mkdirSync(outputRoot, { recursive: true });
@@ -237,7 +239,10 @@ export function runRepoWikiContextAbEval(
     comparisons,
     gates
   };
-  writeJson(reportPath, buildAbReport(summaryWithoutInventory));
+  assertNoSecretLikeText(summaryWithoutInventory, "repo-wiki context A/B summary");
+  const reportText = buildAbReport(summaryWithoutInventory);
+  assertNoSecretLikeText(reportText, "repo-wiki context A/B report");
+  writeJson(reportPath, reportText);
   const artifactInventory = buildArtifactInventory(outputRoot, [
     "baseline/scorecard.json",
     "deterministic/scorecard.json",
@@ -245,6 +250,7 @@ export function runRepoWikiContextAbEval(
     "repo-wiki-context-ab-report.md"
   ]);
   const summary = { ...summaryWithoutInventory, artifactInventory };
+  assertNoSecretLikeText(summary, "repo-wiki context A/B summary with artifact inventory");
   writeJson(summaryPath, summary);
   return {
     ok: summary.ok,
@@ -269,6 +275,10 @@ function validateRepoWikiContextAbModes(value: unknown): Record<RepoWikiEvalMode
   return value as Record<RepoWikiEvalMode, RepoWikiContextModeInput>;
 }
 
+function validateRepoWikiContextAbThresholds(thresholds: EvalScenarioInput["thresholds"]): void {
+  buildEvalThresholds(thresholds, "gating");
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -279,6 +289,7 @@ export function runDocsDriftEval(
 ): DocsDriftEvalResult {
   const now = options.now ?? new Date();
   const evalName = input.evalName ?? "neondiff-openwiki-docs-drift-v0.1";
+  const thresholds = validateDocsDriftThresholds(input.thresholds);
   const outputRoot = assertEvalOutputDirSafe(options.outputRoot);
   guardEmptyOutputRoot(outputRoot, "OpenWiki docs-drift eval");
   mkdirSync(outputRoot, { recursive: true });
@@ -289,10 +300,6 @@ export function runDocsDriftEval(
     if (result.suggestion) suggestions.push(result.suggestion);
     return result.claimSummary;
   });
-  const thresholds = {
-    minStaleCaught: input.thresholds?.minStaleCaught ?? 4,
-    maxMaterialFalsePositives: input.thresholds?.maxMaterialFalsePositives ?? 0
-  };
   const staleClaims = input.claims.filter((claim) => claim.expected === "stale").length;
   const trueTraps = input.claims.filter((claim) => claim.expected === "true").length;
   const staleCaught = claims.filter((claim) => claim.expected === "stale" && claim.detected === "suggested").length;
@@ -315,7 +322,8 @@ export function runDocsDriftEval(
     },
     {
       name: "suggestions_have_citations",
-      ok: suggestions.every((suggestion) => suggestion.sourceCitation.path.length > 0 && suggestion.packetSectionIds.length > 0),
+      ok: suggestions.length > 0 &&
+        suggestions.every((suggestion) => suggestion.sourceCitation.path.length > 0 && suggestion.packetSectionIds.length > 0),
       detail: `${suggestions.length} suggestion(s) checked`
     }
   ];
@@ -374,6 +382,20 @@ export function runDocsDriftEval(
       "suggested-doc-edits.md": suggestionsPath
     }
   };
+}
+
+function validateDocsDriftThresholds(thresholds: DocsDriftEvalInput["thresholds"]): DocsDriftEvalSummary["thresholds"] {
+  const merged = {
+    minStaleCaught: thresholds?.minStaleCaught ?? 4,
+    maxMaterialFalsePositives: thresholds?.maxMaterialFalsePositives ?? 0
+  };
+  if (!Number.isInteger(merged.minStaleCaught) || merged.minStaleCaught < 1) {
+    throw new Error("minStaleCaught must be a positive integer");
+  }
+  if (!Number.isInteger(merged.maxMaterialFalsePositives) || merged.maxMaterialFalsePositives < 0) {
+    throw new Error("maxMaterialFalsePositives must be a non-negative integer");
+  }
+  return merged;
 }
 
 function summarizeMode(input: {

--- a/src/openwiki-eval-gates.ts
+++ b/src/openwiki-eval-gates.ts
@@ -4,6 +4,7 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
   assertEvalOutputDirSafe,
   countEvalFalsePositiveSeverities,
+  guardEmptyOutputRoot,
   runOfflineEval,
   type EvalLabelInput,
   type EvalRunResult,
@@ -16,6 +17,8 @@ import type { Severity } from "./types.js";
 import { codeUnitCompare, type RepoWikiPacket } from "./repo-wiki-packet.js";
 
 export type RepoWikiEvalMode = "baseline" | "deterministic" | "openwiki";
+
+const REPO_WIKI_EVAL_MODES = ["baseline", "deterministic", "openwiki"] as const;
 
 export interface RepoWikiContextModeInput {
   botFindings: unknown;
@@ -180,11 +183,13 @@ export function runRepoWikiContextAbEval(
 ): RepoWikiContextAbEvalResult {
   const now = options.now ?? new Date();
   const evalName = input.evalName ?? "neondiff-openwiki-context-ab-v0.1";
+  const modeInputs = validateRepoWikiContextAbModes(input.modes);
   const outputRoot = assertEvalOutputDirSafe(options.outputRoot);
+  guardEmptyOutputRoot(outputRoot, "repo-wiki context A/B eval");
   mkdirSync(outputRoot, { recursive: true });
   const modes = Object.fromEntries(
-    (["baseline", "deterministic", "openwiki"] as const).map((mode) => {
-      const modeInput = input.modes[mode];
+    REPO_WIKI_EVAL_MODES.map((mode) => {
+      const modeInput = modeInputs[mode];
       const result = runOfflineEval({
         evalName,
         runId: `${input.runId}-${mode}`,
@@ -250,6 +255,22 @@ export function runRepoWikiContextAbEval(
       "repo-wiki-context-ab-report.md": reportPath
     }
   };
+}
+
+function validateRepoWikiContextAbModes(value: unknown): Record<RepoWikiEvalMode, RepoWikiContextModeInput> {
+  if (!isRecord(value)) {
+    throw new Error("repoWikiContextAb.modes must be an object");
+  }
+  for (const mode of REPO_WIKI_EVAL_MODES) {
+    if (!isRecord(value[mode])) {
+      throw new Error(`repoWikiContextAb.modes.${mode} is required`);
+    }
+  }
+  return value as Record<RepoWikiEvalMode, RepoWikiContextModeInput>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 export function runDocsDriftEval(

--- a/src/openwiki-eval-gates.ts
+++ b/src/openwiki-eval-gates.ts
@@ -1,0 +1,681 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import { parseFindings } from "./findings.js";
+import {
+  runOfflineEval,
+  type EvalLabelInput,
+  type EvalRunResult,
+  type EvalScenarioInput,
+  type EvalScorecard,
+  type EvalSuiteName
+} from "./eval-harness.js";
+import { containsSecretLikeText, redactSecrets } from "./secrets.js";
+import type { Finding, Severity } from "./types.js";
+import type { RepoWikiPacket } from "./repo-wiki-packet.js";
+
+export type RepoWikiEvalMode = "baseline" | "deterministic" | "openwiki";
+
+export interface RepoWikiContextModeInput {
+  botFindings: unknown;
+  rawOutput?: unknown;
+  packetSha?: string;
+  freshness?: "fresh" | "stale" | "missing" | "unknown";
+  degraded?: boolean;
+}
+
+export interface RepoWikiContextAbEvalInput {
+  evalName?: string;
+  runId: string;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  suite: EvalSuiteName;
+  labels: EvalLabelInput[];
+  thresholds?: EvalScenarioInput["thresholds"];
+  providerProof?: {
+    mode?: "offline_fixture" | "zai_glm" | "unknown";
+    paidFallbackUsed?: boolean;
+    notes?: string;
+  };
+  modes: Record<RepoWikiEvalMode, RepoWikiContextModeInput>;
+}
+
+export interface RepoWikiContextAbEvalSummary {
+  evalName: string;
+  artifactVersion: "0.1";
+  runId: string;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  suite: EvalSuiteName;
+  ok: boolean;
+  generatedAt: string;
+  proofBoundary: string;
+  providerProof: {
+    mode: "offline_fixture" | "zai_glm" | "unknown";
+    paidFallbackUsed: boolean;
+    notes?: string;
+  };
+  modes: Record<RepoWikiEvalMode, RepoWikiModeSummary>;
+  comparisons: Record<Exclude<RepoWikiEvalMode, "baseline">, RepoWikiComparisonSummary>;
+  gates: Array<{ name: string; ok: boolean; detail: string }>;
+  artifactInventory: Array<{ name: string; sha256: string }>;
+}
+
+export interface RepoWikiModeSummary {
+  outputDir: string;
+  ok: boolean;
+  packetSha?: string;
+  freshness?: string;
+  degraded?: boolean;
+  scorecard: EvalScorecard;
+  falsePositiveSeverities: Record<Severity, number>;
+  p0p1FalsePositives: number;
+}
+
+export interface RepoWikiComparisonSummary {
+  precisionDelta: number;
+  recallDelta: number;
+  falsePositiveDelta: number;
+  p0p1FalsePositiveDelta: number;
+  secretFindingDelta: number;
+}
+
+export interface RepoWikiContextAbEvalResult {
+  ok: boolean;
+  outputRoot: string;
+  summary: RepoWikiContextAbEvalSummary;
+  artifacts: Record<string, string>;
+}
+
+export interface DocsDriftSeedClaim {
+  id: string;
+  expected: "stale" | "true";
+  docPath: string;
+  line: number;
+  claim: string;
+  sourcePath: string;
+  currentText: string;
+  suggestion: string;
+}
+
+export interface DocsDriftEvalInput {
+  evalName?: string;
+  runId: string;
+  repo: string;
+  headSha: string;
+  worktreePath: string;
+  packetPath: string;
+  claims: DocsDriftSeedClaim[];
+  thresholds?: {
+    minStaleCaught?: number;
+    maxMaterialFalsePositives?: number;
+  };
+}
+
+export interface DocsDriftEvalSummary {
+  evalName: string;
+  artifactVersion: "0.1";
+  runId: string;
+  repo: string;
+  headSha: string;
+  ok: boolean;
+  generatedAt: string;
+  packet: {
+    path: string;
+    sha256?: string;
+    freshness: string;
+    degraded: boolean;
+    includedSourceFiles: string[];
+  };
+  thresholds: {
+    minStaleCaught: number;
+    maxMaterialFalsePositives: number;
+  };
+  counts: {
+    staleClaims: number;
+    trueTraps: number;
+    staleCaught: number;
+    materialFalsePositives: number;
+    suggestions: number;
+  };
+  claims: Array<{
+    id: string;
+    expected: "stale" | "true";
+    detected: "suggested" | "not_suggested";
+    ok: boolean;
+    detail: string;
+  }>;
+  suggestions: DocsDriftSuggestion[];
+  gates: Array<{ name: string; ok: boolean; detail: string }>;
+  artifactInventory: Array<{ name: string; sha256: string }>;
+  proofBoundary: string;
+}
+
+export interface DocsDriftSuggestion {
+  claimId: string;
+  docPath: string;
+  line: number;
+  currentClaim: string;
+  suggestedText: string;
+  sourceCitation: {
+    path: string;
+    text: string;
+  };
+  packetSectionIds: string[];
+}
+
+export interface DocsDriftEvalResult {
+  ok: boolean;
+  outputRoot: string;
+  summary: DocsDriftEvalSummary;
+  artifacts: Record<string, string>;
+}
+
+export function runRepoWikiContextAbEval(
+  input: RepoWikiContextAbEvalInput,
+  options: { outputRoot: string; now?: Date }
+): RepoWikiContextAbEvalResult {
+  const now = options.now ?? new Date();
+  const evalName = input.evalName ?? "neondiff-openwiki-context-ab-v0.1";
+  mkdirSync(options.outputRoot, { recursive: true });
+  const modes = Object.fromEntries(
+    (["baseline", "deterministic", "openwiki"] as const).map((mode) => {
+      const modeInput = input.modes[mode];
+      const result = runOfflineEval({
+        evalName,
+        runId: `${input.runId}-${mode}`,
+        repo: input.repo,
+        pullNumber: input.pullNumber,
+        headSha: input.headSha,
+        suite: input.suite,
+        labels: input.labels,
+        thresholds: input.thresholds,
+        botFindings: modeInput.botFindings,
+        rawOutput: modeInput.rawOutput ?? modeInput.botFindings
+      }, {
+        outputDir: join(options.outputRoot, mode),
+        now
+      });
+      return [mode, summarizeMode({ modeInput, result, labels: input.labels })];
+    })
+  ) as Record<RepoWikiEvalMode, RepoWikiModeSummary>;
+
+  const comparisons = {
+    deterministic: compareMode(modes.baseline, modes.deterministic),
+    openwiki: compareMode(modes.baseline, modes.openwiki)
+  };
+  const providerProof = {
+    mode: input.providerProof?.mode ?? "offline_fixture",
+    paidFallbackUsed: input.providerProof?.paidFallbackUsed ?? false,
+    ...(input.providerProof?.notes ? { notes: redactSecrets(input.providerProof.notes) } : {})
+  };
+  const gates = buildAbGates({ modes, comparisons, providerProof });
+  const summaryPath = join(options.outputRoot, "repo-wiki-context-ab-summary.json");
+  const reportPath = join(options.outputRoot, "repo-wiki-context-ab-report.md");
+  const summaryWithoutInventory: Omit<RepoWikiContextAbEvalSummary, "artifactInventory"> = {
+    evalName,
+    artifactVersion: "0.1",
+    runId: input.runId,
+    repo: input.repo,
+    pullNumber: input.pullNumber,
+    headSha: input.headSha,
+    suite: input.suite,
+    ok: gates.every((gate) => gate.ok),
+    generatedAt: now.toISOString(),
+    proofBoundary: "offline A/B eval packet only; no model call, GitHub posting, daemon enablement, cron, or production config change",
+    providerProof,
+    modes,
+    comparisons,
+    gates
+  };
+  writeJson(reportPath, buildAbReport(summaryWithoutInventory));
+  const artifactInventory = buildArtifactInventory(options.outputRoot, [
+    "baseline/scorecard.json",
+    "deterministic/scorecard.json",
+    "openwiki/scorecard.json",
+    "repo-wiki-context-ab-report.md"
+  ]);
+  const summary = { ...summaryWithoutInventory, artifactInventory };
+  writeJson(summaryPath, summary);
+  return {
+    ok: summary.ok,
+    outputRoot: options.outputRoot,
+    summary,
+    artifacts: {
+      "repo-wiki-context-ab-summary.json": summaryPath,
+      "repo-wiki-context-ab-report.md": reportPath
+    }
+  };
+}
+
+export function runDocsDriftEval(
+  input: DocsDriftEvalInput,
+  options: { outputRoot: string; now?: Date }
+): DocsDriftEvalResult {
+  const now = options.now ?? new Date();
+  const evalName = input.evalName ?? "neondiff-openwiki-docs-drift-v0.1";
+  mkdirSync(options.outputRoot, { recursive: true });
+  const packet = readRepoWikiPacket(input);
+  const suggestions: DocsDriftSuggestion[] = [];
+  const claims = input.claims.map((claim) => {
+    const result = evaluateDocsDriftClaim({ claim, input, packet });
+    if (result.suggestion) suggestions.push(result.suggestion);
+    return result.claimSummary;
+  });
+  const thresholds = {
+    minStaleCaught: input.thresholds?.minStaleCaught ?? 4,
+    maxMaterialFalsePositives: input.thresholds?.maxMaterialFalsePositives ?? 1
+  };
+  const staleClaims = input.claims.filter((claim) => claim.expected === "stale").length;
+  const trueTraps = input.claims.filter((claim) => claim.expected === "true").length;
+  const staleCaught = claims.filter((claim) => claim.expected === "stale" && claim.detected === "suggested").length;
+  const materialFalsePositives = claims.filter((claim) => claim.expected === "true" && claim.detected === "suggested").length;
+  const gates = [
+    {
+      name: "packet_readable",
+      ok: packet.ok,
+      detail: packet.ok ? "curated repo-wiki packet parsed" : packet.error ?? "packet parse failed"
+    },
+    {
+      name: "stale_claim_recall",
+      ok: staleCaught >= thresholds.minStaleCaught,
+      detail: `${staleCaught} >= ${thresholds.minStaleCaught}`
+    },
+    {
+      name: "false_positive_limit",
+      ok: materialFalsePositives <= thresholds.maxMaterialFalsePositives,
+      detail: `${materialFalsePositives} <= ${thresholds.maxMaterialFalsePositives}`
+    },
+    {
+      name: "suggestions_have_citations",
+      ok: suggestions.every((suggestion) => suggestion.sourceCitation.path.length > 0 && suggestion.packetSectionIds.length > 0),
+      detail: `${suggestions.length} suggestion(s) checked`
+    }
+  ];
+  const suggestionsPath = join(options.outputRoot, "suggested-doc-edits.md");
+  const summaryPath = join(options.outputRoot, "docs-drift-summary.json");
+  const reportPath = join(options.outputRoot, "docs-drift-report.md");
+  writeFileSync(suggestionsPath, formatDocsDriftSuggestions(suggestions), "utf8");
+  const summaryWithoutInventory: Omit<DocsDriftEvalSummary, "artifactInventory"> = {
+    evalName,
+    artifactVersion: "0.1",
+    runId: input.runId,
+    repo: input.repo,
+    headSha: input.headSha,
+    ok: gates.every((gate) => gate.ok),
+    generatedAt: now.toISOString(),
+    packet: {
+      path: input.packetPath,
+      ...(packet.packetSha ? { sha256: packet.packetSha } : {}),
+      freshness: packet.repoWiki?.source.status ?? "unknown",
+      degraded: packet.repoWiki?.degraded ?? true,
+      includedSourceFiles: packet.includedSourceFiles
+    },
+    thresholds,
+    counts: {
+      staleClaims,
+      trueTraps,
+      staleCaught,
+      materialFalsePositives,
+      suggestions: suggestions.length
+    },
+    claims,
+    suggestions,
+    gates,
+    proofBoundary: "suggest-only docs-drift eval artifact; no docs, source, config, workflow, daemon, or GitHub comments are modified"
+  };
+  writeJson(reportPath, buildDocsDriftReport(summaryWithoutInventory));
+  const artifactInventory = buildArtifactInventory(options.outputRoot, [
+    "suggested-doc-edits.md",
+    "docs-drift-report.md"
+  ]);
+  const summary = { ...summaryWithoutInventory, artifactInventory };
+  writeJson(summaryPath, summary);
+  return {
+    ok: summary.ok,
+    outputRoot: options.outputRoot,
+    summary,
+    artifacts: {
+      "docs-drift-summary.json": summaryPath,
+      "docs-drift-report.md": reportPath,
+      "suggested-doc-edits.md": suggestionsPath
+    }
+  };
+}
+
+function summarizeMode(input: {
+  modeInput: RepoWikiContextModeInput;
+  result: EvalRunResult;
+  labels: EvalLabelInput[];
+}): RepoWikiModeSummary {
+  const falsePositiveSeverities = countFalsePositiveSeverities(input.modeInput.botFindings, input.labels);
+  return {
+    outputDir: input.result.outputDir,
+    ok: input.result.ok,
+    ...(input.modeInput.packetSha ? { packetSha: input.modeInput.packetSha } : {}),
+    ...(input.modeInput.freshness ? { freshness: input.modeInput.freshness } : {}),
+    ...(typeof input.modeInput.degraded === "boolean" ? { degraded: input.modeInput.degraded } : {}),
+    scorecard: input.result.scorecard,
+    falsePositiveSeverities,
+    p0p1FalsePositives: falsePositiveSeverities.P0 + falsePositiveSeverities.P1
+  };
+}
+
+function compareMode(baseline: RepoWikiModeSummary, candidate: RepoWikiModeSummary): RepoWikiComparisonSummary {
+  return {
+    precisionDelta: roundMetric(candidate.scorecard.metrics.precision - baseline.scorecard.metrics.precision),
+    recallDelta: roundMetric(candidate.scorecard.metrics.recall - baseline.scorecard.metrics.recall),
+    falsePositiveDelta: candidate.scorecard.counts.falsePositive - baseline.scorecard.counts.falsePositive,
+    p0p1FalsePositiveDelta: candidate.p0p1FalsePositives - baseline.p0p1FalsePositives,
+    secretFindingDelta: candidate.scorecard.counts.secretFindings - baseline.scorecard.counts.secretFindings
+  };
+}
+
+function buildAbGates(input: {
+  modes: Record<RepoWikiEvalMode, RepoWikiModeSummary>;
+  comparisons: Record<Exclude<RepoWikiEvalMode, "baseline">, RepoWikiComparisonSummary>;
+  providerProof: RepoWikiContextAbEvalSummary["providerProof"];
+}): RepoWikiContextAbEvalSummary["gates"] {
+  return [
+    ...(["baseline", "deterministic", "openwiki"] as const).map((mode) => ({
+      name: `${mode}_scorecard_ok`,
+      ok: input.modes[mode].ok,
+      detail: input.modes[mode].ok ? "offline scorecard passed" : "offline scorecard failed"
+    })),
+    ...(["deterministic", "openwiki"] as const).flatMap((mode) => [
+      {
+        name: `${mode}_precision_neutral_or_better`,
+        ok: input.comparisons[mode].precisionDelta >= 0,
+        detail: `${input.comparisons[mode].precisionDelta} >= 0`
+      },
+      {
+        name: `${mode}_no_p0_p1_false_positive_regression`,
+        ok: input.comparisons[mode].p0p1FalsePositiveDelta <= 0,
+        detail: `${input.comparisons[mode].p0p1FalsePositiveDelta} <= 0`
+      },
+      {
+        name: `${mode}_no_secret_regression`,
+        ok: input.comparisons[mode].secretFindingDelta <= 0,
+        detail: `${input.comparisons[mode].secretFindingDelta} <= 0`
+      }
+    ]),
+    {
+      name: "no_paid_provider_fallback",
+      ok: input.providerProof.paidFallbackUsed === false,
+      detail: input.providerProof.paidFallbackUsed
+        ? "provider proof reports paid fallback"
+        : `${input.providerProof.mode} reports no paid fallback`
+    }
+  ];
+}
+
+function countFalsePositiveSeverities(botFindings: unknown, labels: EvalLabelInput[]): Record<Severity, number> {
+  const findings = parseFindings(botFindings).findings;
+  const matchedFindingIndexes = new Set<number>();
+  const usedLabelIndexes = new Set<number>();
+  const candidates = labels.flatMap((label, labelIndex) => findings
+    .map((finding, findingIndex) => ({ finding, findingIndex, label, labelIndex, kind: classifyMatch(finding, label) }))
+    .filter((candidate) => candidate.kind !== undefined));
+  candidates.sort((a, b) =>
+    matchRank(a.kind!) - matchRank(b.kind!) ||
+    Math.abs(a.finding.line - a.label.line) - Math.abs(b.finding.line - b.label.line) ||
+    b.finding.confidence - a.finding.confidence
+  );
+  for (const candidate of candidates) {
+    if (matchedFindingIndexes.has(candidate.findingIndex) || usedLabelIndexes.has(candidate.labelIndex)) continue;
+    matchedFindingIndexes.add(candidate.findingIndex);
+    usedLabelIndexes.add(candidate.labelIndex);
+  }
+  const counts: Record<Severity, number> = { P0: 0, P1: 0, P2: 0, P3: 0 };
+  findings.forEach((finding, index) => {
+    if (!matchedFindingIndexes.has(index)) counts[finding.severity] += 1;
+  });
+  return counts;
+}
+
+function classifyMatch(finding: Finding, label: EvalLabelInput): "exact_line" | "nearby_line" | "semantic" | undefined {
+  if (finding.severity !== label.severity || finding.path !== label.path) return undefined;
+  const overlap = tokenOverlap(finding, label);
+  if (finding.line === label.line && overlap >= 0.25) return "exact_line";
+  if (Math.abs(finding.line - label.line) <= 3 && overlap >= 0.35) return "nearby_line";
+  if (overlap >= 0.55) return "semantic";
+  return undefined;
+}
+
+function matchRank(kind: "exact_line" | "nearby_line" | "semantic"): number {
+  if (kind === "exact_line") return 0;
+  if (kind === "nearby_line") return 1;
+  return 2;
+}
+
+function tokenOverlap(a: Pick<Finding | EvalLabelInput, "title" | "body">, b: Pick<Finding | EvalLabelInput, "title" | "body">): number {
+  const aTokens = tokenize(`${a.title} ${a.body}`);
+  const bTokens = tokenize(`${b.title} ${b.body}`);
+  if (aTokens.size === 0 || bTokens.size === 0) return 0;
+  return [...aTokens].filter((token) => bTokens.has(token)).length / Math.min(aTokens.size, bTokens.size);
+}
+
+function tokenize(text: string): Set<string> {
+  return new Set(text.toLowerCase().split(/[^a-z0-9]+/).filter((token) => token.length >= 4));
+}
+
+function readRepoWikiPacket(input: DocsDriftEvalInput): {
+  ok: boolean;
+  error?: string;
+  repoWiki?: RepoWikiPacket;
+  packetSha?: string;
+  includedSourceFiles: string[];
+  sectionIdsBySourcePath: Map<string, string[]>;
+} {
+  const absolutePath = resolve(input.worktreePath, input.packetPath);
+  if (!isInside(input.worktreePath, absolutePath)) {
+    return { ok: false, error: "packetPath must resolve inside worktreePath", includedSourceFiles: [], sectionIdsBySourcePath: new Map() };
+  }
+  if (!existsSync(absolutePath)) {
+    return { ok: false, error: "packetPath does not exist", includedSourceFiles: [], sectionIdsBySourcePath: new Map() };
+  }
+  const raw = readFileSync(absolutePath, "utf8");
+  if (containsSecretLikeText(raw)) {
+    return { ok: false, error: "packet contains secret-like text", includedSourceFiles: [], sectionIdsBySourcePath: new Map() };
+  }
+  try {
+    const repoWiki = JSON.parse(raw) as RepoWikiPacket;
+    const sectionIdsBySourcePath = new Map<string, string[]>();
+    for (const section of repoWiki.includedSections ?? []) {
+      for (const sourceFile of section.sourceFiles ?? []) {
+        const existing = sectionIdsBySourcePath.get(sourceFile) ?? [];
+        existing.push(section.id);
+        sectionIdsBySourcePath.set(sourceFile, existing);
+      }
+    }
+    const includedSourceFiles = [...sectionIdsBySourcePath.keys()].sort(codeUnitCompare);
+    return {
+      ok: true,
+      repoWiki,
+      packetSha: sha256(raw),
+      includedSourceFiles,
+      sectionIdsBySourcePath
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `packet JSON did not parse: ${error instanceof Error ? error.message : String(error)}`,
+      includedSourceFiles: [],
+      sectionIdsBySourcePath: new Map()
+    };
+  }
+}
+
+function evaluateDocsDriftClaim(input: {
+  claim: DocsDriftSeedClaim;
+  input: DocsDriftEvalInput;
+  packet: ReturnType<typeof readRepoWikiPacket>;
+}): {
+  claimSummary: DocsDriftEvalSummary["claims"][number];
+  suggestion?: DocsDriftSuggestion;
+} {
+  const docText = readWorktreeFile(input.input.worktreePath, input.claim.docPath);
+  const sourceText = readWorktreeFile(input.input.worktreePath, input.claim.sourcePath);
+  const docContainsClaim = docText.includes(input.claim.claim);
+  const sourceContainsCurrentText = sourceText.includes(input.claim.currentText);
+  const packetSectionIds = input.packet.sectionIdsBySourcePath.get(input.claim.sourcePath) ?? [];
+  const sourceBacked = input.packet.ok && packetSectionIds.length > 0 && sourceContainsCurrentText;
+  const shouldSuggest = docContainsClaim &&
+    sourceBacked &&
+    input.claim.claim.trim() !== input.claim.currentText.trim();
+  const falsePositive = input.claim.expected === "true" && shouldSuggest;
+  const ok = input.claim.expected === "stale" ? shouldSuggest : !falsePositive;
+  const detail = !docContainsClaim
+    ? "doc claim text not found"
+    : !sourceContainsCurrentText
+      ? "source evidence text not found"
+      : packetSectionIds.length === 0
+        ? "source path not present in curated packet"
+        : shouldSuggest
+          ? "stale claim suggested with source citation"
+          : "claim left unchanged";
+  return {
+    claimSummary: {
+      id: input.claim.id,
+      expected: input.claim.expected,
+      detected: shouldSuggest ? "suggested" : "not_suggested",
+      ok,
+      detail
+    },
+    ...(shouldSuggest
+      ? {
+          suggestion: {
+            claimId: input.claim.id,
+            docPath: input.claim.docPath,
+            line: input.claim.line,
+            currentClaim: input.claim.claim,
+            suggestedText: input.claim.suggestion,
+            sourceCitation: {
+              path: input.claim.sourcePath,
+              text: input.claim.currentText
+            },
+            packetSectionIds
+          }
+        }
+      : {})
+  };
+}
+
+function readWorktreeFile(worktreePath: string, relativePath: string): string {
+  const absolutePath = resolve(worktreePath, relativePath);
+  if (!isInside(worktreePath, absolutePath)) return "";
+  try {
+    return readFileSync(absolutePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function formatDocsDriftSuggestions(suggestions: DocsDriftSuggestion[]): string {
+  return [
+    "# Suggested Doc Edits",
+    "",
+    "These are suggest-only eval findings. No source or documentation files were edited.",
+    "",
+    ...suggestions.flatMap((suggestion) => [
+      `## ${suggestion.claimId}`,
+      "",
+      `- Doc: ${suggestion.docPath}:${suggestion.line}`,
+      `- Source: ${suggestion.sourceCitation.path}`,
+      `- Packet sections: ${suggestion.packetSectionIds.join(", ")}`,
+      "",
+      "Current claim:",
+      "",
+      `> ${suggestion.currentClaim}`,
+      "",
+      "Suggested replacement:",
+      "",
+      `> ${suggestion.suggestedText}`,
+      ""
+    ])
+  ].join("\n");
+}
+
+function buildAbReport(summary: Omit<RepoWikiContextAbEvalSummary, "artifactInventory">): string {
+  return [
+    "# Repo-Wiki Context A/B Eval",
+    "",
+    `Result: ${summary.ok ? "pass" : "fail"}`,
+    `Scenario: ${summary.repo}#${summary.pullNumber} @ ${summary.headSha}`,
+    "",
+    "| Mode | OK | Precision | Recall | False positives | P0/P1 false positives |",
+    "| --- | --- | ---: | ---: | ---: | ---: |",
+    ...(["baseline", "deterministic", "openwiki"] as const).map((mode) => {
+      const scorecard = summary.modes[mode].scorecard;
+      return `| ${mode} | ${summary.modes[mode].ok ? "yes" : "no"} | ${scorecard.metrics.precision} | ${scorecard.metrics.recall} | ${scorecard.counts.falsePositive} | ${summary.modes[mode].p0p1FalsePositives} |`;
+    }),
+    "",
+    "## Gates",
+    "",
+    ...summary.gates.map((gate) => `- ${gate.ok ? "PASS" : "FAIL"} ${gate.name}: ${gate.detail}`),
+    "",
+    "## Proof Boundary",
+    "",
+    summary.proofBoundary,
+    ""
+  ].join("\n");
+}
+
+function buildDocsDriftReport(summary: Omit<DocsDriftEvalSummary, "artifactInventory">): string {
+  return [
+    "# OpenWiki Docs-Drift Suggestion Eval",
+    "",
+    `Result: ${summary.ok ? "pass" : "fail"}`,
+    `Repo: ${summary.repo} @ ${summary.headSha}`,
+    `Stale caught: ${summary.counts.staleCaught}/${summary.counts.staleClaims}`,
+    `Material false positives: ${summary.counts.materialFalsePositives}/${summary.counts.trueTraps}`,
+    "",
+    "## Gates",
+    "",
+    ...summary.gates.map((gate) => `- ${gate.ok ? "PASS" : "FAIL"} ${gate.name}: ${gate.detail}`),
+    "",
+    "## Proof Boundary",
+    "",
+    summary.proofBoundary,
+    ""
+  ].join("\n");
+}
+
+function buildArtifactInventory(root: string, names: string[]): Array<{ name: string; sha256: string }> {
+  return names
+    .map((name) => ({ name, path: join(root, name) }))
+    .filter((artifact) => existsSync(artifact.path))
+    .map((artifact) => ({ name: artifact.name, sha256: sha256File(artifact.path) }));
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${typeof value === "string" ? value : JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function sha256File(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function sha256(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function roundMetric(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function isInside(rootPath: string, candidatePath: string): boolean {
+  const root = resolve(rootPath);
+  const candidate = resolve(candidatePath);
+  const rel = relative(root, candidate);
+  return rel === "" || (!rel.startsWith("..") && !rel.startsWith(`/`) && basename(rel) !== "");
+}
+
+function codeUnitCompare(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}

--- a/src/openwiki-eval-gates.ts
+++ b/src/openwiki-eval-gates.ts
@@ -13,7 +13,7 @@ import {
 } from "./eval-harness.js";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 import type { Severity } from "./types.js";
-import type { RepoWikiPacket } from "./repo-wiki-packet.js";
+import { codeUnitCompare, type RepoWikiPacket } from "./repo-wiki-packet.js";
 
 export type RepoWikiEvalMode = "baseline" | "deterministic" | "openwiki";
 
@@ -269,7 +269,7 @@ export function runDocsDriftEval(
   });
   const thresholds = {
     minStaleCaught: input.thresholds?.minStaleCaught ?? 4,
-    maxMaterialFalsePositives: input.thresholds?.maxMaterialFalsePositives ?? 1
+    maxMaterialFalsePositives: input.thresholds?.maxMaterialFalsePositives ?? 0
   };
   const staleClaims = input.claims.filter((claim) => claim.expected === "stale").length;
   const trueTraps = input.claims.filter((claim) => claim.expected === "true").length;
@@ -655,10 +655,4 @@ function resolveExistingFileInside(
   } catch (error) {
     return { ok: false, error: `${label} could not be resolved safely: ${error instanceof Error ? error.message : String(error)}` };
   }
-}
-
-function codeUnitCompare(left: string, right: string): number {
-  if (left < right) return -1;
-  if (left > right) return 1;
-  return 0;
 }

--- a/src/openwiki-eval-gates.ts
+++ b/src/openwiki-eval-gates.ts
@@ -322,7 +322,6 @@ export function runDocsDriftEval(
   const suggestionsPath = join(outputRoot, "suggested-doc-edits.md");
   const summaryPath = join(outputRoot, "docs-drift-summary.json");
   const reportPath = join(outputRoot, "docs-drift-report.md");
-  writeFileSync(suggestionsPath, formatDocsDriftSuggestions(suggestions), "utf8");
   const summaryWithoutInventory: Omit<DocsDriftEvalSummary, "artifactInventory"> = {
     evalName,
     artifactVersion: "0.1",
@@ -352,7 +351,12 @@ export function runDocsDriftEval(
     proofBoundary: "suggest-only docs-drift eval artifact; no docs, source, config, workflow, daemon, or GitHub comments are modified"
   };
   assertNoSecretLikeText(summaryWithoutInventory, "docs-drift summary");
-  writeJson(reportPath, buildDocsDriftReport(summaryWithoutInventory));
+  const suggestionsText = formatDocsDriftSuggestions(suggestions);
+  const reportText = buildDocsDriftReport(summaryWithoutInventory);
+  assertNoSecretLikeText(suggestionsText, "docs-drift suggestions");
+  assertNoSecretLikeText(reportText, "docs-drift report");
+  writeFileSync(suggestionsPath, suggestionsText, "utf8");
+  writeJson(reportPath, reportText);
   const artifactInventory = buildArtifactInventory(outputRoot, [
     "suggested-doc-edits.md",
     "docs-drift-report.md"
@@ -500,8 +504,10 @@ function evaluateDocsDriftClaim(input: {
   claimSummary: DocsDriftEvalSummary["claims"][number];
   suggestion?: DocsDriftSuggestion;
 } {
-  const docText = readWorktreeFile(input.input.worktreePath, input.claim.docPath);
-  const sourceText = readWorktreeFile(input.input.worktreePath, input.claim.sourcePath);
+  const docFile = readWorktreeFile(input.input.worktreePath, input.claim.docPath, "docPath");
+  const sourceFile = readWorktreeFile(input.input.worktreePath, input.claim.sourcePath, "sourcePath");
+  const docText = docFile.ok ? docFile.text : "";
+  const sourceText = sourceFile.ok ? sourceFile.text : "";
   const docContainsClaim = docText.includes(input.claim.claim);
   const sourceContainsCurrentText = sourceText.includes(input.claim.currentText);
   const packetSectionIds = input.packet.sectionIdsBySourcePath.get(input.claim.sourcePath) ?? [];
@@ -511,17 +517,24 @@ function evaluateDocsDriftClaim(input: {
     sourceBacked &&
     input.claim.claim.trim() !== input.claim.currentText.trim();
   const ok = input.claim.expected === "stale" ? shouldSuggest : !shouldSuggest;
-  const detail = !docContainsClaim
-    ? "doc claim text not found"
-    : !sourceContainsCurrentText
-      ? "source evidence text not found"
-      : packetSectionIds.length === 0
-        ? "source path not present in curated packet"
-        : shouldSuggest
-          ? input.claim.expected === "true"
-            ? "true trap would be rewritten; counted as material false positive"
-            : "stale claim suggested with source citation"
-          : "claim left unchanged";
+  let detail: string;
+  if (!docFile.ok) {
+    detail = `doc file unreadable: ${docFile.error}`;
+  } else if (!sourceFile.ok) {
+    detail = `source file unreadable: ${sourceFile.error}`;
+  } else if (!docContainsClaim) {
+    detail = "doc claim text not found";
+  } else if (!sourceContainsCurrentText) {
+    detail = "source evidence text not found";
+  } else if (packetSectionIds.length === 0) {
+    detail = "source path not present in curated packet";
+  } else if (shouldSuggest) {
+    detail = input.claim.expected === "true"
+      ? "true trap would be rewritten; counted as material false positive"
+      : "stale claim suggested with source citation";
+  } else {
+    detail = "claim left unchanged";
+  }
   return {
     claimSummary: {
       id: input.claim.id,
@@ -549,13 +562,20 @@ function evaluateDocsDriftClaim(input: {
   };
 }
 
-function readWorktreeFile(worktreePath: string, relativePath: string): string {
-  const filePath = resolveExistingFileInside(worktreePath, relativePath, "path");
-  if (!filePath.ok) return "";
+function readWorktreeFile(
+  worktreePath: string,
+  relativePath: string,
+  label: string
+): { ok: true; text: string } | { ok: false; error: string } {
+  const filePath = resolveExistingFileInside(worktreePath, relativePath, label);
+  if (!filePath.ok) return { ok: false, error: redactSecrets(filePath.error) };
   try {
-    return readFileSync(filePath.path, "utf8");
-  } catch {
-    return "";
+    return { ok: true, text: readFileSync(filePath.path, "utf8") };
+  } catch (error) {
+    return {
+      ok: false,
+      error: redactSecrets(`could not read ${relativePath}: ${error instanceof Error ? error.message : String(error)}`)
+    };
   }
 }
 

--- a/src/openwiki-eval-gates.ts
+++ b/src/openwiki-eval-gates.ts
@@ -205,7 +205,7 @@ export function runRepoWikiContextAbEval(
         outputDir: join(outputRoot, mode),
         now
       });
-      return [mode, summarizeMode({ modeInput, result, labels: input.labels })];
+      return [mode, summarizeMode({ modeInput, result })];
     })
   ) as Record<RepoWikiEvalMode, RepoWikiModeSummary>;
 
@@ -280,6 +280,7 @@ export function runDocsDriftEval(
   const now = options.now ?? new Date();
   const evalName = input.evalName ?? "neondiff-openwiki-docs-drift-v0.1";
   const outputRoot = assertEvalOutputDirSafe(options.outputRoot);
+  guardEmptyOutputRoot(outputRoot, "OpenWiki docs-drift eval");
   mkdirSync(outputRoot, { recursive: true });
   const packet = readRepoWikiPacket(input);
   const suggestions: DocsDriftSuggestion[] = [];
@@ -372,9 +373,8 @@ export function runDocsDriftEval(
 function summarizeMode(input: {
   modeInput: RepoWikiContextModeInput;
   result: EvalRunResult;
-  labels: EvalLabelInput[];
 }): RepoWikiModeSummary {
-  const falsePositiveSeverities = countFalsePositiveSeverities(input.modeInput.botFindings, input.labels);
+  const falsePositiveSeverities = countFalsePositiveSeverities(input.result.scorecard);
   return {
     outputDir: input.result.outputDir,
     ok: input.result.ok,
@@ -440,8 +440,8 @@ function buildAbGates(input: {
   ];
 }
 
-function countFalsePositiveSeverities(botFindings: unknown, labels: EvalLabelInput[]): Record<Severity, number> {
-  return countEvalFalsePositiveSeverities(botFindings, labels);
+function countFalsePositiveSeverities(scorecard: EvalScorecard): Record<Severity, number> {
+  return countEvalFalsePositiveSeverities(scorecard);
 }
 
 function readRepoWikiPacket(input: DocsDriftEvalInput): {

--- a/src/openwiki-eval-gates.ts
+++ b/src/openwiki-eval-gates.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
   assertEvalOutputDirSafe,
@@ -188,6 +188,7 @@ export function runRepoWikiContextAbEval(
   validateRepoWikiContextAbThresholds(input.thresholds);
   const outputRoot = assertEvalOutputDirSafe(options.outputRoot);
   guardEmptyOutputRoot(outputRoot, "repo-wiki context A/B eval");
+  try {
   mkdirSync(outputRoot, { recursive: true });
   const modes = Object.fromEntries(
     REPO_WIKI_EVAL_MODES.map((mode) => {
@@ -261,6 +262,10 @@ export function runRepoWikiContextAbEval(
       "repo-wiki-context-ab-report.md": reportPath
     }
   };
+  } catch (error) {
+    cleanupEvalOutputRoot(outputRoot);
+    throw error;
+  }
 }
 
 function validateRepoWikiContextAbModes(value: unknown): Record<RepoWikiEvalMode, RepoWikiContextModeInput> {
@@ -292,6 +297,7 @@ export function runDocsDriftEval(
   const thresholds = validateDocsDriftThresholds(input.thresholds);
   const outputRoot = assertEvalOutputDirSafe(options.outputRoot);
   guardEmptyOutputRoot(outputRoot, "OpenWiki docs-drift eval");
+  try {
   const packet = readRepoWikiPacket(input);
   const suggestions: DocsDriftSuggestion[] = [];
   const claims = input.claims.map((claim) => {
@@ -381,6 +387,10 @@ export function runDocsDriftEval(
       "suggested-doc-edits.md": suggestionsPath
     }
   };
+  } catch (error) {
+    cleanupEvalOutputRoot(outputRoot);
+    throw error;
+  }
 }
 
 function validateDocsDriftThresholds(thresholds: DocsDriftEvalInput["thresholds"]): DocsDriftEvalSummary["thresholds"] {
@@ -744,6 +754,10 @@ function writeJson(path: string, value: unknown): void {
 function assertNoSecretLikeText(value: unknown, label: string): void {
   const text = typeof value === "string" ? value : JSON.stringify(value) ?? "";
   if (containsSecretLikeText(text)) throw new Error(`${label} contains secret-like text`);
+}
+
+function cleanupEvalOutputRoot(outputRoot: string): void {
+  rmSync(outputRoot, { recursive: true, force: true });
 }
 
 function sha256File(path: string): string {

--- a/src/openwiki-eval-gates.ts
+++ b/src/openwiki-eval-gates.ts
@@ -321,8 +321,7 @@ export function runDocsDriftEval(
     },
     {
       name: "suggestions_have_citations",
-      ok: suggestions.length > 0 &&
-        suggestions.every((suggestion) => suggestion.sourceCitation.path.length > 0 && suggestion.packetSectionIds.length > 0),
+      ok: suggestions.every((suggestion) => suggestion.sourceCitation.path.length > 0 && suggestion.packetSectionIds.length > 0),
       detail: `${suggestions.length} suggestion(s) checked`
     }
   ];
@@ -580,12 +579,14 @@ function evaluateDocsDriftClaim(input: {
   const sourceFile = readWorktreeFile(input.input.worktreePath, input.claim.sourcePath, "sourcePath");
   const docText = docFile.ok ? docFile.text : "";
   const sourceText = sourceFile.ok ? sourceFile.text : "";
-  const docContainsClaim = docText.includes(input.claim.claim);
+  const docLine = readLine(docText, input.claim.line);
+  const docLineContainsClaim = docLine?.includes(input.claim.claim) ?? false;
+  const docContainsClaimElsewhere = docText.includes(input.claim.claim);
   const sourceContainsCurrentText = sourceText.includes(input.claim.currentText);
   const packetSectionIds = input.packet.sectionIdsBySourcePath.get(input.claim.sourcePath) ?? [];
   const sourceBacked = input.packet.ok && packetSectionIds.length > 0 && sourceContainsCurrentText;
   // v0.1 fixtures intentionally use exact, case-sensitive substring matching so seeded claims stay auditable.
-  const shouldSuggest = docContainsClaim &&
+  const shouldSuggest = docLineContainsClaim &&
     sourceBacked &&
     input.claim.claim.trim() !== input.claim.currentText.trim();
   const ok = input.claim.expected === "stale" ? shouldSuggest : !shouldSuggest;
@@ -594,8 +595,10 @@ function evaluateDocsDriftClaim(input: {
     detail = `doc file unreadable: ${docFile.error}`;
   } else if (!sourceFile.ok) {
     detail = `source file unreadable: ${sourceFile.error}`;
-  } else if (!docContainsClaim) {
-    detail = "doc claim text not found";
+  } else if (!docLineContainsClaim) {
+    detail = docContainsClaimElsewhere
+      ? `doc claim text found, but not at reported line ${input.claim.line}`
+      : "doc claim text not found";
   } else if (!sourceContainsCurrentText) {
     detail = "source evidence text not found";
   } else if (packetSectionIds.length === 0) {
@@ -632,6 +635,11 @@ function evaluateDocsDriftClaim(input: {
         }
       : {})
   };
+}
+
+function readLine(text: string, lineNumber: number): string | undefined {
+  if (!Number.isSafeInteger(lineNumber) || lineNumber < 1) return undefined;
+  return text.split(/\r?\n/)[lineNumber - 1];
 }
 
 function readWorktreeFile(

--- a/src/openwiki-eval-gates.ts
+++ b/src/openwiki-eval-gates.ts
@@ -200,7 +200,7 @@ export function runRepoWikiContextAbEval(
         labels: input.labels,
         thresholds: input.thresholds,
         botFindings: modeInput.botFindings,
-        rawOutput: modeInput.rawOutput ?? modeInput.botFindings
+        rawOutput: modeInput.rawOutput
       }, {
         outputDir: join(outputRoot, mode),
         now
@@ -351,12 +351,14 @@ export function runDocsDriftEval(
     gates,
     proofBoundary: "suggest-only docs-drift eval artifact; no docs, source, config, workflow, daemon, or GitHub comments are modified"
   };
+  assertNoSecretLikeText(summaryWithoutInventory, "docs-drift summary");
   writeJson(reportPath, buildDocsDriftReport(summaryWithoutInventory));
   const artifactInventory = buildArtifactInventory(outputRoot, [
     "suggested-doc-edits.md",
     "docs-drift-report.md"
   ]);
   const summary = { ...summaryWithoutInventory, artifactInventory };
+  assertNoSecretLikeText(summary, "docs-drift summary with artifact inventory");
   writeJson(summaryPath, summary);
   return {
     ok: summary.ok,
@@ -435,6 +437,8 @@ function buildAbGates(input: {
       ok: input.providerProof.paidFallbackUsed === false,
       detail: input.providerProof.paidFallbackUsed
         ? "provider proof reports paid fallback"
+        : input.providerProof.mode === "offline_fixture"
+          ? "offline fixture made no provider call and reports no paid fallback"
         : `${input.providerProof.mode} reports no paid fallback`
     }
   ];
@@ -502,6 +506,7 @@ function evaluateDocsDriftClaim(input: {
   const sourceContainsCurrentText = sourceText.includes(input.claim.currentText);
   const packetSectionIds = input.packet.sectionIdsBySourcePath.get(input.claim.sourcePath) ?? [];
   const sourceBacked = input.packet.ok && packetSectionIds.length > 0 && sourceContainsCurrentText;
+  // v0.1 fixtures intentionally use exact, case-sensitive substring matching so seeded claims stay auditable.
   const shouldSuggest = docContainsClaim &&
     sourceBacked &&
     input.claim.claim.trim() !== input.claim.currentText.trim();
@@ -634,6 +639,11 @@ function buildArtifactInventory(root: string, names: string[]): Array<{ name: st
 function writeJson(path: string, value: unknown): void {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, `${typeof value === "string" ? value : JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function assertNoSecretLikeText(value: unknown, label: string): void {
+  const text = typeof value === "string" ? value : JSON.stringify(value) ?? "";
+  if (containsSecretLikeText(text)) throw new Error(`${label} contains secret-like text`);
 }
 
 function sha256File(path: string): string {

--- a/src/repo-wiki-packet.ts
+++ b/src/repo-wiki-packet.ts
@@ -729,7 +729,7 @@ function assertSupportedAddonDryRunBudget(packet: SupportedAddonDryRunPacket): S
   return packet;
 }
 
-function codeUnitCompare(left: string, right: string): number {
+export function codeUnitCompare(left: string, right: string): number {
   if (left < right) return -1;
   if (left > right) return 1;
   return 0;

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -32,7 +32,9 @@ const SAFE_ENV_VAR_NAMES = [
   "NEONDIFF_ALLOW_REMOTE_SMOKE"
 ];
 const SAFE_STRUCTURAL_VALUES = [
-  "missing_secret_env"
+  "missing_secret_env",
+  "neondiff-openwiki-context-ab-v0.1",
+  "neondiff-openwiki-docs-drift-v0.1"
 ];
 const SAFE_REDACTION_LITERALS = [
   ...SAFE_ENV_VAR_NAMES,

--- a/tests/eval-harness.test.ts
+++ b/tests/eval-harness.test.ts
@@ -54,6 +54,7 @@ function promotionScorecard(input: {
       seededRecall: 1,
       maxWilsonLowerBound: input.maxWilsonLowerBound
     },
+    falsePositiveSeverities: { P0: 0, P1: 0, P2: 0, P3: 0 },
     matchedLabelKeys: [],
     thresholds: {
       minPrecision: 0.8,

--- a/tests/openwiki-eval-gates.test.ts
+++ b/tests/openwiki-eval-gates.test.ts
@@ -80,6 +80,31 @@ describe("OpenWiki eval gates", () => {
     }));
   });
 
+  it("throws a clean validation error when a required A/B mode is missing", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-ab-missing-mode-"));
+    roots.push(outputRoot);
+    const input = buildAbInput();
+    delete (input.modes as Partial<RepoWikiContextAbEvalInput["modes"]>).openwiki;
+
+    expect(() => runRepoWikiContextAbEval(input, {
+      outputRoot,
+      now: new Date(generatedAt)
+    })).toThrow("repoWikiContextAb.modes.openwiki is required");
+    expect(existsSync(join(outputRoot, "repo-wiki-context-ab-summary.json"))).toBe(false);
+  });
+
+  it("rejects non-empty A/B output roots before writing new artifacts", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-ab-non-empty-"));
+    roots.push(outputRoot);
+    writeFileSync(join(outputRoot, "previous-run.json"), "{}", "utf8");
+
+    expect(() => runRepoWikiContextAbEval(buildAbInput(), {
+      outputRoot,
+      now: new Date(generatedAt)
+    })).toThrow("outputRoot must be empty before running repo-wiki context A/B eval");
+    expect(existsSync(join(outputRoot, "repo-wiki-context-ab-summary.json"))).toBe(false);
+  });
+
   it("buckets unmatched false positives by their actual severity", () => {
     const labels: EvalLabelInput[] = [{
       source: "seeded_defect",

--- a/tests/openwiki-eval-gates.test.ts
+++ b/tests/openwiki-eval-gates.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -9,6 +9,7 @@ import {
   type RepoWikiContextAbEvalInput
 } from "../src/openwiki-eval-gates.js";
 import { buildRepoWikiPacket, formatRepoWikiPacketJson } from "../src/repo-wiki-packet.js";
+import { containsSecretLikeText } from "../src/secrets.js";
 
 const generatedAt = "2026-07-09T09:10:00.000Z";
 const repo = "electricsheephq/evaos-code-review-bot-neondiff";
@@ -31,6 +32,7 @@ describe("OpenWiki eval gates", () => {
     });
 
     expect(result.ok).toBe(true);
+    expect(containsSecretLikeText(JSON.stringify(result.summary))).toBe(false);
     expect(result.summary.comparisons.openwiki).toMatchObject({
       precisionDelta: 0,
       p0p1FalsePositiveDelta: 0
@@ -68,6 +70,47 @@ describe("OpenWiki eval gates", () => {
     }));
   });
 
+  it("counts expected-false labels the same way as the core scorecard", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-ab-expected-false-"));
+    roots.push(outputRoot);
+    const input = buildAbInput();
+    input.labels.push({
+      source: "seeded_defect",
+      severity: "P1",
+      path: "src/worker.ts",
+      line: 33,
+      title: "Provider fallback leaks paid tokens",
+      body: "This label is an explicit non-finding and must not match false positives.",
+      sourceId: "seed-expected-false",
+      expected: false
+    });
+    input.modes.openwiki.botFindings = {
+      findings: [
+        buildReviewFinding(),
+        {
+          severity: "P1",
+          path: "src/worker.ts",
+          line: 33,
+          title: "Provider fallback leaks paid tokens",
+          body: "This label is an explicit non-finding and must not match false positives.",
+          confidence: 0.9
+        }
+      ]
+    };
+
+    const result = runRepoWikiContextAbEval(input, {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.summary.modes.openwiki.scorecard.counts.falsePositive).toBe(1);
+    expect(result.summary.modes.openwiki.p0p1FalsePositives).toBe(1);
+    expect(result.summary.gates).toContainEqual(expect.objectContaining({
+      name: "openwiki_no_p0_p1_false_positive_regression",
+      ok: false
+    }));
+  });
+
   it("passes docs-drift eval with source-cited suggestions and true-claim traps", () => {
     const { packetPath, root } = createDocsDriftFixture();
     const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-pass-"));
@@ -86,6 +129,7 @@ describe("OpenWiki eval gates", () => {
     });
 
     expect(result.ok).toBe(true);
+    expect(containsSecretLikeText(JSON.stringify(result.summary))).toBe(false);
     expect(result.summary.counts).toMatchObject({
       staleCaught: 5,
       materialFalsePositives: 0,
@@ -121,6 +165,183 @@ describe("OpenWiki eval gates", () => {
       name: "false_positive_limit",
       ok: false
     }));
+  });
+
+  it("rejects packet paths that resolve outside the worktree", () => {
+    const { root } = createDocsDriftFixture();
+    const outsideRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-outside-"));
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-outside-result-"));
+    roots.push(root, outsideRoot, outputRoot);
+    writeFileSync(join(outsideRoot, "packet.json"), "{}", "utf8");
+
+    const result = runDocsDriftEval({
+      runId: "packet-outside-worktree",
+      repo,
+      headSha,
+      worktreePath: root,
+      packetPath: `../${outsideRoot.split("/").at(-1)}/packet.json`,
+      claims: buildDocsDriftClaims()
+    }, {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.gates).toContainEqual(expect.objectContaining({
+      name: "packet_readable",
+      ok: false
+    }));
+  });
+
+  it("rejects symlinked packets that escape the worktree", () => {
+    const { root } = createDocsDriftFixture();
+    const outsideRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-symlink-outside-"));
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-symlink-result-"));
+    roots.push(root, outsideRoot, outputRoot);
+    const outsidePacket = join(outsideRoot, "packet.json");
+    writeFileSync(outsidePacket, formatRepoWikiPacketJson(buildRepoWikiPacket({
+      repo: { fullName: repo, defaultBranch: "main" },
+      source: { ref: "main", headSha, checkedAt: generatedAt, status: "fresh" },
+      generatedAt,
+      budget: { maxBytes: 12_000 },
+      sections: [{
+        id: "external",
+        title: "External Packet",
+        body: "This packet lives outside the worktree.",
+        sourceFiles: ["src/repo-wiki-context.ts"]
+      }]
+    })), "utf8");
+    symlinkSync(outsidePacket, join(root, ".neondiff", "linked-packet.json"));
+
+    const result = runDocsDriftEval({
+      runId: "packet-symlink-escape",
+      repo,
+      headSha,
+      worktreePath: root,
+      packetPath: ".neondiff/linked-packet.json",
+      claims: buildDocsDriftClaims()
+    }, {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.gates).toContainEqual(expect.objectContaining({
+      name: "packet_readable",
+      ok: false
+    }));
+  });
+
+  it("fails closed instead of throwing when packetPath resolves to the worktree root", () => {
+    const { root } = createDocsDriftFixture();
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-root-packet-"));
+    roots.push(root, outputRoot);
+
+    const result = runDocsDriftEval({
+      runId: "packet-root-path",
+      repo,
+      headSha,
+      worktreePath: root,
+      packetPath: ".",
+      claims: buildDocsDriftClaims()
+    }, {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.gates).toContainEqual(expect.objectContaining({
+      name: "packet_readable",
+      ok: false
+    }));
+  });
+
+  it("marks missing, malformed, and secret-like packets unreadable", () => {
+    const malformed = createDocsDriftFixture();
+    const secret = createDocsDriftFixture();
+    const missing = createDocsDriftFixture();
+    const malformedOutput = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-malformed-"));
+    const secretOutput = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-secret-"));
+    const missingOutput = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-missing-"));
+    roots.push(
+      malformed.root,
+      secret.root,
+      missing.root,
+      malformedOutput,
+      secretOutput,
+      missingOutput
+    );
+    writeFileSync(join(malformed.root, malformed.packetPath), "{not json", "utf8");
+    writeFileSync(join(secret.root, secret.packetPath), "{\"token\":\"ghp_1234567890abcdef\"}", "utf8");
+
+    const cases = [
+      { fixture: malformed, outputRoot: malformedOutput },
+      { fixture: secret, outputRoot: secretOutput },
+      { fixture: { root: missing.root, packetPath: ".neondiff/missing.json" }, outputRoot: missingOutput }
+    ];
+
+    for (const [index, item] of cases.entries()) {
+      const result = runDocsDriftEval({
+        runId: `packet-unreadable-${index}`,
+        repo,
+        headSha,
+        worktreePath: item.fixture.root,
+        packetPath: item.fixture.packetPath,
+        claims: buildDocsDriftClaims()
+      }, {
+        outputRoot: item.outputRoot,
+        now: new Date(generatedAt)
+      });
+      expect(result.ok).toBe(false);
+      expect(result.summary.gates).toContainEqual(expect.objectContaining({
+        name: "packet_readable",
+        ok: false
+      }));
+    }
+  });
+
+  it("redacts secret-like text before writing docs-drift artifacts", () => {
+    const { packetPath, root } = createDocsDriftFixture();
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-redaction-"));
+    roots.push(root, outputRoot);
+    const secret = "ghp_1234567890abcdef";
+    writeFileSync(
+      join(root, "docs", "repo-wiki-packet.md"),
+      "The documented token is stale.\n",
+      "utf8"
+    );
+    writeFileSync(
+      join(root, "src", "repo-wiki-context.ts"),
+      `export const secretExample = '${secret}';\n`,
+      "utf8"
+    );
+
+    const result = runDocsDriftEval({
+      runId: "docs-drift-redaction",
+      repo,
+      headSha,
+      worktreePath: root,
+      packetPath,
+      thresholds: { minStaleCaught: 1 },
+      claims: [{
+        id: "secret-redaction",
+        expected: "stale",
+        docPath: "docs/repo-wiki-packet.md",
+        line: 1,
+        claim: "The documented token is stale.",
+        sourcePath: "src/repo-wiki-context.ts",
+        currentText: secret,
+        suggestion: secret
+      }]
+    }, {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.ok).toBe(true);
+    expect(JSON.stringify(result.summary)).not.toContain(secret);
+    expect(readFileSync(result.artifacts["suggested-doc-edits.md"]!, "utf8")).not.toContain(secret);
+    expect(readFileSync(result.artifacts["docs-drift-summary.json"]!, "utf8")).toContain("[redacted-secret]");
   });
 });
 

--- a/tests/openwiki-eval-gates.test.ts
+++ b/tests/openwiki-eval-gates.test.ts
@@ -50,6 +50,27 @@ describe("OpenWiki eval gates", () => {
     expect(readFileSync(result.artifacts["repo-wiki-context-ab-report.md"]!, "utf8")).toContain("Repo-Wiki Context A/B Eval");
   });
 
+  it("redacts provider proof notes before writing A/B summaries", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-ab-provider-notes-"));
+    roots.push(outputRoot);
+    const secret = "ghp_1234567890abcdef";
+    const input = buildAbInput();
+    input.providerProof = {
+      mode: "zai_glm",
+      paidFallbackUsed: false,
+      notes: `Z.AI route used token ${secret}`
+    };
+
+    const result = runRepoWikiContextAbEval(input, {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.summary.providerProof.notes).toContain("[redacted-secret]");
+    expect(result.summary.providerProof.notes).not.toContain(secret);
+    expect(readFileSync(result.artifacts["repo-wiki-context-ab-summary.json"]!, "utf8")).not.toContain(secret);
+  });
+
   it("fails A/B eval when OpenWiki context adds a P1 false positive", () => {
     const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-ab-fail-"));
     roots.push(outputRoot);
@@ -466,6 +487,28 @@ describe("OpenWiki eval gates", () => {
     expect(JSON.stringify(result.summary)).not.toContain(secret);
     expect(readFileSync(result.artifacts["suggested-doc-edits.md"]!, "utf8")).not.toContain(secret);
     expect(readFileSync(result.artifacts["docs-drift-summary.json"]!, "utf8")).toContain("[redacted-secret]");
+  });
+
+  it("fails closed before docs-drift summaries can include secret-like metadata", () => {
+    const { packetPath, root } = createDocsDriftFixture();
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-summary-secret-"));
+    roots.push(root, outputRoot);
+    const secretPacketPath = ".neondiff/ghp_1234567890abcdef.json";
+    writeFileSync(join(root, secretPacketPath), readFileSync(join(root, packetPath), "utf8"), "utf8");
+
+    expect(() => runDocsDriftEval({
+      runId: "docs-drift-summary-secret",
+      repo,
+      headSha,
+      worktreePath: root,
+      packetPath: secretPacketPath,
+      claims: buildDocsDriftClaims()
+    }, {
+      outputRoot,
+      now: new Date(generatedAt)
+    })).toThrow("docs-drift summary contains secret-like text");
+    expect(existsSync(join(outputRoot, "docs-drift-summary.json"))).toBe(false);
+    expect(existsSync(join(outputRoot, "docs-drift-report.md"))).toBe(false);
   });
 });
 

--- a/tests/openwiki-eval-gates.test.ts
+++ b/tests/openwiki-eval-gates.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -35,8 +35,17 @@ describe("OpenWiki eval gates", () => {
     expect(containsSecretLikeText(JSON.stringify(result.summary))).toBe(false);
     expect(result.summary.comparisons.openwiki).toMatchObject({
       precisionDelta: 0,
+      recallDelta: 0,
       p0p1FalsePositiveDelta: 0
     });
+    expect(result.summary.gates).toContainEqual(expect.objectContaining({
+      name: "deterministic_recall_neutral_or_better",
+      ok: true
+    }));
+    expect(result.summary.gates).toContainEqual(expect.objectContaining({
+      name: "openwiki_recall_neutral_or_better",
+      ok: true
+    }));
     expect(readFileSync(result.artifacts["repo-wiki-context-ab-report.md"]!, "utf8")).toContain("Repo-Wiki Context A/B Eval");
   });
 
@@ -66,6 +75,25 @@ describe("OpenWiki eval gates", () => {
     expect(result.ok).toBe(false);
     expect(result.summary.gates).toContainEqual(expect.objectContaining({
       name: "openwiki_no_p0_p1_false_positive_regression",
+      ok: false
+    }));
+  });
+
+  it("fails A/B eval when OpenWiki context drops baseline recall", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-ab-recall-fail-"));
+    roots.push(outputRoot);
+    const input = buildAbInput();
+    input.modes.openwiki.botFindings = { findings: [] };
+
+    const result = runRepoWikiContextAbEval(input, {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.comparisons.openwiki.recallDelta).toBeLessThan(0);
+    expect(result.summary.gates).toContainEqual(expect.objectContaining({
+      name: "openwiki_recall_neutral_or_better",
       ok: false
     }));
   });
@@ -165,6 +193,31 @@ describe("OpenWiki eval gates", () => {
       name: "false_positive_limit",
       ok: false
     }));
+    expect(result.summary.claims).toContainEqual(expect.objectContaining({
+      id: "true-advisory",
+      detail: "true trap would be rewritten; counted as material false positive"
+    }));
+  });
+
+  it("rejects docs-drift output roots inside the checkout before writing artifacts", () => {
+    const { packetPath, root } = createDocsDriftFixture();
+    const outputRoot = join(process.cwd(), ".tmp-openwiki-docs-drift-inside-checkout");
+    roots.push(root, outputRoot);
+    rmSync(outputRoot, { recursive: true, force: true });
+
+    expect(() => runDocsDriftEval({
+      runId: "docs-drift-output-inside-checkout",
+      repo,
+      headSha,
+      worktreePath: root,
+      packetPath,
+      claims: buildDocsDriftClaims()
+    }, {
+      outputRoot,
+      now: new Date(generatedAt)
+    })).toThrow("outputDir must not be inside the current git checkout");
+    expect(existsSync(join(outputRoot, "docs-drift-summary.json"))).toBe(false);
+    expect(existsSync(join(outputRoot, "suggested-doc-edits.md"))).toBe(false);
   });
 
   it("rejects packet paths that resolve outside the worktree", () => {

--- a/tests/openwiki-eval-gates.test.ts
+++ b/tests/openwiki-eval-gates.test.ts
@@ -447,26 +447,32 @@ describe("OpenWiki eval gates", () => {
     }));
   });
 
-  it("marks missing, malformed, and secret-like packets unreadable", () => {
+  it("marks missing, malformed, shapeless, and secret-like packets unreadable", () => {
     const malformed = createDocsDriftFixture();
+    const shapeless = createDocsDriftFixture();
     const secret = createDocsDriftFixture();
     const missing = createDocsDriftFixture();
     const malformedOutput = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-malformed-"));
+    const shapelessOutput = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-shapeless-"));
     const secretOutput = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-secret-"));
     const missingOutput = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-missing-"));
     roots.push(
       malformed.root,
+      shapeless.root,
       secret.root,
       missing.root,
       malformedOutput,
+      shapelessOutput,
       secretOutput,
       missingOutput
     );
     writeFileSync(join(malformed.root, malformed.packetPath), "{not json", "utf8");
+    writeFileSync(join(shapeless.root, shapeless.packetPath), "{}", "utf8");
     writeFileSync(join(secret.root, secret.packetPath), "{\"token\":\"ghp_1234567890abcdef\"}", "utf8");
 
     const cases = [
       { fixture: malformed, outputRoot: malformedOutput },
+      { fixture: shapeless, outputRoot: shapelessOutput },
       { fixture: secret, outputRoot: secretOutput },
       { fixture: { root: missing.root, packetPath: ".neondiff/missing.json" }, outputRoot: missingOutput }
     ];

--- a/tests/openwiki-eval-gates.test.ts
+++ b/tests/openwiki-eval-gates.test.ts
@@ -81,6 +81,10 @@ describe("OpenWiki eval gates", () => {
       outputRoot,
       now: new Date(generatedAt)
     })).toThrow("repo-wiki context A/B summary contains secret-like text");
+    expect(existsSync(outputRoot)).toBe(false);
+    expect(existsSync(join(outputRoot, "baseline"))).toBe(false);
+    expect(existsSync(join(outputRoot, "deterministic"))).toBe(false);
+    expect(existsSync(join(outputRoot, "openwiki"))).toBe(false);
     expect(existsSync(join(outputRoot, "repo-wiki-context-ab-summary.json"))).toBe(false);
     expect(existsSync(join(outputRoot, "repo-wiki-context-ab-report.md"))).toBe(false);
   });
@@ -666,6 +670,7 @@ describe("OpenWiki eval gates", () => {
       outputRoot,
       now: new Date(generatedAt)
     })).toThrow("docs-drift summary contains secret-like text");
+    expect(existsSync(outputRoot)).toBe(false);
     expect(existsSync(join(outputRoot, "docs-drift-summary.json"))).toBe(false);
     expect(existsSync(join(outputRoot, "docs-drift-report.md"))).toBe(false);
     expect(existsSync(join(outputRoot, "suggested-doc-edits.md"))).toBe(false);

--- a/tests/openwiki-eval-gates.test.ts
+++ b/tests/openwiki-eval-gates.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { countEvalFalsePositiveSeverities, type EvalLabelInput } from "../src/eval-harness.js";
+import type { EvalLabelInput } from "../src/eval-harness.js";
 import {
   runDocsDriftEval,
   runRepoWikiContextAbEval,
@@ -105,35 +105,27 @@ describe("OpenWiki eval gates", () => {
     expect(existsSync(join(outputRoot, "repo-wiki-context-ab-summary.json"))).toBe(false);
   });
 
-  it("buckets unmatched false positives by their actual severity", () => {
-    const labels: EvalLabelInput[] = [{
-      source: "seeded_defect",
-      severity: "P0",
-      path: "src/worker.ts",
-      line: 12,
-      title: "Matched outage",
-      body: "This finding is expected and should not count as a false positive.",
-      sourceId: "matched-p0"
-    }];
-
-    const counts = countEvalFalsePositiveSeverities({
+  it("buckets unmatched false positives by their scorecard severity", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-ab-severity-buckets-"));
+    roots.push(outputRoot);
+    const input = buildAbInput();
+    input.modes.openwiki.botFindings = {
       findings: [
-        {
-          severity: "P0",
-          path: "src/worker.ts",
-          line: 12,
-          title: "Matched outage",
-          body: "This finding is expected and should not count as a false positive.",
-          confidence: 0.99
-        },
+        buildReviewFinding(),
         severityFinding("P0", "Unexpected outage"),
         severityFinding("P1", "Unexpected token fallback"),
         severityFinding("P2", "Unexpected docs drift"),
         severityFinding("P3", "Unexpected note")
       ]
-    }, labels);
+    };
 
-    expect(counts).toEqual({ P0: 1, P1: 1, P2: 1, P3: 1 });
+    const result = runRepoWikiContextAbEval(input, {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.summary.modes.openwiki.falsePositiveSeverities).toEqual({ P0: 1, P1: 1, P2: 1, P3: 1 });
+    expect(result.summary.modes.openwiki.p0p1FalsePositives).toBe(2);
   });
 
   it("fails A/B eval when OpenWiki context drops baseline recall", () => {
@@ -274,6 +266,27 @@ describe("OpenWiki eval gates", () => {
       outputRoot,
       now: new Date(generatedAt)
     })).toThrow("outputDir must not be inside the current git checkout");
+    expect(existsSync(join(outputRoot, "docs-drift-summary.json"))).toBe(false);
+    expect(existsSync(join(outputRoot, "suggested-doc-edits.md"))).toBe(false);
+  });
+
+  it("rejects non-empty docs-drift output roots before writing new artifacts", () => {
+    const { packetPath, root } = createDocsDriftFixture();
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-non-empty-"));
+    roots.push(root, outputRoot);
+    writeFileSync(join(outputRoot, "previous-run.json"), "{}", "utf8");
+
+    expect(() => runDocsDriftEval({
+      runId: "docs-drift-output-non-empty",
+      repo,
+      headSha,
+      worktreePath: root,
+      packetPath,
+      claims: buildDocsDriftClaims()
+    }, {
+      outputRoot,
+      now: new Date(generatedAt)
+    })).toThrow("outputRoot must be empty before running OpenWiki docs-drift eval");
     expect(existsSync(join(outputRoot, "docs-drift-summary.json"))).toBe(false);
     expect(existsSync(join(outputRoot, "suggested-doc-edits.md"))).toBe(false);
   });

--- a/tests/openwiki-eval-gates.test.ts
+++ b/tests/openwiki-eval-gates.test.ts
@@ -71,6 +71,20 @@ describe("OpenWiki eval gates", () => {
     expect(readFileSync(result.artifacts["repo-wiki-context-ab-summary.json"]!, "utf8")).not.toContain(secret);
   });
 
+  it("fails closed before A/B summaries can include secret-like packet metadata", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-ab-summary-secret-"));
+    roots.push(outputRoot);
+    const input = buildAbInput();
+    input.modes.openwiki.packetSha = "ghp_1234567890abcdef";
+
+    expect(() => runRepoWikiContextAbEval(input, {
+      outputRoot,
+      now: new Date(generatedAt)
+    })).toThrow("repo-wiki context A/B summary contains secret-like text");
+    expect(existsSync(join(outputRoot, "repo-wiki-context-ab-summary.json"))).toBe(false);
+    expect(existsSync(join(outputRoot, "repo-wiki-context-ab-report.md"))).toBe(false);
+  });
+
   it("fails A/B eval when OpenWiki context adds a P1 false positive", () => {
     const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-ab-fail-"));
     roots.push(outputRoot);
@@ -124,6 +138,18 @@ describe("OpenWiki eval gates", () => {
       now: new Date(generatedAt)
     })).toThrow("outputRoot must be empty before running repo-wiki context A/B eval");
     expect(existsSync(join(outputRoot, "repo-wiki-context-ab-summary.json"))).toBe(false);
+  });
+
+  it("validates A/B thresholds before creating the output root", () => {
+    const outputRoot = join(tmpdir(), `neondiff-ab-invalid-threshold-${Date.now()}`);
+    const input = buildAbInput();
+    input.thresholds = { minPrecision: 0.1 };
+
+    expect(() => runRepoWikiContextAbEval(input, {
+      outputRoot,
+      now: new Date(generatedAt)
+    })).toThrow('minPrecision below the default requires mode="exploratory"');
+    expect(existsSync(outputRoot)).toBe(false);
   });
 
   it("buckets unmatched false positives by their scorecard severity", () => {
@@ -310,6 +336,26 @@ describe("OpenWiki eval gates", () => {
     })).toThrow("outputRoot must be empty before running OpenWiki docs-drift eval");
     expect(existsSync(join(outputRoot, "docs-drift-summary.json"))).toBe(false);
     expect(existsSync(join(outputRoot, "suggested-doc-edits.md"))).toBe(false);
+  });
+
+  it("rejects zero docs-drift stale-claim thresholds before creating artifacts", () => {
+    const { packetPath, root } = createDocsDriftFixture();
+    const outputRoot = join(tmpdir(), `neondiff-docs-drift-zero-threshold-${Date.now()}`);
+    roots.push(root);
+
+    expect(() => runDocsDriftEval({
+      runId: "docs-drift-zero-threshold",
+      repo,
+      headSha,
+      worktreePath: root,
+      packetPath,
+      thresholds: { minStaleCaught: 0 },
+      claims: buildDocsDriftClaims()
+    }, {
+      outputRoot,
+      now: new Date(generatedAt)
+    })).toThrow("minStaleCaught must be a positive integer");
+    expect(existsSync(outputRoot)).toBe(false);
   });
 
   it("rejects packet paths that resolve outside the worktree", () => {

--- a/tests/openwiki-eval-gates.test.ts
+++ b/tests/openwiki-eval-gates.test.ts
@@ -1,0 +1,265 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  runDocsDriftEval,
+  runRepoWikiContextAbEval,
+  type DocsDriftSeedClaim,
+  type RepoWikiContextAbEvalInput
+} from "../src/openwiki-eval-gates.js";
+import { buildRepoWikiPacket, formatRepoWikiPacketJson } from "../src/repo-wiki-packet.js";
+
+const generatedAt = "2026-07-09T09:10:00.000Z";
+const repo = "electricsheephq/evaos-code-review-bot-neondiff";
+const headSha = "b224ecc8146e4005ea471e3f1adc664e55828170";
+
+describe("OpenWiki eval gates", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("passes A/B eval when deterministic and OpenWiki context preserve precision and P0/P1 noise", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-ab-pass-"));
+    roots.push(outputRoot);
+
+    const result = runRepoWikiContextAbEval(buildAbInput(), {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.summary.comparisons.openwiki).toMatchObject({
+      precisionDelta: 0,
+      p0p1FalsePositiveDelta: 0
+    });
+    expect(readFileSync(result.artifacts["repo-wiki-context-ab-report.md"]!, "utf8")).toContain("Repo-Wiki Context A/B Eval");
+  });
+
+  it("fails A/B eval when OpenWiki context adds a P1 false positive", () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-ab-fail-"));
+    roots.push(outputRoot);
+    const input = buildAbInput();
+    input.modes.openwiki.botFindings = {
+      findings: [
+        buildReviewFinding(),
+        {
+          severity: "P1",
+          path: "src/worker.ts",
+          line: 33,
+          title: "Provider fallback leaks paid tokens",
+          body: "This unrelated finding claims paid fallback behavior without label support.",
+          confidence: 0.9
+        }
+      ]
+    };
+
+    const result = runRepoWikiContextAbEval(input, {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.gates).toContainEqual(expect.objectContaining({
+      name: "openwiki_no_p0_p1_false_positive_regression",
+      ok: false
+    }));
+  });
+
+  it("passes docs-drift eval with source-cited suggestions and true-claim traps", () => {
+    const { packetPath, root } = createDocsDriftFixture();
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-pass-"));
+    roots.push(root, outputRoot);
+
+    const result = runDocsDriftEval({
+      runId: "seeded-docs-drift",
+      repo,
+      headSha,
+      worktreePath: root,
+      packetPath,
+      claims: buildDocsDriftClaims()
+    }, {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.summary.counts).toMatchObject({
+      staleCaught: 5,
+      materialFalsePositives: 0,
+      suggestions: 5
+    });
+    expect(result.summary.suggestions.every((suggestion) => suggestion.packetSectionIds.length > 0)).toBe(true);
+    expect(readFileSync(result.artifacts["suggested-doc-edits.md"]!, "utf8")).toContain("Suggested Doc Edits");
+  });
+
+  it("fails docs-drift eval when a true trap would be rewritten", () => {
+    const { packetPath, root } = createDocsDriftFixture({ trueTrapMismatch: true });
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-fail-"));
+    roots.push(root, outputRoot);
+
+    const result = runDocsDriftEval({
+      runId: "seeded-docs-drift-fail",
+      repo,
+      headSha,
+      worktreePath: root,
+      packetPath,
+      claims: buildDocsDriftClaims({ trueTrapMismatch: true }),
+      thresholds: {
+        maxMaterialFalsePositives: 0
+      }
+    }, {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.counts.materialFalsePositives).toBe(1);
+    expect(result.summary.gates).toContainEqual(expect.objectContaining({
+      name: "false_positive_limit",
+      ok: false
+    }));
+  });
+});
+
+function buildAbInput(): RepoWikiContextAbEvalInput {
+  return {
+    runId: "repo-wiki-context-ab",
+    repo,
+    pullNumber: 480,
+    headSha,
+    suite: "seeded_defect_recall",
+    providerProof: { mode: "offline_fixture", paidFallbackUsed: false },
+    labels: [{
+      source: "seeded_defect",
+      severity: "P1",
+      path: "src/worker.ts",
+      line: 12,
+      title: "Fresh repo wiki context must not override the diff",
+      body: "The review should preserve the current diff as authority when repo wiki context is present.",
+      sourceId: "seed-repo-wiki-authority"
+    }],
+    modes: {
+      baseline: { botFindings: { findings: [buildReviewFinding()] } },
+      deterministic: {
+        botFindings: { findings: [buildReviewFinding()] },
+        packetSha: "deterministic-packet",
+        freshness: "fresh",
+        degraded: false
+      },
+      openwiki: {
+        botFindings: { findings: [buildReviewFinding()] },
+        packetSha: "openwiki-packet",
+        freshness: "fresh",
+        degraded: false
+      }
+    }
+  };
+}
+
+function buildReviewFinding() {
+  return {
+    severity: "P1",
+    path: "src/worker.ts",
+    line: 12,
+    title: "Fresh repo wiki context must not override the diff",
+    body: "The review should preserve the current diff as authority when repo wiki context is present.",
+    confidence: 0.96
+  };
+}
+
+function createDocsDriftFixture(options: { trueTrapMismatch?: boolean } = {}): { root: string; packetPath: string } {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-fixture-"));
+  mkdirSync(join(root, "docs"), { recursive: true });
+  mkdirSync(join(root, "src"), { recursive: true });
+  mkdirSync(join(root, ".neondiff"), { recursive: true });
+  writeFileSync(
+    join(root, "docs", "repo-wiki-packet.md"),
+    [
+      "# Repo Wiki Packet",
+      "Use raw OpenWiki Markdown directly in prompts.",
+      "OpenWiki docs may update runtime daemon config.",
+      "Repo wiki context is enabled by default.",
+      "Docs drift edits can rewrite docs directly.",
+      "OpenWiki replaces API documentation.",
+      options.trueTrapMismatch
+        ? "Repo wiki context may override the PR diff."
+        : "Repo wiki context is advisory only.",
+      "Missing packets degrade safely.",
+      "Suggestions are written outside production docs."
+    ].join("\n"),
+    "utf8"
+  );
+  writeFileSync(
+    join(root, "src", "repo-wiki-context.ts"),
+    [
+      "export const promptPolicy = 'Curated packets quote untrusted data only.';",
+      "export const runtimePolicy = 'No production daemon config change.';",
+      "export const defaultPolicy = 'repoWikiContext.enabled defaults false.';",
+      "export const docsPolicy = 'Docs drift is suggest-only.';",
+      "export const apiPolicy = 'OpenWiki is not authoritative API documentation.';",
+      "export const advisoryPolicy = 'Repo wiki context is advisory only.';",
+      "export const missingPolicy = 'Missing packets degrade safely.';",
+      "export const suggestionPolicy = 'Suggestions are written outside production docs.';"
+    ].join("\n"),
+    "utf8"
+  );
+  const packet = buildRepoWikiPacket({
+    repo: { fullName: repo, defaultBranch: "main" },
+    source: { ref: "main", headSha, checkedAt: generatedAt, status: "fresh" },
+    generatedAt,
+    budget: { maxBytes: 12_000 },
+    sections: [{
+      id: "repo-wiki-context",
+      title: "Repo Wiki Context",
+      body: "OpenWiki-derived context is curated, advisory, default-off, and suggest-only for docs drift.",
+      sourceFiles: ["docs/repo-wiki-packet.md", "src/repo-wiki-context.ts"]
+    }]
+  });
+  const packetPath = ".neondiff/repo-wiki-packet.json";
+  writeFileSync(join(root, packetPath), formatRepoWikiPacketJson(packet), "utf8");
+  return { root, packetPath };
+}
+
+function buildDocsDriftClaims(options: { trueTrapMismatch?: boolean } = {}): DocsDriftSeedClaim[] {
+  const stale: DocsDriftSeedClaim[] = [
+    claim("stale-raw-prompt", "Use raw OpenWiki Markdown directly in prompts.", "Curated packets quote untrusted data only."),
+    claim("stale-runtime", "OpenWiki docs may update runtime daemon config.", "No production daemon config change."),
+    claim("stale-default", "Repo wiki context is enabled by default.", "repoWikiContext.enabled defaults false."),
+    claim("stale-doc-edit", "Docs drift edits can rewrite docs directly.", "Docs drift is suggest-only."),
+    claim("stale-api-docs", "OpenWiki replaces API documentation.", "OpenWiki is not authoritative API documentation.")
+  ];
+  const trueClaims: DocsDriftSeedClaim[] = [
+    claim(
+      "true-advisory",
+      options.trueTrapMismatch ? "Repo wiki context may override the PR diff." : "Repo wiki context is advisory only.",
+      "Repo wiki context is advisory only.",
+      "true",
+      7
+    ),
+    claim("true-missing", "Missing packets degrade safely.", "Missing packets degrade safely.", "true", 8),
+    claim("true-suggestions", "Suggestions are written outside production docs.", "Suggestions are written outside production docs.", "true", 9)
+  ];
+  return [...stale, ...trueClaims];
+}
+
+function claim(
+  id: string,
+  currentClaim: string,
+  currentText: string,
+  expected: "stale" | "true" = "stale",
+  line = 2
+): DocsDriftSeedClaim {
+  return {
+    id,
+    expected,
+    docPath: "docs/repo-wiki-packet.md",
+    line,
+    claim: currentClaim,
+    sourcePath: "src/repo-wiki-context.ts",
+    currentText,
+    suggestion: currentText
+  };
+}

--- a/tests/openwiki-eval-gates.test.ts
+++ b/tests/openwiki-eval-gates.test.ts
@@ -296,6 +296,63 @@ describe("OpenWiki eval gates", () => {
     }));
   });
 
+  it("does not suggest docs-drift edits when the seeded line does not contain the claim", () => {
+    const { packetPath, root } = createDocsDriftFixture();
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-wrong-line-"));
+    roots.push(root, outputRoot);
+    const claimWithWrongLine = {
+      ...buildDocsDriftClaims()[0]!,
+      line: 9
+    };
+
+    const result = runDocsDriftEval({
+      runId: "docs-drift-wrong-line",
+      repo,
+      headSha,
+      worktreePath: root,
+      packetPath,
+      thresholds: { minStaleCaught: 1 },
+      claims: [claimWithWrongLine]
+    }, {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.counts.suggestions).toBe(0);
+    expect(result.summary.claims).toContainEqual(expect.objectContaining({
+      id: "stale-raw-prompt",
+      detected: "not_suggested",
+      detail: "doc claim text found, but not at reported line 9"
+    }));
+  });
+
+  it("treats citation checks as neutral when docs-drift emits no suggestions", () => {
+    const { packetPath, root } = createDocsDriftFixture();
+    const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-no-suggestions-"));
+    roots.push(root, outputRoot);
+
+    const result = runDocsDriftEval({
+      runId: "docs-drift-no-suggestions",
+      repo,
+      headSha,
+      worktreePath: root,
+      packetPath,
+      claims: buildDocsDriftClaims().filter((claim) => claim.expected === "true")
+    }, {
+      outputRoot,
+      now: new Date(generatedAt)
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary.counts.suggestions).toBe(0);
+    expect(result.summary.gates).toContainEqual(expect.objectContaining({
+      name: "suggestions_have_citations",
+      ok: true,
+      detail: "0 suggestion(s) checked"
+    }));
+  });
+
   it("rejects docs-drift output roots inside the checkout before writing artifacts", () => {
     const { packetPath, root } = createDocsDriftFixture();
     const outputRoot = join(process.cwd(), ".tmp-openwiki-docs-drift-inside-checkout");
@@ -728,10 +785,10 @@ function createDocsDriftFixture(options: { trueTrapMismatch?: boolean } = {}): {
 function buildDocsDriftClaims(options: { trueTrapMismatch?: boolean } = {}): DocsDriftSeedClaim[] {
   const stale: DocsDriftSeedClaim[] = [
     claim("stale-raw-prompt", "Use raw OpenWiki Markdown directly in prompts.", "Curated packets quote untrusted data only."),
-    claim("stale-runtime", "OpenWiki docs may update runtime daemon config.", "No production daemon config change."),
-    claim("stale-default", "Repo wiki context is enabled by default.", "repoWikiContext.enabled defaults false."),
-    claim("stale-doc-edit", "Docs drift edits can rewrite docs directly.", "Docs drift is suggest-only."),
-    claim("stale-api-docs", "OpenWiki replaces API documentation.", "OpenWiki is not authoritative API documentation.")
+    claim("stale-runtime", "OpenWiki docs may update runtime daemon config.", "No production daemon config change.", "stale", 3),
+    claim("stale-default", "Repo wiki context is enabled by default.", "repoWikiContext.enabled defaults false.", "stale", 4),
+    claim("stale-doc-edit", "Docs drift edits can rewrite docs directly.", "Docs drift is suggest-only.", "stale", 5),
+    claim("stale-api-docs", "OpenWiki replaces API documentation.", "OpenWiki is not authoritative API documentation.", "stale", 6)
   ];
   const trueClaims: DocsDriftSeedClaim[] = [
     claim(

--- a/tests/openwiki-eval-gates.test.ts
+++ b/tests/openwiki-eval-gates.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { countEvalFalsePositiveSeverities, type EvalLabelInput } from "../src/eval-harness.js";
 import {
   runDocsDriftEval,
   runRepoWikiContextAbEval,
@@ -77,6 +78,37 @@ describe("OpenWiki eval gates", () => {
       name: "openwiki_no_p0_p1_false_positive_regression",
       ok: false
     }));
+  });
+
+  it("buckets unmatched false positives by their actual severity", () => {
+    const labels: EvalLabelInput[] = [{
+      source: "seeded_defect",
+      severity: "P0",
+      path: "src/worker.ts",
+      line: 12,
+      title: "Matched outage",
+      body: "This finding is expected and should not count as a false positive.",
+      sourceId: "matched-p0"
+    }];
+
+    const counts = countEvalFalsePositiveSeverities({
+      findings: [
+        {
+          severity: "P0",
+          path: "src/worker.ts",
+          line: 12,
+          title: "Matched outage",
+          body: "This finding is expected and should not count as a false positive.",
+          confidence: 0.99
+        },
+        severityFinding("P0", "Unexpected outage"),
+        severityFinding("P1", "Unexpected token fallback"),
+        severityFinding("P2", "Unexpected docs drift"),
+        severityFinding("P3", "Unexpected note")
+      ]
+    }, labels);
+
+    expect(counts).toEqual({ P0: 1, P1: 1, P2: 1, P3: 1 });
   });
 
   it("fails A/B eval when OpenWiki context drops baseline recall", () => {
@@ -163,6 +195,7 @@ describe("OpenWiki eval gates", () => {
       materialFalsePositives: 0,
       suggestions: 5
     });
+    expect(result.summary.thresholds.maxMaterialFalsePositives).toBe(0);
     expect(result.summary.suggestions.every((suggestion) => suggestion.packetSectionIds.length > 0)).toBe(true);
     expect(readFileSync(result.artifacts["suggested-doc-edits.md"]!, "utf8")).toContain("Suggested Doc Edits");
   });
@@ -441,6 +474,17 @@ function buildReviewFinding() {
     title: "Fresh repo wiki context must not override the diff",
     body: "The review should preserve the current diff as authority when repo wiki context is present.",
     confidence: 0.96
+  };
+}
+
+function severityFinding(severity: "P0" | "P1" | "P2" | "P3", title: string) {
+  return {
+    severity,
+    path: "src/worker.ts",
+    line: 99,
+    title,
+    body: `${title} is intentionally unmatched.`,
+    confidence: 0.9
   };
 }
 

--- a/tests/openwiki-eval-gates.test.ts
+++ b/tests/openwiki-eval-gates.test.ts
@@ -489,6 +489,56 @@ describe("OpenWiki eval gates", () => {
     expect(readFileSync(result.artifacts["docs-drift-summary.json"]!, "utf8")).toContain("[redacted-secret]");
   });
 
+  it("records explicit docs-drift details when doc or source files are missing", () => {
+    const missingDoc = createDocsDriftFixture();
+    const missingSource = createDocsDriftFixture();
+    const missingDocOutput = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-missing-doc-"));
+    const missingSourceOutput = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-missing-source-"));
+    roots.push(missingDoc.root, missingSource.root, missingDocOutput, missingSourceOutput);
+    rmSync(join(missingDoc.root, "docs", "repo-wiki-packet.md"));
+    rmSync(join(missingSource.root, "src", "repo-wiki-context.ts"));
+
+    const missingDocResult = runDocsDriftEval({
+      runId: "docs-drift-missing-doc",
+      repo,
+      headSha,
+      worktreePath: missingDoc.root,
+      packetPath: missingDoc.packetPath,
+      thresholds: { minStaleCaught: 1 },
+      claims: [buildDocsDriftClaims()[0]!]
+    }, {
+      outputRoot: missingDocOutput,
+      now: new Date(generatedAt)
+    });
+    const missingSourceResult = runDocsDriftEval({
+      runId: "docs-drift-missing-source",
+      repo,
+      headSha,
+      worktreePath: missingSource.root,
+      packetPath: missingSource.packetPath,
+      thresholds: { minStaleCaught: 1 },
+      claims: [buildDocsDriftClaims()[0]!]
+    }, {
+      outputRoot: missingSourceOutput,
+      now: new Date(generatedAt)
+    });
+
+    expect(missingDocResult.ok).toBe(false);
+    expect(missingDocResult.summary.claims[0]).toMatchObject({
+      id: "stale-raw-prompt",
+      detected: "not_suggested",
+      ok: false,
+      detail: "doc file unreadable: docPath does not exist"
+    });
+    expect(missingSourceResult.ok).toBe(false);
+    expect(missingSourceResult.summary.claims[0]).toMatchObject({
+      id: "stale-raw-prompt",
+      detected: "not_suggested",
+      ok: false,
+      detail: "source file unreadable: sourcePath does not exist"
+    });
+  });
+
   it("fails closed before docs-drift summaries can include secret-like metadata", () => {
     const { packetPath, root } = createDocsDriftFixture();
     const outputRoot = mkdtempSync(join(tmpdir(), "neondiff-docs-drift-summary-secret-"));
@@ -509,6 +559,7 @@ describe("OpenWiki eval gates", () => {
     })).toThrow("docs-drift summary contains secret-like text");
     expect(existsSync(join(outputRoot, "docs-drift-summary.json"))).toBe(false);
     expect(existsSync(join(outputRoot, "docs-drift-report.md"))).toBe(false);
+    expect(existsSync(join(outputRoot, "suggested-doc-edits.md"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds the offline eval gates for the OpenWiki fork-first roadmap:

- `eval-repo-wiki-context-ab` compares baseline, deterministic repo-wiki, and curated OpenWiki-derived findings.
- `eval-openwiki-docs-drift` scores seeded stale-doc claims and writes suggest-only artifacts.
- Documents the new commands in the eval harness guide.

This is stacked on #480 and keeps the feature default-off. It does not enable production daemon behavior, cron, live posting, raw OpenWiki prompt injection, or arbitrary docs edits.

Refs #415, #476, #478, #480.

## Evidence

Evidence root: `/Volumes/LEXAR/Codex/neondiff-openwiki-context/2026-07-09/eval-gates/`

A/B gate:

- Command: `npx tsx src/cli.ts eval-repo-wiki-context-ab --input /Volumes/LEXAR/Codex/neondiff-openwiki-context/2026-07-09/eval-gates/inputs/repo-wiki-context-ab.json --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/2026-07-09/eval-gates/ab`
- Result: passed; baseline, deterministic, and OpenWiki-derived modes all had precision 1, recall 1, 0 false positives, 0 P0/P1 false-positive regression, 0 secret findings, and no paid-provider fallback.

Docs-drift gate:

- Command: `npx tsx src/cli.ts eval-openwiki-docs-drift --input /Volumes/LEXAR/Codex/neondiff-openwiki-context/2026-07-09/eval-gates/inputs/docs-drift.json --output-root /Volumes/LEXAR/Codex/neondiff-openwiki-context/2026-07-09/eval-gates/docs-drift`
- Result: passed; caught 5/5 seeded stale claims, 0/3 true-trap false positives, 5 source-cited suggestions.

## Validation

- `npx vitest run tests/openwiki-eval-gates.test.ts tests/openwiki-derived-packet.test.ts tests/repo-wiki-context.test.ts tests/eval-harness.test.ts` = 73 passed.
- `npm run build` passed.
- `npm run check:secrets` passed, 438 tracked files.
- `git diff --check` passed.
