### PR TITLE
feat(desktop): make GitHub onboarding failures actionable

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
@@ -15,8 +15,10 @@ final class NeonDiffDesktopModel: ObservableObject {
     @Published var github = GitHubConnectionStatus()
     @Published var githubAuthorizationCode: GitHubDeviceAuthorizationCode?
     @Published var githubAuthorizationStatus = "not connected"
+    @Published var githubRecovery: GitHubConnectionRecovery?
     @Published var discoveredGitHubRepos: [GitHubDiscoveredRepository] = []
     @Published var isGitHubAuthorizationInProgress = false
+    @Published var isGitHubRepositoryRefreshInProgress = false
     @Published var logText = "No logs loaded."
     @Published var lastError: String?
     @Published var lastCommandLine = ""
@@ -32,6 +34,8 @@ final class NeonDiffDesktopModel: ObservableObject {
     private let keychain: DesktopSecretStoring
     private let githubAuthClient: GitHubDesktopAuthenticating
     private var githubAuthorizationTask: Task<Void, Never>?
+    private var githubRepositoryRefreshTask: Task<Void, Never>?
+    private var githubRepositoryRefreshGate = GitHubLatestRequestGate()
 
     init(
         userDefaults: UserDefaults = .standard,
@@ -111,6 +115,24 @@ final class NeonDiffDesktopModel: ObservableObject {
 
     var repoSelectionPatchApplyCommand: DesktopCommand {
         NeonDiffCommandBuilder.configPatch(cliPath: cliPath, configPath: configPath, inputPath: repoSelectionPatchPath.path, dryRun: false)
+    }
+
+    var githubAppInstallURL: URL {
+        GitHubAppInstallLink.url(botLogin: github.botLogin) ?? GitHubAppInstallLink.publicAppURL
+    }
+
+    var githubRecoveryActionTitle: String {
+        switch githubRecovery?.action {
+        case .reconnect: "Reconnect GitHub"
+        case .retryLater, .retry: "Retry Repository Discovery"
+        case .installOrManageApp: "Install / Manage App"
+        case .contactOrganizationOwner: "Manage App Access"
+        case nil: "Retry"
+        }
+    }
+
+    var githubRecoveryShowsAction: Bool {
+        githubRecovery?.action != .contactOrganizationOwner
     }
 
     func persistLocalSettings() {
@@ -232,6 +254,15 @@ final class NeonDiffDesktopModel: ObservableObject {
         logText = "Repo allowlist updated locally. Preview or apply the config patch to persist it."
     }
 
+    func githubAccessCue(for repo: RepoMonitor) -> GitHubRepositoryAccessCue? {
+        guard let discovered = discoveredGitHubRepos.first(where: {
+            $0.fullName.caseInsensitiveCompare(repo.name) == .orderedSame
+        }) else {
+            return nil
+        }
+        return GitHubRepositoryAccessPolicy.cue(for: discovered, licenseEntitlement: license.entitlement)
+    }
+
     func removeRepoFromAllowlist(_ repo: RepoMonitor) {
         repos.removeAll { $0.id == repo.id }
         lastError = nil
@@ -239,6 +270,7 @@ final class NeonDiffDesktopModel: ObservableObject {
     }
 
     func startGitHubAuthorization() {
+        guard !isGitHubRepositoryRefreshInProgress else { return }
         guard let clientId = github.clientId?.trimmingCharacters(in: .whitespacesAndNewlines), !clientId.isEmpty else {
             lastError = "Set the public GitHub App client ID before connecting GitHub."
             githubAuthorizationStatus = "client id missing"
@@ -248,6 +280,7 @@ final class NeonDiffDesktopModel: ObservableObject {
         githubAuthorizationCode = nil
         isGitHubAuthorizationInProgress = true
         githubAuthorizationStatus = "requesting device code"
+        githubRecovery = nil
         lastError = nil
         githubAuthorizationTask = Task { [weak self] in
             guard let self else { return }
@@ -262,9 +295,7 @@ final class NeonDiffDesktopModel: ObservableObject {
             } catch {
                 if Task.isCancelled { return }
                 isGitHubAuthorizationInProgress = false
-                githubAuthorizationStatus = "failed"
-                lastError = NeonDiffRedactor.redact(error.localizedDescription)
-                logText = lastError ?? "GitHub authorization failed."
+                applyGitHubFailure(error, fallbackStatus: "authorization failed")
             }
         }
     }
@@ -291,24 +322,60 @@ final class NeonDiffDesktopModel: ObservableObject {
         githubAuthorizationStatus = "verification page opened"
     }
 
+    func openGitHubAppInstallation() {
+        NSWorkspace.shared.open(githubAppInstallURL)
+        githubAuthorizationStatus = "App installation page opened"
+    }
+
+    func performGitHubRecoveryAction() {
+        switch githubRecovery?.action {
+        case .reconnect:
+            startGitHubAuthorization()
+        case .retryLater, .retry:
+            refreshGitHubRepositories()
+        case .installOrManageApp:
+            openGitHubAppInstallation()
+        case .contactOrganizationOwner:
+            logText = githubRecovery?.message ?? "Ask an organization owner to approve GitHub App access."
+        case nil:
+            refreshGitHubRepositories()
+        }
+    }
+
     func refreshGitHubRepositories() {
-        Task { [weak self] in
+        guard !isGitHubRepositoryRefreshInProgress, !isGitHubAuthorizationInProgress else { return }
+        githubRepositoryRefreshTask?.cancel()
+        let requestGeneration = githubRepositoryRefreshGate.begin()
+        isGitHubRepositoryRefreshInProgress = true
+        githubRepositoryRefreshTask = Task { [weak self] in
             guard let self else { return }
+            defer {
+                if githubRepositoryRefreshGate.isCurrent(requestGeneration) {
+                    isGitHubRepositoryRefreshInProgress = false
+                    githubRepositoryRefreshTask = nil
+                }
+            }
             do {
                 githubAuthorizationStatus = "refreshing repositories"
+                githubRecovery = nil
                 let accessToken = try await gitHubAccessTokenForAPI()
                 let user = try await githubAuthClient.fetchCurrentUser(accessToken: accessToken)
                 let discovered = try await githubAuthClient.listAccessibleRepositories(accessToken: accessToken)
+                guard !Task.isCancelled, githubRepositoryRefreshGate.isCurrent(requestGeneration) else { return }
                 applyGitHubDiscovery(user: user, discovered: discovered)
             } catch {
+                guard !Task.isCancelled, githubRepositoryRefreshGate.isCurrent(requestGeneration) else { return }
                 if error is GitHubDesktopAuthorizationStateError {
                     lastError = NeonDiffRedactor.redact(error.localizedDescription)
                     logText = lastError ?? "Reconnect GitHub."
+                    githubRecovery = GitHubConnectionRecovery(
+                        status: "reconnect required",
+                        message: lastError ?? "Reconnect GitHub before refreshing repositories.",
+                        action: .reconnect
+                    )
                     return
                 }
-                githubAuthorizationStatus = "repository refresh failed"
-                lastError = NeonDiffRedactor.redact(error.localizedDescription)
-                logText = lastError ?? "GitHub repository refresh failed."
+                applyGitHubFailure(error, fallbackStatus: "repository refresh failed")
             }
         }
     }
@@ -540,23 +607,27 @@ final class NeonDiffDesktopModel: ObservableObject {
                     isGitHubAuthorizationInProgress = false
                     githubAuthorizationStatus = error.rawValue
                     github.installationState = "authorization failed"
-                    lastError = NeonDiffRedactor.redact(description ?? error.rawValue)
-                    logText = lastError ?? "GitHub authorization failed."
+                    let recovery = GitHubConnectionRecoveryClassifier.deviceAuthorizationFailure(error, description: description)
+                    githubRecovery = recovery
+                    lastError = recovery.message
+                    logText = recovery.message
                     return
                 }
             } catch {
                 if Task.isCancelled { return }
                 isGitHubAuthorizationInProgress = false
-                githubAuthorizationStatus = "failed"
-                lastError = NeonDiffRedactor.redact(error.localizedDescription)
-                logText = lastError ?? "GitHub authorization failed."
+                applyGitHubFailure(error, fallbackStatus: "authorization failed")
                 return
             }
         }
         if !Task.isCancelled {
             isGitHubAuthorizationInProgress = false
-            githubAuthorizationStatus = "expired"
-            github.installationState = "device code expired"
+            let recovery = GitHubConnectionRecoveryClassifier.deviceCodeExpired
+            githubAuthorizationStatus = recovery.status
+            github.installationState = recovery.status
+            githubRecovery = recovery
+            lastError = recovery.message
+            logText = recovery.message
         }
     }
 
@@ -588,8 +659,9 @@ final class NeonDiffDesktopModel: ObservableObject {
         github.installationCount = Set(discovered.map(\.installationId)).count
         github.discoveredRepositoryCount = discovered.count
         github.installationState = discovered.isEmpty
-            ? "authorized as \(user.login); no accessible installations found"
+            ? "authorized as \(user.login); no accessible App repositories found"
             : "authorized as \(user.login); \(discovered.count) repositories available"
+        githubRecovery = discovered.isEmpty ? GitHubConnectionRecoveryClassifier.noInstallations : nil
         githubAuthorizationStatus = "authorized as \(user.login)"
         lastError = nil
         logText = "GitHub connected as \(user.login). Select repositories, then preview or apply the allowlist patch."
@@ -610,6 +682,20 @@ final class NeonDiffDesktopModel: ObservableObject {
         githubAuthorizationStatus = status
         githubAuthorizationCode = nil
         discoveredGitHubRepos = []
+    }
+
+    private func applyGitHubFailure(_ error: Error, fallbackStatus: String) {
+        let recovery = (error as? GitHubDeviceAuthClientError)?.recovery
+            ?? GitHubConnectionRecovery(
+                status: fallbackStatus,
+                message: NeonDiffRedactor.redact(error.localizedDescription),
+                action: .retry
+            )
+        githubRecovery = recovery
+        githubAuthorizationStatus = recovery.status
+        github.installationState = recovery.status
+        lastError = recovery.message
+        logText = recovery.message
     }
 
     private func readGitHubStoredDate(account: String) -> Date? {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ReposView.swift
@@ -42,14 +42,27 @@ struct ReposView: View {
                                 systemImage: "person.crop.circle.badge.checkmark"
                             )
                         }
-                        .disabled(!model.github.clientIdConfigured || model.isGitHubAuthorizationInProgress)
+                        .disabled(
+                            !model.github.clientIdConfigured
+                                || model.isGitHubAuthorizationInProgress
+                                || model.isGitHubRepositoryRefreshInProgress
+                        )
                         .accessibilityIdentifier("neondiff-github-connect")
 
                         Button { model.refreshGitHubRepositories() } label: {
                             Label("Refresh Repositories", systemImage: "arrow.triangle.2.circlepath")
                         }
-                        .disabled(!model.github.userTokenStored)
+                        .disabled(
+                            !model.github.userTokenStored
+                                || model.isGitHubRepositoryRefreshInProgress
+                                || model.isGitHubAuthorizationInProgress
+                        )
                         .accessibilityIdentifier("neondiff-github-refresh-repos")
+
+                        Button { model.openGitHubAppInstallation() } label: {
+                            Label("Install / Manage App", systemImage: "shippingbox.and.arrow.backward")
+                        }
+                        .accessibilityIdentifier("neondiff-github-manage-app")
 
                         if model.isGitHubAuthorizationInProgress {
                             Button { model.cancelGitHubAuthorization() } label: {
@@ -57,6 +70,31 @@ struct ReposView: View {
                             }
                             .accessibilityIdentifier("neondiff-github-cancel")
                         }
+                    }
+
+                    Text("Use Only select repositories. Core review permissions are Metadata read, Contents read, Pull requests read/write, Checks read, and Actions read. Issues access is only for the separate issue-enrichment feature; organization admin is not a runtime permission.")
+                        .font(.caption)
+                        .foregroundStyle(NeonDiffTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if let recovery = model.githubRecovery {
+                        HStack(alignment: .top, spacing: 10) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(NeonDiffTheme.warning)
+                            Text(recovery.message)
+                                .operatorBodyText()
+                                .fixedSize(horizontal: false, vertical: true)
+                            Spacer()
+                            if model.githubRecoveryShowsAction {
+                                Button(model.githubRecoveryActionTitle) {
+                                    model.performGitHubRecoveryAction()
+                                }
+                                .disabled(model.isGitHubRepositoryRefreshInProgress)
+                                .accessibilityIdentifier("neondiff-github-recovery-action")
+                            }
+                        }
+                        .padding(10)
+                        .background(NeonDiffTheme.warning.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
                     }
 
                     if let code = model.githubAuthorizationCode {
@@ -131,6 +169,21 @@ struct ReposView: View {
                         .accessibilityIdentifier("neondiff-repo-toggle-\(repo.name)")
                     }
                     TableColumn("Profile", value: \.profile)
+                    TableColumn("Access") { repo in
+                        if let cue = model.githubAccessCue(for: repo) {
+                            Text(cue.label)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(
+                                    cue == .licenseRequired || cue == .insufficientReadAccess
+                                        ? NeonDiffTheme.warning
+                                        : NeonDiffTheme.accent
+                                )
+                        } else {
+                            Text("MANUAL · VERIFY INSTALL")
+                                .font(.caption)
+                                .foregroundStyle(NeonDiffTheme.textSecondary)
+                        }
+                    }
                     TableColumn("Last Review", value: \.lastReview)
                     TableColumn("Remove") { repo in
                         Button { model.removeRepoFromAllowlist(repo) } label: {
@@ -167,8 +220,21 @@ struct ReposView: View {
                                 Text(repo.fullName)
                                     .textSelection(.enabled)
                                 Spacer()
-                                Text(repo.permissionsSummary)
-                                    .foregroundStyle(NeonDiffTheme.textSecondary)
+                                VStack(alignment: .trailing, spacing: 2) {
+                                    let cue = GitHubRepositoryAccessPolicy.cue(
+                                        for: repo,
+                                        licenseEntitlement: model.license.entitlement
+                                    )
+                                    Text(cue.label)
+                                        .font(.caption.weight(.semibold))
+                                        .foregroundStyle(
+                                            cue == .licenseRequired || cue == .insufficientReadAccess
+                                                ? NeonDiffTheme.warning
+                                                : NeonDiffTheme.accent
+                                        )
+                                    Text(repo.permissionsSummary)
+                                        .foregroundStyle(NeonDiffTheme.textSecondary)
+                                }
                             }
                             .font(.body)
                         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/GitHubDesktopModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/GitHubDesktopModels.swift
@@ -51,6 +51,201 @@ public enum GitHubDeviceAuthorizationError: String, Equatable {
     case unknown
 }
 
+public enum GitHubConnectionRecoveryAction: String, Equatable {
+    case reconnect
+    case retryLater
+    case installOrManageApp
+    case contactOrganizationOwner
+    case retry
+}
+
+public struct GitHubConnectionRecovery: Equatable {
+    public var status: String
+    public var message: String
+    public var action: GitHubConnectionRecoveryAction
+
+    public init(status: String, message: String, action: GitHubConnectionRecoveryAction) {
+        self.status = status
+        self.message = message
+        self.action = action
+    }
+}
+
+public enum GitHubConnectionRecoveryClassifier {
+    public static func httpFailure(
+        statusCode: Int,
+        headers: [String: String],
+        requestPath: String,
+        responseBody: String? = nil
+    ) -> GitHubConnectionRecovery {
+        let normalizedHeaders = Dictionary(uniqueKeysWithValues: headers.map { ($0.key.lowercased(), $0.value) })
+        let normalizedBody = responseBody?.lowercased() ?? ""
+        let rateLimited = statusCode == 429
+            || (statusCode == 403 && (
+                normalizedHeaders["x-ratelimit-remaining"] == "0"
+                    || normalizedHeaders["retry-after"] != nil
+            ))
+
+        if statusCode == 401 {
+            return GitHubConnectionRecovery(
+                status: "authorization expired",
+                message: "GitHub authorization is expired or revoked. Reconnect GitHub, then refresh repositories.",
+                action: .reconnect
+            )
+        }
+        if rateLimited {
+            return GitHubConnectionRecovery(
+                status: "rate limited",
+                message: "GitHub API rate limit reached. Wait for the API window to recover, then retry repository discovery.",
+                action: .retryLater
+            )
+        }
+        if statusCode == 403 {
+            let confirmedOrganizationPolicy = normalizedBody.contains("organization")
+                && (
+                    normalizedBody.contains("saml")
+                        || normalizedBody.contains("oauth app access restriction")
+                        || normalizedBody.contains("third-party application restriction")
+                )
+            if confirmedOrganizationPolicy {
+                return GitHubConnectionRecovery(
+                    status: "organization access blocked",
+                    message: "GitHub organization policy blocked repository discovery. Ask an organization owner to approve the App or authorize access.",
+                    action: .contactOrganizationOwner
+                )
+            }
+            return GitHubConnectionRecovery(
+                status: "permission denied",
+                message: "GitHub denied repository discovery. The App may lack selected-repository access or required permissions. Manage App access, then retry.",
+                action: .installOrManageApp
+            )
+        }
+        if statusCode == 404 && requestPath.contains("/user/installations") {
+            return GitHubConnectionRecovery(
+                status: "installation unavailable",
+                message: "The GitHub App installation is missing or no longer grants access to this repository. Install or manage the App for selected repositories, then retry.",
+                action: .installOrManageApp
+            )
+        }
+        return GitHubConnectionRecovery(
+            status: "GitHub API error",
+            message: "GitHub API request failed with HTTP \(statusCode). Retry; if the failure persists, inspect App installation and permission state.",
+            action: .retry
+        )
+    }
+
+    public static let noInstallations = GitHubConnectionRecovery(
+        status: "no accessible App repositories",
+        message: "GitHub authorization succeeded, but no App repositories are accessible. Install or manage NeonDiff for selected repositories, then refresh.",
+        action: .installOrManageApp
+    )
+
+    public static let deviceCodeExpired = GitHubConnectionRecovery(
+        status: "device code expired",
+        message: "The GitHub device code expired or is no longer valid. Start a new connection.",
+        action: .reconnect
+    )
+
+    public static func deviceAuthorizationFailure(
+        _ error: GitHubDeviceAuthorizationError,
+        description: String?
+    ) -> GitHubConnectionRecovery {
+        switch error {
+        case .deviceFlowDisabled:
+            return GitHubConnectionRecovery(
+                status: "device flow disabled",
+                message: "GitHub App device flow is disabled. An App owner must enable device flow before users can connect.",
+                action: .installOrManageApp
+            )
+        case .accessDenied:
+            return GitHubConnectionRecovery(
+                status: "authorization denied",
+                message: "GitHub authorization was denied. Reconnect when you are ready to approve access.",
+                action: .reconnect
+            )
+        case .expiredToken, .tokenExpired, .incorrectDeviceCode:
+            return deviceCodeExpired
+        default:
+            let detail = description?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return GitHubConnectionRecovery(
+                status: error.rawValue,
+                message: NeonDiffRedactor.redact(
+                    detail?.isEmpty == false
+                        ? detail!
+                        : "GitHub authorization failed. Retry or inspect the App client configuration."
+                ),
+                action: .retry
+            )
+        }
+    }
+}
+
+public struct GitHubLatestRequestGate {
+    private var generation: UInt64 = 0
+
+    public init() {}
+
+    public mutating func begin() -> UInt64 {
+        generation &+= 1
+        return generation
+    }
+
+    public func isCurrent(_ candidate: UInt64) -> Bool {
+        candidate == generation
+    }
+}
+
+public enum GitHubAppInstallLink {
+    public static let publicAppURL = URL(string: "https://github.com/apps/evaos-code-review-bot/installations/new")!
+
+    public static func url(botLogin: String) -> URL? {
+        let slug = botLogin
+            .replacingOccurrences(of: "[bot]", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard slug.range(of: #"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$"#, options: .regularExpression) != nil else {
+            return nil
+        }
+        return URL(string: "https://github.com/apps/\(slug)/installations/new")
+    }
+}
+
+public enum GitHubRepositoryAccessCue: String, Equatable {
+    case publicFree
+    case licenseActive
+    case licenseRequired
+    case insufficientReadAccess
+
+    public var label: String {
+        switch self {
+        case .publicFree: "PUBLIC · FREE"
+        case .licenseActive: "PRIVATE · LICENSE ACTIVE"
+        case .licenseRequired: "PRIVATE · LICENSE REQUIRED"
+        case .insufficientReadAccess: "INSUFFICIENT READ ACCESS"
+        }
+    }
+}
+
+public enum GitHubRepositoryAccessPolicy {
+    public static func cue(
+        for repository: GitHubDiscoveredRepository,
+        licenseEntitlement: String
+    ) -> GitHubRepositoryAccessCue {
+        if repository.permissionsSummary.lowercased().contains("pull:false") {
+            return .insufficientReadAccess
+        }
+        if repository.visibility.lowercased() == "public" {
+            return .publicFree
+        }
+        let normalizedEntitlement = licenseEntitlement
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        if ["active", "activated", "valid"].contains(normalizedEntitlement) {
+            return .licenseActive
+        }
+        return .licenseRequired
+    }
+}
+
 public enum GitHubDeviceAuthorizationPollResult: Equatable {
     case pending(intervalSeconds: Int)
     case authorized(GitHubUserToken)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubDeviceAuthClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/GitHubDeviceAuthClient.swift
@@ -12,6 +12,7 @@ public enum GitHubDeviceAuthClientError: Error, LocalizedError {
     case invalidURL(String)
     case invalidResponse(String)
     case apiError(String)
+    case actionable(GitHubConnectionRecovery)
 
     public var errorDescription: String? {
         switch self {
@@ -21,7 +22,14 @@ public enum GitHubDeviceAuthClientError: Error, LocalizedError {
             "Invalid GitHub response: \(NeonDiffRedactor.redact(value))"
         case .apiError(let value):
             "GitHub API error: \(NeonDiffRedactor.redact(value))"
+        case .actionable(let recovery):
+            recovery.message
         }
+    }
+
+    public var recovery: GitHubConnectionRecovery? {
+        guard case .actionable(let recovery) = self else { return nil }
+        return recovery
     }
 }
 
@@ -188,8 +196,16 @@ public final class GitHubDeviceAuthClient: GitHubDesktopAuthenticating {
             throw GitHubDeviceAuthClientError.invalidResponse("missing HTTP response")
         }
         guard (200..<300).contains(http.statusCode) else {
-            let body = String(data: data, encoding: .utf8) ?? "<binary response>"
-            throw GitHubDeviceAuthClientError.apiError("HTTP \(http.statusCode): \(body)")
+            let headers = Dictionary(uniqueKeysWithValues: http.allHeaderFields.map {
+                (String(describing: $0.key).lowercased(), String(describing: $0.value))
+            })
+            let recovery = GitHubConnectionRecoveryClassifier.httpFailure(
+                statusCode: http.statusCode,
+                headers: headers,
+                requestPath: request.url?.path ?? "",
+                responseBody: String(data: data, encoding: .utf8)
+            )
+            throw GitHubDeviceAuthClientError.actionable(recovery)
         }
         do {
             return try JSONDecoder.github.decode(T.self, from: data)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
@@ -222,6 +222,34 @@ final class GitHubFixtureURLProtocol: URLProtocol {
     }
 }
 
+final class GitHubRateLimitURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "rate-limit.github.local"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let payload = Data(#"{"message":"API rate limit exceeded","token":"must-not-surface"}"#.utf8)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 403,
+            httpVersion: "HTTP/1.1",
+            headerFields: [
+                "Content-Type": "application/json",
+                "X-RateLimit-Remaining": "0"
+            ]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
 let fixtureSessionConfig = URLSessionConfiguration.ephemeral
 fixtureSessionConfig.protocolClasses = [GitHubFixtureURLProtocol.self]
 let fixtureGitHubClient = GitHubDeviceAuthClient(
@@ -343,5 +371,126 @@ let fakeGitHubRefreshToken = ["ghr", "fixture_token_12345678901234567890"].joine
 let redactedGitHubTokens = NeonDiffRedactor.redact("access=\(fakeGitHubAccessToken) refresh=\(fakeGitHubRefreshToken)")
 check(!redactedGitHubTokens.contains("ghu_fixture"), "GitHub user access tokens are redacted")
 check(!redactedGitHubTokens.contains("ghr_fixture"), "GitHub refresh tokens are redacted")
+
+let unauthorizedRecovery = GitHubConnectionRecoveryClassifier.httpFailure(
+    statusCode: 401,
+    headers: [:],
+    requestPath: "/user/installations"
+)
+check(unauthorizedRecovery.action == .reconnect, "GitHub 401 tells the user to reconnect")
+check(unauthorizedRecovery.status == "authorization expired", "GitHub 401 has a stable visible status")
+
+let rateLimitRecovery = GitHubConnectionRecoveryClassifier.httpFailure(
+    statusCode: 403,
+    headers: ["x-ratelimit-remaining": "0"],
+    requestPath: "/user/installations"
+)
+check(rateLimitRecovery.action == .retryLater, "GitHub rate limits tell the user to retry later")
+check(rateLimitRecovery.message.contains("rate limit"), "GitHub rate limits are named in the visible recovery copy")
+
+let secondaryRateLimitRecovery = GitHubConnectionRecoveryClassifier.httpFailure(
+    statusCode: 403,
+    headers: ["Retry-After": "60"],
+    requestPath: "/user/installations"
+)
+check(secondaryRateLimitRecovery.action == .retryLater, "GitHub secondary rate limits are not mislabeled as organization policy")
+
+let organizationRecovery = GitHubConnectionRecoveryClassifier.httpFailure(
+    statusCode: 403,
+    headers: [:],
+    requestPath: "/user/installations"
+)
+check(organizationRecovery.action == .installOrManageApp, "Ambiguous GitHub 403 responses use permission recovery without assuming org policy")
+check(organizationRecovery.status == "permission denied", "Ambiguous GitHub 403 responses have a stable permission status")
+
+let confirmedOrganizationRecovery = GitHubConnectionRecoveryClassifier.httpFailure(
+    statusCode: 403,
+    headers: [:],
+    requestPath: "/user/installations",
+    responseBody: #"{"message":"Resource protected by organization SAML enforcement"}"#
+)
+check(confirmedOrganizationRecovery.action == .contactOrganizationOwner, "Confirmed GitHub org policy blocks name the organization-owner recovery")
+check(confirmedOrganizationRecovery.message.contains("organization policy"), "Confirmed org policy blocks are distinct from permission denials")
+
+let installationRecovery = GitHubConnectionRecoveryClassifier.httpFailure(
+    statusCode: 404,
+    headers: [:],
+    requestPath: "/user/installations/42/repositories"
+)
+check(installationRecovery.action == .installOrManageApp, "Missing installations point to GitHub App management")
+
+check(
+    GitHubAppInstallLink.url(botLogin: "evaos-code-review-bot[bot]")?.absoluteString
+        == "https://github.com/apps/evaos-code-review-bot/installations/new",
+    "GitHub App bot login maps to the selected-repository install URL"
+)
+check(GitHubAppInstallLink.url(botLogin: "configured GitHub App bot") == nil, "Placeholder bot labels do not become install URLs")
+check(
+    GitHubAppInstallLink.publicAppURL.absoluteString
+        == "https://github.com/apps/evaos-code-review-bot/installations/new",
+    "The public product has a stable selected-repository install URL when botLogin is omitted"
+)
+
+let publicRepoCue = GitHubRepositoryAccessPolicy.cue(
+    for: GitHubDiscoveredRepository(
+        fullName: "octo-org/public-repo",
+        visibility: "public",
+        installationId: 42,
+        installationAccount: "octo-org",
+        permissionsSummary: "admin:false,push:false,pull:true"
+    ),
+    licenseEntitlement: "not activated"
+)
+check(publicRepoCue == .publicFree, "Public repositories show the free-path cue")
+
+let privateRepoCue = GitHubRepositoryAccessPolicy.cue(
+    for: GitHubDiscoveredRepository(
+        fullName: "octo-org/private-repo",
+        visibility: "private",
+        installationId: 42,
+        installationAccount: "octo-org",
+        permissionsSummary: "admin:false,push:false,pull:true"
+    ),
+    licenseEntitlement: "stored locally"
+)
+check(privateRepoCue == .licenseRequired, "Private repositories do not treat a stored key as active entitlement")
+
+let unreadableRepoCue = GitHubRepositoryAccessPolicy.cue(
+    for: GitHubDiscoveredRepository(
+        fullName: "octo-org/unreadable-repo",
+        visibility: "private",
+        installationId: 42,
+        installationAccount: "octo-org",
+        permissionsSummary: "admin:false,push:false,pull:false"
+    ),
+    licenseEntitlement: "active"
+)
+check(unreadableRepoCue == .insufficientReadAccess, "Unreadable repositories name the permissions blocker before license state")
+
+let locallyExpiredDeviceCode = GitHubConnectionRecoveryClassifier.deviceCodeExpired
+check(locallyExpiredDeviceCode.action == .reconnect, "Locally detected device-code expiry exposes reconnect recovery")
+check(locallyExpiredDeviceCode.status == "device code expired", "Local and GitHub-returned device expiry share a stable status")
+
+var refreshGate = GitHubLatestRequestGate()
+let firstRefresh = refreshGate.begin()
+let secondRefresh = refreshGate.begin()
+check(!refreshGate.isCurrent(firstRefresh), "An older repository refresh cannot overwrite a newer refresh")
+check(refreshGate.isCurrent(secondRefresh), "The newest repository refresh may update UI state")
+
+let rateLimitSessionConfig = URLSessionConfiguration.ephemeral
+rateLimitSessionConfig.protocolClasses = [GitHubRateLimitURLProtocol.self]
+let rateLimitClient = GitHubDeviceAuthClient(
+    apiBaseURL: URL(string: "https://rate-limit.github.local")!,
+    session: URLSession(configuration: rateLimitSessionConfig)
+)
+do {
+    _ = try await rateLimitClient.fetchCurrentUser(accessToken: "fixture-access-token")
+    check(false, "GitHub client must reject a rate-limited API response")
+} catch let error as GitHubDeviceAuthClientError {
+    check(error.recovery?.action == .retryLater, "GitHub client carries the classified rate-limit recovery to the UI model")
+    check(!error.localizedDescription.contains("must-not-surface"), "GitHub client does not surface raw API response bodies")
+} catch {
+    check(false, "GitHub client must expose a typed, actionable failure")
+}
 
 print("NeonDiffDesktopCoreChecks passed")

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -69,6 +69,24 @@ selects them. It does not post reviews, widen App permissions, or write GitHub
 user tokens into config. Live PR reviews still post only through the configured
 GitHub App bot identity.
 
+The Repos pane links to the public GitHub App's install/manage page and tells
+users to choose `Only select repositories`. It names the core review permissions
+and keeps optional Issues access scoped to the separate issue-enrichment feature.
+It distinguishes expired user
+authorization, API rate limiting, missing App installation, and organization
+policy or permission blocks without showing raw API bodies. Discovered repos
+show one of these access cues:
+
+- `PUBLIC · FREE` for the public-repo path;
+- `PRIVATE · LICENSE REQUIRED` until active entitlement is proven;
+- `PRIVATE · LICENSE ACTIVE` only for an explicit active entitlement state;
+- `INSUFFICIENT READ ACCESS` when GitHub reports that the user cannot read the
+  repository.
+
+A stored license key is not treated as active entitlement. Repo selection still
+writes only the local allowlist; the worker's pre-checkout license and GitHub App
+gates remain authoritative for review execution.
+
 ## Local Dashboard Launcher
 
 The dev app no longer opens a browser tab automatically. It exposes explicit

--- a/docs/superpowers/plans/2026-07-10-issue-487-github-onboarding-recovery.md
+++ b/docs/superpowers/plans/2026-07-10-issue-487-github-onboarding-recovery.md
@@ -9,7 +9,6 @@ Close the remaining functional acceptance gap in the released GitHub desktop onb
 - Issue: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/487
 - Milestone: #11 `v1.1 — Real Mac Desktop Launch`
 - Base: `origin/main` at `7bed4f0f54675739f1c702e181e0d1352132c1e9`
-- Worktree: `/Volumes/LEXAR/repos/worktrees/evaos-code-review-bot-neondiff/487-github-onboarding-errors`
 - Branch: `codex/487-github-onboarding-errors`
 
 ## Scope

--- a/docs/superpowers/plans/2026-07-10-issue-487-github-onboarding-recovery.md
+++ b/docs/superpowers/plans/2026-07-10-issue-487-github-onboarding-recovery.md
@@ -1,0 +1,49 @@
+# Issue #487 GitHub Onboarding Recovery Plan
+
+## Goal
+
+Close the remaining functional acceptance gap in the released GitHub desktop onboarding flow without expanding into the deferred visual-system lane or signed desktop distribution.
+
+## Source Of Truth
+
+- Issue: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/487
+- Milestone: #11 `v1.1 — Real Mac Desktop Launch`
+- Base: `origin/main` at `7bed4f0f54675739f1c702e181e0d1352132c1e9`
+- Worktree: `/Volumes/LEXAR/repos/worktrees/evaos-code-review-bot-neondiff/487-github-onboarding-errors`
+- Branch: `codex/487-github-onboarding-errors`
+
+## Scope
+
+1. Classify GitHub authorization, rate-limit, App-installation, and organization-policy failures into distinct redacted recovery states.
+2. Surface Install/Manage GitHub App guidance with selected-repository and least-privilege copy.
+3. Show public-free, private-license-required, and insufficient-read-access cues for discovered repositories.
+4. Preserve Keychain-only user tokens, config-patch-only allowlist writes, App-authored reviews, and fail-closed private-repo enforcement.
+5. Prove the change through core checks, Swift build/bundle smoke, secret/public-claim scans, and visible unsigned dev-app smoke before PR review.
+
+## Non-goals
+
+- No #508 theme or visual-system work.
+- No signing, notarization, Sparkle/appcast publication, release tag, npm publish, or customer-ready claim.
+- No GitHub App permission expansion or organization-wide install default.
+- No live review posting or production allowlist mutation.
+
+## Stop Conditions
+
+- Any token, private repo name, credential, or transient device code reaches durable logs/evidence.
+- The UI treats a stored license key as active entitlement proof.
+- The implementation needs a client secret in the desktop app.
+- Current-head review or CI finds an unresolved P0-P2 issue.
+
+## Exact Next Action
+
+Commit the green implementation, open the #487 PR, then require exact-current-head CI, review-thread, independent spec/safety, and visible dev-app proof before merge.
+
+## Implementation Proof
+
+- `swift run NeonDiffDesktopCoreChecks`: passed, including HTTP recovery classification, raw-body non-disclosure, request-generation gating, local device-code expiry, App install URL, and repository access cues.
+- `swift run NeonDiffDesktopCoreSmoke`: passed.
+- `swift build`: passed for the complete SwiftUI target.
+- `./script/build_and_run.sh bundle-check`: passed for the unsigned dev bundle.
+- Secret scan, public-claims scan, and `git diff --check`: passed.
+- Visible unsigned dev-app smoke: Repos pane rendered Install / Manage App, exact core/optional permission copy, and the Access column. No live repo discovery was run, so private repo names were not captured.
+- Independent spec and Swift reviews: all reported P2 findings fixed; final re-reviews found no P0-P2 issues.


### PR DESCRIPTION
Closes #487.

## Summary
- classify expired authorization, primary/secondary rate limits, ambiguous permission denials, confirmed organization-policy blocks, missing App access, and local device-code expiry into distinct redacted recovery states
- link the public GitHub App install/manage path and show exact selected-repository/core-permission guidance
- show public-free, private-license-required/active, insufficient-read-access, and manual-verification cues in the repo selector
- make repository refresh single-flight and generation-gated so reconnect/refresh completions cannot race
- preserve Keychain-only user tokens, config-patch-only allowlist writes, App-authored review authority, and worker-side private-repo entitlement gates

## Validation
- swift run NeonDiffDesktopCoreChecks
- swift run NeonDiffDesktopCoreSmoke
- swift build
- ./script/build_and_run.sh bundle-check
- npm run check:secrets
- npm run check:public-claims
- git diff --check
- independent spec and Swift reviews: final rechecks found no P0-P2 issues

## Visual proof
Unsigned dev-app Repos pane rendered Install / Manage App, core/optional permission guidance, and the Access column. No live repo discovery was run, so private repository names were not captured.

Operator evidence ref: neondiff-v1.1/2026-07-10/issue-487/repos-pane-recovery-controls.jpeg
SHA-256: 385c0f49446c064a4960270b6108123e353b45f969215f4f807fbb3a12478cfc

## Proof boundary
This PR proves source behavior and unsigned dev-app UI only. It does not claim signed/notarized distribution, Sparkle/appcast publication, installed customer readiness, browser/native parity, or v1.1 release completion. Those remain tracked by #503, #116, and #449.