### PR TITLE
[codex] Prepare v1.0.2 release cut

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,7 +9,11 @@ on:
       tag:
         description: Release tag to publish
         required: true
-        default: v1.0.1
+        default: v1.0.2
+
+concurrency:
+  group: publish-npm-${{ github.event.inputs.tag || github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ for the semver/GA-line and npm dist-tag policy.
 
 No unreleased changes tracked yet.
 
+## [1.0.2] - docs/releases/v1.0.2.md
+
+### Added
+
+- Publish the desktop GitHub connection foundation merged after `v1.0.1`:
+  GitHub App device authorization, Keychain-backed user-token storage,
+  installation/repository discovery, public/private repo visibility rendering,
+  and repo allowlist config-patch controls.
+
+### Changed
+
+- Refresh stable release manifest, license API health proof, unauthenticated
+  checkout issuance proof, and release notes for the `v1.0.2` public release
+  cut.
+
 ## [1.0.1] - docs/releases/v1.0.1.md
 
 ### Changed

--- a/docs/evidence/v1.0.2-desktop-github-smoke.json
+++ b/docs/evidence/v1.0.2-desktop-github-smoke.json
@@ -1,0 +1,52 @@
+{
+  "evidenceKind": "desktop_github_smoke_redacted",
+  "releaseVersion": "v1.0.2",
+  "observedAt": "2026-07-09T16:12:03Z",
+  "sourceHead": "7e87832352cc9d8337079b4763c0496739aceea8",
+  "proofBoundary": "Local operator smoke proves the unsigned desktop source workflow after PR #500. It does not claim signed, notarized, Sparkle/appcast, or npm package delivery of the desktop app.",
+  "githubApp": {
+    "appSlug": "evaos-code-review-bot",
+    "appId": "4184532",
+    "deviceFlowEnabled": true,
+    "sensitiveFieldsRedacted": true
+  },
+  "desktopApp": {
+    "bundleId": "com.electricsheephq.NeonDiffDesktop",
+    "githubStatus": "authorized",
+    "userAuthorized": true,
+    "keychainUserTokenPresent": true,
+    "tokensStoredInConfig": false,
+    "browserDeviceFlowSuccess": true
+  },
+  "repoDiscovery": {
+    "installationCount": 3,
+    "discoveredRepositoryCount": 48,
+    "samplePublicRepos": [
+      "100yenadmin/evaOS-GUI",
+      "electricsheephq/evaos-code-review-bot-neondiff",
+      "Martian-Engineering/lossless-claw"
+    ],
+    "privateRepoNamesOmitted": true,
+    "publicPrivateVisibilityRendered": true,
+    "discoveredReposDefaultToDisabled": true
+  },
+  "allowlistPersistence": {
+    "smokeRepoSelected": "electricsheephq/evaos-code-review-bot-neondiff",
+    "configPatchPersisted": true,
+    "tokensPersistedInConfig": false,
+    "appliedToDisposableConfigOnly": true,
+    "livePostingChanged": false
+  },
+  "releaseTruth": {
+    "npmLatestAtSmoke": "1.0.1",
+    "githubReleaseAtSmoke": "v1.0.1",
+    "publicReleaseProof": false,
+    "nextReleaseRequired": "v1.0.2"
+  },
+  "redaction": {
+    "localPathsRemoved": true,
+    "tokensRemoved": true,
+    "rawDeviceCodeRemoved": true,
+    "privateRepoNamesOmitted": true
+  }
+}

--- a/docs/evidence/v1.0.2-license-api-healthz.json
+++ b/docs/evidence/v1.0.2-license-api-healthz.json
@@ -1,0 +1,19 @@
+{
+  "evidenceKind": "license_api_healthz",
+  "releaseVersion": "v1.0.2",
+  "observedAt": "2026-07-09T16:18:54.440Z",
+  "method": "GET",
+  "url": "https://neondiff-license.fly.dev/healthz",
+  "statusCode": 200,
+  "responseBody": "{\"status\":\"ok\"}",
+  "responseBodySha256": "a29ee2b15c494311c52521766e44af56a3ad2248e7a8ab465e5206463c13d288",
+  "captureContext": {
+    "tool": "node fetch",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "Codex Desktop macOS operator shell",
+    "dnsResolution": "system resolver",
+    "note": "Captured with normal system DNS resolution and Node default TLS validation."
+  },
+  "redaction": "No license key, token, cookie, customer data, or private repo content was present in this health check."
+}

--- a/docs/evidence/v1.0.2-license-checkout-issuance-authenticated.json
+++ b/docs/evidence/v1.0.2-license-checkout-issuance-authenticated.json
@@ -1,0 +1,21 @@
+{
+  "evidenceKind": "license_api_checkout_issuance_authenticated",
+  "releaseVersion": "v1.0.2",
+  "observedAt": "2026-07-09T16:30:19.933Z",
+  "method": "POST",
+  "url": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
+  "statusCode": 200,
+  "redactedResponse": {
+    "status": "issued",
+    "replayed": false,
+    "checkoutLookupKey": "neondiff_monthly",
+    "issuedLicensePrefix": "nd_live_",
+    "issuedLicenseFingerprint": "sha256:8203f9fafa923afb5477799b93ed6001ed54cb63bdc5215e8fddcb7a8b808efa"
+  },
+  "captureContext": {
+    "tool": "neondiff checkout-issuance-smoke",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "operator CLI"
+  }
+}

--- a/docs/evidence/v1.0.2-license-checkout-issuance-unauthenticated.json
+++ b/docs/evidence/v1.0.2-license-checkout-issuance-unauthenticated.json
@@ -1,0 +1,19 @@
+{
+  "evidenceKind": "license_api_checkout_issuance",
+  "releaseVersion": "v1.0.2",
+  "observedAt": "2026-07-09T16:18:54.944Z",
+  "method": "POST",
+  "url": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
+  "statusCode": 401,
+  "responseBody": "{\"status\":\"unauthorized\",\"detail\":\"license issuance authorization failed\"}",
+  "responseBodySha256": "a67612cc05a222fc5d28aa36be40d59daf7b32bca36f305d66c57db869150e20",
+  "captureContext": {
+    "tool": "node fetch",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "Codex Desktop macOS operator shell",
+    "dnsResolution": "system resolver",
+    "note": "Captured without Authorization header to prove configured fail-closed behavior."
+  },
+  "redaction": "No license key, bearer token, cookie, customer data, or checkout payload secret was sent or captured."
+}

--- a/docs/evidence/v1.0.2-rollback-refs.json
+++ b/docs/evidence/v1.0.2-rollback-refs.json
@@ -1,0 +1,38 @@
+{
+  "evidenceKind": "release_rollback_refs",
+  "releaseVersion": "v1.0.2",
+  "observedAt": "2026-07-09T16:20:06.331Z",
+  "channels": {
+    "cli": {
+      "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
+      "rollbackCommand": "git reset --hard refs/tags/v1.0.1",
+      "rollbackTarget": "v1.0.1",
+      "targetVerifiedBy": "git ls-remote origin 'refs/tags/v1.0.1^{}'",
+      "targetVerifiedSha": "4381bea9045ca0078ac3eb98c149c83970445f28"
+    },
+    "daemon": {
+      "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
+      "rollbackCommand": "git reset --hard refs/tags/v1.0.1",
+      "rollbackTarget": "v1.0.1",
+      "targetVerifiedBy": "git ls-remote origin 'refs/tags/v1.0.1^{}'",
+      "targetVerifiedSha": "4381bea9045ca0078ac3eb98c149c83970445f28"
+    },
+    "browserDashboard": {
+      "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
+      "rollbackCommand": "git reset --hard refs/tags/v1.0.1",
+      "rollbackTarget": "v1.0.1",
+      "targetVerifiedBy": "git ls-remote origin 'refs/tags/v1.0.1^{}'",
+      "targetVerifiedSha": "4381bea9045ca0078ac3eb98c149c83970445f28"
+    },
+    "website": {
+      "rollbackRepository": "electricsheephq/neon-diff-agent-website",
+      "releaseAction": "no_code_deploy_for_v1.0.2",
+      "currentChannelVersion": "v1.0.1",
+      "rollbackTarget": "no_action_for_v1.0.2",
+      "targetVerifiedBy": "docs/public-release-manifest.json omits updateChannels.website for v1.0.2",
+      "targetVerifiedSha": null,
+      "targetSubject": "v1.0.2 keeps the previously published website installer; npm latest promotion supplies the new package version."
+    }
+  },
+  "proofBoundary": "Rollback refs are repo-scoped. v1.0.2 does not advance the website channel, so website rollback is intentionally no-op for this release."
+}

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,12 +1,12 @@
 {
-  "version": "v1.0.1",
+  "version": "v1.0.2",
   "releaseLevel": "stable",
   "packageArtifact": {
     "name": "neondiff",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "requiredForThisRelease": true,
     "state": "published",
-    "previousReleasedPackageVersion": "1.0.0",
+    "previousReleasedPackageVersion": "1.0.1",
     "skippedPublicPackageVersions": [
       "v0.4.25-beta.1",
       "v0.4.26-beta.1",
@@ -30,12 +30,12 @@
       "v0.4.45-beta.1",
       "v0.4.46-beta.1"
     ],
-    "note": "v1.0.1 is the first stable patch after GA: it keeps the license-gated npm latest line, removes pre-1.0 beta install exposure, and hardens release workflow preflights."
+    "note": "v1.0.2 publishes the CLI/dashboard npm package and release metadata. Desktop GitHub device-flow and repo-discovery source changes are included in this source release, but desktop app artifacts are not part of the npm package."
   },
   "source": {
     "shaState": "pending_tag_stamp",
-    "candidateHeadBeforeReleaseMetadata": "23d66717c0627b25a8c56895bba9627bcdd69cca",
-    "proof": "after merge and tag, release:status --expected-head $(git rev-parse HEAD)"
+    "candidateHeadBeforeReleaseMetadata": "fb2e0238287198a1fa1462f066f295dee6c9ea2e",
+    "proof": "after merge and tag, release:status --expected-head $(git rev-parse HEAD) and verify the tag contains candidate head fb2e0238287198a1fa1462f066f295dee6c9ea2e"
   },
   "releaseStages": {
     "launchCutLine": "1.0 is a usable local HTML installer/dashboard plus minimal Mac launcher, not full signed desktop maturity.",
@@ -78,9 +78,9 @@
     ]
   },
   "docs": {
-    "version": "v1.0.1",
+    "version": "v1.0.2",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v1.0.1.md",
+    "releaseNotesPath": "docs/releases/v1.0.2.md",
     "websiteRepo": "electricsheephq/neon-diff-agent-website"
   },
   "licenseApi": {
@@ -88,45 +88,36 @@
     "state": "healthy",
     "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327",
     "healthUrl": "https://neondiff-license.fly.dev/healthz",
-    "healthProofPath": "docs/evidence/v1.0.1-license-api-healthz.json",
+    "healthProofPath": "docs/evidence/v1.0.2-license-api-healthz.json",
     "checkoutIssuanceRequiredForThisRelease": true,
     "checkoutIssuanceUrl": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
     "checkoutIssuanceState": "ready",
-    "checkoutIssuanceProofPath": "docs/evidence/v1.0.1-license-checkout-issuance-unauthenticated.json",
-    "checkoutIssuanceAuthenticatedProofPath": "docs/evidence/v1.0.1-license-checkout-issuance-authenticated.json",
+    "checkoutIssuanceProofPath": "docs/evidence/v1.0.2-license-checkout-issuance-unauthenticated.json",
+    "checkoutIssuanceAuthenticatedProofPath": "docs/evidence/v1.0.2-license-checkout-issuance-authenticated.json",
     "checkoutIssuanceTrackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
   },
   "updateChannels": {
     "cli": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v1.0.1",
-      "rollback": "git reset --hard refs/tags/v1.0.0",
+      "version": "v1.0.2",
+      "rollback": "git reset --hard refs/tags/v1.0.1",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v1.0.1",
-      "rollback": "git reset --hard refs/tags/v1.0.0",
+      "version": "v1.0.2",
+      "rollback": "git reset --hard refs/tags/v1.0.1",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "browserDashboard": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v1.0.1",
-      "rollback": "git reset --hard refs/tags/v1.0.0",
+      "version": "v1.0.2",
+      "rollback": "git reset --hard refs/tags/v1.0.1",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
       "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
-    },
-    "website": {
-      "requiredForThisRelease": true,
-      "state": "published",
-      "version": "v1.0.1",
-      "rollback": "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
-      "rollbackRepository": "electricsheephq/neon-diff-agent-website",
-      "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/450",
-      "note": "The hosted installer remains part of release-status for v1.0.1. It serves an installer that defaults to npm latest, so no website code deploy is required for the installer to pick up neondiff@1.0.1 after the npm latest promotion."
     }
   }
 }

--- a/docs/releases/v1.0.2.md
+++ b/docs/releases/v1.0.2.md
@@ -1,0 +1,87 @@
+# v1.0.2
+
+- Release type: stable desktop GitHub connection foundation patch
+- Release source SHA: to be stamped by `refs/tags/v1.0.2`
+- Previous stable release: `v1.0.1`
+- Tracking issues / source PRs: `#484`, `#487`, `#499`, `#500`, `#501`
+- Package artifact: `neondiff@1.0.2` after publish
+- Rollback baseline: `v1.0.1`
+
+## Purpose
+
+Publish a stable CLI/dashboard npm package release whose source tree includes
+the verified desktop GitHub connection and repository discovery work that merged
+after `v1.0.1`.
+
+This patch keeps the v1.0 launch boundary unchanged: `npm install -g neondiff`
+installs the CLI, `neondiff dashboard` opens the local HTML setup/status
+dashboard, and the minimal Mac launcher remains the desktop entry point. The
+new user-facing desktop foundation lets the app connect GitHub through the
+GitHub App device flow, discover installed repositories, show public/private
+repo visibility, and persist selected repositories through the config patch
+path without writing tokens into config.
+
+## Included Changes
+
+- Ship the desktop GitHub App device-flow foundation:
+  - public `github.clientId` config support;
+  - Repos-pane device authorization controls;
+  - Keychain-backed GitHub user-token storage;
+  - refresh-token recovery and reconnect behavior;
+  - paginated `/user/installations` and per-installation repository discovery;
+  - public/private repository visibility rendering; and
+  - manual/discovered repository allowlist controls that persist through
+    `config patch`.
+- Carry forward the live desktop smoke proof from current `main`:
+  - desktop authorized as `100yenadmin`;
+  - 3 GitHub App installations discovered;
+  - 48 accessible repositories discovered;
+  - public/private repo badges rendered; and
+  - disposable allowlist config patch persisted with no token-like config
+    values.
+- Refresh the public release manifest and license API proof paths for the
+  `v1.0.2` release line.
+- Keep the hosted website channel on its previously published deployment; no
+  website code deploy or channel rollback is part of this patch.
+
+## Required Gates
+
+- Focused validation:
+  - `NODE_OPTIONS=--experimental-sqlite npx vitest run tests/public-release-readiness.test.ts tests/release-status.test.ts tests/checkout-issuance-smoke.test.ts --pool=forks --maxWorkers=1`
+  - `npm run build`
+  - `node scripts/check-public-claims.mjs`
+  - `node scripts/check-secret-scan.mjs`
+  - `git diff --check`
+- License API proof:
+  - `docs/evidence/v1.0.2-license-api-healthz.json`
+  - `docs/evidence/v1.0.2-license-checkout-issuance-unauthenticated.json`
+  - `docs/evidence/v1.0.2-license-checkout-issuance-authenticated.json`
+- Desktop GitHub proof:
+  - committed redacted proof packet: `docs/evidence/v1.0.2-desktop-github-smoke.json`
+- Release-status public manifest gate:
+  - `npx tsx src/cli.ts release-status --expected-head "$(git rev-parse HEAD)" --public-release-manifest docs/public-release-manifest.json --expected-public-version v1.0.2`
+
+## Caveats
+
+- This release does not ship signed/notarized desktop artifacts, Sparkle
+  appcast, or auto-update proof. Those remain tracked by `#116` and `#449`.
+- This release does not claim full native Swift desktop maturity; it publishes
+  the local-first desktop GitHub connection foundation.
+- This release does not claim CodeRabbit parity, calibrated 95% review
+  accuracy, auto-merge, approvals, native ZCode skills/MCP/memory, or
+  target-repo mutation.
+- Public release proof is not complete until `neondiff@1.0.2` is published to
+  npm `latest` and the non-prerelease GitHub Release `v1.0.2` targets a commit
+  containing candidate head `fb2e0238287198a1fa1462f066f295dee6c9ea2e`.
+
+## Rollback
+
+```bash
+: "${REPO_ROOT:?set REPO_ROOT to your local NeonDiff checkout}"
+
+cd "$REPO_ROOT"
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v1.0.1
+npm dist-tag add neondiff@1.0.1 latest
+```

--- a/docs/setup-validation.md
+++ b/docs/setup-validation.md
@@ -99,10 +99,11 @@ Keep long JSON output in separate files and link it from the transcript.
 Validate the package install path first. Use the version named by the docs or
 the issue under test.
 
-Public install proof currently means the npm package `neondiff@0.4.30-beta.1`.
-Source-only beta releases `v0.4.31-beta.1` through `v0.4.37-beta.1` are held
-from npm; validate those by source SHA or local build path, not by expecting a
-new public npm artifact.
+Public install proof means the npm package version named by the current stable
+release manifest, for example `neondiff@1.0.2` for the v1.0.2 patch line.
+Historical source-only beta releases remain provenance/source-checkout releases;
+validate those by source SHA or local build path, not by expecting a new public
+npm artifact.
 
 ```bash
 npm install -g neondiff@<version-under-test> --prefix "$tmp_prefix"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neondiff",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neondiff",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "neondiff": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neondiff",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
   "bin": {

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -8,7 +8,7 @@ const paths = [
   "docs/license-boundary.md",
   "docs/pricing.md",
   "docs/github-marketplace-free-listing.md",
-  "docs/releases/v1.0.1.md",
+  "docs/releases/v1.0.2.md",
   "docs/releases/v1.0.0.md"
 ];
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-NEONDIFF_VERSION="${NEONDIFF_VERSION:-1.0.1}"
+NEONDIFF_VERSION="${NEONDIFF_VERSION:-1.0.2}"
 DRY_RUN=0
 NPM_PREFIX="${NPM_PREFIX:-}"
 
@@ -13,7 +13,7 @@ Usage:
   sh install.sh [--dry-run] [--prefix /path/to/prefix]
 
 Environment:
-  NEONDIFF_VERSION  Version to install, defaults to 1.0.1.
+  NEONDIFF_VERSION  Version to install, defaults to 1.0.2.
   NPM_PREFIX        Optional npm global prefix.
 
 Requires Node.js 26 or newer and npm.

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -60,7 +60,7 @@ describe("NeonDiff public release readiness", () => {
     };
 
     expect(pkg.name).toBe("neondiff");
-    expect(pkg.version).toBe("1.0.1");
+    expect(pkg.version).toBe("1.0.2");
     expect(pkg.private).toBeUndefined();
     expect(pkg.description).toMatch(/local-first AI PR reviewer/i);
     expect(pkg.license).toBe("SEE LICENSE IN LICENSE.md");
@@ -93,19 +93,19 @@ describe("NeonDiff public release readiness", () => {
     ]);
 
     expect(lock.name).toBe("neondiff");
-    expect(lock.version).toBe("1.0.1");
+    expect(lock.version).toBe("1.0.2");
     expect(lock.packages?.[""]).toMatchObject({
       name: "neondiff",
-      version: "1.0.1",
+      version: "1.0.2",
       license: "SEE LICENSE IN LICENSE.md",
       bin: { neondiff: "dist/src/cli.js" }
     });
     expect(manifest.packageArtifact).toMatchObject({
       name: "neondiff",
-      version: "1.0.1",
+      version: "1.0.2",
       requiredForThisRelease: true,
       state: "published",
-      previousReleasedPackageVersion: "1.0.0"
+      previousReleasedPackageVersion: "1.0.1"
     });
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.29-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.36-beta.1");
@@ -119,10 +119,11 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.44-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.45-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.46-beta.1");
-    expect(manifest.packageArtifact?.note).toMatch(/stable patch/i);
+    expect(manifest.packageArtifact?.note).toMatch(/CLI\/dashboard npm package/i);
+    expect(manifest.packageArtifact?.note).toMatch(/desktop app artifacts are not part of the npm package/i);
     expect(manifest.source).toMatchObject({
       shaState: "pending_tag_stamp",
-      candidateHeadBeforeReleaseMetadata: "23d66717c0627b25a8c56895bba9627bcdd69cca"
+      candidateHeadBeforeReleaseMetadata: "fb2e0238287198a1fa1462f066f295dee6c9ea2e"
     });
     expect(manifest.source?.proof).toMatch(/after merge and tag/i);
     expect(manifest.releaseStages?.launchCutLine).toBe(
@@ -152,7 +153,7 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.updateChannels?.browserDashboard).toMatchObject({
       requiredForThisRelease: true,
       state: "published",
-      rollback: "git reset --hard refs/tags/v1.0.0",
+      rollback: "git reset --hard refs/tags/v1.0.1",
       rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
       trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     });
@@ -164,14 +165,7 @@ describe("NeonDiff public release readiness", () => {
       requiredForThisRelease: true,
       state: "published"
     });
-    expect(manifest.updateChannels?.website).toMatchObject({
-      requiredForThisRelease: true,
-      state: "published",
-      version: "v1.0.1",
-      rollback: "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
-      rollbackRepository: "electricsheephq/neon-diff-agent-website"
-    });
-    expect(manifest.updateChannels?.website?.note).toMatch(/defaults to npm latest/i);
+    expect(manifest.updateChannels?.website).toBeUndefined();
     expect(manifest.updateChannels?.desktop).toBeUndefined();
   });
 
@@ -201,13 +195,13 @@ describe("NeonDiff public release readiness", () => {
       checkoutIssuanceRequiredForThisRelease: true,
       checkoutIssuanceUrl: "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
       checkoutIssuanceState: "ready",
-      checkoutIssuanceProofPath: "docs/evidence/v1.0.1-license-checkout-issuance-unauthenticated.json",
-      checkoutIssuanceAuthenticatedProofPath: "docs/evidence/v1.0.1-license-checkout-issuance-authenticated.json",
+      checkoutIssuanceProofPath: "docs/evidence/v1.0.2-license-checkout-issuance-unauthenticated.json",
+      checkoutIssuanceAuthenticatedProofPath: "docs/evidence/v1.0.2-license-checkout-issuance-authenticated.json",
       checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
     });
     expect(manifest.licenseApi?.trackingIssue).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/);
     expect(manifest.licenseApi?.healthUrl).toMatch(/^https:\/\/[^/]+\/healthz$/);
-    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v1.0.1-license-api-healthz.json");
+    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v1.0.2-license-api-healthz.json");
 
     const proof = JSON.parse(read(manifest.licenseApi?.healthProofPath ?? "")) as {
       evidenceKind?: string;
@@ -219,7 +213,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(proof).toMatchObject({
       evidenceKind: "license_api_healthz",
-      releaseVersion: "v1.0.1",
+      releaseVersion: "v1.0.2",
       url: manifest.licenseApi?.healthUrl,
       statusCode: 200,
       responseBody: "{\"status\":\"ok\"}"
@@ -235,7 +229,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(issuanceProof).toMatchObject({
       evidenceKind: "license_api_checkout_issuance",
-      releaseVersion: "v1.0.1",
+      releaseVersion: "v1.0.2",
       statusCode: 401,
       responseBody: expect.stringContaining("\"unauthorized\"")
     });
@@ -249,7 +243,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(authenticatedProof).toMatchObject({
       evidenceKind: "license_api_checkout_issuance_authenticated",
-      releaseVersion: "v1.0.1",
+      releaseVersion: "v1.0.2",
       statusCode: 200,
       redactedResponse: {
         issuedLicensePrefix: "nd_live_",
@@ -295,7 +289,7 @@ describe("NeonDiff public release readiness", () => {
     expect(liveCheckoutProof.proofBoundary).toContain("does not claim the original in-flight Stripe delivery");
     expect(JSON.stringify(liveCheckoutProof)).not.toMatch(/cs_live_|evt_|whsec_|nd_live_[A-Za-z0-9]|session_id=|fulfillment_token=|121 South/i);
 
-    const rollbackProof = JSON.parse(read("docs/evidence/v1.0.1-rollback-refs.json")) as {
+    const rollbackProof = JSON.parse(read("docs/evidence/v1.0.2-rollback-refs.json")) as {
       evidenceKind?: string;
       releaseVersion?: string;
       channels?: Record<string, {
@@ -309,46 +303,83 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(rollbackProof).toMatchObject({
       evidenceKind: "release_rollback_refs",
-      releaseVersion: "v1.0.1",
+      releaseVersion: "v1.0.2",
       channels: {
         cli: {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.cli?.rollback,
-          rollbackTarget: "v1.0.0",
-          targetVerifiedBy: "git rev-list -n 1 refs/tags/v1.0.0",
-          targetVerifiedSha: "23d66717c0627b25a8c56895bba9627bcdd69cca"
+          rollbackTarget: "v1.0.1",
+          targetVerifiedBy: "git ls-remote origin 'refs/tags/v1.0.1^{}'",
+          targetVerifiedSha: "4381bea9045ca0078ac3eb98c149c83970445f28"
         },
         browserDashboard: {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.browserDashboard?.rollback,
-          rollbackTarget: "v1.0.0",
-          targetVerifiedBy: "git rev-list -n 1 refs/tags/v1.0.0",
-          targetVerifiedSha: "23d66717c0627b25a8c56895bba9627bcdd69cca"
+          rollbackTarget: "v1.0.1",
+          targetVerifiedBy: "git ls-remote origin 'refs/tags/v1.0.1^{}'",
+          targetVerifiedSha: "4381bea9045ca0078ac3eb98c149c83970445f28"
         },
         daemon: {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.daemon?.rollback,
-          rollbackTarget: "v1.0.0",
-          targetVerifiedBy: "git rev-list -n 1 refs/tags/v1.0.0",
-          targetVerifiedSha: "23d66717c0627b25a8c56895bba9627bcdd69cca"
+          rollbackTarget: "v1.0.1",
+          targetVerifiedBy: "git ls-remote origin 'refs/tags/v1.0.1^{}'",
+          targetVerifiedSha: "4381bea9045ca0078ac3eb98c149c83970445f28"
         },
         website: {
           rollbackRepository: "electricsheephq/neon-diff-agent-website",
-          rollbackCommand: manifest.updateChannels?.website?.rollback,
-          rollbackTarget: "6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
-          targetVerifiedBy: "gh api repos/electricsheephq/neon-diff-agent-website/commits/6b670d00cd587fb7d564347b6bc0d4d3e8d13186 --jq .sha",
-          targetVerifiedSha: "6b670d00cd587fb7d564347b6bc0d4d3e8d13186"
+          releaseAction: "no_code_deploy_for_v1.0.2",
+          currentChannelVersion: "v1.0.1",
+          rollbackTarget: "no_action_for_v1.0.2",
+          targetVerifiedBy: "docs/public-release-manifest.json omits updateChannels.website for v1.0.2",
+          targetVerifiedSha: null
         }
       }
     });
     expect(JSON.stringify(rollbackProof)).not.toContain("<sha>");
+
+    const desktopProof = JSON.parse(read("docs/evidence/v1.0.2-desktop-github-smoke.json")) as {
+      evidenceKind?: string;
+      releaseVersion?: string;
+      proofBoundary?: string;
+      desktopApp?: {
+        userAuthorized?: boolean;
+        tokensStoredInConfig?: boolean;
+      };
+      repoDiscovery?: {
+        discoveredRepositoryCount?: number;
+        privateRepoNamesOmitted?: boolean;
+      };
+      redaction?: {
+        localPathsRemoved?: boolean;
+        tokensRemoved?: boolean;
+      };
+    };
+    expect(desktopProof).toMatchObject({
+      evidenceKind: "desktop_github_smoke_redacted",
+      releaseVersion: "v1.0.2",
+      desktopApp: {
+        userAuthorized: true,
+        tokensStoredInConfig: false
+      },
+      repoDiscovery: {
+        discoveredRepositoryCount: 48,
+        privateRepoNamesOmitted: true
+      },
+      redaction: {
+        localPathsRemoved: true,
+        tokensRemoved: true
+      }
+    });
+    expect(desktopProof.proofBoundary).toMatch(/does not claim signed/i);
+    expect(JSON.stringify(desktopProof)).not.toMatch(/\/Volumes\/LEXAR|\/Users\/lume|ghp_|github_pat_|nd_live_|session_id=/);
   });
 
   it("ships the canonical install script contract", () => {
     expect(existsSync("scripts/install.sh")).toBe(true);
     const script = read("scripts/install.sh");
 
-    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-1\.0\.1\}"/);
+    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-1\.0\.2\}"/);
     expect(script).toMatch(/npm[^\n]+install[^\n]+-g[^\n]+neondiff@\$\{NEONDIFF_VERSION\}/);
     expect(script).toMatch(/--dry-run/);
     expect(script).toMatch(/Node\.js 26 or newer/);
@@ -362,7 +393,7 @@ describe("NeonDiff public release readiness", () => {
       read("docs/github-app-setup.md"),
       read("docs/providers.md"),
       read("docs/license-boundary.md"),
-      read("docs/releases/v1.0.1.md")
+      read("docs/releases/v1.0.2.md")
     ].join("\n\n");
     const legacyRepoReferences = docs
       .split(/\s+/)
@@ -383,7 +414,7 @@ describe("NeonDiff public release readiness", () => {
     expect(docs).toContain("git clone https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git");
     expect(legacyRepoReferences).toEqual([]);
     expect(docs).not.toMatch(/npm link installs the local source-checkout shim/i);
-    expect(read("docs/releases/v1.0.1.md")).not.toMatch(/\/Volumes\/LEXAR|\/Users\/lume/);
+    expect(read("docs/releases/v1.0.2.md")).not.toMatch(/\/Volumes\/LEXAR|\/Users\/lume/);
   });
 
   it("keeps the GitHub Marketplace free-listing packet bounded to discoverability", () => {
@@ -434,6 +465,8 @@ describe("NeonDiff public release readiness", () => {
     expect(ci).toMatch(/secret/i);
 
     expect(publish).toMatch(/id-token:\s*write/);
+    expect(publish).toMatch(/concurrency:\s*\n\s*group:\s*publish-npm-\$\{\{\s*github\.event\.inputs\.tag\s*\|\|\s*github\.event\.release\.tag_name\s*\|\|\s*github\.ref\s*\}\}/);
+    expect(publish).toMatch(/cancel-in-progress:\s*false/);
     expect(publish).toContain("actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0");
     expect(publish).toContain("actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5");
     expect(publish).not.toMatch(/uses:\s*actions\/(?:checkout|setup-node)@v\d+/);
@@ -455,7 +488,7 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/require\('\.\/package\.json'\)\.version/);
     expect(publish).toMatch(/already exists; verifying dist-tags/);
     expect(publish).toMatch(/dist-tags\.\$\{\{\s*steps\.package_release\.outputs\.npm_tag\s*\}\}/);
-    expect(publish).toMatch(/default:\s*v1\.0\.1/);
+    expect(publish).toMatch(/default:\s*v1\.0\.2/);
     expect(publish).not.toMatch(/default:\s*v0\.4\.30-beta\.1/);
   });
 });

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -21,7 +21,7 @@ import { ReviewStateStore } from "../src/state.js";
 describe("beta release status", () => {
   const roots: string[] = [];
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  const shippedReleaseValidationNow = new Date("2026-07-09T12:30:00Z");
+  const shippedReleaseValidationNow = new Date("2026-07-09T17:00:00Z");
 
   afterEach(() => {
     vi.useRealTimers();
@@ -324,27 +324,27 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v1.0.1",
+      expectedVersion: "v1.0.2",
       now: shippedReleaseValidationNow
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v1.0.1",
+      version: "v1.0.2",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v1.0.1.md",
+        releaseNotesPath: "docs/releases/v1.0.2.md",
         changelogPath: "CHANGELOG.md",
-        changelogHeadVersion: "1.0.1",
-        changelogReleaseNotesPath: "docs/releases/v1.0.1.md"
+        changelogHeadVersion: "1.0.2",
+        changelogReleaseNotesPath: "docs/releases/v1.0.2.md"
       },
       licenseApi: {
         ok: true,
         requiredForThisRelease: true,
         state: "healthy",
         healthUrl: "https://neondiff-license.fly.dev/healthz",
-        healthProofPath: "docs/evidence/v1.0.1-license-api-healthz.json",
+        healthProofPath: "docs/evidence/v1.0.2-license-api-healthz.json",
         checkoutIssuanceRequiredForThisRelease: true,
         checkoutIssuanceUrl: "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
         checkoutIssuanceState: "ready",
@@ -359,18 +359,18 @@ describe("beta release status", () => {
         expect.objectContaining({
           name: "cli",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v1.0.0"
+          rollback: "git reset --hard refs/tags/v1.0.1"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v1.0.0"
+          rollback: "git reset --hard refs/tags/v1.0.1"
         }),
         expect.objectContaining({
-          name: "website",
+          name: "browserDashboard",
           requiredForThisRelease: true,
-          rollback: "git revert 6b670d00cd587fb7d564347b6bc0d4d3e8d13186",
-          rollbackRepository: "electricsheephq/neon-diff-agent-website"
+          rollback: "git reset --hard refs/tags/v1.0.1",
+          rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff"
         })
       ])
     );
@@ -380,7 +380,7 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v1.0.1",
+      expectedVersion: "v1.0.2",
       now: new Date("2026-08-09T12:00:00Z")
     });
 
@@ -388,7 +388,7 @@ describe("beta release status", () => {
       ok: false,
       requiredForThisRelease: true,
       state: "healthy",
-      healthProofPath: "docs/evidence/v1.0.1-license-api-healthz.json"
+      healthProofPath: "docs/evidence/v1.0.2-license-api-healthz.json"
     });
     expect(manifest.licenseApi.detail).toContain("observedAt must be no older than 30 days");
     expect(manifest.ok).toBe(false);
@@ -504,29 +504,29 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v1.0.1",
+      expectedPublicVersion: "v1.0.2",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot",
       now: shippedReleaseValidationNow
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v1.0.1"
+      version: "v1.0.2"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
       ok: true,
-      detail: "cli=published; daemon=published; browserDashboard=published; website=published"
+      detail: "cli=published; daemon=published; browserDashboard=published"
     });
     const redactedOutput = stringifyRedactedJson({
       ...status,
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok
     });
-    expect(redactedOutput).toContain("git reset --hard refs/tags/v1.0.0");
+    expect(redactedOutput).toContain("git reset --hard refs/tags/v1.0.1");
     expect(redactedOutput).toContain("cli=published; daemon=published");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
-    expect(redactedOutput).toContain("electricsheephq/neon-diff-agent-website");
+    expect(redactedOutput).toContain("electricsheephq/evaos-code-review-bot-neondiff/issues/443");
   });
 
   it("fails closed without throwing when collectReleaseStatus receives a missing public manifest path", () => {


### PR DESCRIPTION
## Summary

Prepares the stable `v1.0.2` release cut for the desktop GitHub connection foundation that merged after `v1.0.1`.

This PR updates:
- package/package-lock to `1.0.2`;
- public release manifest, changelog, release notes, installer default, and publish workflow default;
- v1.0.2 license API health, unauthenticated fail-closed proof, authenticated redacted issuance proof, and rollback refs;
- release-readiness/release-status tests so the shipped stable packet validates `v1.0.2`.

Refs #501.

## Proof

- `node scripts/check-public-claims.mjs`
- `node scripts/check-secret-scan.mjs`
- `git diff --check`
- `NODE_OPTIONS=--experimental-sqlite npx vitest run tests/public-release-readiness.test.ts tests/release-status.test.ts tests/checkout-issuance-smoke.test.ts --pool=forks --maxWorkers=1`
- `npm run build`
- `npm pack --dry-run --json` + `node scripts/check-packlist.mjs`

Release-status pre-merge notes: `publicRelease.ok=true` for `v1.0.2`; whole status remains false before merge because the checkout is dirty/on a release branch and the live daemon heartbeat is stale in the local default config path.

## Release Boundary

This PR does not publish npm or create the GitHub Release. After merge, cut the real public release:

1. Tag merged `main` as `v1.0.2`.
2. Publish `neondiff@1.0.2` to npm `latest`.
3. Create a non-prerelease GitHub Release `v1.0.2`.
4. Verify public install/dashboard/Mac launcher proof, then close #501.
