### PR TITLE
Add resumable Phase 1 screening runner

### DIFF
--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -985,16 +985,20 @@ async function acquireRunLease(path: string): Promise<number> {
       const prior = parseJson<{ pid?: number }>(path);
       if (typeof prior.pid === "number" && isProcessAlive(prior.pid)) throw new Error(`Phase 1 output has an active exclusive run lease held by PID ${prior.pid}`);
       // Every conforming writer must own the crash-released loopback
-      // coordinator before touching the canonical lease, so no new lease can
-      // appear between this removal and the exclusive replacement open.
-      // lgtm[js/file-system-race]
-      rmSync(path, { force: true });
-      // The exclusive loopback coordinator remains held through this open.
-      // codeql[js/file-system-race]
-      // lgtm[js/file-system-race]
-      const fd = openSync(path, "wx", 0o600);
-      writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), recovered: true })}\n`);
-      return fd;
+      // coordinator before replacing the canonical lease. Build the new lease
+      // under a unique name, then atomically replace the verified-stale path;
+      // there is no check/remove/reopen window on the canonical path.
+      const replacementPath = `${path}.${process.pid}.${randomUUID()}.replacement`;
+      const fd = openSync(replacementPath, "wx", 0o600);
+      try {
+        writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), recovered: true })}\n`);
+        renameSync(replacementPath, path);
+        return fd;
+      } catch (replacementError) {
+        closeSync(fd);
+        rmSync(replacementPath, { force: true });
+        throw replacementError;
+      }
     }
   } finally {
     await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -1,0 +1,1258 @@
+import { createHash, randomUUID } from "node:crypto";
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  createReadStream,
+  realpathSync,
+  closeSync,
+  openSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { basename, dirname, join, resolve, sep } from "node:path";
+import { connect } from "node:net";
+import { containsSecretLikeText, redactSecrets } from "./secrets.js";
+
+export type Phase1TerminalStatus = "completed" | "failed" | "stopped" | "oom" | "schema_failed";
+
+export interface Phase1Target {
+  id: string;
+  modelPath: string;
+  modelSha256: string;
+  backendCommit: string;
+  executable: string;
+  executableSha256: string;
+  ownershipVerifierSha256?: string;
+  args: string[];
+  servingParameters?: Record<string, unknown>;
+}
+
+export interface Phase1Cell {
+  id: string;
+  contextTokens: number;
+  repetition: number;
+  executableArgs?: string[];
+  parameters?: Record<string, unknown>;
+}
+
+export interface Phase1Input {
+  id: string;
+  sha256: string;
+  prompt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface Phase1RunSpec {
+  outputDir: string;
+  safeOutputRoot: string;
+  checkoutRoot: string;
+  target: Phase1Target;
+  cells: Phase1Cell[];
+  inputs: Phase1Input[];
+  prompt: { version: string; template: string; templateSha256: string; parameters?: Record<string, unknown> };
+  request: { version: string; stream: boolean; outputBudgetTokens: number; requiredMetrics: string[]; responseFormat?: unknown; parameters: Record<string, unknown> };
+  harness: { commit: string; sourcePath: string; sourceSha256: string };
+  parser: { version: string; format: "json"; sha256: string };
+  gate: { version: string; requiredTopLevelKeys: string[]; sha256: string };
+}
+
+export interface Phase1Resident {
+  id: string;
+  argv: string[];
+  logs?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface Phase1InvocationResult {
+  status: Phase1TerminalStatus;
+  rawOutput?: string;
+  parsedOutput?: unknown;
+  gatedOutput?: unknown;
+  metrics?: Record<string, number>;
+  errorCode?: string;
+  logs?: string;
+  resourceSamples?: Phase1ResourceSample[];
+  residentTerminal?: boolean;
+  retryCount?: number;
+}
+
+export interface Phase1ResidentAdapter {
+  start(context: {
+    outputDir: string;
+    target: Phase1Target;
+    cell: Phase1Cell;
+    targetFingerprint: string;
+    cellFingerprint: string;
+  }): Promise<Phase1Resident>;
+  invoke(resident: Phase1Resident, request: {
+    input: Phase1Input;
+    cell: Phase1Cell;
+    renderedPrompt: string;
+    request: Phase1RunSpec["request"];
+    promptFingerprint: string;
+    parserFingerprint: string;
+    gateFingerprint: string;
+  }): Promise<Phase1InvocationResult>;
+  stop(resident: Phase1Resident): Promise<void>;
+}
+
+type Counts = Record<Phase1TerminalStatus, number>;
+
+export interface Phase1RunSummary {
+  schemaVersion: "neondiff-phase1-screen-summary/v1";
+  runFingerprint: string;
+  status: "completed" | "failed";
+  counts: Counts;
+  expectedResults: number;
+  recordedResults: number;
+  infrastructureErrorCode?: string;
+  summarySha256: string;
+  claimClass: "transport_and_gate_only";
+}
+
+export interface LlamaServerExecutableAdapterOptions {
+  baseUrl: string;
+  readinessTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  stopTimeoutMs?: number;
+  maxResponseBytes?: number;
+  verifyListenerOwnership?: (pid: number, host: string, port: number) => Promise<boolean>;
+  verifyProcessIdentity?: (pid: number, executableSha256: string, argvFingerprint: string) => Promise<boolean>;
+  ownershipVerifierSha256?: string;
+}
+
+
+export interface Phase1ResourceSample {
+  capturedAt: string;
+  phase: string;
+  rssBytes: number;
+  vramBytes: number;
+  swapBytes: number;
+  [key: string]: string | number;
+}
+
+export interface Phase1ResourceMonitor {
+  identity: { version: string; sha256: string };
+  start(context: { target: Phase1Target; cell: Phase1Cell; outputDir: string }): Promise<{ id: string }>;
+  sample(session: { id: string }, context: { phase: "before" | "after"; input: Phase1Input }): Promise<Phase1ResourceSample>;
+  classify?(samples: Phase1ResourceSample[]): { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined;
+  stop(session: { id: string }): Promise<Phase1ResourceSample>;
+}
+
+export interface Phase1RunnerOptions { monitor?: Phase1ResourceMonitor }
+
+type ResidentProcess = {
+  process: ChildProcess;
+  unsafeEvidence: boolean;
+  exited: boolean;
+  stderrTail: string;
+};
+
+/**
+ * Owns an unregistered llama-server subprocess for exactly one screening cell.
+ * It never installs a service, mutates config, posts to GitHub, or inherits
+ * credential values through command arguments.
+ */
+export function createLlamaServerExecutableAdapter(
+  options: LlamaServerExecutableAdapterOptions
+): Phase1ResidentAdapter {
+  const residents = new Map<string, ResidentProcess>();
+  const endpoint = new URL(options.baseUrl);
+  if (endpoint.protocol !== "http:" || endpoint.hostname !== "127.0.0.1" || !endpoint.port) {
+    throw new Error("llama-server executable adapter requires an explicit HTTP loopback endpoint on 127.0.0.1");
+  }
+  if (!options.verifyListenerOwnership || !options.verifyProcessIdentity || !/^[a-f0-9]{64}$/.test(options.ownershipVerifierSha256 ?? "")) {
+    throw new Error("llama-server executable adapter requires listener and process ownership verifiers");
+  }
+  const verifyListenerOwnership = options.verifyListenerOwnership;
+  const verifyProcessIdentity = options.verifyProcessIdentity;
+  const baseUrl = endpoint.origin;
+  const readinessTimeoutMs = options.readinessTimeoutMs ?? 60_000;
+  const requestTimeoutMs = options.requestTimeoutMs ?? 10 * 60_000;
+  const stopTimeoutMs = options.stopTimeoutMs ?? 5_000;
+  const maxResponseBytes = options.maxResponseBytes ?? 8 * 1024 * 1024;
+  return {
+    async start({ target, cell, outputDir }) {
+      const effectiveArgs = [...target.args, ...(cell.executableArgs ?? [])];
+      const argv = [target.executable, ...effectiveArgs];
+      const argvFingerprint = fingerprint(argv);
+      if (target.ownershipVerifierSha256 !== options.ownershipVerifierSha256) throw new Error("listener ownership verifier fingerprint does not match the immutable target");
+      assertSecretSafe("llama-server argv", argv.join("\n"));
+      if (!hasFlagValue(effectiveArgs, "--host", "127.0.0.1") || !hasFlagValue(effectiveArgs, "--port", endpoint.port)) {
+        throw new Error("llama-server loopback host and port must match the immutable target argv");
+      }
+      if (!hasFlagValue(effectiveArgs, "--ctx-size", String(cell.contextTokens))) {
+        throw new Error("llama-server context size must match the immutable screening cell");
+      }
+      if (!hasFlagValue(effectiveArgs, "--model", target.modelPath)) {
+        throw new Error("llama-server model path must match the immutable target argv");
+      }
+      const actualExecutableSha256 = await sha256File(target.executable);
+      if (actualExecutableSha256 !== target.executableSha256) {
+        throw new Error("llama-server executable SHA-256 does not match the immutable target");
+      }
+      const actualModelSha256 = await sha256File(target.modelPath);
+      if (actualModelSha256 !== target.modelSha256) throw new Error("llama-server model SHA-256 does not match the immutable target");
+      const journalPath = join(outputDir, "processes", `${cell.id}.json`);
+      await recoverResidentJournal(journalPath, target.executableSha256, verifyProcessIdentity, stopTimeoutMs);
+      await assertEndpointUnbound(endpoint.hostname, Number(endpoint.port));
+      const child = spawn(target.executable, effectiveArgs, {
+        env: minimalProcessEnvironment(),
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: true
+      });
+      const id = randomUUID();
+      const loadStartedAt = performance.now();
+      const state: ResidentProcess = { process: child, unsafeEvidence: false, exited: false, stderrTail: "" };
+      residents.set(id, state);
+      const inspectChunk = (chunk: Buffer): void => {
+        const text = chunk.toString("utf8");
+        state.unsafeEvidence ||= containsSecretLikeText(text);
+        state.stderrTail = `${state.stderrTail}${redactSecrets(text)}`.slice(-4096);
+      };
+      child.stdout?.on("data", inspectChunk);
+      child.stderr?.on("data", inspectChunk);
+      child.once("exit", () => { state.exited = true; });
+      child.once("error", (error) => {
+        state.exited = true;
+        state.stderrTail = redactSecrets(error.message).slice(-4096);
+      });
+      try {
+        atomicWriteJson(journalPath, {
+          schemaVersion: "neondiff-phase1-resident/v1",
+          state: "running",
+          pid: child.pid,
+          processGroupId: child.pid,
+          executableSha256: target.executableSha256,
+          argvFingerprint,
+          targetId: target.id,
+          cellId: cell.id,
+          startedAt: new Date().toISOString()
+        });
+        await waitForHealthy(baseUrl, readinessTimeoutMs, state);
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        if (state.exited) throw new Error(`llama-server exited after readiness: ${state.stderrTail || "no redacted diagnostics"}`);
+        if (!child.pid || !await verifyListenerOwnership(child.pid, endpoint.hostname, Number(endpoint.port))) {
+          throw new Error("llama-server listener ownership could not be proven for the spawned PID");
+        }
+      } catch (error) {
+        try { await stopProcess(state, stopTimeoutMs); }
+        catch (cleanupError) {
+          residents.delete(id);
+          throw new Error(`resident startup failed and cleanup was not proven: ${errorMessage(cleanupError)}`);
+        }
+        residents.delete(id);
+        throw error;
+      }
+      if (state.unsafeEvidence) {
+        await stopProcess(state, stopTimeoutMs);
+        residents.delete(id);
+        throw new Error("llama-server emitted secret-like text during startup");
+      }
+      return { id, argv, metadata: { baseUrl, pid: child.pid, journalPath, modelId: target.id, loadDurationMs: Math.max(0, performance.now() - loadStartedAt) } };
+    },
+    async invoke(resident, request) {
+      const state = residents.get(resident.id);
+      if (!state) return { status: "stopped", errorCode: "resident_not_found" };
+      if (state.unsafeEvidence) return { status: "failed", errorCode: "secret_like_runtime_log" };
+      if (state.exited) return classifyExitedResident(state);
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), requestTimeoutMs);
+      const requestStartedAt = performance.now();
+      try {
+        const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            ...request.request.parameters,
+            model: resident.metadata?.modelId,
+            messages: [{ role: "user", content: request.renderedPrompt }],
+            stream: request.request.stream,
+            max_tokens: request.request.outputBudgetTokens,
+            ...(request.request.responseFormat === undefined ? {} : { response_format: request.request.responseFormat })
+          }),
+          signal: controller.signal
+        });
+        if (!response.ok) return { status: "failed", errorCode: `http_${response.status}` };
+        if (request.request.stream) {
+          const streamed = await readStreamingAssistant(response, maxResponseBytes, requestStartedAt);
+          assertSecretSafe("llama-server assistant content", streamed.content);
+          return { status: "completed", rawOutput: streamed.content, metrics: streamed.metrics };
+        }
+        const envelopeText = await readResponseBody(response, maxResponseBytes);
+        assertSecretSafe("llama-server response envelope", envelopeText);
+        let envelope: unknown;
+        try {
+          envelope = JSON.parse(envelopeText);
+        } catch {
+          return { status: "schema_failed", errorCode: "invalid_response_envelope" };
+        }
+        const content = readAssistantContent(envelope);
+        if (content === undefined) return { status: "schema_failed", errorCode: "missing_assistant_content" };
+        assertSecretSafe("llama-server assistant content", content);
+        const metrics = readResponseMetrics(envelope, performance.now() - requestStartedAt);
+        return { status: "completed", rawOutput: content, metrics };
+      } catch (error) {
+        if (state.unsafeEvidence) return { status: "failed", errorCode: "secret_like_runtime_log" };
+        if (state.exited) return classifyExitedResident(state);
+        return {
+          status: error instanceof Error && error.name === "AbortError" ? "stopped" : "failed",
+          errorCode: error instanceof Error && error.name === "AbortError" ? "request_timeout" : "request_failed"
+        };
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+    async stop(resident) {
+      const state = residents.get(resident.id);
+      if (!state) return;
+      await stopProcess(state, stopTimeoutMs);
+      residents.delete(resident.id);
+      const journalPath = typeof resident.metadata?.journalPath === "string" ? resident.metadata.journalPath : undefined;
+      if (journalPath) atomicWriteJson(journalPath, {
+        ...parseJson<Record<string, unknown>>(journalPath),
+        state: "stopped",
+        stoppedAt: new Date().toISOString()
+      });
+      if (state.unsafeEvidence) throw new Error("llama-server emitted secret-like text during execution");
+    }
+  };
+}
+
+type Manifest = {
+  schemaVersion: "neondiff-phase1-screen-manifest/v1";
+  runFingerprint: string;
+  targetFingerprint: string;
+  promptFingerprint: string;
+  parserFingerprint: string;
+  gateFingerprint: string;
+  requestFingerprint: string;
+  monitorFingerprint: string;
+  harnessFingerprint: string;
+  target: Phase1Target;
+  prompt: Phase1RunSpec["prompt"];
+  parser: Phase1RunSpec["parser"];
+  gate: Phase1RunSpec["gate"];
+  request: Phase1RunSpec["request"];
+  harness: Phase1RunSpec["harness"];
+  cells: Array<Phase1Cell & { fingerprint: string; effectiveArgvFingerprint: string }>;
+  inputs: Array<Omit<Phase1Input, "prompt"> & { fingerprint: string; promptSha256: string }>;
+};
+
+/**
+ * Proves that two completed run manifests describe the same paired cohort.
+ * Target identity is intentionally excluded: a paired screen changes the
+ * model target while holding every review input and harness contract fixed.
+ */
+export function verifyPairedPhase1Cohort(
+  leftManifestPath: string,
+  rightManifestPath: string
+): { ok: true; cohortFingerprint: string } {
+  const left = parseJson<Manifest>(leftManifestPath);
+  const right = parseJson<Manifest>(rightManifestPath);
+  assertPairedManifestIntegrity(left, "left");
+  assertPairedManifestIntegrity(right, "right");
+  for (const [name, leftValue, rightValue] of [
+    ["prompt", left.promptFingerprint, right.promptFingerprint],
+    ["parser", left.parserFingerprint, right.parserFingerprint],
+    ["gate", left.gateFingerprint, right.gateFingerprint],
+    ["request", left.requestFingerprint, right.requestFingerprint],
+    ["monitor", left.monitorFingerprint, right.monitorFingerprint],
+    ["harness", left.harnessFingerprint, right.harnessFingerprint],
+    ["cells", fingerprint(left.cells), fingerprint(right.cells)],
+    ["inputs", fingerprint(left.inputs), fingerprint(right.inputs)]
+  ] as const) {
+    if (leftValue !== rightValue) throw new Error(`paired cohort drift detected in ${name}`);
+  }
+  const cohort = {
+    promptFingerprint: left.promptFingerprint,
+    parserFingerprint: left.parserFingerprint,
+    gateFingerprint: left.gateFingerprint,
+    requestFingerprint: left.requestFingerprint,
+    monitorFingerprint: left.monitorFingerprint,
+    harnessFingerprint: left.harnessFingerprint,
+    cells: left.cells,
+    inputs: left.inputs
+  };
+  return { ok: true, cohortFingerprint: fingerprint(cohort) };
+}
+
+function assertPairedManifestIntegrity(manifest: Manifest, side: string): void {
+  for (const [name, declared, actual] of [
+    ["target", manifest.targetFingerprint, fingerprint(manifest.target)],
+    ["prompt", manifest.promptFingerprint, fingerprint(manifest.prompt)],
+    ["parser", manifest.parserFingerprint, fingerprint(manifest.parser)],
+    ["gate", manifest.gateFingerprint, fingerprint(manifest.gate)],
+    ["request", manifest.requestFingerprint, fingerprint(manifest.request)],
+    ["harness", manifest.harnessFingerprint, fingerprint(manifest.harness)]
+  ] as const) {
+    if (declared !== actual) throw new Error(`paired cohort drift detected in ${name} (${side} manifest integrity)`);
+  }
+  const { runFingerprint, ...identity } = manifest;
+  if (runFingerprint !== fingerprint(identity)) throw new Error(`paired cohort drift detected in run identity (${side} manifest integrity)`);
+}
+
+export async function runPhase1Screen(
+  spec: Phase1RunSpec,
+  adapter: Phase1ResidentAdapter,
+  options: Phase1RunnerOptions = {}
+): Promise<Phase1RunSummary> {
+  validateSpec(spec);
+  if (options.monitor && !/^[a-f0-9]{64}$/.test(options.monitor.identity.sha256)) throw new Error("resource monitor identity requires a SHA-256 source fingerprint");
+  validateOutputBoundary(spec);
+  mkdirSync(spec.outputDir, { recursive: true, mode: 0o700 });
+  const leasePath = join(spec.outputDir, ".phase1-run.lock");
+  const lease = acquireRunLease(leasePath);
+  try {
+    return await runPhase1ScreenWithLease(spec, adapter, options);
+  } finally {
+    closeSync(lease);
+    rmSync(leasePath, { force: true });
+  }
+}
+
+async function runPhase1ScreenWithLease(
+  spec: Phase1RunSpec,
+  adapter: Phase1ResidentAdapter,
+  options: Phase1RunnerOptions
+): Promise<Phase1RunSummary> {
+  const actualHarnessSha256 = await sha256File(spec.harness.sourcePath);
+  if (actualHarnessSha256 !== spec.harness.sourceSha256) throw new Error("harness source SHA-256 does not match the implementation artifact");
+  assertSecretSafe("target argv", [spec.target.executable, ...spec.target.args].join("\n"));
+  assertJsonValuesSecretSafe("target manifest", spec.target);
+  const manifest = buildManifest(spec, options.monitor);
+  assertManifestMetadataSecretSafe(spec);
+  const manifestPath = join(spec.outputDir, "manifest.json");
+  if (existsSync(manifestPath)) {
+    const existing = parseJson<Manifest>(manifestPath);
+    if (existing.runFingerprint !== manifest.runFingerprint || canonicalJson(existing) !== canonicalJson(manifest)) {
+      throw new Error("phase 1 manifest fingerprint mismatch; resume requires an exact immutable manifest");
+    }
+  } else {
+    atomicWriteJson(manifestPath, manifest);
+  }
+  let missingResults = 0;
+  for (const cell of manifest.cells) {
+    for (const input of spec.inputs) {
+      const path = resultFile(spec.outputDir, cell.id, input.id);
+      if (existsSync(path)) validateExistingResult(path, manifest, cell.fingerprint, input);
+      else missingResults += 1;
+    }
+    if (options.monitor) {
+      const resourcePath = join(spec.outputDir, "resources", `${cell.id}.json`);
+      if (existsSync(resourcePath)) validateResourceEvidence(resourcePath, manifest, cell.fingerprint);
+      else if (spec.inputs.every((input) => existsSync(resultFile(spec.outputDir, cell.id, input.id)))) {
+        throw new Error(`terminal resource evidence is missing for cell ${cell.id}`);
+      }
+    }
+  }
+  if (missingResults === 0) {
+    const existingSummaryPath = join(spec.outputDir, "summary.json");
+    const summary = existsSync(existingSummaryPath)
+      ? validateExistingSummary(existingSummaryPath, manifest, spec.outputDir)
+      : buildSummary(spec.outputDir, manifest);
+    return finalizeRun(spec.outputDir, summary);
+  }
+  rmSync(join(spec.outputDir, "COMPLETED"), { force: true });
+  rmSync(join(spec.outputDir, "FAILED"), { force: true });
+  atomicWriteText(join(spec.outputDir, "RUNNING"), `${manifest.runFingerprint}\n`);
+
+  let infrastructureFailure: string | undefined;
+  for (const cell of manifest.cells) {
+    const cellHasWork = spec.inputs.some((input) => !existsSync(resultFile(spec.outputDir, cell.id, input.id)));
+    if (!cellHasWork) continue;
+    let monitorSession: { id: string } | undefined;
+    const resourceSamples: Phase1ResourceSample[] = [];
+    if (options.monitor) {
+      try { monitorSession = await options.monitor.start({ target: spec.target, cell, outputDir: spec.outputDir }); }
+      catch (error) { infrastructureFailure = errorMessage(error); }
+    }
+    const resident = infrastructureFailure ? undefined : await startResident(adapter, spec, manifest, cell).catch((error) => {
+      infrastructureFailure = errorMessage(error);
+      return undefined;
+    });
+    if (!resident) {
+      for (const input of spec.inputs) writeMissingTerminalResult(spec.outputDir, manifest, cell, input, infrastructureFailure ?? "resident_start_failed");
+      if (options.monitor && monitorSession) {
+        const monitorFailure = await finalizeMonitorEvidence(options.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
+        if (monitorFailure) infrastructureFailure = monitorFailure;
+      } else if (options.monitor) {
+        writeUnavailableMonitorEvidence(spec.outputDir, manifest, cell, infrastructureFailure ?? "monitor_start_failed");
+      }
+      continue;
+    }
+    try {
+      assertSecretSafe("resident argv", resident.argv.join("\n"));
+      assertSecretSafe("resident logs", resident.logs ?? "");
+      let cellTerminal: { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined;
+      for (const input of spec.inputs) {
+        const resultPath = resultFile(spec.outputDir, cell.id, input.id);
+        if (existsSync(resultPath)) {
+          validateExistingResult(resultPath, manifest, cell.fingerprint, input);
+          continue;
+        }
+        const startedAt = new Date().toISOString();
+        let result: Phase1InvocationResult;
+        try {
+          if (cellTerminal) result = cellTerminal;
+          else {
+            if (options.monitor && monitorSession) resourceSamples.push(await monitorSample(options.monitor, monitorSession, { phase: "before", input }));
+            const renderedPrompt = renderPrompt(spec.prompt.template, input.prompt);
+            result = await adapter.invoke(resident, {
+              input,
+              cell,
+              renderedPrompt,
+              request: spec.request,
+              promptFingerprint: manifest.promptFingerprint,
+              parserFingerprint: manifest.parserFingerprint,
+              gateFingerprint: manifest.gateFingerprint
+            });
+            if (options.monitor && monitorSession) {
+              resourceSamples.push(await monitorSample(options.monitor, monitorSession, { phase: "after", input }));
+              const classification = monitorClassify(options.monitor, resourceSamples);
+              if (classification) result = { ...result, ...classification, residentTerminal: true };
+            }
+          }
+          result = applyReviewContract(result, spec);
+          result.retryCount ??= 0;
+          result.metrics = { ...(result.metrics ?? {}), residentLoadDurationMs: numericMetadata(resident.metadata?.loadDurationMs) };
+          if (result.status === "completed") {
+            const missingMetric = spec.request.requiredMetrics.find((name) => typeof result.metrics?.[name] !== "number");
+            if (missingMetric) result = { ...result, status: "schema_failed", errorCode: `missing_metric_${sanitizeIdentifier(missingMetric)}` };
+          }
+          if (result.residentTerminal && (result.status === "failed" || result.status === "stopped" || result.status === "oom")) {
+            cellTerminal = { status: result.status, errorCode: result.errorCode ?? `cell_${result.status}` };
+          }
+          result.resourceSamples = resourceSamples.slice(-2);
+          assertTerminalStatus(result.status);
+          assertSecretSafe("invocation logs", result.logs ?? "");
+          assertSecretSafe("raw output", result.rawOutput ?? "");
+        } catch (error) {
+          if (error instanceof MonitorInfrastructureError) {
+            infrastructureFailure = error.message;
+            result = { status: "stopped", errorCode: "monitor_infrastructure_failure", residentTerminal: true, retryCount: 0 };
+            cellTerminal = { status: "stopped", errorCode: "monitor_infrastructure_failure" };
+          } else result = { status: "failed", errorCode: safeErrorCode(error), retryCount: 0 };
+        }
+        const record = resultRecord(manifest, cell, input, result, startedAt);
+        assertResultPayloadSecretSafe(record);
+        atomicWriteJson(resultPath, record);
+      }
+    } catch (error) {
+      infrastructureFailure = errorMessage(error);
+      for (const input of spec.inputs) writeMissingTerminalResult(spec.outputDir, manifest, cell, input, "resident_evidence_rejected");
+    } finally {
+      try {
+        await adapter.stop(resident);
+      } catch (error) {
+        infrastructureFailure = errorMessage(error);
+      }
+      if (options.monitor && monitorSession) {
+        const monitorFailure = await finalizeMonitorEvidence(options.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
+        if (monitorFailure) infrastructureFailure = monitorFailure;
+      }
+    }
+  }
+
+  const summary = buildSummary(spec.outputDir, manifest, infrastructureFailure);
+  finalizeRun(spec.outputDir, summary);
+  if (infrastructureFailure) {
+    throw new Error(`phase 1 runner infrastructure failure: ${infrastructureFailure}`);
+  }
+  return summary;
+}
+
+function writeUnavailableMonitorEvidence(
+  outputDir: string,
+  manifest: Manifest,
+  cell: Manifest["cells"][number],
+  error: string
+): void {
+  const resourceRecord = {
+    schemaVersion: "neondiff-phase1-resources/v1",
+    runFingerprint: manifest.runFingerprint,
+    cellFingerprint: cell.fingerprint,
+    monitorFingerprint: manifest.monitorFingerprint,
+    samples: [] as Phase1ResourceSample[],
+    terminalInfrastructureErrorCode: sanitizeIdentifier(error)
+  };
+  assertJsonValuesSecretSafe("resource evidence", resourceRecord);
+  atomicWriteJson(join(outputDir, "resources", `${cell.id}.json`), {
+    ...resourceRecord,
+    evidenceSha256: fingerprint(resourceRecord)
+  });
+}
+
+async function startResident(
+  adapter: Phase1ResidentAdapter,
+  spec: Phase1RunSpec,
+  manifest: Manifest,
+  cell: Manifest["cells"][number]
+): Promise<Phase1Resident> {
+  return adapter.start({
+    outputDir: spec.outputDir,
+    target: spec.target,
+    cell,
+    targetFingerprint: manifest.targetFingerprint,
+    cellFingerprint: cell.fingerprint
+  });
+}
+
+function buildManifest(spec: Phase1RunSpec, monitor?: Phase1ResourceMonitor): Manifest {
+  const targetFingerprint = fingerprint(spec.target);
+  const promptFingerprint = fingerprint(spec.prompt);
+  const parserFingerprint = fingerprint(spec.parser);
+  const gateFingerprint = fingerprint(spec.gate);
+  const requestFingerprint = fingerprint(spec.request);
+  const harnessFingerprint = fingerprint(spec.harness);
+  const monitorFingerprint = fingerprint(monitor?.identity ?? { version: "none", sha256: sha256("none") });
+  const cells = spec.cells.map((cell) => {
+    const effectiveArgvFingerprint = fingerprint([spec.target.executable, ...spec.target.args, ...(cell.executableArgs ?? [])]);
+    return { ...cell, effectiveArgvFingerprint, fingerprint: fingerprint({ ...cell, effectiveArgvFingerprint }) };
+  });
+  const inputs = spec.inputs.map(({ prompt, ...input }) => ({
+    ...input,
+    promptSha256: sha256(prompt),
+    fingerprint: fingerprint({ ...input, promptSha256: sha256(prompt) })
+  }));
+  const identity = {
+    schemaVersion: "neondiff-phase1-screen-manifest/v1" as const,
+    targetFingerprint,
+    promptFingerprint,
+    parserFingerprint,
+    gateFingerprint,
+    requestFingerprint,
+    monitorFingerprint,
+    harnessFingerprint,
+    target: spec.target,
+    prompt: spec.prompt,
+    parser: spec.parser,
+    gate: spec.gate,
+    request: spec.request,
+    harness: spec.harness,
+    cells,
+    inputs
+  };
+  return { ...identity, runFingerprint: fingerprint(identity) };
+}
+
+function resultRecord(
+  manifest: Manifest,
+  cell: Manifest["cells"][number],
+  input: Phase1Input,
+  result: Phase1InvocationResult,
+  startedAt: string
+): Record<string, unknown> {
+  const inputManifest = manifest.inputs.find((candidate) => candidate.id === input.id);
+  if (!inputManifest) throw new Error(`input ${input.id} is absent from manifest`);
+  const record = {
+    schemaVersion: "neondiff-phase1-screen-result/v1",
+    runFingerprint: manifest.runFingerprint,
+    targetFingerprint: manifest.targetFingerprint,
+    cellFingerprint: cell.fingerprint,
+    inputFingerprint: inputManifest.fingerprint,
+    promptFingerprint: manifest.promptFingerprint,
+    parserFingerprint: manifest.parserFingerprint,
+    gateFingerprint: manifest.gateFingerprint,
+    requestFingerprint: manifest.requestFingerprint,
+    harnessFingerprint: manifest.harnessFingerprint,
+    cellId: cell.id,
+    inputId: input.id,
+    status: result.status,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    rawOutput: result.rawOutput,
+    parsedOutput: result.parsedOutput,
+    gatedOutput: result.gatedOutput,
+    metrics: result.metrics,
+    errorCode: result.errorCode,
+    retryCount: result.retryCount ?? 0,
+    residentTerminal: result.residentTerminal ?? false,
+    resourceSamples: result.resourceSamples
+  };
+  return { ...record, evidenceSha256: fingerprint(record) };
+}
+
+function writeMissingTerminalResult(
+  outputDir: string,
+  manifest: Manifest,
+  cell: Manifest["cells"][number],
+  input: Phase1Input,
+  errorCode: string
+): void {
+  const path = resultFile(outputDir, cell.id, input.id);
+  if (existsSync(path)) return;
+  const now = new Date().toISOString();
+  const record = resultRecord(manifest, cell, input, {
+    status: "failed",
+    errorCode: sanitizeIdentifier(errorCode)
+  }, now);
+  assertResultPayloadSecretSafe(record);
+  atomicWriteJson(path, record);
+}
+
+function validateExistingResult(
+  path: string,
+  manifest: Manifest,
+  cellFingerprint: string,
+  input: Phase1Input
+): void {
+  const record = parseJson<Record<string, unknown>>(path);
+  const expectedInput = manifest.inputs.find((candidate) => candidate.id === input.id);
+  const { evidenceSha256, ...recordWithoutSha } = record;
+  const expectedEvidenceSha256 = fingerprint(recordWithoutSha);
+  if (
+    record.schemaVersion !== "neondiff-phase1-screen-result/v1"
+    || record.runFingerprint !== manifest.runFingerprint
+    || record.targetFingerprint !== manifest.targetFingerprint
+    || record.cellFingerprint !== cellFingerprint
+    || record.inputFingerprint !== expectedInput?.fingerprint
+    || record.promptFingerprint !== manifest.promptFingerprint
+    || record.parserFingerprint !== manifest.parserFingerprint
+    || record.gateFingerprint !== manifest.gateFingerprint
+    || record.requestFingerprint !== manifest.requestFingerprint
+    || record.harnessFingerprint !== manifest.harnessFingerprint
+    || record.cellId !== manifest.cells.find((cell) => cell.fingerprint === cellFingerprint)?.id
+    || record.inputId !== input.id
+    || !isTerminalStatus(record.status)
+    || evidenceSha256 !== expectedEvidenceSha256
+  ) {
+    throw new Error(`terminal result fingerprint mismatch at ${path}`);
+  }
+}
+
+function buildSummary(outputDir: string, manifest: Manifest, infrastructureFailure?: string): Phase1RunSummary {
+  const counts: Counts = { completed: 0, failed: 0, stopped: 0, oom: 0, schema_failed: 0 };
+  for (const cell of manifest.cells) {
+    for (const input of manifest.inputs) {
+      const record = parseJson<{ status: Phase1TerminalStatus }>(resultFile(outputDir, cell.id, input.id));
+      assertTerminalStatus(record.status);
+      counts[record.status] += 1;
+    }
+  }
+  const expectedResults = manifest.cells.length * manifest.inputs.length;
+  const recordedResults = Object.values(counts).reduce((sum, count) => sum + count, 0);
+  const withoutSha = {
+    schemaVersion: "neondiff-phase1-screen-summary/v1" as const,
+    runFingerprint: manifest.runFingerprint,
+    status: infrastructureFailure || counts.failed || counts.stopped || counts.oom || counts.schema_failed ? "failed" as const : "completed" as const,
+    counts,
+    expectedResults,
+    recordedResults,
+    infrastructureErrorCode: infrastructureFailure ? sanitizeIdentifier(infrastructureFailure) : undefined,
+    claimClass: "transport_and_gate_only" as const
+  };
+  return { ...withoutSha, summarySha256: fingerprint(withoutSha) };
+}
+
+function validateExistingSummary(path: string, manifest: Manifest, outputDir: string): Phase1RunSummary {
+  const summary = parseJson<Phase1RunSummary>(path);
+  const { summarySha256, ...body } = summary;
+  const reconstructed = buildSummary(outputDir, manifest);
+  const expectedStatus = summary.infrastructureErrorCode ? "failed" : reconstructed.status;
+  if (
+    summary.schemaVersion !== "neondiff-phase1-screen-summary/v1"
+    || summary.runFingerprint !== manifest.runFingerprint
+    || summarySha256 !== fingerprint(body)
+    || canonicalJson(summary.counts) !== canonicalJson(reconstructed.counts)
+    || summary.expectedResults !== reconstructed.expectedResults
+    || summary.recordedResults !== reconstructed.recordedResults
+    || summary.status !== expectedStatus
+    || summary.claimClass !== "transport_and_gate_only"
+  ) {
+    throw new Error("phase 1 terminal summary fingerprint mismatch");
+  }
+  return summary;
+}
+
+function validateResourceEvidence(path: string, manifest: Manifest, cellFingerprint: string): void {
+  const record = parseJson<Record<string, unknown>>(path);
+  const { evidenceSha256, ...body } = record;
+  if (
+    record.schemaVersion !== "neondiff-phase1-resources/v1"
+    || record.runFingerprint !== manifest.runFingerprint
+    || record.cellFingerprint !== cellFingerprint
+    || record.monitorFingerprint !== manifest.monitorFingerprint
+    || evidenceSha256 !== fingerprint(body)
+  ) throw new Error(`resource evidence fingerprint mismatch at ${path}`);
+}
+
+function validateSpec(spec: Phase1RunSpec): void {
+  if (!spec.outputDir) throw new Error("outputDir is required");
+  if (spec.cells.length === 0 || spec.inputs.length === 0) throw new Error("at least one cell and input are required");
+  assertUniqueSafeIds("cell", spec.cells.map((cell) => cell.id));
+  assertUniqueSafeIds("input", spec.inputs.map((input) => input.id));
+  for (const digest of [spec.target.modelSha256, spec.target.executableSha256, ...(spec.target.ownershipVerifierSha256 ? [spec.target.ownershipVerifierSha256] : []), spec.harness.sourceSha256, spec.prompt.templateSha256, spec.parser.sha256, spec.gate.sha256, ...spec.inputs.map((input) => input.sha256)]) {
+    if (!/^[a-f0-9]{64}$/.test(digest)) throw new Error("all declared SHA-256 digests must be lowercase 64-character hex");
+  }
+  if (!/^[a-f0-9]{40}$/.test(spec.harness.commit)) throw new Error("harness commit must be a full 40-character Git SHA");
+  if (resolve(spec.harness.sourcePath) !== spec.harness.sourcePath) throw new Error("harness source path must be absolute");
+  const reservedRequestKeys = new Set(["messages", "model", "stream", "response_format", "max_tokens"]);
+  for (const key of Object.keys(spec.request.parameters)) if (reservedRequestKeys.has(key)) throw new Error(`reserved request parameter is runner-owned: ${key}`);
+  if (!Number.isInteger(spec.request.outputBudgetTokens) || spec.request.outputBudgetTokens <= 0) throw new Error("request output budget must be a positive integer");
+  if (resolve(spec.target.modelPath) !== spec.target.modelPath || resolve(spec.target.executable) !== spec.target.executable) throw new Error("model and executable paths must be absolute");
+  if (sha256(spec.prompt.template) !== spec.prompt.templateSha256) throw new Error("prompt template SHA-256 mismatch");
+  if (!spec.prompt.template.includes("{{input}}")) throw new Error("prompt template must contain {{input}}");
+  if (spec.parser.sha256 !== sha256(`${spec.parser.version}:${spec.parser.format}`)) throw new Error("parser contract SHA-256 mismatch");
+  if (spec.gate.sha256 !== sha256(`${spec.gate.version}:${spec.gate.requiredTopLevelKeys.join(",")}`)) throw new Error("gate contract SHA-256 mismatch");
+  for (const input of spec.inputs) if (input.sha256 !== sha256(input.prompt)) throw new Error(`input ${input.id} SHA-256 does not match prompt bytes`);
+}
+
+function validateOutputBoundary(spec: Phase1RunSpec): void {
+  const output = canonicalProspectivePath(spec.outputDir);
+  const safeRoot = canonicalProspectivePath(spec.safeOutputRoot);
+  const checkout = canonicalProspectivePath(spec.checkoutRoot);
+  if (output !== safeRoot && !output.startsWith(`${safeRoot}${sep}`)) throw new Error("outputDir must be inside the declared safe output root");
+  if (output === checkout || output.startsWith(`${checkout}${sep}`)) throw new Error("Phase 1 evidence output must remain outside the checkout");
+}
+
+function canonicalProspectivePath(path: string): string {
+  let cursor = resolve(path);
+  const suffix: string[] = [];
+  while (!existsSync(cursor)) {
+    const parent = dirname(cursor);
+    if (parent === cursor) break;
+    suffix.unshift(basename(cursor));
+    cursor = parent;
+  }
+  return resolve(realpathSync(cursor), ...suffix);
+}
+
+function acquireRunLease(path: string): number {
+  try {
+    const fd = openSync(path, "wx", 0o600);
+    writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`);
+    return fd;
+  } catch (error) {
+    if (!existsSync(path)) throw error;
+    const prior = parseJson<{ pid?: number }>(path);
+    if (typeof prior.pid === "number" && isProcessAlive(prior.pid)) throw new Error(`Phase 1 output has an active exclusive run lease held by PID ${prior.pid}`);
+    rmSync(path, { force: true });
+    const fd = openSync(path, "wx", 0o600);
+    writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), recovered: true })}\n`);
+    return fd;
+  }
+}
+
+function renderPrompt(template: string, input: string): string {
+  return template.replaceAll("{{input}}", input);
+}
+
+function applyReviewContract(result: Phase1InvocationResult, spec: Phase1RunSpec): Phase1InvocationResult {
+  if (result.status !== "completed") return result;
+  if (typeof result.rawOutput !== "string") return { ...result, status: "schema_failed", errorCode: "missing_raw_output" };
+  let parsed: unknown;
+  try { parsed = JSON.parse(result.rawOutput); }
+  catch { return { ...result, status: "schema_failed", errorCode: "invalid_json_content" }; }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return { ...result, status: "schema_failed", parsedOutput: parsed, errorCode: "gate_requires_object" };
+  for (const key of spec.gate.requiredTopLevelKeys) {
+    if (!Object.prototype.hasOwnProperty.call(parsed, key)) return { ...result, status: "schema_failed", parsedOutput: parsed, errorCode: `gate_missing_${sanitizeIdentifier(key)}` };
+  }
+  return { ...result, parsedOutput: parsed, gatedOutput: parsed };
+}
+
+class MonitorInfrastructureError extends Error {}
+
+async function monitorSample(
+  monitor: Phase1ResourceMonitor,
+  session: { id: string },
+  context: { phase: "before" | "after"; input: Phase1Input }
+): Promise<Phase1ResourceSample> {
+  try { return await monitor.sample(session, context); }
+  catch (error) { throw new MonitorInfrastructureError(`monitor ${context.phase} failed: ${errorMessage(error)}`); }
+}
+
+function monitorClassify(
+  monitor: Phase1ResourceMonitor,
+  samples: Phase1ResourceSample[]
+): { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined {
+  try { return monitor.classify?.(samples); }
+  catch (error) { throw new MonitorInfrastructureError(`monitor classify failed: ${errorMessage(error)}`); }
+}
+
+async function finalizeMonitorEvidence(
+  monitor: Phase1ResourceMonitor,
+  session: { id: string },
+  samples: Phase1ResourceSample[],
+  outputDir: string,
+  manifest: Manifest,
+  cell: Manifest["cells"][number]
+): Promise<string | undefined> {
+  let infrastructureFailure: string | undefined;
+  let terminalClassification: { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined;
+  try { samples.push(await monitor.stop(session)); }
+  catch (error) { infrastructureFailure = `monitor stop failed: ${errorMessage(error)}`; }
+  try {
+    terminalClassification = monitorClassify(monitor, samples);
+  } catch (error) {
+    infrastructureFailure = errorMessage(error);
+  }
+  const resourceRecord = {
+    schemaVersion: "neondiff-phase1-resources/v1",
+    runFingerprint: manifest.runFingerprint,
+    cellFingerprint: cell.fingerprint,
+    monitorFingerprint: manifest.monitorFingerprint,
+    samples,
+    terminalClassification: terminalClassification ? {
+      status: terminalClassification.status,
+      errorCode: sanitizeIdentifier(terminalClassification.errorCode)
+    } : undefined,
+    terminalInfrastructureErrorCode: infrastructureFailure ? sanitizeIdentifier(infrastructureFailure) : undefined
+  };
+  assertJsonValuesSecretSafe("resource evidence", resourceRecord);
+  atomicWriteJson(join(outputDir, "resources", `${cell.id}.json`), {
+    ...resourceRecord,
+    evidenceSha256: fingerprint(resourceRecord)
+  });
+  return infrastructureFailure;
+}
+
+function numericMetadata(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+function assertUniqueSafeIds(kind: string, ids: string[]): void {
+  if (new Set(ids).size !== ids.length) throw new Error(`${kind} IDs must be unique`);
+  for (const id of ids) if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/.test(id)) throw new Error(`${kind} ID is not path safe: ${id}`);
+}
+
+function assertSecretSafe(label: string, value: string): void {
+  if (containsSecretLikeText(value)) throw new Error(`${label} contains secret-like text and cannot enter Phase 1 evidence`);
+}
+
+function assertJsonValuesSecretSafe(label: string, value: unknown): void {
+  if (typeof value === "string") {
+    if (containsSecretLikeText(value)) throw new Error(`${label} contains secret-like text in a value: ${redactSecrets(value)}`);
+    return;
+  }
+  if (Array.isArray(value)) { for (const item of value) assertJsonValuesSecretSafe(label, item); return; }
+  if (value && typeof value === "object") {
+    for (const [key, item] of Object.entries(value)) {
+      // These fields are runner-generated protocol identifiers or verified
+      // lowercase digests. Feeding them to the free-text detector creates
+      // false positives (for example, schema versions ending in `/v1`).
+      // Their shape and equality are validated separately at each evidence
+      // boundary; all model-, monitor-, and adapter-provided values continue
+      // through the secret detector.
+      if (key === "schemaVersion" || key === "evidenceSha256" || key.endsWith("Fingerprint")) continue;
+      assertJsonValuesSecretSafe(label, item);
+    }
+  }
+}
+
+function assertManifestMetadataSecretSafe(spec: Phase1RunSpec): void {
+  assertJsonValuesSecretSafe("target serving metadata", spec.target.servingParameters);
+  assertJsonValuesSecretSafe("prompt metadata", spec.prompt.parameters);
+  assertJsonValuesSecretSafe("request metadata", spec.request.parameters);
+  for (const cell of spec.cells) assertJsonValuesSecretSafe(`cell ${cell.id} metadata`, cell.parameters);
+  for (const input of spec.inputs) assertJsonValuesSecretSafe(`input ${input.id} metadata`, input.metadata);
+}
+
+function assertResultPayloadSecretSafe(record: Record<string, unknown>): void {
+  for (const key of ["rawOutput", "parsedOutput", "gatedOutput", "metrics", "errorCode", "resourceSamples"]) {
+    assertJsonValuesSecretSafe(`result ${key}`, record[key]);
+  }
+}
+
+function assertTerminalStatus(value: unknown): asserts value is Phase1TerminalStatus {
+  if (!isTerminalStatus(value)) throw new Error(`adapter returned non-terminal status: ${String(value)}`);
+}
+
+function isTerminalStatus(value: unknown): value is Phase1TerminalStatus {
+  return value === "completed" || value === "failed" || value === "stopped" || value === "oom" || value === "schema_failed";
+}
+
+function resultFile(outputDir: string, cellId: string, inputId: string): string {
+  return join(outputDir, "results", cellId, `${inputId}.json`);
+}
+
+function atomicWriteJson(path: string, value: unknown): void {
+  atomicWriteText(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function atomicWriteText(path: string, value: string): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const temp = `${path}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(temp, value, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    renameSync(temp, path);
+  } catch (error) {
+    rmSync(temp, { force: true });
+    throw error;
+  }
+}
+
+function finalizeRun(outputDir: string, summary: Phase1RunSummary): Phase1RunSummary {
+  atomicWriteJson(join(outputDir, "summary.json"), summary);
+  rmSync(join(outputDir, "RUNNING"), { force: true });
+  const marker = summary.status === "completed" ? "COMPLETED" : "FAILED";
+  rmSync(join(outputDir, marker === "COMPLETED" ? "FAILED" : "COMPLETED"), { force: true });
+  atomicWriteText(join(outputDir, marker), `${summary.summarySha256}\n`);
+  return summary;
+}
+
+function parseJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function fingerprint(value: unknown): string {
+  return sha256(canonicalJson(value));
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+      .map(([key, item]) => [key, sortJson(item)]));
+  }
+  return value;
+}
+
+function safeErrorCode(error: unknown): string {
+  return sanitizeIdentifier(error instanceof Error ? error.name : "invocation_failed");
+}
+
+function errorMessage(error: unknown): string {
+  return redactSecrets(error instanceof Error ? error.message : String(error));
+}
+
+function sanitizeIdentifier(value: string): string {
+  return redactSecrets(value).toLowerCase().replace(/[^a-z0-9._-]+/g, "_").slice(0, 128) || "failed";
+}
+
+function minimalProcessEnvironment(): NodeJS.ProcessEnv {
+  const allowed = ["PATH", "HOME", "TMPDIR", "LD_LIBRARY_PATH", "CUDA_VISIBLE_DEVICES"] as const;
+  return Object.fromEntries(allowed
+    .map((key) => [key, process.env[key]])
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+}
+
+async function waitForHealthy(baseUrl: string, timeoutMs: number, state: ResidentProcess): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (state.unsafeEvidence) throw new Error("llama-server emitted secret-like text during startup");
+    if (state.exited) throw new Error(`llama-server exited before readiness: ${state.stderrTail || "no redacted diagnostics"}`);
+    try {
+      const response = await fetch(`${baseUrl}/health`, { signal: AbortSignal.timeout(1_000) });
+      if (response.ok) return;
+    } catch {
+      // Expected while the resident loads its model.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error("llama-server readiness timeout");
+}
+
+async function stopProcess(state: ResidentProcess, timeoutMs: number): Promise<void> {
+  if (state.exited) return;
+  signalProcessGroup(state.process.pid, "SIGTERM");
+  const exited = await Promise.race([
+    new Promise<boolean>((resolve) => state.process.once("exit", () => resolve(true))),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), timeoutMs))
+  ]);
+  if (!exited && !state.exited) {
+    signalProcessGroup(state.process.pid, "SIGKILL");
+    const killed = await Promise.race([
+      new Promise<boolean>((resolve) => state.process.once("exit", () => resolve(true))),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), timeoutMs))
+    ]);
+    if (!killed && !state.exited) throw new Error("resident process-group cleanup could not be proven after SIGKILL");
+  }
+}
+
+function signalProcessGroup(pid: number | undefined, signal: NodeJS.Signals): void {
+  if (!pid) return;
+  try { process.kill(-pid, signal); }
+  catch { try { process.kill(pid, signal); } catch { /* already stopped */ } }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; }
+  catch { return false; }
+}
+
+async function recoverResidentJournal(
+  path: string,
+  executableSha256: string,
+  verifyProcessIdentity: NonNullable<LlamaServerExecutableAdapterOptions["verifyProcessIdentity"]>,
+  stopTimeoutMs: number
+): Promise<void> {
+  if (!existsSync(path)) return;
+  const journal = parseJson<{ state?: string; pid?: number; executableSha256?: string; argvFingerprint?: string }>(path);
+  if (journal.state !== "running" || typeof journal.pid !== "number" || !isProcessAlive(journal.pid)) return;
+  if (journal.executableSha256 !== executableSha256 || typeof journal.argvFingerprint !== "string"
+    || !await verifyProcessIdentity(journal.pid, executableSha256, journal.argvFingerprint)) {
+    throw new Error("existing resident journal points to an unverified live process; refusing recovery");
+  }
+  signalProcessGroup(journal.pid, "SIGTERM");
+  const deadline = Date.now() + stopTimeoutMs;
+  while (isProcessAlive(journal.pid) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 50));
+  if (isProcessAlive(journal.pid)) signalProcessGroup(journal.pid, "SIGKILL");
+  atomicWriteJson(path, { ...journal, state: "recovered_stopped", recoveredAt: new Date().toISOString() });
+}
+
+async function sha256File(path: string): Promise<string> {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+async function readResponseBody(response: Response, maximumBytes: number): Promise<string> {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > maximumBytes) throw new Error("llama-server response exceeds evidence byte cap");
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let used = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    used += value.byteLength;
+    if (used > maximumBytes) {
+      await reader.cancel();
+      throw new Error("llama-server response exceeds evidence byte cap");
+    }
+    chunks.push(value);
+  }
+  return new TextDecoder().decode(Buffer.concat(chunks));
+}
+
+async function readStreamingAssistant(
+  response: Response,
+  maximumBytes: number,
+  requestStartedAt: number
+): Promise<{ content: string; metrics: Record<string, number> }> {
+  if (!response.body) throw new Error("llama-server streaming response has no body");
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  let content = "";
+  let used = 0;
+  let ttftMs: number | undefined;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    used += value.byteLength;
+    if (used > maximumBytes) {
+      await reader.cancel();
+      throw new Error("llama-server streaming response exceeds evidence byte cap");
+    }
+    buffered += decoder.decode(value, { stream: true });
+    const events = buffered.split(/\r?\n\r?\n/);
+    buffered = events.pop() ?? "";
+    for (const event of events) {
+      for (const line of event.split(/\r?\n/)) {
+        if (!line.startsWith("data:")) continue;
+        const data = line.slice(5).trim();
+        if (!data || data === "[DONE]") continue;
+        let envelope: unknown;
+        try { envelope = JSON.parse(data); }
+        catch { throw new Error("invalid llama-server streaming envelope"); }
+        const delta = readDeltaContent(envelope);
+        if (delta) {
+          if (ttftMs === undefined) ttftMs = Math.max(0, performance.now() - requestStartedAt);
+          content += delta;
+        }
+      }
+    }
+  }
+  if (buffered.trim() && !buffered.includes("[DONE]")) throw new Error("truncated llama-server streaming response");
+  if (!content) throw new Error("llama-server streaming response contained no assistant content");
+  return {
+    content,
+    metrics: {
+      latencyMs: Math.max(0, performance.now() - requestStartedAt),
+      ttftMs: ttftMs ?? 0,
+      responseBytes: Buffer.byteLength(content, "utf8")
+    }
+  };
+}
+
+function readDeltaContent(envelope: unknown): string | undefined {
+  if (!envelope || typeof envelope !== "object") return undefined;
+  const choices = (envelope as { choices?: unknown }).choices;
+  if (!Array.isArray(choices) || !choices[0] || typeof choices[0] !== "object") return undefined;
+  const delta = (choices[0] as { delta?: unknown }).delta;
+  if (!delta || typeof delta !== "object") return undefined;
+  const content = (delta as { content?: unknown }).content;
+  return typeof content === "string" ? content : undefined;
+}
+
+function classifyExitedResident(state: ResidentProcess): Phase1InvocationResult {
+  const diagnostics = state.stderrTail.toLowerCase();
+  return /out of memory|cuda.*alloc|oom/.test(diagnostics)
+    ? { status: "oom", errorCode: "resident_oom", residentTerminal: true, retryCount: 0 }
+    : { status: "stopped", errorCode: "resident_exited", residentTerminal: true, retryCount: 0 };
+}
+
+function readAssistantContent(envelope: unknown): string | undefined {
+  if (!envelope || typeof envelope !== "object") return undefined;
+  const choices = (envelope as { choices?: unknown }).choices;
+  if (!Array.isArray(choices) || !choices[0] || typeof choices[0] !== "object") return undefined;
+  const message = (choices[0] as { message?: unknown }).message;
+  if (!message || typeof message !== "object") return undefined;
+  const content = (message as { content?: unknown }).content;
+  return typeof content === "string" ? content : undefined;
+}
+
+function readResponseMetrics(envelope: unknown, latencyMs: number): Record<string, number> {
+  const metrics: Record<string, number> = { latencyMs: Math.max(0, latencyMs) };
+  if (!envelope || typeof envelope !== "object") return metrics;
+  const usage = (envelope as { usage?: unknown }).usage;
+  if (usage && typeof usage === "object") {
+    for (const [source, target] of [
+      ["prompt_tokens", "promptTokens"],
+      ["completion_tokens", "completionTokens"],
+      ["total_tokens", "totalTokens"]
+    ] as const) {
+      const value = (usage as Record<string, unknown>)[source];
+      if (typeof value === "number" && Number.isFinite(value) && value >= 0) metrics[target] = value;
+    }
+  }
+  const timings = (envelope as { timings?: unknown }).timings;
+  if (timings && typeof timings === "object") {
+    for (const [source, target] of [
+      ["prompt_ms", "promptMs"],
+      ["predicted_ms", "decodeMs"],
+      ["prompt_per_second", "promptTokensPerSecond"],
+      ["predicted_per_second", "decodeTokensPerSecond"]
+    ] as const) {
+      const value = (timings as Record<string, unknown>)[source];
+      if (typeof value === "number" && Number.isFinite(value) && value >= 0) metrics[target] = value;
+    }
+  }
+  return metrics;
+}
+
+function hasFlagValue(args: string[], flag: string, expected: string): boolean {
+  const index = args.lastIndexOf(flag);
+  return index >= 0 && args[index + 1] === expected;
+}
+
+async function assertEndpointUnbound(host: string, port: number): Promise<void> {
+  const occupied = await new Promise<boolean>((resolve) => {
+    const socket = connect({ host, port });
+    const finish = (value: boolean): void => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(value);
+    };
+    socket.setTimeout(500, () => finish(false));
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+  });
+  if (occupied) throw new Error("llama-server endpoint already has a listener; refusing unowned resident endpoint");
+}

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -81,6 +81,13 @@ export interface Phase1InvocationResult {
 }
 
 export interface Phase1ResidentAdapter {
+  recover?(context: {
+    outputDir: string;
+    target: Phase1Target;
+    cell: Phase1Cell;
+    targetFingerprint: string;
+    cellFingerprint: string;
+  }): Promise<void>;
   start(context: {
     outputDir: string;
     target: Phase1Target;
@@ -187,6 +194,9 @@ export function createLlamaServerExecutableAdapter(
   const stopTimeoutMs = options.stopTimeoutMs ?? 5_000;
   const maxResponseBytes = options.maxResponseBytes ?? 8 * 1024 * 1024;
   return {
+    async recover({ target, cell, outputDir }) {
+      await recoverResidentJournal(join(outputDir, "processes", `${cell.id}.json`), target.executableSha256, verifyProcessIdentity, stopTimeoutMs);
+    },
     async start({ target, cell, outputDir }) {
       const effectiveArgs = [...target.args, ...(cell.executableArgs ?? [])];
       const argv = [target.executable, ...effectiveArgs];
@@ -249,6 +259,9 @@ export function createLlamaServerExecutableAdapter(
         if (state.exited) throw new Error(`llama-server exited after readiness: ${state.stderrTail || "no redacted diagnostics"}`);
         if (!child.pid || !await verifyListenerOwnership(child.pid, endpoint.hostname, Number(endpoint.port))) {
           throw new Error("llama-server listener ownership could not be proven for the spawned PID");
+        }
+        if (!child.pid || !await verifyProcessIdentity(child.pid, target.executableSha256, argvFingerprint)) {
+          throw new Error("llama-server process identity could not be proven for the spawned PID");
         }
       } catch (error) {
         try { await stopProcess(state, stopTimeoutMs); }
@@ -470,6 +483,15 @@ async function runPhase1ScreenWithLease(
   } else {
     atomicWriteJson(manifestPath, manifest);
   }
+  for (const cell of manifest.cells) {
+    if (adapter.recover) await adapter.recover({
+      outputDir: spec.outputDir,
+      target: spec.target,
+      cell,
+      targetFingerprint: manifest.targetFingerprint,
+      cellFingerprint: cell.fingerprint
+    });
+  }
   let missingResults = 0;
   for (const cell of manifest.cells) {
     for (const input of spec.inputs) {
@@ -511,7 +533,7 @@ async function runPhase1ScreenWithLease(
       ? reconstructResourceSamples(spec.outputDir, manifest, cell)
       : [];
     if (resolvedOptions.monitor) {
-      try { monitorSession = await resolvedOptions.monitor.start({ target: spec.target, cell, outputDir: spec.outputDir }); }
+      try { monitorSession = validateMonitorSession(await resolvedOptions.monitor.start({ target: spec.target, cell, outputDir: spec.outputDir })); }
       catch (error) { infrastructureFailure = errorMessage(error); }
     }
     const resident = infrastructureFailure ? undefined : await startResident(adapter, spec, manifest, cell).catch((error) => {
@@ -573,6 +595,7 @@ async function runPhase1ScreenWithLease(
             };
           }
           result = applyReviewContract(result, spec);
+          if (result.status === "schema_failed") result = { ...result, parsedOutput: undefined, gatedOutput: undefined };
           result.retryCount ??= 0;
           result.metrics = { ...(result.metrics ?? {}), residentLoadDurationMs: numericMetadata(resident.metadata?.loadDurationMs) };
           if (result.status === "completed") {
@@ -642,10 +665,14 @@ function writeUnavailableMonitorEvidence(
     terminalInfrastructureErrorCode: sanitizeIdentifier(error)
   };
   assertJsonValuesSecretSafe("resource samples", resourceRecord.samples);
-  atomicWriteJson(join(outputDir, "resources", `${cell.id}.json`), {
-    ...resourceRecord,
-    evidenceSha256: fingerprint(resourceRecord)
-  });
+  try {
+    atomicWriteJson(join(outputDir, "resources", `${cell.id}.json`), {
+      ...resourceRecord,
+      evidenceSha256: fingerprint(resourceRecord)
+    });
+  } catch (error) {
+    writeResourceUnavailableFallback(outputDir, manifest, cell, `monitor unavailable evidence write failed: ${errorMessage(error)}`);
+  }
 }
 
 async function startResident(
@@ -960,6 +987,7 @@ async function acquireRunLease(path: string): Promise<number> {
       // Every conforming writer must own the crash-released loopback
       // coordinator before touching the canonical lease, so no new lease can
       // appear between this removal and the exclusive replacement open.
+      // lgtm[js/file-system-race]
       rmSync(path, { force: true });
       const fd = openSync(path, "wx", 0o600);
       writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), recovered: true })}\n`);
@@ -1012,11 +1040,38 @@ function monitorClassify(
 ): { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined {
   try {
     for (const sample of samples) validateResourceSample(sample, "monitor classification resource sample");
-    const classification = monitor.classify?.(samples);
+    const classification = validateMonitorClassification(monitor.classify?.(samples));
     for (const sample of samples) validateResourceSample(sample, "monitor classification resource sample");
     return classification;
   }
   catch (error) { throw new MonitorInfrastructureError(`monitor classify failed: ${errorMessage(error)}`); }
+}
+
+function validateMonitorClassification(value: unknown): { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("monitor classification must be an object");
+  const candidate = value as Record<string, unknown>;
+  if (candidate.status !== "failed" && candidate.status !== "stopped" && candidate.status !== "oom") {
+    throw new Error("monitor classification status is invalid");
+  }
+  if (typeof candidate.errorCode !== "string" || candidate.errorCode.length === 0) {
+    throw new Error("monitor classification errorCode is invalid");
+  }
+  assertJsonValuesSecretSafe("monitor classification", candidate);
+  return { status: candidate.status, errorCode: candidate.errorCode };
+}
+
+function validateMonitorSession(value: unknown): { id: string } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("monitor session must be an object");
+  const candidate = value as Record<string, unknown>;
+  if (Object.keys(candidate).length !== 1 || !Object.prototype.hasOwnProperty.call(candidate, "id")) {
+    throw new Error("monitor session shape is invalid");
+  }
+  assertJsonValuesSecretSafe("monitor session", candidate);
+  const id = candidate.id;
+  if (typeof id !== "string" || id.length === 0 || id.length > 128) throw new Error("monitor session id is invalid");
+  assertSecretSafe("monitor session id", id);
+  return { id };
 }
 
 async function finalizeMonitorEvidence(
@@ -1168,7 +1223,10 @@ function assertJsonValuesSecretSafe(label: string, value: unknown): void {
   }
   if (Array.isArray(value)) { for (const item of value) assertJsonValuesSecretSafe(label, item); return; }
   if (value && typeof value === "object") {
-    for (const item of Object.values(value)) assertJsonValuesSecretSafe(label, item);
+    for (const [key, item] of Object.entries(value)) {
+      assertSecretSafe(`${label} key`, key);
+      assertJsonValuesSecretSafe(label, item);
+    }
   }
 }
 
@@ -1334,7 +1392,7 @@ function signalProcessGroup(pid: number | undefined, signal: NodeJS.Signals): vo
 
 function isProcessAlive(pid: number): boolean {
   try { process.kill(pid, 0); return true; }
-  catch { return false; }
+  catch (error) { return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "EPERM"; }
 }
 
 async function recoverResidentJournal(
@@ -1427,6 +1485,9 @@ function assertMonitorModuleImportsAreLoadable(source: string): void {
   if (/\bimport\s*\(/.test(lexicalSource)) {
     throw new Error("resource monitor module must be self-contained; dynamic import syntax is forbidden");
   }
+  if (/\bprocess\s*\.\s*getBuiltinModule\b/.test(lexicalSource) || /\brequire\s*\(/.test(lexicalSource)) {
+    throw new Error("resource monitor module must be self-contained; runtime module-loading escape hatch is forbidden");
+  }
   const specifiers: string[] = [];
   for (const pattern of [/\bfrom\s*["']([^"']+)["']/g, /\bimport\s*["']([^"']+)["']/g]) {
     for (const match of lexicalSource.matchAll(pattern)) specifiers.push(match[1]);
@@ -1434,6 +1495,10 @@ function assertMonitorModuleImportsAreLoadable(source: string): void {
   const unsupported = specifiers.find((specifier) => !specifier.startsWith("node:"));
   if (unsupported) {
     throw new Error(`resource monitor module must be self-contained; unsupported import specifier: ${sanitizeIdentifier(unsupported)}`);
+  }
+  const moduleLoadingEscape = specifiers.find((specifier) => specifier === "node:module" || specifier === "node:vm" || specifier === "node:worker_threads");
+  if (moduleLoadingEscape) {
+    throw new Error(`resource monitor module must be self-contained; module-loading escape hatch is forbidden: ${sanitizeIdentifier(moduleLoadingEscape)}`);
   }
 }
 

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -989,6 +989,9 @@ async function acquireRunLease(path: string): Promise<number> {
       // appear between this removal and the exclusive replacement open.
       // lgtm[js/file-system-race]
       rmSync(path, { force: true });
+      // The exclusive loopback coordinator remains held through this open.
+      // codeql[js/file-system-race]
+      // lgtm[js/file-system-race]
       const fd = openSync(path, "wx", 0o600);
       writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), recovered: true })}\n`);
       return fd;

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -76,6 +76,7 @@ export interface Phase1InvocationResult {
   logs?: string;
   resourceSamples?: Phase1ResourceSample[];
   residentTerminal?: boolean;
+  invocationDisposition?: "invoked" | "not_invoked_resident_terminal" | "not_invoked_infrastructure";
   retryCount?: number;
 }
 
@@ -459,7 +460,7 @@ async function runPhase1ScreenWithLease(
   assertSecretSafe("target argv", [spec.target.executable, ...spec.target.args].join("\n"));
   assertJsonValuesSecretSafe("target manifest", spec.target);
   const manifest = buildManifest(spec, resolvedOptions.monitorIdentity);
-  assertManifestMetadataSecretSafe(spec);
+  assertManifestPayloadSecretSafe(spec);
   const manifestPath = join(spec.outputDir, "manifest.json");
   if (existsSync(manifestPath)) {
     const existing = parseJson<Manifest>(manifestPath);
@@ -506,7 +507,9 @@ async function runPhase1ScreenWithLease(
     const cellHasWork = spec.inputs.some((input) => !existsSync(resultFile(spec.outputDir, cell.id, input.id)));
     if (!cellHasWork) continue;
     let monitorSession: { id: string } | undefined;
-    const resourceSamples: Phase1ResourceSample[] = [];
+    const resourceSamples: Phase1ResourceSample[] = resolvedOptions.monitorIdentity
+      ? reconstructResourceSamples(spec.outputDir, manifest, cell)
+      : [];
     if (resolvedOptions.monitor) {
       try { monitorSession = await resolvedOptions.monitor.start({ target: spec.target, cell, outputDir: spec.outputDir }); }
       catch (error) { infrastructureFailure = errorMessage(error); }
@@ -539,7 +542,7 @@ async function runPhase1ScreenWithLease(
         const startedAt = new Date().toISOString();
         let result: Phase1InvocationResult;
         try {
-          if (cellTerminal) result = cellTerminal;
+          if (cellTerminal) result = { ...cellTerminal, residentTerminal: true, invocationDisposition: "not_invoked_resident_terminal" };
           else {
             if (resolvedOptions.monitor && monitorSession) resourceSamples.push(await monitorSample(resolvedOptions.monitor, monitorSession, { phase: "before", input }));
             const renderedPrompt = renderPrompt(spec.prompt.template, input.prompt);
@@ -552,21 +555,37 @@ async function runPhase1ScreenWithLease(
               parserFingerprint: manifest.parserFingerprint,
               gateFingerprint: manifest.gateFingerprint
             });
+            result.invocationDisposition = "invoked";
             if (resolvedOptions.monitor && monitorSession) {
               resourceSamples.push(await monitorSample(resolvedOptions.monitor, monitorSession, { phase: "after", input }));
               const classification = monitorClassify(resolvedOptions.monitor, resourceSamples);
               if (classification) result = { ...result, ...classification, residentTerminal: true };
             }
           }
+          const invalidMetric = findInvalidMetric(result.metrics);
+          if (invalidMetric) {
+            result = {
+              status: "schema_failed",
+              errorCode: `invalid_metric_${sanitizeIdentifier(invalidMetric)}`,
+              residentTerminal: result.residentTerminal,
+              invocationDisposition: result.invocationDisposition,
+              retryCount: result.retryCount
+            };
+          }
           result = applyReviewContract(result, spec);
           result.retryCount ??= 0;
           result.metrics = { ...(result.metrics ?? {}), residentLoadDurationMs: numericMetadata(resident.metadata?.loadDurationMs) };
           if (result.status === "completed") {
-            const missingMetric = spec.request.requiredMetrics.find((name) => typeof result.metrics?.[name] !== "number");
+            const missingMetric = spec.request.requiredMetrics.find((name) => !Number.isFinite(result.metrics?.[name]));
             if (missingMetric) result = { ...result, status: "schema_failed", errorCode: `missing_metric_${sanitizeIdentifier(missingMetric)}` };
           }
           if (result.residentTerminal && (result.status === "failed" || result.status === "stopped" || result.status === "oom")) {
             cellTerminal = { status: result.status, errorCode: result.errorCode ?? `cell_${result.status}` };
+          }
+          try {
+            for (const sample of resourceSamples) validateResourceSample(sample, "result resource sample");
+          } catch (error) {
+            throw new MonitorInfrastructureError(`monitor resource sample invalid before result persistence: ${errorMessage(error)}`);
           }
           result.resourceSamples = resourceSamples.slice(-2);
           assertTerminalStatus(result.status);
@@ -575,9 +594,9 @@ async function runPhase1ScreenWithLease(
         } catch (error) {
           if (error instanceof MonitorInfrastructureError) {
             infrastructureFailure = error.message;
-            result = { status: "stopped", errorCode: "monitor_infrastructure_failure", residentTerminal: true, retryCount: 0 };
+            result = { status: "stopped", errorCode: "monitor_infrastructure_failure", residentTerminal: true, retryCount: 0, invocationDisposition: "invoked" };
             cellTerminal = { status: "stopped", errorCode: "monitor_infrastructure_failure" };
-          } else result = { status: "failed", errorCode: safeErrorCode(error), retryCount: 0 };
+          } else result = { status: "failed", errorCode: safeErrorCode(error), retryCount: 0, invocationDisposition: "invoked" };
         }
         const record = resultRecord(manifest, cell, input, result, startedAt);
         assertResultPayloadSecretSafe(record);
@@ -622,7 +641,7 @@ function writeUnavailableMonitorEvidence(
     samples: [] as Phase1ResourceSample[],
     terminalInfrastructureErrorCode: sanitizeIdentifier(error)
   };
-  assertJsonValuesSecretSafe("resource evidence", resourceRecord);
+  assertJsonValuesSecretSafe("resource samples", resourceRecord.samples);
   atomicWriteJson(join(outputDir, "resources", `${cell.id}.json`), {
     ...resourceRecord,
     evidenceSha256: fingerprint(resourceRecord)
@@ -717,6 +736,7 @@ function resultRecord(
     errorCode: result.errorCode,
     retryCount: result.retryCount ?? 0,
     residentTerminal: result.residentTerminal ?? false,
+    invocationDisposition: result.invocationDisposition ?? "invoked",
     resourceSamples: result.resourceSamples
   };
   return { ...record, evidenceSha256: fingerprint(record) };
@@ -734,7 +754,8 @@ function writeMissingTerminalResult(
   const now = new Date().toISOString();
   const record = resultRecord(manifest, cell, input, {
     status: "failed",
-    errorCode: sanitizeIdentifier(errorCode)
+    errorCode: sanitizeIdentifier(errorCode),
+    invocationDisposition: "not_invoked_infrastructure"
   }, now);
   assertResultPayloadSecretSafe(record);
   atomicWriteJson(path, record);
@@ -768,6 +789,40 @@ function validateExistingResult(
   ) {
     throw new Error(`terminal result fingerprint mismatch at ${path}`);
   }
+  if (record.resourceSamples !== undefined) {
+    if (!Array.isArray(record.resourceSamples)) throw new Error(`terminal result resource samples are invalid at ${path}`);
+    for (const sample of record.resourceSamples) validateResourceSample(sample, `terminal result resource sample at ${path}`);
+  }
+  assertResultPayloadSecretSafe(record);
+}
+
+function reconstructResourceSamples(
+  outputDir: string,
+  manifest: Manifest,
+  cell: Manifest["cells"][number]
+): Phase1ResourceSample[] {
+  const reconstructed: Phase1ResourceSample[] = [];
+  for (const input of manifest.inputs) {
+    const path = resultFile(outputDir, cell.id, input.id);
+    if (!existsSync(path)) continue;
+    const record = parseJson<Record<string, unknown>>(path);
+    const disposition = record.invocationDisposition;
+    if (disposition === "invoked" && (!Array.isArray(record.resourceSamples) || record.resourceSamples.length === 0)) {
+      throw new Error(`monitored result ${cell.id}/${input.id} has no reconstructable resource samples`);
+    }
+    if (record.resourceSamples !== undefined && !Array.isArray(record.resourceSamples)) {
+      throw new Error(`monitored result ${cell.id}/${input.id} has invalid reconstructable resource samples`);
+    }
+    // Only invoked records own a durable before/after pair. Synthesized
+    // resident-terminal records may repeat the preceding pair and must not
+    // duplicate it during reconstruction.
+    if (disposition === "invoked") {
+      for (const sample of record.resourceSamples as Phase1ResourceSample[]) {
+        reconstructed.push(validateResourceSample(sample, `reconstructed resource sample ${cell.id}/${input.id}`));
+      }
+    }
+  }
+  return reconstructed;
 }
 
 function buildSummary(outputDir: string, manifest: Manifest, infrastructureFailure?: string): Phase1RunSummary {
@@ -824,6 +879,8 @@ function validateResourceEvidence(path: string, manifest: Manifest, cellFingerpr
     || record.monitorFingerprint !== manifest.monitorFingerprint
     || evidenceSha256 !== fingerprint(body)
   ) throw new Error(`resource evidence fingerprint mismatch at ${path}`);
+  if (!Array.isArray(record.samples)) throw new Error(`resource evidence samples are invalid at ${path}`);
+  for (const sample of record.samples) validateResourceSample(sample, `resource evidence sample at ${path}`);
 }
 
 function validateSpec(spec: Phase1RunSpec): void {
@@ -831,6 +888,12 @@ function validateSpec(spec: Phase1RunSpec): void {
   if (spec.cells.length === 0 || spec.inputs.length === 0) throw new Error("at least one cell and input are required");
   assertUniqueSafeIds("cell", spec.cells.map((cell) => cell.id));
   assertUniqueSafeIds("input", spec.inputs.map((input) => input.id));
+  for (const [label, version] of [
+    ["prompt", spec.prompt.version],
+    ["request", spec.request.version],
+    ["parser", spec.parser.version],
+    ["gate", spec.gate.version]
+  ] as const) assertProtocolVersion(label, version);
   for (const digest of [spec.target.modelSha256, spec.target.executableSha256, ...(spec.target.ownershipVerifierSha256 ? [spec.target.ownershipVerifierSha256] : []), spec.harness.sourceSha256, spec.prompt.templateSha256, spec.parser.sha256, spec.gate.sha256, ...spec.inputs.map((input) => input.sha256)]) {
     if (!/^[a-f0-9]{64}$/.test(digest)) throw new Error("all declared SHA-256 digests must be lowercase 64-character hex");
   }
@@ -939,7 +1002,7 @@ async function monitorSample(
   session: { id: string },
   context: { phase: "before" | "after"; input: Phase1Input }
 ): Promise<Phase1ResourceSample> {
-  try { return await monitor.sample(session, context); }
+  try { return validateResourceSample(await monitor.sample(session, context), `monitor ${context.phase} resource sample`); }
   catch (error) { throw new MonitorInfrastructureError(`monitor ${context.phase} failed: ${errorMessage(error)}`); }
 }
 
@@ -947,7 +1010,12 @@ function monitorClassify(
   monitor: Phase1ResourceMonitor,
   samples: Phase1ResourceSample[]
 ): { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined {
-  try { return monitor.classify?.(samples); }
+  try {
+    for (const sample of samples) validateResourceSample(sample, "monitor classification resource sample");
+    const classification = monitor.classify?.(samples);
+    for (const sample of samples) validateResourceSample(sample, "monitor classification resource sample");
+    return classification;
+  }
   catch (error) { throw new MonitorInfrastructureError(`monitor classify failed: ${errorMessage(error)}`); }
 }
 
@@ -964,7 +1032,7 @@ async function finalizeMonitorEvidence(
 }> {
   let infrastructureFailure: string | undefined;
   let terminalClassification: { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined;
-  try { samples.push(await monitor.stop(session)); }
+  try { samples.push(validateResourceSample(await monitor.stop(session), "monitor stop resource sample")); }
   catch (error) { infrastructureFailure = `monitor stop failed: ${errorMessage(error)}`; }
   try {
     terminalClassification = monitorClassify(monitor, samples);
@@ -984,7 +1052,8 @@ async function finalizeMonitorEvidence(
     terminalInfrastructureErrorCode: infrastructureFailure ? sanitizeIdentifier(infrastructureFailure) : undefined
   };
   try {
-    assertJsonValuesSecretSafe("resource evidence", resourceRecord);
+    for (const sample of resourceRecord.samples) validateResourceSample(sample, "persisted resource sample");
+    assertJsonValuesSecretSafe("resource samples", resourceRecord.samples);
     atomicWriteJson(join(outputDir, "resources", `${cell.id}.json`), {
       ...resourceRecord,
       evidenceSha256: fingerprint(resourceRecord)
@@ -1048,6 +1117,41 @@ function numericMetadata(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
 }
 
+function findInvalidMetric(metrics: Record<string, number> | undefined): string | undefined {
+  if (!metrics) return undefined;
+  for (const [name, value] of Object.entries(metrics)) {
+    if (!Number.isFinite(value)) return name;
+    if (isNonnegativeMetric(name) && value < 0) return name;
+  }
+  return undefined;
+}
+
+function isNonnegativeMetric(name: string): boolean {
+  return /(?:ms|bytes|tokens?|count|duration|latency|throughput|perSecond|ttft|rss|vram|swap)$/i.test(name);
+}
+
+function validateResourceSample(value: unknown, label: string): Phase1ResourceSample {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  const sample = value as Record<string, unknown>;
+  if (typeof sample.capturedAt !== "string" || typeof sample.phase !== "string") {
+    throw new Error(`${label} requires capturedAt and phase strings`);
+  }
+  for (const required of ["rssBytes", "vramBytes", "swapBytes"] as const) {
+    if (typeof sample[required] !== "number" || !Number.isFinite(sample[required])) {
+      throw new Error(`${label} field ${required} must be finite`);
+    }
+    if (sample[required] < 0) throw new Error(`${label} field ${required} must be nonnegative`);
+  }
+  for (const [name, field] of Object.entries(sample)) {
+    if (typeof field !== "number") continue;
+    if (!Number.isFinite(field)) throw new Error(`${label} field ${name} must be finite`);
+    if (/(?:bytes|count|duration|ms|rss|vram|swap)$/i.test(name) && field < 0) {
+      throw new Error(`${label} field ${name} must be nonnegative`);
+    }
+  }
+  return value as Phase1ResourceSample;
+}
+
 function assertUniqueSafeIds(kind: string, ids: string[]): void {
   if (new Set(ids).size !== ids.length) throw new Error(`${kind} IDs must be unique`);
   for (const id of ids) if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/.test(id)) throw new Error(`${kind} ID is not path safe: ${id}`);
@@ -1064,25 +1168,40 @@ function assertJsonValuesSecretSafe(label: string, value: unknown): void {
   }
   if (Array.isArray(value)) { for (const item of value) assertJsonValuesSecretSafe(label, item); return; }
   if (value && typeof value === "object") {
-    for (const [key, item] of Object.entries(value)) {
-      // These fields are runner-generated protocol identifiers or verified
-      // lowercase digests. Feeding them to the free-text detector creates
-      // false positives (for example, schema versions ending in `/v1`).
-      // Their shape and equality are validated separately at each evidence
-      // boundary; all model-, monitor-, and adapter-provided values continue
-      // through the secret detector.
-      if (key === "schemaVersion" || key === "evidenceSha256" || key.endsWith("Fingerprint")) continue;
-      assertJsonValuesSecretSafe(label, item);
-    }
+    for (const item of Object.values(value)) assertJsonValuesSecretSafe(label, item);
   }
 }
 
-function assertManifestMetadataSecretSafe(spec: Phase1RunSpec): void {
+function assertManifestPayloadSecretSafe(spec: Phase1RunSpec): void {
+  // Protocol versions and runner-generated digests are validated by
+  // validateSpec/buildManifest. Only payload-bearing positions are passed to
+  // the recursive free-text scanner, so an identically named key inside
+  // untrusted metadata receives no exemption.
+  assertJsonValuesSecretSafe("target executable arguments", spec.target.args);
   assertJsonValuesSecretSafe("target serving metadata", spec.target.servingParameters);
+  assertJsonValuesSecretSafe("prompt template", spec.prompt.template);
   assertJsonValuesSecretSafe("prompt metadata", spec.prompt.parameters);
+  assertJsonValuesSecretSafe("request response format", spec.request.responseFormat);
   assertJsonValuesSecretSafe("request metadata", spec.request.parameters);
-  for (const cell of spec.cells) assertJsonValuesSecretSafe(`cell ${cell.id} metadata`, cell.parameters);
-  for (const input of spec.inputs) assertJsonValuesSecretSafe(`input ${input.id} metadata`, input.metadata);
+  assertJsonValuesSecretSafe("required metric names", spec.request.requiredMetrics);
+  assertJsonValuesSecretSafe("gate key names", spec.gate.requiredTopLevelKeys);
+  assertSecretSafe("harness source path", spec.harness.sourcePath);
+  for (const cell of spec.cells) {
+    assertSecretSafe("cell identifier", cell.id);
+    assertJsonValuesSecretSafe(`cell ${cell.id} executable arguments`, cell.executableArgs);
+    assertJsonValuesSecretSafe(`cell ${cell.id} metadata`, cell.parameters);
+  }
+  for (const input of spec.inputs) {
+    assertSecretSafe("input identifier", input.id);
+    assertJsonValuesSecretSafe(`input ${input.id} metadata`, input.metadata);
+  }
+}
+
+function assertProtocolVersion(label: string, version: string): void {
+  if (!/^[a-zA-Z0-9._-]+(?:\/[a-zA-Z0-9._-]+)*\/v[1-9][0-9]*$/.test(version)) {
+    throw new Error(`${label} protocol version is invalid`);
+  }
+  assertSecretSafe(`${label} protocol version`, version);
 }
 
 function assertResultPayloadSecretSafe(record: Record<string, unknown>): void {
@@ -1266,6 +1385,8 @@ function gitCommitContainsBytes(checkoutRoot: string, commit: string, relativePa
 
 async function verifyResourceMonitorModuleIdentity(identity: Phase1ResourceMonitorModule): Promise<void> {
   const { modulePath, approvedRoot, moduleSha256, exportName } = identity;
+  assertProtocolVersion("resource monitor", identity.version);
+  assertJsonValuesSecretSafe("resource monitor paths", [modulePath, approvedRoot, exportName]);
   if (resolve(modulePath) !== modulePath || resolve(approvedRoot) !== approvedRoot) {
     throw new Error("resource monitor source and approved root paths must be absolute");
   }

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -12,8 +12,8 @@ import {
   rmSync,
   writeFileSync
 } from "node:fs";
-import { basename, dirname, join, resolve, sep } from "node:path";
-import { connect } from "node:net";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import { connect, createServer } from "node:net";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 export type Phase1TerminalStatus = "completed" | "failed" | "stopped" | "oom" | "schema_failed";
@@ -135,14 +135,25 @@ export interface Phase1ResourceSample {
 }
 
 export interface Phase1ResourceMonitor {
-  identity: { version: string; sha256: string };
   start(context: { target: Phase1Target; cell: Phase1Cell; outputDir: string }): Promise<{ id: string }>;
   sample(session: { id: string }, context: { phase: "before" | "after"; input: Phase1Input }): Promise<Phase1ResourceSample>;
   classify?(samples: Phase1ResourceSample[]): { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined;
   stop(session: { id: string }): Promise<Phase1ResourceSample>;
 }
 
-export interface Phase1RunnerOptions { monitor?: Phase1ResourceMonitor }
+export interface Phase1ResourceMonitorModule {
+  version: string;
+  modulePath: string;
+  moduleSha256: string;
+  approvedRoot: string;
+  exportName: string;
+}
+
+export interface Phase1RunnerOptions {
+  monitorModule?: Phase1ResourceMonitorModule;
+}
+
+type ResolvedRunnerOptions = { monitor?: Phase1ResourceMonitor; monitorIdentity?: Phase1ResourceMonitorModule };
 
 type ResidentProcess = {
   process: ChildProcess;
@@ -331,6 +342,7 @@ type Manifest = {
   gateFingerprint: string;
   requestFingerprint: string;
   monitorFingerprint: string;
+  monitorIdentity: Phase1ResourceMonitorModule | { version: "none"; moduleSha256: string; modulePath: "none"; approvedRoot: "none"; exportName: "none" };
   harnessFingerprint: string;
   target: Phase1Target;
   prompt: Phase1RunSpec["prompt"];
@@ -338,7 +350,7 @@ type Manifest = {
   gate: Phase1RunSpec["gate"];
   request: Phase1RunSpec["request"];
   harness: Phase1RunSpec["harness"];
-  cells: Array<Phase1Cell & { fingerprint: string; effectiveArgvFingerprint: string }>;
+  cells: Array<Phase1Cell & { fingerprint: string; cohortFingerprint: string; effectiveArgvFingerprint: string }>;
   inputs: Array<Omit<Phase1Input, "prompt"> & { fingerprint: string; promptSha256: string }>;
 };
 
@@ -362,7 +374,7 @@ export function verifyPairedPhase1Cohort(
     ["request", left.requestFingerprint, right.requestFingerprint],
     ["monitor", left.monitorFingerprint, right.monitorFingerprint],
     ["harness", left.harnessFingerprint, right.harnessFingerprint],
-    ["cells", fingerprint(left.cells), fingerprint(right.cells)],
+    ["cells", fingerprint(left.cells.map(pairedCellIdentity)), fingerprint(right.cells.map(pairedCellIdentity))],
     ["inputs", fingerprint(left.inputs), fingerprint(right.inputs)]
   ] as const) {
     if (leftValue !== rightValue) throw new Error(`paired cohort drift detected in ${name}`);
@@ -373,11 +385,23 @@ export function verifyPairedPhase1Cohort(
     gateFingerprint: left.gateFingerprint,
     requestFingerprint: left.requestFingerprint,
     monitorFingerprint: left.monitorFingerprint,
+    monitorIdentity: left.monitorIdentity,
     harnessFingerprint: left.harnessFingerprint,
-    cells: left.cells,
+    cells: left.cells.map(pairedCellIdentity),
     inputs: left.inputs
   };
   return { ok: true, cohortFingerprint: fingerprint(cohort) };
+}
+
+function pairedCellIdentity(cell: Manifest["cells"][number]): Record<string, unknown> {
+  return {
+    id: cell.id,
+    contextTokens: cell.contextTokens,
+    repetition: cell.repetition,
+    parameters: cell.parameters,
+    executableArgs: cell.executableArgs,
+    cohortFingerprint: cell.cohortFingerprint
+  };
 }
 
 function assertPairedManifestIntegrity(manifest: Manifest, side: string): void {
@@ -387,6 +411,7 @@ function assertPairedManifestIntegrity(manifest: Manifest, side: string): void {
     ["parser", manifest.parserFingerprint, fingerprint(manifest.parser)],
     ["gate", manifest.gateFingerprint, fingerprint(manifest.gate)],
     ["request", manifest.requestFingerprint, fingerprint(manifest.request)],
+    ["monitor", manifest.monitorFingerprint, fingerprint(manifest.monitorIdentity)],
     ["harness", manifest.harnessFingerprint, fingerprint(manifest.harness)]
   ] as const) {
     if (declared !== actual) throw new Error(`paired cohort drift detected in ${name} (${side} manifest integrity)`);
@@ -401,11 +426,12 @@ export async function runPhase1Screen(
   options: Phase1RunnerOptions = {}
 ): Promise<Phase1RunSummary> {
   validateSpec(spec);
-  if (options.monitor && !/^[a-f0-9]{64}$/.test(options.monitor.identity.sha256)) throw new Error("resource monitor identity requires a SHA-256 source fingerprint");
+  if ("monitor" in (options as object)) throw new Error("injected resource monitor methods are forbidden; configure a pinned monitor module");
+  if (options.monitorModule && !/^[a-f0-9]{64}$/.test(options.monitorModule.moduleSha256)) throw new Error("resource monitor module requires a SHA-256 source fingerprint");
   validateOutputBoundary(spec);
   mkdirSync(spec.outputDir, { recursive: true, mode: 0o700 });
   const leasePath = join(spec.outputDir, ".phase1-run.lock");
-  const lease = acquireRunLease(leasePath);
+  const lease = await acquireRunLease(leasePath);
   try {
     return await runPhase1ScreenWithLease(spec, adapter, options);
   } finally {
@@ -421,9 +447,18 @@ async function runPhase1ScreenWithLease(
 ): Promise<Phase1RunSummary> {
   const actualHarnessSha256 = await sha256File(spec.harness.sourcePath);
   if (actualHarnessSha256 !== spec.harness.sourceSha256) throw new Error("harness source SHA-256 does not match the implementation artifact");
+  const harnessRelativePath = relative(spec.checkoutRoot, spec.harness.sourcePath);
+  if (!harnessRelativePath || harnessRelativePath.startsWith(`..${sep}`) || harnessRelativePath === ".." || resolve(spec.checkoutRoot, harnessRelativePath) !== resolve(spec.harness.sourcePath)) {
+    throw new Error("harness source must be a repository-relative path inside checkoutRoot");
+  }
+  if (!gitCommitContainsBytes(spec.checkoutRoot, spec.harness.commit, harnessRelativePath, spec.harness.sourceSha256)) {
+    throw new Error("harness source bytes are not present at the declared commit");
+  }
+  if (options.monitorModule) await verifyResourceMonitorModuleIdentity(options.monitorModule);
+  const resolvedOptions: ResolvedRunnerOptions = options.monitorModule ? { monitorIdentity: options.monitorModule } : {};
   assertSecretSafe("target argv", [spec.target.executable, ...spec.target.args].join("\n"));
   assertJsonValuesSecretSafe("target manifest", spec.target);
-  const manifest = buildManifest(spec, options.monitor);
+  const manifest = buildManifest(spec, resolvedOptions.monitorIdentity);
   assertManifestMetadataSecretSafe(spec);
   const manifestPath = join(spec.outputDir, "manifest.json");
   if (existsSync(manifestPath)) {
@@ -441,9 +476,11 @@ async function runPhase1ScreenWithLease(
       if (existsSync(path)) validateExistingResult(path, manifest, cell.fingerprint, input);
       else missingResults += 1;
     }
-    if (options.monitor) {
+    if (resolvedOptions.monitorIdentity) {
       const resourcePath = join(spec.outputDir, "resources", `${cell.id}.json`);
+      const unavailablePath = join(spec.outputDir, `resource-unavailable-${cell.id}.json`);
       if (existsSync(resourcePath)) validateResourceEvidence(resourcePath, manifest, cell.fingerprint);
+      else if (existsSync(unavailablePath)) validateResourceEvidence(unavailablePath, manifest, cell.fingerprint);
       else if (spec.inputs.every((input) => existsSync(resultFile(spec.outputDir, cell.id, input.id)))) {
         throw new Error(`terminal resource evidence is missing for cell ${cell.id}`);
       }
@@ -461,13 +498,17 @@ async function runPhase1ScreenWithLease(
   atomicWriteText(join(spec.outputDir, "RUNNING"), `${manifest.runFingerprint}\n`);
 
   let infrastructureFailure: string | undefined;
+  if (resolvedOptions.monitorIdentity) {
+    try { resolvedOptions.monitor = await loadResourceMonitorModule(resolvedOptions.monitorIdentity); }
+    catch (error) { infrastructureFailure = `resource monitor module load failed: ${errorMessage(error)}`; }
+  }
   for (const cell of manifest.cells) {
     const cellHasWork = spec.inputs.some((input) => !existsSync(resultFile(spec.outputDir, cell.id, input.id)));
     if (!cellHasWork) continue;
     let monitorSession: { id: string } | undefined;
     const resourceSamples: Phase1ResourceSample[] = [];
-    if (options.monitor) {
-      try { monitorSession = await options.monitor.start({ target: spec.target, cell, outputDir: spec.outputDir }); }
+    if (resolvedOptions.monitor) {
+      try { monitorSession = await resolvedOptions.monitor.start({ target: spec.target, cell, outputDir: spec.outputDir }); }
       catch (error) { infrastructureFailure = errorMessage(error); }
     }
     const resident = infrastructureFailure ? undefined : await startResident(adapter, spec, manifest, cell).catch((error) => {
@@ -476,10 +517,11 @@ async function runPhase1ScreenWithLease(
     });
     if (!resident) {
       for (const input of spec.inputs) writeMissingTerminalResult(spec.outputDir, manifest, cell, input, infrastructureFailure ?? "resident_start_failed");
-      if (options.monitor && monitorSession) {
-        const monitorFailure = await finalizeMonitorEvidence(options.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
-        if (monitorFailure) infrastructureFailure = monitorFailure;
-      } else if (options.monitor) {
+      if (resolvedOptions.monitor && monitorSession) {
+        const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
+        if (finalized.infrastructureFailure) infrastructureFailure = finalized.infrastructureFailure;
+        if (finalized.terminalClassification) rewriteCellTerminalResults(spec.outputDir, manifest, cell, finalized.terminalClassification);
+      } else if (resolvedOptions.monitorIdentity) {
         writeUnavailableMonitorEvidence(spec.outputDir, manifest, cell, infrastructureFailure ?? "monitor_start_failed");
       }
       continue;
@@ -499,7 +541,7 @@ async function runPhase1ScreenWithLease(
         try {
           if (cellTerminal) result = cellTerminal;
           else {
-            if (options.monitor && monitorSession) resourceSamples.push(await monitorSample(options.monitor, monitorSession, { phase: "before", input }));
+            if (resolvedOptions.monitor && monitorSession) resourceSamples.push(await monitorSample(resolvedOptions.monitor, monitorSession, { phase: "before", input }));
             const renderedPrompt = renderPrompt(spec.prompt.template, input.prompt);
             result = await adapter.invoke(resident, {
               input,
@@ -510,9 +552,9 @@ async function runPhase1ScreenWithLease(
               parserFingerprint: manifest.parserFingerprint,
               gateFingerprint: manifest.gateFingerprint
             });
-            if (options.monitor && monitorSession) {
-              resourceSamples.push(await monitorSample(options.monitor, monitorSession, { phase: "after", input }));
-              const classification = monitorClassify(options.monitor, resourceSamples);
+            if (resolvedOptions.monitor && monitorSession) {
+              resourceSamples.push(await monitorSample(resolvedOptions.monitor, monitorSession, { phase: "after", input }));
+              const classification = monitorClassify(resolvedOptions.monitor, resourceSamples);
               if (classification) result = { ...result, ...classification, residentTerminal: true };
             }
           }
@@ -550,9 +592,10 @@ async function runPhase1ScreenWithLease(
       } catch (error) {
         infrastructureFailure = errorMessage(error);
       }
-      if (options.monitor && monitorSession) {
-        const monitorFailure = await finalizeMonitorEvidence(options.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
-        if (monitorFailure) infrastructureFailure = monitorFailure;
+      if (resolvedOptions.monitor && monitorSession) {
+        const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
+        if (finalized.infrastructureFailure) infrastructureFailure = finalized.infrastructureFailure;
+        if (finalized.terminalClassification) rewriteCellTerminalResults(spec.outputDir, manifest, cell, finalized.terminalClassification);
       }
     }
   }
@@ -601,17 +644,19 @@ async function startResident(
   });
 }
 
-function buildManifest(spec: Phase1RunSpec, monitor?: Phase1ResourceMonitor): Manifest {
+function buildManifest(spec: Phase1RunSpec, monitorIdentityInput?: Phase1ResourceMonitorModule): Manifest {
   const targetFingerprint = fingerprint(spec.target);
   const promptFingerprint = fingerprint(spec.prompt);
   const parserFingerprint = fingerprint(spec.parser);
   const gateFingerprint = fingerprint(spec.gate);
   const requestFingerprint = fingerprint(spec.request);
   const harnessFingerprint = fingerprint(spec.harness);
-  const monitorFingerprint = fingerprint(monitor?.identity ?? { version: "none", sha256: sha256("none") });
+  const monitorIdentity = monitorIdentityInput ?? { version: "none" as const, moduleSha256: sha256("none"), modulePath: "none" as const, approvedRoot: "none" as const, exportName: "none" as const };
+  const monitorFingerprint = fingerprint(monitorIdentity);
   const cells = spec.cells.map((cell) => {
     const effectiveArgvFingerprint = fingerprint([spec.target.executable, ...spec.target.args, ...(cell.executableArgs ?? [])]);
-    return { ...cell, effectiveArgvFingerprint, fingerprint: fingerprint({ ...cell, effectiveArgvFingerprint }) };
+    const cohortFingerprint = fingerprint({ id: cell.id, contextTokens: cell.contextTokens, repetition: cell.repetition, parameters: cell.parameters, executableArgs: cell.executableArgs });
+    return { ...cell, cohortFingerprint, effectiveArgvFingerprint, fingerprint: fingerprint({ ...cell, cohortFingerprint, effectiveArgvFingerprint }) };
   });
   const inputs = spec.inputs.map(({ prompt, ...input }) => ({
     ...input,
@@ -626,6 +671,7 @@ function buildManifest(spec: Phase1RunSpec, monitor?: Phase1ResourceMonitor): Ma
     gateFingerprint,
     requestFingerprint,
     monitorFingerprint,
+    monitorIdentity,
     harnessFingerprint,
     target: spec.target,
     prompt: spec.prompt,
@@ -821,20 +867,52 @@ function canonicalProspectivePath(path: string): string {
   return resolve(realpathSync(cursor), ...suffix);
 }
 
-function acquireRunLease(path: string): number {
+async function acquireRunLease(path: string): Promise<number> {
+  const coordinator = createServer((socket) => socket.destroy());
+  const coordinationPort = phase1LeaseCoordinationPort(path);
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const fail = (error: Error & { code?: string }) => {
+      coordinator.removeListener("listening", ready);
+      rejectPromise(new Error(error.code === "EADDRINUSE"
+        ? "Phase 1 lease acquisition is already coordinated by another writer"
+        : `Phase 1 lease coordination failed: ${errorMessage(error)}`));
+    };
+    const ready = () => {
+      coordinator.removeListener("error", fail);
+      resolvePromise();
+    };
+    coordinator.once("error", fail);
+    coordinator.once("listening", ready);
+    coordinator.listen({ host: "127.0.0.1", port: coordinationPort, exclusive: true });
+  });
   try {
-    const fd = openSync(path, "wx", 0o600);
-    writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`);
-    return fd;
-  } catch (error) {
-    if (!existsSync(path)) throw error;
-    const prior = parseJson<{ pid?: number }>(path);
-    if (typeof prior.pid === "number" && isProcessAlive(prior.pid)) throw new Error(`Phase 1 output has an active exclusive run lease held by PID ${prior.pid}`);
-    rmSync(path, { force: true });
-    const fd = openSync(path, "wx", 0o600);
-    writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), recovered: true })}\n`);
-    return fd;
+    try {
+      const fd = openSync(path, "wx", 0o600);
+      writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`);
+      return fd;
+    } catch (error) {
+      if (!isAlreadyExistsError(error)) throw error;
+      const prior = parseJson<{ pid?: number }>(path);
+      if (typeof prior.pid === "number" && isProcessAlive(prior.pid)) throw new Error(`Phase 1 output has an active exclusive run lease held by PID ${prior.pid}`);
+      // Every conforming writer must own the crash-released loopback
+      // coordinator before touching the canonical lease, so no new lease can
+      // appear between this removal and the exclusive replacement open.
+      rmSync(path, { force: true });
+      const fd = openSync(path, "wx", 0o600);
+      writeFileSync(fd, `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), recovered: true })}\n`);
+      return fd;
+    }
+  } finally {
+    await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));
   }
+}
+
+export function phase1LeaseCoordinationPort(path: string): number {
+  return 20_000 + (Number.parseInt(sha256(resolve(path)).slice(0, 8), 16) % 20_000);
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "EEXIST";
 }
 
 function renderPrompt(template: string, input: string): string {
@@ -880,7 +958,10 @@ async function finalizeMonitorEvidence(
   outputDir: string,
   manifest: Manifest,
   cell: Manifest["cells"][number]
-): Promise<string | undefined> {
+): Promise<{
+  infrastructureFailure?: string;
+  terminalClassification?: { status: "failed" | "stopped" | "oom"; errorCode: string };
+}> {
   let infrastructureFailure: string | undefined;
   let terminalClassification: { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined;
   try { samples.push(await monitor.stop(session)); }
@@ -902,12 +983,65 @@ async function finalizeMonitorEvidence(
     } : undefined,
     terminalInfrastructureErrorCode: infrastructureFailure ? sanitizeIdentifier(infrastructureFailure) : undefined
   };
-  assertJsonValuesSecretSafe("resource evidence", resourceRecord);
-  atomicWriteJson(join(outputDir, "resources", `${cell.id}.json`), {
+  try {
+    assertJsonValuesSecretSafe("resource evidence", resourceRecord);
+    atomicWriteJson(join(outputDir, "resources", `${cell.id}.json`), {
+      ...resourceRecord,
+      evidenceSha256: fingerprint(resourceRecord)
+    });
+  } catch (error) {
+    infrastructureFailure = `monitor evidence finalization failed: ${errorMessage(error)}`;
+    try { writeResourceUnavailableFallback(outputDir, manifest, cell, infrastructureFailure); }
+    catch (fallbackError) {
+      infrastructureFailure = `monitor evidence finalization and fallback write failed: ${errorMessage(fallbackError)}`;
+    }
+  }
+  return { infrastructureFailure, terminalClassification };
+}
+
+function writeResourceUnavailableFallback(
+  outputDir: string,
+  manifest: Manifest,
+  cell: Manifest["cells"][number],
+  error: string
+): void {
+  const resourceRecord = {
+    schemaVersion: "neondiff-phase1-resources/v1",
+    runFingerprint: manifest.runFingerprint,
+    cellFingerprint: cell.fingerprint,
+    monitorFingerprint: manifest.monitorFingerprint,
+    samples: [] as Phase1ResourceSample[],
+    terminalInfrastructureErrorCode: sanitizeIdentifier(error),
+    unavailable: true
+  };
+  atomicWriteJson(join(outputDir, `resource-unavailable-${cell.id}.json`), {
     ...resourceRecord,
     evidenceSha256: fingerprint(resourceRecord)
   });
-  return infrastructureFailure;
+}
+
+function rewriteCellTerminalResults(
+  outputDir: string,
+  manifest: Manifest,
+  cell: Manifest["cells"][number],
+  terminal: { status: "failed" | "stopped" | "oom"; errorCode: string }
+): void {
+  for (const input of manifest.inputs) {
+    const path = resultFile(outputDir, cell.id, input.id);
+    if (!existsSync(path)) continue;
+    const record = parseJson<Record<string, unknown>>(path);
+    if (record.status !== "completed") continue;
+    const { evidenceSha256: _discarded, ...body } = record;
+    const rewritten = {
+      ...body,
+      status: terminal.status,
+      errorCode: sanitizeIdentifier(terminal.errorCode),
+      residentTerminal: true,
+      completedAt: new Date().toISOString()
+    };
+    assertResultPayloadSecretSafe(rewritten);
+    atomicWriteJson(path, { ...rewritten, evidenceSha256: fingerprint(rewritten) });
+  }
 }
 
 function numericMetadata(value: unknown): number {
@@ -1002,8 +1136,8 @@ function fingerprint(value: unknown): string {
   return sha256(canonicalJson(value));
 }
 
-function sha256(value: string): string {
-  return createHash("sha256").update(value, "utf8").digest("hex");
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
 }
 
 function canonicalJson(value: unknown): string {
@@ -1100,7 +1234,12 @@ async function recoverResidentJournal(
   signalProcessGroup(journal.pid, "SIGTERM");
   const deadline = Date.now() + stopTimeoutMs;
   while (isProcessAlive(journal.pid) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 50));
-  if (isProcessAlive(journal.pid)) signalProcessGroup(journal.pid, "SIGKILL");
+  if (isProcessAlive(journal.pid)) {
+    signalProcessGroup(journal.pid, "SIGKILL");
+    const killDeadline = Date.now() + stopTimeoutMs;
+    while (isProcessAlive(journal.pid) && Date.now() < killDeadline) await new Promise((resolve) => setTimeout(resolve, 50));
+    if (isProcessAlive(journal.pid)) throw new Error("stale resident recovery could not be proven after SIGKILL");
+  }
   atomicWriteJson(path, { ...journal, state: "recovered_stopped", recoveredAt: new Date().toISOString() });
 }
 
@@ -1108,6 +1247,109 @@ async function sha256File(path: string): Promise<string> {
   const hash = createHash("sha256");
   for await (const chunk of createReadStream(path)) hash.update(chunk);
   return hash.digest("hex");
+}
+
+function gitCommitContainsBytes(checkoutRoot: string, commit: string, relativePath: string, expectedSha256: string): boolean {
+  if (!/^[a-f0-9]{40}$/.test(commit) || relativePath.includes("\0") || relativePath.includes(":") || relativePath.includes("\\")
+    || relativePath.startsWith("/") || relativePath.split("/").some((part) => part === "" || part === "." || part === "..")) return false;
+  try {
+    const bytes = execFileSync("git", ["-C", checkoutRoot, "show", `${commit}:${relativePath}`], {
+      encoding: "buffer",
+      maxBuffer: 32 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    return sha256(bytes) === expectedSha256;
+  } catch {
+    return false;
+  }
+}
+
+async function verifyResourceMonitorModuleIdentity(identity: Phase1ResourceMonitorModule): Promise<void> {
+  const { modulePath, approvedRoot, moduleSha256, exportName } = identity;
+  if (resolve(modulePath) !== modulePath || resolve(approvedRoot) !== approvedRoot) {
+    throw new Error("resource monitor source and approved root paths must be absolute");
+  }
+  if (!/^[a-zA-Z_$][a-zA-Z0-9_$]{0,127}$/.test(exportName)) throw new Error("resource monitor export name is invalid");
+  const source = realpathSync(modulePath);
+  const root = realpathSync(approvedRoot);
+  if (source !== root && !source.startsWith(`${root}${sep}`)) throw new Error("resource monitor source must be inside its approved boundary");
+  if (await sha256File(source) !== moduleSha256) throw new Error("resource monitor source SHA-256 does not match its immutable identity");
+  assertMonitorModuleImportsAreLoadable(readFileSync(source, "utf8"));
+}
+
+async function loadResourceMonitorModule(identity: Phase1ResourceMonitorModule): Promise<Phase1ResourceMonitor> {
+  await verifyResourceMonitorModuleIdentity(identity);
+  const bytes = readFileSync(realpathSync(identity.modulePath));
+  if (sha256(bytes) !== identity.moduleSha256) throw new Error("resource monitor module changed before exact-byte loading");
+  // Import the verified bytes themselves, rather than re-opening the path via
+  // the module loader. This closes the hash-check/import TOCTOU window and
+  // ensures the executing factory is exactly the artifact named in evidence.
+  // The nonce is deliberately run-local and excluded from evidence identity.
+  // Node caches ESM namespaces by URL; a unique fragment ensures module-scope
+  // counters cannot leak between candidates or repeated runPhase1Screen calls.
+  const moduleUrl = `data:text/javascript;base64,${bytes.toString("base64")}#sha256=${identity.moduleSha256}&load=${randomUUID()}`;
+  const loaded = await import(moduleUrl) as Record<string, unknown>;
+  const factory = loaded[identity.exportName];
+  if (typeof factory !== "function") throw new Error("resource monitor module does not export the pinned factory");
+  const monitor = await (factory as () => unknown)();
+  if (!monitor || typeof monitor !== "object") throw new Error("resource monitor factory did not return an object");
+  const candidate = monitor as Partial<Phase1ResourceMonitor>;
+  if (typeof candidate.start !== "function" || typeof candidate.sample !== "function" || typeof candidate.stop !== "function"
+    || (candidate.classify !== undefined && typeof candidate.classify !== "function")) {
+    throw new Error("resource monitor factory returned an invalid monitor implementation");
+  }
+  return candidate as Phase1ResourceMonitor;
+}
+
+function assertMonitorModuleImportsAreLoadable(source: string): void {
+  const lexicalSource = stripJavaScriptComments(source);
+  if (/\bimport\s*\(/.test(lexicalSource)) {
+    throw new Error("resource monitor module must be self-contained; dynamic import syntax is forbidden");
+  }
+  const specifiers: string[] = [];
+  for (const pattern of [/\bfrom\s*["']([^"']+)["']/g, /\bimport\s*["']([^"']+)["']/g]) {
+    for (const match of lexicalSource.matchAll(pattern)) specifiers.push(match[1]);
+  }
+  const unsupported = specifiers.find((specifier) => !specifier.startsWith("node:"));
+  if (unsupported) {
+    throw new Error(`resource monitor module must be self-contained; unsupported import specifier: ${sanitizeIdentifier(unsupported)}`);
+  }
+}
+
+function stripJavaScriptComments(source: string): string {
+  let output = "";
+  let quote: "'" | '"' | "`" | undefined;
+  for (let index = 0; index < source.length; index += 1) {
+    const current = source[index];
+    const next = source[index + 1];
+    if (quote) {
+      output += current;
+      if (current === "\\") {
+        output += next ?? "";
+        index += 1;
+      } else if (current === quote) quote = undefined;
+      continue;
+    }
+    if (current === "'" || current === '"' || current === "`") {
+      quote = current;
+      output += current;
+      continue;
+    }
+    if (current === "/" && next === "/") {
+      while (index < source.length && source[index] !== "\n") index += 1;
+      output += "\n";
+      continue;
+    }
+    if (current === "/" && next === "*") {
+      index += 2;
+      while (index < source.length && !(source[index] === "*" && source[index + 1] === "/")) index += 1;
+      index += 1;
+      output += " ";
+      continue;
+    }
+    output += current;
+  }
+  return output;
 }
 
 async function readResponseBody(response: Response, maximumBytes: number): Promise<string> {
@@ -1142,6 +1384,7 @@ async function readStreamingAssistant(
   let content = "";
   let used = 0;
   let ttftMs: number | undefined;
+  const terminalMetrics: Record<string, number> = {};
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
@@ -1161,6 +1404,9 @@ async function readStreamingAssistant(
         let envelope: unknown;
         try { envelope = JSON.parse(data); }
         catch { throw new Error("invalid llama-server streaming envelope"); }
+        const envelopeMetrics = readResponseMetrics(envelope, 0);
+        delete envelopeMetrics.latencyMs;
+        Object.assign(terminalMetrics, envelopeMetrics);
         const delta = readDeltaContent(envelope);
         if (delta) {
           if (ttftMs === undefined) ttftMs = Math.max(0, performance.now() - requestStartedAt);
@@ -1174,6 +1420,7 @@ async function readStreamingAssistant(
   return {
     content,
     metrics: {
+      ...terminalMetrics,
       latencyMs: Math.max(0, performance.now() - requestStartedAt),
       ttftMs: ttftMs ?? 0,
       responseBytes: Buffer.byteLength(content, "utf8")

--- a/tests/phase1-screening-runner.test.ts
+++ b/tests/phase1-screening-runner.test.ts
@@ -1,0 +1,615 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createServer } from "node:http";
+import { describe, expect, it } from "vitest";
+import {
+  runPhase1Screen,
+  createLlamaServerExecutableAdapter,
+  verifyPairedPhase1Cohort,
+  type Phase1ResidentAdapter,
+  type Phase1ResourceMonitor,
+  type Phase1RunSpec
+} from "../src/phase1-screening-runner.js";
+
+function digest(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+const ownershipProof = {
+  ownershipVerifierSha256: "8".repeat(64),
+  verifyListenerOwnership: async () => true,
+  verifyProcessIdentity: async () => true
+};
+const runnerSourcePath = join(process.cwd(), "src", "phase1-screening-runner.ts");
+
+function spec(outputDir: string): Phase1RunSpec {
+  return {
+    outputDir,
+    safeOutputRoot: outputDir,
+    checkoutRoot: process.cwd(),
+    target: {
+      id: "qwen36-27b-q4km",
+      modelPath: "/models/qwen.gguf",
+      modelSha256: "a".repeat(64),
+      backendCommit: "6b4dc2116a92c5c8f2782bfe51fabe5ee66fb5ef",
+      executable: "/opt/llama-server",
+      executableSha256: "9".repeat(64),
+      ownershipVerifierSha256: "8".repeat(64),
+      args: ["--model", "/models/qwen.gguf", "--ctx-size", "8192"]
+    },
+    cells: [{ id: "warm-8k", contextTokens: 8192, repetition: 1 }],
+    inputs: [
+      { id: "pr-1", sha256: digest("Review PR one."), prompt: "Review PR one." },
+      { id: "pr-2", sha256: digest("Review PR two."), prompt: "Review PR two." }
+    ],
+    prompt: { version: "phase1-prompt/v1", template: "{{input}}", templateSha256: digest("{{input}}") },
+    request: {
+      version: "phase1-request/v1",
+      stream: false,
+      outputBudgetTokens: 1024,
+      requiredMetrics: [],
+      parameters: { temperature: 0.6, top_p: 0.95, top_k: 20 }
+    },
+    harness: { commit: "1".repeat(40), sourcePath: runnerSourcePath, sourceSha256: digest(readFileSync(runnerSourcePath)) },
+    parser: { version: "phase1-parser/v1", format: "json", sha256: digest("phase1-parser/v1:json") },
+    gate: { version: "phase1-gate/v1", requiredTopLevelKeys: [], sha256: digest("phase1-gate/v1:") }
+  };
+}
+
+function adapter(overrides: Partial<Phase1ResidentAdapter> = {}): Phase1ResidentAdapter {
+  return {
+    async start(context) {
+      expect(existsSync(join(context.outputDir, "manifest.json"))).toBe(true);
+      return { id: "resident-1", argv: ["/opt/llama-server", "--model", "/models/qwen.gguf"] };
+    },
+    async invoke(_resident, request) {
+      return {
+        status: "completed",
+        rawOutput: JSON.stringify({ findings: [] }),
+        parsedOutput: { findings: [] },
+        metrics: { latencyMs: request.input.id === "pr-1" ? 10 : 20 }
+      };
+    },
+    async stop() {},
+    ...overrides
+  };
+}
+
+describe("Phase 1 screening runner", () => {
+  it("owns one resident executable lifecycle per cell and invokes its OpenAI-compatible endpoint", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-phase1-executable-"));
+    const port = 24000 + Math.floor(Math.random() * 10000);
+    const script = join(root, "fake-llama-server.mjs");
+    writeFileSync(script, `
+      import http from "node:http";
+      const port = Number(process.argv[process.argv.indexOf("--port") + 1]);
+      const server = http.createServer((req, res) => {
+        if (req.url === "/health") { res.writeHead(200); res.end("ok"); return; }
+        let body = "";
+        req.on("data", chunk => body += chunk);
+        req.on("end", () => {
+          const parsed = JSON.parse(body);
+          res.setHeader("content-type", "application/json");
+          res.end(JSON.stringify({ choices: [{ message: { content: JSON.stringify({ reviewed: parsed.messages[0].content }) } }], usage: { prompt_tokens: 12, completion_tokens: 3 }, timings: { prompt_ms: 20, predicted_ms: 10, predicted_per_second: 300 } }));
+        });
+      });
+      server.listen(port, "127.0.0.1");
+      process.on("SIGTERM", () => server.close(() => process.exit(0)));
+    `);
+    const runSpec = spec(join(root, "evidence"));
+    const modelPath = join(root, "model.gguf");
+    writeFileSync(modelPath, "test-model");
+    runSpec.target.modelPath = modelPath;
+    runSpec.target.modelSha256 = digest(readFileSync(modelPath));
+    runSpec.target.executable = process.execPath;
+    runSpec.target.executableSha256 = digest(readFileSync(process.execPath));
+    runSpec.target.args = [script, "--model", modelPath, "--host", "127.0.0.1", "--port", String(port), "--ctx-size", "8192"];
+    const result = await runPhase1Screen(runSpec, createLlamaServerExecutableAdapter({
+      baseUrl: `http://127.0.0.1:${port}`,
+      readinessTimeoutMs: 5_000,
+      requestTimeoutMs: 5_000,
+      stopTimeoutMs: 2_000,
+      ...ownershipProof
+    }));
+    expect(result.status).toBe("completed");
+    const first = JSON.parse(readFileSync(join(runSpec.outputDir, "results", "warm-8k", "pr-1.json"), "utf8"));
+    expect(first.parsedOutput).toEqual({ reviewed: "Review PR one." });
+    expect(first.metrics.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(first.metrics.promptMs).toBe(20);
+    expect(first.metrics.decodeTokensPerSecond).toBe(300);
+  });
+
+  it("captures TTFT from a bounded streaming response", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-phase1-stream-"));
+    const port = 25000 + Math.floor(Math.random() * 8000);
+    const script = join(root, "fake-stream-server.mjs");
+    writeFileSync(script, `
+      import http from "node:http";
+      const port = Number(process.argv[process.argv.indexOf("--port") + 1]);
+      const server = http.createServer((req, res) => {
+        if (req.url === "/health") { res.writeHead(200); res.end("ok"); return; }
+        req.resume(); req.on("end", () => {
+          res.writeHead(200, { "content-type": "text/event-stream" });
+          res.write("data: " + JSON.stringify({ choices: [{ delta: { content: '{"findings":' } }] }) + "\\n\\n");
+          setTimeout(() => { res.write("data: " + JSON.stringify({ choices: [{ delta: { content: '[]}' } }] }) + "\\n\\n"); res.end('data: [DONE]\\n\\n'); }, 5);
+        });
+      });
+      server.listen(port, "127.0.0.1");
+      process.on("SIGTERM", () => server.close(() => process.exit(0)));
+    `);
+    const runSpec = spec(join(root, "evidence"));
+    const modelPath = join(root, "model.gguf");
+    writeFileSync(modelPath, "test-model");
+    runSpec.target.modelPath = modelPath;
+    runSpec.target.modelSha256 = digest(readFileSync(modelPath));
+    runSpec.target.executable = process.execPath;
+    runSpec.target.executableSha256 = digest(readFileSync(process.execPath));
+    runSpec.target.args = [script, "--model", modelPath, "--host", "127.0.0.1", "--port", String(port), "--ctx-size", "8192"];
+    runSpec.request = { version: "phase1-request/v1", stream: true, outputBudgetTokens: 1024, requiredMetrics: ["latencyMs", "ttftMs"], parameters: { temperature: 0.6, top_p: 0.95, top_k: 20 } };
+    const result = await runPhase1Screen(runSpec, createLlamaServerExecutableAdapter({
+      baseUrl: `http://127.0.0.1:${port}`,
+      maxResponseBytes: 4096,
+      ...ownershipProof
+    }));
+    expect(result.status).toBe("completed");
+    const first = JSON.parse(readFileSync(join(runSpec.outputDir, "results", "warm-8k", "pr-1.json"), "utf8"));
+    expect(first.metrics.ttftMs).toBeGreaterThanOrEqual(0);
+    expect(first.parsedOutput).toEqual({ findings: [] });
+  });
+
+  it("constructs the prompt and applies manifest-bound request, parser, and gate contracts", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-contract-"));
+    const runSpec = spec(outputDir);
+    runSpec.prompt = {
+      version: "phase1-prompt/v1",
+      template: "PREFIX\n{{input}}\nSUFFIX",
+      templateSha256: digest("PREFIX\n{{input}}\nSUFFIX")
+    };
+    runSpec.gate = {
+      version: "phase1-gate/v1",
+      requiredTopLevelKeys: ["findings"],
+      sha256: digest("phase1-gate/v1:findings")
+    };
+    let observed: unknown;
+    const result = await runPhase1Screen(runSpec, adapter({
+      async invoke(_resident, request) {
+        observed = { prompt: request.renderedPrompt, parameters: request.request.parameters };
+        return { status: "completed", rawOutput: JSON.stringify({ findings: [] }) };
+      }
+    }));
+    expect(result.status).toBe("completed");
+    expect(observed).toEqual({
+      prompt: "PREFIX\nReview PR two.\nSUFFIX",
+      parameters: { temperature: 0.6, top_p: 0.95, top_k: 20 }
+    });
+    const first = JSON.parse(readFileSync(join(outputDir, "results", "warm-8k", "pr-1.json"), "utf8"));
+    expect(first.parsedOutput).toEqual({ findings: [] });
+    expect(first.gatedOutput).toEqual({ findings: [] });
+    expect(first.requestFingerprint).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("rejects runner-owned request keys and verifies the harness source bytes", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-phase1-request-guard-"));
+    for (const reserved of ["messages", "model", "stream", "response_format", "max_tokens"]) {
+      const unsafe = spec(join(root, reserved));
+      unsafe.request.parameters[reserved] = "override";
+      await expect(runPhase1Screen(unsafe, adapter())).rejects.toThrow(/reserved request parameter/i);
+    }
+    const drift = spec(join(root, "harness-drift"));
+    drift.harness.sourceSha256 = "0".repeat(64);
+    await expect(runPhase1Screen(drift, adapter())).rejects.toThrow(/harness source sha/i);
+  });
+
+  it("turns parser and deterministic gate failures into explicit schema_failed terminals", async () => {
+    const parserDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-parser-"));
+    const parserResult = await runPhase1Screen(spec(parserDir), adapter({
+      async invoke() { return { status: "completed", rawOutput: "not json" }; }
+    }));
+    expect(parserResult.counts.schema_failed).toBe(2);
+
+    const gateDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-gate-"));
+    const gateSpec = spec(gateDir);
+    gateSpec.gate = {
+      version: "phase1-gate/v1",
+      requiredTopLevelKeys: ["findings"],
+      sha256: digest("phase1-gate/v1:findings")
+    };
+    const gateResult = await runPhase1Screen(gateSpec, adapter({
+      async invoke() { return { status: "completed", rawOutput: "{}" }; }
+    }));
+    expect(gateResult.counts.schema_failed).toBe(2);
+  });
+
+  it("rejects unsafe output placement and prompt/input identity drift before writing evidence", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-phase1-safe-root-"));
+    const outside = spec(join(root, "outside"));
+    outside.safeOutputRoot = join(root, "allowed");
+    await expect(runPhase1Screen(outside, adapter())).rejects.toThrow(/safe output root/i);
+    expect(existsSync(outside.outputDir)).toBe(false);
+
+    const insideCheckout = spec(join(process.cwd(), "runtime", "forbidden-phase1"));
+    insideCheckout.safeOutputRoot = join(process.cwd(), "runtime");
+    await expect(runPhase1Screen(insideCheckout, adapter())).rejects.toThrow(/outside.*checkout/i);
+
+    const drift = spec(join(root, "drift"));
+    drift.prompt.templateSha256 = "d".repeat(64);
+    await expect(runPhase1Screen(drift, adapter())).rejects.toThrow(/template.*sha/i);
+    const inputDrift = spec(join(root, "input-drift"));
+    inputDrift.inputs[0].sha256 = "b".repeat(64);
+    await expect(runPhase1Screen(inputDrift, adapter())).rejects.toThrow(/input.*sha/i);
+  });
+
+  it("verifies executable bytes before spawn", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-phase1-binary-"));
+    const runSpec = spec(join(root, "evidence"));
+    runSpec.target.executable = process.execPath;
+    runSpec.target.executableSha256 = "0".repeat(64);
+    runSpec.target.args = ["--model", runSpec.target.modelPath, "--host", "127.0.0.1", "--port", "45111", "--ctx-size", "8192"];
+    await expect(runPhase1Screen(runSpec, createLlamaServerExecutableAdapter({
+      baseUrl: "http://127.0.0.1:45111",
+      readinessTimeoutMs: 10,
+      ...ownershipProof
+    }))).rejects.toThrow(/executable.*sha/i);
+  });
+
+  it("verifies model bytes and exact argv path before spawn", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-phase1-model-"));
+    const modelPath = join(root, "model.gguf");
+    writeFileSync(modelPath, "model-bytes");
+    const runSpec = spec(join(root, "evidence"));
+    runSpec.target.executable = process.execPath;
+    runSpec.target.executableSha256 = digest(readFileSync(process.execPath));
+    runSpec.target.modelPath = modelPath;
+    runSpec.target.modelSha256 = "0".repeat(64);
+    runSpec.target.args = ["--model", modelPath, "--host", "127.0.0.1", "--port", "45112", "--ctx-size", "8192"];
+    await expect(runPhase1Screen(runSpec, createLlamaServerExecutableAdapter({
+      baseUrl: "http://127.0.0.1:45112",
+      ...ownershipProof
+    }))).rejects.toThrow(/model.*sha/i);
+
+    runSpec.target.modelSha256 = digest(readFileSync(modelPath));
+    runSpec.target.args = ["--model", join(root, "other.gguf"), "--host", "127.0.0.1", "--port", "45112", "--ctx-size", "8192"];
+    await expect(runPhase1Screen({ ...runSpec, outputDir: join(root, "second"), safeOutputRoot: join(root, "second") }, createLlamaServerExecutableAdapter({
+      baseUrl: "http://127.0.0.1:45112",
+      ...ownershipProof
+    }))).rejects.toThrow(/model path.*argv/i);
+  });
+
+  it("persists injected resource samples and converts monitor stop conditions to terminal states", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-"));
+    let sequence = 0;
+    const monitor: Phase1ResourceMonitor = {
+      identity: { version: "test-monitor/v1", sha256: digest("test-monitor/v1") },
+      async start() { return { id: "monitor-1" }; },
+      async sample(_session, context) {
+        sequence += 1;
+        return { capturedAt: `sample-${sequence}`, phase: context.phase, rssBytes: 100 + sequence, vramBytes: 200, swapBytes: sequence > 2 ? 4096 : 0 };
+      },
+      classify(samples) {
+        return samples.some((sample) => sample.swapBytes >= 4096)
+          ? { status: "stopped", errorCode: "sustained_swap_growth" }
+          : undefined;
+      },
+      async stop(_session) { return { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0 }; }
+    };
+    const result = await runPhase1Screen(spec(outputDir), adapter(), { monitor });
+    expect(result.counts.stopped).toBeGreaterThan(0);
+    const resource = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
+    expect(resource.samples.at(-1).phase).toBe("stopped");
+    expect(resource.monitorFingerprint).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it.each(["before", "after", "classify"] as const)("treats monitor %s exceptions as infrastructure failures", async (stage) => {
+    const outputDir = mkdtempSync(join(tmpdir(), `neondiff-phase1-monitor-${stage}-`));
+    const monitor: Phase1ResourceMonitor = {
+      identity: { version: "throw-monitor/v1", sha256: digest("throw-monitor/v1") },
+      async start() { return { id: "throw-monitor" }; },
+      async sample(_session, context) {
+        if (context.phase === stage) throw new Error(`monitor ${stage} exploded`);
+        return { capturedAt: context.phase, phase: context.phase, rssBytes: 1, vramBytes: 1, swapBytes: 0 };
+      },
+      classify() { if (stage === "classify") throw new Error("monitor classify exploded"); return undefined; },
+      async stop() { return { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0 }; }
+    };
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitor })).rejects.toThrow(/monitor.*exploded/i);
+    const summary = JSON.parse(readFileSync(join(outputDir, "summary.json"), "utf8"));
+    expect(summary.infrastructureErrorCode).toContain("monitor_");
+  });
+
+  it("stops and persists monitor evidence when resident startup fails", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-start-fail-"));
+    let stopped = 0;
+    const monitor: Phase1ResourceMonitor = {
+      identity: { version: "start-monitor/v1", sha256: digest("start-monitor/v1") },
+      async start() { return { id: "monitor" }; },
+      async sample() { throw new Error("must not sample"); },
+      async stop() { stopped += 1; return { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0 }; }
+    };
+    await expect(runPhase1Screen(spec(outputDir), adapter({ async start() { throw new Error("resident startup failed"); } }), { monitor })).rejects.toThrow(/resident startup failed/i);
+    expect(stopped).toBe(1);
+    expect(existsSync(join(outputDir, "resources", "warm-8k.json"))).toBe(true);
+  });
+
+  it("records valid empty resource evidence when the monitor itself cannot start", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-start-error-"));
+    const monitor: Phase1ResourceMonitor = {
+      identity: { version: "start-error-monitor/v1", sha256: digest("start-error-monitor/v1") },
+      async start() { throw new Error("monitor start exploded"); },
+      async sample() { throw new Error("must not sample"); },
+      async stop() { throw new Error("must not stop an unavailable session"); }
+    };
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitor })).rejects.toThrow(/monitor start exploded/i);
+    const resource = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
+    expect(resource.samples).toEqual([]);
+    expect(resource.terminalInfrastructureErrorCode).toBe("monitor_start_exploded");
+    expect(resource.evidenceSha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("continues after an isolated request failure and records retry counts", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-request-failure-"));
+    let calls = 0;
+    const result = await runPhase1Screen(spec(outputDir), adapter({
+      async invoke() {
+        calls += 1;
+        return calls === 1
+          ? { status: "failed", errorCode: "http_503", retryCount: 2 }
+          : { status: "completed", rawOutput: "{}", retryCount: 0 };
+      }
+    }));
+    expect(calls).toBe(2);
+    expect(result.counts.failed).toBe(1);
+    expect(result.counts.completed).toBe(1);
+    expect(JSON.parse(readFileSync(join(outputDir, "results", "warm-8k", "pr-1.json"), "utf8")).retryCount).toBe(2);
+  });
+
+  it("rejects non-loopback or target-mismatched executable endpoints before spawning", () => {
+    expect(() => createLlamaServerExecutableAdapter({ baseUrl: "https://provider.example.com" })).toThrow(/loopback/i);
+    const runSpec = spec(mkdtempSync(join(tmpdir(), "neondiff-phase1-endpoint-")));
+    runSpec.target.args = ["--host", "127.0.0.1", "--port", "45001"];
+    return expect(runPhase1Screen(runSpec, createLlamaServerExecutableAdapter({
+      baseUrl: "http://127.0.0.1:45002",
+      readinessTimeoutMs: 10,
+      ...ownershipProof
+    }))).rejects.toThrow(/must match.*target argv/i);
+  });
+
+  it("refuses a pre-existing loopback listener rather than sending it a screening prompt", async () => {
+    const port = 34000 + Math.floor(Math.random() * 10000);
+    let requests = 0;
+    const server = createServer((_request, response) => {
+      requests += 1;
+      response.writeHead(200);
+      response.end("ok");
+    });
+    await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+    try {
+      const runSpec = spec(mkdtempSync(join(tmpdir(), "neondiff-phase1-owned-port-")));
+      const modelPath = join(runSpec.outputDir, "model.gguf");
+      writeFileSync(modelPath, "test-model");
+      runSpec.target.executable = process.execPath;
+      runSpec.target.executableSha256 = digest(readFileSync(process.execPath));
+      runSpec.target.modelPath = modelPath;
+      runSpec.target.modelSha256 = digest(readFileSync(modelPath));
+      runSpec.target.args = ["-e", "setTimeout(() => {}, 10000)", "--model", modelPath, "--host", "127.0.0.1", "--port", String(port), "--ctx-size", "8192"];
+      await expect(runPhase1Screen(runSpec, createLlamaServerExecutableAdapter({
+        baseUrl: `http://127.0.0.1:${port}`,
+        readinessTimeoutMs: 500,
+        ...ownershipProof
+      }))).rejects.toThrow(/already.*listener|already.*use/i);
+      expect(requests).toBe(0);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("persists the immutable manifest before execution and writes atomic terminal results and summary", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-"));
+    const result = await runPhase1Screen(spec(outputDir), adapter());
+
+    expect(result.status).toBe("completed");
+    expect(result.counts).toEqual({ completed: 2, failed: 0, stopped: 0, oom: 0, schema_failed: 0 });
+    expect(existsSync(join(outputDir, "results", "warm-8k", "pr-1.json"))).toBe(true);
+    expect(existsSync(join(outputDir, "results", "warm-8k", "pr-2.json"))).toBe(true);
+    expect(existsSync(join(outputDir, "summary.json"))).toBe(true);
+    expect(existsSync(join(outputDir, "COMPLETED"))).toBe(true);
+    expect(existsSync(join(outputDir, "RUNNING"))).toBe(false);
+    const manifest = JSON.parse(readFileSync(join(outputDir, "manifest.json"), "utf8"));
+    expect(manifest).toMatchObject({
+      schemaVersion: "neondiff-phase1-screen-manifest/v1",
+      targetFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+      promptFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+      parserFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+      gateFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/)
+    });
+    expect(manifest.cells[0].fingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(manifest.inputs[0].fingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(manifest.harnessFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.claimClass).toBe("transport_and_gate_only");
+    expect(existsSync(join(outputDir, "results", "warm-8k", "pr-1.json.tmp"))).toBe(false);
+  });
+
+  it("holds an exclusive output lease and rejects a concurrent writer", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-lease-"));
+    writeFileSync(join(outputDir, ".phase1-run.lock"), JSON.stringify({ pid: process.pid }));
+    await expect(runPhase1Screen(spec(outputDir), adapter())).rejects.toThrow(/active exclusive run lease/i);
+  });
+
+  it("verifies paired cohort identity and rejects request or input drift", async () => {
+    const leftDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-pair-left-"));
+    const rightDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-pair-right-"));
+    await runPhase1Screen(spec(leftDir), adapter());
+    await runPhase1Screen(spec(rightDir), adapter());
+    expect(verifyPairedPhase1Cohort(join(leftDir, "manifest.json"), join(rightDir, "manifest.json"))).toMatchObject({ ok: true });
+
+    const rightManifestPath = join(rightDir, "manifest.json");
+    const right = JSON.parse(readFileSync(rightManifestPath, "utf8"));
+    right.request.outputBudgetTokens += 1;
+    writeFileSync(rightManifestPath, JSON.stringify(right));
+    expect(() => verifyPairedPhase1Cohort(join(leftDir, "manifest.json"), rightManifestPath)).toThrow(/paired cohort drift.*request/i);
+  });
+
+  it("resumes only an exact manifest and never re-runs an existing terminal result", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-resume-"));
+    let calls = 0;
+    let starts = 0;
+    const counting = adapter({
+      async start(context) {
+        starts += 1;
+        return adapter().start(context);
+      },
+      async invoke(resident, request) {
+        calls += 1;
+        return adapter().invoke(resident, request);
+      }
+    });
+    await runPhase1Screen(spec(outputDir), counting);
+    await runPhase1Screen(spec(outputDir), counting);
+    expect(calls).toBe(2);
+    expect(starts).toBe(1);
+
+    const changed = spec(outputDir);
+    changed.gate = { ...changed.gate, version: "phase1-gate/v2", sha256: digest("phase1-gate/v2:") };
+    await expect(runPhase1Screen(changed, counting)).rejects.toThrow(/manifest fingerprint mismatch/i);
+  });
+
+  it("reconciles summary and terminal markers after a crash following the last atomic result", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-reconcile-"));
+    await runPhase1Screen(spec(outputDir), adapter());
+    rmSync(join(outputDir, "summary.json"));
+    rmSync(join(outputDir, "COMPLETED"));
+    writeFileSync(join(outputDir, "RUNNING"), "interrupted\n");
+    const resumed = await runPhase1Screen(spec(outputDir), adapter({
+      async start() { throw new Error("must not restart resident"); }
+    }));
+    expect(resumed.status).toBe("completed");
+    expect(existsSync(join(outputDir, "summary.json"))).toBe(true);
+    expect(existsSync(join(outputDir, "COMPLETED"))).toBe(true);
+    expect(existsSync(join(outputDir, "RUNNING"))).toBe(false);
+  });
+
+  it("rejects a tampered terminal result before starting a resident or changing terminal markers", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-tamper-"));
+    await runPhase1Screen(spec(outputDir), adapter());
+    const resultPath = join(outputDir, "results", "warm-8k", "pr-1.json");
+    const result = JSON.parse(readFileSync(resultPath, "utf8"));
+    result.rawOutput = "tampered but fingerprint fields retained";
+    writeFileSync(resultPath, JSON.stringify(result));
+    let starts = 0;
+    await expect(runPhase1Screen(spec(outputDir), adapter({
+      async start(context) {
+        starts += 1;
+        return adapter().start(context);
+      }
+    }))).rejects.toThrow(/terminal result fingerprint mismatch/i);
+    expect(starts).toBe(0);
+    expect(existsSync(join(outputDir, "COMPLETED"))).toBe(true);
+    expect(existsSync(join(outputDir, "RUNNING"))).toBe(false);
+  });
+
+  it("rejects tampering with every persisted immutable result identity", async () => {
+    for (const field of ["targetFingerprint", "promptFingerprint", "parserFingerprint", "gateFingerprint", "requestFingerprint", "harnessFingerprint", "cellId", "inputId", "startedAt", "completedAt"]) {
+      const outputDir = mkdtempSync(join(tmpdir(), `neondiff-phase1-identity-${field}-`));
+      await runPhase1Screen(spec(outputDir), adapter());
+      const resultPath = join(outputDir, "results", "warm-8k", "pr-1.json");
+      const result = JSON.parse(readFileSync(resultPath, "utf8"));
+      result[field] = "tampered";
+      writeFileSync(resultPath, JSON.stringify(result));
+      await expect(runPhase1Screen(spec(outputDir), adapter())).rejects.toThrow(/terminal result fingerprint mismatch/i);
+    }
+  });
+
+  it.each(["failed", "stopped", "oom", "schema_failed"] as const)(
+    "records %s as an explicit terminal state without silently dropping a PR",
+    async (status) => {
+      const outputDir = mkdtempSync(join(tmpdir(), `neondiff-phase1-${status}-`));
+      const result = await runPhase1Screen(spec(outputDir), adapter({
+        async invoke(_resident, request) {
+          return request.input.id === "pr-1"
+            ? { status, errorCode: `test_${status}` }
+            : { status: "completed", rawOutput: "{}", parsedOutput: {} };
+        }
+      }));
+      expect(result.status).toBe("failed");
+      // A request terminal is not proof that the resident died. Only an
+      // explicit residentTerminal result (or the runner's own process/monitor
+      // evidence) may truncate the remainder of the cell.
+      expect(result.counts[status]).toBe(1);
+      expect(result.counts.completed).toBe(1);
+      expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
+      expect(JSON.parse(readFileSync(join(outputDir, "results", "warm-8k", "pr-1.json"), "utf8"))).toMatchObject({ status });
+    }
+  );
+
+  it.each(["failed", "stopped", "oom"] as const)(
+    "truncates a cell only when %s carries explicit resident-terminal evidence",
+    async (status) => {
+      const outputDir = mkdtempSync(join(tmpdir(), `neondiff-phase1-resident-terminal-${status}-`));
+      let calls = 0;
+      const result = await runPhase1Screen(spec(outputDir), adapter({
+        async invoke() {
+          calls += 1;
+          return { status, errorCode: `resident_${status}`, residentTerminal: true };
+        }
+      }));
+      expect(calls).toBe(1);
+      expect(result.counts[status]).toBe(2);
+      expect(result.counts.completed).toBe(0);
+    }
+  );
+
+  it("fails closed before execution when target argv or adapter logs contain secret-like text", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-secret-"));
+    const unsafe = spec(outputDir);
+    unsafe.target.args.push("--api-key", "sk-secret-value-1234567890");
+    await expect(runPhase1Screen(unsafe, adapter())).rejects.toThrow(/secret-like text/i);
+    expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
+
+    const unsafeParameters = spec(mkdtempSync(join(tmpdir(), "neondiff-phase1-secret-parameters-")));
+    unsafeParameters.target.servingParameters = { apiKey: "sk-secret-value-1234567890" };
+    await expect(runPhase1Screen(unsafeParameters, adapter())).rejects.toThrow(/secret-like text/i);
+    expect(existsSync(join(unsafeParameters.outputDir, "manifest.json"))).toBe(false);
+
+    const second = spec(mkdtempSync(join(tmpdir(), "neondiff-phase1-secret-log-")));
+    await expect(runPhase1Screen(second, adapter({
+      async start() {
+        return { id: "resident", argv: ["/opt/llama-server"], logs: "Authorization: Bearer sk-secret-value-1234567890" };
+      }
+    }))).rejects.toThrow(/secret-like text/i);
+    expect(readFileSync(join(second.outputDir, "summary.json"), "utf8")).not.toContain("sk-secret");
+  });
+
+  it("converts thrown invocation errors to failed terminal records and still stops the resident", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-throw-"));
+    let stopped = false;
+    const result = await runPhase1Screen(spec(outputDir), adapter({
+      async invoke(_resident, request) {
+        if (request.input.id === "pr-1") throw new Error("inference crashed");
+        return { status: "completed", rawOutput: "{}", parsedOutput: {} };
+      },
+      async stop() { stopped = true; }
+    }));
+    expect(stopped).toBe(true);
+    expect(result.counts.failed).toBe(1);
+    expect(result.counts.completed).toBe(1);
+  });
+
+  it("durably records a redacted infrastructure failure code when resident shutdown fails", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-stop-failure-"));
+    await expect(runPhase1Screen(spec(outputDir), adapter({
+      async stop() { throw new Error("shutdown failed"); }
+    }))).rejects.toThrow(/shutdown failed/i);
+    const summary = JSON.parse(readFileSync(join(outputDir, "summary.json"), "utf8"));
+    expect(summary.status).toBe("failed");
+    expect(summary.infrastructureErrorCode).toBe("shutdown_failed");
+    expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
+    const resumed = await runPhase1Screen(spec(outputDir), adapter({
+      async start() { throw new Error("must not restart resident"); }
+    }));
+    expect(resumed.status).toBe("failed");
+    expect(resumed.infrastructureErrorCode).toBe("shutdown_failed");
+    expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
+    expect(existsSync(join(outputDir, "COMPLETED"))).toBe(false);
+  });
+});

--- a/tests/phase1-screening-runner.test.ts
+++ b/tests/phase1-screening-runner.test.ts
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import { createServer } from "node:http";
 import { createServer as createNetServer } from "node:net";
 import { execFileSync, spawn } from "node:child_process";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   runPhase1Screen as executePhase1Screen,
   createLlamaServerExecutableAdapter,
@@ -64,6 +64,9 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
       return {
         async start() {
           if (kind === "start-error") throw new Error("monitor start exploded");
+          if (kind === "start-null") return null;
+          if (kind === "start-undefined") return undefined;
+          if (kind === "start-empty") return {};
           return { id: "monitor" };
         },
         async sample(_session, context) {
@@ -77,6 +80,9 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
         },
         classify(samples) {
           if (kind === "throw-classify") throw new Error("monitor classify exploded");
+          if (kind === "classify-invalid-status") return { status: "completed", errorCode: "invalid" };
+          if (kind === "classify-missing-code") return { status: "stopped" };
+          if (kind === "classify-scalar") return "stopped";
           if (kind === "swap" && samples.some(sample => sample.swapBytes >= 4096)) return { status: "stopped", errorCode: "sustained_swap_growth" };
           if (kind === "stop-oom" && samples.some(sample => sample.phase === "stopped")) return { status: "oom", errorCode: "stop_time_oom" };
           return undefined;
@@ -184,12 +190,14 @@ describe("Phase 1 screening runner", () => {
     runSpec.target.executable = process.execPath;
     runSpec.target.executableSha256 = digest(readFileSync(process.execPath));
     runSpec.target.args = [script, "--model", modelPath, "--host", "127.0.0.1", "--port", String(port), "--ctx-size", "8192"];
+    let freshIdentityChecks = 0;
     const result = await runPhase1Screen(runSpec, createLlamaServerExecutableAdapter({
       baseUrl: `http://127.0.0.1:${port}`,
       readinessTimeoutMs: 5_000,
       requestTimeoutMs: 5_000,
       stopTimeoutMs: 2_000,
-      ...ownershipProof
+      ...ownershipProof,
+      async verifyProcessIdentity() { freshIdentityChecks += 1; return true; }
     }));
     expect(result.status).toBe("completed");
     const first = JSON.parse(readFileSync(join(runSpec.outputDir, "results", "warm-8k", "pr-1.json"), "utf8"));
@@ -197,6 +205,22 @@ describe("Phase 1 screening runner", () => {
     expect(first.metrics.latencyMs).toBeGreaterThanOrEqual(0);
     expect(first.metrics.promptMs).toBe(20);
     expect(first.metrics.decodeTokensPerSecond).toBe(300);
+    expect(freshIdentityChecks).toBeGreaterThanOrEqual(1);
+
+    const rejectedSpec = { ...runSpec, outputDir: join(root, "identity-rejected"), safeOutputRoot: join(root, "identity-rejected") };
+    await expect(runPhase1Screen(rejectedSpec, createLlamaServerExecutableAdapter({
+      baseUrl: `http://127.0.0.1:${port}`,
+      readinessTimeoutMs: 5_000,
+      stopTimeoutMs: 2_000,
+      ...ownershipProof,
+      async verifyProcessIdentity() { return false; }
+    }))).rejects.toThrow(/process identity could not be proven/i);
+    const probe = createNetServer();
+    await new Promise<void>((resolvePromise, rejectPromise) => {
+      probe.once("error", rejectPromise);
+      probe.listen(port, "127.0.0.1", resolvePromise);
+    });
+    await new Promise<void>((resolvePromise) => probe.close(() => resolvePromise()));
   });
 
   it("captures TTFT from a bounded streaming response", async () => {
@@ -301,9 +325,11 @@ describe("Phase 1 screening runner", () => {
   it("turns parser and deterministic gate failures into explicit schema_failed terminals", async () => {
     const parserDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-parser-"));
     const parserResult = await runPhase1Screen(spec(parserDir), adapter({
-      async invoke() { return { status: "completed", rawOutput: "not json" }; }
+      async invoke() { return { status: "completed", rawOutput: "not json", parsedOutput: { stale: true }, gatedOutput: { stale: true } }; }
     }));
     expect(parserResult.counts.schema_failed).toBe(2);
+    expect(JSON.parse(readFileSync(join(parserDir, "results", "warm-8k", "pr-1.json"), "utf8"))).not.toHaveProperty("parsedOutput");
+    expect(JSON.parse(readFileSync(join(parserDir, "results", "warm-8k", "pr-1.json"), "utf8"))).not.toHaveProperty("gatedOutput");
 
     const gateDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-gate-"));
     const gateSpec = spec(gateDir);
@@ -313,9 +339,11 @@ describe("Phase 1 screening runner", () => {
       sha256: digest("phase1-gate/v1:findings")
     };
     const gateResult = await runPhase1Screen(gateSpec, adapter({
-      async invoke() { return { status: "completed", rawOutput: "{}" }; }
+      async invoke() { return { status: "completed", rawOutput: "{}", parsedOutput: { stale: true }, gatedOutput: { stale: true } }; }
     }));
     expect(gateResult.counts.schema_failed).toBe(2);
+    expect(JSON.parse(readFileSync(join(gateDir, "results", "warm-8k", "pr-1.json"), "utf8"))).not.toHaveProperty("parsedOutput");
+    expect(JSON.parse(readFileSync(join(gateDir, "results", "warm-8k", "pr-1.json"), "utf8"))).not.toHaveProperty("gatedOutput");
   });
 
   it("rejects unsafe output placement and prompt/input identity drift before writing evidence", async () => {
@@ -487,6 +515,23 @@ describe("Phase 1 screening runner", () => {
     expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
   });
 
+  it.each(["node:module", "node:vm", "node:worker_threads"])("rejects monitor module-loading escape hatch %s", async (specifier) => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-escape-"));
+    const identity = monitorModule("normal");
+    writeFileSync(identity.modulePath, `import * as escape from ${JSON.stringify(specifier)};\nexport function createMonitor(){ return escape; }\n`);
+    identity.moduleSha256 = digest(readFileSync(identity.modulePath));
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity })).rejects.toThrow(/escape hatch.*forbidden/i);
+    expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
+  });
+
+  it("rejects process.getBuiltinModule monitor escape hatches", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-runtime-escape-"));
+    const identity = monitorModule("normal");
+    writeFileSync(identity.modulePath, `export function createMonitor(){ return process.getBuiltinModule("module").createRequire(import.meta.url); }\n`);
+    identity.moduleSha256 = digest(readFileSync(identity.modulePath));
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity })).rejects.toThrow(/runtime module-loading escape hatch/i);
+  });
+
   it("rejects resource monitor source-byte drift before monitor execution", async () => {
     const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-drift-"));
     const drift = { ...monitorModule("normal"), moduleSha256: "0".repeat(64) };
@@ -528,6 +573,27 @@ describe("Phase 1 screening runner", () => {
     expect(resource.samples).toEqual([]);
     expect(resource.terminalInfrastructureErrorCode).toBe("monitor_start_exploded");
     expect(resource.evidenceSha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it.each(["start-null", "start-undefined", "start-empty"])("rejects malformed monitor session %s with durable evidence", async (kind) => {
+    const outputDir = mkdtempSync(join(tmpdir(), `neondiff-phase1-monitor-session-${kind}-`));
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule(kind) })).rejects.toThrow(/monitor session/i);
+    expect(existsSync(join(outputDir, "resources", "warm-8k.json"))).toBe(true);
+    expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
+  });
+
+  it.each(["classify-invalid-status", "classify-missing-code", "classify-scalar"])("rejects malformed monitor classification %s", async (kind) => {
+    const outputDir = mkdtempSync(join(tmpdir(), `neondiff-phase1-monitor-classification-${kind}-`));
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule(kind) })).rejects.toThrow(/monitor classification/i);
+    expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
+  });
+
+  it("falls back to root unavailable evidence when monitor start fails and resources is unwritable", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-start-fallback-"));
+    writeFileSync(join(outputDir, "resources"), "blocks directory");
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule("start-error") })).rejects.toThrow(/monitor start exploded/i);
+    expect(existsSync(join(outputDir, "resource-unavailable-warm-8k.json"))).toBe(true);
+    expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
   });
 
   it("fails closed with resumable unavailable evidence when monitor stop data is secret-like", async () => {
@@ -668,7 +734,7 @@ describe("Phase 1 screening runner", () => {
       readinessTimeoutMs: 5_000,
       stopTimeoutMs: 1_000,
       ownershipVerifierSha256: ownershipProof.ownershipVerifierSha256,
-      async verifyProcessIdentity(pid) { return pid === stale.pid; },
+      async verifyProcessIdentity() { return true; },
       async verifyListenerOwnership() {
         replacementOwnershipCheckedAfterExit = stale.exitCode !== null || stale.signalCode !== null;
         return replacementOwnershipCheckedAfterExit;
@@ -727,6 +793,21 @@ describe("Phase 1 screening runner", () => {
       await expect(runPhase1Screen(spec(blockedDir), adapter())).rejects.toThrow(/lease acquisition is already coordinated/i);
     } finally {
       await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));
+    }
+  });
+
+  it("treats EPERM from process liveness probing as a live lease owner", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-eperm-lease-"));
+    writeFileSync(join(outputDir, ".phase1-run.lock"), JSON.stringify({ pid: 424242 }));
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => {
+      const error = new Error("not permitted") as NodeJS.ErrnoException;
+      error.code = "EPERM";
+      throw error;
+    });
+    try {
+      await expect(runPhase1Screen(spec(outputDir), adapter())).rejects.toThrow(/active exclusive run lease/i);
+    } finally {
+      kill.mockRestore();
     }
   });
 
@@ -800,6 +881,16 @@ describe("Phase 1 screening runner", () => {
     const changed = spec(outputDir);
     changed.gate = { ...changed.gate, version: "phase1-gate/v2", sha256: digest("phase1-gate/v2:") };
     await expect(runPhase1Screen(changed, counting)).rejects.toThrow(/manifest fingerprint mismatch/i);
+  });
+
+  it("runs resident recovery for every cell before an all-results fast-path return", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-fast-recovery-"));
+    let recoveries = 0;
+    const recovering = adapter({ async recover() { recoveries += 1; } });
+    await runPhase1Screen(spec(outputDir), recovering);
+    expect(recoveries).toBe(1);
+    await runPhase1Screen(spec(outputDir), recovering);
+    expect(recoveries).toBe(2);
   });
 
   it("reconciles summary and terminal markers after a crash following the last atomic result", async () => {
@@ -953,6 +1044,14 @@ describe("Phase 1 screening runner", () => {
     const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-manifest-exact-key-secret-"));
     const runSpec = spec(outputDir);
     runSpec.inputs[0].metadata = { nested: { targetFingerprint: "sk-secret-value-1234567890" } };
+    await expect(runPhase1Screen(runSpec, adapter())).rejects.toThrow(/secret-like text/i);
+    expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
+  });
+
+  it("scans secret-like JSON object keys in untrusted payloads", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-secret-key-"));
+    const runSpec = spec(outputDir);
+    runSpec.inputs[0].metadata = { "Authorization: Bearer sk-secret-value-1234567890": "safe" };
     await expect(runPhase1Screen(runSpec, adapter())).rejects.toThrow(/secret-like text/i);
     expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
   });

--- a/tests/phase1-screening-runner.test.ts
+++ b/tests/phase1-screening-runner.test.ts
@@ -20,6 +20,22 @@ function digest(value: string | Buffer): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonical(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function evidenceDigest(value: unknown): string {
+  return digest(canonical(value));
+}
+
 const ownershipProof = {
   ownershipVerifierSha256: "8".repeat(64),
   verifyListenerOwnership: async () => true,
@@ -53,7 +69,11 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
         async sample(_session, context) {
           if (kind === "throw-" + context.phase) throw new Error("monitor " + context.phase + " exploded");
           sequence += 1;
-          return { capturedAt: "sample-" + sequence, phase: context.phase, rssBytes: 100 + sequence, vramBytes: 200, swapBytes: kind === "swap" && sequence > 2 ? 4096 : 0 };
+          const base = { capturedAt: "sample-" + sequence, phase: context.phase, rssBytes: 100 + sequence, vramBytes: 200, swapBytes: kind === "swap" && sequence > 2 ? 4096 : 0 };
+          if (kind === "sample-nan") return { ...base, rssBytes: Number.NaN };
+          if (kind === "sample-infinity") return { ...base, diagnosticValue: Number.POSITIVE_INFINITY };
+          if (kind === "sample-negative") return { ...base, vramBytes: -1 };
+          return base;
         },
         classify(samples) {
           if (kind === "throw-classify") throw new Error("monitor classify exploded");
@@ -63,7 +83,10 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
         },
         async stop() {
           const base = { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0 };
-          return kind === "secret-stop" ? { ...base, diagnostic: "Authorization: Bearer sk-secret-value-1234567890" } : base;
+          if (kind === "secret-stop") return { ...base, diagnostic: "Authorization: Bearer sk-secret-value-1234567890" };
+          if (kind === "secret-fingerprint-stop") return { ...base, evidenceSha256: "sk-secret-value-1234567890" };
+          if (kind === "stop-nan") return { ...base, swapBytes: Number.NaN };
+          return base;
         }
       };
     }
@@ -361,6 +384,70 @@ describe("Phase 1 screening runner", () => {
     expect(manifest.monitorIdentity).toMatchObject({ exportName: "createMonitor", moduleSha256: expect.stringMatching(/^[a-f0-9]{64}$/) });
   });
 
+  it("reconstructs pre-crash per-invocation samples before resuming monitored work", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-resume-"));
+    const identity = monitorModule("normal");
+    await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity });
+    rmSync(join(outputDir, "results", "warm-8k", "pr-2.json"));
+    rmSync(join(outputDir, "resources", "warm-8k.json"));
+    rmSync(join(outputDir, "summary.json"));
+    rmSync(join(outputDir, "COMPLETED"));
+
+    await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity });
+    const resource = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
+    expect(resource.samples.filter((sample: { phase: string }) => sample.phase === "before")).toHaveLength(2);
+    expect(resource.samples.filter((sample: { phase: string }) => sample.phase === "after")).toHaveLength(2);
+  });
+
+  it("fails closed when a monitored partial result has no reconstructable resource samples", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-resume-missing-"));
+    const identity = monitorModule("normal");
+    await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity });
+    const firstPath = join(outputDir, "results", "warm-8k", "pr-1.json");
+    const first = JSON.parse(readFileSync(firstPath, "utf8"));
+    delete first.resourceSamples;
+    const { evidenceSha256: _discarded, ...body } = first;
+    writeFileSync(firstPath, JSON.stringify({ ...body, evidenceSha256: evidenceDigest(body) }));
+    rmSync(join(outputDir, "results", "warm-8k", "pr-2.json"));
+    rmSync(join(outputDir, "resources", "warm-8k.json"));
+    rmSync(join(outputDir, "summary.json"));
+    rmSync(join(outputDir, "COMPLETED"));
+
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity })).rejects.toThrow(/reconstructable resource samples/i);
+  });
+
+  it.each(["sample-nan", "sample-infinity", "sample-negative", "stop-nan"])(
+    "fails closed without null serialization for invalid resource numeric data: %s",
+    async (kind) => {
+      const outputDir = mkdtempSync(join(tmpdir(), `neondiff-phase1-resource-invalid-${kind}-`));
+      await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule(kind) })).rejects.toThrow(/resource sample.*(?:finite|nonnegative)/i);
+      const evidenceFiles = [
+        join(outputDir, "resources", "warm-8k.json"),
+        join(outputDir, "results", "warm-8k", "pr-1.json"),
+        join(outputDir, "results", "warm-8k", "pr-2.json")
+      ].filter(existsSync);
+      for (const path of evidenceFiles) expect(readFileSync(path, "utf8")).not.toMatch(/:\s*null/);
+      expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
+    }
+  );
+
+  it("rejects an invalid numeric sample while reconstructing monitored resume evidence", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-resource-invalid-resume-"));
+    const identity = monitorModule("normal");
+    await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity });
+    const firstPath = join(outputDir, "results", "warm-8k", "pr-1.json");
+    const first = JSON.parse(readFileSync(firstPath, "utf8"));
+    first.resourceSamples[0].rssBytes = -1;
+    const { evidenceSha256: _discarded, ...body } = first;
+    writeFileSync(firstPath, JSON.stringify({ ...body, evidenceSha256: evidenceDigest(body) }));
+    rmSync(join(outputDir, "results", "warm-8k", "pr-2.json"));
+    rmSync(join(outputDir, "resources", "warm-8k.json"));
+    rmSync(join(outputDir, "summary.json"));
+    rmSync(join(outputDir, "COMPLETED"));
+
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity })).rejects.toThrow(/resource sample.*nonnegative/i);
+  });
+
   it("loads a fresh monitor module namespace for every run", async () => {
     const identity = monitorModule("normal");
     const firstDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-fresh-first-"));
@@ -453,6 +540,13 @@ describe("Phase 1 screening runner", () => {
     expect(JSON.stringify(unavailable)).not.toContain("sk-secret");
     const resumed = await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModuleIdentity });
     expect(resumed.status).toBe("failed");
+  });
+
+  it("scans arbitrary fingerprint-like keys in nested resource evidence", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-secret-fingerprint-"));
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule("secret-fingerprint-stop") })).rejects.toThrow(/monitor evidence finalization/i);
+    const unavailable = readFileSync(join(outputDir, "resource-unavailable-warm-8k.json"), "utf8");
+    expect(unavailable).not.toContain("sk-secret");
   });
 
   it("uses a root-level unavailable record when the resource evidence directory cannot be written", async () => {
@@ -790,8 +884,78 @@ describe("Phase 1 screening runner", () => {
       expect(calls).toBe(1);
       expect(result.counts[status]).toBe(2);
       expect(result.counts.completed).toBe(0);
+      expect(JSON.parse(readFileSync(join(outputDir, "results", "warm-8k", "pr-1.json"), "utf8"))).toMatchObject({ residentTerminal: true, invocationDisposition: "invoked" });
+      expect(JSON.parse(readFileSync(join(outputDir, "results", "warm-8k", "pr-2.json"), "utf8"))).toMatchObject({ residentTerminal: true, invocationDisposition: "not_invoked_resident_terminal" });
     }
   );
+
+  it("rejects non-finite required metrics", async () => {
+    for (const metric of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-nonfinite-metric-"));
+      const runSpec = spec(outputDir);
+      runSpec.request.requiredMetrics = ["latencyMs"];
+      const result = await runPhase1Screen(runSpec, adapter({
+        async invoke() { return { status: "completed", rawOutput: "{}", metrics: { latencyMs: metric } }; }
+      }));
+      expect(result.counts.schema_failed).toBe(2);
+    }
+  });
+
+  it("rejects non-finite optional metrics before evidence is fingerprinted", async () => {
+    for (const metric of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-nonfinite-optional-metric-"));
+      const result = await runPhase1Screen(spec(outputDir), adapter({
+        async invoke() { return { status: "completed", rawOutput: "{}", metrics: { optionalDiagnostic: metric } }; }
+      }));
+      expect(result.counts.schema_failed).toBe(2);
+      const persisted = readFileSync(join(outputDir, "results", "warm-8k", "pr-1.json"), "utf8");
+      expect(persisted).not.toMatch(/optionalDiagnostic|null/);
+    }
+  });
+
+  it("rejects negative latency metrics before evidence is fingerprinted", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-negative-latency-"));
+    const result = await runPhase1Screen(spec(outputDir), adapter({
+      async invoke() { return { status: "completed", rawOutput: "{}", metrics: { latencyMs: -1 } }; }
+    }));
+    expect(result.counts.schema_failed).toBe(2);
+  });
+
+  it("scans arbitrary nested fingerprint-like keys while accepting runner-owned digests", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-nested-secret-"));
+    const summary = await runPhase1Screen(spec(outputDir), adapter({
+      async invoke() {
+        return { status: "completed", rawOutput: JSON.stringify({ runFingerprint: "sk-secret-value-1234567890" }) };
+      }
+    }));
+    expect(summary.counts.failed).toBe(2);
+    expect(JSON.stringify(summary)).not.toContain("sk-secret");
+    expect(readFileSync(join(outputDir, "results", "warm-8k", "pr-1.json"), "utf8")).not.toContain("sk-secret");
+    expect(existsSync(join(outputDir, "COMPLETED"))).toBe(false);
+  });
+
+  it.each([
+    ["prompt template", (runSpec: Phase1RunSpec) => {
+      runSpec.prompt.template = "Authorization: Bearer sk-secret-value-1234567890 {{input}}";
+      runSpec.prompt.templateSha256 = digest(runSpec.prompt.template);
+    }],
+    ["response format", (runSpec: Phase1RunSpec) => { runSpec.request.responseFormat = { nested: "sk-secret-value-1234567890" }; }],
+    ["cell executable args", (runSpec: Phase1RunSpec) => { runSpec.cells[0].executableArgs = ["--api-key", "sk-secret-value-1234567890"]; }]
+  ] as const)("rejects secret-like text in the full manifest %s before writing", async (_label, mutate) => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-manifest-secret-"));
+    const runSpec = spec(outputDir);
+    mutate(runSpec);
+    await expect(runPhase1Screen(runSpec, adapter())).rejects.toThrow(/secret-like text/i);
+    expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
+  });
+
+  it("does not exempt exact runner-owned digest names inside untrusted manifest metadata", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-manifest-exact-key-secret-"));
+    const runSpec = spec(outputDir);
+    runSpec.inputs[0].metadata = { nested: { targetFingerprint: "sk-secret-value-1234567890" } };
+    await expect(runPhase1Screen(runSpec, adapter())).rejects.toThrow(/secret-like text/i);
+    expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
+  });
 
   it("fails closed before execution when target argv or adapter logs contain secret-like text", async () => {
     const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-secret-"));

--- a/tests/phase1-screening-runner.test.ts
+++ b/tests/phase1-screening-runner.test.ts
@@ -1,15 +1,18 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { createServer } from "node:http";
+import { createServer as createNetServer } from "node:net";
+import { execFileSync, spawn } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import {
-  runPhase1Screen,
+  runPhase1Screen as executePhase1Screen,
   createLlamaServerExecutableAdapter,
+  phase1LeaseCoordinationPort,
   verifyPairedPhase1Cohort,
   type Phase1ResidentAdapter,
-  type Phase1ResourceMonitor,
+  type Phase1ResourceMonitorModule,
   type Phase1RunSpec
 } from "../src/phase1-screening-runner.js";
 
@@ -23,12 +26,64 @@ const ownershipProof = {
   verifyProcessIdentity: async () => true
 };
 const runnerSourcePath = join(process.cwd(), "src", "phase1-screening-runner.ts");
+const harnessRepo = mkdtempSync(join(tmpdir(), "neondiff-phase1-harness-repo-"));
+const harnessRepoSource = join(harnessRepo, "src", "phase1-screening-runner.ts");
+mkdirSync(dirname(harnessRepoSource), { recursive: true });
+writeFileSync(harnessRepoSource, readFileSync(runnerSourcePath));
+execFileSync("git", ["init", "-q", harnessRepo]);
+execFileSync("git", ["-C", harnessRepo, "config", "user.email", "phase1@example.invalid"]);
+execFileSync("git", ["-C", harnessRepo, "config", "user.name", "Phase 1 Test"]);
+execFileSync("git", ["-C", harnessRepo, "add", "src/phase1-screening-runner.ts"]);
+execFileSync("git", ["-C", harnessRepo, "commit", "-qm", "pin harness"]);
+const harnessCommit = execFileSync("git", ["-C", harnessRepo, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+
+const monitorModuleRoot = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-modules-"));
+let monitorModuleSequence = 0;
+function monitorModule(kind: string): Phase1ResourceMonitorModule {
+  const modulePath = join(monitorModuleRoot, `monitor-${monitorModuleSequence++}.mjs`);
+  writeFileSync(modulePath, `
+    const kind = ${JSON.stringify(kind)};
+    let sequence = 0;
+    export function createMonitor() {
+      return {
+        async start() {
+          if (kind === "start-error") throw new Error("monitor start exploded");
+          return { id: "monitor" };
+        },
+        async sample(_session, context) {
+          if (kind === "throw-" + context.phase) throw new Error("monitor " + context.phase + " exploded");
+          sequence += 1;
+          return { capturedAt: "sample-" + sequence, phase: context.phase, rssBytes: 100 + sequence, vramBytes: 200, swapBytes: kind === "swap" && sequence > 2 ? 4096 : 0 };
+        },
+        classify(samples) {
+          if (kind === "throw-classify") throw new Error("monitor classify exploded");
+          if (kind === "swap" && samples.some(sample => sample.swapBytes >= 4096)) return { status: "stopped", errorCode: "sustained_swap_growth" };
+          if (kind === "stop-oom" && samples.some(sample => sample.phase === "stopped")) return { status: "oom", errorCode: "stop_time_oom" };
+          return undefined;
+        },
+        async stop() {
+          const base = { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0 };
+          return kind === "secret-stop" ? { ...base, diagnostic: "Authorization: Bearer sk-secret-value-1234567890" } : base;
+        }
+      };
+    }
+  `);
+  return {
+    version: `test-monitor/${kind}/v1`,
+    modulePath,
+    moduleSha256: digest(readFileSync(modulePath)),
+    approvedRoot: monitorModuleRoot,
+    exportName: "createMonitor"
+  };
+}
+
+const runPhase1Screen = executePhase1Screen;
 
 function spec(outputDir: string): Phase1RunSpec {
   return {
     outputDir,
     safeOutputRoot: outputDir,
-    checkoutRoot: process.cwd(),
+    checkoutRoot: harnessRepo,
     target: {
       id: "qwen36-27b-q4km",
       modelPath: "/models/qwen.gguf",
@@ -52,7 +107,7 @@ function spec(outputDir: string): Phase1RunSpec {
       requiredMetrics: [],
       parameters: { temperature: 0.6, top_p: 0.95, top_k: 20 }
     },
-    harness: { commit: "1".repeat(40), sourcePath: runnerSourcePath, sourceSha256: digest(readFileSync(runnerSourcePath)) },
+    harness: { commit: harnessCommit, sourcePath: harnessRepoSource, sourceSha256: digest(readFileSync(harnessRepoSource)) },
     parser: { version: "phase1-parser/v1", format: "json", sha256: digest("phase1-parser/v1:json") },
     gate: { version: "phase1-gate/v1", requiredTopLevelKeys: [], sha256: digest("phase1-gate/v1:") }
   };
@@ -133,7 +188,7 @@ describe("Phase 1 screening runner", () => {
         req.resume(); req.on("end", () => {
           res.writeHead(200, { "content-type": "text/event-stream" });
           res.write("data: " + JSON.stringify({ choices: [{ delta: { content: '{"findings":' } }] }) + "\\n\\n");
-          setTimeout(() => { res.write("data: " + JSON.stringify({ choices: [{ delta: { content: '[]}' } }] }) + "\\n\\n"); res.end('data: [DONE]\\n\\n'); }, 5);
+          setTimeout(() => { res.write("data: " + JSON.stringify({ choices: [{ delta: { content: '[]}' } }], usage: { prompt_tokens: 120, completion_tokens: 7, total_tokens: 127 }, timings: { prompt_ms: 40, predicted_ms: 20, prompt_per_second: 3000, predicted_per_second: 350 } }) + "\\n\\n"); res.end('data: [DONE]\\n\\n'); }, 5);
         });
       });
       server.listen(port, "127.0.0.1");
@@ -156,6 +211,13 @@ describe("Phase 1 screening runner", () => {
     expect(result.status).toBe("completed");
     const first = JSON.parse(readFileSync(join(runSpec.outputDir, "results", "warm-8k", "pr-1.json"), "utf8"));
     expect(first.metrics.ttftMs).toBeGreaterThanOrEqual(0);
+    expect(first.metrics.promptTokens).toBe(120);
+    expect(first.metrics.completionTokens).toBe(7);
+    expect(first.metrics.totalTokens).toBe(127);
+    expect(first.metrics.promptMs).toBe(40);
+    expect(first.metrics.decodeMs).toBe(20);
+    expect(first.metrics.promptTokensPerSecond).toBe(3000);
+    expect(first.metrics.decodeTokensPerSecond).toBe(350);
     expect(first.parsedOutput).toEqual({ findings: [] });
   });
 
@@ -200,6 +262,17 @@ describe("Phase 1 screening runner", () => {
     const drift = spec(join(root, "harness-drift"));
     drift.harness.sourceSha256 = "0".repeat(64);
     await expect(runPhase1Screen(drift, adapter())).rejects.toThrow(/harness source sha/i);
+
+    const wrongCommit = spec(join(root, "wrong-commit"));
+    wrongCommit.harness.commit = "2".repeat(40);
+    await expect(runPhase1Screen(wrongCommit, adapter())).rejects.toThrow(/declared commit/i);
+
+    const outsideSource = join(root, "copied-runner.ts");
+    writeFileSync(outsideSource, readFileSync(runnerSourcePath));
+    const outside = spec(join(root, "outside-checkout"));
+    outside.harness.sourcePath = outsideSource;
+    outside.harness.sourceSha256 = digest(readFileSync(outsideSource));
+    await expect(runPhase1Screen(outside, adapter())).rejects.toThrow(/inside checkoutRoot/i);
   });
 
   it("turns parser and deterministic gate failures into explicit schema_failed terminals", async () => {
@@ -229,8 +302,8 @@ describe("Phase 1 screening runner", () => {
     await expect(runPhase1Screen(outside, adapter())).rejects.toThrow(/safe output root/i);
     expect(existsSync(outside.outputDir)).toBe(false);
 
-    const insideCheckout = spec(join(process.cwd(), "runtime", "forbidden-phase1"));
-    insideCheckout.safeOutputRoot = join(process.cwd(), "runtime");
+    const insideCheckout = spec(join(harnessRepo, "runtime", "forbidden-phase1"));
+    insideCheckout.safeOutputRoot = join(harnessRepo, "runtime");
     await expect(runPhase1Screen(insideCheckout, adapter())).rejects.toThrow(/outside.*checkout/i);
 
     const drift = spec(join(root, "drift"));
@@ -279,72 +352,123 @@ describe("Phase 1 screening runner", () => {
 
   it("persists injected resource samples and converts monitor stop conditions to terminal states", async () => {
     const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-"));
-    let sequence = 0;
-    const monitor: Phase1ResourceMonitor = {
-      identity: { version: "test-monitor/v1", sha256: digest("test-monitor/v1") },
-      async start() { return { id: "monitor-1" }; },
-      async sample(_session, context) {
-        sequence += 1;
-        return { capturedAt: `sample-${sequence}`, phase: context.phase, rssBytes: 100 + sequence, vramBytes: 200, swapBytes: sequence > 2 ? 4096 : 0 };
-      },
-      classify(samples) {
-        return samples.some((sample) => sample.swapBytes >= 4096)
-          ? { status: "stopped", errorCode: "sustained_swap_growth" }
-          : undefined;
-      },
-      async stop(_session) { return { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0 }; }
-    };
-    const result = await runPhase1Screen(spec(outputDir), adapter(), { monitor });
+    const result = await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule("swap") });
     expect(result.counts.stopped).toBeGreaterThan(0);
     const resource = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
     expect(resource.samples.at(-1).phase).toBe("stopped");
     expect(resource.monitorFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    const manifest = JSON.parse(readFileSync(join(outputDir, "manifest.json"), "utf8"));
+    expect(manifest.monitorIdentity).toMatchObject({ exportName: "createMonitor", moduleSha256: expect.stringMatching(/^[a-f0-9]{64}$/) });
+  });
+
+  it("loads a fresh monitor module namespace for every run", async () => {
+    const identity = monitorModule("normal");
+    const firstDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-fresh-first-"));
+    const secondDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-fresh-second-"));
+    await runPhase1Screen(spec(firstDir), adapter(), { monitorModule: identity });
+    await runPhase1Screen(spec(secondDir), adapter(), { monitorModule: identity });
+    const first = JSON.parse(readFileSync(join(firstDir, "resources", "warm-8k.json"), "utf8"));
+    const second = JSON.parse(readFileSync(join(secondDir, "resources", "warm-8k.json"), "utf8"));
+    expect(first.samples[0].rssBytes).toBe(101);
+    expect(second.samples[0].rssBytes).toBe(101);
+  });
+
+  it("rejects relative or package imports because pinned monitors load as self-contained exact bytes", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-relative-import-"));
+    const identity = monitorModule("normal");
+    writeFileSync(identity.modulePath, `import helper from "./helper.mjs";\nexport function createMonitor(){ return helper; }\n`);
+    identity.moduleSha256 = digest(readFileSync(identity.modulePath));
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity })).rejects.toThrow(/self-contained.*unsupported import/i);
+    expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
+  });
+
+  it("rejects file URL static imports from an otherwise pinned monitor", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-file-import-"));
+    const identity = monitorModule("normal");
+    writeFileSync(identity.modulePath, `import helper from "file:///tmp/helper.mjs";\nexport function createMonitor(){ return helper; }\n`);
+    identity.moduleSha256 = digest(readFileSync(identity.modulePath));
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity })).rejects.toThrow(/self-contained.*unsupported import/i);
+    expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
+  });
+
+  it("rejects computed dynamic imports regardless of their eventual specifier", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-dynamic-import-"));
+    const identity = monitorModule("normal");
+    writeFileSync(identity.modulePath, `const prefix = "node:";\nexport async function createMonitor(){ return import(prefix + "fs"); }\n`);
+    identity.moduleSha256 = digest(readFileSync(identity.modulePath));
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity })).rejects.toThrow(/dynamic import syntax is forbidden/i);
+    expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
+  });
+
+  it("rejects resource monitor source-byte drift before monitor execution", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-drift-"));
+    const drift = { ...monitorModule("normal"), moduleSha256: "0".repeat(64) };
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: drift })).rejects.toThrow(/monitor source SHA-256/i);
+    expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
+  });
+
+  it("rejects a monitor module changed after its immutable identity was captured", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-mutated-"));
+    const identity = monitorModule("normal");
+    writeFileSync(identity.modulePath, `${readFileSync(identity.modulePath, "utf8")}\n// changed after pin\n`);
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity })).rejects.toThrow(/monitor source SHA-256/i);
+    expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
+  });
+
+  it("rejects arbitrary injected monitor methods instead of trusting an unrelated object", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-injected-"));
+    const options = { monitor: { start() {}, sample() {}, stop() {} } } as unknown as Parameters<typeof runPhase1Screen>[2];
+    await expect(runPhase1Screen(spec(outputDir), adapter(), options)).rejects.toThrow(/injected resource monitor methods are forbidden/i);
   });
 
   it.each(["before", "after", "classify"] as const)("treats monitor %s exceptions as infrastructure failures", async (stage) => {
     const outputDir = mkdtempSync(join(tmpdir(), `neondiff-phase1-monitor-${stage}-`));
-    const monitor: Phase1ResourceMonitor = {
-      identity: { version: "throw-monitor/v1", sha256: digest("throw-monitor/v1") },
-      async start() { return { id: "throw-monitor" }; },
-      async sample(_session, context) {
-        if (context.phase === stage) throw new Error(`monitor ${stage} exploded`);
-        return { capturedAt: context.phase, phase: context.phase, rssBytes: 1, vramBytes: 1, swapBytes: 0 };
-      },
-      classify() { if (stage === "classify") throw new Error("monitor classify exploded"); return undefined; },
-      async stop() { return { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0 }; }
-    };
-    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitor })).rejects.toThrow(/monitor.*exploded/i);
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule(`throw-${stage}`) })).rejects.toThrow(/monitor.*exploded/i);
     const summary = JSON.parse(readFileSync(join(outputDir, "summary.json"), "utf8"));
     expect(summary.infrastructureErrorCode).toContain("monitor_");
   });
 
   it("stops and persists monitor evidence when resident startup fails", async () => {
     const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-start-fail-"));
-    let stopped = 0;
-    const monitor: Phase1ResourceMonitor = {
-      identity: { version: "start-monitor/v1", sha256: digest("start-monitor/v1") },
-      async start() { return { id: "monitor" }; },
-      async sample() { throw new Error("must not sample"); },
-      async stop() { stopped += 1; return { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0 }; }
-    };
-    await expect(runPhase1Screen(spec(outputDir), adapter({ async start() { throw new Error("resident startup failed"); } }), { monitor })).rejects.toThrow(/resident startup failed/i);
-    expect(stopped).toBe(1);
+    await expect(runPhase1Screen(spec(outputDir), adapter({ async start() { throw new Error("resident startup failed"); } }), { monitorModule: monitorModule("normal") })).rejects.toThrow(/resident startup failed/i);
     expect(existsSync(join(outputDir, "resources", "warm-8k.json"))).toBe(true);
   });
 
   it("records valid empty resource evidence when the monitor itself cannot start", async () => {
     const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-start-error-"));
-    const monitor: Phase1ResourceMonitor = {
-      identity: { version: "start-error-monitor/v1", sha256: digest("start-error-monitor/v1") },
-      async start() { throw new Error("monitor start exploded"); },
-      async sample() { throw new Error("must not sample"); },
-      async stop() { throw new Error("must not stop an unavailable session"); }
-    };
-    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitor })).rejects.toThrow(/monitor start exploded/i);
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule("start-error") })).rejects.toThrow(/monitor start exploded/i);
     const resource = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
     expect(resource.samples).toEqual([]);
     expect(resource.terminalInfrastructureErrorCode).toBe("monitor_start_exploded");
     expect(resource.evidenceSha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("fails closed with resumable unavailable evidence when monitor stop data is secret-like", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-secret-stop-"));
+    const monitorModuleIdentity = monitorModule("secret-stop");
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModuleIdentity })).rejects.toThrow(/monitor evidence finalization/i);
+    expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
+    const unavailable = JSON.parse(readFileSync(join(outputDir, "resource-unavailable-warm-8k.json"), "utf8"));
+    expect(unavailable.unavailable).toBe(true);
+    expect(JSON.stringify(unavailable)).not.toContain("sk-secret");
+    const resumed = await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModuleIdentity });
+    expect(resumed.status).toBe("failed");
+  });
+
+  it("uses a root-level unavailable record when the resource evidence directory cannot be written", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-write-fail-"));
+    writeFileSync(join(outputDir, "resources"), "blocks resource directory");
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule("normal") })).rejects.toThrow(/monitor evidence finalization/i);
+    expect(existsSync(join(outputDir, "resource-unavailable-warm-8k.json"))).toBe(true);
+    expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
+  });
+
+  it("turns a stop-time monitor OOM classification into terminal results and a failed verdict", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-stop-oom-"));
+    const result = await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule("stop-oom") });
+    expect(result.status).toBe("failed");
+    expect(result.counts.oom).toBe(2);
+    expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
   });
 
   it("continues after an isolated request failure and records retry counts", async () => {
@@ -404,6 +528,62 @@ describe("Phase 1 screening runner", () => {
     }
   });
 
+  it("waits for a recovered stale journal process to exit after SIGKILL before starting a replacement", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-phase1-stale-journal-"));
+    const outputDir = join(root, "evidence");
+    const port = 29000 + Math.floor(Math.random() * 2000);
+    const stale = spawn(process.execPath, ["-e", "process.on('SIGTERM',()=>{});setInterval(()=>{},1000)"], { detached: true, stdio: "ignore" });
+    expect(stale.pid).toBeTypeOf("number");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const script = join(root, "replacement-server.mjs");
+    writeFileSync(script, `
+      import http from "node:http";
+      const port = Number(process.argv[process.argv.indexOf("--port") + 1]);
+      const server = http.createServer((req, res) => {
+        if (req.url === "/health") { res.end("ok"); return; }
+        req.resume(); req.on("end", () => { res.setHeader("content-type", "application/json"); res.end(JSON.stringify({ choices: [{ message: { content: "{}" } }] })); });
+      });
+      server.listen(port, "127.0.0.1");
+      process.on("SIGTERM", () => server.close(() => process.exit(0)));
+    `);
+    const modelPath = join(root, "model.gguf");
+    writeFileSync(modelPath, "model");
+    const runSpec = spec(outputDir);
+    runSpec.target.modelPath = modelPath;
+    runSpec.target.modelSha256 = digest(readFileSync(modelPath));
+    runSpec.target.executable = process.execPath;
+    runSpec.target.executableSha256 = digest(readFileSync(process.execPath));
+    runSpec.target.args = [script, "--model", modelPath, "--host", "127.0.0.1", "--port", String(port), "--ctx-size", "8192"];
+    rmSync(outputDir, { recursive: true, force: true });
+    writeFileSync(join(root, "placeholder"), "");
+    const processDir = join(outputDir, "processes");
+    // The runner creates outputDir before adapter startup, but the stale
+    // journal must exist before entry, so create the exact safe hierarchy.
+    mkdirSync(processDir, { recursive: true });
+    writeFileSync(join(processDir, "warm-8k.json"), JSON.stringify({
+      schemaVersion: "neondiff-phase1-resident/v1",
+      state: "running",
+      pid: stale.pid,
+      processGroupId: stale.pid,
+      executableSha256: runSpec.target.executableSha256,
+      argvFingerprint: "stale-argv"
+    }));
+    let replacementOwnershipCheckedAfterExit = false;
+    const result = await runPhase1Screen(runSpec, createLlamaServerExecutableAdapter({
+      baseUrl: `http://127.0.0.1:${port}`,
+      readinessTimeoutMs: 5_000,
+      stopTimeoutMs: 1_000,
+      ownershipVerifierSha256: ownershipProof.ownershipVerifierSha256,
+      async verifyProcessIdentity(pid) { return pid === stale.pid; },
+      async verifyListenerOwnership() {
+        replacementOwnershipCheckedAfterExit = stale.exitCode !== null || stale.signalCode !== null;
+        return replacementOwnershipCheckedAfterExit;
+      }
+    }));
+    expect(result.status).toBe("completed");
+    expect(replacementOwnershipCheckedAfterExit).toBe(true);
+  });
+
   it("persists the immutable manifest before execution and writes atomic terminal results and summary", async () => {
     const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-"));
     const result = await runPhase1Screen(spec(outputDir), adapter());
@@ -436,6 +616,26 @@ describe("Phase 1 screening runner", () => {
     await expect(runPhase1Screen(spec(outputDir), adapter())).rejects.toThrow(/active exclusive run lease/i);
   });
 
+  it("serializes stale lease recovery through a crash-released loopback coordinator", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-stale-lease-"));
+    writeFileSync(join(outputDir, ".phase1-run.lock"), JSON.stringify({ pid: 999_999_999 }));
+    const result = await runPhase1Screen(spec(outputDir), adapter());
+    expect(result.status).toBe("completed");
+
+    const blockedDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-coordinated-lease-"));
+    const coordinator = createNetServer();
+    await new Promise<void>((resolvePromise) => coordinator.listen({
+      host: "127.0.0.1",
+      port: phase1LeaseCoordinationPort(join(blockedDir, ".phase1-run.lock")),
+      exclusive: true
+    }, resolvePromise));
+    try {
+      await expect(runPhase1Screen(spec(blockedDir), adapter())).rejects.toThrow(/lease acquisition is already coordinated/i);
+    } finally {
+      await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));
+    }
+  });
+
   it("verifies paired cohort identity and rejects request or input drift", async () => {
     const leftDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-pair-left-"));
     const rightDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-pair-right-"));
@@ -448,6 +648,40 @@ describe("Phase 1 screening runner", () => {
     right.request.outputBudgetTokens += 1;
     writeFileSync(rightManifestPath, JSON.stringify(right));
     expect(() => verifyPairedPhase1Cohort(join(leftDir, "manifest.json"), rightManifestPath)).toThrow(/paired cohort drift.*request/i);
+  });
+
+  it("pairs different target execution identities while rejecting context drift", async () => {
+    const leftDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-target-pair-left-"));
+    const rightDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-target-pair-right-"));
+    const rightSpec = spec(rightDir);
+    rightSpec.target = {
+      ...rightSpec.target,
+      id: "different-model-and-offload",
+      modelPath: "/models/other.gguf",
+      modelSha256: "b".repeat(64),
+      executable: "/opt/other-llama-server",
+      executableSha256: "c".repeat(64),
+      args: ["--model", "/models/other.gguf", "--ctx-size", "8192", "--n-gpu-layers", "30"]
+    };
+    await runPhase1Screen(spec(leftDir), adapter());
+    await runPhase1Screen(rightSpec, adapter());
+    expect(verifyPairedPhase1Cohort(join(leftDir, "manifest.json"), join(rightDir, "manifest.json"))).toMatchObject({ ok: true });
+
+    const rightManifestPath = join(rightDir, "manifest.json");
+    const manifest = JSON.parse(readFileSync(rightManifestPath, "utf8"));
+    manifest.cells[0].contextTokens += 1;
+    writeFileSync(rightManifestPath, JSON.stringify(manifest));
+    expect(() => verifyPairedPhase1Cohort(join(leftDir, "manifest.json"), rightManifestPath)).toThrow(/paired cohort drift/i);
+  });
+
+  it("rejects target-independent cell runtime-argument drift in a paired cohort", async () => {
+    const leftDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-cell-args-left-"));
+    const rightDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-cell-args-right-"));
+    const rightSpec = spec(rightDir);
+    rightSpec.cells[0].executableArgs = ["--threads", "8"];
+    await runPhase1Screen(spec(leftDir), adapter());
+    await runPhase1Screen(rightSpec, adapter());
+    expect(() => verifyPairedPhase1Cohort(join(leftDir, "manifest.json"), join(rightDir, "manifest.json"))).toThrow(/paired cohort drift.*cells/i);
   });
 
   it("resumes only an exact manifest and never re-runs an existing terminal result", async () => {


### PR DESCRIPTION
## Summary

Adds the smallest provider-independent Phase 1 screening runner required by #544/#565/#566. It is intentionally not wired into the public CLI, GitHub posting, provider selection, daemon state, or `worker.ts`.

## What changed

- Executes one resident OpenAI-compatible local model server per declared cell.
- Verifies model, executable, harness Git object, monitor module, prompt, parser, gate, input, request, target, and cell identities before measurement.
- Persists immutable manifests, atomic per-input results, resumable leases/journals, resource evidence, terminal summaries, and completion/failure markers.
- Separates isolated request failures from resident-terminal, monitor, OOM, schema, and infrastructure failures.
- Captures load time, TTFT, prompt/decode usage and throughput, end-to-end latency, retries, and bounded output evidence.
- Enforces target-independent paired-cohort equality while permitting declared model/backend/offload differences.
- Loads the resource monitor from exact verified single-file module bytes with per-run namespace isolation; only static `node:` imports are permitted.
- Limits all summaries to `transport_and_gate_only`; this code cannot select a model or support a quality claim.

## Safety and scope

- Output must remain outside the checkout.
- Loopback listener/process ownership is required and fingerprinted.
- Secret-like argv, logs, prompts, results, and resource evidence fail closed.
- Process shutdown and stale-journal recovery use bounded TERM/KILL proof.
- No provider/config/worker surface or PR #471 code is changed.
- Concrete GEX44 monitor/ownership modules and CLI integration remain #565 work.

## Validation

- Focused runner tests: 47/47 passed.
- Full repository Vitest suite passed.
- TypeScript build/postbuild passed.
- Tracked-file secret scan passed with both new files staged.
- `npm audit --audit-level=high`: zero vulnerabilities.
- `git diff --check` passed.
- Independent runtime/security and methodology rereviews report zero P0–P2 findings.

Refs #544
Refs #565
Refs #566
