### PR TITLE
[codex] Add review lens eval gate

### DIFF
--- a/docs/eval-harness.md
+++ b/docs/eval-harness.md
@@ -24,6 +24,20 @@ npm run eval:sticky-vs-cold -- \
   --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold-seeded-quality
 ```
 
+Run the review-lenses dry-run comparison gate:
+
+```bash
+npx tsx src/cli.ts review-lenses-eval \
+  --input-dir tests/fixtures/review-lenses-eval \
+  --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/review-lenses-eval-gate-$(date +%H%M%S) \
+  --dry-run true
+```
+
+This command follows the same packet discipline: output stays outside the
+checkout, the output root must be fresh or empty, artifacts are redacted,
+thresholds are explicit, and the decision is advisory-only until a separate
+live activation promotion gate passes.
+
 The suite command exits non-zero when any scenario fails, when two scenarios use
 the same `runId`, when a `runId` is not a safe path segment, or when any required
 suite is missing from the input directory.

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -109,6 +109,11 @@ evaos-review-bot status --config config.local.json
   `github-related-context-packet.md` evidence. This command never posts
   comments, calls ZCode, auto-applies labels/reviewers, or searches GitHub
   beyond explicit references.
+- `review-lenses-eval`: dry-run evidence builder for default-off review lenses.
+  It compares configured lens packets against baseline output and writes an eval
+  packet to a fresh or empty output root. It does not post comments, mutate
+  GitHub, write SQLite, restart launchd, activate lenses, or widen
+  issue-enrichment/PR review allowlists.
 - `build-skill-pack`: compiles configured read-only skill-pack files into an
   advisory prompt packet. It emits JSON/Markdown with packet SHA, byte/token
   estimates, source provenance, omitted-source reasons, and a redaction report.

--- a/docs/review-lenses.md
+++ b/docs/review-lenses.md
@@ -25,6 +25,18 @@ validation, current-head checks, redaction, and deterministic posting policy rem
 - `pr_shadow`: lean suggestions are recorded in evidence, not posted as blocking findings.
 - `walkthrough`: reserved for future compact summaries after fixture/eval review.
 
+## Dry-Run Eval Gate
+
+Use `review-lenses-eval` before any live activation. The command compares
+lens-enabled output against a no-lens baseline and writes redacted evidence only.
+The output root must be fresh or empty so stale artifacts cannot affect the
+scorecard. It does not flip `reviewLenses.enabled`, change public defaults, post
+comments, alter GitHub permissions, widen monitored repos, mutate live config,
+or promote the `walkthrough` surface.
+
+Each scenario writes `manifest.json`, paired `baseline/` and `lens/` artifacts,
+`diff-summary.json`, `redaction-report.json`, and `lens-scorecard.json`.
+
 ## Config Sketch
 
 ```json

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,6 +70,7 @@ import {
 import { buildReviewBudgetStatus } from "./review-budget.js";
 import { selectReviewMode } from "./review-mode-router.js";
 import type { ReviewMode } from "./review-mode-types.js";
+import { readReviewLensEvalScenario, runReviewLensEval, type ReviewLensEvalMode } from "./review-lens-eval.js";
 import type { PullFilePatch, PullRequestSummary } from "./types.js";
 import {
   buildOperatorDashboard,
@@ -1583,6 +1584,29 @@ async function main(): Promise<void> {
     });
     console.log(JSON.stringify(result.summary, null, 2));
     if (!result.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "review-lenses-eval") {
+    if (args["output-root"] === undefined || (Array.isArray(args["output-root"]) && args["output-root"].length === 0)) {
+      throw new Error("--output-root is required for review-lenses-eval");
+    }
+    const hasInput = args.input !== undefined;
+    const hasInputDir = args["input-dir"] !== undefined;
+    if (hasInput === hasInputDir) throw new Error("review-lenses-eval requires exactly one of --input or --input-dir");
+    const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
+    const mode = parseReviewLensEvalMode(args.mode);
+    const scenarioPaths = hasInput
+      ? [parseSingleArg(args.input!, "--input")]
+      : listJsonFiles(parseSingleArg(args["input-dir"]!, "--input-dir"));
+    const result = runReviewLensEval({
+      scenarios: scenarioPaths.map((scenarioPath) => readReviewLensEvalScenario(scenarioPath)),
+      outputRoot: parseSingleArg(args["output-root"], "--output-root"),
+      mode,
+      dryRun
+    });
+    console.log(stringifyRedactedJson(result.summary));
+    if (!result.summary.ok) process.exitCode = 1;
     return;
   }
 
@@ -3162,6 +3186,16 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--confirm", description: "Must be true to allow --dry-run false." }
     ]
   },
+  "review-lenses-eval": {
+    description: "Run dry-run comparison evidence for default-off review lenses; no posting, provider calls, live config mutation, or activation.",
+    flags: [
+      { name: "--input", description: "Single review-lens eval scenario JSON." },
+      { name: "--input-dir", description: "Directory of review-lens eval scenario JSON files." },
+      { name: "--output-root", description: "Eval evidence output root outside the checkout." },
+      { name: "--mode", description: "deterministic (default) or model-shadow; model-shadow remains provider-free and dry-run only." },
+      { name: "--dry-run", description: "true by default; false is rejected." }
+    ]
+  },
   daemon: {
     description: "Control or run the review daemon: `daemon start|stop|status`, or no subcommand to run the poll loop directly.",
     flags: [
@@ -3270,6 +3304,7 @@ function buildHelp(command?: string) {
         "eval-offline",
         "eval-suite",
         "eval-sticky-vs-cold",
+        "review-lenses-eval",
         "outcome-ledger",
         "outcome-scorecard",
         "review-mode",
@@ -3328,6 +3363,7 @@ function buildHelp(command?: string) {
       "npx tsx src/cli.ts clear-issue-enrichment-leases --config /path/to/live.json --dry-run true --expired-only true",
       "npx tsx src/cli.ts clear-review-queue-leases --config /path/to/live.json --dry-run true --expired-only true",
       "npx tsx src/cli.ts eval-sticky-vs-cold --input /path/to/sticky-vs-cold.json --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/sticky-vs-cold",
+      "npx tsx src/cli.ts review-lenses-eval --input-dir tests/fixtures/review-lenses-eval --output-root /Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/$(date +%F)/review-lenses-eval-gate-$(date +%H%M%S) --dry-run true",
       "npx tsx src/cli.ts outcome-ledger --input /path/to/outcome-ledger-input.json --dry-run true --output-dir /path/to/evidence/outcome-ledger-run",
       "npx tsx src/cli.ts outcome-scorecard --input /path/to/outcome-scorecard-input.json --dry-run true --output-dir /path/to/evidence/outcome-scorecard-run",
       "npx tsx src/cli.ts outcome-observe --config /path/to/live.json --input /path/to/outcome-observer-input.json --dry-run true --output-dir /path/to/evidence/outcome-observe-run",
@@ -3772,6 +3808,13 @@ function readReviewModeInput(path: string): {
     files: record.files as PullFilePatch[],
     ...(override !== undefined ? { repoOverrideMode: override as ReviewMode } : {})
   };
+}
+
+function parseReviewLensEvalMode(value?: string | string[]): ReviewLensEvalMode {
+  if (value === undefined) return "deterministic";
+  const parsed = parseSingleArg(value, "--mode");
+  if (parsed === "deterministic" || parsed === "model-shadow") return parsed;
+  throw new Error("--mode must be deterministic or model-shadow");
 }
 
 function listJsonFiles(inputDir: string): string[] {

--- a/src/review-lens-eval.ts
+++ b/src/review-lens-eval.ts
@@ -1,0 +1,755 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync
+} from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { assertEvalOutputDirSafe } from "./eval-harness.js";
+import { buildIssueEnrichmentComment } from "./enrichment.js";
+import type { GitHubRelatedIssueOrPull } from "./github-related-context.js";
+import {
+  buildLeanReviewShadow,
+  buildReviewLensPacket,
+  DEFAULT_REVIEW_LENS_CONFIG,
+  type LeanReviewShadow,
+  type ReviewLensConfig,
+  type ReviewLensPacket,
+  type ReviewLensSurface
+} from "./review-lenses.js";
+import { containsSecretLikeText, redactSecrets, stringifyRedactedJson } from "./secrets.js";
+import type { PullFilePatch, PullRequestSummary } from "./types.js";
+import { buildReviewPrompt } from "./zcode.js";
+
+export type ReviewLensEvalMode = "deterministic" | "model-shadow";
+export type ReviewLensEvalSuite = "review_lens_packet_safety";
+
+export interface ReviewLensEvalScenario {
+  evalName: string;
+  runId: string;
+  suite: ReviewLensEvalSuite;
+  surface: ReviewLensSurface;
+  negativeControl?: boolean;
+  reviewLenses: ReviewLensConfig;
+  issue?: ReviewLensEvalIssueInput;
+  pull?: ReviewLensEvalPullInput;
+  files?: PullFilePatch[];
+  decision?: {
+    status: "block" | "warn" | "accept_with_evidence" | "defer" | "human_review";
+    reason: string;
+  };
+  expected?: {
+    includedLenses?: string[];
+    omittedReasons?: string[];
+    maxPacketBytes?: number;
+    secretFindings?: number;
+    requestChangesEligible?: false;
+    leanSuggestionsMin?: number;
+    leanSuggestionsMax?: number;
+    architectureSection?: boolean;
+  };
+}
+
+export interface ReviewLensEvalIssueInput {
+  repo: string;
+  number: number;
+  state: string;
+  title: string;
+  body?: string;
+  html_url?: string;
+}
+
+export interface ReviewLensEvalPullInput {
+  repo: string;
+  number: number;
+  title: string;
+  draft: boolean;
+  body?: string;
+  headSha: string;
+  baseSha: string;
+  headRef: string;
+  baseRef: string;
+  html_url?: string;
+}
+
+export interface ReviewLensEvalOptions {
+  scenarios: ReviewLensEvalScenario[];
+  outputRoot: string;
+  mode: ReviewLensEvalMode;
+  dryRun: boolean;
+  now?: Date;
+}
+
+export interface ReviewLensEvalSummary {
+  ok: boolean;
+  command: "review-lenses-eval";
+  mode: ReviewLensEvalMode;
+  dryRun: boolean;
+  scenarioCount: number;
+  passed: number;
+  failed: number;
+  outputRoot: string;
+  generatedAt: string;
+  proofBoundary: string;
+  results: ReviewLensEvalRunSummary[];
+}
+
+export interface ReviewLensEvalRunSummary {
+  ok: boolean;
+  evalName: string;
+  runId: string;
+  suite: ReviewLensEvalSuite;
+  surface: ReviewLensSurface;
+  outputDir: string;
+  scorecard: ReviewLensEvalScorecard;
+}
+
+export interface ReviewLensEvalScorecard {
+  evalName: string;
+  runId: string;
+  suite: ReviewLensEvalSuite;
+  surface: ReviewLensSurface;
+  mode: ReviewLensEvalMode;
+  generatedAt: string;
+  counts: {
+    includedLenses: number;
+    omittedLenses: number;
+    disallowedDirectiveOmissions: number;
+    secretFindings: number;
+    rawRedactedSources: number;
+    byteEstimate: number;
+    leanSuggestions: number;
+    requestChangesEligibleSuggestions: number;
+  };
+  gates: Array<{ name: string; ok: boolean; detail: string }>;
+  publicConfidence: "uncalibrated";
+  proofBoundary: string;
+}
+
+export function readReviewLensEvalScenario(path: string): ReviewLensEvalScenario {
+  const parsed = JSON.parse(readFileSync(path, "utf8"));
+  return normalizeScenario(parsed, path);
+}
+
+export function runReviewLensEval(input: ReviewLensEvalOptions): { summary: ReviewLensEvalSummary } {
+  if (!input.dryRun) throw new Error("review-lenses-eval is dry-run only; live posting or config mutation is not implemented");
+  if (input.scenarios.length === 0) throw new Error("review-lenses-eval requires at least one scenario");
+  const outputRoot = prepareOutputRoot(input.outputRoot);
+  const generatedAt = (input.now ?? new Date()).toISOString();
+
+  const seenRunIds = new Set<string>();
+  const results = input.scenarios.map((scenario) => {
+    if (seenRunIds.has(scenario.runId)) throw new Error(`duplicate review-lenses-eval runId "${scenario.runId}"`);
+    seenRunIds.add(scenario.runId);
+    return runScenario({ scenario, outputRoot, mode: input.mode, generatedAt });
+  });
+  const summary: ReviewLensEvalSummary = {
+    ok: results.every((result) => result.ok),
+    command: "review-lenses-eval",
+    mode: input.mode,
+    dryRun: input.dryRun,
+    scenarioCount: results.length,
+    passed: results.filter((result) => result.ok).length,
+    failed: results.filter((result) => !result.ok).length,
+    outputRoot,
+    generatedAt,
+    proofBoundary:
+      "Review lens eval proves dry-run/eval plumbing only. It does not prove production review-quality improvement, live activation readiness, or calibrated confidence.",
+    results
+  };
+  writeJson(join(outputRoot, "suite-summary.json"), summary);
+  writeText(join(outputRoot, "promotion-decision.md"), buildPromotionDecision(summary));
+  return { summary };
+}
+
+function runScenario(input: {
+  scenario: ReviewLensEvalScenario;
+  outputRoot: string;
+  mode: ReviewLensEvalMode;
+  generatedAt: string;
+}): ReviewLensEvalRunSummary {
+  const outputDir = join(input.outputRoot, input.scenario.runId);
+  const baselineDir = join(outputDir, "baseline");
+  const lensDir = join(outputDir, "lens");
+  mkdirSync(baselineDir, { recursive: true });
+  mkdirSync(lensDir, { recursive: true });
+
+  const baselineConfig = { ...DEFAULT_REVIEW_LENS_CONFIG, enabled: false, active: [] };
+  const lensBuild = buildReviewLensPacket({
+    config: input.scenario.reviewLenses,
+    surface: input.scenario.surface,
+    generatedAt: input.generatedAt
+  });
+  const baselineBuild = buildReviewLensPacket({
+    config: baselineConfig,
+    surface: input.scenario.surface,
+    generatedAt: input.generatedAt
+  });
+  if (!baselineBuild.ok) throw new Error(`Baseline review lens packet failed: ${baselineBuild.error}`);
+  const packet = lensBuild.ok ? lensBuild.packet : undefined;
+  let leanShadow: LeanReviewShadow | undefined;
+  let lensIssueBody: string | undefined;
+  const sourceTexts: Array<{ id: string; text: string }> = [
+    { id: "scenario", text: JSON.stringify(input.scenario) }
+  ];
+
+  if (baselineBuild.ok) {
+    writeJson(join(baselineDir, `review-lens-${input.scenario.surface}-packet.json`), baselineBuild.packet);
+    writeText(join(baselineDir, `review-lens-${input.scenario.surface}-packet.md`), baselineBuild.packet.markdown);
+    sourceTexts.push({ id: "baseline-packet", text: baselineBuild.packet.markdown });
+  }
+
+  if (packet) {
+    writeJson(join(lensDir, `review-lens-${input.scenario.surface}-packet.json`), packet);
+    writeText(join(lensDir, `review-lens-${input.scenario.surface}-packet.md`), packet.markdown);
+    sourceTexts.push({ id: "lens-packet", text: packet.markdown });
+  }
+
+  if (input.scenario.surface === "issue_enrichment") {
+    const issue = scenarioIssue(input.scenario);
+    const baselineComment = buildIssueEnrichmentComment({ repo: issue.repo, issue: issue.issue });
+    const lensComment = buildIssueEnrichmentComment({
+      repo: issue.repo,
+      issue: issue.issue,
+      ...(packet ? { reviewLensPacket: packet } : {})
+    });
+    writeText(join(baselineDir, "issue-enrichment.md"), baselineComment.body);
+    writeText(join(lensDir, "issue-enrichment.md"), lensComment.body);
+    lensIssueBody = lensComment.body;
+    sourceTexts.push({ id: "baseline-issue-enrichment", text: baselineComment.body });
+    sourceTexts.push({ id: "lens-issue-enrichment", text: lensComment.body });
+  } else if (input.scenario.surface === "pr_shadow") {
+    const pull = scenarioPull(input.scenario);
+    const files = input.scenario.files ?? [];
+    const baselinePrompt = buildReviewPrompt({ repo: pull.repo, pull: pull.pull, files });
+    const lensPrompt = buildReviewPrompt({
+      repo: pull.repo,
+      pull: pull.pull,
+      files,
+      ...(packet ? { reviewLensPacket: packet } : {})
+    });
+    writeText(join(baselineDir, "review-prompt.md"), baselinePrompt);
+    writeText(join(lensDir, "review-prompt.md"), lensPrompt);
+    leanShadow = buildLeanReviewShadow({ files });
+    writeJson(join(lensDir, "lean-review-shadow.json"), leanShadow);
+    sourceTexts.push({ id: "baseline-review-prompt", text: baselinePrompt });
+    sourceTexts.push({ id: "lens-review-prompt", text: lensPrompt });
+    sourceTexts.push({ id: "lean-review-shadow", text: JSON.stringify(leanShadow) });
+  } else {
+    writeJson(join(baselineDir, "decision-evidence.json"), {
+      status: "not_evaluated",
+      reason: "Baseline has no decision lens packet."
+    });
+    writeJson(join(lensDir, "decision-evidence.json"), {
+      ...(input.scenario.decision ?? {
+        status: "human_review",
+        reason: "No explicit decision fixture supplied."
+      }),
+      advisoryOnly: true
+    });
+  }
+
+  if (input.mode === "model-shadow") {
+    writeJson(join(outputDir, "model-shadow-summary.json"), {
+      mode: "model-shadow",
+      providerCalls: 0,
+      githubPosts: 0,
+      generatedAt: input.generatedAt,
+      proofBoundary:
+        "No provider call or GitHub posting was performed. This model-shadow packet compares prompt/evidence surfaces only."
+    });
+  }
+
+  const redactionReport = buildEvalRedactionReport(sourceTexts);
+  writeJson(join(outputDir, "redaction-report.json"), redactionReport);
+  const scorecard = buildScorecard({
+    scenario: input.scenario,
+    mode: input.mode,
+    generatedAt: input.generatedAt,
+    packet,
+    packetBuildOk: lensBuild.ok,
+    packetBuildError: lensBuild.ok ? undefined : lensBuild.error,
+    redactionReport,
+    leanShadow,
+    lensIssueBody
+  });
+  writeJson(join(outputDir, "lens-scorecard.json"), scorecard);
+  writeJson(join(outputDir, "diff-summary.json"), buildDiffSummary(outputDir));
+  writeJson(join(outputDir, "manifest.json"), {
+    evalName: input.scenario.evalName,
+    runId: input.scenario.runId,
+    suite: input.scenario.suite,
+    surface: input.scenario.surface,
+    mode: input.mode,
+    generatedAt: input.generatedAt,
+    publicConfidence: "uncalibrated",
+    activeLenses: input.scenario.reviewLenses.active,
+    expected: input.scenario.expected ?? {},
+    artifacts: inventoryArtifacts(outputDir),
+    proofBoundary:
+      "Review lens scenario evidence is dry-run only; it does not post comments, mutate GitHub, activate lenses, or widen repository allowlists."
+  });
+
+  return {
+    ok: scorecard.gates.every((gate) => gate.ok),
+    evalName: input.scenario.evalName,
+    runId: input.scenario.runId,
+    suite: input.scenario.suite,
+    surface: input.scenario.surface,
+    outputDir,
+    scorecard
+  };
+}
+
+function buildScorecard(input: {
+  scenario: ReviewLensEvalScenario;
+  mode: ReviewLensEvalMode;
+  generatedAt: string;
+  packet?: ReviewLensPacket;
+  packetBuildOk: boolean;
+  packetBuildError?: string;
+  redactionReport: ReviewLensEvalRedactionReport;
+  leanShadow?: LeanReviewShadow;
+  lensIssueBody?: string;
+}): ReviewLensEvalScorecard {
+  const packet = input.packet;
+  const includedLensIds = packet?.lenses.map((lens) => lens.id) ?? [];
+  const omittedReasons = packet?.omittedLenses.map((lens) => lens.reason) ?? [];
+  const leanSuggestions = input.leanShadow?.suggestions ?? [];
+  const requestChangesEligibleSuggestions = leanSuggestions.filter((suggestion) => suggestion.requestChangesEligible).length;
+  const gates = [
+    {
+      name: "packet_build_ok",
+      ok: input.packetBuildOk,
+      detail: input.packetBuildOk ? "packet rendered" : input.packetBuildError ?? "packet failed"
+    },
+    {
+      name: "secret_redaction",
+      ok: input.redactionReport.secretFindings === 0,
+      detail: `${input.redactionReport.secretFindings} unredacted secret-like artifact(s) after rendering`
+    },
+    {
+      name: "advisory_only",
+      ok: requestChangesEligibleSuggestions === 0,
+      detail: `${requestChangesEligibleSuggestions} REQUEST_CHANGES-eligible lens suggestion(s)`
+    },
+    {
+      name: "packet_budget",
+      ok: !packet || packet.byteEstimate <= (input.scenario.expected?.maxPacketBytes ?? input.scenario.reviewLenses.maxPacketBytes),
+      detail: packet ? `${packet.byteEstimate} bytes` : "no packet"
+    },
+    {
+      name: "disallowed_directives_omitted",
+      ok: (packet?.omittedLenses.filter((lens) => lens.reason === "disallowed_directive").length ?? 0) <=
+        (input.scenario.expected?.omittedReasons?.filter((reason) => reason === "disallowed_directive").length ?? 0),
+      detail: `${packet?.omittedLenses.filter((lens) => lens.reason === "disallowed_directive").length ?? 0} disallowed directive omission(s)`
+    },
+    {
+      name: "surface_filtering",
+      ok: expectedIncludedLensesMatch(input.scenario.expected?.includedLenses, includedLensIds),
+      detail: `included lenses: ${includedLensIds.join(", ") || "none"}`
+    },
+    {
+      name: "lean_shadow_non_blocking",
+      ok: leanSuggestions.every((suggestion) => !suggestion.blocking && !suggestion.requestChangesEligible),
+      detail: `${leanSuggestions.length} lean shadow suggestion(s)`
+    },
+    {
+      name: "safety_negative_control",
+      ok: !input.scenario.negativeControl || leanSuggestions.length === 0,
+      detail: input.scenario.negativeControl ? `${leanSuggestions.length} lean suggestion(s) in negative control` : "not a negative control"
+    }
+  ];
+  const min = input.scenario.expected?.leanSuggestionsMin;
+  if (min !== undefined) {
+    gates.push({
+      name: "lean_suggestion_min",
+      ok: leanSuggestions.length >= min,
+      detail: `${leanSuggestions.length} lean suggestion(s), expected at least ${min}`
+    });
+  }
+  const max = input.scenario.expected?.leanSuggestionsMax;
+  if (max !== undefined) {
+    gates.push({
+      name: "lean_suggestion_max",
+      ok: leanSuggestions.length <= max,
+      detail: `${leanSuggestions.length} lean suggestion(s), expected at most ${max}`
+    });
+  }
+  const expectedArchitectureSection = input.scenario.expected?.architectureSection;
+  if (expectedArchitectureSection !== undefined) {
+    const hasArchitectureSection = input.lensIssueBody?.includes("### Architecture lens") ?? false;
+    gates.push({
+      name: "architecture_section_expectation",
+      ok: hasArchitectureSection === expectedArchitectureSection,
+      detail: `architecture section present=${hasArchitectureSection}, expected=${expectedArchitectureSection}`
+    });
+  }
+  const expectedSecretFindings = input.scenario.expected?.secretFindings;
+  if (expectedSecretFindings !== undefined) {
+    gates.push({
+      name: "expected_redaction_findings",
+      ok: input.redactionReport.secretFindings <= expectedSecretFindings,
+      detail: `${input.redactionReport.secretFindings} secret finding(s), expected at most ${expectedSecretFindings}`
+    });
+  }
+  return {
+    evalName: input.scenario.evalName,
+    runId: input.scenario.runId,
+    suite: input.scenario.suite,
+    surface: input.scenario.surface,
+    mode: input.mode,
+    generatedAt: input.generatedAt,
+    counts: {
+      includedLenses: includedLensIds.length,
+      omittedLenses: packet?.omittedLenses.length ?? 0,
+      disallowedDirectiveOmissions: omittedReasons.filter((reason) => reason === "disallowed_directive").length,
+      secretFindings: input.redactionReport.secretFindings,
+      rawRedactedSources: input.redactionReport.redactedSources.length,
+      byteEstimate: packet?.byteEstimate ?? 0,
+      leanSuggestions: leanSuggestions.length,
+      requestChangesEligibleSuggestions
+    },
+    gates,
+    publicConfidence: "uncalibrated",
+    proofBoundary:
+      "Review lens scorecard is advisory dry-run evidence only. It cannot activate lenses, request changes, or make calibrated-confidence claims."
+  };
+}
+
+interface ReviewLensEvalRedactionReport {
+  ok: boolean;
+  checkedSources: number;
+  redactedSources: Array<{ id: string; redactedPreview: string }>;
+  secretFindings: number;
+}
+
+function buildEvalRedactionReport(sources: Array<{ id: string; text: string }>): ReviewLensEvalRedactionReport {
+  const redactedSources = sources
+    .filter((source) => containsSecretLikeText(source.text))
+    .map((source) => ({
+      id: source.id,
+      redactedPreview: truncate(redactSecrets(source.text).replace(/\s+/g, " ").trim(), 160)
+    }));
+  const renderedText = sources.map((source) => redactSecrets(source.text)).join("\n");
+  const secretFindings = containsSecretLikeText(renderedText) ? 1 : 0;
+  return {
+    ok: secretFindings === 0,
+    checkedSources: sources.length,
+    redactedSources,
+    secretFindings
+  };
+}
+
+function buildDiffSummary(outputDir: string): {
+  baselineArtifacts: string[];
+  lensArtifacts: string[];
+  comparisons: Array<{ artifact: string; baselineSha256: string; lensSha256: string; changed: boolean }>;
+  baselineOnly: string[];
+  lensOnly: string[];
+  changed: boolean;
+  proofBoundary: string;
+} {
+  const baselineArtifacts = listRelativeFiles(join(outputDir, "baseline"));
+  const lensArtifacts = listRelativeFiles(join(outputDir, "lens"));
+  const baselineSet = new Set(baselineArtifacts);
+  const lensSet = new Set(lensArtifacts);
+  const common = baselineArtifacts.filter((artifact) => lensSet.has(artifact));
+  const comparisons = common.map((artifact) => {
+    const baselineSha256 = sha256(readFileSync(join(outputDir, "baseline", artifact), "utf8"));
+    const lensSha256 = sha256(readFileSync(join(outputDir, "lens", artifact), "utf8"));
+    return {
+      artifact,
+      baselineSha256,
+      lensSha256,
+      changed: baselineSha256 !== lensSha256
+    };
+  });
+  const baselineOnly = baselineArtifacts.filter((artifact) => !lensSet.has(artifact));
+  const lensOnly = lensArtifacts.filter((artifact) => !baselineSet.has(artifact));
+  return {
+    baselineArtifacts,
+    lensArtifacts,
+    comparisons,
+    baselineOnly,
+    lensOnly,
+    changed: comparisons.some((comparison) => comparison.changed) || baselineOnly.length > 0 || lensOnly.length > 0,
+    proofBoundary: "Diff summary compares baseline and lens artifact content hashes; semantic quality comparison requires labeled outcome review."
+  };
+}
+
+function prepareOutputRoot(outputRoot: string): string {
+  const safeOutputRoot = assertEvalOutputDirSafe(outputRoot);
+  if (existsSync(safeOutputRoot)) {
+    const stat = lstatSync(safeOutputRoot);
+    if (stat.isSymbolicLink()) throw new Error("outputRoot must not be a symbolic link");
+    if (!stat.isDirectory()) throw new Error("outputRoot must be a directory when it already exists");
+    if (readdirSync(safeOutputRoot).length > 0) {
+      throw new Error("outputRoot must be empty before running review-lenses-eval; choose a fresh output root to avoid stale artifacts");
+    }
+  }
+  mkdirSync(safeOutputRoot, { recursive: true });
+  return safeOutputRoot;
+}
+
+function normalizeScenario(value: unknown, path: string): ReviewLensEvalScenario {
+  if (!isRecord(value)) throw new Error(`${path} must contain a JSON object`);
+  const scenario = value as Record<string, unknown>;
+  const runId = requireSafeSegment(scenario.runId, `${path}.runId`);
+  const evalName = requireString(scenario.evalName, `${path}.evalName`);
+  if (scenario.suite !== "review_lens_packet_safety") throw new Error(`${path}.suite must be review_lens_packet_safety`);
+  const surface = requireSurface(scenario.surface, `${path}.surface`);
+  const reviewLenses = normalizeReviewLensConfig(scenario.reviewLenses, `${path}.reviewLenses`);
+  return {
+    evalName,
+    runId,
+    suite: "review_lens_packet_safety",
+    surface,
+    ...(scenario.negativeControl === true ? { negativeControl: true } : {}),
+    reviewLenses,
+    ...(scenario.issue ? { issue: normalizeIssue(scenario.issue, `${path}.issue`) } : {}),
+    ...(scenario.pull ? { pull: normalizePull(scenario.pull, `${path}.pull`) } : {}),
+    ...(scenario.files ? { files: normalizeFiles(scenario.files, `${path}.files`) } : {}),
+    ...(scenario.decision ? { decision: normalizeDecision(scenario.decision, `${path}.decision`) } : {}),
+    ...(scenario.expected ? { expected: normalizeExpected(scenario.expected, `${path}.expected`) } : {})
+  };
+}
+
+function normalizeReviewLensConfig(value: unknown, label: string): ReviewLensConfig {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  return {
+    enabled: value.enabled === undefined ? true : requireBoolean(value.enabled, `${label}.enabled`),
+    packetVersion: value.packetVersion === undefined ? DEFAULT_REVIEW_LENS_CONFIG.packetVersion : requireString(value.packetVersion, `${label}.packetVersion`),
+    active: Array.isArray(value.active) ? value.active as ReviewLensConfig["active"] : [],
+    maxLensBytes: value.maxLensBytes === undefined ? DEFAULT_REVIEW_LENS_CONFIG.maxLensBytes : requirePositiveInteger(value.maxLensBytes, `${label}.maxLensBytes`),
+    maxPacketBytes: value.maxPacketBytes === undefined ? DEFAULT_REVIEW_LENS_CONFIG.maxPacketBytes : requirePositiveInteger(value.maxPacketBytes, `${label}.maxPacketBytes`)
+  };
+}
+
+function normalizeIssue(value: unknown, label: string): ReviewLensEvalIssueInput {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  return {
+    repo: requireRepo(value.repo, `${label}.repo`),
+    number: requirePositiveInteger(value.number, `${label}.number`),
+    state: requireString(value.state, `${label}.state`),
+    title: requireString(value.title, `${label}.title`),
+    ...(value.body === undefined ? {} : { body: requireString(value.body, `${label}.body`) }),
+    ...(value.html_url === undefined ? {} : { html_url: requireString(value.html_url, `${label}.html_url`) })
+  };
+}
+
+function normalizePull(value: unknown, label: string): ReviewLensEvalPullInput {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  return {
+    repo: requireRepo(value.repo, `${label}.repo`),
+    number: requirePositiveInteger(value.number, `${label}.number`),
+    title: requireString(value.title, `${label}.title`),
+    draft: requireBoolean(value.draft, `${label}.draft`),
+    ...(value.body === undefined ? {} : { body: requireString(value.body, `${label}.body`) }),
+    headSha: requireSha(value.headSha, `${label}.headSha`),
+    baseSha: requireSha(value.baseSha, `${label}.baseSha`),
+    headRef: requireString(value.headRef, `${label}.headRef`),
+    baseRef: requireString(value.baseRef, `${label}.baseRef`),
+    ...(value.html_url === undefined ? {} : { html_url: requireString(value.html_url, `${label}.html_url`) })
+  };
+}
+
+function normalizeFiles(value: unknown, label: string): PullFilePatch[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value.map((entry, index) => {
+    if (!isRecord(entry)) throw new Error(`${label}.${index} must be an object`);
+    return {
+      filename: requireString(entry.filename, `${label}.${index}.filename`),
+      ...(entry.patch === undefined || entry.patch === null ? {} : { patch: requireString(entry.patch, `${label}.${index}.patch`) })
+    };
+  });
+}
+
+function normalizeDecision(value: unknown, label: string): ReviewLensEvalScenario["decision"] {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  const status = value.status;
+  if (status !== "block" && status !== "warn" && status !== "accept_with_evidence" && status !== "defer" && status !== "human_review") {
+    throw new Error(`${label}.status must be block, warn, accept_with_evidence, defer, or human_review`);
+  }
+  return { status, reason: requireString(value.reason, `${label}.reason`) };
+}
+
+function normalizeExpected(value: unknown, label: string): NonNullable<ReviewLensEvalScenario["expected"]> {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  return {
+    ...(value.includedLenses === undefined ? {} : { includedLenses: requireStringArray(value.includedLenses, `${label}.includedLenses`) }),
+    ...(value.omittedReasons === undefined ? {} : { omittedReasons: requireStringArray(value.omittedReasons, `${label}.omittedReasons`) }),
+    ...(value.maxPacketBytes === undefined ? {} : { maxPacketBytes: requirePositiveInteger(value.maxPacketBytes, `${label}.maxPacketBytes`) }),
+    ...(value.secretFindings === undefined ? {} : { secretFindings: requireNonNegativeInteger(value.secretFindings, `${label}.secretFindings`) }),
+    ...(value.requestChangesEligible === undefined ? {} : { requestChangesEligible: false }),
+    ...(value.leanSuggestionsMin === undefined ? {} : { leanSuggestionsMin: requireNonNegativeInteger(value.leanSuggestionsMin, `${label}.leanSuggestionsMin`) }),
+    ...(value.leanSuggestionsMax === undefined ? {} : { leanSuggestionsMax: requireNonNegativeInteger(value.leanSuggestionsMax, `${label}.leanSuggestionsMax`) }),
+    ...(value.architectureSection === undefined ? {} : { architectureSection: requireBoolean(value.architectureSection, `${label}.architectureSection`) })
+  };
+}
+
+function scenarioIssue(scenario: ReviewLensEvalScenario): { repo: string; issue: GitHubRelatedIssueOrPull } {
+  if (!scenario.issue) throw new Error(`scenario ${scenario.runId} requires issue for issue_enrichment surface`);
+  return {
+    repo: scenario.issue.repo,
+    issue: {
+      number: scenario.issue.number,
+      title: scenario.issue.title,
+      state: scenario.issue.state,
+      body: scenario.issue.body ?? "",
+      html_url: scenario.issue.html_url,
+      labels: []
+    }
+  };
+}
+
+function scenarioPull(scenario: ReviewLensEvalScenario): { repo: string; pull: PullRequestSummary } {
+  if (!scenario.pull) throw new Error(`scenario ${scenario.runId} requires pull for pr_shadow surface`);
+  return {
+    repo: scenario.pull.repo,
+    pull: {
+      number: scenario.pull.number,
+      title: scenario.pull.title,
+      draft: scenario.pull.draft,
+      body: scenario.pull.body ?? "",
+      html_url: scenario.pull.html_url ?? `https://github.test/${scenario.pull.repo}/pull/${scenario.pull.number}`,
+      head: {
+        sha: scenario.pull.headSha,
+        ref: scenario.pull.headRef,
+        repo: { full_name: scenario.pull.repo }
+      },
+      base: {
+        sha: scenario.pull.baseSha,
+        ref: scenario.pull.baseRef,
+        repo: { full_name: scenario.pull.repo }
+      },
+      requested_reviewers: [],
+      labels: []
+    }
+  };
+}
+
+function expectedIncludedLensesMatch(expected: string[] | undefined, actual: string[]): boolean {
+  if (!expected) return true;
+  return JSON.stringify([...expected].sort()) === JSON.stringify([...actual].sort());
+}
+
+function buildPromotionDecision(summary: ReviewLensEvalSummary): string {
+  return [
+    "# Review Lenses Eval Promotion Decision",
+    "",
+    `Decision: ${summary.ok ? "advisory dry-run evidence passed" : "not ready"}`,
+    "Live activation: disabled",
+    "Calibrated public confidence: disabled",
+    "",
+    summary.proofBoundary,
+    "",
+    "## Scenario Results",
+    "",
+    ...summary.results.map((result) => `- ${result.ok ? "PASS" : "FAIL"} ${result.runId} (${result.surface})`)
+  ].join("\n");
+}
+
+function inventoryArtifacts(root: string): Array<{ path: string; sha256: string }> {
+  return listRelativeFiles(root).map((artifactPath) => {
+    const fullPath = join(root, artifactPath);
+    return {
+      path: artifactPath,
+      sha256: sha256(readFileSync(fullPath, "utf8"))
+    };
+  });
+}
+
+function listRelativeFiles(root: string): string[] {
+  if (!existsSync(root)) return [];
+  const files: string[] = [];
+  const visit = (dir: string) => {
+    for (const entry of readdirSync(dir).sort()) {
+      const fullPath = join(dir, entry);
+      const stat = statSync(fullPath);
+      if (stat.isDirectory()) {
+        visit(fullPath);
+      } else if (stat.isFile()) {
+        files.push(relative(root, fullPath));
+      }
+    }
+  };
+  visit(root);
+  return files.sort();
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${stringifyRedactedJson(value)}\n`);
+}
+
+function writeText(path: string, value: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, redactSecrets(value));
+}
+
+function requireSurface(value: unknown, label: string): ReviewLensSurface {
+  if (value === "issue_enrichment" || value === "pr_shadow" || value === "walkthrough") return value;
+  throw new Error(`${label} must be issue_enrichment, pr_shadow, or walkthrough`);
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+
+function requireStringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) throw new Error(`${label} must be an array of strings`);
+  return value;
+}
+
+function requireRepo(value: unknown, label: string): string {
+  const repo = requireString(value, label);
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) throw new Error(`${label} must be owner/name`);
+  return repo;
+}
+
+function requireSha(value: unknown, label: string): string {
+  const sha = requireString(value, label);
+  if (!/^[0-9a-f]{40}$/i.test(sha)) throw new Error(`${label} must be a 40-character SHA`);
+  return sha;
+}
+
+function requireSafeSegment(value: unknown, label: string): string {
+  const segment = requireString(value, label);
+  if (!/^[A-Za-z0-9._-]+$/.test(segment)) throw new Error(`${label} must be a safe path segment`);
+  return segment;
+}
+
+function requireBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${label} must be a boolean`);
+  return value;
+}
+
+function requirePositiveInteger(value: unknown, label: string): number {
+  const parsed = requireNonNegativeInteger(value, label);
+  if (parsed < 1) throw new Error(`${label} must be positive`);
+  return parsed;
+}
+
+function requireNonNegativeInteger(value: unknown, label: string): number {
+  if (!Number.isInteger(value) || Number(value) < 0) throw new Error(`${label} must be a non-negative integer`);
+  return Number(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 3))}...`;
+}

--- a/tests/fixtures/review-lenses-eval/decision-human-review.json
+++ b/tests/fixtures/review-lenses-eval/decision-human-review.json
@@ -1,0 +1,25 @@
+{
+  "evalName": "review-lenses-eval-gate-v0.1",
+  "runId": "decision-human-review",
+  "suite": "review_lens_packet_safety",
+  "surface": "walkthrough",
+  "reviewLenses": {
+    "enabled": true,
+    "packetVersion": "review-lens-packet-v0.1",
+    "active": [
+      { "id": "decision", "surface": "walkthrough", "mode": "dry_run" }
+    ],
+    "maxLensBytes": 4000,
+    "maxPacketBytes": 12000
+  },
+  "decision": {
+    "status": "human_review",
+    "reason": "Ambiguous rollout boundary needs maintainer confirmation before live activation."
+  },
+  "expected": {
+    "includedLenses": ["decision"],
+    "maxPacketBytes": 12000,
+    "secretFindings": 0,
+    "requestChangesEligible": false
+  }
+}

--- a/tests/fixtures/review-lenses-eval/issue-architecture-runtime.json
+++ b/tests/fixtures/review-lenses-eval/issue-architecture-runtime.json
@@ -1,0 +1,30 @@
+{
+  "evalName": "review-lenses-eval-gate-v0.1",
+  "runId": "issue-architecture-runtime",
+  "suite": "review_lens_packet_safety",
+  "surface": "issue_enrichment",
+  "reviewLenses": {
+    "enabled": true,
+    "packetVersion": "review-lens-packet-v0.1",
+    "active": [
+      { "id": "first_principles", "surface": "issue_enrichment", "mode": "summary" },
+      { "id": "architecture", "surface": "issue_enrichment", "mode": "summary" }
+    ],
+    "maxLensBytes": 4000,
+    "maxPacketBytes": 12000
+  },
+  "issue": {
+    "repo": "owner/repo",
+    "number": 42,
+    "state": "open",
+    "title": "Architecture migration for provider queue",
+    "body": "Need a bounded adapter, degraded mode, and rollback before changing scheduler runtime.",
+    "html_url": "https://github.test/owner/repo/issues/42"
+  },
+  "expected": {
+    "includedLenses": ["architecture", "first_principles"],
+    "maxPacketBytes": 12000,
+    "secretFindings": 0,
+    "requestChangesEligible": false
+  }
+}

--- a/tests/fixtures/review-lenses-eval/issue-redaction-safety.json
+++ b/tests/fixtures/review-lenses-eval/issue-redaction-safety.json
@@ -1,0 +1,29 @@
+{
+  "evalName": "review-lenses-eval-gate-v0.1",
+  "runId": "issue-redaction-safety",
+  "suite": "review_lens_packet_safety",
+  "surface": "issue_enrichment",
+  "reviewLenses": {
+    "enabled": true,
+    "packetVersion": "review-lens-packet-v0.1",
+    "active": [
+      { "id": "first_principles", "surface": "issue_enrichment", "mode": "summary" }
+    ],
+    "maxLensBytes": 4000,
+    "maxPacketBytes": 12000
+  },
+  "issue": {
+    "repo": "owner/repo",
+    "number": 44,
+    "state": "open",
+    "title": "Redact leaked setup token",
+    "body": "The setup log included a placeholder token and needs a safe runbook correction.",
+    "html_url": "https://github.test/owner/repo/issues/44"
+  },
+  "expected": {
+    "includedLenses": ["first_principles"],
+    "maxPacketBytes": 12000,
+    "secretFindings": 0,
+    "requestChangesEligible": false
+  }
+}

--- a/tests/fixtures/review-lenses-eval/issue-routine-no-architecture.json
+++ b/tests/fixtures/review-lenses-eval/issue-routine-no-architecture.json
@@ -1,0 +1,31 @@
+{
+  "evalName": "review-lenses-eval-gate-v0.1",
+  "runId": "issue-routine-no-architecture",
+  "suite": "review_lens_packet_safety",
+  "surface": "issue_enrichment",
+  "reviewLenses": {
+    "enabled": true,
+    "packetVersion": "review-lens-packet-v0.1",
+    "active": [
+      { "id": "first_principles", "surface": "issue_enrichment", "mode": "summary" },
+      { "id": "architecture", "surface": "issue_enrichment", "mode": "summary" }
+    ],
+    "maxLensBytes": 4000,
+    "maxPacketBytes": 12000
+  },
+  "issue": {
+    "repo": "owner/repo",
+    "number": 43,
+    "state": "open",
+    "title": "Fix README typo",
+    "body": "Correct spelling in the setup section.",
+    "html_url": "https://github.test/owner/repo/issues/43"
+  },
+  "expected": {
+    "includedLenses": ["architecture", "first_principles"],
+    "maxPacketBytes": 12000,
+    "secretFindings": 0,
+    "requestChangesEligible": false,
+    "architectureSection": false
+  }
+}

--- a/tests/fixtures/review-lenses-eval/pr-overbuilt-lean.json
+++ b/tests/fixtures/review-lenses-eval/pr-overbuilt-lean.json
@@ -1,0 +1,40 @@
+{
+  "evalName": "review-lenses-eval-gate-v0.1",
+  "runId": "pr-overbuilt-lean",
+  "suite": "review_lens_packet_safety",
+  "surface": "pr_shadow",
+  "reviewLenses": {
+    "enabled": true,
+    "packetVersion": "review-lens-packet-v0.1",
+    "active": [
+      { "id": "lean", "surface": "pr_shadow", "mode": "shadow" }
+    ],
+    "maxLensBytes": 4000,
+    "maxPacketBytes": 12000
+  },
+  "pull": {
+    "repo": "owner/repo",
+    "number": 7,
+    "title": "Add custom date picker wrapper",
+    "draft": false,
+    "body": "Adds a custom picker abstraction.",
+    "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "baseSha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "headRef": "feature/custom-picker",
+    "baseRef": "main",
+    "html_url": "https://github.test/owner/repo/pull/7"
+  },
+  "files": [
+    {
+      "filename": "src/components/custom-date-picker.tsx",
+      "patch": "@@ -1 +1 @@\n+export class CustomDatePickerWrapperFactory {}"
+    }
+  ],
+  "expected": {
+    "includedLenses": ["lean"],
+    "maxPacketBytes": 12000,
+    "secretFindings": 0,
+    "requestChangesEligible": false,
+    "leanSuggestionsMin": 1
+  }
+}

--- a/tests/fixtures/review-lenses-eval/pr-safety-negative-control.json
+++ b/tests/fixtures/review-lenses-eval/pr-safety-negative-control.json
@@ -1,0 +1,41 @@
+{
+  "evalName": "review-lenses-eval-gate-v0.1",
+  "runId": "pr-safety-negative-control",
+  "suite": "review_lens_packet_safety",
+  "surface": "pr_shadow",
+  "negativeControl": true,
+  "reviewLenses": {
+    "enabled": true,
+    "packetVersion": "review-lens-packet-v0.1",
+    "active": [
+      { "id": "lean", "surface": "pr_shadow", "mode": "shadow" }
+    ],
+    "maxLensBytes": 4000,
+    "maxPacketBytes": 12000
+  },
+  "pull": {
+    "repo": "owner/repo",
+    "number": 8,
+    "title": "Add security validation guard",
+    "draft": false,
+    "body": "Adds auth/session validation and tests.",
+    "headSha": "cccccccccccccccccccccccccccccccccccccccc",
+    "baseSha": "dddddddddddddddddddddddddddddddddddddddd",
+    "headRef": "feature/security-validation",
+    "baseRef": "main",
+    "html_url": "https://github.test/owner/repo/pull/8"
+  },
+  "files": [
+    {
+      "filename": "src/auth/session.ts",
+      "patch": "@@ -1 +1 @@\n+export function validateSessionAndAuditSecurityBoundary() {}"
+    }
+  ],
+  "expected": {
+    "includedLenses": ["lean"],
+    "maxPacketBytes": 12000,
+    "secretFindings": 0,
+    "requestChangesEligible": false,
+    "leanSuggestionsMax": 0
+  }
+}

--- a/tests/review-lens-eval.test.ts
+++ b/tests/review-lens-eval.test.ts
@@ -1,0 +1,272 @@
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  readReviewLensEvalScenario,
+  runReviewLensEval
+} from "../src/review-lens-eval.js";
+
+const FIXTURE_DIR = "tests/fixtures/review-lenses-eval";
+const NOW = new Date("2026-07-09T00:00:00.000Z");
+const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
+const tsxCliPath = require.resolve("tsx/cli");
+
+describe("review-lenses-eval", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("writes deterministic issue-enrichment baseline and lens evidence without posting", () => {
+    const outputRoot = tempRoot(roots);
+    const scenario = readReviewLensEvalScenario(join(FIXTURE_DIR, "issue-architecture-runtime.json"));
+
+    const result = runReviewLensEval({
+      scenarios: [scenario],
+      outputRoot,
+      mode: "deterministic",
+      dryRun: true,
+      now: NOW
+    });
+
+    expect(result.summary).toMatchObject({
+      ok: true,
+      command: "review-lenses-eval",
+      mode: "deterministic",
+      dryRun: true,
+      scenarioCount: 1
+    });
+    expect(result.summary.proofBoundary).toContain("dry-run/eval plumbing only");
+    expect(existsSync(join(outputRoot, "suite-summary.json"))).toBe(true);
+    expect(existsSync(join(outputRoot, "promotion-decision.md"))).toBe(true);
+
+    const runDir = join(outputRoot, "issue-architecture-runtime");
+    expect(existsSync(join(runDir, "manifest.json"))).toBe(true);
+    expect(existsSync(join(runDir, "baseline", "issue-enrichment.md"))).toBe(true);
+    expect(existsSync(join(runDir, "lens", "issue-enrichment.md"))).toBe(true);
+    expect(existsSync(join(runDir, "lens", "review-lens-issue_enrichment-packet.json"))).toBe(true);
+    expect(existsSync(join(runDir, "lens", "review-lens-issue_enrichment-packet.md"))).toBe(true);
+    expect(existsSync(join(runDir, "redaction-report.json"))).toBe(true);
+    expect(existsSync(join(runDir, "lens-scorecard.json"))).toBe(true);
+
+    const baseline = readFileSync(join(runDir, "baseline", "issue-enrichment.md"), "utf8");
+    const lens = readFileSync(join(runDir, "lens", "issue-enrichment.md"), "utf8");
+    expect(baseline).not.toContain("### First-principles lens");
+    expect(lens).toContain("### First-principles lens");
+    expect(lens).toContain("### Architecture lens");
+
+    const scorecard = JSON.parse(readFileSync(join(runDir, "lens-scorecard.json"), "utf8"));
+    expect(scorecard.gates).toContainEqual(expect.objectContaining({ name: "advisory_only", ok: true }));
+    expect(scorecard.gates).toContainEqual(expect.objectContaining({ name: "packet_budget", ok: true }));
+    expect(scorecard.counts.includedLenses).toBe(2);
+    expect(scorecard.counts.secretFindings).toBe(0);
+    const diffSummary = JSON.parse(readFileSync(join(runDir, "diff-summary.json"), "utf8"));
+    expect(diffSummary.comparisons).toContainEqual(expect.objectContaining({
+      artifact: "issue-enrichment.md",
+      changed: true,
+      baselineSha256: expect.any(String),
+      lensSha256: expect.any(String)
+    }));
+  });
+
+  it("writes lean PR shadow suggestions as non-blocking evidence only", () => {
+    const outputRoot = tempRoot(roots);
+    const scenario = readReviewLensEvalScenario(join(FIXTURE_DIR, "pr-overbuilt-lean.json"));
+
+    const result = runReviewLensEval({
+      scenarios: [scenario],
+      outputRoot,
+      mode: "deterministic",
+      dryRun: true,
+      now: NOW
+    });
+
+    expect(result.summary.ok).toBe(true);
+    const runDir = join(outputRoot, "pr-overbuilt-lean");
+    const shadow = JSON.parse(readFileSync(join(runDir, "lens", "lean-review-shadow.json"), "utf8"));
+    expect(shadow.suggestions).toMatchObject([
+      {
+        tag: "native",
+        blocking: false,
+        requestChangesEligible: false
+      }
+    ]);
+    const scorecard = JSON.parse(readFileSync(join(runDir, "lens-scorecard.json"), "utf8"));
+    expect(scorecard.counts.leanSuggestions).toBeGreaterThan(0);
+    expect(scorecard.counts.requestChangesEligibleSuggestions).toBe(0);
+    expect(scorecard.gates).toContainEqual(expect.objectContaining({ name: "lean_shadow_non_blocking", ok: true }));
+  });
+
+  it("keeps safety negative controls from producing delete or shrink advice", () => {
+    const outputRoot = tempRoot(roots);
+    const scenario = readReviewLensEvalScenario(join(FIXTURE_DIR, "pr-safety-negative-control.json"));
+
+    const result = runReviewLensEval({
+      scenarios: [scenario],
+      outputRoot,
+      mode: "deterministic",
+      dryRun: true,
+      now: NOW
+    });
+
+    expect(result.summary.ok).toBe(true);
+    const runDir = join(outputRoot, "pr-safety-negative-control");
+    const shadow = JSON.parse(readFileSync(join(runDir, "lens", "lean-review-shadow.json"), "utf8"));
+    expect(shadow.suggestions).toEqual([]);
+    const scorecard = JSON.parse(readFileSync(join(runDir, "lens-scorecard.json"), "utf8"));
+    expect(scorecard.gates).toContainEqual(expect.objectContaining({ name: "safety_negative_control", ok: true }));
+  });
+
+  it("redacts secret-like fixture text from every artifact", () => {
+    const outputRoot = tempRoot(roots);
+    const scenario = readReviewLensEvalScenario(join(FIXTURE_DIR, "issue-redaction-safety.json"));
+    const rawSecret = ["ghp", "abcdefghijklmnopqrstuvwxyz123456"].join("_");
+    if (!scenario.issue) throw new Error("expected issue fixture");
+    scenario.issue.body = `The setup log included ${rawSecret} and needs a safe runbook correction.`;
+
+    const result = runReviewLensEval({
+      scenarios: [scenario],
+      outputRoot,
+      mode: "deterministic",
+      dryRun: true,
+      now: NOW
+    });
+
+    expect(result.summary.ok).toBe(true);
+    const runDir = join(outputRoot, "issue-redaction-safety");
+    expect(readFileSync(join(runDir, "lens", "issue-enrichment.md"), "utf8")).toContain("[redacted-secret]");
+    const artifactText = [
+      readFileSync(join(outputRoot, "suite-summary.json"), "utf8"),
+      readFileSync(join(runDir, "manifest.json"), "utf8"),
+      readFileSync(join(runDir, "baseline", "issue-enrichment.md"), "utf8"),
+      readFileSync(join(runDir, "lens", "issue-enrichment.md"), "utf8"),
+      readFileSync(join(runDir, "redaction-report.json"), "utf8"),
+      readFileSync(join(runDir, "lens-scorecard.json"), "utf8")
+    ].join("\n");
+    expect(artifactText).not.toContain(rawSecret);
+  });
+
+  it("enforces architecture-section expectations from issue fixtures", () => {
+    const outputRoot = tempRoot(roots);
+    const scenario = readReviewLensEvalScenario(join(FIXTURE_DIR, "issue-routine-no-architecture.json"));
+
+    const result = runReviewLensEval({
+      scenarios: [scenario],
+      outputRoot,
+      mode: "deterministic",
+      dryRun: true,
+      now: NOW
+    });
+
+    expect(result.summary.ok).toBe(true);
+    const runDir = join(outputRoot, "issue-routine-no-architecture");
+    const lens = readFileSync(join(runDir, "lens", "issue-enrichment.md"), "utf8");
+    expect(lens).not.toContain("### Architecture lens");
+    const scorecard = JSON.parse(readFileSync(join(runDir, "lens-scorecard.json"), "utf8"));
+    expect(scorecard.gates).toContainEqual(expect.objectContaining({ name: "architecture_section_expectation", ok: true }));
+  });
+
+  it("rejects reusable or symlinked output roots before writing artifacts", () => {
+    const scenario = readReviewLensEvalScenario(join(FIXTURE_DIR, "pr-overbuilt-lean.json"));
+    const nonEmptyRoot = tempRoot(roots);
+    writeFileSync(join(nonEmptyRoot, "stale.json"), "{}\n");
+
+    expect(() =>
+      runReviewLensEval({
+        scenarios: [scenario],
+        outputRoot: nonEmptyRoot,
+        mode: "deterministic",
+        dryRun: true,
+        now: NOW
+      })
+    ).toThrow(/outputRoot must be empty/);
+
+    const realRoot = tempRoot(roots);
+    const symlinkRoot = `${realRoot}-link`;
+    roots.push(symlinkRoot);
+    symlinkSync(realRoot, symlinkRoot, "dir");
+    expect(() =>
+      runReviewLensEval({
+        scenarios: [scenario],
+        outputRoot: symlinkRoot,
+        mode: "deterministic",
+        dryRun: true,
+        now: NOW
+      })
+    ).toThrow(/outputRoot must not be a symbolic link/);
+  });
+
+  it("rejects non-dry-run model-shadow execution and keeps dry-run model-shadow provider-free", () => {
+    const scenario = readReviewLensEvalScenario(join(FIXTURE_DIR, "pr-overbuilt-lean.json"));
+
+    expect(() =>
+      runReviewLensEval({
+        scenarios: [scenario],
+        outputRoot: tempRoot(roots),
+        mode: "model-shadow",
+        dryRun: false,
+        now: NOW
+      })
+    ).toThrow(/review-lenses-eval is dry-run only/);
+
+    const outputRoot = tempRoot(roots);
+    const result = runReviewLensEval({
+      scenarios: [scenario],
+      outputRoot,
+      mode: "model-shadow",
+      dryRun: true,
+      now: NOW
+    });
+
+    expect(result.summary.ok).toBe(true);
+    const modelShadow = JSON.parse(readFileSync(join(outputRoot, "pr-overbuilt-lean", "model-shadow-summary.json"), "utf8"));
+    expect(modelShadow).toMatchObject({
+      mode: "model-shadow",
+      providerCalls: 0,
+      githubPosts: 0
+    });
+    expect(modelShadow.proofBoundary).toContain("No provider call or GitHub posting was performed");
+  });
+
+  it("runs the CLI command against a fixture directory and writes suite artifacts", async () => {
+    const outputRoot = tempRoot(roots);
+
+    const { stdout } = await execFileAsync(process.execPath, [
+      tsxCliPath,
+      "src/cli.ts",
+      "review-lenses-eval",
+      "--input-dir",
+      FIXTURE_DIR,
+      "--output-root",
+      outputRoot,
+      "--mode",
+      "deterministic",
+      "--dry-run",
+      "true"
+    ], { cwd: process.cwd(), env: { ...process.env, NODE_OPTIONS: "--experimental-sqlite" } });
+    const parsed = JSON.parse(stdout);
+
+    expect(parsed).toMatchObject({
+      ok: true,
+      command: "review-lenses-eval",
+      mode: "deterministic",
+      dryRun: true,
+      scenarioCount: 6
+    });
+    expect(existsSync(join(outputRoot, "suite-summary.json"))).toBe(true);
+    expect(existsSync(join(outputRoot, "promotion-decision.md"))).toBe(true);
+    expect(readFileSync(join(outputRoot, "promotion-decision.md"), "utf8")).toContain("Live activation: disabled");
+  });
+});
+
+function tempRoot(roots: string[]): string {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-review-lenses-eval-"));
+  roots.push(root);
+  return root;
+}


### PR DESCRIPTION
Closes #495.

## Summary
- Adds a dry-run-only `review-lenses-eval` CLI for deterministic and provider-free model-shadow review-lens evidence.
- Adds fixture scenarios for issue enrichment, architecture guidance, lean PR shadow suggestions, safety negative controls, redaction, and decision evidence.
- Writes fresh evidence packets with `manifest.json`, paired `baseline/` and `lens/` artifacts, `diff-summary.json`, `redaction-report.json`, `lens-scorecard.json`, and promotion guidance.
- Documents the eval gate without enabling review lenses live or mutating active config.

## Proof Boundary
This PR proves advisory eval plumbing and fixture behavior only. It does not activate review lenses, post to GitHub, change issue-enrichment allowlists, call providers, or make review-quality / Ponytail-parity / calibrated-confidence claims.

## Evidence
- Current PR head after branch sync: `9741ff511b88083c2fba71c4a15e617d11a8a64c`
- Deterministic eval: `/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-09/review-lenses-eval-gate-495-postsync-210520`
- Model-shadow dry-run: `/Volumes/LEXAR/Codex/evals/zcode-glm-pr-review/2026-07-09/review-lenses-model-shadow-495-postsync-210520`
- Live config check: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json` still has `reviewLenses: null`

## Validation
- `NODE_OPTIONS=--experimental-sqlite npm test -- tests/review-lenses.test.ts tests/review-lens-eval.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `npm run check:secrets`
- `npm run check:public-claims`
- `git diff --check`
- `review-lenses-eval --mode deterministic` over 6 fixtures: passed 6 / failed 0
- `review-lenses-eval --mode model-shadow` over lean PR fixture: passed 1 / failed 0
- Evidence leak probe: no raw `ghp_...` fixture token found in deterministic packet
