### PR TITLE
[codex] Add desktop GitHub setup and repo allowlist foundation

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
@@ -12,11 +12,13 @@ final class NeonDiffDesktopModel: ObservableObject {
     @Published var repos: [RepoMonitor] = []
     @Published var providers = ProviderSettings()
     @Published var license = LicenseStatus()
+    @Published var github = GitHubConnectionStatus()
     @Published var logText = "No logs loaded."
     @Published var lastError: String?
     @Published var lastCommandLine = ""
     @Published var dashboardLaunchStatus = "not opened"
     @Published var dashboardProcessIdentifier: Int32?
+    @Published var pendingRepoName = ""
     @Published var pendingProviderKey = ""
     @Published var pendingLicenseKey = ""
     @Published var onboardingFlow = OnboardingFlow()
@@ -37,6 +39,8 @@ final class NeonDiffDesktopModel: ObservableObject {
         let providerKeyStored = keychain.containsSecret(account: providerKeyAccount)
         self.providers.providerKeyStored = providerKeyStored
         self.license.keyStored = keychain.containsSecret(account: licenseKeyAccount)
+        self.github.userTokenStored = keychain.containsSecret(account: githubUserTokenAccount)
+        self.github.installationState = self.github.userTokenStored ? "user authorized" : "not connected"
         self.onboardingFlow = OnboardingFlow(providerKeyStored: providerKeyStored)
         self.isOnboardingPresented = !userDefaults.bool(forKey: onboardingCompletedKey)
         self.lastCommandLine = statusCommand.commandLine
@@ -80,6 +84,14 @@ final class NeonDiffDesktopModel: ObservableObject {
 
     var providerPatchApplyCommand: DesktopCommand {
         NeonDiffCommandBuilder.configPatch(cliPath: cliPath, configPath: configPath, inputPath: providerPatchPath.path, dryRun: false)
+    }
+
+    var repoSelectionPatchPreviewCommand: DesktopCommand {
+        NeonDiffCommandBuilder.configPatch(cliPath: cliPath, configPath: configPath, inputPath: repoSelectionPatchPath.path)
+    }
+
+    var repoSelectionPatchApplyCommand: DesktopCommand {
+        NeonDiffCommandBuilder.configPatch(cliPath: cliPath, configPath: configPath, inputPath: repoSelectionPatchPath.path, dryRun: false)
     }
 
     func persistLocalSettings() {
@@ -171,6 +183,44 @@ final class NeonDiffDesktopModel: ObservableObject {
 
     func applyProviderConfigPatch() {
         runProviderConfigPatch(dryRun: false)
+    }
+
+    func addPendingRepoToAllowlist() {
+        let repoName = pendingRepoName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isValidRepoName(repoName) else {
+            lastError = "Enter a GitHub repository as owner/repo."
+            return
+        }
+        if let index = repos.firstIndex(where: { $0.name.caseInsensitiveCompare(repoName) == .orderedSame }) {
+            repos[index].enabled = true
+        } else {
+            repos.append(RepoMonitor(name: repoName, enabled: true, profile: "selected"))
+            repos.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        }
+        pendingRepoName = ""
+        lastError = nil
+        logText = "Repo allowlist updated locally. Preview or apply the config patch to persist it."
+    }
+
+    func toggleRepoAllowlist(_ repo: RepoMonitor) {
+        guard let index = repos.firstIndex(where: { $0.id == repo.id }) else { return }
+        repos[index].enabled.toggle()
+        lastError = nil
+        logText = "Repo allowlist updated locally. Preview or apply the config patch to persist it."
+    }
+
+    func removeRepoFromAllowlist(_ repo: RepoMonitor) {
+        repos.removeAll { $0.id == repo.id }
+        lastError = nil
+        logText = "Repo removed locally. Preview or apply the config patch to persist it."
+    }
+
+    func previewRepoAllowlistPatch() {
+        runRepoSelectionPatch(dryRun: true)
+    }
+
+    func applyRepoAllowlistPatch() {
+        runRepoSelectionPatch(dryRun: false)
     }
 
     func storeProviderKey() {
@@ -284,6 +334,10 @@ final class NeonDiffDesktopModel: ObservableObject {
         appSupportDirectory.appendingPathComponent("provider-settings-patch.json")
     }
 
+    private var repoSelectionPatchPath: URL {
+        appSupportDirectory.appendingPathComponent("repo-allowlist-patch.json")
+    }
+
     private var appSupportDirectory: URL {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? FileManager.default.temporaryDirectory
@@ -307,6 +361,42 @@ final class NeonDiffDesktopModel: ObservableObject {
         try data.write(to: providerPatchPath, options: [.atomic])
     }
 
+    private func runRepoSelectionPatch(dryRun: Bool) {
+        do {
+            try writeRepoSelectionPatch()
+        } catch {
+            lastError = NeonDiffRedactor.redact(error.localizedDescription)
+            return
+        }
+        var arguments = [
+            "config",
+            "patch",
+            "--config",
+            configPath,
+            "--input",
+            repoSelectionPatchPath.path,
+            "--dry-run",
+            dryRun ? "true" : "false"
+        ]
+        if !dryRun {
+            arguments.append(contentsOf: ["--confirm", "true"])
+        }
+        runCLI(arguments: arguments, displayCommand: dryRun ? repoSelectionPatchPreviewCommand : repoSelectionPatchApplyCommand)
+    }
+
+    private func writeRepoSelectionPatch() throws {
+        try FileManager.default.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        let selectedRepos = repos
+            .filter(\.enabled)
+            .map(\.name)
+        let uniqueRepos = uniqueSortedRepoNames(selectedRepos)
+        let patch: [String: Any] = [
+            "pilotRepos": uniqueRepos
+        ]
+        let data = try JSONSerialization.data(withJSONObject: patch, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: repoSelectionPatchPath, options: [.atomic])
+    }
+
     private func applyCLIResult(_ result: CLIRunResult, fallbackCommand: String, configPath: String, launchdLabel: String) {
         let redactedStdout = result.redactedStdout.trimmingCharacters(in: .whitespacesAndNewlines)
         let redactedStderr = result.redactedStderr.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -318,11 +408,13 @@ final class NeonDiffDesktopModel: ObservableObject {
             if let snapshot = ConfigInspectParser.parse(
                 result.stdout,
                 providerKeyStored: keychain.containsSecret(account: providerKeyAccount),
-                licenseKeyStored: keychain.containsSecret(account: licenseKeyAccount)
+                licenseKeyStored: keychain.containsSecret(account: licenseKeyAccount),
+                githubUserTokenStored: keychain.containsSecret(account: githubUserTokenAccount)
             ) {
                 if !snapshot.repos.isEmpty { repos = snapshot.repos }
                 providers = snapshot.providers
                 license = snapshot.license
+                github = snapshot.github
             }
             return
         }
@@ -349,4 +441,23 @@ final class NeonDiffDesktopModel: ObservableObject {
 
 private let providerKeyAccount = "provider/glm/api-key"
 private let licenseKeyAccount = "license/default"
+private let githubUserTokenAccount = "github/user-access-token"
 private let onboardingCompletedKey = "neondiff.hasCompletedOnboarding"
+
+private func isValidRepoName(_ value: String) -> Bool {
+    let parts = value.split(separator: "/", omittingEmptySubsequences: false)
+    guard parts.count == 2 else { return false }
+    return parts.allSatisfy { part in
+        !part.isEmpty && part != "." && part != ".." && part.allSatisfy { character in
+            character.isLetter || character.isNumber || character == "-" || character == "_" || character == "."
+        }
+    }
+}
+
+private func uniqueSortedRepoNames(_ names: [String]) -> [String] {
+    var seen = Set<String>()
+    return names
+        .filter(isValidRepoName)
+        .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        .filter { seen.insert($0.lowercased()).inserted }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -6,13 +6,47 @@ struct ReposView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
+            OperatorSection("GitHub Connection") {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(spacing: 10) {
+                        OperatorBadge(
+                            text: model.github.userTokenStored ? "USER AUTHORIZED" : "USER NOT CONNECTED",
+                            color: model.github.userTokenStored ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                        )
+                        OperatorBadge(
+                            text: model.github.clientIdConfigured ? "CLIENT ID READY" : "CLIENT ID MISSING",
+                            color: model.github.clientIdConfigured ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                        )
+                        OperatorBadge(
+                            text: model.github.appIdConfigured ? "APP ID READY" : "APP ID MISSING",
+                            color: model.github.appIdConfigured ? NeonDiffTheme.accent : NeonDiffTheme.warning
+                        )
+                    }
+
+                    Text("Use GitHub App device authorization to discover repositories later. This release keeps tokens in Keychain and persists selected repositories through config patch only.")
+                        .operatorBodyText()
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    HStack {
+                        Label("Bot: \(model.github.botLogin)", systemImage: "app.connected.to.app.below.fill")
+                            .foregroundStyle(NeonDiffTheme.textPrimary)
+                        Spacer()
+                        Text(model.github.installationState)
+                            .foregroundStyle(NeonDiffTheme.textSecondary)
+                    }
+                }
+            }
+
             HStack(spacing: 10) {
                 Button { model.inspectConfig() } label: {
                     Label("Load From Config", systemImage: "doc.text.magnifyingglass")
                 }
+                .accessibilityIdentifier("neondiff-repos-load-config")
+
                 Button { model.refreshStatus() } label: {
                     Label("Refresh Runtime", systemImage: "arrow.clockwise")
                 }
+                .accessibilityIdentifier("neondiff-repos-refresh-runtime")
             }
 
             VStack(alignment: .leading, spacing: 10) {
@@ -26,14 +60,48 @@ struct ReposView: View {
                             .textSelection(.enabled)
                     }
                     TableColumn("Enabled") { repo in
-                        Image(systemName: repo.enabled ? "checkmark.circle.fill" : "pause.circle")
-                            .foregroundStyle(repo.enabled ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary)
+                        Button { model.toggleRepoAllowlist(repo) } label: {
+                            Image(systemName: repo.enabled ? "checkmark.circle.fill" : "pause.circle")
+                                .foregroundStyle(repo.enabled ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("neondiff-repo-toggle-\(repo.name)")
                     }
                     TableColumn("Profile", value: \.profile)
                     TableColumn("Last Review", value: \.lastReview)
+                    TableColumn("Remove") { repo in
+                        Button { model.removeRepoFromAllowlist(repo) } label: {
+                            Image(systemName: "minus.circle")
+                                .foregroundStyle(NeonDiffTheme.warning)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("neondiff-repo-remove-\(repo.name)")
+                    }
                 }
                 .scrollContentBackground(.hidden)
                 .frame(minHeight: 360)
+
+                HStack(spacing: 10) {
+                    TextField("owner/repo", text: $model.pendingRepoName)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityIdentifier("neondiff-repo-name-input")
+                    Button { model.addPendingRepoToAllowlist() } label: {
+                        Label("Add Repo", systemImage: "plus.circle")
+                    }
+                    .accessibilityIdentifier("neondiff-repo-add")
+                }
+
+                HStack(spacing: 10) {
+                    Button { model.previewRepoAllowlistPatch() } label: {
+                        Label("Preview Allowlist Patch", systemImage: "eye")
+                    }
+                    .accessibilityIdentifier("neondiff-repo-preview-patch")
+
+                    Button { model.applyRepoAllowlistPatch() } label: {
+                        Label("Apply Allowlist", systemImage: "checkmark.seal")
+                    }
+                    .accessibilityIdentifier("neondiff-repo-apply-patch")
+                }
             }
             .operatorPanel()
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
@@ -123,6 +123,28 @@ public struct LicenseStatus: Equatable {
     }
 }
 
+public struct GitHubConnectionStatus: Equatable {
+    public var appIdConfigured: Bool
+    public var clientIdConfigured: Bool
+    public var botLogin: String
+    public var userTokenStored: Bool
+    public var installationState: String
+
+    public init(
+        appIdConfigured: Bool = false,
+        clientIdConfigured: Bool = false,
+        botLogin: String = "not configured",
+        userTokenStored: Bool = false,
+        installationState: String = "not connected"
+    ) {
+        self.appIdConfigured = appIdConfigured
+        self.clientIdConfigured = clientIdConfigured
+        self.botLogin = botLogin
+        self.userTokenStored = userTokenStored
+        self.installationState = installationState
+    }
+}
+
 public struct DesktopCommand: Identifiable, Equatable {
     public var id: String { commandLine }
     public var title: String

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
@@ -4,16 +4,18 @@ public struct ConfigInspectSnapshot: Equatable {
     public var repos: [RepoMonitor]
     public var providers: ProviderSettings
     public var license: LicenseStatus
+    public var github: GitHubConnectionStatus
 
-    public init(repos: [RepoMonitor], providers: ProviderSettings, license: LicenseStatus) {
+    public init(repos: [RepoMonitor], providers: ProviderSettings, license: LicenseStatus, github: GitHubConnectionStatus = GitHubConnectionStatus()) {
         self.repos = repos
         self.providers = providers
         self.license = license
+        self.github = github
     }
 }
 
 public enum ConfigInspectParser {
-    public static func parse(_ jsonText: String, providerKeyStored: Bool, licenseKeyStored: Bool) -> ConfigInspectSnapshot? {
+    public static func parse(_ jsonText: String, providerKeyStored: Bool, licenseKeyStored: Bool, githubUserTokenStored: Bool = false) -> ConfigInspectSnapshot? {
         guard
             let data = jsonText.data(using: .utf8),
             let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -40,6 +42,7 @@ public enum ConfigInspectParser {
 
         let zcode = config["zcode"] as? [String: Any]
         let desktop = config["desktop"] as? [String: Any]
+        let githubConfig = config["github"] as? [String: Any]
         let providers = ProviderSettings(
             zcodeModel: zcode?["model"] as? String ?? "GLM-5.2",
             zcodeCliPath: zcode?["cliPath"] as? String ?? "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
@@ -52,6 +55,16 @@ public enum ConfigInspectParser {
             entitlement: licenseKeyStored ? "stored locally" : "not activated",
             updateChannel: desktop?["updateChannel"] as? String ?? "dev"
         )
-        return ConfigInspectSnapshot(repos: repos, providers: providers, license: license)
+        let appId = githubConfig?["appId"] as? String
+        let clientId = githubConfig?["clientId"] as? String
+        let botLogin = githubConfig?["botLogin"] as? String
+        let github = GitHubConnectionStatus(
+            appIdConfigured: appId?.isEmpty == false,
+            clientIdConfigured: clientId?.isEmpty == false,
+            botLogin: botLogin?.isEmpty == false ? botLogin! : "not configured",
+            userTokenStored: githubUserTokenStored,
+            installationState: githubUserTokenStored ? "user authorized" : "not connected"
+        )
+        return ConfigInspectSnapshot(repos: repos, providers: providers, license: license, github: github)
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
@@ -132,6 +132,38 @@ do {
         throw NSError(domain: "NeonDiffDesktopSmoke", code: 8, userInfo: [NSLocalizedDescriptionKey: "repoProfiles fallback did not map"])
     }
 
+    let githubConfigJSON = """
+    {
+      "ok": true,
+      "command": "config inspect",
+      "config": {
+        "pilotRepos": ["owner/repo-one", "owner/repo-two"],
+        "github": {
+          "appId": "4184532",
+          "clientId": "Iv1.publicclientid123",
+          "botLogin": "neondiff-review-bot"
+        },
+        "repoProfiles": {
+          "repos": {
+            "owner/repo-one": { "enabled": true, "displayName": "Repo One" },
+            "owner/repo-two": { "enabled": false, "reviewProfile": "assertive" }
+          }
+        }
+      }
+    }
+    """
+    guard let githubSnapshot = ConfigInspectParser.parse(githubConfigJSON, providerKeyStored: false, licenseKeyStored: false),
+          githubSnapshot.github.appIdConfigured,
+          githubSnapshot.github.clientIdConfigured,
+          githubSnapshot.github.botLogin == "neondiff-review-bot",
+          githubSnapshot.repos == [
+            RepoMonitor(name: "owner/repo-one", enabled: true, profile: "Repo One"),
+            RepoMonitor(name: "owner/repo-two", enabled: false, profile: "assertive")
+          ]
+    else {
+        throw NSError(domain: "NeonDiffDesktopSmoke", code: 18, userInfo: [NSLocalizedDescriptionKey: "GitHub config and selected repo parsing failed"])
+    }
+
     let fakeProductLicense = "NEONDIFF-1234567890-ABCDE"
     let fakeUnderscoreLicense = "NDL_PRIVATE_1234567890"
     let jsonLicense = "fixture-license-secret-1234567890"

--- a/config.example.json
+++ b/config.example.json
@@ -314,6 +314,7 @@
   },
   "github": {
     "appId": "set via NEONDIFF_GITHUB_APP_ID",
+    "clientId": "optional public GitHub App client ID for desktop/device authorization",
     "privateKeyPath": "set via NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH",
     "token": "optional fallback token for local development only"
   }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -333,6 +333,7 @@ set.
 | Variable | Read by | Overrides config value | Notes |
 | --- | --- | --- | --- |
 | `NEONDIFF_GITHUB_APP_ID` | `loadConfig`/`loadConfigFromObject` (`src/config.ts`) | `github.appId` | Set once per step 2; unset falls back to the config-file value. Legacy `EVAOS_REVIEW_BOT_APP_ID` remains supported for existing internal deployments. |
+| `NEONDIFF_GITHUB_APP_CLIENT_ID` | `loadConfig`/`loadConfigFromObject` (`src/config.ts`) | `github.clientId` | Public GitHub App client ID used by desktop/device authorization. This is not a secret. |
 | `NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH` | `loadConfig`/`loadConfigFromObject` (`src/config.ts`) | `github.privateKeyPath` | Path to the GitHub App private key; keep the key itself outside the repo. Legacy `EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH` remains supported for existing internal deployments. |
 | `GITHUB_TOKEN` | `loadConfig`/`loadConfigFromObject` (`src/config.ts`) | `github.token` | Local-development fallback token only; App auth is required for App-authored posting. |
 | `NEONDIFF_PROTECTED_CHECKOUT_ROOT` | `getProtectedCheckoutRoots` (`src/path-safety.ts`) | Adds to the built-in checkout-isolation boundary | Advanced use only: an additional path `config.workRoot` must stay outside of, alongside the current package checkout. Legacy `EVAOS_REVIEW_BOT_PROTECTED_CHECKOUT_ROOT` remains supported for existing internal deployments. |

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -58,8 +58,13 @@ Keep the private key and local config out of git. A typical shell setup is:
 
 ```bash
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
+export NEONDIFF_GITHUB_APP_CLIENT_ID="<github-app-client-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 ```
+
+`NEONDIFF_GITHUB_APP_CLIENT_ID` is public metadata used by the desktop/device
+authorization flow. Do not put user access tokens or refresh tokens in config;
+desktop user tokens belong in Keychain.
 
 ## Verify Installation
 

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -2,15 +2,16 @@
 
 NeonDiff Desktop is a SwiftPM macOS app scaffold for issue #115. It is a thin local control panel over the NeonDiff CLI and daemon contracts.
 For the 1.0 launch bar, the Mac app is intentionally a minimal launcher:
-opening the app starts `neondiff dashboard` and opens the same local HTML
-dashboard used by the CLI.
+opening the app shows local controls that can start `neondiff dashboard` or open
+the same local HTML dashboard used by the CLI.
 
 ## Boundaries
 
 - No review engine runs in the desktop app.
 - No UI path posts GitHub reviews directly.
-- The Mac launcher does not implement a separate native setup flow; the local
-  HTML dashboard remains the first-run/provider/license/status surface.
+- The Mac launcher implements native setup/status controls only where they can
+  write through existing CLI contracts. The local HTML dashboard remains the
+  deeper browser-first setup surface.
 - No signing, notarization, Sparkle appcast, downloadable artifact, TCC, Mac-control, or customer-control proof is claimed here.
 - Provider and license keys are stored in macOS Keychain under a NeonDiff-specific service and are never written to config files.
 
@@ -46,6 +47,16 @@ neondiff dashboard --config config.local.json --launchd-label com.example.neondi
 Patch inputs use nested JSON object shape for editable paths. For example, the advertised `zcode.cliPath` path is supplied as `{ "zcode": { "cliPath": "/path/to/neondiff" } }`; flat dotted keys such as `{ "zcode.cliPath": "/path/to/neondiff" }` are rejected to avoid ambiguous profile keys.
 
 The ZCode defaults in `config.example.json` are developer-machine paths. On any non-author workstation or packaged desktop install, set explicit local values for `zcode.cliPath`, `zcode.appConfigPath`, and `zcode.model` before relying on daemon controls.
+
+## GitHub And Repo Allowlist
+
+The Repos pane shows GitHub App setup state without exposing tokens. The public
+GitHub App `clientId` may be stored in config for the desktop/device
+authorization flow, while GitHub user access tokens belong in Keychain only.
+
+The repo selector persists selected repositories by writing a `pilotRepos` patch
+through `config patch`. It does not post reviews, widen App permissions, or write
+GitHub user tokens into config.
 
 ## Local Dashboard Launcher
 

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -45,6 +45,7 @@ const EXACT_PATCH_PATHS = new Set([
   "zcode.providerId",
   "zcode.timeoutMs",
   "github.appId",
+  "github.clientId",
   "github.botLogin",
   "github.requestTimeoutMs",
   "desktop.openAICompatibleEndpoint",

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,6 +100,7 @@ export interface BotConfig {
   };
   github: {
     appId?: string;
+    clientId?: string;
     privateKeyPath?: string;
     token?: string;
     apiBaseUrl?: string;
@@ -556,6 +557,7 @@ export function loadConfigFromObject(fromFile: unknown): BotConfig {
     legacyName: "EVAOS_REVIEW_BOT_APP_ID",
     valueLabel: "github.appId"
   }) ?? merged.github.appId;
+  merged.github.clientId = process.env.NEONDIFF_GITHUB_APP_CLIENT_ID ?? merged.github.clientId;
   merged.github.privateKeyPath = resolveEnvAlias({
     primaryName: "NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH",
     legacyName: "EVAOS_REVIEW_BOT_PRIVATE_KEY_PATH",
@@ -691,6 +693,8 @@ function validateConfig(config: BotConfig): void {
   validatePositiveInteger(config.zcode.maxPatchBytes, "config.zcode.maxPatchBytes");
   validateNonNegativeInteger(config.zcode.retryMaxRetries, "config.zcode.retryMaxRetries");
   validateOptionalString(config.zcode.providerId, "config.zcode.providerId");
+  validateOptionalString(config.github.appId, "config.github.appId");
+  validateOptionalString(config.github.clientId, "config.github.clientId");
   validateOptionalString(config.github.apiBaseUrl, "config.github.apiBaseUrl");
   validateOptionalString(config.github.botLogin, "config.github.botLogin");
   if (config.github.requestTimeoutMs !== undefined) validatePositiveInteger(config.github.requestTimeoutMs, "config.github.requestTimeoutMs");

--- a/src/local-dashboard.ts
+++ b/src/local-dashboard.ts
@@ -758,8 +758,27 @@ function licenseStatusItemFromResult(status: LicenseStatusResult, checkedAt: str
 
 function buildGitHubAppStatusItem(config: BotConfig, checkedAt: string): LocalDashboardStatusItem {
   const hasApp = Boolean(config.github.appId && config.github.privateKeyPath);
+  const hasAppId = Boolean(config.github.appId);
+  const hasClientId = Boolean(config.github.clientId);
   const hasReadableKeyPath = Boolean(config.github.privateKeyPath && existsSync(config.github.privateKeyPath));
   const hasFallbackToken = Boolean(config.github.token);
+  const baseMetadata = {
+    appIdConfigured: hasAppId,
+    clientIdConfigured: hasClientId,
+    botLogin: config.github.botLogin ?? null
+  };
+  if (hasAppId && hasClientId && !hasReadableKeyPath && !hasFallbackToken) {
+    return {
+      id: "githubApp",
+      label: "GitHub App",
+      state: "configured_unverified",
+      detail: "GitHub App identity is configured for desktop sign-in; install/repo access still needs user authorization and doctor github proof.",
+      checkedAt,
+      redacted: true,
+      actions: ["Connect GitHub from the desktop app, then run neondiff doctor github --config config.local.json --json for installation-scope proof."],
+      metadata: baseMetadata
+    };
+  }
   if (hasApp && hasReadableKeyPath) {
     return {
       id: "githubApp",
@@ -770,6 +789,7 @@ function buildGitHubAppStatusItem(config: BotConfig, checkedAt: string): LocalDa
       redacted: true,
       actions: ["Run neondiff doctor github --config config.local.json --json."],
       metadata: {
+        ...baseMetadata,
         readMode: "app_installation",
         appIdConfigured: true,
         privateKeyPathPresent: true
@@ -785,7 +805,7 @@ function buildGitHubAppStatusItem(config: BotConfig, checkedAt: string): LocalDa
       checkedAt,
       redacted: true,
       actions: ["Create/install the GitHub App and set NEONDIFF_GITHUB_APP_ID plus NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH."],
-      metadata: { readMode: "fallback_token" }
+      metadata: { ...baseMetadata, readMode: "fallback_token" }
     };
   }
   return {
@@ -795,7 +815,8 @@ function buildGitHubAppStatusItem(config: BotConfig, checkedAt: string): LocalDa
     detail: "No GitHub App credentials or fallback token are configured.",
     checkedAt,
     redacted: true,
-    actions: ["Create/install the GitHub App before expecting PR reviews."]
+    actions: ["Create/install the GitHub App before expecting PR reviews."],
+    metadata: baseMetadata
   };
 }
 

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -50,6 +50,7 @@ describe("desktop config CLI", () => {
     expect(output.editablePaths).toContain("zcode.model");
     expect(output.editablePaths).toContain("desktop.openAICompatibleEndpoint");
     expect(output.editablePaths).toContain("github.appId");
+    expect(output.editablePaths).toContain("github.clientId");
     expect(output.editablePaths).toContain("providers.defaultProviderId");
     expect(output.editablePaths).toContain("providers.providers.<provider-id>.<desktop-safe-provider-field>");
     expect(output.editablePaths).not.toContain("github.apiBaseUrl");
@@ -445,6 +446,68 @@ describe("desktop config CLI", () => {
       error: expect.stringContaining("non-desktop-safe path")
     });
     expect(output.error).toContain("github.apiBaseUrl");
+  });
+
+  it("allows desktop patches to set the public GitHub App client id", async () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    const patchPath = join(root, "patch.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    });
+    writeConfig(patchPath, {
+      github: { clientId: "Iv1.publicclientid123" }
+    });
+
+    const output = await runConfig(["config", "patch", "--config", configPath, "--input", patchPath]);
+
+    expect(output).toMatchObject({
+      ok: true,
+      dryRun: true,
+      wrote: false,
+      changedPaths: ["github.clientId"]
+    });
+    expect(output.config.github.clientId).toBe("Iv1.publicclientid123");
+  });
+
+  it("dry-runs repo allowlist selector patches and rejects invalid repo names", async () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    const patchPath = join(root, "repo-selector-patch.json");
+    const invalidPatchPath = join(root, "invalid-repo-selector-patch.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/existing"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    });
+    writeConfig(patchPath, {
+      pilotRepos: ["owner/existing", "owner/next-repo"]
+    });
+    writeConfig(invalidPatchPath, {
+      pilotRepos: ["owner/repo/extra"]
+    });
+
+    const before = readFileSync(configPath, "utf8");
+    const output = await runConfig(["config", "patch", "--config", configPath, "--input", patchPath]);
+
+    expect(output).toMatchObject({
+      ok: true,
+      dryRun: true,
+      wrote: false,
+      changedPaths: ["pilotRepos"]
+    });
+    expect(output.config.pilotRepos).toEqual(["owner/existing", "owner/next-repo"]);
+    expect(readFileSync(configPath, "utf8")).toBe(before);
+
+    const rejected = await runConfig(["config", "patch", "--config", configPath, "--input", invalidPatchPath]);
+    expect(rejected).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("config.pilotRepos entries must be GitHub owner/repo names")
+    });
   });
 
   it("rejects empty ZCode string settings before live desktop writes", async () => {

--- a/tests/local-dashboard.test.ts
+++ b/tests/local-dashboard.test.ts
@@ -39,7 +39,12 @@ describe("local HTML dashboard", () => {
       },
       items: {
         license: expect.objectContaining({ id: "license", redacted: true }),
-        githubApp: expect.objectContaining({ id: "githubApp", state: "not_configured", redacted: true }),
+        githubApp: expect.objectContaining({
+          id: "githubApp",
+          state: "not_configured",
+          redacted: true,
+          metadata: expect.objectContaining({ clientIdConfigured: false })
+        }),
         daemon: expect.objectContaining({ id: "daemon", state: "not_configured", redacted: true }),
         provider: expect.objectContaining({ id: "provider", state: "configured_unverified", redacted: true })
       },
@@ -60,6 +65,34 @@ describe("local HTML dashboard", () => {
     expect(html).toContain("Daemon");
     expect(html).toContain("Provider");
     expect(html).toContain("openai-compatible");
+  });
+
+  it("reports GitHub App client-id readiness without exposing user tokens", async () => {
+    const config = loadConfigFromObject({
+      github: {
+        appId: "4184532",
+        clientId: "Iv1.publicclientid123",
+        botLogin: "neondiff-review-bot"
+      }
+    });
+    const status = await buildLocalDashboardStatus({
+      config,
+      configPath: "/Volumes/LEXAR/Codex/neondiff/config.local.json",
+      configExists: true,
+      now: new Date("2026-07-08T12:00:00.000Z")
+    });
+
+    expect(status.items.githubApp).toMatchObject({
+      id: "githubApp",
+      state: "configured_unverified",
+      redacted: true,
+      metadata: {
+        appIdConfigured: true,
+        clientIdConfigured: true,
+        botLogin: "neondiff-review-bot"
+      }
+    });
+    expect(JSON.stringify(status)).not.toMatch(/ghu_|ghr_|github_pat_|ghp_/);
   });
 
   it("verifies provider API key input without echoing the submitted key", async () => {


### PR DESCRIPTION
## Summary

Refs #487. This PR adds the desktop-safe foundation for GitHub setup and repo allowlist selection without claiming full GitHub OAuth/device-flow repo discovery yet.

- adds public `github.clientId` config/env/desktop patch support for future GitHub App device authorization
- exposes redacted GitHub App readiness metadata in the local dashboard status payload
- adds native desktop GitHub connection badges plus add/toggle/remove repo allowlist controls that persist through `config patch` to `pilotRepos`
- documents that GitHub user access tokens stay in Keychain and are not written to config

## Scope Boundary

This does not implement live GitHub device-code token exchange or `/user/installations` repository discovery yet. Per GitHub docs, the next slice should use the GitHub App device flow with the public client id and then use a user access token for installation/repository discovery:

- https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app
- https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28

## Validation

- `NODE_OPTIONS=--experimental-sqlite npx vitest run tests/config-cli.test.ts tests/local-dashboard.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `swift run NeonDiffDesktopCoreChecks`
- `swift run NeonDiffDesktopCoreSmoke`
- `swift build`
- `./script/build_and_run.sh build && ./script/build_and_run.sh bundle-check`
- `git diff --check`
- `node scripts/check-secret-scan.mjs`
- `node scripts/check-public-claims.mjs`
- `NEONDIFF_DESKTOP_UI_LAUNCH=true apps/neondiff-desktop/script/release-proof.sh`

Evidence: `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-09/v1.0.1-desktop-foundation/487-github-repo-selector-release-proof.json`