### PR TITLE
fix(desktop): quarantine useful work before activation proof

### DIFF
--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/VisualProofDesktopDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Adapters/VisualProofDesktopDependencies.swift
@@ -15,7 +15,8 @@ enum VisualProofDesktopDependencies {
             fileWriter: VisualProofFileWriter(),
             providerVerifier: VisualProofProviderVerifier(),
             secretStore: VisualProofSecretStore(),
-            githubAuthenticator: VisualProofGitHubAuthenticator()
+            githubAuthenticator: VisualProofGitHubAuthenticator(),
+            productionBoundary: .quarantined
         )
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -29,7 +29,8 @@ enum NeonDiffDesktopCompositionRoot {
             providerVerifier: FoundationProviderVerifier(secretStore: keychain),
             secretStore: keychain,
             githubAuthenticator: GitHubDeviceAuthClient(),
-            productionBoundary: .quarantined
+            productionBoundary: .quarantined,
+            cliWorkingDirectory: NeonDiffCLIResolver.defaultWorkingDirectory()
         ))
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/App/NeonDiffDesktopCompositionRoot.swift
@@ -28,7 +28,8 @@ enum NeonDiffDesktopCompositionRoot {
             fileWriter: ApplicationSupportFileWriter(),
             providerVerifier: FoundationProviderVerifier(secretStore: keychain),
             secretStore: keychain,
-            githubAuthenticator: GitHubDeviceAuthClient()
+            githubAuthenticator: GitHubDeviceAuthClient(),
+            productionBoundary: .quarantined
         ))
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonUpdateController.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Support/NeonUpdateController.swift
@@ -1,61 +1,30 @@
 import Foundation
-import Sparkle
 
 @MainActor
 final class NeonUpdateController: ObservableObject {
-    @Published private(set) var lastAction = "Update channel not configured"
-
-    private let controller: SPUStandardUpdaterController?
+    @Published private(set) var lastAction = "Updates blocked pending native activation proof"
 
     init(bundle: Bundle = .main) {
-        guard Self.hasSparkleConfiguration(in: bundle) else {
-            self.controller = nil
-            return
-        }
-        self.controller = SPUStandardUpdaterController(
-            startingUpdater: true,
-            updaterDelegate: nil,
-            userDriverDelegate: nil
-        )
-        self.lastAction = "Update channel configured"
+        _ = bundle
     }
 
     var isConfigured: Bool {
-        controller != nil
+        false
     }
 
     var canCheckForUpdates: Bool {
-        controller?.updater.canCheckForUpdates ?? false
+        false
     }
 
     var badgeText: String {
-        isConfigured ? "UPDATES READY" : "UPDATES OFF"
+        "UPDATES BLOCKED"
     }
 
     var statusText: String {
-        if isConfigured {
-            return canCheckForUpdates ? "Manual update checks are available." : "Sparkle is configured but cannot check right now."
-        }
-        return "No Sparkle feed/public key is bundled for this dev build."
+        "Sparkle startup and manual checks are disabled until the native app proves API-backed activation and update entitlement."
     }
 
     func checkForUpdates() {
-        guard let controller, canCheckForUpdates else {
-            lastAction = "Update channel not configured"
-            return
-        }
-        controller.checkForUpdates(nil)
-        lastAction = "Opened Sparkle update check"
-    }
-
-    private static func hasSparkleConfiguration(in bundle: Bundle) -> Bool {
-        guard
-            let feedURL = bundle.object(forInfoDictionaryKey: "SUFeedURL") as? String,
-            let publicKey = bundle.object(forInfoDictionaryKey: "SUPublicEDKey") as? String
-        else {
-            return false
-        }
-        return !feedURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && !publicKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        lastAction = "Updates blocked pending native activation proof"
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LicenseView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/LicenseView.swift
@@ -11,8 +11,9 @@ struct LicenseView: View {
                     OperatorTextField(title: "License Key", text: $model.pendingLicenseKey, secure: true)
                     HStack(spacing: 10) {
                         Button { model.storeLicenseKey() } label: {
-                            Label("Store License", systemImage: "key.fill")
+                            Label("Activation Unavailable", systemImage: "lock.shield")
                         }
+                        .disabled(!model.productionUsefulWorkAvailable)
                         OperatorBadge(
                             text: model.license.keyStored ? "Stored Locally" : "No Key Stored",
                             color: model.license.keyStored ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary
@@ -27,7 +28,7 @@ struct LicenseView: View {
                 }
 
                 OperatorSection("Boundary") {
-                    Text("This MVP can store a local license key while hosted activation remains pending #327. Signed updater behavior and downloadable app readiness remain separate release work.")
+                    Text(model.productionActivationBoundaryMessage)
                         .operatorBodyText()
                 }
             }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -276,6 +276,13 @@ struct OnboardingWizardView: View {
 
             Spacer()
 
+            if !model.productionUsefulWorkAvailable {
+                Button("Open Read-Only App") {
+                    model.openReadOnlyAppFromQuarantinedOnboarding()
+                }
+                .help("Inspect setup and settings without completing activation onboarding. Useful work remains blocked.")
+            }
+
             if let lastError = model.lastError, !lastError.isEmpty {
                 Text(lastError)
                     .font(.caption)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OnboardingWizardView.swift
@@ -111,7 +111,7 @@ struct OnboardingWizardView: View {
                 }
                 .pickerStyle(.segmented)
 
-                Text("Public repositories can be reviewed without a NeonDiff license. Private repositories stay locked until the hosted license service is deployed and activation succeeds.")
+                Text("All repository review work requires live API-backed activation. This desktop build cannot yet prove the native activation broker, so onboarding cannot complete.")
                     .operatorBodyText()
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -191,15 +191,18 @@ struct OnboardingWizardView: View {
                         Button { model.startDaemon() } label: {
                             Label("Start/Restart", systemImage: "play.circle")
                         }
+                        .disabled(!model.productionUsefulWorkAvailable)
                         Button { model.stopDaemon() } label: {
                             Label("Stop", systemImage: "stop.circle")
                         }
+                        .disabled(!model.productionUsefulWorkAvailable)
                     }
 
                     HStack(spacing: 10) {
                         Button { model.previewStartDaemon() } label: {
                             Label("Preview Start", systemImage: "eye")
                         }
+                        .disabled(!model.productionUsefulWorkAvailable)
                         Button { model.copyCommand(model.statusCommand) } label: {
                             Label("Copy Status", systemImage: "doc.on.doc")
                         }
@@ -210,6 +213,9 @@ struct OnboardingWizardView: View {
                     text: model.onboardingFlow.daemonBootstrapChecked ? "Checked" : "Check Required",
                     color: model.onboardingFlow.daemonBootstrapChecked ? NeonDiffTheme.accent : NeonDiffTheme.warning
                 )
+                Text(model.productionActivationBoundaryMessage)
+                    .operatorBodyText()
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             if !model.repos.isEmpty {
@@ -230,20 +236,16 @@ struct OnboardingWizardView: View {
 
                 HStack(spacing: 10) {
                     Button { model.activateLicenseForOnboarding() } label: {
-                        Label("Store / Check", systemImage: "key")
+                        Label("Activation Unavailable", systemImage: "lock.shield")
                     }
-                    Button {
-                        model.onboardingFlow.mode = .publicReposOnly
-                    } label: {
-                        Label("Use Public Repos", systemImage: "lock.open")
-                    }
+                    .disabled(!model.productionUsefulWorkAvailable)
                     OperatorBadge(
-                        text: model.onboardingFlow.licenseActivation == .activated ? "Activated" : "Service Pending",
+                        text: model.onboardingFlow.licenseActivation == .activated ? "Activated" : "Activation Required",
                         color: model.onboardingFlow.licenseActivation == .activated ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary
                     )
                 }
 
-                Text("Private repository activation is parked until the hosted license service from #327 is deployed. The wizard does not fake activation; public-repo setup can finish now.")
+                Text(model.productionActivationBoundaryMessage)
                     .operatorBodyText()
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/OverviewView.swift
@@ -76,11 +76,13 @@ struct OverviewView: View {
                     Button { model.previewStartDaemon() } label: {
                         Label("Preview Start", systemImage: "play.circle")
                     }
+                    .disabled(!model.productionUsefulWorkAvailable)
                     .accessibilityIdentifier("neondiff-preview-start-daemon")
 
                     Button { model.previewStopDaemon() } label: {
                         Label("Preview Stop", systemImage: "stop.circle")
                     }
+                    .disabled(!model.productionUsefulWorkAvailable)
                     .accessibilityIdentifier("neondiff-preview-stop-daemon")
                 }
 

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktop/Views/ProviderSettingsView.swift
@@ -54,7 +54,7 @@ struct ProviderSettingsView: View {
                                 systemImage: "checkmark.shield"
                             )
                         }
-                        .disabled(!model.canVerifyProviderKey)
+                        .disabled(!model.canVerifyProviderKey || !model.productionUsefulWorkAvailable)
                         OperatorBadge(
                             text: model.providers.providerKeyStored ? "Stored in Keychain" : "Not Stored",
                             color: model.providers.providerKeyStored ? NeonDiffTheme.accent : NeonDiffTheme.textSecondary
@@ -63,6 +63,11 @@ struct ProviderSettingsView: View {
                     Text(model.providerVerificationStatus)
                         .font(.caption)
                         .foregroundStyle(NeonDiffTheme.textSecondary)
+                    if !model.productionUsefulWorkAvailable {
+                        Text(model.productionActivationBoundaryMessage)
+                            .font(.caption)
+                            .foregroundStyle(NeonDiffTheme.warning)
+                    }
 
                     if let verification = model.providerVerification {
                         ProviderVerificationResultCard(snapshot: verification)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -20,6 +20,7 @@ package struct DesktopAppDependencies {
     package let secretStore: any DesktopSecretStoring
     package let githubAuthenticator: any GitHubDesktopAuthenticating
     package let productionBoundary: DesktopProductionBoundary
+    package let cliWorkingDirectory: URL?
 
     package init(
         clipboard: any DesktopClipboard,
@@ -32,7 +33,8 @@ package struct DesktopAppDependencies {
         providerVerifier: any DesktopProviderVerifying,
         secretStore: any DesktopSecretStoring,
         githubAuthenticator: any GitHubDesktopAuthenticating,
-        productionBoundary: DesktopProductionBoundary
+        productionBoundary: DesktopProductionBoundary,
+        cliWorkingDirectory: URL? = nil
     ) {
         self.clipboard = clipboard
         self.urlOpener = urlOpener
@@ -45,5 +47,6 @@ package struct DesktopAppDependencies {
         self.secretStore = secretStore
         self.githubAuthenticator = githubAuthenticator
         self.productionBoundary = productionBoundary
+        self.cliWorkingDirectory = cliWorkingDirectory
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/DesktopAppDependencies.swift
@@ -1,6 +1,13 @@
 import Foundation
 import NeonDiffDesktopCore
 
+package struct DesktopProductionBoundary: Sendable {
+    package let nativeActivationBrokerVerified: Bool
+
+    package static let quarantined = DesktopProductionBoundary(nativeActivationBrokerVerified: false)
+    package static let testVerified = DesktopProductionBoundary(nativeActivationBrokerVerified: true)
+}
+
 package struct DesktopAppDependencies {
     package let clipboard: any DesktopClipboard
     package let urlOpener: any DesktopURLOpener
@@ -12,6 +19,7 @@ package struct DesktopAppDependencies {
     package let providerVerifier: any DesktopProviderVerifying
     package let secretStore: any DesktopSecretStoring
     package let githubAuthenticator: any GitHubDesktopAuthenticating
+    package let productionBoundary: DesktopProductionBoundary
 
     package init(
         clipboard: any DesktopClipboard,
@@ -23,7 +31,8 @@ package struct DesktopAppDependencies {
         fileWriter: any DesktopFileWriting,
         providerVerifier: any DesktopProviderVerifying,
         secretStore: any DesktopSecretStoring,
-        githubAuthenticator: any GitHubDesktopAuthenticating
+        githubAuthenticator: any GitHubDesktopAuthenticating,
+        productionBoundary: DesktopProductionBoundary
     ) {
         self.clipboard = clipboard
         self.urlOpener = urlOpener
@@ -35,5 +44,6 @@ package struct DesktopAppDependencies {
         self.providerVerifier = providerVerifier
         self.secretStore = secretStore
         self.githubAuthenticator = githubAuthenticator
+        self.productionBoundary = productionBoundary
     }
 }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -389,7 +389,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
             openBrowser: openBrowser
         )
         let dashboard = dependencies.dashboard
-        let workingDirectory = NeonDiffCLIResolver.defaultWorkingDirectory()
+        let workingDirectory = dependencies.cliWorkingDirectory
 
         Task { [weak self] in
             guard let self else { return }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1027,7 +1027,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
         guard !dependencies.productionBoundary.nativeActivationBrokerVerified else { return }
         isOnboardingPresented = false
         lastError = nil
-        logText = "Opened the read-only setup surface. (productionActivationBoundaryMessage)"
+        logText = "Opened the read-only setup surface. \(productionActivationBoundaryMessage)"
     }
 
     @discardableResult

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -60,6 +60,14 @@ package final class NeonDiffDesktopModel: ObservableObject {
     @Published package var onboardingFlow = OnboardingFlow()
     @Published package var isOnboardingPresented = false
 
+    package var productionActivationBoundaryMessage: String {
+        "Native activation broker proof is not available in this build. Provider verification, daemon control, updates, and onboarding completion remain blocked."
+    }
+
+    package var productionUsefulWorkAvailable: Bool {
+        dependencies.productionBoundary.nativeActivationBrokerVerified
+    }
+
     private let dependencies: DesktopAppDependencies
     private var providerVerificationTask: Task<Void, Never>?
     private var providerVerificationRequestGeneration: UInt64 = 0
@@ -409,14 +417,17 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func previewStartDaemon() {
+        guard requireVerifiedNativeActivationBroker() else { return }
         runCLI(arguments: ["daemon", "start", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "true"], displayCommand: startDaemonDryRunCommand)
     }
 
     package func previewStopDaemon() {
+        guard requireVerifiedNativeActivationBroker() else { return }
         runCLI(arguments: ["daemon", "stop", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "true"], displayCommand: stopDaemonDryRunCommand)
     }
 
     package func startDaemon() {
+        guard requireVerifiedNativeActivationBroker() else { return }
         persistLocalSettings()
         runCLI(
             arguments: ["daemon", "start", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "false", "--confirm", "true"],
@@ -425,6 +436,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func stopDaemon() {
+        guard requireVerifiedNativeActivationBroker() else { return }
         persistLocalSettings()
         runCLI(
             arguments: ["daemon", "stop", "--config", configPath, "--launchd-label", launchdLabel, "--dry-run", "false", "--confirm", "true"],
@@ -807,6 +819,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func verifyProviderKey() {
+        guard requireVerifiedNativeActivationBroker() else {
+            providerVerification = nil
+            providerVerificationStatus = productionActivationBoundaryMessage
+            return
+        }
         if let providerVerificationSafetyLatchMessage {
             providerVerification = nil
             providerVerificationStatus = providerVerificationSafetyLatchMessage
@@ -955,6 +972,7 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func storeLicenseKey() {
+        guard requireVerifiedNativeActivationBroker() else { return }
         do {
             try dependencies.secretStore.setSecret(pendingLicenseKey, account: licenseKeyAccount)
             pendingLicenseKey = ""
@@ -966,6 +984,11 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func activateLicenseForOnboarding() {
+        guard requireVerifiedNativeActivationBroker() else {
+            onboardingFlow.licenseActivation = .servicePending
+            license.entitlement = "activation unavailable"
+            return
+        }
         if !pendingLicenseKey.isEmpty {
             storeLicenseKey()
         }
@@ -989,8 +1012,25 @@ package final class NeonDiffDesktopModel: ObservableObject {
     }
 
     package func completeOnboarding() {
+        guard dependencies.productionBoundary.nativeActivationBrokerVerified,
+              onboardingFlow.licenseActivation == .activated
+        else {
+            _ = requireVerifiedNativeActivationBroker()
+            isOnboardingPresented = true
+            return
+        }
         dependencies.preferences.set(true, forKey: onboardingCompletedKey)
         isOnboardingPresented = false
+    }
+
+    @discardableResult
+    private func requireVerifiedNativeActivationBroker() -> Bool {
+        guard dependencies.productionBoundary.nativeActivationBrokerVerified else {
+            lastError = productionActivationBoundaryMessage
+            logText = productionActivationBoundaryMessage
+            return false
+        }
+        return true
     }
 
     package func reopenOnboarding() {

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopAppCore/Models/NeonDiffDesktopModel.swift
@@ -1023,6 +1023,13 @@ package final class NeonDiffDesktopModel: ObservableObject {
         isOnboardingPresented = false
     }
 
+    package func openReadOnlyAppFromQuarantinedOnboarding() {
+        guard !dependencies.productionBoundary.nativeActivationBrokerVerified else { return }
+        isOnboardingPresented = false
+        lastError = nil
+        logText = "Opened the read-only setup surface. (productionActivationBoundaryMessage)"
+    }
+
     @discardableResult
     private func requireVerifiedNativeActivationBroker() -> Bool {
         guard dependencies.productionBoundary.nativeActivationBrokerVerified else {
@@ -1850,7 +1857,7 @@ private let githubRefreshTokenAccount = "github/user-refresh-token"
 private let githubTokenExpiresAtAccount = "github/user-token-expires-at"
 private let githubRefreshTokenExpiresAtAccount = "github/user-refresh-token-expires-at"
 private let githubUserLoginAccount = "github/user-login"
-private let onboardingCompletedKey = "neondiff.hasCompletedOnboarding"
+private let onboardingCompletedKey = "neondiff.hasCompletedActivationOnboarding.v2"
 
 private func isValidRepoName(_ value: String) -> Bool {
     let parts = value.split(separator: "/", omittingEmptySubsequences: false)

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/OnboardingModels.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Models/OnboardingModels.swift
@@ -84,7 +84,7 @@ public struct OnboardingFlow: Equatable {
         case .daemon:
             return daemonBootstrapChecked
         case .license:
-            return mode == .publicReposOnly || licenseActivation == .activated
+            return licenseActivation == .activated
         case .done:
             return true
         }
@@ -94,8 +94,6 @@ public struct OnboardingFlow: Equatable {
         switch currentStep {
         case .done:
             return "Finish"
-        case .license where mode == .publicReposOnly:
-            return "Continue Public Setup"
         default:
             return "Continue"
         }

--- a/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
+++ b/apps/neondiff-desktop/Sources/NeonDiffDesktopCore/Services/NeonDiffCLIClient.swift
@@ -570,22 +570,27 @@ public enum NeonDiffCLIResolver {
     }
 
     public static func findPackageRoot(startingAt startURL: URL, fileManager: FileManager = .default) -> URL? {
-        var current = startURL
+        var current = startURL.standardizedFileURL
+        var visitedPaths = Set<String>()
         var isDirectoryValue: ObjCBool = false
         if fileManager.fileExists(atPath: current.path, isDirectory: &isDirectoryValue), !isDirectoryValue.boolValue {
             current.deleteLastPathComponent()
         }
 
-        while true {
+        for _ in 0..<128 {
+            guard visitedPaths.insert(current.path).inserted else {
+                return nil
+            }
             if isNeonDiffPackageRoot(current, fileManager: fileManager) {
                 return current
             }
-            let parent = current.deletingLastPathComponent()
+            let parent = current.deletingLastPathComponent().standardizedFileURL
             if parent.path == current.path {
                 return nil
             }
             current = parent
         }
+        return nil
     }
 
     public static func resolveExecutablePath(

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ConfigurationControlCenterTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ConfigurationControlCenterTests.swift
@@ -82,6 +82,7 @@ import NeonDiffDesktopCore
         #expect(fixture.dashboard.calls.count == 1)
         #expect(fixture.dashboard.calls[0].arguments.first == "dashboard")
         #expect(fixture.dashboard.calls[0].arguments.contains("--open"))
+        #expect(fixture.dashboard.calls[0].workingDirectory == nil)
         #expect(fixture.cli.calls.isEmpty)
         #expect(fixture.model.dashboardProcessIdentifier == 42)
     }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -22,6 +22,33 @@ import Testing
         #expect(fixture.model.lastError?.contains("activation broker") == true)
     }
 
+    @MainActor
+    @Test func quarantineIgnoresLegacyCompletionAndOffersNonPersistentReadOnlyEscape() throws {
+        let fixture = ModelDependencyFixture(
+            preferenceBools: ["neondiff.hasCompletedOnboarding": true],
+            productionBoundary: .quarantined
+        )
+
+        #expect(fixture.model.isOnboardingPresented)
+        fixture.model.openReadOnlyAppFromQuarantinedOnboarding()
+        #expect(!fixture.model.isOnboardingPresented)
+        #expect(fixture.preferences.bool(forKey: "neondiff.hasCompletedOnboarding"))
+        #expect(!fixture.preferences.bool(forKey: "neondiff.hasCompletedActivationOnboarding.v2"))
+        #expect(fixture.model.logText.contains("read-only setup surface"))
+    }
+
+    @MainActor
+    @Test func verifiedActivationCompletionWritesOnlyTheVersionedProofStamp() throws {
+        let fixture = ModelDependencyFixture(productionBoundary: .testVerified)
+        fixture.model.onboardingFlow.licenseActivation = .activated
+
+        fixture.model.completeOnboarding()
+
+        #expect(!fixture.model.isOnboardingPresented)
+        #expect(fixture.preferences.bool(forKey: "neondiff.hasCompletedActivationOnboarding.v2"))
+        #expect(!fixture.preferences.bool(forKey: "neondiff.hasCompletedOnboarding"))
+    }
+
     @Test func sourceBoundaryHelpersRejectDirectoriesNamedLikeSwiftFiles() throws {
         try withSourceBoundaryDirectoryFixture { root, fakeSource in
             #expect(sourceBoundarySwiftFiles(below: root).isEmpty)

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -1,6 +1,27 @@
 import Testing
+@testable import NeonDiffDesktopAppCore
 
 @Suite struct ProductionBoundaryContractTests {
+    @MainActor
+    @Test func quarantinedProductionModelBlocksUsefulWorkAndPseudoActivation() throws {
+        let fixture = ModelDependencyFixture(productionBoundary: .quarantined)
+        fixture.model.pendingLicenseKey = "fixture-license-value"
+
+        fixture.model.previewStartDaemon()
+        fixture.model.startDaemon()
+        fixture.model.verifyProviderKey()
+        fixture.model.storeLicenseKey()
+        fixture.model.activateLicenseForOnboarding()
+        fixture.model.completeOnboarding()
+
+        #expect(fixture.cli.calls.isEmpty)
+        #expect(fixture.providerVerifier.calls.isEmpty)
+        #expect(!fixture.secretStore.containsSecret(account: "license/default"))
+        #expect(fixture.model.onboardingFlow.licenseActivation != .activated)
+        #expect(fixture.model.isOnboardingPresented)
+        #expect(fixture.model.lastError?.contains("activation broker") == true)
+    }
+
     @Test func sourceBoundaryHelpersRejectDirectoriesNamedLikeSwiftFiles() throws {
         try withSourceBoundaryDirectoryFixture { root, fakeSource in
             #expect(sourceBoundarySwiftFiles(below: root).isEmpty)
@@ -64,5 +85,15 @@ import Testing
             #expect(sourceBoundaryFileExists(executableAdapter))
             #expect(!appCoreFileNames.contains("\(adapterName).swift"))
         }
+    }
+
+    @Test func updaterCannotStartBeforeNativeActivationBrokerProof() throws {
+        let updaterSource = sourceBoundaryPackageRoot()
+            .appendingPathComponent("Sources/NeonDiffDesktop/Support/NeonUpdateController.swift")
+        let source = try sourceBoundaryText(at: updaterSource)
+
+        #expect(!source.contains("SPUStandardUpdaterController"))
+        #expect(!source.contains("startingUpdater"))
+        #expect(source.contains("Updates blocked pending native activation proof"))
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/ProductionBoundaryContractTests.swift
@@ -35,6 +35,7 @@ import Testing
         #expect(fixture.preferences.bool(forKey: "neondiff.hasCompletedOnboarding"))
         #expect(!fixture.preferences.bool(forKey: "neondiff.hasCompletedActivationOnboarding.v2"))
         #expect(fixture.model.logText.contains("read-only setup surface"))
+        #expect(fixture.model.logText.contains("Native activation broker proof is not available"))
     }
 
     @MainActor

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -174,6 +174,7 @@ struct ModelDependencyFixture {
     let preferences: MemoryPreferences
     let clock: TestClock
     let fileWriter: TemporaryFileWriter
+    let providerVerifier: RecordingProviderVerifier
     let secretStore: MemorySecretStore
     let githubAuthenticator: ScriptedGitHubAuthenticator
 
@@ -183,7 +184,8 @@ struct ModelDependencyFixture {
         cliOutcomes: [Result<CLIRunResult, Error>] = [],
         clipboardResult: Bool = true,
         urlResult: Bool = true,
-        githubAuthenticator: ScriptedGitHubAuthenticator = ScriptedGitHubAuthenticator()
+        githubAuthenticator: ScriptedGitHubAuthenticator = ScriptedGitHubAuthenticator(),
+        productionBoundary: DesktopProductionBoundary = .testVerified
     ) {
         clipboard = RecordingClipboard(result: clipboardResult)
         urlOpener = RecordingURLOpener(result: urlResult)
@@ -192,6 +194,7 @@ struct ModelDependencyFixture {
         preferences = MemoryPreferences()
         clock = TestClock(now: now)
         fileWriter = TemporaryFileWriter(root: root)
+        providerVerifier = RecordingProviderVerifier()
         secretStore = MemorySecretStore()
         self.githubAuthenticator = githubAuthenticator
         model = NeonDiffDesktopModel(dependencies: DesktopAppDependencies(
@@ -202,9 +205,10 @@ struct ModelDependencyFixture {
             preferences: preferences,
             clock: clock,
             fileWriter: fileWriter,
-            providerVerifier: RecordingProviderVerifier(),
+            providerVerifier: providerVerifier,
             secretStore: secretStore,
-            githubAuthenticator: githubAuthenticator
+            githubAuthenticator: githubAuthenticator,
+            productionBoundary: productionBoundary
         ))
     }
 

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ModelDependencyFixture.swift
@@ -185,6 +185,7 @@ struct ModelDependencyFixture {
         clipboardResult: Bool = true,
         urlResult: Bool = true,
         githubAuthenticator: ScriptedGitHubAuthenticator = ScriptedGitHubAuthenticator(),
+        preferenceBools: [String: Bool] = [:],
         productionBoundary: DesktopProductionBoundary = .testVerified
     ) {
         clipboard = RecordingClipboard(result: clipboardResult)
@@ -192,6 +193,9 @@ struct ModelDependencyFixture {
         cli = ScriptedDesktopCLIExecutor(outcomes: cliOutcomes)
         dashboard = RecordingDashboardLauncher()
         preferences = MemoryPreferences()
+        for (key, value) in preferenceBools {
+            preferences.set(value, forKey: key)
+        }
         clock = TestClock(now: now)
         fileWriter = TemporaryFileWriter(root: root)
         providerVerifier = RecordingProviderVerifier()

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ProviderModelFixture.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/ProviderModelFixture.swift
@@ -253,7 +253,8 @@ struct ProviderModelFixture {
             fileWriter: fileWriter,
             providerVerifier: providerVerifier,
             secretStore: keychain,
-            githubAuthenticator: StubGitHubAuthenticator()
+            githubAuthenticator: StubGitHubAuthenticator(),
+            productionBoundary: .testVerified
         )
 
         self.keychain = keychain

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/RecordingDesktopDependencies.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopAppCoreTests/Support/RecordingDesktopDependencies.swift
@@ -358,7 +358,8 @@ struct RecordingDesktopDependencies {
             fileWriter: fileWriter,
             providerVerifier: providerVerifier,
             secretStore: secretStore,
-            githubAuthenticator: githubAuthenticator
+            githubAuthenticator: githubAuthenticator,
+            productionBoundary: .testVerified
         )
     }
 }

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CommandBuilderScenarios.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CommandBuilderScenarios.swift
@@ -17,9 +17,9 @@ import Darwin
     publicFlow.currentStep = .license
     publicFlow.mode = .publicReposOnly
     publicFlow.licenseActivation = .servicePending
-    context.expect(publicFlow.canAdvance, "public repo path can finish while license service is pending")
+    context.expect(!publicFlow.canAdvance, "public repo path also requires verified activation")
     publicFlow.advance()
-    context.expect(publicFlow.currentStep == .done, "public repo path finishes from license step")
+    context.expect(publicFlow.currentStep == .license, "public repo path remains blocked at license step")
 
     var privateFlow = OnboardingFlow(providerKeyStored: true)
     privateFlow.currentStep = .license

--- a/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
+++ b/apps/neondiff-desktop/Tests/NeonDiffDesktopCoreTests/Support/CoreChecksMigrationLedgerSupport.swift
@@ -22,7 +22,7 @@ struct LegacyCoreChecksScenarioInventory: Sendable {
 }
 
 let legacyCoreChecksScenarioInventory: [LegacyCoreChecksScenario: LegacyCoreChecksScenarioInventory] = [
-    .onboardingFlowContracts: .init(assertionCount: 10, sortedMessageSHA256: "2f06c0bf60cb5ba0326c7ff260454831985fe8528fed73600b35bc3b80764513"),
+    .onboardingFlowContracts: .init(assertionCount: 10, sortedMessageSHA256: "fa52ef66cfc15da0fc622891de083cb4f8c6989b75cda294aa0dce7965ffed11"),
     .cliResolutionAndStandardInputContracts: .init(assertionCount: 5, sortedMessageSHA256: "3d313d66cf17ecdf294b1235dc1f34401b74f52d33ad7d78ed4fb3d783ce1a86"),
     .cliCancellationContracts: .init(assertionCount: 10, sortedMessageSHA256: "4d93d68b30b32e326aad8d2f93dacf515d346cc3fb373a1a9061f829f3c0c0ad"),
     .cliStandardInputTimeoutContracts: .init(assertionCount: 14, sortedMessageSHA256: "a979b18020324519db8eb863c445a7bd2ca9d3a61f7f8e6a447a3742527864d4"),
@@ -65,7 +65,7 @@ final class LegacyCoreChecksAggregate: @unchecked Sendable {
         }
         #expect(messages.count == 389)
         #expect(Set(messages).count == 295)
-        #expect(coreChecksSHA256(messages.sorted()) == "e459d3956cea8d9b839bf7cb86e0f81325d9dc714b6eea09b5177cba48fd91e0")
+        #expect(coreChecksSHA256(messages.sorted()) == "72e1d514eeaca9cc913d0f9318274572466e599e88acec0af35db6cc9ccb3a85")
     }
 }
 


### PR DESCRIPTION
Follow-on desktop quarantine for emergency issue #532, targeting `main` after activation PR #534 merged as `7b56e33`.

Removes the public-repo onboarding bypass, blocks native provider verification and daemon control without a verified activation broker, prevents pseudo license storage/activation and onboarding completion, and disables Sparkle startup/manual update checks. Required Core and AppCore suites pass under full Xcode 26.6.

This is not a release PR; native API-backed activation remains explicitly unproven and the desktop stays fail-closed until a real native broker is implemented and verified.