### PR TITLE
fix: recover v1.0.4 npm promotion with exact provenance

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -294,7 +294,7 @@ jobs:
           elif npm view "neondiff@$PACKAGE_VERSION" version >/dev/null 2>&1; then
             PACKAGE_ALREADY_EXISTS=true
           fi
-          if [ "$GITHUB_REF" = "refs/heads/main" ] && [ "$PROVENANCE_RECOVERY" != "true" ]; then
+          if { [ "$GITHUB_REF" = "refs/heads/main" ] || [ "$WORKFLOW_REF" = "electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main" ]; } && [ "$PROVENANCE_RECOVERY" != "true" ]; then
             echo "::error::Protected-main npm execution must remain in provenance recovery mode"
             exit 1
           fi
@@ -421,17 +421,21 @@ jobs:
             echo "::error::npm signature or provenance verification failed"
             exit 1
           }
-          node "$POLICY_SCRIPT" verify-pack \
-            --local-pack pack.json \
-            --remote-metadata remote-package.json \
-            --expected-version "$PACKAGE_VERSION" \
-            --expected-git-head "$EXPECTED_GIT_HEAD" \
-            --verified-provenance "$VERIFIED_PROVENANCE_PATH" \
-            --expected-package neondiff \
-            --expected-repository "$GITHUB_REPOSITORY" \
-            --expected-workflow .github/workflows/publish-npm.yml \
-            --expected-tag "$RELEASE_TAG" \
-            --recovery-proof "$RECOVERY_PROOF_PATH"
+          VERIFY_PACK_ARGS=(
+            --local-pack pack.json
+            --remote-metadata remote-package.json
+            --expected-version "$PACKAGE_VERSION"
+            --expected-git-head "$EXPECTED_GIT_HEAD"
+            --verified-provenance "$VERIFIED_PROVENANCE_PATH"
+            --expected-package neondiff
+            --expected-repository "$GITHUB_REPOSITORY"
+            --expected-workflow .github/workflows/publish-npm.yml
+            --expected-tag "$RELEASE_TAG"
+          )
+          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+            VERIFY_PACK_ARGS+=(--recovery-proof "$RECOVERY_PROOF_PATH")
+          fi
+          node "$POLICY_SCRIPT" verify-pack "${VERIFY_PACK_ARGS[@]}"
           EXPECTED_PREDECESSOR="$(node -p "require('./docs/public-release-manifest.json').packageArtifact.previousReleasedPackageVersion")"
           rm -f channel-metadata.json channel-metadata.tmp.json
           for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
@@ -482,7 +486,8 @@ jobs:
               if npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"; then
                 echo "npm dist-tag promotion command was accepted; confirming registry state"
               else
-                echo "::warning::npm dist-tag promotion returned nonzero; confirming registry state before deciding recovery outcome"
+                PROMOTION_COMMAND_STATUS=$?
+                echo "::warning::npm dist-tag promotion returned nonzero (exit $PROMOTION_COMMAND_STATUS); confirming registry state before deciding recovery outcome"
               fi
             else
               npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,6 +10,11 @@ on:
         description: Release tag to publish
         required: true
         default: v1.0.4
+      provenance_recovery:
+        description: Recover the already-published v1.0.4 package through exact npm provenance
+        required: true
+        type: boolean
+        default: false
 
 concurrency:
   group: publish-npm-neondiff
@@ -30,6 +35,9 @@ jobs:
       RELEASE_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
       RELEASE_EVENT_NAME: ${{ github.event_name }}
       RELEASE_PRERELEASE: ${{ github.event.release.prerelease || false }}
+      PROVENANCE_RECOVERY: ${{ inputs.provenance_recovery || false }}
+      WORKFLOW_REF: ${{ github.workflow_ref }}
+      WORKFLOW_SHA: ${{ github.workflow_sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -40,11 +48,34 @@ jobs:
 
       - name: Verify release provenance before repository code runs
         run: |
-          test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG" || {
-            echo "::error::Publish workflow must be dispatched from the exact release tag"
-            exit 1
-          }
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+            test "$RELEASE_EVENT_NAME" = "workflow_dispatch" || {
+              echo "::error::Provenance recovery requires workflow_dispatch"
+              exit 1
+            }
+            test "$GITHUB_REF" = "refs/heads/main" || {
+              echo "::error::Provenance recovery must run from protected main"
+              exit 1
+            }
+            test "$WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/publish-npm.yml@refs/heads/main" || {
+              echo "::error::Provenance recovery workflow ref must be publish-npm.yml on protected main"
+              exit 1
+            }
+            test "$WORKFLOW_SHA" = "$GITHUB_SHA" || {
+              echo "::error::Provenance recovery workflow SHA must equal the protected-main dispatch SHA"
+              exit 1
+            }
+            test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA" || {
+              echo "::error::Provenance recovery dispatch SHA is not the current protected-main head"
+              exit 1
+            }
+          else
+            test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG" || {
+              echo "::error::Publish workflow must be dispatched from the exact release tag"
+              exit 1
+            }
+          fi
           test "$(git cat-file -t "$RELEASE_TAG")" = "tag" || {
             echo "::error::Release tag must be annotated"
             exit 1
@@ -146,6 +177,23 @@ jobs:
             --tarball "$PACK_TARBALL" \
             --existing-package-recovery "$PACKAGE_ALREADY_EXISTS"
 
+      - name: Checkout protected-main recovery policy
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.provenance_recovery == true }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .recovery-policy
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify protected-main recovery policy checkout
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.provenance_recovery == true }}
+        run: |
+          test "$(git -C .recovery-policy rev-parse HEAD)" = "$WORKFLOW_SHA" || {
+            echo "::error::Protected-main recovery policy checkout does not match the workflow SHA"
+            exit 1
+          }
+
       - name: Publish or verify existing package
         if: steps.package_release.outputs.should_publish == 'true'
         env:
@@ -157,6 +205,16 @@ jobs:
           EXPECTED_GIT_HEAD="$(git rev-list -n 1 "$RELEASE_TAG")"
           CANDIDATE_HEAD="$(node -p "require('./docs/public-release-manifest.json').source.candidateHeadBeforeReleaseMetadata")"
           PACK_TARBALL="$RUNNER_TEMP/neondiff-reviewed-pack/neondiff-$PACKAGE_VERSION.tgz"
+          POLICY_SCRIPT="scripts/npm-release-policy.mjs"
+          PROVENANCE_VERIFIER="scripts/verify-npm-provenance.mjs"
+          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+            POLICY_SCRIPT=".recovery-policy/scripts/npm-release-policy.mjs"
+            PROVENANCE_VERIFIER=".recovery-policy/scripts/verify-npm-provenance.mjs"
+            test -f "$POLICY_SCRIPT" -a -f "$PROVENANCE_VERIFIER" || {
+              echo "::error::Protected-main recovery policy files are missing"
+              exit 1
+            }
+          fi
           test -f "$PACK_TARBALL" || {
             echo "::error::reviewed npm tarball is missing"
             exit 1
@@ -200,8 +258,32 @@ jobs:
               --deny-self-hosted-runners
           done
           PACKAGE_ALREADY_EXISTS=false
-          if npm view "neondiff@$PACKAGE_VERSION" version >/dev/null 2>&1; then
+          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+            for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+              OBSERVED_PACKAGE_VERSION="$(npm view "neondiff@$PACKAGE_VERSION" version --prefer-online 2>/dev/null || true)"
+              if [ "$OBSERVED_PACKAGE_VERSION" = "$PACKAGE_VERSION" ]; then
+                PACKAGE_ALREADY_EXISTS=true
+                break
+              fi
+              sleep 5
+            done
+          elif npm view "neondiff@$PACKAGE_VERSION" version >/dev/null 2>&1; then
             PACKAGE_ALREADY_EXISTS=true
+          fi
+          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+            node "$POLICY_SCRIPT" verify-recovery-dispatch \
+              --event-name "$RELEASE_EVENT_NAME" \
+              --github-ref "$GITHUB_REF" \
+              --workflow-ref "$WORKFLOW_REF" \
+              --workflow-sha "$WORKFLOW_SHA" \
+              --github-sha "$GITHUB_SHA" \
+              --main-sha "$(git rev-parse refs/remotes/origin/main)" \
+              --tag "$RELEASE_TAG" \
+              --tag-commit "$EXPECTED_GIT_HEAD" \
+              --package-version "$PACKAGE_VERSION" \
+              --provenance-recovery "$PROVENANCE_RECOVERY" \
+              --release-valid true \
+              --package-exists "$PACKAGE_ALREADY_EXISTS"
           fi
           node scripts/check-public-release-ready.mjs \
             --manifest docs/public-release-manifest.json \
@@ -211,16 +293,29 @@ jobs:
             --pack pack.json \
             --tarball "$PACK_TARBALL" \
             --existing-package-recovery "$PACKAGE_ALREADY_EXISTS"
-          if npm view "neondiff@$PACKAGE_VERSION" version >/dev/null 2>&1; then
+          # BEGIN V104_PROVENANCE_RECOVERY_PUBLISH_GUARD
+          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+            test "$PACKAGE_ALREADY_EXISTS" = "true" || {
+              echo "::error::Provenance recovery requires neondiff@$PACKAGE_VERSION to already exist"
+              exit 1
+            }
+            echo "neondiff@$PACKAGE_VERSION already exists; provenance recovery will not publish"
+          elif [ "$PACKAGE_ALREADY_EXISTS" = "true" ]; then
             echo "neondiff@$PACKAGE_VERSION already exists; verifying reviewed tarball identity"
           else
             npm publish "$PACK_TARBALL" --provenance --access public --tag "release-candidate"
           fi
+          # END V104_PROVENANCE_RECOVERY_PUBLISH_GUARD
           rm -f remote-package.json registry-metadata.tmp.json
           for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
             rm -f registry-metadata.tmp.json
-            if npm view "neondiff@$PACKAGE_VERSION" version dist.integrity dist.shasum gitHead dist.attestations --json > registry-metadata.tmp.json 2>/dev/null && \
-              node -e 'JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))' registry-metadata.tmp.json; then
+            if npm view "neondiff@$PACKAGE_VERSION" version dist.integrity dist.shasum gitHead dist.attestations --json --prefer-online > registry-metadata.tmp.json 2>/dev/null && \
+              node -e '
+                const value = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
+                if (!value || Array.isArray(value) || typeof value !== "object") process.exit(1);
+                if (value.version !== process.argv[2] || typeof value["dist.integrity"] !== "string" || typeof value["dist.shasum"] !== "string") process.exit(1);
+                if (typeof value["dist.attestations"]?.url !== "string") process.exit(1);
+              ' registry-metadata.tmp.json "$PACKAGE_VERSION"; then
               mv registry-metadata.tmp.json remote-package.json
               break
             fi
@@ -230,11 +325,6 @@ jobs:
             echo "::error::npm registry metadata remained unavailable or invalid after retries"
             exit 1
           }
-          node scripts/npm-release-policy.mjs verify-pack \
-            --local-pack pack.json \
-            --remote-metadata remote-package.json \
-            --expected-version "$PACKAGE_VERSION" \
-            --expected-git-head "$EXPECTED_GIT_HEAD"
           # shellcheck disable=SC2016
           ATTESTATION_URL="$(node -e '
             const metadata = require("./remote-package.json");
@@ -254,7 +344,9 @@ jobs:
             --retry-max-time 120 \
             "$ATTESTATION_URL" > npm-attestations.json
           EXPECTED_INTEGRITY="$(node -e 'const [pack] = require("./pack.json"); process.stdout.write(pack.integrity ?? "")')"
-          node scripts/verify-npm-provenance.mjs \
+          VERIFIED_PROVENANCE_PATH="$RUNNER_TEMP/verified-npm-provenance.json"
+          rm -f "$VERIFIED_PROVENANCE_PATH"
+          node "$PROVENANCE_VERIFIER" \
             --attestations npm-attestations.json \
             --expected-package neondiff \
             --expected-version "$PACKAGE_VERSION" \
@@ -262,7 +354,22 @@ jobs:
             --expected-repository "$GITHUB_REPOSITORY" \
             --expected-workflow .github/workflows/publish-npm.yml \
             --expected-tag "$RELEASE_TAG" \
-            --expected-commit "$EXPECTED_GIT_HEAD"
+            --expected-commit "$EXPECTED_GIT_HEAD" \
+            > "$VERIFIED_PROVENANCE_PATH"
+          test -s "$VERIFIED_PROVENANCE_PATH" || {
+            echo "::error::Verified npm provenance result is missing"
+            exit 1
+          }
+          node "$POLICY_SCRIPT" verify-pack \
+            --local-pack pack.json \
+            --remote-metadata remote-package.json \
+            --expected-version "$PACKAGE_VERSION" \
+            --expected-git-head "$EXPECTED_GIT_HEAD" \
+            --verified-provenance "$VERIFIED_PROVENANCE_PATH" \
+            --expected-package neondiff \
+            --expected-repository "$GITHUB_REPOSITORY" \
+            --expected-workflow .github/workflows/publish-npm.yml \
+            --expected-tag "$RELEASE_TAG"
           SIGNATURE_VERIFY_ROOT="$RUNNER_TEMP/neondiff-signature-verify"
           rm -rf "$SIGNATURE_VERIFY_ROOT"
           npm install --ignore-scripts --prefix "$SIGNATURE_VERIFY_ROOT" "neondiff@$PACKAGE_VERSION" >/dev/null
@@ -291,19 +398,31 @@ jobs:
             exit 1
           }
           CURRENT_TAG_VERSION="$(node -e 'const tags = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")); process.stdout.write(tags[process.argv[2]] ?? "")' channel-metadata.json "$NPM_TAG")"
-          node scripts/npm-release-policy.mjs verify-channel \
+          node "$POLICY_SCRIPT" verify-channel \
             --current-version "$CURRENT_TAG_VERSION" \
             --target-version "$PACKAGE_VERSION" \
             --expected-predecessor "$EXPECTED_PREDECESSOR" \
             --npm-tag "$NPM_TAG"
           npm view neondiff dist-tags --json --prefer-online > prepromotion-channel.json
           PREPROMOTION_TAG_VERSION="$(node -e 'const tags = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")); if (!tags || Array.isArray(tags) || typeof tags !== "object") process.exit(1); process.stdout.write(tags[process.argv[2]] ?? "")' prepromotion-channel.json "$NPM_TAG")"
-          node scripts/npm-release-policy.mjs verify-channel \
+          PREPROMOTION_QUARANTINE_VERSION="$(node -e 'const tags = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")); if (!tags || Array.isArray(tags) || typeof tags !== "object") process.exit(1); process.stdout.write(tags["release-candidate"] ?? "")' prepromotion-channel.json)"
+          # BEGIN V104_PROVENANCE_RECOVERY_PREPROMOTION_GUARD
+          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+            node "$POLICY_SCRIPT" verify-recovery-channels \
+              --latest-version "$PREPROMOTION_TAG_VERSION" \
+              --quarantine-version "$PREPROMOTION_QUARANTINE_VERSION" \
+              --target-version "$PACKAGE_VERSION" \
+              --expected-predecessor "$EXPECTED_PREDECESSOR"
+          fi
+          node "$POLICY_SCRIPT" verify-channel \
             --current-version "$PREPROMOTION_TAG_VERSION" \
             --target-version "$PACKAGE_VERSION" \
             --expected-predecessor "$EXPECTED_PREDECESSOR" \
             --npm-tag "$NPM_TAG"
-          npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"
+          if [ "$PREPROMOTION_TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+            npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"
+          fi
+          # END V104_PROVENANCE_RECOVERY_PREPROMOTION_GUARD
           # BEGIN POST_PROMOTION_CONFIRMATION
           NPM_CONFIRM_ATTEMPTS="${NPM_CONFIRM_ATTEMPTS:-12}" \
           NPM_CONFIRM_DELAY_MS="${NPM_CONFIRM_DELAY_MS:-5000}" \

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -194,7 +194,7 @@ jobs:
             --existing-package-recovery "$PACKAGE_ALREADY_EXISTS"
 
       - name: Checkout protected-main recovery policy
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.provenance_recovery == true }}
+        if: ${{ steps.package_release.outputs.should_publish == 'true' && github.event_name == 'workflow_dispatch' && inputs.provenance_recovery == true }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.workflow_sha }}
@@ -203,7 +203,7 @@ jobs:
           persist-credentials: false
 
       - name: Verify protected-main recovery policy checkout
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.provenance_recovery == true }}
+        if: ${{ steps.package_release.outputs.should_publish == 'true' && github.event_name == 'workflow_dispatch' && inputs.provenance_recovery == true }}
         env:
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -47,6 +47,12 @@ jobs:
           persist-credentials: false
 
       - name: Verify release provenance before repository code runs
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+          RELEASE_EVENT_NAME: ${{ github.event_name }}
+          PROVENANCE_RECOVERY: ${{ inputs.provenance_recovery || false }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           if [ "$PROVENANCE_RECOVERY" = "true" ]; then
@@ -81,6 +87,16 @@ jobs:
             exit 1
           }
           TAG_COMMIT="$(git rev-list -n 1 "$RELEASE_TAG")"
+          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+            test "$RELEASE_TAG" = "v1.0.4" || {
+              echo "::error::Provenance recovery is scoped only to v1.0.4"
+              exit 1
+            }
+            test "$TAG_COMMIT" = "fc66d27b6ab9f6a1eb8282d289ef63407cd96982" || {
+              echo "::error::Provenance recovery tag must peel to the exact v1.0.4 release commit"
+              exit 1
+            }
+          fi
           git merge-base --is-ancestor "$TAG_COMMIT" refs/remotes/origin/main || {
             echo "::error::Release tag commit must be an ancestor of protected main"
             exit 1
@@ -188,6 +204,8 @@ jobs:
 
       - name: Verify protected-main recovery policy checkout
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.provenance_recovery == true }}
+        env:
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           test "$(git -C .recovery-policy rev-parse HEAD)" = "$WORKFLOW_SHA" || {
             echo "::error::Protected-main recovery policy checkout does not match the workflow SHA"
@@ -200,7 +218,13 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TAG: ${{ steps.package_release.outputs.npm_tag }}
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+          RELEASE_EVENT_NAME: ${{ github.event_name }}
+          PROVENANCE_RECOVERY: ${{ inputs.provenance_recovery || false }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
+          # BEGIN V104_PROVENANCE_RECOVERY_MUTATION_GATE
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
           EXPECTED_GIT_HEAD="$(git rev-list -n 1 "$RELEASE_TAG")"
           CANDIDATE_HEAD="$(node -p "require('./docs/public-release-manifest.json').source.candidateHeadBeforeReleaseMetadata")"
@@ -269,6 +293,10 @@ jobs:
             done
           elif npm view "neondiff@$PACKAGE_VERSION" version >/dev/null 2>&1; then
             PACKAGE_ALREADY_EXISTS=true
+          fi
+          if [ "$GITHUB_REF" = "refs/heads/main" ] && [ "$PROVENANCE_RECOVERY" != "true" ]; then
+            echo "::error::Protected-main npm execution must remain in provenance recovery mode"
+            exit 1
           fi
           if [ "$PROVENANCE_RECOVERY" = "true" ]; then
             node "$POLICY_SCRIPT" verify-recovery-dispatch \
@@ -360,16 +388,6 @@ jobs:
             echo "::error::Verified npm provenance result is missing"
             exit 1
           }
-          node "$POLICY_SCRIPT" verify-pack \
-            --local-pack pack.json \
-            --remote-metadata remote-package.json \
-            --expected-version "$PACKAGE_VERSION" \
-            --expected-git-head "$EXPECTED_GIT_HEAD" \
-            --verified-provenance "$VERIFIED_PROVENANCE_PATH" \
-            --expected-package neondiff \
-            --expected-repository "$GITHUB_REPOSITORY" \
-            --expected-workflow .github/workflows/publish-npm.yml \
-            --expected-tag "$RELEASE_TAG"
           SIGNATURE_VERIFY_ROOT="$RUNNER_TEMP/neondiff-signature-verify"
           rm -rf "$SIGNATURE_VERIFY_ROOT"
           npm install --ignore-scripts --prefix "$SIGNATURE_VERIFY_ROOT" "neondiff@$PACKAGE_VERSION" >/dev/null
@@ -382,6 +400,16 @@ jobs:
             echo "::error::npm signature or provenance verification failed"
             exit 1
           }
+          node "$POLICY_SCRIPT" verify-pack \
+            --local-pack pack.json \
+            --remote-metadata remote-package.json \
+            --expected-version "$PACKAGE_VERSION" \
+            --expected-git-head "$EXPECTED_GIT_HEAD" \
+            --verified-provenance "$VERIFIED_PROVENANCE_PATH" \
+            --expected-package neondiff \
+            --expected-repository "$GITHUB_REPOSITORY" \
+            --expected-workflow .github/workflows/publish-npm.yml \
+            --expected-tag "$RELEASE_TAG"
           EXPECTED_PREDECESSOR="$(node -p "require('./docs/public-release-manifest.json').packageArtifact.previousReleasedPackageVersion")"
           rm -f channel-metadata.json channel-metadata.tmp.json
           for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
@@ -420,7 +448,11 @@ jobs:
             --expected-predecessor "$EXPECTED_PREDECESSOR" \
             --npm-tag "$NPM_TAG"
           if [ "$PREPROMOTION_TAG_VERSION" != "$PACKAGE_VERSION" ]; then
-            npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"
+            if npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"; then
+              echo "npm dist-tag promotion command was accepted; confirming registry state"
+            else
+              echo "::warning::npm dist-tag promotion returned nonzero; confirming registry state before deciding recovery outcome"
+            fi
           fi
           # END V104_PROVENANCE_RECOVERY_PREPROMOTION_GUARD
           # BEGIN POST_PROMOTION_CONFIRMATION
@@ -541,3 +573,4 @@ jobs:
           process.exit(0);
           NODE
           # END POST_PROMOTION_CONFIRMATION
+          # END V104_PROVENANCE_RECOVERY_MUTATION_GATE

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -298,20 +298,41 @@ jobs:
             echo "::error::Protected-main npm execution must remain in provenance recovery mode"
             exit 1
           fi
+          RECOVERY_PROOF_PATH=""
           if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+            git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+            RECOVERY_MAIN_SHA="$(git rev-parse refs/remotes/origin/main)"
+            test "$RECOVERY_MAIN_SHA" = "$GITHUB_SHA" || {
+              echo "::error::Provenance recovery dispatch SHA is no longer the protected-main head"
+              exit 1
+            }
+            RECOVERY_PROOF_PATH="$RUNNER_TEMP/v1.0.4-recovery-dispatch-proof.json"
+            RECOVERY_RELEASE_METADATA_PATH="$RUNNER_TEMP/recovery-release-metadata.json"
+            rm -f "$RECOVERY_PROOF_PATH" "$RECOVERY_RELEASE_METADATA_PATH"
+            gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" > "$RECOVERY_RELEASE_METADATA_PATH"
+            RELEASE_VALID="$(node -e '
+              const release = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
+              const valid = release?.tag_name === process.argv[2] && release?.draft === false && release?.prerelease === false;
+              process.stdout.write(valid ? "true" : "false");
+            ' "$RECOVERY_RELEASE_METADATA_PATH" "$RELEASE_TAG")"
+            test "$RELEASE_VALID" = "true" || {
+              echo "::error::Provenance recovery requires the existing non-draft, non-prerelease GitHub Release"
+              exit 1
+            }
             node "$POLICY_SCRIPT" verify-recovery-dispatch \
               --event-name "$RELEASE_EVENT_NAME" \
               --github-ref "$GITHUB_REF" \
               --workflow-ref "$WORKFLOW_REF" \
               --workflow-sha "$WORKFLOW_SHA" \
               --github-sha "$GITHUB_SHA" \
-              --main-sha "$(git rev-parse refs/remotes/origin/main)" \
+              --main-sha "$RECOVERY_MAIN_SHA" \
               --tag "$RELEASE_TAG" \
               --tag-commit "$EXPECTED_GIT_HEAD" \
               --package-version "$PACKAGE_VERSION" \
               --provenance-recovery "$PROVENANCE_RECOVERY" \
-              --release-valid true \
-              --package-exists "$PACKAGE_ALREADY_EXISTS"
+              --release-valid "$RELEASE_VALID" \
+              --package-exists "$PACKAGE_ALREADY_EXISTS" \
+              --proof-output "$RECOVERY_PROOF_PATH"
           fi
           node scripts/check-public-release-ready.mjs \
             --manifest docs/public-release-manifest.json \
@@ -409,7 +430,8 @@ jobs:
             --expected-package neondiff \
             --expected-repository "$GITHUB_REPOSITORY" \
             --expected-workflow .github/workflows/publish-npm.yml \
-            --expected-tag "$RELEASE_TAG"
+            --expected-tag "$RELEASE_TAG" \
+            --recovery-proof "$RECOVERY_PROOF_PATH"
           EXPECTED_PREDECESSOR="$(node -p "require('./docs/public-release-manifest.json').packageArtifact.previousReleasedPackageVersion")"
           rm -f channel-metadata.json channel-metadata.tmp.json
           for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
@@ -431,6 +453,14 @@ jobs:
             --target-version "$PACKAGE_VERSION" \
             --expected-predecessor "$EXPECTED_PREDECESSOR" \
             --npm-tag "$NPM_TAG"
+          if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+            git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+            PREPROMOTION_MAIN_SHA="$(git rev-parse refs/remotes/origin/main)"
+            test "$PREPROMOTION_MAIN_SHA" = "$GITHUB_SHA" || {
+              echo "::error::Protected main advanced before npm promotion; refusing dist-tag mutation"
+              exit 1
+            }
+          fi
           npm view neondiff dist-tags --json --prefer-online > prepromotion-channel.json
           PREPROMOTION_TAG_VERSION="$(node -e 'const tags = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")); if (!tags || Array.isArray(tags) || typeof tags !== "object") process.exit(1); process.stdout.write(tags[process.argv[2]] ?? "")' prepromotion-channel.json "$NPM_TAG")"
           PREPROMOTION_QUARANTINE_VERSION="$(node -e 'const tags = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")); if (!tags || Array.isArray(tags) || typeof tags !== "object") process.exit(1); process.stdout.write(tags["release-candidate"] ?? "")' prepromotion-channel.json)"
@@ -448,10 +478,14 @@ jobs:
             --expected-predecessor "$EXPECTED_PREDECESSOR" \
             --npm-tag "$NPM_TAG"
           if [ "$PREPROMOTION_TAG_VERSION" != "$PACKAGE_VERSION" ]; then
-            if npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"; then
-              echo "npm dist-tag promotion command was accepted; confirming registry state"
+            if [ "$PROVENANCE_RECOVERY" = "true" ]; then
+              if npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"; then
+                echo "npm dist-tag promotion command was accepted; confirming registry state"
+              else
+                echo "::warning::npm dist-tag promotion returned nonzero; confirming registry state before deciding recovery outcome"
+              fi
             else
-              echo "::warning::npm dist-tag promotion returned nonzero; confirming registry state before deciding recovery outcome"
+              npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"
             fi
           fi
           # END V104_PROVENANCE_RECOVERY_PREPROMOTION_GUARD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ for the semver/GA-line and npm dist-tag policy.
 
 - Add the workflow-only #542 recovery for the immutable v1.0.4 reviewed
   tarball: an absent npm `gitHead` may be replaced only by exact
-  Sigstore/SLSA provenance after package-byte and signature verification, while
+  package bytes, npm signatures, and Sigstore/SLSA provenance, while
   protected-main, predecessor, quarantine-ownership, and no-republish guards
-  remain fail-closed. Promotion and public-install proof remain pending.
+  remain fail-closed. Bounded registry reads reconcile ambiguous nonzero
+  promotion results. Promotion and public-install proof remain pending.
 
 ## [1.0.4] - docs/releases/v1.0.4.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,13 @@ for the semver/GA-line and npm dist-tag policy.
 
 ## [Unreleased]
 
-No unreleased changes tracked yet.
+### Fixed
+
+- Add the workflow-only #542 recovery for the immutable v1.0.4 reviewed
+  tarball: an absent npm `gitHead` may be replaced only by exact
+  Sigstore/SLSA provenance after package-byte and signature verification, while
+  protected-main, predecessor, quarantine-ownership, and no-republish guards
+  remain fail-closed. Promotion and public-install proof remain pending.
 
 ## [1.0.4] - docs/releases/v1.0.4.md
 

--- a/docs/release-candidates/v1.0.4.json
+++ b/docs/release-candidates/v1.0.4.json
@@ -27,7 +27,7 @@
       "protected-main candidate passed production activation lifecycle and no-bypass proof",
       "candidate package bytes are fixed at the recorded shasum and integrity",
       "the real non-prerelease GitHub Release and immutable npm package exist",
-      "npm signatures and Sigstore/SLSA provenance bind the package to the v1.0.4 tag commit"
+      "registry exposes npm attestation metadata pending successful recovery verification"
     ],
     "forbidden": [
       "npm latest points to 1.0.4",

--- a/docs/release-candidates/v1.0.4.json
+++ b/docs/release-candidates/v1.0.4.json
@@ -2,24 +2,37 @@
   "version": "v1.0.4",
   "packageVersion": "1.0.4",
   "publishedVersionAtCandidateCut": "v1.0.3",
-  "state": "protected_main_candidate_proven_pending_publication",
+  "state": "immutable_package_published_quarantined_pending_provenance_recovery",
   "trackingIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/532",
+  "recoveryIssue": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/542",
   "proofWorkflow": ".github/workflows/license-lifecycle-proof.yml",
   "candidateSourceSha": "42db7c8ff7dba6ceac813238dcebfb54dc83851f",
+  "releaseCommit": "fc66d27b6ab9f6a1eb8282d289ef63407cd96982",
+  "githubReleaseUrl": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/tag/v1.0.4",
+  "publishRunUrl": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29185873762",
   "proofRunUrl": "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29185155054",
   "activationProofPath": "docs/evidence/v1.0.4/mandatory-activation-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json",
   "packageArtifact": {
     "shasum": "526c04bd24673351b9cc7136d8747df00ffaa2be",
     "integrity": "sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw=="
   },
+  "registry": {
+    "state": "published_quarantined",
+    "gitHeadState": "absent_reviewed_tarball_publish",
+    "latest": "1.0.3",
+    "releaseCandidate": "1.0.4"
+  },
   "proofBoundary": {
     "allowed": [
       "protected-main candidate passed production activation lifecycle and no-bypass proof",
-      "candidate package bytes are fixed at the recorded shasum and integrity"
+      "candidate package bytes are fixed at the recorded shasum and integrity",
+      "the real non-prerelease GitHub Release and immutable npm package exist",
+      "npm signatures and Sigstore/SLSA provenance bind the package to the v1.0.4 tag commit"
     ],
     "forbidden": [
-      "v1.0.4 is published",
       "npm latest points to 1.0.4",
+      "release-candidate cleanup completed",
+      "public-registry install and activation smoke completed",
       "predecessor releases or artifacts are safe to remove"
     ]
   }

--- a/docs/release-candidates/v1.0.4.json
+++ b/docs/release-candidates/v1.0.4.json
@@ -23,6 +23,8 @@
     "releaseCandidate": "1.0.4"
   },
   "proofBoundaryPhase": "pre_recovery",
+  "nextPhase": "post_recovery",
+  "pendingRecoveryAction": "Replace this pre-recovery ledger with the successful workflow run and converged npm channel truth before closing #532.",
   "proofBoundary": {
     "allowed": [
       "protected-main candidate passed production activation lifecycle and no-bypass proof",

--- a/docs/release-candidates/v1.0.4.json
+++ b/docs/release-candidates/v1.0.4.json
@@ -22,6 +22,7 @@
     "latest": "1.0.3",
     "releaseCandidate": "1.0.4"
   },
+  "proofBoundaryPhase": "pre_recovery",
   "proofBoundary": {
     "allowed": [
       "protected-main candidate passed production activation lifecycle and no-bypass proof",

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -288,9 +288,45 @@ npm view neondiff@<version> version dist.integrity dist.shasum gitHead dist.atte
 test "$(npm view neondiff dist-tags.latest)" = "<version>"
 ```
 
+#### v1.0.4-only reviewed-tarball provenance recovery
+
+Run `29185873762` published the exact reviewed `neondiff@1.0.4` tarball under
+`release-candidate`, but npm 11.17.0 did not synthesize `gitHead` because the
+publish input was the prebuilt tarball rather than the Git checkout. The
+registry version is immutable. Do not republish, unpublish, retag, or directly
+edit dist-tags to compensate.
+
+The v1.0.4-only recovery loads reviewed workflow policy from the exact current
+protected-main SHA while retaining the annotated v1.0.4 tag checkout as the
+sole build and pack source. It cannot publish: the immutable npm version and
+matching non-prerelease GitHub Release must already exist. Missing `gitHead`
+is accepted only after exact shasum/integrity, npm signatures, and Sigstore/SLSA
+provenance verify the repository, publish workflow, tag, and release commit. A
+present malformed or mismatched `gitHead` remains fatal.
+
+After the recovery change is merged to protected main, dispatch only this
+bounded command:
+
+```bash
+gh workflow run publish-npm.yml \
+  --repo electricsheephq/evaos-code-review-bot-neondiff \
+  --ref main \
+  -f tag=v1.0.4 \
+  -f provenance_recovery=true
+```
+
+The recovery fails before mutation unless `latest=1.0.3` and
+`release-candidate=1.0.4`, or unless an idempotent rerun already has
+`latest=1.0.4` with quarantine either owned by `1.0.4` or absent. It preserves
+the package-wide concurrency group, predecessor guard, bounded registry
+confirmation, and owned-only quarantine cleanup. This exception does not
+authorize missing `gitHead` for any later package version; fix the future
+publisher before cutting another npm release.
+
 Record the failed workflow URL, registry identity output, repaired dist-tags,
-and operator in the release tracker. If any identity field is missing or does
-not match, leave `latest` unchanged and treat the package as quarantined.
+and operator in the release tracker. Outside the bounded v1.0.4 provenance
+fallback, if any identity field is missing or does not match, leave `latest`
+unchanged and treat the package as quarantined.
 
 ## Tag And Release
 

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -319,7 +319,8 @@ The recovery fails before mutation unless `latest=1.0.3` and
 `release-candidate=1.0.4`, or unless an idempotent rerun already has
 `latest=1.0.4` with quarantine either owned by `1.0.4` or absent. It preserves
 the package-wide concurrency group, predecessor guard, bounded registry
-confirmation, and owned-only quarantine cleanup. This exception does not
+confirmation (including ambiguous nonzero promotion results), and owned-only
+quarantine cleanup. This exception does not
 authorize missing `gitHead` for any later package version; fix the future
 publisher before cutting another npm release.
 

--- a/docs/superpowers/plans/2026-07-12-v1.0.4-npm-provenance-recovery.md
+++ b/docs/superpowers/plans/2026-07-12-v1.0.4-npm-provenance-recovery.md
@@ -1,0 +1,346 @@
+# v1.0.4 npm Provenance Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recover the already-published immutable `neondiff@1.0.4` through a protected-main GitHub Actions workflow that substitutes exact Sigstore/SLSA provenance only for the absent npm `gitHead`, then safely promotes `latest` and removes its owned quarantine tag.
+
+**Architecture:** Keep the v1.0.4 tag checkout as the sole build and pack source. Add narrowly scoped policy commands and a protected-main recovery mode; after packing, load updated policy code from a second isolated checkout pinned to the workflow SHA. A fresh cryptographically verified provenance-result file authorizes only the absent-property fallback, while explicit predecessor and quarantine guards remain before every dist-tag mutation.
+
+**Tech Stack:** GitHub Actions YAML, Node.js 26, npm 11.17.0, ESM policy scripts, Vitest, Sigstore npm provenance, `actionlint`.
+
+## Global Constraints
+
+- Recovery is scoped exactly to `v1.0.4`, package version `1.0.4`, and release commit `fc66d27b6ab9f6a1eb8282d289ef63407cd96982`.
+- Never retag, republish, unpublish, or run direct local dist-tag mutation.
+- Recovery mode must fail when the immutable npm version is absent; it cannot execute `npm publish`.
+- Only an absent `gitHead` property may use provenance. Every present malformed or mismatched value fails.
+- Exact version, shasum, integrity, npm signatures, repository, publish workflow, annotated tag, and commit remain mandatory.
+- `latest=1.0.3` requires `release-candidate=1.0.4`; `latest=1.0.4` permits quarantine `1.0.4` or absent; every other state fails before mutation.
+- Preserve `publish-npm-neondiff` concurrency, `cancel-in-progress: false`, the `npm-publish` environment, bounded convergence retry, and owned-only quarantine cleanup.
+
+---
+
+### Task 1: Bind the provenance result to every recovery identity dimension
+
+**Files:**
+- Modify: `tests/npm-provenance-policy.test.ts`
+- Modify: `scripts/lib/npm-provenance-policy.mjs`
+
+**Interfaces:**
+- Consumes: `verifyNpmProvenanceBundle(input, verifyBundle)` and its existing exact-input validation.
+- Produces: a JSON-safe result with `package`, `version`, `integrity`, `sha512`, `repository`, `workflow`, `tag`, and `commit`.
+
+- [ ] **Step 1: Write the failing result-schema test**
+
+Extend the successful assertion in `tests/npm-provenance-policy.test.ts`:
+
+```ts
+expect(result).toEqual({
+  package: "neondiff",
+  version: "1.0.4",
+  integrity,
+  sha512: createHash("sha512").update(bytes).digest("hex"),
+  repository: "electricsheephq/evaos-code-review-bot-neondiff",
+  workflow: ".github/workflows/publish-npm.yml",
+  tag: "v1.0.4",
+  commit
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+npx vitest run tests/npm-provenance-policy.test.ts --pool=forks --maxWorkers=1
+```
+
+Expected: FAIL because the current result omits `integrity`, `repository`, `workflow`, and `tag`.
+
+- [ ] **Step 3: Return the already-verified dimensions**
+
+Change only the successful return value in `scripts/lib/npm-provenance-policy.mjs`:
+
+```js
+return {
+  package: input.expectedPackage,
+  version: input.expectedVersion,
+  integrity: input.expectedIntegrity,
+  sha512: expectedSha512,
+  repository: input.expectedRepository,
+  workflow: input.expectedWorkflow,
+  tag: input.expectedTag,
+  commit: input.expectedCommit
+};
+```
+
+- [ ] **Step 4: Run the test and verify GREEN**
+
+Run the Step 2 command. Expected: PASS.
+
+### Task 2: Add strict provenance fallback and recovery-state policy
+
+**Files:**
+- Modify: `tests/npm-release-policy.test.ts`
+- Modify: `scripts/npm-release-policy.mjs`
+
+**Interfaces:**
+- Consumes: `verify-pack` arguments and the fresh JSON output from Task 1.
+- Produces:
+  - `verify-pack --verified-provenance <path> --expected-package neondiff --expected-repository <repo> --expected-workflow <path> --expected-tag v1.0.4`;
+  - `verify-recovery-dispatch` for exact protected-main v1.0.4 recovery;
+  - `verify-recovery-channels` for the pre-promotion `latest`/quarantine matrix.
+
+- [ ] **Step 1: Write failing `verify-pack` cases**
+
+Add independent cases that prove:
+
+```ts
+// Default remains strict.
+expect(runVerifyPack({ remote: exactRemoteWithoutGitHead })).toFailWith(
+  "npm gitHead is missing from published package metadata"
+);
+
+// Exact fresh verifier output permits only an absent property.
+expect(runVerifyPack({
+  remote: exactRemoteWithoutGitHead,
+  verifiedProvenance: exactProvenance
+})).toSucceedWith({ sourceIdentity: "verified_provenance_fallback" });
+
+// Every present value fails despite provenance.
+for (const gitHead of [null, "", "   ", [], {}, "2".repeat(40)]) {
+  expect(runVerifyPack({ remote: { ...exactRemote, gitHead }, verifiedProvenance: exactProvenance })).toFail();
+}
+```
+
+Add one mismatch case for each verifier dimension: package, version, integrity,
+repository, workflow, tag, and commit. Add malformed-JSON and missing-file cases.
+
+- [ ] **Step 2: Write failing dispatch and channel cases**
+
+Exercise wished-for commands with real subprocesses:
+
+```ts
+verify-recovery-dispatch \
+  --event-name workflow_dispatch \
+  --github-ref refs/heads/main \
+  --workflow-ref electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main \
+  --workflow-sha <main-sha> --github-sha <main-sha> --main-sha <main-sha> \
+  --tag v1.0.4 --package-version 1.0.4 --provenance-recovery true
+```
+
+Verify every wrong event/ref/workflow ref/SHA/tag/version/flag fails. For
+`verify-recovery-channels`, test the two allowed states and reject foreign,
+missing-required, or unrelated owners.
+
+- [ ] **Step 3: Run the tests and verify RED**
+
+```bash
+npx vitest run tests/npm-release-policy.test.ts --pool=forks --maxWorkers=1
+```
+
+Expected: FAIL because the new arguments and commands do not exist.
+
+- [ ] **Step 4: Implement the minimal policy**
+
+In `verifyPack`, use `Object.prototype.hasOwnProperty.call(remote, "gitHead")`.
+When present, require a full 40-character SHA equal to `expectedGitHead`; never
+consult provenance. When absent, keep the existing failure unless
+`--verified-provenance` exists and every Task 1 field equals the expected
+inputs and reviewed local-pack integrity.
+
+Implement `verifyRecoveryDispatch(args)` with exact v1.0.4 constants and SHA
+equality checks. Implement `verifyRecoveryChannels(args)` with this matrix:
+
+```js
+if (latest === predecessor && quarantine !== target) fail(...);
+if (latest === target && quarantine !== "" && quarantine !== target) fail(...);
+if (latest !== predecessor && latest !== target) fail(...);
+```
+
+Register both commands in the command dispatcher and include explicit JSON
+success output.
+
+- [ ] **Step 5: Run the tests and verify GREEN**
+
+Run the Step 3 command. Expected: PASS.
+
+### Task 3: Add protected-main, existing-package-only workflow recovery
+
+**Files:**
+- Modify: `tests/public-release-readiness.test.ts`
+- Create: `tests/npm-provenance-recovery.test.ts`
+- Modify: `.github/workflows/publish-npm.yml`
+
+**Interfaces:**
+- Consumes: Task 2 policy commands and Task 1 verifier result.
+- Produces: manual input `provenance_recovery` defaulting to `false`; exact v1.0.4 recovery is dispatched with `--ref main -f tag=v1.0.4 -f provenance_recovery=true`.
+
+- [ ] **Step 1: Write failing workflow choreography assertions**
+
+Require all of these strings/orderings in `tests/public-release-readiness.test.ts`:
+
+- recovery boolean input defaults false;
+- recovery calls `verify-recovery-dispatch` before package or channel mutation;
+- `github.workflow_ref` and `github.workflow_sha` are passed explicitly;
+- the exact tag remains the root checkout used for build/pack;
+- a second checkout into `.recovery-policy` is pinned to the exact workflow SHA,
+  occurs only after the reviewed tarball is packed, and has its HEAD verified;
+- recovery requires the npm version to exist and has an explicit branch that
+  cannot reach `npm publish`;
+- the verifier result is removed, recreated under `$RUNNER_TEMP`, and written
+  only by successful `verify-npm-provenance.mjs` redirection;
+- provenance verification precedes fallback `verify-pack`;
+- signature audit precedes fresh channel retrieval;
+- `verify-recovery-channels` precedes `npm dist-tag add`;
+- concurrency, environment, convergence retry, and owned cleanup remain.
+
+Create `tests/npm-provenance-recovery.test.ts` around marked workflow blocks.
+Execute the dedented recovery preflight/promotion block with a fake `npm`
+binary that records `publish`, `dist-tag add`, and `dist-tag rm`. Cover wrong
+dispatch scope, absent package, failed provenance, failed signature audit,
+foreign predecessor, foreign quarantine, successful predecessor promotion,
+and already-promoted/quarantine-absent idempotency. Every failed row must have
+an empty mutation log.
+
+- [ ] **Step 2: Run the contract test and verify RED**
+
+```bash
+npx vitest run tests/public-release-readiness.test.ts --pool=forks --maxWorkers=1
+```
+
+Expected: FAIL on the missing recovery contract.
+
+- [ ] **Step 3: Implement the guarded workflow path**
+
+Add the boolean input and expose `github.workflow_ref`/`github.workflow_sha`
+through non-secret environment fields. In the pre-code guard, preserve the
+exact-tag rules for normal release/manual events and invoke
+`verify-recovery-dispatch` for the exceptional main-ref path after fetching
+protected main.
+
+Keep tag source in the workspace root. After `npm pack` has produced and
+verified the reviewed tarball, conditionally use `actions/checkout` to place
+the exact protected-main workflow SHA under `.recovery-policy`, verify its
+HEAD, and select `.recovery-policy/scripts/npm-release-policy.mjs` only in
+recovery mode.
+
+Before the publish branch, recovery mode must perform a bounded registry read,
+require version `1.0.4`, set `PACKAGE_ALREADY_EXISTS=true`, and skip the entire
+`npm publish` branch. Fetch and verify provenance into a fresh temporary file,
+then call the selected policy script with the provenance path. Run signature
+audit, retrieve fresh dist-tags, call `verify-recovery-channels`, and only then
+allow promotion/confirmation/owned cleanup.
+
+- [ ] **Step 4: Run the workflow contract and policy suites**
+
+```bash
+npx vitest run \
+  tests/npm-release-policy.test.ts \
+  tests/npm-provenance-policy.test.ts \
+  tests/npm-provenance-recovery.test.ts \
+  tests/public-release-readiness.test.ts \
+  tests/npm-dist-tag-convergence.test.ts \
+  --pool=forks --maxWorkers=1
+```
+
+Expected: all tests PASS.
+
+### Task 4: Document the exceptional recovery and future publisher follow-up
+
+**Files:**
+- Modify: `docs/release-governance.md`
+- Modify: `docs/release-candidates/v1.0.4.json`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: the exact workflow input from Task 3.
+- Produces: a paste-safe operator command and truthful quarantined-release ledger.
+
+- [ ] **Step 1: Add failing documentation assertions**
+
+Update the recovery assertions in `tests/public-release-readiness.test.ts` to
+require:
+
+```bash
+gh workflow run publish-npm.yml \
+  --repo electricsheephq/evaos-code-review-bot-neondiff \
+  --ref main \
+  -f tag=v1.0.4 \
+  -f provenance_recovery=true
+```
+
+Require explicit text that this exception is v1.0.4-only, does not publish,
+and does not authorize direct dist-tag commands.
+
+- [ ] **Step 2: Run the documentation contract and verify RED**
+
+Run the Task 3 Step 2 command. Expected: FAIL because the current runbook says
+`--ref v<version>` only.
+
+- [ ] **Step 3: Update governance and release truth**
+
+Preserve the normal exact-tag rerun instructions. Add a separate v1.0.4
+provenance-recovery subsection with the exact command, guards, and proof
+boundary. Record run 29185873762 as immutable publication with promotion
+blocked by absent `gitHead`; keep `latest`, public-install, and cleanup claims
+pending. Add a concise changelog entry linking #542.
+
+- [ ] **Step 4: Run the documentation contract and verify GREEN**
+
+Run the Task 3 Step 2 command. Expected: PASS.
+
+### Task 5: Verify, review, and publish the recovery PR
+
+**Files:**
+- Verify all files changed in Tasks 1-4.
+
+**Interfaces:**
+- Consumes: complete recovery diff.
+- Produces: exact-head PR evidence safe for the sole maintainer to merge.
+
+- [ ] **Step 1: Run focused and full local validation**
+
+```bash
+pwd
+npm run build
+npx vitest run \
+  tests/npm-release-policy.test.ts \
+  tests/npm-provenance-policy.test.ts \
+  tests/npm-provenance-recovery.test.ts \
+  tests/public-release-readiness.test.ts \
+  tests/npm-dist-tag-convergence.test.ts \
+  --pool=forks --maxWorkers=1
+npx actionlint .github/workflows/publish-npm.yml
+npm run check:public-claims
+npm run check:secrets
+git diff --check
+```
+
+Expected: every command exits zero with no secret/public-claim findings.
+
+- [ ] **Step 2: Request independent exact-diff review**
+
+Require one independent security review and one independent spec review. Both
+must inspect the command ordering, no-publish branch, tag/main checkout split,
+provenance fallback, predecessor/quarantine matrix, and workflow dispatch
+scope.
+
+- [ ] **Step 3: Push and open the issue-linked PR**
+
+Push `codex/542-npm-provenance-recovery`, open a PR linking `#542` and `#532`,
+and include current live npm quarantine truth. Do not dispatch recovery yet.
+
+- [ ] **Step 4: Shepherd exact-head checks and merge**
+
+Wait for CI, CodeQL, Swift impact gate, Socket, evaOS, review comments, and all
+review threads. Resolve every actionable current-head finding and merge only
+when the exact head is clean.
+
+- [ ] **Step 5: Dispatch and verify recovery**
+
+From merged protected main, run only the documented workflow command. Verify
+the run reports no publish, exact provenance fallback, `latest=1.0.4`, and
+owned quarantine removal. Then independently re-verify npm bytes, signatures,
+provenance, GitHub Release/tag identity, and isolated installed behavior before
+starting the post-release stamp or predecessor cleanup.

--- a/docs/superpowers/plans/2026-07-12-v1.0.4-npm-provenance-recovery.md
+++ b/docs/superpowers/plans/2026-07-12-v1.0.4-npm-provenance-recovery.md
@@ -87,8 +87,8 @@ Run the Step 2 command. Expected: PASS.
 **Interfaces:**
 - Consumes: `verify-pack` arguments and the fresh JSON output from Task 1.
 - Produces:
-  - `verify-pack --verified-provenance <path> --expected-package neondiff --expected-repository <repo> --expected-workflow <path> --expected-tag v1.0.4`;
-  - `verify-recovery-dispatch` for exact protected-main v1.0.4 recovery;
+  - `verify-pack --verified-provenance <path> --recovery-proof <path> --expected-package neondiff --expected-repository <repo> --expected-workflow <path> --expected-tag v1.0.4`;
+  - `verify-recovery-dispatch --proof-output <path>` for exact protected-main v1.0.4 recovery;
   - `verify-recovery-channels` for the pre-promotion `latest`/quarantine matrix.
 
 - [ ] **Step 1: Write failing `verify-pack` cases**
@@ -101,10 +101,11 @@ expect(runVerifyPack({ remote: exactRemoteWithoutGitHead })).toFailWith(
   "npm gitHead is missing from published package metadata"
 );
 
-// Exact fresh verifier output permits only an absent property.
+// Exact fresh verifier output plus a successful recovery-dispatch proof permits only an absent property.
 expect(runVerifyPack({
   remote: exactRemoteWithoutGitHead,
-  verifiedProvenance: exactProvenance
+  verifiedProvenance: exactProvenance,
+  recoveryProof: exactRecoveryProof
 })).toSucceedWith({ sourceIdentity: "verified_provenance_fallback" });
 
 // Every present value fails despite provenance.
@@ -126,7 +127,9 @@ verify-recovery-dispatch \
   --github-ref refs/heads/main \
   --workflow-ref electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main \
   --workflow-sha <main-sha> --github-sha <main-sha> --main-sha <main-sha> \
-  --tag v1.0.4 --package-version 1.0.4 --provenance-recovery true
+  --tag v1.0.4 --tag-commit fc66d27b6ab9f6a1eb8282d289ef63407cd96982 \
+  --package-version 1.0.4 --provenance-recovery true \
+  --release-valid true --package-exists true --proof-output <fresh-path>
 ```
 
 Verify every wrong event/ref/workflow ref/SHA/tag/version/flag fails. For
@@ -182,6 +185,10 @@ Require all of these strings/orderings in `tests/public-release-readiness.test.t
 
 - recovery boolean input defaults false;
 - recovery calls `verify-recovery-dispatch` before package or channel mutation;
+- recovery re-fetches protected main beside the dispatch gate and again before
+  dist-tag promotion, failing closed if either head differs from the dispatch SHA;
+- successful dispatch validation exclusively creates a fresh proof under
+  `$RUNNER_TEMP`, and the missing-`gitHead` fallback requires that exact proof;
 - `github.workflow_ref` and `github.workflow_sha` are passed explicitly;
 - the exact tag remains the root checkout used for build/pack;
 - a second checkout into `.recovery-policy` is pinned to the exact workflow SHA,
@@ -217,7 +224,10 @@ Add the boolean input and expose `github.workflow_ref`/`github.workflow_sha`
 through non-secret environment fields. In the pre-code guard, preserve the
 exact-tag rules for normal release/manual events and invoke
 `verify-recovery-dispatch` for the exceptional main-ref path after fetching
-protected main.
+protected main. Write its validated result exclusively to a fresh recovery
+proof file and pass that proof to `verify-pack` for the v1.0.4-only missing-
+`gitHead` fallback. Re-fetch protected main once more immediately before the
+pre-promotion channel guard and refuse all dist-tag mutation if main advanced.
 
 Keep tag source in the workspace root. After `npm pack` has produced and
 verified the reviewed tarball, conditionally use `actions/checkout` to place

--- a/docs/superpowers/plans/2026-07-12-v1.0.4-npm-provenance-recovery.md
+++ b/docs/superpowers/plans/2026-07-12-v1.0.4-npm-provenance-recovery.md
@@ -189,6 +189,8 @@ Require all of these strings/orderings in `tests/public-release-readiness.test.t
   dist-tag promotion, failing closed if either head differs from the dispatch SHA;
 - successful dispatch validation exclusively creates a fresh proof under
   `$RUNNER_TEMP`, and the missing-`gitHead` fallback requires that exact proof;
+- normal releases omit the recovery-proof argument entirely, and the
+  protected-main backstop checks both the event ref and workflow ref;
 - `github.workflow_ref` and `github.workflow_sha` are passed explicitly;
 - the exact tag remains the root checkout used for build/pack;
 - a second checkout into `.recovery-policy` is pinned to the exact workflow SHA,
@@ -200,6 +202,10 @@ Require all of these strings/orderings in `tests/public-release-readiness.test.t
 - provenance verification precedes fallback `verify-pack`;
 - signature audit precedes fresh channel retrieval;
 - `verify-recovery-channels` precedes `npm dist-tag add`;
+- ambiguous recovery promotion logs preserve the command exit code before
+  bounded registry confirmation;
+- the pre-recovery ledger names its required post-recovery transition and
+  cannot be treated as final release truth;
 - concurrency, environment, convergence retry, and owned cleanup remain.
 
 Create `tests/npm-provenance-recovery.test.ts` around marked workflow blocks.

--- a/docs/superpowers/specs/2026-07-12-v1.0.4-npm-provenance-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-12-v1.0.4-npm-provenance-recovery-design.md
@@ -1,6 +1,6 @@
 # v1.0.4 npm Provenance Recovery Design
 
-Issue: [#542](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/542)  
+Issue: [#542](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/542)
 Parent release blocker: [#532](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/532)
 
 ## Context
@@ -110,16 +110,18 @@ remains `publish-npm-neondiff` with cancellation disabled.
 5. Remove any previous verifier-result path, cryptographically verify package,
    integrity, repository, workflow, tag, and release commit, and write only the
    fresh redacted verifier result under `$RUNNER_TEMP`.
-6. Verify npm version, shasum, integrity, and either exact `gitHead` or the
+6. Run npm signature audit.
+7. Verify npm version, shasum, integrity, and either exact `gitHead` or the
    matching verified-provenance record.
-7. Run npm signature audit.
 8. Re-read `latest` and `release-candidate`. When `latest=1.0.3`, require
    `release-candidate=1.0.4`. When `latest=1.0.4`, allow quarantine to be either
    `1.0.4` or absent for idempotent recovery. Any other ownership fails before
    mutation.
 9. Require `latest` to be either the manifest predecessor or the target, then
-   promote through the workflow when needed.
-10. Retry registry reads until `latest=1.0.4` is confirmed.
+   attempt promotion through the workflow when needed. Treat a nonzero
+   promotion command as ambiguous because the registry may have accepted it.
+10. Retry registry reads until `latest=1.0.4` is confirmed; the observed
+    registry state, not the promotion command exit alone, decides the outcome.
 11. Remove `release-candidate` only if it still owns `1.0.4`, and record any
     cleanup uncertainty without undoing a confirmed promotion.
 
@@ -130,7 +132,9 @@ ownership, unexpected quarantine ownership, missing package bytes, bad
 provenance, signature failure, a stale protected-main dispatch, an absent npm
 version, any present malformed `gitHead`, or any SHA mismatch prevents
 promotion. A failed recovery leaves `latest` on its predecessor and the
-package quarantined.
+package quarantined. If a promotion command returns nonzero, bounded reads
+either confirm the accepted mutation and continue owned cleanup or fail without
+assuming that the registry changed.
 
 ## Test Strategy
 
@@ -140,9 +144,9 @@ package quarantined.
   provenance file.
 - Workflow contract tests prove protected-main fallback gating, exact main SHA
   and workflow-ref binding, exact-v1.0.4 scoping, existing-package-only
-  behavior, isolated updated-policy loading, provenance verification before
-  fallback, promotion after all verification, concurrency, predecessor and
-  pre-promotion quarantine guards, and owned quarantine cleanup.
+  behavior, isolated updated-policy loading, provenance and signature
+  verification before fallback, promotion after all verification, concurrency,
+  predecessor and pre-promotion quarantine guards, and owned quarantine cleanup.
 - A command-log integration fixture proves every failed recovery gate performs
   no `npm publish`, `npm dist-tag add`, or `npm dist-tag rm` operation.
 - Existing provenance, public-release readiness, and dist-tag convergence tests

--- a/docs/superpowers/specs/2026-07-12-v1.0.4-npm-provenance-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-12-v1.0.4-npm-provenance-recovery-design.md
@@ -92,6 +92,11 @@ from the exact release tag. The exceptional fallback is allowed only when:
 8. the matching non-draft GitHub Release already exists;
 9. `neondiff@1.0.4` already exists, so this path cannot publish a new package.
 
+Successful dispatch validation exclusively writes a fresh, exact recovery
+proof under `$RUNNER_TEMP`. The exceptional missing-`gitHead` branch requires
+that proof in addition to the verified provenance record; provenance alone is
+never sufficient.
+
 The job still checks out the exact tag for build and package reproduction. It
 loads the updated release-policy script through a second isolated checkout
 pinned to the exact protected-main workflow SHA; it never overwrites tag-root
@@ -100,8 +105,9 @@ remains `publish-npm-neondiff` with cancellation disabled.
 
 ## Ordered Data Flow
 
-1. Verify the dispatch/ref, protected-main SHA, annotated tag, candidate
-   ancestry, and GitHub Release.
+1. Verify the dispatch/ref, protected-main SHA, annotated tag, and candidate
+   ancestry, then independently re-fetch and validate the exact non-draft,
+   non-prerelease GitHub Release adjacent to the recovery policy gate.
 2. Rebuild and repack the exact tag source; reproduce the reviewed shasum and
    integrity.
 3. Require the immutable npm version to exist; never call `npm publish` in
@@ -111,15 +117,17 @@ remains `publish-npm-neondiff` with cancellation disabled.
    integrity, repository, workflow, tag, and release commit, and write only the
    fresh redacted verifier result under `$RUNNER_TEMP`.
 6. Run npm signature audit.
-7. Verify npm version, shasum, integrity, and either exact `gitHead` or the
-   matching verified-provenance record.
+7. Verify npm version, shasum, integrity, and either exact `gitHead` or both
+   the matching verified-provenance record and exact recovery-dispatch proof.
 8. Re-read `latest` and `release-candidate`. When `latest=1.0.3`, require
    `release-candidate=1.0.4`. When `latest=1.0.4`, allow quarantine to be either
    `1.0.4` or absent for idempotent recovery. Any other ownership fails before
    mutation.
-9. Require `latest` to be either the manifest predecessor or the target, then
-   attempt promotion through the workflow when needed. Treat a nonzero
-   promotion command as ambiguous because the registry may have accepted it.
+9. Re-fetch protected main immediately before promotion, require it still to
+   equal the dispatch SHA, require `latest` to be either the manifest
+   predecessor or the target, then attempt promotion through the workflow
+   when needed. Treat a nonzero promotion command as ambiguous because the
+   registry may have accepted it.
 10. Retry registry reads until `latest=1.0.4` is confirmed; the observed
     registry state, not the promotion command exit alone, decides the outcome.
 11. Remove `release-candidate` only if it still owns `1.0.4`, and record any
@@ -138,10 +146,10 @@ assuming that the registry changed.
 
 ## Test Strategy
 
-- Unit tests prove default missing-`gitHead` rejection, exact provenance
-  fallback acceptance, malformed or mismatched provenance rejection, and
-  rejection of every present malformed or mismatched value despite a
-  provenance file.
+- Unit tests prove default missing-`gitHead` rejection, exact provenance plus
+  recovery-proof fallback acceptance, missing/malformed/mismatched recovery
+  proof rejection, malformed or mismatched provenance rejection, and rejection
+  of every present malformed or mismatched value despite a provenance file.
 - Workflow contract tests prove protected-main fallback gating, exact main SHA
   and workflow-ref binding, exact-v1.0.4 scoping, existing-package-only
   behavior, isolated updated-policy loading, provenance and signature

--- a/docs/superpowers/specs/2026-07-12-v1.0.4-npm-provenance-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-12-v1.0.4-npm-provenance-recovery-design.md
@@ -1,0 +1,162 @@
+# v1.0.4 npm Provenance Recovery Design
+
+Issue: [#542](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/542)  
+Parent release blocker: [#532](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/532)
+
+## Context
+
+The release-triggered publish workflow built and verified the reviewed v1.0.4
+tarball, then successfully published `neondiff@1.0.4` under the
+`release-candidate` quarantine tag. The package has the expected shasum,
+integrity, npm signatures, and Sigstore/SLSA provenance for annotated tag
+`v1.0.4` and release commit
+`fc66d27b6ab9f6a1eb8282d289ef63407cd96982`.
+
+Promotion stopped because the npm version metadata has no `gitHead`. The
+hardened workflow publishes an already-reviewed `.tgz` with npm 11.17.0. npm
+therefore obtains the publish manifest from the archive, which does not carry
+Git checkout metadata. The former directory-publish path derived `gitHead`
+from the checkout. The published version is immutable and cannot be
+republished to add the omitted field.
+
+Current safe state:
+
+- `latest=1.0.3`;
+- `release-candidate=1.0.4`;
+- the v1.0.4 GitHub Release is published and non-prerelease;
+- predecessor cleanup has not started.
+
+## Options Considered
+
+### 1. Exact-provenance fallback and workflow-only recovery (selected)
+
+Permit absent `gitHead` only when the same recovery run has already verified
+the exact package bytes and cryptographic npm provenance for the expected
+repository, publish workflow, annotated tag, and release commit. Run the
+updated recovery policy from protected `main`, while checking out and building
+the immutable tag source.
+
+This preserves the reviewed tarball, avoids a second publication, and uses a
+stronger source binding than unsigned registry metadata.
+
+### 2. Abandon v1.0.4 and publish v1.0.5
+
+Patch the publishing path, regenerate lifecycle proof, and release a new
+version. This remains the fallback if the v1.0.4 provenance cannot be verified,
+but it is unnecessary while the existing signed provenance and exact bytes are
+valid. It would also leave an avoidable quarantined/yanked version behind.
+
+### 3. Directly edit registry metadata or dist-tags (rejected)
+
+Direct registry mutation cannot safely repair immutable version metadata and
+would bypass the workflow-only recovery, predecessor guard, and quarantine
+ownership rules. Retagging, republishing, unpublishing, and direct dist-tag
+commands remain prohibited.
+
+## Recovery Contract
+
+The default policy remains strict: when an expected Git commit is supplied,
+missing `gitHead` fails. The only exception is the already-published v1.0.4
+recovery. Its provenance fallback is opt-in and accepts a fresh path under
+`$RUNNER_TEMP` containing the JSON output produced by
+`verify-npm-provenance.mjs` only after that command has returned successfully.
+
+For a missing `gitHead`, the release policy must require the verified
+provenance record to match all of these values:
+
+- package version;
+- reviewed SHA-512 integrity;
+- repository;
+- publish workflow path;
+- annotated release tag;
+- annotated release tag commit.
+
+Only an absent object property counts as missing `gitHead`. A present empty
+string, whitespace, `null`, object, array, or mismatched SHA always fails, even
+when a provenance record is supplied. Integrity, shasum, version, provenance,
+and npm signature checks remain mandatory.
+
+## Protected-main Recovery Dispatch
+
+Normal release events and normal manual retries continue to require execution
+from the exact release tag. The exceptional fallback is allowed only when:
+
+1. the event is `workflow_dispatch`;
+2. the workflow ref is protected `main`;
+3. an explicit provenance-recovery input is true;
+4. the requested tag and package version are exactly `v1.0.4` and `1.0.4`;
+5. `GITHUB_WORKFLOW_REF` identifies `publish-npm.yml` on `refs/heads/main`;
+6. the workflow's `GITHUB_SHA` is exactly the fetched `origin/main` head;
+7. the requested tag is annotated, peels to protected-main ancestry, and
+   contains the declared candidate ancestor;
+8. the matching non-draft GitHub Release already exists;
+9. `neondiff@1.0.4` already exists, so this path cannot publish a new package.
+
+The job still checks out the exact tag for build and package reproduction. It
+loads the updated release-policy script through a second isolated checkout
+pinned to the exact protected-main workflow SHA; it never overwrites tag-root
+files or changes the tag-root build/pack inputs. Package-wide concurrency
+remains `publish-npm-neondiff` with cancellation disabled.
+
+## Ordered Data Flow
+
+1. Verify the dispatch/ref, protected-main SHA, annotated tag, candidate
+   ancestry, and GitHub Release.
+2. Rebuild and repack the exact tag source; reproduce the reviewed shasum and
+   integrity.
+3. Require the immutable npm version to exist; never call `npm publish` in
+   provenance-recovery mode.
+4. Fetch npm version metadata and the attestation bundle.
+5. Remove any previous verifier-result path, cryptographically verify package,
+   integrity, repository, workflow, tag, and release commit, and write only the
+   fresh redacted verifier result under `$RUNNER_TEMP`.
+6. Verify npm version, shasum, integrity, and either exact `gitHead` or the
+   matching verified-provenance record.
+7. Run npm signature audit.
+8. Re-read `latest` and `release-candidate`. When `latest=1.0.3`, require
+   `release-candidate=1.0.4`. When `latest=1.0.4`, allow quarantine to be either
+   `1.0.4` or absent for idempotent recovery. Any other ownership fails before
+   mutation.
+9. Require `latest` to be either the manifest predecessor or the target, then
+   promote through the workflow when needed.
+10. Retry registry reads until `latest=1.0.4` is confirmed.
+11. Remove `release-candidate` only if it still owns `1.0.4`, and record any
+    cleanup uncertainty without undoing a confirmed promotion.
+
+## Failure Behavior
+
+Every validation before promotion is fail-closed. Unexpected `latest`
+ownership, unexpected quarantine ownership, missing package bytes, bad
+provenance, signature failure, a stale protected-main dispatch, an absent npm
+version, any present malformed `gitHead`, or any SHA mismatch prevents
+promotion. A failed recovery leaves `latest` on its predecessor and the
+package quarantined.
+
+## Test Strategy
+
+- Unit tests prove default missing-`gitHead` rejection, exact provenance
+  fallback acceptance, malformed or mismatched provenance rejection, and
+  rejection of every present malformed or mismatched value despite a
+  provenance file.
+- Workflow contract tests prove protected-main fallback gating, exact main SHA
+  and workflow-ref binding, exact-v1.0.4 scoping, existing-package-only
+  behavior, isolated updated-policy loading, provenance verification before
+  fallback, promotion after all verification, concurrency, predecessor and
+  pre-promotion quarantine guards, and owned quarantine cleanup.
+- A command-log integration fixture proves every failed recovery gate performs
+  no `npm publish`, `npm dist-tag add`, or `npm dist-tag rm` operation.
+- Existing provenance, public-release readiness, and dist-tag convergence tests
+  remain green.
+- Local build, focused tests, full CI, actionlint, public-claims scan, and secret
+  scan are required before dispatch.
+
+## Completion Boundary
+
+The recovery is complete only when a reviewed workflow run succeeds without a
+second publish, npm reports `latest=1.0.4`, the owned `release-candidate` tag is
+absent, immutable bytes/signatures/provenance re-verify, and an isolated public
+install plus activation/no-bypass/dashboard smoke passes. Predecessor cleanup
+and the post-release manifest stamp remain separate follow-up gates.
+
+The owner explicitly delegated sole-maintainer release decisions and autonomous
+execution for this lane; that directive approves the selected bounded design.

--- a/docs/superpowers/specs/2026-07-12-v1.0.4-npm-provenance-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-12-v1.0.4-npm-provenance-recovery-design.md
@@ -132,6 +132,9 @@ remains `publish-npm-neondiff` with cancellation disabled.
     registry state, not the promotion command exit alone, decides the outcome.
 11. Remove `release-candidate` only if it still owns `1.0.4`, and record any
     cleanup uncertainty without undoing a confirmed promotion.
+12. Land a post-recovery stamp that replaces the candidate ledger's
+    `pre_recovery` phase with the successful workflow URL and converged npm
+    channel truth before closing the activation release blocker.
 
 ## Failure Behavior
 

--- a/scripts/lib/npm-provenance-policy.mjs
+++ b/scripts/lib/npm-provenance-policy.mjs
@@ -31,5 +31,14 @@ export async function verifyNpmProvenanceBundle(input, verifyBundle) {
   if (dependency?.uri !== `git+https://github.com/${input.expectedRepository}@refs/tags/${input.expectedTag}`) {
     throw new Error("provenance resolved dependency does not match the release tag");
   }
-  return { package: input.expectedPackage, version: input.expectedVersion, commit: input.expectedCommit, sha512: expectedSha512 };
+  return {
+    package: input.expectedPackage,
+    version: input.expectedVersion,
+    integrity: input.expectedIntegrity,
+    sha512: expectedSha512,
+    repository: input.expectedRepository,
+    workflow: input.expectedWorkflow,
+    tag: input.expectedTag,
+    commit: input.expectedCommit
+  };
 }

--- a/scripts/npm-release-policy.mjs
+++ b/scripts/npm-release-policy.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { appendFileSync, readFileSync } from "node:fs";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 
 const V104_PROVENANCE_RECOVERY = Object.freeze({
@@ -201,6 +201,38 @@ function verifyPack(args) {
       ) {
         fail("verified npm provenance fallback is scoped only to the v1.0.4 recovery");
       }
+      const recoveryProofPath = args.get("recovery-proof");
+      if (!recoveryProofPath) {
+        fail("npm gitHead fallback requires a protected-main recovery dispatch proof");
+      }
+      let recoveryProof;
+      try {
+        recoveryProof = JSON.parse(readFileSync(recoveryProofPath, "utf8"));
+      } catch {
+        fail("recovery dispatch proof is not valid JSON");
+      }
+      if (
+        recoveryProof?.schemaVersion !== 1
+        || recoveryProof?.kind !== "neondiff.npm.provenance-recovery-dispatch"
+        || recoveryProof?.eventName !== "workflow_dispatch"
+        || recoveryProof?.githubRef !== "refs/heads/main"
+        || recoveryProof?.workflowRef !== V104_PROVENANCE_RECOVERY.workflowRef
+        || typeof recoveryProof?.githubSha !== "string"
+        || !/^[0-9a-f]{40}$/.test(recoveryProof.githubSha)
+        || recoveryProof?.workflowSha !== recoveryProof.githubSha
+        || recoveryProof?.mainSha !== recoveryProof.githubSha
+        || recoveryProof?.package !== expectedPackage
+        || recoveryProof?.repository !== expectedRepository
+        || recoveryProof?.workflow !== expectedWorkflow
+        || recoveryProof?.tag !== expectedTag
+        || recoveryProof?.tagCommit !== expectedGitHead
+        || recoveryProof?.packageVersion !== expectedVersion
+        || recoveryProof?.provenanceRecovery !== true
+        || recoveryProof?.releaseValid !== true
+        || recoveryProof?.packageExists !== true
+      ) {
+        fail("recovery dispatch proof does not match the exact protected-main v1.0.4 recovery");
+      }
       let provenance;
       try {
         provenance = JSON.parse(readFileSync(provenancePath, "utf8"));
@@ -266,16 +298,32 @@ function verifyRecoveryDispatch(args) {
   }
   if (!releaseValid) fail("provenance recovery requires the existing published GitHub Release");
   if (!packageExists) fail("provenance recovery requires the immutable npm package to already exist");
-  console.log(JSON.stringify({
+  const proof = {
+    schemaVersion: 1,
+    kind: "neondiff.npm.provenance-recovery-dispatch",
     eventName,
     githubRef,
     workflowRef,
     workflowSha,
+    githubSha,
+    mainSha,
+    package: V104_PROVENANCE_RECOVERY.package,
+    repository: V104_PROVENANCE_RECOVERY.repository,
+    workflow: V104_PROVENANCE_RECOVERY.workflow,
     tag,
     tagCommit,
     packageVersion,
+    provenanceRecovery,
+    releaseValid,
     packageExists
-  }));
+  };
+  const proofOutput = required(args, "proof-output");
+  try {
+    writeFileSync(proofOutput, `${JSON.stringify(proof)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+  } catch {
+    fail("provenance recovery dispatch proof could not be written exclusively");
+  }
+  console.log(JSON.stringify(proof));
 }
 
 function verifyRecoveryChannels(args) {

--- a/scripts/npm-release-policy.mjs
+++ b/scripts/npm-release-policy.mjs
@@ -3,6 +3,17 @@
 import { appendFileSync, readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 
+const V104_PROVENANCE_RECOVERY = Object.freeze({
+  package: "neondiff",
+  version: "1.0.4",
+  repository: "electricsheephq/evaos-code-review-bot-neondiff",
+  workflow: ".github/workflows/publish-npm.yml",
+  workflowRef: "electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main",
+  tag: "v1.0.4",
+  commit: "fc66d27b6ab9f6a1eb8282d289ef63407cd96982",
+  predecessor: "1.0.3"
+});
+
 function fail(message) {
   console.error(message);
   process.exit(1);
@@ -163,19 +174,141 @@ function verifyPack(args) {
   if (!localPack.shasum || localPack.shasum !== remote["dist.shasum"]) {
     fail("npm tarball shasum does not match the reviewed pack");
   }
+  let sourceIdentity = "reviewed_tarball";
   if (expectedGitHead) {
-    if (typeof remote.gitHead !== "string" || remote.gitHead.length === 0) {
-      fail("npm gitHead is missing from published package metadata");
-    }
-    if (remote.gitHead !== expectedGitHead) {
-      fail("npm gitHead does not match the reviewed release tag commit");
+    if (Object.prototype.hasOwnProperty.call(remote, "gitHead")) {
+      if (typeof remote.gitHead !== "string" || !/^[0-9a-f]{40}$/.test(remote.gitHead)) {
+        fail("npm gitHead is malformed in published package metadata");
+      }
+      if (remote.gitHead !== expectedGitHead) {
+        fail("npm gitHead does not match the reviewed release tag commit");
+      }
+      sourceIdentity = "registry_git_head";
+    } else {
+      const provenancePath = args.get("verified-provenance");
+      if (!provenancePath) fail("npm gitHead is missing from published package metadata");
+      const expectedPackage = required(args, "expected-package");
+      const expectedRepository = required(args, "expected-repository");
+      const expectedWorkflow = required(args, "expected-workflow");
+      const expectedTag = required(args, "expected-tag");
+      if (
+        expectedPackage !== V104_PROVENANCE_RECOVERY.package
+        || expectedVersion !== V104_PROVENANCE_RECOVERY.version
+        || expectedRepository !== V104_PROVENANCE_RECOVERY.repository
+        || expectedWorkflow !== V104_PROVENANCE_RECOVERY.workflow
+        || expectedTag !== V104_PROVENANCE_RECOVERY.tag
+        || expectedGitHead !== V104_PROVENANCE_RECOVERY.commit
+      ) {
+        fail("verified npm provenance fallback is scoped only to the v1.0.4 recovery");
+      }
+      let provenance;
+      try {
+        provenance = JSON.parse(readFileSync(provenancePath, "utf8"));
+      } catch {
+        fail("verified npm provenance is not valid JSON");
+      }
+      const expectedSha512 = localPack.integrity.startsWith("sha512-")
+        ? Buffer.from(localPack.integrity.slice("sha512-".length), "base64").toString("hex")
+        : "";
+      if (
+        provenance?.package !== expectedPackage
+        || provenance?.version !== expectedVersion
+        || provenance?.integrity !== localPack.integrity
+        || provenance?.sha512 !== expectedSha512
+        || provenance?.repository !== expectedRepository
+        || provenance?.workflow !== expectedWorkflow
+        || provenance?.tag !== expectedTag
+        || provenance?.commit !== expectedGitHead
+      ) {
+        fail("verified npm provenance does not match the reviewed release");
+      }
+      sourceIdentity = "verified_provenance_fallback";
     }
   }
   console.log(JSON.stringify({
     version: expectedVersion,
     integrity: localPack.integrity,
     shasum: localPack.shasum,
-    gitHead: remote.gitHead
+    ...(Object.prototype.hasOwnProperty.call(remote, "gitHead") ? { gitHead: remote.gitHead } : {}),
+    sourceIdentity
+  }));
+}
+
+function verifyRecoveryDispatch(args) {
+  const eventName = required(args, "event-name");
+  const githubRef = required(args, "github-ref");
+  const workflowRef = required(args, "workflow-ref");
+  const workflowSha = required(args, "workflow-sha");
+  const githubSha = required(args, "github-sha");
+  const mainSha = required(args, "main-sha");
+  const tag = required(args, "tag");
+  const tagCommit = required(args, "tag-commit");
+  const packageVersion = required(args, "package-version");
+  const provenanceRecovery = parseBoolean(required(args, "provenance-recovery"), "provenance-recovery");
+  const releaseValid = parseBoolean(required(args, "release-valid"), "release-valid");
+  const packageExists = parseBoolean(required(args, "package-exists"), "package-exists");
+
+  if (eventName !== "workflow_dispatch" || githubRef !== "refs/heads/main" || !provenanceRecovery) {
+    fail("provenance recovery requires an explicit protected-main workflow dispatch");
+  }
+  if (workflowRef !== V104_PROVENANCE_RECOVERY.workflowRef) {
+    fail("provenance recovery workflow ref must be publish-npm.yml on protected main");
+  }
+  if (!/^[0-9a-f]{40}$/.test(githubSha) || workflowSha !== githubSha || mainSha !== githubSha) {
+    fail("provenance recovery workflow and protected-main SHAs must match exactly");
+  }
+  if (
+    tag !== V104_PROVENANCE_RECOVERY.tag
+    || packageVersion !== V104_PROVENANCE_RECOVERY.version
+    || tagCommit !== V104_PROVENANCE_RECOVERY.commit
+  ) {
+    fail("provenance recovery is scoped only to the exact v1.0.4 release commit");
+  }
+  if (!releaseValid) fail("provenance recovery requires the existing published GitHub Release");
+  if (!packageExists) fail("provenance recovery requires the immutable npm package to already exist");
+  console.log(JSON.stringify({
+    eventName,
+    githubRef,
+    workflowRef,
+    workflowSha,
+    tag,
+    tagCommit,
+    packageVersion,
+    packageExists
+  }));
+}
+
+function verifyRecoveryChannels(args) {
+  const latestVersion = required(args, "latest-version");
+  const quarantineVersion = args.get("quarantine-version") ?? "";
+  const targetVersion = required(args, "target-version");
+  const expectedPredecessor = required(args, "expected-predecessor");
+  if (
+    targetVersion !== V104_PROVENANCE_RECOVERY.version
+    || expectedPredecessor !== V104_PROVENANCE_RECOVERY.predecessor
+  ) {
+    fail("provenance recovery channels are scoped only to v1.0.4 and its v1.0.3 predecessor");
+  }
+  let action;
+  if (latestVersion === expectedPredecessor) {
+    if (quarantineVersion !== targetVersion) {
+      fail("v1.0.4 recovery requires the target to own release-candidate before promotion");
+    }
+    action = "promote";
+  } else if (latestVersion === targetVersion) {
+    if (quarantineVersion !== "" && quarantineVersion !== targetVersion) {
+      fail("v1.0.4 recovery refuses unexpected release-candidate ownership");
+    }
+    action = quarantineVersion === targetVersion ? "confirm_and_cleanup" : "confirmed";
+  } else {
+    fail("v1.0.4 recovery refuses unexpected latest ownership");
+  }
+  console.log(JSON.stringify({
+    latestVersion,
+    quarantineVersion,
+    targetVersion,
+    expectedPredecessor,
+    action
   }));
 }
 
@@ -206,4 +339,6 @@ if (command === "classify") classify(args);
 else if (command === "verify-git") verifyGit(args);
 else if (command === "verify-pack") verifyPack(args);
 else if (command === "verify-channel") verifyChannel(args);
-else fail("command must be classify, verify-git, verify-pack, or verify-channel");
+else if (command === "verify-recovery-dispatch") verifyRecoveryDispatch(args);
+else if (command === "verify-recovery-channels") verifyRecoveryChannels(args);
+else fail("command must be classify, verify-git, verify-pack, verify-channel, verify-recovery-dispatch, or verify-recovery-channels");

--- a/tests/npm-provenance-policy.test.ts
+++ b/tests/npm-provenance-policy.test.ts
@@ -58,7 +58,16 @@ describe("npm provenance policy", () => {
       expectedCommit: commit
     }, async (bundle) => { verifiedBundle = bundle; return {} as never; });
     expect(verifiedBundle).toBe(document.attestations[0].bundle);
-    expect(result.commit).toBe(commit);
+    expect(result).toEqual({
+      package: "neondiff",
+      version: "1.0.4",
+      integrity,
+      sha512: createHash("sha512").update(bytes).digest("hex"),
+      repository: "electricsheephq/evaos-code-review-bot-neondiff",
+      workflow: ".github/workflows/publish-npm.yml",
+      tag: "v1.0.4",
+      commit
+    });
 
     await expect(verifyNpmProvenanceBundle({
       document,

--- a/tests/npm-provenance-recovery.test.ts
+++ b/tests/npm-provenance-recovery.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -40,6 +40,212 @@ describe("v1.0.4 npm provenance recovery workflow", () => {
     writeFileSync(npm, `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "$NPM_MUTATION_LOG"\n`, { mode: 0o700 });
     chmodSync(npm, 0o700);
     return { root, bin, log };
+  }
+
+  function orchestrationHarness(initialLatest = "1.0.3", initialQuarantine = "1.0.4") {
+    const { root, bin, log } = harness();
+    const integrity = `sha512-${Buffer.from("reviewed-v1.0.4-tarball").toString("base64")}`;
+    const sha512 = Buffer.from(integrity.slice("sha512-".length), "base64").toString("hex");
+    const shasum = "1".repeat(40);
+    const releaseCommit = "fc66d27b6ab9f6a1eb8282d289ef63407cd96982";
+    const mainSha = "a".repeat(40);
+    const candidateHead = "42db7c8ff7dba6ceac813238dcebfb54dc83851f";
+    const policyScript = resolve("scripts/npm-release-policy.mjs");
+    mkdirSync(join(root, "scripts"), { recursive: true });
+    mkdirSync(join(root, ".recovery-policy", "scripts"), { recursive: true });
+    mkdirSync(join(root, "docs"), { recursive: true });
+    mkdirSync(join(root, "evidence"), { recursive: true });
+    mkdirSync(join(root, "neondiff-reviewed-pack"), { recursive: true });
+    writeFileSync(join(root, "package.json"), JSON.stringify({ version: "1.0.4" }));
+    writeFileSync(join(root, "pack.json"), JSON.stringify([{ version: "1.0.4", integrity, shasum }]));
+    const evidenceKinds = [
+      "production-lifecycle",
+      "no-bypass-matrix",
+      "useful-work-boundaries",
+      "dashboard",
+      "desktop",
+      "install-upgrade"
+    ];
+    const artifacts = evidenceKinds.map((kind) => ({ kind, ref: `evidence/${kind}.json` }));
+    for (const artifact of artifacts) writeFileSync(join(root, artifact.ref), "{}\n");
+    writeFileSync(join(root, "evidence", "activation-proof.json"), JSON.stringify({ artifacts }));
+    writeFileSync(join(root, "docs", "public-release-manifest.json"), JSON.stringify({
+      source: { candidateHeadBeforeReleaseMetadata: candidateHead },
+      licenseApi: { activationProofPath: "evidence/activation-proof.json" },
+      packageArtifact: { previousReleasedPackageVersion: "1.0.3" }
+    }));
+    writeFileSync(join(root, "neondiff-reviewed-pack", "neondiff-1.0.4.tgz"), "reviewed-v1.0.4-tarball");
+    writeFileSync(join(root, "scripts", "check-public-release-ready.mjs"), `
+      if (process.env.FAIL_STAGE === "readiness") process.exit(41);
+    `);
+    copyFileSync(policyScript, join(root, ".recovery-policy", "scripts", "npm-release-policy.mjs"));
+    const provenanceVerifier = join(root, ".recovery-policy", "scripts", "verify-npm-provenance.mjs");
+    writeFileSync(provenanceVerifier, `
+      if (process.env.FAIL_STAGE === "provenance") process.exit(42);
+      if (process.env.FAIL_STAGE === "provenance-empty") process.exit(0);
+      process.stdout.write(JSON.stringify(${JSON.stringify({
+        package: "neondiff",
+        version: "1.0.4",
+        integrity,
+        sha512,
+        repository: "electricsheephq/evaos-code-review-bot-neondiff",
+        workflow: ".github/workflows/publish-npm.yml",
+        tag: "v1.0.4",
+        commit: releaseCommit
+      })}));
+    `);
+    writeFileSync(join(root, "scripts", "npm-release-policy.mjs"), "throw new Error('tag-root recovery policy must not execute');\n");
+    writeFileSync(join(root, "scripts", "verify-npm-provenance.mjs"), "throw new Error('tag-root provenance verifier must not execute');\n");
+    const state = join(root, "npm-state");
+    writeFileSync(state, `LATEST=${JSON.stringify(initialLatest)}\nQUARANTINE=${JSON.stringify(initialQuarantine)}\nCHANNEL_READS=0\n`);
+    const npm = join(bin, "npm");
+    writeFileSync(npm, `#!/usr/bin/env bash
+set -euo pipefail
+source "$NPM_STATE_FILE"
+write_state() {
+  printf 'LATEST=%q\\nQUARANTINE=%q\\nCHANNEL_READS=%q\\n' "$LATEST" "$QUARANTINE" "$CHANNEL_READS" > "$NPM_STATE_FILE.tmp"
+  mv "$NPM_STATE_FILE.tmp" "$NPM_STATE_FILE"
+}
+case "\${1:-}" in
+  publish)
+    printf '%s\\n' "$*" >> "$NPM_MUTATION_LOG"
+    ;;
+  dist-tag)
+    printf '%s\\n' "$*" >> "$NPM_MUTATION_LOG"
+    if [ "\${2:-}" = "add" ]; then
+      if [ "\${FAIL_STAGE:-}" = "promotion-rejected-error" ]; then exit 47; fi
+      LATEST="1.0.4"
+    elif [ "\${2:-}" = "rm" ]; then
+      QUARANTINE=""
+    fi
+    write_state
+    if [ "\${2:-}" = "add" ] && [ "\${FAIL_STAGE:-}" = "promotion-accepted-error" ]; then exit 47; fi
+    ;;
+  install)
+    if [ "\${FAIL_STAGE:-}" = "signature-install" ]; then exit 43; fi
+    ;;
+  audit)
+    if [ "\${FAIL_STAGE:-}" = "signature" ]; then exit 43; fi
+    if [ "\${FAIL_STAGE:-}" = "signature-content" ]; then
+      printf '%s\\n' '{"invalid":[{"name":"neondiff"}],"missing":[]}'
+      exit 0
+    fi
+    printf '%s\\n' '{"invalid":[],"missing":[]}'
+    ;;
+  view)
+    if [[ "$*" == *"version dist.integrity dist.shasum gitHead dist.attestations"* ]]; then
+      if [ "\${FAIL_STAGE:-}" = "registry" ]; then exit 44; fi
+      REMOTE_INTEGRITY=${JSON.stringify(integrity)}
+      if [ "\${FAIL_STAGE:-}" = "verify-pack" ]; then REMOTE_INTEGRITY="sha512-mismatch"; fi
+      ATTESTATION_URL="https://registry.npmjs.org/-/npm/v1/attestations/neondiff@1.0.4"
+      if [ "\${FAIL_STAGE:-}" = "attestation-url" ]; then ATTESTATION_URL="https://example.invalid/untrusted"; fi
+      printf '{"version":"1.0.4","dist.integrity":"%s","dist.shasum":"%s","dist.attestations":{"url":"%s"}}\\n' "$REMOTE_INTEGRITY" ${JSON.stringify(shasum)} "$ATTESTATION_URL"
+    elif [[ "$*" == *"dist-tags"* ]]; then
+      CHANNEL_READS=$((CHANNEL_READS + 1))
+      write_state
+      if [ "\${FAIL_STAGE:-}" = "channel-registry" ]; then exit 44; fi
+      if [ "\${FAIL_STAGE:-}" = "channel-json" ]; then printf '%s\\n' '[]'; exit 0; fi
+      if [ "\${FAIL_STAGE:-}" = "prepromotion-channel-registry" ] && [ "$CHANNEL_READS" = "2" ]; then exit 44; fi
+      if [ "\${FAIL_STAGE:-}" = "prepromotion-channel-json" ] && [ "$CHANNEL_READS" = "2" ]; then printf '%s\\n' '[]'; exit 0; fi
+      if [ -n "$QUARANTINE" ]; then
+        printf '{"latest":"%s","release-candidate":"%s"}\\n' "$LATEST" "$QUARANTINE"
+      else
+        printf '{"latest":"%s"}\\n' "$LATEST"
+      fi
+    else
+      if [ "\${FAIL_STAGE:-}" = "package-missing" ]; then exit 44; fi
+      printf '%s\\n' '1.0.4'
+    fi
+    ;;
+  *)
+    echo "unexpected npm command: $*" >&2
+    exit 45
+    ;;
+esac
+`, { mode: 0o700 });
+    const curl = join(bin, "curl");
+    writeFileSync(curl, `#!/usr/bin/env bash
+if [ "\${FAIL_STAGE:-}" = "attestation-download" ]; then exit 45; fi
+printf '%s\\n' '{}'
+`, { mode: 0o700 });
+    const gh = join(bin, "gh");
+    writeFileSync(gh, `#!/usr/bin/env bash
+if [ "\${FAIL_STAGE:-}" = "attestation" ]; then exit 45; fi
+exit 0
+`, { mode: 0o700 });
+    const git = join(bin, "git");
+    writeFileSync(git, `#!/usr/bin/env bash
+if [ "\${1:-}" = "rev-parse" ] && [ "\${2:-}" = "refs/remotes/origin/main" ]; then
+  printf '%s\\n' "\${MAIN_SHA_OVERRIDE:-$GITHUB_SHA}"
+elif [ "\${1:-}" = "rev-list" ] && [ "\${2:-}" = "-n" ] && [ "\${3:-}" = "1" ]; then
+  printf '%s\\n' "\${TAG_COMMIT_OVERRIDE:-${releaseCommit}}"
+else
+  echo "unexpected git command: $*" >&2
+  exit 46
+fi
+`, { mode: 0o700 });
+    const sleep = join(bin, "sleep");
+    writeFileSync(sleep, "#!/usr/bin/env bash\nexit 0\n", { mode: 0o700 });
+    for (const executable of [npm, curl, gh, git, sleep]) chmodSync(executable, 0o700);
+    return {
+      root,
+      bin,
+      log,
+      state,
+      provenanceVerifier,
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+        NPM_MUTATION_LOG: log,
+        NPM_STATE_FILE: state,
+        FAIL_STAGE: "",
+        PROVENANCE_RECOVERY: "true",
+        RUNNER_TEMP: root,
+        RELEASE_EVENT_NAME: "workflow_dispatch",
+        GITHUB_REF: "refs/heads/main",
+        WORKFLOW_REF: "electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main",
+        WORKFLOW_SHA: mainSha,
+        GITHUB_SHA: mainSha,
+        GITHUB_REPOSITORY: "electricsheephq/evaos-code-review-bot-neondiff",
+        RELEASE_TAG: "v1.0.4",
+        NPM_TAG: "latest",
+        NPM_CONFIRM_ATTEMPTS: "2",
+        NPM_CONFIRM_DELAY_MS: "0",
+        NPM_CONFIRM_TIMEOUT_MS: "1000"
+      }
+    };
+  }
+
+  function runOrchestration(
+    overrides: Record<string, string> = {},
+    initialState: { latest?: string; quarantine?: string } = {}
+  ) {
+    const block = extractBlock("V104_PROVENANCE_RECOVERY_MUTATION_GATE");
+    const { root, bin, log, state, env } = orchestrationHarness(
+      initialState.latest ?? "1.0.3",
+      initialState.quarantine ?? "1.0.4"
+    );
+    if (overrides.REMOVE_FIXTURE === "tarball") {
+      rmSync(join(root, "neondiff-reviewed-pack", "neondiff-1.0.4.tgz"));
+    } else if (overrides.REMOVE_FIXTURE === "evidence") {
+      rmSync(join(root, "evidence", "dashboard.json"));
+    } else if (overrides.REMOVE_FIXTURE === "proof-inventory") {
+      writeFileSync(join(root, "evidence", "activation-proof.json"), JSON.stringify({ artifacts: [] }));
+    } else if (overrides.REMOVE_FIXTURE === "recovery-policy") {
+      rmSync(join(root, ".recovery-policy", "scripts", "npm-release-policy.mjs"));
+    }
+    const environmentOverrides = { ...overrides };
+    delete environmentOverrides.REMOVE_FIXTURE;
+    const result = spawnSync("bash", ["-euo", "pipefail", "-c", block], {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...env, ...environmentOverrides, PATH: `${bin}:${process.env.PATH}` }
+    });
+    return {
+      result,
+      commands: readFileSync(log, "utf8"),
+      registryState: readFileSync(state, "utf8")
+    };
   }
 
   it("never publishes from protected-main provenance recovery", () => {
@@ -99,5 +305,87 @@ describe("v1.0.4 npm provenance recovery workflow", () => {
       expect(commands.includes("dist-tag add neondiff@1.0.4 latest"), `${row.latest}/${row.quarantine}`).toBe(row.mutation);
       if (!row.mutation) expect(commands).not.toMatch(/^dist-tag\s+(?:add|rm)\b/m);
     }
+  });
+
+  it("executes the complete recovery mutation gate before promotion and owned cleanup", () => {
+    const { result, commands } = runOrchestration();
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(commands).toBe([
+      "dist-tag add neondiff@1.0.4 latest",
+      "dist-tag rm neondiff release-candidate",
+      ""
+    ].join("\n"));
+    expect(commands).not.toMatch(/^publish\b/m);
+  });
+
+  it("leaves every npm mutation command unreachable when an upstream recovery gate fails", () => {
+    const rows: Array<[string, Record<string, string>]> = [
+      ["wrong event", { RELEASE_EVENT_NAME: "release" }],
+      ["wrong protected ref", { GITHUB_REF: "refs/tags/v1.0.4" }],
+      ["wrong workflow ref", { WORKFLOW_REF: "other" }],
+      ["wrong workflow sha", { WORKFLOW_SHA: "b".repeat(40) }],
+      ["stale fetched main sha", { MAIN_SHA_OVERRIDE: "b".repeat(40) }],
+      ["wrong tag", { RELEASE_TAG: "v1.0.5" }],
+      ["wrong tag commit", { TAG_COMMIT_OVERRIDE: "b".repeat(40) }],
+      ["recovery-mode downgrade", { PROVENANCE_RECOVERY: "false" }],
+      ["missing reviewed tarball", { REMOVE_FIXTURE: "tarball" }],
+      ["missing protected-main recovery policy", { REMOVE_FIXTURE: "recovery-policy" }],
+      ["invalid activation proof inventory", { REMOVE_FIXTURE: "proof-inventory" }],
+      ["missing activation evidence", { REMOVE_FIXTURE: "evidence" }],
+      ["activation attestation failure", { FAIL_STAGE: "attestation" }],
+      ["package missing", { FAIL_STAGE: "package-missing" }],
+      ["readiness failure", { FAIL_STAGE: "readiness" }],
+      ["registry failure", { FAIL_STAGE: "registry" }],
+      ["untrusted attestation URL", { FAIL_STAGE: "attestation-url" }],
+      ["attestation download failure", { FAIL_STAGE: "attestation-download" }],
+      ["provenance verifier failure", { FAIL_STAGE: "provenance" }],
+      ["missing verified provenance result", { FAIL_STAGE: "provenance-empty" }],
+      ["signature package install failure", { FAIL_STAGE: "signature-install" }],
+      ["signature audit failure", { FAIL_STAGE: "signature" }],
+      ["signature audit invalid result", { FAIL_STAGE: "signature-content" }],
+      ["channel registry failure", { FAIL_STAGE: "channel-registry" }],
+      ["channel metadata parse failure", { FAIL_STAGE: "channel-json" }],
+      ["prepromotion channel registry failure", { FAIL_STAGE: "prepromotion-channel-registry" }],
+      ["prepromotion channel parse failure", { FAIL_STAGE: "prepromotion-channel-json" }],
+      ["fallback policy failure", { FAIL_STAGE: "verify-pack" }]
+    ];
+    for (const [name, overrides] of rows) {
+      const { result, commands } = runOrchestration(overrides);
+      expect(result.status, name).not.toBe(0);
+      expect(commands, name).not.toMatch(/^(?:publish|dist-tag\s+(?:add|rm))\b/m);
+    }
+    for (const [name, state] of [
+      ["foreign predecessor", { latest: "9.9.9", quarantine: "1.0.4" }],
+      ["foreign quarantine", { latest: "1.0.3", quarantine: "9.9.9" }]
+    ] as const) {
+      const { result, commands } = runOrchestration({}, state);
+      expect(result.status, name).not.toBe(0);
+      expect(commands, name).not.toMatch(/^(?:publish|dist-tag\s+(?:add|rm))\b/m);
+    }
+  }, 60_000);
+
+  it("is idempotent after promotion and owned quarantine cleanup already converged", () => {
+    const { result, commands } = runOrchestration({}, { latest: "1.0.4", quarantine: "" });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(commands).toBe("");
+  });
+
+  it("reconciles both accepted and rejected ambiguous promotion command failures", () => {
+    const accepted = runOrchestration({ FAIL_STAGE: "promotion-accepted-error" });
+    expect(accepted.result.status, `${accepted.result.stdout}\n${accepted.result.stderr}`).toBe(0);
+    expect(accepted.commands).toBe([
+      "dist-tag add neondiff@1.0.4 latest",
+      "dist-tag rm neondiff release-candidate",
+      ""
+    ].join("\n"));
+    expect(accepted.registryState).toMatch(/^LATEST=1\.0\.4$/m);
+    expect(accepted.registryState).toMatch(/^QUARANTINE=''$/m);
+
+    const rejected = runOrchestration({ FAIL_STAGE: "promotion-rejected-error" });
+    expect(rejected.result.status).not.toBe(0);
+    expect(rejected.commands).toBe("dist-tag add neondiff@1.0.4 latest\n");
+    expect(rejected.registryState).toMatch(/^LATEST=1\.0\.3$/m);
+    expect(rejected.registryState).toMatch(/^QUARANTINE=1\.0\.4$/m);
+    expect(rejected.registryState).toMatch(/^CHANNEL_READS=4$/m);
   });
 });

--- a/tests/npm-provenance-recovery.test.ts
+++ b/tests/npm-provenance-recovery.test.ts
@@ -97,13 +97,13 @@ describe("v1.0.4 npm provenance recovery workflow", () => {
     writeFileSync(join(root, "scripts", "npm-release-policy.mjs"), "throw new Error('tag-root recovery policy must not execute');\n");
     writeFileSync(join(root, "scripts", "verify-npm-provenance.mjs"), "throw new Error('tag-root provenance verifier must not execute');\n");
     const state = join(root, "npm-state");
-    writeFileSync(state, `LATEST=${JSON.stringify(initialLatest)}\nQUARANTINE=${JSON.stringify(initialQuarantine)}\nCHANNEL_READS=0\n`);
+    writeFileSync(state, `LATEST=${JSON.stringify(initialLatest)}\nQUARANTINE=${JSON.stringify(initialQuarantine)}\nCHANNEL_READS=0\nPACKAGE_READS=0\n`);
     const npm = join(bin, "npm");
     writeFileSync(npm, `#!/usr/bin/env bash
 set -euo pipefail
 source "$NPM_STATE_FILE"
 write_state() {
-  printf 'LATEST=%q\\nQUARANTINE=%q\\nCHANNEL_READS=%q\\n' "$LATEST" "$QUARANTINE" "$CHANNEL_READS" > "$NPM_STATE_FILE.tmp"
+  printf 'LATEST=%q\\nQUARANTINE=%q\\nCHANNEL_READS=%q\\nPACKAGE_READS=%q\\n' "$LATEST" "$QUARANTINE" "$CHANNEL_READS" "$PACKAGE_READS" > "$NPM_STATE_FILE.tmp"
   mv "$NPM_STATE_FILE.tmp" "$NPM_STATE_FILE"
 }
 case "\${1:-}" in
@@ -153,7 +153,10 @@ case "\${1:-}" in
         printf '{"latest":"%s"}\\n' "$LATEST"
       fi
     else
+      PACKAGE_READS=$((PACKAGE_READS + 1))
+      write_state
       if [ "\${FAIL_STAGE:-}" = "package-missing" ]; then exit 44; fi
+      if [ "\${FAIL_STAGE:-}" = "package-transient" ] && [ "$PACKAGE_READS" -lt 3 ]; then exit 44; fi
       printf '%s\\n' '1.0.4'
     fi
     ;;
@@ -368,6 +371,18 @@ fi
     const { result, commands } = runOrchestration({}, { latest: "1.0.4", quarantine: "" });
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(commands).toBe("");
+  });
+
+  it("converges transient package existence reads before the no-publish recovery guard", () => {
+    const { result, commands, registryState } = runOrchestration({ FAIL_STAGE: "package-transient" });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(commands).toBe([
+      "dist-tag add neondiff@1.0.4 latest",
+      "dist-tag rm neondiff release-candidate",
+      ""
+    ].join("\n"));
+    expect(commands).not.toMatch(/^publish\b/m);
+    expect(registryState).toMatch(/^PACKAGE_READS=3$/m);
   });
 
   it("reconciles both accepted and rejected ambiguous promotion command failures", () => {

--- a/tests/npm-provenance-recovery.test.ts
+++ b/tests/npm-provenance-recovery.test.ts
@@ -443,6 +443,7 @@ fi
     ].join("\n"));
     expect(accepted.registryState).toMatch(/^LATEST=1\.0\.4$/m);
     expect(accepted.registryState).toMatch(/^QUARANTINE=''$/m);
+    expect(accepted.result.stdout).toContain("npm dist-tag promotion returned nonzero (exit 47)");
 
     const rejected = runOrchestration({ FAIL_STAGE: "promotion-rejected-error" });
     expect(rejected.result.status).not.toBe(0);
@@ -450,6 +451,7 @@ fi
     expect(rejected.registryState).toMatch(/^LATEST=1\.0\.3$/m);
     expect(rejected.registryState).toMatch(/^QUARANTINE=1\.0\.4$/m);
     expect(rejected.registryState).toMatch(/^CHANNEL_READS=4$/m);
+    expect(rejected.result.stdout).toContain("npm dist-tag promotion returned nonzero (exit 47)");
   }, 15_000);
 
   it("keeps non-recovery promotion command failures fail-fast", () => {

--- a/tests/npm-provenance-recovery.test.ts
+++ b/tests/npm-provenance-recovery.test.ts
@@ -1,0 +1,103 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+function extractBlock(name: string): string {
+  const workflow = readFileSync(".github/workflows/publish-npm.yml", "utf8");
+  const beginMarker = `# BEGIN ${name}`;
+  const endMarker = `# END ${name}`;
+  const begin = workflow.indexOf(beginMarker);
+  if (begin < 0) throw new Error(`${beginMarker} is missing`);
+  const contentStart = workflow.indexOf("\n", begin) + 1;
+  const contentEnd = workflow.indexOf(endMarker, contentStart);
+  if (contentEnd < 0) throw new Error(`${endMarker} is missing`);
+  const lines = workflow.slice(contentStart, contentEnd).split("\n").filter(Boolean);
+  const indent = lines[0]?.match(/^\s*/)?.[0] ?? "";
+  return lines.map((line) => {
+    if (!line.startsWith(indent)) throw new Error(`${name} indentation is inconsistent`);
+    return line.slice(indent.length);
+  }).join("\n");
+}
+
+describe("v1.0.4 npm provenance recovery workflow", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function harness() {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-npm-provenance-recovery-"));
+    roots.push(root);
+    const bin = join(root, "bin");
+    const log = join(root, "npm-mutations.log");
+    const npm = join(bin, "npm");
+    writeFileSync(join(root, "mkdir.sh"), `mkdir -p ${JSON.stringify(bin)}\n`, { mode: 0o700 });
+    spawnSync("bash", [join(root, "mkdir.sh")]);
+    writeFileSync(log, "");
+    writeFileSync(npm, `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "$NPM_MUTATION_LOG"\n`, { mode: 0o700 });
+    chmodSync(npm, 0o700);
+    return { root, bin, log };
+  }
+
+  it("never publishes from protected-main provenance recovery", () => {
+    const block = extractBlock("V104_PROVENANCE_RECOVERY_PUBLISH_GUARD");
+    for (const packageAlreadyExists of ["true", "false"]) {
+      const { root, bin, log } = harness();
+      const result = spawnSync("bash", ["-euo", "pipefail", "-c", block], {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH}`,
+          NPM_MUTATION_LOG: log,
+          PROVENANCE_RECOVERY: "true",
+          PACKAGE_ALREADY_EXISTS: packageAlreadyExists,
+          PACKAGE_VERSION: "1.0.4",
+          PACK_TARBALL: "/tmp/neondiff-1.0.4.tgz"
+        }
+      });
+      const commands = readFileSync(log, "utf8");
+      expect(commands).not.toMatch(/^publish\b/m);
+      expect(result.status).toBe(packageAlreadyExists === "true" ? 0 : 1);
+    }
+  });
+
+  it("blocks foreign predecessor or quarantine ownership before latest mutation", () => {
+    const block = extractBlock("V104_PROVENANCE_RECOVERY_PREPROMOTION_GUARD");
+    const policyScript = resolve("scripts/npm-release-policy.mjs");
+    const rows = [
+      { latest: "1.0.3", quarantine: "1.0.4", status: 0, mutation: true },
+      { latest: "1.0.3", quarantine: "", status: 1, mutation: false },
+      { latest: "1.0.3", quarantine: "9.9.9", status: 1, mutation: false },
+      { latest: "1.0.4", quarantine: "", status: 0, mutation: false },
+      { latest: "1.0.4", quarantine: "9.9.9", status: 1, mutation: false },
+      { latest: "9.9.9", quarantine: "1.0.4", status: 1, mutation: false }
+    ];
+    for (const row of rows) {
+      const { root, bin, log } = harness();
+      const result = spawnSync("bash", ["-euo", "pipefail", "-c", block], {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH}`,
+          NPM_MUTATION_LOG: log,
+          PROVENANCE_RECOVERY: "true",
+          POLICY_SCRIPT: policyScript,
+          PREPROMOTION_TAG_VERSION: row.latest,
+          PREPROMOTION_QUARANTINE_VERSION: row.quarantine,
+          PACKAGE_VERSION: "1.0.4",
+          EXPECTED_PREDECESSOR: "1.0.3",
+          NPM_TAG: "latest"
+        }
+      });
+      const commands = readFileSync(log, "utf8");
+      expect(result.status, `${row.latest}/${row.quarantine}`).toBe(row.status);
+      expect(commands.includes("dist-tag add neondiff@1.0.4 latest"), `${row.latest}/${row.quarantine}`).toBe(row.mutation);
+      if (!row.mutation) expect(commands).not.toMatch(/^dist-tag\s+(?:add|rm)\b/m);
+    }
+  });
+});

--- a/tests/npm-provenance-recovery.test.ts
+++ b/tests/npm-provenance-recovery.test.ts
@@ -98,6 +98,8 @@ describe("v1.0.4 npm provenance recovery workflow", () => {
     writeFileSync(join(root, "scripts", "verify-npm-provenance.mjs"), "throw new Error('tag-root provenance verifier must not execute');\n");
     const state = join(root, "npm-state");
     writeFileSync(state, `LATEST=${JSON.stringify(initialLatest)}\nQUARANTINE=${JSON.stringify(initialQuarantine)}\nCHANNEL_READS=0\nPACKAGE_READS=0\n`);
+    const gitState = join(root, "git-state");
+    writeFileSync(gitState, "FETCHES=0\n");
     const npm = join(bin, "npm");
     writeFileSync(npm, `#!/usr/bin/env bash
 set -euo pipefail
@@ -173,13 +175,44 @@ printf '%s\\n' '{}'
 `, { mode: 0o700 });
     const gh = join(bin, "gh");
     writeFileSync(gh, `#!/usr/bin/env bash
-if [ "\${FAIL_STAGE:-}" = "attestation" ]; then exit 45; fi
-exit 0
+if [ "\${1:-}" = "api" ]; then
+  if [ "\${FAIL_STAGE:-}" = "release-metadata" ]; then exit 45; fi
+  if [ "\${FAIL_STAGE:-}" = "release-metadata-shape" ]; then
+    printf '%s\\n' '{"tag_name":"v1.0.4","draft":true,"prerelease":false}'
+    exit 0
+  fi
+  if [ "\${FAIL_STAGE:-}" = "release-metadata-tag" ]; then
+    printf '%s\\n' '{"tag_name":"v1.0.5","draft":false,"prerelease":false}'
+    exit 0
+  fi
+  if [ "\${FAIL_STAGE:-}" = "release-metadata-prerelease" ]; then
+    printf '%s\\n' '{"tag_name":"v1.0.4","draft":false,"prerelease":true}'
+    exit 0
+  fi
+  printf '%s\\n' '{"tag_name":"v1.0.4","draft":false,"prerelease":false}'
+  exit 0
+fi
+if [ "\${1:-}" = "attestation" ]; then
+  if [ "\${FAIL_STAGE:-}" = "attestation" ]; then exit 45; fi
+  exit 0
+fi
+echo "unexpected gh command: $*" >&2
+exit 46
 `, { mode: 0o700 });
     const git = join(bin, "git");
     writeFileSync(git, `#!/usr/bin/env bash
-if [ "\${1:-}" = "rev-parse" ] && [ "\${2:-}" = "refs/remotes/origin/main" ]; then
-  printf '%s\\n' "\${MAIN_SHA_OVERRIDE:-$GITHUB_SHA}"
+source "$GIT_STATE_FILE"
+if [ "\${1:-}" = "fetch" ]; then
+  FETCHES=$((FETCHES + 1))
+  printf 'FETCHES=%q\\n' "$FETCHES" > "$GIT_STATE_FILE"
+  if [ "\${FAIL_STAGE:-}" = "main-refetch" ]; then exit 45; fi
+  exit 0
+elif [ "\${1:-}" = "rev-parse" ] && [ "\${2:-}" = "refs/remotes/origin/main" ]; then
+  if [ "\${FAIL_STAGE:-}" = "main-advanced-before-promotion" ] && [ "$FETCHES" -ge 2 ]; then
+    printf '%040d\\n' 0 | tr '0' 'b'
+  else
+    printf '%s\\n' "\${MAIN_SHA_OVERRIDE:-$GITHUB_SHA}"
+  fi
 elif [ "\${1:-}" = "rev-list" ] && [ "\${2:-}" = "-n" ] && [ "\${3:-}" = "1" ]; then
   printf '%s\\n' "\${TAG_COMMIT_OVERRIDE:-${releaseCommit}}"
 else
@@ -195,12 +228,14 @@ fi
       bin,
       log,
       state,
+      gitState,
       provenanceVerifier,
       env: {
         ...process.env,
         PATH: `${bin}:${process.env.PATH}`,
         NPM_MUTATION_LOG: log,
         NPM_STATE_FILE: state,
+        GIT_STATE_FILE: gitState,
         FAIL_STAGE: "",
         PROVENANCE_RECOVERY: "true",
         RUNNER_TEMP: root,
@@ -224,7 +259,7 @@ fi
     initialState: { latest?: string; quarantine?: string } = {}
   ) {
     const block = extractBlock("V104_PROVENANCE_RECOVERY_MUTATION_GATE");
-    const { root, bin, log, state, env } = orchestrationHarness(
+    const { root, bin, log, state, gitState, env } = orchestrationHarness(
       initialState.latest ?? "1.0.3",
       initialState.quarantine ?? "1.0.4"
     );
@@ -247,7 +282,8 @@ fi
     return {
       result,
       commands: readFileSync(log, "utf8"),
-      registryState: readFileSync(state, "utf8")
+      registryState: readFileSync(state, "utf8"),
+      gitState: readFileSync(gitState, "utf8")
     };
   }
 
@@ -319,59 +355,64 @@ fi
       ""
     ].join("\n"));
     expect(commands).not.toMatch(/^publish\b/m);
-  });
+  }, 15_000);
 
-  it("leaves every npm mutation command unreachable when an upstream recovery gate fails", () => {
-    const rows: Array<[string, Record<string, string>]> = [
-      ["wrong event", { RELEASE_EVENT_NAME: "release" }],
-      ["wrong protected ref", { GITHUB_REF: "refs/tags/v1.0.4" }],
-      ["wrong workflow ref", { WORKFLOW_REF: "other" }],
-      ["wrong workflow sha", { WORKFLOW_SHA: "b".repeat(40) }],
-      ["stale fetched main sha", { MAIN_SHA_OVERRIDE: "b".repeat(40) }],
-      ["wrong tag", { RELEASE_TAG: "v1.0.5" }],
-      ["wrong tag commit", { TAG_COMMIT_OVERRIDE: "b".repeat(40) }],
-      ["recovery-mode downgrade", { PROVENANCE_RECOVERY: "false" }],
-      ["missing reviewed tarball", { REMOVE_FIXTURE: "tarball" }],
-      ["missing protected-main recovery policy", { REMOVE_FIXTURE: "recovery-policy" }],
-      ["invalid activation proof inventory", { REMOVE_FIXTURE: "proof-inventory" }],
-      ["missing activation evidence", { REMOVE_FIXTURE: "evidence" }],
-      ["activation attestation failure", { FAIL_STAGE: "attestation" }],
-      ["package missing", { FAIL_STAGE: "package-missing" }],
-      ["readiness failure", { FAIL_STAGE: "readiness" }],
-      ["registry failure", { FAIL_STAGE: "registry" }],
-      ["untrusted attestation URL", { FAIL_STAGE: "attestation-url" }],
-      ["attestation download failure", { FAIL_STAGE: "attestation-download" }],
-      ["provenance verifier failure", { FAIL_STAGE: "provenance" }],
-      ["missing verified provenance result", { FAIL_STAGE: "provenance-empty" }],
-      ["signature package install failure", { FAIL_STAGE: "signature-install" }],
-      ["signature audit failure", { FAIL_STAGE: "signature" }],
-      ["signature audit invalid result", { FAIL_STAGE: "signature-content" }],
-      ["channel registry failure", { FAIL_STAGE: "channel-registry" }],
-      ["channel metadata parse failure", { FAIL_STAGE: "channel-json" }],
-      ["prepromotion channel registry failure", { FAIL_STAGE: "prepromotion-channel-registry" }],
-      ["prepromotion channel parse failure", { FAIL_STAGE: "prepromotion-channel-json" }],
-      ["fallback policy failure", { FAIL_STAGE: "verify-pack" }]
-    ];
-    for (const [name, overrides] of rows) {
-      const { result, commands } = runOrchestration(overrides);
-      expect(result.status, name).not.toBe(0);
-      expect(commands, name).not.toMatch(/^(?:publish|dist-tag\s+(?:add|rm))\b/m);
-    }
-    for (const [name, state] of [
-      ["foreign predecessor", { latest: "9.9.9", quarantine: "1.0.4" }],
-      ["foreign quarantine", { latest: "1.0.3", quarantine: "9.9.9" }]
-    ] as const) {
-      const { result, commands } = runOrchestration({}, state);
-      expect(result.status, name).not.toBe(0);
-      expect(commands, name).not.toMatch(/^(?:publish|dist-tag\s+(?:add|rm))\b/m);
-    }
-  }, 60_000);
+  const upstreamFailureRows: Array<[string, Record<string, string>]> = [
+    ["wrong event", { RELEASE_EVENT_NAME: "release" }],
+    ["wrong protected ref", { GITHUB_REF: "refs/tags/v1.0.4" }],
+    ["wrong workflow ref", { WORKFLOW_REF: "other" }],
+    ["wrong workflow sha", { WORKFLOW_SHA: "b".repeat(40) }],
+    ["protected main refetch failure", { FAIL_STAGE: "main-refetch" }],
+    ["stale fetched main sha", { MAIN_SHA_OVERRIDE: "b".repeat(40) }],
+    ["wrong tag", { RELEASE_TAG: "v1.0.5" }],
+    ["wrong tag commit", { TAG_COMMIT_OVERRIDE: "b".repeat(40) }],
+    ["recovery-mode downgrade", { PROVENANCE_RECOVERY: "false" }],
+    ["release metadata fetch failure", { FAIL_STAGE: "release-metadata" }],
+    ["release metadata validation failure", { FAIL_STAGE: "release-metadata-shape" }],
+    ["release metadata tag mismatch", { FAIL_STAGE: "release-metadata-tag" }],
+    ["release metadata prerelease", { FAIL_STAGE: "release-metadata-prerelease" }],
+    ["missing reviewed tarball", { REMOVE_FIXTURE: "tarball" }],
+    ["missing protected-main recovery policy", { REMOVE_FIXTURE: "recovery-policy" }],
+    ["invalid activation proof inventory", { REMOVE_FIXTURE: "proof-inventory" }],
+    ["missing activation evidence", { REMOVE_FIXTURE: "evidence" }],
+    ["activation attestation failure", { FAIL_STAGE: "attestation" }],
+    ["package missing", { FAIL_STAGE: "package-missing" }],
+    ["readiness failure", { FAIL_STAGE: "readiness" }],
+    ["registry failure", { FAIL_STAGE: "registry" }],
+    ["untrusted attestation URL", { FAIL_STAGE: "attestation-url" }],
+    ["attestation download failure", { FAIL_STAGE: "attestation-download" }],
+    ["provenance verifier failure", { FAIL_STAGE: "provenance" }],
+    ["missing verified provenance result", { FAIL_STAGE: "provenance-empty" }],
+    ["signature package install failure", { FAIL_STAGE: "signature-install" }],
+    ["signature audit failure", { FAIL_STAGE: "signature" }],
+    ["signature audit invalid result", { FAIL_STAGE: "signature-content" }],
+    ["channel registry failure", { FAIL_STAGE: "channel-registry" }],
+    ["channel metadata parse failure", { FAIL_STAGE: "channel-json" }],
+    ["prepromotion channel registry failure", { FAIL_STAGE: "prepromotion-channel-registry" }],
+    ["prepromotion channel parse failure", { FAIL_STAGE: "prepromotion-channel-json" }],
+    ["fallback policy failure", { FAIL_STAGE: "verify-pack" }]
+  ];
+
+  it.each(upstreamFailureRows)("leaves npm mutations unreachable when the %s gate fails", (name, overrides) => {
+    const { result, commands } = runOrchestration(overrides);
+    expect(result.status, name).not.toBe(0);
+    expect(commands, name).not.toMatch(/^(?:publish|dist-tag\s+(?:add|rm))\b/m);
+  }, 15_000);
+
+  it.each([
+    ["foreign predecessor", { latest: "9.9.9", quarantine: "1.0.4" }],
+    ["foreign quarantine", { latest: "1.0.3", quarantine: "9.9.9" }]
+  ] as const)("leaves npm mutations unreachable for %s state", (name, state) => {
+    const { result, commands } = runOrchestration({}, state);
+    expect(result.status, name).not.toBe(0);
+    expect(commands, name).not.toMatch(/^(?:publish|dist-tag\s+(?:add|rm))\b/m);
+  }, 15_000);
 
   it("is idempotent after promotion and owned quarantine cleanup already converged", () => {
     const { result, commands } = runOrchestration({}, { latest: "1.0.4", quarantine: "" });
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(commands).toBe("");
-  });
+  }, 15_000);
 
   it("converges transient package existence reads before the no-publish recovery guard", () => {
     const { result, commands, registryState } = runOrchestration({ FAIL_STAGE: "package-transient" });
@@ -383,7 +424,14 @@ fi
     ].join("\n"));
     expect(commands).not.toMatch(/^publish\b/m);
     expect(registryState).toMatch(/^PACKAGE_READS=3$/m);
-  });
+  }, 15_000);
+
+  it("blocks every npm mutation if protected main advances before promotion", () => {
+    const { result, commands, gitState } = runOrchestration({ FAIL_STAGE: "main-advanced-before-promotion" });
+    expect(result.status).not.toBe(0);
+    expect(commands).not.toMatch(/^(?:publish|dist-tag\s+(?:add|rm))\b/m);
+    expect(gitState).toMatch(/^FETCHES=2$/m);
+  }, 15_000);
 
   it("reconciles both accepted and rejected ambiguous promotion command failures", () => {
     const accepted = runOrchestration({ FAIL_STAGE: "promotion-accepted-error" });
@@ -402,5 +450,35 @@ fi
     expect(rejected.registryState).toMatch(/^LATEST=1\.0\.3$/m);
     expect(rejected.registryState).toMatch(/^QUARANTINE=1\.0\.4$/m);
     expect(rejected.registryState).toMatch(/^CHANNEL_READS=4$/m);
+  }, 15_000);
+
+  it("keeps non-recovery promotion command failures fail-fast", () => {
+    const block = extractBlock("V104_PROVENANCE_RECOVERY_PREPROMOTION_GUARD");
+    const policyScript = resolve("scripts/npm-release-policy.mjs");
+    const { root, bin, log } = harness();
+    const npm = join(bin, "npm");
+    writeFileSync(npm, `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$NPM_MUTATION_LOG"
+exit 47
+`, { mode: 0o700 });
+    chmodSync(npm, 0o700);
+    const result = spawnSync("bash", ["-euo", "pipefail", "-c", block], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+        NPM_MUTATION_LOG: log,
+        PROVENANCE_RECOVERY: "false",
+        POLICY_SCRIPT: policyScript,
+        PREPROMOTION_TAG_VERSION: "1.0.3",
+        PREPROMOTION_QUARANTINE_VERSION: "1.0.4",
+        PACKAGE_VERSION: "1.0.4",
+        EXPECTED_PREDECESSOR: "1.0.3",
+        NPM_TAG: "latest"
+      }
+    });
+    expect(result.status).toBe(47);
+    expect(readFileSync(log, "utf8")).toBe("dist-tag add neondiff@1.0.4 latest\n");
   });
 });

--- a/tests/npm-release-policy.test.ts
+++ b/tests/npm-release-policy.test.ts
@@ -9,6 +9,7 @@ describe("npm release policy", () => {
   const roots: string[] = [];
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
   const policyScript = join(repoRoot, "scripts", "npm-release-policy.mjs");
+  const releaseCommit = "fc66d27b6ab9f6a1eb8282d289ef63407cd96982";
 
   afterEach(() => {
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
@@ -245,6 +246,220 @@ describe("npm release policy", () => {
 
     expect(pack.integrity).toMatch(/^sha512-/);
     expect(pack.shasum).toMatch(/^[a-f0-9]{40}$/);
+  });
+
+  it("accepts an absent npm gitHead only with exact v1.0.4 verified provenance", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-npm-provenance-fallback-"));
+    roots.push(root);
+    const localPath = join(root, "pack.json");
+    const remotePath = join(root, "remote.json");
+    const provenancePath = join(root, "verified-provenance.json");
+    const integrity = `sha512-${Buffer.from("reviewed-v1.0.4-tarball").toString("base64")}`;
+    writeFileSync(localPath, JSON.stringify([{
+      version: "1.0.4",
+      integrity,
+      shasum: "1".repeat(40)
+    }]));
+    writeFileSync(remotePath, JSON.stringify({
+      version: "1.0.4",
+      "dist.integrity": integrity,
+      "dist.shasum": "1".repeat(40)
+    }));
+    writeFileSync(provenancePath, JSON.stringify({
+      package: "neondiff",
+      version: "1.0.4",
+      integrity,
+      sha512: Buffer.from(integrity.slice("sha512-".length), "base64").toString("hex"),
+      repository: "electricsheephq/evaos-code-review-bot-neondiff",
+      workflow: ".github/workflows/publish-npm.yml",
+      tag: "v1.0.4",
+      commit: releaseCommit
+    }));
+
+    const result = spawnSync(process.execPath, [
+      policyScript, "verify-pack",
+      "--local-pack", localPath,
+      "--remote-metadata", remotePath,
+      "--expected-version", "1.0.4",
+      "--expected-git-head", releaseCommit,
+      "--verified-provenance", provenancePath,
+      "--expected-package", "neondiff",
+      "--expected-repository", "electricsheephq/evaos-code-review-bot-neondiff",
+      "--expected-workflow", ".github/workflows/publish-npm.yml",
+      "--expected-tag", "v1.0.4"
+    ], { encoding: "utf8" });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      version: "1.0.4",
+      sourceIdentity: "verified_provenance_fallback"
+    });
+  });
+
+  it("rejects malformed, mismatched, or under-bound provenance for an absent gitHead", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-npm-provenance-rejections-"));
+    roots.push(root);
+    const localPath = join(root, "pack.json");
+    const remotePath = join(root, "remote.json");
+    const provenancePath = join(root, "verified-provenance.json");
+    const integrity = `sha512-${Buffer.from("reviewed-v1.0.4-tarball").toString("base64")}`;
+    const exactProvenance = {
+      package: "neondiff",
+      version: "1.0.4",
+      integrity,
+      sha512: Buffer.from(integrity.slice("sha512-".length), "base64").toString("hex"),
+      repository: "electricsheephq/evaos-code-review-bot-neondiff",
+      workflow: ".github/workflows/publish-npm.yml",
+      tag: "v1.0.4",
+      commit: releaseCommit
+    };
+    writeFileSync(localPath, JSON.stringify([{
+      version: "1.0.4",
+      integrity,
+      shasum: "1".repeat(40)
+    }]));
+    writeFileSync(remotePath, JSON.stringify({
+      version: "1.0.4",
+      "dist.integrity": integrity,
+      "dist.shasum": "1".repeat(40)
+    }));
+
+    const run = () => spawnSync(process.execPath, [
+      policyScript, "verify-pack",
+      "--local-pack", localPath,
+      "--remote-metadata", remotePath,
+      "--expected-version", "1.0.4",
+      "--expected-git-head", releaseCommit,
+      "--verified-provenance", provenancePath,
+      "--expected-package", "neondiff",
+      "--expected-repository", "electricsheephq/evaos-code-review-bot-neondiff",
+      "--expected-workflow", ".github/workflows/publish-npm.yml",
+      "--expected-tag", "v1.0.4"
+    ], { encoding: "utf8" });
+
+    for (const [field, value] of [
+      ["package", "other"],
+      ["version", "1.0.5"],
+      ["integrity", "sha512-other"],
+      ["sha512", "00"],
+      ["repository", "other/repo"],
+      ["workflow", ".github/workflows/other.yml"],
+      ["tag", "v1.0.5"],
+      ["commit", "2".repeat(40)]
+    ] as const) {
+      writeFileSync(provenancePath, JSON.stringify({ ...exactProvenance, [field]: value }));
+      const result = run();
+      expect(result.status, field).not.toBe(0);
+      expect(result.stderr, field).toContain("verified npm provenance does not match the reviewed release");
+    }
+
+    writeFileSync(provenancePath, "not-json");
+    const malformed = run();
+    expect(malformed.status).not.toBe(0);
+    expect(malformed.stderr).toContain("verified npm provenance is not valid JSON");
+  });
+
+  it("rejects every present malformed or mismatched gitHead despite exact provenance", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-npm-present-git-head-"));
+    roots.push(root);
+    const localPath = join(root, "pack.json");
+    const remotePath = join(root, "remote.json");
+    const provenancePath = join(root, "verified-provenance.json");
+    const integrity = `sha512-${Buffer.from("reviewed-v1.0.4-tarball").toString("base64")}`;
+    writeFileSync(localPath, JSON.stringify([{ version: "1.0.4", integrity, shasum: "1".repeat(40) }]));
+    writeFileSync(provenancePath, JSON.stringify({
+      package: "neondiff", version: "1.0.4", integrity,
+      sha512: Buffer.from(integrity.slice("sha512-".length), "base64").toString("hex"),
+      repository: "electricsheephq/evaos-code-review-bot-neondiff",
+      workflow: ".github/workflows/publish-npm.yml", tag: "v1.0.4", commit: releaseCommit
+    }));
+
+    for (const gitHead of [null, "", "   ", [], {}, "2".repeat(40)]) {
+      writeFileSync(remotePath, JSON.stringify({
+        version: "1.0.4",
+        "dist.integrity": integrity,
+        "dist.shasum": "1".repeat(40),
+        gitHead
+      }));
+      const result = spawnSync(process.execPath, [
+        policyScript, "verify-pack",
+        "--local-pack", localPath,
+        "--remote-metadata", remotePath,
+        "--expected-version", "1.0.4",
+        "--expected-git-head", releaseCommit,
+        "--verified-provenance", provenancePath,
+        "--expected-package", "neondiff",
+        "--expected-repository", "electricsheephq/evaos-code-review-bot-neondiff",
+        "--expected-workflow", ".github/workflows/publish-npm.yml",
+        "--expected-tag", "v1.0.4"
+      ], { encoding: "utf8" });
+      expect(result.status, JSON.stringify(gitHead)).not.toBe(0);
+      expect(result.stderr).toMatch(/npm gitHead (?:is malformed|does not match)/);
+    }
+  });
+
+  it("scopes protected-main provenance recovery to the exact existing v1.0.4 release", () => {
+    const mainSha = "a".repeat(40);
+    const exactArgs = [
+      policyScript, "verify-recovery-dispatch",
+      "--event-name", "workflow_dispatch",
+      "--github-ref", "refs/heads/main",
+      "--workflow-ref", "electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main",
+      "--workflow-sha", mainSha,
+      "--github-sha", mainSha,
+      "--main-sha", mainSha,
+      "--tag", "v1.0.4",
+      "--tag-commit", releaseCommit,
+      "--package-version", "1.0.4",
+      "--provenance-recovery", "true",
+      "--release-valid", "true",
+      "--package-exists", "true"
+    ];
+    const accepted = spawnSync(process.execPath, exactArgs, { encoding: "utf8" });
+    expect(accepted.status).toBe(0);
+
+    const mutations: Array<[string, string]> = [
+      ["--event-name", "release"],
+      ["--github-ref", "refs/tags/v1.0.4"],
+      ["--workflow-ref", "other"],
+      ["--workflow-sha", "b".repeat(40)],
+      ["--github-sha", "b".repeat(40)],
+      ["--main-sha", "b".repeat(40)],
+      ["--tag", "v1.0.5"],
+      ["--tag-commit", "b".repeat(40)],
+      ["--package-version", "1.0.5"],
+      ["--provenance-recovery", "false"],
+      ["--release-valid", "false"],
+      ["--package-exists", "false"]
+    ];
+    for (const [flag, value] of mutations) {
+      const args = [...exactArgs];
+      args[args.indexOf(flag) + 1] = value;
+      const rejected = spawnSync(process.execPath, args, { encoding: "utf8" });
+      expect(rejected.status, flag).not.toBe(0);
+    }
+  });
+
+  it("requires exact predecessor and quarantine ownership before recovery promotion", () => {
+    const run = (latestVersion: string, quarantineVersion: string) => spawnSync(process.execPath, [
+      policyScript, "verify-recovery-channels",
+      "--latest-version", latestVersion,
+      "--quarantine-version", quarantineVersion,
+      "--target-version", "1.0.4",
+      "--expected-predecessor", "1.0.3"
+    ], { encoding: "utf8" });
+
+    expect(JSON.parse(run("1.0.3", "1.0.4").stdout)).toMatchObject({ action: "promote" });
+    expect(JSON.parse(run("1.0.4", "1.0.4").stdout)).toMatchObject({ action: "confirm_and_cleanup" });
+    expect(JSON.parse(run("1.0.4", "").stdout)).toMatchObject({ action: "confirmed" });
+    for (const [latest, quarantine] of [
+      ["1.0.3", ""],
+      ["1.0.3", "9.9.9"],
+      ["1.0.4", "9.9.9"],
+      ["9.9.9", "1.0.4"]
+    ]) {
+      expect(run(latest, quarantine).status, `${latest}/${quarantine}`).not.toBe(0);
+    }
   });
 
   it("runs the activation-aware public release gate after packing and before npm publication", () => {

--- a/tests/npm-release-policy.test.ts
+++ b/tests/npm-release-policy.test.ts
@@ -248,12 +248,13 @@ describe("npm release policy", () => {
     expect(pack.shasum).toMatch(/^[a-f0-9]{40}$/);
   });
 
-  it("accepts an absent npm gitHead only with exact v1.0.4 verified provenance", () => {
+  it("accepts an absent npm gitHead only with exact v1.0.4 provenance and recovery-dispatch proof", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-npm-provenance-fallback-"));
     roots.push(root);
     const localPath = join(root, "pack.json");
     const remotePath = join(root, "remote.json");
     const provenancePath = join(root, "verified-provenance.json");
+    const recoveryProofPath = join(root, "recovery-dispatch-proof.json");
     const integrity = `sha512-${Buffer.from("reviewed-v1.0.4-tarball").toString("base64")}`;
     writeFileSync(localPath, JSON.stringify([{
       version: "1.0.4",
@@ -276,7 +277,7 @@ describe("npm release policy", () => {
       commit: releaseCommit
     }));
 
-    const result = spawnSync(process.execPath, [
+    const verifyPackArgs = [
       policyScript, "verify-pack",
       "--local-pack", localPath,
       "--remote-metadata", remotePath,
@@ -287,6 +288,33 @@ describe("npm release policy", () => {
       "--expected-repository", "electricsheephq/evaos-code-review-bot-neondiff",
       "--expected-workflow", ".github/workflows/publish-npm.yml",
       "--expected-tag", "v1.0.4"
+    ];
+    const unbound = spawnSync(process.execPath, verifyPackArgs, { encoding: "utf8" });
+    expect(unbound.status).not.toBe(0);
+    expect(unbound.stderr).toContain("protected-main recovery dispatch proof");
+
+    const mainSha = "a".repeat(40);
+    const dispatch = spawnSync(process.execPath, [
+      policyScript, "verify-recovery-dispatch",
+      "--event-name", "workflow_dispatch",
+      "--github-ref", "refs/heads/main",
+      "--workflow-ref", "electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main",
+      "--workflow-sha", mainSha,
+      "--github-sha", mainSha,
+      "--main-sha", mainSha,
+      "--tag", "v1.0.4",
+      "--tag-commit", releaseCommit,
+      "--package-version", "1.0.4",
+      "--provenance-recovery", "true",
+      "--release-valid", "true",
+      "--package-exists", "true",
+      "--proof-output", recoveryProofPath
+    ], { encoding: "utf8" });
+    expect(dispatch.status, dispatch.stderr).toBe(0);
+
+    const result = spawnSync(process.execPath, [
+      ...verifyPackArgs,
+      "--recovery-proof", recoveryProofPath
     ], { encoding: "utf8" });
 
     expect(result.status).toBe(0);
@@ -294,6 +322,33 @@ describe("npm release policy", () => {
       version: "1.0.4",
       sourceIdentity: "verified_provenance_fallback"
     });
+
+    const exactProof = JSON.parse(readFileSync(recoveryProofPath, "utf8"));
+    for (const [field, value] of [
+      ["workflowSha", "b".repeat(40)],
+      ["mainSha", "b".repeat(40)],
+      ["tag", "v1.0.5"],
+      ["tagCommit", "b".repeat(40)],
+      ["packageVersion", "1.0.5"],
+      ["provenanceRecovery", false],
+      ["releaseValid", false],
+      ["packageExists", false]
+    ] as const) {
+      writeFileSync(recoveryProofPath, JSON.stringify({ ...exactProof, [field]: value }));
+      const rejected = spawnSync(process.execPath, [
+        ...verifyPackArgs,
+        "--recovery-proof", recoveryProofPath
+      ], { encoding: "utf8" });
+      expect(rejected.status, field).not.toBe(0);
+      expect(rejected.stderr, field).toContain("recovery dispatch proof does not match");
+    }
+    writeFileSync(recoveryProofPath, "not-json");
+    const malformedProof = spawnSync(process.execPath, [
+      ...verifyPackArgs,
+      "--recovery-proof", recoveryProofPath
+    ], { encoding: "utf8" });
+    expect(malformedProof.status).not.toBe(0);
+    expect(malformedProof.stderr).toContain("recovery dispatch proof is not valid JSON");
   });
 
   it("rejects malformed, mismatched, or under-bound provenance for an absent gitHead", () => {
@@ -302,6 +357,7 @@ describe("npm release policy", () => {
     const localPath = join(root, "pack.json");
     const remotePath = join(root, "remote.json");
     const provenancePath = join(root, "verified-provenance.json");
+    const recoveryProofPath = join(root, "recovery-dispatch-proof.json");
     const integrity = `sha512-${Buffer.from("reviewed-v1.0.4-tarball").toString("base64")}`;
     const exactProvenance = {
       package: "neondiff",
@@ -323,6 +379,23 @@ describe("npm release policy", () => {
       "dist.integrity": integrity,
       "dist.shasum": "1".repeat(40)
     }));
+    const mainSha = "a".repeat(40);
+    execFileSync(process.execPath, [
+      policyScript, "verify-recovery-dispatch",
+      "--event-name", "workflow_dispatch",
+      "--github-ref", "refs/heads/main",
+      "--workflow-ref", "electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main",
+      "--workflow-sha", mainSha,
+      "--github-sha", mainSha,
+      "--main-sha", mainSha,
+      "--tag", "v1.0.4",
+      "--tag-commit", releaseCommit,
+      "--package-version", "1.0.4",
+      "--provenance-recovery", "true",
+      "--release-valid", "true",
+      "--package-exists", "true",
+      "--proof-output", recoveryProofPath
+    ]);
 
     const run = () => spawnSync(process.execPath, [
       policyScript, "verify-pack",
@@ -334,7 +407,8 @@ describe("npm release policy", () => {
       "--expected-package", "neondiff",
       "--expected-repository", "electricsheephq/evaos-code-review-bot-neondiff",
       "--expected-workflow", ".github/workflows/publish-npm.yml",
-      "--expected-tag", "v1.0.4"
+      "--expected-tag", "v1.0.4",
+      "--recovery-proof", recoveryProofPath
     ], { encoding: "utf8" });
 
     for (const [field, value] of [
@@ -399,6 +473,9 @@ describe("npm release policy", () => {
   });
 
   it("scopes protected-main provenance recovery to the exact existing v1.0.4 release", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-recovery-dispatch-proof-"));
+    roots.push(root);
+    const proofPath = join(root, "proof.json");
     const mainSha = "a".repeat(40);
     const exactArgs = [
       policyScript, "verify-recovery-dispatch",
@@ -413,10 +490,22 @@ describe("npm release policy", () => {
       "--package-version", "1.0.4",
       "--provenance-recovery", "true",
       "--release-valid", "true",
-      "--package-exists", "true"
+      "--package-exists", "true",
+      "--proof-output", proofPath
     ];
     const accepted = spawnSync(process.execPath, exactArgs, { encoding: "utf8" });
     expect(accepted.status).toBe(0);
+    expect(JSON.parse(readFileSync(proofPath, "utf8"))).toMatchObject({
+      eventName: "workflow_dispatch",
+      workflowSha: mainSha,
+      mainSha,
+      tag: "v1.0.4",
+      tagCommit: releaseCommit,
+      packageVersion: "1.0.4",
+      provenanceRecovery: true,
+      releaseValid: true,
+      packageExists: true
+    });
 
     const mutations: Array<[string, string]> = [
       ["--event-name", "release"],
@@ -433,6 +522,7 @@ describe("npm release policy", () => {
       ["--package-exists", "false"]
     ];
     for (const [flag, value] of mutations) {
+      rmSync(proofPath, { force: true });
       const args = [...exactArgs];
       args[args.indexOf(flag) + 1] = value;
       const rejected = spawnSync(process.execPath, args, { encoding: "utf8" });

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -121,6 +121,8 @@ describe("NeonDiff public release readiness", () => {
       githubReleaseUrl?: string;
       publishRunUrl?: string;
       proofBoundaryPhase?: string;
+      nextPhase?: string;
+      pendingRecoveryAction?: string;
       packageArtifact?: { shasum?: string; integrity?: string };
       registry?: { state?: string; gitHeadState?: string; latest?: string; releaseCandidate?: string };
       proofBoundary?: { allowed?: string[]; forbidden?: string[] };
@@ -137,6 +139,8 @@ describe("NeonDiff public release readiness", () => {
       githubReleaseUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/tag/v1.0.4",
       publishRunUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29185873762",
       proofBoundaryPhase: "pre_recovery",
+      nextPhase: "post_recovery",
+      pendingRecoveryAction: expect.stringMatching(/replace this pre-recovery ledger.*successful workflow run/i),
       proofRunUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29185155054",
       activationProofPath:
         "docs/evidence/v1.0.4/mandatory-activation-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json",
@@ -621,7 +625,7 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/npm-release-policy\.mjs classify/);
     expect(publish).toMatch(/npm-release-policy\.mjs verify-git/);
     expect(publish).toMatch(/node "\$POLICY_SCRIPT" verify-pack/);
-    expect(publish).toMatch(/node "\$POLICY_SCRIPT" verify-pack[\s\S]*--expected-git-head "\$EXPECTED_GIT_HEAD"/);
+    expect(publish).toMatch(/VERIFY_PACK_ARGS=\([\s\S]*--expected-git-head "\$EXPECTED_GIT_HEAD"[\s\S]*node "\$POLICY_SCRIPT" verify-pack/);
     expect(publish).toMatch(/verify-npm-provenance\.mjs/);
     expect(publish).toMatch(/npm audit signatures --prefix "\$SIGNATURE_VERIFY_ROOT" --json/);
     expect(publish).toMatch(/REQUIRED_EVIDENCE_KINDS/);
@@ -702,6 +706,7 @@ describe("NeonDiff public release readiness", () => {
     expect(publishStepHeader).toMatch(/WORKFLOW_REF:\s*\$\{\{\s*github\.workflow_ref\s*\}\}/);
     expect(publishStepHeader).toMatch(/WORKFLOW_SHA:\s*\$\{\{\s*github\.workflow_sha\s*\}\}/);
     expect(publish).toMatch(/verify-recovery-dispatch/);
+    expect(publish).toContain('[ "$GITHUB_REF" = "refs/heads/main" ] || [ "$WORKFLOW_REF" = "electricsheephq/evaos-code-review-bot-neondiff/.github/workflows/publish-npm.yml@refs/heads/main" ]');
     expect(publish).toMatch(/gh api "repos\/\$GITHUB_REPOSITORY\/releases\/tags\/\$RELEASE_TAG"/);
     const mutationGateStart = publish.indexOf("BEGIN V104_PROVENANCE_RECOVERY_MUTATION_GATE");
     const recoveryMainFetch = publish.indexOf(
@@ -725,6 +730,7 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/RECOVERY_PROOF_PATH="\$RUNNER_TEMP\/v1\.0\.4-recovery-dispatch-proof\.json"/);
     expect(publish).toMatch(/--proof-output "\$RECOVERY_PROOF_PATH"/);
     expect(publish).toMatch(/--recovery-proof "\$RECOVERY_PROOF_PATH"/);
+    expect(publish).toMatch(/if \[ "\$PROVENANCE_RECOVERY" = "true" \]; then\s+VERIFY_PACK_ARGS\+=\(--recovery-proof "\$RECOVERY_PROOF_PATH"\)\s+fi\s+node "\$POLICY_SCRIPT" verify-pack "\$\{VERIFY_PACK_ARGS\[@\]\}"/);
     expect(publish.indexOf('--proof-output "$RECOVERY_PROOF_PATH"')).toBeLessThan(
       publish.indexOf('--recovery-proof "$RECOVERY_PROOF_PATH"')
     );

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -122,7 +122,7 @@ describe("NeonDiff public release readiness", () => {
       publishRunUrl?: string;
       packageArtifact?: { shasum?: string; integrity?: string };
       registry?: { state?: string; gitHeadState?: string; latest?: string; releaseCandidate?: string };
-      proofBoundary?: { forbidden?: string[] };
+      proofBoundary?: { allowed?: string[]; forbidden?: string[] };
     };
     expect(candidateLedger).toMatchObject({
       version: "v1.0.4",
@@ -150,6 +150,10 @@ describe("NeonDiff public release readiness", () => {
         releaseCandidate: "1.0.4"
       }
     });
+    expect(candidateLedger.proofBoundary?.allowed).toContain(
+      "registry exposes npm attestation metadata pending successful recovery verification"
+    );
+    expect(candidateLedger.proofBoundary?.allowed?.join("\n")).not.toMatch(/npm signatures.*bind/i);
     expect(candidateLedger.proofBoundary?.forbidden).not.toContain("v1.0.4 activation proof exists");
     expect(read("scripts/install.sh")).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-1\.0\.3\}"/);
     for (const path of ["README.md", "docs/SETUP.md"]) {
@@ -632,6 +636,14 @@ describe("NeonDiff public release readiness", () => {
     expect(publish.indexOf('test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"')).toBeLessThan(
       publish.indexOf('npm publish "$PACK_TARBALL" --provenance')
     );
+    expect(publish).toContain('test "$RELEASE_TAG" = "v1.0.4"');
+    expect(publish).toContain('test "$TAG_COMMIT" = "fc66d27b6ab9f6a1eb8282d289ef63407cd96982"');
+    expect(publish.indexOf('test "$RELEASE_TAG" = "v1.0.4"')).toBeLessThan(
+      publish.indexOf("node scripts/npm-release-policy.mjs verify-git")
+    );
+    expect(publish.indexOf('test "$TAG_COMMIT" = "fc66d27b6ab9f6a1eb8282d289ef63407cd96982"')).toBeLessThan(
+      publish.indexOf("Classify npm package release")
+    );
     expect(releasePolicy).toMatch(/npm tarball integrity does not match the reviewed pack/);
     expect(publish.indexOf("verify-npm-provenance.mjs")).toBeLessThan(
       publish.indexOf('npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"')
@@ -676,6 +688,11 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/provenance_recovery:\s*\n\s*description:[^\n]*\n\s*required:\s*true\n\s*type:\s*boolean\n\s*default:\s*false/);
     expect(publish).toMatch(/WORKFLOW_REF:\s*\$\{\{\s*github\.workflow_ref\s*\}\}/);
     expect(publish).toMatch(/WORKFLOW_SHA:\s*\$\{\{\s*github\.workflow_sha\s*\}\}/);
+    const publishStepHeader = publish.split("- name: Publish or verify existing package")[1]?.split("run: |")[0] ?? "";
+    expect(publishStepHeader).toMatch(/PROVENANCE_RECOVERY:\s*\$\{\{\s*inputs\.provenance_recovery \|\| false\s*\}\}/);
+    expect(publishStepHeader).toMatch(/RELEASE_TAG:\s*\$\{\{\s*github\.event\.inputs\.tag \|\| github\.event\.release\.tag_name\s*\}\}/);
+    expect(publishStepHeader).toMatch(/WORKFLOW_REF:\s*\$\{\{\s*github\.workflow_ref\s*\}\}/);
+    expect(publishStepHeader).toMatch(/WORKFLOW_SHA:\s*\$\{\{\s*github\.workflow_sha\s*\}\}/);
     expect(publish).toMatch(/verify-recovery-dispatch/);
     expect(publish).toMatch(/--github-ref "\$GITHUB_REF"/);
     expect(publish).toMatch(/--workflow-ref "\$WORKFLOW_REF"/);
@@ -697,6 +714,9 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/--verified-provenance "\$VERIFIED_PROVENANCE_PATH"/);
     expect(publish.indexOf('> "$VERIFIED_PROVENANCE_PATH"')).toBeLessThan(
       publish.indexOf('--verified-provenance "$VERIFIED_PROVENANCE_PATH"')
+    );
+    expect(publish.indexOf('npm audit signatures --prefix "$SIGNATURE_VERIFY_ROOT" --json')).toBeLessThan(
+      publish.indexOf('node "$POLICY_SCRIPT" verify-pack')
     );
     expect(publish.indexOf('npm audit signatures --prefix "$SIGNATURE_VERIFY_ROOT" --json')).toBeLessThan(
       publish.indexOf("BEGIN V104_PROVENANCE_RECOVERY_PREPROMOTION_GUARD")

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -154,6 +154,12 @@ describe("NeonDiff public release readiness", () => {
       "registry exposes npm attestation metadata pending successful recovery verification"
     );
     expect(candidateLedger.proofBoundary?.allowed?.join("\n")).not.toMatch(/npm signatures.*bind/i);
+    expect(candidateLedger.proofBoundary?.forbidden).toEqual([
+      "npm latest points to 1.0.4",
+      "release-candidate cleanup completed",
+      "public-registry install and activation smoke completed",
+      "predecessor releases or artifacts are safe to remove"
+    ]);
     expect(candidateLedger.proofBoundary?.forbidden).not.toContain("v1.0.4 activation proof exists");
     expect(read("scripts/install.sh")).toMatch(/NEONDIFF_VERSION="\$\{NEONDIFF_VERSION:-1\.0\.3\}"/);
     for (const path of ["README.md", "docs/SETUP.md"]) {

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -120,6 +120,7 @@ describe("NeonDiff public release readiness", () => {
       releaseCommit?: string;
       githubReleaseUrl?: string;
       publishRunUrl?: string;
+      proofBoundaryPhase?: string;
       packageArtifact?: { shasum?: string; integrity?: string };
       registry?: { state?: string; gitHeadState?: string; latest?: string; releaseCandidate?: string };
       proofBoundary?: { allowed?: string[]; forbidden?: string[] };
@@ -135,6 +136,7 @@ describe("NeonDiff public release readiness", () => {
       releaseCommit: "fc66d27b6ab9f6a1eb8282d289ef63407cd96982",
       githubReleaseUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/tag/v1.0.4",
       publishRunUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29185873762",
+      proofBoundaryPhase: "pre_recovery",
       proofRunUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29185155054",
       activationProofPath:
         "docs/evidence/v1.0.4/mandatory-activation-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json",
@@ -700,6 +702,32 @@ describe("NeonDiff public release readiness", () => {
     expect(publishStepHeader).toMatch(/WORKFLOW_REF:\s*\$\{\{\s*github\.workflow_ref\s*\}\}/);
     expect(publishStepHeader).toMatch(/WORKFLOW_SHA:\s*\$\{\{\s*github\.workflow_sha\s*\}\}/);
     expect(publish).toMatch(/verify-recovery-dispatch/);
+    expect(publish).toMatch(/gh api "repos\/\$GITHUB_REPOSITORY\/releases\/tags\/\$RELEASE_TAG"/);
+    const mutationGateStart = publish.indexOf("BEGIN V104_PROVENANCE_RECOVERY_MUTATION_GATE");
+    const recoveryMainFetch = publish.indexOf(
+      "git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main",
+      mutationGateStart
+    );
+    expect(recoveryMainFetch).toBeGreaterThan(mutationGateStart);
+    expect(recoveryMainFetch).toBeLessThan(
+      publish.indexOf('RECOVERY_RELEASE_METADATA_PATH="$RUNNER_TEMP/recovery-release-metadata.json"')
+    );
+    expect(publish).toMatch(/RECOVERY_MAIN_SHA="\$\(git rev-parse refs\/remotes\/origin\/main\)"/);
+    expect(publish).toMatch(/--main-sha "\$RECOVERY_MAIN_SHA"/);
+    expect(publish.indexOf('RECOVERY_RELEASE_METADATA_PATH="$RUNNER_TEMP/recovery-release-metadata.json"')).toBeGreaterThan(
+      mutationGateStart
+    );
+    expect(publish.indexOf('RECOVERY_RELEASE_METADATA_PATH="$RUNNER_TEMP/recovery-release-metadata.json"')).toBeLessThan(
+      publish.indexOf('node "$POLICY_SCRIPT" verify-recovery-dispatch')
+    );
+    expect(publish).toMatch(/--release-valid "\$RELEASE_VALID"/);
+    expect(publish).not.toContain("--release-valid true");
+    expect(publish).toMatch(/RECOVERY_PROOF_PATH="\$RUNNER_TEMP\/v1\.0\.4-recovery-dispatch-proof\.json"/);
+    expect(publish).toMatch(/--proof-output "\$RECOVERY_PROOF_PATH"/);
+    expect(publish).toMatch(/--recovery-proof "\$RECOVERY_PROOF_PATH"/);
+    expect(publish.indexOf('--proof-output "$RECOVERY_PROOF_PATH"')).toBeLessThan(
+      publish.indexOf('--recovery-proof "$RECOVERY_PROOF_PATH"')
+    );
     expect(publish).toMatch(/--github-ref "\$GITHUB_REF"/);
     expect(publish).toMatch(/--workflow-ref "\$WORKFLOW_REF"/);
     expect(publish).toMatch(/--workflow-sha "\$WORKFLOW_SHA"/);
@@ -727,6 +755,16 @@ describe("NeonDiff public release readiness", () => {
       publish.indexOf('node "$POLICY_SCRIPT" verify-pack')
     );
     expect(publish.indexOf('npm audit signatures --prefix "$SIGNATURE_VERIFY_ROOT" --json')).toBeLessThan(
+      publish.indexOf("BEGIN V104_PROVENANCE_RECOVERY_PREPROMOTION_GUARD")
+    );
+    const prepromotionMainFetch = publish.indexOf(
+      "git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main",
+      recoveryMainFetch + 1
+    );
+    expect(prepromotionMainFetch).toBeGreaterThan(
+      publish.indexOf('node "$POLICY_SCRIPT" verify-pack')
+    );
+    expect(prepromotionMainFetch).toBeLessThan(
       publish.indexOf("BEGIN V104_PROVENANCE_RECOVERY_PREPROMOTION_GUARD")
     );
     expect(publish).toMatch(/verify-recovery-channels/);

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -593,8 +593,8 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/fetch-depth:\s*0/);
     expect(publish).toMatch(/npm-release-policy\.mjs classify/);
     expect(publish).toMatch(/npm-release-policy\.mjs verify-git/);
-    expect(publish).toMatch(/npm-release-policy\.mjs verify-pack/);
-    expect(publish).toMatch(/npm-release-policy\.mjs verify-pack[\s\S]*--expected-git-head "\$EXPECTED_GIT_HEAD"/);
+    expect(publish).toMatch(/node "\$POLICY_SCRIPT" verify-pack/);
+    expect(publish).toMatch(/node "\$POLICY_SCRIPT" verify-pack[\s\S]*--expected-git-head "\$EXPECTED_GIT_HEAD"/);
     expect(publish).toMatch(/verify-npm-provenance\.mjs/);
     expect(publish).toMatch(/npm audit signatures --prefix "\$SIGNATURE_VERIFY_ROOT" --json/);
     expect(publish).toMatch(/REQUIRED_EVIDENCE_KINDS/);
@@ -604,7 +604,7 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/--signer-workflow electricsheephq\/evaos-code-review-bot-neondiff\/\.github\/workflows\/license-lifecycle-proof\.yml/);
     expect(publish).toMatch(/--signer-digest "\$CANDIDATE_HEAD"/);
     expect(publish).toMatch(/--source-ref refs\/heads\/main/);
-    expect(publish).toMatch(/npm-release-policy\.mjs verify-channel/);
+    expect(publish).toMatch(/node "\$POLICY_SCRIPT" verify-channel/);
     expect(publish).toMatch(/prepromotion-channel\.json/);
     expect(publish.indexOf("prepromotion-channel.json")).toBeLessThan(
       publish.indexOf('npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"')
@@ -645,9 +645,9 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/previousReleasedPackageVersion/);
     expect(publish).toMatch(/npm publish "\$PACK_TARBALL" --provenance --access public --tag "release-candidate"/);
     expect(publish.indexOf('npm publish "$PACK_TARBALL" --provenance --access public --tag "release-candidate"')).toBeLessThan(
-      publish.indexOf("npm-release-policy.mjs verify-pack")
+      publish.indexOf('node "$POLICY_SCRIPT" verify-pack')
     );
-    expect(publish.indexOf("npm-release-policy.mjs verify-pack")).toBeLessThan(
+    expect(publish.indexOf('node "$POLICY_SCRIPT" verify-pack')).toBeLessThan(
       publish.indexOf('npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"')
     );
     expect(publish).toMatch(/default:\s*v1\.0\.4/);
@@ -658,6 +658,40 @@ describe("NeonDiff public release readiness", () => {
       publish.indexOf('npm publish "$PACK_TARBALL" --provenance')
     );
     expect(publish).toMatch(/curl[\s\S]*--connect-timeout 10[\s\S]*--max-time 30[\s\S]*--retry 3[\s\S]*--retry-all-errors/);
+    expect(publish).toMatch(/provenance_recovery:\s*\n\s*description:[^\n]*\n\s*required:\s*true\n\s*type:\s*boolean\n\s*default:\s*false/);
+    expect(publish).toMatch(/WORKFLOW_REF:\s*\$\{\{\s*github\.workflow_ref\s*\}\}/);
+    expect(publish).toMatch(/WORKFLOW_SHA:\s*\$\{\{\s*github\.workflow_sha\s*\}\}/);
+    expect(publish).toMatch(/verify-recovery-dispatch/);
+    expect(publish).toMatch(/--github-ref "\$GITHUB_REF"/);
+    expect(publish).toMatch(/--workflow-ref "\$WORKFLOW_REF"/);
+    expect(publish).toMatch(/--workflow-sha "\$WORKFLOW_SHA"/);
+    expect(publish).toMatch(/--package-exists "\$PACKAGE_ALREADY_EXISTS"/);
+    expect(publish).toMatch(/Checkout protected-main recovery policy/);
+    expect(publish).toMatch(/path:\s*\.recovery-policy/);
+    expect(publish).toMatch(/ref:\s*\$\{\{\s*github\.workflow_sha\s*\}\}/);
+    expect(publish.indexOf('npm pack --json --pack-destination "$PACK_DIR" > pack.json')).toBeLessThan(
+      publish.indexOf("Checkout protected-main recovery policy")
+    );
+    expect(publish).toMatch(/git -C \.recovery-policy rev-parse HEAD/);
+    expect(publish).toMatch(/BEGIN V104_PROVENANCE_RECOVERY_PUBLISH_GUARD/);
+    expect(publish).toMatch(/END V104_PROVENANCE_RECOVERY_PUBLISH_GUARD/);
+    expect(publish).toMatch(/provenance recovery requires neondiff@\$PACKAGE_VERSION to already exist/i);
+    expect(publish).toMatch(/VERIFIED_PROVENANCE_PATH="\$RUNNER_TEMP\/verified-npm-provenance\.json"/);
+    expect(publish).toMatch(/rm -f "\$VERIFIED_PROVENANCE_PATH"/);
+    expect(publish).toMatch(/verify-npm-provenance\.mjs[\s\S]*> "\$VERIFIED_PROVENANCE_PATH"/);
+    expect(publish).toMatch(/--verified-provenance "\$VERIFIED_PROVENANCE_PATH"/);
+    expect(publish.indexOf('> "$VERIFIED_PROVENANCE_PATH"')).toBeLessThan(
+      publish.indexOf('--verified-provenance "$VERIFIED_PROVENANCE_PATH"')
+    );
+    expect(publish.indexOf('npm audit signatures --prefix "$SIGNATURE_VERIFY_ROOT" --json')).toBeLessThan(
+      publish.indexOf("BEGIN V104_PROVENANCE_RECOVERY_PREPROMOTION_GUARD")
+    );
+    expect(publish).toMatch(/verify-recovery-channels/);
+    expect(publish).toMatch(/BEGIN V104_PROVENANCE_RECOVERY_PREPROMOTION_GUARD/);
+    expect(publish).toMatch(/END V104_PROVENANCE_RECOVERY_PREPROMOTION_GUARD/);
+    expect(publish.indexOf("verify-recovery-channels")).toBeLessThan(
+      publish.indexOf('npm dist-tag add "neondiff@$PACKAGE_VERSION" "$NPM_TAG"')
+    );
 
     expect(lifecycle).toMatch(/workflow_dispatch:/);
     expect(lifecycle).toMatch(/concurrency:\s*\n\s*group:\s*neondiff-license-lifecycle-production/);

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -116,16 +116,25 @@ describe("NeonDiff public release readiness", () => {
       candidateSourceSha?: string;
       proofRunUrl?: string;
       activationProofPath?: string;
+      recoveryIssue?: string;
+      releaseCommit?: string;
+      githubReleaseUrl?: string;
+      publishRunUrl?: string;
       packageArtifact?: { shasum?: string; integrity?: string };
+      registry?: { state?: string; gitHeadState?: string; latest?: string; releaseCandidate?: string };
       proofBoundary?: { forbidden?: string[] };
     };
     expect(candidateLedger).toMatchObject({
       version: "v1.0.4",
       packageVersion: "1.0.4",
       publishedVersionAtCandidateCut: "v1.0.3",
-      state: "protected_main_candidate_proven_pending_publication",
+      state: "immutable_package_published_quarantined_pending_provenance_recovery",
       trackingIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/532",
+      recoveryIssue: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/542",
       candidateSourceSha: "42db7c8ff7dba6ceac813238dcebfb54dc83851f",
+      releaseCommit: "fc66d27b6ab9f6a1eb8282d289ef63407cd96982",
+      githubReleaseUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/releases/tag/v1.0.4",
+      publishRunUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29185873762",
       proofRunUrl: "https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29185155054",
       activationProofPath:
         "docs/evidence/v1.0.4/mandatory-activation-42db7c8ff7dba6ceac813238dcebfb54dc83851f.json",
@@ -133,6 +142,12 @@ describe("NeonDiff public release readiness", () => {
         shasum: "526c04bd24673351b9cc7136d8747df00ffaa2be",
         integrity:
           "sha512-ng6g4Ivn+eFzZWkxhDAOsvaimYQi8HWktnK9xTptNLg37EK/LRh2Xr5Y+sAYnX6Sqa1YBVd3iUZBMtQLQbYvcw=="
+      },
+      registry: {
+        state: "published_quarantined",
+        gitHeadState: "absent_reviewed_tarball_publish",
+        latest: "1.0.3",
+        releaseCandidate: "1.0.4"
       }
     });
     expect(candidateLedger.proofBoundary?.forbidden).not.toContain("v1.0.4 activation proof exists");
@@ -728,12 +743,22 @@ describe("NeonDiff public release readiness", () => {
     const recovery = governance.split("### Partial Quarantine Promotion Recovery")[1]?.split("## Tag And Release")[0] ?? "";
     expect(recovery).toMatch(/gh workflow run publish-npm\.yml/);
     expect(recovery).toMatch(/--ref v<version>/);
-    expect(recovery).not.toMatch(/--ref main/);
     expect(recovery).toMatch(/-f tag=v<version>/);
+    expect(recovery).toMatch(/--ref main/);
+    expect(recovery).toMatch(/-f tag=v1\.0\.4/);
+    expect(recovery).toMatch(/-f provenance_recovery=true/);
+    expect(recovery).toMatch(/v1\.0\.4-only/i);
+    expect(recovery).toMatch(/cannot publish|does not publish/i);
     expect(recovery).toMatch(/direct dist-tag mutation is not supported/i);
     expect(recovery).toMatch(/waives only the normal 24-hour activation-proof/);
     expect(recovery).toMatch(/30-day maximum-age ceiling/);
     expect(recovery).not.toMatch(/npm dist-tag add/);
     expect(recovery).not.toMatch(/npm dist-tag rm/);
+
+    const changelog = read("CHANGELOG.md").split("## [1.0.4]")[0] ?? "";
+    expect(changelog).toMatch(/#542/);
+    expect(changelog).toMatch(/reviewed\s+tarball/i);
+    expect(changelog).toMatch(/Sigstore\/SLSA provenance/i);
+    expect(changelog).not.toMatch(/latest=1\.0\.4|public install succeeded/i);
   });
 });

--- a/tests/public-release-readiness.test.ts
+++ b/tests/public-release-readiness.test.ts
@@ -699,6 +699,8 @@ describe("NeonDiff public release readiness", () => {
     expect(publish).toMatch(/--workflow-sha "\$WORKFLOW_SHA"/);
     expect(publish).toMatch(/--package-exists "\$PACKAGE_ALREADY_EXISTS"/);
     expect(publish).toMatch(/Checkout protected-main recovery policy/);
+    expect(publish).toMatch(/- name: Checkout protected-main recovery policy\n\s+if: \$\{\{[^\n]*steps\.package_release\.outputs\.should_publish == 'true'[^\n]*\}\}/);
+    expect(publish).toMatch(/- name: Verify protected-main recovery policy checkout\n\s+if: \$\{\{[^\n]*steps\.package_release\.outputs\.should_publish == 'true'[^\n]*\}\}/);
     expect(publish).toMatch(/path:\s*\.recovery-policy/);
     expect(publish).toMatch(/ref:\s*\$\{\{\s*github\.workflow_sha\s*\}\}/);
     expect(publish.indexOf('npm pack --json --pack-destination "$PACK_DIR" > pack.json')).toBeLessThan(


### PR DESCRIPTION
Related: #542
Supports: #532

## Why

The reviewed `neondiff@1.0.4` tarball is immutable and already exists under `release-candidate`, but npm 11.17.0 did not synthesize `gitHead` when the workflow published the reviewed `.tgz`. The original workflow therefore stopped before promotion and left `latest=1.0.3`.

## What changes

- add a workflow-only, default-off recovery dispatch scoped to the exact annotated `v1.0.4` tag and release commit;
- keep the v1.0.4 tag checkout as the sole build/pack source while loading recovery policy from a second protected-main checkout pinned to the workflow SHA;
- accept only an actually absent `gitHead`, and only after exact tarball identity, npm signatures, Sigstore/SLSA provenance, and a fresh protected-main recovery proof bind package, repository, workflow, tag, and commit;
- require an existing immutable package and GitHub Release, exact predecessor ownership, target-owned quarantine, package-wide concurrency, fresh protected-main checks, and owned-only cleanup;
- prohibit recovery publication and fail every unexpected or malformed identity/channel state;
- reconcile ambiguous nonzero `npm dist-tag add` results through bounded registry reads while preserving the command exit code;
- keep the release ledger explicitly `pre_recovery` with a required post-recovery stamp.

## Current-head test and review evidence

Exact head: `3115ff67e1c3759d778060310822982181c355bd`

- local focused recovery/policy/readiness/convergence suite: 5 files / 71 tests passed;
- `npm run build`, actionlint, public-claims scan, secret scan, and diff check passed;
- exact-head CI including the full suite and package checks passed: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29189338901;
- exact-head CodeQL passed: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/actions/runs/29189337789;
- Swift and Socket gates passed; expected desktop smoke skipped because this diff has no desktop impact;
- independent security and specification reviews: clean;
- exact-head Codex review: clean: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/554#issuecomment-4950882003;
- exact-head evaOS review: no validated findings: https://github.com/electricsheephq/evaos-code-review-bot-neondiff/pull/554#pullrequestreview-4679894553;
- CodeRabbit completed; its issue-routing and WORKFLOW_REF findings were dispositioned against live #542 text and the exact public v1.0.4 provenance certificate.

The executable recovery fixture runs the real workflow block from reviewed tarball and activation evidence through promotion confirmation and owned quarantine cleanup. Every upstream failure leaves `npm publish`, `npm dist-tag add`, and `npm dist-tag rm` unreachable; accepted-then-nonzero and nonmutating-nonzero promotion outcomes are covered.

## Release boundary

This PR does not retag, republish, unpublish, or directly mutate npm dist-tags. After merge and green main CI, the protected-main workflow will be dispatched for `v1.0.4`. Public install/activation smoke, the post-recovery manifest stamp, and predecessor cleanup remain separate gates. #542 stays open until those recovery exit criteria are met.