### PR TITLE
chore(release): publish v1.0.3 startup-stability patch

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Classify npm package release
         id: package_release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
           RELEASE_LEVEL="$(node -p "require('./docs/public-release-manifest.json').releaseLevel")"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -131,14 +131,18 @@ jobs:
           else
             npm publish --provenance --access public --tag "release-candidate"
           fi
+          rm -f remote-package.json registry-metadata.tmp.json
           for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
-            if npm view "neondiff@$PACKAGE_VERSION" version dist.integrity dist.shasum gitHead --json > remote-package.json 2>/dev/null; then
+            rm -f registry-metadata.tmp.json
+            if npm view "neondiff@$PACKAGE_VERSION" version dist.integrity dist.shasum gitHead --json > registry-metadata.tmp.json 2>/dev/null && \
+              node -e 'JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))' registry-metadata.tmp.json; then
+              mv registry-metadata.tmp.json remote-package.json
               break
             fi
             sleep 5
           done
           test -s remote-package.json || {
-            echo "::error::Published npm metadata did not become readable"
+            echo "::error::npm registry metadata remained unavailable or invalid after retries"
             exit 1
           }
           node scripts/npm-release-policy.mjs verify-pack \

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,7 +9,7 @@ on:
       tag:
         description: Release tag to publish
         required: true
-        default: v1.0.2
+        default: v1.0.3
 
 concurrency:
   group: publish-npm-${{ github.event.inputs.tag || github.event.release.tag_name || github.ref }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -12,7 +12,7 @@ on:
         default: v1.0.3
 
 concurrency:
-  group: publish-npm-${{ github.event.inputs.tag || github.event.release.tag_name || github.ref }}
+  group: publish-npm-neondiff
   cancel-in-progress: false
 
 permissions:
@@ -151,6 +151,27 @@ jobs:
             --remote-metadata remote-package.json \
             --expected-version "$PACKAGE_VERSION" \
             --expected-git-head "$EXPECTED_GIT_HEAD"
+          EXPECTED_PREDECESSOR="$(node -p "require('./docs/public-release-manifest.json').packageArtifact.previousReleasedPackageVersion")"
+          rm -f channel-metadata.json channel-metadata.tmp.json
+          for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+            rm -f channel-metadata.tmp.json
+            if npm view neondiff dist-tags --json > channel-metadata.tmp.json 2>/dev/null && \
+              node -e 'const value = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")); if (!value || Array.isArray(value) || typeof value !== "object") process.exit(1)' channel-metadata.tmp.json; then
+              mv channel-metadata.tmp.json channel-metadata.json
+              break
+            fi
+            sleep 5
+          done
+          test -s channel-metadata.json || {
+            echo "::error::npm dist-tag metadata remained unavailable or invalid after retries"
+            exit 1
+          }
+          CURRENT_TAG_VERSION="$(node -e 'const tags = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")); process.stdout.write(tags[process.argv[2]] ?? "")' channel-metadata.json "$NPM_TAG")"
+          node scripts/npm-release-policy.mjs verify-channel \
+            --current-version "$CURRENT_TAG_VERSION" \
+            --target-version "$PACKAGE_VERSION" \
+            --expected-predecessor "$EXPECTED_PREDECESSOR" \
+            --npm-tag "$NPM_TAG"
           npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"
           test "$(npm view neondiff "dist-tags.$NPM_TAG")" = "$PACKAGE_VERSION"
           if [ "$(npm view neondiff dist-tags.release-candidate 2>/dev/null || true)" = "$PACKAGE_VERSION" ]; then

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,39 +23,59 @@ jobs:
   publish:
     name: Publish neondiff
     runs-on: ubuntu-latest
+    environment: npm-publish
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' }}
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+      RELEASE_EVENT_NAME: ${{ github.event_name }}
+      RELEASE_PRERELEASE: ${{ github.event.release.prerelease || false }}
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: Verify release provenance before repository code runs
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          test "$(git cat-file -t "$RELEASE_TAG")" = "tag" || {
+            echo "::error::Release tag must be annotated"
+            exit 1
+          }
+          TAG_COMMIT="$(git rev-list -n 1 "$RELEASE_TAG")"
+          git merge-base --is-ancestor "$TAG_COMMIT" refs/remotes/origin/main || {
+            echo "::error::Release tag commit must be an ancestor of protected main"
+            exit 1
+          }
+          CANDIDATE_HEAD="$(node -e 'const manifest = require("./docs/public-release-manifest.json"); process.stdout.write(manifest.source?.candidateHeadBeforeReleaseMetadata ?? "");')"
+          test "$(printf '%s' "$CANDIDATE_HEAD" | wc -c | tr -d ' ')" = "40" || {
+            echo "::error::Release candidate head must be a full Git SHA"
+            exit 1
+          }
+          git merge-base --is-ancestor "$CANDIDATE_HEAD" "$TAG_COMMIT" || {
+            echo "::error::Declared release candidate head must be an ancestor of the release tag commit"
+            exit 1
+          }
+          node scripts/npm-release-policy.mjs verify-git \
+            --tag "$RELEASE_TAG" \
+            --candidate-head "$CANDIDATE_HEAD" \
+            --main-ref refs/remotes/origin/main
 
       - name: Classify npm package release
         id: package_release
         run: |
-          TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          if node -e "process.exit(require('./package.json').version.includes('-') ? 0 : 1)"; then
-            NPM_TAG="beta"
-          else
-            NPM_TAG="latest"
-          fi
-          if [ "$TAG" != "v$PACKAGE_VERSION" ]; then
-            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-              echo "::error::Manual npm publish tag $TAG does not match package.json version v$PACKAGE_VERSION"
-              exit 1
-            fi
-            SKIPPED_SOURCE_RELEASE="$(TAG="$TAG" node -e 'const manifest = require("./docs/public-release-manifest.json"); const skippedVersions = manifest.packageArtifact?.skippedPublicPackageVersions ?? []; process.stdout.write(manifest.releaseLevel === "source-beta" && skippedVersions.includes(process.env.TAG) ? "true" : "false");')"
-            if [ "$SKIPPED_SOURCE_RELEASE" = "true" ]; then
-              echo "::notice::Skipping npm publish for source-only prerelease $TAG; package.json remains v$PACKAGE_VERSION"
-              echo "should_publish=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            echo "::error::Release tag $TAG does not match package.json version v$PACKAGE_VERSION and is not listed in docs/public-release-manifest.json packageArtifact.skippedPublicPackageVersions"
-            exit 1
-          fi
-          echo "should_publish=true" >> "$GITHUB_OUTPUT"
-          echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
+          RELEASE_LEVEL="$(node -p "require('./docs/public-release-manifest.json').releaseLevel")"
+          SKIPPED_VERSIONS="$(node -p "JSON.stringify(require('./docs/public-release-manifest.json').packageArtifact?.skippedPublicPackageVersions ?? [])")"
+          node scripts/npm-release-policy.mjs classify \
+            --event-name "$RELEASE_EVENT_NAME" \
+            --release-prerelease "$RELEASE_PRERELEASE" \
+            --tag "$RELEASE_TAG" \
+            --package-version "$PACKAGE_VERSION" \
+            --release-level "$RELEASE_LEVEL" \
+            --skipped-versions-json "$SKIPPED_VERSIONS" \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Verify npm publish token is configured
         if: steps.package_release.outputs.should_publish == 'true'
@@ -94,11 +114,29 @@ jobs:
         if: steps.package_release.outputs.should_publish == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TAG: ${{ steps.package_release.outputs.npm_tag }}
         run: |
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          EXPECTED_GIT_HEAD="$(git rev-list -n 1 "$RELEASE_TAG")"
           if npm view "neondiff@$PACKAGE_VERSION" version >/dev/null 2>&1; then
-            echo "neondiff@$PACKAGE_VERSION already exists; verifying dist-tags"
-            test "$(npm view neondiff dist-tags.${{ steps.package_release.outputs.npm_tag }})" = "$PACKAGE_VERSION"
-            exit 0
+            echo "neondiff@$PACKAGE_VERSION already exists; verifying reviewed tarball identity"
+          else
+            npm publish --provenance --access public --tag "$NPM_TAG"
           fi
-          npm publish --provenance --access public --tag "${{ steps.package_release.outputs.npm_tag }}"
+          for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+            if npm view "neondiff@$PACKAGE_VERSION" version dist.integrity dist.shasum gitHead --json > remote-package.json 2>/dev/null; then
+              break
+            fi
+            sleep 5
+          done
+          test -s remote-package.json || {
+            echo "::error::Published npm metadata did not become readable"
+            exit 1
+          }
+          node scripts/npm-release-policy.mjs verify-pack \
+            --local-pack pack.json \
+            --remote-metadata remote-package.json \
+            --expected-version "$PACKAGE_VERSION" \
+            --expected-git-head "$EXPECTED_GIT_HEAD"
+          npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"
+          test "$(npm view neondiff "dist-tags.$NPM_TAG")" = "$PACKAGE_VERSION"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify release provenance before repository code runs
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -68,6 +68,11 @@ jobs:
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
           RELEASE_LEVEL="$(node -p "require('./docs/public-release-manifest.json').releaseLevel")"
           SKIPPED_VERSIONS="$(node -p "JSON.stringify(require('./docs/public-release-manifest.json').packageArtifact?.skippedPublicPackageVersions ?? [])")"
+          RELEASE_METADATA_ARGS=()
+          if [ "$RELEASE_EVENT_NAME" = "workflow_dispatch" ]; then
+            gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" > "$RUNNER_TEMP/release-metadata.json"
+            RELEASE_METADATA_ARGS=(--release-metadata "$RUNNER_TEMP/release-metadata.json")
+          fi
           node scripts/npm-release-policy.mjs classify \
             --event-name "$RELEASE_EVENT_NAME" \
             --release-prerelease "$RELEASE_PRERELEASE" \
@@ -75,6 +80,7 @@ jobs:
             --package-version "$PACKAGE_VERSION" \
             --release-level "$RELEASE_LEVEL" \
             --skipped-versions-json "$SKIPPED_VERSIONS" \
+            "${RELEASE_METADATA_ARGS[@]}" \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Verify npm publish token is configured
@@ -121,7 +127,7 @@ jobs:
           if npm view "neondiff@$PACKAGE_VERSION" version >/dev/null 2>&1; then
             echo "neondiff@$PACKAGE_VERSION already exists; verifying reviewed tarball identity"
           else
-            npm publish --provenance --access public --tag "$NPM_TAG"
+            npm publish --provenance --access public --tag "release-candidate"
           fi
           for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
             if npm view "neondiff@$PACKAGE_VERSION" version dist.integrity dist.shasum gitHead --json > remote-package.json 2>/dev/null; then
@@ -140,3 +146,6 @@ jobs:
             --expected-git-head "$EXPECTED_GIT_HEAD"
           npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"
           test "$(npm view neondiff "dist-tags.$NPM_TAG")" = "$PACKAGE_VERSION"
+          if [ "$(npm view neondiff dist-tags.release-candidate 2>/dev/null || true)" = "$PACKAGE_VERSION" ]; then
+            npm dist-tag rm neondiff release-candidate
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ for the semver/GA-line and npm dist-tag policy.
 
 No unreleased changes tracked yet.
 
+## [1.0.3] - docs/releases/v1.0.3.md
+
+### Fixed
+
+- Prevent NeonDiff Desktop startup from decrypting Keychain values or opening
+  repeated authorization prompts before the native window stabilizes.
+- Keep metadata-only startup checks noninteractive for modern and legacy
+  Keychain items while preserving explicit user-triggered secret reads.
+
+### Changed
+
+- Use one shared argument contract so displayed and detached dashboard launches
+  explicitly select browser mode with `--operator false`.
+- Pin Swift desktop and unsigned release-smoke builds to macOS 15, compile the
+  focused Keychain contract there, and keep Security-linked helper execution in
+  the local visible-smoke lane.
+
 ## [1.0.2] - docs/releases/v1.0.2.md
 
 ### Added

--- a/docs/evidence/v1.0.3-desktop-startup-smoke.json
+++ b/docs/evidence/v1.0.3-desktop-startup-smoke.json
@@ -41,7 +41,7 @@
     "visibleLocalSourcesMatchMergedCandidate": true,
     "hostedReleaseSurfaceMatchesMergedCandidate": true,
     "visibleLocalBinaryIsHostedArtifact": false,
-    "verification": "git diff --quiet visible-source merged-candidate -- apps/neondiff-desktop/Sources; git diff --quiet hosted-source merged-candidate -- apps/neondiff-desktop .github/workflows/desktop-release-smoke.yml .github/workflows/swift-desktop.yml",
+    "verification": "git diff --quiet visible-source merged-candidate -- apps/neondiff-desktop/Sources; git diff --quiet hosted-source merged-candidate -- apps/neondiff-desktop .github/workflows/desktop-release-smoke.yml .github/workflows/swift-desktop-gate.yml",
     "note": "PR #506 was squash-merged, so the reviewed branch commits are not Git ancestors of the merged candidate. The visible app sources and hosted release surface match the merged candidate over the stated paths; the local and hosted artifact hashes remain intentionally separate."
   },
   "proofBoundary": "Visible local proof covers the named unsigned local binary at sourceHead only. The hosted macOS 15 artifact is separately identified by workflow head, artifact IDs, and archive SHA and covers compilation, bundle shape, and packaging only. Neither proves signing, notarization, Sparkle updates, or customer-ready installation."

--- a/docs/evidence/v1.0.3-desktop-startup-smoke.json
+++ b/docs/evidence/v1.0.3-desktop-startup-smoke.json
@@ -3,6 +3,8 @@
   "releaseVersion": "v1.0.3",
   "observedAt": "2026-07-09T20:56:23Z",
   "sourceHead": "b22b81ca85a41abe888f3054eea25bb397d08d68",
+  "sourceCommitUrl": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/commit/b22b81ca85a41abe888f3054eea25bb397d08d68",
+  "sourceReachability": "public_commit_api",
   "mergedCandidateHead": "bcd2f7ace5b190dc86b5f86983aa62aae5e40652",
   "bundleId": "com.electricsheephq.NeonDiffDesktop",
   "binarySha256": "575d2b5ed97d81a869a5cbedfc16d1abbd07ee17f075f3f3e6184b2413f9f8d6",

--- a/docs/evidence/v1.0.3-desktop-startup-smoke.json
+++ b/docs/evidence/v1.0.3-desktop-startup-smoke.json
@@ -28,7 +28,6 @@
     "metadataArtifactName": "neondiff-desktop-release-smoke-metadata",
     "coreChecksCompiled": true,
     "keychainChecksCompiled": true,
-    "appcastChecksPassed": true,
     "unsignedBundlePackaged": true
   },
   "redaction": {

--- a/docs/evidence/v1.0.3-desktop-startup-smoke.json
+++ b/docs/evidence/v1.0.3-desktop-startup-smoke.json
@@ -36,10 +36,13 @@
     "privateRepoNamesOmitted": true
   },
   "artifactRelationship": {
-    "visibleLocalBundleSourceIsCandidateAncestor": true,
-    "hostedWorkflowSourceIsCandidateAncestor": true,
+    "visibleLocalBundleSourceIsCandidateAncestor": false,
+    "hostedWorkflowSourceIsCandidateAncestor": false,
+    "visibleLocalSourcesMatchMergedCandidate": true,
+    "hostedReleaseSurfaceMatchesMergedCandidate": true,
     "visibleLocalBinaryIsHostedArtifact": false,
-    "note": "The visible local smoke and hosted unsigned workflow are separate named artifacts from reviewed ancestors of the merged candidate; their hashes are intentionally recorded separately."
+    "verification": "git diff --quiet visible-source merged-candidate -- apps/neondiff-desktop/Sources; git diff --quiet hosted-source merged-candidate -- apps/neondiff-desktop .github/workflows/desktop-release-smoke.yml .github/workflows/swift-desktop.yml",
+    "note": "PR #506 was squash-merged, so the reviewed branch commits are not Git ancestors of the merged candidate. The visible app sources and hosted release surface match the merged candidate over the stated paths; the local and hosted artifact hashes remain intentionally separate."
   },
   "proofBoundary": "Visible local proof covers the named unsigned local binary at sourceHead only. The hosted macOS 15 artifact is separately identified by workflow head, artifact IDs, and archive SHA and covers compilation, bundle shape, and packaging only. Neither proves signing, notarization, Sparkle updates, or customer-ready installation."
 }

--- a/docs/evidence/v1.0.3-desktop-startup-smoke.json
+++ b/docs/evidence/v1.0.3-desktop-startup-smoke.json
@@ -17,6 +17,13 @@
   },
   "macos15ReleaseSmoke": {
     "workflowRun": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29049779156",
+    "workflowHead": "9eba343c8e69e832978e51c0fb63527b61939760",
+    "appArtifactId": 8211347648,
+    "appArtifactName": "neondiff-desktop-unsigned-app",
+    "appArchiveName": "NeonDiffDesktop.app.zip",
+    "appArchiveSha256": "f546568f0e10ebc7abd4adcf99cc40af8a96ad635bf3fbb6333195d0a8d1a7e7",
+    "metadataArtifactId": 8211347876,
+    "metadataArtifactName": "neondiff-desktop-release-smoke-metadata",
     "coreChecksCompiled": true,
     "keychainChecksCompiled": true,
     "appcastChecksPassed": true,
@@ -28,5 +35,11 @@
     "credentialsRemoved": true,
     "privateRepoNamesOmitted": true
   },
-  "proofBoundary": "Visible local proof covers the named unsigned bundle only. macOS 15 hosted proof covers compilation, bundle shape, and packaging only. Neither proves signing, notarization, Sparkle updates, or customer-ready installation."
+  "artifactRelationship": {
+    "visibleLocalBundleSourceIsCandidateAncestor": true,
+    "hostedWorkflowSourceIsCandidateAncestor": true,
+    "visibleLocalBinaryIsHostedArtifact": false,
+    "note": "The visible local smoke and hosted unsigned workflow are separate named artifacts from reviewed ancestors of the merged candidate; their hashes are intentionally recorded separately."
+  },
+  "proofBoundary": "Visible local proof covers the named unsigned local binary at sourceHead only. The hosted macOS 15 artifact is separately identified by workflow head, artifact IDs, and archive SHA and covers compilation, bundle shape, and packaging only. Neither proves signing, notarization, Sparkle updates, or customer-ready installation."
 }

--- a/docs/evidence/v1.0.3-desktop-startup-smoke.json
+++ b/docs/evidence/v1.0.3-desktop-startup-smoke.json
@@ -1,0 +1,32 @@
+{
+  "evidenceKind": "desktop_startup_smoke_redacted",
+  "releaseVersion": "v1.0.3",
+  "observedAt": "2026-07-09T20:56:23Z",
+  "sourceHead": "b22b81ca85a41abe888f3054eea25bb397d08d68",
+  "mergedCandidateHead": "bcd2f7ace5b190dc86b5f86983aa62aae5e40652",
+  "bundleId": "com.electricsheephq.NeonDiffDesktop",
+  "binarySha256": "575d2b5ed97d81a869a5cbedfc16d1abbd07ee17f075f3f3e6184b2413f9f8d6",
+  "signingIdentityClass": "unsigned-dev",
+  "nativeUi": {
+    "welcomeVisible": true,
+    "providerStepVisibleAfterContinue": true,
+    "providerModel": "GLM-5.2",
+    "appRemainedAlive": true,
+    "securityAgentPresent": false,
+    "webViewEmbedded": false
+  },
+  "macos15ReleaseSmoke": {
+    "workflowRun": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29049779156",
+    "coreChecksCompiled": true,
+    "keychainChecksCompiled": true,
+    "appcastChecksPassed": true,
+    "unsignedBundlePackaged": true
+  },
+  "redaction": {
+    "localPathsRemoved": true,
+    "tokensRemoved": true,
+    "credentialsRemoved": true,
+    "privateRepoNamesOmitted": true
+  },
+  "proofBoundary": "Visible local proof covers the named unsigned bundle only. macOS 15 hosted proof covers compilation, bundle shape, and packaging only. Neither proves signing, notarization, Sparkle updates, or customer-ready installation."
+}

--- a/docs/evidence/v1.0.3-license-api-healthz.json
+++ b/docs/evidence/v1.0.3-license-api-healthz.json
@@ -1,0 +1,19 @@
+{
+  "evidenceKind": "license_api_healthz",
+  "releaseVersion": "v1.0.3",
+  "observedAt": "2026-07-09T21:08:54.284Z",
+  "method": "GET",
+  "url": "https://neondiff-license.fly.dev/healthz",
+  "statusCode": 200,
+  "responseBody": "{\"status\":\"ok\"}",
+  "responseBodySha256": "a29ee2b15c494311c52521766e44af56a3ad2248e7a8ab465e5206463c13d288",
+  "captureContext": {
+    "tool": "node fetch",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "Codex Desktop macOS operator shell",
+    "dnsResolution": "system resolver",
+    "note": "Captured with normal system DNS resolution and Node default TLS validation."
+  },
+  "redaction": "No license key, token, cookie, customer data, or private repo content was present in this health check."
+}

--- a/docs/evidence/v1.0.3-license-checkout-issuance-authenticated.json
+++ b/docs/evidence/v1.0.3-license-checkout-issuance-authenticated.json
@@ -1,0 +1,21 @@
+{
+  "evidenceKind": "license_api_checkout_issuance_authenticated",
+  "releaseVersion": "v1.0.3",
+  "observedAt": "2026-07-09T21:09:23.410Z",
+  "method": "POST",
+  "url": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
+  "statusCode": 200,
+  "redactedResponse": {
+    "status": "issued",
+    "replayed": false,
+    "checkoutLookupKey": "neondiff_monthly",
+    "issuedLicensePrefix": "nd_live_",
+    "issuedLicenseFingerprint": "sha256:14ebc3a0cf5749aa489f32e459658f83e5ae187e470c279315f77a2985bd7e63"
+  },
+  "captureContext": {
+    "tool": "neondiff checkout-issuance-smoke",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "operator CLI"
+  }
+}

--- a/docs/evidence/v1.0.3-license-checkout-issuance-unauthenticated.json
+++ b/docs/evidence/v1.0.3-license-checkout-issuance-unauthenticated.json
@@ -1,7 +1,7 @@
 {
   "evidenceKind": "license_api_checkout_issuance",
   "releaseVersion": "v1.0.3",
-  "observedAt": "2026-07-09T21:08:54.284Z",
+  "observedAt": "2026-07-09T22:16:41.379Z",
   "method": "POST",
   "url": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
   "statusCode": 401,

--- a/docs/evidence/v1.0.3-license-checkout-issuance-unauthenticated.json
+++ b/docs/evidence/v1.0.3-license-checkout-issuance-unauthenticated.json
@@ -1,0 +1,19 @@
+{
+  "evidenceKind": "license_api_checkout_issuance",
+  "releaseVersion": "v1.0.3",
+  "observedAt": "2026-07-09T21:08:54.284Z",
+  "method": "POST",
+  "url": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
+  "statusCode": 401,
+  "responseBody": "{\"status\":\"unauthorized\",\"detail\":\"license issuance authorization failed\"}",
+  "responseBodySha256": "a67612cc05a222fc5d28aa36be40d59daf7b32bca36f305d66c57db869150e20",
+  "captureContext": {
+    "tool": "node fetch",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "Codex Desktop macOS operator shell",
+    "dnsResolution": "system resolver",
+    "note": "Captured without Authorization header to prove configured fail-closed behavior."
+  },
+  "redaction": "No license key, bearer token, cookie, customer data, or checkout payload secret was sent or captured."
+}

--- a/docs/evidence/v1.0.3-rollback-refs.json
+++ b/docs/evidence/v1.0.3-rollback-refs.json
@@ -5,21 +5,24 @@
   "channels": {
     "cli": {
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
-      "rollbackCommand": "npm dist-tag add neondiff@1.0.2 latest",
+      "rollbackCommand": "git reset --hard refs/tags/v1.0.2",
+      "operatorRollbackCommand": "npm dist-tag add neondiff@1.0.2 latest",
       "rollbackTarget": "v1.0.2",
       "targetVerifiedBy": "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
       "targetVerifiedShasum": "d62619b1ee2c539e3230572135a29a299be3a6ed"
     },
     "daemon": {
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
-      "rollbackCommand": "npm install -g neondiff@1.0.2",
+      "rollbackCommand": "git reset --hard refs/tags/v1.0.2",
+      "operatorRollbackCommand": "npm install -g neondiff@1.0.2",
       "rollbackTarget": "v1.0.2",
       "targetVerifiedBy": "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
       "targetVerifiedShasum": "d62619b1ee2c539e3230572135a29a299be3a6ed"
     },
     "browserDashboard": {
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
-      "rollbackCommand": "npm install -g neondiff@1.0.2",
+      "rollbackCommand": "git reset --hard refs/tags/v1.0.2",
+      "operatorRollbackCommand": "npm install -g neondiff@1.0.2",
       "rollbackTarget": "v1.0.2",
       "targetVerifiedBy": "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
       "targetVerifiedShasum": "d62619b1ee2c539e3230572135a29a299be3a6ed"
@@ -34,5 +37,5 @@
       "targetSubject": "v1.0.3 keeps the previously published website installer; npm latest promotion supplies the new package version."
     }
   },
-  "proofBoundary": "npm is immutable: rollback moves latest to v1.0.2 and reinstalls v1.0.2 for affected local daemon/dashboard surfaces. The v1.0.3 package and tag remain as incident provenance. v1.0.3 does not advance the website channel, so website rollback is intentionally no-op."
+  "proofBoundary": "Manifest rollbackCommand values are source-checkout revert references for an isolated recovery checkout and must not reset protected main. npm is immutable: operator rollback moves latest to v1.0.2 and reinstalls v1.0.2 for affected local daemon/dashboard surfaces. The v1.0.3 package and tag remain as incident provenance. v1.0.3 does not advance the website channel, so website rollback is intentionally no-op."
 }

--- a/docs/evidence/v1.0.3-rollback-refs.json
+++ b/docs/evidence/v1.0.3-rollback-refs.json
@@ -5,24 +5,24 @@
   "channels": {
     "cli": {
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
-      "rollbackCommand": "git reset --hard refs/tags/v1.0.2",
+      "rollbackCommand": "npm dist-tag add neondiff@1.0.2 latest",
       "rollbackTarget": "v1.0.2",
-      "targetVerifiedBy": "git ls-remote origin refs/tags/v1.0.2",
-      "targetVerifiedSha": "bf76be80ccb573dde7b3ca0d0c2d6883259093fe"
+      "targetVerifiedBy": "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
+      "targetVerifiedShasum": "d62619b1ee2c539e3230572135a29a299be3a6ed"
     },
     "daemon": {
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
-      "rollbackCommand": "git reset --hard refs/tags/v1.0.2",
+      "rollbackCommand": "npm install -g neondiff@1.0.2",
       "rollbackTarget": "v1.0.2",
-      "targetVerifiedBy": "git ls-remote origin refs/tags/v1.0.2",
-      "targetVerifiedSha": "bf76be80ccb573dde7b3ca0d0c2d6883259093fe"
+      "targetVerifiedBy": "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
+      "targetVerifiedShasum": "d62619b1ee2c539e3230572135a29a299be3a6ed"
     },
     "browserDashboard": {
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
-      "rollbackCommand": "git reset --hard refs/tags/v1.0.2",
+      "rollbackCommand": "npm install -g neondiff@1.0.2",
       "rollbackTarget": "v1.0.2",
-      "targetVerifiedBy": "git ls-remote origin refs/tags/v1.0.2",
-      "targetVerifiedSha": "bf76be80ccb573dde7b3ca0d0c2d6883259093fe"
+      "targetVerifiedBy": "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
+      "targetVerifiedShasum": "d62619b1ee2c539e3230572135a29a299be3a6ed"
     },
     "website": {
       "rollbackRepository": "electricsheephq/neon-diff-agent-website",
@@ -34,5 +34,5 @@
       "targetSubject": "v1.0.3 keeps the previously published website installer; npm latest promotion supplies the new package version."
     }
   },
-  "proofBoundary": "Rollback refs are repo-scoped. v1.0.3 does not advance the website channel, so website rollback is intentionally no-op for this release."
+  "proofBoundary": "npm is immutable: rollback moves latest to v1.0.2 and reinstalls v1.0.2 for affected local daemon/dashboard surfaces. The v1.0.3 package and tag remain as incident provenance. v1.0.3 does not advance the website channel, so website rollback is intentionally no-op."
 }

--- a/docs/evidence/v1.0.3-rollback-refs.json
+++ b/docs/evidence/v1.0.3-rollback-refs.json
@@ -1,0 +1,38 @@
+{
+  "evidenceKind": "release_rollback_refs",
+  "releaseVersion": "v1.0.3",
+  "observedAt": "2026-07-09T21:09:40.000Z",
+  "channels": {
+    "cli": {
+      "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
+      "rollbackCommand": "git reset --hard refs/tags/v1.0.2",
+      "rollbackTarget": "v1.0.2",
+      "targetVerifiedBy": "git ls-remote origin refs/tags/v1.0.2",
+      "targetVerifiedSha": "bf76be80ccb573dde7b3ca0d0c2d6883259093fe"
+    },
+    "daemon": {
+      "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
+      "rollbackCommand": "git reset --hard refs/tags/v1.0.2",
+      "rollbackTarget": "v1.0.2",
+      "targetVerifiedBy": "git ls-remote origin refs/tags/v1.0.2",
+      "targetVerifiedSha": "bf76be80ccb573dde7b3ca0d0c2d6883259093fe"
+    },
+    "browserDashboard": {
+      "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
+      "rollbackCommand": "git reset --hard refs/tags/v1.0.2",
+      "rollbackTarget": "v1.0.2",
+      "targetVerifiedBy": "git ls-remote origin refs/tags/v1.0.2",
+      "targetVerifiedSha": "bf76be80ccb573dde7b3ca0d0c2d6883259093fe"
+    },
+    "website": {
+      "rollbackRepository": "electricsheephq/neon-diff-agent-website",
+      "releaseAction": "no_code_deploy_for_v1.0.3",
+      "currentChannelVersion": "v1.0.1",
+      "rollbackTarget": "no_action_for_v1.0.3",
+      "targetVerifiedBy": "docs/public-release-manifest.json omits updateChannels.website for v1.0.3",
+      "targetVerifiedSha": null,
+      "targetSubject": "v1.0.3 keeps the previously published website installer; npm latest promotion supplies the new package version."
+    }
+  },
+  "proofBoundary": "Rollback refs are repo-scoped. v1.0.3 does not advance the website channel, so website rollback is intentionally no-op for this release."
+}

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,12 +1,12 @@
 {
-  "version": "v1.0.2",
+  "version": "v1.0.3",
   "releaseLevel": "stable",
   "packageArtifact": {
     "name": "neondiff",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "requiredForThisRelease": true,
     "state": "published",
-    "previousReleasedPackageVersion": "1.0.1",
+    "previousReleasedPackageVersion": "1.0.2",
     "skippedPublicPackageVersions": [
       "v0.4.25-beta.1",
       "v0.4.26-beta.1",
@@ -30,12 +30,12 @@
       "v0.4.45-beta.1",
       "v0.4.46-beta.1"
     ],
-    "note": "v1.0.2 publishes the CLI/dashboard npm package and release metadata. Desktop GitHub device-flow and repo-discovery source changes are included in this source release, but desktop app artifacts are not part of the npm package."
+    "note": "v1.0.3 publishes the CLI/dashboard npm package and release metadata. Desktop Keychain startup-stability source changes are included in this source release, but desktop app artifacts are not part of the npm package."
   },
   "source": {
     "shaState": "pending_tag_stamp",
-    "candidateHeadBeforeReleaseMetadata": "fb2e0238287198a1fa1462f066f295dee6c9ea2e",
-    "proof": "after merge and tag, release:status --expected-head $(git rev-parse HEAD) and verify the tag contains candidate head fb2e0238287198a1fa1462f066f295dee6c9ea2e"
+    "candidateHeadBeforeReleaseMetadata": "bcd2f7ace5b190dc86b5f86983aa62aae5e40652",
+    "proof": "after merge and tag, release:status --expected-head $(git rev-parse HEAD) and verify the tag contains candidate head bcd2f7ace5b190dc86b5f86983aa62aae5e40652"
   },
   "releaseStages": {
     "launchCutLine": "1.0 is a usable local HTML installer/dashboard plus minimal Mac launcher, not full signed desktop maturity.",
@@ -78,9 +78,9 @@
     ]
   },
   "docs": {
-    "version": "v1.0.2",
+    "version": "v1.0.3",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v1.0.2.md",
+    "releaseNotesPath": "docs/releases/v1.0.3.md",
     "websiteRepo": "electricsheephq/neon-diff-agent-website"
   },
   "licenseApi": {
@@ -88,34 +88,34 @@
     "state": "healthy",
     "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327",
     "healthUrl": "https://neondiff-license.fly.dev/healthz",
-    "healthProofPath": "docs/evidence/v1.0.2-license-api-healthz.json",
+    "healthProofPath": "docs/evidence/v1.0.3-license-api-healthz.json",
     "checkoutIssuanceRequiredForThisRelease": true,
     "checkoutIssuanceUrl": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
     "checkoutIssuanceState": "ready",
-    "checkoutIssuanceProofPath": "docs/evidence/v1.0.2-license-checkout-issuance-unauthenticated.json",
-    "checkoutIssuanceAuthenticatedProofPath": "docs/evidence/v1.0.2-license-checkout-issuance-authenticated.json",
+    "checkoutIssuanceProofPath": "docs/evidence/v1.0.3-license-checkout-issuance-unauthenticated.json",
+    "checkoutIssuanceAuthenticatedProofPath": "docs/evidence/v1.0.3-license-checkout-issuance-authenticated.json",
     "checkoutIssuanceTrackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
   },
   "updateChannels": {
     "cli": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v1.0.2",
-      "rollback": "git reset --hard refs/tags/v1.0.1",
+      "version": "v1.0.3",
+      "rollback": "git reset --hard refs/tags/v1.0.2",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v1.0.2",
-      "rollback": "git reset --hard refs/tags/v1.0.1",
+      "version": "v1.0.3",
+      "rollback": "git reset --hard refs/tags/v1.0.2",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "browserDashboard": {
       "requiredForThisRelease": true,
       "state": "published",
-      "version": "v1.0.2",
-      "rollback": "git reset --hard refs/tags/v1.0.1",
+      "version": "v1.0.3",
+      "rollback": "git reset --hard refs/tags/v1.0.2",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
       "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     }

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -101,21 +101,21 @@
       "requiredForThisRelease": true,
       "state": "source_checkout",
       "version": "v1.0.3",
-      "rollback": "npm dist-tag add neondiff@1.0.2 latest",
+      "rollback": "git reset --hard refs/tags/v1.0.2",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "daemon": {
       "requiredForThisRelease": true,
       "state": "source_checkout",
       "version": "v1.0.3",
-      "rollback": "npm install -g neondiff@1.0.2",
+      "rollback": "git reset --hard refs/tags/v1.0.2",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "browserDashboard": {
       "requiredForThisRelease": true,
       "state": "source_checkout",
       "version": "v1.0.3",
-      "rollback": "npm install -g neondiff@1.0.2",
+      "rollback": "git reset --hard refs/tags/v1.0.2",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
       "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     }

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -5,7 +5,7 @@
     "name": "neondiff",
     "version": "1.0.3",
     "requiredForThisRelease": true,
-    "state": "published",
+    "state": "release_candidate",
     "previousReleasedPackageVersion": "1.0.2",
     "skippedPublicPackageVersions": [
       "v0.4.25-beta.1",
@@ -30,12 +30,12 @@
       "v0.4.45-beta.1",
       "v0.4.46-beta.1"
     ],
-    "note": "v1.0.3 publishes the CLI/dashboard npm package and release metadata. Desktop Keychain startup-stability source changes are included in this source release, but desktop app artifacts are not part of the npm package."
+    "note": "v1.0.3 is prepared as the CLI/dashboard npm package release candidate. After the non-prerelease GitHub Release, npm integrity verification, and installed-package smoke pass, a post-release state stamp records publication. Desktop Keychain startup-stability source changes are included, but desktop app artifacts are not part of the npm package."
   },
   "source": {
     "shaState": "pending_tag_stamp",
     "candidateHeadBeforeReleaseMetadata": "bcd2f7ace5b190dc86b5f86983aa62aae5e40652",
-    "proof": "after merge and tag, release:status --expected-head $(git rev-parse HEAD) and verify the tag contains candidate head bcd2f7ace5b190dc86b5f86983aa62aae5e40652"
+    "proof": "before publish, verify the annotated tag and candidate are ancestors of protected main; after npm/GitHub/install proof, stamp release_candidate and source_checkout states to published on main without moving the release tag"
   },
   "releaseStages": {
     "launchCutLine": "1.0 is a usable local HTML installer/dashboard plus minimal Mac launcher, not full signed desktop maturity.",
@@ -99,23 +99,23 @@
   "updateChannels": {
     "cli": {
       "requiredForThisRelease": true,
-      "state": "published",
+      "state": "source_checkout",
       "version": "v1.0.3",
-      "rollback": "git reset --hard refs/tags/v1.0.2",
+      "rollback": "npm dist-tag add neondiff@1.0.2 latest",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "daemon": {
       "requiredForThisRelease": true,
-      "state": "published",
+      "state": "source_checkout",
       "version": "v1.0.3",
-      "rollback": "git reset --hard refs/tags/v1.0.2",
+      "rollback": "npm install -g neondiff@1.0.2",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "browserDashboard": {
       "requiredForThisRelease": true,
-      "state": "published",
+      "state": "source_checkout",
       "version": "v1.0.3",
-      "rollback": "git reset --hard refs/tags/v1.0.2",
+      "rollback": "npm install -g neondiff@1.0.2",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
       "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     }

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -182,6 +182,19 @@ kickstart` alone is a restart, not a rollback. `git checkout` detaches HEAD or
 resets the working tree; it is not accepted as a release rollback for this
 manifest gate.
 
+Run a manifest `git reset --hard refs/tags/<tag>` only in an isolated recovery
+checkout. Never reset protected `main` or a maintainer's active worktree. Public
+npm rollback is a separate operator action: move the stable dist-tag to the
+verified prior package, reinstall that package on affected hosts, restart the
+host-specific daemon/dashboard, and preserve the immutable release tag and
+package as incident provenance.
+
+Stable npm publication uses a quarantine dist-tag first. Verify the registry
+integrity, shasum, and `gitHead` against the reviewed pack and annotated tag,
+then promote the package to `latest`. Manual retry runs must resolve the exact
+existing GitHub Release and prove it is published and non-prerelease before
+promotion.
+
 ## Tag And Release
 
 Create an annotated tag from the merged source SHA:

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -209,10 +209,21 @@ attestation against the reviewed release packet and annotated tag:
 npm view neondiff@<version> version dist.integrity dist.shasum gitHead dist.attestations --json
 ```
 
-Only after that identity check passes, complete the interrupted promotion and
-verify the stable channel:
+The preferred recovery is to rerun the serialized `Publish npm` workflow for
+the exact existing release tag. If direct operator recovery is required, run
+it from an isolated checkout of that tag and apply the same channel guard as
+the workflow. Confirm that `release-candidate` still belongs to this exact
+version before changing `latest`:
 
 ```bash
+CURRENT_TAG_VERSION="$(npm view neondiff dist-tags.latest 2>/dev/null || true)"
+EXPECTED_PREDECESSOR="$(node -p "require('./docs/public-release-manifest.json').packageArtifact.previousReleasedPackageVersion")"
+node scripts/npm-release-policy.mjs verify-channel \
+  --current-version "$CURRENT_TAG_VERSION" \
+  --target-version "<version>" \
+  --expected-predecessor "$EXPECTED_PREDECESSOR" \
+  --npm-tag latest
+test "$(npm view neondiff dist-tags.release-candidate)" = "<version>"
 npm dist-tag add neondiff@<version> latest
 test "$(npm view neondiff dist-tags.latest)" = "<version>"
 ```

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -193,7 +193,10 @@ Stable npm publication uses a quarantine dist-tag first. Verify the registry
 integrity, shasum, and `gitHead` against the reviewed pack and annotated tag,
 then promote the package to `latest`. Manual retry runs must resolve the exact
 existing GitHub Release and prove it is published and non-prerelease before
-promotion.
+promotion. All NeonDiff npm releases share one workflow concurrency group.
+Before moving `latest` or `beta`, the workflow also requires the channel to be
+absent, already at the target, or exactly at the manifest-declared predecessor;
+an unexpected channel version blocks promotion instead of moving backward.
 
 ### Partial Quarantine Promotion Recovery
 

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -202,40 +202,28 @@ an unexpected channel version blocks promotion instead of moving backward.
 
 If publication succeeds under `release-candidate` but promotion to `latest`
 does not complete, do not republish, retag, or unpublish the immutable package.
-First compare the package's registry integrity, shasum, `gitHead`, and
-attestation against the reviewed release packet and annotated tag:
+Direct dist-tag mutation is not supported for recovery because it bypasses the
+serialized workflow's registry retries, provenance checks, channel predecessor
+guard, and quarantine ownership check. Rerun the hardened workflow from
+protected `main` for the exact existing release tag:
+
+```bash
+gh workflow run publish-npm.yml \
+  --repo electricsheephq/evaos-code-review-bot-neondiff \
+  --ref main \
+  -f tag=v<version>
+gh run list \
+  --repo electricsheephq/evaos-code-review-bot-neondiff \
+  --workflow publish-npm.yml \
+  --limit 5
+```
+
+After that exact-tag run succeeds, verify the registry package identity and
+stable channel without mutating either one:
 
 ```bash
 npm view neondiff@<version> version dist.integrity dist.shasum gitHead dist.attestations --json
-```
-
-The preferred recovery is to rerun the serialized `Publish npm` workflow for
-the exact existing release tag. If direct operator recovery is required, run
-it from an isolated checkout of that tag and apply the same channel guard as
-the workflow. Confirm that `release-candidate` still belongs to this exact
-version before changing `latest`:
-
-```bash
-CURRENT_TAG_VERSION="$(npm view neondiff dist-tags.latest 2>/dev/null || true)"
-EXPECTED_PREDECESSOR="$(node -p "require('./docs/public-release-manifest.json').packageArtifact.previousReleasedPackageVersion")"
-node scripts/npm-release-policy.mjs verify-channel \
-  --current-version "$CURRENT_TAG_VERSION" \
-  --target-version "<version>" \
-  --expected-predecessor "$EXPECTED_PREDECESSOR" \
-  --npm-tag latest
-test "$(npm view neondiff dist-tags.release-candidate)" = "<version>"
-npm dist-tag add neondiff@<version> latest
 test "$(npm view neondiff dist-tags.latest)" = "<version>"
-```
-
-Remove the quarantine tag only when it still points to the same verified
-version. A different value means another release owns the tag and must not be
-changed by this recovery:
-
-```bash
-if [ "$(npm view neondiff dist-tags.release-candidate 2>/dev/null || true)" = "<version>" ]; then
-  npm dist-tag rm neondiff release-candidate
-fi
 ```
 
 Record the failed workflow URL, registry identity output, repaired dist-tags,

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -195,6 +195,39 @@ then promote the package to `latest`. Manual retry runs must resolve the exact
 existing GitHub Release and prove it is published and non-prerelease before
 promotion.
 
+### Partial Quarantine Promotion Recovery
+
+If publication succeeds under `release-candidate` but promotion to `latest`
+does not complete, do not republish, retag, or unpublish the immutable package.
+First compare the package's registry integrity, shasum, `gitHead`, and
+attestation against the reviewed release packet and annotated tag:
+
+```bash
+npm view neondiff@<version> version dist.integrity dist.shasum gitHead dist.attestations --json
+```
+
+Only after that identity check passes, complete the interrupted promotion and
+verify the stable channel:
+
+```bash
+npm dist-tag add neondiff@<version> latest
+test "$(npm view neondiff dist-tags.latest)" = "<version>"
+```
+
+Remove the quarantine tag only when it still points to the same verified
+version. A different value means another release owns the tag and must not be
+changed by this recovery:
+
+```bash
+if [ "$(npm view neondiff dist-tags.release-candidate 2>/dev/null || true)" = "<version>" ]; then
+  npm dist-tag rm neondiff release-candidate
+fi
+```
+
+Record the failed workflow URL, registry identity output, repaired dist-tags,
+and operator in the release tracker. If any identity field is missing or does
+not match, leave `latest` unchanged and treat the package as quarantined.
+
 ## Tag And Release
 
 Create an annotated tag from the merged source SHA:

--- a/docs/releases/v1.0.3.md
+++ b/docs/releases/v1.0.3.md
@@ -55,7 +55,8 @@ an embedded replacement for the native UI.
   - the tag must be annotated and reachable from protected `main`
   - the declared pre-metadata candidate must be an ancestor of the tag
   - a stable package is rejected from a prerelease-marked GitHub Release
-  - the published registry integrity, shasum, and `gitHead` must match the reviewed tag and dry-run pack
+  - manual retries must resolve the matching existing non-prerelease GitHub Release
+  - new packages publish under a quarantine dist-tag; registry integrity, shasum, and `gitHead` must match the reviewed tag and dry-run pack before promotion to `latest`
 
 Before publication, `release_candidate` and `source_checkout` describe the
 candidate honestly. The manifest gate validates release metadata and proofs; it
@@ -99,3 +100,8 @@ use the launchd label and configuration selected during that installation, for
 example `neondiff daemon start --launchd-label <label> --dry-run false` after
 the package downgrade. Browser dashboard sessions are restarted from the newly
 installed `neondiff@1.0.2` binary.
+
+The manifest's `rollback` fields remain source-checkout revert references to
+satisfy the canonical governance gate. They may be used only in an isolated
+recovery checkout, never against protected `main`; the npm/install commands
+above are the public operator rollback.

--- a/docs/releases/v1.0.3.md
+++ b/docs/releases/v1.0.3.md
@@ -35,8 +35,8 @@ an embedded replacement for the native UI.
 
 - Focused validation:
   - `NODE_OPTIONS=--experimental-sqlite npx vitest run tests/desktop-keychain-startup.test.ts tests/desktop-release-pipeline.test.ts tests/swift-ci-velocity.test.ts tests/public-release-readiness.test.ts tests/release-status.test.ts tests/checkout-issuance-smoke.test.ts --pool=forks --maxWorkers=1`
-  - `swift run NeonDiffDesktopKeychainChecks`
-  - `swift run NeonDiffDesktopCoreSmoke`
+  - `swift run --package-path apps/neondiff-desktop NeonDiffDesktopKeychainChecks`
+  - `swift run --package-path apps/neondiff-desktop NeonDiffDesktopCoreSmoke`
   - `npm run build`
   - `node scripts/check-public-claims.mjs`
   - `node scripts/check-secret-scan.mjs`
@@ -97,7 +97,7 @@ gh release edit v1.0.3 \
 
 The host-specific restart is intentionally not hard-coded here: operators must
 use the launchd label and configuration selected during that installation, for
-example `neondiff daemon start --launchd-label <label> --dry-run false` after
+example `neondiff daemon start --launchd-label <label> --dry-run false --confirm true` after
 the package downgrade. Browser dashboard sessions are restarted from the newly
 installed `neondiff@1.0.2` binary.
 

--- a/docs/releases/v1.0.3.md
+++ b/docs/releases/v1.0.3.md
@@ -51,6 +51,17 @@ an embedded replacement for the native UI.
   - `docs/evidence/v1.0.3-desktop-startup-smoke.json`
 - Release-status public manifest gate:
   - `npx tsx src/cli.ts release-status --expected-head "$(git rev-parse HEAD)" --public-release-manifest docs/public-release-manifest.json --expected-public-version v1.0.3`
+- npm publication governance:
+  - the tag must be annotated and reachable from protected `main`
+  - the declared pre-metadata candidate must be an ancestor of the tag
+  - a stable package is rejected from a prerelease-marked GitHub Release
+  - the published registry integrity, shasum, and `gitHead` must match the reviewed tag and dry-run pack
+
+Before publication, `release_candidate` and `source_checkout` describe the
+candidate honestly. The manifest gate validates release metadata and proofs; it
+does not claim npm or GitHub publication. After the public registry, GitHub
+Release, and installed-package smoke pass, a separate post-release state stamp
+updates `main` to `published` without moving `refs/tags/v1.0.3`.
 
 ## Caveats
 
@@ -64,12 +75,27 @@ an embedded replacement for the native UI.
 
 ## Rollback
 
-```bash
-: "${REPO_ROOT:?set REPO_ROOT to your local NeonDiff checkout}"
+Published npm versions and release tags are immutable provenance. Rollback does
+not delete or rewrite `v1.0.3`, and it never resets a maintainer's `main`
+checkout. Instead:
 
-cd "$REPO_ROOT"
-git fetch origin --tags
-git checkout main
-git reset --hard refs/tags/v1.0.2
+1. Move the public install channel back to the verified `1.0.2` package.
+2. Reinstall `1.0.2` on affected daemon/dashboard hosts.
+3. Restart each host's configured daemon and dashboard process using its own
+   launchd label and config path.
+4. Mark the GitHub `v1.0.3` release as not latest and add an incident note that
+   points users to `v1.0.2`.
+
+```bash
 npm dist-tag add neondiff@1.0.2 latest
+npm install -g neondiff@1.0.2
+gh release edit v1.0.3 \
+  --repo electricsheephq/evaos-code-review-bot-neondiff \
+  --latest=false
 ```
+
+The host-specific restart is intentionally not hard-coded here: operators must
+use the launchd label and configuration selected during that installation, for
+example `neondiff daemon start --launchd-label <label> --dry-run false` after
+the package downgrade. Browser dashboard sessions are restarted from the newly
+installed `neondiff@1.0.2` binary.

--- a/docs/releases/v1.0.3.md
+++ b/docs/releases/v1.0.3.md
@@ -1,0 +1,75 @@
+# v1.0.3
+
+- Release type: stable Mac startup-stability patch
+- Release source SHA: to be stamped by `refs/tags/v1.0.3`
+- Previous stable release: `v1.0.2`
+- Tracking issues / source PR: `#484`, `#503`, `#505`, `#506`
+- Package artifact: `neondiff@1.0.3` after publish
+- Rollback baseline: `v1.0.2`
+
+## Purpose
+
+Publish the Keychain startup-stability fix without changing NeonDiff's public
+1.0 launch boundary. The native Mac app remains the advanced product surface;
+the local HTML dashboard remains a browser preview and setup surface rather than
+an embedded replacement for the native UI.
+
+## Included Changes
+
+- Stop desktop model initialization from decrypting stored GitHub login or
+  expiration values.
+- Use metadata-only Keychain presence queries with
+  `kSecUseAuthenticationUISkip`, including legacy ACL-protected items, without
+  constructing a `LocalAuthentication` context during startup.
+- Preserve interactive Keychain reads for explicit user actions and source
+  compatibility for existing secret-store conformers.
+- Share the detached dashboard argument contract with the displayed command so
+  both paths explicitly use `--operator false`.
+- Pin the Swift PR and unsigned desktop-release workflows to macOS 15, compile
+  the broad and Keychain check targets there, and keep Security-linked helper
+  execution in the local visible-smoke lane.
+- Preserve the advanced native SwiftUI onboarding/provider experience; no
+  WebView or embedded-browser takeover is included.
+
+## Required Gates
+
+- Focused validation:
+  - `NODE_OPTIONS=--experimental-sqlite npx vitest run tests/desktop-keychain-startup.test.ts tests/desktop-release-pipeline.test.ts tests/swift-ci-velocity.test.ts tests/public-release-readiness.test.ts tests/release-status.test.ts tests/checkout-issuance-smoke.test.ts --pool=forks --maxWorkers=1`
+  - `swift run NeonDiffDesktopKeychainChecks`
+  - `swift run NeonDiffDesktopCoreSmoke`
+  - `npm run build`
+  - `node scripts/check-public-claims.mjs`
+  - `node scripts/check-secret-scan.mjs`
+  - `git diff --check`
+- macOS 15 release workflow proof:
+  - [Desktop release smoke run 29049779156](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29049779156)
+- License API proof:
+  - `docs/evidence/v1.0.3-license-api-healthz.json`
+  - `docs/evidence/v1.0.3-license-checkout-issuance-unauthenticated.json`
+  - `docs/evidence/v1.0.3-license-checkout-issuance-authenticated.json`
+- Desktop startup proof:
+  - `docs/evidence/v1.0.3-desktop-startup-smoke.json`
+- Release-status public manifest gate:
+  - `npx tsx src/cli.ts release-status --expected-head "$(git rev-parse HEAD)" --public-release-manifest docs/public-release-manifest.json --expected-public-version v1.0.3`
+
+## Caveats
+
+- This release does not ship signed/notarized desktop artifacts, Sparkle
+  appcast, or auto-update proof. Those remain tracked by `#116` and `#449`.
+- The macOS 15 hosted workflow proves compilation, bundle shape, and unsigned
+  artifact packaging. Visible startup behavior is proven only for the named
+  local unsigned bundle.
+- This release does not claim browser/native dashboard parity, full native
+  desktop maturity, customer-ready installation, or calibrated review accuracy.
+
+## Rollback
+
+```bash
+: "${REPO_ROOT:?set REPO_ROOT to your local NeonDiff checkout}"
+
+cd "$REPO_ROOT"
+git fetch origin --tags
+git checkout main
+git reset --hard refs/tags/v1.0.2
+npm dist-tag add neondiff@1.0.2 latest
+```

--- a/docs/setup-validation.md
+++ b/docs/setup-validation.md
@@ -100,7 +100,7 @@ Validate the package install path first. Use the version named by the docs or
 the issue under test.
 
 Public install proof means the npm package version named by the current stable
-release manifest, for example `neondiff@1.0.2` for the v1.0.2 patch line.
+release manifest, for example `neondiff@1.0.3` for the v1.0.3 patch line.
 Historical source-only beta releases remain provenance/source-checkout releases;
 validate those by source SHA or local build path, not by expecting a new public
 npm artifact.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neondiff",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neondiff",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "neondiff": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neondiff",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
   "bin": {

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -8,7 +8,7 @@ const paths = [
   "docs/license-boundary.md",
   "docs/pricing.md",
   "docs/github-marketplace-free-listing.md",
-  "docs/releases/v1.0.2.md",
+  "docs/releases/v1.0.3.md",
   "docs/releases/v1.0.0.md"
 ];
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-NEONDIFF_VERSION="${NEONDIFF_VERSION:-1.0.2}"
+NEONDIFF_VERSION="${NEONDIFF_VERSION:-1.0.3}"
 DRY_RUN=0
 NPM_PREFIX="${NPM_PREFIX:-}"
 
@@ -13,7 +13,7 @@ Usage:
   sh install.sh [--dry-run] [--prefix /path/to/prefix]
 
 Environment:
-  NEONDIFF_VERSION  Version to install, defaults to 1.0.2.
+  NEONDIFF_VERSION  Version to install, defaults to 1.0.3.
   NPM_PREFIX        Optional npm global prefix.
 
 Requires Node.js 26 or newer and npm.

--- a/scripts/npm-release-policy.mjs
+++ b/scripts/npm-release-policy.mjs
@@ -160,8 +160,13 @@ function verifyPack(args) {
   if (!localPack.shasum || localPack.shasum !== remote["dist.shasum"]) {
     fail("npm tarball shasum does not match the reviewed pack");
   }
-  if (expectedGitHead && remote.gitHead !== expectedGitHead) {
-    fail("npm gitHead does not match the reviewed release tag commit");
+  if (expectedGitHead) {
+    if (typeof remote.gitHead !== "string" || remote.gitHead.length === 0) {
+      fail("npm gitHead is missing from published package metadata");
+    }
+    if (remote.gitHead !== expectedGitHead) {
+      fail("npm gitHead does not match the reviewed release tag commit");
+    }
   }
   console.log(JSON.stringify({
     version: expectedVersion,

--- a/scripts/npm-release-policy.mjs
+++ b/scripts/npm-release-policy.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+import { appendFileSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function parseArgs(values) {
+  const parsed = new Map();
+  for (let index = 0; index < values.length; index += 2) {
+    const key = values[index];
+    const value = values[index + 1];
+    if (!key?.startsWith("--") || value === undefined) fail(`invalid argument list near ${key ?? "(missing)"}`);
+    parsed.set(key.slice(2), value);
+  }
+  return parsed;
+}
+
+function required(args, name) {
+  const value = args.get(name);
+  if (!value) fail(`--${name} is required`);
+  return value;
+}
+
+function parseBoolean(value, name) {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  fail(`--${name} must be true or false`);
+}
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function isAncestor(ancestor, descendant) {
+  try {
+    execFileSync("git", ["merge-base", "--is-ancestor", ancestor, descendant], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function classify(args) {
+  const eventName = required(args, "event-name");
+  const releasePrerelease = parseBoolean(required(args, "release-prerelease"), "release-prerelease");
+  const tag = required(args, "tag");
+  const packageVersion = required(args, "package-version");
+  const releaseLevel = required(args, "release-level");
+  let skippedVersions;
+  try {
+    skippedVersions = JSON.parse(required(args, "skipped-versions-json"));
+  } catch {
+    fail("--skipped-versions-json must be valid JSON");
+  }
+  if (!Array.isArray(skippedVersions) || !skippedVersions.every((value) => typeof value === "string")) {
+    fail("--skipped-versions-json must be a JSON array of strings");
+  }
+
+  const npmTag = packageVersion.includes("-") ? "beta" : "latest";
+  if (eventName === "release" && releasePrerelease && npmTag === "latest") {
+    fail("stable npm packages require a non-prerelease GitHub Release");
+  }
+
+  let shouldPublish = true;
+  if (tag !== `v${packageVersion}`) {
+    if (eventName === "workflow_dispatch") {
+      fail(`manual npm publish tag ${tag} does not match package.json version v${packageVersion}`);
+    }
+    if (releaseLevel === "source-beta" && skippedVersions.includes(tag)) {
+      shouldPublish = false;
+    } else {
+      fail(`release tag ${tag} does not match package.json version v${packageVersion}`);
+    }
+  }
+
+  const result = { shouldPublish, npmTag };
+  const githubOutput = args.get("github-output");
+  if (githubOutput) {
+    appendFileSync(githubOutput, `should_publish=${shouldPublish}\nnpm_tag=${npmTag}\n`, { encoding: "utf8" });
+  }
+  console.log(JSON.stringify(result));
+}
+
+function verifyGit(args) {
+  const tag = required(args, "tag");
+  const candidateHead = required(args, "candidate-head");
+  const mainRef = required(args, "main-ref");
+  if (!/^[0-9a-f]{40}$/i.test(candidateHead)) fail("candidate head must be a full 40-character Git SHA");
+
+  let tagType;
+  try {
+    tagType = git(["cat-file", "-t", tag]);
+  } catch {
+    fail(`release tag ${tag} is missing`);
+  }
+  if (tagType !== "tag") fail("release tag must be annotated");
+
+  let tagCommit;
+  try {
+    tagCommit = git(["rev-list", "-n", "1", tag]);
+    git(["rev-parse", "--verify", `${candidateHead}^{commit}`]);
+    git(["rev-parse", "--verify", `${mainRef}^{commit}`]);
+  } catch {
+    fail("release tag, candidate head, or protected main ref is not a valid commit");
+  }
+  if (!isAncestor(tagCommit, mainRef)) {
+    fail("release tag commit must be an ancestor of protected main");
+  }
+  if (!isAncestor(candidateHead, tagCommit)) {
+    fail("declared release candidate head must be an ancestor of the release tag commit");
+  }
+  console.log(JSON.stringify({ tag, tagCommit, candidateHead, mainRef }));
+}
+
+function verifyPack(args) {
+  const localPackPath = required(args, "local-pack");
+  const remoteMetadataPath = required(args, "remote-metadata");
+  const expectedVersion = required(args, "expected-version");
+  const expectedGitHead = args.get("expected-git-head");
+  let localPack;
+  let remote;
+  try {
+    [localPack] = JSON.parse(readFileSync(localPackPath, "utf8"));
+    remote = JSON.parse(readFileSync(remoteMetadataPath, "utf8"));
+  } catch {
+    fail("local pack or remote npm metadata is not valid JSON");
+  }
+  if (localPack?.version !== expectedVersion || remote?.version !== expectedVersion) {
+    fail(`npm package version must match ${expectedVersion}`);
+  }
+  if (!localPack.integrity || localPack.integrity !== remote["dist.integrity"]) {
+    fail("npm tarball integrity does not match the reviewed pack");
+  }
+  if (!localPack.shasum || localPack.shasum !== remote["dist.shasum"]) {
+    fail("npm tarball shasum does not match the reviewed pack");
+  }
+  if (expectedGitHead && remote.gitHead !== expectedGitHead) {
+    fail("npm gitHead does not match the reviewed release tag commit");
+  }
+  console.log(JSON.stringify({
+    version: expectedVersion,
+    integrity: localPack.integrity,
+    shasum: localPack.shasum,
+    gitHead: remote.gitHead
+  }));
+}
+
+const [command, ...rawArgs] = process.argv.slice(2);
+const args = parseArgs(rawArgs);
+if (command === "classify") classify(args);
+else if (command === "verify-git") verifyGit(args);
+else if (command === "verify-pack") verifyPack(args);
+else fail("command must be classify, verify-git, or verify-pack");

--- a/scripts/npm-release-policy.mjs
+++ b/scripts/npm-release-policy.mjs
@@ -64,6 +64,9 @@ function classify(args) {
   if (eventName === "release" && releasePrerelease && npmTag === "latest") {
     fail("stable npm packages require a non-prerelease GitHub Release");
   }
+  if (eventName === "release" && !releasePrerelease && npmTag === "beta") {
+    fail("beta npm packages require a prerelease GitHub Release");
+  }
   if (eventName === "workflow_dispatch") {
     const releaseMetadataPath = args.get("release-metadata");
     if (!releaseMetadataPath && npmTag === "latest") {
@@ -176,9 +179,31 @@ function verifyPack(args) {
   }));
 }
 
+function verifyChannel(args) {
+  const currentVersion = args.get("current-version") ?? "";
+  const targetVersion = required(args, "target-version");
+  const expectedPredecessor = required(args, "expected-predecessor");
+  const npmTag = required(args, "npm-tag");
+  const validVersion = /^[0-9A-Za-z][0-9A-Za-z.+-]{0,127}$/;
+  if (!validVersion.test(targetVersion) || !validVersion.test(expectedPredecessor)) {
+    fail("target and expected predecessor must be bounded npm package versions");
+  }
+  if (currentVersion && !validVersion.test(currentVersion)) {
+    fail("current npm channel version must be a bounded npm package version");
+  }
+  if (npmTag !== "latest" && npmTag !== "beta") {
+    fail("npm tag must be latest or beta");
+  }
+  if (currentVersion && currentVersion !== targetVersion && currentVersion !== expectedPredecessor) {
+    fail(`refusing to move npm dist-tag ${npmTag} from unexpected ${currentVersion} to ${targetVersion}`);
+  }
+  console.log(JSON.stringify({ npmTag, currentVersion, targetVersion, expectedPredecessor }));
+}
+
 const [command, ...rawArgs] = process.argv.slice(2);
 const args = parseArgs(rawArgs);
 if (command === "classify") classify(args);
 else if (command === "verify-git") verifyGit(args);
 else if (command === "verify-pack") verifyPack(args);
-else fail("command must be classify, verify-git, or verify-pack");
+else if (command === "verify-channel") verifyChannel(args);
+else fail("command must be classify, verify-git, verify-pack, or verify-channel");

--- a/scripts/npm-release-policy.mjs
+++ b/scripts/npm-release-policy.mjs
@@ -64,6 +64,28 @@ function classify(args) {
   if (eventName === "release" && releasePrerelease && npmTag === "latest") {
     fail("stable npm packages require a non-prerelease GitHub Release");
   }
+  if (eventName === "workflow_dispatch") {
+    const releaseMetadataPath = args.get("release-metadata");
+    if (!releaseMetadataPath && npmTag === "latest") {
+      fail("manual stable publish requires an existing non-prerelease GitHub Release");
+    }
+    if (!releaseMetadataPath) fail("manual npm publish requires existing GitHub Release metadata");
+    let releaseMetadata;
+    try {
+      releaseMetadata = JSON.parse(readFileSync(releaseMetadataPath, "utf8"));
+    } catch {
+      fail("manual npm publish release metadata is not valid JSON");
+    }
+    if (releaseMetadata.tag_name !== tag || releaseMetadata.draft !== false) {
+      fail("manual npm publish requires matching published GitHub Release metadata");
+    }
+    if (npmTag === "latest" && releaseMetadata.prerelease !== false) {
+      fail("manual stable publish requires an existing non-prerelease GitHub Release");
+    }
+    if (npmTag === "beta" && releaseMetadata.prerelease !== true) {
+      fail("manual beta publish requires an existing prerelease GitHub Release");
+    }
+  }
 
   let shouldPublish = true;
   if (tag !== `v${packageVersion}`) {

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -885,10 +885,6 @@ function checkRollbackCommand(
   if (resetTarget) return checkRollbackTarget(resetTarget, options);
   const revertTarget = command.match(/^git\s+revert\s+(?:--no-edit\s+)?([^\s;&|]+)$/)?.[1];
   if (revertTarget) return checkRollbackTarget(revertTarget, options);
-  const npmDistTagVersion = command.match(/^npm\s+dist-tag\s+add\s+neondiff@([^\s;&|]+)\s+latest$/)?.[1];
-  if (npmDistTagVersion && isSemver(npmDistTagVersion)) return { ok: true, missingMetadata: "rollback command" };
-  const npmInstallVersion = command.match(/^npm\s+install\s+-g\s+neondiff@([^\s;&|]+)$/)?.[1];
-  if (npmInstallVersion && isSemver(npmInstallVersion)) return { ok: true, missingMetadata: "rollback command" };
   return { ok: false, missingMetadata: "rollback command" };
 }
 

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -885,6 +885,10 @@ function checkRollbackCommand(
   if (resetTarget) return checkRollbackTarget(resetTarget, options);
   const revertTarget = command.match(/^git\s+revert\s+(?:--no-edit\s+)?([^\s;&|]+)$/)?.[1];
   if (revertTarget) return checkRollbackTarget(revertTarget, options);
+  const npmDistTagVersion = command.match(/^npm\s+dist-tag\s+add\s+neondiff@([^\s;&|]+)\s+latest$/)?.[1];
+  if (npmDistTagVersion && isSemver(npmDistTagVersion)) return { ok: true, missingMetadata: "rollback command" };
+  const npmInstallVersion = command.match(/^npm\s+install\s+-g\s+neondiff@([^\s;&|]+)$/)?.[1];
+  if (npmInstallVersion && isSemver(npmInstallVersion)) return { ok: true, missingMetadata: "rollback command" };
   return { ok: false, missingMetadata: "rollback command" };
 }
 

--- a/tests/npm-release-policy.test.ts
+++ b/tests/npm-release-policy.test.ts
@@ -194,5 +194,21 @@ describe("npm release policy", () => {
     ], { encoding: "utf8" });
     expect(gitHeadRejected.status).not.toBe(0);
     expect(gitHeadRejected.stderr).toContain("npm gitHead does not match the reviewed release tag commit");
+
+    writeFileSync(remotePath, JSON.stringify({
+      version: "1.0.3",
+      "dist.integrity": "sha512-reviewed",
+      "dist.shasum": "1111111111111111111111111111111111111111"
+    }));
+    const missingGitHeadRejected = spawnSync(process.execPath, [
+      policyScript,
+      "verify-pack",
+      "--local-pack", localPath,
+      "--remote-metadata", remotePath,
+      "--expected-version", "1.0.3",
+      "--expected-git-head", "1111111111111111111111111111111111111111"
+    ], { encoding: "utf8" });
+    expect(missingGitHeadRejected.status).not.toBe(0);
+    expect(missingGitHeadRejected.stderr).toContain("npm gitHead is missing from published package metadata");
   });
 });

--- a/tests/npm-release-policy.test.ts
+++ b/tests/npm-release-policy.test.ts
@@ -121,6 +121,19 @@ describe("npm release policy", () => {
     ], { cwd: root, encoding: "utf8" });
     expect(rejected.status).not.toBe(0);
     expect(rejected.stderr).toContain("release tag commit must be an ancestor of protected main");
+
+    const unsafeCandidate = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    execFileSync("git", ["checkout", "main"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["tag", "-a", "v1.0.5", "-m", "v1.0.5"], { cwd: root });
+    const candidateRejected = spawnSync(process.execPath, [
+      policyScript,
+      "verify-git",
+      "--tag", "v1.0.5",
+      "--candidate-head", unsafeCandidate,
+      "--main-ref", "refs/remotes/origin/main"
+    ], { cwd: root, encoding: "utf8" });
+    expect(candidateRejected.status).not.toBe(0);
+    expect(candidateRejected.stderr).toContain("declared release candidate head must be an ancestor of the release tag commit");
   });
 
   it("rejects an existing npm tarball whose integrity differs from the reviewed pack", () => {
@@ -149,5 +162,37 @@ describe("npm release policy", () => {
 
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("npm tarball integrity does not match the reviewed pack");
+
+    writeFileSync(remotePath, JSON.stringify({
+      version: "1.0.3",
+      "dist.integrity": "sha512-reviewed",
+      "dist.shasum": "2222222222222222222222222222222222222222"
+    }));
+    const shasumRejected = spawnSync(process.execPath, [
+      policyScript,
+      "verify-pack",
+      "--local-pack", localPath,
+      "--remote-metadata", remotePath,
+      "--expected-version", "1.0.3"
+    ], { encoding: "utf8" });
+    expect(shasumRejected.status).not.toBe(0);
+    expect(shasumRejected.stderr).toContain("npm tarball shasum does not match the reviewed pack");
+
+    writeFileSync(remotePath, JSON.stringify({
+      version: "1.0.3",
+      "dist.integrity": "sha512-reviewed",
+      "dist.shasum": "1111111111111111111111111111111111111111",
+      gitHead: "2222222222222222222222222222222222222222"
+    }));
+    const gitHeadRejected = spawnSync(process.execPath, [
+      policyScript,
+      "verify-pack",
+      "--local-pack", localPath,
+      "--remote-metadata", remotePath,
+      "--expected-version", "1.0.3",
+      "--expected-git-head", "1111111111111111111111111111111111111111"
+    ], { encoding: "utf8" });
+    expect(gitHeadRejected.status).not.toBe(0);
+    expect(gitHeadRejected.stderr).toContain("npm gitHead does not match the reviewed release tag commit");
   });
 });

--- a/tests/npm-release-policy.test.ts
+++ b/tests/npm-release-policy.test.ts
@@ -1,0 +1,116 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+describe("npm release policy", () => {
+  const roots: string[] = [];
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const policyScript = join(repoRoot, "scripts", "npm-release-policy.mjs");
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("rejects a stable npm package from a prerelease GitHub Release", () => {
+    const result = spawnSync(process.execPath, [
+      policyScript,
+      "classify",
+      "--event-name", "release",
+      "--release-prerelease", "true",
+      "--tag", "v1.0.3",
+      "--package-version", "1.0.3",
+      "--release-level", "stable",
+      "--skipped-versions-json", "[]"
+    ], { encoding: "utf8" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("stable npm packages require a non-prerelease GitHub Release");
+  });
+
+  it("classifies a matching stable release for npm latest", () => {
+    const output = execFileSync(process.execPath, [
+      policyScript,
+      "classify",
+      "--event-name", "release",
+      "--release-prerelease", "false",
+      "--tag", "v1.0.3",
+      "--package-version", "1.0.3",
+      "--release-level", "stable",
+      "--skipped-versions-json", "[]"
+    ], { encoding: "utf8" });
+
+    expect(JSON.parse(output)).toEqual({ shouldPublish: true, npmTag: "latest" });
+  });
+
+  it("requires the release tag and declared candidate to be ancestors of protected main", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-npm-release-policy-"));
+    roots.push(root);
+    execFileSync("git", ["init", "-b", "main"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "release-policy@example.invalid"], { cwd: root });
+    execFileSync("git", ["config", "user.name", "Release Policy Test"], { cwd: root });
+    writeFileSync(join(root, "candidate.txt"), "candidate\n");
+    execFileSync("git", ["add", "candidate.txt"], { cwd: root });
+    execFileSync("git", ["commit", "-m", "candidate"], { cwd: root, stdio: "ignore" });
+    const candidate = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    writeFileSync(join(root, "release.txt"), "release\n");
+    execFileSync("git", ["add", "release.txt"], { cwd: root });
+    execFileSync("git", ["commit", "-m", "release"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["tag", "-a", "v1.0.3", "-m", "v1.0.3"], { cwd: root });
+    execFileSync("git", ["update-ref", "refs/remotes/origin/main", "HEAD"], { cwd: root });
+
+    expect(() => execFileSync(process.execPath, [
+      policyScript,
+      "verify-git",
+      "--tag", "v1.0.3",
+      "--candidate-head", candidate,
+      "--main-ref", "refs/remotes/origin/main"
+    ], { cwd: root, stdio: "pipe" })).not.toThrow();
+
+    execFileSync("git", ["checkout", "-b", "unsafe", candidate], { cwd: root, stdio: "ignore" });
+    writeFileSync(join(root, "unsafe.txt"), "unsafe\n");
+    execFileSync("git", ["add", "unsafe.txt"], { cwd: root });
+    execFileSync("git", ["commit", "-m", "unsafe"], { cwd: root, stdio: "ignore" });
+    execFileSync("git", ["tag", "-a", "v1.0.4", "-m", "v1.0.4"], { cwd: root });
+
+    const rejected = spawnSync(process.execPath, [
+      policyScript,
+      "verify-git",
+      "--tag", "v1.0.4",
+      "--candidate-head", candidate,
+      "--main-ref", "refs/remotes/origin/main"
+    ], { cwd: root, encoding: "utf8" });
+    expect(rejected.status).not.toBe(0);
+    expect(rejected.stderr).toContain("release tag commit must be an ancestor of protected main");
+  });
+
+  it("rejects an existing npm tarball whose integrity differs from the reviewed pack", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-npm-pack-integrity-"));
+    roots.push(root);
+    const localPath = join(root, "pack.json");
+    const remotePath = join(root, "remote.json");
+    writeFileSync(localPath, JSON.stringify([{
+      version: "1.0.3",
+      integrity: "sha512-reviewed",
+      shasum: "1111111111111111111111111111111111111111"
+    }]));
+    writeFileSync(remotePath, JSON.stringify({
+      version: "1.0.3",
+      "dist.integrity": "sha512-different",
+      "dist.shasum": "2222222222222222222222222222222222222222"
+    }));
+
+    const result = spawnSync(process.execPath, [
+      policyScript,
+      "verify-pack",
+      "--local-pack", localPath,
+      "--remote-metadata", remotePath,
+      "--expected-version", "1.0.3"
+    ], { encoding: "utf8" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("npm tarball integrity does not match the reviewed pack");
+  });
+});

--- a/tests/npm-release-policy.test.ts
+++ b/tests/npm-release-policy.test.ts
@@ -30,6 +30,22 @@ describe("npm release policy", () => {
     expect(result.stderr).toContain("stable npm packages require a non-prerelease GitHub Release");
   });
 
+  it("rejects a beta npm package from a non-prerelease GitHub Release", () => {
+    const result = spawnSync(process.execPath, [
+      policyScript,
+      "classify",
+      "--event-name", "release",
+      "--release-prerelease", "false",
+      "--tag", "v1.1.0-beta.1",
+      "--package-version", "1.1.0-beta.1",
+      "--release-level", "beta",
+      "--skipped-versions-json", "[]"
+    ], { encoding: "utf8" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("beta npm packages require a prerelease GitHub Release");
+  });
+
   it("classifies a matching stable release for npm latest", () => {
     const output = execFileSync(process.execPath, [
       policyScript,
@@ -229,5 +245,35 @@ describe("npm release policy", () => {
 
     expect(pack.integrity).toMatch(/^sha512-/);
     expect(pack.shasum).toMatch(/^[a-f0-9]{40}$/);
+  });
+
+  it("allows only absent, identical, or manifest-declared predecessor channel values", () => {
+    for (const currentVersion of ["", "1.0.2", "1.0.3"]) {
+      const output = execFileSync(process.execPath, [
+        policyScript,
+        "verify-channel",
+        "--current-version", currentVersion,
+        "--target-version", "1.0.3",
+        "--expected-predecessor", "1.0.2",
+        "--npm-tag", "latest"
+      ], { encoding: "utf8" });
+      expect(JSON.parse(output)).toEqual({
+        npmTag: "latest",
+        currentVersion,
+        targetVersion: "1.0.3",
+        expectedPredecessor: "1.0.2"
+      });
+    }
+
+    const rejected = spawnSync(process.execPath, [
+      policyScript,
+      "verify-channel",
+      "--current-version", "1.0.4",
+      "--target-version", "1.0.3",
+      "--expected-predecessor", "1.0.2",
+      "--npm-tag", "latest"
+    ], { encoding: "utf8" });
+    expect(rejected.status).not.toBe(0);
+    expect(rejected.stderr).toContain("refusing to move npm dist-tag latest from unexpected 1.0.4 to 1.0.3");
   });
 });

--- a/tests/npm-release-policy.test.ts
+++ b/tests/npm-release-policy.test.ts
@@ -211,4 +211,23 @@ describe("npm release policy", () => {
     expect(missingGitHeadRejected.status).not.toBe(0);
     expect(missingGitHeadRejected.stderr).toContain("npm gitHead is missing from published package metadata");
   });
+
+  it("receives integrity and shasum from the npm dry-run pack used by the publish gate", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-npm-pack-dry-run-"));
+    roots.push(root);
+    writeFileSync(join(root, "package.json"), JSON.stringify({
+      name: "neondiff-pack-shape-probe",
+      version: "1.0.3",
+      files: ["index.js"]
+    }));
+    writeFileSync(join(root, "index.js"), "export const probe = true;\n");
+
+    const [pack] = JSON.parse(execFileSync("npm", ["pack", "--dry-run", "--json"], {
+      cwd: root,
+      encoding: "utf8"
+    })) as Array<{ integrity?: string; shasum?: string }>;
+
+    expect(pack.integrity).toMatch(/^sha512-/);
+    expect(pack.shasum).toMatch(/^[a-f0-9]{40}$/);
+  });
 });

--- a/tests/npm-release-policy.test.ts
+++ b/tests/npm-release-policy.test.ts
@@ -45,6 +45,43 @@ describe("npm release policy", () => {
     expect(JSON.parse(output)).toEqual({ shouldPublish: true, npmTag: "latest" });
   });
 
+  it("requires manual stable retries to prove an existing non-prerelease GitHub Release", () => {
+    const result = spawnSync(process.execPath, [
+      policyScript,
+      "classify",
+      "--event-name", "workflow_dispatch",
+      "--release-prerelease", "false",
+      "--tag", "v1.0.3",
+      "--package-version", "1.0.3",
+      "--release-level", "stable",
+      "--skipped-versions-json", "[]"
+    ], { encoding: "utf8" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("manual stable publish requires an existing non-prerelease GitHub Release");
+  });
+
+  it("accepts a manual stable retry only with matching published release metadata", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-manual-release-metadata-"));
+    roots.push(root);
+    const metadataPath = join(root, "release.json");
+    writeFileSync(metadataPath, JSON.stringify({ tag_name: "v1.0.3", draft: false, prerelease: false }));
+
+    const output = execFileSync(process.execPath, [
+      policyScript,
+      "classify",
+      "--event-name", "workflow_dispatch",
+      "--release-prerelease", "false",
+      "--tag", "v1.0.3",
+      "--package-version", "1.0.3",
+      "--release-level", "stable",
+      "--skipped-versions-json", "[]",
+      "--release-metadata", metadataPath
+    ], { encoding: "utf8" });
+
+    expect(JSON.parse(output)).toEqual({ shouldPublish: true, npmTag: "latest" });
+  });
+
   it("requires the release tag and declared candidate to be ancestors of protected main", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-npm-release-policy-"));
     roots.push(root);

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -209,6 +209,7 @@ describe("NeonDiff public release readiness", () => {
     const proof = JSON.parse(read(manifest.licenseApi?.healthProofPath ?? "")) as {
       evidenceKind?: string;
       releaseVersion?: string;
+      observedAt?: string;
       url?: string;
       statusCode?: number;
       responseBody?: string;
@@ -226,6 +227,7 @@ describe("NeonDiff public release readiness", () => {
     const issuanceProof = JSON.parse(read(manifest.licenseApi?.checkoutIssuanceProofPath ?? "")) as {
       evidenceKind?: string;
       releaseVersion?: string;
+      observedAt?: string;
       statusCode?: number;
       responseBody?: string;
       responseBodySha256?: string;
@@ -237,6 +239,7 @@ describe("NeonDiff public release readiness", () => {
       responseBody: expect.stringContaining("\"unauthorized\"")
     });
     expect(createHash("sha256").update(issuanceProof.responseBody ?? "").digest("hex")).toBe(issuanceProof.responseBodySha256);
+    expect(issuanceProof.observedAt).not.toBe(proof.observedAt);
 
     const authenticatedProof = JSON.parse(read(manifest.licenseApi?.checkoutIssuanceAuthenticatedProofPath ?? "")) as {
       evidenceKind?: string;
@@ -420,6 +423,7 @@ describe("NeonDiff public release readiness", () => {
       }
     });
     expect(desktopProof.artifactRelationship?.verification).not.toContain(".github/workflows/swift-desktop.yml");
+    expect(JSON.stringify(desktopProof)).not.toContain("appcastChecksPassed");
     expect(desktopProof.proofBoundary).toMatch(/signing/i);
     expect(JSON.stringify(desktopProof)).not.toMatch(/\/Volumes\/LEXAR|\/Users\/lume|ghp_|github_pat_|nd_live_|session_id=/);
   });
@@ -519,6 +523,7 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/cancel-in-progress:\s*false/);
     expect(publish).toContain("actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0");
     expect(publish).toContain("actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5");
+    expect(publish).toMatch(/persist-credentials:\s*false/);
     expect(publish).not.toMatch(/uses:\s*actions\/(?:checkout|setup-node)@v\d+/);
     expect(publish).toMatch(/NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
     expect(publish).toMatch(/Verify npm publish token is configured/);
@@ -557,5 +562,10 @@ describe("NeonDiff public release readiness", () => {
     );
     expect(publish).toMatch(/default:\s*v1\.0\.3/);
     expect(publish).not.toMatch(/default:\s*v0\.4\.30-beta\.1/);
+
+    const governance = read("docs/release-governance.md");
+    expect(governance).toMatch(/partial quarantine promotion/i);
+    expect(governance).toMatch(/npm dist-tag add neondiff@<version> latest/);
+    expect(governance).toMatch(/npm dist-tag rm neondiff release-candidate/);
   });
 });

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -154,19 +154,19 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.updateChannels?.browserDashboard).toMatchObject({
       requiredForThisRelease: true,
       state: "source_checkout",
-      rollback: "npm install -g neondiff@1.0.2",
+      rollback: "git reset --hard refs/tags/v1.0.2",
       rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
       trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     });
     expect(manifest.updateChannels?.cli).toMatchObject({
       requiredForThisRelease: true,
       state: "source_checkout",
-      rollback: "npm dist-tag add neondiff@1.0.2 latest"
+      rollback: "git reset --hard refs/tags/v1.0.2"
     });
     expect(manifest.updateChannels?.daemon).toMatchObject({
       requiredForThisRelease: true,
       state: "source_checkout",
-      rollback: "npm install -g neondiff@1.0.2"
+      rollback: "git reset --hard refs/tags/v1.0.2"
     });
     expect(manifest.updateChannels?.website).toBeUndefined();
     expect(manifest.updateChannels?.desktop).toBeUndefined();
@@ -298,6 +298,7 @@ describe("NeonDiff public release readiness", () => {
       channels?: Record<string, {
         rollbackRepository?: string;
         rollbackCommand?: string;
+        operatorRollbackCommand?: string;
         rollbackTarget?: string;
         targetVerifiedBy?: string;
         targetVerifiedSha?: string;
@@ -312,6 +313,7 @@ describe("NeonDiff public release readiness", () => {
         cli: {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.cli?.rollback,
+          operatorRollbackCommand: "npm dist-tag add neondiff@1.0.2 latest",
           rollbackTarget: "v1.0.2",
           targetVerifiedBy: "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
           targetVerifiedShasum: "d62619b1ee2c539e3230572135a29a299be3a6ed"
@@ -319,6 +321,7 @@ describe("NeonDiff public release readiness", () => {
         browserDashboard: {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.browserDashboard?.rollback,
+          operatorRollbackCommand: "npm install -g neondiff@1.0.2",
           rollbackTarget: "v1.0.2",
           targetVerifiedBy: "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
           targetVerifiedShasum: "d62619b1ee2c539e3230572135a29a299be3a6ed"
@@ -326,6 +329,7 @@ describe("NeonDiff public release readiness", () => {
         daemon: {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.daemon?.rollback,
+          operatorRollbackCommand: "npm install -g neondiff@1.0.2",
           rollbackTarget: "v1.0.2",
           targetVerifiedBy: "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
           targetVerifiedShasum: "d62619b1ee2c539e3230572135a29a299be3a6ed"
@@ -504,13 +508,13 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/NPM_TOKEN Actions secret is not configured; publish cannot continue/);
     expect(publish).toMatch(/npm publish --provenance/);
     expect(releasePolicy).toMatch(/npmTag = packageVersion\.includes\("-"\) \? "beta" : "latest"/);
-    expect(publish).toMatch(/--tag "\$NPM_TAG"/);
     expect(publish).toMatch(/github\.event_name == 'release'/);
     expect(publish).toMatch(/environment:\s*npm-publish/);
     expect(publish).toMatch(/fetch-depth:\s*0/);
     expect(publish).toMatch(/npm-release-policy\.mjs classify/);
     expect(publish).toMatch(/npm-release-policy\.mjs verify-git/);
     expect(publish).toMatch(/npm-release-policy\.mjs verify-pack/);
+    expect(publish).toMatch(/gh api "repos\/\$GITHUB_REPOSITORY\/releases\/tags\/\$RELEASE_TAG"/);
     expect(releasePolicy).toMatch(/stable npm packages require a non-prerelease GitHub Release/);
     expect(publish).toMatch(/release tag commit must be an ancestor of protected main/i);
     expect(releasePolicy).toMatch(/npm tarball integrity does not match the reviewed pack/);
@@ -523,6 +527,13 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/require\('\.\/package\.json'\)\.version/);
     expect(publish).toMatch(/already exists; verifying reviewed tarball identity/);
     expect(publish).toMatch(/dist-tags\.\$NPM_TAG/);
+    expect(publish).toMatch(/npm publish --provenance --access public --tag "release-candidate"/);
+    expect(publish.indexOf('npm publish --provenance --access public --tag "release-candidate"')).toBeLessThan(
+      publish.indexOf("npm-release-policy.mjs verify-pack")
+    );
+    expect(publish.indexOf("npm-release-policy.mjs verify-pack")).toBeLessThan(
+      publish.indexOf('npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"')
+    );
     expect(publish).toMatch(/default:\s*v1\.0\.3/);
     expect(publish).not.toMatch(/default:\s*v0\.4\.30-beta\.1/);
   });

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -515,6 +515,7 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/npm-release-policy\.mjs verify-git/);
     expect(publish).toMatch(/npm-release-policy\.mjs verify-pack/);
     expect(publish).toMatch(/gh api "repos\/\$GITHUB_REPOSITORY\/releases\/tags\/\$RELEASE_TAG"/);
+    expect(publish).toMatch(/GH_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/);
     expect(releasePolicy).toMatch(/stable npm packages require a non-prerelease GitHub Release/);
     expect(publish).toMatch(/release tag commit must be an ancestor of protected main/i);
     expect(releasePolicy).toMatch(/npm tarball integrity does not match the reviewed pack/);

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -374,6 +374,12 @@ describe("NeonDiff public release readiness", () => {
         localPathsRemoved?: boolean;
         tokensRemoved?: boolean;
       };
+      artifactRelationship?: {
+        visibleLocalBundleSourceIsCandidateAncestor?: boolean;
+        hostedWorkflowSourceIsCandidateAncestor?: boolean;
+        visibleLocalSourcesMatchMergedCandidate?: boolean;
+        hostedReleaseSurfaceMatchesMergedCandidate?: boolean;
+      };
     };
     expect(desktopProof).toMatchObject({
       evidenceKind: "desktop_startup_smoke_redacted",
@@ -401,6 +407,12 @@ describe("NeonDiff public release readiness", () => {
       redaction: {
         localPathsRemoved: true,
         tokensRemoved: true
+      },
+      artifactRelationship: {
+        visibleLocalBundleSourceIsCandidateAncestor: false,
+        hostedWorkflowSourceIsCandidateAncestor: false,
+        visibleLocalSourcesMatchMergedCandidate: true,
+        hostedReleaseSurfaceMatchesMergedCandidate: true
       }
     });
     expect(desktopProof.proofBoundary).toMatch(/signing/i);

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -519,7 +519,7 @@ describe("NeonDiff public release readiness", () => {
     expect(ci).toMatch(/secret/i);
 
     expect(publish).toMatch(/id-token:\s*write/);
-    expect(publish).toMatch(/concurrency:\s*\n\s*group:\s*publish-npm-\$\{\{\s*github\.event\.inputs\.tag\s*\|\|\s*github\.event\.release\.tag_name\s*\|\|\s*github\.ref\s*\}\}/);
+    expect(publish).toMatch(/concurrency:\s*\n\s*group:\s*publish-npm-neondiff/);
     expect(publish).toMatch(/cancel-in-progress:\s*false/);
     expect(publish).toContain("actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0");
     expect(publish).toContain("actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5");
@@ -536,6 +536,7 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/npm-release-policy\.mjs classify/);
     expect(publish).toMatch(/npm-release-policy\.mjs verify-git/);
     expect(publish).toMatch(/npm-release-policy\.mjs verify-pack/);
+    expect(publish).toMatch(/npm-release-policy\.mjs verify-channel/);
     expect(publish).toMatch(/gh api "repos\/\$GITHUB_REPOSITORY\/releases\/tags\/\$RELEASE_TAG"/);
     expect(publish).toMatch(/GH_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/);
     expect(releasePolicy).toMatch(/stable npm packages require a non-prerelease GitHub Release/);
@@ -553,6 +554,7 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/JSON\.parse/);
     expect(publish).toMatch(/npm registry metadata remained unavailable or invalid after retries/);
     expect(publish).toMatch(/dist-tags\.\$NPM_TAG/);
+    expect(publish).toMatch(/previousReleasedPackageVersion/);
     expect(publish).toMatch(/npm publish --provenance --access public --tag "release-candidate"/);
     expect(publish.indexOf('npm publish --provenance --access public --tag "release-candidate"')).toBeLessThan(
       publish.indexOf("npm-release-policy.mjs verify-pack")

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -349,6 +349,7 @@ describe("NeonDiff public release readiness", () => {
     const desktopProof = JSON.parse(read("docs/evidence/v1.0.3-desktop-startup-smoke.json")) as {
       evidenceKind?: string;
       releaseVersion?: string;
+      sourceCommitUrl?: string;
       proofBoundary?: string;
       bundleId?: string;
       binarySha256?: string;
@@ -385,6 +386,7 @@ describe("NeonDiff public release readiness", () => {
     expect(desktopProof).toMatchObject({
       evidenceKind: "desktop_startup_smoke_redacted",
       releaseVersion: "v1.0.3",
+      sourceCommitUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/commit/b22b81ca85a41abe888f3054eea25bb397d08d68",
       bundleId: "com.electricsheephq.NeonDiffDesktop",
       binarySha256: expect.stringMatching(/^[a-f0-9]{64}$/),
       signingIdentityClass: "unsigned-dev",
@@ -542,6 +544,9 @@ describe("NeonDiff public release readiness", () => {
     expect(publish.match(/if: steps\.package_release\.outputs\.should_publish == 'true'/g)).toHaveLength(6);
     expect(publish).toMatch(/require\('\.\/package\.json'\)\.version/);
     expect(publish).toMatch(/already exists; verifying reviewed tarball identity/);
+    expect(publish).toMatch(/registry-metadata\.tmp\.json/);
+    expect(publish).toMatch(/JSON\.parse/);
+    expect(publish).toMatch(/npm registry metadata remained unavailable or invalid after retries/);
     expect(publish).toMatch(/dist-tags\.\$NPM_TAG/);
     expect(publish).toMatch(/npm publish --provenance --access public --tag "release-candidate"/);
     expect(publish.indexOf('npm publish --provenance --access public --tag "release-candidate"')).toBeLessThan(

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -104,7 +104,7 @@ describe("NeonDiff public release readiness", () => {
       name: "neondiff",
       version: "1.0.3",
       requiredForThisRelease: true,
-      state: "published",
+      state: "release_candidate",
       previousReleasedPackageVersion: "1.0.2"
     });
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.29-beta.1");
@@ -125,7 +125,8 @@ describe("NeonDiff public release readiness", () => {
       shaState: "pending_tag_stamp",
       candidateHeadBeforeReleaseMetadata: "bcd2f7ace5b190dc86b5f86983aa62aae5e40652"
     });
-    expect(manifest.source?.proof).toMatch(/after merge and tag/i);
+    expect(manifest.source?.proof).toMatch(/before publish/i);
+    expect(manifest.source?.proof).toMatch(/stamp release_candidate.*to published/i);
     expect(manifest.releaseStages?.launchCutLine).toBe(
       "1.0 is a usable local HTML installer/dashboard plus minimal Mac launcher, not full signed desktop maturity."
     );
@@ -152,18 +153,20 @@ describe("NeonDiff public release readiness", () => {
     );
     expect(manifest.updateChannels?.browserDashboard).toMatchObject({
       requiredForThisRelease: true,
-      state: "published",
-      rollback: "git reset --hard refs/tags/v1.0.2",
+      state: "source_checkout",
+      rollback: "npm install -g neondiff@1.0.2",
       rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
       trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     });
     expect(manifest.updateChannels?.cli).toMatchObject({
       requiredForThisRelease: true,
-      state: "published"
+      state: "source_checkout",
+      rollback: "npm dist-tag add neondiff@1.0.2 latest"
     });
     expect(manifest.updateChannels?.daemon).toMatchObject({
       requiredForThisRelease: true,
-      state: "published"
+      state: "source_checkout",
+      rollback: "npm install -g neondiff@1.0.2"
     });
     expect(manifest.updateChannels?.website).toBeUndefined();
     expect(manifest.updateChannels?.desktop).toBeUndefined();
@@ -298,6 +301,7 @@ describe("NeonDiff public release readiness", () => {
         rollbackTarget?: string;
         targetVerifiedBy?: string;
         targetVerifiedSha?: string;
+        targetVerifiedShasum?: string;
         targetUrl?: string;
       }>;
     };
@@ -309,22 +313,22 @@ describe("NeonDiff public release readiness", () => {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.cli?.rollback,
           rollbackTarget: "v1.0.2",
-          targetVerifiedBy: "git ls-remote origin refs/tags/v1.0.2",
-          targetVerifiedSha: "bf76be80ccb573dde7b3ca0d0c2d6883259093fe"
+          targetVerifiedBy: "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
+          targetVerifiedShasum: "d62619b1ee2c539e3230572135a29a299be3a6ed"
         },
         browserDashboard: {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.browserDashboard?.rollback,
           rollbackTarget: "v1.0.2",
-          targetVerifiedBy: "git ls-remote origin refs/tags/v1.0.2",
-          targetVerifiedSha: "bf76be80ccb573dde7b3ca0d0c2d6883259093fe"
+          targetVerifiedBy: "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
+          targetVerifiedShasum: "d62619b1ee2c539e3230572135a29a299be3a6ed"
         },
         daemon: {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.daemon?.rollback,
           rollbackTarget: "v1.0.2",
-          targetVerifiedBy: "git ls-remote origin refs/tags/v1.0.2",
-          targetVerifiedSha: "bf76be80ccb573dde7b3ca0d0c2d6883259093fe"
+          targetVerifiedBy: "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
+          targetVerifiedShasum: "d62619b1ee2c539e3230572135a29a299be3a6ed"
         },
         website: {
           rollbackRepository: "electricsheephq/neon-diff-agent-website",
@@ -353,6 +357,11 @@ describe("NeonDiff public release readiness", () => {
         webViewEmbedded?: boolean;
       };
       macos15ReleaseSmoke?: {
+        workflowHead?: string;
+        appArtifactId?: number;
+        appArtifactName?: string;
+        appArchiveSha256?: string;
+        metadataArtifactId?: number;
         coreChecksCompiled?: boolean;
         keychainChecksCompiled?: boolean;
         unsignedBundlePackaged?: boolean;
@@ -376,6 +385,11 @@ describe("NeonDiff public release readiness", () => {
         webViewEmbedded: false
       },
       macos15ReleaseSmoke: {
+        workflowHead: "9eba343c8e69e832978e51c0fb63527b61939760",
+        appArtifactId: 8211347648,
+        appArtifactName: "neondiff-desktop-unsigned-app",
+        appArchiveSha256: "f546568f0e10ebc7abd4adcf99cc40af8a96ad635bf3fbb6333195d0a8d1a7e7",
+        metadataArtifactId: 8211347876,
         coreChecksCompiled: true,
         keychainChecksCompiled: true,
         unsignedBundlePackaged: true
@@ -466,6 +480,7 @@ describe("NeonDiff public release readiness", () => {
 
     const ci = read(".github/workflows/ci.yml");
     const publish = read(".github/workflows/publish-npm.yml");
+    const releasePolicy = read("scripts/npm-release-policy.mjs");
 
     expect(ci).toMatch(/node-version:\s*26/);
     expect(ci).toContain("actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0");
@@ -488,20 +503,26 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/Verify npm publish token is configured/);
     expect(publish).toMatch(/NPM_TOKEN Actions secret is not configured; publish cannot continue/);
     expect(publish).toMatch(/npm publish --provenance/);
-    expect(publish).toMatch(/NPM_TAG="beta"/);
-    expect(publish).toMatch(/NPM_TAG="latest"/);
-    expect(publish).toMatch(/--tag "\$\{\{\s*steps\.package_release\.outputs\.npm_tag\s*\}\}"/);
+    expect(releasePolicy).toMatch(/npmTag = packageVersion\.includes\("-"\) \? "beta" : "latest"/);
+    expect(publish).toMatch(/--tag "\$NPM_TAG"/);
     expect(publish).toMatch(/github\.event_name == 'release'/);
+    expect(publish).toMatch(/environment:\s*npm-publish/);
+    expect(publish).toMatch(/fetch-depth:\s*0/);
+    expect(publish).toMatch(/npm-release-policy\.mjs classify/);
+    expect(publish).toMatch(/npm-release-policy\.mjs verify-git/);
+    expect(publish).toMatch(/npm-release-policy\.mjs verify-pack/);
+    expect(releasePolicy).toMatch(/stable npm packages require a non-prerelease GitHub Release/);
+    expect(publish).toMatch(/release tag commit must be an ancestor of protected main/i);
+    expect(releasePolicy).toMatch(/npm tarball integrity does not match the reviewed pack/);
     expect(publish).not.toMatch(/github\.event\.release\.prerelease\s*==\s*true/);
     expect(publish).toMatch(/Classify npm package release/);
-    expect(publish).toMatch(/Skipping npm publish for source-only prerelease/);
-    expect(publish).toMatch(/Manual npm publish tag .* does not match package\.json version/);
+    expect(releasePolicy).toMatch(/manual npm publish tag .* does not match package\.json version/i);
     expect(publish).toMatch(/docs\/public-release-manifest\.json/);
     expect(publish).toMatch(/skippedPublicPackageVersions/);
     expect(publish.match(/if: steps\.package_release\.outputs\.should_publish == 'true'/g)).toHaveLength(6);
     expect(publish).toMatch(/require\('\.\/package\.json'\)\.version/);
-    expect(publish).toMatch(/already exists; verifying dist-tags/);
-    expect(publish).toMatch(/dist-tags\.\$\{\{\s*steps\.package_release\.outputs\.npm_tag\s*\}\}/);
+    expect(publish).toMatch(/already exists; verifying reviewed tarball identity/);
+    expect(publish).toMatch(/dist-tags\.\$NPM_TAG/);
     expect(publish).toMatch(/default:\s*v1\.0\.3/);
     expect(publish).not.toMatch(/default:\s*v0\.4\.30-beta\.1/);
   });

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -60,7 +60,7 @@ describe("NeonDiff public release readiness", () => {
     };
 
     expect(pkg.name).toBe("neondiff");
-    expect(pkg.version).toBe("1.0.2");
+    expect(pkg.version).toBe("1.0.3");
     expect(pkg.private).toBeUndefined();
     expect(pkg.description).toMatch(/local-first AI PR reviewer/i);
     expect(pkg.license).toBe("SEE LICENSE IN LICENSE.md");
@@ -93,19 +93,19 @@ describe("NeonDiff public release readiness", () => {
     ]);
 
     expect(lock.name).toBe("neondiff");
-    expect(lock.version).toBe("1.0.2");
+    expect(lock.version).toBe("1.0.3");
     expect(lock.packages?.[""]).toMatchObject({
       name: "neondiff",
-      version: "1.0.2",
+      version: "1.0.3",
       license: "SEE LICENSE IN LICENSE.md",
       bin: { neondiff: "dist/src/cli.js" }
     });
     expect(manifest.packageArtifact).toMatchObject({
       name: "neondiff",
-      version: "1.0.2",
+      version: "1.0.3",
       requiredForThisRelease: true,
       state: "published",
-      previousReleasedPackageVersion: "1.0.1"
+      previousReleasedPackageVersion: "1.0.2"
     });
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.29-beta.1");
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.36-beta.1");
@@ -123,7 +123,7 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.packageArtifact?.note).toMatch(/desktop app artifacts are not part of the npm package/i);
     expect(manifest.source).toMatchObject({
       shaState: "pending_tag_stamp",
-      candidateHeadBeforeReleaseMetadata: "fb2e0238287198a1fa1462f066f295dee6c9ea2e"
+      candidateHeadBeforeReleaseMetadata: "bcd2f7ace5b190dc86b5f86983aa62aae5e40652"
     });
     expect(manifest.source?.proof).toMatch(/after merge and tag/i);
     expect(manifest.releaseStages?.launchCutLine).toBe(
@@ -153,7 +153,7 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.updateChannels?.browserDashboard).toMatchObject({
       requiredForThisRelease: true,
       state: "published",
-      rollback: "git reset --hard refs/tags/v1.0.1",
+      rollback: "git reset --hard refs/tags/v1.0.2",
       rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
       trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     });
@@ -195,13 +195,13 @@ describe("NeonDiff public release readiness", () => {
       checkoutIssuanceRequiredForThisRelease: true,
       checkoutIssuanceUrl: "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
       checkoutIssuanceState: "ready",
-      checkoutIssuanceProofPath: "docs/evidence/v1.0.2-license-checkout-issuance-unauthenticated.json",
-      checkoutIssuanceAuthenticatedProofPath: "docs/evidence/v1.0.2-license-checkout-issuance-authenticated.json",
+      checkoutIssuanceProofPath: "docs/evidence/v1.0.3-license-checkout-issuance-unauthenticated.json",
+      checkoutIssuanceAuthenticatedProofPath: "docs/evidence/v1.0.3-license-checkout-issuance-authenticated.json",
       checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
     });
     expect(manifest.licenseApi?.trackingIssue).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/);
     expect(manifest.licenseApi?.healthUrl).toMatch(/^https:\/\/[^/]+\/healthz$/);
-    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v1.0.2-license-api-healthz.json");
+    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v1.0.3-license-api-healthz.json");
 
     const proof = JSON.parse(read(manifest.licenseApi?.healthProofPath ?? "")) as {
       evidenceKind?: string;
@@ -213,7 +213,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(proof).toMatchObject({
       evidenceKind: "license_api_healthz",
-      releaseVersion: "v1.0.2",
+      releaseVersion: "v1.0.3",
       url: manifest.licenseApi?.healthUrl,
       statusCode: 200,
       responseBody: "{\"status\":\"ok\"}"
@@ -229,7 +229,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(issuanceProof).toMatchObject({
       evidenceKind: "license_api_checkout_issuance",
-      releaseVersion: "v1.0.2",
+      releaseVersion: "v1.0.3",
       statusCode: 401,
       responseBody: expect.stringContaining("\"unauthorized\"")
     });
@@ -243,7 +243,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(authenticatedProof).toMatchObject({
       evidenceKind: "license_api_checkout_issuance_authenticated",
-      releaseVersion: "v1.0.2",
+      releaseVersion: "v1.0.3",
       statusCode: 200,
       redactedResponse: {
         issuedLicensePrefix: "nd_live_",
@@ -289,7 +289,7 @@ describe("NeonDiff public release readiness", () => {
     expect(liveCheckoutProof.proofBoundary).toContain("does not claim the original in-flight Stripe delivery");
     expect(JSON.stringify(liveCheckoutProof)).not.toMatch(/cs_live_|evt_|whsec_|nd_live_[A-Za-z0-9]|session_id=|fulfillment_token=|121 South/i);
 
-    const rollbackProof = JSON.parse(read("docs/evidence/v1.0.2-rollback-refs.json")) as {
+    const rollbackProof = JSON.parse(read("docs/evidence/v1.0.3-rollback-refs.json")) as {
       evidenceKind?: string;
       releaseVersion?: string;
       channels?: Record<string, {
@@ -303,52 +303,59 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(rollbackProof).toMatchObject({
       evidenceKind: "release_rollback_refs",
-      releaseVersion: "v1.0.2",
+      releaseVersion: "v1.0.3",
       channels: {
         cli: {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.cli?.rollback,
-          rollbackTarget: "v1.0.1",
-          targetVerifiedBy: "git ls-remote origin 'refs/tags/v1.0.1^{}'",
-          targetVerifiedSha: "4381bea9045ca0078ac3eb98c149c83970445f28"
+          rollbackTarget: "v1.0.2",
+          targetVerifiedBy: "git ls-remote origin refs/tags/v1.0.2",
+          targetVerifiedSha: "bf76be80ccb573dde7b3ca0d0c2d6883259093fe"
         },
         browserDashboard: {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.browserDashboard?.rollback,
-          rollbackTarget: "v1.0.1",
-          targetVerifiedBy: "git ls-remote origin 'refs/tags/v1.0.1^{}'",
-          targetVerifiedSha: "4381bea9045ca0078ac3eb98c149c83970445f28"
+          rollbackTarget: "v1.0.2",
+          targetVerifiedBy: "git ls-remote origin refs/tags/v1.0.2",
+          targetVerifiedSha: "bf76be80ccb573dde7b3ca0d0c2d6883259093fe"
         },
         daemon: {
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
           rollbackCommand: manifest.updateChannels?.daemon?.rollback,
-          rollbackTarget: "v1.0.1",
-          targetVerifiedBy: "git ls-remote origin 'refs/tags/v1.0.1^{}'",
-          targetVerifiedSha: "4381bea9045ca0078ac3eb98c149c83970445f28"
+          rollbackTarget: "v1.0.2",
+          targetVerifiedBy: "git ls-remote origin refs/tags/v1.0.2",
+          targetVerifiedSha: "bf76be80ccb573dde7b3ca0d0c2d6883259093fe"
         },
         website: {
           rollbackRepository: "electricsheephq/neon-diff-agent-website",
-          releaseAction: "no_code_deploy_for_v1.0.2",
+          releaseAction: "no_code_deploy_for_v1.0.3",
           currentChannelVersion: "v1.0.1",
-          rollbackTarget: "no_action_for_v1.0.2",
-          targetVerifiedBy: "docs/public-release-manifest.json omits updateChannels.website for v1.0.2",
+          rollbackTarget: "no_action_for_v1.0.3",
+          targetVerifiedBy: "docs/public-release-manifest.json omits updateChannels.website for v1.0.3",
           targetVerifiedSha: null
         }
       }
     });
     expect(JSON.stringify(rollbackProof)).not.toContain("<sha>");
 
-    const desktopProof = JSON.parse(read("docs/evidence/v1.0.2-desktop-github-smoke.json")) as {
+    const desktopProof = JSON.parse(read("docs/evidence/v1.0.3-desktop-startup-smoke.json")) as {
       evidenceKind?: string;
       releaseVersion?: string;
       proofBoundary?: string;
-      desktopApp?: {
-        userAuthorized?: boolean;
-        tokensStoredInConfig?: boolean;
+      bundleId?: string;
+      binarySha256?: string;
+      signingIdentityClass?: string;
+      nativeUi?: {
+        welcomeVisible?: boolean;
+        providerStepVisibleAfterContinue?: boolean;
+        appRemainedAlive?: boolean;
+        securityAgentPresent?: boolean;
+        webViewEmbedded?: boolean;
       };
-      repoDiscovery?: {
-        discoveredRepositoryCount?: number;
-        privateRepoNamesOmitted?: boolean;
+      macos15ReleaseSmoke?: {
+        coreChecksCompiled?: boolean;
+        keychainChecksCompiled?: boolean;
+        unsignedBundlePackaged?: boolean;
       };
       redaction?: {
         localPathsRemoved?: boolean;
@@ -356,22 +363,29 @@ describe("NeonDiff public release readiness", () => {
       };
     };
     expect(desktopProof).toMatchObject({
-      evidenceKind: "desktop_github_smoke_redacted",
-      releaseVersion: "v1.0.2",
-      desktopApp: {
-        userAuthorized: true,
-        tokensStoredInConfig: false
+      evidenceKind: "desktop_startup_smoke_redacted",
+      releaseVersion: "v1.0.3",
+      bundleId: "com.electricsheephq.NeonDiffDesktop",
+      binarySha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      signingIdentityClass: "unsigned-dev",
+      nativeUi: {
+        welcomeVisible: true,
+        providerStepVisibleAfterContinue: true,
+        appRemainedAlive: true,
+        securityAgentPresent: false,
+        webViewEmbedded: false
       },
-      repoDiscovery: {
-        discoveredRepositoryCount: 48,
-        privateRepoNamesOmitted: true
+      macos15ReleaseSmoke: {
+        coreChecksCompiled: true,
+        keychainChecksCompiled: true,
+        unsignedBundlePackaged: true
       },
       redaction: {
         localPathsRemoved: true,
         tokensRemoved: true
       }
     });
-    expect(desktopProof.proofBoundary).toMatch(/does not claim signed/i);
+    expect(desktopProof.proofBoundary).toMatch(/signing/i);
     expect(JSON.stringify(desktopProof)).not.toMatch(/\/Volumes\/LEXAR|\/Users\/lume|ghp_|github_pat_|nd_live_|session_id=/);
   });
 
@@ -379,7 +393,7 @@ describe("NeonDiff public release readiness", () => {
     expect(existsSync("scripts/install.sh")).toBe(true);
     const script = read("scripts/install.sh");
 
-    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-1\.0\.2\}"/);
+    expect(script).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-1\.0\.3\}"/);
     expect(script).toMatch(/npm[^\n]+install[^\n]+-g[^\n]+neondiff@\$\{NEONDIFF_VERSION\}/);
     expect(script).toMatch(/--dry-run/);
     expect(script).toMatch(/Node\.js 26 or newer/);
@@ -393,7 +407,7 @@ describe("NeonDiff public release readiness", () => {
       read("docs/github-app-setup.md"),
       read("docs/providers.md"),
       read("docs/license-boundary.md"),
-      read("docs/releases/v1.0.2.md")
+      read("docs/releases/v1.0.3.md")
     ].join("\n\n");
     const legacyRepoReferences = docs
       .split(/\s+/)
@@ -414,7 +428,7 @@ describe("NeonDiff public release readiness", () => {
     expect(docs).toContain("git clone https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git");
     expect(legacyRepoReferences).toEqual([]);
     expect(docs).not.toMatch(/npm link installs the local source-checkout shim/i);
-    expect(read("docs/releases/v1.0.2.md")).not.toMatch(/\/Volumes\/LEXAR|\/Users\/lume/);
+    expect(read("docs/releases/v1.0.3.md")).not.toMatch(/\/Volumes\/LEXAR|\/Users\/lume/);
   });
 
   it("keeps the GitHub Marketplace free-listing packet bounded to discoverability", () => {
@@ -488,7 +502,7 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/require\('\.\/package\.json'\)\.version/);
     expect(publish).toMatch(/already exists; verifying dist-tags/);
     expect(publish).toMatch(/dist-tags\.\$\{\{\s*steps\.package_release\.outputs\.npm_tag\s*\}\}/);
-    expect(publish).toMatch(/default:\s*v1\.0\.2/);
+    expect(publish).toMatch(/default:\s*v1\.0\.3/);
     expect(publish).not.toMatch(/default:\s*v0\.4\.30-beta\.1/);
   });
 });

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -379,6 +379,7 @@ describe("NeonDiff public release readiness", () => {
         hostedWorkflowSourceIsCandidateAncestor?: boolean;
         visibleLocalSourcesMatchMergedCandidate?: boolean;
         hostedReleaseSurfaceMatchesMergedCandidate?: boolean;
+        verification?: string;
       };
     };
     expect(desktopProof).toMatchObject({
@@ -412,9 +413,11 @@ describe("NeonDiff public release readiness", () => {
         visibleLocalBundleSourceIsCandidateAncestor: false,
         hostedWorkflowSourceIsCandidateAncestor: false,
         visibleLocalSourcesMatchMergedCandidate: true,
-        hostedReleaseSurfaceMatchesMergedCandidate: true
+        hostedReleaseSurfaceMatchesMergedCandidate: true,
+        verification: expect.stringContaining(".github/workflows/swift-desktop-gate.yml")
       }
     });
+    expect(desktopProof.artifactRelationship?.verification).not.toContain(".github/workflows/swift-desktop.yml");
     expect(desktopProof.proofBoundary).toMatch(/signing/i);
     expect(JSON.stringify(desktopProof)).not.toMatch(/\/Volumes\/LEXAR|\/Users\/lume|ghp_|github_pat_|nd_live_|session_id=/);
   });

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -567,15 +567,12 @@ describe("NeonDiff public release readiness", () => {
 
     const governance = read("docs/release-governance.md");
     expect(governance).toMatch(/partial quarantine promotion/i);
-    expect(governance).toMatch(/npm dist-tag add neondiff@<version> latest/);
-    expect(governance).toMatch(/npm dist-tag rm neondiff release-candidate/);
-    expect(governance).toMatch(/npm-release-policy\.mjs verify-channel/);
-    expect(governance).toMatch(/npm view neondiff dist-tags\.release-candidate/);
-    expect(governance.indexOf("npm-release-policy.mjs verify-channel")).toBeLessThan(
-      governance.indexOf("npm dist-tag add neondiff@<version> latest")
-    );
-    expect(governance.indexOf("npm view neondiff dist-tags.release-candidate")).toBeLessThan(
-      governance.indexOf("npm dist-tag add neondiff@<version> latest")
-    );
+    const recovery = governance.split("### Partial Quarantine Promotion Recovery")[1]?.split("## Tag And Release")[0] ?? "";
+    expect(recovery).toMatch(/gh workflow run publish-npm\.yml/);
+    expect(recovery).toMatch(/--ref main/);
+    expect(recovery).toMatch(/-f tag=v<version>/);
+    expect(recovery).toMatch(/direct dist-tag mutation is not supported/i);
+    expect(recovery).not.toMatch(/npm dist-tag add/);
+    expect(recovery).not.toMatch(/npm dist-tag rm/);
   });
 });

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -569,5 +569,13 @@ describe("NeonDiff public release readiness", () => {
     expect(governance).toMatch(/partial quarantine promotion/i);
     expect(governance).toMatch(/npm dist-tag add neondiff@<version> latest/);
     expect(governance).toMatch(/npm dist-tag rm neondiff release-candidate/);
+    expect(governance).toMatch(/npm-release-policy\.mjs verify-channel/);
+    expect(governance).toMatch(/npm view neondiff dist-tags\.release-candidate/);
+    expect(governance.indexOf("npm-release-policy.mjs verify-channel")).toBeLessThan(
+      governance.indexOf("npm dist-tag add neondiff@<version> latest")
+    );
+    expect(governance.indexOf("npm view neondiff dist-tags.release-candidate")).toBeLessThan(
+      governance.indexOf("npm dist-tag add neondiff@<version> latest")
+    );
   });
 });

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -359,17 +359,20 @@ describe("beta release status", () => {
         expect.objectContaining({
           name: "cli",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v1.0.2"
+          state: "source_checkout",
+          rollback: "npm dist-tag add neondiff@1.0.2 latest"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v1.0.2"
+          state: "source_checkout",
+          rollback: "npm install -g neondiff@1.0.2"
         }),
         expect.objectContaining({
           name: "browserDashboard",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v1.0.2",
+          state: "source_checkout",
+          rollback: "npm install -g neondiff@1.0.2",
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff"
         })
       ])
@@ -516,15 +519,15 @@ describe("beta release status", () => {
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
       ok: true,
-      detail: "cli=published; daemon=published; browserDashboard=published"
+      detail: "cli=source_checkout; daemon=source_checkout; browserDashboard=source_checkout"
     });
     const redactedOutput = stringifyRedactedJson({
       ...status,
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok
     });
-    expect(redactedOutput).toContain("git reset --hard refs/tags/v1.0.2");
-    expect(redactedOutput).toContain("cli=published; daemon=published");
+    expect(redactedOutput).toContain("npm dist-tag add neondiff@1.0.2 latest");
+    expect(redactedOutput).toContain("cli=source_checkout; daemon=source_checkout");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
     expect(redactedOutput).toContain("electricsheephq/evaos-code-review-bot-neondiff/issues/443");
   });

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -21,7 +21,7 @@ import { ReviewStateStore } from "../src/state.js";
 describe("beta release status", () => {
   const roots: string[] = [];
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  const shippedReleaseValidationNow = new Date("2026-07-09T22:00:00Z");
+  const shippedReleaseValidationNow = new Date("2026-07-09T22:20:00Z");
 
   afterEach(() => {
     vi.useRealTimers();

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -360,19 +360,19 @@ describe("beta release status", () => {
           name: "cli",
           requiredForThisRelease: true,
           state: "source_checkout",
-          rollback: "npm dist-tag add neondiff@1.0.2 latest"
+          rollback: "git reset --hard refs/tags/v1.0.2"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
           state: "source_checkout",
-          rollback: "npm install -g neondiff@1.0.2"
+          rollback: "git reset --hard refs/tags/v1.0.2"
         }),
         expect.objectContaining({
           name: "browserDashboard",
           requiredForThisRelease: true,
           state: "source_checkout",
-          rollback: "npm install -g neondiff@1.0.2",
+          rollback: "git reset --hard refs/tags/v1.0.2",
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff"
         })
       ])
@@ -526,7 +526,7 @@ describe("beta release status", () => {
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok
     });
-    expect(redactedOutput).toContain("npm dist-tag add neondiff@1.0.2 latest");
+    expect(redactedOutput).toContain("git reset --hard refs/tags/v1.0.2");
     expect(redactedOutput).toContain("cli=source_checkout; daemon=source_checkout");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
     expect(redactedOutput).toContain("electricsheephq/evaos-code-review-bot-neondiff/issues/443");

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -21,7 +21,7 @@ import { ReviewStateStore } from "../src/state.js";
 describe("beta release status", () => {
   const roots: string[] = [];
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  const shippedReleaseValidationNow = new Date("2026-07-09T17:00:00Z");
+  const shippedReleaseValidationNow = new Date("2026-07-09T22:00:00Z");
 
   afterEach(() => {
     vi.useRealTimers();
@@ -324,27 +324,27 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v1.0.2",
+      expectedVersion: "v1.0.3",
       now: shippedReleaseValidationNow
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v1.0.2",
+      version: "v1.0.3",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v1.0.2.md",
+        releaseNotesPath: "docs/releases/v1.0.3.md",
         changelogPath: "CHANGELOG.md",
-        changelogHeadVersion: "1.0.2",
-        changelogReleaseNotesPath: "docs/releases/v1.0.2.md"
+        changelogHeadVersion: "1.0.3",
+        changelogReleaseNotesPath: "docs/releases/v1.0.3.md"
       },
       licenseApi: {
         ok: true,
         requiredForThisRelease: true,
         state: "healthy",
         healthUrl: "https://neondiff-license.fly.dev/healthz",
-        healthProofPath: "docs/evidence/v1.0.2-license-api-healthz.json",
+        healthProofPath: "docs/evidence/v1.0.3-license-api-healthz.json",
         checkoutIssuanceRequiredForThisRelease: true,
         checkoutIssuanceUrl: "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
         checkoutIssuanceState: "ready",
@@ -359,17 +359,17 @@ describe("beta release status", () => {
         expect.objectContaining({
           name: "cli",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v1.0.1"
+          rollback: "git reset --hard refs/tags/v1.0.2"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v1.0.1"
+          rollback: "git reset --hard refs/tags/v1.0.2"
         }),
         expect.objectContaining({
           name: "browserDashboard",
           requiredForThisRelease: true,
-          rollback: "git reset --hard refs/tags/v1.0.1",
+          rollback: "git reset --hard refs/tags/v1.0.2",
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff"
         })
       ])
@@ -380,7 +380,7 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v1.0.2",
+      expectedVersion: "v1.0.3",
       now: new Date("2026-08-09T12:00:00Z")
     });
 
@@ -388,7 +388,7 @@ describe("beta release status", () => {
       ok: false,
       requiredForThisRelease: true,
       state: "healthy",
-      healthProofPath: "docs/evidence/v1.0.2-license-api-healthz.json"
+      healthProofPath: "docs/evidence/v1.0.3-license-api-healthz.json"
     });
     expect(manifest.licenseApi.detail).toContain("observedAt must be no older than 30 days");
     expect(manifest.ok).toBe(false);
@@ -504,14 +504,14 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v1.0.2",
+      expectedPublicVersion: "v1.0.3",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot",
       now: shippedReleaseValidationNow
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v1.0.2"
+      version: "v1.0.3"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
@@ -523,7 +523,7 @@ describe("beta release status", () => {
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok
     });
-    expect(redactedOutput).toContain("git reset --hard refs/tags/v1.0.1");
+    expect(redactedOutput).toContain("git reset --hard refs/tags/v1.0.2");
     expect(redactedOutput).toContain("cli=published; daemon=published");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
     expect(redactedOutput).toContain("electricsheephq/evaos-code-review-bot-neondiff/issues/443");


### PR DESCRIPTION
## Summary

Prepare the real `v1.0.3` stable release after #506 merged the focused NeonDiff Desktop startup/Keychain fix.

- align npm package, lockfile, installer, manifest, changelog, and release notes on `1.0.3`
- include fresh redacted license health and authenticated issuance evidence
- include rollback proof to `v1.0.2`
- preserve the advanced native SwiftUI app and explicitly avoid the rejected WebView takeover
- keep signed/notarized desktop artifacts, Sparkle/appcast, and full browser/native parity out of this patch claim

Refs #505
Refs #503

## Verification

- 6 focused Vitest files / 145 tests passed
- `npm run build`
- `node scripts/check-public-claims.mjs`
- `node scripts/check-secret-scan.mjs`
- `jq empty docs/public-release-manifest.json docs/evidence/v1.0.3-*.json`
- `npm pack --dry-run --json` + packlist check (95 files)
- `git diff --check`
- release-status public manifest gate: `publicRelease.ok=true`, version `v1.0.3`
- macOS 15 unsigned workflow: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29049779156

## Proof boundary

This PR prepares the package/release metadata and records proof for the named unsigned startup-stability fix. It does not claim signed/notarized desktop distribution, Sparkle updates, full browser/native parity, or v1.1 customer readiness. Issue #505 remains open until the non-prerelease GitHub Release, npm `latest`, clean installed-package dashboard smoke, and public rollback proof are verified.
