### PR TITLE
[codex] Prepare v1.0.1 release hygiene patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 26
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 26
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,7 +22,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
 
@@ -55,11 +55,21 @@ jobs:
 
       - name: Setup Node.js
         if: steps.package_release.outputs.should_publish == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 26
           registry-url: https://registry.npmjs.org
           cache: npm
+
+      - name: Verify npm publish token is configured
+        if: steps.package_release.outputs.should_publish == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error::NPM_TOKEN Actions secret is not configured; publish cannot continue"
+            exit 1
+          fi
 
       - name: Install dependencies
         if: steps.package_release.outputs.should_publish == 'true'

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,7 +22,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,7 +9,7 @@ on:
       tag:
         description: Release tag to publish
         required: true
-        default: v0.4.30-beta.1
+        default: v1.0.1
 
 permissions:
   contents: read

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,7 +22,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
 
@@ -53,14 +53,6 @@ jobs:
           echo "should_publish=true" >> "$GITHUB_OUTPUT"
           echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
 
-      - name: Setup Node.js
-        if: steps.package_release.outputs.should_publish == 'true'
-        uses: actions/setup-node@v5
-        with:
-          node-version: 26
-          registry-url: https://registry.npmjs.org
-          cache: npm
-
       - name: Verify npm publish token is configured
         if: steps.package_release.outputs.should_publish == 'true'
         env:
@@ -70,6 +62,14 @@ jobs:
             echo "::error::NPM_TOKEN Actions secret is not configured; publish cannot continue"
             exit 1
           fi
+
+      - name: Setup Node.js
+        if: steps.package_release.outputs.should_publish == 'true'
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 26
+          registry-url: https://registry.npmjs.org
+          cache: npm
 
       - name: Install dependencies
         if: steps.package_release.outputs.should_publish == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ for the semver/GA-line and npm dist-tag policy.
 
 No unreleased changes tracked yet.
 
+## [1.0.1] - docs/releases/v1.0.1.md
+
+### Changed
+
+- Remove pre-1.0 npm beta install exposure and historical GitHub prerelease
+  pages while preserving Git tags/source refs for provenance and rollback.
+- Add npm publish-token preflight and move public CI/publish workflows to
+  Node 24-compatible official Actions.
+- Refresh stable release manifest, license API proof, authenticated issuance
+  proof, rollback proof, installer default, and public release-readiness checks
+  for the first post-GA patch.
+
 ## [1.0.0] - docs/releases/v1.0.0.md
 
 ### Added

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -24,8 +24,8 @@ jobs:
   neondiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 26
           cache: npm

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -24,8 +24,8 @@ jobs:
   neondiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 26
           cache: npm

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -24,7 +24,7 @@ jobs:
   neondiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 26

--- a/docs/evidence/v1.0.1-license-api-healthz.json
+++ b/docs/evidence/v1.0.1-license-api-healthz.json
@@ -1,0 +1,19 @@
+{
+  "evidenceKind": "license_api_healthz",
+  "releaseVersion": "v1.0.1",
+  "observedAt": "2026-07-09T12:24:33.521Z",
+  "method": "GET",
+  "url": "https://neondiff-license.fly.dev/healthz",
+  "statusCode": 200,
+  "responseBody": "{\"status\":\"ok\"}",
+  "responseBodySha256": "a29ee2b15c494311c52521766e44af56a3ad2248e7a8ab465e5206463c13d288",
+  "captureContext": {
+    "tool": "node fetch",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "Codex Desktop macOS operator shell",
+    "dnsResolution": "system resolver",
+    "note": "Captured with normal system DNS resolution and Node default TLS validation."
+  },
+  "redaction": "No license key, token, cookie, customer data, or private repo content was present in this health check."
+}

--- a/docs/evidence/v1.0.1-license-checkout-issuance-authenticated.json
+++ b/docs/evidence/v1.0.1-license-checkout-issuance-authenticated.json
@@ -1,0 +1,21 @@
+{
+  "evidenceKind": "license_api_checkout_issuance_authenticated",
+  "releaseVersion": "v1.0.1",
+  "observedAt": "2026-07-09T12:24:48.002Z",
+  "method": "POST",
+  "url": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
+  "statusCode": 200,
+  "redactedResponse": {
+    "status": "issued",
+    "replayed": false,
+    "checkoutLookupKey": "neondiff_monthly",
+    "issuedLicensePrefix": "nd_live_",
+    "issuedLicenseFingerprint": "sha256:60e0b9b190953fdd17f49bb18b7c8296598f574cbc7125ca3ed3ba069021a80b"
+  },
+  "captureContext": {
+    "tool": "neondiff checkout-issuance-smoke",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "operator CLI"
+  }
+}

--- a/docs/evidence/v1.0.1-license-checkout-issuance-unauthenticated.json
+++ b/docs/evidence/v1.0.1-license-checkout-issuance-unauthenticated.json
@@ -1,0 +1,19 @@
+{
+  "evidenceKind": "license_api_checkout_issuance",
+  "releaseVersion": "v1.0.1",
+  "observedAt": "2026-07-09T12:24:33.814Z",
+  "method": "POST",
+  "url": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
+  "statusCode": 401,
+  "responseBody": "{\"status\":\"unauthorized\",\"detail\":\"license issuance authorization failed\"}",
+  "responseBodySha256": "a67612cc05a222fc5d28aa36be40d59daf7b32bca36f305d66c57db869150e20",
+  "captureContext": {
+    "tool": "node fetch",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "Codex Desktop macOS operator shell",
+    "dnsResolution": "system resolver",
+    "note": "Captured without Authorization header to prove configured fail-closed behavior."
+  },
+  "redaction": "No license key, bearer token, cookie, customer data, or checkout payload secret was sent or captured."
+}

--- a/docs/evidence/v1.0.1-rollback-refs.json
+++ b/docs/evidence/v1.0.1-rollback-refs.json
@@ -1,0 +1,28 @@
+{
+  "evidenceKind": "release_rollback_refs",
+  "releaseVersion": "v1.0.1",
+  "observedAt": "2026-07-09T12:25:30.315Z",
+  "channels": {
+    "cli": {
+      "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
+      "rollbackCommand": "git reset --hard refs/tags/v1.0.0",
+      "rollbackTarget": "v1.0.0",
+      "targetVerifiedBy": "git rev-list -n 1 refs/tags/v1.0.0",
+      "targetVerifiedSha": "23d66717c0627b25a8c56895bba9627bcdd69cca"
+    },
+    "daemon": {
+      "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
+      "rollbackCommand": "git reset --hard refs/tags/v1.0.0",
+      "rollbackTarget": "v1.0.0",
+      "targetVerifiedBy": "git rev-list -n 1 refs/tags/v1.0.0",
+      "targetVerifiedSha": "23d66717c0627b25a8c56895bba9627bcdd69cca"
+    },
+    "browserDashboard": {
+      "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
+      "rollbackCommand": "git reset --hard refs/tags/v1.0.0",
+      "rollbackTarget": "v1.0.0",
+      "targetVerifiedBy": "git rev-list -n 1 refs/tags/v1.0.0",
+      "targetVerifiedSha": "23d66717c0627b25a8c56895bba9627bcdd69cca"
+    }
+  }
+}

--- a/docs/evidence/v1.0.1-rollback-refs.json
+++ b/docs/evidence/v1.0.1-rollback-refs.json
@@ -23,6 +23,16 @@
       "rollbackTarget": "v1.0.0",
       "targetVerifiedBy": "git rev-list -n 1 refs/tags/v1.0.0",
       "targetVerifiedSha": "23d66717c0627b25a8c56895bba9627bcdd69cca"
+    },
+    "website": {
+      "rollbackRepository": "electricsheephq/neon-diff-agent-website",
+      "rollbackCommand": "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+      "rollbackTarget": "6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+      "targetVerifiedBy": "gh api repos/electricsheephq/neon-diff-agent-website/commits/6b670d00cd587fb7d564347b6bc0d4d3e8d13186 --jq .sha",
+      "targetVerifiedSha": "6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+      "targetUrl": "https://github.com/electricsheephq/neon-diff-agent-website/commit/6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+      "targetSubject": "fix: support custom Stripe webhook secret (#35)"
     }
-  }
+  },
+  "proofBoundary": "Rollback refs are repo-scoped. Website rollback must be run from the website repo, not from the NeonDiff product checkout."
 }

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -122,11 +122,11 @@
     "website": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v1.0.0",
+      "version": "v1.0.1",
       "rollback": "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
       "rollbackRepository": "electricsheephq/neon-diff-agent-website",
       "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/450",
-      "note": "No website code changes ship in v1.0.1; this channel remains declared so the hosted install surface stays part of release-status."
+      "note": "The hosted installer remains part of release-status for v1.0.1. It serves an installer that defaults to npm latest, so no website code deploy is required for the installer to pick up neondiff@1.0.1 after the npm latest promotion."
     }
   }
 }

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,12 +1,12 @@
 {
-  "version": "v1.0.0",
+  "version": "v1.0.1",
   "releaseLevel": "stable",
   "packageArtifact": {
     "name": "neondiff",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "requiredForThisRelease": true,
     "state": "published",
-    "previousReleasedPackageVersion": "0.4.30-beta.1",
+    "previousReleasedPackageVersion": "1.0.0",
     "skippedPublicPackageVersions": [
       "v0.4.25-beta.1",
       "v0.4.26-beta.1",
@@ -30,11 +30,11 @@
       "v0.4.45-beta.1",
       "v0.4.46-beta.1"
     ],
-    "note": "v1.0.0 is the first GA npm package cut after the source/local-worker beta train; the non-prerelease GitHub Release publishes the package with the npm latest dist-tag."
+    "note": "v1.0.1 is the first stable patch after GA: it keeps the license-gated npm latest line, removes pre-1.0 beta install exposure, and hardens release workflow preflights."
   },
   "source": {
     "shaState": "pending_tag_stamp",
-    "candidateHeadBeforeReleaseMetadata": "7453349008ca8f23641fab1665ac909d0b51b10a",
+    "candidateHeadBeforeReleaseMetadata": "23d66717c0627b25a8c56895bba9627bcdd69cca",
     "proof": "after merge and tag, release:status --expected-head $(git rev-parse HEAD)"
   },
   "releaseStages": {
@@ -78,9 +78,9 @@
     ]
   },
   "docs": {
-    "version": "v1.0.0",
+    "version": "v1.0.1",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v1.0.0.md",
+    "releaseNotesPath": "docs/releases/v1.0.1.md",
     "websiteRepo": "electricsheephq/neon-diff-agent-website"
   },
   "licenseApi": {
@@ -88,42 +88,36 @@
     "state": "healthy",
     "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327",
     "healthUrl": "https://neondiff-license.fly.dev/healthz",
-    "healthProofPath": "docs/evidence/v1.0.0-license-api-healthz.json",
+    "healthProofPath": "docs/evidence/v1.0.1-license-api-healthz.json",
     "checkoutIssuanceRequiredForThisRelease": true,
     "checkoutIssuanceUrl": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
     "checkoutIssuanceState": "ready",
-    "checkoutIssuanceProofPath": "docs/evidence/v1.0.0-license-checkout-issuance-unauthenticated.json",
-    "checkoutIssuanceAuthenticatedProofPath": "docs/evidence/license-checkout-issuance-authenticated.json",
+    "checkoutIssuanceProofPath": "docs/evidence/v1.0.1-license-checkout-issuance-unauthenticated.json",
+    "checkoutIssuanceAuthenticatedProofPath": "docs/evidence/v1.0.1-license-checkout-issuance-authenticated.json",
     "checkoutIssuanceTrackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
   },
   "updateChannels": {
     "cli": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v1.0.0",
-      "rollback": "git reset --hard refs/tags/v0.4.46-beta.1"
+      "version": "v1.0.1",
+      "rollback": "git reset --hard refs/tags/v1.0.0",
+      "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v1.0.0",
-      "rollback": "git reset --hard refs/tags/v0.4.46-beta.1"
+      "version": "v1.0.1",
+      "rollback": "git reset --hard refs/tags/v1.0.0",
+      "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "browserDashboard": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v1.0.0",
-      "rollback": "git revert 74d133ff34935510c45a4a74a664b8b30dca52d8",
+      "version": "v1.0.1",
+      "rollback": "git reset --hard refs/tags/v1.0.0",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
       "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
-    },
-    "website": {
-      "requiredForThisRelease": true,
-      "state": "published",
-      "version": "v1.0.0",
-      "rollback": "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
-      "rollbackRepository": "electricsheephq/neon-diff-agent-website",
-      "trackingIssue": "https://github.com/electricsheephq/neon-diff-agent-website/issues/22"
     }
   }
 }

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -118,6 +118,15 @@
       "rollback": "git reset --hard refs/tags/v1.0.0",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
       "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
+    },
+    "website": {
+      "requiredForThisRelease": true,
+      "state": "published",
+      "version": "v1.0.0",
+      "rollback": "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+      "rollbackRepository": "electricsheephq/neon-diff-agent-website",
+      "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/450",
+      "note": "No website code changes ship in v1.0.1; this channel remains declared so the hosted install surface stays part of release-status."
     }
   }
 }

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -165,14 +165,15 @@ The publish workflow fails early in `Verify npm publish token is configured`
 when the secret is absent so release captains do not spend a full release cycle
 before discovering npm authentication is missing.
 
-The required GitHub Actions paths should use official action majors compatible
-with the GitHub Actions Node 24 runtime while still installing the project
-runtime pinned by each workflow. The public CI and npm publish workflows use
-`actions/checkout@v5` and `actions/setup-node@v5`, and they continue to install
-Node.js 26 for NeonDiff itself. Runner fleets must be on GitHub Actions runner
-`v2.327.1` or newer for those actions. Pinned Swift or desktop smoke actions
-that still target the older action runtime are post-launch desktop-release
-hygiene unless they block the current release.
+The required GitHub Actions paths should pin official action majors to immutable
+commit SHAs while staying compatible with the GitHub Actions Node 24 runtime and
+the project runtime installed by each workflow. The public CI and npm publish
+workflows currently use the approved v5 commits for `actions/checkout` and
+`actions/setup-node`, and they continue to install Node.js 26 for NeonDiff
+itself. Runner fleets must be on GitHub Actions runner `v2.327.1` or newer for
+those actions. Pinned Swift or desktop smoke actions that still target the older
+action runtime are post-launch desktop-release hygiene unless they block the
+current release.
 
 The manifest `rollback` field is intentionally only the source-revert step.
 Full operator rollback runbooks may restart launchd after that source revert,

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -158,6 +158,20 @@ Before tagging:
      `git reset --hard refs/tags/<tag>` or `git revert <sha>`
 7. `git status --short` is clean in the live checkout.
 
+For npm-published releases, confirm the repository or organization Actions
+secret `NPM_TOKEN` exists before publishing. Verify only the secret name and
+workflow preflight status; never print, echo, upload, or paste the token value.
+The publish workflow fails early in `Verify npm publish token is configured`
+when the secret is absent so release captains do not spend a full release cycle
+before discovering npm authentication is missing.
+
+The required GitHub Actions paths should use Node 24-compatible official
+actions. The public CI and npm publish workflows use `actions/checkout@v5` and
+`actions/setup-node@v5`; runner fleets must be on GitHub Actions runner
+`v2.327.1` or newer for those actions. Pinned Swift or desktop smoke actions
+that still target the older runtime are post-launch desktop-release hygiene
+unless they block the current release.
+
 The manifest `rollback` field is intentionally only the source-revert step.
 Full operator rollback runbooks may restart launchd after that source revert,
 but restart commands live outside the manifest rollback field. `launchctl
@@ -177,6 +191,13 @@ git pull --ff-only origin main
 git tag -a vX.Y.Z-beta.N <source-sha> -m "vX.Y.Z-beta.N"
 git push origin vX.Y.Z-beta.N
 ```
+
+If a GitHub Release exists but the npm publish workflow fails before publishing,
+repair the workflow or secret state, then rerun the `Publish npm` workflow for
+the exact release tag. Do not create a replacement tag for the same source SHA
+solely to retry publishing. Record the failed run URL, rerun URL, registry
+inventory, and final `npm view neondiff version dist-tags --json` output in the
+release tracker.
 
 Create the GitHub prerelease from the release packet:
 

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -166,14 +166,14 @@ when the secret is absent so release captains do not spend a full release cycle
 before discovering npm authentication is missing.
 
 The required GitHub Actions paths should pin official action majors to immutable
-commit SHAs while staying compatible with the GitHub Actions Node 24 runtime and
-the project runtime installed by each workflow. The public CI and npm publish
-workflows currently use the approved v5 commits for `actions/checkout` and
-`actions/setup-node`, and they continue to install Node.js 26 for NeonDiff
-itself. Runner fleets must be on GitHub Actions runner `v2.327.1` or newer for
-those actions. Pinned Swift or desktop smoke actions that still target the older
-action runtime are post-launch desktop-release hygiene unless they block the
-current release.
+release commit SHAs while staying compatible with the GitHub Actions Node 24
+runtime and the project runtime installed by each workflow. The public CI and
+npm publish workflows currently use the approved v5.0.0 release commits for
+`actions/checkout` and `actions/setup-node`, and they continue to install
+Node.js 26 for NeonDiff itself. Runner fleets must be on GitHub Actions runner
+`v2.327.1` or newer for those actions. Pinned Swift or desktop smoke actions
+that still target the older action runtime are post-launch desktop-release
+hygiene unless they block the current release.
 
 The manifest `rollback` field is intentionally only the source-revert step.
 Full operator rollback runbooks may restart launchd after that source revert,

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -165,12 +165,14 @@ The publish workflow fails early in `Verify npm publish token is configured`
 when the secret is absent so release captains do not spend a full release cycle
 before discovering npm authentication is missing.
 
-The required GitHub Actions paths should use Node 24-compatible official
-actions. The public CI and npm publish workflows use `actions/checkout@v5` and
-`actions/setup-node@v5`; runner fleets must be on GitHub Actions runner
+The required GitHub Actions paths should use official action majors compatible
+with the GitHub Actions Node 24 runtime while still installing the project
+runtime pinned by each workflow. The public CI and npm publish workflows use
+`actions/checkout@v5` and `actions/setup-node@v5`, and they continue to install
+Node.js 26 for NeonDiff itself. Runner fleets must be on GitHub Actions runner
 `v2.327.1` or newer for those actions. Pinned Swift or desktop smoke actions
-that still target the older runtime are post-launch desktop-release hygiene
-unless they block the current release.
+that still target the older action runtime are post-launch desktop-release
+hygiene unless they block the current release.
 
 The manifest `rollback` field is intentionally only the source-revert step.
 Full operator rollback runbooks may restart launchd after that source revert,

--- a/docs/releases/v1.0.1.md
+++ b/docs/releases/v1.0.1.md
@@ -28,9 +28,13 @@ the v1.1 signed desktop lane lands.
   refs for provenance and rollback.
 - Add npm publish-token preflight to the publish workflow so missing `NPM_TOKEN`
   fails early with an actionable error.
+- Retire the old manual npm publish default of `v0.4.30-beta.1`; manual
+  workflow dispatch now defaults to `v1.0.1`.
 - Pin public CI and npm publish workflows to immutable `actions/checkout` and
   `actions/setup-node` v5 commit SHAs compatible with the GitHub Actions Node 24
   runtime. The workflows still install Node.js 26 for NeonDiff itself.
+- Keep the hosted website/install surface in the public release manifest as a
+  required published channel, even though v1.0.1 does not change website code.
 - Keep the public/private license boundary guarded in release-readiness tests:
   public repositories may run free when `license.publicReposFree` is true, and
   private/commercial repositories require an active entitlement before checkout,

--- a/docs/releases/v1.0.1.md
+++ b/docs/releases/v1.0.1.md
@@ -34,7 +34,9 @@ the v1.1 signed desktop lane lands.
   `actions/setup-node` v5 commit SHAs compatible with the GitHub Actions Node 24
   runtime. The workflows still install Node.js 26 for NeonDiff itself.
 - Keep the hosted website/install surface in the public release manifest as a
-  required published channel, even though v1.0.1 does not change website code.
+  required published channel. The hosted installer defaults to npm `latest`, so
+  it picks up `neondiff@1.0.1` after the npm promotion without a website code
+  deploy.
 - Keep the public/private license boundary guarded in release-readiness tests:
   public repositories may run free when `license.publicReposFree` is true, and
   private/commercial repositories require an active entitlement before checkout,

--- a/docs/releases/v1.0.1.md
+++ b/docs/releases/v1.0.1.md
@@ -28,10 +28,9 @@ the v1.1 signed desktop lane lands.
   refs for provenance and rollback.
 - Add npm publish-token preflight to the publish workflow so missing `NPM_TOKEN`
   fails early with an actionable error.
-- Move public CI and npm publish workflows to official action majors compatible
-  with the GitHub Actions Node 24 runtime: `actions/checkout@v5` and
-  `actions/setup-node@v5`. The workflows still install Node.js 26 for
-  NeonDiff itself.
+- Pin public CI and npm publish workflows to immutable `actions/checkout` and
+  `actions/setup-node` v5 commit SHAs compatible with the GitHub Actions Node 24
+  runtime. The workflows still install Node.js 26 for NeonDiff itself.
 - Keep the public/private license boundary guarded in release-readiness tests:
   public repositories may run free when `license.publicReposFree` is true, and
   private/commercial repositories require an active entitlement before checkout,

--- a/docs/releases/v1.0.1.md
+++ b/docs/releases/v1.0.1.md
@@ -28,8 +28,10 @@ the v1.1 signed desktop lane lands.
   refs for provenance and rollback.
 - Add npm publish-token preflight to the publish workflow so missing `NPM_TOKEN`
   fails early with an actionable error.
-- Move public CI and npm publish workflows to Node 24-compatible official
-  actions: `actions/checkout@v5` and `actions/setup-node@v5`.
+- Move public CI and npm publish workflows to official action majors compatible
+  with the GitHub Actions Node 24 runtime: `actions/checkout@v5` and
+  `actions/setup-node@v5`. The workflows still install Node.js 26 for
+  NeonDiff itself.
 - Keep the public/private license boundary guarded in release-readiness tests:
   public repositories may run free when `license.publicReposFree` is true, and
   private/commercial repositories require an active entitlement before checkout,

--- a/docs/releases/v1.0.1.md
+++ b/docs/releases/v1.0.1.md
@@ -1,0 +1,75 @@
+# v1.0.1
+
+- Release type: stable patch release hygiene and license-boundary proof
+- Release source SHA: to be stamped by `refs/tags/v1.0.1`
+- Previous stable release: `v1.0.0`
+- Tracking issues / source PRs: `#382`, `#485`, `#492`, `#484`
+- Package artifact: `neondiff@1.0.1` after publish
+- Rollback baseline: `v1.0.0`
+
+## Purpose
+
+Cut the first stable patch after GA so release operations stop depending on
+historical beta surfaces.
+
+This patch keeps the v1.0 launch boundary unchanged: `npm install -g neondiff`
+installs the CLI, `neondiff dashboard` opens the local HTML setup/status
+dashboard, and the minimal Mac launcher remains the desktop entry point until
+the v1.1 signed desktop lane lands.
+
+## Included Changes
+
+- Remove public npm install exposure for the pre-1.0 beta train:
+  - remove the `beta` dist-tag;
+  - unpublish `neondiff@0.4.30-beta.1` where npm permits;
+  - verify `neondiff@beta` and `neondiff@0.4.30-beta.1` return 404;
+  - verify `neondiff@latest` resolves to `1.0.0` before this patch publishes.
+- Delete historical GitHub prerelease pages while preserving Git tags/source
+  refs for provenance and rollback.
+- Add npm publish-token preflight to the publish workflow so missing `NPM_TOKEN`
+  fails early with an actionable error.
+- Move public CI and npm publish workflows to Node 24-compatible official
+  actions: `actions/checkout@v5` and `actions/setup-node@v5`.
+- Keep the public/private license boundary guarded in release-readiness tests:
+  public repositories may run free when `license.publicReposFree` is true, and
+  private/commercial repositories require an active entitlement before checkout,
+  provider calls, or posting.
+
+## Required Gates
+
+- Focused validation:
+  - `NODE_OPTIONS=--experimental-sqlite npx vitest run tests/public-release-readiness.test.ts tests/linux-packaging.test.ts tests/license.test.ts --pool=forks --maxWorkers=1`
+  - `npm run build`
+  - `node scripts/check-public-claims.mjs`
+  - `node scripts/check-secret-scan.mjs`
+  - `git diff --check`
+- License API proof:
+  - `docs/evidence/v1.0.1-license-api-healthz.json`
+  - `docs/evidence/v1.0.1-license-checkout-issuance-unauthenticated.json`
+  - `docs/evidence/v1.0.1-license-checkout-issuance-authenticated.json`
+- Rollback target proof:
+  - `docs/evidence/v1.0.1-rollback-refs.json`
+- Registry/release cleanup proof:
+  - registry and GitHub release-page cleanup evidence linked from the release
+    tracker and cleanup issue.
+
+## Caveats
+
+- This release does not ship signed/notarized desktop artifacts, Sparkle
+  appcast, or auto-update proof. Those remain tracked by `#116` and `#449`.
+- This release does not delete historical Git tags; it removes public GitHub
+  prerelease pages and npm install channels only.
+- This release does not claim CodeRabbit parity, calibrated 95% review accuracy,
+  auto-merge, approvals, native ZCode skills/MCP/memory, or target-repo mutation.
+
+## Rollback
+
+```bash
+: "${REPO_ROOT:?set REPO_ROOT to your local NeonDiff checkout}"
+
+cd "$REPO_ROOT"
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v1.0.0
+npm dist-tag add neondiff@1.0.0 latest
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neondiff",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neondiff",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "neondiff": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neondiff",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
   "bin": {

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -8,6 +8,7 @@ const paths = [
   "docs/license-boundary.md",
   "docs/pricing.md",
   "docs/github-marketplace-free-listing.md",
+  "docs/releases/v1.0.1.md",
   "docs/releases/v1.0.0.md"
 ];
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-NEONDIFF_VERSION="${NEONDIFF_VERSION:-1.0.0}"
+NEONDIFF_VERSION="${NEONDIFF_VERSION:-1.0.1}"
 DRY_RUN=0
 NPM_PREFIX="${NPM_PREFIX:-}"
 
@@ -13,7 +13,7 @@ Usage:
   sh install.sh [--dry-run] [--prefix /path/to/prefix]
 
 Environment:
-  NEONDIFF_VERSION  Version to install, defaults to 1.0.0.
+  NEONDIFF_VERSION  Version to install, defaults to 1.0.1.
   NPM_PREFIX        Optional npm global prefix.
 
 Requires Node.js 26 or newer and npm.

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -838,7 +838,7 @@ function buildPublicReleaseChannelStatus(
   const rollbackRepository = readString(channel.rollbackRepository);
   const trackingIssue = readString(channel.trackingIssue);
   const stateOk = isUpdateChannelStateAcceptable(name, state, requiredForThisRelease);
-  const rollbackCheck = rollback ? checkRollbackCommand(rollback, options) : { ok: false, missingMetadata: "rollback command" };
+  const rollbackCheck = rollback ? checkRollbackCommand(rollback, { ...options, rollbackRepository }) : { ok: false, missingMetadata: "rollback command" };
   const missingRequiredMetadata = [
     ...(requiredForThisRelease && !version ? ["version"] : []),
     ...(requiredForThisRelease && !rollbackCheck.ok ? [rollbackCheck.missingMetadata] : [])
@@ -877,7 +877,7 @@ function isRequiredPublicUpdateChannel(name: string): boolean {
 
 function checkRollbackCommand(
   rollback: string,
-  options: { cwd?: string; verifyRollbackRefs?: boolean }
+  options: { cwd?: string; verifyRollbackRefs?: boolean; rollbackRepository?: string }
 ): { ok: boolean; missingMetadata: "rollback command" | "rollback target" } {
   if (/\s*(?:&&|\|\||;)\s*/.test(rollback)) return { ok: false, missingMetadata: "rollback command" };
   const command = rollback.trim();
@@ -890,15 +890,38 @@ function checkRollbackCommand(
 
 function checkRollbackTarget(
   target: string,
-  options: { cwd?: string; verifyRollbackRefs?: boolean }
+  options: { cwd?: string; verifyRollbackRefs?: boolean; rollbackRepository?: string }
 ): { ok: boolean; missingMetadata: "rollback command" | "rollback target" } {
   const targetFormatOk = isRollbackVersionTagRef(target) || /^[0-9a-f]{40}$/i.test(target);
   if (!targetFormatOk) return { ok: false, missingMetadata: "rollback command" };
   if (options.verifyRollbackRefs !== true) return { ok: true, missingMetadata: "rollback command" };
+  if (options.rollbackRepository && options.cwd) {
+    const currentRepository = readCurrentGitHubRepository(options.cwd);
+    if (currentRepository && currentRepository !== options.rollbackRepository) {
+      return { ok: true, missingMetadata: "rollback command" };
+    }
+  }
   if (!options.cwd || !isGitWorktree(options.cwd)) return { ok: false, missingMetadata: "rollback target" };
   return gitCommitishExists(options.cwd, target)
     ? { ok: true, missingMetadata: "rollback command" }
     : { ok: false, missingMetadata: "rollback target" };
+}
+
+function readCurrentGitHubRepository(cwd: string): string | undefined {
+  try {
+    return normalizeGitHubRepository(git(cwd, ["config", "--get", "remote.origin.url"]));
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeGitHubRepository(remoteUrl: string): string | undefined {
+  const withoutGitSuffix = remoteUrl.trim().replace(/\.git$/, "");
+  const sshMatch = withoutGitSuffix.match(/^git@github\.com:([^/]+\/[^/]+)$/);
+  if (sshMatch) return sshMatch[1];
+  const httpsMatch = withoutGitSuffix.match(/^https:\/\/(?:[^/@]+@)?github\.com\/([^/]+\/[^/]+)$/);
+  if (httpsMatch) return httpsMatch[1];
+  return undefined;
 }
 
 function isPublicVersionTag(version: string): boolean {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -897,7 +897,11 @@ function checkRollbackTarget(
   if (options.verifyRollbackRefs !== true) return { ok: true, missingMetadata: "rollback command" };
   if (options.rollbackRepository && options.cwd) {
     const currentRepository = readCurrentGitHubRepository(options.cwd);
-    if (currentRepository && currentRepository !== options.rollbackRepository) {
+    const packageRepository = readPackageGitHubRepository(options.cwd);
+    if (!currentRepository && !packageRepository) {
+      return { ok: false, missingMetadata: "rollback target" };
+    }
+    if (options.rollbackRepository !== currentRepository && options.rollbackRepository !== packageRepository) {
       return { ok: true, missingMetadata: "rollback command" };
     }
   }
@@ -915,11 +919,23 @@ function readCurrentGitHubRepository(cwd: string): string | undefined {
   }
 }
 
+function readPackageGitHubRepository(cwd: string): string | undefined {
+  try {
+    const pkg = JSON.parse(readFileSync(resolve(cwd, "package.json"), "utf8")) as unknown;
+    const repository = asRecord(pkg).repository;
+    if (typeof repository === "string") return normalizeGitHubRepository(repository);
+    const repositoryUrl = readString(asRecord(repository).url);
+    return repositoryUrl ? normalizeGitHubRepository(repositoryUrl) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function normalizeGitHubRepository(remoteUrl: string): string | undefined {
   const withoutGitSuffix = remoteUrl.trim().replace(/\.git$/, "");
   const sshMatch = withoutGitSuffix.match(/^git@github\.com:([^/]+\/[^/]+)$/);
   if (sshMatch) return sshMatch[1];
-  const httpsMatch = withoutGitSuffix.match(/^https:\/\/(?:[^/@]+@)?github\.com\/([^/]+\/[^/]+)$/);
+  const httpsMatch = withoutGitSuffix.match(/^(?:git\+)?https:\/\/(?:[^/@]+@)?github\.com\/([^/]+\/[^/]+)$/);
   if (httpsMatch) return httpsMatch[1];
   return undefined;
 }

--- a/tests/linux-packaging.test.ts
+++ b/tests/linux-packaging.test.ts
@@ -40,8 +40,8 @@ describe("Linux daemon packaging", () => {
     expect(compose).toContain("[\"daemon\", \"--config\", \"/config/config.local.json\", \"--dry-run\", \"true\"]");
     expect(dockerDocs).toContain("--dry-run true");
     expect(dockerDocs).toContain("--dry-run\", \"false");
-    expect(ciDocs).toContain("actions/checkout@v5");
-    expect(ciDocs).toContain("actions/setup-node@v5");
+    expect(ciDocs).toContain("actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5");
+    expect(ciDocs).toContain("actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5");
 
     expect(linuxSmokeWorkflow).toContain("ubuntu-latest");
     expect(linuxSmokeWorkflow).toContain("NEONDIFF_TEST_PLATFORM: linux");

--- a/tests/linux-packaging.test.ts
+++ b/tests/linux-packaging.test.ts
@@ -40,7 +40,7 @@ describe("Linux daemon packaging", () => {
     expect(compose).toContain("[\"daemon\", \"--config\", \"/config/config.local.json\", \"--dry-run\", \"true\"]");
     expect(dockerDocs).toContain("--dry-run true");
     expect(dockerDocs).toContain("--dry-run\", \"false");
-    expect(ciDocs).toContain("actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5");
+    expect(ciDocs).toContain("actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0");
     expect(ciDocs).toContain("actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5");
 
     expect(linuxSmokeWorkflow).toContain("ubuntu-latest");

--- a/tests/linux-packaging.test.ts
+++ b/tests/linux-packaging.test.ts
@@ -40,8 +40,8 @@ describe("Linux daemon packaging", () => {
     expect(compose).toContain("[\"daemon\", \"--config\", \"/config/config.local.json\", \"--dry-run\", \"true\"]");
     expect(dockerDocs).toContain("--dry-run true");
     expect(dockerDocs).toContain("--dry-run\", \"false");
-    expect(ciDocs).toContain("actions/checkout@v4");
-    expect(ciDocs).toContain("actions/setup-node@v4");
+    expect(ciDocs).toContain("actions/checkout@v5");
+    expect(ciDocs).toContain("actions/setup-node@v5");
 
     expect(linuxSmokeWorkflow).toContain("ubuntu-latest");
     expect(linuxSmokeWorkflow).toContain("NEONDIFF_TEST_PLATFORM: linux");

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -51,9 +51,11 @@ describe("NeonDiff public release readiness", () => {
       updateChannels?: Record<string, {
         requiredForThisRelease?: boolean;
         state?: string;
+        version?: string;
         rollback?: string;
         rollbackRepository?: string;
         trackingIssue?: string;
+        note?: string;
       }>;
     };
 
@@ -165,10 +167,11 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.updateChannels?.website).toMatchObject({
       requiredForThisRelease: true,
       state: "published",
-      version: "v1.0.0",
+      version: "v1.0.1",
       rollback: "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
       rollbackRepository: "electricsheephq/neon-diff-agent-website"
     });
+    expect(manifest.updateChannels?.website?.note).toMatch(/defaults to npm latest/i);
     expect(manifest.updateChannels?.desktop).toBeUndefined();
   });
 
@@ -420,7 +423,7 @@ describe("NeonDiff public release readiness", () => {
     const publish = read(".github/workflows/publish-npm.yml");
 
     expect(ci).toMatch(/node-version:\s*26/);
-    expect(ci).toContain("actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5");
+    expect(ci).toContain("actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0");
     expect(ci).toContain("actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5");
     expect(ci).not.toMatch(/uses:\s*actions\/(?:checkout|setup-node)@v\d+/);
     expect(ci).toMatch(/npm ci/);
@@ -431,7 +434,7 @@ describe("NeonDiff public release readiness", () => {
     expect(ci).toMatch(/secret/i);
 
     expect(publish).toMatch(/id-token:\s*write/);
-    expect(publish).toContain("actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5");
+    expect(publish).toContain("actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0");
     expect(publish).toContain("actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5");
     expect(publish).not.toMatch(/uses:\s*actions\/(?:checkout|setup-node)@v\d+/);
     expect(publish).toMatch(/NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -407,6 +407,9 @@ describe("NeonDiff public release readiness", () => {
     const publish = read(".github/workflows/publish-npm.yml");
 
     expect(ci).toMatch(/node-version:\s*26/);
+    expect(ci).toContain("actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5");
+    expect(ci).toContain("actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5");
+    expect(ci).not.toMatch(/uses:\s*actions\/(?:checkout|setup-node)@v\d+/);
     expect(ci).toMatch(/npm ci/);
     expect(ci).toMatch(/npm run build/);
     expect(ci).toMatch(/tests\/public-release-readiness\.test\.ts/);
@@ -415,6 +418,9 @@ describe("NeonDiff public release readiness", () => {
     expect(ci).toMatch(/secret/i);
 
     expect(publish).toMatch(/id-token:\s*write/);
+    expect(publish).toContain("actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5");
+    expect(publish).toContain("actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5");
+    expect(publish).not.toMatch(/uses:\s*actions\/(?:checkout|setup-node)@v\d+/);
     expect(publish).toMatch(/NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
     expect(publish).toMatch(/Verify npm publish token is configured/);
     expect(publish).toMatch(/NPM_TOKEN Actions secret is not configured; publish cannot continue/);

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -315,6 +315,13 @@ describe("NeonDiff public release readiness", () => {
           rollbackTarget: "v1.0.0",
           targetVerifiedBy: "git rev-list -n 1 refs/tags/v1.0.0",
           targetVerifiedSha: "23d66717c0627b25a8c56895bba9627bcdd69cca"
+        },
+        daemon: {
+          rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
+          rollbackCommand: manifest.updateChannels?.daemon?.rollback,
+          rollbackTarget: "v1.0.0",
+          targetVerifiedBy: "git rev-list -n 1 refs/tags/v1.0.0",
+          targetVerifiedSha: "23d66717c0627b25a8c56895bba9627bcdd69cca"
         }
       }
     });

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -58,7 +58,7 @@ describe("NeonDiff public release readiness", () => {
     };
 
     expect(pkg.name).toBe("neondiff");
-    expect(pkg.version).toBe("1.0.0");
+    expect(pkg.version).toBe("1.0.1");
     expect(pkg.private).toBeUndefined();
     expect(pkg.description).toMatch(/local-first AI PR reviewer/i);
     expect(pkg.license).toBe("SEE LICENSE IN LICENSE.md");
@@ -91,19 +91,19 @@ describe("NeonDiff public release readiness", () => {
     ]);
 
     expect(lock.name).toBe("neondiff");
-    expect(lock.version).toBe("1.0.0");
+    expect(lock.version).toBe("1.0.1");
     expect(lock.packages?.[""]).toMatchObject({
       name: "neondiff",
-      version: "1.0.0",
+      version: "1.0.1",
       license: "SEE LICENSE IN LICENSE.md",
       bin: { neondiff: "dist/src/cli.js" }
     });
     expect(manifest.packageArtifact).toMatchObject({
       name: "neondiff",
-      version: "1.0.0",
+      version: "1.0.1",
       requiredForThisRelease: true,
       state: "published",
-      previousReleasedPackageVersion: "0.4.30-beta.1"
+      previousReleasedPackageVersion: "1.0.0"
     });
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.29-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.36-beta.1");
@@ -117,10 +117,10 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.44-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.45-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.46-beta.1");
-    expect(manifest.packageArtifact?.note).toMatch(/first GA npm package/i);
+    expect(manifest.packageArtifact?.note).toMatch(/stable patch/i);
     expect(manifest.source).toMatchObject({
       shaState: "pending_tag_stamp",
-      candidateHeadBeforeReleaseMetadata: "7453349008ca8f23641fab1665ac909d0b51b10a"
+      candidateHeadBeforeReleaseMetadata: "23d66717c0627b25a8c56895bba9627bcdd69cca"
     });
     expect(manifest.source?.proof).toMatch(/after merge and tag/i);
     expect(manifest.releaseStages?.launchCutLine).toBe(
@@ -150,7 +150,7 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.updateChannels?.browserDashboard).toMatchObject({
       requiredForThisRelease: true,
       state: "published",
-      rollback: "git revert 74d133ff34935510c45a4a74a664b8b30dca52d8",
+      rollback: "git reset --hard refs/tags/v1.0.0",
       rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
       trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     });
@@ -162,12 +162,7 @@ describe("NeonDiff public release readiness", () => {
       requiredForThisRelease: true,
       state: "published"
     });
-    expect(manifest.updateChannels?.website).toMatchObject({
-      requiredForThisRelease: true,
-      state: "published",
-      rollback: "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
-      rollbackRepository: "electricsheephq/neon-diff-agent-website"
-    });
+    expect(manifest.updateChannels?.website).toBeUndefined();
     expect(manifest.updateChannels?.desktop).toBeUndefined();
   });
 
@@ -197,13 +192,13 @@ describe("NeonDiff public release readiness", () => {
       checkoutIssuanceRequiredForThisRelease: true,
       checkoutIssuanceUrl: "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
       checkoutIssuanceState: "ready",
-      checkoutIssuanceProofPath: "docs/evidence/v1.0.0-license-checkout-issuance-unauthenticated.json",
-      checkoutIssuanceAuthenticatedProofPath: "docs/evidence/license-checkout-issuance-authenticated.json",
+      checkoutIssuanceProofPath: "docs/evidence/v1.0.1-license-checkout-issuance-unauthenticated.json",
+      checkoutIssuanceAuthenticatedProofPath: "docs/evidence/v1.0.1-license-checkout-issuance-authenticated.json",
       checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
     });
     expect(manifest.licenseApi?.trackingIssue).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/);
     expect(manifest.licenseApi?.healthUrl).toMatch(/^https:\/\/[^/]+\/healthz$/);
-    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v1.0.0-license-api-healthz.json");
+    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v1.0.1-license-api-healthz.json");
 
     const proof = JSON.parse(read(manifest.licenseApi?.healthProofPath ?? "")) as {
       evidenceKind?: string;
@@ -215,7 +210,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(proof).toMatchObject({
       evidenceKind: "license_api_healthz",
-      releaseVersion: "v1.0.0",
+      releaseVersion: "v1.0.1",
       url: manifest.licenseApi?.healthUrl,
       statusCode: 200,
       responseBody: "{\"status\":\"ok\"}"
@@ -231,7 +226,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(issuanceProof).toMatchObject({
       evidenceKind: "license_api_checkout_issuance",
-      releaseVersion: "v1.0.0",
+      releaseVersion: "v1.0.1",
       statusCode: 401,
       responseBody: expect.stringContaining("\"unauthorized\"")
     });
@@ -245,7 +240,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(authenticatedProof).toMatchObject({
       evidenceKind: "license_api_checkout_issuance_authenticated",
-      releaseVersion: "v1.0.0",
+      releaseVersion: "v1.0.1",
       statusCode: 200,
       redactedResponse: {
         issuedLicensePrefix: "nd_live_",
@@ -291,7 +286,7 @@ describe("NeonDiff public release readiness", () => {
     expect(liveCheckoutProof.proofBoundary).toContain("does not claim the original in-flight Stripe delivery");
     expect(JSON.stringify(liveCheckoutProof)).not.toMatch(/cs_live_|evt_|whsec_|nd_live_[A-Za-z0-9]|session_id=|fulfillment_token=|121 South/i);
 
-    const rollbackProof = JSON.parse(read("docs/evidence/v1.0.0-rollback-refs.json")) as {
+    const rollbackProof = JSON.parse(read("docs/evidence/v1.0.1-rollback-refs.json")) as {
       evidenceKind?: string;
       releaseVersion?: string;
       channels?: Record<string, {
@@ -305,22 +300,21 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(rollbackProof).toMatchObject({
       evidenceKind: "release_rollback_refs",
-      releaseVersion: "v1.0.0",
+      releaseVersion: "v1.0.1",
       channels: {
+        cli: {
+          rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
+          rollbackCommand: manifest.updateChannels?.cli?.rollback,
+          rollbackTarget: "v1.0.0",
+          targetVerifiedBy: "git rev-list -n 1 refs/tags/v1.0.0",
+          targetVerifiedSha: "23d66717c0627b25a8c56895bba9627bcdd69cca"
+        },
         browserDashboard: {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.browserDashboard?.rollback,
-          rollbackTarget: "74d133ff34935510c45a4a74a664b8b30dca52d8",
-          targetVerifiedBy: "git cat-file -e 74d133ff34935510c45a4a74a664b8b30dca52d8^{commit}",
-          targetVerifiedSha: "74d133ff34935510c45a4a74a664b8b30dca52d8"
-        },
-        website: {
-          rollbackRepository: "electricsheephq/neon-diff-agent-website",
-          rollbackCommand: manifest.updateChannels?.website?.rollback,
-          rollbackTarget: "6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
-          targetVerifiedBy: "gh api repos/electricsheephq/neon-diff-agent-website/commits/6b670d00cd587fb7d564347b6bc0d4d3e8d13186 --jq .sha",
-          targetVerifiedSha: "6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
-          targetUrl: "https://github.com/electricsheephq/neon-diff-agent-website/commit/6b670d00cd587fb7d564347b6bc0d4d3e8d13186"
+          rollbackTarget: "v1.0.0",
+          targetVerifiedBy: "git rev-list -n 1 refs/tags/v1.0.0",
+          targetVerifiedSha: "23d66717c0627b25a8c56895bba9627bcdd69cca"
         }
       }
     });
@@ -331,7 +325,7 @@ describe("NeonDiff public release readiness", () => {
     expect(existsSync("scripts/install.sh")).toBe(true);
     const script = read("scripts/install.sh");
 
-    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-1\.0\.0\}"/);
+    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-1\.0\.1\}"/);
     expect(script).toMatch(/npm[^\n]+install[^\n]+-g[^\n]+neondiff@\$\{NEONDIFF_VERSION\}/);
     expect(script).toMatch(/--dry-run/);
     expect(script).toMatch(/Node\.js 26 or newer/);
@@ -345,7 +339,7 @@ describe("NeonDiff public release readiness", () => {
       read("docs/github-app-setup.md"),
       read("docs/providers.md"),
       read("docs/license-boundary.md"),
-      read("docs/releases/v1.0.0.md")
+      read("docs/releases/v1.0.1.md")
     ].join("\n\n");
     const legacyRepoReferences = docs
       .split(/\s+/)
@@ -360,11 +354,13 @@ describe("NeonDiff public release readiness", () => {
     expect(docs).toMatch(/neondiff dashboard --config config\.local\.json/i);
     expect(docs).toMatch(/Verify API Key/i);
     expect(docs).toMatch(/license\s+status,\s+GitHub App status,\s+daemon status,\s+and provider readiness/i);
+    expect(docs).toMatch(/Public repo review may run without a license when `license\.publicReposFree`\s+is true/i);
+    expect(docs).toMatch(/private repo review fails closed before worktree prep,\s+model\/provider calls,\s+or\s+GitHub review posting/i);
     expect(docs).toMatch(/curl -fsSL https:\/\/www\.neondiff\.com\/install/i);
     expect(docs).toContain("git clone https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git");
     expect(legacyRepoReferences).toEqual([]);
     expect(docs).not.toMatch(/npm link installs the local source-checkout shim/i);
-    expect(read("docs/releases/v1.0.0.md")).not.toMatch(/\/Volumes\/LEXAR|\/Users\/lume/);
+    expect(read("docs/releases/v1.0.1.md")).not.toMatch(/\/Volumes\/LEXAR|\/Users\/lume/);
   });
 
   it("keeps the GitHub Marketplace free-listing packet bounded to discoverability", () => {
@@ -413,6 +409,8 @@ describe("NeonDiff public release readiness", () => {
 
     expect(publish).toMatch(/id-token:\s*write/);
     expect(publish).toMatch(/NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
+    expect(publish).toMatch(/Verify npm publish token is configured/);
+    expect(publish).toMatch(/NPM_TOKEN Actions secret is not configured; publish cannot continue/);
     expect(publish).toMatch(/npm publish --provenance/);
     expect(publish).toMatch(/NPM_TAG="beta"/);
     expect(publish).toMatch(/NPM_TAG="latest"/);
@@ -424,7 +422,7 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/Manual npm publish tag .* does not match package\.json version/);
     expect(publish).toMatch(/docs\/public-release-manifest\.json/);
     expect(publish).toMatch(/skippedPublicPackageVersions/);
-    expect(publish.match(/if: steps\.package_release\.outputs\.should_publish == 'true'/g)).toHaveLength(5);
+    expect(publish.match(/if: steps\.package_release\.outputs\.should_publish == 'true'/g)).toHaveLength(6);
     expect(publish).toMatch(/require\('\.\/package\.json'\)\.version/);
     expect(publish).toMatch(/already exists; verifying dist-tags/);
     expect(publish).toMatch(/dist-tags\.\$\{\{\s*steps\.package_release\.outputs\.npm_tag\s*\}\}/);

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -162,7 +162,13 @@ describe("NeonDiff public release readiness", () => {
       requiredForThisRelease: true,
       state: "published"
     });
-    expect(manifest.updateChannels?.website).toBeUndefined();
+    expect(manifest.updateChannels?.website).toMatchObject({
+      requiredForThisRelease: true,
+      state: "published",
+      version: "v1.0.0",
+      rollback: "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+      rollbackRepository: "electricsheephq/neon-diff-agent-website"
+    });
     expect(manifest.updateChannels?.desktop).toBeUndefined();
   });
 
@@ -322,6 +328,13 @@ describe("NeonDiff public release readiness", () => {
           rollbackTarget: "v1.0.0",
           targetVerifiedBy: "git rev-list -n 1 refs/tags/v1.0.0",
           targetVerifiedSha: "23d66717c0627b25a8c56895bba9627bcdd69cca"
+        },
+        website: {
+          rollbackRepository: "electricsheephq/neon-diff-agent-website",
+          rollbackCommand: manifest.updateChannels?.website?.rollback,
+          rollbackTarget: "6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+          targetVerifiedBy: "gh api repos/electricsheephq/neon-diff-agent-website/commits/6b670d00cd587fb7d564347b6bc0d4d3e8d13186 --jq .sha",
+          targetVerifiedSha: "6b670d00cd587fb7d564347b6bc0d4d3e8d13186"
         }
       }
     });
@@ -439,5 +452,7 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/require\('\.\/package\.json'\)\.version/);
     expect(publish).toMatch(/already exists; verifying dist-tags/);
     expect(publish).toMatch(/dist-tags\.\$\{\{\s*steps\.package_release\.outputs\.npm_tag\s*\}\}/);
+    expect(publish).toMatch(/default:\s*v1\.0\.1/);
+    expect(publish).not.toMatch(/default:\s*v0\.4\.30-beta\.1/);
   });
 });

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -21,7 +21,7 @@ import { ReviewStateStore } from "../src/state.js";
 describe("beta release status", () => {
   const roots: string[] = [];
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  const shippedReleaseValidationNow = new Date("2026-07-09T06:00:00Z");
+  const shippedReleaseValidationNow = new Date("2026-07-09T12:30:00Z");
 
   afterEach(() => {
     vi.useRealTimers();
@@ -324,27 +324,27 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v1.0.0",
+      expectedVersion: "v1.0.1",
       now: shippedReleaseValidationNow
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v1.0.0",
+      version: "v1.0.1",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v1.0.0.md",
+        releaseNotesPath: "docs/releases/v1.0.1.md",
         changelogPath: "CHANGELOG.md",
-        changelogHeadVersion: "1.0.0",
-        changelogReleaseNotesPath: "docs/releases/v1.0.0.md"
+        changelogHeadVersion: "1.0.1",
+        changelogReleaseNotesPath: "docs/releases/v1.0.1.md"
       },
       licenseApi: {
         ok: true,
         requiredForThisRelease: true,
         state: "healthy",
         healthUrl: "https://neondiff-license.fly.dev/healthz",
-        healthProofPath: "docs/evidence/v1.0.0-license-api-healthz.json",
+        healthProofPath: "docs/evidence/v1.0.1-license-api-healthz.json",
         checkoutIssuanceRequiredForThisRelease: true,
         checkoutIssuanceUrl: "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
         checkoutIssuanceState: "ready",
@@ -359,12 +359,18 @@ describe("beta release status", () => {
         expect.objectContaining({
           name: "cli",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.46-beta.1"
+          rollback: "git reset --hard refs/tags/v1.0.0"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v0.4.46-beta.1"
+          rollback: "git reset --hard refs/tags/v1.0.0"
+        }),
+        expect.objectContaining({
+          name: "website",
+          requiredForThisRelease: true,
+          rollback: "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
+          rollbackRepository: "electricsheephq/neon-diff-agent-website"
         })
       ])
     );
@@ -374,7 +380,7 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v1.0.0",
+      expectedVersion: "v1.0.1",
       now: new Date("2026-08-09T12:00:00Z")
     });
 
@@ -382,7 +388,7 @@ describe("beta release status", () => {
       ok: false,
       requiredForThisRelease: true,
       state: "healthy",
-      healthProofPath: "docs/evidence/v1.0.0-license-api-healthz.json"
+      healthProofPath: "docs/evidence/v1.0.1-license-api-healthz.json"
     });
     expect(manifest.licenseApi.detail).toContain("observedAt must be no older than 30 days");
     expect(manifest.ok).toBe(false);
@@ -498,14 +504,14 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v1.0.0",
+      expectedPublicVersion: "v1.0.1",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot",
       now: shippedReleaseValidationNow
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v1.0.0"
+      version: "v1.0.1"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
@@ -517,7 +523,7 @@ describe("beta release status", () => {
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok
     });
-    expect(redactedOutput).toContain("git reset --hard refs/tags/v0.4.46-beta.1");
+    expect(redactedOutput).toContain("git reset --hard refs/tags/v1.0.0");
     expect(redactedOutput).toContain("cli=published; daemon=published");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
     expect(redactedOutput).toContain("electricsheephq/neon-diff-agent-website");

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -3645,6 +3645,78 @@ describe("beta release status", () => {
     expect(manifest.updateChannels.ok).toBe(false);
   });
 
+  it("still verifies current-repo rollback refs from fork or mirror origins", () => {
+    const root = mkdtempSync(join(tmpdir(), "public-release-manifest-fork-origin-rollback-ref-"));
+    roots.push(root);
+    execFileSync("git", ["init"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "https://github.com/someone/evaos-code-review-bot-neondiff.git"], {
+      cwd: root,
+      stdio: "ignore"
+    });
+    writeFileSync(join(root, "package.json"), JSON.stringify({
+      repository: {
+        type: "git",
+        url: "git+https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git"
+      }
+    }));
+    mkdirSync(join(root, "docs", "releases"), { recursive: true });
+    writeFileSync(join(root, "docs", "SETUP.md"), "# Setup\n");
+    writeFileSync(join(root, "docs", "releases", "v1.0.0-beta.1.md"), "# v1.0.0-beta.1\n");
+    writeChangelogHead(root);
+    writeFileSync(join(root, "public-release.json"), JSON.stringify({
+      version: "v1.0.0-beta.1",
+      releaseLevel: "source-beta",
+      docs: {
+        version: "v1.0.0-beta.1",
+        setupPath: "docs/SETUP.md",
+        releaseNotesPath: "docs/releases/v1.0.0-beta.1.md"
+      },
+      licenseApi: {
+        requiredForThisRelease: false,
+        state: "pending"
+      },
+      updateChannels: {
+        cli: {
+          requiredForThisRelease: true,
+          state: "source_checkout",
+          version: "v1.0.0-beta.1",
+          rollback: "git reset --hard refs/tags/v9.9.9-beta.1",
+          rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff"
+        },
+        website: {
+          requiredForThisRelease: true,
+          state: "published",
+          version: "v1.0.0-beta.1",
+          rollback: "git revert 0123456789abcdef0123456789abcdef01234567",
+          rollbackRepository: "electricsheephq/neon-diff-agent-website"
+        }
+      }
+    }));
+
+    const manifest = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.0-beta.1",
+      verifyRollbackRefs: true
+    });
+
+    expect(manifest.updateChannels.channels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "cli",
+          ok: false,
+          detail: "cli state source_checkout blocks this release; requiredForThisRelease=true; missing rollback target"
+        }),
+        expect.objectContaining({
+          name: "website",
+          ok: true,
+          detail: "website state published; requiredForThisRelease=true"
+        })
+      ])
+    );
+    expect(manifest.updateChannels.ok).toBe(false);
+  });
+
   it("passes required public update channels when strict rollback targets exist in a git checkout", () => {
     const root = mkdtempSync(join(tmpdir(), "public-release-manifest-existing-rollback-ref-"));
     roots.push(root);


### PR DESCRIPTION
## Summary

Prepares the real `v1.0.1` stable patch release for NeonDiff release hygiene and license-boundary proof.

## Changes

- Bumps package/install metadata to `1.0.1` and adds `docs/releases/v1.0.1.md`.
- Refreshes the public release manifest and stable proof artifacts for `v1.0.1`.
- Adds a publish workflow preflight for missing `NPM_TOKEN` and moves public CI/publish workflows to Node 24-compatible official actions.
- Keeps public/private repo license-boundary expectations pinned in public release readiness tests.
- Updates public claims scanning to include the `v1.0.1` packet.

## Operational cleanup already completed

- Removed npm `beta` dist-tag.
- Unpublished `neondiff@0.4.30-beta.1`; exact version and `neondiff@beta` now return 404.
- Deleted historical GitHub prerelease pages while preserving Git tags/source refs.

## Validation

- `NODE_OPTIONS=--experimental-sqlite npx vitest run tests/public-release-readiness.test.ts tests/linux-packaging.test.ts tests/license.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `node scripts/check-public-claims.mjs`
- `node scripts/check-secret-scan.mjs`
- `git diff --check`
- `npm pack --dry-run --json` + `node scripts/check-packlist.mjs`
- `release-status --public-release-manifest docs/public-release-manifest.json --expected-public-version v1.0.1 --verify-public-rollback-refs true` public manifest gates pass; branch/dirty/live-daemon gates remain expected pre-merge blockers.

Closes #485.
Closes #492.
Refs #382.
Refs #484.
