### PR TITLE
fix(license): accept GitHub OIDC nbf backdating

### DIFF
--- a/services/license-api/src/oidc-lifecycle.ts
+++ b/services/license-api/src/oidc-lifecycle.ts
@@ -119,11 +119,9 @@ function validateLifecycleClaims(payload: JWTPayload, now: Date): LifecycleOidcC
     throw new Error("OIDC timestamp claims are invalid");
   }
   const iat = payload.iat as number;
-  const nbf = payload.nbf as number;
   const exp = payload.exp as number;
   const nowSeconds = Math.floor(now.getTime() / 1000);
   if (iat > nowSeconds + 5 || nowSeconds - iat > 300) throw new Error("OIDC iat is outside the allowed window");
-  if (nbf < iat - 5 || nbf > iat + 5) throw new Error("OIDC nbf is outside the allowed window");
   if (exp <= iat || exp - iat > 300) throw new Error("OIDC exp is outside the allowed window");
   return payload as LifecycleOidcClaims;
 }

--- a/services/license-api/test/oidc-lifecycle.test.ts
+++ b/services/license-api/test/oidc-lifecycle.test.ts
@@ -306,6 +306,18 @@ describe("GitHub Actions OIDC verifier", () => {
     assert.equal(claims.run_id, "123456789");
   });
 
+  it("accepts GitHub's documented backdated nbf while enforcing a fresh iat", async () => {
+    const material = await signingMaterial("key-backdated-nbf");
+    keys = [material.jwk];
+    const verifier = createGitHubActionsOidcVerifier({ jwksUrl, now: () => NOW, cooldownDuration: 0 });
+    const now = Math.floor(NOW.getTime() / 1000);
+    const claims = await verifier.verify(
+      await sign(material.privateKey, "key-backdated-nbf", { nbf: now - 600 })
+    );
+    assert.equal(claims.iat, now);
+    assert.equal(claims.nbf, now - 600);
+  });
+
   it("rejects every mismatched protected-workflow claim and false ref protection", async () => {
     const material = await signingMaterial("key-claims");
     keys = [material.jwk];


### PR DESCRIPTION
## Root cause

Production lifecycle run [29183017469](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29183017469) failed closed at lifecycle issuance. The broker required `nbf` to be within five seconds of `iat`, but GitHub documents OIDC tokens with `nbf` backdated by minutes. Existing fixtures used exactly `iat - 5`, masking the production token shape.

JOSE already verifies signature, issuer, audience, `nbf`, expiry, clock tolerance, and a five-minute max token age. NeonDiff separately retains exact workflow/repo/environment/ref claims, protected-ref enforcement, fresh `iat`, and bounded expiry.

## Fix

- remove only the incompatible custom `nbf ≈ iat` relationship
- add a regression test using GitHub's documented ten-minute backdating
- preserve the existing future-`nbf` rejection test

## Validation

- red before fix: `OIDC nbf is outside the allowed window`
- `npm --prefix services/license-api test` — 42/42
- `npm --prefix services/license-api run build`
- `npm test` — 111 files / 1,817 tests
- `npm run check:secrets`
- `git diff --check`

## Release boundary

This PR does not publish npm, change npm package bytes, create/move a tag or Release, promote `latest`, or clean predecessor surfaces. After merge and broker redeploy, the exact protected-main v1.0.4 lifecycle proof must be rerun and pass before evidence metadata or publication.

Related: #532
