### PR TITLE
fix(desktop): harden evidence packet identity

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopEvaluationEvidenceManifest.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopEvaluationEvidenceManifest.swift
@@ -137,12 +137,14 @@ public struct DesktopEvaluationEvidenceManifest: Codable, Equatable, Sendable {
         }
         guard testSummary.testCount > 0,
               testSummary.testCount <= 100_000,
+              !cases.isEmpty,
               testSummary.durationSeconds >= 0,
               testSummary.durationSeconds.isFinite,
               Self.isHash(testSummary.xcresultSHA256) else {
             throw DesktopEvaluationFixtureError.invalidValue("manifest test summary")
         }
         var caseIdentities = Set<String>()
+        var evidencePaths = Set<String>()
         for item in cases {
             let identity = "\(item.fixtureId)|\(item.appearance.rawValue)|\(item.requestedContentSize.width)x\(item.requestedContentSize.height)|\(platform.backingScale)"
             guard caseIdentities.insert(identity).inserted,
@@ -155,7 +157,9 @@ public struct DesktopEvaluationEvidenceManifest: Codable, Equatable, Sendable {
                 throw DesktopEvaluationFixtureError.invalidValue("manifest case")
             }
             for evidence in [item.screenshot, item.accessibility, item.geometry] {
-                guard Self.isSafeRelativePath(evidence.path), Self.isHash(evidence.sha256) else {
+                guard Self.isSafeRelativePath(evidence.path),
+                      evidencePaths.insert(evidence.path).inserted,
+                      Self.isHash(evidence.sha256) else {
                     throw DesktopEvaluationFixtureError.invalidValue("manifest evidence file")
                 }
             }
@@ -197,10 +201,16 @@ public struct DesktopEvaluationEvidenceManifest: Codable, Equatable, Sendable {
     }
 
     private static func isSafeRelativePath(_ value: String) -> Bool {
-        !value.isEmpty
-            && !value.hasPrefix("/")
-            && !value.split(separator: "/", omittingEmptySubsequences: false).contains("..")
-            && value.utf8.count <= 512
+        guard !value.isEmpty, !value.hasPrefix("/"), value.utf8.count <= 512 else {
+            return false
+        }
+        let segments = value.split(separator: "/", omittingEmptySubsequences: false)
+        return segments.allSatisfy { segment in
+            !segment.isEmpty
+                && segment != "."
+                && segment != ".."
+                && segment.range(of: #"^[A-Za-z0-9_.-]+$"#, options: .regularExpression) != nil
+        }
     }
 
     private static func isValidFrame(_ frame: Frame) -> Bool {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopFixtureChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopFixtureChecks/main.swift
@@ -41,6 +41,24 @@ func expectCatalogFailure(_ message: String, url: URL) {
     }
 }
 
+func expectManifestFailure(_ message: String, data: Data) {
+    do {
+        _ = try DesktopEvaluationEvidenceManifest.decode(data: data)
+        fputs("check failed: \(message) did not fail\n", stderr)
+        exit(1)
+    } catch {
+        check(!error.localizedDescription.isEmpty, "\(message) returns a bounded diagnostic")
+    }
+}
+
+func mutatedManifest(_ data: Data, _ mutate: (inout [String: Any]) -> Void) throws -> Data {
+    guard var object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        throw DesktopEvaluationFixtureError.invalidJSON
+    }
+    mutate(&object)
+    return try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+}
+
 let validFixture = Data(
     #"""
     {
@@ -346,5 +364,31 @@ let failingRunManifest = Data(
 let failingManifest = try DesktopEvaluationEvidenceManifest.decode(data: failingRunManifest)
 check(failingManifest.unresolvedFindings.first?.severity == .p0, "manifest truthfully records blocking findings")
 check(failingManifest.cases.first?.goldenMetrics.ssim == 0.8, "manifest truthfully records below-threshold goldens")
+
+let emptyCasesManifest = try mutatedManifest(validManifest) { object in
+    object["cases"] = []
+}
+expectManifestFailure("manifest without capture cases", data: emptyCasesManifest)
+
+let URLArtifactManifest = try mutatedManifest(validManifest) { object in
+    var artifact = object["artifact"] as! [String: Any]
+    artifact["path"] = "https://example.com/NeonDiffDesktop.app"
+    object["artifact"] = artifact
+}
+expectManifestFailure("URL-like packet path", data: URLArtifactManifest)
+
+let emptySegmentManifest = try mutatedManifest(validManifest) { object in
+    var artifact = object["artifact"] as! [String: Any]
+    artifact["path"] = "artifacts//NeonDiffDesktop.app"
+    object["artifact"] = artifact
+}
+expectManifestFailure("empty packet path segment", data: emptySegmentManifest)
+
+let duplicateEvidencePathManifest = try mutatedManifest(validManifest) { object in
+    var cases = object["cases"] as! [[String: Any]]
+    cases[1]["screenshot"] = cases[0]["screenshot"]
+    object["cases"] = cases
+}
+expectManifestFailure("reused evidence artifact path", data: duplicateEvidencePathManifest)
 
 print("NeonDiffDesktop fixture checks passed")

--- a/apps/neondiff-desktop/docs/ui-evaluation.md
+++ b/apps/neondiff-desktop/docs/ui-evaluation.md
@@ -53,9 +53,11 @@ these arguments may be treated as an executable user-interface test path.
 
 The manifest allows the same fixture at different canonical sizes but rejects a
 duplicate `(fixture, appearance, size, scale)` case. Test count and capture-case
-count are recorded independently. It rejects unknown fields, malformed hashes,
-non-canonical sizes, unsafe evidence paths, failed scans, out-of-range metrics,
-and empty proof boundaries. It deliberately records below-threshold goldens and
+count are recorded independently. It requires at least one capture case and a
+unique packet-relative path for every screenshot, AX tree, and geometry file.
+It rejects unknown fields, malformed hashes, non-canonical sizes, URL-like or
+ambiguous evidence paths, failed scans, out-of-range metrics, and empty proof
+boundaries. It deliberately records below-threshold goldens and
 typed P0/P1 findings truthfully; the GA gate, not the evidence decoder, stops
 progression on those results. Canonical packets belong in the dated external evidence
 directory and CI artifacts; raw screenshots, AX trees, and geometry output do


### PR DESCRIPTION
## Summary

Immediate follow-up to #526 after a review-thread race was visible in the final merge command.

- require at least one capture case in an evidence manifest
- reject URL-like, absolute, empty-segment, dot-segment, and unsafe packet paths
- require every screenshot, AX-tree, and geometry path to be unique across the packet
- add failing-first regressions for all three findings
- clarify the packet identity contract

Related: #515
Follow-up to: #526

## TDD evidence

The new Swift checks first proved that empty case arrays, URL-like paths, empty path segments, and reused evidence paths were accepted. The manifest validator was then tightened until all regressions passed.

## Validation

- swift run --package-path apps/neondiff-desktop NeonDiffDesktopFixtureChecks
- git diff --check

## Merge-race correction

The final pre-merge query for #526 returned four unresolved threads after CodeRabbit completed. One was an explicit P3/no-action CI-cost note; these three P2 findings are fixed here. #526 must not be treated as a clean-thread merge until this follow-up lands and the merged PR threads are replied to/resolved.

## Proof boundary

This hardens evidence structure only. It does not add DEBUG app wiring, launched captures, AX/geometry generation, signed/notarized distribution, parity, or GA proof.
