### PR TITLE
Record v1.0.4 activation and release-candidate proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ for the semver/GA-line and npm dist-tag policy.
 
 No unreleased changes tracked yet.
 
+## [1.0.4] - docs/releases/v1.0.4.md
+
+### Changed
+
+- Require API-backed activation for supported review work across public,
+  private, internal, and unknown repository visibility, with no user-editable
+  enforcement-disable fallback.
+- Add production OIDC lifecycle issuance, activation, refresh, deactivation,
+  no-bypass, fresh-install, v1.0.3 upgrade, dashboard, and Desktop quarantine
+  proof for the exact protected-main candidate.
+- Require the strict release validator to preserve the public-repository
+  visibility exercised by the retired disabled-enforcement/free-public bypass
+  scenario.
+- Keep the release metadata truthful as a prepublication candidate until the
+  immutable GitHub Release, npm registry convergence, and installed-package
+  activation smoke complete.
+
 ## [1.0.3] - docs/releases/v1.0.3.md
 
 ### Fixed

--- a/docs/evidence/v1.0.4-license-api-healthz.json
+++ b/docs/evidence/v1.0.4-license-api-healthz.json
@@ -1,0 +1,19 @@
+{
+  "evidenceKind": "license_api_healthz",
+  "releaseVersion": "v1.0.4",
+  "observedAt": "2026-07-12T07:39:28.918Z",
+  "method": "GET",
+  "url": "https://neondiff-license.fly.dev/healthz",
+  "statusCode": 200,
+  "responseBody": "{\"status\":\"ok\"}",
+  "responseBodySha256": "a29ee2b15c494311c52521766e44af56a3ad2248e7a8ab465e5206463c13d288",
+  "captureContext": {
+    "tool": "node fetch",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "Codex Desktop macOS operator shell",
+    "dnsResolution": "system resolver",
+    "note": "Captured with normal system DNS resolution and Node default TLS validation."
+  },
+  "redaction": "No license key, token, cookie, customer data, or private repo content was present in this health check."
+}

--- a/docs/evidence/v1.0.4-license-checkout-issuance-authenticated.json
+++ b/docs/evidence/v1.0.4-license-checkout-issuance-authenticated.json
@@ -1,0 +1,21 @@
+{
+  "evidenceKind": "license_api_checkout_issuance_authenticated",
+  "releaseVersion": "v1.0.4",
+  "observedAt": "2026-07-12T07:39:16.500Z",
+  "method": "POST",
+  "url": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
+  "statusCode": 200,
+  "redactedResponse": {
+    "status": "issued",
+    "replayed": false,
+    "checkoutLookupKey": "neondiff_monthly",
+    "issuedLicensePrefix": "nd_live_",
+    "issuedLicenseFingerprint": "sha256:08b3b893d3155536fe7bdfb9b7f67dc0a867c46a42cfa5af8adf43076dba250a"
+  },
+  "captureContext": {
+    "tool": "production-safe protocol-equivalent checkout issuance smoke",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "Fly production machine via operator CLI"
+  }
+}

--- a/docs/evidence/v1.0.4-license-checkout-issuance-unauthenticated.json
+++ b/docs/evidence/v1.0.4-license-checkout-issuance-unauthenticated.json
@@ -1,0 +1,19 @@
+{
+  "evidenceKind": "license_api_checkout_issuance",
+  "releaseVersion": "v1.0.4",
+  "observedAt": "2026-07-12T07:39:29.197Z",
+  "method": "POST",
+  "url": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
+  "statusCode": 401,
+  "responseBody": "{\"status\":\"unauthorized\",\"detail\":\"license issuance authorization failed\"}",
+  "responseBodySha256": "a67612cc05a222fc5d28aa36be40d59daf7b32bca36f305d66c57db869150e20",
+  "captureContext": {
+    "tool": "node fetch",
+    "transport": "https",
+    "tlsValidation": "node default CA validation",
+    "capturedFrom": "Codex Desktop macOS operator shell",
+    "dnsResolution": "system resolver",
+    "note": "Captured without Authorization header to prove configured fail-closed behavior."
+  },
+  "redaction": "No license key, bearer token, cookie, customer data, or checkout payload secret was sent or captured."
+}

--- a/docs/evidence/v1.0.4/dashboard-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
+++ b/docs/evidence/v1.0.4/dashboard-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
@@ -1,0 +1,15 @@
+{
+  "evidenceKind": "dashboard",
+  "releaseVersion": "v1.0.4",
+  "candidateHead": "42db7c8ff7dba6ceac813238dcebfb54dc83851f",
+  "packShasum": "526c04bd24673351b9cc7136d8747df00ffaa2be",
+  "packIntegrity": "sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw==",
+  "harnessRunId": "4c246a4cb724779c1e311fb7942c2046fc76df12afb6280e5c2c9ccbe0955a2a",
+  "records": [
+    {
+      "setupBlockedBeforeActivation": true,
+      "providerBlockedBeforeActivation": true,
+      "activatedStatusVisible": true
+    }
+  ]
+}

--- a/docs/evidence/v1.0.4/desktop-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
+++ b/docs/evidence/v1.0.4/desktop-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
@@ -1,0 +1,14 @@
+{
+  "evidenceKind": "desktop",
+  "releaseVersion": "v1.0.4",
+  "candidateHead": "42db7c8ff7dba6ceac813238dcebfb54dc83851f",
+  "packShasum": "526c04bd24673351b9cc7136d8747df00ffaa2be",
+  "packIntegrity": "sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw==",
+  "harnessRunId": "4c246a4cb724779c1e311fb7942c2046fc76df12afb6280e5c2c9ccbe0955a2a",
+  "records": [
+    {
+      "brokerUnavailable": true,
+      "usefulWorkBlocked": true
+    }
+  ]
+}

--- a/docs/evidence/v1.0.4/install-upgrade-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
+++ b/docs/evidence/v1.0.4/install-upgrade-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
@@ -1,0 +1,15 @@
+{
+  "evidenceKind": "install-upgrade",
+  "releaseVersion": "v1.0.4",
+  "candidateHead": "42db7c8ff7dba6ceac813238dcebfb54dc83851f",
+  "packShasum": "526c04bd24673351b9cc7136d8747df00ffaa2be",
+  "packIntegrity": "sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw==",
+  "harnessRunId": "4c246a4cb724779c1e311fb7942c2046fc76df12afb6280e5c2c9ccbe0955a2a",
+  "records": [
+    {
+      "freshInstallPassed": true,
+      "upgradedFromVersion": "1.0.3",
+      "upgradePassed": true
+    }
+  ]
+}

--- a/docs/evidence/v1.0.4/mandatory-activation-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
+++ b/docs/evidence/v1.0.4/mandatory-activation-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
@@ -1,0 +1,319 @@
+{
+  "evidenceKind": "mandatory_activation_no_bypass",
+  "releaseVersion": "v1.0.4",
+  "observedAt": "2026-07-12T08:04:11.399Z",
+  "harness": {
+    "name": "neondiff-license-lifecycle-smoke",
+    "version": 1,
+    "sourceHead": "42db7c8ff7dba6ceac813238dcebfb54dc83851f",
+    "runId": "4c246a4cb724779c1e311fb7942c2046fc76df12afb6280e5c2c9ccbe0955a2a"
+  },
+  "installedCandidate": {
+    "packageVersion": "1.0.4",
+    "binaryVersion": "1.0.4",
+    "sourceHead": "42db7c8ff7dba6ceac813238dcebfb54dc83851f",
+    "packShasum": "526c04bd24673351b9cc7136d8747df00ffaa2be",
+    "packIntegrity": "sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw==",
+    "installSource": "npm_pack_tarball"
+  },
+  "productionLifecycle": {
+    "apiBaseUrl": "https://neondiff-license.fly.dev",
+    "licenseFingerprint": "sha256:99b11e3b6ca66f416d8e0f8dec13ff026b811ba50abe91c7abb3b41cf81ebf33",
+    "steps": [
+      {
+        "id": "issue",
+        "outcome": "succeeded",
+        "statusCode": 200,
+        "apiBaseUrl": "https://neondiff-license.fly.dev",
+        "redactedResponse": {
+          "status": "issued"
+        },
+        "responseSha256": "db39729fbf39606818951fdd7f204be24a9e978e5d8eae13210b81d1ada858b8"
+      },
+      {
+        "id": "activate",
+        "outcome": "succeeded",
+        "statusCode": 200,
+        "apiBaseUrl": "https://neondiff-license.fly.dev",
+        "redactedResponse": {
+          "status": "active",
+          "source": "api"
+        },
+        "responseSha256": "e5b310ba6a63039dcfddf7b3790efcec023fd50c478b6a80efb7cb2821f61ff3"
+      },
+      {
+        "id": "validate_active",
+        "outcome": "succeeded",
+        "statusCode": 200,
+        "apiBaseUrl": "https://neondiff-license.fly.dev",
+        "redactedResponse": {
+          "status": "active",
+          "source": "api"
+        },
+        "responseSha256": "e5b310ba6a63039dcfddf7b3790efcec023fd50c478b6a80efb7cb2821f61ff3"
+      },
+      {
+        "id": "deactivate",
+        "outcome": "succeeded",
+        "statusCode": 200,
+        "apiBaseUrl": "https://neondiff-license.fly.dev",
+        "redactedResponse": {
+          "status": "deactivated"
+        },
+        "responseSha256": "61e8e39cc6ca2e8ad1e9d9c55fb64e7cbd2aec7ee2aa7195202679de79052f11"
+      },
+      {
+        "id": "validate_denied",
+        "outcome": "denied",
+        "statusCode": 409,
+        "apiBaseUrl": "https://neondiff-license.fly.dev",
+        "redactedResponse": {
+          "status": "scope_mismatch"
+        },
+        "responseSha256": "1f5bbf0030b90422c0722d0105bb6944f7fe9d1b058d68e5392b9a319853f693"
+      }
+    ]
+  },
+  "matrix": {
+    "bypassAllowedCases": 0,
+    "scenarios": [
+      {
+        "id": "public_active",
+        "visibility": "public",
+        "expected": "allowed",
+        "actual": "allowed",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "e86241864d32daef1b7b37ec2584bf11578298357d4705270dc2bf18f37547cf"
+      },
+      {
+        "id": "private_active",
+        "visibility": "private",
+        "expected": "allowed",
+        "actual": "allowed",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "d4135f25438afd68f799279856720570b79bc7a3007dd5c884c668b545a5c9c7"
+      },
+      {
+        "id": "unknown_repo",
+        "visibility": "unknown",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "2283019bf11f1bd809497bd4d994ce3b9e5524a5f1e98a1ac95e218073fe21b8"
+      },
+      {
+        "id": "public_denied",
+        "visibility": "public",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "a7c894e15f2301a64ddf1014076a555d1766a454538aa437ff62495afe046076"
+      },
+      {
+        "id": "private_denied",
+        "visibility": "private",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "7ec3ccccae0ef0bb775262b4882c623fbe0e678d1e78fb8a450efdf73ec03dc7"
+      },
+      {
+        "id": "missing_key",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 0,
+        "licenseApiCalls": 0,
+        "resultSha256": "97af2d992c8a29ace5bfe83944e6f1b7d2311740ecd497d40983dc433b0129d2"
+      },
+      {
+        "id": "missing_api_url",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "2fbe1182402aad54a12535d8906c0b6a2b4eaa20383f24a0db4a1bfbdbe83857"
+      },
+      {
+        "id": "offline",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "b98f9f8a54acbb037898968bb627956a437bedd15729b1c3c2587f1cfaac8bc1"
+      },
+      {
+        "id": "timeout",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "d885c417ccb53275530d7911ff2de893dc40250d46ae872d906c266fc52e59ad"
+      },
+      {
+        "id": "forged_cache",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 0,
+        "licenseApiCalls": 0,
+        "resultSha256": "944509eaf2da99710b138e291f5ab507d349487352050401e234c20022352484"
+      },
+      {
+        "id": "mismatched_cache",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "3d145e07aee6cd380a63dd1282e26f638aa8264010a1cf32e5ae945b6aef7e7f"
+      },
+      {
+        "id": "disabled_policy_attempt",
+        "visibility": "public",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 0,
+        "licenseApiCalls": 0,
+        "resultSha256": "639c6b77e5e83d7e6cf6b8872eb4fe7cf74024091925c646a312f66887fa3141"
+      },
+      {
+        "id": "fake_api",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "cfb7c014262fb941b22a3c1cde4e436fb48359a39c661598594f514e38a567b1"
+      },
+      {
+        "id": "rate_limited",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "98a5da4b8aa6a37e425ca80bdf639c7c7ec6cde7a94ab2a1079c7972652f4a57"
+      },
+      {
+        "id": "server_error",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "635e5daa00ef20106540b508210fde30ce3bab56daa5d28f010154f04e322f22"
+      },
+      {
+        "id": "malformed_response",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "f04f1e9b4a181a7fc8fc8a9ff44ec323001ed394b0d195a3f9f787ea66c76e5f"
+      },
+      {
+        "id": "revoked",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "738c4d042db7a3a9b69bf6baef657fd6323d47757c8c4acd74480f33a8975b03"
+      },
+      {
+        "id": "expired",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 1,
+        "licenseApiCalls": 1,
+        "resultSha256": "ecd373de277dcffc9c72d31f022a90d42c737f1a940b3153e21f3b35edd7c6ea"
+      },
+      {
+        "id": "dashboard_provider_pre_activation",
+        "visibility": "not_applicable",
+        "expected": "denied",
+        "actual": "denied",
+        "expectedLicenseApiCalls": 0,
+        "licenseApiCalls": 0,
+        "resultSha256": "b66b4c0fc91860bb4d0460d605f698d1cb4278b6ab0ce5e8d0d0953cfef3678d"
+      }
+    ]
+  },
+  "usefulWorkBoundaries": {
+    "reportPassed": true,
+    "totalTests": 197,
+    "requiredPassingTests": [
+      "providers verify license admission denies before provider-key stdin or provider network",
+      "public NeonDiff CLI surface blocks provider-key stdin and provider network before activation",
+      "public NeonDiff CLI surface blocks run-once before the first GitHub request without activation",
+      "public NeonDiff CLI surface applies default-deny admission to useful commands without scoped help metadata",
+      "local HTML dashboard serves HTML status but blocks provider verification before activation"
+    ],
+    "resultSha256": "ed0575e9d58dabc0b2fa1f319fc1757f442fe6eb4a8f3f3f67c8252a1ab3259c"
+  },
+  "installUpgrade": {
+    "freshInstallPassed": true,
+    "upgradedFromVersion": "1.0.3",
+    "upgradePassed": true,
+    "resultSha256": "f12ab8b63fe0eaf412422d0837c78a3b6cf39ca17c10bd7f1b0d1123a7325108"
+  },
+  "dashboard": {
+    "setupBlockedBeforeActivation": true,
+    "providerBlockedBeforeActivation": true,
+    "activatedStatusVisible": true,
+    "resultSha256": "88db5f8b5e3797b3a1080bf3107f9517ff7677b0888ab6a3f3c641bb5f5b9e83"
+  },
+  "desktop": {
+    "brokerUnavailable": true,
+    "usefulWorkBlocked": true,
+    "resultSha256": "d3804db15e08bbf0e19920a86c6ded27fc105b56cc8a8308d7e906d33dae1fd2"
+  },
+  "redaction": {
+    "rawLicenseKeyAbsent": true,
+    "bearerTokenAbsent": true,
+    "privatePathsAbsent": true
+  },
+  "artifacts": [
+    {
+      "kind": "production-lifecycle",
+      "ref": "docs/evidence/v1.0.4/production-lifecycle-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json",
+      "sha256": "50220952428583c46db1b15c38a7705e24f2c7d1cc1b4f2f1a6fdb70388610bf"
+    },
+    {
+      "kind": "no-bypass-matrix",
+      "ref": "docs/evidence/v1.0.4/no-bypass-matrix-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json",
+      "sha256": "f9ca2b2548cb3624d26544ce0d8a20c09a43bff7c016651ae03f58f8623de91c"
+    },
+    {
+      "kind": "useful-work-boundaries",
+      "ref": "docs/evidence/v1.0.4/useful-work-boundaries-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json",
+      "sha256": "cdc2147ff6706c451a0e90880dbf246526c0cd654e78135214c67cbf8b62311a"
+    },
+    {
+      "kind": "dashboard",
+      "ref": "docs/evidence/v1.0.4/dashboard-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json",
+      "sha256": "a75d98cd4c3b70ddb91b2065ba92ff4271c49c97eea5d649a8bce07289f70cf6"
+    },
+    {
+      "kind": "desktop",
+      "ref": "docs/evidence/v1.0.4/desktop-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json",
+      "sha256": "ace63ad733837d89d6c6914c1c54cb397a4f3c7d13a58eb3abb7ef0f86d13fdb"
+    },
+    {
+      "kind": "install-upgrade",
+      "ref": "docs/evidence/v1.0.4/install-upgrade-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json",
+      "sha256": "84e3476bce93af1177fd6263ea9e86557c47140f0a55ea5a1468847d0cf8f020"
+    }
+  ]
+}

--- a/docs/evidence/v1.0.4/no-bypass-matrix-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
+++ b/docs/evidence/v1.0.4/no-bypass-matrix-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
@@ -1,0 +1,162 @@
+{
+  "evidenceKind": "no-bypass-matrix",
+  "releaseVersion": "v1.0.4",
+  "candidateHead": "42db7c8ff7dba6ceac813238dcebfb54dc83851f",
+  "packShasum": "526c04bd24673351b9cc7136d8747df00ffaa2be",
+  "packIntegrity": "sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw==",
+  "harnessRunId": "4c246a4cb724779c1e311fb7942c2046fc76df12afb6280e5c2c9ccbe0955a2a",
+  "records": [
+    {
+      "id": "public_active",
+      "visibility": "public",
+      "expected": "allowed",
+      "actual": "allowed",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "private_active",
+      "visibility": "private",
+      "expected": "allowed",
+      "actual": "allowed",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "unknown_repo",
+      "visibility": "unknown",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "public_denied",
+      "visibility": "public",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "private_denied",
+      "visibility": "private",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "missing_key",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 0,
+      "licenseApiCalls": 0
+    },
+    {
+      "id": "missing_api_url",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "offline",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "timeout",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "forged_cache",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 0,
+      "licenseApiCalls": 0
+    },
+    {
+      "id": "mismatched_cache",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "disabled_policy_attempt",
+      "visibility": "public",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 0,
+      "licenseApiCalls": 0
+    },
+    {
+      "id": "fake_api",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "rate_limited",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "server_error",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "malformed_response",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "revoked",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "expired",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 1,
+      "licenseApiCalls": 1
+    },
+    {
+      "id": "dashboard_provider_pre_activation",
+      "visibility": "not_applicable",
+      "expected": "denied",
+      "actual": "denied",
+      "expectedLicenseApiCalls": 0,
+      "licenseApiCalls": 0
+    }
+  ]
+}

--- a/docs/evidence/v1.0.4/production-lifecycle-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
+++ b/docs/evidence/v1.0.4/production-lifecycle-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
@@ -1,0 +1,57 @@
+{
+  "evidenceKind": "production-lifecycle",
+  "releaseVersion": "v1.0.4",
+  "candidateHead": "42db7c8ff7dba6ceac813238dcebfb54dc83851f",
+  "packShasum": "526c04bd24673351b9cc7136d8747df00ffaa2be",
+  "packIntegrity": "sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw==",
+  "harnessRunId": "4c246a4cb724779c1e311fb7942c2046fc76df12afb6280e5c2c9ccbe0955a2a",
+  "records": [
+    {
+      "id": "issue",
+      "outcome": "succeeded",
+      "statusCode": 200,
+      "apiBaseUrl": "https://neondiff-license.fly.dev",
+      "redactedResponse": {
+        "status": "issued"
+      }
+    },
+    {
+      "id": "activate",
+      "outcome": "succeeded",
+      "statusCode": 200,
+      "apiBaseUrl": "https://neondiff-license.fly.dev",
+      "redactedResponse": {
+        "status": "active",
+        "source": "api"
+      }
+    },
+    {
+      "id": "validate_active",
+      "outcome": "succeeded",
+      "statusCode": 200,
+      "apiBaseUrl": "https://neondiff-license.fly.dev",
+      "redactedResponse": {
+        "status": "active",
+        "source": "api"
+      }
+    },
+    {
+      "id": "deactivate",
+      "outcome": "succeeded",
+      "statusCode": 200,
+      "apiBaseUrl": "https://neondiff-license.fly.dev",
+      "redactedResponse": {
+        "status": "deactivated"
+      }
+    },
+    {
+      "id": "validate_denied",
+      "outcome": "denied",
+      "statusCode": 409,
+      "apiBaseUrl": "https://neondiff-license.fly.dev",
+      "redactedResponse": {
+        "status": "scope_mismatch"
+      }
+    }
+  ]
+}

--- a/docs/evidence/v1.0.4/useful-work-boundaries-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
+++ b/docs/evidence/v1.0.4/useful-work-boundaries-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json
@@ -1,0 +1,21 @@
+{
+  "evidenceKind": "useful-work-boundaries",
+  "releaseVersion": "v1.0.4",
+  "candidateHead": "42db7c8ff7dba6ceac813238dcebfb54dc83851f",
+  "packShasum": "526c04bd24673351b9cc7136d8747df00ffaa2be",
+  "packIntegrity": "sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw==",
+  "harnessRunId": "4c246a4cb724779c1e311fb7942c2046fc76df12afb6280e5c2c9ccbe0955a2a",
+  "records": [
+    {
+      "reportPassed": true,
+      "totalTests": 197,
+      "requiredPassingTests": [
+        "providers verify license admission denies before provider-key stdin or provider network",
+        "public NeonDiff CLI surface blocks provider-key stdin and provider network before activation",
+        "public NeonDiff CLI surface blocks run-once before the first GitHub request without activation",
+        "public NeonDiff CLI surface applies default-deny admission to useful commands without scoped help metadata",
+        "local HTML dashboard serves HTML status but blocks provider verification before activation"
+      ]
+    }
+  ]
+}

--- a/docs/public-release-manifest.json
+++ b/docs/public-release-manifest.json
@@ -1,13 +1,12 @@
 {
-  "version": "v1.0.3",
+  "version": "v1.0.4",
   "releaseLevel": "stable",
-  "publicationProofPath": "docs/evidence/v1.0.3-publication-proof.json",
   "packageArtifact": {
     "name": "neondiff",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "requiredForThisRelease": true,
-    "state": "published",
-    "previousReleasedPackageVersion": "1.0.2",
+    "state": "release_candidate",
+    "previousReleasedPackageVersion": "1.0.3",
     "skippedPublicPackageVersions": [
       "v0.4.25-beta.1",
       "v0.4.26-beta.1",
@@ -31,12 +30,12 @@
       "v0.4.45-beta.1",
       "v0.4.46-beta.1"
     ],
-    "note": "v1.0.3 publishes the CLI/dashboard npm package with verified provenance, registry identity, and installed-package browser-dashboard proof. Desktop Keychain startup-stability source changes are included, but desktop app artifacts are not part of the npm package."
+    "note": "v1.0.4 is the reviewed CLI/dashboard npm package release candidate for mandatory API-backed activation. Publication and public-registry install proof remain pending; desktop app artifacts are not part of the npm package."
   },
   "source": {
-    "shaState": "published",
-    "candidateHeadBeforeReleaseMetadata": "bcd2f7ace5b190dc86b5f86983aa62aae5e40652",
-    "proof": "annotated tag v1.0.3 peels to published main source SHA 5411365f73f0093b085eda056fe55c4cec4779d3 and contains candidate bcd2f7ace5b190dc86b5f86983aa62aae5e40652; the post-release stamp does not move the tag"
+    "shaState": "pending_tag_stamp",
+    "candidateHeadBeforeReleaseMetadata": "42db7c8ff7dba6ceac813238dcebfb54dc83851f",
+    "proof": "protected-main candidate 42db7c8ff7dba6ceac813238dcebfb54dc83851f passed mandatory production activation lifecycle run 29185155054; the annotated v1.0.4 tag, GitHub Release, and npm publication remain pending"
   },
   "releaseStages": {
     "launchCutLine": "1.0 is a usable local HTML installer/dashboard plus minimal Mac launcher, not full signed desktop maturity.",
@@ -79,9 +78,9 @@
     ]
   },
   "docs": {
-    "version": "v1.0.3",
+    "version": "v1.0.4",
     "setupPath": "docs/SETUP.md",
-    "releaseNotesPath": "docs/releases/v1.0.3.md",
+    "releaseNotesPath": "docs/releases/v1.0.4.md",
     "websiteRepo": "electricsheephq/neon-diff-agent-website"
   },
   "licenseApi": {
@@ -89,34 +88,35 @@
     "state": "healthy",
     "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327",
     "healthUrl": "https://neondiff-license.fly.dev/healthz",
-    "healthProofPath": "docs/evidence/v1.0.3-license-api-healthz.json",
+    "healthProofPath": "docs/evidence/v1.0.4-license-api-healthz.json",
     "checkoutIssuanceRequiredForThisRelease": true,
     "checkoutIssuanceUrl": "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
     "checkoutIssuanceState": "ready",
-    "checkoutIssuanceProofPath": "docs/evidence/v1.0.3-license-checkout-issuance-unauthenticated.json",
-    "checkoutIssuanceAuthenticatedProofPath": "docs/evidence/v1.0.3-license-checkout-issuance-authenticated.json",
-    "checkoutIssuanceTrackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
+    "checkoutIssuanceProofPath": "docs/evidence/v1.0.4-license-checkout-issuance-unauthenticated.json",
+    "checkoutIssuanceAuthenticatedProofPath": "docs/evidence/v1.0.4-license-checkout-issuance-authenticated.json",
+    "checkoutIssuanceTrackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421",
+    "activationProofPath": "docs/evidence/v1.0.4/mandatory-activation-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json"
   },
   "updateChannels": {
     "cli": {
       "requiredForThisRelease": true,
-      "state": "published",
-      "version": "v1.0.3",
-      "rollback": "git reset --hard refs/tags/v1.0.2",
+      "state": "source_checkout",
+      "version": "v1.0.4",
+      "rollback": "git reset --hard refs/tags/v1.0.3",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "daemon": {
       "requiredForThisRelease": true,
-      "state": "published",
-      "version": "v1.0.3",
-      "rollback": "git reset --hard refs/tags/v1.0.2",
+      "state": "source_checkout",
+      "version": "v1.0.4",
+      "rollback": "git reset --hard refs/tags/v1.0.3",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff"
     },
     "browserDashboard": {
       "requiredForThisRelease": true,
-      "state": "published",
-      "version": "v1.0.3",
-      "rollback": "git reset --hard refs/tags/v1.0.2",
+      "state": "source_checkout",
+      "version": "v1.0.4",
+      "rollback": "git reset --hard refs/tags/v1.0.3",
       "rollbackRepository": "electricsheephq/evaos-code-review-bot-neondiff",
       "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     }

--- a/docs/release-candidates/v1.0.4.json
+++ b/docs/release-candidates/v1.0.4.json
@@ -2,16 +2,23 @@
   "version": "v1.0.4",
   "packageVersion": "1.0.4",
   "publishedVersionAtCandidateCut": "v1.0.3",
-  "state": "protected_main_candidate_pending_production_proof",
+  "state": "protected_main_candidate_proven_pending_publication",
   "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/532",
   "proofWorkflow": ".github/workflows/license-lifecycle-proof.yml",
+  "candidateSourceSha": "42db7c8ff7dba6ceac813238dcebfb54dc83851f",
+  "proofRunUrl": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29185155054",
+  "activationProofPath": "docs/evidence/v1.0.4/mandatory-activation-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json",
+  "packageArtifact": {
+    "shasum": "526c04bd24673351b9cc7136d8747df00ffaa2be",
+    "integrity": "sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw=="
+  },
   "proofBoundary": {
     "allowed": [
-      "package bytes and version are ready for protected-main lifecycle proof"
+      "protected-main candidate passed production activation lifecycle and no-bypass proof",
+      "candidate package bytes are fixed at the recorded shasum and integrity"
     ],
     "forbidden": [
       "v1.0.4 is published",
-      "v1.0.4 activation proof exists",
       "npm latest points to 1.0.4",
       "predecessor releases or artifacts are safe to remove"
     ]

--- a/docs/releases/v1.0.4.md
+++ b/docs/releases/v1.0.4.md
@@ -1,0 +1,115 @@
+# v1.0.4
+
+- Release type: stable mandatory-activation replacement candidate
+- Protected-main candidate SHA: `42db7c8ff7dba6ceac813238dcebfb54dc83851f`
+- Previous stable release: `v1.0.3`
+- Tracking issue: [#532](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/532)
+- Candidate package: `neondiff@1.0.4`
+- Rollback baseline: `v1.0.3`
+
+## Purpose
+
+Replace the older free-use-compatible package line with a supported release
+that fails closed before useful review or provider work unless NeonDiff has a
+current API-backed entitlement. This packet records prepublication proof only:
+the GitHub Release, npm publication, `latest` promotion, installed public
+package smoke, and predecessor cleanup remain pending.
+
+## Included Changes
+
+- Require API-backed activation for supported public, private, internal, and
+  unknown-repository review work.
+- Reject missing API configuration, missing or invalid credentials, offline
+  validation without a permitted cache state, deactivated credentials, and
+  attempts to disable enforcement through user-editable configuration.
+- Gate CLI, daemon, dashboard, provider verification, and Desktop useful-work
+  boundaries before protected work begins.
+- Support GitHub OIDC issuance for disposable production lifecycle proof while
+  preserving signature, issuer, audience, time, repository, workflow, ref, and
+  exact-SHA claims.
+- Bind the release-status validator to the public-repository visibility that
+  the retired disabled-enforcement/free-public bypass scenario actually
+  exercises.
+- Preserve the advanced native SwiftUI Desktop application. The local HTML
+  dashboard remains a setup and browser surface, not a WebView replacement.
+
+## Exact Candidate Proof
+
+- [Production lifecycle workflow run 29185155054](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29185155054)
+- [GitHub attestation 34935405](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/attestations/34935405)
+- Candidate package shasum:
+  `526c04bd24673351b9cc7136d8747df00ffaa2be`
+- Candidate package integrity:
+  `sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw==`
+
+The hosted proof passed production OIDC issuance, activation, refreshed active
+validation, deactivation, denied post-deactivation validation, 19 no-bypass
+scenarios, 197 useful-work boundary tests, a fresh candidate install, a
+`1.0.3` to `1.0.4` upgrade, dashboard preactivation blocking, active-state
+rendering, and Desktop broker-unavailable quarantine.
+
+The seven attested JSON subjects are committed byte-for-byte under
+`docs/evidence/v1.0.4/`. The aggregate activation proof is
+`docs/evidence/v1.0.4/mandatory-activation-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json`.
+
+## Production License API Proof
+
+- `docs/evidence/v1.0.4-license-api-healthz.json`
+- `docs/evidence/v1.0.4-license-checkout-issuance-unauthenticated.json`
+- `docs/evidence/v1.0.4-license-checkout-issuance-authenticated.json`
+
+The live health check returned HTTP 200. An unauthenticated checkout issuance
+request returned HTTP 401. An idempotent authenticated production issuance
+returned HTTP 200, and only the approved status, replay flag, lookup key,
+prefix, and one-way license fingerprint were retained. No bearer value, raw
+license, secret name or value, cookie, customer data, or private path is stored
+in this packet.
+
+## Required Prepublication Gates
+
+- `npm run build`
+- Focused public-release, release-status, mandatory-activation, and npm-release
+  policy tests
+- Public-claims and secret scans
+- Exact hosted-Linux package-byte comparison to the candidate shasum and
+  integrity above
+- Exact-head CI, evaOS review, independent spec/security review, and zero
+  unresolved review threads
+- `release-status` against `v1.0.4` with rollback verification
+
+The activation lifecycle proof was observed at
+`2026-07-12T08:04:11.399Z`. Initial publication must complete within the
+24-hour freshness window or the lifecycle workflow must be rerun.
+
+## Publication Boundary
+
+This candidate does not yet prove:
+
+- a public non-prerelease `v1.0.4` GitHub Release;
+- `neondiff@1.0.4` on npm or `latest=1.0.4`;
+- an install from the public npm registry;
+- predecessor deprecation, release/tag deletion, or Actions-artifact cleanup;
+- signed or notarized Mac distribution, Sparkle/appcast readiness,
+  browser/native parity, or v1.1 customer readiness.
+
+After the immutable GitHub/npm release and installed-package activation smoke
+pass, a separate state-stamp PR will record public identities and advance the
+installer default without moving `refs/tags/v1.0.4`.
+
+## Rollback
+
+Before publication, abandon the candidate and retain `v1.0.3` as the public
+install channel. After publication, an operator rollback moves `latest` back
+to the verified predecessor and reinstalls it:
+
+```bash
+npm dist-tag add neondiff@1.0.3 latest
+npm install -g neondiff@1.0.3
+gh release edit v1.0.4 \
+  --repo electricsheephq/evaos-code-review-bot-neondiff \
+  --latest=false
+```
+
+The manifest source rollback remains
+`git reset --hard refs/tags/v1.0.3` for isolated recovery checkouts only. It
+must never be run against a maintainer's protected `main` checkout.

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -104,20 +104,38 @@ describe("NeonDiff public release readiness", () => {
     });
     expect(manifest.packageArtifact).toMatchObject({
       name: "neondiff",
-      version: "1.0.3",
+      version: "1.0.4",
       requiredForThisRelease: true,
-      state: "published",
-      previousReleasedPackageVersion: "1.0.2"
+      state: "release_candidate",
+      previousReleasedPackageVersion: "1.0.3"
     });
     expect(existsSync("docs/release-candidates/v1.0.4.json")).toBe(true);
     if (!existsSync("docs/release-candidates/v1.0.4.json")) return;
-    expect(JSON.parse(read("docs/release-candidates/v1.0.4.json"))).toMatchObject({
+    const candidateLedger = JSON.parse(read("docs/release-candidates/v1.0.4.json")) as {
+      state?: string;
+      candidateSourceSha?: string;
+      proofRunUrl?: string;
+      activationProofPath?: string;
+      packageArtifact?: { shasum?: string; integrity?: string };
+      proofBoundary?: { forbidden?: string[] };
+    };
+    expect(candidateLedger).toMatchObject({
       version: "v1.0.4",
       packageVersion: "1.0.4",
       publishedVersionAtCandidateCut: "v1.0.3",
-      state: "protected_main_candidate_pending_production_proof",
-      trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/532"
+      state: "protected_main_candidate_proven_pending_publication",
+      trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/532",
+      candidateSourceSha: "42db7c8ff7dba6ceac813238dcebfb54dc83851f",
+      proofRunUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29185155054",
+      activationProofPath:
+        "docs/evidence/v1.0.4/mandatory-activation-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json",
+      packageArtifact: {
+        shasum: "526c04bd24673351b9cc7136d8747df00ffaa2be",
+        integrity:
+          "sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw=="
+      }
     });
+    expect(candidateLedger.proofBoundary?.forbidden).not.toContain("v1.0.4 activation proof exists");
     expect(read("scripts/install.sh")).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-1\.0\.3\}"/);
     for (const path of ["README.md", "docs/SETUP.md"]) {
       const releaseNotice = read(path);
@@ -148,11 +166,11 @@ describe("NeonDiff public release readiness", () => {
     expect(manifest.packageArtifact?.note).toMatch(/CLI\/dashboard npm package/i);
     expect(manifest.packageArtifact?.note).toMatch(/desktop app artifacts are not part of the npm package/i);
     expect(manifest.source).toMatchObject({
-      shaState: "published",
-      candidateHeadBeforeReleaseMetadata: "bcd2f7ace5b190dc86b5f86983aa62aae5e40652"
+      shaState: "pending_tag_stamp",
+      candidateHeadBeforeReleaseMetadata: "42db7c8ff7dba6ceac813238dcebfb54dc83851f"
     });
-    expect(manifest.source?.proof).toMatch(/5411365f73f0093b085eda056fe55c4cec4779d3/);
-    expect(manifest.source?.proof).toMatch(/annotated tag v1\.0\.3/i);
+    expect(manifest.source?.proof).toMatch(/29185155054/);
+    expect(manifest.source?.proof).toMatch(/tag, GitHub Release, and npm publication remain pending/i);
     expect(manifest.releaseStages?.launchCutLine).toBe(
       "1.0 is a usable local HTML installer/dashboard plus minimal Mac launcher, not full signed desktop maturity."
     );
@@ -179,108 +197,81 @@ describe("NeonDiff public release readiness", () => {
     );
     expect(manifest.updateChannels?.browserDashboard).toMatchObject({
       requiredForThisRelease: true,
-      state: "published",
-      rollback: "git reset --hard refs/tags/v1.0.2",
+      state: "source_checkout",
+      version: "v1.0.4",
+      rollback: "git reset --hard refs/tags/v1.0.3",
       rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
       trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/443"
     });
     expect(manifest.updateChannels?.cli).toMatchObject({
       requiredForThisRelease: true,
-      state: "published",
-      rollback: "git reset --hard refs/tags/v1.0.2"
+      state: "source_checkout",
+      version: "v1.0.4",
+      rollback: "git reset --hard refs/tags/v1.0.3"
     });
     expect(manifest.updateChannels?.daemon).toMatchObject({
       requiredForThisRelease: true,
-      state: "published",
-      rollback: "git reset --hard refs/tags/v1.0.2"
+      state: "source_checkout",
+      version: "v1.0.4",
+      rollback: "git reset --hard refs/tags/v1.0.3"
     });
     expect(manifest.updateChannels?.website).toBeUndefined();
     expect(manifest.updateChannels?.desktop).toBeUndefined();
 
-    expect(manifest.publicationProofPath).toBe("docs/evidence/v1.0.3-publication-proof.json");
-    expect(existsSync(manifest.publicationProofPath!)).toBe(true);
-    const publicationProof = JSON.parse(read(manifest.publicationProofPath!)) as {
+    expect(manifest.publicationProofPath).toBeUndefined();
+    const aggregatePath =
+      "docs/evidence/v1.0.4/mandatory-activation-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json";
+    const aggregateRaw = read(aggregatePath);
+    const aggregate = JSON.parse(aggregateRaw) as {
+      evidenceKind?: string;
       releaseVersion?: string;
-      releaseSourceSha?: string;
-      github?: { releaseUrl?: string; publishWorkflowUrl?: string; nonPrerelease?: boolean };
-      npm?: {
+      harness?: { sourceHead?: string };
+      installedCandidate?: {
         packageVersion?: string;
-        latest?: string;
-        releaseCandidatePresent?: boolean;
-        gitHead?: string;
-        shasum?: string;
-        integrity?: string;
-        provenanceAttestationUrl?: string;
-      };
-      installedPackage?: {
         binaryVersion?: string;
-        evidenceRootId?: string;
-        isolatedPrefixRef?: string;
-        previewSmokeRef?: string;
-        browserProofRefs?: string[];
-        artifacts?: Array<{ kind?: string; ref?: string; sha256?: string }>;
-        providerVerification?: { ok?: boolean; mode?: string; result?: string };
+        packShasum?: string;
+        packIntegrity?: string;
       };
-      proofBoundary?: { allowed?: string[]; forbidden?: string[] };
+      matrix?: { bypassAllowedCases?: number; scenarios?: unknown[] };
+      usefulWorkBoundaries?: { reportPassed?: boolean; totalTests?: number };
+      installUpgrade?: { freshInstallPassed?: boolean; upgradedFromVersion?: string; upgradePassed?: boolean };
+      dashboard?: { setupBlockedBeforeActivation?: boolean; providerBlockedBeforeActivation?: boolean; activatedStatusVisible?: boolean };
+      desktop?: { brokerUnavailable?: boolean; usefulWorkBlocked?: boolean };
+      redaction?: { rawLicenseKeyAbsent?: boolean; bearerTokenAbsent?: boolean; privatePathsAbsent?: boolean };
+      artifacts?: Array<{ ref?: string; sha256?: string }>;
     };
-    expect(publicationProof).toMatchObject({
-      releaseVersion: "v1.0.3",
-      releaseSourceSha: "5411365f73f0093b085eda056fe55c4cec4779d3",
-      github: {
-        releaseUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/tag/v1.0.3",
-        publishWorkflowUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29055263065",
-        nonPrerelease: true
-      },
-      npm: {
-        packageVersion: "1.0.3",
-        latest: "1.0.3",
-        releaseCandidatePresent: false,
-        gitHead: "5411365f73f0093b085eda056fe55c4cec4779d3",
-        shasum: "99e9e74402ffe602f81584b1adf5e9b8d0b22e59",
-        integrity: "sha512-zkoatWQEq1ymbIEtCUTmbC5+ZWCplRlsJyiECLQQlXMMNn1QmsfTQ0M1Yqknn8UAYFD47zhtU1etsg/Qk+tSYQ=="
-      },
-      installedPackage: {
-        binaryVersion: "1.0.3",
-        providerVerification: { ok: true, mode: "metadata_only", result: "configured_unverified" }
-      }
-    });
-    expect(publicationProof.npm?.provenanceAttestationUrl).toMatch(/^https:\/\/registry\.npmjs\.org\//);
-    expect(publicationProof.installedPackage?.evidenceRootId).toBe("neondiff-ga/2026-07-10/v1.0.3/install-smoke");
-    expect(publicationProof.installedPackage?.isolatedPrefixRef).toBe("prefix");
-    expect(publicationProof.installedPackage?.previewSmokeRef).toBe("dashboard-preview-smoke/preview-smoke.json");
-    expect(publicationProof.installedPackage?.browserProofRefs).toHaveLength(2);
-    expect(publicationProof.installedPackage?.artifacts).toEqual([
-      {
-        kind: "installed-cli",
-        ref: "prefix/lib/node_modules/neondiff/dist/src/cli.js",
-        sha256: "f0274f200f451f9bab1ae7b1cc710589fb9d3a446bd45a41698f40b2634f7b69"
-      },
-      {
-        kind: "preview-smoke",
-        ref: "dashboard-preview-smoke/preview-smoke.json",
-        sha256: "048bc1b5f542aafbd02015c998ddf5f61b4c2864e9bf35f32b6af24adf83ff96"
-      },
-      {
-        kind: "browser-dashboard",
-        ref: "dashboard-installed-1.0.3.png",
-        sha256: "5ed63505149832fba630173ea72b915e6d94b120ff1e012dd9d6fb45bb6d17ff"
-      },
-      {
-        kind: "provider-verification-viewport",
-        ref: "dashboard-installed-1.0.3-provider-verified-viewport.png",
-        sha256: "74a36839276d715588b0f3700909ab07650d2d63d64a5977c2a6c67740b503d2"
-      }
-    ]);
-    expect(JSON.stringify(publicationProof)).not.toContain("/Volumes/");
-    expect(publicationProof.proofBoundary?.allowed).toContain("installed CLI and local browser dashboard flow for neondiff@1.0.3");
-    expect(publicationProof.proofBoundary?.forbidden).toEqual(
-      expect.arrayContaining([
-        "signed or notarized Mac distribution",
-        "Sparkle or appcast readiness",
-        "browser and native UI parity",
-        "v1.1 customer readiness"
-      ])
+    expect(createHash("sha256").update(aggregateRaw).digest("hex")).toBe(
+      "82372b6dad9992741392017116de3b423c134b8b26ad605a3a6cfcafd59c721c"
     );
+    expect(aggregate).toMatchObject({
+      evidenceKind: "mandatory_activation_no_bypass",
+      releaseVersion: "v1.0.4",
+      harness: { sourceHead: "42db7c8ff7dba6ceac813238dcebfb54dc83851f" },
+      installedCandidate: {
+        packageVersion: "1.0.4",
+        binaryVersion: "1.0.4",
+        packShasum: "526c04bd24673351b9cc7136d8747df00ffaa2be",
+        packIntegrity:
+          "sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw=="
+      },
+      matrix: { bypassAllowedCases: 0 },
+      usefulWorkBoundaries: { reportPassed: true, totalTests: 197 },
+      installUpgrade: { freshInstallPassed: true, upgradedFromVersion: "1.0.3", upgradePassed: true },
+      dashboard: {
+        setupBlockedBeforeActivation: true,
+        providerBlockedBeforeActivation: true,
+        activatedStatusVisible: true
+      },
+      desktop: { brokerUnavailable: true, usefulWorkBlocked: true },
+      redaction: { rawLicenseKeyAbsent: true, bearerTokenAbsent: true, privatePathsAbsent: true }
+    });
+    expect(aggregate.matrix?.scenarios).toHaveLength(19);
+    expect(aggregate.artifacts).toHaveLength(6);
+    for (const artifact of aggregate.artifacts ?? []) {
+      expect(artifact.ref).toMatch(/^docs\/evidence\/v1\.0\.4\/[a-z-]+-42db7c8ff7dba6ceac813238dcebfb54dc83851f\.json$/);
+      expect(existsSync(artifact.ref ?? "")).toBe(true);
+      expect(createHash("sha256").update(read(artifact.ref ?? "")).digest("hex")).toBe(artifact.sha256);
+    }
   });
 
   it("requires the live production license API and checkout issuance for GA", () => {
@@ -295,6 +286,7 @@ describe("NeonDiff public release readiness", () => {
         checkoutIssuanceUrl?: string;
         checkoutIssuanceProofPath?: string;
         checkoutIssuanceAuthenticatedProofPath?: string;
+        activationProofPath?: string;
         checkoutIssuanceState?: string;
         checkoutIssuanceTrackingIssue?: string;
       };
@@ -309,13 +301,15 @@ describe("NeonDiff public release readiness", () => {
       checkoutIssuanceRequiredForThisRelease: true,
       checkoutIssuanceUrl: "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
       checkoutIssuanceState: "ready",
-      checkoutIssuanceProofPath: "docs/evidence/v1.0.3-license-checkout-issuance-unauthenticated.json",
-      checkoutIssuanceAuthenticatedProofPath: "docs/evidence/v1.0.3-license-checkout-issuance-authenticated.json",
+      checkoutIssuanceProofPath: "docs/evidence/v1.0.4-license-checkout-issuance-unauthenticated.json",
+      checkoutIssuanceAuthenticatedProofPath: "docs/evidence/v1.0.4-license-checkout-issuance-authenticated.json",
+      activationProofPath:
+        "docs/evidence/v1.0.4/mandatory-activation-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json",
       checkoutIssuanceTrackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/421"
     });
     expect(manifest.licenseApi?.trackingIssue).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/);
     expect(manifest.licenseApi?.healthUrl).toMatch(/^https:\/\/[^/]+\/healthz$/);
-    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v1.0.3-license-api-healthz.json");
+    expect(manifest.licenseApi?.healthProofPath).toBe("docs/evidence/v1.0.4-license-api-healthz.json");
 
     const proof = JSON.parse(read(manifest.licenseApi?.healthProofPath ?? "")) as {
       evidenceKind?: string;
@@ -328,7 +322,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(proof).toMatchObject({
       evidenceKind: "license_api_healthz",
-      releaseVersion: "v1.0.3",
+      releaseVersion: "v1.0.4",
       url: manifest.licenseApi?.healthUrl,
       statusCode: 200,
       responseBody: "{\"status\":\"ok\"}"
@@ -345,7 +339,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(issuanceProof).toMatchObject({
       evidenceKind: "license_api_checkout_issuance",
-      releaseVersion: "v1.0.3",
+      releaseVersion: "v1.0.4",
       statusCode: 401,
       responseBody: expect.stringContaining("\"unauthorized\"")
     });
@@ -360,7 +354,7 @@ describe("NeonDiff public release readiness", () => {
     };
     expect(authenticatedProof).toMatchObject({
       evidenceKind: "license_api_checkout_issuance_authenticated",
-      releaseVersion: "v1.0.3",
+      releaseVersion: "v1.0.4",
       statusCode: 200,
       redactedResponse: {
         issuedLicensePrefix: "nd_live_",
@@ -406,59 +400,9 @@ describe("NeonDiff public release readiness", () => {
     expect(liveCheckoutProof.proofBoundary).toContain("does not claim the original in-flight Stripe delivery");
     expect(JSON.stringify(liveCheckoutProof)).not.toMatch(/cs_live_|evt_|whsec_|nd_live_[A-Za-z0-9]|session_id=|fulfillment_token=|121 South/i);
 
-    const rollbackProof = JSON.parse(read("docs/evidence/v1.0.3-rollback-refs.json")) as {
-      evidenceKind?: string;
-      releaseVersion?: string;
-      channels?: Record<string, {
-        rollbackRepository?: string;
-        rollbackCommand?: string;
-        operatorRollbackCommand?: string;
-        rollbackTarget?: string;
-        targetVerifiedBy?: string;
-        targetVerifiedSha?: string;
-        targetVerifiedShasum?: string;
-        targetUrl?: string;
-      }>;
-    };
-    expect(rollbackProof).toMatchObject({
-      evidenceKind: "release_rollback_refs",
-      releaseVersion: "v1.0.3",
-      channels: {
-        cli: {
-          rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
-          rollbackCommand: manifest.updateChannels?.cli?.rollback,
-          operatorRollbackCommand: "npm dist-tag add neondiff@1.0.2 latest",
-          rollbackTarget: "v1.0.2",
-          targetVerifiedBy: "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
-          targetVerifiedShasum: "d62619b1ee2c539e3230572135a29a299be3a6ed"
-        },
-        browserDashboard: {
-          rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
-          rollbackCommand: manifest.updateChannels?.browserDashboard?.rollback,
-          operatorRollbackCommand: "npm install -g neondiff@1.0.2",
-          rollbackTarget: "v1.0.2",
-          targetVerifiedBy: "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
-          targetVerifiedShasum: "d62619b1ee2c539e3230572135a29a299be3a6ed"
-        },
-        daemon: {
-          rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff",
-          rollbackCommand: manifest.updateChannels?.daemon?.rollback,
-          operatorRollbackCommand: "npm install -g neondiff@1.0.2",
-          rollbackTarget: "v1.0.2",
-          targetVerifiedBy: "npm view neondiff@1.0.2 version dist.integrity dist.shasum --json",
-          targetVerifiedShasum: "d62619b1ee2c539e3230572135a29a299be3a6ed"
-        },
-        website: {
-          rollbackRepository: "electricsheephq/neon-diff-agent-website",
-          releaseAction: "no_code_deploy_for_v1.0.3",
-          currentChannelVersion: "v1.0.1",
-          rollbackTarget: "no_action_for_v1.0.3",
-          targetVerifiedBy: "docs/public-release-manifest.json omits updateChannels.website for v1.0.3",
-          targetVerifiedSha: null
-        }
-      }
-    });
-    expect(JSON.stringify(rollbackProof)).not.toContain("<sha>");
+    for (const channel of ["cli", "daemon", "browserDashboard"]) {
+      expect(manifest.updateChannels?.[channel]?.rollback).toBe("git reset --hard refs/tags/v1.0.3");
+    }
 
     const desktopProof = JSON.parse(read("docs/evidence/v1.0.3-desktop-startup-smoke.json")) as {
       evidenceKind?: string;
@@ -557,7 +501,7 @@ describe("NeonDiff public release readiness", () => {
       read("docs/github-app-setup.md"),
       read("docs/providers.md"),
       read("docs/license-boundary.md"),
-      read("docs/releases/v1.0.3.md")
+      read("docs/releases/v1.0.4.md")
     ].join("\n\n");
     const legacyRepoReferences = docs
       .split(/\s+/)
@@ -578,7 +522,7 @@ describe("NeonDiff public release readiness", () => {
     expect(docs).toContain("git clone https://github.com/electricsheephq/evaos-code-review-bot-neondiff.git");
     expect(legacyRepoReferences).toEqual([]);
     expect(docs).not.toMatch(/npm link installs the local source-checkout shim/i);
-    expect(read("docs/releases/v1.0.3.md")).not.toMatch(/\/Volumes\/LEXAR|\/Users\/lume/);
+    expect(read("docs/releases/v1.0.4.md")).not.toMatch(/\/Volumes\/LEXAR|\/Users\/lume/);
   });
 
   it("keeps the retired GitHub Marketplace free-listing packet explicitly non-publishable", () => {

--- a/tests/release-status.test.ts
+++ b/tests/release-status.test.ts
@@ -21,7 +21,7 @@ import { ReviewStateStore } from "../src/state.js";
 describe("beta release status", () => {
   const roots: string[] = [];
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  const shippedReleaseValidationNow = new Date("2026-07-09T22:20:00Z");
+  const shippedReleaseValidationNow = new Date("2026-07-12T08:10:00Z");
 
   afterEach(() => {
     vi.useRealTimers();
@@ -324,27 +324,27 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v1.0.3",
+      expectedVersion: "v1.0.4",
       now: shippedReleaseValidationNow
     });
 
     expect(manifest).toMatchObject({
       ok: true,
-      version: "v1.0.3",
+      version: "v1.0.4",
       docs: {
         ok: true,
         setupPath: "docs/SETUP.md",
-        releaseNotesPath: "docs/releases/v1.0.3.md",
+        releaseNotesPath: "docs/releases/v1.0.4.md",
         changelogPath: "CHANGELOG.md",
-        changelogHeadVersion: "1.0.3",
-        changelogReleaseNotesPath: "docs/releases/v1.0.3.md"
+        changelogHeadVersion: "1.0.4",
+        changelogReleaseNotesPath: "docs/releases/v1.0.4.md"
       },
       licenseApi: {
         ok: true,
         requiredForThisRelease: true,
         state: "healthy",
         healthUrl: "https://neondiff-license.fly.dev/healthz",
-        healthProofPath: "docs/evidence/v1.0.3-license-api-healthz.json",
+        healthProofPath: "docs/evidence/v1.0.4-license-api-healthz.json",
         checkoutIssuanceRequiredForThisRelease: true,
         checkoutIssuanceUrl: "https://neondiff-license.fly.dev/v1/admin/licenses/issue",
         checkoutIssuanceState: "ready",
@@ -359,20 +359,20 @@ describe("beta release status", () => {
         expect.objectContaining({
           name: "cli",
           requiredForThisRelease: true,
-          state: "published",
-          rollback: "git reset --hard refs/tags/v1.0.2"
+          state: "source_checkout",
+          rollback: "git reset --hard refs/tags/v1.0.3"
         }),
         expect.objectContaining({
           name: "daemon",
           requiredForThisRelease: true,
-          state: "published",
-          rollback: "git reset --hard refs/tags/v1.0.2"
+          state: "source_checkout",
+          rollback: "git reset --hard refs/tags/v1.0.3"
         }),
         expect.objectContaining({
           name: "browserDashboard",
           requiredForThisRelease: true,
-          state: "published",
-          rollback: "git reset --hard refs/tags/v1.0.2",
+          state: "source_checkout",
+          rollback: "git reset --hard refs/tags/v1.0.3",
           rollbackRepository: "electricsheephq/evaos-code-review-bot-neondiff"
         })
       ])
@@ -383,15 +383,15 @@ describe("beta release status", () => {
     const manifest = readPublicReleaseManifestStatus({
       cwd: repoRoot,
       manifestPath: "docs/public-release-manifest.json",
-      expectedVersion: "v1.0.3",
-      now: new Date("2026-08-09T12:00:00Z")
+      expectedVersion: "v1.0.4",
+      now: new Date("2026-08-12T12:00:00Z")
     });
 
     expect(manifest.licenseApi).toMatchObject({
       ok: false,
       requiredForThisRelease: true,
       state: "healthy",
-      healthProofPath: "docs/evidence/v1.0.3-license-api-healthz.json"
+      healthProofPath: "docs/evidence/v1.0.4-license-api-healthz.json"
     });
     expect(manifest.licenseApi.detail).toContain("observedAt must be no older than 30 days");
     expect(manifest.ok).toBe(false);
@@ -1063,27 +1063,27 @@ describe("beta release status", () => {
       statePath: join(root, "missing-live-state.sqlite"),
       configPath: "/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json",
       publicReleaseManifestPath: "docs/public-release-manifest.json",
-      expectedPublicVersion: "v1.0.3",
+      expectedPublicVersion: "v1.0.4",
       launchdLabel: "com.electricsheephq.evaos-code-review-bot",
       now: shippedReleaseValidationNow
     });
 
     expect(status.publicRelease).toMatchObject({
       ok: true,
-      version: "v1.0.3"
+      version: "v1.0.4"
     });
     expect(status.gates).toContainEqual({
       name: "public_update_channels",
       ok: true,
-      detail: "cli=published; daemon=published; browserDashboard=published"
+      detail: "cli=source_checkout; daemon=source_checkout; browserDashboard=source_checkout"
     });
     const redactedOutput = stringifyRedactedJson({
       ...status,
       healthState: status.ok ? "runtime_ok" : "runtime_blocked",
       runtimeOk: status.ok
     });
-    expect(redactedOutput).toContain("git reset --hard refs/tags/v1.0.2");
-    expect(redactedOutput).toContain("cli=published; daemon=published");
+    expect(redactedOutput).toContain("git reset --hard refs/tags/v1.0.3");
+    expect(redactedOutput).toContain("cli=source_checkout; daemon=source_checkout");
     expect(redactedOutput).toContain("https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327");
     expect(redactedOutput).toContain("electricsheephq/evaos-code-review-bot-neondiff/issues/443");
   });


### PR DESCRIPTION
## Summary

- advance the v1.0.4 manifest and candidate ledger from pending proof to proven, still-unpublished release-candidate state
- commit the seven exact attested lifecycle subjects from protected-main run 29185155054
- commit fresh v1.0.4 production health, unauthenticated 401, and redacted authenticated checkout issuance proofs
- add release notes/changelog and update shipped-manifest tests without changing npm-included paths

## Exact candidate proof

- protected-main candidate: `42db7c8ff7dba6ceac813238dcebfb54dc83851f`
- lifecycle run: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29185155054
- attestation: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/attestations/34935405
- package shasum: `526c04bd24673351b9cc7136d8747df00ffaa2be`
- package integrity: `sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw==`
- aggregate SHA-256: `82372b6dad9992741392017116de3b423c134b8b26ad605a3a6cfcafd59c721c`

All seven files verify against the exact workflow, source SHA, `refs/heads/main`, and GitHub-hosted runners. The matrix has 19 scenarios, zero bypasses, and proves the retired disabled-enforcement/free-public attempt is denied on a public repo with zero API calls.

## Truth boundary

This PR does not claim v1.0.4 is published. The manifest remains:

- package: `release_candidate`
- source: `pending_tag_stamp`
- CLI/daemon/browser dashboard: `source_checkout`
- installer default: `1.0.3`
- no publication proof path

No v1.0.4 npm package, tag, or GitHub Release exists yet. No predecessor has been deprecated or deleted.

## Validation

- `npm run build`
- 130/130 focused public-release, release-status, mandatory-proof, and npm-policy tests
- public manifest + license API + strict rollback refs: green
- public-claims scan: green
- tracked and explicit evidence secret/path scans: green
- `git diff --check`
- all seven evidence copies byte-identical to run artifacts
- independent spec/security reviews: no findings
- live npm/GitHub prepublication audit: clean

A macOS pack archive has a different local digest, so it is not used as release proof. The lifecycle and publication gates both use hosted Ubuntu with npm 11.17.0. This PR changes no path included by `package.json.files`; the publish workflow must reproduce the hosted digest before any npm publication.

Initial publication must complete before `2026-07-13T08:04:11.399Z` or the lifecycle proof must be rerun.

Part of #532.