### PR TITLE
fix(release): harden npm promotion confirmation

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -200,7 +200,12 @@ jobs:
           const temporaryPath = `${outputPath}.tmp`;
           rmSync(outputPath, { force: true });
           rmSync(temporaryPath, { force: true });
+          const writeResult = (distTags, quarantineCleanup) => {
+            writeFileSync(temporaryPath, `${JSON.stringify({ distTags, quarantineCleanup })}\n`, { encoding: "utf8", mode: 0o600 });
+            renameSync(temporaryPath, outputPath);
+          };
           let promotionConfirmed = false;
+          let promotionTags = {};
           for (let attempt = 1; attempt <= attempts; attempt += 1) {
             try {
               const raw = execFileSync("npm", ["view", packageName, "dist-tags", "--json"], {
@@ -211,6 +216,7 @@ jobs:
               const tags = JSON.parse(raw);
               if (tags && !Array.isArray(tags) && typeof tags === "object" && tags[npmTag] === expectedVersion) {
                 promotionConfirmed = true;
+                promotionTags = tags;
                 break;
               }
             } catch {
@@ -223,6 +229,9 @@ jobs:
             process.exit(1);
           }
 
+          let lastTags = promotionTags;
+          let removalAttempted = false;
+          let removalAccepted = false;
           for (let attempt = 1; attempt <= attempts; attempt += 1) {
             try {
               const raw = execFileSync("npm", ["view", packageName, "dist-tags", "--json"], {
@@ -232,27 +241,53 @@ jobs:
               });
               const tags = JSON.parse(raw);
               if (!tags || Array.isArray(tags) || typeof tags !== "object") throw new Error("invalid npm dist-tag response");
+              lastTags = tags;
               const quarantineVersion = tags["release-candidate"];
               if (quarantineVersion === undefined) {
-                writeFileSync(temporaryPath, `${JSON.stringify(tags)}\n`, { encoding: "utf8", mode: 0o600 });
-                renameSync(temporaryPath, outputPath);
+                writeResult(tags, {
+                  state: "confirmed_absent",
+                  observedVersion: null,
+                  removalAttempted,
+                  removalAccepted
+                });
                 process.exit(0);
               }
               if (quarantineVersion !== expectedVersion) {
-                console.error(`refusing to remove unexpected release-candidate version ${quarantineVersion}`);
-                process.exit(1);
+                console.error(`::warning::refusing to remove unexpected release-candidate version ${quarantineVersion}`);
+                writeResult(tags, {
+                  state: "unexpected_owner",
+                  observedVersion: quarantineVersion,
+                  removalAttempted,
+                  removalAccepted
+                });
+                process.exit(0);
               }
-              execFileSync("npm", ["dist-tag", "rm", packageName, "release-candidate"], {
-                stdio: ["ignore", "ignore", "ignore"],
-                timeout: timeoutMs
-              });
+              if (!removalAttempted) {
+                removalAttempted = true;
+                try {
+                  execFileSync("npm", ["dist-tag", "rm", packageName, "release-candidate"], {
+                    stdio: ["ignore", "ignore", "pipe"],
+                    timeout: timeoutMs
+                  });
+                  removalAccepted = true;
+                } catch {
+                  // The removal may still have reached the registry; bounded reads below determine the recorded state.
+                }
+              }
             } catch {
-              // Retry until absence is confirmed; a timed-out removal may still have reached the registry.
+              // Registry, timeout, and JSON failures remain retryable for state recording.
             }
             if (attempt < attempts && delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
           }
-          rmSync(temporaryPath, { force: true });
-          console.error(`release-candidate did not disappear after ${attempts} attempts`);
-          process.exit(1);
+          const observedVersion = lastTags["release-candidate"] ?? null;
+          const cleanupState = removalAccepted ? "pending_registry_convergence" : "removal_unconfirmed";
+          console.error(`::warning::release-candidate cleanup remains unconfirmed after ${attempts} attempts`);
+          writeResult(lastTags, {
+            state: cleanupState,
+            observedVersion,
+            removalAttempted,
+            removalAccepted
+          });
+          process.exit(0);
           NODE
           # END POST_PROMOTION_CONFIRMATION

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -200,6 +200,7 @@ jobs:
           const temporaryPath = `${outputPath}.tmp`;
           rmSync(outputPath, { force: true });
           rmSync(temporaryPath, { force: true });
+          let promotionConfirmed = false;
           for (let attempt = 1; attempt <= attempts; attempt += 1) {
             try {
               const raw = execFileSync("npm", ["view", packageName, "dist-tags", "--json"], {
@@ -209,20 +210,49 @@ jobs:
               });
               const tags = JSON.parse(raw);
               if (tags && !Array.isArray(tags) && typeof tags === "object" && tags[npmTag] === expectedVersion) {
-                writeFileSync(temporaryPath, `${JSON.stringify(tags)}\n`, { encoding: "utf8", mode: 0o600 });
-                renameSync(temporaryPath, outputPath);
-                process.exit(0);
+                promotionConfirmed = true;
+                break;
               }
             } catch {
               // Registry, timeout, and JSON failures remain retryable until the bounded attempt count is exhausted.
             }
             if (attempt < attempts && delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
           }
+          if (!promotionConfirmed) {
+            console.error(`npm dist-tag did not converge to the promoted package after ${attempts} attempts`);
+            process.exit(1);
+          }
+
+          for (let attempt = 1; attempt <= attempts; attempt += 1) {
+            try {
+              const raw = execFileSync("npm", ["view", packageName, "dist-tags", "--json"], {
+                encoding: "utf8",
+                stdio: ["ignore", "pipe", "ignore"],
+                timeout: timeoutMs
+              });
+              const tags = JSON.parse(raw);
+              if (!tags || Array.isArray(tags) || typeof tags !== "object") throw new Error("invalid npm dist-tag response");
+              const quarantineVersion = tags["release-candidate"];
+              if (quarantineVersion === undefined) {
+                writeFileSync(temporaryPath, `${JSON.stringify(tags)}\n`, { encoding: "utf8", mode: 0o600 });
+                renameSync(temporaryPath, outputPath);
+                process.exit(0);
+              }
+              if (quarantineVersion !== expectedVersion) {
+                console.error(`refusing to remove unexpected release-candidate version ${quarantineVersion}`);
+                process.exit(1);
+              }
+              execFileSync("npm", ["dist-tag", "rm", packageName, "release-candidate"], {
+                stdio: ["ignore", "ignore", "ignore"],
+                timeout: timeoutMs
+              });
+            } catch {
+              // Retry until absence is confirmed; a timed-out removal may still have reached the registry.
+            }
+            if (attempt < attempts && delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+          }
           rmSync(temporaryPath, { force: true });
-          console.error(`npm dist-tag did not converge to the promoted package after ${attempts} attempts`);
+          console.error(`release-candidate did not disappear after ${attempts} attempts`);
           process.exit(1);
           NODE
           # END POST_PROMOTION_CONFIRMATION
-          if [ "$(npm view neondiff dist-tags.release-candidate 2>/dev/null || true)" = "$PACKAGE_VERSION" ]; then
-            npm dist-tag rm neondiff release-candidate
-          fi

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -173,7 +173,56 @@ jobs:
             --expected-predecessor "$EXPECTED_PREDECESSOR" \
             --npm-tag "$NPM_TAG"
           npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"
-          test "$(npm view neondiff "dist-tags.$NPM_TAG")" = "$PACKAGE_VERSION"
+          # BEGIN POST_PROMOTION_CONFIRMATION
+          NPM_CONFIRM_ATTEMPTS="${NPM_CONFIRM_ATTEMPTS:-12}" \
+          NPM_CONFIRM_DELAY_MS="${NPM_CONFIRM_DELAY_MS:-5000}" \
+          NPM_CONFIRM_TIMEOUT_MS="${NPM_CONFIRM_TIMEOUT_MS:-15000}" \
+          NPM_CONFIRM_PACKAGE="${NPM_CONFIRM_PACKAGE:-neondiff}" \
+          NPM_CONFIRM_TAG="${NPM_CONFIRM_TAG:-$NPM_TAG}" \
+          NPM_CONFIRM_VERSION="${NPM_CONFIRM_VERSION:-$PACKAGE_VERSION}" \
+          NPM_CONFIRM_OUTPUT="${NPM_CONFIRM_OUTPUT:-post-promotion-channel.json}" \
+          node --input-type=module <<'NODE'
+          import { execFileSync } from "node:child_process";
+          import { renameSync, rmSync, writeFileSync } from "node:fs";
+
+          const attempts = Number(process.env.NPM_CONFIRM_ATTEMPTS);
+          const delayMs = Number(process.env.NPM_CONFIRM_DELAY_MS);
+          const timeoutMs = Number(process.env.NPM_CONFIRM_TIMEOUT_MS);
+          const packageName = process.env.NPM_CONFIRM_PACKAGE;
+          const npmTag = process.env.NPM_CONFIRM_TAG;
+          const expectedVersion = process.env.NPM_CONFIRM_VERSION;
+          const outputPath = process.env.NPM_CONFIRM_OUTPUT;
+          if (!Number.isInteger(attempts) || attempts < 1 || attempts > 100) throw new Error("invalid npm confirmation attempt count");
+          if (!Number.isInteger(delayMs) || delayMs < 0 || delayMs > 60000) throw new Error("invalid npm confirmation delay");
+          if (!Number.isInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 60000) throw new Error("invalid npm confirmation timeout");
+          if (!packageName || !npmTag || !expectedVersion || !outputPath) throw new Error("missing npm confirmation input");
+
+          const temporaryPath = `${outputPath}.tmp`;
+          rmSync(outputPath, { force: true });
+          rmSync(temporaryPath, { force: true });
+          for (let attempt = 1; attempt <= attempts; attempt += 1) {
+            try {
+              const raw = execFileSync("npm", ["view", packageName, "dist-tags", "--json"], {
+                encoding: "utf8",
+                stdio: ["ignore", "pipe", "ignore"],
+                timeout: timeoutMs
+              });
+              const tags = JSON.parse(raw);
+              if (tags && !Array.isArray(tags) && typeof tags === "object" && tags[npmTag] === expectedVersion) {
+                writeFileSync(temporaryPath, `${JSON.stringify(tags)}\n`, { encoding: "utf8", mode: 0o600 });
+                renameSync(temporaryPath, outputPath);
+                process.exit(0);
+              }
+            } catch {
+              // Registry, timeout, and JSON failures remain retryable until the bounded attempt count is exhausted.
+            }
+            if (attempt < attempts && delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+          }
+          rmSync(temporaryPath, { force: true });
+          console.error(`npm dist-tag did not converge to the promoted package after ${attempts} attempts`);
+          process.exit(1);
+          NODE
+          # END POST_PROMOTION_CONFIRMATION
           if [ "$(npm view neondiff dist-tags.release-candidate 2>/dev/null || true)" = "$PACKAGE_VERSION" ]; then
             npm dist-tag rm neondiff release-candidate
           fi

--- a/docs/evidence/v1.0.3-publication-proof.json
+++ b/docs/evidence/v1.0.3-publication-proof.json
@@ -24,31 +24,32 @@
   },
   "installedPackage": {
     "binaryVersion": "1.0.3",
-    "isolatedPrefixPath": "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/prefix",
-    "previewSmokePath": "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-preview-smoke/preview-smoke.json",
-    "browserProofPaths": [
-      "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-installed-1.0.3.png",
-      "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-installed-1.0.3-provider-verified-viewport.png"
+    "evidenceRootId": "neondiff-ga/2026-07-10/v1.0.3/install-smoke",
+    "isolatedPrefixRef": "prefix",
+    "previewSmokeRef": "dashboard-preview-smoke/preview-smoke.json",
+    "browserProofRefs": [
+      "dashboard-installed-1.0.3.png",
+      "dashboard-installed-1.0.3-provider-verified-viewport.png"
     ],
     "artifacts": [
       {
         "kind": "installed-cli",
-        "path": "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/prefix/lib/node_modules/neondiff/dist/src/cli.js",
+        "ref": "prefix/lib/node_modules/neondiff/dist/src/cli.js",
         "sha256": "f0274f200f451f9bab1ae7b1cc710589fb9d3a446bd45a41698f40b2634f7b69"
       },
       {
         "kind": "preview-smoke",
-        "path": "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-preview-smoke/preview-smoke.json",
+        "ref": "dashboard-preview-smoke/preview-smoke.json",
         "sha256": "048bc1b5f542aafbd02015c998ddf5f61b4c2864e9bf35f32b6af24adf83ff96"
       },
       {
         "kind": "browser-dashboard",
-        "path": "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-installed-1.0.3.png",
+        "ref": "dashboard-installed-1.0.3.png",
         "sha256": "5ed63505149832fba630173ea72b915e6d94b120ff1e012dd9d6fb45bb6d17ff"
       },
       {
         "kind": "provider-verification-viewport",
-        "path": "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-installed-1.0.3-provider-verified-viewport.png",
+        "ref": "dashboard-installed-1.0.3-provider-verified-viewport.png",
         "sha256": "74a36839276d715588b0f3700909ab07650d2d63d64a5977c2a6c67740b503d2"
       }
     ],

--- a/docs/evidence/v1.0.3-publication-proof.json
+++ b/docs/evidence/v1.0.3-publication-proof.json
@@ -1,0 +1,78 @@
+{
+  "schemaVersion": 1,
+  "observedAt": "2026-07-10T09:41:31Z",
+  "releaseVersion": "v1.0.3",
+  "releaseSourceSha": "5411365f73f0093b085eda056fe55c4cec4779d3",
+  "annotatedTagObjectSha": "bba2afcc32e9d085aeed970ab06288766e620b9e",
+  "github": {
+    "releaseUrl": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/tag/v1.0.3",
+    "publishedAt": "2026-07-09T22:41:38Z",
+    "nonPrerelease": true,
+    "publishWorkflowUrl": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29055263065",
+    "mainCiUrl": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29055091896",
+    "codeqlUrl": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29055091327"
+  },
+  "npm": {
+    "packageUrl": "https://www.npmjs.com/package/neondiff/v/1.0.3",
+    "packageVersion": "1.0.3",
+    "latest": "1.0.3",
+    "releaseCandidatePresent": false,
+    "gitHead": "5411365f73f0093b085eda056fe55c4cec4779d3",
+    "shasum": "99e9e74402ffe602f81584b1adf5e9b8d0b22e59",
+    "integrity": "sha512-zkoatWQEq1ymbIEtCUTmbC5+ZWCplRlsJyiECLQQlXMMNn1QmsfTQ0M1Yqknn8UAYFD47zhtU1etsg/Qk+tSYQ==",
+    "provenanceAttestationUrl": "https://registry.npmjs.org/-/npm/v1/attestations/neondiff@1.0.3"
+  },
+  "installedPackage": {
+    "binaryVersion": "1.0.3",
+    "isolatedPrefixPath": "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/prefix",
+    "previewSmokePath": "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-preview-smoke/preview-smoke.json",
+    "browserProofPaths": [
+      "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-installed-1.0.3.png",
+      "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-installed-1.0.3-provider-verified-viewport.png"
+    ],
+    "artifacts": [
+      {
+        "kind": "installed-cli",
+        "path": "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/prefix/lib/node_modules/neondiff/dist/src/cli.js",
+        "sha256": "f0274f200f451f9bab1ae7b1cc710589fb9d3a446bd45a41698f40b2634f7b69"
+      },
+      {
+        "kind": "preview-smoke",
+        "path": "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-preview-smoke/preview-smoke.json",
+        "sha256": "048bc1b5f542aafbd02015c998ddf5f61b4c2864e9bf35f32b6af24adf83ff96"
+      },
+      {
+        "kind": "browser-dashboard",
+        "path": "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-installed-1.0.3.png",
+        "sha256": "5ed63505149832fba630173ea72b915e6d94b120ff1e012dd9d6fb45bb6d17ff"
+      },
+      {
+        "kind": "provider-verification-viewport",
+        "path": "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-installed-1.0.3-provider-verified-viewport.png",
+        "sha256": "74a36839276d715588b0f3700909ab07650d2d63d64a5977c2a6c67740b503d2"
+      }
+    ],
+    "providerVerification": {
+      "ok": true,
+      "mode": "metadata_only",
+      "result": "configured_unverified",
+      "provider": "zcode-glm",
+      "redacted": true
+    },
+    "browserConsoleErrors": 0,
+    "browserConsoleWarnings": 0
+  },
+  "proofBoundary": {
+    "allowed": [
+      "real non-prerelease GitHub Release v1.0.3",
+      "public npm package neondiff@1.0.3 with signed provenance",
+      "installed CLI and local browser dashboard flow for neondiff@1.0.3"
+    ],
+    "forbidden": [
+      "signed or notarized Mac distribution",
+      "Sparkle or appcast readiness",
+      "browser and native UI parity",
+      "v1.1 customer readiness"
+    ]
+  }
+}

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,11 +1,12 @@
 {
   "version": "v1.0.3",
   "releaseLevel": "stable",
+  "publicationProofPath": "docs/evidence/v1.0.3-publication-proof.json",
   "packageArtifact": {
     "name": "neondiff",
     "version": "1.0.3",
     "requiredForThisRelease": true,
-    "state": "release_candidate",
+    "state": "published",
     "previousReleasedPackageVersion": "1.0.2",
     "skippedPublicPackageVersions": [
       "v0.4.25-beta.1",
@@ -30,12 +31,12 @@
       "v0.4.45-beta.1",
       "v0.4.46-beta.1"
     ],
-    "note": "v1.0.3 is prepared as the CLI/dashboard npm package release candidate. After the non-prerelease GitHub Release, npm integrity verification, and installed-package smoke pass, a post-release state stamp records publication. Desktop Keychain startup-stability source changes are included, but desktop app artifacts are not part of the npm package."
+    "note": "v1.0.3 publishes the CLI/dashboard npm package with verified provenance, registry identity, and installed-package browser-dashboard proof. Desktop Keychain startup-stability source changes are included, but desktop app artifacts are not part of the npm package."
   },
   "source": {
-    "shaState": "pending_tag_stamp",
+    "shaState": "published",
     "candidateHeadBeforeReleaseMetadata": "bcd2f7ace5b190dc86b5f86983aa62aae5e40652",
-    "proof": "before publish, verify the annotated tag and candidate are ancestors of protected main; after npm/GitHub/install proof, stamp release_candidate and source_checkout states to published on main without moving the release tag"
+    "proof": "annotated tag v1.0.3 peels to published main source SHA 5411365f73f0093b085eda056fe55c4cec4779d3 and contains candidate bcd2f7ace5b190dc86b5f86983aa62aae5e40652; the post-release stamp does not move the tag"
   },
   "releaseStages": {
     "launchCutLine": "1.0 is a usable local HTML installer/dashboard plus minimal Mac launcher, not full signed desktop maturity.",
@@ -99,21 +100,21 @@
   "updateChannels": {
     "cli": {
       "requiredForThisRelease": true,
-      "state": "source_checkout",
+      "state": "published",
       "version": "v1.0.3",
       "rollback": "git reset --hard refs/tags/v1.0.2",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "daemon": {
       "requiredForThisRelease": true,
-      "state": "source_checkout",
+      "state": "published",
       "version": "v1.0.3",
       "rollback": "git reset --hard refs/tags/v1.0.2",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "browserDashboard": {
       "requiredForThisRelease": true,
-      "state": "source_checkout",
+      "state": "published",
       "version": "v1.0.3",
       "rollback": "git reset --hard refs/tags/v1.0.2",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",

--- a/docs/releases/v1.0.3.md
+++ b/docs/releases/v1.0.3.md
@@ -72,9 +72,10 @@ owned `release-candidate` tag, and the isolated installed-package dashboard
 smoke. The first workflow attempt exposed npm registry view convergence lag
 after promotion; the idempotent rerun completed safely, and the workflow now
 uses bounded validated retries for that post-promotion confirmation.
-The publication proof binds the installed CLI, preview-smoke JSON, and both
-browser captures to SHA-256 identities so the machine-local evidence cannot be
-replaced silently.
+The publication proof binds stable operator-evidence references for the
+installed CLI, preview-smoke JSON, and both browser captures to SHA-256
+identities so those artifacts cannot be replaced silently without changing the
+tracked proof.
 
 ## Caveats
 

--- a/docs/releases/v1.0.3.md
+++ b/docs/releases/v1.0.3.md
@@ -1,10 +1,10 @@
 # v1.0.3
 
 - Release type: stable Mac startup-stability patch
-- Release source SHA: to be stamped by `refs/tags/v1.0.3`
+- Release source SHA: `5411365f73f0093b085eda056fe55c4cec4779d3`
 - Previous stable release: `v1.0.2`
 - Tracking issues / source PR: `#484`, `#503`, `#505`, `#506`
-- Package artifact: `neondiff@1.0.3` after publish
+- Package artifact: published `neondiff@1.0.3`
 - Rollback baseline: `v1.0.2`
 
 ## Purpose
@@ -63,6 +63,18 @@ candidate honestly. The manifest gate validates release metadata and proofs; it
 does not claim npm or GitHub publication. After the public registry, GitHub
 Release, and installed-package smoke pass, a separate post-release state stamp
 updates `main` to `published` without moving `refs/tags/v1.0.3`.
+
+The post-release state stamp is backed by
+`docs/evidence/v1.0.3-publication-proof.json`. It records the non-prerelease
+GitHub Release, the GitHub-triggered npm publication run, exact public registry
+integrity/shasum/`gitHead`/provenance identity, `latest=1.0.3`, absence of the
+owned `release-candidate` tag, and the isolated installed-package dashboard
+smoke. The first workflow attempt exposed npm registry view convergence lag
+after promotion; the idempotent rerun completed safely, and the workflow now
+uses bounded validated retries for that post-promotion confirmation.
+The publication proof binds the installed CLI, preview-smoke JSON, and both
+browser captures to SHA-256 identities so the machine-local evidence cannot be
+replaced silently.
 
 ## Caveats
 

--- a/docs/releases/v1.0.3.md
+++ b/docs/releases/v1.0.3.md
@@ -71,7 +71,11 @@ integrity/shasum/`gitHead`/provenance identity, `latest=1.0.3`, absence of the
 owned `release-candidate` tag, and the isolated installed-package dashboard
 smoke. The first workflow attempt exposed npm registry view convergence lag
 after promotion; the idempotent rerun completed safely, and the workflow now
-uses bounded validated retries for that post-promotion confirmation.
+uses bounded validated retries for that post-promotion confirmation. Primary
+channel convergence is the hard success gate. Quarantine removal is attempted
+at most once; bounded follow-up reads record confirmed absence, unexpected
+ownership, or pending convergence without falsely failing an irreversible
+successful promotion.
 The publication proof binds stable operator-evidence references for the
 installed CLI, preview-smoke JSON, and both browser captures to SHA-256
 identities so those artifacts cannot be replaced silently without changing the

--- a/docs/superpowers/plans/2026-07-10-v1.0.3-post-release-hardening.md
+++ b/docs/superpowers/plans/2026-07-10-v1.0.3-post-release-hardening.md
@@ -1,0 +1,130 @@
+# v1.0.3 Post-Release Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent npm registry read-after-write lag from failing a successful channel promotion and stamp the proven v1.0.3 public release state.
+
+**Architecture:** Keep publication and all existing fail-closed guards in `.github/workflows/publish-npm.yml`. Replace only the single post-promotion scalar read with a bounded, validated dist-tag JSON retry. Record immutable GitHub/npm/install/browser proof in a public-safe evidence JSON and point the release manifest at it while changing candidate/source-checkout states to published.
+
+**Tech Stack:** GitHub Actions shell, npm registry CLI, Node.js JSON validation, Vitest, JSON release manifest.
+
+## Global Constraints
+
+- Do not retag, republish, unpublish, or directly mutate npm dist-tags outside the workflow.
+- Preserve package-wide concurrency, predecessor guard, quarantine publication, provenance, immutable tarball verification, and workflow-only recovery.
+- Keep `#503` open and do not claim browser/native parity, signed/notarized Mac distribution, Sparkle/appcast readiness, or v1.1 completion.
+- Never print or store credentials, provider keys, npm tokens, cookies, or raw customer data.
+
+## Durable Plan Contract
+
+- Goal: Land the bounded registry-convergence retry and truthful v1.0.3 post-release state stamp.
+- Resume identity: `electricsheephq/evaos-code-review-bot-neondiff`; worktree `/Volumes/LEXAR/repos/worktrees/evaos-code-review-bot-neondiff/505-post-release-stamp`; branch `codex/505-post-release-stamp`; base/head `5411365f73f0093b085eda056fe55c4cec4779d3`; issue `#505`; tracker `#484`; milestone `#15`.
+- Tracking / source of truth: GitHub issue/PR/checks/reviews/releases and public npm registry; repository manifest/evidence after merge.
+- Scope / non-goals: Harden post-promotion confirmation and stamp v1.0.3 publication only. Do not touch `#503`, `#471`, OpenWiki/provider PRs, v1.1 feature work, the release tag, or npm dist-tags directly.
+- Current state: v1.0.3 GitHub/npm/install/browser proof exists; first workflow run exposed immediate registry-view lag; exact idempotent rerun succeeded; manifest still says candidate/source checkout.
+- Exact next action: Write a failing workflow contract test requiring bounded validated post-promotion confirmation.
+- Critical invariants: `v1.0.3` remains at `5411365f73f0093b085eda056fe55c4cec4779d3`; public package identity remains integrity `sha512-zkoatWQEq1ymbIEtCUTmbC5+ZWCplRlsJyiECLQQlXMMNn1QmsfTQ0M1Yqknn8UAYFD47zhtU1etsg/Qk+tSYQ==`, shasum `99e9e74402ffe602f81584b1adf5e9b8d0b22e59`, and matching `gitHead`; no secrets in evidence.
+- Execution lanes: test-first retry contract; minimal workflow change; test-first state-stamp/evidence contract; manifest/evidence update; focused and broad validation; PR/review/merge; post-merge source-of-truth closeout.
+- Validation / eval gates:
+  - Eval required: yes
+  - Eval claim class: merge_ready
+  - Required eval suites: focused public-release readiness tests, full Vitest suite, TypeScript build, actionlint, public-claim scan, tracked-file secret scan, JSON parse/integrity, diff check, current-head CI and review threads.
+  - Eval name/version: `neondiff-v1.0.3-post-release-hardening-v1`
+  - Dataset/scenario refs: issue `#505`; publish run `29055263065`; GitHub Release `v1.0.3`; public npm `neondiff@1.0.3`; isolated installed-package smoke packet.
+  - Baseline/comparison: released main SHA `5411365f73f0093b085eda056fe55c4cec4779d3`, whose immediate scalar post-promotion read can observe stale registry state.
+  - Metrics and thresholds: bounded retry present; validated dist-tag object; exact channel target match before quarantine cleanup; 0 focused/full test failures; build/actionlint/scans clean; 0 unresolved P0-P2 current-head threads.
+  - Runner/CI location: local Lexar worktree plus GitHub Actions on the PR.
+  - Failure owner: NeonDiff product release manager.
+  - Eval evidence path: `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/` and GitHub PR/check links.
+  - Trace feedback target: issue `#505`, PR, tracker `#484`, milestone `#15`.
+  - Eval proof boundary: proves workflow hardening and truthful v1.0.3 public package/dashboard state only; not signed Mac or browser/native parity.
+- Proof-claim boundary: May claim real GitHub/npm v1.0.3 and installed CLI/dashboard flow. Must not claim signed/notarized Mac distribution, Sparkle/appcast, full customer readiness, parity, or v1.1 completion.
+- Stop conditions: package identity drift; release tag movement; unexpected dist-tag state; secret exposure; failing current-head CI; unresolved blocking review; requested change broadens into desktop/parity/release mutation.
+- Evidence path / packet: `/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/`, `docs/evidence/v1.0.3-publication-proof.json`, issue `#505`, tracker `#484`, PR checks/reviews.
+- Review lanes: two read-only independent reviews after local validation, focused on spec completeness and release safety; P0-P2 findings block merge; findings land on the PR/issue packet.
+- Post-merge / closeout: reverify GitHub/npm/tag identity; close `#505` and milestone `#15` only after merged manifest/evidence; update `#484`; leave `#503` open.
+- Rollback / recovery: revert the hardening PR if it regresses workflow validation. Do not move `v1.0.3` or mutate npm directly; use the existing serialized workflow recovery and documented v1.0.2 channel rollback only if separately authorized.
+
+---
+
+### Task 1: Bounded post-promotion channel confirmation
+
+**Files:**
+- Modify: `tests/public-release-readiness.test.ts`
+- Modify: `.github/workflows/publish-npm.yml`
+
+**Interfaces:**
+- Consumes: `PACKAGE_VERSION`, `NPM_TAG`, and the existing successful `npm dist-tag add` operation.
+- Produces: `post-promotion-channel.json` only when validated registry metadata reports `NPM_TAG === PACKAGE_VERSION`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add contract assertions requiring `post-promotion-channel.tmp.json`, a bounded retry loop, validated JSON object parsing, exact target-version comparison, and the error text `npm dist-tag did not converge to the promoted package after retries`; reject the old scalar `test "$(npm view ...)"` check.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- tests/public-release-readiness.test.ts`
+Expected: FAIL because `.github/workflows/publish-npm.yml` still contains the scalar one-shot confirmation.
+
+- [ ] **Step 3: Write minimal implementation**
+
+After `npm dist-tag add`, retry `npm view neondiff dist-tags --json` up to 12 times with five-second intervals. Parse a non-array object and exit the validator unless `tags[NPM_TAG] === PACKAGE_VERSION`; atomically move the valid response to `post-promotion-channel.json`. Fail with the named error if no matching file exists.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- tests/public-release-readiness.test.ts`
+Expected: 6 tests pass.
+
+### Task 2: Truthful published-state stamp
+
+**Files:**
+- Modify: `tests/public-release-readiness.test.ts`
+- Modify: `docs/public-release-manifest.json`
+- Create: `docs/evidence/v1.0.3-publication-proof.json`
+- Modify: `docs/releases/v1.0.3.md`
+
+**Interfaces:**
+- Consumes: immutable GitHub Release/tag/npm identity and isolated install/browser evidence.
+- Produces: manifest `published` states and a stable repository evidence path.
+
+- [ ] **Step 1: Write the failing test**
+
+Require package, source, CLI, daemon, and browser-dashboard states to be `published`; require `docs/evidence/v1.0.3-publication-proof.json`; verify exact release SHA, npm identity, release/workflow URLs, installed binary version, redacted provider verification result, and forbidden-claim boundary.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- tests/public-release-readiness.test.ts`
+Expected: FAIL because the manifest remains `release_candidate`/`source_checkout` and the publication evidence file is absent.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the public-safe evidence JSON, stamp the manifest states to `published`, link the evidence path, and update the release notes with the completed release proof while preserving all forbidden desktop/parity claims.
+
+- [ ] **Step 4: Run focused and broad validation**
+
+Run the focused test, full `npm test`, `npm run build`, `actionlint`, public-claim scan, secret scan, JSON parse checks, and `git diff --check`. Expected: all exit 0 with no test failures or scan findings.
+
+### Task 3: PR, current-head review, merge, and closeout
+
+**Files:**
+- No additional source files expected.
+
+**Interfaces:**
+- Consumes: verified branch head and local evidence.
+- Produces: merged PR, current-head checks/reviews, closed `#505`/milestone `#15` if earned, updated `#484`, and preserved open `#503`.
+
+- [ ] **Step 1: Commit, push, and open the PR**
+
+Use issue-closing wording for `#505`, include the proof boundary, and request current-head reviews.
+
+- [ ] **Step 2: Shepherd checks and review threads**
+
+Fix actionable P0-P2 findings test-first, rerun focused validation, reply/resolve, and re-read checks plus unresolved threads on the newest head.
+
+- [ ] **Step 3: Merge and reverify public state**
+
+Merge only with current-head green CI and no blocking threads. Re-read GitHub Release/tag/npm identity and verify the merged manifest/evidence on `main`.
+
+- [ ] **Step 4: Close source-of-truth items**
+
+Close `#505` and milestone `#15` only after merged proof; update `#484` with exact PR/SHA/release/npm/install evidence; explicitly note that `#503` remains open.

--- a/tests/npm-dist-tag-convergence.test.ts
+++ b/tests/npm-dist-tag-convergence.test.ts
@@ -66,7 +66,13 @@ process.stdout.write(JSON.stringify(tags));
   return binDir;
 }
 
-function runWorkflowBlock(root: string, mode: "converge" | "stale" | "hang" | "unexpected", attempts: number, convergeAt = attempts) {
+function runWorkflowBlock(
+  root: string,
+  mode: "converge" | "stale" | "hang" | "unexpected",
+  attempts: number,
+  convergeAt = attempts,
+  cleanupConvergeAt = 2
+) {
   const binDir = writeFakeNpm(root);
   const counterPath = join(root, "view-counter.txt");
   const cleanupCounterPath = join(root, "cleanup-counter.txt");
@@ -91,7 +97,7 @@ function runWorkflowBlock(root: string, mode: "converge" | "stale" | "hang" | "u
       NPM_CONFIRM_OUTPUT: outputPath,
       FAKE_NPM_VIEW_COUNTER: counterPath,
       FAKE_NPM_CLEANUP_COUNTER: cleanupCounterPath,
-      FAKE_NPM_CLEANUP_CONVERGE_AT: "2",
+      FAKE_NPM_CLEANUP_CONVERGE_AT: String(cleanupConvergeAt),
       FAKE_NPM_RM_COUNTER: rmCounterPath,
       FAKE_NPM_RM_MARKER: rmMarkerPath,
       FAKE_NPM_MODE: mode,
@@ -109,8 +115,16 @@ describe("npm dist-tag convergence confirmation", () => {
     expect(result.status).toBe(0);
     expect(Number(readFileSync(counterPath, "utf8"))).toBeGreaterThan(3);
     expect(readFileSync(cleanupCounterPath, "utf8")).toBe("2");
-    expect(Number(readFileSync(rmCounterPath, "utf8"))).toBeGreaterThanOrEqual(1);
-    expect(JSON.parse(readFileSync(outputPath, "utf8"))).toEqual({ latest: "1.0.3" });
+    expect(readFileSync(rmCounterPath, "utf8")).toBe("1");
+    expect(JSON.parse(readFileSync(outputPath, "utf8"))).toEqual({
+      distTags: { latest: "1.0.3" },
+      quarantineCleanup: {
+        state: "confirmed_absent",
+        observedVersion: null,
+        removalAttempted: true,
+        removalAccepted: true
+      }
+    });
   });
 
   it("fails closed after the bounded attempt count when the tag never converges", () => {
@@ -133,14 +147,39 @@ describe("npm dist-tag convergence confirmation", () => {
     expect(result.stderr).toContain("npm dist-tag did not converge to the promoted package after 2 attempts");
   });
 
-  it("fails closed without removing a quarantine tag owned by another version", () => {
+  it("preserves and records a quarantine tag owned by another version without failing promotion", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-dist-tag-unexpected-"));
     const { outputPath, result, rmCounterPath } = runWorkflowBlock(root, "unexpected", 2);
 
-    expect(result.status).toBe(1);
-    expect(existsSync(outputPath)).toBe(false);
+    expect(result.status).toBe(0);
     expect(existsSync(rmCounterPath)).toBe(false);
-    expect(result.stderr).toContain("refusing to remove unexpected release-candidate version 9.9.9");
+    expect(result.stderr).toContain("::warning::refusing to remove unexpected release-candidate version 9.9.9");
+    expect(JSON.parse(readFileSync(outputPath, "utf8"))).toMatchObject({
+      quarantineCleanup: {
+        state: "unexpected_owner",
+        observedVersion: "9.9.9",
+        removalAttempted: false,
+        removalAccepted: false
+      }
+    });
+  });
+
+  it("warns and records cleanup lag without failing a confirmed promotion", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-dist-tag-cleanup-lag-"));
+    const { outputPath, result, rmCounterPath } = runWorkflowBlock(root, "converge", 2, 1, 99);
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(rmCounterPath, "utf8")).toBe("1");
+    expect(result.stderr).toContain("::warning::release-candidate cleanup remains unconfirmed after 2 attempts");
+    expect(JSON.parse(readFileSync(outputPath, "utf8"))).toMatchObject({
+      distTags: { latest: "1.0.3", "release-candidate": "1.0.3" },
+      quarantineCleanup: {
+        state: "pending_registry_convergence",
+        observedVersion: "1.0.3",
+        removalAttempted: true,
+        removalAccepted: true
+      }
+    });
   });
 
   it("derives the workflow block indentation from its marker", () => {

--- a/tests/npm-dist-tag-convergence.test.ts
+++ b/tests/npm-dist-tag-convergence.test.ts
@@ -1,0 +1,97 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+function extractConfirmationBlock(): string {
+  const workflow = readFileSync(".github/workflows/publish-npm.yml", "utf8");
+  const match = workflow.match(/# BEGIN POST_PROMOTION_CONFIRMATION\n([\s\S]*?)          # END POST_PROMOTION_CONFIRMATION/);
+  if (!match) throw new Error("post-promotion confirmation block markers are missing");
+  return match[1]
+    .split("\n")
+    .map((line) => line.replace(/^ {10}/, ""))
+    .join("\n");
+}
+
+function writeFakeNpm(root: string): string {
+  const binDir = join(root, "bin");
+  const npmPath = join(binDir, "npm");
+  mkdirSync(binDir);
+  writeFileSync(
+    npmPath,
+    `#!/usr/bin/env node
+const { existsSync, readFileSync, writeFileSync } = require("node:fs");
+const counterPath = process.env.FAKE_NPM_COUNTER;
+const previous = existsSync(counterPath) ? Number(readFileSync(counterPath, "utf8")) : 0;
+const count = previous + 1;
+writeFileSync(counterPath, String(count));
+if (process.env.FAKE_NPM_MODE === "hang") {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5000);
+}
+const converged = process.env.FAKE_NPM_MODE === "converge" && count >= Number(process.env.FAKE_NPM_CONVERGE_AT);
+process.stdout.write(JSON.stringify({ latest: converged ? "1.0.3" : "1.0.2" }));
+`
+  );
+  chmodSync(npmPath, 0o755);
+  return binDir;
+}
+
+function runWorkflowBlock(root: string, mode: "converge" | "stale" | "hang", attempts: number, convergeAt = attempts) {
+  const binDir = writeFakeNpm(root);
+  const counterPath = join(root, "counter.txt");
+  const outputPath = join(root, "confirmed.json");
+  const scriptPath = join(root, "confirm.sh");
+  writeFileSync(scriptPath, `#!/bin/sh\nset -eu\n${extractConfirmationBlock()}\n`);
+  chmodSync(scriptPath, 0o755);
+  const result = spawnSync("/bin/sh", [scriptPath], {
+    cwd: root,
+    encoding: "utf8",
+    timeout: 5000,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      PACKAGE_VERSION: "1.0.3",
+      NPM_TAG: "latest",
+      NPM_CONFIRM_ATTEMPTS: String(attempts),
+      NPM_CONFIRM_DELAY_MS: "1",
+      NPM_CONFIRM_TIMEOUT_MS: "500",
+      NPM_CONFIRM_OUTPUT: outputPath,
+      FAKE_NPM_COUNTER: counterPath,
+      FAKE_NPM_MODE: mode,
+      FAKE_NPM_CONVERGE_AT: String(convergeAt)
+    }
+  });
+  return { counterPath, outputPath, result };
+}
+
+describe("npm dist-tag convergence confirmation", () => {
+  it("retries stale registry reads until the promoted tag converges", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-dist-tag-converges-"));
+    const { counterPath, outputPath, result } = runWorkflowBlock(root, "converge", 4, 3);
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(counterPath, "utf8")).toBe("3");
+    expect(JSON.parse(readFileSync(outputPath, "utf8"))).toEqual({ latest: "1.0.3" });
+  });
+
+  it("fails closed after the bounded attempt count when the tag never converges", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-dist-tag-stale-"));
+    const { counterPath, outputPath, result } = runWorkflowBlock(root, "stale", 3);
+
+    expect(result.status).toBe(1);
+    expect(readFileSync(counterPath, "utf8")).toBe("3");
+    expect(existsSync(outputPath)).toBe(false);
+    expect(result.stderr).toContain("npm dist-tag did not converge to the promoted package after 3 attempts");
+  });
+
+  it("times out each hung npm read while preserving the overall attempt bound", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-dist-tag-hangs-"));
+    const { counterPath, outputPath, result } = runWorkflowBlock(root, "hang", 2);
+
+    expect(result.status).toBe(1);
+    expect(readFileSync(counterPath, "utf8")).toBe("2");
+    expect(existsSync(outputPath)).toBe(false);
+    expect(result.stderr).toContain("npm dist-tag did not converge to the promoted package after 2 attempts");
+  });
+});

--- a/tests/npm-dist-tag-convergence.test.ts
+++ b/tests/npm-dist-tag-convergence.test.ts
@@ -4,14 +4,23 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
-function extractConfirmationBlock(): string {
-  const workflow = readFileSync(".github/workflows/publish-npm.yml", "utf8");
-  const match = workflow.match(/# BEGIN POST_PROMOTION_CONFIRMATION\n([\s\S]*?)          # END POST_PROMOTION_CONFIRMATION/);
-  if (!match) throw new Error("post-promotion confirmation block markers are missing");
-  return match[1]
+function extractConfirmationBlock(workflow = readFileSync(".github/workflows/publish-npm.yml", "utf8")): string {
+  const begin = /^([ \t]*)# BEGIN POST_PROMOTION_CONFIRMATION$/m.exec(workflow);
+  if (!begin || begin.index === undefined) throw new Error("post-promotion confirmation block start marker is missing");
+  const indent = begin[1];
+  const contentStart = begin.index + begin[0].length + 1;
+  const endMarker = `${indent}# END POST_PROMOTION_CONFIRMATION`;
+  const contentEnd = workflow.indexOf(endMarker, contentStart);
+  if (contentEnd < 0) throw new Error("post-promotion confirmation block end marker is missing");
+  const block = workflow.slice(contentStart, contentEnd)
     .split("\n")
-    .map((line) => line.replace(/^ {10}/, ""))
+    .map((line) => {
+      if (line && !line.startsWith(indent)) throw new Error("post-promotion confirmation indentation is inconsistent");
+      return line.slice(indent.length);
+    })
     .join("\n");
+  if (!block.includes("tags[npmTag] === expectedVersion")) throw new Error("post-promotion validator is missing");
+  return block;
 }
 
 function writeFakeNpm(root: string): string {
@@ -22,24 +31,47 @@ function writeFakeNpm(root: string): string {
     npmPath,
     `#!/usr/bin/env node
 const { existsSync, readFileSync, writeFileSync } = require("node:fs");
-const counterPath = process.env.FAKE_NPM_COUNTER;
-const previous = existsSync(counterPath) ? Number(readFileSync(counterPath, "utf8")) : 0;
-const count = previous + 1;
+const args = process.argv.slice(2);
+if (args[0] === "dist-tag" && args[1] === "rm") {
+  const previousRm = existsSync(process.env.FAKE_NPM_RM_COUNTER) ? Number(readFileSync(process.env.FAKE_NPM_RM_COUNTER, "utf8")) : 0;
+  writeFileSync(process.env.FAKE_NPM_RM_COUNTER, String(previousRm + 1));
+  writeFileSync(process.env.FAKE_NPM_RM_MARKER, "removed");
+  process.exit(0);
+}
+const counterPath = process.env.FAKE_NPM_VIEW_COUNTER;
+const previousView = existsSync(counterPath) ? Number(readFileSync(counterPath, "utf8")) : 0;
+const count = previousView + 1;
 writeFileSync(counterPath, String(count));
 if (process.env.FAKE_NPM_MODE === "hang") {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5000);
 }
 const converged = process.env.FAKE_NPM_MODE === "converge" && count >= Number(process.env.FAKE_NPM_CONVERGE_AT);
-process.stdout.write(JSON.stringify({ latest: converged ? "1.0.3" : "1.0.2" }));
+const tags = { latest: converged || process.env.FAKE_NPM_MODE === "unexpected" ? "1.0.3" : "1.0.2" };
+if (process.env.FAKE_NPM_MODE === "unexpected") {
+  tags["release-candidate"] = "9.9.9";
+} else if (process.env.FAKE_NPM_MODE === "converge") {
+  if (!existsSync(process.env.FAKE_NPM_RM_MARKER)) {
+    tags["release-candidate"] = "1.0.3";
+  } else {
+    const previousCleanup = existsSync(process.env.FAKE_NPM_CLEANUP_COUNTER) ? Number(readFileSync(process.env.FAKE_NPM_CLEANUP_COUNTER, "utf8")) : 0;
+    const cleanupCount = previousCleanup + 1;
+    writeFileSync(process.env.FAKE_NPM_CLEANUP_COUNTER, String(cleanupCount));
+    if (cleanupCount < Number(process.env.FAKE_NPM_CLEANUP_CONVERGE_AT)) tags["release-candidate"] = "1.0.3";
+  }
+}
+process.stdout.write(JSON.stringify(tags));
 `
   );
   chmodSync(npmPath, 0o755);
   return binDir;
 }
 
-function runWorkflowBlock(root: string, mode: "converge" | "stale" | "hang", attempts: number, convergeAt = attempts) {
+function runWorkflowBlock(root: string, mode: "converge" | "stale" | "hang" | "unexpected", attempts: number, convergeAt = attempts) {
   const binDir = writeFakeNpm(root);
-  const counterPath = join(root, "counter.txt");
+  const counterPath = join(root, "view-counter.txt");
+  const cleanupCounterPath = join(root, "cleanup-counter.txt");
+  const rmCounterPath = join(root, "rm-counter.txt");
+  const rmMarkerPath = join(root, "rm-marker.txt");
   const outputPath = join(root, "confirmed.json");
   const scriptPath = join(root, "confirm.sh");
   writeFileSync(scriptPath, `#!/bin/sh\nset -eu\n${extractConfirmationBlock()}\n`);
@@ -57,21 +89,27 @@ function runWorkflowBlock(root: string, mode: "converge" | "stale" | "hang", att
       NPM_CONFIRM_DELAY_MS: "1",
       NPM_CONFIRM_TIMEOUT_MS: "500",
       NPM_CONFIRM_OUTPUT: outputPath,
-      FAKE_NPM_COUNTER: counterPath,
+      FAKE_NPM_VIEW_COUNTER: counterPath,
+      FAKE_NPM_CLEANUP_COUNTER: cleanupCounterPath,
+      FAKE_NPM_CLEANUP_CONVERGE_AT: "2",
+      FAKE_NPM_RM_COUNTER: rmCounterPath,
+      FAKE_NPM_RM_MARKER: rmMarkerPath,
       FAKE_NPM_MODE: mode,
       FAKE_NPM_CONVERGE_AT: String(convergeAt)
     }
   });
-  return { counterPath, outputPath, result };
+  return { cleanupCounterPath, counterPath, outputPath, result, rmCounterPath };
 }
 
 describe("npm dist-tag convergence confirmation", () => {
   it("retries stale registry reads until the promoted tag converges", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-dist-tag-converges-"));
-    const { counterPath, outputPath, result } = runWorkflowBlock(root, "converge", 4, 3);
+    const { cleanupCounterPath, counterPath, outputPath, result, rmCounterPath } = runWorkflowBlock(root, "converge", 4, 3);
 
     expect(result.status).toBe(0);
-    expect(readFileSync(counterPath, "utf8")).toBe("3");
+    expect(Number(readFileSync(counterPath, "utf8"))).toBeGreaterThan(3);
+    expect(readFileSync(cleanupCounterPath, "utf8")).toBe("2");
+    expect(Number(readFileSync(rmCounterPath, "utf8"))).toBeGreaterThanOrEqual(1);
     expect(JSON.parse(readFileSync(outputPath, "utf8"))).toEqual({ latest: "1.0.3" });
   });
 
@@ -93,5 +131,20 @@ describe("npm dist-tag convergence confirmation", () => {
     expect(readFileSync(counterPath, "utf8")).toBe("2");
     expect(existsSync(outputPath)).toBe(false);
     expect(result.stderr).toContain("npm dist-tag did not converge to the promoted package after 2 attempts");
+  });
+
+  it("fails closed without removing a quarantine tag owned by another version", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-dist-tag-unexpected-"));
+    const { outputPath, result, rmCounterPath } = runWorkflowBlock(root, "unexpected", 2);
+
+    expect(result.status).toBe(1);
+    expect(existsSync(outputPath)).toBe(false);
+    expect(existsSync(rmCounterPath)).toBe(false);
+    expect(result.stderr).toContain("refusing to remove unexpected release-candidate version 9.9.9");
+  });
+
+  it("derives the workflow block indentation from its marker", () => {
+    const shifted = `jobs:\n    # BEGIN POST_PROMOTION_CONFIRMATION\n    tags[npmTag] === expectedVersion\n    # END POST_PROMOTION_CONFIRMATION`;
+    expect(extractConfirmationBlock(shifted)).toBe("tags[npmTag] === expectedVersion\n");
   });
 });

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -25,6 +25,7 @@ describe("NeonDiff public release readiness", () => {
       packages?: Record<string, { name?: string; version?: string; license?: string; bin?: Record<string, string> }>;
     };
     const manifest = JSON.parse(read("docs/public-release-manifest.json")) as {
+      publicationProofPath?: string;
       packageArtifact?: {
         name?: string;
         version?: string;
@@ -104,7 +105,7 @@ describe("NeonDiff public release readiness", () => {
       name: "neondiff",
       version: "1.0.3",
       requiredForThisRelease: true,
-      state: "release_candidate",
+      state: "published",
       previousReleasedPackageVersion: "1.0.2"
     });
     expect(manifest.packageArtifact?.skippedPublicPackageVersions).toContain("v0.4.29-beta.1");
@@ -122,11 +123,11 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.packageArtifact?.note).toMatch(/CLI\/dashboard npm package/i);
     expect(manifest.packageArtifact?.note).toMatch(/desktop app artifacts are not part of the npm package/i);
     expect(manifest.source).toMatchObject({
-      shaState: "pending_tag_stamp",
+      shaState: "published",
       candidateHeadBeforeReleaseMetadata: "bcd2f7ace5b190dc86b5f86983aa62aae5e40652"
     });
-    expect(manifest.source?.proof).toMatch(/before publish/i);
-    expect(manifest.source?.proof).toMatch(/stamp release_candidate.*to published/i);
+    expect(manifest.source?.proof).toMatch(/5411365f73f0093b085eda056fe55c4cec4779d3/);
+    expect(manifest.source?.proof).toMatch(/annotated tag v1\.0\.3/i);
     expect(manifest.releaseStages?.launchCutLine).toBe(
       "1.0 is a usable local HTML installer/dashboard plus minimal Mac launcher, not full signed desktop maturity."
     );
@@ -153,23 +154,103 @@ describe("NeonDiff public release readiness", () => {
     );
     expect(manifest.updateChannels?.browserDashboard).toMatchObject({
       requiredForThisRelease: true,
-      state: "source_checkout",
+      state: "published",
       rollback: "git reset --hard refs/tags/v1.0.2",
       rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
       trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     });
     expect(manifest.updateChannels?.cli).toMatchObject({
       requiredForThisRelease: true,
-      state: "source_checkout",
+      state: "published",
       rollback: "git reset --hard refs/tags/v1.0.2"
     });
     expect(manifest.updateChannels?.daemon).toMatchObject({
       requiredForThisRelease: true,
-      state: "source_checkout",
+      state: "published",
       rollback: "git reset --hard refs/tags/v1.0.2"
     });
     expect(manifest.updateChannels?.website).toBeUndefined();
     expect(manifest.updateChannels?.desktop).toBeUndefined();
+
+    expect(manifest.publicationProofPath).toBe("docs/evidence/v1.0.3-publication-proof.json");
+    expect(existsSync(manifest.publicationProofPath!)).toBe(true);
+    const publicationProof = JSON.parse(read(manifest.publicationProofPath!)) as {
+      releaseVersion?: string;
+      releaseSourceSha?: string;
+      github?: { releaseUrl?: string; publishWorkflowUrl?: string; nonPrerelease?: boolean };
+      npm?: {
+        packageVersion?: string;
+        latest?: string;
+        releaseCandidatePresent?: boolean;
+        gitHead?: string;
+        shasum?: string;
+        integrity?: string;
+        provenanceAttestationUrl?: string;
+      };
+      installedPackage?: {
+        binaryVersion?: string;
+        previewSmokePath?: string;
+        browserProofPaths?: string[];
+        artifacts?: Array<{ kind?: string; path?: string; sha256?: string }>;
+        providerVerification?: { ok?: boolean; mode?: string; result?: string };
+      };
+      proofBoundary?: { allowed?: string[]; forbidden?: string[] };
+    };
+    expect(publicationProof).toMatchObject({
+      releaseVersion: "v1.0.3",
+      releaseSourceSha: "5411365f73f0093b085eda056fe55c4cec4779d3",
+      github: {
+        releaseUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/tag/v1.0.3",
+        publishWorkflowUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29055263065",
+        nonPrerelease: true
+      },
+      npm: {
+        packageVersion: "1.0.3",
+        latest: "1.0.3",
+        releaseCandidatePresent: false,
+        gitHead: "5411365f73f0093b085eda056fe55c4cec4779d3",
+        shasum: "99e9e74402ffe602f81584b1adf5e9b8d0b22e59",
+        integrity: "sha512-zkoatWQEq1ymbIEtCUTmbC5+ZWCplRlsJyiECLQQlXMMNn1QmsfTQ0M1Yqknn8UAYFD47zhtU1etsg/Qk+tSYQ=="
+      },
+      installedPackage: {
+        binaryVersion: "1.0.3",
+        providerVerification: { ok: true, mode: "metadata_only", result: "configured_unverified" }
+      }
+    });
+    expect(publicationProof.npm?.provenanceAttestationUrl).toMatch(/^https:\/\/registry\.npmjs\.org\//);
+    expect(publicationProof.installedPackage?.previewSmokePath).toMatch(/dashboard-preview-smoke\/preview-smoke\.json$/);
+    expect(publicationProof.installedPackage?.browserProofPaths).toHaveLength(2);
+    expect(publicationProof.installedPackage?.artifacts).toEqual([
+      {
+        kind: "installed-cli",
+        path: "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/prefix/lib/node_modules/neondiff/dist/src/cli.js",
+        sha256: "f0274f200f451f9bab1ae7b1cc710589fb9d3a446bd45a41698f40b2634f7b69"
+      },
+      {
+        kind: "preview-smoke",
+        path: "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-preview-smoke/preview-smoke.json",
+        sha256: "048bc1b5f542aafbd02015c998ddf5f61b4c2864e9bf35f32b6af24adf83ff96"
+      },
+      {
+        kind: "browser-dashboard",
+        path: "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-installed-1.0.3.png",
+        sha256: "5ed63505149832fba630173ea72b915e6d94b120ff1e012dd9d6fb45bb6d17ff"
+      },
+      {
+        kind: "provider-verification-viewport",
+        path: "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-installed-1.0.3-provider-verified-viewport.png",
+        sha256: "74a36839276d715588b0f3700909ab07650d2d63d64a5977c2a6c67740b503d2"
+      }
+    ]);
+    expect(publicationProof.proofBoundary?.allowed).toContain("installed CLI and local browser dashboard flow for neondiff@1.0.3");
+    expect(publicationProof.proofBoundary?.forbidden).toEqual(
+      expect.arrayContaining([
+        "signed or notarized Mac distribution",
+        "Sparkle or appcast readiness",
+        "browser and native UI parity",
+        "v1.1 customer readiness"
+      ])
+    );
   });
 
   it("requires the live production license API and checkout issuance for GA", () => {
@@ -553,7 +634,16 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/registry-metadata\.tmp\.json/);
     expect(publish).toMatch(/JSON\.parse/);
     expect(publish).toMatch(/npm registry metadata remained unavailable or invalid after retries/);
-    expect(publish).toMatch(/dist-tags\.\$NPM_TAG/);
+    expect(publish).toMatch(/npm view neondiff dist-tags --json/);
+    expect(publish).toMatch(/BEGIN POST_PROMOTION_CONFIRMATION/);
+    expect(publish).toMatch(/END POST_PROMOTION_CONFIRMATION/);
+    expect(publish).toMatch(/post-promotion-channel\.json/);
+    expect(publish).toMatch(/NPM_CONFIRM_ATTEMPTS="\$\{NPM_CONFIRM_ATTEMPTS:-12\}"/);
+    expect(publish).toMatch(/NPM_CONFIRM_DELAY_MS="\$\{NPM_CONFIRM_DELAY_MS:-5000\}"/);
+    expect(publish).toMatch(/NPM_CONFIRM_TIMEOUT_MS="\$\{NPM_CONFIRM_TIMEOUT_MS:-15000\}"/);
+    expect(publish).not.toContain('test "$(npm view neondiff "dist-tags.$NPM_TAG")" = "$PACKAGE_VERSION"');
+    expect(publish).toMatch(/tags\[npmTag\].*expectedVersion/);
+    expect(publish).toMatch(/npm dist-tag did not converge to the promoted package after/);
     expect(publish).toMatch(/previousReleasedPackageVersion/);
     expect(publish).toMatch(/npm publish --provenance --access public --tag "release-candidate"/);
     expect(publish.indexOf('npm publish --provenance --access public --tag "release-candidate"')).toBeLessThan(

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -189,9 +189,11 @@ describe("NeonDiff public release readiness", () => {
       };
       installedPackage?: {
         binaryVersion?: string;
-        previewSmokePath?: string;
-        browserProofPaths?: string[];
-        artifacts?: Array<{ kind?: string; path?: string; sha256?: string }>;
+        evidenceRootId?: string;
+        isolatedPrefixRef?: string;
+        previewSmokeRef?: string;
+        browserProofRefs?: string[];
+        artifacts?: Array<{ kind?: string; ref?: string; sha256?: string }>;
         providerVerification?: { ok?: boolean; mode?: string; result?: string };
       };
       proofBoundary?: { allowed?: string[]; forbidden?: string[] };
@@ -218,30 +220,33 @@ describe("NeonDiff public release readiness", () => {
       }
     });
     expect(publicationProof.npm?.provenanceAttestationUrl).toMatch(/^https:\/\/registry\.npmjs\.org\//);
-    expect(publicationProof.installedPackage?.previewSmokePath).toMatch(/dashboard-preview-smoke\/preview-smoke\.json$/);
-    expect(publicationProof.installedPackage?.browserProofPaths).toHaveLength(2);
+    expect(publicationProof.installedPackage?.evidenceRootId).toBe("neondiff-ga/2026-07-10/v1.0.3/install-smoke");
+    expect(publicationProof.installedPackage?.isolatedPrefixRef).toBe("prefix");
+    expect(publicationProof.installedPackage?.previewSmokeRef).toBe("dashboard-preview-smoke/preview-smoke.json");
+    expect(publicationProof.installedPackage?.browserProofRefs).toHaveLength(2);
     expect(publicationProof.installedPackage?.artifacts).toEqual([
       {
         kind: "installed-cli",
-        path: "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/prefix/lib/node_modules/neondiff/dist/src/cli.js",
+        ref: "prefix/lib/node_modules/neondiff/dist/src/cli.js",
         sha256: "f0274f200f451f9bab1ae7b1cc710589fb9d3a446bd45a41698f40b2634f7b69"
       },
       {
         kind: "preview-smoke",
-        path: "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-preview-smoke/preview-smoke.json",
+        ref: "dashboard-preview-smoke/preview-smoke.json",
         sha256: "048bc1b5f542aafbd02015c998ddf5f61b4c2864e9bf35f32b6af24adf83ff96"
       },
       {
         kind: "browser-dashboard",
-        path: "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-installed-1.0.3.png",
+        ref: "dashboard-installed-1.0.3.png",
         sha256: "5ed63505149832fba630173ea72b915e6d94b120ff1e012dd9d6fb45bb6d17ff"
       },
       {
         kind: "provider-verification-viewport",
-        path: "/Volumes/LEXAR/Codex/evidence/neondiff-ga/2026-07-10/v1.0.3/install-smoke/dashboard-installed-1.0.3-provider-verified-viewport.png",
+        ref: "dashboard-installed-1.0.3-provider-verified-viewport.png",
         sha256: "74a36839276d715588b0f3700909ab07650d2d63d64a5977c2a6c67740b503d2"
       }
     ]);
+    expect(JSON.stringify(publicationProof)).not.toContain("/Volumes/");
     expect(publicationProof.proofBoundary?.allowed).toContain("installed CLI and local browser dashboard flow for neondiff@1.0.3");
     expect(publicationProof.proofBoundary?.forbidden).toEqual(
       expect.arrayContaining([

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -359,19 +359,19 @@ describe("beta release status", () => {
         expect.objectContaining({
           name: "cli",
           requiredForThisRelease: true,
-          state: "source_checkout",
+          state: "published",
           rollback: "git reset --hard refs/tags/v1.0.2"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
-          state: "source_checkout",
+          state: "published",
           rollback: "git reset --hard refs/tags/v1.0.2"
         }),
         expect.objectContaining({
           name: "browserDashboard",
           requiredForThisRelease: true,
-          state: "source_checkout",
+          state: "published",
           rollback: "git reset --hard refs/tags/v1.0.2",
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff"
         })
@@ -519,7 +519,7 @@ describe("beta release status", () => {
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
       ok: true,
-      detail: "cli=source_checkout; daemon=source_checkout; browserDashboard=source_checkout"
+      detail: "cli=published; daemon=published; browserDashboard=published"
     });
     const redactedOutput = stringifyRedactedJson({
       ...status,
@@ -527,7 +527,7 @@ describe("beta release status", () => {
       runtimeOk: status.ok
     });
     expect(redactedOutput).toContain("git reset --hard refs/tags/v1.0.2");
-    expect(redactedOutput).toContain("cli=source_checkout; daemon=source_checkout");
+    expect(redactedOutput).toContain("cli=published; daemon=published");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
     expect(redactedOutput).toContain("electricsheephq/evaos-code-review-bot-neondiff/issues/443");
   });


### PR DESCRIPTION
## Summary

- retry post-promotion npm dist-tag confirmation with bounded total attempts and a timeout on every registry read
- execute-test the exact embedded workflow block for stale-to-converged, never-converges, and hung-read scenarios
- stamp the v1.0.3 package, source, CLI, daemon, and browser-dashboard states as published
- record GitHub/npm/install/browser proof with exact release/package identities and SHA-256-bound local artifacts

## Incident addressed

The first v1.0.3 publication run successfully published, verified, and promoted `neondiff@1.0.3`, but its immediate read-after-`npm dist-tag add` observed stale registry state. The idempotent rerun succeeded and removed the owned quarantine tag. This patch keeps the confirmation code embedded in the workflow so manual recovery against the immutable v1.0.3 checkout can execute it.

## Validation

- `npm test` — 95 files / 1,670 tests
- `npm run build`
- `actionlint`
- `node scripts/check-public-claims.mjs`
- `node scripts/check-secret-scan.mjs` — 484 tracked files
- JSON parse checks for the release manifest and publication proof
- `git diff --cached --check`
- independent spec/evidence review — no P0-P2 findings
- independent release-safety review — no P0-P2 findings after resolving checkout-boundary and hung-read findings

## Proof boundary

This PR records the already-proven real v1.0.3 GitHub/npm release and installed CLI/local browser-dashboard flow. It does not prove signed/notarized Mac distribution, Sparkle/appcast readiness, browser/native parity, v1.1 completion, or customer readiness. #503 remains open.

Closes #505
Refs #484, #503
