### PR TITLE
Add GEX44 characterization runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "build": "node scripts/prepare-build-output.mjs && tsc -p tsconfig.build.json",
-    "postbuild": "chmod +x dist/src/cli.js && node scripts/generate-secret-rules.mjs --check-node",
+    "postbuild": "chmod +x dist/src/cli.js && node scripts/generate-secret-rules.mjs --check-node && node scripts/check-phase1-verified-loader.mjs",
     "cli": "tsx src/cli.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/check-phase1-verified-loader.mjs
+++ b/scripts/check-phase1-verified-loader.mjs
@@ -1,0 +1,24 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, realpathSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const directory = realpathSync(mkdtempSync(join(tmpdir(), "neondiff-phase1-verified-loader-")));
+try {
+  const marker = join(directory, "unverified-executed");
+  const modulePath = join(directory, "payload.js");
+  const replacementPath = join(directory, "replacement.js");
+  const source = "export const provenance = 'verified';\n";
+  writeFileSync(modulePath, source);
+  writeFileSync(replacementPath, `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(marker)}, "executed"); export const provenance = "replacement";\n`);
+  const { importVerifiedModule } = await import(pathToFileURL(join(process.cwd(), "dist", "src", "phase1-characterization-cli.js")).href);
+  const loaded = await importVerifiedModule(modulePath, createHash("sha256").update(source).digest("hex"), "payload", () => {
+    unlinkSync(modulePath);
+    symlinkSync(replacementPath, modulePath);
+  });
+  if (loaded.provenance !== "verified" || existsSync(marker)) throw new Error("verified module loader executed path-replacement bytes");
+  process.stdout.write("phase1 verified loader check passed\n");
+} finally {
+  rmSync(directory, { recursive: true, force: true });
+}

--- a/src/linux-phase1-runtime.ts
+++ b/src/linux-phase1-runtime.ts
@@ -1,0 +1,234 @@
+import { createHash, randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFileSync, readlinkSync, readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export type LinuxResourceSample = {
+  capturedAt: string;
+  phase: string;
+  rssBytes: number;
+  vramBytes: number;
+  swapBytes: number;
+  processSwapBytes: number;
+  processAlive: number;
+  pid: number;
+};
+
+type Session = {
+  id: string;
+  pid?: number;
+  processStartToken?: string;
+  samples: LinuxResourceSample[];
+  timer?: ReturnType<typeof setInterval>;
+  periodicFailure?: string;
+};
+
+const NVIDIA_SMI = "/usr/bin/nvidia-smi";
+const MAX_SAMPLES = 4096;
+const SAMPLE_INTERVAL_MS = 1000;
+const SWAP_GROWTH_LIMIT_BYTES = 64 * 1024 * 1024;
+const sessions = new Map<string, Session>();
+
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b)).map(([key, entry]) => `${JSON.stringify(key)}:${canonical(entry)}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function canonicalArgvFingerprint(argv: string[]): string {
+  return createHash("sha256").update(canonical(argv)).digest("hex");
+}
+
+export function appendBoundedLinuxTrace(samples: LinuxResourceSample[], sample: LinuxResourceSample, maximum = MAX_SAMPLES): void {
+  if (!Number.isSafeInteger(maximum) || maximum < 2) throw new Error("resource trace cap must preserve a baseline and terminal tail");
+  samples.push(sample);
+  if (samples.length > maximum) samples.splice(1, samples.length - maximum);
+}
+
+export function linuxRuntimeModulePath(): string {
+  return fileURLToPath(import.meta.url);
+}
+
+export function assertGex44LinuxPreflight(expectedNvidiaSmiSha256: string): void {
+  if (process.platform !== "linux") throw new Error("GEX44 characterization requires Linux");
+  if (!/^[a-f0-9]{64}$/.test(expectedNvidiaSmiSha256)) throw new Error("nvidia-smi SHA-256 is invalid");
+  const metadata = statSync(NVIDIA_SMI);
+  if (!metadata.isFile() || (metadata.mode & 0o111) === 0) throw new Error("pinned nvidia-smi path is not executable");
+  if (sha256File(NVIDIA_SMI) !== expectedNvidiaSmiSha256) throw new Error("nvidia-smi SHA-256 does not match the immutable plan");
+}
+
+function sha256File(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function positivePid(value: unknown): number {
+  const pid = Number(value);
+  if (!Number.isSafeInteger(pid) || pid <= 1) throw new Error("resident metadata does not contain a safe PID");
+  return pid;
+}
+
+export async function verifyLinuxProcessIdentity(pid: number, executableSha256: string, argvFingerprint: string): Promise<boolean> {
+  try {
+    const executableHandle = `/proc/${positivePid(pid)}/exe`;
+    const argv = readFileSync(`/proc/${pid}/cmdline`).toString("utf8").split("\0").filter(Boolean);
+    return sha256File(executableHandle) === executableSha256 && canonicalArgvFingerprint(argv) === argvFingerprint;
+  } catch {
+    return false;
+  }
+}
+
+function listenerInodes(host: string, port: number): Set<string> {
+  if (host !== "127.0.0.1" || !Number.isSafeInteger(port) || port < 1 || port > 65535) return new Set();
+  const expectedAddress = "0100007F";
+  const expectedPort = port.toString(16).toUpperCase().padStart(4, "0");
+  const found = new Set<string>();
+  for (const path of ["/proc/net/tcp", "/proc/net/tcp6"]) {
+    let lines: string[];
+    try { lines = readFileSync(path, "utf8").trim().split("\n").slice(1); } catch { continue; }
+    for (const line of lines) {
+      const fields = line.trim().split(/\s+/);
+      const [address, encodedPort] = (fields[1] ?? "").split(":");
+      const ipv4MappedLoopback = address === "0000000000000000FFFF00000100007F";
+      if ((address === expectedAddress || ipv4MappedLoopback) && encodedPort === expectedPort && fields[3] === "0A" && /^\d+$/.test(fields[9] ?? "")) found.add(fields[9]);
+    }
+  }
+  return found;
+}
+
+export async function verifyLinuxListenerOwnership(pid: number, host: string, port: number): Promise<boolean> {
+  const inodes = listenerInodes(host, port);
+  if (inodes.size === 0) return false;
+  try {
+    for (const descriptor of readdirSync(`/proc/${positivePid(pid)}/fd`)) {
+      let target: string;
+      try { target = readlinkSync(`/proc/${pid}/fd/${descriptor}`); } catch { continue; }
+      const match = /^socket:\[(\d+)\]$/.exec(target);
+      if (match && inodes.has(match[1])) return true;
+    }
+  } catch { return false; }
+  return false;
+}
+
+function statusBytes(pid: number, field: "VmRSS" | "VmSwap"): number {
+  try {
+    const line = readFileSync(`/proc/${pid}/status`, "utf8").split("\n").find((candidate) => candidate.startsWith(`${field}:`));
+    const match = line?.match(/^\w+:\s+(\d+)\s+kB$/);
+    return match ? Number(match[1]) * 1024 : 0;
+  } catch { return 0; }
+}
+
+function hostSwapUsedBytes(): number {
+  const values = new Map<string, number>();
+  for (const line of readFileSync("/proc/meminfo", "utf8").split("\n")) {
+    const match = line.match(/^(SwapTotal|SwapFree):\s+(\d+)\s+kB$/);
+    if (match) values.set(match[1], Number(match[2]) * 1024);
+  }
+  const total = values.get("SwapTotal");
+  const free = values.get("SwapFree");
+  if (total === undefined || free === undefined || free > total) throw new Error("host swap counters are unavailable");
+  return total - free;
+}
+
+function processStartToken(pid: number): string | undefined {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const close = stat.lastIndexOf(")");
+    const fieldsAfterCommand = stat.slice(close + 2).trim().split(/\s+/);
+    return fieldsAfterCommand[19]; // proc(5) field 22, after pid and parenthesized comm
+  } catch { return undefined; }
+}
+
+function processAlive(pid: number, expectedStartToken?: string): boolean {
+  try {
+    if (!statSync(`/proc/${pid}`).isDirectory()) return false;
+    return expectedStartToken === undefined || processStartToken(pid) === expectedStartToken;
+  } catch { return false; }
+}
+
+function queryVramBytes(pid: number): number {
+  const output = execFileSync(NVIDIA_SMI, ["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"], {
+    encoding: "utf8",
+    timeout: 5000,
+    maxBuffer: 1024 * 1024,
+    env: { PATH: "/usr/bin:/bin", LANG: "C", LC_ALL: "C" },
+    stdio: ["ignore", "pipe", "ignore"]
+  });
+  let mib = 0;
+  for (const line of output.trim().split("\n")) {
+    const match = line.match(/^\s*(\d+)\s*,\s*(\d+(?:\.\d+)?)\s*$/);
+    if (match && Number(match[1]) === pid) mib += Number(match[2]);
+  }
+  return Math.round(mib * 1024 * 1024);
+}
+
+function capture(session: Session, phase: string): LinuxResourceSample {
+  if (!session.pid) throw new Error("resource monitor is not attached to a resident PID");
+  const alive = processAlive(session.pid, session.processStartToken);
+  const sample: LinuxResourceSample = {
+    capturedAt: new Date().toISOString(),
+    phase,
+    rssBytes: alive ? statusBytes(session.pid, "VmRSS") : 0,
+    vramBytes: alive ? queryVramBytes(session.pid) : 0,
+    swapBytes: hostSwapUsedBytes(),
+    processSwapBytes: alive ? statusBytes(session.pid, "VmSwap") : 0,
+    processAlive: alive ? 1 : 0,
+    pid: session.pid
+  };
+  appendBoundedLinuxTrace(session.samples, sample);
+  return sample;
+}
+
+/** Pinned, self-contained module factory loaded from exact verified bytes. */
+export function createGex44ResourceMonitor() {
+  return {
+    async start() {
+      const id = randomUUID();
+      sessions.set(id, { id, samples: [] });
+      return { id };
+    },
+    async attach(sessionRef: { id: string }, resident: { metadata?: Record<string, unknown> }) {
+      const session = sessions.get(sessionRef.id);
+      if (!session) throw new Error("resource monitor session is unknown");
+      session.pid = positivePid(resident.metadata?.pid);
+      session.processStartToken = processStartToken(session.pid);
+      if (!session.processStartToken) throw new Error("resident process start identity is unavailable");
+      capture(session, "attached");
+      session.timer = setInterval(() => {
+        try { capture(session, "periodic"); }
+        catch (error) { session.periodicFailure = error instanceof Error ? error.name : "periodic_sample_failed"; }
+      }, SAMPLE_INTERVAL_MS);
+      session.timer.unref();
+    },
+    async sample(sessionRef: { id: string }, context: { phase: string }) {
+      const session = sessions.get(sessionRef.id);
+      if (!session) throw new Error("resource monitor session is unknown");
+      if (session.periodicFailure) throw new Error(`periodic resource sampling failed: ${session.periodicFailure}`);
+      return capture(session, context.phase);
+    },
+    classify(samples: LinuxResourceSample[]) {
+      if (samples.length === 0) return { status: "stopped" as const, errorCode: "resource_trace_empty" };
+      const baseline = samples[0].swapBytes;
+      const sustained = samples.slice(-3);
+      if (sustained.length === 3 && sustained.every((sample) => sample.swapBytes - baseline > SWAP_GROWTH_LIMIT_BYTES)) {
+        return { status: "stopped" as const, errorCode: "sustained_swap_growth" };
+      }
+      const terminal = samples[samples.length - 1];
+      if (terminal.phase === "cleanup" && terminal.processAlive !== 0) return { status: "stopped" as const, errorCode: "resident_cleanup_not_proven" };
+      return undefined;
+    },
+    async stop(sessionRef: { id: string }) {
+      const session = sessions.get(sessionRef.id);
+      if (!session) throw new Error("resource monitor session is unknown");
+      if (session.timer) clearInterval(session.timer);
+      if (session.periodicFailure) {
+        sessions.delete(sessionRef.id);
+        throw new Error(`periodic resource sampling failed: ${session.periodicFailure}`);
+      }
+      const final = capture(session, "cleanup");
+      sessions.delete(sessionRef.id);
+      return [...session.samples.slice(0, -1), final];
+    }
+  };
+}

--- a/src/linux-phase1-runtime.ts
+++ b/src/linux-phase1-runtime.ts
@@ -17,6 +17,7 @@ export type LinuxResourceSample = {
   periodicFailure?: number;
   cleanupFailure?: number;
   nvidiaSmiDrift?: number;
+  nvidiaSmiVerificationFailure?: number;
 };
 
 type Session = {
@@ -297,6 +298,7 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
       const integrityFailures = [
         samples.some((sample) => sample.periodicFailure === 1) ? "periodic_resource_sampling_failed" : undefined,
         samples.some((sample) => sample.cleanupFailure === 1) ? "resource_cleanup_sampling_failed" : undefined,
+        samples.some((sample) => sample.nvidiaSmiVerificationFailure === 1) ? "nvidia_smi_descriptor_verification_failed" : undefined,
         samples.some((sample) => sample.nvidiaSmiDrift === 1) ? "nvidia_smi_descriptor_drift" : undefined
       ].filter((value): value is string => value !== undefined);
       if (integrityFailures.length > 0) return { status: "stopped" as const, errorCode: integrityFailures.join("+") };
@@ -338,12 +340,14 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
           };
           appendBoundedLinuxTrace(session.samples, final);
         }
-        try {
-          if (session.nvidiaSmiFd !== undefined && sha256Descriptor(session.nvidiaSmiFd) !== expectedNvidiaSmiSha256) final.nvidiaSmiDrift = 1;
-        } catch {
-          final.nvidiaSmiDrift = 1;
+        if (session.nvidiaSmiFd !== undefined) {
+          try {
+            if (sha256Descriptor(session.nvidiaSmiFd) !== expectedNvidiaSmiSha256) final.nvidiaSmiDrift = 1;
+          } catch {
+            final.nvidiaSmiVerificationFailure = 1;
+          }
         }
-        return [...session.samples.slice(0, -1), final];
+        return [...session.samples];
       } finally {
         if (session.nvidiaSmiFd !== undefined) {
           closeSync(session.nvidiaSmiFd);

--- a/src/linux-phase1-runtime.ts
+++ b/src/linux-phase1-runtime.ts
@@ -245,10 +245,18 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
       const startToken = processStartToken(pid);
       if (!startToken) throw new Error("resident process start identity is unavailable");
       const nvidiaSmiFd = openPinnedNvidiaSmi(expectedNvidiaSmiSha256);
+      const attached: Session = { ...session, samples: [...session.samples], pid, processStartToken: startToken, nvidiaSmiFd };
+      try {
+        capture(attached, "attached");
+      } catch (error) {
+        closeSync(nvidiaSmiFd);
+        throw error;
+      }
       session.pid = pid;
       session.processStartToken = startToken;
       session.nvidiaSmiFd = nvidiaSmiFd;
-      capture(session, "attached");
+      session.samples = attached.samples;
+      session.sequence = attached.sequence;
       session.timer = setInterval(() => {
         try { capture(session, "periodic"); }
         catch (error) { session.periodicFailure = error instanceof Error ? error.name : "periodic_sample_failed"; }

--- a/src/linux-phase1-runtime.ts
+++ b/src/linux-phase1-runtime.ts
@@ -14,6 +14,8 @@ export type LinuxResourceSample = {
   processSwapBytes: number;
   processAlive: number;
   pid: number;
+  periodicFailure?: number;
+  nvidiaSmiDrift?: number;
 };
 
 type Session = {
@@ -177,6 +179,11 @@ function openPinnedNvidiaSmi(expectedNvidiaSmiSha256: string): number {
 }
 
 function queryVramBytes(pid: number, nvidiaSmiFd: number): { bytes: number; observed: number } {
+  // The descriptor is pinned and hashed at attach, then re-hashed before the
+  // run can terminate successfully. This prevents pathname replacement and
+  // fails terminal evidence on ordinary in-session inode mutation without
+  // adding full-binary hashing overhead to every one-second sample. A
+  // privileged mutate-and-restore attack is outside this evidence boundary.
   const output = execFileSync(`/proc/${process.pid}/fd/${nvidiaSmiFd}`, ["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"], {
     encoding: "utf8",
     timeout: 5000,
@@ -211,7 +218,8 @@ function capture(session: Session, phase: string): LinuxResourceSample {
     swapBytes: hostSwapUsedBytes(),
     processSwapBytes: alive ? statusBytes(session.pid, "VmSwap") : 0,
     processAlive: alive ? 1 : 0,
-    pid: session.pid
+    pid: session.pid,
+    periodicFailure: session.periodicFailure ? 1 : 0
   };
   appendBoundedLinuxTrace(session.samples, sample);
   return sample;
@@ -251,6 +259,8 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
     },
     classify(samples: LinuxResourceSample[]) {
       if (samples.length === 0) return { status: "stopped" as const, errorCode: "resource_trace_empty" };
+      if (samples.some((sample) => sample.periodicFailure === 1)) return { status: "stopped" as const, errorCode: "periodic_resource_sampling_failed" };
+      if (samples.some((sample) => sample.nvidiaSmiDrift === 1)) return { status: "stopped" as const, errorCode: "nvidia_smi_descriptor_drift" };
       const baseline = samples[0].swapBytes;
       const sustained = samples.slice(-3);
       if (sustained.length === 3 && sustained.every((sample) => sample.swapBytes - baseline > SWAP_GROWTH_LIMIT_BYTES)) {
@@ -265,24 +275,18 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
       if (!session) throw new Error("resource monitor session is unknown");
       try {
         if (session.timer) clearInterval(session.timer);
-        if (session.periodicFailure) {
-          throw new Error(`periodic resource sampling failed: ${session.periodicFailure}`);
-        }
         const final = capture(session, "cleanup");
+        try {
+          if (session.nvidiaSmiFd !== undefined && sha256Descriptor(session.nvidiaSmiFd) !== expectedNvidiaSmiSha256) final.nvidiaSmiDrift = 1;
+        } catch {
+          final.nvidiaSmiDrift = 1;
+        }
         return [...session.samples.slice(0, -1), final];
       } finally {
-        let descriptorFailure: Error | undefined;
         if (session.nvidiaSmiFd !== undefined) {
-          try {
-            if (sha256Descriptor(session.nvidiaSmiFd) !== expectedNvidiaSmiSha256) descriptorFailure = new Error("nvidia-smi SHA-256 drifted during the monitoring session");
-          } catch (error) {
-            descriptorFailure = error instanceof Error ? error : new Error("nvidia-smi descriptor verification failed");
-          } finally {
-            closeSync(session.nvidiaSmiFd);
-          }
+          closeSync(session.nvidiaSmiFd);
         }
         sessions.delete(sessionRef.id);
-        if (descriptorFailure) throw descriptorFailure;
       }
     }
   };

--- a/src/linux-phase1-runtime.ts
+++ b/src/linux-phase1-runtime.ts
@@ -277,9 +277,9 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
         samples.some((sample) => sample.nvidiaSmiDrift === 1) ? "nvidia_smi_descriptor_drift" : undefined
       ].filter((value): value is string => value !== undefined);
       if (integrityFailures.length > 0) return { status: "stopped" as const, errorCode: integrityFailures.join("+") };
-      const baseline = samples[0].swapBytes;
+      const baseline = samples[0].processSwapBytes;
       const sustained = samples.slice(-3);
-      if (sustained.length === 3 && sustained.every((sample) => sample.swapBytes - baseline > SWAP_GROWTH_LIMIT_BYTES)) {
+      if (sustained.length === 3 && sustained.every((sample) => sample.processSwapBytes - baseline > SWAP_GROWTH_LIMIT_BYTES)) {
         return { status: "stopped" as const, errorCode: "sustained_swap_growth" };
       }
       const terminal = samples[samples.length - 1];

--- a/src/linux-phase1-runtime.ts
+++ b/src/linux-phase1-runtime.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { closeSync, fstatSync, openSync, readFileSync, readlinkSync, readSync, readdirSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
@@ -26,7 +26,9 @@ type Session = {
   nvidiaSmiFd?: number;
   sequence: number;
   samples: LinuxResourceSample[];
-  timer?: ReturnType<typeof setInterval>;
+  captureQueue: Promise<void>;
+  timer?: ReturnType<typeof setTimeout>;
+  stopping?: boolean;
   periodicFailure?: string;
 };
 
@@ -179,18 +181,22 @@ function openPinnedNvidiaSmi(expectedNvidiaSmiSha256: string): number {
   }
 }
 
-function queryVramBytes(pid: number, nvidiaSmiFd: number): { bytes: number; observed: number } {
+async function queryVramBytes(pid: number, nvidiaSmiFd: number): Promise<{ bytes: number; observed: number }> {
   // The descriptor is pinned and hashed at attach, then re-hashed before the
   // run can terminate successfully. This prevents pathname replacement and
   // fails terminal evidence on ordinary in-session inode mutation without
   // adding full-binary hashing overhead to every one-second sample. A
   // privileged mutate-and-restore attack is outside this evidence boundary.
-  const output = execFileSync(`/proc/${process.pid}/fd/${nvidiaSmiFd}`, ["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"], {
-    encoding: "utf8",
-    timeout: 5000,
-    maxBuffer: 1024 * 1024,
-    env: { PATH: "/usr/bin:/bin", LANG: "C", LC_ALL: "C" },
-    stdio: ["ignore", "pipe", "ignore"]
+  const output = await new Promise<string>((resolvePromise, rejectPromise) => {
+    execFile(`/proc/${process.pid}/fd/${nvidiaSmiFd}`, ["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"], {
+      encoding: "utf8",
+      timeout: 5000,
+      maxBuffer: 1024 * 1024,
+      env: { PATH: "/usr/bin:/bin", LANG: "C", LC_ALL: "C" }
+    }, (error, stdout) => {
+      if (error) rejectPromise(error);
+      else resolvePromise(stdout);
+    });
   });
   let mib = 0;
   let observed = 0;
@@ -204,11 +210,11 @@ function queryVramBytes(pid: number, nvidiaSmiFd: number): { bytes: number; obse
   return { bytes: Math.round(mib * 1024 * 1024), observed };
 }
 
-function capture(session: Session, phase: string): LinuxResourceSample {
+async function capture(session: Session, phase: string): Promise<LinuxResourceSample> {
   if (!session.pid) throw new Error("resource monitor is not attached to a resident PID");
   const alive = processAlive(session.pid, session.processStartToken);
   if (alive && session.nvidiaSmiFd === undefined) throw new Error("resource monitor has no pinned nvidia-smi descriptor");
-  const vram = alive ? queryVramBytes(session.pid, session.nvidiaSmiFd as number) : { bytes: 0, observed: 0 };
+  const vram = alive ? await queryVramBytes(session.pid, session.nvidiaSmiFd as number) : { bytes: 0, observed: 0 };
   const sample: LinuxResourceSample = {
     capturedAt: new Date().toISOString(),
     sequence: ++session.sequence,
@@ -226,6 +232,20 @@ function capture(session: Session, phase: string): LinuxResourceSample {
   return sample;
 }
 
+function enqueueCapture(session: Session, phase: string, rejectOnPeriodicFailure = false): Promise<LinuxResourceSample> {
+  const operation = session.captureQueue.then(async () => {
+    if (rejectOnPeriodicFailure && session.periodicFailure) throw new Error(`periodic resource sampling failed: ${session.periodicFailure}`);
+    return capture(session, phase);
+  });
+  session.captureQueue = operation.then(
+    () => undefined,
+    (error) => {
+      if (phase === "periodic") session.periodicFailure = error instanceof Error ? error.name : "periodic_sample_failed";
+    }
+  );
+  return operation;
+}
+
 /** Pinned, self-contained module factory loaded from exact verified bytes. */
 export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string }) {
   const expectedNvidiaSmiSha256 = parameters?.nvidiaSmiSha256;
@@ -234,7 +254,7 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
   return {
     async start() {
       const id = randomUUID();
-      sessions.set(id, { id, samples: [], sequence: 0 });
+      sessions.set(id, { id, samples: [], sequence: 0, captureQueue: Promise.resolve() });
       return { id };
     },
     async attach(sessionRef: { id: string }, resident: { metadata?: Record<string, unknown> }) {
@@ -247,7 +267,7 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
       const nvidiaSmiFd = openPinnedNvidiaSmi(expectedNvidiaSmiSha256);
       const attached: Session = { ...session, samples: [...session.samples], pid, processStartToken: startToken, nvidiaSmiFd };
       try {
-        capture(attached, "attached");
+        await enqueueCapture(attached, "attached");
       } catch (error) {
         closeSync(nvidiaSmiFd);
         throw error;
@@ -257,17 +277,20 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
       session.nvidiaSmiFd = nvidiaSmiFd;
       session.samples = attached.samples;
       session.sequence = attached.sequence;
-      session.timer = setInterval(() => {
-        try { capture(session, "periodic"); }
-        catch (error) { session.periodicFailure = error instanceof Error ? error.name : "periodic_sample_failed"; }
-      }, SAMPLE_INTERVAL_MS);
-      session.timer.unref();
+      session.captureQueue = attached.captureQueue;
+      const schedulePeriodic = () => {
+        if (session.stopping || session.periodicFailure) return;
+        session.timer = setTimeout(() => {
+          void enqueueCapture(session, "periodic").then(schedulePeriodic, schedulePeriodic);
+        }, SAMPLE_INTERVAL_MS);
+        session.timer.unref();
+      };
+      schedulePeriodic();
     },
     async sample(sessionRef: { id: string }, context: { phase: string }) {
       const session = sessions.get(sessionRef.id);
       if (!session) throw new Error("resource monitor session is unknown");
-      if (session.periodicFailure) throw new Error(`periodic resource sampling failed: ${session.periodicFailure}`);
-      return capture(session, context.phase);
+      return enqueueCapture(session, context.phase, true);
     },
     classify(samples: LinuxResourceSample[]) {
       if (samples.length === 0) return { status: "stopped" as const, errorCode: "resource_trace_empty" };
@@ -290,10 +313,11 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
       const session = sessions.get(sessionRef.id);
       if (!session) throw new Error("resource monitor session is unknown");
       try {
-        if (session.timer) clearInterval(session.timer);
+        session.stopping = true;
+        if (session.timer) clearTimeout(session.timer);
         let final: LinuxResourceSample;
         try {
-          final = capture(session, "cleanup");
+          final = await enqueueCapture(session, "cleanup");
         } catch (error) {
           if (!session.pid || !session.processStartToken || session.nvidiaSmiFd === undefined) throw error;
           const previous = session.samples.at(-1);

--- a/src/linux-phase1-runtime.ts
+++ b/src/linux-phase1-runtime.ts
@@ -15,6 +15,7 @@ export type LinuxResourceSample = {
   processAlive: number;
   pid: number;
   periodicFailure?: number;
+  cleanupFailure?: number;
   nvidiaSmiDrift?: number;
 };
 
@@ -240,10 +241,13 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
       const session = sessions.get(sessionRef.id);
       if (!session) throw new Error("resource monitor session is unknown");
       if (session.nvidiaSmiFd !== undefined) throw new Error("resource monitor session is already attached");
-      session.pid = positivePid(resident.metadata?.pid);
-      session.processStartToken = processStartToken(session.pid);
-      if (!session.processStartToken) throw new Error("resident process start identity is unavailable");
-      session.nvidiaSmiFd = openPinnedNvidiaSmi(expectedNvidiaSmiSha256);
+      const pid = positivePid(resident.metadata?.pid);
+      const startToken = processStartToken(pid);
+      if (!startToken) throw new Error("resident process start identity is unavailable");
+      const nvidiaSmiFd = openPinnedNvidiaSmi(expectedNvidiaSmiSha256);
+      session.pid = pid;
+      session.processStartToken = startToken;
+      session.nvidiaSmiFd = nvidiaSmiFd;
       capture(session, "attached");
       session.timer = setInterval(() => {
         try { capture(session, "periodic"); }
@@ -259,8 +263,12 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
     },
     classify(samples: LinuxResourceSample[]) {
       if (samples.length === 0) return { status: "stopped" as const, errorCode: "resource_trace_empty" };
-      if (samples.some((sample) => sample.periodicFailure === 1)) return { status: "stopped" as const, errorCode: "periodic_resource_sampling_failed" };
-      if (samples.some((sample) => sample.nvidiaSmiDrift === 1)) return { status: "stopped" as const, errorCode: "nvidia_smi_descriptor_drift" };
+      const integrityFailures = [
+        samples.some((sample) => sample.periodicFailure === 1) ? "periodic_resource_sampling_failed" : undefined,
+        samples.some((sample) => sample.cleanupFailure === 1) ? "resource_cleanup_sampling_failed" : undefined,
+        samples.some((sample) => sample.nvidiaSmiDrift === 1) ? "nvidia_smi_descriptor_drift" : undefined
+      ].filter((value): value is string => value !== undefined);
+      if (integrityFailures.length > 0) return { status: "stopped" as const, errorCode: integrityFailures.join("+") };
       const baseline = samples[0].swapBytes;
       const sustained = samples.slice(-3);
       if (sustained.length === 3 && sustained.every((sample) => sample.swapBytes - baseline > SWAP_GROWTH_LIMIT_BYTES)) {
@@ -275,7 +283,29 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
       if (!session) throw new Error("resource monitor session is unknown");
       try {
         if (session.timer) clearInterval(session.timer);
-        const final = capture(session, "cleanup");
+        let final: LinuxResourceSample;
+        try {
+          final = capture(session, "cleanup");
+        } catch (error) {
+          if (!session.pid || !session.processStartToken || session.nvidiaSmiFd === undefined) throw error;
+          const previous = session.samples.at(-1);
+          const alive = processAlive(session.pid, session.processStartToken);
+          final = {
+            capturedAt: new Date().toISOString(),
+            sequence: ++session.sequence,
+            phase: "cleanup",
+            rssBytes: alive ? statusBytes(session.pid, "VmRSS") : 0,
+            vramBytes: previous?.vramBytes ?? 0,
+            vramObserved: 0,
+            swapBytes: previous?.swapBytes ?? 0,
+            processSwapBytes: alive ? statusBytes(session.pid, "VmSwap") : 0,
+            processAlive: alive ? 1 : 0,
+            pid: session.pid,
+            periodicFailure: session.periodicFailure ? 1 : 0,
+            cleanupFailure: 1
+          };
+          appendBoundedLinuxTrace(session.samples, final);
+        }
         try {
           if (session.nvidiaSmiFd !== undefined && sha256Descriptor(session.nvidiaSmiFd) !== expectedNvidiaSmiSha256) final.nvidiaSmiDrift = 1;
         } catch {

--- a/src/linux-phase1-runtime.ts
+++ b/src/linux-phase1-runtime.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { readFileSync, readlinkSync, readdirSync, statSync } from "node:fs";
+import { closeSync, fstatSync, openSync, readFileSync, readlinkSync, readSync, readdirSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 export type LinuxResourceSample = {
@@ -27,7 +27,6 @@ const NVIDIA_SMI = "/usr/bin/nvidia-smi";
 const MAX_SAMPLES = 4096;
 const SAMPLE_INTERVAL_MS = 1000;
 const SWAP_GROWTH_LIMIT_BYTES = 64 * 1024 * 1024;
-const sessions = new Map<string, Session>();
 
 function canonical(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
@@ -61,6 +60,19 @@ export function assertGex44LinuxPreflight(expectedNvidiaSmiSha256: string): void
 
 function sha256File(path: string): string {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function sha256Descriptor(fd: number): string {
+  const size = fstatSync(fd).size;
+  const hash = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(64 * 1024);
+  for (let offset = 0; offset < size;) {
+    const bytesRead = readSync(fd, buffer, 0, Math.min(buffer.length, size - offset), offset);
+    if (bytesRead === 0) throw new Error("pinned executable changed while hashing");
+    hash.update(buffer.subarray(0, bytesRead));
+    offset += bytesRead;
+  }
+  return hash.digest("hex");
 }
 
 function positivePid(value: unknown): number {
@@ -147,14 +159,24 @@ function processAlive(pid: number, expectedStartToken?: string): boolean {
   } catch { return false; }
 }
 
-function queryVramBytes(pid: number): number {
-  const output = execFileSync(NVIDIA_SMI, ["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"], {
-    encoding: "utf8",
-    timeout: 5000,
-    maxBuffer: 1024 * 1024,
-    env: { PATH: "/usr/bin:/bin", LANG: "C", LC_ALL: "C" },
-    stdio: ["ignore", "pipe", "ignore"]
-  });
+function queryVramBytes(pid: number, expectedNvidiaSmiSha256: string): number {
+  const fd = openSync(NVIDIA_SMI, "r");
+  let output: string;
+  try {
+    const metadata = fstatSync(fd);
+    if (!metadata.isFile() || (metadata.mode & 0o111) === 0) throw new Error("pinned nvidia-smi image is not executable");
+    if (sha256Descriptor(fd) !== expectedNvidiaSmiSha256) throw new Error("nvidia-smi SHA-256 drifted before execution");
+    output = execFileSync(`/proc/${process.pid}/fd/${fd}`, ["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"], {
+      encoding: "utf8",
+      timeout: 5000,
+      maxBuffer: 1024 * 1024,
+      env: { PATH: "/usr/bin:/bin", LANG: "C", LC_ALL: "C" },
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    if (sha256Descriptor(fd) !== expectedNvidiaSmiSha256) throw new Error("nvidia-smi SHA-256 drifted during execution");
+  } finally {
+    closeSync(fd);
+  }
   let mib = 0;
   for (const line of output.trim().split("\n")) {
     const match = line.match(/^\s*(\d+)\s*,\s*(\d+(?:\.\d+)?)\s*$/);
@@ -163,14 +185,14 @@ function queryVramBytes(pid: number): number {
   return Math.round(mib * 1024 * 1024);
 }
 
-function capture(session: Session, phase: string): LinuxResourceSample {
+function capture(session: Session, phase: string, expectedNvidiaSmiSha256: string): LinuxResourceSample {
   if (!session.pid) throw new Error("resource monitor is not attached to a resident PID");
   const alive = processAlive(session.pid, session.processStartToken);
   const sample: LinuxResourceSample = {
     capturedAt: new Date().toISOString(),
     phase,
     rssBytes: alive ? statusBytes(session.pid, "VmRSS") : 0,
-    vramBytes: alive ? queryVramBytes(session.pid) : 0,
+    vramBytes: alive ? queryVramBytes(session.pid, expectedNvidiaSmiSha256) : 0,
     swapBytes: hostSwapUsedBytes(),
     processSwapBytes: alive ? statusBytes(session.pid, "VmSwap") : 0,
     processAlive: alive ? 1 : 0,
@@ -181,7 +203,10 @@ function capture(session: Session, phase: string): LinuxResourceSample {
 }
 
 /** Pinned, self-contained module factory loaded from exact verified bytes. */
-export function createGex44ResourceMonitor() {
+export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string }) {
+  const expectedNvidiaSmiSha256 = parameters?.nvidiaSmiSha256;
+  if (!/^[a-f0-9]{64}$/.test(expectedNvidiaSmiSha256 ?? "")) throw new Error("nvidia-smi SHA-256 factory parameter is invalid");
+  const sessions = new Map<string, Session>();
   return {
     async start() {
       const id = randomUUID();
@@ -194,9 +219,9 @@ export function createGex44ResourceMonitor() {
       session.pid = positivePid(resident.metadata?.pid);
       session.processStartToken = processStartToken(session.pid);
       if (!session.processStartToken) throw new Error("resident process start identity is unavailable");
-      capture(session, "attached");
+      capture(session, "attached", expectedNvidiaSmiSha256);
       session.timer = setInterval(() => {
-        try { capture(session, "periodic"); }
+        try { capture(session, "periodic", expectedNvidiaSmiSha256); }
         catch (error) { session.periodicFailure = error instanceof Error ? error.name : "periodic_sample_failed"; }
       }, SAMPLE_INTERVAL_MS);
       session.timer.unref();
@@ -205,7 +230,7 @@ export function createGex44ResourceMonitor() {
       const session = sessions.get(sessionRef.id);
       if (!session) throw new Error("resource monitor session is unknown");
       if (session.periodicFailure) throw new Error(`periodic resource sampling failed: ${session.periodicFailure}`);
-      return capture(session, context.phase);
+      return capture(session, context.phase, expectedNvidiaSmiSha256);
     },
     classify(samples: LinuxResourceSample[]) {
       if (samples.length === 0) return { status: "stopped" as const, errorCode: "resource_trace_empty" };
@@ -221,14 +246,16 @@ export function createGex44ResourceMonitor() {
     async stop(sessionRef: { id: string }) {
       const session = sessions.get(sessionRef.id);
       if (!session) throw new Error("resource monitor session is unknown");
-      if (session.timer) clearInterval(session.timer);
-      if (session.periodicFailure) {
+      try {
+        if (session.timer) clearInterval(session.timer);
+        if (session.periodicFailure) {
+          throw new Error(`periodic resource sampling failed: ${session.periodicFailure}`);
+        }
+        const final = capture(session, "cleanup", expectedNvidiaSmiSha256);
+        return [...session.samples.slice(0, -1), final];
+      } finally {
         sessions.delete(sessionRef.id);
-        throw new Error(`periodic resource sampling failed: ${session.periodicFailure}`);
       }
-      const final = capture(session, "cleanup");
-      sessions.delete(sessionRef.id);
-      return [...session.samples.slice(0, -1), final];
     }
   };
 }

--- a/src/linux-phase1-runtime.ts
+++ b/src/linux-phase1-runtime.ts
@@ -5,9 +5,11 @@ import { fileURLToPath } from "node:url";
 
 export type LinuxResourceSample = {
   capturedAt: string;
+  sequence: number;
   phase: string;
   rssBytes: number;
   vramBytes: number;
+  vramObserved: number;
   swapBytes: number;
   processSwapBytes: number;
   processAlive: number;
@@ -18,6 +20,8 @@ type Session = {
   id: string;
   pid?: number;
   processStartToken?: string;
+  nvidiaSmiFd?: number;
+  sequence: number;
   samples: LinuxResourceSample[];
   timer?: ReturnType<typeof setInterval>;
   periodicFailure?: string;
@@ -159,40 +163,51 @@ function processAlive(pid: number, expectedStartToken?: string): boolean {
   } catch { return false; }
 }
 
-function queryVramBytes(pid: number, expectedNvidiaSmiSha256: string): number {
+function openPinnedNvidiaSmi(expectedNvidiaSmiSha256: string): number {
   const fd = openSync(NVIDIA_SMI, "r");
-  let output: string;
   try {
     const metadata = fstatSync(fd);
     if (!metadata.isFile() || (metadata.mode & 0o111) === 0) throw new Error("pinned nvidia-smi image is not executable");
     if (sha256Descriptor(fd) !== expectedNvidiaSmiSha256) throw new Error("nvidia-smi SHA-256 drifted before execution");
-    output = execFileSync(`/proc/${process.pid}/fd/${fd}`, ["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"], {
-      encoding: "utf8",
-      timeout: 5000,
-      maxBuffer: 1024 * 1024,
-      env: { PATH: "/usr/bin:/bin", LANG: "C", LC_ALL: "C" },
-      stdio: ["ignore", "pipe", "ignore"]
-    });
-    if (sha256Descriptor(fd) !== expectedNvidiaSmiSha256) throw new Error("nvidia-smi SHA-256 drifted during execution");
-  } finally {
+    return fd;
+  } catch (error) {
     closeSync(fd);
+    throw error;
   }
-  let mib = 0;
-  for (const line of output.trim().split("\n")) {
-    const match = line.match(/^\s*(\d+)\s*,\s*(\d+(?:\.\d+)?)\s*$/);
-    if (match && Number(match[1]) === pid) mib += Number(match[2]);
-  }
-  return Math.round(mib * 1024 * 1024);
 }
 
-function capture(session: Session, phase: string, expectedNvidiaSmiSha256: string): LinuxResourceSample {
+function queryVramBytes(pid: number, nvidiaSmiFd: number): { bytes: number; observed: number } {
+  const output = execFileSync(`/proc/${process.pid}/fd/${nvidiaSmiFd}`, ["--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits"], {
+    encoding: "utf8",
+    timeout: 5000,
+    maxBuffer: 1024 * 1024,
+    env: { PATH: "/usr/bin:/bin", LANG: "C", LC_ALL: "C" },
+    stdio: ["ignore", "pipe", "ignore"]
+  });
+  let mib = 0;
+  let observed = 0;
+  for (const line of output.trim().split("\n")) {
+    const match = line.match(/^\s*(\d+)\s*,\s*(\d+(?:\.\d+)?)\s*$/);
+    if (match && Number(match[1]) === pid) {
+      observed = 1;
+      mib += Number(match[2]);
+    }
+  }
+  return { bytes: Math.round(mib * 1024 * 1024), observed };
+}
+
+function capture(session: Session, phase: string): LinuxResourceSample {
   if (!session.pid) throw new Error("resource monitor is not attached to a resident PID");
   const alive = processAlive(session.pid, session.processStartToken);
+  if (alive && session.nvidiaSmiFd === undefined) throw new Error("resource monitor has no pinned nvidia-smi descriptor");
+  const vram = alive ? queryVramBytes(session.pid, session.nvidiaSmiFd as number) : { bytes: 0, observed: 0 };
   const sample: LinuxResourceSample = {
     capturedAt: new Date().toISOString(),
+    sequence: ++session.sequence,
     phase,
     rssBytes: alive ? statusBytes(session.pid, "VmRSS") : 0,
-    vramBytes: alive ? queryVramBytes(session.pid, expectedNvidiaSmiSha256) : 0,
+    vramBytes: vram.bytes,
+    vramObserved: vram.observed,
     swapBytes: hostSwapUsedBytes(),
     processSwapBytes: alive ? statusBytes(session.pid, "VmSwap") : 0,
     processAlive: alive ? 1 : 0,
@@ -210,18 +225,20 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
   return {
     async start() {
       const id = randomUUID();
-      sessions.set(id, { id, samples: [] });
+      sessions.set(id, { id, samples: [], sequence: 0 });
       return { id };
     },
     async attach(sessionRef: { id: string }, resident: { metadata?: Record<string, unknown> }) {
       const session = sessions.get(sessionRef.id);
       if (!session) throw new Error("resource monitor session is unknown");
+      if (session.nvidiaSmiFd !== undefined) throw new Error("resource monitor session is already attached");
       session.pid = positivePid(resident.metadata?.pid);
       session.processStartToken = processStartToken(session.pid);
       if (!session.processStartToken) throw new Error("resident process start identity is unavailable");
-      capture(session, "attached", expectedNvidiaSmiSha256);
+      session.nvidiaSmiFd = openPinnedNvidiaSmi(expectedNvidiaSmiSha256);
+      capture(session, "attached");
       session.timer = setInterval(() => {
-        try { capture(session, "periodic", expectedNvidiaSmiSha256); }
+        try { capture(session, "periodic"); }
         catch (error) { session.periodicFailure = error instanceof Error ? error.name : "periodic_sample_failed"; }
       }, SAMPLE_INTERVAL_MS);
       session.timer.unref();
@@ -230,7 +247,7 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
       const session = sessions.get(sessionRef.id);
       if (!session) throw new Error("resource monitor session is unknown");
       if (session.periodicFailure) throw new Error(`periodic resource sampling failed: ${session.periodicFailure}`);
-      return capture(session, context.phase, expectedNvidiaSmiSha256);
+      return capture(session, context.phase);
     },
     classify(samples: LinuxResourceSample[]) {
       if (samples.length === 0) return { status: "stopped" as const, errorCode: "resource_trace_empty" };
@@ -251,10 +268,21 @@ export function createGex44ResourceMonitor(parameters: { nvidiaSmiSha256: string
         if (session.periodicFailure) {
           throw new Error(`periodic resource sampling failed: ${session.periodicFailure}`);
         }
-        const final = capture(session, "cleanup", expectedNvidiaSmiSha256);
+        const final = capture(session, "cleanup");
         return [...session.samples.slice(0, -1), final];
       } finally {
+        let descriptorFailure: Error | undefined;
+        if (session.nvidiaSmiFd !== undefined) {
+          try {
+            if (sha256Descriptor(session.nvidiaSmiFd) !== expectedNvidiaSmiSha256) descriptorFailure = new Error("nvidia-smi SHA-256 drifted during the monitoring session");
+          } catch (error) {
+            descriptorFailure = error instanceof Error ? error : new Error("nvidia-smi descriptor verification failed");
+          } finally {
+            closeSync(session.nvidiaSmiFd);
+          }
+        }
         sessions.delete(sessionRef.id);
+        if (descriptorFailure) throw descriptorFailure;
       }
     }
   };

--- a/src/phase1-characterization-cli.ts
+++ b/src/phase1-characterization-cli.ts
@@ -39,6 +39,12 @@ type LoadedArtifactPlan = {
   };
 };
 
+export function assertMonitorNvidiaBinding(nvidiaSmiSha256: string, monitorModule: Phase1ResourceMonitorModule): void {
+  if (!/^[a-f0-9]{64}$/.test(nvidiaSmiSha256) || monitorModule.factoryParameters?.nvidiaSmiSha256 !== nvidiaSmiSha256) {
+    throw new Error("resource monitor nvidia-smi identity is not bound to the immutable plan");
+  }
+}
+
 export function assertCharacterizationLoadedArtifacts(
   plan: LoadedArtifactPlan,
   loaded: { entrypointPath: string; runnerPath: string }
@@ -81,6 +87,7 @@ async function main(argv: string[]): Promise<void> {
   if (realpathSync(plan.monitorModule.modulePath) !== runtimePath || plan.monitorModule.moduleSha256 !== plan.runtimeSha256 || plan.monitorModule.exportName !== "createGex44ResourceMonitor") {
     throw new Error("resource monitor identity is not bound to the loaded Linux runtime");
   }
+  assertMonitorNvidiaBinding(plan.nvidiaSmiSha256, plan.monitorModule);
   assertGex44LinuxPreflight(plan.nvidiaSmiSha256);
   const adapter = createLlamaServerExecutableAdapter({
     baseUrl: plan.baseUrl,

--- a/src/phase1-characterization-cli.ts
+++ b/src/phase1-characterization-cli.ts
@@ -1,8 +1,8 @@
 import { createHash } from "node:crypto";
 import { readFileSync, realpathSync, statSync } from "node:fs";
 import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
-import { createLlamaServerExecutableAdapter, runPhase1Screen, type Phase1RunSpec, type Phase1ResourceMonitorModule } from "./phase1-screening-runner.js";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createLlamaServerExecutableAdapter, phase1ScreeningRunnerModulePath, runPhase1Screen, type Phase1RunSpec, type Phase1ResourceMonitorModule } from "./phase1-screening-runner.js";
 import { assertGex44LinuxPreflight, linuxRuntimeModulePath, verifyLinuxListenerOwnership, verifyLinuxProcessIdentity } from "./linux-phase1-runtime.js";
 
 type CharacterizationPlan = {
@@ -18,6 +18,35 @@ function sha256File(path: string): string {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
+export function assertPinnedLoadedJavaScript(actualPath: string, declaredPath: string, declaredSha256: string, label: string): void {
+  if (!actualPath.endsWith(".js") || !declaredPath.endsWith(".js")) throw new Error(`${label} must be a pinned built JavaScript artifact`);
+  const actual = realpathSync(actualPath);
+  const declared = realpathSync(declaredPath);
+  if (actual !== declared) throw new Error(`${label} loaded path does not match the immutable plan`);
+  if (!/^[a-f0-9]{64}$/.test(declaredSha256) || sha256File(actual) !== declaredSha256) {
+    throw new Error(`${label} SHA-256 does not match the immutable plan`);
+  }
+}
+
+type LoadedArtifactPlan = {
+  spec: {
+    harness: {
+      entrypointPath: string;
+      entrypointSha256: string;
+      runnerPath: string;
+      runnerSha256: string;
+    };
+  };
+};
+
+export function assertCharacterizationLoadedArtifacts(
+  plan: LoadedArtifactPlan,
+  loaded: { entrypointPath: string; runnerPath: string }
+): void {
+  assertPinnedLoadedJavaScript(loaded.entrypointPath, plan.spec.harness.entrypointPath, plan.spec.harness.entrypointSha256, "characterization entrypoint");
+  assertPinnedLoadedJavaScript(loaded.runnerPath, plan.spec.harness.runnerPath, plan.spec.harness.runnerSha256, "screening runner");
+}
+
 function absoluteRegularFile(path: string, label: string): void {
   if (resolve(path) !== path || realpathSync(path) !== path || !statSync(path).isFile()) throw new Error(`${label} must be an absolute canonical regular file`);
 }
@@ -30,12 +59,21 @@ function readPlan(path: string, expectedSha256: string): CharacterizationPlan {
   const plan = JSON.parse(bytes.toString("utf8")) as CharacterizationPlan;
   if (plan.schemaVersion !== "neondiff-phase1-characterization-plan/v1") throw new Error("characterization plan schema is unsupported");
   if (!plan.spec || !plan.monitorModule || typeof plan.baseUrl !== "string") throw new Error("characterization plan is incomplete");
+  const harness = plan.spec.harness;
+  if (!harness || typeof harness.entrypointPath !== "string" || typeof harness.entrypointSha256 !== "string"
+    || typeof harness.runnerPath !== "string" || typeof harness.runnerSha256 !== "string") {
+    throw new Error("characterization plan loaded JavaScript identities are incomplete");
+  }
   return plan;
 }
 
 async function main(argv: string[]): Promise<void> {
   if (argv.length !== 4 || argv[0] !== "--plan" || argv[2] !== "--sha256") throw new Error("usage: phase1-characterization-cli --plan <absolute-plan.json> --sha256 <digest>");
   const plan = readPlan(argv[1], argv[3]);
+  assertCharacterizationLoadedArtifacts(plan, {
+    entrypointPath: fileURLToPath(import.meta.url),
+    runnerPath: phase1ScreeningRunnerModulePath()
+  });
   const runtimePath = realpathSync(linuxRuntimeModulePath());
   if (!runtimePath.endsWith(".js")) throw new Error("characterization must run from the pinned built JavaScript artifact");
   if (sha256File(runtimePath) !== plan.runtimeSha256) throw new Error("loaded Linux runtime SHA-256 does not match the immutable plan");

--- a/src/phase1-characterization-cli.ts
+++ b/src/phase1-characterization-cli.ts
@@ -1,0 +1,64 @@
+import { createHash } from "node:crypto";
+import { readFileSync, realpathSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createLlamaServerExecutableAdapter, runPhase1Screen, type Phase1RunSpec, type Phase1ResourceMonitorModule } from "./phase1-screening-runner.js";
+import { assertGex44LinuxPreflight, linuxRuntimeModulePath, verifyLinuxListenerOwnership, verifyLinuxProcessIdentity } from "./linux-phase1-runtime.js";
+
+type CharacterizationPlan = {
+  schemaVersion: "neondiff-phase1-characterization-plan/v1";
+  spec: Phase1RunSpec;
+  baseUrl: string;
+  runtimeSha256: string;
+  nvidiaSmiSha256: string;
+  monitorModule: Phase1ResourceMonitorModule;
+};
+
+function sha256File(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function absoluteRegularFile(path: string, label: string): void {
+  if (resolve(path) !== path || realpathSync(path) !== path || !statSync(path).isFile()) throw new Error(`${label} must be an absolute canonical regular file`);
+}
+
+function readPlan(path: string, expectedSha256: string): CharacterizationPlan {
+  absoluteRegularFile(path, "characterization plan");
+  if (!/^[a-f0-9]{64}$/.test(expectedSha256)) throw new Error("characterization plan SHA-256 is invalid");
+  const bytes = readFileSync(path);
+  if (createHash("sha256").update(bytes).digest("hex") !== expectedSha256) throw new Error("characterization plan SHA-256 does not match");
+  const plan = JSON.parse(bytes.toString("utf8")) as CharacterizationPlan;
+  if (plan.schemaVersion !== "neondiff-phase1-characterization-plan/v1") throw new Error("characterization plan schema is unsupported");
+  if (!plan.spec || !plan.monitorModule || typeof plan.baseUrl !== "string") throw new Error("characterization plan is incomplete");
+  return plan;
+}
+
+async function main(argv: string[]): Promise<void> {
+  if (argv.length !== 4 || argv[0] !== "--plan" || argv[2] !== "--sha256") throw new Error("usage: phase1-characterization-cli --plan <absolute-plan.json> --sha256 <digest>");
+  const plan = readPlan(argv[1], argv[3]);
+  const runtimePath = realpathSync(linuxRuntimeModulePath());
+  if (!runtimePath.endsWith(".js")) throw new Error("characterization must run from the pinned built JavaScript artifact");
+  if (sha256File(runtimePath) !== plan.runtimeSha256) throw new Error("loaded Linux runtime SHA-256 does not match the immutable plan");
+  if (plan.spec.target.ownershipVerifierSha256 !== plan.runtimeSha256) throw new Error("target ownership verifier is not bound to the loaded Linux runtime");
+  if (realpathSync(plan.monitorModule.modulePath) !== runtimePath || plan.monitorModule.moduleSha256 !== plan.runtimeSha256 || plan.monitorModule.exportName !== "createGex44ResourceMonitor") {
+    throw new Error("resource monitor identity is not bound to the loaded Linux runtime");
+  }
+  assertGex44LinuxPreflight(plan.nvidiaSmiSha256);
+  const adapter = createLlamaServerExecutableAdapter({
+    baseUrl: plan.baseUrl,
+    ownershipVerifierSha256: plan.runtimeSha256,
+    verifyListenerOwnership: verifyLinuxListenerOwnership,
+    verifyProcessIdentity: verifyLinuxProcessIdentity
+  });
+  const summary = await runPhase1Screen(plan.spec, adapter, { monitorModule: plan.monitorModule });
+  process.stdout.write(`${JSON.stringify({ runFingerprint: summary.runFingerprint, status: summary.status, claimClass: summary.claimClass })}\n`);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(realpathSync(process.argv[1])).href : "";
+if (import.meta.url === invokedPath) {
+  main(process.argv.slice(2)).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : "unknown characterization failure";
+    process.stderr.write(`${message.replace(/[\r\n]+/g, " ").slice(0, 512)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/phase1-characterization-cli.ts
+++ b/src/phase1-characterization-cli.ts
@@ -1,9 +1,9 @@
-import { createHash } from "node:crypto";
-import { readFileSync, realpathSync, statSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { registerHooks } from "node:module";
 import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { createLlamaServerExecutableAdapter, phase1ScreeningRunnerModulePath, runPhase1Screen, type Phase1RunSpec, type Phase1ResourceMonitorModule } from "./phase1-screening-runner.js";
-import { assertGex44LinuxPreflight, linuxRuntimeModulePath, verifyLinuxListenerOwnership, verifyLinuxProcessIdentity } from "./linux-phase1-runtime.js";
+import type { Phase1RunSpec, Phase1ResourceMonitorModule } from "./phase1-screening-runner.js";
 
 type CharacterizationPlan = {
   schemaVersion: "neondiff-phase1-characterization-plan/v1";
@@ -16,6 +16,43 @@ type CharacterizationPlan = {
 
 function sha256File(path: string): string {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+export async function importVerifiedModule<T>(path: string, expectedSha256: string, label: string, afterVerify?: () => void): Promise<T> {
+  if (!path.endsWith(".js")) throw new Error(`${label} must be a pinned built JavaScript artifact`);
+  const canonicalPath = realpathSync(path);
+  if (canonicalPath !== path) throw new Error(`${label} must use its canonical path`);
+  const source = readFileSync(canonicalPath);
+  if (!/^[a-f0-9]{64}$/.test(expectedSha256) || createHash("sha256").update(source).digest("hex") !== expectedSha256) {
+    throw new Error(`${label} SHA-256 does not match the immutable plan`);
+  }
+  const loadNonce = randomUUID();
+  const verifiedUrl = new URL(pathToFileURL(canonicalPath));
+  verifiedUrl.searchParams.set("sha256", expectedSha256);
+  verifiedUrl.searchParams.set("load", loadNonce);
+  const href = verifiedUrl.href;
+  const isVerifiedRequest = (value: string): boolean => {
+    try {
+      const candidate = new URL(value);
+      return candidate.protocol === "file:" && candidate.searchParams.get("sha256") === expectedSha256 && candidate.searchParams.get("load") === loadNonce;
+    } catch { return false; }
+  };
+  const hooks = registerHooks({
+    resolve(specifier, context, nextResolve) {
+      if (isVerifiedRequest(specifier)) return { url: href, shortCircuit: true };
+      return nextResolve(specifier, context);
+    },
+    load(url, context, nextLoad) {
+      if (isVerifiedRequest(url)) return { format: "module", source, shortCircuit: true };
+      return nextLoad(url, context);
+    }
+  });
+  try {
+    afterVerify?.();
+    return await import(href) as T;
+  } finally {
+    hooks.deregister();
+  }
 }
 
 export function assertPinnedLoadedJavaScript(actualPath: string, declaredPath: string, declaredSha256: string, label: string): void {
@@ -76,11 +113,15 @@ function readPlan(path: string, expectedSha256: string): CharacterizationPlan {
 async function main(argv: string[]): Promise<void> {
   if (argv.length !== 4 || argv[0] !== "--plan" || argv[2] !== "--sha256") throw new Error("usage: phase1-characterization-cli --plan <absolute-plan.json> --sha256 <digest>");
   const plan = readPlan(argv[1], argv[3]);
+  const runnerCandidate = fileURLToPath(new URL("./phase1-screening-runner.js", import.meta.url));
+  const runtimeCandidate = fileURLToPath(new URL("./linux-phase1-runtime.js", import.meta.url));
+  if (!existsSync(runnerCandidate) || !existsSync(runtimeCandidate)) throw new Error("characterization must run from pinned built JavaScript artifacts");
+  const runnerPath = realpathSync(runnerCandidate);
+  const runtimePath = realpathSync(runtimeCandidate);
   assertCharacterizationLoadedArtifacts(plan, {
     entrypointPath: fileURLToPath(import.meta.url),
-    runnerPath: phase1ScreeningRunnerModulePath()
+    runnerPath
   });
-  const runtimePath = realpathSync(linuxRuntimeModulePath());
   if (!runtimePath.endsWith(".js")) throw new Error("characterization must run from the pinned built JavaScript artifact");
   if (sha256File(runtimePath) !== plan.runtimeSha256) throw new Error("loaded Linux runtime SHA-256 does not match the immutable plan");
   if (plan.spec.target.ownershipVerifierSha256 !== plan.runtimeSha256) throw new Error("target ownership verifier is not bound to the loaded Linux runtime");
@@ -88,6 +129,10 @@ async function main(argv: string[]): Promise<void> {
     throw new Error("resource monitor identity is not bound to the loaded Linux runtime");
   }
   assertMonitorNvidiaBinding(plan.nvidiaSmiSha256, plan.monitorModule);
+  const runner = await importVerifiedModule<typeof import("./phase1-screening-runner.js")>(runnerPath, plan.spec.harness.runnerSha256, "screening runner");
+  const runtime = await importVerifiedModule<typeof import("./linux-phase1-runtime.js")>(runtimePath, plan.runtimeSha256, "Linux characterization runtime");
+  const { createLlamaServerExecutableAdapter, runPhase1Screen } = runner;
+  const { assertGex44LinuxPreflight, verifyLinuxListenerOwnership, verifyLinuxProcessIdentity } = runtime;
   assertGex44LinuxPreflight(plan.nvidiaSmiSha256);
   const adapter = createLlamaServerExecutableAdapter({
     baseUrl: plan.baseUrl,

--- a/src/phase1-characterization-cli.ts
+++ b/src/phase1-characterization-cli.ts
@@ -144,7 +144,15 @@ async function main(argv: string[]): Promise<void> {
   process.stdout.write(`${JSON.stringify({ runFingerprint: summary.runFingerprint, status: summary.status, claimClass: summary.claimClass })}\n`);
 }
 
-const invokedPath = process.argv[1] ? pathToFileURL(realpathSync(process.argv[1])).href : "";
+export function invokedModuleUrl(path: string | undefined): string {
+  try {
+    return path ? pathToFileURL(realpathSync(path)).href : "";
+  } catch {
+    return "";
+  }
+}
+
+const invokedPath = invokedModuleUrl(process.argv[1]);
 if (import.meta.url === invokedPath) {
   main(process.argv.slice(2)).catch((error: unknown) => {
     const message = error instanceof Error ? error.message : "unknown characterization failure";

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -1017,23 +1017,7 @@ function canonicalProspectivePath(path: string): string {
 }
 
 async function acquireRunLease(path: string): Promise<number> {
-  const coordinator = createServer((socket) => socket.destroy());
-  const coordinationPort = phase1LeaseCoordinationPort(path);
-  await new Promise<void>((resolvePromise, rejectPromise) => {
-    const fail = (error: Error & { code?: string }) => {
-      coordinator.removeListener("listening", ready);
-      rejectPromise(new Error(error.code === "EADDRINUSE"
-        ? "Phase 1 lease acquisition is already coordinated by another writer"
-        : `Phase 1 lease coordination failed: ${errorMessage(error)}`));
-    };
-    const ready = () => {
-      coordinator.removeListener("error", fail);
-      resolvePromise();
-    };
-    coordinator.once("error", fail);
-    coordinator.once("listening", ready);
-    coordinator.listen({ host: "127.0.0.1", port: coordinationPort, exclusive: true });
-  });
+  const coordinator = await startLeaseCoordinator(path);
   try {
     try {
       const fd = openSync(path, "wx", 0o600);
@@ -1062,6 +1046,72 @@ async function acquireRunLease(path: string): Promise<number> {
   } finally {
     await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));
   }
+}
+
+async function startLeaseCoordinator(path: string): Promise<ReturnType<typeof createServer>> {
+  const token = sha256(resolve(path));
+  for (const port of phase1LeaseCoordinationPorts(path)) {
+    const coordinator = createServer((socket) => socket.end(`${token}\n`));
+    try {
+      await new Promise<void>((resolvePromise, rejectPromise) => {
+        const fail = (error: Error & { code?: string }) => {
+          coordinator.removeListener("listening", ready);
+          rejectPromise(error);
+        };
+        const ready = () => {
+          coordinator.removeListener("error", fail);
+          resolvePromise();
+        };
+        coordinator.once("error", fail);
+        coordinator.once("listening", ready);
+        coordinator.listen({ host: "127.0.0.1", port, exclusive: true });
+      });
+      return coordinator;
+    } catch (error) {
+      coordinator.removeAllListeners();
+      if (!(typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "EADDRINUSE")) {
+        throw new Error(`Phase 1 lease coordination failed: ${errorMessage(error)}`);
+      }
+      if (await readLeaseCoordinatorToken(port) === token) {
+        throw new Error("Phase 1 lease acquisition is already coordinated by another writer");
+      }
+    }
+  }
+  throw new Error("Phase 1 lease coordination exhausted collision-safe loopback ports");
+}
+
+function phase1LeaseCoordinationPorts(path: string): number[] {
+  const token = sha256(resolve(path));
+  const ports = [phase1LeaseCoordinationPort(path)];
+  for (let attempt = 1; attempt < 16; attempt += 1) {
+    const port = 20_000 + (Number.parseInt(sha256(`${token}:${attempt}`).slice(0, 8), 16) % 20_000);
+    if (!ports.includes(port)) ports.push(port);
+  }
+  return ports;
+}
+
+async function readLeaseCoordinatorToken(port: number): Promise<string> {
+  return new Promise((resolvePromise) => {
+    let value = "";
+    let settled = false;
+    const socket = connect({ host: "127.0.0.1", port });
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolvePromise(value.trim());
+    };
+    socket.setEncoding("utf8");
+    socket.setTimeout(1000);
+    socket.on("data", (chunk: string) => {
+      value = `${value}${chunk}`.slice(0, 256);
+      if (value.includes("\n")) finish();
+    });
+    socket.once("end", finish);
+    socket.once("close", finish);
+    socket.once("timeout", finish);
+    socket.once("error", finish);
+  });
 }
 
 export function phase1LeaseCoordinationPort(path: string): number {

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -144,9 +144,10 @@ export interface Phase1ResourceSample {
 
 export interface Phase1ResourceMonitor {
   start(context: { target: Phase1Target; cell: Phase1Cell; outputDir: string }): Promise<{ id: string }>;
+  attach?(session: { id: string }, resident: Phase1Resident): Promise<void>;
   sample(session: { id: string }, context: { phase: "before" | "after"; input: Phase1Input }): Promise<Phase1ResourceSample>;
   classify?(samples: Phase1ResourceSample[]): { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined;
-  stop(session: { id: string }): Promise<Phase1ResourceSample>;
+  stop(session: { id: string }): Promise<Phase1ResourceSample | Phase1ResourceSample[]>;
 }
 
 export interface Phase1ResourceMonitorModule {
@@ -550,6 +551,17 @@ async function runPhase1ScreenWithLease(
         writeUnavailableMonitorEvidence(spec.outputDir, manifest, cell, infrastructureFailure ?? "monitor_start_failed");
       }
       continue;
+    }
+    if (resolvedOptions.monitor && monitorSession && resolvedOptions.monitor.attach) {
+      try { await resolvedOptions.monitor.attach(monitorSession, resident); }
+      catch (error) {
+        infrastructureFailure = `monitor attach failed: ${errorMessage(error)}`;
+        for (const input of spec.inputs) writeMissingTerminalResult(spec.outputDir, manifest, cell, input, "monitor_attach_failed");
+        try { await adapter.stop(resident); } catch (stopError) { infrastructureFailure = `resident stop after monitor attach failure failed: ${errorMessage(stopError)}`; }
+        const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
+        if (finalized.infrastructureFailure) infrastructureFailure = finalized.infrastructureFailure;
+        continue;
+      }
     }
     try {
       assertSecretSafe("resident argv", resident.argv.join("\n"));
@@ -1094,7 +1106,14 @@ async function finalizeMonitorEvidence(
 }> {
   let infrastructureFailure: string | undefined;
   let terminalClassification: { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined;
-  try { samples.push(validateResourceSample(await monitor.stop(session), "monitor stop resource sample")); }
+  try {
+    const stopped = await monitor.stop(session);
+    if (Array.isArray(stopped)) {
+      if (stopped.length > 16_384) throw new Error("monitor terminal trace exceeds the evidence sample cap");
+      const validated = stopped.map((sample, index) => validateResourceSample(sample, `monitor stop resource sample ${index}`));
+      samples.splice(0, samples.length, ...validated);
+    } else samples.push(validateResourceSample(stopped, "monitor stop resource sample"));
+  }
   catch (error) { infrastructureFailure = `monitor stop failed: ${errorMessage(error)}`; }
   try {
     terminalClassification = monitorClassify(monitor, samples);
@@ -1481,6 +1500,7 @@ async function loadResourceMonitorModule(identity: Phase1ResourceMonitorModule):
   if (!monitor || typeof monitor !== "object") throw new Error("resource monitor factory did not return an object");
   const candidate = monitor as Partial<Phase1ResourceMonitor>;
   if (typeof candidate.start !== "function" || typeof candidate.sample !== "function" || typeof candidate.stop !== "function"
+    || (candidate.attach !== undefined && typeof candidate.attach !== "function")
     || (candidate.classify !== undefined && typeof candidate.classify !== "function")) {
     throw new Error("resource monitor factory returned an invalid monitor implementation");
   }

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -14,6 +14,7 @@ import {
 } from "node:fs";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import { connect, createServer } from "node:net";
+import { fileURLToPath } from "node:url";
 import { containsSecretLikeText, redactSecrets } from "./secrets.js";
 
 export type Phase1TerminalStatus = "completed" | "failed" | "stopped" | "oom" | "schema_failed";
@@ -54,7 +55,15 @@ export interface Phase1RunSpec {
   inputs: Phase1Input[];
   prompt: { version: string; template: string; templateSha256: string; parameters?: Record<string, unknown> };
   request: { version: string; stream: boolean; outputBudgetTokens: number; requiredMetrics: string[]; responseFormat?: unknown; parameters: Record<string, unknown> };
-  harness: { commit: string; sourcePath: string; sourceSha256: string };
+  harness: {
+    commit: string;
+    sourcePath: string;
+    sourceSha256: string;
+    entrypointPath: string;
+    entrypointSha256: string;
+    runnerPath: string;
+    runnerSha256: string;
+  };
   parser: { version: string; format: "json"; sha256: string };
   gate: { version: string; requiredTopLevelKeys: string[]; sha256: string };
 }
@@ -160,6 +169,10 @@ export interface Phase1ResourceMonitorModule {
 
 export interface Phase1RunnerOptions {
   monitorModule?: Phase1ResourceMonitorModule;
+}
+
+export function phase1ScreeningRunnerModulePath(): string {
+  return fileURLToPath(import.meta.url);
 }
 
 type ResolvedRunnerOptions = { monitor?: Phase1ResourceMonitor; monitorIdentity?: Phase1ResourceMonitorModule };
@@ -933,11 +946,13 @@ function validateSpec(spec: Phase1RunSpec): void {
     ["parser", spec.parser.version],
     ["gate", spec.gate.version]
   ] as const) assertProtocolVersion(label, version);
-  for (const digest of [spec.target.modelSha256, spec.target.executableSha256, ...(spec.target.ownershipVerifierSha256 ? [spec.target.ownershipVerifierSha256] : []), spec.harness.sourceSha256, spec.prompt.templateSha256, spec.parser.sha256, spec.gate.sha256, ...spec.inputs.map((input) => input.sha256)]) {
+  for (const digest of [spec.target.modelSha256, spec.target.executableSha256, ...(spec.target.ownershipVerifierSha256 ? [spec.target.ownershipVerifierSha256] : []), spec.harness.sourceSha256, spec.harness.entrypointSha256, spec.harness.runnerSha256, spec.prompt.templateSha256, spec.parser.sha256, spec.gate.sha256, ...spec.inputs.map((input) => input.sha256)]) {
     if (!/^[a-f0-9]{64}$/.test(digest)) throw new Error("all declared SHA-256 digests must be lowercase 64-character hex");
   }
   if (!/^[a-f0-9]{40}$/.test(spec.harness.commit)) throw new Error("harness commit must be a full 40-character Git SHA");
-  if (resolve(spec.harness.sourcePath) !== spec.harness.sourcePath) throw new Error("harness source path must be absolute");
+  if ([spec.harness.sourcePath, spec.harness.entrypointPath, spec.harness.runnerPath].some((path) => resolve(path) !== path)) {
+    throw new Error("harness source and loaded JavaScript paths must be absolute");
+  }
   const reservedRequestKeys = new Set(["messages", "model", "stream", "response_format", "max_tokens"]);
   for (const key of Object.keys(spec.request.parameters)) if (reservedRequestKeys.has(key)) throw new Error(`reserved request parameter is runner-owned: ${key}`);
   if (!Number.isInteger(spec.request.outputBudgetTokens) || spec.request.outputBudgetTokens <= 0) throw new Error("request output budget must be a positive integer");
@@ -1270,6 +1285,8 @@ function assertManifestPayloadSecretSafe(spec: Phase1RunSpec): void {
   assertJsonValuesSecretSafe("required metric names", spec.request.requiredMetrics);
   assertJsonValuesSecretSafe("gate key names", spec.gate.requiredTopLevelKeys);
   assertSecretSafe("harness source path", spec.harness.sourcePath);
+  assertSecretSafe("harness entrypoint path", spec.harness.entrypointPath);
+  assertSecretSafe("harness runner path", spec.harness.runnerPath);
   for (const cell of spec.cells) {
     assertSecretSafe("cell identifier", cell.id);
     assertJsonValuesSecretSafe(`cell ${cell.id} executable arguments`, cell.executableArgs);

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -165,6 +165,7 @@ export interface Phase1ResourceMonitorModule {
   moduleSha256: string;
   approvedRoot: string;
   exportName: string;
+  factoryParameters?: Readonly<Record<string, string>>;
 }
 
 export interface Phase1RunnerOptions {
@@ -542,6 +543,9 @@ async function runPhase1ScreenWithLease(
   for (const cell of manifest.cells) {
     const cellHasWork = spec.inputs.some((input) => !existsSync(resultFile(spec.outputDir, cell.id, input.id)));
     if (!cellHasWork) continue;
+    const preexistingResultPaths = new Set(spec.inputs
+      .map((input) => resultFile(spec.outputDir, cell.id, input.id))
+      .filter((path) => existsSync(path)));
     let monitorSession: { id: string } | undefined;
     const resourceSamples: Phase1ResourceSample[] = resolvedOptions.monitorIdentity
       ? reconstructResourceSamples(spec.outputDir, manifest, cell)
@@ -555,13 +559,18 @@ async function runPhase1ScreenWithLease(
       return undefined;
     });
     if (!resident) {
-      for (const input of spec.inputs) writeMissingTerminalResult(spec.outputDir, manifest, cell, input, infrastructureFailure ?? "resident_start_failed");
-      if (resolvedOptions.monitor && monitorSession) {
-        const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
-        if (finalized.infrastructureFailure) infrastructureFailure = finalized.infrastructureFailure;
-        if (finalized.terminalClassification) rewriteCellTerminalResults(spec.outputDir, manifest, cell, finalized.terminalClassification);
-      } else if (resolvedOptions.monitorIdentity) {
-        writeUnavailableMonitorEvidence(spec.outputDir, manifest, cell, infrastructureFailure ?? "monitor_start_failed");
+      try {
+        for (const input of spec.inputs) writeMissingTerminalResult(spec.outputDir, manifest, cell, input, infrastructureFailure ?? "resident_start_failed");
+      } catch (writeError) {
+        infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, `terminal result write after resident start failure failed: ${errorMessage(writeError)}`);
+      } finally {
+        if (resolvedOptions.monitor && monitorSession) {
+          const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
+          if (finalized.infrastructureFailure) infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, finalized.infrastructureFailure);
+          if (finalized.terminalClassification) rewriteCellTerminalResults(spec.outputDir, manifest, cell, finalized.terminalClassification, preexistingResultPaths);
+        } else if (resolvedOptions.monitorIdentity) {
+          writeUnavailableMonitorEvidence(spec.outputDir, manifest, cell, infrastructureFailure ?? "monitor_start_failed");
+        }
       }
       continue;
     }
@@ -569,23 +578,35 @@ async function runPhase1ScreenWithLease(
       assertSecretSafe("resident argv", resident.argv.join("\n"));
       assertSecretSafe("resident logs", resident.logs ?? "");
     } catch (error) {
-      infrastructureFailure = errorMessage(error);
-      for (const input of spec.inputs) writeMissingTerminalResult(spec.outputDir, manifest, cell, input, "resident_evidence_rejected");
-      try { await adapter.stop(resident); } catch (stopError) { infrastructureFailure = `resident stop after evidence rejection failed: ${errorMessage(stopError)}`; }
-      if (resolvedOptions.monitor && monitorSession) {
-        const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
-        if (finalized.infrastructureFailure) infrastructureFailure = finalized.infrastructureFailure;
+      infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, errorMessage(error));
+      try {
+        for (const input of spec.inputs) writeMissingTerminalResult(spec.outputDir, manifest, cell, input, "resident_evidence_rejected");
+      } catch (writeError) {
+        infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, `terminal result write after resident evidence rejection failed: ${errorMessage(writeError)}`);
+      } finally {
+        try { await adapter.stop(resident); }
+        catch (stopError) { infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, `resident stop after evidence rejection failed: ${errorMessage(stopError)}`); }
+        if (resolvedOptions.monitor && monitorSession) {
+          const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
+          if (finalized.infrastructureFailure) infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, finalized.infrastructureFailure);
+        }
       }
       continue;
     }
     if (resolvedOptions.monitor && monitorSession && resolvedOptions.monitor.attach) {
       try { await resolvedOptions.monitor.attach(monitorSession, resident); }
       catch (error) {
-        infrastructureFailure = `monitor attach failed: ${errorMessage(error)}`;
-        for (const input of spec.inputs) writeMissingTerminalResult(spec.outputDir, manifest, cell, input, "monitor_attach_failed");
-        try { await adapter.stop(resident); } catch (stopError) { infrastructureFailure = `resident stop after monitor attach failure failed: ${errorMessage(stopError)}`; }
-        const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
-        if (finalized.infrastructureFailure) infrastructureFailure = finalized.infrastructureFailure;
+        infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, `monitor attach failed: ${errorMessage(error)}`);
+        try {
+          for (const input of spec.inputs) writeMissingTerminalResult(spec.outputDir, manifest, cell, input, "monitor_attach_failed");
+        } catch (writeError) {
+          infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, `terminal result write after monitor attach failure failed: ${errorMessage(writeError)}`);
+        } finally {
+          try { await adapter.stop(resident); }
+          catch (stopError) { infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, `resident stop after monitor attach failure failed: ${errorMessage(stopError)}`); }
+          const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
+          if (finalized.infrastructureFailure) infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, finalized.infrastructureFailure);
+        }
         continue;
       }
     }
@@ -662,18 +683,18 @@ async function runPhase1ScreenWithLease(
         atomicWriteJson(resultPath, record);
       }
     } catch (error) {
-      infrastructureFailure = errorMessage(error);
+      infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, errorMessage(error));
       for (const input of spec.inputs) writeMissingTerminalResult(spec.outputDir, manifest, cell, input, "resident_evidence_rejected");
     } finally {
       try {
         await adapter.stop(resident);
       } catch (error) {
-        infrastructureFailure = errorMessage(error);
+        infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, errorMessage(error));
       }
       if (resolvedOptions.monitor && monitorSession) {
         const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
-        if (finalized.infrastructureFailure) infrastructureFailure = finalized.infrastructureFailure;
-        if (finalized.terminalClassification) rewriteCellTerminalResults(spec.outputDir, manifest, cell, finalized.terminalClassification);
+        if (finalized.infrastructureFailure) infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, finalized.infrastructureFailure);
+        if (finalized.terminalClassification) rewriteCellTerminalResults(spec.outputDir, manifest, cell, finalized.terminalClassification, preexistingResultPaths);
       }
     }
   }
@@ -1135,6 +1156,7 @@ async function finalizeMonitorEvidence(
   try {
     const stopped = await monitor.stop(session);
     if (Array.isArray(stopped)) {
+      if (stopped.length === 0) throw new Error("monitor terminal trace is empty");
       if (stopped.length > 16_384) throw new Error("monitor terminal trace exceeds the evidence sample cap");
       const validated = stopped.map((sample, index) => validateResourceSample(sample, `monitor stop resource sample ${index}`));
       const merged = mergeResourceSamples(samples, validated);
@@ -1142,11 +1164,11 @@ async function finalizeMonitorEvidence(
       samples.splice(0, samples.length, ...merged);
     } else samples.push(validateResourceSample(stopped, "monitor stop resource sample"));
   }
-  catch (error) { infrastructureFailure = `monitor stop failed: ${errorMessage(error)}`; }
+  catch (error) { infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, `monitor stop failed: ${errorMessage(error)}`); }
   try {
     terminalClassification = monitorClassify(monitor, samples);
   } catch (error) {
-    infrastructureFailure = errorMessage(error);
+    infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, errorMessage(error));
   }
   const resourceRecord = {
     schemaVersion: "neondiff-phase1-resources/v1",
@@ -1168,10 +1190,10 @@ async function finalizeMonitorEvidence(
       evidenceSha256: fingerprint(resourceRecord)
     });
   } catch (error) {
-    infrastructureFailure = `monitor evidence finalization failed: ${errorMessage(error)}`;
+    infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, `monitor evidence finalization failed: ${errorMessage(error)}`);
     try { writeResourceUnavailableFallback(outputDir, manifest, cell, infrastructureFailure); }
     catch (fallbackError) {
-      infrastructureFailure = `monitor evidence finalization and fallback write failed: ${errorMessage(fallbackError)}`;
+      infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, `monitor evidence finalization and fallback write failed: ${errorMessage(fallbackError)}`);
     }
   }
   return { infrastructureFailure, terminalClassification };
@@ -1187,6 +1209,14 @@ function mergeResourceSamples(existing: Phase1ResourceSample[], terminal: Phase1
     merged.push(sample);
   }
   return merged;
+}
+
+function appendInfrastructureFailure(existing: string | undefined, next: string): string {
+  const redacted = errorMessage(next).replace(/[\r\n]+/g, " ").trim().slice(0, 512) || "infrastructure_failure";
+  if (!existing) return redacted;
+  const separator = "; ";
+  const prefixLength = Math.max(0, 2048 - separator.length - redacted.length);
+  return `${existing.slice(0, prefixLength)}${separator}${redacted}`;
 }
 
 function writeResourceUnavailableFallback(
@@ -1214,11 +1244,12 @@ function rewriteCellTerminalResults(
   outputDir: string,
   manifest: Manifest,
   cell: Manifest["cells"][number],
-  terminal: { status: "failed" | "stopped" | "oom"; errorCode: string }
+  terminal: { status: "failed" | "stopped" | "oom"; errorCode: string },
+  preexistingResultPaths: ReadonlySet<string>
 ): void {
   for (const input of manifest.inputs) {
     const path = resultFile(outputDir, cell.id, input.id);
-    if (!existsSync(path)) continue;
+    if (!existsSync(path) || preexistingResultPaths.has(path)) continue;
     const record = parseJson<Record<string, unknown>>(path);
     if (record.status !== "completed") continue;
     const { evidenceSha256: _discarded, ...body } = record;
@@ -1510,13 +1541,24 @@ function gitCommitContainsBytes(checkoutRoot: string, commit: string, relativePa
 }
 
 async function verifyResourceMonitorModuleIdentity(identity: Phase1ResourceMonitorModule): Promise<void> {
-  const { modulePath, approvedRoot, moduleSha256, exportName } = identity;
+  const { modulePath, approvedRoot, moduleSha256, exportName, factoryParameters } = identity;
   assertProtocolVersion("resource monitor", identity.version);
   assertJsonValuesSecretSafe("resource monitor paths", [modulePath, approvedRoot, exportName]);
   if (resolve(modulePath) !== modulePath || resolve(approvedRoot) !== approvedRoot) {
     throw new Error("resource monitor source and approved root paths must be absolute");
   }
   if (!/^[a-zA-Z_$][a-zA-Z0-9_$]{0,127}$/.test(exportName)) throw new Error("resource monitor export name is invalid");
+  if (factoryParameters !== undefined) {
+    if (!factoryParameters || typeof factoryParameters !== "object" || Array.isArray(factoryParameters) || Object.keys(factoryParameters).length > 32) {
+      throw new Error("resource monitor factory parameters are invalid");
+    }
+    for (const [key, value] of Object.entries(factoryParameters)) {
+      if (!/^[a-zA-Z][a-zA-Z0-9_.-]{0,63}$/.test(key) || typeof value !== "string" || value.length > 512) {
+        throw new Error("resource monitor factory parameters are invalid");
+      }
+    }
+    assertJsonValuesSecretSafe("resource monitor factory parameters", factoryParameters);
+  }
   const source = realpathSync(modulePath);
   const root = realpathSync(approvedRoot);
   if (source !== root && !source.startsWith(`${root}${sep}`)) throw new Error("resource monitor source must be inside its approved boundary");
@@ -1538,7 +1580,8 @@ async function loadResourceMonitorModule(identity: Phase1ResourceMonitorModule):
   const loaded = await import(moduleUrl) as Record<string, unknown>;
   const factory = loaded[identity.exportName];
   if (typeof factory !== "function") throw new Error("resource monitor module does not export the pinned factory");
-  const monitor = await (factory as () => unknown)();
+  const factoryParameters = Object.freeze({ ...(identity.factoryParameters ?? {}) });
+  const monitor = await (factory as (parameters: Readonly<Record<string, string>>) => unknown)(factoryParameters);
   if (!monitor || typeof monitor !== "object") throw new Error("resource monitor factory did not return an object");
   const candidate = monitor as Partial<Phase1ResourceMonitor>;
   if (typeof candidate.start !== "function" || typeof candidate.sample !== "function" || typeof candidate.stop !== "function"

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -565,6 +565,19 @@ async function runPhase1ScreenWithLease(
       }
       continue;
     }
+    try {
+      assertSecretSafe("resident argv", resident.argv.join("\n"));
+      assertSecretSafe("resident logs", resident.logs ?? "");
+    } catch (error) {
+      infrastructureFailure = errorMessage(error);
+      for (const input of spec.inputs) writeMissingTerminalResult(spec.outputDir, manifest, cell, input, "resident_evidence_rejected");
+      try { await adapter.stop(resident); } catch (stopError) { infrastructureFailure = `resident stop after evidence rejection failed: ${errorMessage(stopError)}`; }
+      if (resolvedOptions.monitor && monitorSession) {
+        const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
+        if (finalized.infrastructureFailure) infrastructureFailure = finalized.infrastructureFailure;
+      }
+      continue;
+    }
     if (resolvedOptions.monitor && monitorSession && resolvedOptions.monitor.attach) {
       try { await resolvedOptions.monitor.attach(monitorSession, resident); }
       catch (error) {
@@ -577,8 +590,6 @@ async function runPhase1ScreenWithLease(
       }
     }
     try {
-      assertSecretSafe("resident argv", resident.argv.join("\n"));
-      assertSecretSafe("resident logs", resident.logs ?? "");
       let cellTerminal: { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined;
       for (const input of spec.inputs) {
         const resultPath = resultFile(spec.outputDir, cell.id, input.id);
@@ -1126,7 +1137,9 @@ async function finalizeMonitorEvidence(
     if (Array.isArray(stopped)) {
       if (stopped.length > 16_384) throw new Error("monitor terminal trace exceeds the evidence sample cap");
       const validated = stopped.map((sample, index) => validateResourceSample(sample, `monitor stop resource sample ${index}`));
-      samples.splice(0, samples.length, ...validated);
+      const merged = mergeResourceSamples(samples, validated);
+      if (merged.length > 16_384) throw new Error("combined reconstructed and terminal resource trace exceeds the evidence sample cap");
+      samples.splice(0, samples.length, ...merged);
     } else samples.push(validateResourceSample(stopped, "monitor stop resource sample"));
   }
   catch (error) { infrastructureFailure = `monitor stop failed: ${errorMessage(error)}`; }
@@ -1162,6 +1175,18 @@ async function finalizeMonitorEvidence(
     }
   }
   return { infrastructureFailure, terminalClassification };
+}
+
+function mergeResourceSamples(existing: Phase1ResourceSample[], terminal: Phase1ResourceSample[]): Phase1ResourceSample[] {
+  const merged: Phase1ResourceSample[] = [];
+  const seen = new Set<string>();
+  for (const sample of [...existing, ...terminal]) {
+    const identity = canonicalJson(sample);
+    if (seen.has(identity)) continue;
+    seen.add(identity);
+    merged.push(sample);
+  }
+  return merged;
 }
 
 function writeResourceUnavailableFallback(

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -156,6 +156,7 @@ export interface Phase1ResourceMonitor {
   attach?(session: { id: string }, resident: Phase1Resident): Promise<void>;
   sample(session: { id: string }, context: { phase: "before" | "after"; input: Phase1Input }): Promise<Phase1ResourceSample>;
   classify?(samples: Phase1ResourceSample[]): { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined;
+  /** An array is the complete ordered current-attempt trace; a scalar is one terminal delta. */
   stop(session: { id: string }): Promise<Phase1ResourceSample | Phase1ResourceSample[]>;
 }
 
@@ -474,6 +475,16 @@ async function runPhase1ScreenWithLease(
   adapter: Phase1ResidentAdapter,
   options: Phase1RunnerOptions
 ): Promise<Phase1RunSummary> {
+  for (const [label, path, expectedSha256] of [
+    ["harness entrypoint", spec.harness.entrypointPath, spec.harness.entrypointSha256],
+    ["screening runner", spec.harness.runnerPath, spec.harness.runnerSha256]
+  ] as const) {
+    if (realpathSync(path) !== path) throw new Error(`${label} must be an absolute canonical file`);
+    if (await sha256File(path) !== expectedSha256) throw new Error(`${label} SHA-256 does not match the implementation artifact`);
+  }
+  if (realpathSync(spec.harness.runnerPath) !== realpathSync(phase1ScreeningRunnerModulePath())) {
+    throw new Error("screening runner path does not identify the executing implementation artifact");
+  }
   const actualHarnessSha256 = await sha256File(spec.harness.sourcePath);
   if (actualHarnessSha256 !== spec.harness.sourceSha256) throw new Error("harness source SHA-256 does not match the implementation artifact");
   const harnessRelativePath = relative(spec.checkoutRoot, spec.harness.sourcePath);
@@ -550,6 +561,7 @@ async function runPhase1ScreenWithLease(
     const resourceSamples: Phase1ResourceSample[] = resolvedOptions.monitorIdentity
       ? reconstructResourceSamples(spec.outputDir, manifest, cell)
       : [];
+    const attemptSamples: Phase1ResourceSample[] = [];
     if (resolvedOptions.monitor) {
       try { monitorSession = validateMonitorSession(await resolvedOptions.monitor.start({ target: spec.target, cell, outputDir: spec.outputDir })); }
       catch (error) { infrastructureFailure = errorMessage(error); }
@@ -565,7 +577,7 @@ async function runPhase1ScreenWithLease(
         infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, `terminal result write after resident start failure failed: ${errorMessage(writeError)}`);
       } finally {
         if (resolvedOptions.monitor && monitorSession) {
-          const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
+          const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, attemptSamples, spec.outputDir, manifest, cell);
           if (finalized.infrastructureFailure) infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, finalized.infrastructureFailure);
           if (finalized.terminalClassification) rewriteCellTerminalResults(spec.outputDir, manifest, cell, finalized.terminalClassification, preexistingResultPaths);
         } else if (resolvedOptions.monitorIdentity) {
@@ -587,7 +599,7 @@ async function runPhase1ScreenWithLease(
         try { await adapter.stop(resident); }
         catch (stopError) { infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, `resident stop after evidence rejection failed: ${errorMessage(stopError)}`); }
         if (resolvedOptions.monitor && monitorSession) {
-          const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
+          const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, attemptSamples, spec.outputDir, manifest, cell);
           if (finalized.infrastructureFailure) infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, finalized.infrastructureFailure);
         }
       }
@@ -604,7 +616,7 @@ async function runPhase1ScreenWithLease(
         } finally {
           try { await adapter.stop(resident); }
           catch (stopError) { infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, `resident stop after monitor attach failure failed: ${errorMessage(stopError)}`); }
-          const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
+          const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, attemptSamples, spec.outputDir, manifest, cell);
           if (finalized.infrastructureFailure) infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, finalized.infrastructureFailure);
         }
         continue;
@@ -623,7 +635,11 @@ async function runPhase1ScreenWithLease(
         try {
           if (cellTerminal) result = { ...cellTerminal, residentTerminal: true, invocationDisposition: "not_invoked_resident_terminal" };
           else {
-            if (resolvedOptions.monitor && monitorSession) resourceSamples.push(await monitorSample(resolvedOptions.monitor, monitorSession, { phase: "before", input }));
+            if (resolvedOptions.monitor && monitorSession) {
+              const sample = await monitorSample(resolvedOptions.monitor, monitorSession, { phase: "before", input });
+              resourceSamples.push(sample);
+              attemptSamples.push(sample);
+            }
             const renderedPrompt = renderPrompt(spec.prompt.template, input.prompt);
             result = await adapter.invoke(resident, {
               input,
@@ -636,8 +652,10 @@ async function runPhase1ScreenWithLease(
             });
             result.invocationDisposition = "invoked";
             if (resolvedOptions.monitor && monitorSession) {
-              resourceSamples.push(await monitorSample(resolvedOptions.monitor, monitorSession, { phase: "after", input }));
-              const classification = monitorClassify(resolvedOptions.monitor, resourceSamples);
+              const sample = await monitorSample(resolvedOptions.monitor, monitorSession, { phase: "after", input });
+              resourceSamples.push(sample);
+              attemptSamples.push(sample);
+              const classification = monitorClassify(resolvedOptions.monitor, attemptSamples);
               if (classification) result = { ...result, ...classification, residentTerminal: true };
             }
           }
@@ -692,7 +710,7 @@ async function runPhase1ScreenWithLease(
         infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, errorMessage(error));
       }
       if (resolvedOptions.monitor && monitorSession) {
-        const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, spec.outputDir, manifest, cell);
+        const finalized = await finalizeMonitorEvidence(resolvedOptions.monitor, monitorSession, resourceSamples, attemptSamples, spec.outputDir, manifest, cell);
         if (finalized.infrastructureFailure) infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, finalized.infrastructureFailure);
         if (finalized.terminalClassification) rewriteCellTerminalResults(spec.outputDir, manifest, cell, finalized.terminalClassification, preexistingResultPaths);
       }
@@ -1194,6 +1212,7 @@ async function finalizeMonitorEvidence(
   monitor: Phase1ResourceMonitor,
   session: { id: string },
   samples: Phase1ResourceSample[],
+  attemptSamples: Phase1ResourceSample[],
   outputDir: string,
   manifest: Manifest,
   cell: Manifest["cells"][number]
@@ -1203,20 +1222,26 @@ async function finalizeMonitorEvidence(
 }> {
   let infrastructureFailure: string | undefined;
   let terminalClassification: { status: "failed" | "stopped" | "oom"; errorCode: string } | undefined;
+  let classificationSamples = attemptSamples;
   try {
     const stopped = await monitor.stop(session);
     if (Array.isArray(stopped)) {
       if (stopped.length === 0) throw new Error("monitor terminal trace is empty");
       if (stopped.length > 16_384) throw new Error("monitor terminal trace exceeds the evidence sample cap");
       const validated = stopped.map((sample, index) => validateResourceSample(sample, `monitor stop resource sample ${index}`));
+      classificationSamples = validated;
       const merged = mergeResourceSamples(samples, validated);
       if (merged.length > 16_384) throw new Error("combined reconstructed and terminal resource trace exceeds the evidence sample cap");
       samples.splice(0, samples.length, ...merged);
-    } else samples.push(validateResourceSample(stopped, "monitor stop resource sample"));
+    } else {
+      const terminal = validateResourceSample(stopped, "monitor stop resource sample");
+      samples.push(terminal);
+      classificationSamples = [...attemptSamples, terminal];
+    }
   }
   catch (error) { infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, `monitor stop failed: ${errorMessage(error)}`); }
   try {
-    terminalClassification = monitorClassify(monitor, samples);
+    terminalClassification = monitorClassify(monitor, classificationSamples);
   } catch (error) {
     infrastructureFailure = appendInfrastructureFailure(infrastructureFailure, errorMessage(error));
   }

--- a/src/phase1-screening-runner.ts
+++ b/src/phase1-screening-runner.ts
@@ -1068,32 +1068,41 @@ async function acquireRunLease(path: string): Promise<number> {
 
 async function startLeaseCoordinator(path: string): Promise<ReturnType<typeof createServer>> {
   const token = sha256(resolve(path));
+  portLoop:
   for (const port of phase1LeaseCoordinationPorts(path)) {
-    const coordinator = createServer((socket) => socket.end(`${token}\n`));
-    try {
-      await new Promise<void>((resolvePromise, rejectPromise) => {
-        const fail = (error: Error & { code?: string }) => {
-          coordinator.removeListener("listening", ready);
-          rejectPromise(error);
-        };
-        const ready = () => {
-          coordinator.removeListener("error", fail);
-          resolvePromise();
-        };
-        coordinator.once("error", fail);
-        coordinator.once("listening", ready);
-        coordinator.listen({ host: "127.0.0.1", port, exclusive: true });
+    for (let bindAttempt = 0; bindAttempt < 3; bindAttempt += 1) {
+      const coordinator = createServer((socket) => {
+        socket.once("error", () => {});
+        socket.end(leaseCoordinatorFrame(token));
       });
-      return coordinator;
-    } catch (error) {
-      coordinator.removeAllListeners();
-      if (!(typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "EADDRINUSE")) {
-        throw new Error(`Phase 1 lease coordination failed: ${errorMessage(error)}`);
-      }
-      if (await readLeaseCoordinatorToken(port) === token) {
+      try {
+        await new Promise<void>((resolvePromise, rejectPromise) => {
+          const fail = (error: Error & { code?: string }) => {
+            coordinator.removeListener("listening", ready);
+            rejectPromise(error);
+          };
+          const ready = () => {
+            coordinator.removeListener("error", fail);
+            resolvePromise();
+          };
+          coordinator.once("error", fail);
+          coordinator.once("listening", ready);
+          coordinator.listen({ host: "127.0.0.1", port, exclusive: true });
+        });
+        return coordinator;
+      } catch (error) {
+        coordinator.removeAllListeners();
+        if (!(typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "EADDRINUSE")) {
+          throw new Error(`Phase 1 lease coordination failed: ${errorMessage(error)}`);
+        }
+        const probe = await probeLeaseCoordinatorToken(port);
+        if (probe.status === "vacant") continue;
+        if (probe.status === "foreign" || (probe.status === "complete" && probe.token !== token)) continue portLoop;
+        if (probe.status === "inconclusive") throw new Error("Phase 1 lease coordination probe was inconclusive");
         throw new Error("Phase 1 lease acquisition is already coordinated by another writer");
       }
     }
+    throw new Error("Phase 1 lease coordination probe remained vacant after bounded rebind attempts");
   }
   throw new Error("Phase 1 lease coordination exhausted collision-safe loopback ports");
 }
@@ -1108,27 +1117,57 @@ function phase1LeaseCoordinationPorts(path: string): number[] {
   return ports;
 }
 
-async function readLeaseCoordinatorToken(port: number): Promise<string> {
+const LEASE_COORDINATOR_FRAME_PREFIX = "neondiff-phase1-lease-v1:";
+
+function leaseCoordinatorFrame(token: string): string {
+  return `${LEASE_COORDINATOR_FRAME_PREFIX}${token}\n`;
+}
+
+type LeaseCoordinatorProbe =
+  | { status: "complete"; token: string }
+  | { status: "foreign" | "inconclusive" | "vacant" };
+
+async function probeLeaseCoordinatorToken(port: number): Promise<LeaseCoordinatorProbe> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const probe = await readLeaseCoordinatorToken(port);
+    if (probe.status !== "inconclusive") return probe;
+  }
+  return { status: "inconclusive" };
+}
+
+async function readLeaseCoordinatorToken(port: number): Promise<LeaseCoordinatorProbe> {
   return new Promise((resolvePromise) => {
     let value = "";
     let settled = false;
+    let deadline: ReturnType<typeof setTimeout> | undefined;
     const socket = connect({ host: "127.0.0.1", port });
-    const finish = () => {
+    const finish = (result: LeaseCoordinatorProbe) => {
       if (settled) return;
       settled = true;
+      if (deadline) clearTimeout(deadline);
       socket.destroy();
-      resolvePromise(value.trim());
+      resolvePromise(result);
     };
+    deadline = setTimeout(() => finish({ status: "inconclusive" }), 1000);
+    deadline.unref();
     socket.setEncoding("utf8");
     socket.setTimeout(1000);
     socket.on("data", (chunk: string) => {
       value = `${value}${chunk}`.slice(0, 256);
-      if (value.includes("\n")) finish();
+      const match = value.match(new RegExp(`^${LEASE_COORDINATOR_FRAME_PREFIX}([a-f0-9]{64})\\n`));
+      const legacyMatch = value.match(/^([a-f0-9]{64})\n/);
+      if (match || legacyMatch) finish({ status: "complete", token: (match ?? legacyMatch)![1] });
+      else if (
+        !LEASE_COORDINATOR_FRAME_PREFIX.startsWith(value)
+        && !value.startsWith(LEASE_COORDINATOR_FRAME_PREFIX)
+        && !/^[a-f0-9]{0,64}$/.test(value)
+      ) finish({ status: "foreign" });
+      else if (value.includes("\n")) finish({ status: "inconclusive" });
     });
-    socket.once("end", finish);
-    socket.once("close", finish);
-    socket.once("timeout", finish);
-    socket.once("error", finish);
+    socket.once("end", () => finish({ status: "inconclusive" }));
+    socket.once("close", () => finish({ status: "inconclusive" }));
+    socket.once("timeout", () => finish({ status: "inconclusive" }));
+    socket.once("error", (error: NodeJS.ErrnoException) => finish({ status: error.code === "ECONNREFUSED" ? "vacant" : "inconclusive" }));
   });
 }
 

--- a/tests/linux-phase1-runtime.test.ts
+++ b/tests/linux-phase1-runtime.test.ts
@@ -111,11 +111,22 @@ describe("GEX44 Linux Phase 1 runtime", () => {
     expect(() => createGex44ResourceMonitor({ nvidiaSmiSha256: "not-a-digest" })).toThrow(/nvidia-smi SHA-256/i);
   });
 
+  it("does not commit a PID when its process start identity is unavailable", async () => {
+    const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: "0".repeat(64) });
+    const session = await monitor.start();
+    await expect(monitor.attach(session, { metadata: { pid: Number.MAX_SAFE_INTEGER } })).rejects.toThrow(/start identity/i);
+    await expect(monitor.stop(session)).rejects.toThrow(/not attached/i);
+  });
+
   it("classifies periodic sampling and terminal descriptor drift without masking either signal", () => {
     const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: "0".repeat(64) });
     const base = { capturedAt: "terminal", sequence: 1, phase: "cleanup", rssBytes: 0, vramBytes: 0, vramObserved: 0, swapBytes: 0, processSwapBytes: 0, processAlive: 0, pid: 42 };
     expect(monitor.classify([{ ...base, periodicFailure: 1 }])).toEqual({ status: "stopped", errorCode: "periodic_resource_sampling_failed" });
     expect(monitor.classify([{ ...base, nvidiaSmiDrift: 1 }])).toEqual({ status: "stopped", errorCode: "nvidia_smi_descriptor_drift" });
+    expect(monitor.classify([{ ...base, periodicFailure: 1, cleanupFailure: 1, nvidiaSmiDrift: 1 }])).toEqual({
+      status: "stopped",
+      errorCode: "periodic_resource_sampling_failed+resource_cleanup_sampling_failed+nvidia_smi_descriptor_drift"
+    });
   });
 
   it.skipIf(!functionalNvidiaSmi)("rejects a well-formed but incorrect pinned nvidia-smi digest", async () => {

--- a/tests/linux-phase1-runtime.test.ts
+++ b/tests/linux-phase1-runtime.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { spawn } from "node:child_process";
 import { createServer } from "node:net";
-import { chmodSync, copyFileSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -75,9 +75,37 @@ describe("GEX44 Linux Phase 1 runtime", () => {
   });
 
   it("fails closed until a monitor session is attached to a resident PID", async () => {
-    const monitor = createGex44ResourceMonitor();
+    const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: "0".repeat(64) });
     const session = await monitor.start();
     await expect(monitor.sample(session, { phase: "before" })).rejects.toThrow(/not attached/i);
+  });
+
+  it("isolates sessions between independently created monitor instances", async () => {
+    const first = createGex44ResourceMonitor({ nvidiaSmiSha256: "0".repeat(64) });
+    const second = createGex44ResourceMonitor({ nvidiaSmiSha256: "0".repeat(64) });
+    const session = await first.start();
+    await expect(second.sample(session, { phase: "before" })).rejects.toThrow(/session is unknown/i);
+  });
+
+  it("deletes a monitor session even when terminal capture fails", async () => {
+    const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: "0".repeat(64) });
+    const session = await monitor.start();
+    await expect(monitor.stop(session)).rejects.toThrow(/not attached/i);
+    await expect(monitor.stop(session)).rejects.toThrow(/session is unknown/i);
+  });
+
+  it("rejects missing or malformed immutable nvidia-smi factory parameters", () => {
+    expect(() => createGex44ResourceMonitor({} as { nvidiaSmiSha256: string })).toThrow(/nvidia-smi SHA-256/i);
+    expect(() => createGex44ResourceMonitor({ nvidiaSmiSha256: "not-a-digest" })).toThrow(/nvidia-smi SHA-256/i);
+  });
+
+  it.skipIf(process.platform !== "linux" || !existsSync("/usr/bin/nvidia-smi"))("executes the opened pinned nvidia-smi image through procfs", async () => {
+    const expectedSha256 = createHash("sha256").update(readFileSync("/usr/bin/nvidia-smi")).digest("hex");
+    const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: expectedSha256 });
+    const session = await monitor.start();
+    await monitor.attach(session, { metadata: { pid: process.pid } });
+    await expect(monitor.sample(session, { phase: "before" })).resolves.toMatchObject({ pid: process.pid, processAlive: 1 });
+    await expect(monitor.stop(session)).resolves.toEqual(expect.any(Array));
   });
 
   it("exposes the exact module path used for immutable runtime binding", () => {

--- a/tests/linux-phase1-runtime.test.ts
+++ b/tests/linux-phase1-runtime.test.ts
@@ -1,0 +1,86 @@
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { chmodSync, copyFileSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  canonicalArgvFingerprint,
+  appendBoundedLinuxTrace,
+  createGex44ResourceMonitor,
+  linuxRuntimeModulePath,
+  verifyLinuxListenerOwnership,
+  verifyLinuxProcessIdentity
+} from "../src/linux-phase1-runtime.js";
+
+describe("GEX44 Linux Phase 1 runtime", () => {
+  it("uses the runner's canonical sorted-object argv identity", () => {
+    const argv = ["/bin/tool", "--port", "8080"];
+    expect(canonicalArgvFingerprint(argv)).toBe(createHash("sha256").update(JSON.stringify(argv)).digest("hex"));
+    expect(canonicalArgvFingerprint(["/bin/tool", "--port", "8080"])).not.toBe(canonicalArgvFingerprint(["/bin/tool", "8080", "--port"]));
+  });
+
+  it("preserves the run-start swap baseline while bounding a long trace", () => {
+    const sample = (index: number) => ({ capturedAt: String(index), phase: index === 0 ? "attached" : "periodic", rssBytes: 0, vramBytes: 0, swapBytes: index * 1024, processSwapBytes: 0, processAlive: 1, pid: 42 });
+    const trace: ReturnType<typeof sample>[] = [];
+    for (let index = 0; index < 10; index += 1) appendBoundedLinuxTrace(trace, sample(index), 4);
+    expect(trace.map((entry) => entry.capturedAt)).toEqual(["0", "7", "8", "9"]);
+    expect(trace[0].swapBytes).toBe(0);
+  });
+
+  it.skipIf(process.platform !== "linux")("proves the current process executable and argv from procfs", async () => {
+    const realExecutable = (await import("node:fs")).readlinkSync(`/proc/${process.pid}/exe`);
+    const executableSha = createHash("sha256").update(readFileSync(realExecutable)).digest("hex");
+    const argv = readFileSync(`/proc/${process.pid}/cmdline`).toString("utf8").split("\0").filter(Boolean);
+    expect(await verifyLinuxProcessIdentity(process.pid, executableSha, canonicalArgvFingerprint(argv))).toBe(true);
+    expect(await verifyLinuxProcessIdentity(process.pid, "0".repeat(64), canonicalArgvFingerprint(argv))).toBe(false);
+  });
+
+  it.skipIf(process.platform !== "linux")("hashes the running procfs image rather than a replaced executable pathname", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "phase1-proc-image-"));
+    const executable = join(directory, "node-copy");
+    copyFileSync(process.execPath, executable);
+    chmodSync(executable, 0o700);
+    const expectedSha = createHash("sha256").update(readFileSync(executable)).digest("hex");
+    const child = spawn(executable, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        child.once("spawn", resolve);
+        child.once("error", reject);
+      });
+      if (!child.pid) throw new Error("test process has no PID");
+      const argv = readFileSync(`/proc/${child.pid}/cmdline`).toString("utf8").split("\0").filter(Boolean);
+      unlinkSync(executable);
+      writeFileSync(executable, "replacement bytes", { mode: 0o700 });
+      expect(await verifyLinuxProcessIdentity(child.pid, expectedSha, canonicalArgvFingerprint(argv))).toBe(true);
+    } finally {
+      child.kill("SIGKILL");
+      if (child.exitCode === null && child.signalCode === null) await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform !== "linux")("proves exact PID ownership of a loopback listener", async () => {
+    const server = createServer();
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") throw new Error("test listener has no TCP address");
+      expect(await verifyLinuxListenerOwnership(process.pid, "127.0.0.1", address.port)).toBe(true);
+      expect(await verifyLinuxListenerOwnership(process.pid, "127.0.0.1", address.port + 1)).toBe(false);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  it("fails closed until a monitor session is attached to a resident PID", async () => {
+    const monitor = createGex44ResourceMonitor();
+    const session = await monitor.start();
+    await expect(monitor.sample(session, { phase: "before" })).rejects.toThrow(/not attached/i);
+  });
+
+  it("exposes the exact module path used for immutable runtime binding", () => {
+    expect(linuxRuntimeModulePath()).toMatch(/linux-phase1-runtime\.(?:ts|js)$/);
+  });
+});

--- a/tests/linux-phase1-runtime.test.ts
+++ b/tests/linux-phase1-runtime.test.ts
@@ -129,6 +129,15 @@ describe("GEX44 Linux Phase 1 runtime", () => {
     });
   });
 
+  it("uses resident swap growth rather than noisy host-wide swap for stop decisions", () => {
+    const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: "0".repeat(64) });
+    const base = { capturedAt: "sample", sequence: 1, phase: "periodic", rssBytes: 0, vramBytes: 0, vramObserved: 0, swapBytes: 0, processSwapBytes: 0, processAlive: 1, pid: 42 };
+    const hostNoise = [base, 1, 2, 3].map((entry, index) => typeof entry === "number" ? { ...base, sequence: index + 1, swapBytes: 128 * 1024 * 1024 } : entry);
+    expect(monitor.classify(hostNoise)).toBeUndefined();
+    const residentGrowth = [base, 1, 2, 3].map((entry, index) => typeof entry === "number" ? { ...base, sequence: index + 1, processSwapBytes: 65 * 1024 * 1024 } : entry);
+    expect(monitor.classify(residentGrowth)).toEqual({ status: "stopped", errorCode: "sustained_swap_growth" });
+  });
+
   it.skipIf(!functionalNvidiaSmi)("rejects a well-formed but incorrect pinned nvidia-smi digest", async () => {
     const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: "f".repeat(64) });
     const session = await monitor.start();

--- a/tests/linux-phase1-runtime.test.ts
+++ b/tests/linux-phase1-runtime.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { createServer } from "node:net";
 import { chmodSync, copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -13,6 +13,18 @@ import {
   verifyLinuxListenerOwnership,
   verifyLinuxProcessIdentity
 } from "../src/linux-phase1-runtime.js";
+
+function nvidiaSmiIsFunctional(): boolean {
+  if (process.platform !== "linux" || !existsSync("/usr/bin/nvidia-smi")) return false;
+  try {
+    execFileSync("/usr/bin/nvidia-smi", ["-L"], { stdio: "ignore", timeout: 2000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const functionalNvidiaSmi = nvidiaSmiIsFunctional();
 
 describe("GEX44 Linux Phase 1 runtime", () => {
   it("uses the runner's canonical sorted-object argv identity", () => {
@@ -99,7 +111,14 @@ describe("GEX44 Linux Phase 1 runtime", () => {
     expect(() => createGex44ResourceMonitor({ nvidiaSmiSha256: "not-a-digest" })).toThrow(/nvidia-smi SHA-256/i);
   });
 
-  it.skipIf(process.platform !== "linux" || !existsSync("/usr/bin/nvidia-smi"))("executes the opened pinned nvidia-smi image through procfs", async () => {
+  it.skipIf(!functionalNvidiaSmi)("rejects a well-formed but incorrect pinned nvidia-smi digest", async () => {
+    const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: "f".repeat(64) });
+    const session = await monitor.start();
+    await expect(monitor.attach(session, { metadata: { pid: process.pid } })).rejects.toThrow(/SHA-256.*drifted/i);
+    await expect(monitor.stop(session)).rejects.toThrow(/no pinned nvidia-smi descriptor/i);
+  });
+
+  it.skipIf(!functionalNvidiaSmi)("executes the opened pinned nvidia-smi image through procfs", async () => {
     const expectedSha256 = createHash("sha256").update(readFileSync("/usr/bin/nvidia-smi")).digest("hex");
     const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: expectedSha256 });
     const session = await monitor.start();

--- a/tests/linux-phase1-runtime.test.ts
+++ b/tests/linux-phase1-runtime.test.ts
@@ -22,7 +22,7 @@ describe("GEX44 Linux Phase 1 runtime", () => {
   });
 
   it("preserves the run-start swap baseline while bounding a long trace", () => {
-    const sample = (index: number) => ({ capturedAt: String(index), phase: index === 0 ? "attached" : "periodic", rssBytes: 0, vramBytes: 0, swapBytes: index * 1024, processSwapBytes: 0, processAlive: 1, pid: 42 });
+    const sample = (index: number) => ({ capturedAt: String(index), sequence: index + 1, phase: index === 0 ? "attached" : "periodic", rssBytes: 0, vramBytes: 0, vramObserved: 1, swapBytes: index * 1024, processSwapBytes: 0, processAlive: 1, pid: 42 });
     const trace: ReturnType<typeof sample>[] = [];
     for (let index = 0; index < 10; index += 1) appendBoundedLinuxTrace(trace, sample(index), 4);
     expect(trace.map((entry) => entry.capturedAt)).toEqual(["0", "7", "8", "9"]);
@@ -104,8 +104,12 @@ describe("GEX44 Linux Phase 1 runtime", () => {
     const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: expectedSha256 });
     const session = await monitor.start();
     await monitor.attach(session, { metadata: { pid: process.pid } });
-    await expect(monitor.sample(session, { phase: "before" })).resolves.toMatchObject({ pid: process.pid, processAlive: 1 });
-    await expect(monitor.stop(session)).resolves.toEqual(expect.any(Array));
+    await expect(monitor.sample(session, { phase: "before" })).resolves.toMatchObject({ pid: process.pid, processAlive: 1, vramObserved: 0, sequence: 2 });
+    await expect(monitor.stop(session)).resolves.toEqual(expect.arrayContaining([
+      expect.objectContaining({ sequence: 1 }),
+      expect.objectContaining({ sequence: 2 }),
+      expect.objectContaining({ sequence: 3 })
+    ]));
   });
 
   it("exposes the exact module path used for immutable runtime binding", () => {

--- a/tests/linux-phase1-runtime.test.ts
+++ b/tests/linux-phase1-runtime.test.ts
@@ -133,7 +133,7 @@ describe("GEX44 Linux Phase 1 runtime", () => {
     const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: "f".repeat(64) });
     const session = await monitor.start();
     await expect(monitor.attach(session, { metadata: { pid: process.pid } })).rejects.toThrow(/SHA-256.*drifted/i);
-    await expect(monitor.stop(session)).rejects.toThrow(/no pinned nvidia-smi descriptor/i);
+    await expect(monitor.stop(session)).rejects.toThrow(/not attached/i);
   });
 
   it.skipIf(!functionalNvidiaSmi)("executes the opened pinned nvidia-smi image through procfs", async () => {

--- a/tests/linux-phase1-runtime.test.ts
+++ b/tests/linux-phase1-runtime.test.ts
@@ -122,10 +122,11 @@ describe("GEX44 Linux Phase 1 runtime", () => {
     const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: "0".repeat(64) });
     const base = { capturedAt: "terminal", sequence: 1, phase: "cleanup", rssBytes: 0, vramBytes: 0, vramObserved: 0, swapBytes: 0, processSwapBytes: 0, processAlive: 0, pid: 42 };
     expect(monitor.classify([{ ...base, periodicFailure: 1 }])).toEqual({ status: "stopped", errorCode: "periodic_resource_sampling_failed" });
+    expect(monitor.classify([{ ...base, nvidiaSmiVerificationFailure: 1 }])).toEqual({ status: "stopped", errorCode: "nvidia_smi_descriptor_verification_failed" });
     expect(monitor.classify([{ ...base, nvidiaSmiDrift: 1 }])).toEqual({ status: "stopped", errorCode: "nvidia_smi_descriptor_drift" });
-    expect(monitor.classify([{ ...base, periodicFailure: 1, cleanupFailure: 1, nvidiaSmiDrift: 1 }])).toEqual({
+    expect(monitor.classify([{ ...base, periodicFailure: 1, cleanupFailure: 1, nvidiaSmiVerificationFailure: 1, nvidiaSmiDrift: 1 }])).toEqual({
       status: "stopped",
-      errorCode: "periodic_resource_sampling_failed+resource_cleanup_sampling_failed+nvidia_smi_descriptor_drift"
+      errorCode: "periodic_resource_sampling_failed+resource_cleanup_sampling_failed+nvidia_smi_descriptor_verification_failed+nvidia_smi_descriptor_drift"
     });
   });
 

--- a/tests/linux-phase1-runtime.test.ts
+++ b/tests/linux-phase1-runtime.test.ts
@@ -111,6 +111,13 @@ describe("GEX44 Linux Phase 1 runtime", () => {
     expect(() => createGex44ResourceMonitor({ nvidiaSmiSha256: "not-a-digest" })).toThrow(/nvidia-smi SHA-256/i);
   });
 
+  it("classifies periodic sampling and terminal descriptor drift without masking either signal", () => {
+    const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: "0".repeat(64) });
+    const base = { capturedAt: "terminal", sequence: 1, phase: "cleanup", rssBytes: 0, vramBytes: 0, vramObserved: 0, swapBytes: 0, processSwapBytes: 0, processAlive: 0, pid: 42 };
+    expect(monitor.classify([{ ...base, periodicFailure: 1 }])).toEqual({ status: "stopped", errorCode: "periodic_resource_sampling_failed" });
+    expect(monitor.classify([{ ...base, nvidiaSmiDrift: 1 }])).toEqual({ status: "stopped", errorCode: "nvidia_smi_descriptor_drift" });
+  });
+
   it.skipIf(!functionalNvidiaSmi)("rejects a well-formed but incorrect pinned nvidia-smi digest", async () => {
     const monitor = createGex44ResourceMonitor({ nvidiaSmiSha256: "f".repeat(64) });
     const session = await monitor.start();

--- a/tests/phase1-characterization-cli.test.ts
+++ b/tests/phase1-characterization-cli.test.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtempSync, realpathSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
+import { assertCharacterizationLoadedArtifacts, assertPinnedLoadedJavaScript } from "../src/phase1-characterization-cli.js";
 
 const cli = join(process.cwd(), "src", "phase1-characterization-cli.ts");
 const tsx = join(process.cwd(), "node_modules", ".bin", "tsx");
@@ -19,6 +20,43 @@ function run(args: string[]): { status: number | null; stderr: string; stdout: s
 }
 
 describe("private Phase 1 characterization entrypoint", () => {
+  it("binds each actually loaded JavaScript artifact to its declared canonical path and bytes", () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "phase1-characterization-loaded-js-")));
+    const entrypoint = join(directory, "entrypoint.js");
+    const runner = join(directory, "runner.js");
+    writeFileSync(entrypoint, "export const entrypoint = true;\n");
+    writeFileSync(runner, "export const runner = true;\n");
+    const entrypointSha256 = createHash("sha256").update("export const entrypoint = true;\n").digest("hex");
+
+    expect(() => assertPinnedLoadedJavaScript(entrypoint, entrypoint, entrypointSha256, "characterization entrypoint")).not.toThrow();
+    expect(() => assertPinnedLoadedJavaScript(entrypoint, runner, entrypointSha256, "characterization entrypoint")).toThrow(/loaded path/i);
+    expect(() => assertPinnedLoadedJavaScript(entrypoint, entrypoint, "0".repeat(64), "characterization entrypoint")).toThrow(/SHA-256/i);
+    expect(() => assertPinnedLoadedJavaScript(entrypoint.replace(/\.js$/, ".ts"), entrypoint.replace(/\.js$/, ".ts"), entrypointSha256, "characterization entrypoint")).toThrow(/built JavaScript/i);
+  });
+
+  it("requires both the loaded entrypoint and imported runner bytes named by the plan", () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "phase1-characterization-artifact-set-")));
+    const entrypoint = join(directory, "entrypoint.js");
+    const runner = join(directory, "runner.js");
+    writeFileSync(entrypoint, "export const entrypoint = true;\n");
+    writeFileSync(runner, "export const runner = true;\n");
+    const digest = (path: string) => createHash("sha256").update(readFileSync(path)).digest("hex");
+    const plan = {
+      spec: {
+        harness: {
+          entrypointPath: entrypoint,
+          entrypointSha256: digest(entrypoint),
+          runnerPath: runner,
+          runnerSha256: digest(runner)
+        }
+      }
+    };
+
+    expect(() => assertCharacterizationLoadedArtifacts(plan, { entrypointPath: entrypoint, runnerPath: runner })).not.toThrow();
+    writeFileSync(runner, "export const runner = false;\n");
+    expect(() => assertCharacterizationLoadedArtifacts(plan, { entrypointPath: entrypoint, runnerPath: runner })).toThrow(/screening runner SHA-256/i);
+  });
+
   it("requires one explicit absolute plan and exposes no broad command surface", () => {
     const result = run([]);
     expect(result.status).toBe(1);
@@ -45,10 +83,40 @@ describe("private Phase 1 characterization entrypoint", () => {
     expect(result.stderr).toMatch(/SHA-256 does not match/);
   });
 
+  it("rejects a plan that omits the loaded entrypoint or runner identities", () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "phase1-characterization-missing-loaded-js-")));
+    const path = join(directory, "plan.json");
+    const bytes = JSON.stringify({
+      schemaVersion: "neondiff-phase1-characterization-plan/v1",
+      spec: { harness: {} },
+      baseUrl: "http://127.0.0.1:8080",
+      runtimeSha256: "0".repeat(64),
+      nvidiaSmiSha256: "0".repeat(64),
+      monitorModule: {}
+    });
+    writeFileSync(path, bytes);
+    const result = run(["--plan", path, "--sha256", createHash("sha256").update(bytes).digest("hex")]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/loaded JavaScript identities/i);
+  });
+
   it("requires the built pinned JavaScript runtime rather than executing mutable TypeScript source", () => {
     const directory = realpathSync(mkdtempSync(join(tmpdir(), "phase1-characterization-cli-source-")));
     const path = join(directory, "plan.json");
-    const bytes = JSON.stringify({ schemaVersion: "neondiff-phase1-characterization-plan/v1", spec: {}, baseUrl: "http://127.0.0.1:8080", monitorModule: {} });
+    const runnerSource = join(process.cwd(), "src", "phase1-screening-runner.ts");
+    const bytes = JSON.stringify({
+      schemaVersion: "neondiff-phase1-characterization-plan/v1",
+      spec: {
+        harness: {
+          entrypointPath: cli,
+          entrypointSha256: createHash("sha256").update(readFileSync(cli)).digest("hex"),
+          runnerPath: runnerSource,
+          runnerSha256: createHash("sha256").update(readFileSync(runnerSource)).digest("hex")
+        }
+      },
+      baseUrl: "http://127.0.0.1:8080",
+      monitorModule: {}
+    });
     writeFileSync(path, bytes);
     const result = run(["--plan", path, "--sha256", createHash("sha256").update(bytes).digest("hex")]);
     expect(result.status).toBe(1);

--- a/tests/phase1-characterization-cli.test.ts
+++ b/tests/phase1-characterization-cli.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs"
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
-import { assertCharacterizationLoadedArtifacts, assertPinnedLoadedJavaScript } from "../src/phase1-characterization-cli.js";
+import { assertCharacterizationLoadedArtifacts, assertMonitorNvidiaBinding, assertPinnedLoadedJavaScript } from "../src/phase1-characterization-cli.js";
 
 const cli = join(process.cwd(), "src", "phase1-characterization-cli.ts");
 const tsx = join(process.cwd(), "node_modules", ".bin", "tsx");
@@ -20,6 +20,14 @@ function run(args: string[]): { status: number | null; stderr: string; stdout: s
 }
 
 describe("private Phase 1 characterization entrypoint", () => {
+  it("binds the monitor factory to the plan's exact nvidia-smi digest", () => {
+    const digest = "a".repeat(64);
+    const identity = { version: "monitor/v1", modulePath: "/tmp/monitor.js", moduleSha256: "b".repeat(64), approvedRoot: "/tmp", exportName: "createMonitor", factoryParameters: { nvidiaSmiSha256: digest } };
+    expect(() => assertMonitorNvidiaBinding(digest, identity)).not.toThrow();
+    expect(() => assertMonitorNvidiaBinding("c".repeat(64), identity)).toThrow(/not bound/i);
+    expect(() => assertMonitorNvidiaBinding(digest, { ...identity, factoryParameters: undefined })).toThrow(/not bound/i);
+  });
+
   it("binds each actually loaded JavaScript artifact to its declared canonical path and bytes", () => {
     const directory = realpathSync(mkdtempSync(join(tmpdir(), "phase1-characterization-loaded-js-")));
     const entrypoint = join(directory, "entrypoint.js");

--- a/tests/phase1-characterization-cli.test.ts
+++ b/tests/phase1-characterization-cli.test.ts
@@ -1,0 +1,57 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, realpathSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+
+const cli = join(process.cwd(), "src", "phase1-characterization-cli.ts");
+const tsx = join(process.cwd(), "node_modules", ".bin", "tsx");
+
+function run(args: string[]): { status: number | null; stderr: string; stdout: string } {
+  try {
+    const stdout = execFileSync(tsx, [cli, ...args], { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "pipe"] });
+    return { status: 0, stderr: "", stdout };
+  } catch (error) {
+    const result = error as { status?: number; stderr?: string; stdout?: string };
+    return { status: result.status ?? null, stderr: String(result.stderr ?? ""), stdout: String(result.stdout ?? "") };
+  }
+}
+
+describe("private Phase 1 characterization entrypoint", () => {
+  it("requires one explicit absolute plan and exposes no broad command surface", () => {
+    const result = run([]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/usage: phase1-characterization-cli --plan/);
+  });
+
+  it("rejects an unsupported plan before starting a resident", () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "phase1-characterization-cli-")));
+    const path = join(directory, "plan.json");
+    const bytes = JSON.stringify({ schemaVersion: "wrong" });
+    writeFileSync(path, bytes);
+    const result = run(["--plan", path, "--sha256", createHash("sha256").update(bytes).digest("hex")]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/schema is unsupported/);
+    expect(result.stdout).toBe("");
+  });
+
+  it("rejects plan-byte drift before parsing or process startup", () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "phase1-characterization-cli-drift-")));
+    const path = join(directory, "plan.json");
+    writeFileSync(path, JSON.stringify({ schemaVersion: "neondiff-phase1-characterization-plan/v1" }));
+    const result = run(["--plan", path, "--sha256", "0".repeat(64)]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/SHA-256 does not match/);
+  });
+
+  it("requires the built pinned JavaScript runtime rather than executing mutable TypeScript source", () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "phase1-characterization-cli-source-")));
+    const path = join(directory, "plan.json");
+    const bytes = JSON.stringify({ schemaVersion: "neondiff-phase1-characterization-plan/v1", spec: {}, baseUrl: "http://127.0.0.1:8080", monitorModule: {} });
+    writeFileSync(path, bytes);
+    const result = run(["--plan", path, "--sha256", createHash("sha256").update(bytes).digest("hex")]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/pinned built JavaScript artifact/);
+  });
+});

--- a/tests/phase1-characterization-cli.test.ts
+++ b/tests/phase1-characterization-cli.test.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } fr
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
-import { assertCharacterizationLoadedArtifacts, assertMonitorNvidiaBinding, assertPinnedLoadedJavaScript, importVerifiedModule } from "../src/phase1-characterization-cli.js";
+import { assertCharacterizationLoadedArtifacts, assertMonitorNvidiaBinding, assertPinnedLoadedJavaScript, importVerifiedModule, invokedModuleUrl } from "../src/phase1-characterization-cli.js";
 
 const cli = join(process.cwd(), "src", "phase1-characterization-cli.ts");
 const tsx = join(process.cwd(), "node_modules", ".bin", "tsx");
@@ -20,6 +20,12 @@ function run(args: string[]): { status: number | null; stderr: string; stdout: s
 }
 
 describe("private Phase 1 characterization entrypoint", () => {
+  it("treats a missing or broken invoked path as not directly invoked", () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "phase1-missing-invoked-path-")));
+    expect(invokedModuleUrl(join(directory, "missing-entrypoint.js"))).toBe("");
+    expect(invokedModuleUrl(undefined)).toBe("");
+  });
+
   it("rejects unverified module bytes before their top-level code can execute", async () => {
     const directory = realpathSync(mkdtempSync(join(tmpdir(), "phase1-verified-module-")));
     const marker = join(directory, "executed");

--- a/tests/phase1-characterization-cli.test.ts
+++ b/tests/phase1-characterization-cli.test.ts
@@ -1,10 +1,10 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
-import { assertCharacterizationLoadedArtifacts, assertMonitorNvidiaBinding, assertPinnedLoadedJavaScript } from "../src/phase1-characterization-cli.js";
+import { assertCharacterizationLoadedArtifacts, assertMonitorNvidiaBinding, assertPinnedLoadedJavaScript, importVerifiedModule } from "../src/phase1-characterization-cli.js";
 
 const cli = join(process.cwd(), "src", "phase1-characterization-cli.ts");
 const tsx = join(process.cwd(), "node_modules", ".bin", "tsx");
@@ -20,6 +20,19 @@ function run(args: string[]): { status: number | null; stderr: string; stdout: s
 }
 
 describe("private Phase 1 characterization entrypoint", () => {
+  it("rejects unverified module bytes before their top-level code can execute", async () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "phase1-verified-module-")));
+    const marker = join(directory, "executed");
+    const modulePath = join(directory, "payload.js");
+    const source = `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(marker)}, "executed"); export const ok = true;\n`;
+    writeFileSync(modulePath, source);
+    await expect(importVerifiedModule(modulePath, "0".repeat(64), "payload")).rejects.toThrow(/SHA-256/i);
+    expect(existsSync(marker)).toBe(false);
+    const loaded = await importVerifiedModule<{ ok: boolean }>(modulePath, createHash("sha256").update(source).digest("hex"), "payload");
+    expect(loaded.ok).toBe(true);
+    expect(existsSync(marker)).toBe(true);
+  });
+
   it("binds the monitor factory to the plan's exact nvidia-smi digest", () => {
     const digest = "a".repeat(64);
     const identity = { version: "monitor/v1", modulePath: "/tmp/monitor.js", moduleSha256: "b".repeat(64), approvedRoot: "/tmp", exportName: "createMonitor", factoryParameters: { nvidiaSmiSha256: digest } };

--- a/tests/phase1-characterization-cli.test.ts
+++ b/tests/phase1-characterization-cli.test.ts
@@ -39,7 +39,9 @@ describe("private Phase 1 characterization entrypoint", () => {
     expect(() => assertPinnedLoadedJavaScript(entrypoint, entrypoint, entrypointSha256, "characterization entrypoint")).not.toThrow();
     expect(() => assertPinnedLoadedJavaScript(entrypoint, runner, entrypointSha256, "characterization entrypoint")).toThrow(/loaded path/i);
     expect(() => assertPinnedLoadedJavaScript(entrypoint, entrypoint, "0".repeat(64), "characterization entrypoint")).toThrow(/SHA-256/i);
-    expect(() => assertPinnedLoadedJavaScript(entrypoint.replace(/\.js$/, ".ts"), entrypoint.replace(/\.js$/, ".ts"), entrypointSha256, "characterization entrypoint")).toThrow(/built JavaScript/i);
+    const TypeScriptPath = entrypoint.replace(/\.js$/, ".ts");
+    expect(() => assertPinnedLoadedJavaScript(entrypoint, TypeScriptPath, entrypointSha256, "characterization entrypoint")).toThrow(/built JavaScript/i);
+    expect(() => assertPinnedLoadedJavaScript(TypeScriptPath, entrypoint, entrypointSha256, "characterization entrypoint")).toThrow(/built JavaScript/i);
   });
 
   it("requires both the loaded entrypoint and imported runner bytes named by the plan", () => {

--- a/tests/phase1-screening-runner.test.ts
+++ b/tests/phase1-screening-runner.test.ts
@@ -65,6 +65,7 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
   writeFileSync(modulePath, `
     const kind = ${JSON.stringify(kind)};
     let sequence = 0;
+    let attachObserved = false;
     export function createMonitor() {
       return {
         async start() {
@@ -76,6 +77,7 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
         },
         async attach(_session, resident) {
           if (kind === "attach-error") throw new Error("monitor attach exploded");
+          if (kind === "attach-unsafe-probe") attachObserved = true;
           if (!resident.metadata || resident.metadata.pid !== 42) throw new Error("monitor did not receive resident metadata");
         },
         async sample(_session, context) {
@@ -97,7 +99,7 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
           return undefined;
         },
         async stop() {
-          const base = { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0 };
+          const base = { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0, attachObserved: attachObserved ? 1 : 0 };
           if (kind === "stop-array") return [{ ...base, capturedAt: "periodic", phase: "periodic" }, base];
           if (kind === "secret-stop") return { ...base, diagnostic: "Authorization: Bearer sk-secret-value-1234567890" };
           if (kind === "secret-fingerprint-stop") return { ...base, evidenceSha256: "sk-secret-value-1234567890" };
@@ -510,7 +512,7 @@ describe("Phase 1 screening runner", () => {
     const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-attach-"));
     await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule("stop-array") });
     const resource = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
-    expect(resource.samples.map((sample: { phase: string }) => sample.phase)).toEqual(["periodic", "stopped"]);
+    expect(resource.samples.map((sample: { phase: string }) => sample.phase)).toEqual(["before", "after", "before", "after", "periodic", "stopped"]);
   });
 
   it("fails closed and stops the resident when monitor attachment fails", async () => {
@@ -519,6 +521,32 @@ describe("Phase 1 screening runner", () => {
     await expect(runPhase1Screen(spec(outputDir), adapter({ async stop() { stopped = true; } }), { monitorModule: monitorModule("attach-error") })).rejects.toThrow(/monitor attach exploded/i);
     expect(stopped).toBe(true);
     expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
+  });
+
+  it("rejects unsafe resident evidence before it can reach monitor attachment", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-attach-secret-"));
+    await expect(runPhase1Screen(spec(outputDir), adapter({
+      async start() {
+        return { id: "resident", argv: ["/opt/llama-server"], logs: "Authorization: Bearer sk-secret-value-1234567890", metadata: { pid: 42 } };
+      }
+    }), { monitorModule: monitorModule("attach-unsafe-probe") })).rejects.toThrow(/secret-like text/i);
+    const resources = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
+    expect(resources.samples.every((sample: { attachObserved?: number }) => sample.attachObserved === 0)).toBe(true);
+  });
+
+  it("preserves reconstructed resource samples when a resumed monitor returns a terminal trace array", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-resume-trace-"));
+    const identity = monitorModule("stop-array");
+    await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity });
+    const firstResult = JSON.parse(readFileSync(join(outputDir, "results", "warm-8k", "pr-1.json"), "utf8"));
+    const reconstructedCapturedAt = firstResult.resourceSamples.map((sample: { capturedAt: string }) => sample.capturedAt);
+    rmSync(join(outputDir, "results", "warm-8k", "pr-2.json"));
+    rmSync(join(outputDir, "summary.json"));
+    rmSync(join(outputDir, "COMPLETED"));
+
+    await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity });
+    const resources = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
+    expect(resources.samples.map((sample: { capturedAt: string }) => sample.capturedAt)).toEqual(expect.arrayContaining(reconstructedCapturedAt));
   });
 
   it("rejects relative or package imports because pinned monitors load as self-contained exact bytes", async () => {

--- a/tests/phase1-screening-runner.test.ts
+++ b/tests/phase1-screening-runner.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { createServer } from "node:http";
 import { createServer as createNetServer } from "node:net";
 import { execFileSync, spawn } from "node:child_process";
@@ -971,14 +971,36 @@ describe("Phase 1 screening runner", () => {
     expect(result.status).toBe("completed");
 
     const blockedDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-coordinated-lease-"));
-    const coordinator = createNetServer();
+    const blockedLeasePath = join(blockedDir, ".phase1-run.lock");
+    const coordinator = createNetServer((socket) => socket.end(`${digest(resolve(blockedLeasePath))}\n`));
     await new Promise<void>((resolvePromise) => coordinator.listen({
       host: "127.0.0.1",
-      port: phase1LeaseCoordinationPort(join(blockedDir, ".phase1-run.lock")),
+      port: phase1LeaseCoordinationPort(blockedLeasePath),
       exclusive: true
     }, resolvePromise));
     try {
       await expect(runPhase1Screen(spec(blockedDir), adapter())).rejects.toThrow(/lease acquisition is already coordinated/i);
+    } finally {
+      await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));
+    }
+  });
+
+  it("falls through a loopback coordination-port collision owned by a different output path", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-phase1-port-collision-"));
+    const seen = new Map<number, string>();
+    let collision: { first: string; second: string; port: number } | undefined;
+    for (let index = 0; index < 2_000 && !collision; index += 1) {
+      const candidate = join(root, `candidate-${index}`);
+      const port = phase1LeaseCoordinationPort(join(candidate, ".phase1-run.lock"));
+      const first = seen.get(port);
+      if (first) collision = { first, second: candidate, port };
+      else seen.set(port, candidate);
+    }
+    expect(collision).toBeDefined();
+    const coordinator = createNetServer((socket) => socket.end(`${digest(resolve(join(collision!.first, ".phase1-run.lock")))}\n`));
+    await new Promise<void>((resolvePromise) => coordinator.listen({ host: "127.0.0.1", port: collision!.port, exclusive: true }, resolvePromise));
+    try {
+      await expect(runPhase1Screen(spec(collision!.second), adapter())).resolves.toMatchObject({ status: "completed" });
     } finally {
       await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));
     }

--- a/tests/phase1-screening-runner.test.ts
+++ b/tests/phase1-screening-runner.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -9,6 +9,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   runPhase1Screen as executePhase1Screen,
   createLlamaServerExecutableAdapter,
+  phase1ScreeningRunnerModulePath,
   phase1LeaseCoordinationPort,
   verifyPairedPhase1Cohort,
   type Phase1ResidentAdapter,
@@ -42,15 +43,14 @@ const ownershipProof = {
   verifyProcessIdentity: async () => true
 };
 const runnerSourcePath = join(process.cwd(), "src", "phase1-screening-runner.ts");
-const harnessRepo = mkdtempSync(join(tmpdir(), "neondiff-phase1-harness-repo-"));
+const harnessRepo = realpathSync(mkdtempSync(join(tmpdir(), "neondiff-phase1-harness-repo-")));
 const harnessRepoSource = join(harnessRepo, "src", "phase1-screening-runner.ts");
 const harnessEntrypoint = join(harnessRepo, "dist", "src", "phase1-characterization-cli.js");
-const harnessRunner = join(harnessRepo, "dist", "src", "phase1-screening-runner.js");
+const harnessRunner = realpathSync(phase1ScreeningRunnerModulePath());
 mkdirSync(dirname(harnessRepoSource), { recursive: true });
 mkdirSync(dirname(harnessEntrypoint), { recursive: true });
 writeFileSync(harnessRepoSource, readFileSync(runnerSourcePath));
 writeFileSync(harnessEntrypoint, "export const entrypoint = true;\n");
-writeFileSync(harnessRunner, "export const runner = true;\n");
 execFileSync("git", ["init", "-q", harnessRepo]);
 execFileSync("git", ["-C", harnessRepo, "config", "user.email", "phase1@example.invalid"]);
 execFileSync("git", ["-C", harnessRepo, "config", "user.name", "Phase 1 Test"]);
@@ -67,6 +67,7 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
     let sequence = 0;
     let attachObserved = false;
     let forceStopOom = false;
+    let attemptTag = "none";
     export function createMonitor(factoryParameters) {
       if (kind === "factory-parameters" && (!Object.isFrozen(factoryParameters) || factoryParameters?.nvidiaSmiSha256 !== ${JSON.stringify("a".repeat(64))})) {
         throw new Error("factory parameters were not immutably bound");
@@ -85,12 +86,13 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
           if (kind === "attach-and-stop-error") throw new Error("monitor attach exploded");
           if (kind === "attach-unsafe-probe") attachObserved = true;
           if (kind === "conditional-stop-oom") forceStopOom = resident.metadata?.forceStopOom === true;
+          if (kind === "attempt-tagged") attemptTag = resident.metadata?.attemptTag ?? "none";
           if (!resident.metadata || resident.metadata.pid !== 42) throw new Error("monitor did not receive resident metadata");
         },
         async sample(_session, context) {
           if (kind === "throw-" + context.phase) throw new Error("monitor " + context.phase + " exploded");
           sequence += 1;
-          const base = { capturedAt: "sample-" + sequence, phase: context.phase, rssBytes: 100 + sequence, vramBytes: 200, swapBytes: kind === "swap" && sequence > 2 ? 4096 : 0, factoryParametersBound: kind === "factory-parameters" ? 1 : 0 };
+          const base = { capturedAt: "sample-" + sequence, phase: context.phase, rssBytes: 100 + sequence, vramBytes: 200, swapBytes: kind === "swap" && sequence > 2 ? 4096 : 0, factoryParametersBound: kind === "factory-parameters" ? 1 : 0, attemptTag };
           if (kind === "sample-nan") return { ...base, rssBytes: Number.NaN };
           if (kind === "sample-infinity") return { ...base, diagnosticValue: Number.POSITIVE_INFINITY };
           if (kind === "sample-negative") return { ...base, vramBytes: -1 };
@@ -101,13 +103,14 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
           if (kind === "classify-invalid-status") return { status: "completed", errorCode: "invalid" };
           if (kind === "classify-missing-code") return { status: "stopped" };
           if (kind === "classify-scalar") return "stopped";
+          if (kind === "attempt-tagged" && samples.some(sample => sample.attemptTag === "old") && samples.some(sample => sample.attemptTag === "current")) return { status: "stopped", errorCode: "stale_attempt_included" };
           if (kind === "swap" && samples.some(sample => sample.swapBytes >= 4096)) return { status: "stopped", errorCode: "sustained_swap_growth" };
           if (kind === "stop-oom" && samples.some(sample => sample.phase === "stopped")) return { status: "oom", errorCode: "stop_time_oom" };
           if (kind === "conditional-stop-oom" && forceStopOom && samples.some(sample => sample.phase === "stopped")) return { status: "oom", errorCode: "stop_time_oom" };
           return undefined;
         },
         async stop() {
-          const base = { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0, attachObserved: attachObserved ? 1 : 0 };
+          const base = { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0, attachObserved: attachObserved ? 1 : 0, attemptTag };
           if (kind === "attach-and-stop-error") throw new Error("monitor stop exploded");
           if (kind === "stop-empty") return [];
           if (kind === "stop-array") return [{ ...base, capturedAt: "periodic", phase: "periodic" }, base];
@@ -351,6 +354,37 @@ describe("Phase 1 screening runner", () => {
     outside.harness.sourcePath = outsideSource;
     outside.harness.sourceSha256 = digest(readFileSync(outsideSource));
     await expect(runPhase1Screen(outside, adapter())).rejects.toThrow(/inside checkoutRoot/i);
+  });
+
+  it("verifies declared entrypoint and runner bytes before manifest persistence or adapter startup", async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "neondiff-phase1-loaded-artifacts-")));
+    for (const artifact of ["entrypoint", "runner"] as const) {
+      const outputDir = join(root, artifact);
+      const runSpec = spec(outputDir);
+      const path = join(root, `${artifact}.js`);
+      writeFileSync(path, `export const ${artifact} = true;\n`);
+      runSpec.harness[`${artifact}Path`] = path;
+      runSpec.harness[`${artifact}Sha256`] = "0".repeat(64);
+      let starts = 0;
+      await expect(runPhase1Screen(runSpec, adapter({
+        async start() { starts += 1; return { id: "resident", argv: ["/opt/llama-server"], metadata: { pid: 42 } }; }
+      }))).rejects.toThrow(new RegExp(`${artifact} SHA-256`, "i"));
+      expect(starts).toBe(0);
+      expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
+    }
+
+    const outputDir = join(root, "unrelated-runner");
+    const runSpec = spec(outputDir);
+    const unrelatedRunner = join(root, "unrelated-runner.js");
+    writeFileSync(unrelatedRunner, "export const runner = true;\n");
+    runSpec.harness.runnerPath = unrelatedRunner;
+    runSpec.harness.runnerSha256 = digest(readFileSync(unrelatedRunner));
+    let starts = 0;
+    await expect(runPhase1Screen(runSpec, adapter({
+      async start() { starts += 1; return { id: "resident", argv: ["/opt/llama-server"], metadata: { pid: 42 } }; }
+    }))).rejects.toThrow(/does not identify the executing implementation artifact/i);
+    expect(starts).toBe(0);
+    expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
   });
 
   it("turns parser and deterministic gate failures into explicit schema_failed terminals", async () => {
@@ -624,6 +658,32 @@ describe("Phase 1 screening runner", () => {
     await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity });
     const resources = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
     expect(resources.samples.map((sample: { capturedAt: string }) => sample.capturedAt)).toEqual(expect.arrayContaining(reconstructedCapturedAt));
+  });
+
+  it("excludes reconstructed history from resumed terminal classification while retaining it as evidence", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-current-terminal-classification-"));
+    const identity = monitorModule("attempt-tagged");
+    let starts = 0;
+    const taggedAdapter = adapter({
+      async start() {
+        starts += 1;
+        return { id: `resident-${starts}`, argv: ["/opt/llama-server"], metadata: { pid: 42, attemptTag: starts === 1 ? "old" : "current" } };
+      }
+    });
+    await runPhase1Screen(spec(outputDir), taggedAdapter, { monitorModule: identity });
+    const existingPath = join(outputDir, "results", "warm-8k", "pr-1.json");
+    const existingBytes = readFileSync(existingPath);
+    rmSync(join(outputDir, "results", "warm-8k", "pr-2.json"));
+    rmSync(join(outputDir, "resources", "warm-8k.json"));
+    rmSync(join(outputDir, "summary.json"));
+    rmSync(join(outputDir, "COMPLETED"));
+    const result = await runPhase1Screen(spec(outputDir), taggedAdapter, { monitorModule: identity });
+    expect(result.status).toBe("completed");
+    expect(readFileSync(existingPath)).toEqual(existingBytes);
+    const resources = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
+    expect(resources.samples.some((sample: { attemptTag: string }) => sample.attemptTag === "old")).toBe(true);
+    expect(resources.samples.some((sample: { attemptTag: string }) => sample.attemptTag === "current")).toBe(true);
+    expect(resources.terminalClassification).toBeUndefined();
   });
 
   it("rejects an empty terminal monitor trace", async () => {

--- a/tests/phase1-screening-runner.test.ts
+++ b/tests/phase1-screening-runner.test.ts
@@ -69,6 +69,10 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
           if (kind === "start-empty") return {};
           return { id: "monitor" };
         },
+        async attach(_session, resident) {
+          if (kind === "attach-error") throw new Error("monitor attach exploded");
+          if (!resident.metadata || resident.metadata.pid !== 42) throw new Error("monitor did not receive resident metadata");
+        },
         async sample(_session, context) {
           if (kind === "throw-" + context.phase) throw new Error("monitor " + context.phase + " exploded");
           sequence += 1;
@@ -89,6 +93,7 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
         },
         async stop() {
           const base = { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0 };
+          if (kind === "stop-array") return [{ ...base, capturedAt: "periodic", phase: "periodic" }, base];
           if (kind === "secret-stop") return { ...base, diagnostic: "Authorization: Bearer sk-secret-value-1234567890" };
           if (kind === "secret-fingerprint-stop") return { ...base, evidenceSha256: "sk-secret-value-1234567890" };
           if (kind === "stop-nan") return { ...base, swapBytes: Number.NaN };
@@ -146,7 +151,7 @@ function adapter(overrides: Partial<Phase1ResidentAdapter> = {}): Phase1Resident
   return {
     async start(context) {
       expect(existsSync(join(context.outputDir, "manifest.json"))).toBe(true);
-      return { id: "resident-1", argv: ["/opt/llama-server", "--model", "/models/qwen.gguf"] };
+      return { id: "resident-1", argv: ["/opt/llama-server", "--model", "/models/qwen.gguf"], metadata: { pid: 42 } };
     },
     async invoke(_resident, request) {
       return {
@@ -486,6 +491,21 @@ describe("Phase 1 screening runner", () => {
     const second = JSON.parse(readFileSync(join(secondDir, "resources", "warm-8k.json"), "utf8"));
     expect(first.samples[0].rssBytes).toBe(101);
     expect(second.samples[0].rssBytes).toBe(101);
+  });
+
+  it("attaches the pinned monitor after resident start and persists a bounded stop trace array", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-attach-"));
+    await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule("stop-array") });
+    const resource = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
+    expect(resource.samples.map((sample: { phase: string }) => sample.phase)).toEqual(["periodic", "stopped"]);
+  });
+
+  it("fails closed and stops the resident when monitor attachment fails", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-attach-fail-"));
+    let stopped = false;
+    await expect(runPhase1Screen(spec(outputDir), adapter({ async stop() { stopped = true; } }), { monitorModule: monitorModule("attach-error") })).rejects.toThrow(/monitor attach exploded/i);
+    expect(stopped).toBe(true);
+    expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
   });
 
   it("rejects relative or package imports because pinned monitors load as self-contained exact bytes", async () => {

--- a/tests/phase1-screening-runner.test.ts
+++ b/tests/phase1-screening-runner.test.ts
@@ -1032,7 +1032,11 @@ describe("Phase 1 screening runner", () => {
 
     const blockedDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-coordinated-lease-"));
     const blockedLeasePath = join(blockedDir, ".phase1-run.lock");
-    const coordinator = createNetServer((socket) => socket.end(`${digest(resolve(blockedLeasePath))}\n`));
+    const coordinator = createNetServer((socket) => {
+      socket.once("error", () => {});
+      socket.write("neondiff-phase1-lease-v1:");
+      setImmediate(() => socket.end(`${digest(resolve(blockedLeasePath))}\n`));
+    });
     await new Promise<void>((resolvePromise) => coordinator.listen({
       host: "127.0.0.1",
       port: phase1LeaseCoordinationPort(blockedLeasePath),
@@ -1057,7 +1061,10 @@ describe("Phase 1 screening runner", () => {
       else seen.set(port, candidate);
     }
     expect(collision).toBeDefined();
-    const coordinator = createNetServer((socket) => socket.end(`${digest(resolve(join(collision!.first, ".phase1-run.lock")))}\n`));
+    const coordinator = createNetServer((socket) => {
+      socket.once("error", () => {});
+      socket.end(`neondiff-phase1-lease-v1:${digest(resolve(join(collision!.first, ".phase1-run.lock")))}\n`);
+    });
     await new Promise<void>((resolvePromise) => coordinator.listen({ host: "127.0.0.1", port: collision!.port, exclusive: true }, resolvePromise));
     try {
       await expect(runPhase1Screen(spec(collision!.second), adapter())).resolves.toMatchObject({ status: "completed" });
@@ -1065,6 +1072,99 @@ describe("Phase 1 screening runner", () => {
       await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));
     }
   });
+
+  it("blocks a same-path legacy raw-token coordinator during mixed-version acquisition", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-legacy-coordinator-"));
+    const leasePath = join(outputDir, ".phase1-run.lock");
+    const coordinator = createNetServer((socket) => {
+      socket.once("error", () => {});
+      const token = digest(resolve(leasePath));
+      socket.write(token.slice(0, 17));
+      setImmediate(() => socket.end(`${token.slice(17)}\n`));
+    });
+    await new Promise<void>((resolvePromise) => coordinator.listen({
+      host: "127.0.0.1",
+      port: phase1LeaseCoordinationPort(leasePath),
+      exclusive: true
+    }, resolvePromise));
+    try {
+      await expect(runPhase1Screen(spec(outputDir), adapter())).rejects.toThrow(/lease acquisition is already coordinated/i);
+      expect(existsSync(leasePath)).toBe(false);
+    } finally {
+      await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));
+    }
+  });
+
+  it("fails closed when an occupied lease coordination port returns an incomplete token", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-inconclusive-coordinator-"));
+    const leasePath = join(outputDir, ".phase1-run.lock");
+    let connections = 0;
+    const coordinator = createNetServer((socket) => {
+      connections += 1;
+      socket.once("error", () => {});
+      socket.end("neondiff-phase1-lease-v1:partial-token");
+    });
+    await new Promise<void>((resolvePromise) => coordinator.listen({
+      host: "127.0.0.1",
+      port: phase1LeaseCoordinationPort(leasePath),
+      exclusive: true
+    }, resolvePromise));
+    try {
+      await expect(runPhase1Screen(spec(outputDir), adapter())).rejects.toThrow(/coordination probe.*inconclusive/i);
+      expect(existsSync(leasePath)).toBe(false);
+      expect(connections).toBe(3);
+    } finally {
+      await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));
+    }
+  });
+
+  it("falls through an occupied coordination port owned by a foreign protocol", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-foreign-coordinator-"));
+    const leasePath = join(outputDir, ".phase1-run.lock");
+    const coordinator = createNetServer((socket) => {
+      socket.once("error", () => {});
+      socket.end("HTTP/1.1 204 No Content\r\n\r\n");
+    });
+    await new Promise<void>((resolvePromise) => coordinator.listen({
+      host: "127.0.0.1",
+      port: phase1LeaseCoordinationPort(leasePath),
+      exclusive: true
+    }, resolvePromise));
+    try {
+      await expect(runPhase1Screen(spec(outputDir), adapter())).resolves.toMatchObject({ status: "completed" });
+    } finally {
+      await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));
+    }
+  });
+
+  it("bounds a slow-drip partial lease frame with an absolute probe deadline", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-drip-coordinator-"));
+    const leasePath = join(outputDir, ".phase1-run.lock");
+    let connections = 0;
+    const coordinator = createNetServer((socket) => {
+      connections += 1;
+      socket.once("error", () => {});
+      let offset = 0;
+      const prefix = "neondiff-phase1-lease-v1:";
+      const interval = setInterval(() => {
+        if (offset < prefix.length) socket.write(prefix[offset++]);
+      }, 100);
+      socket.once("close", () => clearInterval(interval));
+    });
+    await new Promise<void>((resolvePromise) => coordinator.listen({
+      host: "127.0.0.1",
+      port: phase1LeaseCoordinationPort(leasePath),
+      exclusive: true
+    }, resolvePromise));
+    const startedAt = Date.now();
+    try {
+      await expect(runPhase1Screen(spec(outputDir), adapter())).rejects.toThrow(/coordination probe.*inconclusive/i);
+      expect(Date.now() - startedAt).toBeLessThan(4500);
+      expect(connections).toBe(3);
+    } finally {
+      await new Promise<void>((resolvePromise) => coordinator.close(() => resolvePromise()));
+    }
+  }, 6000);
 
   it("treats EPERM from process liveness probing as a live lease owner", async () => {
     const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-eperm-lease-"));

--- a/tests/phase1-screening-runner.test.ts
+++ b/tests/phase1-screening-runner.test.ts
@@ -44,8 +44,13 @@ const ownershipProof = {
 const runnerSourcePath = join(process.cwd(), "src", "phase1-screening-runner.ts");
 const harnessRepo = mkdtempSync(join(tmpdir(), "neondiff-phase1-harness-repo-"));
 const harnessRepoSource = join(harnessRepo, "src", "phase1-screening-runner.ts");
+const harnessEntrypoint = join(harnessRepo, "dist", "src", "phase1-characterization-cli.js");
+const harnessRunner = join(harnessRepo, "dist", "src", "phase1-screening-runner.js");
 mkdirSync(dirname(harnessRepoSource), { recursive: true });
+mkdirSync(dirname(harnessEntrypoint), { recursive: true });
 writeFileSync(harnessRepoSource, readFileSync(runnerSourcePath));
+writeFileSync(harnessEntrypoint, "export const entrypoint = true;\n");
+writeFileSync(harnessRunner, "export const runner = true;\n");
 execFileSync("git", ["init", "-q", harnessRepo]);
 execFileSync("git", ["-C", harnessRepo, "config", "user.email", "phase1@example.invalid"]);
 execFileSync("git", ["-C", harnessRepo, "config", "user.name", "Phase 1 Test"]);
@@ -141,7 +146,15 @@ function spec(outputDir: string): Phase1RunSpec {
       requiredMetrics: [],
       parameters: { temperature: 0.6, top_p: 0.95, top_k: 20 }
     },
-    harness: { commit: harnessCommit, sourcePath: harnessRepoSource, sourceSha256: digest(readFileSync(harnessRepoSource)) },
+    harness: {
+      commit: harnessCommit,
+      sourcePath: harnessRepoSource,
+      sourceSha256: digest(readFileSync(harnessRepoSource)),
+      entrypointPath: harnessEntrypoint,
+      entrypointSha256: digest(readFileSync(harnessEntrypoint)),
+      runnerPath: harnessRunner,
+      runnerSha256: digest(readFileSync(harnessRunner))
+    },
     parser: { version: "phase1-parser/v1", format: "json", sha256: digest("phase1-parser/v1:json") },
     gate: { version: "phase1-gate/v1", requiredTopLevelKeys: [], sha256: digest("phase1-gate/v1:") }
   };

--- a/tests/phase1-screening-runner.test.ts
+++ b/tests/phase1-screening-runner.test.ts
@@ -66,7 +66,11 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
     const kind = ${JSON.stringify(kind)};
     let sequence = 0;
     let attachObserved = false;
-    export function createMonitor() {
+    let forceStopOom = false;
+    export function createMonitor(factoryParameters) {
+      if (kind === "factory-parameters" && (!Object.isFrozen(factoryParameters) || factoryParameters?.nvidiaSmiSha256 !== ${JSON.stringify("a".repeat(64))})) {
+        throw new Error("factory parameters were not immutably bound");
+      }
       return {
         async start() {
           if (kind === "start-error") throw new Error("monitor start exploded");
@@ -77,13 +81,16 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
         },
         async attach(_session, resident) {
           if (kind === "attach-error") throw new Error("monitor attach exploded");
+          if (kind === "conditional-attach-error" && resident.metadata?.failAttach) throw new Error("monitor attach exploded");
+          if (kind === "attach-and-stop-error") throw new Error("monitor attach exploded");
           if (kind === "attach-unsafe-probe") attachObserved = true;
+          if (kind === "conditional-stop-oom") forceStopOom = resident.metadata?.forceStopOom === true;
           if (!resident.metadata || resident.metadata.pid !== 42) throw new Error("monitor did not receive resident metadata");
         },
         async sample(_session, context) {
           if (kind === "throw-" + context.phase) throw new Error("monitor " + context.phase + " exploded");
           sequence += 1;
-          const base = { capturedAt: "sample-" + sequence, phase: context.phase, rssBytes: 100 + sequence, vramBytes: 200, swapBytes: kind === "swap" && sequence > 2 ? 4096 : 0 };
+          const base = { capturedAt: "sample-" + sequence, phase: context.phase, rssBytes: 100 + sequence, vramBytes: 200, swapBytes: kind === "swap" && sequence > 2 ? 4096 : 0, factoryParametersBound: kind === "factory-parameters" ? 1 : 0 };
           if (kind === "sample-nan") return { ...base, rssBytes: Number.NaN };
           if (kind === "sample-infinity") return { ...base, diagnosticValue: Number.POSITIVE_INFINITY };
           if (kind === "sample-negative") return { ...base, vramBytes: -1 };
@@ -96,10 +103,13 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
           if (kind === "classify-scalar") return "stopped";
           if (kind === "swap" && samples.some(sample => sample.swapBytes >= 4096)) return { status: "stopped", errorCode: "sustained_swap_growth" };
           if (kind === "stop-oom" && samples.some(sample => sample.phase === "stopped")) return { status: "oom", errorCode: "stop_time_oom" };
+          if (kind === "conditional-stop-oom" && forceStopOom && samples.some(sample => sample.phase === "stopped")) return { status: "oom", errorCode: "stop_time_oom" };
           return undefined;
         },
         async stop() {
           const base = { capturedAt: "stop", phase: "stopped", rssBytes: 0, vramBytes: 0, swapBytes: 0, attachObserved: attachObserved ? 1 : 0 };
+          if (kind === "attach-and-stop-error") throw new Error("monitor stop exploded");
+          if (kind === "stop-empty") return [];
           if (kind === "stop-array") return [{ ...base, capturedAt: "periodic", phase: "periodic" }, base];
           if (kind === "secret-stop") return { ...base, diagnostic: "Authorization: Bearer sk-secret-value-1234567890" };
           if (kind === "secret-fingerprint-stop") return { ...base, evidenceSha256: "sk-secret-value-1234567890" };
@@ -114,7 +124,8 @@ function monitorModule(kind: string): Phase1ResourceMonitorModule {
     modulePath,
     moduleSha256: digest(readFileSync(modulePath)),
     approvedRoot: monitorModuleRoot,
-    exportName: "createMonitor"
+    exportName: "createMonitor",
+    ...(kind === "factory-parameters" ? { factoryParameters: { nvidiaSmiSha256: "a".repeat(64) } } : {})
   };
 }
 
@@ -508,6 +519,26 @@ describe("Phase 1 screening runner", () => {
     expect(second.samples[0].rssBytes).toBe(101);
   });
 
+  it("binds frozen factory parameters into monitor identity and resume fingerprints", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-parameters-"));
+    const identity = monitorModule("factory-parameters");
+    await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity });
+    const manifest = JSON.parse(readFileSync(join(outputDir, "manifest.json"), "utf8"));
+    expect(manifest.monitorIdentity.factoryParameters).toEqual({ nvidiaSmiSha256: "a".repeat(64) });
+    const resources = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
+    expect(resources.samples.some((sample: { factoryParametersBound?: number }) => sample.factoryParametersBound === 1)).toBe(true);
+
+    const drift = { ...identity, factoryParameters: { nvidiaSmiSha256: "b".repeat(64) } };
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: drift })).rejects.toThrow(/manifest fingerprint mismatch/i);
+  });
+
+  it("rejects secret-like monitor factory parameters before writing evidence", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-parameter-secret-"));
+    const identity = { ...monitorModule("normal"), factoryParameters: { token: "sk-secret-value-1234567890" } };
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity })).rejects.toThrow(/secret-like text/i);
+    expect(existsSync(join(outputDir, "manifest.json"))).toBe(false);
+  });
+
   it("attaches the pinned monitor after resident start and persists a bounded stop trace array", async () => {
     const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-attach-"));
     await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule("stop-array") });
@@ -518,9 +549,55 @@ describe("Phase 1 screening runner", () => {
   it("fails closed and stops the resident when monitor attachment fails", async () => {
     const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-attach-fail-"));
     let stopped = false;
-    await expect(runPhase1Screen(spec(outputDir), adapter({ async stop() { stopped = true; } }), { monitorModule: monitorModule("attach-error") })).rejects.toThrow(/monitor attach exploded/i);
+    let invoked = false;
+    await expect(runPhase1Screen(spec(outputDir), adapter({
+      async invoke() { invoked = true; return { status: "completed", rawOutput: "{}" }; },
+      async stop() { stopped = true; }
+    }), { monitorModule: monitorModule("attach-error") })).rejects.toThrow(/monitor attach exploded/i);
     expect(stopped).toBe(true);
+    expect(invoked).toBe(false);
     expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
+  });
+
+  it("preserves completed results when attachment fails during a partial resume", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-attach-resume-"));
+    const identity = monitorModule("conditional-attach-error");
+    await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity });
+    const completedPath = join(outputDir, "results", "warm-8k", "pr-1.json");
+    const completedBytes = readFileSync(completedPath);
+    rmSync(join(outputDir, "results", "warm-8k", "pr-2.json"));
+    rmSync(join(outputDir, "summary.json"));
+    rmSync(join(outputDir, "COMPLETED"));
+
+    await expect(runPhase1Screen(spec(outputDir), adapter({
+      async start() { return { id: "resident", argv: ["/opt/llama-server"], metadata: { pid: 42, failAttach: true } }; }
+    }), { monitorModule: identity })).rejects.toThrow(/monitor attach exploded/i);
+    expect(readFileSync(completedPath)).toEqual(completedBytes);
+  });
+
+  it("cleans up the resident and monitor when attach-failure result persistence also fails", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-attach-write-fail-"));
+    const resultsPath = join(outputDir, "results");
+    let stopped = false;
+    await expect(runPhase1Screen(spec(outputDir), adapter({
+      async start() {
+        writeFileSync(resultsPath, "blocks result directory");
+        return { id: "resident", argv: ["/opt/llama-server"], metadata: { pid: 42 } };
+      },
+      async stop() {
+        stopped = true;
+        rmSync(resultsPath);
+      }
+    }), { monitorModule: monitorModule("attach-error") })).rejects.toThrow();
+    expect(stopped).toBe(true);
+    expect(existsSync(join(outputDir, "resources", "warm-8k.json"))).toBe(true);
+  });
+
+  it("retains ordered attachment and cleanup failures", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-multi-failure-"));
+    await expect(runPhase1Screen(spec(outputDir), adapter({
+      async stop() { throw new Error("resident stop exploded"); }
+    }), { monitorModule: monitorModule("attach-and-stop-error") })).rejects.toThrow(/monitor attach exploded.*resident stop exploded.*monitor stop exploded/i);
   });
 
   it("rejects unsafe resident evidence before it can reach monitor attachment", async () => {
@@ -547,6 +624,12 @@ describe("Phase 1 screening runner", () => {
     await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity });
     const resources = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
     expect(resources.samples.map((sample: { capturedAt: string }) => sample.capturedAt)).toEqual(expect.arrayContaining(reconstructedCapturedAt));
+  });
+
+  it("rejects an empty terminal monitor trace", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-empty-stop-"));
+    await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule("stop-empty") })).rejects.toThrow(/terminal trace.*empty/i);
+    expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
   });
 
   it("rejects relative or package imports because pinned monitors load as self-contained exact bytes", async () => {
@@ -627,6 +710,32 @@ describe("Phase 1 screening runner", () => {
     expect(existsSync(join(outputDir, "resources", "warm-8k.json"))).toBe(true);
   });
 
+  it("finalizes monitor evidence even when resident startup and terminal-result persistence both fail", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-start-write-fail-"));
+    await expect(runPhase1Screen(spec(outputDir), adapter({
+      async start(context) {
+        writeFileSync(join(context.outputDir, "results"), "blocks result directory");
+        throw new Error("resident startup failed");
+      }
+    }), { monitorModule: monitorModule("normal") })).rejects.toThrow();
+    expect(existsSync(join(outputDir, "resources", "warm-8k.json"))).toBe(true);
+  });
+
+  it("stops resident and monitor when unsafe resident evidence cannot persist terminal results", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-unsafe-write-fail-"));
+    let stopped = false;
+    await expect(runPhase1Screen(spec(outputDir), adapter({
+      async start(context) {
+        writeFileSync(join(context.outputDir, "results"), "blocks result directory");
+        return { id: "resident", argv: ["/opt/llama-server"], logs: "Authorization: Bearer sk-secret-value-1234567890", metadata: { pid: 42 } };
+      },
+      async stop() { stopped = true; }
+    }), { monitorModule: monitorModule("attach-unsafe-probe") })).rejects.toThrow();
+    expect(stopped).toBe(true);
+    const resources = JSON.parse(readFileSync(join(outputDir, "resources", "warm-8k.json"), "utf8"));
+    expect(resources.samples.every((sample: { attachObserved?: number }) => sample.attachObserved === 0)).toBe(true);
+  });
+
   it("records valid empty resource evidence when the monitor itself cannot start", async () => {
     const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-start-error-"));
     await expect(runPhase1Screen(spec(outputDir), adapter(), { monitorModule: monitorModule("start-error") })).rejects.toThrow(/monitor start exploded/i);
@@ -690,6 +799,24 @@ describe("Phase 1 screening runner", () => {
     expect(result.status).toBe("failed");
     expect(result.counts.oom).toBe(2);
     expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
+  });
+
+  it("does not rewrite a prior completed result when a resumed attempt stops with OOM", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-monitor-resume-stop-oom-"));
+    const identity = monitorModule("conditional-stop-oom");
+    await runPhase1Screen(spec(outputDir), adapter(), { monitorModule: identity });
+    const existingPath = join(outputDir, "results", "warm-8k", "pr-1.json");
+    const existingBytes = readFileSync(existingPath);
+    rmSync(join(outputDir, "results", "warm-8k", "pr-2.json"));
+    rmSync(join(outputDir, "summary.json"));
+    rmSync(join(outputDir, "COMPLETED"));
+
+    const resumed = await runPhase1Screen(spec(outputDir), adapter({
+      async start() { return { id: "resident", argv: ["/opt/llama-server"], metadata: { pid: 42, forceStopOom: true } }; }
+    }), { monitorModule: identity });
+    expect(resumed.status).toBe("failed");
+    expect(readFileSync(existingPath)).toEqual(existingBytes);
+    expect(JSON.parse(readFileSync(join(outputDir, "results", "warm-8k", "pr-2.json"), "utf8"))).toMatchObject({ status: "oom" });
   });
 
   it("continues after an isolated request failure and records retry counts", async () => {
@@ -1169,5 +1296,16 @@ describe("Phase 1 screening runner", () => {
     expect(resumed.infrastructureErrorCode).toBe("shutdown_failed");
     expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
     expect(existsSync(join(outputDir, "COMPLETED"))).toBe(false);
+  });
+
+  it("fails closed when an infrastructure exception has an empty message", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "neondiff-phase1-empty-stop-failure-"));
+    await expect(runPhase1Screen(spec(outputDir), adapter({
+      async stop() { throw new Error(""); }
+    }))).rejects.toThrow(/infrastructure_failure/i);
+    const summary = JSON.parse(readFileSync(join(outputDir, "summary.json"), "utf8"));
+    expect(summary.status).toBe("failed");
+    expect(summary.infrastructureErrorCode).toBe("infrastructure_failure");
+    expect(existsSync(join(outputDir, "FAILED"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- add a Linux/procfs runtime that proves exact resident executable identity, argv, listener/socket ownership, RSS/process swap/system swap, and pinned `/usr/bin/nvidia-smi` telemetry
- attach the monitor only after the runner establishes the resident process identity, preserve bounded chronological traces, and carry authoritative stop samples into terminal evidence
- add a built-JavaScript-only private characterization entrypoint with immutable plan/runtime/monitor/NVIDIA binary SHA bindings

## Scope boundary

This is the runtime/preflight slice for #565 under #405 and milestone #17. It does not add a public CLI command, provider/worker/posting integration, daemon state, active configuration, default switch, release, or public quality claim. It does not touch PR #471 provider surfaces.

## Validation

- `npm test -- tests/phase1-screening-runner.test.ts tests/linux-phase1-runtime.test.ts tests/phase1-characterization-cli.test.ts` — 88 passed, 3 Linux-only skipped on macOS
- `npm run build`
- `npm run check:secrets` — 661 tracked files
- `git diff --check origin/main...HEAD`
- independent runtime/security adversarial review — no P0-P2 findings

## Remaining proof before readiness

The three procfs/listener/image-replacement tests must pass on GEX44 Linux. The built runtime, monitor, and `/usr/bin/nvidia-smi` identities must then be frozen into the private characterization plan before any candidate cell starts.

Refs #565
Parent: #405