### PR TITLE
[codex] Add desktop GitHub device flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ version is:
 neondiff init --config config.local.json
 neondiff dashboard --config config.local.json
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
+export NEONDIFF_GITHUB_APP_CLIENT_ID="<github-app-client-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 neondiff doctor github --config config.local.json --json
 neondiff providers list --config config.local.json --json
@@ -124,7 +125,9 @@ includes a `Verify API Key` control that reports redacted pass/fail output.
 Create or install the GitHub App before expecting PR reviews to run. The App
 must be installed on the same selected repositories listed in `pilotRepos`; see
 [docs/github-app-setup.md](docs/github-app-setup.md) for the permission set and
-selected-repo install path.
+selected-repo install path. Enable device flow in the GitHub App settings before
+using the Mac desktop "Connect GitHub" repo selector; the desktop uses the
+public client ID for that user-code authorization flow.
 
 Do not store the GitHub App private key, provider API key, license key, tokens,
 or customer data in this repository. Keep local config, secrets, state DBs, and

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
@@ -13,6 +13,10 @@ final class NeonDiffDesktopModel: ObservableObject {
     @Published var providers = ProviderSettings()
     @Published var license = LicenseStatus()
     @Published var github = GitHubConnectionStatus()
+    @Published var githubAuthorizationCode: GitHubDeviceAuthorizationCode?
+    @Published var githubAuthorizationStatus = "not connected"
+    @Published var discoveredGitHubRepos: [GitHubDiscoveredRepository] = []
+    @Published var isGitHubAuthorizationInProgress = false
     @Published var logText = "No logs loaded."
     @Published var lastError: String?
     @Published var lastCommandLine = ""
@@ -26,21 +30,44 @@ final class NeonDiffDesktopModel: ObservableObject {
 
     private let userDefaults: UserDefaults
     private let keychain: DesktopSecretStoring
+    private let githubAuthClient: GitHubDesktopAuthenticating
+    private var githubAuthorizationTask: Task<Void, Never>?
 
     init(
         userDefaults: UserDefaults = .standard,
-        keychain: DesktopSecretStoring = KeychainSecretStore()
+        keychain: DesktopSecretStoring = KeychainSecretStore(),
+        githubAuthClient: GitHubDesktopAuthenticating = GitHubDeviceAuthClient()
     ) {
         self.userDefaults = userDefaults
         self.keychain = keychain
+        self.githubAuthClient = githubAuthClient
         self.configPath = userDefaults.string(forKey: "neondiff.configPath") ?? "config.local.json"
         self.cliPath = userDefaults.string(forKey: "neondiff.cliPath") ?? "neondiff"
         self.launchdLabel = userDefaults.string(forKey: "neondiff.launchdLabel") ?? "com.electricsheephq.evaos-code-review-bot"
         let providerKeyStored = keychain.containsSecret(account: providerKeyAccount)
+        let githubUserTokenStored = keychain.containsSecret(account: githubUserTokenAccount)
+        let githubAccessTokenExpired = Self.storedDate(
+            keychain: keychain,
+            account: githubTokenExpiresAtAccount
+        ).map { $0 <= Date() } ?? false
+        let githubRefreshTokenValid = keychain.containsSecret(account: githubRefreshTokenAccount)
+            && !(Self.storedDate(keychain: keychain, account: githubRefreshTokenExpiresAtAccount).map { $0 <= Date() } ?? false)
         self.providers.providerKeyStored = providerKeyStored
         self.license.keyStored = keychain.containsSecret(account: licenseKeyAccount)
-        self.github.userTokenStored = keychain.containsSecret(account: githubUserTokenAccount)
-        self.github.installationState = self.github.userTokenStored ? "user authorized" : "not connected"
+        self.github.userTokenStored = githubUserTokenStored && (!githubAccessTokenExpired || githubRefreshTokenValid)
+        if githubUserTokenStored && githubAccessTokenExpired && githubRefreshTokenValid {
+            self.github.installationState = "authorization refresh needed"
+            self.githubAuthorizationStatus = "authorization refresh needed"
+        } else if githubUserTokenStored && githubAccessTokenExpired {
+            self.github.installationState = "authorization expired; reconnect GitHub"
+            self.githubAuthorizationStatus = "authorization expired; reconnect GitHub"
+        } else {
+            self.github.installationState = self.github.userTokenStored ? "user authorized" : "not connected"
+        }
+        self.github.authorizedUserLogin = try? keychain.readSecret(account: githubUserLoginAccount)
+        if let login = self.github.authorizedUserLogin, !githubAccessTokenExpired {
+            self.githubAuthorizationStatus = "authorized as \(login)"
+        }
         self.onboardingFlow = OnboardingFlow(providerKeyStored: providerKeyStored)
         self.isOnboardingPresented = !userDefaults.bool(forKey: onboardingCompletedKey)
         self.lastCommandLine = statusCommand.commandLine
@@ -215,6 +242,81 @@ final class NeonDiffDesktopModel: ObservableObject {
         logText = "Repo removed locally. Preview or apply the config patch to persist it."
     }
 
+    func startGitHubAuthorization() {
+        guard let clientId = github.clientId?.trimmingCharacters(in: .whitespacesAndNewlines), !clientId.isEmpty else {
+            lastError = "Set the public GitHub App client ID before connecting GitHub."
+            githubAuthorizationStatus = "client id missing"
+            return
+        }
+        githubAuthorizationTask?.cancel()
+        githubAuthorizationCode = nil
+        isGitHubAuthorizationInProgress = true
+        githubAuthorizationStatus = "requesting device code"
+        lastError = nil
+        githubAuthorizationTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let code = try await githubAuthClient.requestDeviceCode(clientId: clientId)
+                if Task.isCancelled { return }
+                githubAuthorizationCode = code
+                githubAuthorizationStatus = "enter code \(code.userCode)"
+                github.installationState = "waiting for GitHub authorization"
+                logText = "Open \(code.verificationURI.absoluteString) and enter code \(code.userCode)."
+                await pollGitHubAuthorization(clientId: clientId, code: code)
+            } catch {
+                if Task.isCancelled { return }
+                isGitHubAuthorizationInProgress = false
+                githubAuthorizationStatus = "failed"
+                lastError = NeonDiffRedactor.redact(error.localizedDescription)
+                logText = lastError ?? "GitHub authorization failed."
+            }
+        }
+    }
+
+    func cancelGitHubAuthorization() {
+        githubAuthorizationTask?.cancel()
+        githubAuthorizationTask = nil
+        isGitHubAuthorizationInProgress = false
+        githubAuthorizationCode = nil
+        githubAuthorizationStatus = "cancelled"
+        github.installationState = github.userTokenStored ? "user authorized" : "not connected"
+    }
+
+    func copyGitHubUserCode() {
+        guard let userCode = githubAuthorizationCode?.userCode else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(userCode, forType: .string)
+        githubAuthorizationStatus = "code copied"
+    }
+
+    func openGitHubDeviceVerification() {
+        guard let verificationURI = githubAuthorizationCode?.verificationURI else { return }
+        NSWorkspace.shared.open(verificationURI)
+        githubAuthorizationStatus = "verification page opened"
+    }
+
+    func refreshGitHubRepositories() {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                githubAuthorizationStatus = "refreshing repositories"
+                let accessToken = try await gitHubAccessTokenForAPI()
+                let user = try await githubAuthClient.fetchCurrentUser(accessToken: accessToken)
+                let discovered = try await githubAuthClient.listAccessibleRepositories(accessToken: accessToken)
+                applyGitHubDiscovery(user: user, discovered: discovered)
+            } catch {
+                if error is GitHubDesktopAuthorizationStateError {
+                    lastError = NeonDiffRedactor.redact(error.localizedDescription)
+                    logText = lastError ?? "Reconnect GitHub."
+                    return
+                }
+                githubAuthorizationStatus = "repository refresh failed"
+                lastError = NeonDiffRedactor.redact(error.localizedDescription)
+                logText = lastError ?? "GitHub repository refresh failed."
+            }
+        }
+    }
+
     func previewRepoAllowlistPatch() {
         runRepoSelectionPatch(dryRun: true)
     }
@@ -384,6 +486,140 @@ final class NeonDiffDesktopModel: ObservableObject {
         runCLI(arguments: arguments, displayCommand: dryRun ? repoSelectionPatchPreviewCommand : repoSelectionPatchApplyCommand)
     }
 
+    private func gitHubAccessTokenForAPI() async throws -> String {
+        guard let accessToken = try keychain.readSecret(account: githubUserTokenAccount), !accessToken.isEmpty else {
+            clearStoredGitHubAuthorization(status: "connect GitHub first")
+            throw GitHubDesktopAuthorizationStateError.reconnectRequired("Connect GitHub before refreshing accessible repositories.")
+        }
+        guard let expiresAt = readGitHubStoredDate(account: githubTokenExpiresAtAccount) else {
+            return accessToken
+        }
+        if expiresAt > Date().addingTimeInterval(60) {
+            return accessToken
+        }
+        guard let clientId = github.clientId?.trimmingCharacters(in: .whitespacesAndNewlines), !clientId.isEmpty else {
+            clearStoredGitHubAuthorization(status: "authorization expired; reconnect GitHub")
+            throw GitHubDesktopAuthorizationStateError.reconnectRequired("GitHub authorization expired and the public client ID is missing. Reconnect GitHub after loading config.")
+        }
+        guard let refreshToken = try keychain.readSecret(account: githubRefreshTokenAccount), !refreshToken.isEmpty else {
+            clearStoredGitHubAuthorization(status: "authorization expired; reconnect GitHub")
+            throw GitHubDesktopAuthorizationStateError.reconnectRequired("GitHub authorization expired. Reconnect GitHub.")
+        }
+        if let refreshExpiresAt = readGitHubStoredDate(account: githubRefreshTokenExpiresAtAccount), refreshExpiresAt <= Date() {
+            clearStoredGitHubAuthorization(status: "refresh expired; reconnect GitHub")
+            throw GitHubDesktopAuthorizationStateError.reconnectRequired("GitHub refresh token expired. Reconnect GitHub.")
+        }
+        githubAuthorizationStatus = "refreshing GitHub authorization"
+        let refreshedToken: GitHubUserToken
+        do {
+            refreshedToken = try await githubAuthClient.refreshUserToken(clientId: clientId, refreshToken: refreshToken)
+        } catch {
+            clearStoredGitHubAuthorization(status: "refresh failed; reconnect GitHub")
+            throw GitHubDesktopAuthorizationStateError.reconnectRequired("GitHub authorization refresh failed. Reconnect GitHub.")
+        }
+        try storeGitHubToken(refreshedToken)
+        githubAuthorizationStatus = "GitHub authorization refreshed"
+        return refreshedToken.accessToken
+    }
+
+    private func pollGitHubAuthorization(clientId: String, code: GitHubDeviceAuthorizationCode) async {
+        var intervalSeconds = code.intervalSeconds
+        while !Task.isCancelled && Date() < code.expiresAt {
+            do {
+                try await Task.sleep(nanoseconds: UInt64(max(1, intervalSeconds)) * 1_000_000_000)
+                let result = try await githubAuthClient.pollDeviceAuthorization(clientId: clientId, deviceCode: code.deviceCode)
+                switch result {
+                case .pending(let nextInterval):
+                    intervalSeconds = max(1, nextInterval)
+                    githubAuthorizationStatus = "waiting for authorization"
+                case .authorized(let token):
+                    try storeGitHubToken(token)
+                    let user = try await githubAuthClient.fetchCurrentUser(accessToken: token.accessToken)
+                    let discovered = try await githubAuthClient.listAccessibleRepositories(accessToken: token.accessToken)
+                    applyGitHubDiscovery(user: user, discovered: discovered)
+                    isGitHubAuthorizationInProgress = false
+                    githubAuthorizationCode = nil
+                    return
+                case .failed(let error, let description):
+                    isGitHubAuthorizationInProgress = false
+                    githubAuthorizationStatus = error.rawValue
+                    github.installationState = "authorization failed"
+                    lastError = NeonDiffRedactor.redact(description ?? error.rawValue)
+                    logText = lastError ?? "GitHub authorization failed."
+                    return
+                }
+            } catch {
+                if Task.isCancelled { return }
+                isGitHubAuthorizationInProgress = false
+                githubAuthorizationStatus = "failed"
+                lastError = NeonDiffRedactor.redact(error.localizedDescription)
+                logText = lastError ?? "GitHub authorization failed."
+                return
+            }
+        }
+        if !Task.isCancelled {
+            isGitHubAuthorizationInProgress = false
+            githubAuthorizationStatus = "expired"
+            github.installationState = "device code expired"
+        }
+    }
+
+    private func storeGitHubToken(_ token: GitHubUserToken) throws {
+        try keychain.setSecret(token.accessToken, account: githubUserTokenAccount)
+        if let refreshToken = token.refreshToken {
+            try keychain.setSecret(refreshToken, account: githubRefreshTokenAccount)
+        } else {
+            try? keychain.deleteSecret(account: githubRefreshTokenAccount)
+        }
+        if let expiresAt = token.expiresAt {
+            try keychain.setSecret(ISO8601DateFormatter().string(from: expiresAt), account: githubTokenExpiresAtAccount)
+        } else {
+            try? keychain.deleteSecret(account: githubTokenExpiresAtAccount)
+        }
+        if let refreshTokenExpiresAt = token.refreshTokenExpiresAt {
+            try keychain.setSecret(ISO8601DateFormatter().string(from: refreshTokenExpiresAt), account: githubRefreshTokenExpiresAtAccount)
+        } else {
+            try? keychain.deleteSecret(account: githubRefreshTokenExpiresAtAccount)
+        }
+        github.userTokenStored = true
+    }
+
+    private func applyGitHubDiscovery(user: GitHubAuthenticatedUser, discovered: [GitHubDiscoveredRepository]) {
+        discoveredGitHubRepos = discovered
+        repos = GitHubRepositoryDiscovery.mergeConfiguredAndDiscoveredRepos(configured: repos, discovered: discovered)
+        github.userTokenStored = true
+        github.authorizedUserLogin = user.login
+        github.installationCount = Set(discovered.map(\.installationId)).count
+        github.discoveredRepositoryCount = discovered.count
+        github.installationState = discovered.isEmpty
+            ? "authorized as \(user.login); no accessible installations found"
+            : "authorized as \(user.login); \(discovered.count) repositories available"
+        githubAuthorizationStatus = "authorized as \(user.login)"
+        lastError = nil
+        logText = "GitHub connected as \(user.login). Select repositories, then preview or apply the allowlist patch."
+        try? keychain.setSecret(user.login, account: githubUserLoginAccount)
+    }
+
+    private func clearStoredGitHubAuthorization(status: String) {
+        try? keychain.deleteSecret(account: githubUserTokenAccount)
+        try? keychain.deleteSecret(account: githubRefreshTokenAccount)
+        try? keychain.deleteSecret(account: githubTokenExpiresAtAccount)
+        try? keychain.deleteSecret(account: githubRefreshTokenExpiresAtAccount)
+        try? keychain.deleteSecret(account: githubUserLoginAccount)
+        github.userTokenStored = false
+        github.authorizedUserLogin = nil
+        github.installationCount = 0
+        github.discoveredRepositoryCount = 0
+        github.installationState = status
+        githubAuthorizationStatus = status
+        githubAuthorizationCode = nil
+        discoveredGitHubRepos = []
+    }
+
+    private func readGitHubStoredDate(account: String) -> Date? {
+        Self.storedDate(keychain: keychain, account: account)
+    }
+
     private func writeRepoSelectionPatch() throws {
         try FileManager.default.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
         let selectedRepos = repos
@@ -414,7 +650,15 @@ final class NeonDiffDesktopModel: ObservableObject {
                 if !snapshot.repos.isEmpty { repos = snapshot.repos }
                 providers = snapshot.providers
                 license = snapshot.license
-                github = snapshot.github
+                var parsedGitHub = snapshot.github
+                parsedGitHub.userTokenStored = keychain.containsSecret(account: githubUserTokenAccount)
+                parsedGitHub.authorizedUserLogin = github.authorizedUserLogin
+                parsedGitHub.installationCount = github.installationCount
+                parsedGitHub.discoveredRepositoryCount = github.discoveredRepositoryCount
+                if parsedGitHub.userTokenStored && parsedGitHub.installationState == "not connected" {
+                    parsedGitHub.installationState = github.installationState
+                }
+                github = parsedGitHub
             }
             return
         }
@@ -437,11 +681,33 @@ final class NeonDiffDesktopModel: ObservableObject {
         }
         return root["command"] as? String
     }
+
+    private static func storedDate(keychain: DesktopSecretStoring, account: String) -> Date? {
+        guard let value = try? keychain.readSecret(account: account) else {
+            return nil
+        }
+        return ISO8601DateFormatter().date(from: value)
+    }
+}
+
+private enum GitHubDesktopAuthorizationStateError: LocalizedError {
+    case reconnectRequired(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .reconnectRequired(let message):
+            message
+        }
+    }
 }
 
 private let providerKeyAccount = "provider/glm/api-key"
 private let licenseKeyAccount = "license/default"
 private let githubUserTokenAccount = "github/user-access-token"
+private let githubRefreshTokenAccount = "github/user-refresh-token"
+private let githubTokenExpiresAtAccount = "github/user-token-expires-at"
+private let githubRefreshTokenExpiresAtAccount = "github/user-refresh-token-expires-at"
+private let githubUserLoginAccount = "github/user-login"
 private let onboardingCompletedKey = "neondiff.hasCompletedOnboarding"
 
 private func isValidRepoName(_ value: String) -> Bool {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -23,7 +23,7 @@ struct ReposView: View {
                         )
                     }
 
-                    Text("Use GitHub App device authorization to discover repositories later. This release keeps tokens in Keychain and persists selected repositories through config patch only.")
+                    Text("Use GitHub App device authorization to discover accessible repositories. Tokens stay in Keychain and selected repositories persist through config patch only.")
                         .operatorBodyText()
                         .fixedSize(horizontal: false, vertical: true)
 
@@ -32,6 +32,69 @@ struct ReposView: View {
                             .foregroundStyle(NeonDiffTheme.textPrimary)
                         Spacer()
                         Text(model.github.installationState)
+                            .foregroundStyle(NeonDiffTheme.textSecondary)
+                    }
+
+                    HStack(spacing: 10) {
+                        Button { model.startGitHubAuthorization() } label: {
+                            Label(
+                                model.github.userTokenStored ? "Reconnect GitHub" : "Connect GitHub",
+                                systemImage: "person.crop.circle.badge.checkmark"
+                            )
+                        }
+                        .disabled(!model.github.clientIdConfigured || model.isGitHubAuthorizationInProgress)
+                        .accessibilityIdentifier("neondiff-github-connect")
+
+                        Button { model.refreshGitHubRepositories() } label: {
+                            Label("Refresh Repositories", systemImage: "arrow.triangle.2.circlepath")
+                        }
+                        .disabled(!model.github.userTokenStored)
+                        .accessibilityIdentifier("neondiff-github-refresh-repos")
+
+                        if model.isGitHubAuthorizationInProgress {
+                            Button { model.cancelGitHubAuthorization() } label: {
+                                Label("Cancel", systemImage: "xmark.circle")
+                            }
+                            .accessibilityIdentifier("neondiff-github-cancel")
+                        }
+                    }
+
+                    if let code = model.githubAuthorizationCode {
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack(spacing: 10) {
+                                Text(code.userCode)
+                                    .font(.system(.title3, design: .monospaced).weight(.semibold))
+                                    .foregroundStyle(NeonDiffTheme.accentSoft)
+                                    .textSelection(.enabled)
+                                    .accessibilityIdentifier("neondiff-github-user-code")
+
+                                Button { model.copyGitHubUserCode() } label: {
+                                    Label("Copy Code", systemImage: "doc.on.doc")
+                                }
+                                .accessibilityIdentifier("neondiff-github-copy-code")
+
+                                Button { model.openGitHubDeviceVerification() } label: {
+                                    Label("Open GitHub", systemImage: "safari")
+                                }
+                                .accessibilityIdentifier("neondiff-github-open-device")
+                            }
+
+                            Text("Expires \(code.expiresAt.formatted(date: .omitted, time: .shortened)); status: \(model.githubAuthorizationStatus)")
+                                .operatorBodyText()
+                        }
+                    } else {
+                        Text("GitHub status: \(model.githubAuthorizationStatus)")
+                            .operatorBodyText()
+                    }
+
+                    HStack(spacing: 10) {
+                        if let login = model.github.authorizedUserLogin {
+                            Label("@\(login)", systemImage: "person.crop.circle")
+                                .foregroundStyle(NeonDiffTheme.textPrimary)
+                        }
+                        Label("\(model.github.installationCount) installations", systemImage: "square.stack.3d.up")
+                            .foregroundStyle(NeonDiffTheme.textSecondary)
+                        Label("\(model.github.discoveredRepositoryCount) repos discovered", systemImage: "folder.badge.plus")
                             .foregroundStyle(NeonDiffTheme.textSecondary)
                     }
                 }
@@ -89,6 +152,27 @@ struct ReposView: View {
                         Label("Add Repo", systemImage: "plus.circle")
                     }
                     .accessibilityIdentifier("neondiff-repo-add")
+                }
+
+                if !model.discoveredGitHubRepos.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Discovered From GitHub")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(NeonDiffTheme.textPrimary)
+
+                        ForEach(model.discoveredGitHubRepos.prefix(8)) { repo in
+                            HStack(spacing: 8) {
+                                Image(systemName: repo.visibility == "private" ? "lock.fill" : "globe")
+                                    .foregroundStyle(repo.visibility == "private" ? NeonDiffTheme.warning : NeonDiffTheme.accent)
+                                Text(repo.fullName)
+                                    .textSelection(.enabled)
+                                Spacer()
+                                Text(repo.permissionsSummary)
+                                    .foregroundStyle(NeonDiffTheme.textSecondary)
+                            }
+                            .font(.body)
+                        }
+                    }
                 }
 
                 HStack(spacing: 10) {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
@@ -126,22 +126,34 @@ public struct LicenseStatus: Equatable {
 public struct GitHubConnectionStatus: Equatable {
     public var appIdConfigured: Bool
     public var clientIdConfigured: Bool
+    public var clientId: String?
     public var botLogin: String
     public var userTokenStored: Bool
     public var installationState: String
+    public var authorizedUserLogin: String?
+    public var installationCount: Int
+    public var discoveredRepositoryCount: Int
 
     public init(
         appIdConfigured: Bool = false,
         clientIdConfigured: Bool = false,
+        clientId: String? = nil,
         botLogin: String = "not configured",
         userTokenStored: Bool = false,
-        installationState: String = "not connected"
+        installationState: String = "not connected",
+        authorizedUserLogin: String? = nil,
+        installationCount: Int = 0,
+        discoveredRepositoryCount: Int = 0
     ) {
         self.appIdConfigured = appIdConfigured
         self.clientIdConfigured = clientIdConfigured
+        self.clientId = clientId
         self.botLogin = botLogin
         self.userTokenStored = userTokenStored
         self.installationState = installationState
+        self.authorizedUserLogin = authorizedUserLogin
+        self.installationCount = installationCount
+        self.discoveredRepositoryCount = discoveredRepositoryCount
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/GitHubDesktopModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/GitHubDesktopModels.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+public struct GitHubDeviceAuthorizationCode: Equatable {
+    public var deviceCode: String
+    public var userCode: String
+    public var verificationURI: URL
+    public var expiresAt: Date
+    public var intervalSeconds: Int
+
+    public init(deviceCode: String, userCode: String, verificationURI: URL, expiresAt: Date, intervalSeconds: Int) {
+        self.deviceCode = deviceCode
+        self.userCode = userCode
+        self.verificationURI = verificationURI
+        self.expiresAt = expiresAt
+        self.intervalSeconds = intervalSeconds
+    }
+}
+
+public struct GitHubUserToken: Equatable {
+    public var accessToken: String
+    public var refreshToken: String?
+    public var expiresAt: Date?
+    public var refreshTokenExpiresAt: Date?
+    public var tokenType: String
+
+    public init(
+        accessToken: String,
+        refreshToken: String? = nil,
+        expiresAt: Date? = nil,
+        refreshTokenExpiresAt: Date? = nil,
+        tokenType: String = "bearer"
+    ) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.expiresAt = expiresAt
+        self.refreshTokenExpiresAt = refreshTokenExpiresAt
+        self.tokenType = tokenType
+    }
+}
+
+public enum GitHubDeviceAuthorizationError: String, Equatable {
+    case authorizationPending = "authorization_pending"
+    case slowDown = "slow_down"
+    case expiredToken = "expired_token"
+    case tokenExpired = "token_expired"
+    case unsupportedGrantType = "unsupported_grant_type"
+    case incorrectClientCredentials = "incorrect_client_credentials"
+    case incorrectDeviceCode = "incorrect_device_code"
+    case accessDenied = "access_denied"
+    case deviceFlowDisabled = "device_flow_disabled"
+    case unknown
+}
+
+public enum GitHubDeviceAuthorizationPollResult: Equatable {
+    case pending(intervalSeconds: Int)
+    case authorized(GitHubUserToken)
+    case failed(error: GitHubDeviceAuthorizationError, description: String?)
+
+    public var minimumNextPollIntervalSeconds: Int {
+        switch self {
+        case .pending(let intervalSeconds):
+            return intervalSeconds
+        case .authorized, .failed:
+            return 0
+        }
+    }
+
+    public func applyingSlowDown() -> GitHubDeviceAuthorizationPollResult {
+        switch self {
+        case .pending(let intervalSeconds):
+            return .pending(intervalSeconds: intervalSeconds + 5)
+        case .authorized, .failed:
+            return self
+        }
+    }
+}
+
+public struct GitHubAuthenticatedUser: Equatable {
+    public var login: String
+
+    public init(login: String) {
+        self.login = login
+    }
+}
+
+public struct GitHubDiscoveredRepository: Identifiable, Hashable {
+    public var id: String { fullName }
+    public var fullName: String
+    public var visibility: String
+    public var installationId: Int
+    public var installationAccount: String
+    public var permissionsSummary: String
+
+    public init(
+        fullName: String,
+        visibility: String,
+        installationId: Int,
+        installationAccount: String,
+        permissionsSummary: String = "metadata:read"
+    ) {
+        self.fullName = fullName
+        self.visibility = visibility
+        self.installationId = installationId
+        self.installationAccount = installationAccount
+        self.permissionsSummary = permissionsSummary
+    }
+}
+
+public enum GitHubRepositoryDiscovery {
+    public static func mergeConfiguredAndDiscoveredRepos(
+        configured: [RepoMonitor],
+        discovered: [GitHubDiscoveredRepository]
+    ) -> [RepoMonitor] {
+        var byName: [String: RepoMonitor] = [:]
+        for repo in configured {
+            byName[repo.name.lowercased()] = repo
+        }
+        for repo in discovered where byName[repo.fullName.lowercased()] == nil {
+            byName[repo.fullName.lowercased()] = RepoMonitor(
+                name: repo.fullName,
+                enabled: false,
+                profile: repo.visibility,
+                lastReview: "discovered via GitHub App installation \(repo.installationId)"
+            )
+        }
+        return byName.values.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
@@ -61,6 +61,7 @@ public enum ConfigInspectParser {
         let github = GitHubConnectionStatus(
             appIdConfigured: appId?.isEmpty == false,
             clientIdConfigured: clientId?.isEmpty == false,
+            clientId: clientId,
             botLogin: botLogin?.isEmpty == false ? botLogin! : "not configured",
             userTokenStored: githubUserTokenStored,
             installationState: githubUserTokenStored ? "user authorized" : "not connected"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubDeviceAuthClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubDeviceAuthClient.swift
@@ -1,0 +1,298 @@
+import Foundation
+
+public protocol GitHubDesktopAuthenticating {
+    func requestDeviceCode(clientId: String) async throws -> GitHubDeviceAuthorizationCode
+    func pollDeviceAuthorization(clientId: String, deviceCode: String) async throws -> GitHubDeviceAuthorizationPollResult
+    func refreshUserToken(clientId: String, refreshToken: String) async throws -> GitHubUserToken
+    func fetchCurrentUser(accessToken: String) async throws -> GitHubAuthenticatedUser
+    func listAccessibleRepositories(accessToken: String) async throws -> [GitHubDiscoveredRepository]
+}
+
+public enum GitHubDeviceAuthClientError: Error, LocalizedError {
+    case invalidURL(String)
+    case invalidResponse(String)
+    case apiError(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL(let value):
+            "Invalid GitHub URL: \(value)"
+        case .invalidResponse(let value):
+            "Invalid GitHub response: \(NeonDiffRedactor.redact(value))"
+        case .apiError(let value):
+            "GitHub API error: \(NeonDiffRedactor.redact(value))"
+        }
+    }
+}
+
+public final class GitHubDeviceAuthClient: GitHubDesktopAuthenticating {
+    private let githubBaseURL: URL
+    private let apiBaseURL: URL
+    private let session: URLSession
+    private let now: () -> Date
+    private let pageSize: Int
+
+    public init(
+        githubBaseURL: URL = URL(string: "https://github.com")!,
+        apiBaseURL: URL = URL(string: "https://api.github.com")!,
+        session: URLSession = .shared,
+        now: @escaping () -> Date = Date.init,
+        pageSize: Int = 100
+    ) {
+        self.githubBaseURL = githubBaseURL
+        self.apiBaseURL = apiBaseURL
+        self.session = session
+        self.now = now
+        self.pageSize = max(1, min(pageSize, 100))
+    }
+
+    public func requestDeviceCode(clientId: String) async throws -> GitHubDeviceAuthorizationCode {
+        let response: DeviceCodeResponse = try await postForm(
+            baseURL: githubBaseURL,
+            path: "/login/device/code",
+            fields: ["client_id": clientId]
+        )
+        guard let verificationURL = URL(string: response.verificationUri) else {
+            throw GitHubDeviceAuthClientError.invalidResponse("verification_uri was not a valid URL")
+        }
+        return GitHubDeviceAuthorizationCode(
+            deviceCode: response.deviceCode,
+            userCode: response.userCode,
+            verificationURI: verificationURL,
+            expiresAt: now().addingTimeInterval(TimeInterval(response.expiresIn)),
+            intervalSeconds: response.interval ?? 5
+        )
+    }
+
+    public func pollDeviceAuthorization(clientId: String, deviceCode: String) async throws -> GitHubDeviceAuthorizationPollResult {
+        let response: TokenResponse = try await postForm(
+            baseURL: githubBaseURL,
+            path: "/login/oauth/access_token",
+            fields: [
+                "client_id": clientId,
+                "device_code": deviceCode,
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code"
+            ]
+        )
+        if let accessToken = response.accessToken {
+            return .authorized(GitHubUserToken(
+                accessToken: accessToken,
+                refreshToken: response.refreshToken,
+                expiresAt: response.expiresIn.map { now().addingTimeInterval(TimeInterval($0)) },
+                refreshTokenExpiresAt: response.refreshTokenExpiresIn.map { now().addingTimeInterval(TimeInterval($0)) },
+                tokenType: response.tokenType ?? "bearer"
+            ))
+        }
+        let error = GitHubDeviceAuthorizationError(rawValue: response.error ?? "") ?? .unknown
+        if error == .authorizationPending {
+            return .pending(intervalSeconds: response.interval ?? 5)
+        }
+        if error == .slowDown {
+            return .pending(intervalSeconds: (response.interval ?? 5) + 5)
+        }
+        return .failed(error: error, description: response.errorDescription)
+    }
+
+    public func refreshUserToken(clientId: String, refreshToken: String) async throws -> GitHubUserToken {
+        let response: TokenResponse = try await postForm(
+            baseURL: githubBaseURL,
+            path: "/login/oauth/access_token",
+            fields: [
+                "client_id": clientId,
+                "grant_type": "refresh_token",
+                "refresh_token": refreshToken
+            ]
+        )
+        if let accessToken = response.accessToken {
+            return GitHubUserToken(
+                accessToken: accessToken,
+                refreshToken: response.refreshToken,
+                expiresAt: response.expiresIn.map { now().addingTimeInterval(TimeInterval($0)) },
+                refreshTokenExpiresAt: response.refreshTokenExpiresIn.map { now().addingTimeInterval(TimeInterval($0)) },
+                tokenType: response.tokenType ?? "bearer"
+            )
+        }
+        let error = response.error ?? "missing_access_token"
+        throw GitHubDeviceAuthClientError.apiError(response.errorDescription ?? error)
+    }
+
+    public func fetchCurrentUser(accessToken: String) async throws -> GitHubAuthenticatedUser {
+        let user: CurrentUserResponse = try await getJSON(path: "/user", accessToken: accessToken)
+        return GitHubAuthenticatedUser(login: user.login)
+    }
+
+    public func listAccessibleRepositories(accessToken: String) async throws -> [GitHubDiscoveredRepository] {
+        var installationPage = 1
+        var installations: [InstallationResponse] = []
+        while true {
+            let response: InstallationsResponse = try await getJSON(
+                path: "/user/installations?per_page=\(pageSize)&page=\(installationPage)",
+                accessToken: accessToken
+            )
+            installations.append(contentsOf: response.installations)
+            if response.installations.count < pageSize { break }
+            installationPage += 1
+        }
+        var repositories: [GitHubDiscoveredRepository] = []
+        for installation in installations {
+            var page = 1
+            while true {
+                let path = "/user/installations/\(installation.id)/repositories?per_page=\(pageSize)&page=\(page)"
+                let response: InstallationRepositoriesResponse = try await getJSON(path: path, accessToken: accessToken)
+                repositories.append(contentsOf: response.repositories.map { repository in
+                    GitHubDiscoveredRepository(
+                        fullName: repository.fullName,
+                        visibility: repository.visibility ?? (repository.private == true ? "private" : "public"),
+                        installationId: installation.id,
+                        installationAccount: installation.account.login,
+                        permissionsSummary: repository.permissions.summary
+                    )
+                })
+                if response.repositories.count < 100 { break }
+                page += 1
+            }
+        }
+        return repositories.sorted { $0.fullName.localizedCaseInsensitiveCompare($1.fullName) == .orderedAscending }
+    }
+
+    private func postForm<T: Decodable>(baseURL: URL, path: String, fields: [String: String]) async throws -> T {
+        let body = fields
+            .map { key, value in "\(urlEncode(key))=\(urlEncode(value))" }
+            .joined(separator: "&")
+        var request = try makeRequest(baseURL: baseURL, path: path)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data(body.utf8)
+        return try await decode(request)
+    }
+
+    private func getJSON<T: Decodable>(path: String, accessToken: String) async throws -> T {
+        var request = try makeRequest(baseURL: apiBaseURL, path: path)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+        return try await decode(request)
+    }
+
+    private func makeRequest(baseURL: URL, path: String) throws -> URLRequest {
+        guard let url = URL(string: path, relativeTo: baseURL)?.absoluteURL else {
+            throw GitHubDeviceAuthClientError.invalidURL(path)
+        }
+        return URLRequest(url: url)
+    }
+
+    private func decode<T: Decodable>(_ request: URLRequest) async throws -> T {
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw GitHubDeviceAuthClientError.invalidResponse("missing HTTP response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? "<binary response>"
+            throw GitHubDeviceAuthClientError.apiError("HTTP \(http.statusCode): \(body)")
+        }
+        do {
+            return try JSONDecoder.github.decode(T.self, from: data)
+        } catch {
+            throw GitHubDeviceAuthClientError.invalidResponse(error.localizedDescription)
+        }
+    }
+}
+
+private struct DeviceCodeResponse: Decodable {
+    var deviceCode: String
+    var userCode: String
+    var verificationUri: String
+    var expiresIn: Int
+    var interval: Int?
+}
+
+private struct TokenResponse: Decodable {
+    var accessToken: String?
+    var refreshToken: String?
+    var expiresIn: Int?
+    var refreshTokenExpiresIn: Int?
+    var tokenType: String?
+    var error: String?
+    var errorDescription: String?
+    var interval: Int?
+}
+
+private struct CurrentUserResponse: Decodable {
+    var login: String
+}
+
+private struct InstallationsResponse: Decodable {
+    var installations: [InstallationResponse]
+}
+
+private struct InstallationResponse: Decodable {
+    var id: Int
+    var account: InstallationAccountResponse
+}
+
+private struct InstallationAccountResponse: Decodable {
+    var login: String
+}
+
+private struct InstallationRepositoriesResponse: Decodable {
+    var repositories: [InstallationRepositoryResponse]
+}
+
+private struct InstallationRepositoryResponse: Decodable {
+    var fullName: String
+    var visibility: String?
+    var `private`: Bool?
+    var permissions: RepositoryPermissionsResponse
+}
+
+private struct RepositoryPermissionsResponse: Decodable {
+    var admin: Bool?
+    var push: Bool?
+    var pull: Bool?
+    var metadata: String?
+    var pullRequests: String?
+    var contents: String?
+    var issues: String?
+
+    var summary: String {
+        [
+            admin.map { "admin:\($0)" },
+            push.map { "push:\($0)" },
+            pull.map { "pull:\($0)" },
+            metadata.map { "metadata:\($0)" },
+            pullRequests.map { "pull_requests:\($0)" },
+            contents.map { "contents:\($0)" },
+            issues.map { "issues:\($0)" }
+        ]
+            .compactMap { $0 }
+            .joined(separator: ",")
+            .ifEmpty("permissions:unknown")
+    }
+}
+
+private extension JSONDecoder {
+    static var github: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }
+}
+
+private func urlEncode(_ value: String) -> String {
+    value.addingPercentEncoding(withAllowedCharacters: .urlFormAllowed) ?? value
+}
+
+private extension CharacterSet {
+    static var urlFormAllowed: CharacterSet {
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "&=+")
+        return allowed
+    }
+}
+
+private extension String {
+    func ifEmpty(_ fallback: String) -> String {
+        isEmpty ? fallback : self
+    }
+}

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
@@ -10,6 +10,15 @@ func check(_ condition: @autoclosure () -> Bool, _ message: String) -> Bool {
     exit(1)
 }
 
+func checkedAsync<T>(_ message: String, _ operation: () async throws -> T) async -> T {
+    do {
+        return try await operation()
+    } catch {
+        fputs("check failed: \(message): \(NeonDiffRedactor.redact(error.localizedDescription))\n", stderr)
+        exit(1)
+    }
+}
+
 var providerFlow = OnboardingFlow()
 check(providerFlow.currentStep == .welcome, "flow starts at welcome")
 providerFlow.advance()
@@ -66,6 +75,215 @@ check(
     "local package CLI is preferred over GUI PATH fallback"
 )
 
+final class GitHubFixtureURLProtocol: URLProtocol {
+    static var requests: [URLRequest] = []
+    static var requestBodies: [String] = []
+    private static let lock = NSLock()
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host?.hasSuffix("github.local") == true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let capturedBody = Self.captureBody(from: request)
+        Self.lock.lock()
+        Self.requests.append(request)
+        Self.requestBodies.append(capturedBody)
+        Self.lock.unlock()
+
+        let path = request.url?.path ?? ""
+        let query = request.url?.query ?? ""
+        let statusCode = 200
+        let payload: String
+        switch path {
+        case "/login/device/code":
+            payload = """
+            {
+              "device_code": "device-fixture",
+              "user_code": "WDJB-MJHT",
+              "verification_uri": "https://github.com/login/device",
+              "expires_in": 900,
+              "interval": 5
+            }
+            """
+        case "/login/oauth/access_token":
+            if capturedBody.contains("grant_type=refresh_token") {
+                payload = """
+                {
+                  "access_token": "fixture-refreshed-access-token",
+                  "refresh_token": "fixture-refreshed-refresh-token",
+                  "expires_in": 28800,
+                  "refresh_token_expires_in": 15811200,
+                  "token_type": "bearer"
+                }
+                """
+            } else {
+                payload = """
+                {
+                  "access_token": "fixture-access-token",
+                  "refresh_token": "fixture-refresh-token",
+                  "expires_in": 28800,
+                  "refresh_token_expires_in": 15811200,
+                  "token_type": "bearer"
+                }
+                """
+            }
+        case "/user":
+            payload = #"{"login":"octo-user"}"#
+        case "/user/installations":
+            if query.contains("page=2") {
+                payload = #"{"installations":[{"id":43,"account":{"login":"second-org"}}]}"#
+            } else if query.contains("page=3") {
+                payload = #"{"installations":[]}"#
+            } else {
+                payload = #"{"installations":[{"id":42,"account":{"login":"octo-org"}}]}"#
+            }
+        case "/user/installations/42/repositories":
+            if query.contains("page=2") {
+                payload = #"{"repositories":[]}"#
+            } else {
+                payload = """
+                {
+                  "repositories": [
+                    {
+                      "full_name": "octo-org/private-repo",
+                      "visibility": "private",
+                      "private": true,
+                      "permissions": {
+                        "admin": false,
+                        "push": false,
+                        "pull": true
+                      }
+                    }
+                  ]
+                }
+                """
+            }
+        case "/user/installations/43/repositories":
+            if query.contains("page=2") {
+                payload = #"{"repositories":[]}"#
+            } else {
+                payload = """
+                {
+                  "repositories": [
+                    {
+                      "full_name": "second-org/public-repo",
+                      "visibility": "public",
+                      "private": false,
+                      "permissions": {
+                        "admin": false,
+                        "push": true,
+                        "pull": true
+                      }
+                    }
+                  ]
+                }
+                """
+            }
+        default:
+            payload = #"{"message":"unexpected fixture path"}"#
+        }
+
+        let data = Data(payload.utf8)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func captureBody(from request: URLRequest) -> String {
+        if let body = request.httpBody {
+            return String(data: body, encoding: .utf8) ?? ""
+        }
+        guard let stream = request.httpBodyStream else { return "" }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let count = stream.read(buffer, maxLength: bufferSize)
+            if count <= 0 { break }
+            data.append(buffer, count: count)
+        }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}
+
+let fixtureSessionConfig = URLSessionConfiguration.ephemeral
+fixtureSessionConfig.protocolClasses = [GitHubFixtureURLProtocol.self]
+let fixtureGitHubClient = GitHubDeviceAuthClient(
+    githubBaseURL: URL(string: "https://github.local")!,
+    apiBaseURL: URL(string: "https://api.github.local")!,
+    session: URLSession(configuration: fixtureSessionConfig),
+    now: { Date(timeIntervalSince1970: 1000) },
+    pageSize: 1
+)
+let fixtureDeviceCode = await checkedAsync("GitHub client requests device code") {
+    try await fixtureGitHubClient.requestDeviceCode(clientId: "Iv1.publicclientid123")
+}
+check(fixtureDeviceCode.userCode == "WDJB-MJHT", "GitHub client parses device authorization user code")
+check(fixtureDeviceCode.expiresAt == Date(timeIntervalSince1970: 1900), "GitHub client maps device authorization expiry")
+let fixtureToken = await checkedAsync("GitHub client polls device token") {
+    try await fixtureGitHubClient.pollDeviceAuthorization(clientId: "Iv1.publicclientid123", deviceCode: fixtureDeviceCode.deviceCode)
+}
+if case .authorized(let token) = fixtureToken {
+    check(token.accessToken == "fixture-access-token", "GitHub client parses device token response")
+} else {
+    check(false, "GitHub client did not parse authorized device token response")
+}
+let fixtureUser = await checkedAsync("GitHub client fetches current user") {
+    try await fixtureGitHubClient.fetchCurrentUser(accessToken: "fixture-access-token")
+}
+check(fixtureUser.login == "octo-user", "GitHub client fetches current user")
+let fixtureRepos = await checkedAsync("GitHub client lists accessible repositories") {
+    try await fixtureGitHubClient.listAccessibleRepositories(accessToken: "fixture-access-token")
+}
+check(fixtureRepos.count == 2, "GitHub client lists accessible repositories across installation pages")
+check(fixtureRepos.first?.fullName == "octo-org/private-repo", "GitHub client maps repository full name")
+check(fixtureRepos.first?.permissionsSummary == "admin:false,push:false,pull:true", "GitHub client maps documented repository permissions")
+check(fixtureRepos.last?.fullName == "second-org/public-repo", "GitHub client follows later installation pages")
+let refreshedToken = await checkedAsync("GitHub client refreshes expiring user tokens") {
+    try await fixtureGitHubClient.refreshUserToken(clientId: "Iv1.publicclientid123", refreshToken: "fixture-refresh-token")
+}
+check(refreshedToken.accessToken == "fixture-refreshed-access-token", "GitHub refresh token grant returns a new access token")
+let fixtureRequests = GitHubFixtureURLProtocol.requests
+let fixtureRequestBodies = GitHubFixtureURLProtocol.requestBodies
+let deviceCodeBody = zip(fixtureRequests, fixtureRequestBodies)
+    .first { request, _ in request.url?.path == "/login/device/code" }?
+    .1 ?? ""
+check(deviceCodeBody.contains("client_id=Iv1.publicclientid123"), "GitHub device-code request includes the public client id")
+let tokenBody = zip(fixtureRequests, fixtureRequestBodies)
+    .first { request, body in
+        request.url?.path == "/login/oauth/access_token" && body.contains("device_code=device-fixture")
+    }?
+    .1 ?? ""
+check(tokenBody.contains("device_code=device-fixture"), "GitHub token request includes the device code")
+check(tokenBody.contains("grant_type=urn:ietf:params:oauth:grant-type:device_code"), "GitHub token request uses the device-code grant")
+let refreshBody = zip(fixtureRequests, fixtureRequestBodies)
+    .first { request, body in
+        request.url?.path == "/login/oauth/access_token" && body.contains("grant_type=refresh_token")
+    }?
+    .1 ?? ""
+check(refreshBody.contains("refresh_token=fixture-refresh-token"), "GitHub refresh request includes the refresh token")
+let authorizedAPIRequests = fixtureRequests.filter { $0.url?.host == "api.github.local" }
+check(
+    authorizedAPIRequests.allSatisfy { $0.value(forHTTPHeaderField: "Authorization") == "Bearer fixture-access-token" },
+    "GitHub API requests use the user access token authorization header"
+)
+
 let launchMarker = tempRoot.appendingPathComponent("dashboard-launch-marker.txt")
 let launchScript = tempRoot.appendingPathComponent("dashboard-launcher")
 try """
@@ -79,10 +297,51 @@ let launchResult = try launchClient.launchDetached(arguments: ["dashboard", "--c
 check(launchResult.processIdentifier > 0, "dashboard launcher returns a child process identifier")
 let markerDeadline = Date().addingTimeInterval(3)
 while !FileManager.default.fileExists(atPath: launchMarker.path), Date() < markerDeadline {
-    Thread.sleep(forTimeInterval: 0.05)
+    try await Task.sleep(nanoseconds: 50_000_000)
 }
 check(FileManager.default.fileExists(atPath: launchMarker.path), "dashboard launcher writes its marker file")
 let markerContents = try String(contentsOf: launchMarker, encoding: .utf8)
 check(markerContents.contains("dashboard --config config.local.json --open true"), "dashboard launcher passes expected CLI arguments")
+
+let authCode = GitHubDeviceAuthorizationCode(
+    deviceCode: "device-code",
+    userCode: "WDJB-MJHT",
+    verificationURI: URL(string: "https://github.com/login/device")!,
+    expiresAt: Date(timeIntervalSince1970: 1000),
+    intervalSeconds: 5
+)
+check(authCode.userCode == "WDJB-MJHT", "device authorization exposes the user code for visible desktop setup")
+check(authCode.intervalSeconds == 5, "device authorization preserves GitHub polling interval")
+
+let pendingPoll = GitHubDeviceAuthorizationPollResult.pending(intervalSeconds: 5)
+let slowedPoll = pendingPoll.applyingSlowDown()
+check(slowedPoll.minimumNextPollIntervalSeconds == 10, "slow_down adds five seconds to the polling interval")
+
+let discoveredRepos = GitHubRepositoryDiscovery.mergeConfiguredAndDiscoveredRepos(
+    configured: [RepoMonitor(name: "owner/manual", enabled: true, profile: "selected")],
+    discovered: [
+        GitHubDiscoveredRepository(
+            fullName: "owner/discovered",
+            visibility: "private",
+            installationId: 123,
+            installationAccount: "owner",
+            permissionsSummary: "metadata:read,pull_requests:write"
+        )
+    ]
+)
+check(
+    discoveredRepos.map(\.name) == ["owner/discovered", "owner/manual"],
+    "discovered repositories merge with configured allowlist without dropping manual repos"
+)
+check(
+    discoveredRepos.first(where: { $0.name == "owner/discovered" })?.enabled == false,
+    "discovered repositories are not enabled until the user selects them"
+)
+
+let fakeGitHubAccessToken = ["ghu", "fixture_token_12345678901234567890"].joined(separator: "_")
+let fakeGitHubRefreshToken = ["ghr", "fixture_token_12345678901234567890"].joined(separator: "_")
+let redactedGitHubTokens = NeonDiffRedactor.redact("access=\(fakeGitHubAccessToken) refresh=\(fakeGitHubRefreshToken)")
+check(!redactedGitHubTokens.contains("ghu_fixture"), "GitHub user access tokens are redacted")
+check(!redactedGitHubTokens.contains("ghr_fixture"), "GitHub refresh tokens are redacted")
 
 print("NeonDiffDesktopCoreChecks passed")

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
@@ -155,6 +155,7 @@ do {
     guard let githubSnapshot = ConfigInspectParser.parse(githubConfigJSON, providerKeyStored: false, licenseKeyStored: false),
           githubSnapshot.github.appIdConfigured,
           githubSnapshot.github.clientIdConfigured,
+          githubSnapshot.github.clientId == "Iv1.publicclientid123",
           githubSnapshot.github.botLogin == "neondiff-review-bot",
           githubSnapshot.repos == [
             RepoMonitor(name: "owner/repo-one", enabled: true, profile: "Repo One"),

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -92,8 +92,14 @@ Save the generated private key outside the repository.
 
 ```bash
 export NEONDIFF_GITHUB_APP_ID="<github-app-id>"
+export NEONDIFF_GITHUB_APP_CLIENT_ID="<github-app-client-id>"
 export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-key.pem"
 ```
+
+For the Mac desktop Repos pane, copy the GitHub App client ID into
+`github.clientId` or `NEONDIFF_GITHUB_APP_CLIENT_ID`, and enable device flow in
+the GitHub App settings. Without that optional feature, GitHub will return
+`device_flow_disabled` when the desktop tries to show a user authorization code.
 
 ## 3. Configure Provider And License
 

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -66,6 +66,10 @@ export NEONDIFF_GITHUB_APP_PRIVATE_KEY_PATH="/absolute/path/to/neondiff.private-
 authorization flow. Do not put user access tokens or refresh tokens in config;
 desktop user tokens belong in Keychain.
 
+For the desktop Repos pane, enable device flow in the GitHub App settings before
+testing "Connect GitHub". If device flow is disabled, GitHub returns
+`device_flow_disabled` and the desktop cannot issue a user code.
+
 ## Verify Installation
 
 Run the GitHub-only doctor before provider or daemon checks:

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -54,9 +54,20 @@ The Repos pane shows GitHub App setup state without exposing tokens. The public
 GitHub App `clientId` may be stored in config for the desktop/device
 authorization flow, while GitHub user access tokens belong in Keychain only.
 
+When `github.clientId` is configured and device flow is enabled in the GitHub
+App settings, the Repos pane can start GitHub device authorization, show the
+short user code, open GitHub's verification page, store the resulting user token
+in Keychain, and list repositories visible through the user's GitHub App
+installations. Repository discovery is read-only and uses the standard GitHub
+user installation APIs; the desktop never stores the user token in config or
+release evidence. If GitHub returns `device_flow_disabled`, enable device flow
+on the GitHub App before retrying.
+
 The repo selector persists selected repositories by writing a `pilotRepos` patch
-through `config patch`. It does not post reviews, widen App permissions, or write
-GitHub user tokens into config.
+through `config patch`. Discovered repositories are disabled until the user
+selects them. It does not post reviews, widen App permissions, or write GitHub
+user tokens into config. Live PR reviews still post only through the configured
+GitHub App bot identity.
 
 ## Local Dashboard Launcher
 


### PR DESCRIPTION
## Summary
- add GitHub device authorization client/model types for the NeonDiff desktop app
- store GitHub user tokens in Keychain and discover accessible repositories through GitHub App user-installation APIs
- wire the Repos pane with Connect GitHub, Refresh Repositories, discovered repo metadata, and existing config-patch allowlist persistence
- document the desktop GitHub device-flow boundary

Refs #487.

## Validation
- `swift run NeonDiffDesktopCoreChecks`
- `swift run NeonDiffDesktopCoreSmoke`
- `swift build`
- `./script/build_and_run.sh build && ./script/build_and_run.sh bundle-check`
- `git diff --check`
- `node scripts/check-secret-scan.mjs`
- `node scripts/check-public-claims.mjs`
- `npm ci`
- `npm run build`
- visible Computer Use smoke on unsigned dev app: Repos pane rendered Connect GitHub, Refresh Repositories, repo selection controls, and no-live-posting boundary

## Evidence
`/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-09/v1.0.1-desktop-foundation/487-github-device-flow-pr-proof.json`

## Proof Boundary
This PR proves mocked GitHub device-flow/repository discovery, desktop UI wiring, Keychain-token storage paths, and local unsigned app rendering. It does not prove live OAuth completion against the production GitHub App, signed/notarized desktop distribution, Sparkle updates, or paid/private license activation.