### PR TITLE
feat(desktop): add safe configuration control center

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
@@ -334,15 +334,22 @@ final class NeonDiffDesktopModel: ObservableObject {
             return
         }
         let snapshot = currentControlCenterSnapshot
+        let operation = ControlCenterOperation.preview(
+            snapshot: snapshot,
+            baseline: baseline,
+            expectedRevision: expectedRevision
+        )
+        guard beginControlCenterOperation(operation) else { return }
         do {
             try writeControlCenterPatch(snapshot.settings, to: controlCenterPatchPath)
         } catch {
             lastError = NeonDiffRedactor.redact(error.localizedDescription)
             controlCenterStatus = lastError ?? "Control-center patch generation failed."
+            isControlCenterOperationInProgress = false
             return
         }
         runControlCenterPatch(
-            operation: .preview(snapshot: snapshot, baseline: baseline, expectedRevision: expectedRevision),
+            operation: operation,
             arguments: [
                 "config", "patch", "--config", configPath, "--input", controlCenterPatchPath.path,
                 "--dry-run", "true", "--expected-revision", expectedRevision
@@ -362,15 +369,22 @@ final class NeonDiffDesktopModel: ObservableObject {
             lastError = "Preview the current control-center settings before Apply."
             return
         }
+        let operation = ControlCenterOperation.apply(
+            snapshot: snapshot,
+            baseline: baseline,
+            expectedRevision: expectedRevision
+        )
+        guard beginControlCenterOperation(operation) else { return }
         do {
             try writeControlCenterPatch(snapshot.settings, to: controlCenterPatchPath)
         } catch {
             lastError = NeonDiffRedactor.redact(error.localizedDescription)
             controlCenterStatus = lastError ?? "Control-center patch generation failed."
+            isControlCenterOperationInProgress = false
             return
         }
         runControlCenterPatch(
-            operation: .apply(snapshot: snapshot, baseline: baseline, expectedRevision: expectedRevision),
+            operation: operation,
             arguments: [
                 "config", "patch", "--config", configPath, "--input", controlCenterPatchPath.path,
                 "--dry-run", "false", "--confirm", "true", "--expected-revision", expectedRevision
@@ -388,15 +402,21 @@ final class NeonDiffDesktopModel: ObservableObject {
             lastError = "No applied control-center change is available to roll back."
             return
         }
+        let operation = ControlCenterOperation.rollback(
+            snapshot: rollback,
+            expectedRevision: expectedRevision
+        )
+        guard beginControlCenterOperation(operation) else { return }
         do {
             try writeControlCenterPatch(rollback.settings, to: controlCenterRollbackPath)
         } catch {
             lastError = NeonDiffRedactor.redact(error.localizedDescription)
             controlCenterStatus = lastError ?? "Control-center rollback generation failed."
+            isControlCenterOperationInProgress = false
             return
         }
         runControlCenterPatch(
-            operation: .rollback(snapshot: rollback, expectedRevision: expectedRevision),
+            operation: operation,
             arguments: [
                 "config", "patch", "--config", configPath, "--input", controlCenterRollbackPath.path,
                 "--dry-run", "false", "--confirm", "true", "--expected-revision", expectedRevision
@@ -686,7 +706,9 @@ final class NeonDiffDesktopModel: ObservableObject {
                         self.isConfigInspectInProgress = false
                     }
                     if controlCenterOperation != nil {
-                        self.controlCenterStatus = self.lastError ?? "Control-center command failed."
+                        self.invalidateControlCenterAfterPatchFailure(
+                            self.lastError ?? "Control-center command failed before a response was received."
+                        )
                         self.isControlCenterOperationInProgress = false
                     }
                 }
@@ -762,10 +784,17 @@ final class NeonDiffDesktopModel: ObservableObject {
         try data.write(to: path, options: [.atomic])
     }
 
-    private func runControlCenterPatch(operation: ControlCenterOperation, arguments: [String], command: DesktopCommand) {
-        guard !isControlCenterOperationInProgress else { return }
+    private func beginControlCenterOperation(_ operation: ControlCenterOperation) -> Bool {
+        guard !isControlCenterOperationInProgress else {
+            lastError = "Another control-center operation is still running."
+            return false
+        }
         isControlCenterOperationInProgress = true
         controlCenterStatus = operation.statusText
+        return true
+    }
+
+    private func runControlCenterPatch(operation: ControlCenterOperation, arguments: [String], command: DesktopCommand) {
         runCLI(arguments: arguments, displayCommand: command, controlCenterOperation: operation)
     }
 
@@ -979,6 +1008,33 @@ final class NeonDiffDesktopModel: ObservableObject {
         logText = [result.redactedStdout, result.redactedStderr].filter { !$0.isEmpty }.joined(separator: "\n")
 
         let commandName = parseCommandName(result.stdout)
+        let parsedSnapshot = (commandName == "config inspect" || commandName == "config patch")
+            ? ConfigInspectParser.parse(
+                result.stdout,
+                providerKeyStored: keychain.containsSecret(account: providerKeyAccount),
+                licenseKeyStored: keychain.containsSecret(account: licenseKeyAccount),
+                githubUserTokenStored: keychain.containsSecret(account: githubUserTokenAccount)
+            )
+            : nil
+        var validatedPatchRevisionAfter: String?
+        if let operation = controlCenterOperation {
+            validatedPatchRevisionAfter = ConfigPatchProofValidator.revisionAfter(
+                snapshot: parsedSnapshot,
+                expectedRevision: operation.expectedRevision,
+                mode: operation.proofMode
+            )
+            guard
+                result.exitCode == 0,
+                commandName == "config patch",
+                validatedPatchRevisionAfter != nil
+            else {
+                let patchError = ConfigInspectParser.error(result.stdout, command: "config patch")
+                    ?? lastError
+                    ?? "Config patch returned an invalid or mismatched response. Reload current config before further edits."
+                invalidateControlCenterAfterPatchFailure(patchError)
+                return
+            }
+        }
         if isConfigInspectCommand && (result.exitCode != 0 || commandName != "config inspect") {
             let inspectError = ConfigInspectParser.error(result.stdout)
                 ?? lastError
@@ -987,12 +1043,6 @@ final class NeonDiffDesktopModel: ObservableObject {
             return
         }
         if commandName == "config inspect" || commandName == "config patch" {
-            let parsedSnapshot = ConfigInspectParser.parse(
-                result.stdout,
-                providerKeyStored: keychain.containsSecret(account: providerKeyAccount),
-                licenseKeyStored: keychain.containsSecret(account: licenseKeyAccount),
-                githubUserTokenStored: keychain.containsSecret(account: githubUserTokenAccount)
-            )
             if let snapshot = parsedSnapshot {
                 if !snapshot.repos.isEmpty { repos = snapshot.repos }
                 providers = snapshot.providers
@@ -1032,88 +1082,58 @@ final class NeonDiffDesktopModel: ObservableObject {
                 invalidateControlCenterAfterInspectFailure(inspectError)
                 return
             }
-            if commandName == "config patch", let operation = controlCenterOperation {
-                let succeeded = result.exitCode == 0 && lastError == nil
+            if commandName == "config patch",
+               let operation = controlCenterOperation,
+               let revisionAfter = validatedPatchRevisionAfter {
                 switch operation {
                 case .preview(let snapshot, let baseline, let expectedRevision):
-                    if succeeded {
-                        previewedControlCenterSnapshot = snapshot
-                        previewedControlCenterBaseline = baseline
-                        previewedControlCenterExpectedRevision = expectedRevision
-                        controlCenterStatus = snapshot == currentControlCenterSnapshot
-                            ? "Preview passed. Apply is enabled for this exact settings snapshot."
-                            : "Preview passed for an earlier settings snapshot. Preview the current edits before Apply."
-                    } else {
-                        previewedControlCenterSnapshot = nil
-                        previewedControlCenterBaseline = nil
-                        previewedControlCenterExpectedRevision = nil
-                        controlCenterLoadedRevision = nil
-                        controlCenterStatus = lastError ?? "Preview failed."
-                    }
+                    previewedControlCenterSnapshot = snapshot
+                    previewedControlCenterBaseline = baseline
+                    previewedControlCenterExpectedRevision = expectedRevision
+                    controlCenterStatus = snapshot == currentControlCenterSnapshot
+                        ? "Preview passed. Apply is enabled for this exact settings snapshot."
+                        : "Preview passed for an earlier settings snapshot. Preview the current edits before Apply."
                 case .apply(let snapshot, let baseline, _):
-                    if succeeded, let revisionAfter = ConfigInspectParser.parse(
-                        result.stdout,
-                        providerKeyStored: keychain.containsSecret(account: providerKeyAccount),
-                        licenseKeyStored: keychain.containsSecret(account: licenseKeyAccount),
-                        githubUserTokenStored: keychain.containsSecret(account: githubUserTokenAccount)
-                    )?.revisionAfter {
-                        controlCenter = snapshot.settings
+                    controlCenter = snapshot.settings
+                    controlCenterLoadedSnapshot = snapshot
+                    controlCenterLoadedRevision = revisionAfter
+                    previewedControlCenterSnapshot = nil
+                    previewedControlCenterBaseline = nil
+                    previewedControlCenterExpectedRevision = nil
+                    if parsedSnapshot?.wrote == true {
                         controlCenterRollbackSnapshot = baseline
                         controlCenterRollbackExpectedRevision = revisionAfter
-                        controlCenterLoadedSnapshot = snapshot
-                        controlCenterLoadedRevision = revisionAfter
-                        previewedControlCenterSnapshot = nil
-                        previewedControlCenterBaseline = nil
-                        previewedControlCenterExpectedRevision = nil
                         controlCenterStatus = self.configPath == snapshot.configPath
                             ? "Config applied. Apply Last Rollback is now available."
                             : "Config applied to the previously selected path. Return to that path to roll back, or load the current config."
-                    } else if succeeded {
-                        controlCenterLoadedRevision = nil
-                        controlCenterRollbackSnapshot = nil
-                        controlCenterRollbackExpectedRevision = nil
-                        previewedControlCenterSnapshot = nil
-                        previewedControlCenterBaseline = nil
-                        previewedControlCenterExpectedRevision = nil
-                        lastError = "Config write returned without revision proof. Reload current config before further edits."
-                        controlCenterStatus = lastError ?? "Reload current config."
                     } else {
-                        controlCenterLoadedRevision = nil
-                        previewedControlCenterSnapshot = nil
-                        previewedControlCenterBaseline = nil
-                        previewedControlCenterExpectedRevision = nil
-                        controlCenterStatus = lastError ?? "Apply failed."
+                        if controlCenterRollbackSnapshot?.configPath != snapshot.configPath
+                            || controlCenterRollbackExpectedRevision != revisionAfter {
+                            controlCenterRollbackSnapshot = nil
+                            controlCenterRollbackExpectedRevision = nil
+                        }
+                        controlCenterStatus = "No config changes were needed."
                     }
                 case .rollback(let snapshot, _):
-                    if succeeded, let revisionAfter = ConfigInspectParser.parse(
-                        result.stdout,
-                        providerKeyStored: keychain.containsSecret(account: providerKeyAccount),
-                        licenseKeyStored: keychain.containsSecret(account: licenseKeyAccount),
-                        githubUserTokenStored: keychain.containsSecret(account: githubUserTokenAccount)
-                    )?.revisionAfter {
-                        controlCenter = snapshot.settings
-                        controlCenterLoadedSnapshot = snapshot
-                        controlCenterLoadedRevision = revisionAfter
-                        controlCenterRollbackSnapshot = nil
-                        controlCenterRollbackExpectedRevision = nil
-                        previewedControlCenterSnapshot = nil
-                        previewedControlCenterBaseline = nil
-                        previewedControlCenterExpectedRevision = nil
+                    controlCenter = snapshot.settings
+                    controlCenterLoadedSnapshot = snapshot
+                    controlCenterLoadedRevision = revisionAfter
+                    controlCenterRollbackSnapshot = nil
+                    controlCenterRollbackExpectedRevision = nil
+                    previewedControlCenterSnapshot = nil
+                    previewedControlCenterBaseline = nil
+                    previewedControlCenterExpectedRevision = nil
+                    if parsedSnapshot?.wrote == true {
                         controlCenterStatus = self.configPath == snapshot.configPath
                             ? "Rollback applied. Reload config before further edits."
                             : "Rollback applied to the previously selected path. Load the current config before further edits."
-                    } else if succeeded {
-                        controlCenterLoadedRevision = nil
-                        controlCenterRollbackSnapshot = nil
-                        controlCenterRollbackExpectedRevision = nil
-                        lastError = "Rollback returned without revision proof. Reload current config before further edits."
-                        controlCenterStatus = lastError ?? "Reload current config."
                     } else {
-                        controlCenterLoadedRevision = nil
-                        controlCenterRollbackSnapshot = nil
-                        controlCenterRollbackExpectedRevision = nil
-                        controlCenterStatus = lastError ?? "Rollback failed."
+                        controlCenterStatus = "Config was already at the rollback target. Reload before further edits."
                     }
+                }
+                if let warning = parsedSnapshot?.warning {
+                    lastError = NeonDiffRedactor.redact(warning)
+                    controlCenterStatus = lastError ?? "Config patch completed with a lock-cleanup warning."
                 }
                 isControlCenterOperationInProgress = false
             }
@@ -1140,6 +1160,16 @@ final class NeonDiffDesktopModel: ObservableObject {
     }
 
     private func invalidateControlCenterAfterInspectFailure(_ message: String) {
+        invalidateControlCenterAuthorization(message)
+        controlCenterStatus = lastError ?? "Config inspect failed."
+    }
+
+    private func invalidateControlCenterAfterPatchFailure(_ message: String) {
+        invalidateControlCenterAuthorization(message)
+        controlCenterStatus = lastError ?? "Config patch failed. Reload current config."
+    }
+
+    private func invalidateControlCenterAuthorization(_ message: String) {
         controlCenterLoadedSnapshot = nil
         controlCenterLoadedRevision = nil
         controlCenterRollbackSnapshot = nil
@@ -1148,7 +1178,6 @@ final class NeonDiffDesktopModel: ObservableObject {
         previewedControlCenterBaseline = nil
         previewedControlCenterExpectedRevision = nil
         lastError = NeonDiffRedactor.redact(message)
-        controlCenterStatus = lastError ?? "Config inspect failed."
     }
 
 }
@@ -1171,6 +1200,22 @@ private enum ControlCenterOperation: Sendable {
         case .preview: "Previewing control-center patch..."
         case .apply: "Applying validated control-center patch..."
         case .rollback: "Applying last control-center rollback..."
+        }
+    }
+
+    var expectedRevision: String {
+        switch self {
+        case .preview(_, _, let expectedRevision),
+             .apply(_, _, let expectedRevision),
+             .rollback(_, let expectedRevision):
+            expectedRevision
+        }
+    }
+
+    var proofMode: ConfigPatchProofMode {
+        switch self {
+        case .preview: .preview
+        case .apply, .rollback: .apply
         }
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
@@ -12,6 +12,12 @@ final class NeonDiffDesktopModel: ObservableObject {
     @Published var repos: [RepoMonitor] = []
     @Published var providers = ProviderSettings()
     @Published var license = LicenseStatus()
+    @Published var controlCenter = DesktopControlCenterSettings()
+    @Published var controlCenterStatus = "Load current config before editing."
+    @Published var isControlCenterOperationInProgress = false
+    @Published var isConfigPatchInProgress = false
+    @Published var isConfigInspectInProgress = false
+    @Published var pendingIssueRepoName = ""
     @Published var github = GitHubConnectionStatus()
     @Published var githubAuthorizationCode: GitHubDeviceAuthorizationCode?
     @Published var githubAuthorizationStatus = "not connected"
@@ -36,6 +42,13 @@ final class NeonDiffDesktopModel: ObservableObject {
     private var githubAuthorizationTask: Task<Void, Never>?
     private var githubRepositoryRefreshTask: Task<Void, Never>?
     private var githubRepositoryRefreshGate = GitHubLatestRequestGate()
+    private var controlCenterLoadedSnapshot: DesktopControlCenterSnapshot?
+    private var controlCenterRollbackSnapshot: DesktopControlCenterSnapshot?
+    private var previewedControlCenterSnapshot: DesktopControlCenterSnapshot?
+    private var previewedControlCenterBaseline: DesktopControlCenterSnapshot?
+    private var controlCenterLoadedRevision: String?
+    private var controlCenterRollbackExpectedRevision: String?
+    private var previewedControlCenterExpectedRevision: String?
 
     init(
         userDefaults: UserDefaults = .standard,
@@ -117,6 +130,68 @@ final class NeonDiffDesktopModel: ObservableObject {
         NeonDiffCommandBuilder.configPatch(cliPath: cliPath, configPath: configPath, inputPath: repoSelectionPatchPath.path, dryRun: false)
     }
 
+    var controlCenterPatchPreviewCommand: DesktopCommand {
+        NeonDiffCommandBuilder.configPatch(
+            cliPath: cliPath,
+            configPath: configPath,
+            inputPath: controlCenterPatchPath.path,
+            expectedRevision: controlCenterLoadedRevision
+        )
+    }
+
+    var controlCenterPatchApplyCommand: DesktopCommand {
+        NeonDiffCommandBuilder.configPatch(
+            cliPath: cliPath,
+            configPath: configPath,
+            inputPath: controlCenterPatchPath.path,
+            dryRun: false,
+            expectedRevision: previewedControlCenterExpectedRevision
+        )
+    }
+
+    var controlCenterRollbackCommand: DesktopCommand {
+        NeonDiffCommandBuilder.configPatch(
+            cliPath: cliPath,
+            configPath: configPath,
+            inputPath: controlCenterRollbackPath.path,
+            dryRun: false,
+            expectedRevision: controlCenterRollbackExpectedRevision
+        )
+    }
+
+    var controlCenterValidationError: String? {
+        DesktopControlCenterPatchBuilder.validationError(for: controlCenter)
+    }
+
+    var canPreviewControlCenter: Bool {
+        controlCenterLoadedSnapshot?.configPath == configPath
+            && controlCenterLoadedRevision != nil
+            && controlCenterValidationError == nil
+            && !isControlCenterOperationInProgress
+            && !isConfigPatchInProgress
+            && !isConfigInspectInProgress
+    }
+
+    var canApplyControlCenter: Bool {
+        canPreviewControlCenter
+            && previewedControlCenterSnapshot == currentControlCenterSnapshot
+            && previewedControlCenterBaseline?.configPath == configPath
+            && previewedControlCenterExpectedRevision != nil
+    }
+
+    var canRollbackControlCenter: Bool {
+        controlCenterRollbackSnapshot?.configPath == configPath
+            && controlCenterRollbackExpectedRevision != nil
+            && controlCenterLoadedRevision == controlCenterRollbackExpectedRevision
+            && !isControlCenterOperationInProgress
+            && !isConfigPatchInProgress
+            && !isConfigInspectInProgress
+    }
+
+    private var currentControlCenterSnapshot: DesktopControlCenterSnapshot {
+        DesktopControlCenterSnapshot(settings: controlCenter, configPath: configPath)
+    }
+
     var githubAppInstallURL: URL {
         GitHubAppInstallLink.url(botLogin: github.botLogin) ?? GitHubAppInstallLink.publicAppURL
     }
@@ -139,6 +214,12 @@ final class NeonDiffDesktopModel: ObservableObject {
         userDefaults.set(configPath, forKey: "neondiff.configPath")
         userDefaults.set(cliPath, forKey: "neondiff.cliPath")
         userDefaults.set(launchdLabel, forKey: "neondiff.launchdLabel")
+        if controlCenterLoadedSnapshot?.configPath != configPath {
+            previewedControlCenterSnapshot = nil
+            previewedControlCenterBaseline = nil
+            previewedControlCenterExpectedRevision = nil
+            controlCenterStatus = "Config path changed. Load current config before editing."
+        }
     }
 
     func refreshStatus() {
@@ -219,7 +300,109 @@ final class NeonDiffDesktopModel: ObservableObject {
     }
 
     func inspectConfig() {
+        guard !isConfigPatchInProgress, !isConfigInspectInProgress else { return }
         runCLI(arguments: ["config", "inspect", "--config", configPath], displayCommand: configInspectCommand)
+    }
+
+    func addPendingIssueRepo() {
+        let repo = pendingIssueRepoName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isValidRepoName(repo) else {
+            lastError = "Enter an issue-enrichment repository as owner/repo."
+            return
+        }
+        if !controlCenter.issueAllowlist.contains(where: { $0.caseInsensitiveCompare(repo) == .orderedSame }) {
+            controlCenter.issueAllowlist.append(repo)
+            controlCenter.issueAllowlist.sort { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        }
+        pendingIssueRepoName = ""
+        lastError = nil
+        controlCenterStatus = "Issue-enrichment allowlist changed locally; Preview is required before Apply."
+    }
+
+    func removeIssueRepo(_ repo: String) {
+        controlCenter.issueAllowlist.removeAll { $0.caseInsensitiveCompare(repo) == .orderedSame }
+        controlCenterStatus = "Issue-enrichment allowlist changed locally; Preview is required before Apply."
+    }
+
+    func previewControlCenterPatch() {
+        guard
+            let baseline = controlCenterLoadedSnapshot,
+            baseline.configPath == configPath,
+            let expectedRevision = controlCenterLoadedRevision
+        else {
+            lastError = "Load current config before previewing control-center changes."
+            return
+        }
+        let snapshot = currentControlCenterSnapshot
+        do {
+            try writeControlCenterPatch(snapshot.settings, to: controlCenterPatchPath)
+        } catch {
+            lastError = NeonDiffRedactor.redact(error.localizedDescription)
+            controlCenterStatus = lastError ?? "Control-center patch generation failed."
+            return
+        }
+        runControlCenterPatch(
+            operation: .preview(snapshot: snapshot, baseline: baseline, expectedRevision: expectedRevision),
+            arguments: [
+                "config", "patch", "--config", configPath, "--input", controlCenterPatchPath.path,
+                "--dry-run", "true", "--expected-revision", expectedRevision
+            ],
+            command: controlCenterPatchPreviewCommand
+        )
+    }
+
+    func applyControlCenterPatch() {
+        guard
+            let snapshot = previewedControlCenterSnapshot,
+            let baseline = previewedControlCenterBaseline,
+            let expectedRevision = previewedControlCenterExpectedRevision,
+            snapshot == currentControlCenterSnapshot,
+            baseline.configPath == configPath
+        else {
+            lastError = "Preview the current control-center settings before Apply."
+            return
+        }
+        do {
+            try writeControlCenterPatch(snapshot.settings, to: controlCenterPatchPath)
+        } catch {
+            lastError = NeonDiffRedactor.redact(error.localizedDescription)
+            controlCenterStatus = lastError ?? "Control-center patch generation failed."
+            return
+        }
+        runControlCenterPatch(
+            operation: .apply(snapshot: snapshot, baseline: baseline, expectedRevision: expectedRevision),
+            arguments: [
+                "config", "patch", "--config", configPath, "--input", controlCenterPatchPath.path,
+                "--dry-run", "false", "--confirm", "true", "--expected-revision", expectedRevision
+            ],
+            command: controlCenterPatchApplyCommand
+        )
+    }
+
+    func rollbackControlCenterPatch() {
+        guard
+            let rollback = controlCenterRollbackSnapshot,
+            rollback.configPath == configPath,
+            let expectedRevision = controlCenterRollbackExpectedRevision
+        else {
+            lastError = "No applied control-center change is available to roll back."
+            return
+        }
+        do {
+            try writeControlCenterPatch(rollback.settings, to: controlCenterRollbackPath)
+        } catch {
+            lastError = NeonDiffRedactor.redact(error.localizedDescription)
+            controlCenterStatus = lastError ?? "Control-center rollback generation failed."
+            return
+        }
+        runControlCenterPatch(
+            operation: .rollback(snapshot: rollback, expectedRevision: expectedRevision),
+            arguments: [
+                "config", "patch", "--config", configPath, "--input", controlCenterRollbackPath.path,
+                "--dry-run", "false", "--confirm", "true", "--expected-revision", expectedRevision
+            ],
+            command: controlCenterRollbackCommand
+        )
     }
 
     func previewProviderConfigPatch() {
@@ -450,7 +633,27 @@ final class NeonDiffDesktopModel: ObservableObject {
         lastCommandLine = command.commandLine
     }
 
-    private func runCLI(arguments: [String], displayCommand: DesktopCommand) {
+    private func runCLI(
+        arguments: [String],
+        displayCommand: DesktopCommand,
+        controlCenterOperation: ControlCenterOperation? = nil
+    ) {
+        let isConfigPatchCommand = arguments.count >= 2 && arguments[0] == "config" && arguments[1] == "patch"
+        let isConfigInspectCommand = arguments.count >= 2 && arguments[0] == "config" && arguments[1] == "inspect"
+        if isConfigPatchCommand && (isConfigPatchInProgress || isConfigInspectInProgress) {
+            lastError = "Another config operation is still running."
+            if controlCenterOperation != nil {
+                controlCenterStatus = lastError ?? "Control-center command deferred."
+                isControlCenterOperationInProgress = false
+            }
+            return
+        }
+        if isConfigInspectCommand && (isConfigPatchInProgress || isConfigInspectInProgress) {
+            lastError = "Another config operation is still running."
+            return
+        }
+        if isConfigPatchCommand { isConfigPatchInProgress = true }
+        if isConfigInspectCommand { isConfigInspectInProgress = true }
         lastCommandLine = displayCommand.commandLine
         let executablePath = cliPath
         Task.detached { [configPath, launchdLabel] in
@@ -461,12 +664,27 @@ final class NeonDiffDesktopModel: ObservableObject {
             do {
                 let result = try client.run(arguments: arguments, timeout: 15)
                 await MainActor.run {
-                    self.applyCLIResult(result, fallbackCommand: displayCommand.commandLine, configPath: configPath, launchdLabel: launchdLabel)
+                    self.applyCLIResult(
+                        result,
+                        fallbackCommand: displayCommand.commandLine,
+                        configPath: configPath,
+                        launchdLabel: launchdLabel,
+                        controlCenterOperation: controlCenterOperation
+                    )
+                    if isConfigPatchCommand { self.isConfigPatchInProgress = false }
+                    if isConfigInspectCommand { self.isConfigInspectInProgress = false }
+                    if controlCenterOperation != nil { self.isControlCenterOperationInProgress = false }
                 }
             } catch {
                 await MainActor.run {
                     self.lastError = NeonDiffRedactor.redact(error.localizedDescription)
                     self.logText = self.lastError ?? "Unknown CLI error"
+                    if isConfigPatchCommand { self.isConfigPatchInProgress = false }
+                    if isConfigInspectCommand { self.isConfigInspectInProgress = false }
+                    if controlCenterOperation != nil {
+                        self.controlCenterStatus = self.lastError ?? "Control-center command failed."
+                        self.isControlCenterOperationInProgress = false
+                    }
                 }
             }
         }
@@ -503,6 +721,14 @@ final class NeonDiffDesktopModel: ObservableObject {
         appSupportDirectory.appendingPathComponent("repo-allowlist-patch.json")
     }
 
+    private var controlCenterPatchPath: URL {
+        appSupportDirectory.appendingPathComponent("control-center-patch.json")
+    }
+
+    private var controlCenterRollbackPath: URL {
+        appSupportDirectory.appendingPathComponent("control-center-rollback.json")
+    }
+
     private var appSupportDirectory: URL {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? FileManager.default.temporaryDirectory
@@ -524,6 +750,19 @@ final class NeonDiffDesktopModel: ObservableObject {
         ]
         let data = try JSONSerialization.data(withJSONObject: patch, options: [.prettyPrinted, .sortedKeys])
         try data.write(to: providerPatchPath, options: [.atomic])
+    }
+
+    private func writeControlCenterPatch(_ settings: DesktopControlCenterSettings, to path: URL) throws {
+        try FileManager.default.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        let data = try DesktopControlCenterPatchBuilder.data(for: settings)
+        try data.write(to: path, options: [.atomic])
+    }
+
+    private func runControlCenterPatch(operation: ControlCenterOperation, arguments: [String], command: DesktopCommand) {
+        guard !isControlCenterOperationInProgress else { return }
+        isControlCenterOperationInProgress = true
+        controlCenterStatus = operation.statusText
+        runCLI(arguments: arguments, displayCommand: command, controlCenterOperation: operation)
     }
 
     private func runRepoSelectionPatch(dryRun: Bool) {
@@ -722,7 +961,13 @@ final class NeonDiffDesktopModel: ObservableObject {
         try data.write(to: repoSelectionPatchPath, options: [.atomic])
     }
 
-    private func applyCLIResult(_ result: CLIRunResult, fallbackCommand: String, configPath: String, launchdLabel: String) {
+    private func applyCLIResult(
+        _ result: CLIRunResult,
+        fallbackCommand: String,
+        configPath: String,
+        launchdLabel: String,
+        controlCenterOperation: ControlCenterOperation? = nil
+    ) {
         let redactedStdout = result.redactedStdout.trimmingCharacters(in: .whitespacesAndNewlines)
         let redactedStderr = result.redactedStderr.trimmingCharacters(in: .whitespacesAndNewlines)
         lastError = result.exitCode == 0 ? nil : (redactedStderr.isEmpty ? redactedStdout : redactedStderr)
@@ -748,6 +993,109 @@ final class NeonDiffDesktopModel: ObservableObject {
                     parsedGitHub.installationState = github.installationState
                 }
                 github = parsedGitHub
+                if commandName == "config inspect" {
+                    controlCenter = snapshot.policy
+                    controlCenterLoadedSnapshot = DesktopControlCenterSnapshot(
+                        settings: snapshot.policy,
+                        configPath: configPath
+                    )
+                    controlCenterLoadedRevision = snapshot.revision
+                    controlCenterRollbackSnapshot = nil
+                    controlCenterRollbackExpectedRevision = nil
+                    previewedControlCenterSnapshot = nil
+                    previewedControlCenterBaseline = nil
+                    previewedControlCenterExpectedRevision = nil
+                    if self.configPath == configPath {
+                        controlCenterStatus = "Current config loaded. Edit settings, then Preview."
+                    } else {
+                        controlCenterStatus = "Config loaded from a previous path. Reload the current config before editing."
+                    }
+                }
+            }
+            if commandName == "config patch", let operation = controlCenterOperation {
+                let succeeded = result.exitCode == 0 && lastError == nil
+                switch operation {
+                case .preview(let snapshot, let baseline, let expectedRevision):
+                    if succeeded {
+                        previewedControlCenterSnapshot = snapshot
+                        previewedControlCenterBaseline = baseline
+                        previewedControlCenterExpectedRevision = expectedRevision
+                        controlCenterStatus = snapshot == currentControlCenterSnapshot
+                            ? "Preview passed. Apply is enabled for this exact settings snapshot."
+                            : "Preview passed for an earlier settings snapshot. Preview the current edits before Apply."
+                    } else {
+                        previewedControlCenterSnapshot = nil
+                        previewedControlCenterBaseline = nil
+                        previewedControlCenterExpectedRevision = nil
+                        controlCenterLoadedRevision = nil
+                        controlCenterStatus = lastError ?? "Preview failed."
+                    }
+                case .apply(let snapshot, let baseline, _):
+                    if succeeded, let revisionAfter = ConfigInspectParser.parse(
+                        result.stdout,
+                        providerKeyStored: keychain.containsSecret(account: providerKeyAccount),
+                        licenseKeyStored: keychain.containsSecret(account: licenseKeyAccount),
+                        githubUserTokenStored: keychain.containsSecret(account: githubUserTokenAccount)
+                    )?.revisionAfter {
+                        controlCenter = snapshot.settings
+                        controlCenterRollbackSnapshot = baseline
+                        controlCenterRollbackExpectedRevision = revisionAfter
+                        controlCenterLoadedSnapshot = snapshot
+                        controlCenterLoadedRevision = revisionAfter
+                        previewedControlCenterSnapshot = nil
+                        previewedControlCenterBaseline = nil
+                        previewedControlCenterExpectedRevision = nil
+                        controlCenterStatus = self.configPath == snapshot.configPath
+                            ? "Config applied. Apply Last Rollback is now available."
+                            : "Config applied to the previously selected path. Return to that path to roll back, or load the current config."
+                    } else if succeeded {
+                        controlCenterLoadedRevision = nil
+                        controlCenterRollbackSnapshot = nil
+                        controlCenterRollbackExpectedRevision = nil
+                        previewedControlCenterSnapshot = nil
+                        previewedControlCenterBaseline = nil
+                        previewedControlCenterExpectedRevision = nil
+                        lastError = "Config write returned without revision proof. Reload current config before further edits."
+                        controlCenterStatus = lastError ?? "Reload current config."
+                    } else {
+                        controlCenterLoadedRevision = nil
+                        previewedControlCenterSnapshot = nil
+                        previewedControlCenterBaseline = nil
+                        previewedControlCenterExpectedRevision = nil
+                        controlCenterStatus = lastError ?? "Apply failed."
+                    }
+                case .rollback(let snapshot, _):
+                    if succeeded, let revisionAfter = ConfigInspectParser.parse(
+                        result.stdout,
+                        providerKeyStored: keychain.containsSecret(account: providerKeyAccount),
+                        licenseKeyStored: keychain.containsSecret(account: licenseKeyAccount),
+                        githubUserTokenStored: keychain.containsSecret(account: githubUserTokenAccount)
+                    )?.revisionAfter {
+                        controlCenter = snapshot.settings
+                        controlCenterLoadedSnapshot = snapshot
+                        controlCenterLoadedRevision = revisionAfter
+                        controlCenterRollbackSnapshot = nil
+                        controlCenterRollbackExpectedRevision = nil
+                        previewedControlCenterSnapshot = nil
+                        previewedControlCenterBaseline = nil
+                        previewedControlCenterExpectedRevision = nil
+                        controlCenterStatus = self.configPath == snapshot.configPath
+                            ? "Rollback applied. Reload config before further edits."
+                            : "Rollback applied to the previously selected path. Load the current config before further edits."
+                    } else if succeeded {
+                        controlCenterLoadedRevision = nil
+                        controlCenterRollbackSnapshot = nil
+                        controlCenterRollbackExpectedRevision = nil
+                        lastError = "Rollback returned without revision proof. Reload current config before further edits."
+                        controlCenterStatus = lastError ?? "Reload current config."
+                    } else {
+                        controlCenterLoadedRevision = nil
+                        controlCenterRollbackSnapshot = nil
+                        controlCenterRollbackExpectedRevision = nil
+                        controlCenterStatus = lastError ?? "Rollback failed."
+                    }
+                }
+                isControlCenterOperationInProgress = false
             }
             return
         }
@@ -771,6 +1119,28 @@ final class NeonDiffDesktopModel: ObservableObject {
         return root["command"] as? String
     }
 
+}
+
+private enum ControlCenterOperation: Sendable {
+    case preview(
+        snapshot: DesktopControlCenterSnapshot,
+        baseline: DesktopControlCenterSnapshot,
+        expectedRevision: String
+    )
+    case apply(
+        snapshot: DesktopControlCenterSnapshot,
+        baseline: DesktopControlCenterSnapshot,
+        expectedRevision: String
+    )
+    case rollback(snapshot: DesktopControlCenterSnapshot, expectedRevision: String)
+
+    var statusText: String {
+        switch self {
+        case .preview: "Previewing control-center patch..."
+        case .apply: "Applying validated control-center patch..."
+        case .rollback: "Applying last control-center rollback..."
+        }
+    }
 }
 
 private enum GitHubDesktopAuthorizationStateError: LocalizedError {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Models/NeonDiffDesktopModel.swift
@@ -669,6 +669,7 @@ final class NeonDiffDesktopModel: ObservableObject {
                         fallbackCommand: displayCommand.commandLine,
                         configPath: configPath,
                         launchdLabel: launchdLabel,
+                        isConfigInspectCommand: isConfigInspectCommand,
                         controlCenterOperation: controlCenterOperation
                     )
                     if isConfigPatchCommand { self.isConfigPatchInProgress = false }
@@ -680,7 +681,10 @@ final class NeonDiffDesktopModel: ObservableObject {
                     self.lastError = NeonDiffRedactor.redact(error.localizedDescription)
                     self.logText = self.lastError ?? "Unknown CLI error"
                     if isConfigPatchCommand { self.isConfigPatchInProgress = false }
-                    if isConfigInspectCommand { self.isConfigInspectInProgress = false }
+                    if isConfigInspectCommand {
+                        self.invalidateControlCenterAfterInspectFailure(self.lastError ?? "Config inspect failed.")
+                        self.isConfigInspectInProgress = false
+                    }
                     if controlCenterOperation != nil {
                         self.controlCenterStatus = self.lastError ?? "Control-center command failed."
                         self.isControlCenterOperationInProgress = false
@@ -966,6 +970,7 @@ final class NeonDiffDesktopModel: ObservableObject {
         fallbackCommand: String,
         configPath: String,
         launchdLabel: String,
+        isConfigInspectCommand: Bool,
         controlCenterOperation: ControlCenterOperation? = nil
     ) {
         let redactedStdout = result.redactedStdout.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -974,13 +979,21 @@ final class NeonDiffDesktopModel: ObservableObject {
         logText = [result.redactedStdout, result.redactedStderr].filter { !$0.isEmpty }.joined(separator: "\n")
 
         let commandName = parseCommandName(result.stdout)
+        if isConfigInspectCommand && (result.exitCode != 0 || commandName != "config inspect") {
+            let inspectError = ConfigInspectParser.error(result.stdout)
+                ?? lastError
+                ?? "Config inspect returned an invalid response."
+            invalidateControlCenterAfterInspectFailure(inspectError)
+            return
+        }
         if commandName == "config inspect" || commandName == "config patch" {
-            if let snapshot = ConfigInspectParser.parse(
+            let parsedSnapshot = ConfigInspectParser.parse(
                 result.stdout,
                 providerKeyStored: keychain.containsSecret(account: providerKeyAccount),
                 licenseKeyStored: keychain.containsSecret(account: licenseKeyAccount),
                 githubUserTokenStored: keychain.containsSecret(account: githubUserTokenAccount)
-            ) {
+            )
+            if let snapshot = parsedSnapshot {
                 if !snapshot.repos.isEmpty { repos = snapshot.repos }
                 providers = snapshot.providers
                 license = snapshot.license
@@ -1011,6 +1024,13 @@ final class NeonDiffDesktopModel: ObservableObject {
                         controlCenterStatus = "Config loaded from a previous path. Reload the current config before editing."
                     }
                 }
+            }
+            if commandName == "config inspect", result.exitCode != 0 || parsedSnapshot == nil {
+                let inspectError = ConfigInspectParser.error(result.stdout)
+                    ?? lastError
+                    ?? "Config inspect returned an invalid response."
+                invalidateControlCenterAfterInspectFailure(inspectError)
+                return
             }
             if commandName == "config patch", let operation = controlCenterOperation {
                 let succeeded = result.exitCode == 0 && lastError == nil
@@ -1117,6 +1137,18 @@ final class NeonDiffDesktopModel: ObservableObject {
             return nil
         }
         return root["command"] as? String
+    }
+
+    private func invalidateControlCenterAfterInspectFailure(_ message: String) {
+        controlCenterLoadedSnapshot = nil
+        controlCenterLoadedRevision = nil
+        controlCenterRollbackSnapshot = nil
+        controlCenterRollbackExpectedRevision = nil
+        previewedControlCenterSnapshot = nil
+        previewedControlCenterBaseline = nil
+        previewedControlCenterExpectedRevision = nil
+        lastError = NeonDiffRedactor.redact(message)
+        controlCenterStatus = lastError ?? "Config inspect failed."
     }
 
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/PolicyView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/PolicyView.swift
@@ -7,22 +7,176 @@ struct PolicyView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
-                OperatorSection("Review Policy Defaults") {
-                    Label("No direct review posting from desktop UI", systemImage: "checkmark.shield")
-                    Label("Daemon duplicate, stale-head, secret, and inline-coordinate gates stay authoritative", systemImage: "checkmark.shield")
-                    Label("Config writes use `config patch` with dry-run preview first", systemImage: "checkmark.shield")
+                OperatorSection("Control Center Status") {
+                    Text(model.controlCenterStatus)
+                        .operatorBodyText()
+                        .fixedSize(horizontal: false, vertical: true)
+                    Button { model.inspectConfig() } label: {
+                        Label("Load Current Config", systemImage: "doc.text.magnifyingglass")
+                    }
+                    .disabled(model.isConfigPatchInProgress || model.isConfigInspectInProgress)
+                    .accessibilityIdentifier("neondiff-control-load")
                 }
-                .foregroundStyle(NeonDiffTheme.textSecondary)
+
+                OperatorSection("PR Review And Daemon") {
+                    Toggle("Skip draft pull requests", isOn: $model.controlCenter.skipDrafts)
+                    Stepper(
+                        "Poll interval: \(model.controlCenter.pollIntervalMs / 1_000)s",
+                        value: $model.controlCenter.pollIntervalMs,
+                        in: 1_000...3_600_000,
+                        step: 1_000
+                    )
+                    Stepper(
+                        "Max concurrent reviews: \(model.controlCenter.reviewMaxActiveRuns)",
+                        value: $model.controlCenter.reviewMaxActiveRuns,
+                        in: 1...32
+                    )
+                    Stepper(
+                        "Review lease TTL: \(model.controlCenter.reviewLeaseTtlMs / 60_000)m",
+                        value: $model.controlCenter.reviewLeaseTtlMs,
+                        in: 60_000...7_200_000,
+                        step: 60_000
+                    )
+                    Stepper(
+                        "Max inline comments: \(model.controlCenter.maxInlineComments)",
+                        value: $model.controlCenter.maxInlineComments,
+                        in: 1...100
+                    )
+                    Text("PR review repositories remain in the Repos pane. These settings never modify the separate issue-enrichment allowlist.")
+                        .font(.caption)
+                        .foregroundStyle(NeonDiffTheme.textSecondary)
+                }
+
+                OperatorSection("Issue Enrichment") {
+                    Toggle("Enable issue enrichment", isOn: $model.controlCenter.issueEnrichmentEnabled)
+                    Toggle("Allow App-authored issue comments", isOn: $model.controlCenter.issuePostComment)
+                        .disabled(!model.controlCenter.issueEnrichmentEnabled)
+                    Toggle(
+                        "Process existing open issues on activation",
+                        isOn: $model.controlCenter.issueProcessExistingOnActivation
+                    )
+                    .disabled(!model.controlCenter.issueEnrichmentEnabled)
+
+                    HStack(spacing: 10) {
+                        TextField("owner/repo", text: $model.pendingIssueRepoName)
+                            .textFieldStyle(.roundedBorder)
+                            .accessibilityIdentifier("neondiff-issue-repo-input")
+                        Button { model.addPendingIssueRepo() } label: {
+                            Label("Add Issue Repo", systemImage: "plus.circle")
+                        }
+                        .accessibilityIdentifier("neondiff-issue-repo-add")
+                    }
+
+                    ForEach(model.controlCenter.issueAllowlist, id: \.self) { repo in
+                        HStack {
+                            Label(repo, systemImage: "exclamationmark.bubble")
+                            Spacer()
+                            Button { model.removeIssueRepo(repo) } label: {
+                                Image(systemName: "minus.circle")
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("neondiff-issue-repo-remove-\(repo)")
+                        }
+                    }
+
+                    Stepper(
+                        "Issues per cycle: \(model.controlCenter.issueMaxIssuesPerCycle)",
+                        value: $model.controlCenter.issueMaxIssuesPerCycle,
+                        in: 1...100
+                    )
+                    Stepper(
+                        "Comments per cycle: \(model.controlCenter.issueMaxCommentsPerCycle)",
+                        value: $model.controlCenter.issueMaxCommentsPerCycle,
+                        in: 0...100
+                    )
+                    Stepper(
+                        "Global issues per cycle: \(model.controlCenter.issueGlobalMaxIssuesPerCycle)",
+                        value: $model.controlCenter.issueGlobalMaxIssuesPerCycle,
+                        in: 1...500
+                    )
+                    Stepper(
+                        "Global comments per cycle: \(model.controlCenter.issueGlobalMaxCommentsPerCycle)",
+                        value: $model.controlCenter.issueGlobalMaxCommentsPerCycle,
+                        in: 0...500
+                    )
+                    Stepper(
+                        "Issue max active runs: \(model.controlCenter.issueMaxActiveRuns)",
+                        value: $model.controlCenter.issueMaxActiveRuns,
+                        in: 1...16
+                    )
+                    Stepper(
+                        "Issue lease TTL: \(model.controlCenter.issueLeaseTtlMs / 60_000)m",
+                        value: $model.controlCenter.issueLeaseTtlMs,
+                        in: 60_000...7_200_000,
+                        step: 60_000
+                    )
+                    Stepper(
+                        "Cooldown: \(model.controlCenter.issueCooldownMs / 60_000)m",
+                        value: $model.controlCenter.issueCooldownMs,
+                        in: 60_000...86_400_000,
+                        step: 60_000
+                    )
+                    Stepper(
+                        "Burst window: \(model.controlCenter.issueBurstWindowMs / 60_000)m",
+                        value: $model.controlCenter.issueBurstWindowMs,
+                        in: 60_000...86_400_000,
+                        step: 60_000
+                    )
+                    Stepper(
+                        "Issues per burst: \(model.controlCenter.issueMaxIssuesPerBurst)",
+                        value: $model.controlCenter.issueMaxIssuesPerBurst,
+                        in: 1...500
+                    )
+                    Stepper(
+                        "Lookback: \(model.controlCenter.issueLookbackMs / 60_000)m",
+                        value: $model.controlCenter.issueLookbackMs,
+                        in: 60_000...86_400_000,
+                        step: 60_000
+                    )
+                }
+
+                OperatorSection("Preview, Apply, Rollback") {
+                    if let validationError = model.controlCenterValidationError {
+                        Label(validationError, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(NeonDiffTheme.warning)
+                    } else {
+                        Label("Native validation passed; the CLI performs canonical validation again.", systemImage: "checkmark.shield")
+                            .foregroundStyle(NeonDiffTheme.accent)
+                    }
+                    HStack(spacing: 10) {
+                        Button { model.previewControlCenterPatch() } label: {
+                            Label("Preview", systemImage: "eye")
+                        }
+                        .disabled(!model.canPreviewControlCenter)
+                        .opacity(model.canPreviewControlCenter ? 1 : 0.45)
+                        .accessibilityIdentifier("neondiff-control-preview")
+
+                        Button { model.applyControlCenterPatch() } label: {
+                            Label("Apply", systemImage: "checkmark.square")
+                        }
+                        .disabled(!model.canApplyControlCenter)
+                        .opacity(model.canApplyControlCenter ? 1 : 0.45)
+                        .accessibilityIdentifier("neondiff-control-apply")
+
+                        Button { model.rollbackControlCenterPatch() } label: {
+                            Label("Apply Last Rollback", systemImage: "arrow.uturn.backward.circle")
+                        }
+                        .disabled(!model.canRollbackControlCenter)
+                        .opacity(model.canRollbackControlCenter ? 1 : 0.45)
+                        .accessibilityIdentifier("neondiff-control-rollback")
+                    }
+                    Text("Apply is enabled only for the exact settings snapshot that passed Preview. The rollback patch contains only these non-secret desktop-safe fields.")
+                        .font(.caption)
+                        .foregroundStyle(NeonDiffTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
                 OperatorSection("Proof Boundary") {
-                    Text("This desktop shell previews and copies operator-safe commands. Runtime gates, live review posting, signing, updater, and release claims remain outside this MVP.")
-                        .operatorBodyText()
+                    Label("No direct review or issue posting from this screen", systemImage: "checkmark.shield")
+                    Label("Daemon stale-head, duplicate, secret, license, and posting gates stay authoritative", systemImage: "checkmark.shield")
+                    Label("Provider and license keys remain in Keychain", systemImage: "checkmark.shield")
                 }
-
-                CommandPanel(commands: [
-                    model.configInspectCommand,
-                    model.providerPatchPreviewCommand
-                ], copy: model.copyCommand)
+                .foregroundStyle(NeonDiffTheme.textSecondary)
             }
             .padding(24)
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/PolicyView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/PolicyView.swift
@@ -169,6 +169,10 @@ struct PolicyView: View {
                         .font(.caption)
                         .foregroundStyle(NeonDiffTheme.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
+                    Text("Close external config editors before Apply. The writer lock coordinates NeonDiff config commands; unrelated tools do not participate in that lock.")
+                        .font(.caption)
+                        .foregroundStyle(NeonDiffTheme.warning)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 OperatorSection("Proof Boundary") {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/DesktopModels.swift
@@ -157,6 +157,168 @@ public struct GitHubConnectionStatus: Equatable {
     }
 }
 
+public struct DesktopControlCenterSettings: Equatable, Sendable {
+    public var pollIntervalMs: Int
+    public var skipDrafts: Bool
+    public var reviewMaxActiveRuns: Int
+    public var reviewLeaseTtlMs: Int
+    public var maxInlineComments: Int
+    public var issueEnrichmentEnabled: Bool
+    public var issuePostComment: Bool
+    public var issueAllowlist: [String]
+    public var issueMaxIssuesPerCycle: Int
+    public var issueMaxCommentsPerCycle: Int
+    public var issueGlobalMaxIssuesPerCycle: Int
+    public var issueGlobalMaxCommentsPerCycle: Int
+    public var issueMaxActiveRuns: Int
+    public var issueLeaseTtlMs: Int
+    public var issueCooldownMs: Int
+    public var issueBurstWindowMs: Int
+    public var issueMaxIssuesPerBurst: Int
+    public var issueLookbackMs: Int
+    public var issueProcessExistingOnActivation: Bool
+
+    public init(
+        pollIntervalMs: Int = 90_000,
+        skipDrafts: Bool = true,
+        reviewMaxActiveRuns: Int = 1,
+        reviewLeaseTtlMs: Int = 900_000,
+        maxInlineComments: Int = 25,
+        issueEnrichmentEnabled: Bool = false,
+        issuePostComment: Bool = false,
+        issueAllowlist: [String] = [],
+        issueMaxIssuesPerCycle: Int = 5,
+        issueMaxCommentsPerCycle: Int = 1,
+        issueGlobalMaxIssuesPerCycle: Int = 5,
+        issueGlobalMaxCommentsPerCycle: Int = 1,
+        issueMaxActiveRuns: Int = 1,
+        issueLeaseTtlMs: Int = 1_200_000,
+        issueCooldownMs: Int = 3_600_000,
+        issueBurstWindowMs: Int = 3_600_000,
+        issueMaxIssuesPerBurst: Int = 10,
+        issueLookbackMs: Int = 600_000,
+        issueProcessExistingOnActivation: Bool = false
+    ) {
+        self.pollIntervalMs = pollIntervalMs
+        self.skipDrafts = skipDrafts
+        self.reviewMaxActiveRuns = reviewMaxActiveRuns
+        self.reviewLeaseTtlMs = reviewLeaseTtlMs
+        self.maxInlineComments = maxInlineComments
+        self.issueEnrichmentEnabled = issueEnrichmentEnabled
+        self.issuePostComment = issuePostComment
+        self.issueAllowlist = issueAllowlist
+        self.issueMaxIssuesPerCycle = issueMaxIssuesPerCycle
+        self.issueMaxCommentsPerCycle = issueMaxCommentsPerCycle
+        self.issueGlobalMaxIssuesPerCycle = issueGlobalMaxIssuesPerCycle
+        self.issueGlobalMaxCommentsPerCycle = issueGlobalMaxCommentsPerCycle
+        self.issueMaxActiveRuns = issueMaxActiveRuns
+        self.issueLeaseTtlMs = issueLeaseTtlMs
+        self.issueCooldownMs = issueCooldownMs
+        self.issueBurstWindowMs = issueBurstWindowMs
+        self.issueMaxIssuesPerBurst = issueMaxIssuesPerBurst
+        self.issueLookbackMs = issueLookbackMs
+        self.issueProcessExistingOnActivation = issueProcessExistingOnActivation
+    }
+}
+
+public struct DesktopControlCenterSnapshot: Equatable, Sendable {
+    public let settings: DesktopControlCenterSettings
+    public let configPath: String
+
+    public init(settings: DesktopControlCenterSettings, configPath: String) {
+        self.settings = settings
+        self.configPath = configPath
+    }
+}
+
+public enum DesktopControlCenterPatchBuilder {
+    public static func validationError(for settings: DesktopControlCenterSettings) -> String? {
+        let positiveValues: [(String, Int)] = [
+            ("poll interval", settings.pollIntervalMs),
+            ("review max active runs", settings.reviewMaxActiveRuns),
+            ("review lease TTL", settings.reviewLeaseTtlMs),
+            ("max inline comments", settings.maxInlineComments),
+            ("issue max issues per cycle", settings.issueMaxIssuesPerCycle),
+            ("issue global max issues per cycle", settings.issueGlobalMaxIssuesPerCycle),
+            ("issue max active runs", settings.issueMaxActiveRuns),
+            ("issue lease TTL", settings.issueLeaseTtlMs),
+            ("issue cooldown", settings.issueCooldownMs),
+            ("issue burst window", settings.issueBurstWindowMs),
+            ("issue max issues per burst", settings.issueMaxIssuesPerBurst),
+            ("issue lookback", settings.issueLookbackMs)
+        ]
+        if let invalid = positiveValues.first(where: { $0.1 <= 0 }) {
+            return "\(invalid.0) must be a positive integer"
+        }
+        if settings.issueMaxCommentsPerCycle < 0 || settings.issueGlobalMaxCommentsPerCycle < 0 {
+            return "issue comments per cycle must be zero or greater"
+        }
+        if settings.issueMaxCommentsPerCycle > settings.issueMaxIssuesPerCycle {
+            return "issue comments per cycle must be less than or equal to issues per cycle"
+        }
+        if settings.issueGlobalMaxCommentsPerCycle > settings.issueGlobalMaxIssuesPerCycle {
+            return "global issue comments per cycle must be less than or equal to global issues per cycle"
+        }
+        for repo in settings.issueAllowlist where !isValidRepoName(repo) {
+            return "issue-enrichment allowlist entries must use owner/repo"
+        }
+        return nil
+    }
+
+    public static func data(for settings: DesktopControlCenterSettings) throws -> Data {
+        if let error = validationError(for: settings) {
+            throw DesktopControlCenterPatchError.invalidSettings(error)
+        }
+        let patch: [String: Any] = [
+            "pollIntervalMs": settings.pollIntervalMs,
+            "skipDrafts": settings.skipDrafts,
+            "reviewConcurrency": [
+                "maxActiveRuns": settings.reviewMaxActiveRuns,
+                "leaseTtlMs": settings.reviewLeaseTtlMs
+            ],
+            "reviewGate": [
+                "maxInlineComments": settings.maxInlineComments
+            ],
+            "issueEnrichment": [
+                "enabled": settings.issueEnrichmentEnabled,
+                "postIssueComment": settings.issuePostComment,
+                "allowlist": settings.issueAllowlist,
+                "maxIssuesPerCycle": settings.issueMaxIssuesPerCycle,
+                "maxCommentsPerCycle": settings.issueMaxCommentsPerCycle,
+                "globalMaxIssuesPerCycle": settings.issueGlobalMaxIssuesPerCycle,
+                "globalMaxCommentsPerCycle": settings.issueGlobalMaxCommentsPerCycle,
+                "maxActiveRuns": settings.issueMaxActiveRuns,
+                "leaseTtlMs": settings.issueLeaseTtlMs,
+                "cooldownMs": settings.issueCooldownMs,
+                "burstWindowMs": settings.issueBurstWindowMs,
+                "maxIssuesPerBurst": settings.issueMaxIssuesPerBurst,
+                "lookbackMs": settings.issueLookbackMs,
+                "processExistingOpenIssuesOnActivation": settings.issueProcessExistingOnActivation
+            ]
+        ]
+        return try JSONSerialization.data(withJSONObject: patch, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    private static func isValidRepoName(_ value: String) -> Bool {
+        let parts = value.split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return false }
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_.-"))
+        return parts.allSatisfy { part in
+            !part.isEmpty && part.unicodeScalars.allSatisfy { allowed.contains($0) }
+        }
+    }
+}
+
+public enum DesktopControlCenterPatchError: Error, LocalizedError {
+    case invalidSettings(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidSettings(let message): message
+        }
+    }
+}
+
 public struct DesktopCommand: Identifiable, Equatable {
     public var id: String { commandLine }
     public var title: String

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/CommandBuilders.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/CommandBuilders.swift
@@ -8,8 +8,17 @@ public enum NeonDiffCommandBuilder {
         )
     }
 
-    public static func configPatch(cliPath: String, configPath: String, inputPath: String, dryRun: Bool = true) -> DesktopCommand {
+    public static func configPatch(
+        cliPath: String,
+        configPath: String,
+        inputPath: String,
+        dryRun: Bool = true,
+        expectedRevision: String? = nil
+    ) -> DesktopCommand {
         var command = "\(shellQuote(cliPath)) config patch --config \(shellQuote(configPath)) --input \(shellQuote(inputPath)) --dry-run \(dryRun ? "true" : "false")"
+        if let expectedRevision {
+            command += " --expected-revision \(shellQuote(expectedRevision))"
+        }
         if !dryRun {
             command += " --confirm true"
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
@@ -5,12 +5,29 @@ public struct ConfigInspectSnapshot: Equatable {
     public var providers: ProviderSettings
     public var license: LicenseStatus
     public var github: GitHubConnectionStatus
+    public var policy: DesktopControlCenterSettings
+    public var revision: String?
+    public var revisionBefore: String?
+    public var revisionAfter: String?
 
-    public init(repos: [RepoMonitor], providers: ProviderSettings, license: LicenseStatus, github: GitHubConnectionStatus = GitHubConnectionStatus()) {
+    public init(
+        repos: [RepoMonitor],
+        providers: ProviderSettings,
+        license: LicenseStatus,
+        github: GitHubConnectionStatus = GitHubConnectionStatus(),
+        policy: DesktopControlCenterSettings = DesktopControlCenterSettings(),
+        revision: String? = nil,
+        revisionBefore: String? = nil,
+        revisionAfter: String? = nil
+    ) {
         self.repos = repos
         self.providers = providers
         self.license = license
         self.github = github
+        self.policy = policy
+        self.revision = revision
+        self.revisionBefore = revisionBefore
+        self.revisionAfter = revisionAfter
     }
 }
 
@@ -43,6 +60,9 @@ public enum ConfigInspectParser {
         let zcode = config["zcode"] as? [String: Any]
         let desktop = config["desktop"] as? [String: Any]
         let githubConfig = config["github"] as? [String: Any]
+        let reviewConcurrency = config["reviewConcurrency"] as? [String: Any]
+        let reviewGate = config["reviewGate"] as? [String: Any]
+        let issueEnrichment = config["issueEnrichment"] as? [String: Any]
         let providers = ProviderSettings(
             zcodeModel: zcode?["model"] as? String ?? "GLM-5.2",
             zcodeCliPath: zcode?["cliPath"] as? String ?? "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
@@ -66,6 +86,41 @@ public enum ConfigInspectParser {
             userTokenStored: githubUserTokenStored,
             installationState: githubUserTokenStored ? "user authorized" : "not connected"
         )
-        return ConfigInspectSnapshot(repos: repos, providers: providers, license: license, github: github)
+        let policy = DesktopControlCenterSettings(
+            pollIntervalMs: config["pollIntervalMs"] as? Int ?? 90_000,
+            skipDrafts: config["skipDrafts"] as? Bool ?? true,
+            reviewMaxActiveRuns: reviewConcurrency?["maxActiveRuns"] as? Int ?? 1,
+            reviewLeaseTtlMs: reviewConcurrency?["leaseTtlMs"] as? Int ?? 900_000,
+            maxInlineComments: reviewGate?["maxInlineComments"] as? Int ?? 25,
+            issueEnrichmentEnabled: issueEnrichment?["enabled"] as? Bool ?? false,
+            issuePostComment: issueEnrichment?["postIssueComment"] as? Bool ?? false,
+            issueAllowlist: issueEnrichment?["allowlist"] as? [String] ?? [],
+            issueMaxIssuesPerCycle: issueEnrichment?["maxIssuesPerCycle"] as? Int ?? 5,
+            issueMaxCommentsPerCycle: issueEnrichment?["maxCommentsPerCycle"] as? Int ?? 1,
+            issueGlobalMaxIssuesPerCycle: issueEnrichment?["globalMaxIssuesPerCycle"] as? Int ?? 5,
+            issueGlobalMaxCommentsPerCycle: issueEnrichment?["globalMaxCommentsPerCycle"] as? Int ?? 1,
+            issueMaxActiveRuns: issueEnrichment?["maxActiveRuns"] as? Int ?? 1,
+            issueLeaseTtlMs: issueEnrichment?["leaseTtlMs"] as? Int ?? 1_200_000,
+            issueCooldownMs: issueEnrichment?["cooldownMs"] as? Int ?? 3_600_000,
+            issueBurstWindowMs: issueEnrichment?["burstWindowMs"] as? Int ?? 3_600_000,
+            issueMaxIssuesPerBurst: issueEnrichment?["maxIssuesPerBurst"] as? Int ?? 10,
+            issueLookbackMs: issueEnrichment?["lookbackMs"] as? Int ?? 600_000,
+            issueProcessExistingOnActivation: issueEnrichment?["processExistingOpenIssuesOnActivation"] as? Bool ?? false
+        )
+        return ConfigInspectSnapshot(
+            repos: repos,
+            providers: providers,
+            license: license,
+            github: github,
+            policy: policy,
+            revision: nonEmptyString(root["revision"]),
+            revisionBefore: root["revisionBefore"] as? String,
+            revisionAfter: root["revisionAfter"] as? String
+        )
+    }
+
+    private static func nonEmptyString(_ value: Any?) -> String? {
+        guard let value = value as? String, !value.isEmpty else { return nil }
+        return value
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
@@ -32,6 +32,20 @@ public struct ConfigInspectSnapshot: Equatable {
 }
 
 public enum ConfigInspectParser {
+    public static func error(_ jsonText: String) -> String? {
+        guard
+            let data = jsonText.data(using: .utf8),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            root["command"] as? String == "config inspect",
+            root["ok"] as? Bool == false,
+            let error = root["error"] as? String,
+            !error.isEmpty
+        else {
+            return nil
+        }
+        return error
+    }
+
     public static func parse(_ jsonText: String, providerKeyStored: Bool, licenseKeyStored: Bool, githubUserTokenStored: Bool = false) -> ConfigInspectSnapshot? {
         guard
             let data = jsonText.data(using: .utf8),

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/ConfigInspectParser.swift
@@ -9,6 +9,9 @@ public struct ConfigInspectSnapshot: Equatable {
     public var revision: String?
     public var revisionBefore: String?
     public var revisionAfter: String?
+    public var warning: String?
+    public var dryRun: Bool?
+    public var wrote: Bool?
 
     public init(
         repos: [RepoMonitor],
@@ -18,7 +21,10 @@ public struct ConfigInspectSnapshot: Equatable {
         policy: DesktopControlCenterSettings = DesktopControlCenterSettings(),
         revision: String? = nil,
         revisionBefore: String? = nil,
-        revisionAfter: String? = nil
+        revisionAfter: String? = nil,
+        warning: String? = nil,
+        dryRun: Bool? = nil,
+        wrote: Bool? = nil
     ) {
         self.repos = repos
         self.providers = providers
@@ -28,15 +34,18 @@ public struct ConfigInspectSnapshot: Equatable {
         self.revision = revision
         self.revisionBefore = revisionBefore
         self.revisionAfter = revisionAfter
+        self.warning = warning
+        self.dryRun = dryRun
+        self.wrote = wrote
     }
 }
 
 public enum ConfigInspectParser {
-    public static func error(_ jsonText: String) -> String? {
+    public static func error(_ jsonText: String, command: String = "config inspect") -> String? {
         guard
             let data = jsonText.data(using: .utf8),
             let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            root["command"] as? String == "config inspect",
+            root["command"] as? String == command,
             root["ok"] as? Bool == false,
             let error = root["error"] as? String,
             !error.isEmpty
@@ -50,6 +59,9 @@ public enum ConfigInspectParser {
         guard
             let data = jsonText.data(using: .utf8),
             let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            root["ok"] as? Bool == true,
+            let command = root["command"] as? String,
+            command == "config inspect" || command == "config patch",
             let config = root["config"] as? [String: Any]
         else {
             return nil
@@ -128,13 +140,59 @@ public enum ConfigInspectParser {
             github: github,
             policy: policy,
             revision: nonEmptyString(root["revision"]),
-            revisionBefore: root["revisionBefore"] as? String,
-            revisionAfter: root["revisionAfter"] as? String
+            revisionBefore: nonEmptyString(root["revisionBefore"]),
+            revisionAfter: nonEmptyString(root["revisionAfter"]),
+            warning: nonEmptyString(root["warning"]),
+            dryRun: root["dryRun"] as? Bool,
+            wrote: root["wrote"] as? Bool
         )
     }
 
     private static func nonEmptyString(_ value: Any?) -> String? {
         guard let value = value as? String, !value.isEmpty else { return nil }
         return value
+    }
+}
+
+public enum ConfigPatchProofMode {
+    case preview
+    case apply
+}
+
+public enum ConfigPatchProofValidator {
+    public static func revisionAfter(
+        snapshot: ConfigInspectSnapshot?,
+        expectedRevision: String,
+        mode: ConfigPatchProofMode
+    ) -> String? {
+        guard
+            let snapshot,
+            snapshot.revisionBefore == expectedRevision,
+            isLowercaseSHA256(expectedRevision),
+            let revisionAfter = snapshot.revisionAfter,
+            isLowercaseSHA256(revisionAfter),
+            let dryRun = snapshot.dryRun,
+            let wrote = snapshot.wrote
+        else {
+            return nil
+        }
+        switch mode {
+        case .preview:
+            guard dryRun, !wrote, revisionAfter == expectedRevision else { return nil }
+        case .apply:
+            guard
+                !dryRun,
+                wrote ? revisionAfter != expectedRevision : revisionAfter == expectedRevision
+            else {
+                return nil
+            }
+        }
+        return revisionAfter
+    }
+
+    private static func isLowercaseSHA256(_ value: String) -> Bool {
+        value.utf8.count == 64 && value.utf8.allSatisfy { byte in
+            (48...57).contains(byte) || (97...102).contains(byte)
+        }
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
@@ -512,6 +512,7 @@ do {
 let controlCenterSnapshot = ConfigInspectParser.parse(
     #"""
     {
+      "ok": true,
       "command": "config inspect",
       "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "config": {
@@ -555,6 +556,99 @@ check(
 check(
     ConfigInspectParser.parse(failedInspectJSON, providerKeyStored: false, licenseKeyStored: false) == nil,
     "failed inspect responses cannot install a config snapshot"
+)
+let expectedPatchRevision = String(repeating: "b", count: 64)
+let successfulPatchJSON = #"{"ok":true,"command":"config patch","dryRun":true,"wrote":false,"revisionBefore":"\#(expectedPatchRevision)","revisionAfter":"\#(expectedPatchRevision)","warning":"remove the owned lock","config":{"pilotRepos":[]}}"#
+let successfulPatchSnapshot = ConfigInspectParser.parse(
+    successfulPatchJSON,
+    providerKeyStored: false,
+    licenseKeyStored: false
+)
+check(successfulPatchSnapshot != nil, "successful config patch envelopes parse")
+check(successfulPatchSnapshot?.warning == "remove the owned lock", "config patch cleanup warnings remain visible to the native caller")
+check(
+    ConfigPatchProofValidator.revisionAfter(
+        snapshot: successfulPatchSnapshot,
+        expectedRevision: expectedPatchRevision,
+        mode: .preview
+    ) == expectedPatchRevision,
+    "preview proof binds both response revisions to the requested revision"
+)
+check(
+    ConfigPatchProofValidator.revisionAfter(
+        snapshot: successfulPatchSnapshot,
+        expectedRevision: expectedPatchRevision,
+        mode: .apply
+    ) == nil,
+    "an Apply operation rejects a preview-shaped dry-run envelope"
+)
+let appliedRevision = String(repeating: "c", count: 64)
+let successfulApplySnapshot = ConfigInspectParser.parse(
+    #"{"ok":true,"command":"config patch","dryRun":false,"wrote":true,"revisionBefore":"\#(expectedPatchRevision)","revisionAfter":"\#(appliedRevision)","config":{"pilotRepos":[]}}"#,
+    providerKeyStored: false,
+    licenseKeyStored: false
+)
+check(
+    ConfigPatchProofValidator.revisionAfter(
+        snapshot: successfulApplySnapshot,
+        expectedRevision: expectedPatchRevision,
+        mode: .apply
+    ) == appliedRevision,
+    "Apply proof requires a typed live-write envelope and accepts its new SHA-256 revision"
+)
+let contradictoryNoOpSnapshot = ConfigInspectParser.parse(
+    #"{"ok":true,"command":"config patch","dryRun":false,"wrote":false,"revisionBefore":"\#(expectedPatchRevision)","revisionAfter":"\#(appliedRevision)","config":{"pilotRepos":[]}}"#,
+    providerKeyStored: false,
+    licenseKeyStored: false
+)
+check(
+    ConfigPatchProofValidator.revisionAfter(
+        snapshot: contradictoryNoOpSnapshot,
+        expectedRevision: expectedPatchRevision,
+        mode: .apply
+    ) == nil,
+    "a no-op Apply cannot claim a changed revision"
+)
+let contradictoryWriteSnapshot = ConfigInspectParser.parse(
+    #"{"ok":true,"command":"config patch","dryRun":false,"wrote":true,"revisionBefore":"\#(expectedPatchRevision)","revisionAfter":"\#(expectedPatchRevision)","config":{"pilotRepos":[]}}"#,
+    providerKeyStored: false,
+    licenseKeyStored: false
+)
+check(
+    ConfigPatchProofValidator.revisionAfter(
+        snapshot: contradictoryWriteSnapshot,
+        expectedRevision: expectedPatchRevision,
+        mode: .apply
+    ) == nil,
+    "a reported Apply write must advance the content revision"
+)
+check(
+    ConfigPatchProofValidator.revisionAfter(
+        snapshot: successfulApplySnapshot,
+        expectedRevision: expectedPatchRevision.uppercased(),
+        mode: .apply
+    ) == nil,
+    "uppercase or otherwise malformed revisions cannot authorize Apply"
+)
+check(
+    ConfigInspectParser.parse(
+        #"{"ok":true,"command":"daemon status","revisionBefore":"\#(expectedPatchRevision)","revisionAfter":"\#(expectedPatchRevision)","config":{"pilotRepos":[]}}"#,
+        providerKeyStored: false,
+        licenseKeyStored: false
+    ) == nil,
+    "wrong-command envelopes cannot authorize a config patch"
+)
+check(
+    ConfigPatchProofValidator.revisionAfter(
+        snapshot: ConfigInspectParser.parse(
+            #"{"ok":true,"command":"config patch","revisionBefore":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","revisionAfter":"\#(expectedPatchRevision)","config":{"pilotRepos":[]}}"#,
+            providerKeyStored: false,
+            licenseKeyStored: false
+        ),
+        expectedRevision: expectedPatchRevision,
+        mode: .apply
+    ) == nil,
+    "mismatched patch revision proof fails closed"
 )
 
 var desiredControlCenter = DesktopControlCenterSettings()

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
@@ -531,6 +531,15 @@ check(controlCenterSnapshot?.revision == String(repeating: "a", count: 64), "con
 check(controlCenterSnapshot?.policy.reviewMaxActiveRuns == 2, "config inspect parses review concurrency")
 check(controlCenterSnapshot?.policy.issueAllowlist == ["owner/issues-repo"], "issue-enrichment allowlist remains separate from review repos")
 check(controlCenterSnapshot?.repos.map(\.name) == ["owner/review-repo"], "PR review allowlist remains in the repo selector")
+let failedInspectJSON = #"{"ok":false,"command":"config inspect","error":"config changed while reading; retry"}"#
+check(
+    ConfigInspectParser.error(failedInspectJSON) == "config changed while reading; retry",
+    "structured inspect failures expose a bounded retry message"
+)
+check(
+    ConfigInspectParser.parse(failedInspectJSON, providerKeyStored: false, licenseKeyStored: false) == nil,
+    "failed inspect responses cannot install a config snapshot"
+)
 
 var desiredControlCenter = DesktopControlCenterSettings()
 desiredControlCenter.pollIntervalMs = 120_000

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
@@ -493,4 +493,101 @@ do {
     check(false, "GitHub client must expose a typed, actionable failure")
 }
 
+let controlCenterSnapshot = ConfigInspectParser.parse(
+    #"""
+    {
+      "command": "config inspect",
+      "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "config": {
+        "pilotRepos": ["owner/review-repo"],
+        "pollIntervalMs": 120000,
+        "skipDrafts": false,
+        "reviewConcurrency": { "maxActiveRuns": 2, "leaseTtlMs": 600000 },
+        "reviewGate": { "maxInlineComments": 12 },
+        "issueEnrichment": {
+          "enabled": true,
+          "postIssueComment": false,
+          "allowlist": ["owner/issues-repo"],
+          "maxIssuesPerCycle": 4,
+          "maxCommentsPerCycle": 1,
+          "globalMaxIssuesPerCycle": 4,
+          "globalMaxCommentsPerCycle": 1,
+          "maxActiveRuns": 1,
+          "leaseTtlMs": 900000,
+          "cooldownMs": 3600000,
+          "burstWindowMs": 3600000,
+          "maxIssuesPerBurst": 8,
+          "lookbackMs": 600000,
+          "processExistingOpenIssuesOnActivation": false
+        }
+      }
+    }
+    """#,
+    providerKeyStored: false,
+    licenseKeyStored: false
+)
+check(controlCenterSnapshot?.policy.pollIntervalMs == 120_000, "config inspect parses daemon poll interval")
+check(controlCenterSnapshot?.revision == String(repeating: "a", count: 64), "config inspect preserves the compare-and-swap revision")
+check(controlCenterSnapshot?.policy.reviewMaxActiveRuns == 2, "config inspect parses review concurrency")
+check(controlCenterSnapshot?.policy.issueAllowlist == ["owner/issues-repo"], "issue-enrichment allowlist remains separate from review repos")
+check(controlCenterSnapshot?.repos.map(\.name) == ["owner/review-repo"], "PR review allowlist remains in the repo selector")
+
+var desiredControlCenter = DesktopControlCenterSettings()
+desiredControlCenter.pollIntervalMs = 120_000
+desiredControlCenter.skipDrafts = false
+desiredControlCenter.reviewMaxActiveRuns = 2
+desiredControlCenter.reviewLeaseTtlMs = 600_000
+desiredControlCenter.maxInlineComments = 12
+desiredControlCenter.issueEnrichmentEnabled = true
+desiredControlCenter.issuePostComment = false
+desiredControlCenter.issueAllowlist = ["owner/issues-repo"]
+desiredControlCenter.issueMaxIssuesPerCycle = 4
+desiredControlCenter.issueMaxCommentsPerCycle = 1
+
+check(DesktopControlCenterPatchBuilder.validationError(for: desiredControlCenter) == nil, "valid control-center settings pass native validation")
+let desiredPatchData = try DesktopControlCenterPatchBuilder.data(for: desiredControlCenter)
+let desiredPatch = try JSONSerialization.jsonObject(with: desiredPatchData) as! [String: Any]
+check(desiredPatch["pilotRepos"] == nil, "control-center patch never couples issue enrichment to the PR allowlist")
+let desiredIssuePatch = desiredPatch["issueEnrichment"] as? [String: Any]
+check(desiredIssuePatch?["allowlist"] as? [String] == ["owner/issues-repo"], "control-center patch writes only the issue-enrichment allowlist")
+
+let rollbackSettings = controlCenterSnapshot!.policy
+let rollbackPatchData = try DesktopControlCenterPatchBuilder.data(for: rollbackSettings)
+let rollbackPatch = try JSONSerialization.jsonObject(with: rollbackPatchData) as! [String: Any]
+let rollbackIssuePatch = rollbackPatch["issueEnrichment"] as? [String: Any]
+check(rollbackPatch["pollIntervalMs"] as? Int == 120_000, "rollback patch preserves the loaded daemon baseline")
+check(rollbackIssuePatch?["allowlist"] as? [String] == ["owner/issues-repo"], "rollback patch preserves the loaded issue allowlist")
+check(rollbackPatch["pilotRepos"] == nil, "rollback patch cannot modify the separate PR review allowlist")
+
+let previewSnapshot = DesktopControlCenterSnapshot(
+    settings: desiredControlCenter,
+    configPath: "/tmp/config-a.json"
+)
+var editedAfterPreview = desiredControlCenter
+editedAfterPreview.pollIntervalMs += 1_000
+check(
+    previewSnapshot != DesktopControlCenterSnapshot(settings: editedAfterPreview, configPath: "/tmp/config-a.json"),
+    "an edit made after preview cannot match the immutable preview snapshot"
+)
+check(
+    previewSnapshot != DesktopControlCenterSnapshot(settings: desiredControlCenter, configPath: "/tmp/config-b.json"),
+    "a preview for one config path cannot authorize a different config target"
+)
+let revisionBoundCommand = NeonDiffCommandBuilder.configPatch(
+    cliPath: "/tmp/neondiff",
+    configPath: "/tmp/config-a.json",
+    inputPath: "/tmp/patch.json",
+    dryRun: false,
+    expectedRevision: String(repeating: "a", count: 64)
+)
+check(revisionBoundCommand.commandLine.contains("--expected-revision"), "live control-center commands expose their revision guard")
+
+var invalidControlCenter = desiredControlCenter
+invalidControlCenter.issueMaxIssuesPerCycle = 1
+invalidControlCenter.issueMaxCommentsPerCycle = 2
+check(
+    DesktopControlCenterPatchBuilder.validationError(for: invalidControlCenter)?.contains("comments per cycle") == true,
+    "native validation blocks issue comment caps above issue caps"
+)
+
 print("NeonDiffDesktopCoreChecks passed")

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCoreChecks/main.swift
@@ -19,6 +19,22 @@ func checkedAsync<T>(_ message: String, _ operation: () async throws -> T) async
     }
 }
 
+func checkedCast<T>(_ value: Any, _ message: String) -> T {
+    guard let value = value as? T else {
+        fputs("check failed: \(message)\n", stderr)
+        exit(1)
+    }
+    return value
+}
+
+func checkedValue<T>(_ value: T?, _ message: String) -> T {
+    guard let value else {
+        fputs("check failed: \(message)\n", stderr)
+        exit(1)
+    }
+    return value
+}
+
 var providerFlow = OnboardingFlow()
 check(providerFlow.currentStep == .welcome, "flow starts at welcome")
 providerFlow.advance()
@@ -555,14 +571,20 @@ desiredControlCenter.issueMaxCommentsPerCycle = 1
 
 check(DesktopControlCenterPatchBuilder.validationError(for: desiredControlCenter) == nil, "valid control-center settings pass native validation")
 let desiredPatchData = try DesktopControlCenterPatchBuilder.data(for: desiredControlCenter)
-let desiredPatch = try JSONSerialization.jsonObject(with: desiredPatchData) as! [String: Any]
+let desiredPatch: [String: Any] = checkedCast(
+    try JSONSerialization.jsonObject(with: desiredPatchData),
+    "desired control-center patch must serialize to a JSON object"
+)
 check(desiredPatch["pilotRepos"] == nil, "control-center patch never couples issue enrichment to the PR allowlist")
 let desiredIssuePatch = desiredPatch["issueEnrichment"] as? [String: Any]
 check(desiredIssuePatch?["allowlist"] as? [String] == ["owner/issues-repo"], "control-center patch writes only the issue-enrichment allowlist")
 
-let rollbackSettings = controlCenterSnapshot!.policy
+let rollbackSettings = checkedValue(controlCenterSnapshot, "control-center fixture must parse").policy
 let rollbackPatchData = try DesktopControlCenterPatchBuilder.data(for: rollbackSettings)
-let rollbackPatch = try JSONSerialization.jsonObject(with: rollbackPatchData) as! [String: Any]
+let rollbackPatch: [String: Any] = checkedCast(
+    try JSONSerialization.jsonObject(with: rollbackPatchData),
+    "rollback control-center patch must serialize to a JSON object"
+)
 let rollbackIssuePatch = rollbackPatch["issueEnrichment"] as? [String: Any]
 check(rollbackPatch["pollIntervalMs"] as? Int == 120_000, "rollback patch preserves the loaded daemon baseline")
 check(rollbackIssuePatch?["allowlist"] as? [String] == ["owner/issues-repo"], "rollback patch preserves the loaded issue allowlist")

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -59,9 +59,9 @@ it converges on the fully-old or fully-new file during an in-flight writer.
 Preview, Apply, and rollback each carry an immutable settings snapshot and config path,
 so edits or target-path changes made while the CLI is running cannot authorize
 or relabel a different operation.
-The inspect response includes a secret-safe SHA-256 revision token over file
-identity/version metadata plus length-delimited file bytes; the token exposes no
-raw config values. Policy Preview binds to that revision, and Apply fails closed
+The inspect response includes a secret-safe SHA-256 revision token over the
+length-delimited file bytes; the token exposes no raw config values. Policy
+Preview binds to that revision, and Apply fails closed
 if the config changed before the write. A
 successful Apply returns the next revision, which becomes the compare-and-swap
 guard for the one-shot rollback.
@@ -81,6 +81,12 @@ close external config editors before Apply; the Policy pane shows this boundary
 next to the mutation controls. The revision check rejects external drift
 observed before the lock-held pre-commit read, but it does not claim a universal
 filesystem transaction against non-participating writers.
+
+If a crash leaves an old lock with an invalid or unverifiable owner, the CLI
+keeps failing closed instead of guessing. Verify that no NeonDiff `config patch`
+process is running, resolve the config's canonical path, then remove only its
+`<config-realpath>.neondiff.lock` sibling before retrying Load and Preview. Never
+remove a lock whose recorded PID is still alive.
 
 The PR review allowlist remains `pilotRepos` in the Repos pane. The Policy pane
 edits only `issueEnrichment.allowlist` plus bounded review, daemon, cap, lease,

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -65,11 +65,21 @@ Preview binds to that revision, and Apply fails closed
 if the config changed before the write. A
 successful Apply returns the next revision, which becomes the compare-and-swap
 guard for the one-shot rollback.
+The native client accepts patch success only from an `ok=true`, `config patch`
+envelope whose lowercase SHA-256 revisions match the requested operation.
+Preview additionally requires `dryRun=true` and `wrote=false`; Apply and rollback
+require `dryRun=false` plus a typed write result. Malformed, mismatched, failed,
+or transport-ambiguous responses clear all loaded, preview, and rollback
+authorization until the config is loaded again.
 Live `config patch` writers also hold one exclusive sibling lock across stable
 read, validation, revision check, temp-file write, and atomic rename. A second
 writer fails closed. Every existing sibling lock fails closed; the CLI never
 deletes a lock it did not create. The error identifies a live owner when one can
 be verified, or reports the exact stale/corrupt lock path for manual recovery.
+If an atomic config write commits but owned-lock cleanup fails, the CLI preserves
+`ok`, `wrote`, and revision proof and adds an actionable `warning` with the exact
+lock path. The native Policy pane surfaces that warning instead of reporting the
+committed write as a failure.
 Existing config paths are canonicalized through `realpath` before the sibling
 lock is chosen, so symlink aliases to the same physical file share one writer
 lock.

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -43,7 +43,7 @@ neondiff daemon stop --config config.local.json --launchd-label com.example.neon
 neondiff dashboard --config config.local.json --launchd-label com.example.neondiff --open true
 ```
 
-`config patch` writes only whitelisted non-secret fields, defaults to dry-run, and requires `--confirm true` for live writes.
+`config patch` writes only whitelisted non-secret fields, defaults to dry-run, and requires `--confirm true` for live writes. Direct CLI callers may make an intentional confirmation-only write without `--expected-revision`; that path is serialized and re-reads under the writer lock, but it is not bound to an earlier Preview. The native Policy control center always supplies the inspected revision for Preview, Apply, and rollback.
 Patch inputs use nested JSON object shape for editable paths. For example, the advertised `zcode.cliPath` path is supplied as `{ "zcode": { "cliPath": "/path/to/neondiff" } }`; flat dotted keys such as `{ "zcode.cliPath": "/path/to/neondiff" }` are rejected to avoid ambiguous profile keys.
 
 The native Policy pane is a bounded configuration control center for daemon
@@ -95,8 +95,10 @@ filesystem transaction against non-participating writers.
 If a crash leaves an old, empty, or malformed lock, the CLI keeps failing closed
 instead of guessing. Verify that no NeonDiff `config patch`
 process is running, resolve the config's canonical path, then remove only its
-`<config-realpath>.neondiff.lock` sibling before retrying Load and Preview. Never
-remove a lock whose recorded PID is still alive.
+`<config-realpath>.neondiff.lock` sibling before retrying Load and Preview. A PID
+record is a conservative liveness signal, not owner identity: macOS can recycle
+PIDs. If the recorded PID is in use, confirm that process is actually the active
+NeonDiff config patch before deciding whether the sibling lock is stale.
 
 The PR review allowlist remains `pilotRepos` in the Repos pane. The Policy pane
 edits only `issueEnrichment.allowlist` plus bounded review, daemon, cap, lease,

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -36,7 +36,7 @@ The desktop uses these JSON-first CLI surfaces:
 
 ```bash
 neondiff config inspect --config config.local.json
-neondiff config patch --config config.local.json --input desktop-patch.json --dry-run true
+neondiff config patch --config config.local.json --input desktop-patch.json --dry-run true --expected-revision <sha256>
 neondiff daemon status --config config.local.json --launchd-label com.example.neondiff
 neondiff daemon start --config config.local.json --launchd-label com.example.neondiff --dry-run true
 neondiff daemon stop --config config.local.json --launchd-label com.example.neondiff --dry-run true
@@ -45,6 +45,35 @@ neondiff dashboard --config config.local.json --launchd-label com.example.neondi
 
 `config patch` writes only whitelisted non-secret fields, defaults to dry-run, and requires `--confirm true` for live writes.
 Patch inputs use nested JSON object shape for editable paths. For example, the advertised `zcode.cliPath` path is supplied as `{ "zcode": { "cliPath": "/path/to/neondiff" } }`; flat dotted keys such as `{ "zcode.cliPath": "/path/to/neondiff" }` are rejected to avoid ambiguous profile keys.
+
+The native Policy pane is a bounded configuration control center for daemon
+polling, PR review policy, and issue-enrichment policy. It loads current values
+through `config inspect`, validates them natively, and requires a successful
+dry-run Preview of the exact settings snapshot before Apply is enabled. Apply
+uses the CLI's canonical validation and confirmation contract. The app keeps one
+in-memory, non-secret baseline so the most recent Apply can be reversed with an
+explicit rollback patch; reopening or reloading the app clears that rollback.
+All config patches are serialized so provider, repository, and policy writes
+cannot race one another. Inspect is serialized with patching as well. Preview,
+Apply, and rollback each carry an immutable settings snapshot and config path,
+so edits or target-path changes made while the CLI is running cannot authorize
+or relabel a different operation.
+The inspect response includes a secret-safe SHA-256 revision token derived from
+file identity/version metadata, never config values. Policy Preview binds to
+that revision, and Apply fails closed if the config changed before the write. A
+successful Apply returns the next revision, which becomes the compare-and-swap
+guard for the one-shot rollback.
+Live `config patch` writers also hold one exclusive sibling lock across stable
+read, validation, revision check, temp-file write, and atomic rename. A second
+writer fails closed. A lock older than five minutes is recovered before one
+bounded retry only when its recorded owner PID is no longer alive; old locks
+owned by live or unverifiable processes remain fail-closed.
+
+The PR review allowlist remains `pilotRepos` in the Repos pane. The Policy pane
+edits only `issueEnrichment.allowlist` plus bounded review, daemon, cap, lease,
+cooldown, burst, and lookback settings. Neither preview nor rollback can alter
+provider/license secrets, GitHub tokens, working directories, commands, or the
+separate PR review allowlist.
 
 The ZCode defaults in `config.example.json` are developer-machine paths. On any non-author workstation or packaged desktop install, set explicit local values for `zcode.cliPath`, `zcode.appConfigPath`, and `zcode.model` before relying on daemon controls.
 

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -67,9 +67,9 @@ successful Apply returns the next revision, which becomes the compare-and-swap
 guard for the one-shot rollback.
 Live `config patch` writers also hold one exclusive sibling lock across stable
 read, validation, revision check, temp-file write, and atomic rename. A second
-writer fails closed. A lock older than five minutes is recovered before one
-bounded retry only when its recorded owner PID is no longer alive; old locks
-owned by live or unverifiable processes remain fail-closed.
+writer fails closed. Every existing sibling lock fails closed; the CLI never
+deletes a lock it did not create. The error identifies a live owner when one can
+be verified, or reports the exact stale/corrupt lock path for manual recovery.
 Existing config paths are canonicalized through `realpath` before the sibling
 lock is chosen, so symlink aliases to the same physical file share one writer
 lock.
@@ -82,8 +82,8 @@ next to the mutation controls. The revision check rejects external drift
 observed before the lock-held pre-commit read, but it does not claim a universal
 filesystem transaction against non-participating writers.
 
-If a crash leaves an old lock with an invalid or unverifiable owner, the CLI
-keeps failing closed instead of guessing. Verify that no NeonDiff `config patch`
+If a crash leaves an old, empty, or malformed lock, the CLI keeps failing closed
+instead of guessing. Verify that no NeonDiff `config patch`
 process is running, resolve the config's canonical path, then remove only its
 `<config-realpath>.neondiff.lock` sibling before retrying Load and Preview. Never
 remove a lock whose recorded PID is still alive.

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -53,14 +53,16 @@ dry-run Preview of the exact settings snapshot before Apply is enabled. Apply
 uses the CLI's canonical validation and confirmation contract. The app keeps one
 in-memory, non-secret baseline so the most recent Apply can be reversed with an
 explicit rollback patch; reopening or reloading the app clears that rollback.
-All config patches are serialized so provider, repository, and policy writes
-cannot race one another. Inspect is serialized with patching as well. Preview,
-Apply, and rollback each carry an immutable settings snapshot and config path,
+All live config patches are serialized so provider, repository, and policy
+writes cannot race one another. Inspect uses a retrying stable-snapshot read so
+it converges on the fully-old or fully-new file during an in-flight writer.
+Preview, Apply, and rollback each carry an immutable settings snapshot and config path,
 so edits or target-path changes made while the CLI is running cannot authorize
 or relabel a different operation.
-The inspect response includes a secret-safe SHA-256 revision token derived from
-file identity/version metadata, never config values. Policy Preview binds to
-that revision, and Apply fails closed if the config changed before the write. A
+The inspect response includes a secret-safe SHA-256 revision token over file
+identity/version metadata plus length-delimited file bytes; the token exposes no
+raw config values. Policy Preview binds to that revision, and Apply fails closed
+if the config changed before the write. A
 successful Apply returns the next revision, which becomes the compare-and-swap
 guard for the one-shot rollback.
 Live `config patch` writers also hold one exclusive sibling lock across stable
@@ -68,6 +70,9 @@ read, validation, revision check, temp-file write, and atomic rename. A second
 writer fails closed. A lock older than five minutes is recovered before one
 bounded retry only when its recorded owner PID is no longer alive; old locks
 owned by live or unverifiable processes remain fail-closed.
+Existing config paths are canonicalized through `realpath` before the sibling
+lock is chosen, so symlink aliases to the same physical file share one writer
+lock.
 
 The PR review allowlist remains `pilotRepos` in the Repos pane. The Policy pane
 edits only `issueEnrichment.allowlist` plus bounded review, daemon, cap, lease,

--- a/docs/neondiff-desktop.md
+++ b/docs/neondiff-desktop.md
@@ -74,6 +74,14 @@ Existing config paths are canonicalized through `realpath` before the sibling
 lock is chosen, so symlink aliases to the same physical file share one writer
 lock.
 
+This concurrency guarantee coordinates NeonDiff `config patch` writers on the
+same machine/path. An unrelated editor or external tool does not honor the
+sibling lock and can still race the final portable atomic rename. Operators must
+close external config editors before Apply; the Policy pane shows this boundary
+next to the mutation controls. The revision check rejects external drift
+observed before the lock-held pre-commit read, but it does not claim a universal
+filesystem transaction against non-participating writers.
+
 The PR review allowlist remains `pilotRepos` in the Repos pane. The Policy pane
 edits only `issueEnrichment.allowlist` plus bounded review, daemon, cap, lease,
 cooldown, burst, and lookback settings. Neither preview nor rollback can alter

--- a/docs/superpowers/plans/2026-07-10-issue-488-config-control-center.md
+++ b/docs/superpowers/plans/2026-07-10-issue-488-config-control-center.md
@@ -46,7 +46,8 @@ Commit Slice A, open its PR, and shepherd current-head CI plus bot/human review.
 
 ## Slice A Proof
 
-- 23 focused config CLI tests cover bounded paths, revision-bound preview/apply, stable/structured inspect reads, content-sensitive revisions, truthful post-commit results, symlink-alias lock convergence, same-process and child-process writer rejection, and live/dead/empty/invalid-owner fail-closed lock behavior with manual recovery.
+- 24 focused config CLI tests cover bounded paths, revision-bound preview/apply, stable/structured inspect reads, content-sensitive revisions, truthful post-commit results and cleanup warnings, symlink-alias lock convergence, same-process and child-process writer rejection, and live/dead/empty/invalid-owner fail-closed lock behavior with manual recovery.
+- Native core checks require typed dry-run/write semantics, lowercase SHA-256 revision proof, and exact operation binding before Preview, Apply, or rollback authorization is accepted.
 - TypeScript build, Swift core checks/smoke, Swift build, unsigned bundle check, actionlint, secret scan, public-claims scan, and `git diff --check` pass.
 - Two independent read-only reviews are clean after resolving mutable-snapshot, config-path, inspect-ordering, rollback-file, external-drift, and stale-lock liveness findings.
 - Visible unsigned dev-app proof:

--- a/docs/superpowers/plans/2026-07-10-issue-488-config-control-center.md
+++ b/docs/superpowers/plans/2026-07-10-issue-488-config-control-center.md
@@ -46,7 +46,7 @@ Commit Slice A, open its PR, and shepherd current-head CI plus bot/human review.
 
 ## Slice A Proof
 
-- 21 focused config CLI tests cover bounded paths, revision-bound preview/apply, stable/structured inspect reads, content-sensitive revisions, symlink-alias lock convergence, competing-writer rejection, and live/dead/invalid-owner stale-lock behavior.
+- 23 focused config CLI tests cover bounded paths, revision-bound preview/apply, stable/structured inspect reads, content-sensitive revisions, truthful post-commit results, symlink-alias lock convergence, same-process and child-process writer rejection, and live/dead/invalid-owner stale-lock behavior.
 - TypeScript build, Swift core checks/smoke, Swift build, unsigned bundle check, actionlint, secret scan, public-claims scan, and `git diff --check` pass.
 - Two independent read-only reviews are clean after resolving mutable-snapshot, config-path, inspect-ordering, rollback-file, external-drift, and stale-lock liveness findings.
 - Visible unsigned dev-app proof:

--- a/docs/superpowers/plans/2026-07-10-issue-488-config-control-center.md
+++ b/docs/superpowers/plans/2026-07-10-issue-488-config-control-center.md
@@ -46,7 +46,7 @@ Commit Slice A, open its PR, and shepherd current-head CI plus bot/human review.
 
 ## Slice A Proof
 
-- 24 focused config CLI tests cover bounded paths, revision-bound preview/apply, stable/structured inspect reads, content-sensitive revisions, truthful post-commit results and cleanup warnings, symlink-alias lock convergence, same-process and child-process writer rejection, and live/dead/empty/invalid-owner fail-closed lock behavior with manual recovery.
+- 25 focused config CLI tests cover bounded paths, revision-bound preview/apply, stable/structured inspect reads including transient torn JSON, content-sensitive revisions, truthful post-commit results and cleanup warnings, symlink-alias lock convergence, same-process and child-process writer rejection, and live/dead/empty/invalid-owner fail-closed lock behavior with manual recovery.
 - Native core checks require typed dry-run/write semantics, lowercase SHA-256 revision proof, and exact operation binding before Preview, Apply, or rollback authorization is accepted.
 - TypeScript build, Swift core checks/smoke, Swift build, unsigned bundle check, actionlint, secret scan, public-claims scan, and `git diff --check` pass.
 - Two independent read-only reviews are clean after resolving mutable-snapshot, config-path, inspect-ordering, rollback-file, external-drift, and stale-lock liveness findings.

--- a/docs/superpowers/plans/2026-07-10-issue-488-config-control-center.md
+++ b/docs/superpowers/plans/2026-07-10-issue-488-config-control-center.md
@@ -1,0 +1,54 @@
+# Issue #488 Desktop Configuration Control Center Plan
+
+## Goal
+
+Expose supported NeonDiff configuration in the native desktop app without raw JSON editing, while keeping secrets in Keychain and every config write validated, preview-first, and reversible.
+
+## Source Of Truth
+
+- Issue: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/488
+- Milestone: #11 `v1.1 — Real Mac Desktop Launch`
+- Base: `origin/main` at `04694f0a94b265db4b0f65a9c1105497f0c422bc`
+- Branch: `codex/488-config-control-center`
+
+## Slice A: Safe Config And Rollback Foundation
+
+1. Expand the desktop-safe config patch allowlist only for bounded review, daemon, and issue-enrichment settings.
+2. Parse those settings from the redacted `config inspect` result into a native desktop model.
+3. Add separate PR-review and issue-enrichment controls; never reuse `pilotRepos` as the issue allowlist.
+4. Generate desired and rollback patches from typed, non-secret settings.
+5. Require a successful dry-run preview before Apply; expose Apply Last Rollback after a successful write.
+6. Keep invalid values fail-closed in both native validation and the canonical TypeScript config validator.
+
+## Slice B: Provider Verification And Full UI Proof
+
+1. Add an explicit Verify API Key action that reads the provider key from Keychain, returns redacted pass/fail metadata, and never writes the raw key to config, logs, or evidence.
+2. Prove Providers, Repos, Policy, License, Logs, and Settings through visible unsigned dev-app smoke.
+3. Close #488 only after both slices merge with current-head CI/review proof.
+
+## Non-goals
+
+- No provider adapter changes from PR #471.
+- No live daemon config mutation, review posting, issue comment posting, or production allowlist change during smoke.
+- No #508 visual-system work.
+- No signing, notarization, appcast publication, or v1.1 release claim.
+
+## Stop Conditions
+
+- A provider key, GitHub token, license key, private repo name, or raw config secret reaches logs/evidence.
+- PR review and issue-enrichment allowlists are coupled.
+- Apply can run without a successful preview or without a rollback patch.
+- The desktop validator accepts a setting that the canonical config loader rejects.
+
+## Exact Next Action
+
+Commit Slice A, open its PR, and shepherd current-head CI plus bot/human review. Keep #488 open for Slice B provider verification after Slice A merges.
+
+## Slice A Proof
+
+- 19 focused config CLI tests cover bounded paths, revision-bound preview/apply, stable inspect reads, competing-writer rejection, and live/dead stale-lock behavior.
+- TypeScript build, Swift core checks/smoke, Swift build, unsigned bundle check, actionlint, secret scan, public-claims scan, and `git diff --check` pass.
+- Two independent read-only reviews are clean after resolving mutable-snapshot, config-path, inspect-ordering, rollback-file, external-drift, and stale-lock liveness findings.
+- Visible unsigned dev-app proof:
+  - `/Volumes/LEXAR/Codex/evidence/neondiff-v1.1/2026-07-10/issue-488/config-control-center.png`
+  - `/Volumes/LEXAR/Codex/evidence/neondiff-v1.1/2026-07-10/issue-488/config-control-center-validation.png`

--- a/docs/superpowers/plans/2026-07-10-issue-488-config-control-center.md
+++ b/docs/superpowers/plans/2026-07-10-issue-488-config-control-center.md
@@ -46,7 +46,7 @@ Commit Slice A, open its PR, and shepherd current-head CI plus bot/human review.
 
 ## Slice A Proof
 
-- 19 focused config CLI tests cover bounded paths, revision-bound preview/apply, stable inspect reads, competing-writer rejection, and live/dead stale-lock behavior.
+- 21 focused config CLI tests cover bounded paths, revision-bound preview/apply, stable/structured inspect reads, content-sensitive revisions, symlink-alias lock convergence, competing-writer rejection, and live/dead/invalid-owner stale-lock behavior.
 - TypeScript build, Swift core checks/smoke, Swift build, unsigned bundle check, actionlint, secret scan, public-claims scan, and `git diff --check` pass.
 - Two independent read-only reviews are clean after resolving mutable-snapshot, config-path, inspect-ordering, rollback-file, external-drift, and stale-lock liveness findings.
 - Visible unsigned dev-app proof:

--- a/docs/superpowers/plans/2026-07-10-issue-488-config-control-center.md
+++ b/docs/superpowers/plans/2026-07-10-issue-488-config-control-center.md
@@ -46,7 +46,7 @@ Commit Slice A, open its PR, and shepherd current-head CI plus bot/human review.
 
 ## Slice A Proof
 
-- 23 focused config CLI tests cover bounded paths, revision-bound preview/apply, stable/structured inspect reads, content-sensitive revisions, truthful post-commit results, symlink-alias lock convergence, same-process and child-process writer rejection, and live/dead/invalid-owner stale-lock behavior.
+- 23 focused config CLI tests cover bounded paths, revision-bound preview/apply, stable/structured inspect reads, content-sensitive revisions, truthful post-commit results, symlink-alias lock convergence, same-process and child-process writer rejection, and live/dead/empty/invalid-owner fail-closed lock behavior with manual recovery.
 - TypeScript build, Swift core checks/smoke, Swift build, unsigned bundle check, actionlint, secret scan, public-claims scan, and `git diff --check` pass.
 - Two independent read-only reviews are clean after resolving mutable-snapshot, config-path, inspect-ordering, rollback-file, external-drift, and stale-lock liveness findings.
 - Visible unsigned dev-app proof:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -163,7 +163,10 @@ async function main(): Promise<void> {
         configPath: parseSingleArg(args.config, "--config"),
         inputPath: parseSingleArg(args.input, "--input"),
         dryRun: args["dry-run"] !== "false",
-        confirm: args.confirm === "true"
+        confirm: args.confirm === "true",
+        expectedRevision: args["expected-revision"]
+          ? parseSingleArg(args["expected-revision"], "--expected-revision")
+          : undefined
       });
       console.log(JSON.stringify(result, null, 2));
       if (!result.ok) process.exitCode = 1;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -165,7 +165,7 @@ async function main(): Promise<void> {
         inputPath: parseSingleArg(args.input, "--input"),
         dryRun: args["dry-run"] !== "false",
         confirm: args.confirm === "true",
-        expectedRevision: args["expected-revision"]
+        expectedRevision: args["expected-revision"] !== undefined
           ? parseSingleArg(args["expected-revision"], "--expected-revision")
           : undefined
       });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -154,6 +154,7 @@ async function main(): Promise<void> {
     if (configAction === "inspect") {
       const result = inspectConfigForDesktop(args.config ? parseSingleArg(args.config, "--config") : undefined);
       console.log(JSON.stringify(result, null, 2));
+      if (!result.ok) process.exitCode = 1;
       return;
     }
     if (configAction === "patch") {

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -301,8 +301,7 @@ function patchConfigForDesktopUnlocked(
       if (liveRevision !== revisionBefore) {
         return failedPatch(input, configPath, inputPath, "config changed while applying patch; reload and preview again");
       }
-      writeConfigAtomic(configPath, next, input.fileOps);
-      revisionAfter = readStableConfigSnapshot(configPath, input.fileOps).revision;
+      revisionAfter = writeConfigAtomic(configPath, next, input.fileOps);
     } catch (error) {
       return failedPatch(input, configPath, inputPath, `failed to write config atomically: ${error instanceof Error ? error.message : String(error)}`);
     }
@@ -438,6 +437,14 @@ function configMetadataForPath(configPath: string, fileOps?: Partial<ConfigFileO
   return [stat.dev, stat.ino, stat.size, stat.mtimeNs, stat.ctimeNs].join(":");
 }
 
+function configRevision(text: string): string {
+  return createHash("sha256")
+    .update(String(Buffer.byteLength(text)))
+    .update("\0")
+    .update(text)
+    .digest("hex");
+}
+
 function readStableConfigSnapshot(configPath: string, fileOps?: Partial<ConfigFileOps>): { value: unknown; revision: string } {
   const ops = { ...defaultConfigFileOps, ...fileOps };
   for (let attempt = 0; attempt < 3; attempt += 1) {
@@ -445,13 +452,7 @@ function readStableConfigSnapshot(configPath: string, fileOps?: Partial<ConfigFi
     const text = ops.readFileSync(configPath, "utf8");
     const metadataAfter = configMetadataForPath(configPath, fileOps);
     if (metadataBefore !== metadataAfter) continue;
-    const revision = createHash("sha256")
-      .update(metadataAfter)
-      .update("\0")
-      .update(String(Buffer.byteLength(text)))
-      .update("\0")
-      .update(text)
-      .digest("hex");
+    const revision = configRevision(text);
     return { value: JSON.parse(text), revision };
   }
   throw new Error("config changed while reading; retry after the other writer finishes");
@@ -532,7 +533,7 @@ function validateCandidateConfig(candidate: unknown): string | undefined {
   }
 }
 
-function writeConfigAtomic(configPath: string, value: unknown, fileOps?: Partial<ConfigFileOps>): void {
+function writeConfigAtomic(configPath: string, value: unknown, fileOps?: Partial<ConfigFileOps>): string {
   const ops = { ...defaultConfigFileOps, ...fileOps };
   ops.mkdirSync(dirname(configPath), { recursive: true });
   const mode = ops.existsSync(configPath) ? ops.statSync(configPath).mode & 0o777 : 0o600;
@@ -547,6 +548,7 @@ function writeConfigAtomic(configPath: string, value: unknown, fileOps?: Partial
     fd = undefined;
     ops.chmodSync(tempPath, mode);
     ops.renameSync(tempPath, configPath);
+    return configRevision(data);
   } catch (error) {
     if (fd !== undefined) {
       try {

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -126,6 +126,7 @@ type ConfigFileOps = {
   mkdirSync: typeof mkdirSync;
   openSync: typeof openSync;
   readFileSync: typeof readFileSync;
+  realpathSync: typeof realpathSync;
   renameSync: typeof renameSync;
   statSync: typeof statSync;
   unlinkSync: typeof unlinkSync;
@@ -140,6 +141,7 @@ const defaultConfigFileOps: ConfigFileOps = {
   mkdirSync,
   openSync,
   readFileSync,
+  realpathSync,
   renameSync,
   statSync,
   unlinkSync,
@@ -152,7 +154,7 @@ export function inspectConfigForDesktop(configPath?: string, fileOps?: Partial<C
   let resolvedConfigPath = requestedConfigPath;
   let exists = requestedConfigPath ? ops.existsSync(requestedConfigPath) : false;
   try {
-    if (requestedConfigPath && exists) resolvedConfigPath = realpathSync(requestedConfigPath);
+    if (requestedConfigPath && exists) resolvedConfigPath = ops.realpathSync(requestedConfigPath);
     exists = resolvedConfigPath ? ops.existsSync(resolvedConfigPath) : false;
     const snapshot = exists && resolvedConfigPath ? readStableConfigSnapshot(resolvedConfigPath, fileOps) : undefined;
     const config = snapshot ? loadConfigFromObject(snapshot.value) : loadConfig();
@@ -188,11 +190,12 @@ export function patchConfigForDesktop(input: {
   expectedRevision?: string;
   fileOps?: Partial<ConfigFileOps>;
 }): ConfigPatchResult {
+  const ops = { ...defaultConfigFileOps, ...input.fileOps };
   const requestedConfigPath = resolve(input.configPath);
   const inputPath = resolve(input.inputPath);
   let configPath = requestedConfigPath;
   try {
-    if (existsSync(requestedConfigPath)) configPath = realpathSync(requestedConfigPath);
+    if (ops.existsSync(requestedConfigPath)) configPath = ops.realpathSync(requestedConfigPath);
   } catch (error) {
     return failedPatch(input, requestedConfigPath, inputPath, `failed to resolve config path: ${error instanceof Error ? error.message : String(error)}`);
   }

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -112,6 +112,7 @@ export interface ConfigPatchResult {
   revisionAfter?: string;
   config?: unknown;
   error?: string;
+  warning?: string;
 }
 
 interface FlattenedPatch {
@@ -223,11 +224,22 @@ export function patchConfigForDesktop(input: {
   } catch (error) {
     return failedPatch(input, configPath, inputPath, error instanceof Error ? error.message : String(error));
   }
+  const result = patchConfigForDesktopUnlocked(input, configPath, inputPath);
   try {
-    return patchConfigForDesktopUnlocked(input, configPath, inputPath);
-  } finally {
     releaseLock();
+  } catch (error) {
+    const lockPath = `${configPath}.neondiff.lock`;
+    const outcome = result.ok && result.wrote ? "config write committed" : "config patch completed";
+    return {
+      ...result,
+      warning: redactSecrets(
+        `${outcome}, but failed to release owned lock ${lockPath}: `
+        + `${error instanceof Error ? error.message : String(error)}; `
+        + "verify no NeonDiff config patch is running, then remove this lock and retry"
+      )
+    };
   }
+  return result;
 }
 
 function patchConfigForDesktopUnlocked(

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -462,14 +462,20 @@ function configRevision(text: string): string {
 
 function readStableConfigSnapshot(configPath: string, fileOps?: Partial<ConfigFileOps>): { value: unknown; revision: string } {
   const ops = { ...defaultConfigFileOps, ...fileOps };
+  let lastParseError: unknown;
   for (let attempt = 0; attempt < 3; attempt += 1) {
     const metadataBefore = configMetadataForPath(configPath, fileOps);
     const text = ops.readFileSync(configPath, "utf8");
     const metadataAfter = configMetadataForPath(configPath, fileOps);
     if (metadataBefore !== metadataAfter) continue;
     const revision = configRevision(text);
-    return { value: JSON.parse(text), revision };
+    try {
+      return { value: JSON.parse(text), revision };
+    } catch (error) {
+      lastParseError = error;
+    }
   }
+  if (lastParseError !== undefined) throw lastParseError;
   throw new Error("config changed while reading; retry after the other writer finishes");
 }
 
@@ -505,7 +511,7 @@ function acquireConfigPatchLock(configPath: string, fileOps?: Partial<ConfigFile
     if (code === "EEXIST") {
       const ownerPid = readConfigLockOwnerPid(lockPath, ops);
       const owner = ownerPid !== undefined && isProcessAlive(ownerPid)
-        ? `owned by live PID ${ownerPid}`
+        ? `records PID ${ownerPid}, which is currently in use (PID reuse is possible)`
         : "stale, corrupt, or owned by an unavailable process";
       throw new Error(
         `another config patch is running or left lock ${lockPath} (${owner}); `

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  realpathSync,
   renameSync,
   statSync,
   unlinkSync,
@@ -86,14 +87,15 @@ const PROVIDER_CAPABILITY_PATTERN =
   new RegExp(`^providers\\.providers\\.(${CONFIG_NAME_SEGMENT_PATTERN})\\.capabilities\\.(?:review|jsonOutput|local|streaming)$`);
 
 export interface ConfigInspectResult {
-  ok: true;
+  ok: boolean;
   command: "config inspect";
   configPath?: string;
   exists: boolean;
   source: "file" | "defaults";
   revision: string;
   editablePaths: string[];
-  config: unknown;
+  config?: unknown;
+  error?: string;
 }
 
 export interface ConfigPatchResult {
@@ -146,20 +148,36 @@ const defaultConfigFileOps: ConfigFileOps = {
 
 export function inspectConfigForDesktop(configPath?: string, fileOps?: Partial<ConfigFileOps>): ConfigInspectResult {
   const ops = { ...defaultConfigFileOps, ...fileOps };
-  const resolvedConfigPath = configPath ? resolve(configPath) : undefined;
-  const exists = resolvedConfigPath ? ops.existsSync(resolvedConfigPath) : false;
-  const snapshot = exists && resolvedConfigPath ? readStableConfigSnapshot(resolvedConfigPath, fileOps) : undefined;
-  const config = snapshot ? loadConfigFromObject(snapshot.value) : loadConfig();
-  return {
-    ok: true,
-    command: "config inspect",
-    ...(resolvedConfigPath ? { configPath: resolvedConfigPath } : {}),
-    exists,
-    source: exists ? "file" : "defaults",
-    revision: snapshot?.revision ?? "",
-    editablePaths: editablePatchPaths(),
-    config: redactConfigObject(config)
-  };
+  const requestedConfigPath = configPath ? resolve(configPath) : undefined;
+  let resolvedConfigPath = requestedConfigPath;
+  let exists = requestedConfigPath ? ops.existsSync(requestedConfigPath) : false;
+  try {
+    if (requestedConfigPath && exists) resolvedConfigPath = realpathSync(requestedConfigPath);
+    exists = resolvedConfigPath ? ops.existsSync(resolvedConfigPath) : false;
+    const snapshot = exists && resolvedConfigPath ? readStableConfigSnapshot(resolvedConfigPath, fileOps) : undefined;
+    const config = snapshot ? loadConfigFromObject(snapshot.value) : loadConfig();
+    return {
+      ok: true,
+      command: "config inspect",
+      ...(resolvedConfigPath ? { configPath: resolvedConfigPath } : {}),
+      exists,
+      source: exists ? "file" : "defaults",
+      revision: snapshot?.revision ?? "",
+      editablePaths: editablePatchPaths(),
+      config: redactConfigObject(config)
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      command: "config inspect",
+      ...(resolvedConfigPath ? { configPath: resolvedConfigPath } : {}),
+      exists,
+      source: exists ? "file" : "defaults",
+      revision: "",
+      editablePaths: editablePatchPaths(),
+      error: redactSecrets(error instanceof Error ? error.message : String(error))
+    };
+  }
 }
 
 export function patchConfigForDesktop(input: {
@@ -170,8 +188,14 @@ export function patchConfigForDesktop(input: {
   expectedRevision?: string;
   fileOps?: Partial<ConfigFileOps>;
 }): ConfigPatchResult {
-  const configPath = resolve(input.configPath);
+  const requestedConfigPath = resolve(input.configPath);
   const inputPath = resolve(input.inputPath);
+  let configPath = requestedConfigPath;
+  try {
+    if (existsSync(requestedConfigPath)) configPath = realpathSync(requestedConfigPath);
+  } catch (error) {
+    return failedPatch(input, requestedConfigPath, inputPath, `failed to resolve config path: ${error instanceof Error ? error.message : String(error)}`);
+  }
   if (!existsSync(configPath)) {
     return failedPatch(input, configPath, inputPath, "config file does not exist");
   }
@@ -270,12 +294,12 @@ function patchConfigForDesktopUnlocked(
 
   if (!input.dryRun && changedPaths.length > 0) {
     try {
-      const liveRevision = configRevisionForPath(configPath, input.fileOps);
+      const liveRevision = readStableConfigSnapshot(configPath, input.fileOps).revision;
       if (liveRevision !== revisionBefore) {
         return failedPatch(input, configPath, inputPath, "config changed while applying patch; reload and preview again");
       }
       writeConfigAtomic(configPath, next, input.fileOps);
-      revisionAfter = configRevisionForPath(configPath, input.fileOps);
+      revisionAfter = readStableConfigSnapshot(configPath, input.fileOps).revision;
     } catch (error) {
       return failedPatch(input, configPath, inputPath, `failed to write config atomically: ${error instanceof Error ? error.message : String(error)}`);
     }
@@ -405,21 +429,27 @@ function deepEqual(left: unknown, right: unknown): boolean {
   return false;
 }
 
-function configRevisionForPath(configPath: string, fileOps?: Partial<ConfigFileOps>): string {
+function configMetadataForPath(configPath: string, fileOps?: Partial<ConfigFileOps>): string {
   const ops = { ...defaultConfigFileOps, ...fileOps };
   const stat = ops.statSync(configPath, { bigint: true });
-  const identity = [stat.dev, stat.ino, stat.size, stat.mtimeNs, stat.ctimeNs].join(":");
-  return createHash("sha256").update(identity).digest("hex");
+  return [stat.dev, stat.ino, stat.size, stat.mtimeNs, stat.ctimeNs].join(":");
 }
 
 function readStableConfigSnapshot(configPath: string, fileOps?: Partial<ConfigFileOps>): { value: unknown; revision: string } {
   const ops = { ...defaultConfigFileOps, ...fileOps };
   for (let attempt = 0; attempt < 3; attempt += 1) {
-    const revisionBefore = configRevisionForPath(configPath, fileOps);
+    const metadataBefore = configMetadataForPath(configPath, fileOps);
     const text = ops.readFileSync(configPath, "utf8");
-    const revisionAfter = configRevisionForPath(configPath, fileOps);
-    if (revisionBefore !== revisionAfter) continue;
-    return { value: JSON.parse(text), revision: revisionAfter };
+    const metadataAfter = configMetadataForPath(configPath, fileOps);
+    if (metadataBefore !== metadataAfter) continue;
+    const revision = createHash("sha256")
+      .update(metadataAfter)
+      .update("\0")
+      .update(String(Buffer.byteLength(text)))
+      .update("\0")
+      .update(text)
+      .digest("hex");
+    return { value: JSON.parse(text), revision };
   }
   throw new Error("config changed while reading; retry after the other writer finishes");
 }

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -11,6 +11,7 @@ import {
   unlinkSync,
   writeFileSync
 } from "node:fs";
+import { createHash } from "node:crypto";
 import { dirname, resolve } from "node:path";
 import { loadConfig, loadConfigFromObject, type RepoProfileConfig } from "./config.js";
 import { isApiKeyEnvName } from "./providers.js";
@@ -34,11 +35,30 @@ const REPO_PROFILE_DESKTOP_SAFE_FIELDS = [
 
 const REPO_PROFILE_DESKTOP_SAFE_FIELD_PATTERN = REPO_PROFILE_DESKTOP_SAFE_FIELDS.join("|");
 const CONFIG_NAME_SEGMENT_PATTERN = "[A-Za-z0-9_.-]+";
+const CONFIG_REVISION_PATTERN = /^[a-f0-9]{64}$/;
 
 const EXACT_PATCH_PATHS = new Set([
   "pilotRepos",
+  "pollIntervalMs",
   "skipDrafts",
   "canaryPulls",
+  "reviewConcurrency.maxActiveRuns",
+  "reviewConcurrency.leaseTtlMs",
+  "reviewGate.maxInlineComments",
+  "issueEnrichment.enabled",
+  "issueEnrichment.postIssueComment",
+  "issueEnrichment.allowlist",
+  "issueEnrichment.maxIssuesPerCycle",
+  "issueEnrichment.maxCommentsPerCycle",
+  "issueEnrichment.globalMaxIssuesPerCycle",
+  "issueEnrichment.globalMaxCommentsPerCycle",
+  "issueEnrichment.maxActiveRuns",
+  "issueEnrichment.leaseTtlMs",
+  "issueEnrichment.cooldownMs",
+  "issueEnrichment.burstWindowMs",
+  "issueEnrichment.maxIssuesPerBurst",
+  "issueEnrichment.lookbackMs",
+  "issueEnrichment.processExistingOpenIssuesOnActivation",
   "zcode.cliPath",
   "zcode.appConfigPath",
   "zcode.model",
@@ -71,6 +91,7 @@ export interface ConfigInspectResult {
   configPath?: string;
   exists: boolean;
   source: "file" | "defaults";
+  revision: string;
   editablePaths: string[];
   config: unknown;
 }
@@ -84,6 +105,8 @@ export interface ConfigPatchResult {
   wrote: boolean;
   changedPaths: string[];
   noopPaths: string[];
+  revisionBefore?: string;
+  revisionAfter?: string;
   config?: unknown;
   error?: string;
 }
@@ -100,6 +123,7 @@ type ConfigFileOps = {
   fsyncSync: typeof fsyncSync;
   mkdirSync: typeof mkdirSync;
   openSync: typeof openSync;
+  readFileSync: typeof readFileSync;
   renameSync: typeof renameSync;
   statSync: typeof statSync;
   unlinkSync: typeof unlinkSync;
@@ -113,21 +137,26 @@ const defaultConfigFileOps: ConfigFileOps = {
   fsyncSync,
   mkdirSync,
   openSync,
+  readFileSync,
   renameSync,
   statSync,
   unlinkSync,
   writeFileSync
 };
 
-export function inspectConfigForDesktop(configPath?: string): ConfigInspectResult {
+export function inspectConfigForDesktop(configPath?: string, fileOps?: Partial<ConfigFileOps>): ConfigInspectResult {
+  const ops = { ...defaultConfigFileOps, ...fileOps };
   const resolvedConfigPath = configPath ? resolve(configPath) : undefined;
-  const config = loadConfig(resolvedConfigPath);
+  const exists = resolvedConfigPath ? ops.existsSync(resolvedConfigPath) : false;
+  const snapshot = exists && resolvedConfigPath ? readStableConfigSnapshot(resolvedConfigPath, fileOps) : undefined;
+  const config = snapshot ? loadConfigFromObject(snapshot.value) : loadConfig();
   return {
     ok: true,
     command: "config inspect",
     ...(resolvedConfigPath ? { configPath: resolvedConfigPath } : {}),
-    exists: resolvedConfigPath ? existsSync(resolvedConfigPath) : false,
-    source: resolvedConfigPath && existsSync(resolvedConfigPath) ? "file" : "defaults",
+    exists,
+    source: exists ? "file" : "defaults",
+    revision: snapshot?.revision ?? "",
     editablePaths: editablePatchPaths(),
     config: redactConfigObject(config)
   };
@@ -138,6 +167,7 @@ export function patchConfigForDesktop(input: {
   inputPath: string;
   dryRun: boolean;
   confirm: boolean;
+  expectedRevision?: string;
   fileOps?: Partial<ConfigFileOps>;
 }): ConfigPatchResult {
   const configPath = resolve(input.configPath);
@@ -151,17 +181,54 @@ export function patchConfigForDesktop(input: {
   if (!input.dryRun && !input.confirm) {
     return failedPatch(input, configPath, inputPath, "config patch with --dry-run false requires --confirm true");
   }
+  if (input.expectedRevision !== undefined && !CONFIG_REVISION_PATTERN.test(input.expectedRevision)) {
+    return failedPatch(input, configPath, inputPath, "--expected-revision must be a lowercase SHA-256 value");
+  }
+
+  if (input.dryRun) return patchConfigForDesktopUnlocked(input, configPath, inputPath);
+
+  let releaseLock: (() => void) | undefined;
+  try {
+    releaseLock = acquireConfigPatchLock(configPath, input.fileOps);
+  } catch (error) {
+    return failedPatch(input, configPath, inputPath, error instanceof Error ? error.message : String(error));
+  }
+  try {
+    return patchConfigForDesktopUnlocked(input, configPath, inputPath);
+  } finally {
+    releaseLock();
+  }
+}
+
+function patchConfigForDesktopUnlocked(
+  input: {
+    configPath: string;
+    inputPath: string;
+    dryRun: boolean;
+    confirm: boolean;
+    expectedRevision?: string;
+    fileOps?: Partial<ConfigFileOps>;
+  },
+  configPath: string,
+  inputPath: string
+): ConfigPatchResult {
 
   let current: unknown;
   let patch: unknown;
+  let revisionBefore: string;
   try {
-    current = JSON.parse(readFileSync(configPath, "utf8"));
+    const snapshot = readStableConfigSnapshot(configPath, input.fileOps);
+    current = snapshot.value;
+    revisionBefore = snapshot.revision;
     patch = JSON.parse(readFileSync(inputPath, "utf8"));
   } catch (error) {
     return failedPatch(input, configPath, inputPath, `invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
   }
   if (!isRecord(current)) {
     return failedPatch(input, configPath, inputPath, "config file must contain a JSON object");
+  }
+  if (input.expectedRevision !== undefined && input.expectedRevision !== revisionBefore) {
+    return failedPatch(input, configPath, inputPath, "config changed since preview; reload and preview again");
   }
   if (!isRecord(patch)) {
     return failedPatch(input, configPath, inputPath, "patch input must contain a JSON object");
@@ -196,13 +263,19 @@ export function patchConfigForDesktop(input: {
     setNestedValue(next, entry.path, entry.value);
   }
   const changedPaths = changed.map((entry) => entry.path.join("."));
+  let revisionAfter = revisionBefore;
 
   const validationError = validateCandidateConfig(next);
   if (validationError) return failedPatch(input, configPath, inputPath, validationError);
 
   if (!input.dryRun && changedPaths.length > 0) {
     try {
+      const liveRevision = configRevisionForPath(configPath, input.fileOps);
+      if (liveRevision !== revisionBefore) {
+        return failedPatch(input, configPath, inputPath, "config changed while applying patch; reload and preview again");
+      }
       writeConfigAtomic(configPath, next, input.fileOps);
+      revisionAfter = configRevisionForPath(configPath, input.fileOps);
     } catch (error) {
       return failedPatch(input, configPath, inputPath, `failed to write config atomically: ${error instanceof Error ? error.message : String(error)}`);
     }
@@ -217,6 +290,8 @@ export function patchConfigForDesktop(input: {
     wrote: !input.dryRun && changedPaths.length > 0,
     changedPaths,
     noopPaths,
+    revisionBefore,
+    revisionAfter,
     config: redactConfigObject(next)
   };
 }
@@ -328,6 +403,91 @@ function deepEqual(left: unknown, right: unknown): boolean {
     return leftKeys.every((key) => deepEqual(left[key], right[key]));
   }
   return false;
+}
+
+function configRevisionForPath(configPath: string, fileOps?: Partial<ConfigFileOps>): string {
+  const ops = { ...defaultConfigFileOps, ...fileOps };
+  const stat = ops.statSync(configPath, { bigint: true });
+  const identity = [stat.dev, stat.ino, stat.size, stat.mtimeNs, stat.ctimeNs].join(":");
+  return createHash("sha256").update(identity).digest("hex");
+}
+
+function readStableConfigSnapshot(configPath: string, fileOps?: Partial<ConfigFileOps>): { value: unknown; revision: string } {
+  const ops = { ...defaultConfigFileOps, ...fileOps };
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const revisionBefore = configRevisionForPath(configPath, fileOps);
+    const text = ops.readFileSync(configPath, "utf8");
+    const revisionAfter = configRevisionForPath(configPath, fileOps);
+    if (revisionBefore !== revisionAfter) continue;
+    return { value: JSON.parse(text), revision: revisionAfter };
+  }
+  throw new Error("config changed while reading; retry after the other writer finishes");
+}
+
+function acquireConfigPatchLock(configPath: string, fileOps?: Partial<ConfigFileOps>): () => void {
+  const ops = { ...defaultConfigFileOps, ...fileOps };
+  const lockPath = `${configPath}.neondiff.lock`;
+  const staleAfterMs = 5 * 60 * 1_000;
+  let fd: number | undefined;
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let createdLock = false;
+    try {
+      fd = ops.openSync(lockPath, "wx", 0o600);
+      createdLock = true;
+      ops.writeFileSync(fd, `${JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() })}\n`);
+      ops.fsyncSync(fd);
+      const lockInode = ops.statSync(lockPath).ino;
+      ops.closeSync(fd);
+      fd = undefined;
+      return () => {
+        if (ops.existsSync(lockPath) && ops.statSync(lockPath).ino === lockInode) {
+          ops.unlinkSync(lockPath);
+        }
+      };
+    } catch (error) {
+      if (fd !== undefined) {
+        try { ops.closeSync(fd); } catch { /* cleanup below */ }
+        fd = undefined;
+      }
+      if (createdLock && ops.existsSync(lockPath)) {
+        try { ops.unlinkSync(lockPath); } catch { /* surface the original acquisition failure */ }
+      }
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EEXIST" && attempt === 0) {
+        const ageMs = Date.now() - ops.statSync(lockPath).mtimeMs;
+        const ownerPid = readConfigLockOwnerPid(lockPath, ops);
+        if (ageMs > staleAfterMs && ownerPid !== undefined && !isProcessAlive(ownerPid)) {
+          ops.unlinkSync(lockPath);
+          continue;
+        }
+      }
+      throw new Error(code === "EEXIST"
+        ? "another config patch is running; retry after it finishes"
+        : `failed to acquire config patch lock: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  throw new Error("another config patch is running; retry after it finishes");
+}
+
+function readConfigLockOwnerPid(lockPath: string, ops: ConfigFileOps): number | undefined {
+  try {
+    const payload = JSON.parse(ops.readFileSync(lockPath, "utf8")) as { pid?: unknown };
+    return typeof payload.pid === "number" && Number.isSafeInteger(payload.pid) && payload.pid > 0
+      ? payload.pid
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
 }
 
 function validateCandidateConfig(candidate: unknown): string | undefined {

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -2,6 +2,7 @@ import {
   chmodSync,
   closeSync,
   existsSync,
+  fstatSync,
   fsyncSync,
   mkdirSync,
   openSync,
@@ -122,6 +123,7 @@ type ConfigFileOps = {
   chmodSync: typeof chmodSync;
   closeSync: typeof closeSync;
   existsSync: typeof existsSync;
+  fstatSync: typeof fstatSync;
   fsyncSync: typeof fsyncSync;
   mkdirSync: typeof mkdirSync;
   openSync: typeof openSync;
@@ -137,6 +139,7 @@ const defaultConfigFileOps: ConfigFileOps = {
   chmodSync,
   closeSync,
   existsSync,
+  fstatSync,
   fsyncSync,
   mkdirSync,
   openSync,
@@ -199,10 +202,10 @@ export function patchConfigForDesktop(input: {
   } catch (error) {
     return failedPatch(input, requestedConfigPath, inputPath, `failed to resolve config path: ${error instanceof Error ? error.message : String(error)}`);
   }
-  if (!existsSync(configPath)) {
+  if (!ops.existsSync(configPath)) {
     return failedPatch(input, configPath, inputPath, "config file does not exist");
   }
-  if (!existsSync(inputPath)) {
+  if (!ops.existsSync(inputPath)) {
     return failedPatch(input, configPath, inputPath, "patch input file does not exist");
   }
   if (!input.dryRun && !input.confirm) {
@@ -461,47 +464,44 @@ function readStableConfigSnapshot(configPath: string, fileOps?: Partial<ConfigFi
 function acquireConfigPatchLock(configPath: string, fileOps?: Partial<ConfigFileOps>): () => void {
   const ops = { ...defaultConfigFileOps, ...fileOps };
   const lockPath = `${configPath}.neondiff.lock`;
-  const staleAfterMs = 5 * 60 * 1_000;
   let fd: number | undefined;
-
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    let createdLock = false;
-    try {
-      fd = ops.openSync(lockPath, "wx", 0o600);
-      createdLock = true;
-      ops.writeFileSync(fd, `${JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() })}\n`);
-      ops.fsyncSync(fd);
-      const lockInode = ops.statSync(lockPath).ino;
-      ops.closeSync(fd);
+  let createdLock = false;
+  let lockInode: number | undefined;
+  try {
+    fd = ops.openSync(lockPath, "wx", 0o600);
+    createdLock = true;
+    lockInode = ops.fstatSync(fd).ino;
+    ops.writeFileSync(fd, `${JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() })}\n`);
+    ops.fsyncSync(fd);
+    ops.closeSync(fd);
+    fd = undefined;
+    return () => {
+      if (ops.existsSync(lockPath) && ops.statSync(lockPath).ino === lockInode) {
+        ops.unlinkSync(lockPath);
+      }
+    };
+  } catch (error) {
+    if (fd !== undefined) {
+      try { ops.closeSync(fd); } catch { /* cleanup below */ }
       fd = undefined;
-      return () => {
-        if (ops.existsSync(lockPath) && ops.statSync(lockPath).ino === lockInode) {
-          ops.unlinkSync(lockPath);
-        }
-      };
-    } catch (error) {
-      if (fd !== undefined) {
-        try { ops.closeSync(fd); } catch { /* cleanup below */ }
-        fd = undefined;
-      }
-      if (createdLock && ops.existsSync(lockPath)) {
-        try { ops.unlinkSync(lockPath); } catch { /* surface the original acquisition failure */ }
-      }
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === "EEXIST" && attempt === 0) {
-        const ageMs = Date.now() - ops.statSync(lockPath).mtimeMs;
-        const ownerPid = readConfigLockOwnerPid(lockPath, ops);
-        if (ageMs > staleAfterMs && ownerPid !== undefined && !isProcessAlive(ownerPid)) {
-          ops.unlinkSync(lockPath);
-          continue;
-        }
-      }
-      throw new Error(code === "EEXIST"
-        ? "another config patch is running; retry after it finishes"
-        : `failed to acquire config patch lock: ${error instanceof Error ? error.message : String(error)}`);
     }
+    if (createdLock && lockInode !== undefined && ops.existsSync(lockPath)
+      && ops.statSync(lockPath).ino === lockInode) {
+      try { ops.unlinkSync(lockPath); } catch { /* surface the original acquisition failure */ }
+    }
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EEXIST") {
+      const ownerPid = readConfigLockOwnerPid(lockPath, ops);
+      const owner = ownerPid !== undefined && isProcessAlive(ownerPid)
+        ? `owned by live PID ${ownerPid}`
+        : "stale, corrupt, or owned by an unavailable process";
+      throw new Error(
+        `another config patch is running or left lock ${lockPath} (${owner}); `
+        + "verify no NeonDiff config patch is running, then remove this lock and retry"
+      );
+    }
+    throw new Error(`failed to acquire config patch lock: ${error instanceof Error ? error.message : String(error)}`);
   }
-  throw new Error("another config patch is running; retry after it finishes");
 }
 
 function readConfigLockOwnerPid(lockPath: string, ops: ConfigFileOps): number | undefined {

--- a/src/config-cli.ts
+++ b/src/config-cli.ts
@@ -216,6 +216,9 @@ export function patchConfigForDesktop(input: {
     return failedPatch(input, configPath, inputPath, "--expected-revision must be a lowercase SHA-256 value");
   }
 
+  // Read-only previews stay lock-free. Every live write acquires the writer lock;
+  // when an expected revision is supplied, it is re-checked inside that lock
+  // before the atomic rename.
   if (input.dryRun) return patchConfigForDesktopUnlocked(input, configPath, inputPath);
 
   let releaseLock: (() => void) | undefined;
@@ -229,11 +232,13 @@ export function patchConfigForDesktop(input: {
     releaseLock();
   } catch (error) {
     const lockPath = `${configPath}.neondiff.lock`;
-    const outcome = result.ok && result.wrote ? "config write committed" : "config patch completed";
+    const outcome = result.ok
+      ? result.wrote ? "config write committed, but" : "config patch succeeded without a write, but"
+      : "config patch failed, and";
     return {
       ...result,
       warning: redactSecrets(
-        `${outcome}, but failed to release owned lock ${lockPath}: `
+        `${outcome} failed to release owned lock ${lockPath}: `
         + `${error instanceof Error ? error.message : String(error)}; `
         + "verify no NeonDiff config patch is running, then remove this lock and retry"
       )

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -151,6 +151,29 @@ describe("desktop config CLI", () => {
     expect(inspected.config).toBeUndefined();
   });
 
+  it("retries a transient torn JSON read before failing closed", () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      pollIntervalMs: 90_000,
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    });
+    let reads = 0;
+    const hookedReadFileSync = ((path: Parameters<typeof readFileSync>[0], options?: unknown) => {
+      reads += 1;
+      return reads === 1 ? "{" : readFileSync(path, options as BufferEncoding);
+    }) as typeof readFileSync;
+
+    const inspected = inspectConfigForDesktop(configPath, { readFileSync: hookedReadFileSync });
+
+    expect(inspected.ok).toBe(true);
+    expect(reads).toBe(2);
+    expect((inspected.config as { pollIntervalMs: number }).pollIntervalMs).toBe(90_000);
+  });
+
   it("changes the revision when content changes even with fixed metadata", () => {
     const root = mkRoot();
     const configPath = join(root, "config.json");
@@ -345,6 +368,16 @@ describe("desktop config CLI", () => {
       error: expect.stringContaining("requires --confirm true")
     });
 
+    const emptyRevisionRejected = await runConfig([
+      "config", "patch", "--config", configPath, "--input", patchPath,
+      "--dry-run", "false", "--confirm", "true", "--expected-revision", ""
+    ]);
+    expect(emptyRevisionRejected).toMatchObject({
+      ok: false,
+      wrote: false,
+      error: expect.stringContaining("lowercase SHA-256")
+    });
+
     const output = await runConfig([
       "config",
       "patch",
@@ -447,7 +480,7 @@ describe("desktop config CLI", () => {
     expect(previewed).toMatchObject({
       ok: true,
       revisionBefore: inspected.revision,
-      revisionAfter: expect.stringMatching(/^[a-f0-9]{64}$/)
+      revisionAfter: inspected.revision
     });
     writeConfig(configPath, {
       pilotRepos: ["owner/review-repo"],
@@ -973,7 +1006,7 @@ describe("desktop config CLI", () => {
     });
     expect(liveOwnerRejected).toMatchObject({
       ok: false,
-      error: expect.stringContaining(`owned by live PID ${process.pid}`)
+      error: expect.stringContaining(`records PID ${process.pid}, which is currently in use`)
     });
 
     unlinkSync(lockPath);

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -1,11 +1,11 @@
 import { execFile } from "node:child_process";
-import { chmodSync, existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readdirSync, readFileSync, renameSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
-import { patchConfigForDesktop } from "../src/config-cli.js";
+import { inspectConfigForDesktop, patchConfigForDesktop } from "../src/config-cli.js";
 
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
@@ -93,6 +93,34 @@ describe("desktop config CLI", () => {
     });
   });
 
+  it("retries inspect when the config changes during its stable read", () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      pollIntervalMs: 90_000,
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    });
+
+    let injectedWrite = false;
+    const hookedReadFileSync = ((path: Parameters<typeof readFileSync>[0], options?: unknown) => {
+      const text = readFileSync(path, options as BufferEncoding);
+      if (!injectedWrite && path === configPath) {
+        injectedWrite = true;
+        writeConfig(configPath, { ...JSON.parse(text), pollIntervalMs: 120_000 });
+      }
+      return text;
+    }) as typeof readFileSync;
+    const inspected = inspectConfigForDesktop(configPath, { readFileSync: hookedReadFileSync });
+    const current = inspectConfigForDesktop(configPath);
+
+    expect(injectedWrite).toBe(true);
+    expect((inspected.config as { pollIntervalMs: number }).pollIntervalMs).toBe(120_000);
+    expect(inspected.revision).toBe(current.revision);
+  });
+
   it("dry-runs whitelisted non-secret patches without writing", async () => {
     const root = mkRoot();
     const configPath = join(root, "config.json");
@@ -123,6 +151,8 @@ describe("desktop config CLI", () => {
 
     const before = readFileSync(configPath, "utf8");
     const output = await runConfig(["config", "patch", "--config", configPath, "--input", patchPath]);
+    const inspected = await runConfig(["config", "inspect", "--config", configPath]);
+    expect(inspected.revision).toMatch(/^[a-f0-9]{64}$/);
 
     expect(output).toMatchObject({
       ok: true,
@@ -288,6 +318,112 @@ describe("desktop config CLI", () => {
     expect(existsSync(configPath)).toBe(true);
   });
 
+  it("dry-runs separate review, daemon, and issue-enrichment control-center settings", async () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    const patchPath = join(root, "control-center-patch.json");
+    const invalidPatchPath = join(root, "invalid-control-center-patch.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/review-repo"],
+      pollIntervalMs: 90_000,
+      skipDrafts: true,
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    });
+    writeConfig(patchPath, {
+      pollIntervalMs: 120_000,
+      skipDrafts: false,
+      reviewConcurrency: {
+        maxActiveRuns: 2,
+        leaseTtlMs: 600_000
+      },
+      reviewGate: {
+        maxInlineComments: 12
+      },
+      issueEnrichment: {
+        enabled: true,
+        postIssueComment: false,
+        allowlist: ["owner/issues-repo"],
+        maxIssuesPerCycle: 4,
+        maxCommentsPerCycle: 1,
+        globalMaxIssuesPerCycle: 4,
+        globalMaxCommentsPerCycle: 1,
+        maxActiveRuns: 1,
+        leaseTtlMs: 900_000,
+        cooldownMs: 3_600_000,
+        burstWindowMs: 3_600_000,
+        maxIssuesPerBurst: 8,
+        lookbackMs: 600_000,
+        processExistingOpenIssuesOnActivation: false
+      }
+    });
+    writeConfig(invalidPatchPath, {
+      issueEnrichment: {
+        maxIssuesPerCycle: 1,
+        maxCommentsPerCycle: 2
+      }
+    });
+
+    const output = await runConfig(["config", "patch", "--config", configPath, "--input", patchPath]);
+    expect(output).toMatchObject({
+      ok: true,
+      dryRun: true,
+      wrote: false,
+      changedPaths: expect.arrayContaining([
+        "pollIntervalMs",
+        "skipDrafts",
+        "reviewConcurrency.maxActiveRuns",
+        "reviewConcurrency.leaseTtlMs",
+        "reviewGate.maxInlineComments",
+        "issueEnrichment.enabled",
+        "issueEnrichment.postIssueComment",
+        "issueEnrichment.allowlist",
+        "issueEnrichment.maxIssuesPerCycle",
+        "issueEnrichment.maxCommentsPerCycle"
+      ])
+    });
+    expect(output.config.pilotRepos).toEqual(["owner/review-repo"]);
+    expect(output.config.issueEnrichment.allowlist).toEqual(["owner/issues-repo"]);
+
+    const inspected = await runConfig(["config", "inspect", "--config", configPath]);
+    expect(inspected.revision).toMatch(/^[a-f0-9]{64}$/);
+    const previewed = await runConfig([
+      "config", "patch", "--config", configPath, "--input", patchPath,
+      "--expected-revision", inspected.revision
+    ]);
+    expect(previewed).toMatchObject({
+      ok: true,
+      revisionBefore: inspected.revision,
+      revisionAfter: expect.stringMatching(/^[a-f0-9]{64}$/)
+    });
+    writeConfig(configPath, {
+      pilotRepos: ["owner/review-repo"],
+      pollIntervalMs: 95_000,
+      skipDrafts: true,
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    });
+    const drifted = await runConfig([
+      "config", "patch", "--config", configPath, "--input", patchPath,
+      "--dry-run", "false", "--confirm", "true",
+      "--expected-revision", inspected.revision
+    ]);
+    expect(drifted).toMatchObject({
+      ok: false,
+      wrote: false,
+      error: expect.stringContaining("changed since preview")
+    });
+    expect(JSON.parse(readFileSync(configPath, "utf8")).pollIntervalMs).toBe(95_000);
+
+    expect(await runConfig(["config", "patch", "--config", configPath, "--input", invalidPatchPath])).toMatchObject({
+      ok: false,
+      wrote: false,
+      error: expect.stringContaining("maxCommentsPerCycle must be <=")
+    });
+  });
+
   it("reports no-op patch leaves separately and skips redundant live writes", async () => {
     const root = mkRoot();
     const configPath = join(root, "config.json");
@@ -388,7 +524,7 @@ describe("desktop config CLI", () => {
       desktop: { updateChannel: "NEONDIFF-PRIVATE-1234567890123456" }
     });
     writeConfig(blockedPatchPath, {
-      pollIntervalMs: 120_000
+      workRoot: "/tmp/not-desktop-safe"
     });
     writeConfig(sensitivePathPatchPath, {
       "NDL_SECRETLIKEPATH12345": "not-a-secret-value"
@@ -619,6 +755,77 @@ describe("desktop config CLI", () => {
     });
     expect(readFileSync(configPath, "utf8")).toBe(before);
     expect(readdirSync(root).filter((name) => name.includes(".tmp"))).toEqual([]);
+  });
+
+  it("serializes live config writers and recovers a bounded stale lock", () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    const firstPatchPath = join(root, "first-patch.json");
+    const secondPatchPath = join(root, "second-patch.json");
+    const lockPath = `${configPath}.neondiff.lock`;
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      desktop: { updateChannel: "dev" }
+    });
+    writeConfig(firstPatchPath, { desktop: { updateChannel: "beta" } });
+    writeConfig(secondPatchPath, { desktop: { updateChannel: "stable" } });
+
+    let competingResult: ReturnType<typeof patchConfigForDesktop> | undefined;
+    const firstResult = patchConfigForDesktop({
+      configPath,
+      inputPath: firstPatchPath,
+      dryRun: false,
+      confirm: true,
+      fileOps: {
+        renameSync: (from, to) => {
+          competingResult = patchConfigForDesktop({
+            configPath,
+            inputPath: secondPatchPath,
+            dryRun: false,
+            confirm: true
+          });
+          renameSync(from, to);
+        }
+      }
+    });
+
+    expect(firstResult).toMatchObject({ ok: true, wrote: true });
+    expect(competingResult).toMatchObject({
+      ok: false,
+      wrote: false,
+      error: expect.stringContaining("another config patch is running")
+    });
+    expect(JSON.parse(readFileSync(configPath, "utf8")).desktop.updateChannel).toBe("beta");
+    expect(existsSync(lockPath)).toBe(false);
+
+    writeFileSync(lockPath, `${JSON.stringify({ pid: process.pid, startedAt: "fixture" })}\n`, { mode: 0o600 });
+    const staleTime = new Date(Date.now() - 10 * 60 * 1_000);
+    utimesSync(lockPath, staleTime, staleTime);
+    const liveOwnerRejected = patchConfigForDesktop({
+      configPath,
+      inputPath: secondPatchPath,
+      dryRun: false,
+      confirm: true
+    });
+    expect(liveOwnerRejected).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("another config patch is running")
+    });
+
+    writeFileSync(lockPath, `${JSON.stringify({ pid: 2_147_483_647, startedAt: "fixture" })}\n`, { mode: 0o600 });
+    utimesSync(lockPath, staleTime, staleTime);
+    const recovered = patchConfigForDesktop({
+      configPath,
+      inputPath: secondPatchPath,
+      dryRun: false,
+      confirm: true
+    });
+    expect(recovered).toMatchObject({ ok: true, wrote: true });
+    expect(JSON.parse(readFileSync(configPath, "utf8")).desktop.updateChannel).toBe("stable");
+    expect(existsSync(lockPath)).toBe(false);
   });
 
   it("rejects empty object patches with a clear message", async () => {

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { chmodSync, closeSync, existsSync, mkdtempSync, openSync, readdirSync, readFileSync, renameSync, rmSync, statSync, symlinkSync, unlinkSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, closeSync, existsSync, mkdtempSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, symlinkSync, unlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -835,6 +835,23 @@ describe("desktop config CLI", () => {
         closeSync(fd);
       }
     };
+    const failingRealpathSync = (() => {
+      throw new Error("forced realpath failure");
+    }) as unknown as typeof realpathSync;
+    expect(inspectConfigForDesktop(configPath, { realpathSync: failingRealpathSync })).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("forced realpath failure")
+    });
+    expect(patchConfigForDesktop({
+      configPath,
+      inputPath: firstPatchPath,
+      dryRun: false,
+      confirm: true,
+      fileOps: { realpathSync: failingRealpathSync }
+    })).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("failed to resolve config path")
+    });
 
     let competingResult: ReturnType<typeof patchConfigForDesktop> | undefined;
     const firstResult = patchConfigForDesktop({
@@ -894,6 +911,16 @@ describe("desktop config CLI", () => {
 
     unlinkSync(lockPath);
     writeFixtureLock(2_147_483_647);
+    const freshDeadOwnerRejected = patchConfigForDesktop({
+      configPath,
+      inputPath: secondPatchPath,
+      dryRun: false,
+      confirm: true
+    });
+    expect(freshDeadOwnerRejected).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("another config patch is running")
+    });
     utimesSync(lockPath, staleTime, staleTime);
     const recovered = patchConfigForDesktop({
       configPath,

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -975,8 +975,7 @@ describe("desktop config CLI", () => {
       error: expect.stringContaining(lockPath)
     });
 
-    unlinkSync(lockPath);
-    writeFileSync(lockPath, "", { flag: "wx", mode: 0o600 });
+    writeFileSync(lockPath, "");
     const emptyLockRejected = patchConfigForDesktop({
       configPath,
       inputPath: secondPatchPath,

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -975,12 +975,21 @@ describe("desktop config CLI", () => {
       error: expect.stringContaining(lockPath)
     });
 
-    writeFileSync(lockPath, "");
+    const existingLockOpenSync = (() => {
+      throw Object.assign(new Error("fixture lock already exists"), { code: "EEXIST" });
+    }) as typeof openSync;
+    const emptyLockReadFileSync = ((path: Parameters<typeof readFileSync>[0], options?: unknown) => (
+      path === lockPath ? "" : readFileSync(path, options as never)
+    )) as typeof readFileSync;
     const emptyLockRejected = patchConfigForDesktop({
       configPath,
       inputPath: secondPatchPath,
       dryRun: false,
-      confirm: true
+      confirm: true,
+      fileOps: {
+        openSync: existingLockOpenSync,
+        readFileSync: emptyLockReadFileSync
+      }
     });
     expect(emptyLockRejected).toMatchObject({
       ok: false,

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -851,6 +851,45 @@ describe("desktop config CLI", () => {
     expect(JSON.parse(readFileSync(configPath, "utf8")).desktop.updateChannel).toBe("beta");
   });
 
+  it("preserves committed-write truth when owned lock cleanup fails", () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    const patchPath = join(root, "patch.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      desktop: { updateChannel: "dev" }
+    });
+    writeConfig(patchPath, { desktop: { updateChannel: "beta" } });
+    const lockPath = `${realpathSync(configPath)}.neondiff.lock`;
+    const output = patchConfigForDesktop({
+      configPath,
+      inputPath: patchPath,
+      dryRun: false,
+      confirm: true,
+      fileOps: {
+        renameSync: (from, to) => {
+          renameSync(from, to);
+        },
+        unlinkSync: (path) => {
+          if (String(path) === lockPath) throw new Error("forced lock cleanup failure");
+          unlinkSync(path);
+        }
+      }
+    });
+
+    expect(output).toMatchObject({
+      ok: true,
+      wrote: true,
+      revisionAfter: expect.stringMatching(/^[a-f0-9]{64}$/),
+      warning: expect.stringContaining(lockPath)
+    });
+    expect(JSON.parse(readFileSync(configPath, "utf8")).desktop.updateChannel).toBe("beta");
+    unlinkSync(lockPath);
+  });
+
   it("serializes live config writers and fails closed for every unowned lock state", () => {
     const root = mkRoot();
     const configPath = join(root, "config.json");

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -976,7 +976,7 @@ describe("desktop config CLI", () => {
     });
 
     unlinkSync(lockPath);
-    closeSync(openSync(lockPath, "wx", 0o600));
+    writeFileSync(lockPath, "", { flag: "wx", mode: 0o600 });
     const emptyLockRejected = patchConfigForDesktop({
       configPath,
       inputPath: secondPatchPath,

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { chmodSync, existsSync, mkdtempSync, readdirSync, readFileSync, renameSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, closeSync, existsSync, mkdtempSync, openSync, readdirSync, readFileSync, renameSync, rmSync, statSync, unlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -772,6 +772,14 @@ describe("desktop config CLI", () => {
     });
     writeConfig(firstPatchPath, { desktop: { updateChannel: "beta" } });
     writeConfig(secondPatchPath, { desktop: { updateChannel: "stable" } });
+    const writeFixtureLock = (pid: number) => {
+      const fd = openSync(lockPath, "wx", 0o600);
+      try {
+        writeFileSync(fd, `${JSON.stringify({ pid, startedAt: "fixture" })}\n`);
+      } finally {
+        closeSync(fd);
+      }
+    };
 
     let competingResult: ReturnType<typeof patchConfigForDesktop> | undefined;
     const firstResult = patchConfigForDesktop({
@@ -801,7 +809,7 @@ describe("desktop config CLI", () => {
     expect(JSON.parse(readFileSync(configPath, "utf8")).desktop.updateChannel).toBe("beta");
     expect(existsSync(lockPath)).toBe(false);
 
-    writeFileSync(lockPath, `${JSON.stringify({ pid: process.pid, startedAt: "fixture" })}\n`, { mode: 0o600 });
+    writeFixtureLock(process.pid);
     const staleTime = new Date(Date.now() - 10 * 60 * 1_000);
     utimesSync(lockPath, staleTime, staleTime);
     const liveOwnerRejected = patchConfigForDesktop({
@@ -815,7 +823,8 @@ describe("desktop config CLI", () => {
       error: expect.stringContaining("another config patch is running")
     });
 
-    writeFileSync(lockPath, `${JSON.stringify({ pid: 2_147_483_647, startedAt: "fixture" })}\n`, { mode: 0o600 });
+    unlinkSync(lockPath);
+    writeFixtureLock(2_147_483_647);
     utimesSync(lockPath, staleTime, staleTime);
     const recovered = patchConfigForDesktop({
       configPath,

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { chmodSync, closeSync, existsSync, mkdtempSync, openSync, readdirSync, readFileSync, renameSync, rmSync, statSync, unlinkSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, closeSync, existsSync, mkdtempSync, openSync, readdirSync, readFileSync, renameSync, rmSync, statSync, symlinkSync, unlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -107,7 +107,7 @@ describe("desktop config CLI", () => {
     let injectedWrite = false;
     const hookedReadFileSync = ((path: Parameters<typeof readFileSync>[0], options?: unknown) => {
       const text = readFileSync(path, options as BufferEncoding);
-      if (!injectedWrite && path === configPath) {
+      if (!injectedWrite) {
         injectedWrite = true;
         writeConfig(configPath, { ...JSON.parse(text), pollIntervalMs: 120_000 });
       }
@@ -119,6 +119,57 @@ describe("desktop config CLI", () => {
     expect(injectedWrite).toBe(true);
     expect((inspected.config as { pollIntervalMs: number }).pollIntervalMs).toBe(120_000);
     expect(inspected.revision).toBe(current.revision);
+  });
+
+  it("returns a structured inspect failure when a stable snapshot cannot be obtained", () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      pollIntervalMs: 90_000,
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    });
+
+    let pollIntervalMs = 90_000;
+    const hookedReadFileSync = ((path: Parameters<typeof readFileSync>[0], options?: unknown) => {
+      const text = readFileSync(path, options as BufferEncoding);
+      pollIntervalMs += 1_000;
+      writeConfig(configPath, { ...JSON.parse(text), pollIntervalMs });
+      return text;
+    }) as typeof readFileSync;
+    const inspected = inspectConfigForDesktop(configPath, { readFileSync: hookedReadFileSync });
+
+    expect(inspected).toMatchObject({
+      ok: false,
+      command: "config inspect",
+      revision: "",
+      error: expect.stringContaining("config changed while reading")
+    });
+    expect(inspected.config).toBeUndefined();
+  });
+
+  it("changes the revision when content changes even with fixed metadata", () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      pollIntervalMs: 90_000,
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence")
+    });
+    const fixedStat = statSync(configPath, { bigint: true });
+    const fixedStatSync = (() => fixedStat) as unknown as typeof statSync;
+    const before = inspectConfigForDesktop(configPath, { statSync: fixedStatSync });
+    const current = JSON.parse(readFileSync(configPath, "utf8"));
+    writeConfig(configPath, { ...current, pollIntervalMs: 91_000 });
+    const after = inspectConfigForDesktop(configPath, { statSync: fixedStatSync });
+
+    expect(before.ok).toBe(true);
+    expect(after.ok).toBe(true);
+    expect(after.revision).not.toBe(before.revision);
   });
 
   it("dry-runs whitelisted non-secret patches without writing", async () => {
@@ -763,6 +814,9 @@ describe("desktop config CLI", () => {
     const firstPatchPath = join(root, "first-patch.json");
     const secondPatchPath = join(root, "second-patch.json");
     const lockPath = `${configPath}.neondiff.lock`;
+    const aliasDirectory = join(root, "alias");
+    symlinkSync(".", aliasDirectory, "dir");
+    const aliasConfigPath = join(aliasDirectory, "config.json");
     writeConfig(configPath, {
       pilotRepos: ["owner/repo"],
       workRoot: join(root, "runtime"),
@@ -783,7 +837,7 @@ describe("desktop config CLI", () => {
 
     let competingResult: ReturnType<typeof patchConfigForDesktop> | undefined;
     const firstResult = patchConfigForDesktop({
-      configPath,
+      configPath: aliasConfigPath,
       inputPath: firstPatchPath,
       dryRun: false,
       confirm: true,
@@ -819,6 +873,20 @@ describe("desktop config CLI", () => {
       confirm: true
     });
     expect(liveOwnerRejected).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("another config patch is running")
+    });
+
+    unlinkSync(lockPath);
+    writeFixtureLock(Number.NaN);
+    utimesSync(lockPath, staleTime, staleTime);
+    const invalidOwnerRejected = patchConfigForDesktop({
+      configPath,
+      inputPath: secondPatchPath,
+      dryRun: false,
+      confirm: true
+    });
+    expect(invalidOwnerRejected).toMatchObject({
       ok: false,
       error: expect.stringContaining("another config patch is running")
     });

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -470,6 +470,7 @@ describe("desktop config CLI", () => {
     });
     expect(output.config.pilotRepos).toEqual(["owner/review-repo"]);
     expect(output.config.issueEnrichment.allowlist).toEqual(["owner/issues-repo"]);
+    expect(output.changedPaths).not.toContain("pilotRepos");
 
     const inspected = await runConfig(["config", "inspect", "--config", configPath]);
     expect(inspected.revision).toMatch(/^[a-f0-9]{64}$/);
@@ -701,6 +702,7 @@ describe("desktop config CLI", () => {
     const invalidPatchPath = join(root, "invalid-repo-selector-patch.json");
     writeConfig(configPath, {
       pilotRepos: ["owner/existing"],
+      issueEnrichment: { allowlist: ["owner/issues-only"] },
       workRoot: join(root, "runtime"),
       statePath: join(root, "state.sqlite"),
       evidenceDir: join(root, "evidence")
@@ -722,6 +724,8 @@ describe("desktop config CLI", () => {
       changedPaths: ["pilotRepos"]
     });
     expect(output.config.pilotRepos).toEqual(["owner/existing", "owner/next-repo"]);
+    expect(output.config.issueEnrichment.allowlist).toEqual(["owner/issues-only"]);
+    expect(output.changedPaths).not.toContain("issueEnrichment.allowlist");
     expect(readFileSync(configPath, "utf8")).toBe(before);
 
     const rejected = await runConfig(["config", "patch", "--config", configPath, "--input", invalidPatchPath]);
@@ -920,6 +924,27 @@ describe("desktop config CLI", () => {
       warning: expect.stringContaining(lockPath)
     });
     expect(JSON.parse(readFileSync(configPath, "utf8")).desktop.updateChannel).toBe("beta");
+    unlinkSync(lockPath);
+
+    writeConfig(patchPath, {});
+    const failedOutput = patchConfigForDesktop({
+      configPath,
+      inputPath: patchPath,
+      dryRun: false,
+      confirm: true,
+      fileOps: {
+        unlinkSync: (path) => {
+          if (String(path) === lockPath) throw new Error("forced lock cleanup failure");
+          unlinkSync(path);
+        }
+      }
+    });
+    expect(failedOutput).toMatchObject({
+      ok: false,
+      wrote: false,
+      error: "patch input did not contain any leaf settings",
+      warning: expect.stringContaining("config patch failed, and failed to release owned lock")
+    });
     unlinkSync(lockPath);
   });
 

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -851,7 +851,7 @@ describe("desktop config CLI", () => {
     expect(JSON.parse(readFileSync(configPath, "utf8")).desktop.updateChannel).toBe("beta");
   });
 
-  it("serializes live config writers and recovers a bounded stale lock", () => {
+  it("serializes live config writers and fails closed for every unowned lock state", () => {
     const root = mkRoot();
     const configPath = join(root, "config.json");
     const firstPatchPath = join(root, "first-patch.json");
@@ -934,7 +934,7 @@ describe("desktop config CLI", () => {
     });
     expect(liveOwnerRejected).toMatchObject({
       ok: false,
-      error: expect.stringContaining("another config patch is running")
+      error: expect.stringContaining(`owned by live PID ${process.pid}`)
     });
 
     unlinkSync(lockPath);
@@ -948,7 +948,7 @@ describe("desktop config CLI", () => {
     });
     expect(invalidOwnerRejected).toMatchObject({
       ok: false,
-      error: expect.stringContaining("another config patch is running")
+      error: expect.stringContaining("stale, corrupt, or owned by an unavailable process")
     });
 
     unlinkSync(lockPath);
@@ -961,9 +961,34 @@ describe("desktop config CLI", () => {
     });
     expect(freshDeadOwnerRejected).toMatchObject({
       ok: false,
-      error: expect.stringContaining("another config patch is running")
+      error: expect.stringContaining("verify no NeonDiff config patch is running")
     });
     utimesSync(lockPath, staleTime, staleTime);
+    const staleDeadOwnerRejected = patchConfigForDesktop({
+      configPath,
+      inputPath: secondPatchPath,
+      dryRun: false,
+      confirm: true
+    });
+    expect(staleDeadOwnerRejected).toMatchObject({
+      ok: false,
+      error: expect.stringContaining(lockPath)
+    });
+
+    unlinkSync(lockPath);
+    closeSync(openSync(lockPath, "wx", 0o600));
+    const emptyLockRejected = patchConfigForDesktop({
+      configPath,
+      inputPath: secondPatchPath,
+      dryRun: false,
+      confirm: true
+    });
+    expect(emptyLockRejected).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("then remove this lock and retry")
+    });
+
+    unlinkSync(lockPath);
     const recovered = patchConfigForDesktop({
       configPath,
       inputPath: secondPatchPath,

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -809,6 +809,48 @@ describe("desktop config CLI", () => {
     expect(readdirSync(root).filter((name) => name.includes(".tmp"))).toEqual([]);
   });
 
+  it("reports a committed write truthfully without post-rename metadata I/O", () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    const patchPath = join(root, "patch.json");
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      desktop: { updateChannel: "dev" }
+    });
+    writeConfig(patchPath, { desktop: { updateChannel: "beta" } });
+    let committed = false;
+    const injectedStatSync = ((path: Parameters<typeof statSync>[0], options?: unknown) => {
+      if (committed && String(path) === configPath) {
+        throw new Error("post-commit config metadata unavailable");
+      }
+      return statSync(path, options as never);
+    }) as unknown as typeof statSync;
+
+    const output = patchConfigForDesktop({
+      configPath,
+      inputPath: patchPath,
+      dryRun: false,
+      confirm: true,
+      fileOps: {
+        statSync: injectedStatSync,
+        renameSync: (from, to) => {
+          renameSync(from, to);
+          committed = true;
+        }
+      }
+    });
+
+    expect(output).toMatchObject({
+      ok: true,
+      wrote: true,
+      revisionAfter: expect.stringMatching(/^[a-f0-9]{64}$/)
+    });
+    expect(JSON.parse(readFileSync(configPath, "utf8")).desktop.updateChannel).toBe("beta");
+  });
+
   it("serializes live config writers and recovers a bounded stale lock", () => {
     const root = mkRoot();
     const configPath = join(root, "config.json");
@@ -931,6 +973,40 @@ describe("desktop config CLI", () => {
     expect(recovered).toMatchObject({ ok: true, wrote: true });
     expect(JSON.parse(readFileSync(configPath, "utf8")).desktop.updateChannel).toBe("stable");
     expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("rejects a separate CLI process while a live owner holds the config lock", async () => {
+    const root = mkRoot();
+    const configPath = join(root, "config.json");
+    const patchPath = join(root, "patch.json");
+    const lockPath = `${configPath}.neondiff.lock`;
+    writeConfig(configPath, {
+      pilotRepos: ["owner/repo"],
+      workRoot: join(root, "runtime"),
+      statePath: join(root, "state.sqlite"),
+      evidenceDir: join(root, "evidence"),
+      desktop: { updateChannel: "dev" }
+    });
+    writeConfig(patchPath, { desktop: { updateChannel: "beta" } });
+    const fd = openSync(lockPath, "wx", 0o600);
+    try {
+      writeFileSync(fd, `${JSON.stringify({ pid: process.pid, startedAt: "fixture" })}\n`);
+    } finally {
+      closeSync(fd);
+    }
+
+    const result = await runConfig([
+      "config", "patch", "--config", configPath, "--input", patchPath,
+      "--dry-run", "false", "--confirm", "true"
+    ]);
+
+    expect(result).toMatchObject({
+      ok: false,
+      wrote: false,
+      error: expect.stringContaining("another config patch is running")
+    });
+    expect(JSON.parse(readFileSync(configPath, "utf8")).desktop.updateChannel).toBe("dev");
+    unlinkSync(lockPath);
   });
 
   it("rejects empty object patches with a clear message", async () => {

--- a/tests/config-cli.test.ts
+++ b/tests/config-cli.test.ts
@@ -96,13 +96,14 @@ describe("desktop config CLI", () => {
   it("retries inspect when the config changes during its stable read", () => {
     const root = mkRoot();
     const configPath = join(root, "config.json");
-    writeConfig(configPath, {
+    const config = {
       pilotRepos: ["owner/repo"],
       pollIntervalMs: 90_000,
       workRoot: join(root, "runtime"),
       statePath: join(root, "state.sqlite"),
       evidenceDir: join(root, "evidence")
-    });
+    };
+    writeConfig(configPath, config);
 
     let injectedWrite = false;
     const hookedReadFileSync = ((path: Parameters<typeof readFileSync>[0], options?: unknown) => {
@@ -153,18 +154,18 @@ describe("desktop config CLI", () => {
   it("changes the revision when content changes even with fixed metadata", () => {
     const root = mkRoot();
     const configPath = join(root, "config.json");
-    writeConfig(configPath, {
+    const config = {
       pilotRepos: ["owner/repo"],
       pollIntervalMs: 90_000,
       workRoot: join(root, "runtime"),
       statePath: join(root, "state.sqlite"),
       evidenceDir: join(root, "evidence")
-    });
+    };
+    writeConfig(configPath, config);
     const fixedStat = statSync(configPath, { bigint: true });
     const fixedStatSync = (() => fixedStat) as unknown as typeof statSync;
     const before = inspectConfigForDesktop(configPath, { statSync: fixedStatSync });
-    const current = JSON.parse(readFileSync(configPath, "utf8"));
-    writeConfig(configPath, { ...current, pollIntervalMs: 91_000 });
+    writeConfig(configPath, { ...config, pollIntervalMs: 91_000 });
     const after = inspectConfigForDesktop(configPath, { statSync: fixedStatSync });
 
     expect(before.ok).toBe(true);


### PR DESCRIPTION
Part of #488. This PR delivers Slice A only; #488 stays open for Keychain-backed provider verification and the remaining full-pane UI proof in Slice B.

## What changed

- adds a native Policy configuration control center for bounded daemon, PR review, and issue-enrichment settings
- keeps PR review repositories (`pilotRepos`) separate from `issueEnrichment.allowlist`
- requires a revision-bound dry-run Preview before Apply and exposes one-shot non-secret rollback after a proven write
- binds preview/apply/rollback to immutable settings snapshots and exact config paths
- serializes inspect and patch operations in-app
- adds stable config reads, secret-safe filesystem revision tokens, and an exclusive per-config live-writer lock with live-PID-aware stale recovery
- expands only the desktop-safe config patch paths needed by this slice

## Verification

- `npm test -- tests/config-cli.test.ts` — 19/19
- `npm run build`
- `swift run --package-path apps/neondiff-desktop NeonDiffDesktopCoreChecks`
- `swift run --package-path apps/neondiff-desktop NeonDiffDesktopCoreSmoke`
- `swift build --package-path apps/neondiff-desktop`
- `apps/neondiff-desktop/script/build_and_run.sh bundle-check`
- `actionlint`
- `npm run check:secrets`
- `npm run check:public-claims`
- `git diff --check`
- two independent read-only reviews: clean, no remaining P0-P2 findings

Visible unsigned dev-app proof (no config load/preview/apply was invoked):

- `/Volumes/LEXAR/Codex/evidence/neondiff-v1.1/2026-07-10/issue-488/config-control-center.png` — SHA-256 `81d648369b0bd8c09084474150fe74aeb546853bd896a7d7b3367a954b94e57c`
- `/Volumes/LEXAR/Codex/evidence/neondiff-v1.1/2026-07-10/issue-488/config-control-center-validation.png` — SHA-256 `fa6f4eb5677d603618afd76119e1e794881695a2de281bfb98f0d11fb0e95e42`

## Proof boundary

This is unsigned source/dev-app proof. It does not claim provider-key verification complete, live daemon or GitHub mutation, signed/notarized Mac distribution, Sparkle/appcast readiness, browser/native parity, customer readiness, or v1.1 completion.