### PR TITLE
[codex] Prevent NeonDiff desktop startup Keychain prompts

### DIFF
--- a/.github/workflows/desktop-release-smoke.yml
+++ b/.github/workflows/desktop-release-smoke.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   unsigned-desktop-release-smoke:
     name: Unsigned desktop release smoke
-    runs-on: macos-latest
+    runs-on: macos-15
     defaults:
       run:
         working-directory: apps/neondiff-desktop
@@ -48,7 +48,7 @@ jobs:
           NEONDIFF_DESKTOP_ARTIFACT_CLASSIFICATION: unsigned-desktop-release-smoke
           NEONDIFF_DESKTOP_UI_LAUNCH: "false"
           NEONDIFF_DESKTOP_VISUAL_SMOKE_REQUIRED: "true"
-          NEONDIFF_DESKTOP_PROOF_BOUNDARY: non-release app bundle build, hosted-runner-safe Keychain checks, appcast checks, bundle structure check, artifact checksum, and metadata only
+          NEONDIFF_DESKTOP_PROOF_BOUNDARY: non-release app bundle build, macOS 15 Keychain checks, appcast checks, bundle structure check, artifact checksum, and metadata only
         run: script/release-proof.sh
 
       - name: Upload unsigned app bundle

--- a/.github/workflows/desktop-release-smoke.yml
+++ b/.github/workflows/desktop-release-smoke.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Build desktop core checks
         run: swift build --target NeonDiffDesktopCoreChecks
 
-      - name: Run desktop Keychain checks
-        run: swift run NeonDiffDesktopKeychainChecks
+      - name: Build desktop Keychain checks
+        run: swift build --target NeonDiffDesktopKeychainChecks
 
       - name: Run desktop appcast checks
         run: swift run NeonDiffDesktopAppcastChecks
@@ -48,7 +48,7 @@ jobs:
           NEONDIFF_DESKTOP_ARTIFACT_CLASSIFICATION: unsigned-desktop-release-smoke
           NEONDIFF_DESKTOP_UI_LAUNCH: "false"
           NEONDIFF_DESKTOP_VISUAL_SMOKE_REQUIRED: "true"
-          NEONDIFF_DESKTOP_PROOF_BOUNDARY: non-release app bundle build, macOS 15 Keychain checks, appcast checks, bundle structure check, artifact checksum, and metadata only
+          NEONDIFF_DESKTOP_PROOF_BOUNDARY: non-release app bundle build, macOS 15 Keychain contract compilation, appcast checks, bundle structure check, artifact checksum, and metadata only
         run: script/release-proof.sh
 
       - name: Upload unsigned app bundle

--- a/.github/workflows/desktop-release-smoke.yml
+++ b/.github/workflows/desktop-release-smoke.yml
@@ -26,8 +26,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run desktop core checks
-        run: swift run NeonDiffDesktopCoreChecks
+      - name: Build desktop core checks
+        run: swift build --target NeonDiffDesktopCoreChecks
+
+      - name: Run desktop Keychain checks
+        run: swift run NeonDiffDesktopKeychainChecks
 
       - name: Run desktop appcast checks
         run: swift run NeonDiffDesktopAppcastChecks
@@ -45,7 +48,7 @@ jobs:
           NEONDIFF_DESKTOP_ARTIFACT_CLASSIFICATION: unsigned-desktop-release-smoke
           NEONDIFF_DESKTOP_UI_LAUNCH: "false"
           NEONDIFF_DESKTOP_VISUAL_SMOKE_REQUIRED: "true"
-          NEONDIFF_DESKTOP_PROOF_BOUNDARY: non-release app bundle build, hosted-runner-safe core checks, appcast checks, bundle structure check, artifact checksum, and metadata only
+          NEONDIFF_DESKTOP_PROOF_BOUNDARY: non-release app bundle build, hosted-runner-safe Keychain checks, appcast checks, bundle structure check, artifact checksum, and metadata only
         run: script/release-proof.sh
 
       - name: Upload unsigned app bundle

--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -108,9 +108,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build Swift core checks target
+      - name: Run Swift core checks
         working-directory: apps/neondiff-desktop
-        run: swift build --target NeonDiffDesktopCoreChecks
+        run: swift run NeonDiffDesktopCoreChecks
 
       - name: Swift build
         working-directory: apps/neondiff-desktop

--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -108,9 +108,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run Swift core checks
+      - name: Run Swift Keychain checks
         working-directory: apps/neondiff-desktop
-        run: swift run NeonDiffDesktopCoreChecks
+        run: swift run NeonDiffDesktopKeychainChecks
 
       - name: Swift build
         working-directory: apps/neondiff-desktop

--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -101,7 +101,7 @@ jobs:
     name: Swift desktop smoke
     needs: swift-desktop-impact
     if: needs.swift-desktop-impact.outputs.affected == 'true'
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/swift-desktop-gate.yml
+++ b/.github/workflows/swift-desktop-gate.yml
@@ -108,9 +108,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run Swift Keychain checks
+      - name: Build Swift Keychain checks target
         working-directory: apps/neondiff-desktop
-        run: swift run NeonDiffDesktopKeychainChecks
+        run: swift build --target NeonDiffDesktopKeychainChecks
 
       - name: Swift build
         working-directory: apps/neondiff-desktop

--- a/apps/neondiff-desktop/Package.swift
+++ b/apps/neondiff-desktop/Package.swift
@@ -38,6 +38,10 @@ let package = Package(
             dependencies: ["NeonDiffDesktopCore"]
         ),
         .executableTarget(
+            name: "NeonDiffDesktopKeychainChecks",
+            dependencies: ["NeonDiffDesktopCore"]
+        ),
+        .executableTarget(
             name: "NeonDiffDesktopAppcastChecks",
             dependencies: ["NeonDiffDesktopCore"]
         ),

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
@@ -46,28 +46,20 @@ final class NeonDiffDesktopModel: ObservableObject {
         self.launchdLabel = userDefaults.string(forKey: "neondiff.launchdLabel") ?? "com.electricsheephq.evaos-code-review-bot"
         let providerKeyStored = keychain.containsSecret(account: providerKeyAccount)
         let githubUserTokenStored = keychain.containsSecret(account: githubUserTokenAccount)
-        let githubAccessTokenExpired = Self.storedDate(
-            keychain: keychain,
-            account: githubTokenExpiresAtAccount
-        ).map { $0 <= Date() } ?? false
-        let githubRefreshTokenValid = keychain.containsSecret(account: githubRefreshTokenAccount)
-            && !(Self.storedDate(keychain: keychain, account: githubRefreshTokenExpiresAtAccount).map { $0 <= Date() } ?? false)
+        let githubRefreshTokenStored = keychain.containsSecret(account: githubRefreshTokenAccount)
         self.providers.providerKeyStored = providerKeyStored
         self.license.keyStored = keychain.containsSecret(account: licenseKeyAccount)
-        self.github.userTokenStored = githubUserTokenStored && (!githubAccessTokenExpired || githubRefreshTokenValid)
-        if githubUserTokenStored && githubAccessTokenExpired && githubRefreshTokenValid {
-            self.github.installationState = "authorization refresh needed"
-            self.githubAuthorizationStatus = "authorization refresh needed"
-        } else if githubUserTokenStored && githubAccessTokenExpired {
-            self.github.installationState = "authorization expired; reconnect GitHub"
-            self.githubAuthorizationStatus = "authorization expired; reconnect GitHub"
+        self.github.userTokenStored = githubUserTokenStored
+        if githubUserTokenStored {
+            self.github.installationState = "authorization stored; verify"
+            self.githubAuthorizationStatus = "authorization stored; refresh repos to verify"
+        } else if githubRefreshTokenStored {
+            self.github.installationState = "authorization refresh available"
+            self.githubAuthorizationStatus = "authorization refresh available"
         } else {
-            self.github.installationState = self.github.userTokenStored ? "user authorized" : "not connected"
+            self.github.installationState = "not connected"
         }
-        self.github.authorizedUserLogin = try? keychain.readSecret(account: githubUserLoginAccount)
-        if let login = self.github.authorizedUserLogin, !githubAccessTokenExpired {
-            self.githubAuthorizationStatus = "authorized as \(login)"
-        }
+        self.github.authorizedUserLogin = nil
         self.onboardingFlow = OnboardingFlow(providerKeyStored: providerKeyStored)
         self.isOnboardingPresented = !userDefaults.bool(forKey: onboardingCompletedKey)
         self.lastCommandLine = statusCommand.commandLine
@@ -620,6 +612,13 @@ final class NeonDiffDesktopModel: ObservableObject {
         Self.storedDate(keychain: keychain, account: account)
     }
 
+    private static func storedDate(keychain: DesktopSecretStoring, account: String) -> Date? {
+        guard let value = try? keychain.readSecret(account: account) else {
+            return nil
+        }
+        return ISO8601DateFormatter().date(from: value)
+    }
+
     private func writeRepoSelectionPatch() throws {
         try FileManager.default.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
         let selectedRepos = repos
@@ -682,12 +681,6 @@ final class NeonDiffDesktopModel: ObservableObject {
         return root["command"] as? String
     }
 
-    private static func storedDate(keychain: DesktopSecretStoring, account: String) -> Date? {
-        guard let value = try? keychain.readSecret(account: account) else {
-            return nil
-        }
-        return ISO8601DateFormatter().date(from: value)
-    }
 }
 
 private enum GitHubDesktopAuthorizationStateError: LocalizedError {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
@@ -138,7 +138,11 @@ final class NeonDiffDesktopModel: ObservableObject {
         lastCommandLine = command.commandLine
         dashboardLaunchStatus = openBrowser ? "opening browser" : "starting server"
         let executablePath = cliPath
-        let arguments = ["dashboard", "--config", configPath, "--launchd-label", launchdLabel, "--open", openBrowser ? "true" : "false"]
+        let arguments = NeonDiffCommandBuilder.dashboardArguments(
+            configPath: configPath,
+            launchdLabel: launchdLabel,
+            openBrowser: openBrowser
+        )
         let workingDirectory = NeonDiffCLIResolver.defaultWorkingDirectory()
 
         Task { [weak self] in

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/CommandBuilders.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/CommandBuilders.swift
@@ -31,7 +31,7 @@ public enum NeonDiffCommandBuilder {
     ) -> DesktopCommand {
         DesktopCommand(
             title: openBrowser ? "Open local dashboard" : "Start local dashboard",
-            commandLine: "\(shellQuote(cliPath)) dashboard --config \(shellQuote(configPath)) --launchd-label \(shellQuote(launchdLabel)) --open \(openBrowser ? "true" : "false")"
+            commandLine: "\(shellQuote(cliPath)) dashboard --config \(shellQuote(configPath)) --launchd-label \(shellQuote(launchdLabel)) --open \(openBrowser ? "true" : "false") --operator false"
         )
     }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/CommandBuilders.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/CommandBuilders.swift
@@ -35,6 +35,20 @@ public enum NeonDiffCommandBuilder {
         )
     }
 
+    public static func dashboardArguments(
+        configPath: String,
+        launchdLabel: String,
+        openBrowser: Bool = true
+    ) -> [String] {
+        [
+            "dashboard",
+            "--config", configPath,
+            "--launchd-label", launchdLabel,
+            "--open", openBrowser ? "true" : "false",
+            "--operator", "false"
+        ]
+    }
+
     public static func daemonControl(
         action: String,
         cliPath: String,

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/KeychainSecretStore.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/KeychainSecretStore.swift
@@ -1,5 +1,4 @@
 import Foundation
-import LocalAuthentication
 import Security
 
 public protocol DesktopSecretStoring {
@@ -101,12 +100,10 @@ public final class KeychainSecretStore: DesktopSecretStoring {
 
         switch operation {
         case .contains:
-            query[kSecUseAuthenticationContext as String] = noninteractiveContext()
             query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
         case .read(let allowUserInteraction):
             query[kSecReturnData as String] = true
             if !allowUserInteraction {
-                query[kSecUseAuthenticationContext as String] = noninteractiveContext()
                 query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
             }
         }
@@ -121,9 +118,4 @@ public final class KeychainSecretStore: DesktopSecretStoring {
         ]
     }
 
-    private static func noninteractiveContext() -> LAContext {
-        let context = LAContext()
-        context.interactionNotAllowed = true
-        return context
-    }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/KeychainSecretStore.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/KeychainSecretStore.swift
@@ -12,7 +12,8 @@ public protocol DesktopSecretStoring {
 
 public extension DesktopSecretStoring {
     func readSecret(account: String, allowUserInteraction: Bool) throws -> String? {
-        try readSecret(account: account)
+        guard allowUserInteraction else { return nil }
+        return try readSecret(account: account)
     }
 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/KeychainSecretStore.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/KeychainSecretStore.swift
@@ -1,11 +1,24 @@
 import Foundation
+import LocalAuthentication
 import Security
 
 public protocol DesktopSecretStoring {
     func setSecret(_ secret: String, account: String) throws
     func readSecret(account: String) throws -> String?
+    func readSecret(account: String, allowUserInteraction: Bool) throws -> String?
     func containsSecret(account: String) -> Bool
     func deleteSecret(account: String) throws
+}
+
+public extension DesktopSecretStoring {
+    func readSecret(account: String, allowUserInteraction: Bool) throws -> String? {
+        try readSecret(account: account)
+    }
+}
+
+@_spi(Testing) public enum KeychainSecretQueryOperation {
+    case contains
+    case read(allowUserInteraction: Bool)
 }
 
 public enum KeychainSecretError: Error, LocalizedError {
@@ -40,13 +53,20 @@ public final class KeychainSecretStore: DesktopSecretStoring {
     }
 
     public func readSecret(account: String) throws -> String? {
-        var query = baseQuery(account: account)
-        query[kSecReturnData as String] = true
-        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        try readSecret(account: account, allowUserInteraction: true)
+    }
+
+    public func readSecret(account: String, allowUserInteraction: Bool) throws -> String? {
+        let query = Self.query(
+            service: service,
+            account: account,
+            operation: .read(allowUserInteraction: allowUserInteraction)
+        )
 
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound { return nil }
+        if !allowUserInteraction && status == errSecInteractionNotAllowed { return nil }
         guard status == errSecSuccess else { throw KeychainSecretError.unexpectedStatus(status) }
         guard let data = result as? Data, let value = String(data: data, encoding: .utf8) else {
             throw KeychainSecretError.invalidData
@@ -55,7 +75,8 @@ public final class KeychainSecretStore: DesktopSecretStoring {
     }
 
     public func containsSecret(account: String) -> Bool {
-        (try? readSecret(account: account)) != nil
+        let query = Self.query(service: service, account: account, operation: .contains)
+        return SecItemCopyMatching(query as CFDictionary, nil) == errSecSuccess
     }
 
     public func deleteSecret(account: String) throws {
@@ -66,10 +87,42 @@ public final class KeychainSecretStore: DesktopSecretStoring {
     }
 
     private func baseQuery(account: String) -> [String: Any] {
+        Self.baseQuery(service: service, account: account)
+    }
+
+    @_spi(Testing) public static func query(
+        service: String,
+        account: String,
+        operation: KeychainSecretQueryOperation
+    ) -> [String: Any] {
+        var query = baseQuery(service: service, account: account)
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        switch operation {
+        case .contains:
+            query[kSecUseAuthenticationContext as String] = noninteractiveContext()
+            query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
+        case .read(let allowUserInteraction):
+            query[kSecReturnData as String] = true
+            if !allowUserInteraction {
+                query[kSecUseAuthenticationContext as String] = noninteractiveContext()
+                query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
+            }
+        }
+        return query
+    }
+
+    private static func baseQuery(service: String, account: String) -> [String: Any] {
         [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account
         ]
+    }
+
+    private static func noninteractiveContext() -> LAContext {
+        let context = LAContext()
+        context.interactionNotAllowed = true
+        return context
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
@@ -1,7 +1,5 @@
 import Foundation
-import LocalAuthentication
-@_spi(Testing) import NeonDiffDesktopCore
-import Security
+import NeonDiffDesktopCore
 
 @discardableResult
 func check(_ condition: @autoclosure () -> Bool, _ message: String) -> Bool {
@@ -75,63 +73,6 @@ check(
 check(
     NeonDiffCLIResolver.resolveExecutablePath("neondiff", workingDirectory: tempRoot)?.standardizedFileURL == localCLI.standardizedFileURL,
     "local package CLI is preferred over GUI PATH fallback"
-)
-
-let existenceQuery = KeychainSecretStore.query(
-    service: "com.example.neondiff.core-checks",
-    account: "provider",
-    operation: .contains
-)
-check(existenceQuery[kSecReturnData as String] == nil, "startup existence checks never request secret data")
-check(
-    (existenceQuery[kSecUseAuthenticationContext as String] as? LAContext)?.interactionNotAllowed == true,
-    "startup existence checks cannot present Keychain UI"
-)
-check(
-    existenceQuery[kSecUseAuthenticationUI as String] as? String == kSecUseAuthenticationUISkip as String,
-    "startup existence checks skip legacy Keychain items that would present UI"
-)
-
-let noninteractiveReadQuery = KeychainSecretStore.query(
-    service: "com.example.neondiff.core-checks",
-    account: "github/user-login",
-    operation: .read(allowUserInteraction: false)
-)
-check(noninteractiveReadQuery[kSecReturnData as String] as? Bool == true, "noninteractive reads still request secret data")
-check(
-    (noninteractiveReadQuery[kSecUseAuthenticationContext as String] as? LAContext)?.interactionNotAllowed == true,
-    "noninteractive startup reads cannot present Keychain UI"
-)
-check(
-    noninteractiveReadQuery[kSecUseAuthenticationUI as String] as? String == kSecUseAuthenticationUISkip as String,
-    "noninteractive startup reads skip legacy Keychain items that would present UI"
-)
-
-let interactiveReadQuery = KeychainSecretStore.query(
-    service: "com.example.neondiff.core-checks",
-    account: "github/user-token",
-    operation: .read(allowUserInteraction: true)
-)
-check(interactiveReadQuery[kSecReturnData as String] as? Bool == true, "interactive reads request secret data")
-check(interactiveReadQuery[kSecUseAuthenticationContext as String] == nil, "interactive reads leave Keychain UI policy at system default")
-
-final class LegacySecretStoreFixture: DesktopSecretStoring {
-    func setSecret(_ secret: String, account: String) throws {}
-    func readSecret(account: String) throws -> String? { "legacy-fixture" }
-    func containsSecret(account: String) -> Bool { true }
-    func deleteSecret(account: String) throws {}
-}
-
-let legacySecretStore = LegacySecretStoreFixture()
-let legacySecretValue = try legacySecretStore.readSecret(account: "provider", allowUserInteraction: false)
-check(
-    legacySecretValue == nil,
-    "existing secret-store conformers cannot fall back to interactive reads when UI is disallowed"
-)
-let legacyInteractiveSecretValue = try legacySecretStore.readSecret(account: "provider", allowUserInteraction: true)
-check(
-    legacyInteractiveSecretValue == "legacy-fixture",
-    "existing secret-store conformers retain interactive read behavior"
 )
 
 final class GitHubFixtureURLProtocol: URLProtocol {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
@@ -125,8 +125,13 @@ final class LegacySecretStoreFixture: DesktopSecretStoring {
 let legacySecretStore = LegacySecretStoreFixture()
 let legacySecretValue = try legacySecretStore.readSecret(account: "provider", allowUserInteraction: false)
 check(
-    legacySecretValue == "legacy-fixture",
-    "existing secret-store conformers inherit additive noninteractive reads"
+    legacySecretValue == nil,
+    "existing secret-store conformers cannot fall back to interactive reads when UI is disallowed"
+)
+let legacyInteractiveSecretValue = try legacySecretStore.readSecret(account: "provider", allowUserInteraction: true)
+check(
+    legacyInteractiveSecretValue == "legacy-fixture",
+    "existing secret-store conformers retain interactive read behavior"
 )
 
 final class GitHubFixtureURLProtocol: URLProtocol {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
@@ -1,5 +1,7 @@
 import Foundation
-import NeonDiffDesktopCore
+import LocalAuthentication
+@_spi(Testing) import NeonDiffDesktopCore
+import Security
 
 @discardableResult
 func check(_ condition: @autoclosure () -> Bool, _ message: String) -> Bool {
@@ -73,6 +75,58 @@ check(
 check(
     NeonDiffCLIResolver.resolveExecutablePath("neondiff", workingDirectory: tempRoot)?.standardizedFileURL == localCLI.standardizedFileURL,
     "local package CLI is preferred over GUI PATH fallback"
+)
+
+let existenceQuery = KeychainSecretStore.query(
+    service: "com.example.neondiff.core-checks",
+    account: "provider",
+    operation: .contains
+)
+check(existenceQuery[kSecReturnData as String] == nil, "startup existence checks never request secret data")
+check(
+    (existenceQuery[kSecUseAuthenticationContext as String] as? LAContext)?.interactionNotAllowed == true,
+    "startup existence checks cannot present Keychain UI"
+)
+check(
+    existenceQuery[kSecUseAuthenticationUI as String] as? String == kSecUseAuthenticationUISkip as String,
+    "startup existence checks skip legacy Keychain items that would present UI"
+)
+
+let noninteractiveReadQuery = KeychainSecretStore.query(
+    service: "com.example.neondiff.core-checks",
+    account: "github/user-login",
+    operation: .read(allowUserInteraction: false)
+)
+check(noninteractiveReadQuery[kSecReturnData as String] as? Bool == true, "noninteractive reads still request secret data")
+check(
+    (noninteractiveReadQuery[kSecUseAuthenticationContext as String] as? LAContext)?.interactionNotAllowed == true,
+    "noninteractive startup reads cannot present Keychain UI"
+)
+check(
+    noninteractiveReadQuery[kSecUseAuthenticationUI as String] as? String == kSecUseAuthenticationUISkip as String,
+    "noninteractive startup reads skip legacy Keychain items that would present UI"
+)
+
+let interactiveReadQuery = KeychainSecretStore.query(
+    service: "com.example.neondiff.core-checks",
+    account: "github/user-token",
+    operation: .read(allowUserInteraction: true)
+)
+check(interactiveReadQuery[kSecReturnData as String] as? Bool == true, "interactive reads request secret data")
+check(interactiveReadQuery[kSecUseAuthenticationContext as String] == nil, "interactive reads leave Keychain UI policy at system default")
+
+final class LegacySecretStoreFixture: DesktopSecretStoring {
+    func setSecret(_ secret: String, account: String) throws {}
+    func readSecret(account: String) throws -> String? { "legacy-fixture" }
+    func containsSecret(account: String) -> Bool { true }
+    func deleteSecret(account: String) throws {}
+}
+
+let legacySecretStore = LegacySecretStoreFixture()
+let legacySecretValue = try legacySecretStore.readSecret(account: "provider", allowUserInteraction: false)
+check(
+    legacySecretValue == "legacy-fixture",
+    "existing secret-store conformers inherit additive noninteractive reads"
 )
 
 final class GitHubFixtureURLProtocol: URLProtocol {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
@@ -49,6 +49,7 @@ do {
     )
     guard dashboardServerCommand.title == "Start local dashboard",
           dashboardServerCommand.commandLine.contains("--open false"),
+          dashboardServerCommand.commandLine.contains("--operator false"),
           !dashboardServerCommand.commandLine.contains("--open true")
     else {
         throw NSError(domain: "NeonDiffDesktopSmoke", code: 11, userInfo: [NSLocalizedDescriptionKey: "dashboard server command does not stay inside the Mac app launch bar"])

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreSmoke/main.swift
@@ -37,9 +37,22 @@ do {
     guard dashboardCommand.commandLine.contains("dashboard"),
           dashboardCommand.commandLine.contains("--open true"),
           dashboardCommand.commandLine.contains("--launchd-label"),
-          !dashboardCommand.commandLine.contains("--operator true")
+          dashboardCommand.commandLine.contains("--operator false")
     else {
         throw NSError(domain: "NeonDiffDesktopSmoke", code: 10, userInfo: [NSLocalizedDescriptionKey: "dashboard command does not launch the local HTML dashboard"])
+    }
+    let dashboardArguments = NeonDiffCommandBuilder.dashboardArguments(
+        configPath: "/tmp/config.local.json",
+        launchdLabel: "com.example.neondiff"
+    )
+    guard dashboardArguments == [
+        "dashboard",
+        "--config", "/tmp/config.local.json",
+        "--launchd-label", "com.example.neondiff",
+        "--open", "true",
+        "--operator", "false"
+    ] else {
+        throw NSError(domain: "NeonDiffDesktopSmoke", code: 12, userInfo: [NSLocalizedDescriptionKey: "dashboard launch arguments do not explicitly select browser mode"])
     }
     let dashboardServerCommand = NeonDiffCommandBuilder.dashboard(
         cliPath: "neondiff",

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopKeychainChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopKeychainChecks/main.swift
@@ -1,5 +1,4 @@
 import Foundation
-import LocalAuthentication
 @_spi(Testing) import NeonDiffDesktopCore
 import Security
 
@@ -18,10 +17,7 @@ let existenceQuery = KeychainSecretStore.query(
     operation: .contains
 )
 check(existenceQuery[kSecReturnData as String] == nil, "startup existence checks never request secret data")
-check(
-    (existenceQuery[kSecUseAuthenticationContext as String] as? LAContext)?.interactionNotAllowed == true,
-    "startup existence checks cannot present Keychain UI"
-)
+check(existenceQuery[kSecUseAuthenticationContext as String] == nil, "startup checks do not construct a LocalAuthentication context")
 check(
     existenceQuery[kSecUseAuthenticationUI as String] as? String == kSecUseAuthenticationUISkip as String,
     "startup existence checks skip legacy Keychain items that would present UI"
@@ -33,10 +29,7 @@ let noninteractiveReadQuery = KeychainSecretStore.query(
     operation: .read(allowUserInteraction: false)
 )
 check(noninteractiveReadQuery[kSecReturnData as String] as? Bool == true, "noninteractive reads still request secret data")
-check(
-    (noninteractiveReadQuery[kSecUseAuthenticationContext as String] as? LAContext)?.interactionNotAllowed == true,
-    "noninteractive reads cannot present Keychain UI"
-)
+check(noninteractiveReadQuery[kSecUseAuthenticationContext as String] == nil, "noninteractive reads do not construct a LocalAuthentication context")
 check(
     noninteractiveReadQuery[kSecUseAuthenticationUI as String] as? String == kSecUseAuthenticationUISkip as String,
     "noninteractive reads skip legacy Keychain items that would present UI"

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopKeychainChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopKeychainChecks/main.swift
@@ -1,0 +1,72 @@
+import Foundation
+import LocalAuthentication
+@_spi(Testing) import NeonDiffDesktopCore
+import Security
+
+@discardableResult
+func check(_ condition: @autoclosure () -> Bool, _ message: String) -> Bool {
+    guard condition() else {
+        fputs("CHECK FAILED: \(message)\n", stderr)
+        exit(1)
+    }
+    return true
+}
+
+let existenceQuery = KeychainSecretStore.query(
+    service: "com.example.neondiff.keychain-checks",
+    account: "provider",
+    operation: .contains
+)
+check(existenceQuery[kSecReturnData as String] == nil, "startup existence checks never request secret data")
+check(
+    (existenceQuery[kSecUseAuthenticationContext as String] as? LAContext)?.interactionNotAllowed == true,
+    "startup existence checks cannot present Keychain UI"
+)
+check(
+    existenceQuery[kSecUseAuthenticationUI as String] as? String == kSecUseAuthenticationUISkip as String,
+    "startup existence checks skip legacy Keychain items that would present UI"
+)
+
+let noninteractiveReadQuery = KeychainSecretStore.query(
+    service: "com.example.neondiff.keychain-checks",
+    account: "github/user-login",
+    operation: .read(allowUserInteraction: false)
+)
+check(noninteractiveReadQuery[kSecReturnData as String] as? Bool == true, "noninteractive reads still request secret data")
+check(
+    (noninteractiveReadQuery[kSecUseAuthenticationContext as String] as? LAContext)?.interactionNotAllowed == true,
+    "noninteractive reads cannot present Keychain UI"
+)
+check(
+    noninteractiveReadQuery[kSecUseAuthenticationUI as String] as? String == kSecUseAuthenticationUISkip as String,
+    "noninteractive reads skip legacy Keychain items that would present UI"
+)
+
+let interactiveReadQuery = KeychainSecretStore.query(
+    service: "com.example.neondiff.keychain-checks",
+    account: "github/user-token",
+    operation: .read(allowUserInteraction: true)
+)
+check(interactiveReadQuery[kSecReturnData as String] as? Bool == true, "interactive reads request secret data")
+check(interactiveReadQuery[kSecUseAuthenticationContext as String] == nil, "interactive reads leave Keychain UI policy at system default")
+
+final class LegacySecretStoreFixture: DesktopSecretStoring {
+    func setSecret(_ secret: String, account: String) throws {}
+    func readSecret(account: String) throws -> String? { "legacy-fixture" }
+    func containsSecret(account: String) -> Bool { true }
+    func deleteSecret(account: String) throws {}
+}
+
+let legacySecretStore = LegacySecretStoreFixture()
+let legacySecretValue = try legacySecretStore.readSecret(account: "provider", allowUserInteraction: false)
+check(
+    legacySecretValue == nil,
+    "existing secret-store conformers cannot fall back to interactive reads when UI is disallowed"
+)
+let legacyInteractiveSecretValue = try legacySecretStore.readSecret(account: "provider", allowUserInteraction: true)
+check(
+    legacyInteractiveSecretValue == "legacy-fixture",
+    "existing secret-store conformers retain interactive read behavior"
+)
+
+print("NeonDiffDesktopKeychainChecks passed")

--- a/apps/neondiff-desktop/docs/desktop-release-smoke.md
+++ b/apps/neondiff-desktop/docs/desktop-release-smoke.md
@@ -1,6 +1,6 @@
 # Desktop Release Smoke
 
-`.github/workflows/desktop-release-smoke.yml` is the unsigned macOS app-bundle smoke lane for NeonDiff Desktop. It is manual and tag-oriented, runs the hosted-runner-safe `NeonDiffDesktopCoreChecks` and appcast checks, builds the `.app`, validates bundle structure, and uploads the zipped bundle with metadata.
+`.github/workflows/desktop-release-smoke.yml` is the unsigned macOS app-bundle smoke lane for NeonDiff Desktop. It is manual and tag-oriented, compiles `NeonDiffDesktopCoreChecks`, runs the focused hosted-runner-safe `NeonDiffDesktopKeychainChecks` and appcast checks, builds the `.app`, validates bundle structure, and uploads the zipped bundle with metadata.
 
 The uploaded bundle is non-release proof. Its metadata marks `release_ready: false`, `customer_ready: false`, and `artifact_classification: unsigned-desktop-release-smoke`, so it is customer-not-ready by design.
 
@@ -12,4 +12,4 @@ keeps `ui_launch: false`; a real release packet still needs a local visible smok
 that opens the app artifact and clicks through first-run controls before claiming
 user-ready desktop behavior.
 
-The Keychain-backed `NeonDiffDesktopCoreSmoke` executable remains a local or release-smoke proof on a runner with known-good Keychain behavior. Hosted CI does not run that target because the unsigned release-smoke lane is meant to prove build, package, and app-bundle shape without touching credentials or local Keychain state.
+`NeonDiffDesktopCoreChecks` and the Keychain-backed `NeonDiffDesktopCoreSmoke` executable remain local proof on a runner with known-good detached-process and Keychain behavior. Hosted CI compiles the broad checks but executes only the focused Keychain contract target because the unsigned release-smoke lane must stay deterministic without touching credentials or depending on a long-lived detached process.

--- a/apps/neondiff-desktop/docs/desktop-release-smoke.md
+++ b/apps/neondiff-desktop/docs/desktop-release-smoke.md
@@ -1,6 +1,6 @@
 # Desktop Release Smoke
 
-`.github/workflows/desktop-release-smoke.yml` is the unsigned macOS app-bundle smoke lane for NeonDiff Desktop. It is manual and tag-oriented, compiles `NeonDiffDesktopCoreChecks`, runs the focused hosted-runner-safe `NeonDiffDesktopKeychainChecks` and appcast checks, builds the `.app`, validates bundle structure, and uploads the zipped bundle with metadata.
+`.github/workflows/desktop-release-smoke.yml` is the unsigned macOS app-bundle smoke lane for NeonDiff Desktop. It is manual and tag-oriented, compiles `NeonDiffDesktopCoreChecks` and `NeonDiffDesktopKeychainChecks`, runs the hosted-safe appcast checks, builds the `.app`, validates bundle structure, and uploads the zipped bundle with metadata.
 
 The uploaded bundle is non-release proof. Its metadata marks `release_ready: false`, `customer_ready: false`, and `artifact_classification: unsigned-desktop-release-smoke`, so it is customer-not-ready by design.
 
@@ -12,4 +12,4 @@ keeps `ui_launch: false`; a real release packet still needs a local visible smok
 that opens the app artifact and clicks through first-run controls before claiming
 user-ready desktop behavior.
 
-`NeonDiffDesktopCoreChecks` and the Keychain-backed `NeonDiffDesktopCoreSmoke` executable remain local proof on a runner with known-good detached-process and Keychain behavior. Hosted CI compiles the broad checks but executes only the focused Keychain contract target on a pinned `macos-15` runner because the unsigned release-smoke lane must stay deterministic without touching credentials or depending on a long-lived detached process.
+`NeonDiffDesktopCoreChecks`, `NeonDiffDesktopKeychainChecks`, and the Keychain-backed `NeonDiffDesktopCoreSmoke` executable remain local proof on a runner with known-good detached-process and Keychain behavior. Hosted CI compiles both check targets on a pinned `macos-15` runner but does not execute Security.framework-linked helpers because the headless macOS 15 image can kill those executables after a successful link. Runtime proof comes from the named local bundle's visible startup smoke, not from treating a hosted helper process as an app launch.

--- a/apps/neondiff-desktop/docs/desktop-release-smoke.md
+++ b/apps/neondiff-desktop/docs/desktop-release-smoke.md
@@ -12,4 +12,4 @@ keeps `ui_launch: false`; a real release packet still needs a local visible smok
 that opens the app artifact and clicks through first-run controls before claiming
 user-ready desktop behavior.
 
-`NeonDiffDesktopCoreChecks` and the Keychain-backed `NeonDiffDesktopCoreSmoke` executable remain local proof on a runner with known-good detached-process and Keychain behavior. Hosted CI compiles the broad checks but executes only the focused Keychain contract target because the unsigned release-smoke lane must stay deterministic without touching credentials or depending on a long-lived detached process.
+`NeonDiffDesktopCoreChecks` and the Keychain-backed `NeonDiffDesktopCoreSmoke` executable remain local proof on a runner with known-good detached-process and Keychain behavior. Hosted CI compiles the broad checks but executes only the focused Keychain contract target on a pinned `macos-15` runner because the unsigned release-smoke lane must stay deterministic without touching credentials or depending on a long-lived detached process.

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -280,12 +280,13 @@ change, the product-behavior proof is missing even when `swift build`,
 
 Remote CI should keep a stable, always-reporting `Swift desktop gate` check.
 That check passes quickly with an explicit `not affected` result on non-desktop
-changes, and compiles `NeonDiffDesktopCoreChecks`, runs `swift build`, app
-bundle build, and bundle check only when Swift desktop paths changed or when
-manually dispatched. Keep `NeonDiffDesktopCoreChecks` execution,
-`NeonDiffDesktopCoreSmoke`, and visible UI clicks in the local/release-smoke
-lane because hosted macOS runners can kill smoke executables after a successful
-build unless the runner has a known-good interactive session.
+changes, and compiles `NeonDiffDesktopCoreChecks` plus
+`NeonDiffDesktopKeychainChecks`, runs `swift build`, app bundle build, and bundle
+check only when Swift desktop paths changed or when manually dispatched. Keep
+both check executables, `NeonDiffDesktopCoreSmoke`, and visible UI clicks in the
+local/release-smoke lane because hosted macOS runners can kill
+Security.framework-linked helpers after a successful build unless the runner
+has a known-good interactive session.
 
 Swift CodeQL is a release/security gate, not the PR iteration loop. The durable
 policy lives in `docs/swift-codeql-policy.md`: the checked-in path-aware Swift

--- a/tests/desktop-keychain-startup.test.ts
+++ b/tests/desktop-keychain-startup.test.ts
@@ -18,4 +18,16 @@ describe("NeonDiff desktop Keychain startup safety", () => {
     expect(initializer).not.toContain("readSecret(");
     expect(initializer).not.toContain("storedDate(");
   });
+
+  it("uses the Security framework's UI-skip policy without constructing LAContext", () => {
+    const source = readFileSync(
+      "apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/KeychainSecretStore.swift",
+      "utf8"
+    );
+
+    expect(source).not.toContain("import LocalAuthentication");
+    expect(source).not.toContain("noninteractiveContext");
+    expect(source.match(/kSecUseAuthenticationUISkip/g)).toHaveLength(2);
+    expect(source).not.toContain("kSecUseAuthenticationContext");
+  });
 });

--- a/tests/desktop-keychain-startup.test.ts
+++ b/tests/desktop-keychain-startup.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("NeonDiff desktop Keychain startup safety", () => {
+  it("uses metadata-only secret presence checks during model initialization", () => {
+    const source = readFileSync(
+      "apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift",
+      "utf8"
+    );
+    const initializerStart = source.indexOf("    init(\n");
+    const initializerEnd = source.indexOf("\n    var statusCommand", initializerStart);
+
+    expect(initializerStart).toBeGreaterThanOrEqual(0);
+    expect(initializerEnd).toBeGreaterThan(initializerStart);
+
+    const initializer = source.slice(initializerStart, initializerEnd);
+    expect(initializer).toContain("containsSecret(");
+    expect(initializer).not.toContain("readSecret(");
+    expect(initializer).not.toContain("storedDate(");
+  });
+});

--- a/tests/desktop-keychain-startup.test.ts
+++ b/tests/desktop-keychain-startup.test.ts
@@ -1,19 +1,31 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
+function swiftBlock(source: string, declaration: string): string {
+  const declarationStart = source.indexOf(declaration);
+  expect(declarationStart).toBeGreaterThanOrEqual(0);
+
+  const blockStart = source.indexOf("{", declarationStart);
+  expect(blockStart).toBeGreaterThan(declarationStart);
+
+  let depth = 0;
+  for (let index = blockStart; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] !== "}") continue;
+    depth -= 1;
+    if (depth === 0) return source.slice(declarationStart, index + 1);
+  }
+
+  throw new Error(`Unterminated Swift block for ${declaration}`);
+}
+
 describe("NeonDiff desktop Keychain startup safety", () => {
   it("uses metadata-only secret presence checks during model initialization", () => {
     const source = readFileSync(
       "apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift",
       "utf8"
     );
-    const initializerStart = source.indexOf("    init(\n");
-    const initializerEnd = source.indexOf("\n    var statusCommand", initializerStart);
-
-    expect(initializerStart).toBeGreaterThanOrEqual(0);
-    expect(initializerEnd).toBeGreaterThan(initializerStart);
-
-    const initializer = source.slice(initializerStart, initializerEnd);
+    const initializer = swiftBlock(source, "init(\n");
     expect(initializer).toContain("containsSecret(");
     expect(initializer).not.toContain("readSecret(");
     expect(initializer).not.toContain("storedDate(");

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -42,7 +42,7 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
 
     for (const command of [
       "swift build --target NeonDiffDesktopCoreChecks",
-      "swift run NeonDiffDesktopKeychainChecks",
+      "swift build --target NeonDiffDesktopKeychainChecks",
       "swift run NeonDiffDesktopAppcastChecks",
       "script/build_and_run.sh build",
       "script/build_and_run.sh bundle-check",
@@ -53,8 +53,9 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
 
     expect(workflow).not.toContain("NeonDiffDesktopCoreSmoke");
     expect(workflow).not.toContain("swift run NeonDiffDesktopCoreChecks");
+    expect(workflow).not.toContain("swift run NeonDiffDesktopKeychainChecks");
     expect(workflow).toContain("unsigned");
-    expect(workflow).toMatch(/macOS 15 Keychain checks/);
+    expect(workflow).toMatch(/macOS 15 Keychain contract compilation/);
     expect(workflow).toMatch(/persist-credentials:\s*false/);
     expect(workflow).toMatch(/SOURCE_SHA:/);
     expect(workflow).toMatch(/SOURCE_REF:/);

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -41,7 +41,8 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(job?.defaults?.run?.["working-directory"]).toBe("apps/neondiff-desktop");
 
     for (const command of [
-      "swift run NeonDiffDesktopCoreChecks",
+      "swift build --target NeonDiffDesktopCoreChecks",
+      "swift run NeonDiffDesktopKeychainChecks",
       "swift run NeonDiffDesktopAppcastChecks",
       "script/build_and_run.sh build",
       "script/build_and_run.sh bundle-check",
@@ -51,8 +52,9 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     }
 
     expect(workflow).not.toContain("NeonDiffDesktopCoreSmoke");
+    expect(workflow).not.toContain("swift run NeonDiffDesktopCoreChecks");
     expect(workflow).toContain("unsigned");
-    expect(workflow).toMatch(/hosted-runner-safe core checks/);
+    expect(workflow).toMatch(/hosted-runner-safe Keychain checks/);
     expect(workflow).toMatch(/persist-credentials:\s*false/);
     expect(workflow).toMatch(/SOURCE_SHA:/);
     expect(workflow).toMatch(/SOURCE_REF:/);
@@ -120,6 +122,7 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(docs).toMatch(/non-release proof/i);
     expect(docs).toMatch(/customer-not-ready/i);
     expect(docs).toMatch(/NeonDiffDesktopCoreChecks/);
+    expect(docs).toMatch(/NeonDiffDesktopKeychainChecks/);
     expect(docs).toMatch(/Keychain/i);
     expect(docs).toMatch(/artifact_sha256/i);
     expect(docs).toMatch(/bundle_id/i);

--- a/tests/desktop-release-pipeline.test.ts
+++ b/tests/desktop-release-pipeline.test.ts
@@ -37,7 +37,7 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(parsed.permissions).toEqual({ contents: "read" });
 
     const job = parsed.jobs?.["unsigned-desktop-release-smoke"];
-    expect(job?.["runs-on"]).toBe("macos-latest");
+    expect(job?.["runs-on"]).toBe("macos-15");
     expect(job?.defaults?.run?.["working-directory"]).toBe("apps/neondiff-desktop");
 
     for (const command of [
@@ -54,7 +54,7 @@ describe("NeonDiff desktop release-smoke pipeline", () => {
     expect(workflow).not.toContain("NeonDiffDesktopCoreSmoke");
     expect(workflow).not.toContain("swift run NeonDiffDesktopCoreChecks");
     expect(workflow).toContain("unsigned");
-    expect(workflow).toMatch(/hosted-runner-safe Keychain checks/);
+    expect(workflow).toMatch(/macOS 15 Keychain checks/);
     expect(workflow).toMatch(/persist-credentials:\s*false/);
     expect(workflow).toMatch(/SOURCE_SHA:/);
     expect(workflow).toMatch(/SOURCE_REF:/);

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -61,8 +61,9 @@ describe("Swift CI velocity policy", () => {
     expect(gate).toMatch(/No Swift desktop files changed; macOS smoke correctly skipped/);
     expect(gate).toMatch(/scripts\/swift-affected\.mjs/);
     expect(gate).toMatch(/No Swift desktop files changed/);
-    expect(gate).toMatch(/swift run NeonDiffDesktopKeychainChecks/);
+    expect(gate).toMatch(/swift build --target NeonDiffDesktopKeychainChecks/);
     expect(gate).not.toMatch(/swift run NeonDiffDesktopCoreChecks/);
+    expect(gate).not.toMatch(/swift run NeonDiffDesktopKeychainChecks/);
     expect(gate).toMatch(/swift build/);
     expect(gate).toMatch(/script\/build_and_run\.sh build/);
     expect(gate).toMatch(/script\/build_and_run\.sh bundle-check/);
@@ -166,6 +167,7 @@ describe("Swift CI velocity policy", () => {
     expect(betaRunbook).toMatch(/preview server\/browser\s+smoke/);
     expect(betaRunbook).toMatch(/Swift desktop gate/);
     expect(betaRunbook).toMatch(/compiles `NeonDiffDesktopCoreChecks`/);
+    expect(betaRunbook).toMatch(/`NeonDiffDesktopKeychainChecks`/);
     expect(betaRunbook).toMatch(/docs\/swift-codeql-policy\.md/);
     expect(betaRunbook).toMatch(/must not contain `swift`/);
     expect(betaRunbook).toMatch(/code-scanning\/default-setup/);

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -61,7 +61,7 @@ describe("Swift CI velocity policy", () => {
     expect(gate).toMatch(/No Swift desktop files changed; macOS smoke correctly skipped/);
     expect(gate).toMatch(/scripts\/swift-affected\.mjs/);
     expect(gate).toMatch(/No Swift desktop files changed/);
-    expect(gate).toMatch(/swift build --target NeonDiffDesktopCoreChecks/);
+    expect(gate).toMatch(/swift run NeonDiffDesktopKeychainChecks/);
     expect(gate).not.toMatch(/swift run NeonDiffDesktopCoreChecks/);
     expect(gate).toMatch(/swift build/);
     expect(gate).toMatch(/script\/build_and_run\.sh build/);

--- a/tests/swift-ci-velocity.test.ts
+++ b/tests/swift-ci-velocity.test.ts
@@ -53,7 +53,7 @@ describe("Swift CI velocity policy", () => {
     expect(gate).toMatch(/name:\s*Swift desktop smoke/);
     expect(gate).toMatch(/needs:\s*swift-desktop-impact/);
     expect(gate).toMatch(/if:\s*needs\.swift-desktop-impact\.outputs\.affected == 'true'/);
-    expect(gate).toMatch(/runs-on:\s*macos-latest/);
+    expect(gate).toMatch(/runs-on:\s*macos-15/);
     expect(gate).toMatch(/swift-desktop-gate:/);
     expect(gate).toMatch(/Swift desktop gate/);
     expect(gate).toMatch(/needs:\s*\n\s*-\s*swift-desktop-impact\n\s*-\s*swift-desktop-smoke/);


### PR DESCRIPTION
Closes #505.

## Outcome

- prevents desktop startup from decrypting Keychain values or presenting Keychain UI
- uses metadata-only, explicitly noninteractive existence queries for startup readiness
- preserves interactive secret reads for explicit user actions
- keeps existing `DesktopSecretStoring` conformers source-compatible
- launches the local HTML dashboard in explicit non-operator browser mode
- preserves the advanced native SwiftUI app; this PR does not embed a WebView

## Root Cause

`NeonDiffDesktopModel.init` synchronously read stored GitHub login and expiration secrets. On legacy ACL-protected Keychain items, `SecItemCopyMatching` could launch `SecurityAgent`, block the main thread, and produce repeated permission prompts before the window stabilized.

## Verification

- `NODE_OPTIONS=--experimental-sqlite npx vitest run tests/desktop-keychain-startup.test.ts --pool=forks --maxWorkers=1`
- `swift run NeonDiffDesktopCoreChecks`
- `swift run NeonDiffDesktopCoreSmoke`
- `./script/build_and_run.sh bundle-check`
- `npm run build`
- `npm run check:secrets`
- `git diff --check origin/main...HEAD`
- built-in Computer Use visible smoke of the exact rebased unsigned bundle: Welcome -> Provider controls, app remained alive, no `SecurityAgent` process

Evidence: `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/503-dashboard-parity/dev-proof.json`

## Proof Boundary

This proves startup stability for the named unsigned development bundle. Browser/native product parity remains in #503. Signing, notarization, Sparkle/appcast, installed-customer proof, and the full desktop control surface remain in milestone #11.
