### PR TITLE
Fix mandatory-activation proof visibility validation

### DIFF
--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -1307,7 +1307,7 @@ function validateMandatoryActivationProofPath(input: {
     }
     if (scenario.expected !== expectedOutcome) failures.push(`matrix.${id}.expected must be ${expectedOutcome}`);
     if (scenario.actual !== expectedOutcome) failures.push(`matrix.${id}.actual must be ${expectedOutcome}`);
-    const expectedVisibility = id === "public_active" || id === "public_denied"
+    const expectedVisibility = id === "public_active" || id === "public_denied" || id === "disabled_policy_attempt"
       ? "public"
       : id === "private_active" || id === "private_denied"
         ? "private"

--- a/tests/mandatory-activation-matrix.test.ts
+++ b/tests/mandatory-activation-matrix.test.ts
@@ -22,5 +22,13 @@ describe("mandatory activation no-bypass matrix", () => {
       public_active: 1,
       private_active: 1
     });
+    expect(result.records.find((record) => record.id === "disabled_policy_attempt")).toEqual({
+      id: "disabled_policy_attempt",
+      visibility: "public",
+      expected: "denied",
+      actual: "denied",
+      expectedLicenseApiCalls: 0,
+      licenseApiCalls: 0
+    });
   });
 });

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -577,7 +577,14 @@ describe("beta release status", () => {
       { id: "private_active", visibility: "private", expected: "allowed", actual: "allowed", expectedLicenseApiCalls: 1, licenseApiCalls: 1 },
       ...deniedScenarioIds.map((id) => ({
         id,
-        visibility: id === "public_denied" ? "public" : id === "private_denied" ? "private" : id === "unknown_repo" ? "unknown" : "not_applicable",
+        visibility:
+          id === "public_denied" || id === "disabled_policy_attempt"
+            ? "public"
+            : id === "private_denied"
+              ? "private"
+              : id === "unknown_repo"
+                ? "unknown"
+                : "not_applicable",
         expected: "denied",
         actual: "denied",
         expectedLicenseApiCalls: ["missing_key", "forged_cache", "disabled_policy_attempt", "dashboard_provider_pre_activation"].includes(id) ? 0 : 1,
@@ -686,6 +693,116 @@ describe("beta release status", () => {
     expect(validManifest.licenseApi.ok).toBe(true);
     expect(validManifest.licenseApi.detail).toContain(`validated mandatory activation proof ${activationProofPath}`);
     expect(validManifest.ok).toBe(true);
+
+    const matrixArtifact = artifacts.find((artifact) => artifact.kind === "no-bypass-matrix")!;
+    const writeSynchronizedMatrixMutation = (
+      mutate: (record: (typeof scenarioRecords)[number]) => (typeof scenarioRecords)[number],
+      duplicateDisabledScenario = false
+    ): void => {
+      let mutatedRecords = scenarioRecords.map((record) =>
+        record.id === "disabled_policy_attempt" ? mutate({ ...record }) : record
+      );
+      if (duplicateDisabledScenario) {
+        mutatedRecords = [
+          ...mutatedRecords,
+          mutate({ ...scenarioRecords.find((record) => record.id === "disabled_policy_attempt")! })
+        ];
+      }
+      const matrixPayload = `${JSON.stringify({
+        evidenceKind: "no-bypass-matrix",
+        releaseVersion: "v1.0.4",
+        candidateHead: sourceHead,
+        packShasum,
+        packIntegrity,
+        harnessRunId,
+        records: mutatedRecords
+      })}\n`;
+      writeFileSync(join(root, matrixArtifact.ref), matrixPayload);
+      const mutatedArtifacts = artifacts.map((artifact) =>
+        artifact.kind === "no-bypass-matrix"
+          ? { ...artifact, sha256: createHash("sha256").update(matrixPayload).digest("hex") }
+          : artifact
+      );
+      writeFileSync(join(root, activationProofPath), JSON.stringify({
+        ...validProof,
+        matrix: {
+          ...validProof.matrix,
+          scenarios: mutatedRecords.map((record) => ({ ...record, resultSha256: digestRecord(record) }))
+        },
+        artifacts: mutatedArtifacts
+      }));
+    };
+
+    for (const visibility of ["not_applicable", "private", "unknown"] as const) {
+      writeSynchronizedMatrixMutation((record) => ({ ...record, visibility }));
+      const invalidVisibility = readPublicReleaseManifestStatus({
+        cwd: root,
+        manifestPath: "public-release.json",
+        expectedVersion: "v1.0.4",
+        now: new Date("2026-07-12T01:00:00.000Z")
+      });
+      expect(invalidVisibility.licenseApi.ok, visibility).toBe(false);
+      expect(invalidVisibility.licenseApi.detail).toContain(
+        "matrix.disabled_policy_attempt.visibility must be public"
+      );
+    }
+
+    const disabledScenarioMutations: Array<{
+      label: string;
+      mutate: (record: (typeof scenarioRecords)[number]) => (typeof scenarioRecords)[number];
+      expectedDetail: string;
+    }> = [
+      {
+        label: "allowed result",
+        mutate: (record) => ({ ...record, actual: "allowed" }),
+        expectedDetail: "matrix.disabled_policy_attempt.actual must be denied"
+      },
+      {
+        label: "expected API call",
+        mutate: (record) => ({ ...record, expectedLicenseApiCalls: 1 }),
+        expectedDetail: "matrix.disabled_policy_attempt.expectedLicenseApiCalls must be 0"
+      },
+      {
+        label: "observed API call",
+        mutate: (record) => ({ ...record, licenseApiCalls: 1 }),
+        expectedDetail: "matrix.disabled_policy_attempt.licenseApiCalls must be 0"
+      }
+    ];
+    for (const mutation of disabledScenarioMutations) {
+      writeSynchronizedMatrixMutation(mutation.mutate);
+      const invalidDisabledScenario = readPublicReleaseManifestStatus({
+        cwd: root,
+        manifestPath: "public-release.json",
+        expectedVersion: "v1.0.4",
+        now: new Date("2026-07-12T01:00:00.000Z")
+      });
+      expect(invalidDisabledScenario.licenseApi.ok, mutation.label).toBe(false);
+      expect(invalidDisabledScenario.licenseApi.detail).toContain(mutation.expectedDetail);
+    }
+
+    writeSynchronizedMatrixMutation((record) => record, true);
+    const duplicateDisabledScenario = readPublicReleaseManifestStatus({
+      cwd: root,
+      manifestPath: "public-release.json",
+      expectedVersion: "v1.0.4",
+      now: new Date("2026-07-12T01:00:00.000Z")
+    });
+    expect(duplicateDisabledScenario.licenseApi.ok).toBe(false);
+    expect(duplicateDisabledScenario.licenseApi.detail).toContain(
+      "matrix.scenarios must have unique named scenarios"
+    );
+
+    const originalMatrixPayload = `${JSON.stringify({
+      evidenceKind: "no-bypass-matrix",
+      releaseVersion: "v1.0.4",
+      candidateHead: sourceHead,
+      packShasum,
+      packIntegrity,
+      harnessRunId,
+      records: scenarioRecords
+    })}\n`;
+    writeFileSync(join(root, matrixArtifact.ref), originalMatrixPayload);
+    writeFileSync(join(root, activationProofPath), JSON.stringify(validProof));
 
     const manifestDocument = JSON.parse(readFileSync(join(root, "public-release.json"), "utf8"));
     manifestDocument.source.candidateHeadBeforeReleaseMetadata = "e".repeat(40);


### PR DESCRIPTION
## Summary

- require `disabled_policy_attempt` to carry the exact `public` visibility exercised by the mandatory-activation matrix
- lock the generator record to denied / zero API calls
- reject alternate visibility, allowed results, nonzero expected or observed API calls, duplicates, and missing scenarios even when aggregate and child hashes are synchronized

## Root cause

The producer correctly exercises the retired `license.enabled=false` plus `publicReposFree=true` bypass on a public-repository review cycle. The independent release-status validator incorrectly classified every denied scenario outside three named cases as `not_applicable`. That caused the publish gate to reject the truthful, attested lifecycle artifact.

The evidence must not be rewritten: `public` describes the security boundary actually tested.

## TDD and validation

- observed the updated valid-proof fixture fail against the old validator
- observed it pass after the one-condition production fix
- replayed the original v1.0.4 evidence packet through the fixed validator: license API and update-channel gates pass
- `npm run build`
- 131/131 focused release tests passed
- 114/114 validator + matrix tests passed
- full local suite: 1,814/1,817 passed; three unrelated CLI subprocess tests hit the existing 5-second timeout under full serial load, then all 3/3 passed in 2.36 seconds when rerun in isolation
- public-claims scan passed
- secret scan passed across 627 tracked files
- `git diff --check`
- independent spec and security reviews: no findings

## Release impact

This changes npm-included `dist/src/release-status.js`. Run 29184232577 and its candidate package digests remain valid historical evidence but are superseded for publication. After this PR merges, the complete production lifecycle proof must rerun against the new protected-main SHA before v1.0.4 can be tagged or published.

Part of #532.