### PR TITLE
fix(desktop): canonicalize evidence packet paths

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopEvaluationEvidenceManifest.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopEvaluationSupport/DesktopEvaluationEvidenceManifest.swift
@@ -158,7 +158,7 @@ public struct DesktopEvaluationEvidenceManifest: Codable, Equatable, Sendable {
             }
             for evidence in [item.screenshot, item.accessibility, item.geometry] {
                 guard Self.isSafeRelativePath(evidence.path),
-                      evidencePaths.insert(evidence.path).inserted,
+                      evidencePaths.insert(Self.canonicalPacketPath(evidence.path)).inserted,
                       Self.isHash(evidence.sha256) else {
                     throw DesktopEvaluationFixtureError.invalidValue("manifest evidence file")
                 }
@@ -209,8 +209,21 @@ public struct DesktopEvaluationEvidenceManifest: Codable, Equatable, Sendable {
             !segment.isEmpty
                 && segment != "."
                 && segment != ".."
-                && segment.range(of: #"^[A-Za-z0-9_.-]+$"#, options: .regularExpression) != nil
+                && segment.utf8.allSatisfy(Self.isSafePathByte)
         }
+    }
+
+    private static func isSafePathByte(_ byte: UInt8) -> Bool {
+        (byte >= 48 && byte <= 57)
+            || (byte >= 65 && byte <= 90)
+            || (byte >= 97 && byte <= 122)
+            || [45, 46, 95].contains(byte)
+    }
+
+    private static func canonicalPacketPath(_ value: String) -> String {
+        String(decoding: value.utf8.map { byte in
+            byte >= 65 && byte <= 90 ? byte + 32 : byte
+        }, as: UTF8.self)
     }
 
     private static func isValidFrame(_ frame: Frame) -> Bool {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopFixtureChecks/main.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopFixtureChecks/main.swift
@@ -391,4 +391,43 @@ let duplicateEvidencePathManifest = try mutatedManifest(validManifest) { object 
 }
 expectManifestFailure("reused evidence artifact path", data: duplicateEvidencePathManifest)
 
+let lineTerminatedEvidencePathManifest = try mutatedManifest(validManifest) { object in
+    var cases = object["cases"] as! [[String: Any]]
+    var screenshot = cases[0]["screenshot"] as! [String: Any]
+    screenshot["path"] = "tab-overview-1040x680.png\n"
+    cases[0]["screenshot"] = screenshot
+    object["cases"] = cases
+}
+expectManifestFailure("line-terminated evidence artifact path", data: lineTerminatedEvidencePathManifest)
+
+for lineSeparator in ["\r", "\r\n", "\u{2028}", "\u{2029}"] {
+    let separatedPathManifest = try mutatedManifest(validManifest) { object in
+        var artifact = object["artifact"] as! [String: Any]
+        artifact["path"] = "artifacts/NeonDiffDesktop.app\(lineSeparator)"
+        object["artifact"] = artifact
+    }
+    expectManifestFailure("line-separated artifact packet path", data: separatedPathManifest)
+}
+
+let caseAliasedEvidencePathManifest = try mutatedManifest(validManifest) { object in
+    var cases = object["cases"] as! [[String: Any]]
+    var screenshot = cases[1]["screenshot"] as! [String: Any]
+    screenshot["path"] = "TAB-OVERVIEW-1040X680.PNG"
+    cases[1]["screenshot"] = screenshot
+    object["cases"] = cases
+}
+expectManifestFailure("case-aliased evidence artifact path", data: caseAliasedEvidencePathManifest)
+
+let directoryCaseAliasedEvidencePathManifest = try mutatedManifest(validManifest) { object in
+    var cases = object["cases"] as! [[String: Any]]
+    var firstScreenshot = cases[0]["screenshot"] as! [String: Any]
+    firstScreenshot["path"] = "captures/tab.png"
+    cases[0]["screenshot"] = firstScreenshot
+    var secondGeometry = cases[1]["geometry"] as! [String: Any]
+    secondGeometry["path"] = "CAPTURES/TAB.PNG"
+    cases[1]["geometry"] = secondGeometry
+    object["cases"] = cases
+}
+expectManifestFailure("directory and cross-role case-aliased evidence path", data: directoryCaseAliasedEvidencePathManifest)
+
 print("NeonDiffDesktop fixture checks passed")


### PR DESCRIPTION
Follow-up for #515 and the two late P2 review findings on #527.

- replace regex-anchored packet path validation with an exact ASCII byte allowlist
- compare evidence paths using locale-independent ASCII case folding across all cases and roles
- add regressions for LF, CR, CRLF, Unicode line separators, basename aliases, directory aliases, and cross-role aliases

Local proof:
- `swift run --package-path apps/neondiff-desktop NeonDiffDesktopFixtureChecks`
- `swift build --package-path apps/neondiff-desktop --product NeonDiffDesktopFixtureChecks`
- `npm run build`
- `npm run check:secrets`
- `actionlint`
- `git diff --check`

Proof boundary: evidence-manifest integrity only; this does not provide canonical UI capture, signed/notarized distribution, or browser/native parity.

Closes the late review defects; #515 remains open.