### PR TITLE
test: codify focused local validation policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,14 @@ CodeRabbit parity, enterprise readiness, or legal adequacy from this file.
 ## Validation Rules
 
 - Prefer a focused failing test first, then the minimal implementation.
-- Run the narrowest relevant local test before broader validation.
-- Use `npm test` and `npm run build` before PR readiness unless CI is the
-  recorded validation path.
+- Coding agents default to the narrowest relevant local test or smoke, followed
+  by `git diff --check`.
+- `npm test` and `npm run build` are broad GitHub CI checks by default.
+- The existing required GitHub Actions `Build, test, and package` job is the
+  authoritative full test, build, package, and safety gate; focused local checks
+  are not a substitute.
+- Run broad local validation only for CI reproduction, a missing focused
+  harness, or an explicit user request.
 - For review-behavior changes, include dry-run evidence and current-head proof.
 - Keep evidence public-safe: summaries, counts, refs, hashes, setup states, and
   command names are fine; raw secrets, raw private diffs, private logs, keys,

--- a/tests/public-community-funnel.test.ts
+++ b/tests/public-community-funnel.test.ts
@@ -264,6 +264,27 @@ describe("NeonDiff public community funnel", () => {
     }
   });
 
+  it("AGENTS defaults coding agents to focused local validation and broad GitHub CI", () => {
+    const validationRules = read("AGENTS.md").match(
+      /(?:^|\n)## Validation Rules\s*\n([\s\S]*?)(?=\n## |\n?$)/
+    )?.[1];
+    expect(validationRules, "AGENTS.md must contain a Validation Rules section").toBeDefined();
+    const rules = validationRules!.replace(/\s+/g, " ");
+
+    expect(rules).toMatch(
+      /coding agents?.*default.*narrowest relevant local test or smoke/i
+    );
+    expect(rules).toMatch(/git diff --check/i);
+    expect(rules).toMatch(/npm test.*npm run build.*broad.*GitHub CI checks by default/i);
+    expect(rules).toMatch(
+      /broad local validation.*CI reproduction.*missing focused harness.*explicit user request/i
+    );
+    expect(rules).toMatch(
+      /required GitHub Actions.*Build, test, and package.*authoritative full test, build, package, and safety gate/i
+    );
+    expect(rules).toMatch(/focused local checks are not a substitute/i);
+  });
+
   it("GitHub issue and PR templates exist and require public-safe evidence", () => {
     for (const path of [
       "CODE_OF_CONDUCT.md",


### PR DESCRIPTION
Closes #569. Parent tracker: https://github.com/100yenadmin/codex-operating-kit/issues/41

## What changed

- coding agents now default to the narrowest relevant local test or smoke plus `git diff --check`
- the required `Build, test, and package` GitHub Actions job is explicitly the authoritative full test/build/package/safety gate
- broad local runs are reserved for CI reproduction, a missing focused harness, or explicit requests
- the existing public policy contract test now checks this boundary inside `## Validation Rules`

## Focused proof

- TDD red: new policy contract failed against the previous ambiguous guidance
- green: `npx vitest run tests/public-community-funnel.test.ts --pool=forks --maxWorkers=1` passed 9/9
- `git diff --check` passes

## Non-goals

No workflow, package script, Swift gate, branch-protection, product, release, or runtime changes.
