### PR TITLE
[codex] Add desktop release proof metadata harness

### DIFF
--- a/.github/workflows/desktop-release-smoke.yml
+++ b/.github/workflows/desktop-release-smoke.yml
@@ -42,22 +42,11 @@ jobs:
         env:
           SOURCE_SHA: ${{ github.sha }}
           SOURCE_REF: ${{ github.ref }}
-        run: |
-          mkdir -p dist/release-smoke
-          ditto -c -k --keepParent dist/NeonDiffDesktop.app dist/release-smoke/NeonDiffDesktop.app.zip
-          cat > dist/release-smoke/desktop-release-smoke-metadata.json <<JSON
-          {
-            "workflow": "desktop-release-smoke",
-            "artifact": "NeonDiffDesktop.app.zip",
-            "artifact_classification": "unsigned-desktop-release-smoke",
-            "source_sha": "$SOURCE_SHA",
-            "source_ref": "$SOURCE_REF",
-            "release_ready": false,
-            "customer_ready": false,
-            "ui_launch": false,
-            "proof_boundary": "non-release app bundle build, hosted-runner-safe core checks, appcast checks, and bundle structure check only"
-          }
-          JSON
+          NEONDIFF_DESKTOP_ARTIFACT_CLASSIFICATION: unsigned-desktop-release-smoke
+          NEONDIFF_DESKTOP_UI_LAUNCH: "false"
+          NEONDIFF_DESKTOP_VISUAL_SMOKE_REQUIRED: "true"
+          NEONDIFF_DESKTOP_PROOF_BOUNDARY: non-release app bundle build, hosted-runner-safe core checks, appcast checks, bundle structure check, artifact checksum, and metadata only
+        run: script/release-proof.sh
 
       - name: Upload unsigned app bundle
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/apps/neondiff-desktop/docs/desktop-release-smoke.md
+++ b/apps/neondiff-desktop/docs/desktop-release-smoke.md
@@ -4,4 +4,12 @@
 
 The uploaded bundle is non-release proof. Its metadata marks `release_ready: false`, `customer_ready: false`, and `artifact_classification: unsigned-desktop-release-smoke`, so it is customer-not-ready by design.
 
+The metadata packet records artifact identity and the proof boundary for later
+release packets: `artifact_sha256`, `source_sha`, `source_ref`,
+`app_bundle_path`, `bundle_id`, `short_version`, `build_version`,
+`signing_identity_class`, `ui_launch`, and `visual_smoke_required`. Hosted CI
+keeps `ui_launch: false`; a real release packet still needs a local visible smoke
+that opens the app artifact and clicks through first-run controls before claiming
+user-ready desktop behavior.
+
 The Keychain-backed `NeonDiffDesktopCoreSmoke` executable remains a local or release-smoke proof on a runner with known-good Keychain behavior. Hosted CI does not run that target because the unsigned release-smoke lane is meant to prove build, package, and app-bundle shape without touching credentials or local Keychain state.

--- a/apps/neondiff-desktop/script/release-proof.sh
+++ b/apps/neondiff-desktop/script/release-proof.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="NeonDiffDesktop"
+ARTIFACT_NAME="NeonDiffDesktop.app.zip"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$ROOT_DIR/../.." && pwd)"
+DIST_DIR="$ROOT_DIR/dist"
+APP_BUNDLE="$DIST_DIR/$APP_NAME.app"
+INFO_PLIST="$APP_BUNDLE/Contents/Info.plist"
+RELEASE_SMOKE_DIR="$DIST_DIR/release-smoke"
+ARTIFACT_PATH="$RELEASE_SMOKE_DIR/$ARTIFACT_NAME"
+METADATA_PATH="$RELEASE_SMOKE_DIR/desktop-release-smoke-metadata.json"
+
+SOURCE_SHA_PROVIDED=0
+SOURCE_REF_PROVIDED=0
+if [ -n "${SOURCE_SHA+x}" ]; then
+  SOURCE_SHA_PROVIDED=1
+fi
+if [ -n "${SOURCE_REF+x}" ]; then
+  SOURCE_REF_PROVIDED=1
+fi
+ARTIFACT_CLASSIFICATION="${NEONDIFF_DESKTOP_ARTIFACT_CLASSIFICATION:-unsigned-desktop-release-smoke}"
+UI_LAUNCH="${NEONDIFF_DESKTOP_UI_LAUNCH:-false}"
+VISUAL_SMOKE_REQUIRED="${NEONDIFF_DESKTOP_VISUAL_SMOKE_REQUIRED:-true}"
+PROOF_BOUNDARY="${NEONDIFF_DESKTOP_PROOF_BOUNDARY:-non-release app bundle build, hosted-runner-safe core checks, appcast checks, bundle structure check, artifact checksum, and metadata only}"
+
+normalize_bool() {
+  local value="$1"
+  local name="$2"
+  case "$value" in
+    true|false)
+      printf '%s\n' "$value"
+      ;;
+    *)
+      echo "$name must be true or false" >&2
+      exit 2
+      ;;
+  esac
+}
+
+ensure_clean_source_tree() {
+  if ! git -C "$REPO_ROOT" diff --quiet --ignore-submodules --; then
+    echo "source tree has unstaged changes; set SOURCE_SHA and SOURCE_REF explicitly or commit/stash before release proof" >&2
+    exit 2
+  fi
+  if ! git -C "$REPO_ROOT" diff --cached --quiet --ignore-submodules --; then
+    echo "source tree has staged changes; set SOURCE_SHA and SOURCE_REF explicitly or commit/stash before release proof" >&2
+    exit 2
+  fi
+  if [ -n "$(git -C "$REPO_ROOT" ls-files --others --exclude-standard)" ]; then
+    echo "source tree has untracked files; set SOURCE_SHA and SOURCE_REF explicitly or clean before release proof" >&2
+    exit 2
+  fi
+}
+
+verify_existing_app_launch() {
+  local app_binary="$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+  /usr/bin/open -n "$APP_BUNDLE"
+  local deadline=$((SECONDS + 10))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    while IFS= read -r pid; do
+      [ -n "$pid" ] || continue
+      proc_path="$(/bin/ps -p "$pid" -o comm= 2>/dev/null || true)"
+      if [ "$proc_path" = "$app_binary" ]; then
+        return 0
+      fi
+    done < <(pgrep -x "$APP_NAME" 2>/dev/null || true)
+    sleep 0.2
+  done
+  echo "app launch proof failed: $APP_NAME did not start from $APP_BUNDLE" >&2
+  exit 1
+}
+
+if [ "$SOURCE_SHA_PROVIDED" -ne "$SOURCE_REF_PROVIDED" ]; then
+  echo "SOURCE_SHA and SOURCE_REF must be provided together" >&2
+  exit 2
+fi
+
+if [ "$SOURCE_SHA_PROVIDED" -eq 1 ]; then
+  if [ -z "$SOURCE_SHA" ] || [ -z "$SOURCE_REF" ]; then
+    echo "SOURCE_SHA and SOURCE_REF must be non-empty when provided" >&2
+    exit 2
+  fi
+  SOURCE_SHA="$SOURCE_SHA"
+  SOURCE_REF="$SOURCE_REF"
+else
+  ensure_clean_source_tree
+  SOURCE_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+  SOURCE_REF="$(git -C "$REPO_ROOT" symbolic-ref -q --short HEAD || git -C "$REPO_ROOT" rev-parse --short HEAD)"
+fi
+
+if [ ! -d "$APP_BUNDLE" ]; then
+  echo "missing app bundle: $APP_BUNDLE" >&2
+  exit 1
+fi
+
+if [ ! -f "$INFO_PLIST" ]; then
+  echo "missing Info.plist: $INFO_PLIST" >&2
+  exit 1
+fi
+
+if [ "$UI_LAUNCH" = "true" ]; then
+  verify_existing_app_launch
+fi
+
+UI_LAUNCH_JSON="$(normalize_bool "$UI_LAUNCH" "NEONDIFF_DESKTOP_UI_LAUNCH")"
+VISUAL_SMOKE_REQUIRED_JSON="$(normalize_bool "$VISUAL_SMOKE_REQUIRED" "NEONDIFF_DESKTOP_VISUAL_SMOKE_REQUIRED")"
+
+mkdir -p "$RELEASE_SMOKE_DIR"
+ditto -c -k --keepParent "$APP_BUNDLE" "$ARTIFACT_PATH"
+
+ARTIFACT_SHA256="$(shasum -a 256 "$ARTIFACT_PATH" | awk '{print $1}')"
+BUNDLE_ID="$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$INFO_PLIST")"
+SHORT_VERSION="$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$INFO_PLIST")"
+BUILD_VERSION="$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$INFO_PLIST")"
+
+SIGNING_DETAILS="$(codesign -dv --verbose=4 "$APP_BUNDLE" 2>&1 || true)"
+SIGNING_IDENTITY_CLASS="unsigned"
+if printf '%s\n' "$SIGNING_DETAILS" | grep -q "Authority=Developer ID Application"; then
+  SIGNING_IDENTITY_CLASS="developer-id"
+elif printf '%s\n' "$SIGNING_DETAILS" | grep -q "Authority="; then
+  SIGNING_IDENTITY_CLASS="signed-non-developer-id"
+fi
+
+jq -n \
+  --arg workflow "desktop-release-smoke" \
+  --arg artifact "$ARTIFACT_NAME" \
+  --arg artifact_sha256 "$ARTIFACT_SHA256" \
+  --arg artifact_classification "$ARTIFACT_CLASSIFICATION" \
+  --arg source_sha "$SOURCE_SHA" \
+  --arg source_ref "$SOURCE_REF" \
+  --arg app_bundle_path "apps/neondiff-desktop/dist/$APP_NAME.app" \
+  --arg bundle_id "$BUNDLE_ID" \
+  --arg short_version "$SHORT_VERSION" \
+  --arg build_version "$BUILD_VERSION" \
+  --arg signing_identity_class "$SIGNING_IDENTITY_CLASS" \
+  --argjson ui_launch "$UI_LAUNCH_JSON" \
+  --argjson visual_smoke_required "$VISUAL_SMOKE_REQUIRED_JSON" \
+  --argjson release_ready false \
+  --argjson customer_ready false \
+  --arg proof_boundary "$PROOF_BOUNDARY" \
+  '{
+    workflow: $workflow,
+    artifact: $artifact,
+    artifact_sha256: $artifact_sha256,
+    artifact_classification: $artifact_classification,
+    source_sha: $source_sha,
+    source_ref: $source_ref,
+    app_bundle_path: $app_bundle_path,
+    bundle_id: $bundle_id,
+    short_version: $short_version,
+    build_version: $build_version,
+    signing_identity_class: $signing_identity_class,
+    ui_launch: $ui_launch,
+    visual_smoke_required: $visual_smoke_required,
+    release_ready: $release_ready,
+    customer_ready: $customer_ready,
+    proof_boundary: $proof_boundary
+  }' >"$METADATA_PATH"
+
+cat "$METADATA_PATH"

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -44,14 +44,13 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
       "swift run NeonDiffDesktopCoreChecks",
       "swift run NeonDiffDesktopAppcastChecks",
       "script/build_and_run.sh build",
-      "script/build_and_run.sh bundle-check"
+      "script/build_and_run.sh bundle-check",
+      "script/release-proof.sh"
     ]) {
       expect(workflow).toContain(command);
     }
 
     expect(workflow).not.toContain("NeonDiffDesktopCoreSmoke");
-    expect(workflow).toContain("release_ready");
-    expect(workflow).toContain("customer_ready");
     expect(workflow).toContain("unsigned");
     expect(workflow).toMatch(/hosted-runner-safe core checks/);
     expect(workflow).toMatch(/persist-credentials:\s*false/);
@@ -62,10 +61,52 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(workflow).not.toMatch(/actions\/upload-artifact@v4/);
     expect(workflow).toMatch(/NeonDiffDesktop\.app\.zip/);
     expect(workflow).toMatch(/desktop-release-smoke-metadata\.json/);
+    expect(workflow).toMatch(/NEONDIFF_DESKTOP_UI_LAUNCH/);
+    expect(workflow).toMatch(/NEONDIFF_DESKTOP_ARTIFACT_CLASSIFICATION/);
 
     expect(workflow).not.toMatch(/\$\{\{\s*secrets\./);
     expect(workflow).not.toMatch(/\b(codesign|notarytool|stapler|spctl)\b/);
     expect(workflow).not.toMatch(/\bopen\s+-n\b/);
+  });
+
+  it("has a reusable release proof script that records artifact identity and proof boundaries", () => {
+    const scriptPath = "apps/neondiff-desktop/script/release-proof.sh";
+
+    expect(existsSync(scriptPath)).toBe(true);
+
+    const script = read(scriptPath);
+    for (const field of [
+      "artifact_sha256",
+      "source_sha",
+      "source_ref",
+      "app_bundle_path",
+      "bundle_id",
+      "short_version",
+      "build_version",
+      "signing_identity_class",
+      "ui_launch",
+      "visual_smoke_required",
+      "release_ready",
+      "customer_ready",
+      "proof_boundary"
+    ]) {
+      expect(script).toContain(field);
+    }
+
+    expect(script).toContain("shasum -a 256");
+    expect(script).toContain("PlistBuddy");
+    expect(script).toContain("codesign");
+    expect(script).toContain("normalize_bool");
+    expect(script).toContain("ensure_clean_source_tree");
+    expect(script).toContain("verify_existing_app_launch");
+    expect(script).toContain("SOURCE_SHA_PROVIDED");
+    expect(script).toContain('git -C "$REPO_ROOT" diff --quiet');
+    expect(script).toContain("ls-files --others --exclude-standard");
+    expect(script).toContain("jq -n");
+    expect(script).toContain("NEONDIFF_DESKTOP_UI_LAUNCH");
+    expect(script).not.toContain('build_and_run.sh" verify');
+    expect(script).not.toMatch(/\$\{\{\s*secrets\./);
+    expect(script).not.toMatch(/\b(notarytool|stapler|spctl)\b/);
   });
 
   it("documents the desktop smoke artifact as non-release proof", () => {
@@ -80,6 +121,9 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(docs).toMatch(/customer-not-ready/i);
     expect(docs).toMatch(/NeonDiffDesktopCoreChecks/);
     expect(docs).toMatch(/Keychain/i);
+    expect(docs).toMatch(/artifact_sha256/i);
+    expect(docs).toMatch(/bundle_id/i);
+    expect(docs).toMatch(/visible smoke/i);
     expect(docs).not.toMatch(/\b(codesign|notarytool|stapler|spctl)\b/);
   });
 });


### PR DESCRIPTION
## Summary
- add a reusable desktop `release-proof.sh` script for the unsigned app-bundle smoke lane
- record artifact checksum, bundle id/version, signing class, source ref/SHA, UI launch state, and proof boundary in metadata
- update the desktop smoke workflow/docs/tests so the hosted lane stays non-release/customer-not-ready while producing better release evidence

Closes #491.

## Validation
- `NODE_OPTIONS=--experimental-sqlite npx vitest run tests/desktop-release-pipeline.test.ts --pool=forks --maxWorkers=1`
- `bash -n apps/neondiff-desktop/script/release-proof.sh`
- `npm run build`
- fake-bundle script smoke wrote valid JSON evidence at `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-09/v1.0.1-desktop-foundation/release-proof-script-fake-bundle.json`

## Proof Boundary
This strengthens unsigned desktop release-smoke metadata only. It does not claim signed/notarized/Sparkle/user-ready desktop release proof; visible installed-app smoke remains required before desktop launch readiness.
