### PR TITLE
[codex] Improve desktop dashboard launch bar

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
@@ -24,7 +24,6 @@ final class NeonDiffDesktopModel: ObservableObject {
 
     private let userDefaults: UserDefaults
     private let keychain: DesktopSecretStoring
-    private var didAutoOpenDashboard = false
 
     init(
         userDefaults: UserDefaults = .standard,
@@ -49,6 +48,10 @@ final class NeonDiffDesktopModel: ObservableObject {
 
     var dashboardCommand: DesktopCommand {
         NeonDiffCommandBuilder.dashboard(cliPath: cliPath, configPath: configPath, launchdLabel: launchdLabel)
+    }
+
+    var dashboardServerCommand: DesktopCommand {
+        NeonDiffCommandBuilder.dashboard(cliPath: cliPath, configPath: configPath, launchdLabel: launchdLabel, openBrowser: false)
     }
 
     var startDaemonDryRunCommand: DesktopCommand {
@@ -90,39 +93,46 @@ final class NeonDiffDesktopModel: ObservableObject {
         runCLI(arguments: ["daemon", "status", "--config", configPath, "--launchd-label", launchdLabel], displayCommand: statusCommand)
     }
 
-    func openDashboardOnLaunch() {
-        guard !didAutoOpenDashboard else { return }
-        didAutoOpenDashboard = true
-        openDashboard()
+    func openDashboard() {
+        launchDashboard(openBrowser: true)
     }
 
-    func openDashboard() {
-        persistLocalSettings()
-        lastCommandLine = dashboardCommand.commandLine
-        dashboardLaunchStatus = "starting"
-        let executablePath = cliPath
-        let arguments = ["dashboard", "--config", configPath, "--launchd-label", launchdLabel, "--open", "true"]
+    func startDashboardServer() {
+        launchDashboard(openBrowser: false)
+    }
 
-        Task.detached {
-            let client = NeonDiffCLIClient(
-                executablePath: executablePath,
-                workingDirectory: NeonDiffCLIResolver.defaultWorkingDirectory()
-            )
+    private func launchDashboard(openBrowser: Bool) {
+        persistLocalSettings()
+        let command = openBrowser ? dashboardCommand : dashboardServerCommand
+        lastCommandLine = command.commandLine
+        dashboardLaunchStatus = openBrowser ? "opening browser" : "starting server"
+        let executablePath = cliPath
+        let arguments = ["dashboard", "--config", configPath, "--launchd-label", launchdLabel, "--open", openBrowser ? "true" : "false"]
+        let workingDirectory = NeonDiffCLIResolver.defaultWorkingDirectory()
+
+        Task { [weak self] in
+            guard let self else { return }
             do {
-                let result = try client.launchDetached(arguments: arguments)
-                await MainActor.run {
-                    self.dashboardProcessIdentifier = result.processIdentifier
-                    self.dashboardLaunchStatus = "launched pid \(result.processIdentifier); browser opens the local HTML dashboard"
-                    self.lastError = nil
-                    self.logText = "Started NeonDiff local dashboard from the desktop launcher. The dashboard process opens the browser and serves the same HTML experience as `neondiff dashboard`."
-                }
+                let result = try await Task.detached(priority: .userInitiated) {
+                    let client = NeonDiffCLIClient(
+                        executablePath: executablePath,
+                        workingDirectory: workingDirectory
+                    )
+                    return try client.launchDetached(arguments: arguments)
+                }.value
+                self.dashboardProcessIdentifier = result.processIdentifier
+                self.dashboardLaunchStatus = openBrowser
+                    ? "launched pid \(result.processIdentifier); browser opens the local HTML dashboard"
+                    : "launched pid \(result.processIdentifier); local dashboard server started"
+                self.lastError = nil
+                self.logText = openBrowser
+                    ? "Started NeonDiff local dashboard from the desktop launcher and opened the browser dashboard."
+                    : "Started NeonDiff local dashboard server from the desktop launcher without opening a browser tab."
             } catch {
-                await MainActor.run {
-                    self.dashboardProcessIdentifier = nil
-                    self.dashboardLaunchStatus = "failed"
-                    self.lastError = NeonDiffRedactor.redact(error.localizedDescription)
-                    self.logText = self.lastError ?? "Unknown dashboard launch error"
-                }
+                self.dashboardProcessIdentifier = nil
+                self.dashboardLaunchStatus = "failed"
+                self.lastError = NeonDiffRedactor.redact(error.localizedDescription)
+                self.logText = self.lastError ?? "Unknown dashboard launch error"
             }
         }
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ContentView.swift
@@ -34,9 +34,6 @@ struct ContentView: View {
         .tint(NeonDiffTheme.accent)
         .buttonStyle(OperatorButtonStyle())
         .preferredColorScheme(.dark)
-        .onAppear {
-            model.openDashboardOnLaunch()
-        }
         .sheet(isPresented: $model.isOnboardingPresented) {
             OnboardingWizardView(model: model)
                 .frame(minWidth: 760, minHeight: 560)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -17,17 +17,25 @@ struct OverviewView: View {
 
                 OperatorSection("Local Dashboard Launcher") {
                     VStack(alignment: .leading, spacing: 10) {
-                        Text("The Mac launcher opens the same local HTML dashboard as the CLI. Provider, license, GitHub App, and daemon readiness remain redacted in the browser dashboard.")
+                        Text("The Mac app stays in control on launch. Start the local dashboard service here, then open the browser dashboard only when you choose to inspect the full HTML setup surface.")
                             .operatorBodyText()
                             .fixedSize(horizontal: false, vertical: true)
 
                         HStack(spacing: 10) {
-                            Button { model.openDashboard() } label: {
-                                Label("Open Dashboard", systemImage: "safari")
+                            Button { model.startDashboardServer() } label: {
+                                Label("Start Local Dashboard", systemImage: "play.circle")
                             }
+                            .accessibilityIdentifier("neondiff-start-dashboard-server")
+
+                            Button { model.openDashboard() } label: {
+                                Label("Open Browser Dashboard", systemImage: "safari")
+                            }
+                            .accessibilityIdentifier("neondiff-open-browser-dashboard")
+
                             Button { model.copyCommand(model.dashboardCommand) } label: {
                                 Label("Copy Dashboard Command", systemImage: "doc.on.doc")
                             }
+                            .accessibilityIdentifier("neondiff-copy-dashboard-command")
                         }
 
                         OperatorCommandText(text: model.dashboardCommand.commandLine, lineLimit: 3)
@@ -35,6 +43,7 @@ struct OverviewView: View {
                 }
 
                 CommandPanel(commands: [
+                    model.dashboardServerCommand,
                     model.dashboardCommand,
                     model.statusCommand,
                     model.startDaemonDryRunCommand,
@@ -43,21 +52,35 @@ struct OverviewView: View {
                 ], copy: model.copyCommand)
 
                 HStack(spacing: 10) {
-                    Button { model.openDashboard() } label: {
-                        Label("Dashboard", systemImage: "macwindow")
+                    Button { model.startDashboardServer() } label: {
+                        Label("Start Dashboard", systemImage: "play.circle")
                     }
+                    .accessibilityIdentifier("neondiff-overview-start-dashboard")
+
+                    Button { model.openDashboard() } label: {
+                        Label("Open Dashboard", systemImage: "macwindow")
+                    }
+                    .accessibilityIdentifier("neondiff-overview-open-dashboard")
+
                     Button { model.refreshStatus() } label: {
                         Label("Refresh", systemImage: "arrow.clockwise")
                     }
+                    .accessibilityIdentifier("neondiff-refresh-status")
+
                     Button { model.inspectConfig() } label: {
                         Label("Load Config", systemImage: "doc.text.magnifyingglass")
                     }
+                    .accessibilityIdentifier("neondiff-load-config")
+
                     Button { model.previewStartDaemon() } label: {
                         Label("Preview Start", systemImage: "play.circle")
                     }
+                    .accessibilityIdentifier("neondiff-preview-start-daemon")
+
                     Button { model.previewStopDaemon() } label: {
                         Label("Preview Stop", systemImage: "stop.circle")
                     }
+                    .accessibilityIdentifier("neondiff-preview-stop-daemon")
                 }
 
                 if let lastError = model.lastError, !lastError.isEmpty {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/CommandBuilders.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/CommandBuilders.swift
@@ -30,7 +30,7 @@ public enum NeonDiffCommandBuilder {
         openBrowser: Bool = true
     ) -> DesktopCommand {
         DesktopCommand(
-            title: "Open local dashboard",
+            title: openBrowser ? "Open local dashboard" : "Start local dashboard",
             commandLine: "\(shellQuote(cliPath)) dashboard --config \(shellQuote(configPath)) --launchd-label \(shellQuote(launchdLabel)) --open \(openBrowser ? "true" : "false")"
         )
     }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
@@ -120,29 +120,42 @@ public final class NeonDiffCLIClient: NeonDiffCLIClienting {
         guard let resolvedExecutable = NeonDiffCLIResolver.resolveExecutablePath(executablePath, workingDirectory: workingDirectory) else {
             throw NeonDiffCLIError.launchFailed("Could not find executable NeonDiff CLI at \(executablePath). Set an absolute CLI path or install the `neondiff` command in a GUI-visible bin directory.")
         }
-        process.executableURL = resolvedExecutable
-        process.arguments = arguments
+        let commandLine = ([resolvedExecutable.path] + arguments).map(shellQuote).joined(separator: " ")
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-lc",
+            "\(commandLine) >/dev/null 2>&1 & pid=$!; sleep 0.25; if kill -0 \"$pid\" 2>/dev/null; then echo \"$pid\"; else wait \"$pid\"; exit $?; fi"
+        ]
         process.environment = guiSafeEnvironment()
         if let workingDirectory {
             process.currentDirectoryURL = workingDirectory
         }
 
-        let nullOutput = FileHandle(forWritingAtPath: "/dev/null")
-        process.standardOutput = nullOutput
-        process.standardError = nullOutput
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
 
         do {
             try process.run()
         } catch {
-            nullOutput?.closeFile()
             throw NeonDiffCLIError.launchFailed("Failed to launch NeonDiff CLI at \(executablePath): \(error.localizedDescription)")
         }
-        nullOutput?.closeFile()
+        process.waitUntilExit()
+
+        let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        guard process.terminationStatus == 0 else {
+            throw NeonDiffCLIError.launchFailed("Failed to launch NeonDiff CLI at \(executablePath): \(NeonDiffRedactor.redact(stderrText.trimmingCharacters(in: .whitespacesAndNewlines)))")
+        }
+        guard let processIdentifier = Int32(stdoutText.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            throw NeonDiffCLIError.launchFailed("Failed to read detached NeonDiff CLI process id")
+        }
 
         return CLILaunchResult(
-            processIdentifier: process.processIdentifier,
-            executablePath: process.executableURL?.path ?? executablePath,
-            arguments: process.arguments ?? arguments
+            processIdentifier: processIdentifier,
+            executablePath: resolvedExecutable.path,
+            arguments: arguments
         )
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
@@ -41,6 +41,18 @@ do {
     else {
         throw NSError(domain: "NeonDiffDesktopSmoke", code: 10, userInfo: [NSLocalizedDescriptionKey: "dashboard command does not launch the local HTML dashboard"])
     }
+    let dashboardServerCommand = NeonDiffCommandBuilder.dashboard(
+        cliPath: "neondiff",
+        configPath: "/tmp/config.local.json",
+        launchdLabel: "com.example.neondiff",
+        openBrowser: false
+    )
+    guard dashboardServerCommand.title == "Start local dashboard",
+          dashboardServerCommand.commandLine.contains("--open false"),
+          !dashboardServerCommand.commandLine.contains("--open true")
+    else {
+        throw NSError(domain: "NeonDiffDesktopSmoke", code: 11, userInfo: [NSLocalizedDescriptionKey: "dashboard server command does not stay inside the Mac app launch bar"])
+    }
 
     let fakeStatusJSON = """
     {

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -49,9 +49,12 @@ The ZCode defaults in `config.example.json` are developer-machine paths. On any 
 
 ## Local Dashboard Launcher
 
-Opening the dev app starts the same local dashboard server as:
+The dev app no longer opens a browser tab automatically. It exposes explicit
+controls to start the same local dashboard server without opening a browser, or
+to open the browser dashboard when the user chooses it:
 
 ```bash
+neondiff dashboard --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --open false
 neondiff dashboard --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --open true
 ```
 


### PR DESCRIPTION
Closes #486
Parent: #484

## Summary
- stop auto-opening the browser when the Mac app launches
- add explicit desktop launch-bar controls to start the local dashboard server, open the browser dashboard, and copy the dashboard command
- make detached CLI dashboard launch durable by backgrounding the resolved CLI command, checking the child PID, and updating UI state asynchronously
- add smoke coverage for the start-only dashboard command and document the explicit `--open false` / `--open true` split

## Validation
- `swift run NeonDiffDesktopCoreChecks`
- `swift run NeonDiffDesktopCoreSmoke`
- `swift build`
- `./script/build_and_run.sh build && ./script/build_and_run.sh bundle-check`
- `NODE_OPTIONS=--experimental-sqlite npx vitest run tests/local-dashboard.test.ts tests/desktop-release-pipeline.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `git diff --check`
- `node scripts/check-secret-scan.mjs`
- `node scripts/check-public-claims.mjs`
- visible smoke via Computer Use on `apps/neondiff-desktop/dist/NeonDiffDesktop.app`: app launched with bundle id `com.electricsheephq.NeonDiffDesktop`, did not auto-open the browser, controls rendered, `Start Local Dashboard` updated status to launched, and the dashboard server listened locally from the clicked app path
- `NEONDIFF_DESKTOP_UI_LAUNCH=true apps/neondiff-desktop/script/release-proof.sh`

## Evidence
- `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-09/v1.0.1-desktop-foundation/486-desktop-launch-bar-release-proof.json`
- source SHA in proof packet: `9743c4e4f5cfed0752c1aec4f4dfa49edc9d9296`
- artifact SHA-256: `eb502f21cdce3c10e2f6e64f44708aa39d2e98c0b908c294c3a9fc95a9e82b4a`

## Proof Boundary
This proves the unsigned desktop launch-bar behavior and visible local app smoke only. It does not claim signed desktop, notarization, Sparkle update, or release-ready customer distribution; #116/#449 remain the release lanes for those.
