### PR TITLE
feat(license): add authoritative subscription lifecycle

### DIFF
--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -400,11 +400,27 @@ npx tsx src/cli.ts review-head-gate \
     --url https://neondiff-license.fly.dev/v1/admin/licenses/issue \
     --release-version <release-version> \
     --checkout-lookup-key neondiff_monthly \
+    --provider-account-id <stripe-account-id> \
+    --provider-mode test \
+    --external-subscription-id <test-subscription-id> \
+    --external-checkout-id <test-checkout-session-id> \
     --secret-env LICENSE_ISSUANCE_SECRET \
     --dry-run false \
     --confirm-live-issuance true \
     --output docs/evidence/license-checkout-issuance-authenticated.json
   ```
+
+  Start with Stripe test-mode correlation. For a separately approved live proof,
+  change `--provider-mode` to `live` and supply the matching live account,
+  subscription, and Checkout Session IDs. Never mix test and live objects, and
+  never synthesize or guess production identifiers. Exact correlation is visible
+  only in the no-network dry-run preview; persisted success/error proof omits the
+  account, subscription, Checkout Session, bearer, and raw license key.
+  The programmatic shared-secret branch of `runLicenseLifecycleSmoke` has the
+  same rule: `checkoutIssuanceCorrelation` is mandatory and must carry one
+  matching Stripe account/mode/subscription/Checkout Session tuple. The trusted
+  GitHub OIDC release-proof wrapper remains separate and does not accept a
+  shared secret or checkout tuple on argv.
 
   Run the same command with `--dry-run true` first when preparing a release
   packet; dry-run mode does not read the secret and does not send the POST.

--- a/docs/beta-release-runbook.md
+++ b/docs/beta-release-runbook.md
@@ -416,6 +416,9 @@ npx tsx src/cli.ts review-head-gate \
   never synthesize or guess production identifiers. Exact correlation is visible
   only in the no-network dry-run preview; persisted success/error proof omits the
   account, subscription, Checkout Session, bearer, and raw license key.
+  When `--idempotency-key` is omitted, the CLI derives an opaque tuple-scoped
+  default, so separately approved test and live proofs do not collide while an
+  exact retry within one environment remains stable.
   The programmatic shared-secret branch of `runLicenseLifecycleSmoke` has the
   same rule: `checkoutIssuanceCorrelation` is mandatory and must carry one
   matching Stripe account/mode/subscription/Checkout Session tuple. The trusted

--- a/docs/license-service-admin.md
+++ b/docs/license-service-admin.md
@@ -38,6 +38,9 @@ Current local proof includes:
   `source="none"` and the review gate fails closed;
 - checkout lifecycle authorization, correlation failures, results, and errors
   are redacted and never echo a raw key or request identifiers;
+- lifecycle revocation persists only a status-derived non-secret reason code;
+  arbitrary provider/customer text and control characters fail closed before
+  storage or admin/client output;
 - secret-bearing values remain outside tracked config, GitHub evidence, and
   operator docs.
 

--- a/docs/license-service-admin.md
+++ b/docs/license-service-admin.md
@@ -1,17 +1,28 @@
 # License Service Admin Readiness
 
-Issue: [#327](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327)
-Status: source-only readiness slice; mock-only proof
+Issues: [#327](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327),
+[#562](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/562)
+Status: v1.0.4 activation contract proven locally; subscription lifecycle and
+schema v2 rollout remain source-only
 
-This document defines the operator/admin boundary for NeonDiff's hosted or
-direct license service integration. It does not prove a staging endpoint,
-admin credential, billing webhook, production service, or customer-ready
-private-repo entitlement flow.
+This document defines the operator/admin boundary for NeonDiff's license
+service integration. It does not prove a staging endpoint, admin credential,
+billing webhook, production lifecycle deploy, checkout reopening, or
+customer-ready entitlement flow.
 
 ## Current Proof Boundary
 
-The source tree can model and test license-service outcomes locally. The proof
-in this slice is limited to mocked API responses and local cache behavior:
+The source tree runs the real v1.0.4 license client against the in-process
+license service. That contract proves checkout-bound issue, activate, paid
+renew, validate, cancel-at-period-end, expiry, terminal revoke, deactivate, and
+different-machine seat behavior without network or production mutation.
+
+The schema v2 subscription lifecycle slice remains source-only. It proves code,
+tests, migration rollback, and documentation; it does not prove a production
+database migration, legacy backfill, Stripe webhook, Fly deploy, or live
+checkout.
+
+Current local proof includes:
 
 - the client recognizes `expired`, `revoked`, `invalid`, `scope_mismatch`,
   `rate_limited`, `unsupported_client`, `clock_skew`, `network`, and `server`
@@ -20,8 +31,13 @@ in this slice is limited to mocked API responses and local cache behavior:
   missing, stale, non-active, or not scoped for the requested visibility;
 - entitlement cache metadata can include the license fingerprint, plan,
   repo visibility coverage, private-repo allowance, update entitlement,
-  expiry, offline grace metadata, and non-active revocation reason when supplied
-  by a service response;
+  expiry, diagnostic cache metadata, and non-active revocation reason when
+  supplied by a service response;
+- mandatory-online configuration uses `offlineGraceMs=0`; a successful
+  activation may create a diagnostic cache, but a simulated API outage returns
+  `source="none"` and the review gate fails closed;
+- checkout lifecycle authorization, correlation failures, results, and errors
+  are redacted and never echo a raw key or request identifiers;
 - secret-bearing values remain outside tracked config, GitHub evidence, and
   operator docs.
 
@@ -44,7 +60,7 @@ private repo contents, provider keys, or customer secrets:
 | Service throttles validation or activation | `rate_limited` | Keep the gate closed; do not treat throttling as live readiness. |
 | Client version is too old for the service contract | `unsupported_client` | Ask the operator to upgrade before retrying. |
 | Client/server time drift is outside service tolerance | `clock_skew` | Ask the operator to correct time sync before retrying. |
-| Network or service failure | `network` or `server` | Use only the existing short offline cache grace for active cached entitlements; otherwise fail closed. |
+| Network or service failure | `network` or `server` | With supported `offlineGraceMs=0`, cache is diagnostic only and review fails closed immediately. Restore the API; do not enable a client-side bypass. |
 
 When a 2xx response body provides a non-`active` status, that status is
 authoritative and the gate fails closed without writing an active cache.
@@ -69,9 +85,9 @@ response supplies them:
   closed even if `repoVisibilityScope` is `private` or `all`;
 - `updateEntitlement`: whether update-channel access is allowed;
 - `expiresAt`: entitlement expiry time;
-- `offlineGraceMs` and `graceUntil`: cache-grace metadata for operator
-  diagnosis; local `config.license.offlineGraceMs` remains the authority for
-  whether cached entitlement grace is accepted;
+- `offlineGraceMs` and `graceUntil`: legacy/diagnostic cache metadata only. The
+  supported mandatory-online configuration fixes `offlineGraceMs=0`; operators
+  must not use client-editable config to grant outage authority;
 - `revocationReason`: redacted, printable, length-capped reason such as refund,
   chargeback, manual disable, or policy violation; preserved only when the
   entitlement status is not `active`.
@@ -81,20 +97,44 @@ treated as an explicit fail-closed private-repo denial. Review gating still
 requires an active entitlement that covers the requested repo visibility and
 passes the existing freshness rules.
 
-## Required Live Readiness Inputs
+## Subscription lifecycle operator boundary
 
-A future PR or release gate needs all of the following before claiming live
-license-service readiness:
+The guarded endpoint is `POST /v1/admin/licenses/lifecycle`. Its five commands
+are `renew_paid`, `reconcile`, `cancel_at_period_end`, `payment_attention`, and
+`revoke`. Exact provider account, `test`/`live` mode, and subscription binding
+must match an immutable checkout issuance tuple. Server policy owns trial,
+maximum period, USD currency, scope, and one-seat authority.
+
+Legacy checkout binding uses the admin
+`bind-checkout-subscription` command. Run `--dry-run` first, review the opaque
+issuance fingerprint and exact tuple, and require explicit production owner
+approval before the write form. Never accept or print a raw key, and do not
+mint a replacement key during reconciliation.
+
+The complete matrix, result mapping, rollout steps, and redaction contract live
+in
+[`services/license-api/docs/subscription-lifecycle.md`](../services/license-api/docs/subscription-lifecycle.md).
+
+## Required live readiness inputs
+
+Issue
+[#559](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/559)
+needs all of the following before claiming live lifecycle/release readiness:
 
 - a staging license API base URL;
 - staging admin credentials or delegated operator access;
-- a non-secret test license or fixture account with documented allowed scope;
-- redacted activation, status, refresh, and deactivate evidence;
-- proof that the admin path can issue, inspect, revoke, and restore an
-  entitlement without exposing private repo contents;
+- a separately identified sandbox and live provider account/mode/database;
+- a verified pre-v2 Litestream recovery point and timed fresh-volume restore;
+- redacted activation, status, refresh, deactivate, renewal, cancellation,
+  expiry, revocation, idempotency, and no-bypass evidence;
+- reviewed legacy-binding dry-run/output, if production data needs backfill;
+- proof that the admin path can inspect and restore an entitlement without
+  exposing private repo contents or minting replacement keys during
+  reconciliation;
 - secret scan and public-claims scan results for the exact evidence packet.
 
-Without those inputs, operators may claim only mocked/local contract coverage.
+Without those inputs, operators may claim only the real local v1.0.4 client
+contract and source-level schema/lifecycle coverage described above.
 
 ## Stop Conditions
 
@@ -107,12 +147,15 @@ Stop and return to the release captain if any of these occur:
 - the service returns a status outside the documented taxonomy;
 - live validation requires expanding GitHub App permissions;
 - evidence would imply production, GA, enterprise, marketplace, or calibrated
-  review-quality readiness from mocked responses alone.
+  review-quality readiness from local contract responses alone.
+- a rollback plan assumes a previous image reverses schema v2, copies an open
+  SQLite database, or restores over the existing volume;
+- test-mode evidence is presented as live-mode proof;
+- reconciliation attempts raw-key recovery or replacement-key minting.
 
-## Follow-Up
+## Release handoff
 
-The next slice should connect this source contract to a staging-only admin
-smoke once the endpoint and credentials exist. That follow-up should update
-issue `#327` with a redacted evidence path under
-the operator-configured `evidenceDir`, for example
-`<evidenceDir>/<date>/production-license-service/`.
+Checkout remains held. #559 owns version/manifest changes, deployment,
+installed-package verification, live activation, public release proof, and the
+decision to reopen checkout. This document, issue #562, and their local tests do
+not mutate or satisfy those release gates.

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -146,10 +146,14 @@ Before tagging:
      path (`checkoutIssuanceAuthenticatedProofPath`) with no raw bearer secret,
      license key, cookie, customer data, checkout payload secret, or raw response
      body. Generate it with `npx tsx src/cli.ts checkout-issuance-smoke
-     --dry-run false --confirm-live-issuance true --secret-env
-     LICENSE_ISSUANCE_SECRET --output
+     --provider-account-id <stripe-account-id> --provider-mode test
+     --external-subscription-id <test-subscription-id>
+     --external-checkout-id <test-checkout-session-id> --dry-run false
+     --confirm-live-issuance true --secret-env LICENSE_ISSUANCE_SECRET --output
      docs/evidence/license-checkout-issuance-authenticated.json` after the
-     paired Fly and server-side checkout secrets are configured.
+     paired Fly and server-side checkout secrets are configured. A live-mode
+     proof must use an explicitly supplied, matching live tuple; never reuse or
+     invent test identifiers for a live request.
    - computed checkout issuance status and, when present, the raw manifest
      declaration that produced it
    - CLI, daemon, website, and desktop update-channel state

--- a/docs/superpowers/plans/2026-07-13-license-subscription-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-13-license-subscription-lifecycle.md
@@ -1,0 +1,144 @@
+# License Subscription Lifecycle Implementation Plan
+
+**Goal:** Implement issue #562's sole-authority subscription lifecycle without changing the shipped v1.0.4 client contract or reopening checkout.
+
+**Authority and boundaries:** The merged design at `edc6aeb6fa293a58844384ceba7f798ac5a8a744` is authoritative, with two explicit corrections from current shipped/public truth: Individual Yearly receives a 7-day initial trial (Monthly 7, Organization Yearly 30), and the initial supported billing currency is USD only. Issue #562 owns implementation; #559 owns the immutable v1.0.5 release; website #46 owns the checkout adapter and live Stripe proof. Do not deploy, mutate Stripe or production SQLite, reopen checkout, publish, or claim customer readiness in this branch.
+
+**Architecture:** Upgrade the license service to a crash-safe SQLite schema v2 with immutable checkout/subscription bindings and an append-only lifecycle ledger. Checkout issuance becomes server-policy-owned. A strict parser validates a small lifecycle command matrix, while a single atomic store transaction enforces replay safety, monotonic renewal, cancellation behavior, and terminal revocation. A separately rate-limited admin endpoint uses the existing issuance-secret boundary. Existing hashes, activations, and the v1.0.4 client protocol remain compatible.
+
+**Execution rule:** Each task follows RED → minimal GREEN → focused/full verification → commit → fresh independent task review. P0-P2 findings block progression.
+
+## Task 1: Crash-safe schema v2 migration
+
+Create `services/license-api/test/store-migration.test.ts`; modify `services/license-api/src/store.ts`.
+
+- Add `SchemaMigrationStep`, `LicenseStoreOptions`, and an optional migration hook for deterministic rollback tests.
+- Empty `user_version=0` creates the complete v2 schema atomically.
+- The exact legacy three-table schema migrates additively; unknown non-empty v0 schemas fail before mutation.
+- Add immutable `checkout_subscription_bindings` and append-only `license_subscription_lifecycle_events`, including the issuance/time index.
+- Verify v2 on reopen and prove hook-triggered failures roll back all DDL while preserving legacy rows.
+
+RED/GREEN: `node --import tsx --test test/store-migration.test.ts`; then service `npm test` and `npm run build`.
+
+Commit: `feat(license-api): add crash-safe schema v2 migration`
+
+## Task 2: Server-owned checkout policy and bound issuance
+
+Create `src/checkout-policy.ts` and `test/issuance-policy.test.ts`; modify issuance, store, and HTTP tests.
+
+- Policies: Monthly 7-day trial/62-day max/USD/1 seat; Individual Yearly 7-day trial/400-day max/USD/1 seat; Organization Yearly 30-day trial/400-day max/USD/1 seat.
+- Require issuance reference plus provider/account/mode/subscription/checkout identifiers.
+- Reject caller authority over expiry, plan, scope, ownership, or seats; compatibility `seats` is accepted only when exactly 1.
+- Derive expiry from the injected clock and insert license, issuance, and binding in one transaction.
+- Quarantine conflicting unbound or multi-seat replays with `409`.
+
+RED/GREEN: `node --import tsx --test test/issuance-policy.test.ts test/http.test.ts`, then the service suite/build.
+
+Commit: `feat(license-api): bind checkout issuance to server policy`
+
+## Task 3: Strict lifecycle parser and canonical hash
+
+Create `src/subscription-lifecycle.ts` and `test/subscription-lifecycle-parser.test.ts`.
+
+- Commands: `renew_paid`, `reconcile`, `cancel_at_period_end`, `payment_attention`, `revoke`.
+- Enforce the exact field set, bounded body/strings, integer event time, five-minute future skew, provider tuple, command/event/status matrix, and lowercase USD.
+- `renew_paid` requires active status, positive provider-collected subscription-cycle payment, reference, and period end; reject zero, credits/trials, out-of-band, non-cycle, and trialing evidence.
+- Canonicalize fixed fields for a stable request hash and store only a one-way payment-reference fingerprint.
+
+RED/GREEN: `node --import tsx --test test/subscription-lifecycle-parser.test.ts`.
+
+Commit: `feat(license-api): validate subscription lifecycle commands`
+
+## Task 4: Atomic replay and monotonic renewal
+
+Create `test/subscription-lifecycle-store.test.ts`; modify store and lifecycle modules.
+
+- In `BEGIN IMMEDIATE`, resolve the bound issuance, hash the request, replay exact event/hash, conflict on event/hash mismatch, and require the exact provider tuple.
+- Enforce plan period caps and extend using `max(existing, incoming)`.
+- Reactivate only non-terminal stored expiry with a future valid paid end.
+- Write ledger and entitlement mutation in one transaction; never store raw keys or payment references.
+
+RED/GREEN: focused `binding|replay|renewal` store tests, then full service suite/build.
+
+Commit: `feat(license-api): apply bound paid renewals atomically`
+
+## Task 5: Ordering, cancellation, attention, and terminal dominance
+
+Extend lifecycle store tests and implementation.
+
+- Reconcile records without extending/reactivating; stale non-mutating events become audited `ignored_stale` results.
+- Cancellation preserves expiry; payment attention grants no time and does not revoke early.
+- Revoke needs no period end, records a bounded reason, and is terminal.
+- Prove no resurrection, max-period convergence, same-second order convergence, and preservation of activation/key hashes.
+
+RED/GREEN: focused `cancel|attention|stale|same-second|terminal` tests, then full service suite/build.
+
+Commit: `feat(license-api): enforce terminal lifecycle ordering`
+
+## Task 6: Guarded lifecycle HTTP endpoint
+
+Create `test/subscription-lifecycle-http.test.ts`; modify `src/http.ts`, `src/server.ts`, and HTTP tests.
+
+- Add `POST /v1/admin/licenses/lifecycle` behind the existing issuance secret and a distinct `subscriptionLifecycleRateLimiter` (never reuse the GitHub OIDC lifecycle limiter).
+- Enforce a 16 KiB body cap, generic pre-lookup `401`, bounded redacted `429`, and no request/exception echo.
+- Map applied/replay/stale/attention/revoke to `200`, terminal/conflict to `409`, unknown/unbound/mismatch to `404`, policy/parser errors to `400`, and transient storage errors to `503`.
+
+RED/GREEN: `node --import tsx --test test/subscription-lifecycle-http.test.ts`, then service suite/build.
+
+Commit: `feat(license-api): add guarded subscription lifecycle endpoint`
+
+## Task 7: Owner-only legacy binding backfill
+
+Modify store, admin CLI, and admin tests.
+
+- Add `bind-checkout-subscription` with provider tuple and optional `--dry-run`; never accept or print a raw key.
+- Bind only existing `source=checkout` issuance, make identical replay idempotent, and conflict on tuple differences.
+- Return only result plus an opaque issuance fingerprint. Production execution remains a separate owner-approved operation.
+
+RED/GREEN: focused admin `bind checkout subscription` tests, then service suite/build.
+
+Commit: `feat(license-api): add guarded checkout binding backfill`
+
+## Task 8: Real v1.0.4 client compatibility
+
+Extend `tests/license-service-contract.test.ts` and service tests.
+
+- With the real client, prove bound issue → activate → paid renew → validate active → cancel while active → expire, plus separate terminal revocation.
+- Prove no raw key appears in lifecycle responses/evidence and the existing activate/validate/deactivate/seat flow is unchanged.
+
+RED/GREEN: focused contract/license/mandatory-activation tests with one worker, then root build.
+
+Commit: `test(license): prove lifecycle compatibility with v1.0.4 client`
+
+## Task 9: Rollout and disaster-recovery contract
+
+Create `services/license-api/docs/subscription-lifecycle.md`; update service/root admin, deploy, DR docs/tests, and only rename the existing CI service gate if needed.
+
+- Document endpoint/matrix/results/redaction/backfill and the continuing checkout hold.
+- Require a verified Litestream recovery point immediately before v2 rollout; forbid copying an open SQLite database.
+- Migration failure must prevent start. Image rollback does not reverse schema; restore uses the reviewed recovery point on a fresh path/volume.
+- Preserve sandbox/live separation, prohibit raw-key recovery/replacement minting during reconciliation, and remove stale offline-cache authorization claims.
+- Explicitly hand release/version/manifest/live proof to #559.
+
+RED/GREEN: focused DR test, then complete verification below.
+
+Commit: `docs(license): add lifecycle rollout and recovery runbook`
+
+## Final verification and proof boundary
+
+Run, in order:
+
+```bash
+npm ci --prefix services/license-api
+npm test --prefix services/license-api
+npm run build --prefix services/license-api
+npm ci
+npx vitest run tests/license-service-contract.test.ts tests/license-service-dr.test.ts tests/license.test.ts tests/mandatory-activation-matrix.test.ts --pool=forks --maxWorkers=1
+npm run build
+npm test -- --pool=forks --maxWorkers=1
+npm run check:public-claims
+npm run check:secrets
+git diff --check
+```
+
+Then require exact-head CI and CodeQL, independent spec/security review, and zero unresolved current-head P0-P2 threads. Merge proves source/contract readiness only. Deployment, production backfill, website integration, live Stripe lifecycle proof, checkout reopening, and immutable v1.0.5 release remain separately gated.

--- a/services/license-api/README.md
+++ b/services/license-api/README.md
@@ -43,6 +43,12 @@ The HTTP-code → client-classification map is fixed by the client
 403/410→revoked · 401/404→invalid · 5xx→server`); the service returns codes that
 match it.
 
+Lifecycle revocation derives a non-secret reason code from subscription status:
+`subscription_canceled`, `subscription_unpaid`, or
+`subscription_incomplete_expired`. Optional caller `reason` must exactly match
+that derived value; arbitrary provider/customer text and control characters are
+rejected before storage.
+
 ### Checkout issuance
 
 `POST /v1/admin/licenses/issue` is for the website/payment webhook only. It is

--- a/services/license-api/README.md
+++ b/services/license-api/README.md
@@ -4,30 +4,33 @@ Self-contained license service for NeonDiff API-backed entitlements
 ([#327](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327)).
 It implements the exact HTTP contract the shipped client (`src/license.ts`)
 already calls — activate / validate / deactivate — backed by SQLite, with an
-admin CLI that mints keys. Checkout fulfillment may also use the guarded
-server-to-server issuance endpoint below; Stripe/Lovable publish wiring remains
-outside this package and must call the endpoint with an owner-held shared
-secret.
+admin CLI that mints keys. Guarded server-to-server routes issue checkout
+licenses and apply provider subscription lifecycle events. Stripe/Lovable
+publish wiring remains outside this package and must use the owner-held shared
+secret; checkout is still held pending the rollout proof in issue #559.
 
 The service is a separate package boundary; it does **not** import the review
 worker and can be deployed on its own (SQLite on a mounted volume).
 
 ## Contract
 
-Three `POST` endpoints, JSON in / JSON out (`Content-Type: application/json`):
+Six `POST` endpoints, JSON in / JSON out (`Content-Type: application/json`):
 
 | Endpoint | Request body | Success (200) | Denials |
 | --- | --- | --- | --- |
 | `/v1/license/activate` | `{ licenseKey, repo?, machineId }` | `{ entitlement: { status:"active", repoVisibilityScope, … } }` | 404 invalid · 403 revoked · 402 expired · **409 scope_mismatch** (seat exhausted) |
 | `/v1/license/validate` | `{ licenseKey, repo?, machineId }` | active entitlement | 404 invalid · 403 revoked · 402 expired · 409 scope_mismatch (never activated on this machine) |
 | `/v1/license/deactivate` | `{ licenseKey, repo?, machineId }` | `{ status:"active", … }` (idempotent) | 404 invalid |
-| `/v1/admin/licenses/issue` | `{ idempotencyKey, checkoutLookupKey, ... }` + `Authorization: Bearer <LICENSE_ISSUANCE_SECRET>` | `{ status:"issued", licenseKey:"nd_live_...", entitlement, replayed }` | 401 unauthorized · 400 malformed/unsupported plan · 409 idempotency conflict |
+| `/v1/admin/licenses/issue` | `{ idempotencyKey, checkoutLookupKey, ... }` + `Authorization: Bearer <LICENSE_ISSUANCE_SECRET>` | `{ status:"issued", licenseKey:"nd_live_...", entitlement, replayed }` | 401 unauthorized · 400 malformed/unsupported lookup or policy · 409 idempotency conflict |
 | `/v1/admin/licenses/issue-lifecycle` | exact release identity + GitHub Actions OIDC bearer | short-lived lifecycle license + all-scope entitlement | 401 invalid workflow token · 403 candidate SHA mismatch · 409 workflow-run conflict · 503 unconfigured |
+| `/v1/admin/licenses/lifecycle` | strict subscription command + `Authorization: Bearer <LICENSE_ISSUANCE_SECRET>` | redacted `{ status, replayed, entitlement }` | 400 invalid · 401 unauthorized · 404 not_found · 409 conflict/terminally_revoked · 429 rate_limited · 503 unavailable |
 
 Cross-cutting: 429 rate_limited (per-key throttle) · 400 malformed · 5xx server.
 `machineId` is the single-activation binding — one machine per seat (default
-`seats=1`). Only `sha256(licenseKey)` is ever stored; the raw key is never
-logged or echoed. `GET /healthz` → `{ "status": "ok" }`.
+`seats=1`). Only `sha256(licenseKey)` is stored. Activation, validation,
+deactivation, lifecycle, and admin inspection responses never echo a submitted
+raw key; issuance returns a raw key only to its authorized caller for one-shot
+fulfillment. `GET /healthz` → `{ "status": "ok" }`.
 
 The HTTP-code → client-classification map is fixed by the client
 (`402→expired · 429→rate_limited · 426→unsupported_client · 409→scope_mismatch ·
@@ -43,19 +46,29 @@ disabled unless `LICENSE_ISSUANCE_SECRET` is configured, and it requires:
 {
   "idempotencyKey": "stripe-checkout-session-or-event-id",
   "checkoutLookupKey": "neondiff_monthly",
-  "customerEmail": "buyer@example.com",
-  "externalCustomerId": "cus_...",
+  "provider": "stripe",
+  "providerAccountId": "acct_...",
+  "providerMode": "test",
+  "externalSubscriptionId": "sub_...",
   "externalCheckoutId": "cs_...",
-  "seats": 1,
-  "expiresAt": "2027-07-08T00:00:00.000Z"
+  "seats": 1
 }
 ```
 
-Supported active checkout lookup keys are `neondiff_monthly`,
-`neondiff_yearly`, and `neondiff_org_yearly`; they map to
-`monthly_support`, `yearly_support`, and `org_yearly_support`. The endpoint
-issues private-repo entitlements with `updateEntitlement=true` and returns the
-raw `nd_live_...` license key to the caller for one-shot customer fulfillment.
+Supported lookup keys are `neondiff_monthly`, `neondiff_yearly`, and
+`neondiff_org_yearly`; they map to `monthly_support`, `yearly_support`, and
+`org_yearly_support`. Server policy owns plan, trial, maximum paid period,
+currency, scope, update access, and seats: monthly is 7 trial days / 62 maximum
+period days, individual yearly is 7 / 400, organization yearly is 30 / 400,
+and all three are USD, one seat, private scope, and update-entitled. Callers
+cannot supply customer identity, plan, expiry, scope, ownership, or seat
+authority. The optional compatibility `seats` field is accepted only when it
+is exactly `1`.
+
+The endpoint returns the raw `nd_live_...` license key to the authorized caller
+for one-shot customer fulfillment. The immutable provider account, test/live
+mode, subscription, and checkout tuple is recorded atomically with issuance.
+Test and live tuples never substitute for each other.
 
 Idempotency is keyed by `idempotencyKey`. Retries with identical request data
 return the same `licenseKey` and `replayed=true` without minting a duplicate
@@ -63,6 +76,12 @@ license. Reusing an idempotency key with different checkout data returns `409
 conflict`. SQLite stores only the license hash plus issuance metadata; the raw
 key is deterministically derived from `LICENSE_ISSUANCE_SECRET` and the
 idempotency key so webhook retries can be safe without storing raw key material.
+
+Checkout remains held. This source contract does not authorize reopening the
+website payment path; issue #559 owns version, manifest, deploy, install, and
+live activation proof. See
+[`docs/subscription-lifecycle.md`](docs/subscription-lifecycle.md) for the
+provider event matrix and rollout boundary.
 
 ### Release lifecycle issuance
 
@@ -134,13 +153,27 @@ npm run admin -- list
 
 # show a single license by key (adds its activations)
 npm run admin -- show --key nd_live_…
+
+# preview a legacy checkout correlation backfill; remove --dry-run only after
+# explicit production owner approval of the exact fingerprint and tuple
+npm run admin -- bind-checkout-subscription \
+  --issuance-idempotency-key <checkout-issuance-reference> \
+  --provider stripe \
+  --provider-account-id <provider-account-id> \
+  --provider-mode <test-or-live> \
+  --external-subscription-id <subscription-id> \
+  --external-checkout-id <checkout-id> \
+  --dry-run
 ```
 
 `issue` flags: `--plan <p>` (required), `--scope <public|private|all>`
 (required), `--seats N` (default 1), `--expires <iso>`,
 `--private-repo-allowed <true|false>`, `--update-entitlement`.
 
-See [`docs/admin-runbook.md`](docs/admin-runbook.md) for the operator runbook.
+See [`docs/admin-runbook.md`](docs/admin-runbook.md) for the operator runbook,
+[`docs/subscription-lifecycle.md`](docs/subscription-lifecycle.md) for the
+lifecycle reference/rollout, and
+[`docs/disaster-recovery.md`](docs/disaster-recovery.md) for recovery.
 
 ## Deploy
 

--- a/services/license-api/README.md
+++ b/services/license-api/README.md
@@ -25,7 +25,13 @@ Six `POST` endpoints, JSON in / JSON out (`Content-Type: application/json`):
 | `/v1/admin/licenses/issue-lifecycle` | exact release identity + GitHub Actions OIDC bearer | short-lived lifecycle license + all-scope entitlement | 401 invalid workflow token · 403 candidate SHA mismatch · 409 workflow-run conflict · 503 unconfigured |
 | `/v1/admin/licenses/lifecycle` | strict subscription command + `Authorization: Bearer <LICENSE_ISSUANCE_SECRET>` | redacted `{ status, replayed, entitlement }` | 400 invalid · 401 unauthorized · 404 not_found · 409 conflict/terminally_revoked · 429 rate_limited · 503 unavailable |
 
-Cross-cutting: 429 rate_limited (per-key throttle) · 400 malformed · 5xx server.
+Activation, validation, and deactivation use per-license-key rate limiting.
+Subscription lifecycle and release-lifecycle issuance use separate client-address rate-limit budgets.
+Checkout issuance has no generic `429`
+claim; its documented authorization, validation, conflict, and server outcomes
+apply. Cross-route failures include `400 malformed` and `5xx server` where the
+endpoint table or detailed section specifies them.
+
 `machineId` is the single-activation binding — one machine per seat (default
 `seats=1`). Only `sha256(licenseKey)` is stored. Activation, validation,
 deactivation, lifecycle, and admin inspection responses never echo a submitted

--- a/services/license-api/docs/admin-runbook.md
+++ b/services/license-api/docs/admin-runbook.md
@@ -1,27 +1,34 @@
 # License API admin runbook
 
 Operator procedures for the NeonDiff license service
-([#327](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327)).
-This runbook covers key issuance and lifecycle. It does **not** cover payment,
-billing, or deploy — deploy is a separate gated step driven by the orchestrator.
+([#327](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/327),
+[#562](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/562)).
+This runbook covers manual key administration and the guarded checkout-binding
+backfill. The server-to-server event contract is documented in
+[`subscription-lifecycle.md`](subscription-lifecycle.md). It does **not**
+authorize payment, billing, deploy, production backfill, or checkout reopening.
 See [`deploy.md`](deploy.md) for the fly.io deploy sequence (`Dockerfile`,
 `fly.toml`, volume/secrets setup, and rollback). See
 [`disaster-recovery.md`](disaster-recovery.md) for Litestream replication,
 restore drills, RPO/RTO, alerting, and the owner-gated DR proof boundary.
 
-All commands open the SQLite database at `LICENSE_DB_PATH`. In production this is
-the file on the mounted fly volume; run the CLI on the instance (or against a
-copy of the volume) so it points at the live database.
+All commands open the SQLite database at `LICENSE_DB_PATH`. In production this
+is the file on the mounted Fly volume. Use the owner-approved in-instance or
+quiesced maintenance procedure. Never copy an open SQLite database: an open
+database may have authoritative WAL state that a file copy omits.
 
 ## Golden rules
 
-- **The raw key is shown exactly once, at issuance.** Copy it to the buyer over a
-  secure channel immediately. Only `sha256(key)` is stored; the key cannot be
-  recovered afterward. If it is lost, revoke and re-issue.
+- **The raw key is shown exactly once, at manual issuance.** Copy it to the
+  authorized recipient over a secure channel immediately. Only `sha256(key)` is
+  stored; the key cannot be recovered afterward.
 - **Never paste a raw key into logs, issues, evidence, or chat.** `list`/`show`
   print hashes only; keep it that way.
 - Default `seats=1` enforces single-activation: one machine per seat. A second
   machine gets `409 scope_mismatch` until a seat is freed via `deactivate`.
+- No raw-key recovery or replacement-key minting is allowed during checkout
+  reconciliation, lifecycle handling, schema migration, or binding backfill.
+  Replacement issuance is a separate owner-authorized support/security action.
 
 ## Issue a key
 
@@ -56,13 +63,44 @@ npm run admin -- list                 # all licenses: hash, status, scope, seats
 npm run admin -- show --key nd_live_…  # one license + its bound machines
 ```
 
+## Backfill a legacy checkout binding
+
+Backfill only an existing issuance whose stored source is already `checkout`.
+The command accepts correlation fields only; it rejects raw key, plan, expiry,
+scope, ownership, update-access, and seat fields.
+
+Run the zero-write preview first:
+
+```sh
+LICENSE_DB_PATH=/data/license.sqlite npm run admin -- \
+  bind-checkout-subscription \
+  --issuance-idempotency-key <checkout-issuance-reference> \
+  --provider stripe \
+  --provider-account-id <provider-account-id> \
+  --provider-mode <test-or-live> \
+  --external-subscription-id <subscription-id> \
+  --external-checkout-id <checkout-id> \
+  --dry-run
+```
+
+`would_bind` plus the opaque issuance fingerprint is evidence for review, not
+permission to write. Stop on `not_found`, `wrong_source`, `conflict`, or
+`unavailable`. A production write requires explicit owner approval of the
+fingerprint, database, provider account, mode, subscription, and checkout tuple.
+Only then repeat the exact command without `--dry-run`; expect `bound`, or
+`already_bound` for an identical replay.
+
+Keep Stripe test and live modes, accounts, subscriptions, databases, and
+evidence separate. Never backfill a production issuance from sandbox data.
+
 ## Free a seat for a customer
 
 A customer who changed machines and hit `409 scope_mismatch` needs the old
 machine deactivated. The client's `neondiff license deactivate` frees the seat
 from the customer side. If they cannot reach the old machine, an operator has no
-raw-key path to delete a single activation by design (the key is hashed); the
-supported recovery is to `revoke` and re-`issue`, or raise `--seats` on a new key.
+raw-key path to delete a single activation by design because the key is hashed.
+Stop and route the case through the separately approved support/security policy;
+do not mint a replacement or alter seat authority as part of reconciliation.
 
 ## Health
 
@@ -70,3 +108,8 @@ supported recovery is to `revoke` and re-`issue`, or raise `--seats` on a new ke
 uptime monitoring. Healthz is not DR proof by itself; pair it with the
 replication freshness and timed staging restore checks in
 [`disaster-recovery.md`](disaster-recovery.md).
+
+Checkout remains held. Issue
+[#559](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/559)
+owns deploy, version/manifest, installed-client, live activation, and checkout
+proof; this runbook does not authorize those mutations.

--- a/services/license-api/docs/admin-runbook.md
+++ b/services/license-api/docs/admin-runbook.md
@@ -29,6 +29,10 @@ database may have authoritative WAL state that a file copy omits.
 - No raw-key recovery or replacement-key minting is allowed during checkout
   reconciliation, lifecycle handling, schema migration, or binding backfill.
   Replacement issuance is a separate owner-authorized support/security action.
+- Subscription lifecycle revocation stores only the status-derived reason codes
+  `subscription_canceled`, `subscription_unpaid`, or
+  `subscription_incomplete_expired`. Never pass provider/customer prose, email,
+  payment identifiers, or control characters as a reason.
 
 ## Issue a key
 

--- a/services/license-api/docs/deploy.md
+++ b/services/license-api/docs/deploy.md
@@ -174,8 +174,10 @@ image against a v2 database is not the rollback procedure.
 
 For a v2 migration or data failure, stop writes, preserve the affected volume,
 select the reviewed pre-v2 Litestream recovery point, and restore it to a fresh
-path or volume. Never overwrite the existing database and never copy or
-force-restore into an open SQLite path. Follow
+path or volume using the timestamp-selected point-in-time restore command in the
+DR runbook. Verify quick-check, `user_version=0`, and the exact legacy schema
+signature before attaching a pre-v2 image. Never overwrite the existing database
+and never copy or force-restore into an open SQLite path. Follow
 [`disaster-recovery.md`](disaster-recovery.md) for verification and evidence.
 
 An emergency service stop makes all supported review work fail closed; it is

--- a/services/license-api/docs/deploy.md
+++ b/services/license-api/docs/deploy.md
@@ -87,11 +87,9 @@ website payment webhook. Keep the same value configured only on the license API
 and the server-side checkout webhook; never expose it to browser code, public
 docs, logs, or generated release packets.
 
-After setting the secret and deploying, capture a non-secret readiness proof for
-release-status: an unauthenticated request to the checkout issuance endpoint must
-return `401` with `{"status":"unauthorized"}`. A `503` response with
-`license issuance is not configured` means the Fly app is still missing
-`LICENSE_ISSUANCE_SECRET` and is not ready for paid/trial checkout activation.
+After setting the secret and deploying, an unauthenticated request to checkout
+issuance or subscription lifecycle must return a redacted `401`. A `503` means
+the service is not configured. Neither response is checkout readiness proof.
 
 The same Fly-only secret derives deterministic short-lived keys for
 `POST /v1/admin/licenses/issue-lifecycle`; it is never valid authorization for
@@ -102,51 +100,14 @@ pins the canonical repository IDs, protected `main` ref, workflow path,
 runner, and candidate SHA. Configure the GitHub environment approval policy
 before treating this route as production proof. No additional OIDC secret is
 required.
-This release-status proof intentionally verifies only the fail-closed public
-boundary. It does not prove that a valid server-side checkout webhook can issue
-a license or write the DB. Stable/GA manifests must also point
-`checkoutIssuanceAuthenticatedProofPath` at an owner-held redacted success proof
-under `docs/evidence/`. That proof may record `statusCode: 200`,
-`status: "issued"`, `replayed`, the checkout lookup key,
-`issuedLicensePrefix: "nd_live_"`, and a `sha256:<64-hex>` fingerprint of the
-issued license key. It must not store raw bearer headers,
-`LICENSE_ISSUANCE_SECRET`, raw `licenseKey`, cookies, customer data, checkout
-payload secrets, or raw response bodies.
-
-Use the repo-owned smoke helper for that owner-held success proof. Start with a
-dry run so the request shape is visible without reading the secret or sending a
-network request:
-
-```sh
-npx tsx src/cli.ts checkout-issuance-smoke \
-  --url https://neondiff-license.fly.dev/v1/admin/licenses/issue \
-  --release-version <release-version> \
-  --checkout-lookup-key neondiff_monthly \
-  --dry-run true
-```
-
-After the same issuance secret has been configured on the license API and the
-server-side checkout webhook, run the live proof capture from a clean checkout:
-
-```sh
-export LICENSE_ISSUANCE_SECRET="<owner-held-shared-secret>"
-npx tsx src/cli.ts checkout-issuance-smoke \
-  --url https://neondiff-license.fly.dev/v1/admin/licenses/issue \
-  --release-version <release-version> \
-  --checkout-lookup-key neondiff_monthly \
-  --secret-env LICENSE_ISSUANCE_SECRET \
-  --dry-run false \
-  --confirm-live-issuance true \
-  --output docs/evidence/license-checkout-issuance-authenticated.json
-```
-
-The command reads the bearer value only from `--secret-env`, never from argv,
-and writes only the strict redacted proof accepted by
-`checkoutIssuanceAuthenticatedProofPath`. It rejects non-HTTPS URLs before
-reading the secret. The smoke request uses a stable synthetic `idempotencyKey`
-as the replay key; `externalCheckoutId` mirrors that value only as smoke
-metadata, while the license API's idempotent issuance contract is keyed by
-`idempotencyKey`.
+Checkout remains held. Do not run authenticated production issuance, lifecycle,
+or checkout proof from this source change. Issue
+[#559](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/559)
+owns the immutable version, public manifest, deploy, installed-client,
+activation/no-bypass, live Stripe, and checkout-reopening gates. Any eventual
+proof must remain redacted: status, replay result, lookup key, and opaque hash
+fingerprints are acceptable; bearer headers, the issuance secret, raw license
+keys, payment/customer identifiers, cookies, and raw bodies are not.
 
 ## 4. Deploy
 
@@ -169,86 +130,54 @@ curl -s -i -X POST https://neondiff-license.fly.dev/v1/admin/licenses/issue \
   -d '{}'
 ```
 
-## 5. Point a client config at the deployed URL
+## 5. Prepare the schema v2 rollout
 
-**Use a copy of the client config, not the committed one** — this step is
-for verifying the deploy, not for flipping enforcement on for real users
-yet. Take `config.example.json`, copy it somewhere scratch, and set:
+1. Keep checkout and lifecycle delivery stopped.
+2. Separate Stripe test and live accounts, modes, subscriptions, databases,
+   replica prefixes, and evidence. Sandbox proof is never live proof.
+3. Immediately before the v2 image rollout, verify and record a fresh pre-v2
+   Litestream recovery point. Do not copy the database file while SQLite is
+   open; WAL state may make that copy incomplete.
+4. Review [`subscription-lifecycle.md`](subscription-lifecycle.md), run its
+   focused contract/DR checks, and confirm any legacy checkout binding list.
 
-```jsonc
-{
-  "license": {
-    "enabled": true,
-    "apiBaseUrl": "https://neondiff-license.fly.dev"  // your app's URL
-  }
-}
-```
+## 6. Deploy and verify schema v2
 
-(`apiBaseUrl` is the exact field the client reads — see
-`src/license.ts`, `config.example.json`'s `_apiBaseUrlComment`.)
+Deploy only after the pre-v2 recovery point is reviewed. `LicenseStore` opens
+the database before the HTTP listener starts. It accepts only an empty database,
+the exact legacy three-table schema, or the exact schema v2 signature. Migration
+runs inside one immediate transaction; verification failure rolls back and
+prevents the service from starting.
 
-## 6. Verify: contract + a live smoke check
+After deploy, verify health, `user_version=2`, redacted admin readback, the real
+v1.0.4 activate/validate/deactivate contract, lifecycle idempotency, and
+mandatory-online outage behavior with `offlineGraceMs=0`. The local entitlement
+cache is diagnostic only; it does not authorize review during an outage.
 
-Two different things, both worth doing:
+## 7. Backfill and release handoff
 
-- **Contract test (pre-deploy correctness, already covered):**
-  `npm test` at the repo root runs
-  `tests/license-service-contract.test.ts`, which drives the real client
-  (`src/license.ts`) against the real service in-process (mocked
-  request/response objects, no network) through
-  activate → validate → deactivate → reactivate-different-machine. This
-  proves the HTTP contract shape is correct *before* you ever deploy — it
-  does not hit a live URL, so it's not a substitute for step 2 below, but
-  there's no need to re-run it post-deploy unless the service code changed.
-- **Live smoke check against the real URL (do this post-deploy):** issue a
-  throwaway key on the deployed instance and drive the three endpoints
-  directly:
+Run `bind-checkout-subscription ... --dry-run` first for every verified legacy
+`source=checkout` issuance. A production write needs explicit owner approval of
+the opaque fingerprint and exact provider tuple. Do not recover a raw key or
+mint a replacement during reconciliation. See
+[`admin-runbook.md`](admin-runbook.md).
 
-  ```sh
-  # on the fly machine, or against a copy of the volume — see admin-runbook.md
-  flyctl ssh console --app neondiff-license -C \
-    "LICENSE_DB_PATH=/data/license.sqlite node dist/admin.js issue --plan yearly --scope private --seats 1"
-  # copy the printed key, then from your workstation:
-  curl -s https://neondiff-license.fly.dev/healthz
-  curl -s -X POST https://neondiff-license.fly.dev/v1/license/activate \
-    -H 'Content-Type: application/json' \
-    -d '{"licenseKey":"<key from above>","machineId":"smoke-test-1"}'
-  ```
-
-  Confirm `/healthz` returns `{"status":"ok"}` and `activate` returns a
-  `200` with an `entitlement` object. Revoke the throwaway key afterward
-  (`admin.js revoke --key … --reason "deploy smoke test"`) so it doesn't
-  linger as a live, unaccounted-for seat.
-
-## 7. Promote
-
-Only after the live smoke check passes: wire the real URL into
-`docs/public-release-manifest.json`'s `licenseApi` slot (currently
-`"state": "pending"`) and flip `license.enabled` / `apiBaseUrl` in the
-actual shipped config for the release that turns enforcement on. This is a
-separate, deliberate change — do not fold it into a deploy-assets PR.
+Then hand the redacted source/contract evidence to #559. This runbook does not
+change a version, release candidate, public manifest, deployed client config,
+checkout state, or public package. Those remain separately reviewed release
+mutations.
 
 ## Rollback
 
-- **Bad release, service still reachable:** `flyctl releases --app
-  neondiff-license` to list, then `flyctl deploy --image <previous image
-  ref>` (or `flyctl releases rollback` if available on your `flyctl`
-  version) to go back to the last good image. The SQLite volume is
-  untouched by an image rollback — activations/keys persist.
-- **Service unreachable / stuck:** `flyctl apps restart neondiff-license`.
-  If a bad migration or admin action corrupted data, use the DR runbook before
-  replacing data. Litestream restore to a fresh/missing DB path is the primary
-  offsite recovery path; Fly volume snapshots remain a secondary rollback
-  surface (`flyctl volumes snapshots list` /
-  `flyctl volumes create --snapshot-id …` to a fresh volume, then swap the
-  mount). Before relying on snapshot rollback in an incident, verify the exact
-  snapshot commands against the `flyctl` version used by production operators
-  and record that version in the evidence packet. There is no in-app migration
-  system today.
-- **Emergency full stop:** `flyctl scale count 0 --app neondiff-license`
-  stops serving entirely. Since license checks fail closed only for
-  all supported review work, this is an emergency stop rather than a
-  customer-transparent action. Existing users see their entitlement checks
-  start failing (client behavior on
-  `apiBaseUrl` unreachable is a server-classified failure, not a silent
-  allow — see `README.md`'s HTTP-code table) until service is restored.
+Image rollback does not reverse the SQLite schema migration. Deploying a pre-v2
+image against a v2 database is not the rollback procedure.
+
+For a v2 migration or data failure, stop writes, preserve the affected volume,
+select the reviewed pre-v2 Litestream recovery point, and restore it to a fresh
+path or volume. Never overwrite the existing database and never copy or
+force-restore into an open SQLite path. Follow
+[`disaster-recovery.md`](disaster-recovery.md) for verification and evidence.
+
+An emergency service stop makes all supported review work fail closed; it is
+not customer-transparent and does not authorize cache fallback. Restoration,
+deployment, or traffic changes remain owner-gated operations under #559.

--- a/services/license-api/docs/disaster-recovery.md
+++ b/services/license-api/docs/disaster-recovery.md
@@ -3,10 +3,11 @@
 This runbook covers disaster recovery for the NeonDiff license API SQLite
 database at `/data/license.sqlite`.
 
-Issue scope: [#423](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/423).
+Issue scope: [#423](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/423)
+and [#562](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/562).
 This source-only PR does not prove live replication; it only adds the buildable
 Litestream wiring, owner runbook, static assertions, and local client outage
-grace verification. Live object storage, Fly secrets, deploy, and timed restore
+fail-closed verification. Live object storage, Fly secrets, deploy, and timed restore
 evidence remain Owner-gated.
 
 ## Targets
@@ -37,6 +38,29 @@ The container fails closed by default when `LICENSE_REPLICA_URL` is absent
 because this service is release-required for supported review entitlements. Local
 development may set `LICENSE_LITESTREAM_REQUIRED=false` to run without
 replication.
+
+## Schema v2 recovery invariant
+
+Immediately before the schema v2 rollout, verify a recoverable Litestream point
+from the running pre-v2 database and record its timestamp/freshness in the
+owner-held evidence packet. This is the reviewed rollback point; a Fly image or
+filesystem copy is not.
+
+Never copy an open SQLite database. An open database may have authoritative WAL
+state that a plain copy of `license.sqlite` omits. Quiesce writes through the
+approved service/platform procedure, or restore through Litestream to a missing
+database path.
+
+Migration failure prevents the service from starting. The store migrates the
+exact legacy schema inside one immediate transaction, verifies the exact v2
+schema and constraints, and sets `user_version=2` only after verification.
+Failure rolls the transaction back and the HTTP listener never starts.
+
+Image rollback does not reverse the SQLite schema migration. A pre-v2 image is
+not approved to open a v2 database. Restore the reviewed pre-v2 Litestream point
+to a fresh path or volume, verify it separately, and only then attach it to the
+reviewed pre-v2 service. Preserve the failed volume for investigation; never
+overwrite it in place.
 
 ## Owner-only secret setup
 
@@ -100,6 +124,11 @@ If no backups are found, the entrypoint may initialize a new empty DB. That is
 acceptable for a brand-new staging replica, but it is not acceptable proof for
 production DR. Production restore proof must show expected existing rows.
 
+For the v2 rollout drill, also prove that the selected pre-v2 recovery point
+opens with the reviewed pre-v2 image on a fresh path or volume. Do not use the
+production replica destination for the drill, and do not let staging write back
+into the production replica prefix.
+
 ## Verification cadence
 
 - Daily: monitor `/healthz` and Fly machine health.
@@ -129,11 +158,16 @@ process is alive; it does not prove offsite recovery data is current.
 
 ## Customer outage playbook
 
-The shipped client already has an offline entitlement cache. If the license API
-is unreachable, paying private-repo users with a fresh active cache should remain
-inside the configured offline grace window; once that window expires, the
-private-repo gate fails closed. This PR includes a local real-server test for
-activate -> stop server -> within-grace allow -> after-grace deny.
+The supported v1.0.4 configuration is mandatory-online:
+`offlineGraceMs=0`. A successful activation writes an entitlement cache for
+setup/status diagnosis, but that cache is diagnostic only and grants no review
+authority. If the API is unreachable, refreshed status reports
+`source="none"` with a network/server classification and the review gate fails
+closed immediately for public, private, internal, and unknown visibility.
+
+Do not raise `offlineGraceMs`, enable a public-repo bypass, or treat a cached
+`active` record as outage authorization. Recovery restores the API; it does not
+move authority into user-editable client config.
 
 During a production outage:
 
@@ -145,5 +179,15 @@ During a production outage:
 4. Do not overwrite an existing production DB with `-force` unless the owner has
    explicitly approved a data replacement and the evidence packet names the
    selected replica timestamp.
-5. Communicate the grace-window boundary clearly: cached private-repo users can
-   continue only while their cache remains inside `offlineGraceMs`.
+5. Verify the real-client outage path still returns `source="none"` and denies
+   review with `offlineGraceMs=0`; the presence of a cache file is diagnostic
+   evidence only.
+6. Keep checkout and subscription event delivery held until database and API
+   verification completes. Do not recover raw keys or mint replacement keys as
+   part of reconciliation.
+
+Issue
+[#559](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/559)
+owns version, manifest, deploy, install, live activation, and checkout proof.
+This source-only PR does not prove live replication, production restore,
+production migration, or customer readiness.

--- a/services/license-api/docs/disaster-recovery.md
+++ b/services/license-api/docs/disaster-recovery.md
@@ -176,9 +176,9 @@ During a production outage:
 2. Preserve the current volume and logs before mutation.
 3. Restore on staging first when time allows; if production replacement is
    required, restore only to a missing DB path or a fresh volume.
-4. Do not overwrite an existing production DB with `-force` unless the owner has
-   explicitly approved a data replacement and the evidence packet names the
-   selected replica timestamp.
+4. Never overwrite an existing production database. Owner approval may select
+   the reviewed replica timestamp and authorize attaching a fresh restore path
+   or volume; it cannot authorize an in-place overwrite.
 5. Verify the real-client outage path still returns `source="none"` and denies
    review with `offlineGraceMs=0`; the presence of a cache file is diagnostic
    evidence only.

--- a/services/license-api/docs/disaster-recovery.md
+++ b/services/license-api/docs/disaster-recovery.md
@@ -62,6 +62,30 @@ to a fresh path or volume, verify it separately, and only then attach it to the
 reviewed pre-v2 service. Preserve the failed volume for investigation; never
 overwrite it in place.
 
+The recorded rollback timestamp must be an RFC3339 instant that Litestream
+0.5.14 can select. A normal missing-file startup uses the latest replica state;
+that is not the schema-v2 rollback procedure. From a quiesced recovery shell,
+restore the selected point to a path that does not exist:
+
+```sh
+PRE_V2_RECOVERY_TIMESTAMP="<recorded-rfc3339-timestamp>"
+FRESH_RESTORE_PATH="<fresh-nonexistent-license-db-path>"
+test ! -e "$FRESH_RESTORE_PATH"
+litestream restore -timestamp "$PRE_V2_RECOVERY_TIMESTAMP" -config "$LITESTREAM_CONFIG" -o "$FRESH_RESTORE_PATH" "$LICENSE_DB_PATH"
+test "$(sqlite3 "$FRESH_RESTORE_PATH" 'pragma quick_check')" = "ok"
+test "$(sqlite3 "$FRESH_RESTORE_PATH" 'pragma user_version')" = "0"
+sqlite3 "$FRESH_RESTORE_PATH" \
+  "select type,name,tbl_name,sql from sqlite_schema where name not like 'sqlite_%' order by type,name"
+```
+
+Compare the final query with the exact legacy schema signature from the reviewed
+pre-v2 source. Any extra/missing object or constraint is a stop condition. Keep
+the restored file detached while checking it; do not let a v2 process open it,
+and do not attach the pre-v2 image until quick-check, version, and exact legacy
+schema verification all pass. The command shape follows Litestream's
+[restore reference](https://litestream.io/reference/restore/): `-timestamp`
+selects the recovery point and `-o` keeps the source database path untouched.
+
 ## Owner-only secret setup
 
 Run these commands from a secure shell after choosing the object-store bucket,
@@ -109,10 +133,13 @@ volume; never destroy the production volume as a drill.
    prefix in the evidence packet.
 2. Create or reset a staging Fly app with a fresh `license_data` volume and no
    `/data/license.sqlite` file.
-3. Set the same shape of secrets as production, but point
-   `LICENSE_REPLICA_URL` at the staging restore replica/prefix.
-4. Deploy the image. The entrypoint must attempt:
-   `litestream restore -if-replica-exists -config "$LITESTREAM_CONFIG" "$LICENSE_DB_PATH"`.
+3. Give the drill read-only credentials to the source replica and a dedicated,
+   non-writing replica destination/prefix. Never run `litestream replicate`
+   against the production replica from the drill.
+4. For a current-state drill, restore to a fresh path and verify it before
+   starting the service. For the v2 rollback drill, use the point-in-time command
+   above with the recorded pre-v2 RFC3339 timestamp; do not use the entrypoint's
+   latest-state `-if-replica-exists` startup behavior as rollback proof.
 5. Wait for `/healthz` to pass and run admin `list` against the restored DB.
 6. Record end time and calculate restore duration. The drill passes only if
    duration is <= 30 minutes and the restored DB contains the expected license
@@ -124,10 +151,11 @@ If no backups are found, the entrypoint may initialize a new empty DB. That is
 acceptable for a brand-new staging replica, but it is not acceptable proof for
 production DR. Production restore proof must show expected existing rows.
 
-For the v2 rollout drill, also prove that the selected pre-v2 recovery point
-opens with the reviewed pre-v2 image on a fresh path or volume. Do not use the
-production replica destination for the drill, and do not let staging write back
-into the production replica prefix.
+For the v2 rollout drill, also prove that the timestamp-selected pre-v2 recovery
+point passes `pragma quick_check`, reports `pragma user_version=0`, matches the
+exact legacy schema signature, and opens with the reviewed pre-v2 image on a
+fresh path or volume. Do not use the production replica destination for writes,
+and do not let staging write back into the production replica prefix.
 
 ## Verification cadence
 

--- a/services/license-api/docs/disaster-recovery.md
+++ b/services/license-api/docs/disaster-recovery.md
@@ -72,17 +72,16 @@ PRE_V2_RECOVERY_TIMESTAMP="<recorded-rfc3339-timestamp>"
 FRESH_RESTORE_PATH="<fresh-nonexistent-license-db-path>"
 test ! -e "$FRESH_RESTORE_PATH"
 litestream restore -timestamp "$PRE_V2_RECOVERY_TIMESTAMP" -config "$LITESTREAM_CONFIG" -o "$FRESH_RESTORE_PATH" "$LICENSE_DB_PATH"
-test "$(sqlite3 "$FRESH_RESTORE_PATH" 'pragma quick_check')" = "ok"
-test "$(sqlite3 "$FRESH_RESTORE_PATH" 'pragma user_version')" = "0"
-sqlite3 "$FRESH_RESTORE_PATH" \
-  "select type,name,tbl_name,sql from sqlite_schema where name not like 'sqlite_%' order by type,name"
+node /app/dist/verify-legacy-restore.js "$FRESH_RESTORE_PATH"
 ```
 
-Compare the final query with the exact legacy schema signature from the reviewed
-pre-v2 source. Any extra/missing object or constraint is a stop condition. Keep
-the restored file detached while checking it; do not let a v2 process open it,
-and do not attach the pre-v2 image until quick-check, version, and exact legacy
-schema verification all pass. The command shape follows Litestream's
+The verifier ships in the Node 26 runtime image and uses built-in `node:sqlite`.
+It requires a regular file, opens it read-only, runs `pragma quick_check`,
+requires `user_version=0`, and compares every non-internal schema object and
+constraint with an in-memory exact legacy schema signature. Any mismatch is a
+stop condition. Keep the restored file detached while checking it; do not let a
+v2 process open it, and do not attach the pre-v2 image until verification passes.
+The restore command shape follows Litestream's
 [restore reference](https://litestream.io/reference/restore/): `-timestamp`
 selects the recovery point and `-o` keeps the source database path untouched.
 

--- a/services/license-api/docs/subscription-lifecycle.md
+++ b/services/license-api/docs/subscription-lifecycle.md
@@ -1,0 +1,211 @@
+# Subscription lifecycle reference and rollout
+
+This document describes the source contract for checkout-backed subscription
+renewal, reconciliation, cancellation, payment attention, and terminal
+revocation. It is both the API reference for webhook integrators and the
+operator checklist for rolling SQLite schema v2 into the license service.
+
+Checkout remains held. The endpoint and migration are source-ready, but issue
+[#559](https://github.com/electricsheephq/evaos-code-review-bot-neondiff/issues/559)
+owns the immutable package version, public release manifest, production deploy,
+installed-client proof, live activation proof, and any decision to reopen
+checkout.
+
+## Reference: authorization and endpoint
+
+`POST /v1/admin/licenses/lifecycle` accepts JSON and requires
+`Authorization: Bearer <LICENSE_ISSUANCE_SECRET>`. This is a server-to-server
+boundary. Never expose the secret to browsers, clients, GitHub evidence, or
+logs.
+
+The endpoint is separate from:
+
+- `/v1/admin/licenses/issue`, which issues a checkout-bound license with the
+  same server-held bearer boundary; and
+- `/v1/admin/licenses/issue-lifecycle`, which accepts a pinned GitHub Actions
+  OIDC token for release proof and does not accept the shared secret as
+  authorization.
+
+Authentication happens before JSON parsing or correlation lookup. Missing or
+wrong authorization returns the same redacted `401` response. The lifecycle
+route has a dedicated per-client limiter; it does not consume the activation or
+release-lifecycle limiter budgets. Fly client-address headers are trusted only
+when the service is running behind Fly's operator-controlled proxy boundary.
+
+## Reference: common request fields
+
+Every request is a JSON object no larger than 16 KiB. Unknown fields are
+rejected. Common fields are:
+
+| Field | Contract |
+| --- | --- |
+| `schemaVersion` | Integer `1`. |
+| `issuanceIdempotencyKey` | Required non-empty string, at most 200 characters. Correlates to an existing `source=checkout` issuance. |
+| `eventId` | Required non-empty provider event identifier, at most 200 characters. Identical replay is idempotent; reuse with different content conflicts. |
+| `eventCreatedAt` | Non-negative integer epoch seconds, no more than five minutes ahead of the service clock. |
+| `provider` | Exactly `stripe`. |
+| `providerAccountId` | Required non-empty string, at most 160 characters. |
+| `providerMode` | Exactly `test` or `live`. |
+| `externalSubscriptionId` | Required non-empty string, at most 160 characters. |
+| `providerEventType` | Event type allowed by the command matrix below. |
+| `command` | One of the five commands below. |
+| `subscriptionStatus` | Status allowed by the command matrix below. |
+| `cancelAtPeriodEnd` | Required boolean with command-specific meaning. |
+
+The provider, provider account, mode, and external subscription must match the
+immutable tuple stored at checkout issuance or owner-approved legacy backfill.
+Unknown, unbound, and mismatched correlations all return the same redacted
+`404 not_found`. A `test` binding cannot accept a `live` event, and a `live`
+binding cannot accept a `test` event.
+
+## Reference: strict command matrix
+
+| Command | Allowed provider events | Allowed subscription statuses | Extra requirements | Effect |
+| --- | --- | --- | --- | --- |
+| `renew_paid` | `invoice.paid`, `invoice.payment_succeeded` | `active` | `paymentReference`; positive integer `amountPaidMinor`; `currency="usd"`; `paidOutOfBand=false`; `billingReason="subscription_cycle"`; strict future UTC `currentPeriodEnd`; `cancelAtPeriodEnd=false` | Extends expiry monotonically and reactivates an expired entitlement. Paid period must remain within the server-owned plan maximum. |
+| `reconcile` | `customer.subscription.updated` | `active`, `trialing` | `cancelAtPeriodEnd=false`; optional future `currentPeriodEnd` is diagnostic only | Records a non-terminal audit event without granting time. Older non-mutating events are `ignored_stale`. |
+| `cancel_at_period_end` | `customer.subscription.updated` | `active`, `trialing` | `cancelAtPeriodEnd=true`; strict future UTC `currentPeriodEnd` | Records the cancellation state without shortening already-paid time. |
+| `payment_attention` | `invoice.payment_failed`, `customer.subscription.updated` | `active`, `past_due`, `incomplete`, `paused` | Payment fields are forbidden; optional future `currentPeriodEnd` is diagnostic only | Records payment attention without revoking or extending the entitlement. |
+| `revoke` | `customer.subscription.deleted`, `customer.subscription.updated` | `canceled`, `unpaid`, `incomplete_expired` | `currentPeriodEnd` and payment fields are forbidden; optional redacted `reason` up to 200 characters | Sets terminal `revoked` state. Later lifecycle commands fail with `terminally_revoked`. |
+
+Only `renew_paid` accepts payment fields. The service hashes
+`paymentReference` into a domain-separated fingerprint before storage. It does
+not store the raw payment reference.
+
+## Reference: server-owned checkout policy
+
+Checkout callers do not choose plan, trial length, maximum renewal period,
+currency, scope, ownership, update access, or seats.
+
+| Lookup key | Plan | Trial | Maximum accepted paid period | Currency | Seats |
+| --- | --- | ---: | ---: | --- | ---: |
+| `neondiff_monthly` | `monthly_support` | 7 days | 62 days from apply time | USD | 1 |
+| `neondiff_yearly` | `yearly_support` | 7 days | 400 days from apply time | USD | 1 |
+| `neondiff_org_yearly` | `org_yearly_support` | 30 days | 400 days from apply time | USD | 1 |
+
+All three policies currently issue private-scope entitlements with private-repo
+access and update entitlement enabled. The optional checkout compatibility
+field `seats` is accepted only when it is exactly `1`; no lifecycle command can
+change seats.
+
+## Reference: response and status mapping
+
+Successful application returns only:
+
+```json
+{
+  "status": "updated",
+  "replayed": false,
+  "entitlement": {
+    "status": "active",
+    "plan": "monthly_support",
+    "seats": 1,
+    "expiresAt": "2026-08-13T00:00:00.000Z"
+  }
+}
+```
+
+The `status` result is one of `updated`, `payment_attention`,
+`terminally_revoked`, `ignored_stale`, or `replayed`. Replayed requests return
+`replayed=true`; other successful results return `false`.
+
+| HTTP | Body status | Meaning |
+| ---: | --- | --- |
+| `200` | lifecycle result above | Applied, replayed, or safely ignored stale event. |
+| `400` | `invalid` | Malformed body, unsupported matrix combination, forbidden authority field, or policy violation. |
+| `401` | `unauthorized` | Missing or invalid bearer. |
+| `404` | `not_found` | Unknown, non-checkout, unbound, orphaned, or tuple-mismatched issuance. |
+| `409` | `conflict` | Existing event ID has different canonical content. |
+| `409` | `terminally_revoked` | Entitlement was already terminally revoked. |
+| `413` | `invalid` | Body exceeds 16 KiB. |
+| `429` | `rate_limited` | Dedicated lifecycle budget exhausted; response includes a bounded `Retry-After`. |
+| `503` | `unavailable` | Issuance secret is absent or SQLite remained busy beyond its bounded wait. |
+| `500` | `server` | Unexpected internal failure. |
+
+Responses never echo the bearer, raw license key, issuance idempotency key,
+provider event ID, provider account, subscription ID, payment reference, revoke
+reason, parser detail, SQLite detail, or caller-controlled unknown field name.
+The lifecycle ledger stores hashes/fingerprints and bounded provider metadata,
+not raw license or payment material.
+
+## How to backfill a legacy checkout binding
+
+Use this only for a verified historical issuance whose
+`license_issuance_events.source` is already `checkout`. The command cannot
+accept a raw key, plan, expiry, scope, ownership, update access, or seat count.
+
+1. Run a no-write preview against the intended database and exact provider
+   environment:
+
+   ```sh
+   LICENSE_DB_PATH=<quiesced-database-path> npm run admin -- \
+     bind-checkout-subscription \
+     --issuance-idempotency-key <checkout-issuance-reference> \
+     --provider stripe \
+     --provider-account-id <provider-account-id> \
+     --provider-mode <test-or-live> \
+     --external-subscription-id <subscription-id> \
+     --external-checkout-id <checkout-id> \
+     --dry-run
+   ```
+
+2. Verify the redacted result is `would_bind` with an opaque `iss_...`
+   fingerprint. `not_found`, `wrong_source`, `conflict`, or `unavailable` is a
+   stop condition.
+3. Record explicit production owner approval against that fingerprint and
+   tuple. Dry-run success is not authorization to write production.
+4. Repeat the same command without `--dry-run` only inside the approved
+   production maintenance procedure. Expect `bound`; an exact retry returns
+   `already_bound`.
+
+No raw-key recovery or replacement-key minting is allowed during
+reconciliation or backfill. If business policy requires replacement issuance,
+route it as a separate support/security action with its own authorization and
+evidence; do not disguise it as lifecycle repair.
+
+## How to roll out schema v2 safely
+
+1. Keep checkout closed and stop lifecycle event delivery.
+2. Confirm test and live provider account IDs, modes, subscriptions, secrets,
+   databases, replica prefixes, and evidence packets are separated. Never use
+   sandbox success as live proof.
+3. Immediately before deploying schema v2, verify a Litestream recovery point
+   from the still-running pre-v2 service. Record its timestamp and freshness
+   without copying credentials or customer data.
+4. Quiesce writes through the platform/service procedure. Never copy an open
+   SQLite database. A filesystem copy of an open database can omit WAL state
+   and is not a valid migration or recovery artifact.
+5. Deploy the reviewed image. `LicenseStore` verifies the exact legacy schema,
+   creates v2 tables and constraints in one immediate transaction, verifies the
+   resulting signature, and only then sets `user_version=2`. Migration failure
+   prevents the service from starting and rolls the transaction back.
+6. Verify health, schema version, redacted admin readback, activation, validate,
+   deactivate, lifecycle idempotency, and mandatory-online outage denial. Keep
+   `offlineGraceMs=0`; the cache is diagnostic only and never authorizes review
+   during an API outage.
+7. Backfill only the approved legacy checkout bindings using the dry-run flow
+   above. Do not replay lifecycle events until the exact tuple is bound.
+8. Run sandbox lifecycle proof, then a separately approved live proof. Keep
+   checkout held until #559 records exact-head CI/review evidence plus version,
+   manifest, deploy, install, activation, and no-bypass proof.
+
+## Rollback and recovery boundary
+
+Image rollback does not reverse the SQLite schema migration. If the v2 service
+cannot proceed, stop writes and follow
+[`disaster-recovery.md`](disaster-recovery.md): select the reviewed pre-v2
+Litestream recovery point and restore it to a fresh path or volume. Do not
+overwrite the existing database, do not force-restore into an open path, and do
+not combine data restoration with replacement-key minting.
+
+Source tests and docs prove the contract only. They do not prove a production
+database migration, backfill, Stripe webhook, checkout reopening, Fly deploy,
+or public release. Those live/release gates remain with #559.
+
+## Related
+
+- [Admin runbook](admin-runbook.md)
+- [Deploy runbook](deploy.md)
+- [Disaster recovery](disaster-recovery.md)
+- [Service README](../README.md)
+- [Root license service admin boundary](../../../docs/license-service-admin.md)

--- a/services/license-api/docs/subscription-lifecycle.md
+++ b/services/license-api/docs/subscription-lifecycle.md
@@ -78,6 +78,11 @@ code, while supplying any other value fails with `400 invalid`. This prevents
 emails, payment/customer identifiers, CR/LF, and terminal controls from reaching
 SQLite, license responses, admin output, logs, or evidence.
 
+For schema-v1 replay compatibility, an omitted reason retains the historical
+canonical request hash (`null` in the reason slot) even though the normalized
+request and stored revocation use the derived safe code. Supplying the exact
+code is explicit content and therefore has its own canonical hash.
+
 ## Reference: server-owned checkout policy
 
 Checkout callers do not choose plan, trial length, maximum renewal period,

--- a/services/license-api/docs/subscription-lifecycle.md
+++ b/services/license-api/docs/subscription-lifecycle.md
@@ -66,11 +66,17 @@ binding cannot accept a `test` event.
 | `reconcile` | `customer.subscription.updated` | `active`, `trialing` | `cancelAtPeriodEnd=false`; optional future `currentPeriodEnd` is diagnostic only | Records a non-terminal audit event without granting time. Older non-mutating events are `ignored_stale`. |
 | `cancel_at_period_end` | `customer.subscription.updated` | `active`, `trialing` | `cancelAtPeriodEnd=true`; strict future UTC `currentPeriodEnd` | Records the cancellation state without shortening already-paid time. |
 | `payment_attention` | `invoice.payment_failed`, `customer.subscription.updated` | `active`, `past_due`, `incomplete`, `paused` | Payment fields are forbidden; optional future `currentPeriodEnd` is diagnostic only | Records payment attention without revoking or extending the entitlement. |
-| `revoke` | `customer.subscription.deleted`, `customer.subscription.updated` | `canceled`, `unpaid`, `incomplete_expired` | `currentPeriodEnd` and payment fields are forbidden; optional redacted `reason` up to 200 characters | Sets terminal `revoked` state. Later lifecycle commands fail with `terminally_revoked`. |
+| `revoke` | `customer.subscription.deleted`, `customer.subscription.updated` | `canceled`, `unpaid`, `incomplete_expired` | `currentPeriodEnd` and payment fields are forbidden; optional `reason` must exactly equal the status-derived code | Sets terminal `revoked` state with `subscription_canceled`, `subscription_unpaid`, or `subscription_incomplete_expired`. Later lifecycle commands fail with `terminally_revoked`. |
 
 Only `renew_paid` accepts payment fields. The service hashes
 `paymentReference` into a domain-separated fingerprint before storage. It does
 not store the raw payment reference.
+
+Revocation never accepts provider/customer prose. The service derives a fixed
+non-secret reason code from `subscriptionStatus`; omitting `reason` uses that
+code, while supplying any other value fails with `400 invalid`. This prevents
+emails, payment/customer identifiers, CR/LF, and terminal controls from reaching
+SQLite, license responses, admin output, logs, or evidence.
 
 ## Reference: server-owned checkout policy
 
@@ -193,10 +199,11 @@ evidence; do not disguise it as lifecycle repair.
 
 Image rollback does not reverse the SQLite schema migration. If the v2 service
 cannot proceed, stop writes and follow
-[`disaster-recovery.md`](disaster-recovery.md): select the reviewed pre-v2
-Litestream recovery point and restore it to a fresh path or volume. Do not
-overwrite the existing database, do not force-restore into an open path, and do
-not combine data restoration with replacement-key minting.
+[`disaster-recovery.md`](disaster-recovery.md): use its Litestream 0.5.14
+point-in-time restore command to select the recorded pre-v2 RFC3339 timestamp and
+write to a fresh path. Verify quick-check, `user_version=0`, and the exact legacy
+schema signature before attaching the pre-v2 image. Do not overwrite the
+existing database or combine restoration with replacement-key minting.
 
 Source tests and docs prove the contract only. They do not prove a production
 database migration, backfill, Stripe webhook, checkout reopening, Fly deploy,

--- a/services/license-api/src/admin.ts
+++ b/services/license-api/src/admin.ts
@@ -1,4 +1,16 @@
-import { LicenseStore, type IssueLicenseInput, type LicenseRecord, type RepoVisibilityScope } from "./store.js";
+import {
+  CheckoutBindingConflictError,
+  CheckoutBindingNotFoundError,
+  CheckoutBindingPolicyError,
+  CheckoutBindingTransientError,
+  CheckoutBindingWrongSourceError,
+  LicenseStore,
+  checkoutIssuanceFingerprint,
+  type BindCheckoutSubscriptionInput,
+  type IssueLicenseInput,
+  type LicenseRecord,
+  type RepoVisibilityScope
+} from "./store.js";
 
 /**
  * Admin issuance CLI (no payment rails — this is how keys are minted until/if
@@ -8,6 +20,9 @@ import { LicenseStore, type IssueLicenseInput, type LicenseRecord, type RepoVisi
  *   revoke --key <k> [--reason <text>]
  *   list
  *   show   --key <k>
+ *   bind-checkout-subscription --issuance-idempotency-key <ref>
+ *          --provider stripe --provider-account-id <id> --provider-mode <test|live>
+ *          --external-subscription-id <id> --external-checkout-id <id> [--dry-run]
  *
  * `issue` prints the raw key EXACTLY ONCE; only the sha256 hash is stored.
  * `list`/`show` never print raw keys.
@@ -25,10 +40,97 @@ export function runAdmin(argv: string[], store: LicenseStore, out: (line: string
       return cmdList(store, out);
     case "show":
       return cmdShow(flags, store, out);
+    case "bind-checkout-subscription":
+      return cmdBindCheckoutSubscription(rest, store, out);
     default:
       out(usage());
       return command ? 2 : 0;
   }
+}
+
+function cmdBindCheckoutSubscription(
+  args: string[],
+  store: LicenseStore,
+  out: (line: string) => void
+): number {
+  const parsed = parseCheckoutBindingFlags(args);
+  if (!parsed) {
+    out(JSON.stringify({ result: "invalid" }));
+    return 2;
+  }
+  const issuanceFingerprint = checkoutIssuanceFingerprint(parsed.input.issuanceIdempotencyKey);
+  try {
+    out(JSON.stringify(store.bindCheckoutSubscription(parsed.input, { dryRun: parsed.dryRun })));
+    return 0;
+  } catch (error) {
+    let result: "invalid" | "not_found" | "wrong_source" | "conflict" | "unavailable";
+    let code: number;
+    if (error instanceof CheckoutBindingPolicyError) {
+      result = "invalid";
+      code = 2;
+    } else if (error instanceof CheckoutBindingNotFoundError) {
+      result = "not_found";
+      code = 1;
+    } else if (error instanceof CheckoutBindingWrongSourceError) {
+      result = "wrong_source";
+      code = 1;
+    } else if (error instanceof CheckoutBindingConflictError) {
+      result = "conflict";
+      code = 1;
+    } else if (error instanceof CheckoutBindingTransientError) {
+      result = "unavailable";
+      code = 1;
+    } else {
+      result = "unavailable";
+      code = 1;
+    }
+    out(JSON.stringify({ result, issuanceFingerprint }));
+    return code;
+  }
+}
+
+function parseCheckoutBindingFlags(
+  args: string[]
+): { input: BindCheckoutSubscriptionInput; dryRun: boolean } | undefined {
+  const valueFlags = new Set([
+    "issuance-idempotency-key",
+    "provider",
+    "provider-account-id",
+    "provider-mode",
+    "external-subscription-id",
+    "external-checkout-id"
+  ]);
+  const values = new Map<string, string>();
+  let dryRun = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--dry-run") {
+      if (dryRun || (args[index + 1] !== undefined && !args[index + 1]!.startsWith("--"))) {
+        return undefined;
+      }
+      dryRun = true;
+      continue;
+    }
+    if (!arg?.startsWith("--")) return undefined;
+    const name = arg.slice(2);
+    if (!valueFlags.has(name) || values.has(name)) return undefined;
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith("--")) return undefined;
+    values.set(name, value);
+    index += 1;
+  }
+  if ([...valueFlags].some((name) => !values.has(name))) return undefined;
+  return {
+    input: {
+      issuanceIdempotencyKey: values.get("issuance-idempotency-key")!,
+      provider: values.get("provider")! as "stripe",
+      providerAccountId: values.get("provider-account-id")!,
+      providerMode: values.get("provider-mode")! as "test" | "live",
+      externalSubscriptionId: values.get("external-subscription-id")!,
+      externalCheckoutId: values.get("external-checkout-id")!
+    },
+    dryRun
+  };
 }
 
 function cmdIssue(flags: Flags, store: LicenseStore, out: (line: string) => void): number {
@@ -116,7 +218,10 @@ function usage(): string {
     "         [--private-repo-allowed <true|false>] [--update-entitlement]",
     "  revoke --key <k> [--reason <text>]",
     "  list",
-    "  show   --key <k>"
+    "  show   --key <k>",
+    "  bind-checkout-subscription --issuance-idempotency-key <ref> --provider stripe",
+    "         --provider-account-id <id> --provider-mode <test|live>",
+    "         --external-subscription-id <id> --external-checkout-id <id> [--dry-run]"
   ].join("\n");
 }
 

--- a/services/license-api/src/checkout-policy.ts
+++ b/services/license-api/src/checkout-policy.ts
@@ -1,5 +1,3 @@
-import type { RepoVisibilityScope } from "./store.js";
-
 export const CHECKOUT_LOOKUP_KEYS = [
   "neondiff_monthly",
   "neondiff_yearly",
@@ -14,7 +12,7 @@ export interface CheckoutPolicy {
   maximumPeriodDays: number;
   currency: "usd";
   seats: 1;
-  repoVisibilityScope: RepoVisibilityScope;
+  repoVisibilityScope: "private";
   privateRepoAllowed: true;
   updateEntitlement: true;
 }

--- a/services/license-api/src/checkout-policy.ts
+++ b/services/license-api/src/checkout-policy.ts
@@ -7,18 +7,18 @@ export const CHECKOUT_LOOKUP_KEYS = [
 export type CheckoutLookupKey = (typeof CHECKOUT_LOOKUP_KEYS)[number];
 
 export interface CheckoutPolicy {
-  plan: string;
-  trialDays: number;
-  maximumPeriodDays: number;
-  currency: "usd";
-  seats: 1;
-  repoVisibilityScope: "private";
-  privateRepoAllowed: true;
-  updateEntitlement: true;
+  readonly plan: string;
+  readonly trialDays: number;
+  readonly maximumPeriodDays: number;
+  readonly currency: "usd";
+  readonly seats: 1;
+  readonly repoVisibilityScope: "private";
+  readonly privateRepoAllowed: true;
+  readonly updateEntitlement: true;
 }
 
-const CHECKOUT_POLICIES: Record<CheckoutLookupKey, CheckoutPolicy> = {
-  neondiff_monthly: {
+const CHECKOUT_POLICIES: Readonly<Record<CheckoutLookupKey, CheckoutPolicy>> = Object.freeze({
+  neondiff_monthly: Object.freeze({
     plan: "monthly_support",
     trialDays: 7,
     maximumPeriodDays: 62,
@@ -27,8 +27,8 @@ const CHECKOUT_POLICIES: Record<CheckoutLookupKey, CheckoutPolicy> = {
     repoVisibilityScope: "private",
     privateRepoAllowed: true,
     updateEntitlement: true
-  },
-  neondiff_yearly: {
+  }),
+  neondiff_yearly: Object.freeze({
     plan: "yearly_support",
     trialDays: 7,
     maximumPeriodDays: 400,
@@ -37,8 +37,8 @@ const CHECKOUT_POLICIES: Record<CheckoutLookupKey, CheckoutPolicy> = {
     repoVisibilityScope: "private",
     privateRepoAllowed: true,
     updateEntitlement: true
-  },
-  neondiff_org_yearly: {
+  }),
+  neondiff_org_yearly: Object.freeze({
     plan: "org_yearly_support",
     trialDays: 30,
     maximumPeriodDays: 400,
@@ -47,8 +47,8 @@ const CHECKOUT_POLICIES: Record<CheckoutLookupKey, CheckoutPolicy> = {
     repoVisibilityScope: "private",
     privateRepoAllowed: true,
     updateEntitlement: true
-  }
-};
+  })
+});
 
 export function checkoutPolicyFor(key: CheckoutLookupKey): CheckoutPolicy {
   return CHECKOUT_POLICIES[key];

--- a/services/license-api/src/checkout-policy.ts
+++ b/services/license-api/src/checkout-policy.ts
@@ -1,0 +1,61 @@
+import type { RepoVisibilityScope } from "./store.js";
+
+export const CHECKOUT_LOOKUP_KEYS = [
+  "neondiff_monthly",
+  "neondiff_yearly",
+  "neondiff_org_yearly"
+] as const;
+
+export type CheckoutLookupKey = (typeof CHECKOUT_LOOKUP_KEYS)[number];
+
+export interface CheckoutPolicy {
+  plan: string;
+  trialDays: number;
+  maximumPeriodDays: number;
+  currency: "usd";
+  seats: 1;
+  repoVisibilityScope: RepoVisibilityScope;
+  privateRepoAllowed: true;
+  updateEntitlement: true;
+}
+
+const CHECKOUT_POLICIES: Record<CheckoutLookupKey, CheckoutPolicy> = {
+  neondiff_monthly: {
+    plan: "monthly_support",
+    trialDays: 7,
+    maximumPeriodDays: 62,
+    currency: "usd",
+    seats: 1,
+    repoVisibilityScope: "private",
+    privateRepoAllowed: true,
+    updateEntitlement: true
+  },
+  neondiff_yearly: {
+    plan: "yearly_support",
+    trialDays: 7,
+    maximumPeriodDays: 400,
+    currency: "usd",
+    seats: 1,
+    repoVisibilityScope: "private",
+    privateRepoAllowed: true,
+    updateEntitlement: true
+  },
+  neondiff_org_yearly: {
+    plan: "org_yearly_support",
+    trialDays: 30,
+    maximumPeriodDays: 400,
+    currency: "usd",
+    seats: 1,
+    repoVisibilityScope: "private",
+    privateRepoAllowed: true,
+    updateEntitlement: true
+  }
+};
+
+export function checkoutPolicyFor(key: CheckoutLookupKey): CheckoutPolicy {
+  return CHECKOUT_POLICIES[key];
+}
+
+export function isCheckoutLookupKey(value: string): value is CheckoutLookupKey {
+  return Object.prototype.hasOwnProperty.call(CHECKOUT_POLICIES, value);
+}

--- a/services/license-api/src/http.ts
+++ b/services/license-api/src/http.ts
@@ -157,7 +157,15 @@ async function handleIssuanceRequest(
 
   try {
     const parsed = parseIssuanceRequest(await readBody(req));
-    return writeResult(res, issueCheckoutLicense(options.store, parsed, options.issuanceSecret));
+    return writeResult(
+      res,
+      issueCheckoutLicense(
+        options.store,
+        parsed,
+        options.issuanceSecret,
+        (options.now ?? (() => new Date()))()
+      )
+    );
   } catch (error) {
     return writeResult(
       res,

--- a/services/license-api/src/http.ts
+++ b/services/license-api/src/http.ts
@@ -48,6 +48,8 @@ export interface LicenseHttpOptions {
   subscriptionLifecycleRateLimiter?: RateLimiter;
   issuanceSecret?: string;
   lifecycleOidcVerifier?: LifecycleOidcVerifier;
+  /** Honor Fly's client-address header only when the listener runs behind Fly's trusted proxy. */
+  trustFlyProxyHeaders?: boolean;
   /** Injectable clock for deterministic tests. */
   now?: () => Date;
 }
@@ -84,9 +86,7 @@ export function createLicenseRequestListener(options: LicenseHttpOptions) {
       return handleIssuanceRequest(options, req, res);
     }
     if (req.method === "POST" && path === "/v1/admin/licenses/issue-lifecycle") {
-      const forwardedAddress = req.headers["fly-client-ip"];
-      const candidateAddress = Array.isArray(forwardedAddress) ? forwardedAddress[0] : forwardedAddress;
-      const sourceAddress = candidateAddress && isIP(candidateAddress) ? candidateAddress : (req.socket.remoteAddress ?? "unknown");
+      const sourceAddress = resolveClientAddress(req, options.trustFlyProxyHeaders === true);
       const lifecycleRateLimitKey = createHash("sha256").update(`lifecycle:${sourceAddress}`).digest("hex");
       if (!lifecycleRateLimiter.allow(lifecycleRateLimitKey, now().getTime())) {
         return writeJson(res, 429, { status: "rate_limited", detail: "too many lifecycle issuance requests" });
@@ -142,11 +142,7 @@ async function handleSubscriptionLifecycleRequest(
     return writeJson(res, 401, { status: "unauthorized" });
   }
 
-  const forwardedAddress = req.headers["fly-client-ip"];
-  const candidateAddress = Array.isArray(forwardedAddress) ? forwardedAddress[0] : forwardedAddress;
-  const sourceAddress = candidateAddress && isIP(candidateAddress)
-    ? candidateAddress
-    : (req.socket.remoteAddress ?? "unknown");
+  const sourceAddress = resolveClientAddress(req, options.trustFlyProxyHeaders === true);
   const rateLimitKey = createHash("sha256")
     .update(`subscription-lifecycle:${sourceAddress}`)
     .digest("hex");
@@ -192,6 +188,18 @@ async function handleSubscriptionLifecycleRequest(
     }
     return writeJson(res, 500, { status: "server" });
   }
+}
+
+function resolveClientAddress(req: IncomingMessage, trustFlyProxyHeaders: boolean): string {
+  const forwardedAddress = req.headers["fly-client-ip"];
+  if (
+    trustFlyProxyHeaders &&
+    typeof forwardedAddress === "string" &&
+    isIP(forwardedAddress)
+  ) {
+    return forwardedAddress;
+  }
+  return req.socket.remoteAddress ?? "unknown";
 }
 
 async function handleLifecycleIssuanceRequest(

--- a/services/license-api/src/http.ts
+++ b/services/license-api/src/http.ts
@@ -162,8 +162,7 @@ async function handleIssuanceRequest(
       issueCheckoutLicense(
         options.store,
         parsed,
-        options.issuanceSecret,
-        (options.now ?? (() => new Date()))()
+        options.issuanceSecret
       )
     );
   } catch (error) {

--- a/services/license-api/src/http.ts
+++ b/services/license-api/src/http.ts
@@ -24,6 +24,18 @@ import {
   parseLifecycleIssuanceRequest,
   type LifecycleOidcVerifier
 } from "./oidc-lifecycle.js";
+import {
+  parseSubscriptionLifecycleRequest,
+  LifecycleRequestError as SubscriptionLifecycleRequestError
+} from "./subscription-lifecycle.js";
+import {
+  SubscriptionLifecycleConflictError,
+  SubscriptionLifecycleNotFoundError,
+  SubscriptionLifecyclePolicyError,
+  SubscriptionLifecycleTerminalError,
+  SubscriptionLifecycleTransientError,
+  SubscriptionLifecycleUnsupportedCommandError
+} from "./store.js";
 
 const MAX_BODY_BYTES = 16 * 1024;
 
@@ -33,6 +45,7 @@ export interface LicenseHttpOptions {
   store: LicenseStore;
   rateLimiter?: RateLimiter;
   lifecycleRateLimiter?: RateLimiter;
+  subscriptionLifecycleRateLimiter?: RateLimiter;
   issuanceSecret?: string;
   lifecycleOidcVerifier?: LifecycleOidcVerifier;
   /** Injectable clock for deterministic tests. */
@@ -58,6 +71,9 @@ export function createLicenseRequestListener(options: LicenseHttpOptions) {
     options.rateLimiter ?? new RateLimiter({ maxPerWindow: 60, windowMs: 60_000 });
   const lifecycleRateLimiter =
     options.lifecycleRateLimiter ?? new RateLimiter({ maxPerWindow: 60, windowMs: 60_000 });
+  const subscriptionLifecycleRateLimiter =
+    options.subscriptionLifecycleRateLimiter ??
+    new RateLimiter({ maxPerWindow: 60, windowMs: 60_000 });
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     if (req.method === "GET" && req.url === "/healthz") {
@@ -76,6 +92,14 @@ export function createLicenseRequestListener(options: LicenseHttpOptions) {
         return writeJson(res, 429, { status: "rate_limited", detail: "too many lifecycle issuance requests" });
       }
       return handleLifecycleIssuanceRequest(options, req, res);
+    }
+    if (req.method === "POST" && path === "/v1/admin/licenses/lifecycle") {
+      return handleSubscriptionLifecycleRequest(
+        options,
+        subscriptionLifecycleRateLimiter,
+        req,
+        res
+      );
     }
 
     const route = path ? ROUTES[path] : undefined;
@@ -103,6 +127,71 @@ export function createLicenseRequestListener(options: LicenseHttpOptions) {
       return writeJson(res, 500, { status: "server", detail: "internal error" });
     }
   };
+}
+
+async function handleSubscriptionLifecycleRequest(
+  options: LicenseHttpOptions,
+  rateLimiter: RateLimiter,
+  req: IncomingMessage,
+  res: ServerResponse
+): Promise<void> {
+  if (!options.issuanceSecret) {
+    return writeJson(res, 503, { status: "unavailable" });
+  }
+  if (!validateBearerSecret(req.headers.authorization, options.issuanceSecret)) {
+    return writeJson(res, 401, { status: "unauthorized" });
+  }
+
+  const forwardedAddress = req.headers["fly-client-ip"];
+  const candidateAddress = Array.isArray(forwardedAddress) ? forwardedAddress[0] : forwardedAddress;
+  const sourceAddress = candidateAddress && isIP(candidateAddress)
+    ? candidateAddress
+    : (req.socket.remoteAddress ?? "unknown");
+  const rateLimitKey = createHash("sha256")
+    .update(`subscription-lifecycle:${sourceAddress}`)
+    .digest("hex");
+  const requestTime = (options.now ?? (() => new Date()))();
+  if (!rateLimiter.allow(rateLimitKey, requestTime.getTime())) {
+    return writeJson(
+      res,
+      429,
+      { status: "rate_limited" },
+      { "Retry-After": "60" }
+    );
+  }
+
+  try {
+    const request = parseSubscriptionLifecycleRequest(await readBody(req), requestTime);
+    return writeJson(
+      res,
+      200,
+      options.store.applyCheckoutSubscriptionLifecycle(request)
+    );
+  } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      return writeJson(res, 413, { status: "invalid" });
+    }
+    if (
+      error instanceof SubscriptionLifecycleRequestError ||
+      error instanceof SubscriptionLifecyclePolicyError ||
+      error instanceof SubscriptionLifecycleUnsupportedCommandError
+    ) {
+      return writeJson(res, 400, { status: "invalid" });
+    }
+    if (error instanceof SubscriptionLifecycleNotFoundError) {
+      return writeJson(res, 404, { status: "not_found" });
+    }
+    if (error instanceof SubscriptionLifecycleConflictError) {
+      return writeJson(res, 409, { status: "conflict" });
+    }
+    if (error instanceof SubscriptionLifecycleTerminalError) {
+      return writeJson(res, 409, { status: "terminally_revoked" });
+    }
+    if (error instanceof SubscriptionLifecycleTransientError) {
+      return writeJson(res, 503, { status: "unavailable" });
+    }
+    return writeJson(res, 500, { status: "server" });
+  }
 }
 
 async function handleLifecycleIssuanceRequest(
@@ -226,8 +315,13 @@ function writeResult(res: ServerResponse, result: ServiceResult, overrideStatus?
   writeJson(res, overrideStatus ?? result.httpStatus, result.body);
 }
 
-function writeJson(res: ServerResponse, status: number, body: unknown): void {
+function writeJson(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {}
+): void {
   const payload = JSON.stringify(body);
-  res.writeHead(status, { "Content-Type": "application/json" });
+  res.writeHead(status, { "Content-Type": "application/json", ...headers });
   res.end(payload);
 }

--- a/services/license-api/src/issuance.ts
+++ b/services/license-api/src/issuance.ts
@@ -103,8 +103,7 @@ export function parseIssuanceRequest(raw: string): LicenseIssuanceRequest {
 export function issueCheckoutLicense(
   store: LicenseStore,
   req: LicenseIssuanceRequest,
-  issuanceSecret: string,
-  now: Date
+  issuanceSecret: string
 ): ServiceResult {
   const issueInput = {
     idempotencyKey: req.idempotencyKey,
@@ -120,7 +119,7 @@ export function issueCheckoutLicense(
   const rawKey = deriveCheckoutLicenseKey(issuanceSecret, req.idempotencyKey);
 
   try {
-    const issued = store.issueBoundCheckoutLicense(rawKey, issueInput, now);
+    const issued = store.issueBoundCheckoutLicense(rawKey, issueInput);
     return {
       httpStatus: 200,
       body: {

--- a/services/license-api/src/issuance.ts
+++ b/services/license-api/src/issuance.ts
@@ -51,7 +51,7 @@ export function parseIssuanceRequest(raw: string): LicenseIssuanceRequest {
   }
   const body = parsed as Record<string, unknown>;
   for (const key of Object.keys(body)) {
-    if (!ISSUANCE_FIELDS.has(key)) throw new Error(`unknown field: ${key}`);
+    if (!ISSUANCE_FIELDS.has(key)) throw new Error("request contains an unknown field");
   }
 
   const idempotencyKey = readBoundedString(body, "idempotencyKey", { required: true, max: 200 });

--- a/services/license-api/src/issuance.ts
+++ b/services/license-api/src/issuance.ts
@@ -1,12 +1,12 @@
 import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import {
   CheckoutIssuanceConflictError,
+  CheckoutIssuanceTransientError,
   type LicenseRecord,
   type LicenseStore
 } from "./store.js";
 import {
   CHECKOUT_LOOKUP_KEYS,
-  checkoutPolicyFor,
   isCheckoutLookupKey,
   type CheckoutLookupKey
 } from "./checkout-policy.js";
@@ -106,19 +106,9 @@ export function issueCheckoutLicense(
   issuanceSecret: string,
   now: Date
 ): ServiceResult {
-  const policy = checkoutPolicyFor(req.checkoutLookupKey);
-  const expiresAt = new Date(now.getTime() + policy.trialDays * 24 * 60 * 60 * 1000).toISOString();
   const issueInput = {
     idempotencyKey: req.idempotencyKey,
-    requestHash: issuanceRequestHash(req),
-    source: "checkout" as const,
-    externalRef: req.externalCheckoutId,
-    plan: policy.plan,
-    repoVisibilityScope: policy.repoVisibilityScope,
-    privateRepoAllowed: policy.privateRepoAllowed,
-    updateEntitlement: policy.updateEntitlement,
-    seats: policy.seats,
-    expiresAt,
+    checkoutLookupKey: req.checkoutLookupKey,
     binding: {
       provider: req.provider,
       providerAccountId: req.providerAccountId,
@@ -130,7 +120,7 @@ export function issueCheckoutLicense(
   const rawKey = deriveCheckoutLicenseKey(issuanceSecret, req.idempotencyKey);
 
   try {
-    const issued = store.issueBoundCheckoutLicense(rawKey, issueInput);
+    const issued = store.issueBoundCheckoutLicense(rawKey, issueInput, now);
     return {
       httpStatus: 200,
       body: {
@@ -145,6 +135,15 @@ export function issueCheckoutLicense(
   } catch (error) {
     if (error instanceof CheckoutIssuanceConflictError) {
       return { httpStatus: 409, body: { status: "conflict", detail: error.message } };
+    }
+    if (error instanceof CheckoutIssuanceTransientError) {
+      return {
+        httpStatus: 503,
+        body: {
+          status: "unavailable",
+          detail: "license issuance temporarily unavailable"
+        }
+      };
     }
     return { httpStatus: 500, body: { status: "server", detail: "license issuance failed" } };
   }
@@ -165,21 +164,6 @@ export function validateBearerSecret(header: string | string[] | undefined, expe
 function deriveCheckoutLicenseKey(secret: string, idempotencyKey: string): string {
   const digest = createHmac("sha256", secret).update(`checkout-license:${idempotencyKey}`).digest();
   return ["nd", "live", digest.subarray(0, 24).toString("base64url")].join("_");
-}
-
-function issuanceRequestHash(req: LicenseIssuanceRequest): string {
-  return createHash("sha256")
-    .update(
-      JSON.stringify({
-        checkoutLookupKey: req.checkoutLookupKey,
-        provider: req.provider,
-        providerAccountId: req.providerAccountId,
-        providerMode: req.providerMode,
-        externalSubscriptionId: req.externalSubscriptionId,
-        externalCheckoutId: req.externalCheckoutId
-      })
-    )
-    .digest("hex");
 }
 
 function entitlementFromRecord(record: LicenseRecord): Record<string, unknown> {

--- a/services/license-api/src/issuance.ts
+++ b/services/license-api/src/issuance.ts
@@ -1,35 +1,37 @@
 import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import {
-  type IssueLicenseInput,
+  CheckoutIssuanceConflictError,
   type LicenseRecord,
-  type LicenseStore,
-  type RepoVisibilityScope
+  type LicenseStore
 } from "./store.js";
+import {
+  CHECKOUT_LOOKUP_KEYS,
+  checkoutPolicyFor,
+  isCheckoutLookupKey,
+  type CheckoutLookupKey
+} from "./checkout-policy.js";
 import { malformedResult, type ServiceResult } from "./service.js";
 
-const ACTIVE_CHECKOUT_LOOKUP_KEYS = {
-  neondiff_monthly: "monthly_support",
-  neondiff_yearly: "yearly_support",
-  neondiff_org_yearly: "org_yearly_support"
-} as const;
-
-type CheckoutLookupKey = keyof typeof ACTIVE_CHECKOUT_LOOKUP_KEYS;
+const ISSUANCE_FIELDS = new Set([
+  "idempotencyKey",
+  "checkoutLookupKey",
+  "provider",
+  "providerAccountId",
+  "providerMode",
+  "externalSubscriptionId",
+  "externalCheckoutId",
+  "seats"
+]);
 
 export interface LicenseIssuanceRequest {
   idempotencyKey: string;
   checkoutLookupKey: CheckoutLookupKey;
-  customerEmail?: string;
-  externalCustomerId?: string;
-  externalCheckoutId?: string;
-  seats?: number;
-  expiresAt?: string;
-}
-
-export interface LicenseIssuanceInput extends IssueLicenseInput {
-  idempotencyKey: string;
-  requestHash: string;
-  source?: string;
-  externalRef?: string;
+  provider: "stripe";
+  providerAccountId: string;
+  providerMode: "test" | "live";
+  externalSubscriptionId: string;
+  externalCheckoutId: string;
+  seats?: 1;
 }
 
 export interface LicenseIssuanceResult {
@@ -39,13 +41,18 @@ export interface LicenseIssuanceResult {
 }
 
 export function checkoutLookupKeys(): readonly string[] {
-  return Object.keys(ACTIVE_CHECKOUT_LOOKUP_KEYS);
+  return CHECKOUT_LOOKUP_KEYS;
 }
 
 export function parseIssuanceRequest(raw: string): LicenseIssuanceRequest {
   const parsed = raw ? (JSON.parse(raw) as unknown) : {};
-  if (typeof parsed !== "object" || parsed === null) throw new Error("request body must be a JSON object");
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("request body must be a JSON object");
+  }
   const body = parsed as Record<string, unknown>;
+  for (const key of Object.keys(body)) {
+    if (!ISSUANCE_FIELDS.has(key)) throw new Error(`unknown field: ${key}`);
+  }
 
   const idempotencyKey = readBoundedString(body, "idempotencyKey", { required: true, max: 200 });
   if (!/^[A-Za-z0-9._:-]+$/.test(idempotencyKey)) {
@@ -57,53 +64,73 @@ export function parseIssuanceRequest(raw: string): LicenseIssuanceRequest {
     throw new Error(`checkoutLookupKey must be one of: ${checkoutLookupKeys().join(", ")}`);
   }
 
-  const seatsRaw = body.seats;
-  const seats = seatsRaw === undefined ? undefined : Number(seatsRaw);
-  if (seats !== undefined && (!Number.isInteger(seats) || seats < 1 || seats > 500)) {
-    throw new Error("seats must be a positive integer <= 500");
+  const provider = readBoundedString(body, "provider", { required: true, max: 40 });
+  if (provider !== "stripe") throw new Error("provider must be stripe");
+  const providerAccountId = readBoundedString(body, "providerAccountId", {
+    required: true,
+    max: 160
+  });
+  const providerMode = readBoundedString(body, "providerMode", { required: true, max: 16 });
+  if (providerMode !== "test" && providerMode !== "live") {
+    throw new Error("providerMode must be test or live");
   }
+  const externalSubscriptionId = readBoundedString(body, "externalSubscriptionId", {
+    required: true,
+    max: 160
+  });
+  const externalCheckoutId = readBoundedString(body, "externalCheckoutId", {
+    required: true,
+    max: 160
+  });
 
-  const expiresAt = readBoundedString(body, "expiresAt", { required: false, max: 80 });
-  if (expiresAt && !Number.isFinite(Date.parse(expiresAt))) {
-    throw new Error("expiresAt must be an ISO timestamp");
+  const seatsRaw = body.seats;
+  if (seatsRaw !== undefined && seatsRaw !== 1) {
+    throw new Error("seats is deprecated and must be exactly 1");
   }
-  const customerEmail = readBoundedString(body, "customerEmail", { required: false, max: 320 });
-  const externalCustomerId = readBoundedString(body, "externalCustomerId", { required: false, max: 160 });
-  const externalCheckoutId = readBoundedString(body, "externalCheckoutId", { required: false, max: 160 });
 
   return {
     idempotencyKey,
     checkoutLookupKey,
-    ...(customerEmail ? { customerEmail } : {}),
-    ...(externalCustomerId ? { externalCustomerId } : {}),
-    ...(externalCheckoutId ? { externalCheckoutId } : {}),
-    ...(seats !== undefined ? { seats } : {}),
-    ...(expiresAt ? { expiresAt } : {})
+    provider,
+    providerAccountId,
+    providerMode,
+    externalSubscriptionId,
+    externalCheckoutId,
+    ...(seatsRaw === 1 ? { seats: 1 as const } : {})
   };
 }
 
 export function issueCheckoutLicense(
   store: LicenseStore,
   req: LicenseIssuanceRequest,
-  issuanceSecret: string
+  issuanceSecret: string,
+  now: Date
 ): ServiceResult {
-  const plan = ACTIVE_CHECKOUT_LOOKUP_KEYS[req.checkoutLookupKey];
-  const issueInput: LicenseIssuanceInput = {
+  const policy = checkoutPolicyFor(req.checkoutLookupKey);
+  const expiresAt = new Date(now.getTime() + policy.trialDays * 24 * 60 * 60 * 1000).toISOString();
+  const issueInput = {
     idempotencyKey: req.idempotencyKey,
     requestHash: issuanceRequestHash(req),
-    source: "checkout",
-    externalRef: req.externalCheckoutId ?? req.externalCustomerId,
-    plan,
-    repoVisibilityScope: "private",
-    privateRepoAllowed: true,
-    updateEntitlement: true,
-    ...(req.seats !== undefined ? { seats: req.seats } : {}),
-    ...(req.expiresAt ? { expiresAt: req.expiresAt } : {})
+    source: "checkout" as const,
+    externalRef: req.externalCheckoutId,
+    plan: policy.plan,
+    repoVisibilityScope: policy.repoVisibilityScope,
+    privateRepoAllowed: policy.privateRepoAllowed,
+    updateEntitlement: policy.updateEntitlement,
+    seats: policy.seats,
+    expiresAt,
+    binding: {
+      provider: req.provider,
+      providerAccountId: req.providerAccountId,
+      providerMode: req.providerMode,
+      externalSubscriptionId: req.externalSubscriptionId,
+      externalCheckoutId: req.externalCheckoutId
+    }
   };
   const rawKey = deriveCheckoutLicenseKey(issuanceSecret, req.idempotencyKey);
 
   try {
-    const issued = store.issueIdempotentLicense(rawKey, issueInput);
+    const issued = store.issueBoundCheckoutLicense(rawKey, issueInput);
     return {
       httpStatus: 200,
       body: {
@@ -116,9 +143,8 @@ export function issueCheckoutLicense(
       }
     };
   } catch (error) {
-    const detail = error instanceof Error ? error.message : "license issuance failed";
-    if (detail.includes("idempotency key")) {
-      return { httpStatus: 409, body: { status: "conflict", detail } };
+    if (error instanceof CheckoutIssuanceConflictError) {
+      return { httpStatus: 409, body: { status: "conflict", detail: error.message } };
     }
     return { httpStatus: 500, body: { status: "server", detail: "license issuance failed" } };
   }
@@ -146,11 +172,11 @@ function issuanceRequestHash(req: LicenseIssuanceRequest): string {
     .update(
       JSON.stringify({
         checkoutLookupKey: req.checkoutLookupKey,
-        customerEmail: req.customerEmail ?? null,
-        externalCustomerId: req.externalCustomerId ?? null,
-        externalCheckoutId: req.externalCheckoutId ?? null,
-        seats: req.seats ?? null,
-        expiresAt: req.expiresAt ?? null
+        provider: req.provider,
+        providerAccountId: req.providerAccountId,
+        providerMode: req.providerMode,
+        externalSubscriptionId: req.externalSubscriptionId,
+        externalCheckoutId: req.externalCheckoutId
       })
     )
     .digest("hex");
@@ -166,10 +192,6 @@ function entitlementFromRecord(record: LicenseRecord): Record<string, unknown> {
     seats: record.seats,
     ...(record.expiresAt ? { expiresAt: record.expiresAt } : {})
   };
-}
-
-function isCheckoutLookupKey(value: string): value is CheckoutLookupKey {
-  return Object.prototype.hasOwnProperty.call(ACTIVE_CHECKOUT_LOOKUP_KEYS, value);
 }
 
 function readBoundedString(

--- a/services/license-api/src/server.ts
+++ b/services/license-api/src/server.ts
@@ -1,6 +1,7 @@
 import { LicenseStore } from "./store.js";
 import { startLicenseServer } from "./http.js";
 import { createGitHubActionsOidcVerifier } from "./oidc-lifecycle.js";
+import { RateLimiter } from "./service.js";
 
 /**
  * Production entrypoint. SQLite lives on a mounted volume in deploy
@@ -17,6 +18,10 @@ async function main(): Promise<void> {
     port,
     host,
     issuanceSecret: process.env.LICENSE_ISSUANCE_SECRET,
+    subscriptionLifecycleRateLimiter: new RateLimiter({
+      maxPerWindow: 60,
+      windowMs: 60_000
+    }),
     lifecycleOidcVerifier: createGitHubActionsOidcVerifier()
   });
   // eslint-disable-next-line no-console

--- a/services/license-api/src/server.ts
+++ b/services/license-api/src/server.ts
@@ -12,12 +12,16 @@ async function main(): Promise<void> {
   const dbPath = process.env.LICENSE_DB_PATH ?? "runtime/license.sqlite";
   const port = Number(process.env.PORT ?? 8080);
   const host = process.env.HOST ?? "0.0.0.0";
+  // Fly injects FLY_APP_NAME into Machines. Outside that operator-controlled
+  // runtime, request-supplied Fly headers are untrusted and ignored.
+  const trustFlyProxyHeaders = Boolean(process.env.FLY_APP_NAME?.trim());
   const store = new LicenseStore(dbPath);
   const { url } = await startLicenseServer({
     store,
     port,
     host,
     issuanceSecret: process.env.LICENSE_ISSUANCE_SECRET,
+    trustFlyProxyHeaders,
     subscriptionLifecycleRateLimiter: new RateLimiter({
       maxPerWindow: 60,
       windowMs: 60_000

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -33,6 +33,7 @@ export type SchemaMigrationStep =
 
 export interface LicenseStoreOptions {
   migrationHook?: (step: SchemaMigrationStep) => void;
+  /** Server-owned clock. Checkout callers cannot override it per issuance. */
   now?: () => Date;
   busyTimeoutMs?: number;
 }
@@ -223,11 +224,11 @@ export interface IssueIdempotentLicenseInput extends IssueLicenseInput {
 }
 
 export interface CheckoutSubscriptionBindingInput {
-  provider: string;
-  providerAccountId: string;
-  providerMode: string;
-  externalSubscriptionId: string;
-  externalCheckoutId: string;
+  readonly provider: "stripe";
+  readonly providerAccountId: string;
+  readonly providerMode: "test" | "live";
+  readonly externalSubscriptionId: string;
+  readonly externalCheckoutId: string;
 }
 
 export interface CheckoutSubscriptionBindingRecord extends CheckoutSubscriptionBindingInput {
@@ -377,27 +378,26 @@ export class LicenseStore {
    */
   issueBoundCheckoutLicense(
     rawKey: string,
-    input: IssueBoundCheckoutLicenseInput,
-    issuedAt: Date = this.now()
+    input: IssueBoundCheckoutLicenseInput
   ): {
     rawKey: string;
     record: LicenseRecord;
     binding: CheckoutSubscriptionBindingRecord;
     replayed: boolean;
   } {
-    validateBoundCheckoutInput(input);
-    const policy = checkoutPolicyFor(input.checkoutLookupKey);
-    const requestHash = boundCheckoutRequestHash(input);
+    const validatedInput = validateBoundCheckoutInput(input);
+    const policy = checkoutPolicyFor(validatedInput.checkoutLookupKey);
+    const requestHash = boundCheckoutRequestHash(validatedInput);
     let transactionStarted = false;
     try {
       this.db.exec("begin immediate");
       transactionStarted = true;
-      const existing = this.getIssuanceEvent(input.idempotencyKey);
+      const existing = this.getIssuanceEvent(validatedInput.idempotencyKey);
       if (existing) {
         if (existing.source !== "checkout") {
           throw new CheckoutIssuanceConflictError("issuance reference is not checkout-owned");
         }
-        const binding = this.getCheckoutSubscriptionBinding(input.idempotencyKey);
+        const binding = this.getCheckoutSubscriptionBinding(validatedInput.idempotencyKey);
         if (!binding) {
           throw new CheckoutIssuanceConflictError("legacy checkout issuance is not bound");
         }
@@ -416,7 +416,7 @@ export class LicenseStore {
             "issuance reference was already used with different request data"
           );
         }
-        if (!sameCheckoutBinding(binding, input.binding)) {
+        if (!sameCheckoutBinding(binding, validatedInput.binding)) {
           throw new CheckoutIssuanceConflictError(
             "issuance reference was already used with different checkout correlation"
           );
@@ -425,6 +425,7 @@ export class LicenseStore {
         return { rawKey, record, binding, replayed: true };
       }
 
+      const issuedAt = this.now();
       if (!Number.isFinite(issuedAt.getTime())) {
         throw new Error("license store clock returned an invalid date");
       }
@@ -446,10 +447,10 @@ export class LicenseStore {
           ) values (?, ?, ?, 'checkout', ?)`
         )
         .run(
-          input.idempotencyKey,
+          validatedInput.idempotencyKey,
           record.licenseKeyHash,
           requestHash,
-          input.binding.externalCheckoutId
+          validatedInput.binding.externalCheckoutId
         );
       this.db
         .prepare(
@@ -459,15 +460,15 @@ export class LicenseStore {
           ) values (?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
-          input.idempotencyKey,
+          validatedInput.idempotencyKey,
           record.licenseKeyHash,
-          input.binding.provider,
-          input.binding.providerAccountId,
-          input.binding.providerMode,
-          input.binding.externalSubscriptionId,
-          input.binding.externalCheckoutId
+          validatedInput.binding.provider,
+          validatedInput.binding.providerAccountId,
+          validatedInput.binding.providerMode,
+          validatedInput.binding.externalSubscriptionId,
+          validatedInput.binding.externalCheckoutId
         );
-      const binding = this.getCheckoutSubscriptionBinding(input.idempotencyKey);
+      const binding = this.getCheckoutSubscriptionBinding(validatedInput.idempotencyKey);
       if (!binding) throw new Error("checkout binding insert did not persist");
       this.db.exec("commit");
       return { rawKey, record, binding, replayed: false };
@@ -632,6 +633,12 @@ function mapActivation(row: ActivationRow): ActivationRecord {
 function mapCheckoutSubscriptionBinding(
   row: CheckoutSubscriptionBindingRow
 ): CheckoutSubscriptionBindingRecord {
+  if (row.provider !== "stripe") {
+    throw new CheckoutIssuanceConflictError("checkout binding provider is unsupported");
+  }
+  if (row.provider_mode !== "test" && row.provider_mode !== "live") {
+    throw new CheckoutIssuanceConflictError("checkout binding mode is unsupported");
+  }
   return {
     issuanceIdempotencyKey: row.issuance_idempotency_key,
     licenseKeyHash: row.license_key_hash,
@@ -665,7 +672,9 @@ function resolveBusyTimeout(value: number | undefined): number {
   return timeout;
 }
 
-function validateBoundCheckoutInput(input: IssueBoundCheckoutLicenseInput): void {
+function validateBoundCheckoutInput(
+  input: IssueBoundCheckoutLicenseInput
+): IssueBoundCheckoutLicenseInput {
   for (const key of Object.keys(input)) {
     if (!BOUND_CHECKOUT_INPUT_FIELDS.has(key)) {
       throw new CheckoutIssuancePolicyError(`unsupported bound checkout field: ${key}`);
@@ -676,6 +685,43 @@ function validateBoundCheckoutInput(input: IssueBoundCheckoutLicenseInput): void
       throw new CheckoutIssuancePolicyError(`unsupported checkout binding field: ${key}`);
     }
   }
+  if (input.binding.provider !== "stripe") {
+    throw new CheckoutIssuancePolicyError("provider must be stripe");
+  }
+  if (input.binding.providerMode !== "test" && input.binding.providerMode !== "live") {
+    throw new CheckoutIssuancePolicyError("providerMode must be test or live");
+  }
+  return {
+    idempotencyKey: input.idempotencyKey,
+    checkoutLookupKey: input.checkoutLookupKey,
+    binding: {
+      provider: input.binding.provider,
+      providerAccountId: readBoundedCheckoutBindingString(
+        input.binding.providerAccountId,
+        "providerAccountId"
+      ),
+      providerMode: input.binding.providerMode,
+      externalSubscriptionId: readBoundedCheckoutBindingString(
+        input.binding.externalSubscriptionId,
+        "externalSubscriptionId"
+      ),
+      externalCheckoutId: readBoundedCheckoutBindingString(
+        input.binding.externalCheckoutId,
+        "externalCheckoutId"
+      )
+    }
+  };
+}
+
+function readBoundedCheckoutBindingString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new CheckoutIssuancePolicyError(`${field} is required`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > 160) {
+    throw new CheckoutIssuancePolicyError(`${field} is too long`);
+  }
+  return trimmed;
 }
 
 function boundCheckoutRequestHash(input: IssueBoundCheckoutLicenseInput): string {

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -2,8 +2,27 @@ import { createHash, randomBytes } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import {
+  checkoutPolicyFor,
+  type CheckoutLookupKey,
+  type CheckoutPolicy
+} from "./checkout-policy.js";
 
 const SCHEMA_VERSION = 2;
+const DEFAULT_BUSY_TIMEOUT_MS = 250;
+const MAX_BUSY_TIMEOUT_MS = 1_000;
+const BOUND_CHECKOUT_INPUT_FIELDS = new Set([
+  "idempotencyKey",
+  "checkoutLookupKey",
+  "binding"
+]);
+const BOUND_CHECKOUT_BINDING_FIELDS = new Set([
+  "provider",
+  "providerAccountId",
+  "providerMode",
+  "externalSubscriptionId",
+  "externalCheckoutId"
+]);
 
 export type SchemaMigrationStep =
   | "transaction-started"
@@ -14,6 +33,8 @@ export type SchemaMigrationStep =
 
 export interface LicenseStoreOptions {
   migrationHook?: (step: SchemaMigrationStep) => void;
+  now?: () => Date;
+  busyTimeoutMs?: number;
 }
 
 interface SchemaObjectSignature {
@@ -215,19 +236,24 @@ export interface CheckoutSubscriptionBindingRecord extends CheckoutSubscriptionB
   createdAt: string;
 }
 
-export interface IssueBoundCheckoutLicenseInput extends IssueIdempotentLicenseInput {
-  source: "checkout";
+export interface IssueBoundCheckoutLicenseInput {
+  idempotencyKey: string;
+  checkoutLookupKey: CheckoutLookupKey;
   binding: CheckoutSubscriptionBindingInput;
 }
 
 export class CheckoutIssuanceConflictError extends Error {}
+export class CheckoutIssuancePolicyError extends Error {}
+export class CheckoutIssuanceTransientError extends Error {}
 
 export class LicenseStore {
   private readonly db: DatabaseSync;
+  private readonly now: () => Date;
 
   constructor(dbPath: string, options: LicenseStoreOptions = {}) {
     if (dbPath !== ":memory:") mkdirSync(dirname(dbPath), { recursive: true });
-    this.db = new DatabaseSync(dbPath);
+    this.now = options.now ?? (() => new Date());
+    this.db = new DatabaseSync(dbPath, { timeout: resolveBusyTimeout(options.busyTimeoutMs) });
     try {
       this.db.exec("pragma foreign_keys = on");
       this.ensureSchema(options);
@@ -351,20 +377,21 @@ export class LicenseStore {
    */
   issueBoundCheckoutLicense(
     rawKey: string,
-    input: IssueBoundCheckoutLicenseInput
+    input: IssueBoundCheckoutLicenseInput,
+    issuedAt: Date = this.now()
   ): {
     rawKey: string;
     record: LicenseRecord;
     binding: CheckoutSubscriptionBindingRecord;
     replayed: boolean;
   } {
-    this.db.exec("begin immediate");
+    validateBoundCheckoutInput(input);
+    const policy = checkoutPolicyFor(input.checkoutLookupKey);
+    const requestHash = boundCheckoutRequestHash(input);
+    let transactionStarted = false;
     try {
-      if (input.seats !== 1) {
-        throw new CheckoutIssuanceConflictError(
-          "bound checkout issuance requires exactly one seat"
-        );
-      }
+      this.db.exec("begin immediate");
+      transactionStarted = true;
       const existing = this.getIssuanceEvent(input.idempotencyKey);
       if (existing) {
         if (existing.source !== "checkout") {
@@ -378,15 +405,13 @@ export class LicenseStore {
         if (!record) {
           throw new Error("issuance reference points to a missing license record");
         }
-        if (record.seats !== 1) {
-          throw new CheckoutIssuanceConflictError("multi-seat checkout issuance requires owner review");
-        }
+        validateStoredCheckoutEntitlement(record, policy);
         if (hashLicenseKey(rawKey) !== existing.license_key_hash) {
           throw new CheckoutIssuanceConflictError(
             "issuance reference was issued with a different key derivation secret"
           );
         }
-        if (existing.request_hash !== input.requestHash) {
+        if (existing.request_hash !== requestHash) {
           throw new CheckoutIssuanceConflictError(
             "issuance reference was already used with different request data"
           );
@@ -400,14 +425,32 @@ export class LicenseStore {
         return { rawKey, record, binding, replayed: true };
       }
 
-      const { record } = this.insertLicense(rawKey, input);
+      if (!Number.isFinite(issuedAt.getTime())) {
+        throw new Error("license store clock returned an invalid date");
+      }
+      const expiresAt = new Date(
+        issuedAt.getTime() + policy.trialDays * 24 * 60 * 60 * 1_000
+      ).toISOString();
+      const { record } = this.insertLicense(rawKey, {
+        plan: policy.plan,
+        repoVisibilityScope: policy.repoVisibilityScope,
+        privateRepoAllowed: policy.privateRepoAllowed,
+        updateEntitlement: policy.updateEntitlement,
+        seats: policy.seats,
+        expiresAt
+      });
       this.db
         .prepare(
           `insert into license_issuance_events (
             idempotency_key, license_key_hash, request_hash, source, external_ref
           ) values (?, ?, ?, 'checkout', ?)`
         )
-        .run(input.idempotencyKey, record.licenseKeyHash, input.requestHash, input.externalRef ?? null);
+        .run(
+          input.idempotencyKey,
+          record.licenseKeyHash,
+          requestHash,
+          input.binding.externalCheckoutId
+        );
       this.db
         .prepare(
           `insert into checkout_subscription_bindings (
@@ -429,7 +472,10 @@ export class LicenseStore {
       this.db.exec("commit");
       return { rawKey, record, binding, replayed: false };
     } catch (error) {
-      this.db.exec("rollback");
+      if (transactionStarted) this.db.exec("rollback");
+      if (isSqliteBusy(error)) {
+        throw new CheckoutIssuanceTransientError("checkout issuance storage is busy");
+      }
       if (
         error instanceof Error &&
         error.message.includes("UNIQUE constraint failed: checkout_subscription_bindings")
@@ -609,6 +655,64 @@ function sameCheckoutBinding(
     existing.externalSubscriptionId === requested.externalSubscriptionId &&
     existing.externalCheckoutId === requested.externalCheckoutId
   );
+}
+
+function resolveBusyTimeout(value: number | undefined): number {
+  const timeout = value ?? DEFAULT_BUSY_TIMEOUT_MS;
+  if (!Number.isInteger(timeout) || timeout < 1 || timeout > MAX_BUSY_TIMEOUT_MS) {
+    throw new Error(`busyTimeoutMs must be an integer from 1 to ${MAX_BUSY_TIMEOUT_MS}`);
+  }
+  return timeout;
+}
+
+function validateBoundCheckoutInput(input: IssueBoundCheckoutLicenseInput): void {
+  for (const key of Object.keys(input)) {
+    if (!BOUND_CHECKOUT_INPUT_FIELDS.has(key)) {
+      throw new CheckoutIssuancePolicyError(`unsupported bound checkout field: ${key}`);
+    }
+  }
+  for (const key of Object.keys(input.binding)) {
+    if (!BOUND_CHECKOUT_BINDING_FIELDS.has(key)) {
+      throw new CheckoutIssuancePolicyError(`unsupported checkout binding field: ${key}`);
+    }
+  }
+}
+
+function boundCheckoutRequestHash(input: IssueBoundCheckoutLicenseInput): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        checkoutLookupKey: input.checkoutLookupKey,
+        provider: input.binding.provider,
+        providerAccountId: input.binding.providerAccountId,
+        providerMode: input.binding.providerMode,
+        externalSubscriptionId: input.binding.externalSubscriptionId,
+        externalCheckoutId: input.binding.externalCheckoutId
+      })
+    )
+    .digest("hex");
+}
+
+function validateStoredCheckoutEntitlement(record: LicenseRecord, policy: CheckoutPolicy): void {
+  if (
+    record.plan !== policy.plan ||
+    record.repoVisibilityScope !== policy.repoVisibilityScope ||
+    record.privateRepoAllowed !== policy.privateRepoAllowed ||
+    record.updateEntitlement !== policy.updateEntitlement ||
+    record.seats !== policy.seats ||
+    !record.expiresAt ||
+    !Number.isFinite(Date.parse(record.expiresAt))
+  ) {
+    throw new CheckoutIssuanceConflictError(
+      "checkout issuance entitlement does not match server policy"
+    );
+  }
+}
+
+function isSqliteBusy(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as Error & { code?: string }).code;
+  return code === "ERR_SQLITE_ERROR" && /database is (?:locked|busy)/i.test(error.message);
 }
 
 function expectedSchemaSignature(schema: string): SchemaObjectSignature[] {

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -154,6 +154,18 @@ interface LicenseIssuanceRow {
   created_at: string;
 }
 
+interface CheckoutSubscriptionBindingRow {
+  issuance_idempotency_key: string;
+  license_key_hash: string;
+  provider: string;
+  provider_account_id: string;
+  provider_mode: string;
+  external_subscription_id: string;
+  external_checkout_id: string;
+  last_non_mutating_event_created_at: number | null;
+  created_at: string;
+}
+
 /**
  * Deterministic at-rest identifier for a license key. Only the hash is ever
  * stored or logged; the raw key is printed once by the admin CLI at issuance
@@ -188,6 +200,27 @@ export interface IssueIdempotentLicenseInput extends IssueLicenseInput {
   source?: string;
   externalRef?: string;
 }
+
+export interface CheckoutSubscriptionBindingInput {
+  provider: string;
+  providerAccountId: string;
+  providerMode: string;
+  externalSubscriptionId: string;
+  externalCheckoutId: string;
+}
+
+export interface CheckoutSubscriptionBindingRecord extends CheckoutSubscriptionBindingInput {
+  issuanceIdempotencyKey: string;
+  licenseKeyHash: string;
+  createdAt: string;
+}
+
+export interface IssueBoundCheckoutLicenseInput extends IssueIdempotentLicenseInput {
+  source: "checkout";
+  binding: CheckoutSubscriptionBindingInput;
+}
+
+export class CheckoutIssuanceConflictError extends Error {}
 
 export class LicenseStore {
   private readonly db: DatabaseSync;
@@ -311,6 +344,102 @@ export class LicenseStore {
     }
   }
 
+  /**
+   * Issue and bind a checkout license in one write transaction. Existing
+   * admin and release issuance continue through issueLicense and
+   * issueIdempotentLicense; only checkout fulfillment uses this stricter path.
+   */
+  issueBoundCheckoutLicense(
+    rawKey: string,
+    input: IssueBoundCheckoutLicenseInput
+  ): {
+    rawKey: string;
+    record: LicenseRecord;
+    binding: CheckoutSubscriptionBindingRecord;
+    replayed: boolean;
+  } {
+    this.db.exec("begin immediate");
+    try {
+      if (input.seats !== 1) {
+        throw new CheckoutIssuanceConflictError(
+          "bound checkout issuance requires exactly one seat"
+        );
+      }
+      const existing = this.getIssuanceEvent(input.idempotencyKey);
+      if (existing) {
+        if (existing.source !== "checkout") {
+          throw new CheckoutIssuanceConflictError("issuance reference is not checkout-owned");
+        }
+        const binding = this.getCheckoutSubscriptionBinding(input.idempotencyKey);
+        if (!binding) {
+          throw new CheckoutIssuanceConflictError("legacy checkout issuance is not bound");
+        }
+        const record = this.getLicenseByHash(existing.license_key_hash);
+        if (!record) {
+          throw new Error("issuance reference points to a missing license record");
+        }
+        if (record.seats !== 1) {
+          throw new CheckoutIssuanceConflictError("multi-seat checkout issuance requires owner review");
+        }
+        if (hashLicenseKey(rawKey) !== existing.license_key_hash) {
+          throw new CheckoutIssuanceConflictError(
+            "issuance reference was issued with a different key derivation secret"
+          );
+        }
+        if (existing.request_hash !== input.requestHash) {
+          throw new CheckoutIssuanceConflictError(
+            "issuance reference was already used with different request data"
+          );
+        }
+        if (!sameCheckoutBinding(binding, input.binding)) {
+          throw new CheckoutIssuanceConflictError(
+            "issuance reference was already used with different checkout correlation"
+          );
+        }
+        this.db.exec("commit");
+        return { rawKey, record, binding, replayed: true };
+      }
+
+      const { record } = this.insertLicense(rawKey, input);
+      this.db
+        .prepare(
+          `insert into license_issuance_events (
+            idempotency_key, license_key_hash, request_hash, source, external_ref
+          ) values (?, ?, ?, 'checkout', ?)`
+        )
+        .run(input.idempotencyKey, record.licenseKeyHash, input.requestHash, input.externalRef ?? null);
+      this.db
+        .prepare(
+          `insert into checkout_subscription_bindings (
+            issuance_idempotency_key, license_key_hash, provider, provider_account_id,
+            provider_mode, external_subscription_id, external_checkout_id
+          ) values (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          input.idempotencyKey,
+          record.licenseKeyHash,
+          input.binding.provider,
+          input.binding.providerAccountId,
+          input.binding.providerMode,
+          input.binding.externalSubscriptionId,
+          input.binding.externalCheckoutId
+        );
+      const binding = this.getCheckoutSubscriptionBinding(input.idempotencyKey);
+      if (!binding) throw new Error("checkout binding insert did not persist");
+      this.db.exec("commit");
+      return { rawKey, record, binding, replayed: false };
+    } catch (error) {
+      this.db.exec("rollback");
+      if (
+        error instanceof Error &&
+        error.message.includes("UNIQUE constraint failed: checkout_subscription_bindings")
+      ) {
+        throw new CheckoutIssuanceConflictError("checkout correlation is already bound");
+      }
+      throw error;
+    }
+  }
+
   private insertLicense(rawKey: string, input: IssueLicenseInput): { rawKey: string; record: LicenseRecord } {
     const licenseKeyHash = hashLicenseKey(rawKey);
     const seats = input.seats ?? 1;
@@ -342,6 +471,17 @@ export class LicenseStore {
     return this.db
       .prepare("select * from license_issuance_events where idempotency_key = ?")
       .get(idempotencyKey) as LicenseIssuanceRow | undefined;
+  }
+
+  private getCheckoutSubscriptionBinding(
+    idempotencyKey: string
+  ): CheckoutSubscriptionBindingRecord | undefined {
+    const row = this.db
+      .prepare(
+        "select * from checkout_subscription_bindings where issuance_idempotency_key = ?"
+      )
+      .get(idempotencyKey) as CheckoutSubscriptionBindingRow | undefined;
+    return row ? mapCheckoutSubscriptionBinding(row) : undefined;
   }
 
   getLicenseByHash(licenseKeyHash: string): LicenseRecord | undefined {
@@ -441,6 +581,34 @@ function mapActivation(row: ActivationRow): ActivationRecord {
     activatedAt: row.activated_at,
     lastSeenAt: row.last_seen_at
   };
+}
+
+function mapCheckoutSubscriptionBinding(
+  row: CheckoutSubscriptionBindingRow
+): CheckoutSubscriptionBindingRecord {
+  return {
+    issuanceIdempotencyKey: row.issuance_idempotency_key,
+    licenseKeyHash: row.license_key_hash,
+    provider: row.provider,
+    providerAccountId: row.provider_account_id,
+    providerMode: row.provider_mode,
+    externalSubscriptionId: row.external_subscription_id,
+    externalCheckoutId: row.external_checkout_id,
+    createdAt: row.created_at
+  };
+}
+
+function sameCheckoutBinding(
+  existing: CheckoutSubscriptionBindingRecord,
+  requested: CheckoutSubscriptionBindingInput
+): boolean {
+  return (
+    existing.provider === requested.provider &&
+    existing.providerAccountId === requested.providerAccountId &&
+    existing.providerMode === requested.providerMode &&
+    existing.externalSubscriptionId === requested.externalSubscriptionId &&
+    existing.externalCheckoutId === requested.externalCheckoutId
+  );
 }
 
 function expectedSchemaSignature(schema: string): SchemaObjectSignature[] {

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -3,7 +3,9 @@ import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import {
+  CHECKOUT_LOOKUP_KEYS,
   checkoutPolicyFor,
+  isCheckoutLookupKey,
   type CheckoutLookupKey,
   type CheckoutPolicy
 } from "./checkout-policy.js";
@@ -388,6 +390,10 @@ export class LicenseStore {
     const validatedInput = validateBoundCheckoutInput(input);
     const policy = checkoutPolicyFor(validatedInput.checkoutLookupKey);
     const requestHash = boundCheckoutRequestHash(validatedInput);
+    const issuedAt = this.now();
+    if (!Number.isFinite(issuedAt.getTime())) {
+      throw new Error("license store clock returned an invalid date");
+    }
     let transactionStarted = false;
     try {
       this.db.exec("begin immediate");
@@ -405,7 +411,7 @@ export class LicenseStore {
         if (!record) {
           throw new Error("issuance reference points to a missing license record");
         }
-        validateStoredCheckoutEntitlement(record, policy);
+        validateStoredCheckoutEntitlement(record, policy, issuedAt);
         if (hashLicenseKey(rawKey) !== existing.license_key_hash) {
           throw new CheckoutIssuanceConflictError(
             "issuance reference was issued with a different key derivation secret"
@@ -425,10 +431,6 @@ export class LicenseStore {
         return { rawKey, record, binding, replayed: true };
       }
 
-      const issuedAt = this.now();
-      if (!Number.isFinite(issuedAt.getTime())) {
-        throw new Error("license store clock returned an invalid date");
-      }
       const expiresAt = new Date(
         issuedAt.getTime() + policy.trialDays * 24 * 60 * 60 * 1_000
       ).toISOString();
@@ -685,6 +687,20 @@ function validateBoundCheckoutInput(
       throw new CheckoutIssuancePolicyError(`unsupported checkout binding field: ${key}`);
     }
   }
+  const idempotencyKey = readBoundedCheckoutString(input.idempotencyKey, "idempotencyKey", 200);
+  if (!/^[A-Za-z0-9._:-]+$/.test(idempotencyKey)) {
+    throw new CheckoutIssuancePolicyError("idempotencyKey contains unsupported characters");
+  }
+  const checkoutLookupKey = readBoundedCheckoutString(
+    input.checkoutLookupKey,
+    "checkoutLookupKey",
+    80
+  );
+  if (!isCheckoutLookupKey(checkoutLookupKey)) {
+    throw new CheckoutIssuancePolicyError(
+      `checkoutLookupKey must be one of: ${CHECKOUT_LOOKUP_KEYS.join(", ")}`
+    );
+  }
   if (input.binding.provider !== "stripe") {
     throw new CheckoutIssuancePolicyError("provider must be stripe");
   }
@@ -692,33 +708,36 @@ function validateBoundCheckoutInput(
     throw new CheckoutIssuancePolicyError("providerMode must be test or live");
   }
   return {
-    idempotencyKey: input.idempotencyKey,
-    checkoutLookupKey: input.checkoutLookupKey,
+    idempotencyKey,
+    checkoutLookupKey,
     binding: {
       provider: input.binding.provider,
-      providerAccountId: readBoundedCheckoutBindingString(
+      providerAccountId: readBoundedCheckoutString(
         input.binding.providerAccountId,
-        "providerAccountId"
+        "providerAccountId",
+        160
       ),
       providerMode: input.binding.providerMode,
-      externalSubscriptionId: readBoundedCheckoutBindingString(
+      externalSubscriptionId: readBoundedCheckoutString(
         input.binding.externalSubscriptionId,
-        "externalSubscriptionId"
+        "externalSubscriptionId",
+        160
       ),
-      externalCheckoutId: readBoundedCheckoutBindingString(
+      externalCheckoutId: readBoundedCheckoutString(
         input.binding.externalCheckoutId,
-        "externalCheckoutId"
+        "externalCheckoutId",
+        160
       )
     }
   };
 }
 
-function readBoundedCheckoutBindingString(value: unknown, field: string): string {
+function readBoundedCheckoutString(value: unknown, field: string, max: number): string {
   if (typeof value !== "string" || value.trim().length === 0) {
     throw new CheckoutIssuancePolicyError(`${field} is required`);
   }
   const trimmed = value.trim();
-  if (trimmed.length > 160) {
+  if (trimmed.length > max) {
     throw new CheckoutIssuancePolicyError(`${field} is too long`);
   }
   return trimmed;
@@ -739,7 +758,11 @@ function boundCheckoutRequestHash(input: IssueBoundCheckoutLicenseInput): string
     .digest("hex");
 }
 
-function validateStoredCheckoutEntitlement(record: LicenseRecord, policy: CheckoutPolicy): void {
+function validateStoredCheckoutEntitlement(
+  record: LicenseRecord,
+  policy: CheckoutPolicy,
+  now: Date
+): void {
   if (
     record.plan !== policy.plan ||
     record.repoVisibilityScope !== policy.repoVisibilityScope ||
@@ -752,6 +775,9 @@ function validateStoredCheckoutEntitlement(record: LicenseRecord, policy: Checko
     throw new CheckoutIssuanceConflictError(
       "checkout issuance entitlement does not match server policy"
     );
+  }
+  if (record.status !== "active" || Date.parse(record.expiresAt) <= now.getTime()) {
+    throw new CheckoutIssuanceConflictError("checkout issuance is no longer usable");
   }
 }
 

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -9,6 +9,11 @@ import {
   type CheckoutLookupKey,
   type CheckoutPolicy
 } from "./checkout-policy.js";
+import {
+  canonicalSubscriptionLifecycleRequestHash,
+  type ParsedSubscriptionLifecycleRequest,
+  type RenewPaidSubscriptionLifecycleRequest
+} from "./subscription-lifecycle.js";
 
 const SCHEMA_VERSION = 2;
 const DEFAULT_BUSY_TIMEOUT_MS = 250;
@@ -190,6 +195,24 @@ interface CheckoutSubscriptionBindingRow {
   created_at: string;
 }
 
+interface SubscriptionLifecycleEventRow {
+  event_id: string;
+  issuance_idempotency_key: string;
+  license_key_hash: string;
+  external_subscription_id: string;
+  request_hash: string;
+  event_created_at: number;
+  provider: string;
+  provider_account_id: string;
+  provider_mode: string;
+  provider_event_type: string;
+  command: string;
+  payment_reference_fingerprint: string | null;
+  normalized_transition: string;
+  result: string;
+  created_at: string;
+}
+
 /**
  * Deterministic at-rest identifier for a license key. Only the hash is ever
  * stored or logged; the raw key is printed once by the admin CLI at issuance
@@ -248,6 +271,26 @@ export interface IssueBoundCheckoutLicenseInput {
 export class CheckoutIssuanceConflictError extends Error {}
 export class CheckoutIssuancePolicyError extends Error {}
 export class CheckoutIssuanceTransientError extends Error {}
+
+export class SubscriptionLifecycleNotFoundError extends Error {}
+export class SubscriptionLifecycleConflictError extends Error {}
+export class SubscriptionLifecyclePolicyError extends Error {}
+export class SubscriptionLifecycleTerminalError extends Error {}
+export class SubscriptionLifecycleTransientError extends Error {}
+export class SubscriptionLifecycleUnsupportedCommandError extends Error {}
+
+export interface SubscriptionLifecycleEntitlement {
+  status: "active";
+  plan: string;
+  seats: number;
+  expiresAt: string;
+}
+
+export interface SubscriptionLifecycleApplyResult {
+  status: "updated" | "replayed";
+  replayed: boolean;
+  entitlement: SubscriptionLifecycleEntitlement;
+}
 
 export class LicenseStore {
   private readonly db: DatabaseSync;
@@ -489,6 +532,123 @@ export class LicenseStore {
     }
   }
 
+  /**
+   * Apply a paid checkout renewal against its immutable issuance binding.
+   * Task 5 owns the remaining lifecycle transitions and their ordering rules.
+   */
+  applyCheckoutSubscriptionLifecycle(
+    input: ParsedSubscriptionLifecycleRequest
+  ): SubscriptionLifecycleApplyResult {
+    if (input.command !== "renew_paid") {
+      throw new SubscriptionLifecycleUnsupportedCommandError(
+        "subscription lifecycle command is not implemented"
+      );
+    }
+
+    const appliedAt = this.now();
+    if (!Number.isFinite(appliedAt.getTime())) {
+      throw new SubscriptionLifecyclePolicyError("license store clock is invalid");
+    }
+    const requestHash = canonicalSubscriptionLifecycleRequestHash(input);
+    let transactionStarted = false;
+    try {
+      this.db.exec("begin immediate");
+      transactionStarted = true;
+
+      const issuance = this.getIssuanceEvent(input.issuanceIdempotencyKey);
+      if (!issuance || issuance.source !== "checkout") {
+        throw new SubscriptionLifecycleNotFoundError("checkout subscription binding was not found");
+      }
+      const binding = this.getCheckoutSubscriptionBinding(input.issuanceIdempotencyKey);
+      if (
+        !binding ||
+        binding.licenseKeyHash !== issuance.license_key_hash ||
+        !sameLifecycleBinding(binding, input)
+      ) {
+        throw new SubscriptionLifecycleNotFoundError("checkout subscription binding was not found");
+      }
+      const record = this.getLicenseByHash(issuance.license_key_hash);
+      if (!record) {
+        throw new SubscriptionLifecycleNotFoundError("checkout subscription binding was not found");
+      }
+
+      const existingEvent = this.getSubscriptionLifecycleEvent(input.eventId);
+      if (existingEvent) {
+        if (existingEvent.request_hash !== requestHash) {
+          throw new SubscriptionLifecycleConflictError(
+            "subscription lifecycle event conflicts with an existing event"
+          );
+        }
+        const replayedRecord = this.getLicenseByHash(existingEvent.license_key_hash);
+        if (!replayedRecord?.expiresAt || replayedRecord.status !== "active") {
+          throw new SubscriptionLifecycleTerminalError("subscription entitlement is terminal");
+        }
+        this.db.exec("commit");
+        return lifecycleResult("replayed", true, replayedRecord);
+      }
+
+      if (record.status === "revoked") {
+        throw new SubscriptionLifecycleTerminalError("subscription entitlement is terminal");
+      }
+      if (record.status !== "active" && record.status !== "expired") {
+        throw new SubscriptionLifecyclePolicyError("subscription entitlement state is invalid");
+      }
+
+      const incomingPeriodEnd = validatePaidPeriodEnd(input, record.plan, appliedAt);
+      const storedPeriodEnd = record.expiresAt ? Date.parse(record.expiresAt) : Number.NaN;
+      if (!Number.isFinite(storedPeriodEnd)) {
+        throw new SubscriptionLifecyclePolicyError("subscription entitlement expiry is invalid");
+      }
+      const effectivePeriodEnd = Math.max(storedPeriodEnd, incomingPeriodEnd);
+      const expiresAt = new Date(effectivePeriodEnd).toISOString();
+
+      this.db
+        .prepare(
+          `update licenses
+           set expires_at = ?, status = 'active'
+           where license_key_hash = ?`
+        )
+        .run(expiresAt, record.licenseKeyHash);
+      this.db
+        .prepare(
+          `insert into license_subscription_lifecycle_events (
+            event_id, issuance_idempotency_key, license_key_hash,
+            external_subscription_id, request_hash, event_created_at,
+            provider, provider_account_id, provider_mode, provider_event_type,
+            command, payment_reference_fingerprint, normalized_transition, result
+          ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'renew_paid', 'updated')`
+        )
+        .run(
+          input.eventId,
+          input.issuanceIdempotencyKey,
+          record.licenseKeyHash,
+          input.externalSubscriptionId,
+          requestHash,
+          input.eventCreatedAt,
+          input.provider,
+          input.providerAccountId,
+          input.providerMode,
+          input.providerEventType,
+          input.command,
+          input.paymentReferenceFingerprint
+        );
+      const updated = this.getLicenseByHash(record.licenseKeyHash);
+      if (!updated?.expiresAt || updated.status !== "active") {
+        throw new Error("subscription entitlement update did not persist");
+      }
+      this.db.exec("commit");
+      return lifecycleResult("updated", false, updated);
+    } catch (error) {
+      if (transactionStarted) this.db.exec("rollback");
+      if (isSqliteBusy(error)) {
+        throw new SubscriptionLifecycleTransientError(
+          "subscription lifecycle storage is temporarily unavailable"
+        );
+      }
+      throw error;
+    }
+  }
+
   private insertLicense(rawKey: string, input: IssueLicenseInput): { rawKey: string; record: LicenseRecord } {
     const licenseKeyHash = hashLicenseKey(rawKey);
     const seats = input.seats ?? 1;
@@ -531,6 +691,14 @@ export class LicenseStore {
       )
       .get(idempotencyKey) as CheckoutSubscriptionBindingRow | undefined;
     return row ? mapCheckoutSubscriptionBinding(row) : undefined;
+  }
+
+  private getSubscriptionLifecycleEvent(
+    eventId: string
+  ): SubscriptionLifecycleEventRow | undefined {
+    return this.db
+      .prepare("select * from license_subscription_lifecycle_events where event_id = ?")
+      .get(eventId) as SubscriptionLifecycleEventRow | undefined;
   }
 
   getLicenseByHash(licenseKeyHash: string): LicenseRecord | undefined {
@@ -664,6 +832,70 @@ function sameCheckoutBinding(
     existing.externalSubscriptionId === requested.externalSubscriptionId &&
     existing.externalCheckoutId === requested.externalCheckoutId
   );
+}
+
+function sameLifecycleBinding(
+  binding: CheckoutSubscriptionBindingRecord,
+  request: ParsedSubscriptionLifecycleRequest
+): boolean {
+  return (
+    binding.provider === request.provider &&
+    binding.providerAccountId === request.providerAccountId &&
+    binding.providerMode === request.providerMode &&
+    binding.externalSubscriptionId === request.externalSubscriptionId
+  );
+}
+
+function validatePaidPeriodEnd(
+  request: RenewPaidSubscriptionLifecycleRequest,
+  plan: string,
+  now: Date
+): number {
+  const value = request.currentPeriodEnd;
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) {
+    throw new SubscriptionLifecyclePolicyError("paid period end is invalid");
+  }
+  const milliseconds = Date.parse(value);
+  if (
+    !Number.isFinite(milliseconds) ||
+    new Date(milliseconds).toISOString() !== value ||
+    milliseconds <= now.getTime()
+  ) {
+    throw new SubscriptionLifecyclePolicyError("paid period end is invalid");
+  }
+  const maximumPeriodDays = maximumPeriodDaysForPlan(plan);
+  if (milliseconds > now.getTime() + maximumPeriodDays * 24 * 60 * 60 * 1_000) {
+    throw new SubscriptionLifecyclePolicyError("paid period end exceeds the plan maximum");
+  }
+  return milliseconds;
+}
+
+function maximumPeriodDaysForPlan(plan: string): number {
+  for (const lookupKey of CHECKOUT_LOOKUP_KEYS) {
+    const policy = checkoutPolicyFor(lookupKey);
+    if (policy.plan === plan) return policy.maximumPeriodDays;
+  }
+  throw new SubscriptionLifecyclePolicyError("subscription entitlement plan is invalid");
+}
+
+function lifecycleResult(
+  status: SubscriptionLifecycleApplyResult["status"],
+  replayed: boolean,
+  record: LicenseRecord
+): SubscriptionLifecycleApplyResult {
+  if (!record.expiresAt) {
+    throw new SubscriptionLifecyclePolicyError("subscription entitlement expiry is invalid");
+  }
+  return {
+    status,
+    replayed,
+    entitlement: {
+      status: "active",
+      plan: record.plan,
+      seats: record.seats,
+      expiresAt: record.expiresAt
+    }
+  };
 }
 
 function resolveBusyTimeout(value: number | undefined): number {

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -16,18 +16,11 @@ export interface LicenseStoreOptions {
   migrationHook?: (step: SchemaMigrationStep) => void;
 }
 
-interface TableColumn {
-  name: string;
+interface SchemaObjectSignature {
   type: string;
-  notnull: number;
-  dflt_value: string | null;
-  pk: number;
-}
-
-interface ForeignKeyRow {
-  table: string;
-  from: string;
-  to: string;
+  name: string;
+  tableName: string;
+  sql: string;
 }
 
 const CORE_SCHEMA = `
@@ -104,73 +97,8 @@ const LIFECYCLE_SCHEMA = `
     on license_subscription_lifecycle_events (issuance_idempotency_key, event_created_at);
 `;
 
-const EXPECTED_COLUMNS: Record<string, readonly TableColumn[]> = {
-  licenses: [
-    column("license_key_hash", "TEXT", 0, null, 1),
-    column("plan", "TEXT", 1),
-    column("repo_visibility_scope", "TEXT", 1),
-    column("private_repo_allowed", "INTEGER", 1, "1"),
-    column("update_entitlement", "INTEGER", 1, "0"),
-    column("seats", "INTEGER", 1, "1"),
-    column("expires_at", "TEXT", 0),
-    column("status", "TEXT", 1, "'active'"),
-    column("revocation_reason", "TEXT", 0),
-    column("created_at", "TEXT", 1, "datetime('now')")
-  ],
-  activations: [
-    column("license_key_hash", "TEXT", 1, null, 1),
-    column("machine_id", "TEXT", 1, null, 2),
-    column("repo", "TEXT", 0),
-    column("activated_at", "TEXT", 1, "datetime('now')"),
-    column("last_seen_at", "TEXT", 1, "datetime('now')")
-  ],
-  license_issuance_events: [
-    column("idempotency_key", "TEXT", 0, null, 1),
-    column("license_key_hash", "TEXT", 1),
-    column("request_hash", "TEXT", 1),
-    column("source", "TEXT", 0),
-    column("external_ref", "TEXT", 0),
-    column("created_at", "TEXT", 1, "datetime('now')")
-  ],
-  checkout_subscription_bindings: [
-    column("issuance_idempotency_key", "TEXT", 0, null, 1),
-    column("license_key_hash", "TEXT", 1),
-    column("provider", "TEXT", 1),
-    column("provider_account_id", "TEXT", 1),
-    column("provider_mode", "TEXT", 1),
-    column("external_subscription_id", "TEXT", 1),
-    column("external_checkout_id", "TEXT", 1),
-    column("last_non_mutating_event_created_at", "INTEGER", 0),
-    column("created_at", "TEXT", 1, "datetime('now')")
-  ],
-  license_subscription_lifecycle_events: [
-    column("event_id", "TEXT", 0, null, 1),
-    column("issuance_idempotency_key", "TEXT", 1),
-    column("license_key_hash", "TEXT", 1),
-    column("external_subscription_id", "TEXT", 1),
-    column("request_hash", "TEXT", 1),
-    column("event_created_at", "INTEGER", 1),
-    column("provider", "TEXT", 1),
-    column("provider_account_id", "TEXT", 1),
-    column("provider_mode", "TEXT", 1),
-    column("provider_event_type", "TEXT", 1),
-    column("command", "TEXT", 1),
-    column("payment_reference_fingerprint", "TEXT", 0),
-    column("normalized_transition", "TEXT", 1),
-    column("result", "TEXT", 1),
-    column("created_at", "TEXT", 1, "datetime('now')")
-  ]
-};
-
-function column(
-  name: string,
-  type: string,
-  notnull: number,
-  dflt_value: string | null = null,
-  pk = 0
-): TableColumn {
-  return { name, type, notnull, dflt_value, pk };
-}
+const LEGACY_SCHEMA_SIGNATURE = expectedSchemaSignature(CORE_SCHEMA);
+const SCHEMA_V2_SIGNATURE = expectedSchemaSignature(`${CORE_SCHEMA}\n${LIFECYCLE_SCHEMA}`);
 
 export type LicenseStatus = "active" | "revoked" | "expired";
 export type RepoVisibilityScope = "public" | "private" | "all";
@@ -286,9 +214,9 @@ export class LicenseStore {
       throw new Error(`unsupported license database schema version ${version}`);
     }
 
-    const tableNames = this.schemaObjectNames("table");
-    const isEmpty = tableNames.length === 0;
-    const isLegacy = this.isExactLegacySchema();
+    const currentSignature = readSchemaSignature(this.db);
+    const isEmpty = currentSignature.length === 0;
+    const isLegacy = signaturesEqual(currentSignature, LEGACY_SCHEMA_SIGNATURE);
     if (!isEmpty && !isLegacy) {
       throw new Error("unknown non-empty schema at user_version 0");
     }
@@ -316,103 +244,12 @@ export class LicenseStore {
     return Number(row.user_version);
   }
 
-  private schemaObjectNames(type: "table" | "index" | "trigger" | "view"): string[] {
-    return (
-      this.db
-        .prepare("select name from sqlite_schema where type = ? and name not like 'sqlite_%' order by name")
-        .all(type) as unknown as Array<{ name: string }>
-    ).map(({ name }) => name);
-  }
-
-  private isExactLegacySchema(): boolean {
-    const legacyTables = ["activations", "license_issuance_events", "licenses"];
-    if (!sameStrings(this.schemaObjectNames("table"), legacyTables)) return false;
-    if (this.schemaObjectNames("index").length > 0) return false;
-    if (this.schemaObjectNames("trigger").length > 0) return false;
-    if (this.schemaObjectNames("view").length > 0) return false;
-    if (!legacyTables.every((table) => this.hasExpectedColumns(table))) return false;
-
-    const issuanceForeignKeys = this.foreignKeys("license_issuance_events");
-    if (
-      issuanceForeignKeys.length !== 1 ||
-      issuanceForeignKeys[0]?.table !== "licenses" ||
-      issuanceForeignKeys[0]?.from !== "license_key_hash" ||
-      issuanceForeignKeys[0]?.to !== "license_key_hash"
-    ) {
-      return false;
-    }
-    return this.foreignKeys("licenses").length === 0 && this.foreignKeys("activations").length === 0;
-  }
-
-  private hasExpectedColumns(table: string): boolean {
-    const actual = this.db.prepare(`pragma table_info(${table})`).all() as unknown as TableColumn[];
-    return JSON.stringify(actual.map(normalizeColumn)) === JSON.stringify(EXPECTED_COLUMNS[table]);
-  }
-
-  private foreignKeys(table: string): ForeignKeyRow[] {
-    return this.db.prepare(`pragma foreign_key_list(${table})`).all() as unknown as ForeignKeyRow[];
-  }
-
-  private uniqueColumnSets(table: string): string[] {
-    const indexes = this.db.prepare(`pragma index_list(${table})`).all() as unknown as Array<{
-      name: string;
-      unique: number;
-    }>;
-    return indexes
-      .filter((index) => index.unique === 1)
-      .map((index) => {
-        const columns = this.db.prepare(`pragma index_info(${index.name})`).all() as unknown as Array<{ name: string }>;
-        return columns.map(({ name }) => name).join(",");
-      })
-      .sort();
-  }
-
   private verifySchemaV2(): void {
-    const expectedTables = [
-      "activations",
-      "checkout_subscription_bindings",
-      "license_issuance_events",
-      "license_subscription_lifecycle_events",
-      "licenses"
-    ];
-    if (!sameStrings(this.schemaObjectNames("table"), expectedTables)) {
-      throw new Error("license database schema v2 has unexpected tables");
+    const actual = readSchemaSignature(this.db);
+    if (!sameStrings(schemaObjectKeys(actual), schemaObjectKeys(SCHEMA_V2_SIGNATURE))) {
+      throw new Error("license database schema v2 has unexpected objects");
     }
-    if (!expectedTables.every((table) => this.hasExpectedColumns(table))) {
-      throw new Error("license database schema v2 has unexpected columns");
-    }
-    const indexes = this.schemaObjectNames("index");
-    if (!sameStrings(indexes, ["license_subscription_lifecycle_events_issuance_time_idx"])) {
-      throw new Error("license database schema v2 has unexpected indexes");
-    }
-
-    const indexColumns = (
-      this.db
-        .prepare("pragma index_info(license_subscription_lifecycle_events_issuance_time_idx)")
-        .all() as unknown as Array<{ name: string }>
-    ).map(({ name }) => name);
-    if (!sameStrings(indexColumns, ["issuance_idempotency_key", "event_created_at"])) {
-      throw new Error("license database schema v2 has an invalid lifecycle index");
-    }
-
-    const bindingForeignKeys = foreignKeySignatures(this.foreignKeys("checkout_subscription_bindings"));
-    const lifecycleForeignKeys = foreignKeySignatures(this.foreignKeys("license_subscription_lifecycle_events"));
-    if (
-      !sameStrings(bindingForeignKeys, [
-        "license_key_hash:licenses.license_key_hash",
-        "issuance_idempotency_key:license_issuance_events.idempotency_key"
-      ].sort()) ||
-      !sameStrings(lifecycleForeignKeys, [
-        "license_key_hash:licenses.license_key_hash",
-        "issuance_idempotency_key:checkout_subscription_bindings.issuance_idempotency_key"
-      ].sort()) ||
-      !sameStrings(this.uniqueColumnSets("checkout_subscription_bindings"), [
-        "issuance_idempotency_key",
-        "license_key_hash",
-        "provider,provider_account_id,provider_mode,external_subscription_id"
-      ].sort()) ||
-      !sameStrings(this.uniqueColumnSets("license_subscription_lifecycle_events"), ["event_id"])
-    ) {
+    if (!signaturesEqual(actual, SCHEMA_V2_SIGNATURE)) {
       throw new Error("license database schema v2 has unexpected constraints");
     }
   }
@@ -606,20 +443,88 @@ function mapActivation(row: ActivationRow): ActivationRecord {
   };
 }
 
-function normalizeColumn(value: TableColumn): TableColumn {
-  return {
-    name: value.name,
-    type: value.type.toUpperCase(),
-    notnull: Number(value.notnull),
-    dflt_value: value.dflt_value?.replaceAll(/\s+/g, " ") ?? null,
-    pk: Number(value.pk)
-  };
+function expectedSchemaSignature(schema: string): SchemaObjectSignature[] {
+  const db = new DatabaseSync(":memory:");
+  try {
+    db.exec(schema);
+    return readSchemaSignature(db);
+  } finally {
+    db.close();
+  }
+}
+
+function readSchemaSignature(db: DatabaseSync): SchemaObjectSignature[] {
+  const rows = db
+    .prepare(
+      `select type, name, tbl_name, sql
+       from sqlite_schema
+       where name not like 'sqlite_%'
+       order by type, name`
+    )
+    .all() as unknown as Array<{ type: string; name: string; tbl_name: string; sql: string }>;
+  return rows.map((row) => ({
+    type: row.type,
+    name: row.name,
+    tableName: row.tbl_name,
+    sql: normalizeSchemaSql(row.sql)
+  }));
+}
+
+function normalizeSchemaSql(sql: string): string {
+  let result = "";
+  let pendingSpace = false;
+  let quote: "'" | '"' | "`" | null = null;
+
+  for (let index = 0; index < sql.length; index += 1) {
+    const character = sql[index]!;
+    if (quote) {
+      result += character;
+      if (character === quote) {
+        if (sql[index + 1] === quote) {
+          result += quote;
+          index += 1;
+        } else {
+          quote = null;
+        }
+      }
+      continue;
+    }
+
+    if (character === "'" || character === '"' || character === "`") {
+      if (pendingSpace && result && !result.endsWith("(") && !result.endsWith(",")) result += " ";
+      pendingSpace = false;
+      quote = character;
+      result += character;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      pendingSpace = true;
+      continue;
+    }
+    if (character === "(" || character === ")" || character === "," || character === ";") {
+      result = result.trimEnd() + character;
+      pendingSpace = false;
+      continue;
+    }
+    if (pendingSpace && result && !result.endsWith("(") && !result.endsWith(",")) result += " ";
+    pendingSpace = false;
+    result += character.toLowerCase();
+  }
+
+  return result.trim().replace(/;$/, "");
+}
+
+function signaturesEqual(
+  actual: readonly SchemaObjectSignature[],
+  expected: readonly SchemaObjectSignature[]
+): boolean {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function schemaObjectKeys(signature: readonly SchemaObjectSignature[]): string[] {
+  return signature.map((object) => `${object.type}:${object.name}:${object.tableName}`);
 }
 
 function sameStrings(actual: readonly string[], expected: readonly string[]): boolean {
   return actual.length === expected.length && actual.every((value, index) => value === expected[index]);
-}
-
-function foreignKeySignatures(rows: readonly ForeignKeyRow[]): string[] {
-  return rows.map((row) => `${row.from}:${row.table}.${row.to}`).sort();
 }

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -584,10 +584,19 @@ export class LicenseStore {
         return lifecycleResult("replayed", true, replayedRecord);
       }
 
-      if (record.status === "revoked") {
+      const sameSecondTerminalRenewal =
+        record.status === "revoked" &&
+        input.command === "renew_paid" &&
+        this.getTerminalRevocationEventCreatedAt(input.issuanceIdempotencyKey) ===
+          input.eventCreatedAt;
+      if (record.status === "revoked" && !sameSecondTerminalRenewal) {
         throw new SubscriptionLifecycleTerminalError("subscription entitlement is terminal");
       }
-      if (record.status !== "active" && record.status !== "expired") {
+      if (
+        record.status !== "active" &&
+        record.status !== "expired" &&
+        !sameSecondTerminalRenewal
+      ) {
         throw new SubscriptionLifecyclePolicyError("subscription entitlement state is invalid");
       }
 
@@ -603,7 +612,8 @@ export class LicenseStore {
           this.db
             .prepare(
               `update licenses
-               set expires_at = ?, status = 'active'
+               set expires_at = ?,
+                   status = case when status = 'revoked' then 'revoked' else 'active' end
                where license_key_hash = ?`
             )
             .run(new Date(effectivePeriodEnd).toISOString(), record.licenseKeyHash);
@@ -746,6 +756,23 @@ export class LicenseStore {
     return this.db
       .prepare("select * from license_subscription_lifecycle_events where event_id = ?")
       .get(eventId) as SubscriptionLifecycleEventRow | undefined;
+  }
+
+  private getTerminalRevocationEventCreatedAt(
+    issuanceIdempotencyKey: string
+  ): number | undefined {
+    const row = this.db
+      .prepare(
+        `select event_created_at
+         from license_subscription_lifecycle_events
+         where issuance_idempotency_key = ?
+           and command = 'revoke'
+           and result = 'terminally_revoked'
+         order by event_created_at desc, event_id desc
+         limit 1`
+      )
+      .get(issuanceIdempotencyKey) as { event_created_at: number } | undefined;
+    return row?.event_created_at;
   }
 
   getLicenseByHash(licenseKeyHash: string): LicenseRecord | undefined {

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -259,6 +259,7 @@ export interface CheckoutSubscriptionBindingInput {
 export interface CheckoutSubscriptionBindingRecord extends CheckoutSubscriptionBindingInput {
   issuanceIdempotencyKey: string;
   licenseKeyHash: string;
+  lastNonMutatingEventCreatedAt?: number;
   createdAt: string;
 }
 
@@ -280,14 +281,19 @@ export class SubscriptionLifecycleTransientError extends Error {}
 export class SubscriptionLifecycleUnsupportedCommandError extends Error {}
 
 export interface SubscriptionLifecycleEntitlement {
-  status: "active";
+  status: LicenseStatus;
   plan: string;
   seats: number;
   expiresAt: string;
 }
 
 export interface SubscriptionLifecycleApplyResult {
-  status: "updated" | "replayed";
+  status:
+    | "updated"
+    | "replayed"
+    | "ignored_stale"
+    | "payment_attention"
+    | "terminally_revoked";
   replayed: boolean;
   entitlement: SubscriptionLifecycleEntitlement;
 }
@@ -532,19 +538,10 @@ export class LicenseStore {
     }
   }
 
-  /**
-   * Apply a paid checkout renewal against its immutable issuance binding.
-   * Task 5 owns the remaining lifecycle transitions and their ordering rules.
-   */
+  /** Apply one checkout lifecycle event against its immutable issuance binding. */
   applyCheckoutSubscriptionLifecycle(
     input: ParsedSubscriptionLifecycleRequest
   ): SubscriptionLifecycleApplyResult {
-    if (input.command !== "renew_paid") {
-      throw new SubscriptionLifecycleUnsupportedCommandError(
-        "subscription lifecycle command is not implemented"
-      );
-    }
-
     const appliedAt = this.now();
     if (!Number.isFinite(appliedAt.getTime())) {
       throw new SubscriptionLifecyclePolicyError("license store clock is invalid");
@@ -580,8 +577,8 @@ export class LicenseStore {
           );
         }
         const replayedRecord = this.getLicenseByHash(existingEvent.license_key_hash);
-        if (!replayedRecord?.expiresAt || replayedRecord.status !== "active") {
-          throw new SubscriptionLifecycleTerminalError("subscription entitlement is terminal");
+        if (!replayedRecord) {
+          throw new Error("subscription lifecycle event points to a missing license");
         }
         this.db.exec("commit");
         return lifecycleResult("replayed", true, replayedRecord);
@@ -594,21 +591,69 @@ export class LicenseStore {
         throw new SubscriptionLifecyclePolicyError("subscription entitlement state is invalid");
       }
 
-      const incomingPeriodEnd = validatePaidPeriodEnd(input, record.plan, appliedAt);
-      const storedPeriodEnd = record.expiresAt ? Date.parse(record.expiresAt) : Number.NaN;
-      if (!Number.isFinite(storedPeriodEnd)) {
-        throw new SubscriptionLifecyclePolicyError("subscription entitlement expiry is invalid");
+      let result: Exclude<SubscriptionLifecycleApplyResult["status"], "replayed">;
+      switch (input.command) {
+        case "renew_paid": {
+          const incomingPeriodEnd = validatePaidPeriodEnd(input, record.plan, appliedAt);
+          const storedPeriodEnd = record.expiresAt ? Date.parse(record.expiresAt) : Number.NaN;
+          if (!Number.isFinite(storedPeriodEnd)) {
+            throw new SubscriptionLifecyclePolicyError("subscription entitlement expiry is invalid");
+          }
+          const effectivePeriodEnd = Math.max(storedPeriodEnd, incomingPeriodEnd);
+          this.db
+            .prepare(
+              `update licenses
+               set expires_at = ?, status = 'active'
+               where license_key_hash = ?`
+            )
+            .run(new Date(effectivePeriodEnd).toISOString(), record.licenseKeyHash);
+          result = "updated";
+          break;
+        }
+        case "reconcile":
+        case "cancel_at_period_end":
+        case "payment_attention": {
+          const stale = isStaleNonMutatingEvent(
+            input.eventCreatedAt,
+            binding.lastNonMutatingEventCreatedAt
+          );
+          if (!stale) {
+            this.db
+              .prepare(
+                `update checkout_subscription_bindings
+                 set last_non_mutating_event_created_at = max(
+                   coalesce(last_non_mutating_event_created_at, ?), ?
+                 )
+                 where issuance_idempotency_key = ?`
+              )
+              .run(
+                input.eventCreatedAt,
+                input.eventCreatedAt,
+                input.issuanceIdempotencyKey
+              );
+          }
+          result = stale
+            ? "ignored_stale"
+            : input.command === "payment_attention"
+              ? "payment_attention"
+              : "updated";
+          break;
+        }
+        case "revoke":
+          this.db
+            .prepare(
+              `update licenses
+               set status = 'revoked', revocation_reason = ?
+               where license_key_hash = ?`
+            )
+            .run(input.reason ?? null, record.licenseKeyHash);
+          result = "terminally_revoked";
+          break;
+        default:
+          throw new SubscriptionLifecycleUnsupportedCommandError(
+            "subscription lifecycle command is not implemented"
+          );
       }
-      const effectivePeriodEnd = Math.max(storedPeriodEnd, incomingPeriodEnd);
-      const expiresAt = new Date(effectivePeriodEnd).toISOString();
-
-      this.db
-        .prepare(
-          `update licenses
-           set expires_at = ?, status = 'active'
-           where license_key_hash = ?`
-        )
-        .run(expiresAt, record.licenseKeyHash);
       this.db
         .prepare(
           `insert into license_subscription_lifecycle_events (
@@ -616,7 +661,7 @@ export class LicenseStore {
             external_subscription_id, request_hash, event_created_at,
             provider, provider_account_id, provider_mode, provider_event_type,
             command, payment_reference_fingerprint, normalized_transition, result
-          ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'renew_paid', 'updated')`
+          ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
           input.eventId,
@@ -630,14 +675,16 @@ export class LicenseStore {
           input.providerMode,
           input.providerEventType,
           input.command,
-          input.paymentReferenceFingerprint
+          input.command === "renew_paid" ? input.paymentReferenceFingerprint : null,
+          input.command,
+          result
         );
       const updated = this.getLicenseByHash(record.licenseKeyHash);
-      if (!updated?.expiresAt || updated.status !== "active") {
+      if (!updated) {
         throw new Error("subscription entitlement update did not persist");
       }
       this.db.exec("commit");
-      return lifecycleResult("updated", false, updated);
+      return lifecycleResult(result, false, updated);
     } catch (error) {
       if (transactionStarted) this.db.exec("rollback");
       if (isSqliteBusy(error)) {
@@ -817,6 +864,9 @@ function mapCheckoutSubscriptionBinding(
     providerMode: row.provider_mode,
     externalSubscriptionId: row.external_subscription_id,
     externalCheckoutId: row.external_checkout_id,
+    ...(row.last_non_mutating_event_created_at !== null
+      ? { lastNonMutatingEventCreatedAt: row.last_non_mutating_event_created_at }
+      : {}),
     createdAt: row.created_at
   };
 }
@@ -870,6 +920,16 @@ function validatePaidPeriodEnd(
   return milliseconds;
 }
 
+function isStaleNonMutatingEvent(
+  eventCreatedAt: number,
+  lastEventCreatedAt: number | undefined
+): boolean {
+  // Provider seconds are not unique. Equal-second events are concurrent and
+  // therefore all remain auditable non-stale updates; command precedence is
+  // carried by terminal revoke, monotonic renewal, and audit-only updates.
+  return lastEventCreatedAt !== undefined && eventCreatedAt < lastEventCreatedAt;
+}
+
 function maximumPeriodDaysForPlan(plan: string): number {
   for (const lookupKey of CHECKOUT_LOOKUP_KEYS) {
     const policy = checkoutPolicyFor(lookupKey);
@@ -890,7 +950,7 @@ function lifecycleResult(
     status,
     replayed,
     entitlement: {
-      status: "active",
+      status: record.status,
       plan: record.plan,
       seats: record.seats,
       expiresAt: record.expiresAt

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -30,6 +30,14 @@ const BOUND_CHECKOUT_BINDING_FIELDS = new Set([
   "externalSubscriptionId",
   "externalCheckoutId"
 ]);
+const CHECKOUT_BINDING_BACKFILL_FIELDS = new Set([
+  "issuanceIdempotencyKey",
+  "provider",
+  "providerAccountId",
+  "providerMode",
+  "externalSubscriptionId",
+  "externalCheckoutId"
+]);
 
 export type SchemaMigrationStep =
   | "transaction-started"
@@ -272,6 +280,29 @@ export interface IssueBoundCheckoutLicenseInput {
 export class CheckoutIssuanceConflictError extends Error {}
 export class CheckoutIssuancePolicyError extends Error {}
 export class CheckoutIssuanceTransientError extends Error {}
+
+export class CheckoutBindingNotFoundError extends Error {}
+export class CheckoutBindingWrongSourceError extends Error {}
+export class CheckoutBindingConflictError extends Error {}
+export class CheckoutBindingPolicyError extends Error {}
+export class CheckoutBindingTransientError extends Error {}
+
+export interface BindCheckoutSubscriptionInput extends CheckoutSubscriptionBindingInput {
+  issuanceIdempotencyKey: string;
+}
+
+export interface BindCheckoutSubscriptionResult {
+  result: "bound" | "already_bound" | "would_bind";
+  issuanceFingerprint: string;
+}
+
+export function checkoutIssuanceFingerprint(issuanceIdempotencyKey: string): string {
+  return `iss_${createHash("sha256")
+    .update("neondiff:checkout-binding-backfill:issuance:v1\0")
+    .update(issuanceIdempotencyKey.trim())
+    .digest("hex")
+    .slice(0, 32)}`;
+}
 
 export class SubscriptionLifecycleNotFoundError extends Error {}
 export class SubscriptionLifecycleConflictError extends Error {}
@@ -533,6 +564,103 @@ export class LicenseStore {
         error.message.includes("UNIQUE constraint failed: checkout_subscription_bindings")
       ) {
         throw new CheckoutIssuanceConflictError("checkout correlation is already bound");
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Bind an existing legacy checkout issuance to its immutable provider tuple.
+   * This owner-only backfill never accepts raw license or entitlement fields.
+   */
+  bindCheckoutSubscription(
+    input: BindCheckoutSubscriptionInput,
+    options: { dryRun?: boolean } = {}
+  ): BindCheckoutSubscriptionResult {
+    const validated = validateCheckoutBindingBackfillInput(input);
+    for (const key of Object.keys(options)) {
+      if (key !== "dryRun") {
+        throw new CheckoutBindingPolicyError(`unsupported checkout binding option: ${key}`);
+      }
+    }
+    if (options.dryRun !== undefined && typeof options.dryRun !== "boolean") {
+      throw new CheckoutBindingPolicyError("dryRun must be boolean");
+    }
+    const issuanceFingerprint = checkoutIssuanceFingerprint(validated.issuanceIdempotencyKey);
+    let transactionStarted = false;
+    try {
+      this.db.exec("begin immediate");
+      transactionStarted = true;
+
+      const issuance = this.getIssuanceEvent(validated.issuanceIdempotencyKey);
+      if (!issuance) {
+        throw new CheckoutBindingNotFoundError("checkout issuance was not found");
+      }
+      if (issuance.source !== "checkout") {
+        throw new CheckoutBindingWrongSourceError("issuance is not checkout-owned");
+      }
+      const record = this.getLicenseByHash(issuance.license_key_hash);
+      if (!record) {
+        throw new CheckoutBindingNotFoundError("checkout issuance license was not found");
+      }
+
+      const requestedBinding: CheckoutSubscriptionBindingInput = {
+        provider: validated.provider,
+        providerAccountId: validated.providerAccountId,
+        providerMode: validated.providerMode,
+        externalSubscriptionId: validated.externalSubscriptionId,
+        externalCheckoutId: validated.externalCheckoutId
+      };
+      const existing = this.getCheckoutSubscriptionBinding(validated.issuanceIdempotencyKey);
+      if (existing) {
+        if (
+          existing.licenseKeyHash !== issuance.license_key_hash ||
+          !sameCheckoutBinding(existing, requestedBinding)
+        ) {
+          throw new CheckoutBindingConflictError(
+            "checkout issuance is already bound to different correlation"
+          );
+        }
+        this.db.exec("commit");
+        transactionStarted = false;
+        return { result: "already_bound", issuanceFingerprint };
+      }
+
+      if (options.dryRun) {
+        this.db.exec("rollback");
+        transactionStarted = false;
+        return { result: "would_bind", issuanceFingerprint };
+      }
+
+      this.db
+        .prepare(
+          `insert into checkout_subscription_bindings (
+            issuance_idempotency_key, license_key_hash, provider, provider_account_id,
+            provider_mode, external_subscription_id, external_checkout_id
+          ) values (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          validated.issuanceIdempotencyKey,
+          issuance.license_key_hash,
+          validated.provider,
+          validated.providerAccountId,
+          validated.providerMode,
+          validated.externalSubscriptionId,
+          validated.externalCheckoutId
+        );
+      this.db.exec("commit");
+      transactionStarted = false;
+      return { result: "bound", issuanceFingerprint };
+    } catch (error) {
+      if (transactionStarted) this.db.exec("rollback");
+      if (isSqliteBusy(error)) {
+        throw new CheckoutBindingTransientError("checkout binding storage is busy");
+      }
+      if (
+        error instanceof Error &&
+        error.message.includes("UNIQUE constraint failed: checkout_subscription_bindings")
+      ) {
+        throw new CheckoutBindingConflictError("checkout correlation is already bound");
       }
       throw error;
     }
@@ -1027,6 +1155,66 @@ function validateBoundCheckoutInput(
       )
     }
   };
+}
+
+function validateCheckoutBindingBackfillInput(
+  input: BindCheckoutSubscriptionInput
+): BindCheckoutSubscriptionInput {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    throw new CheckoutBindingPolicyError("checkout binding input must be an object");
+  }
+  for (const key of Object.keys(input)) {
+    if (!CHECKOUT_BINDING_BACKFILL_FIELDS.has(key)) {
+      throw new CheckoutBindingPolicyError(`unsupported checkout binding field: ${key}`);
+    }
+  }
+  const issuanceIdempotencyKey = readCheckoutBindingString(
+    input.issuanceIdempotencyKey,
+    "issuanceIdempotencyKey",
+    200
+  );
+  if (!/^[A-Za-z0-9._:-]+$/.test(issuanceIdempotencyKey)) {
+    throw new CheckoutBindingPolicyError(
+      "issuanceIdempotencyKey contains unsupported characters"
+    );
+  }
+  if (input.provider !== "stripe") {
+    throw new CheckoutBindingPolicyError("provider must be stripe");
+  }
+  if (input.providerMode !== "test" && input.providerMode !== "live") {
+    throw new CheckoutBindingPolicyError("providerMode must be test or live");
+  }
+  return {
+    issuanceIdempotencyKey,
+    provider: "stripe",
+    providerAccountId: readCheckoutBindingString(
+      input.providerAccountId,
+      "providerAccountId",
+      160
+    ),
+    providerMode: input.providerMode,
+    externalSubscriptionId: readCheckoutBindingString(
+      input.externalSubscriptionId,
+      "externalSubscriptionId",
+      160
+    ),
+    externalCheckoutId: readCheckoutBindingString(
+      input.externalCheckoutId,
+      "externalCheckoutId",
+      160
+    )
+  };
+}
+
+function readCheckoutBindingString(value: unknown, field: string, max: number): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new CheckoutBindingPolicyError(`${field} is required`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > max) {
+    throw new CheckoutBindingPolicyError(`${field} is too long`);
+  }
+  return trimmed;
 }
 
 function readBoundedCheckoutString(value: unknown, field: string, max: number): string {

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -772,6 +772,9 @@ export class LicenseStore {
         case "reconcile":
         case "cancel_at_period_end":
         case "payment_attention": {
+          if (input.command === "cancel_at_period_end") {
+            validateCancellationPeriodEnd(input.currentPeriodEnd, appliedAt);
+          }
           const stale = isStaleNonMutatingEvent(
             input.eventCreatedAt,
             binding.lastNonMutatingEventCreatedAt
@@ -1086,6 +1089,13 @@ function validatePaidPeriodEnd(
   return milliseconds;
 }
 
+function validateCancellationPeriodEnd(value: string, now: Date): void {
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds) || milliseconds <= now.getTime()) {
+    throw new SubscriptionLifecyclePolicyError("cancellation period end is invalid");
+  }
+}
+
 function isStaleNonMutatingEvent(
   eventCreatedAt: number,
   lastEventCreatedAt: number | undefined
@@ -1108,7 +1118,16 @@ function isLifecycleCompatibleEntitlement(record: LicenseRecord): boolean {
   return (
     record.expiresAt !== undefined &&
     Number.isFinite(Date.parse(record.expiresAt)) &&
-    CHECKOUT_LOOKUP_KEYS.some((lookupKey) => checkoutPolicyFor(lookupKey).plan === record.plan)
+    CHECKOUT_LOOKUP_KEYS.some((lookupKey) => {
+      const policy = checkoutPolicyFor(lookupKey);
+      return (
+        record.plan === policy.plan &&
+        record.seats === policy.seats &&
+        record.repoVisibilityScope === policy.repoVisibilityScope &&
+        record.privateRepoAllowed === policy.privateRepoAllowed &&
+        record.updateEntitlement === policy.updateEntitlement
+      );
+    })
   );
 }
 

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -356,15 +356,26 @@ export class LicenseStore {
       throw new Error(`unsupported license database schema version ${version}`);
     }
 
-    const currentSignature = readSchemaSignature(this.db);
-    const isEmpty = currentSignature.length === 0;
-    const isLegacy = signaturesEqual(currentSignature, LEGACY_SCHEMA_SIGNATURE);
-    if (!isEmpty && !isLegacy) {
-      throw new Error("unknown non-empty schema at user_version 0");
-    }
-
     this.db.exec("begin immediate");
     try {
+      // Another process may have completed the migration while this connection
+      // waited for the writer lock. Classify only the state protected by it.
+      const lockedVersion = this.readUserVersion();
+      if (lockedVersion === SCHEMA_VERSION) {
+        this.verifySchemaV2();
+        this.db.exec("commit");
+        return;
+      }
+      if (lockedVersion !== 0) {
+        throw new Error(`unsupported license database schema version ${lockedVersion}`);
+      }
+      const currentSignature = readSchemaSignature(this.db);
+      const isEmpty = currentSignature.length === 0;
+      const isLegacy = signaturesEqual(currentSignature, LEGACY_SCHEMA_SIGNATURE);
+      if (!isEmpty && !isLegacy) {
+        throw new Error("unknown non-empty schema at user_version 0");
+      }
+
       options.migrationHook?.("transaction-started");
       if (isEmpty) this.db.exec(CORE_SCHEMA);
       options.migrationHook?.("core-schema-created");
@@ -603,6 +614,11 @@ export class LicenseStore {
       if (!record) {
         throw new CheckoutBindingNotFoundError("checkout issuance license was not found");
       }
+      if (!isLifecycleCompatibleEntitlement(record)) {
+        throw new CheckoutBindingConflictError(
+          "checkout issuance entitlement is incompatible with subscription lifecycle"
+        );
+      }
 
       const requestedBinding: CheckoutSubscriptionBindingInput = {
         provider: validated.provider,
@@ -684,18 +700,6 @@ export class LicenseStore {
       if (!issuance || issuance.source !== "checkout") {
         throw new SubscriptionLifecycleNotFoundError("checkout subscription binding was not found");
       }
-      const binding = this.getCheckoutSubscriptionBinding(input.issuanceIdempotencyKey);
-      if (
-        !binding ||
-        binding.licenseKeyHash !== issuance.license_key_hash ||
-        !sameLifecycleBinding(binding, input)
-      ) {
-        throw new SubscriptionLifecycleNotFoundError("checkout subscription binding was not found");
-      }
-      const record = this.getLicenseByHash(issuance.license_key_hash);
-      if (!record) {
-        throw new SubscriptionLifecycleNotFoundError("checkout subscription binding was not found");
-      }
 
       const existingEvent = this.getSubscriptionLifecycleEvent(input.eventId);
       if (existingEvent) {
@@ -708,8 +712,33 @@ export class LicenseStore {
         if (!replayedRecord) {
           throw new Error("subscription lifecycle event points to a missing license");
         }
+        if (!isLifecycleCompatibleEntitlement(replayedRecord)) {
+          throw new SubscriptionLifecyclePolicyError(
+            "subscription entitlement is incompatible with lifecycle management"
+          );
+        }
+        const response = lifecycleResult("replayed", true, replayedRecord, appliedAt);
         this.db.exec("commit");
-        return lifecycleResult("replayed", true, replayedRecord);
+        transactionStarted = false;
+        return response;
+      }
+
+      const binding = this.getCheckoutSubscriptionBinding(input.issuanceIdempotencyKey);
+      if (
+        !binding ||
+        binding.licenseKeyHash !== issuance.license_key_hash ||
+        !sameLifecycleBinding(binding, input)
+      ) {
+        throw new SubscriptionLifecycleNotFoundError("checkout subscription binding was not found");
+      }
+      const record = this.getLicenseByHash(issuance.license_key_hash);
+      if (!record) {
+        throw new SubscriptionLifecycleNotFoundError("checkout subscription binding was not found");
+      }
+      if (!isLifecycleCompatibleEntitlement(record)) {
+        throw new SubscriptionLifecyclePolicyError(
+          "subscription entitlement is incompatible with lifecycle management"
+        );
       }
 
       if (record.status === "revoked") {
@@ -816,8 +845,10 @@ export class LicenseStore {
       if (!updated) {
         throw new Error("subscription entitlement update did not persist");
       }
+      const response = lifecycleResult(result, false, updated, appliedAt);
       this.db.exec("commit");
-      return lifecycleResult(result, false, updated);
+      transactionStarted = false;
+      return response;
     } catch (error) {
       if (transactionStarted) this.db.exec("rollback");
       if (isSqliteBusy(error)) {
@@ -1071,22 +1102,40 @@ function maximumPeriodDaysForPlan(plan: string): number {
   throw new SubscriptionLifecyclePolicyError("subscription entitlement plan is invalid");
 }
 
+function isLifecycleCompatibleEntitlement(record: LicenseRecord): boolean {
+  return (
+    record.expiresAt !== undefined &&
+    Number.isFinite(Date.parse(record.expiresAt)) &&
+    CHECKOUT_LOOKUP_KEYS.some((lookupKey) => checkoutPolicyFor(lookupKey).plan === record.plan)
+  );
+}
+
 function lifecycleResult(
   status: SubscriptionLifecycleApplyResult["status"],
   replayed: boolean,
-  record: LicenseRecord
+  record: LicenseRecord,
+  appliedAt: Date
 ): SubscriptionLifecycleApplyResult {
-  if (!record.expiresAt) {
+  const expiresAt = record.expiresAt;
+  if (!expiresAt) {
     throw new SubscriptionLifecyclePolicyError("subscription entitlement expiry is invalid");
   }
+  const expiresAtMs = Date.parse(expiresAt);
+  if (!Number.isFinite(expiresAtMs)) {
+    throw new SubscriptionLifecyclePolicyError("subscription entitlement expiry is invalid");
+  }
+  const effectiveStatus =
+    record.status === "active" && expiresAtMs <= appliedAt.getTime()
+      ? "expired"
+      : record.status;
   return {
     status,
     replayed,
     entitlement: {
-      status: record.status,
+      status: effectiveStatus,
       plan: record.plan,
       seats: record.seats,
-      expiresAt: record.expiresAt
+      expiresAt
     }
   };
 }

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -580,7 +580,7 @@ export class LicenseStore {
     const validated = validateCheckoutBindingBackfillInput(input);
     for (const key of Object.keys(options)) {
       if (key !== "dryRun") {
-        throw new CheckoutBindingPolicyError(`unsupported checkout binding option: ${key}`);
+        throw new CheckoutBindingPolicyError("unsupported checkout binding option");
       }
     }
     if (options.dryRun !== undefined && typeof options.dryRun !== "boolean") {
@@ -1165,7 +1165,7 @@ function validateCheckoutBindingBackfillInput(
   }
   for (const key of Object.keys(input)) {
     if (!CHECKOUT_BINDING_BACKFILL_FIELDS.has(key)) {
-      throw new CheckoutBindingPolicyError(`unsupported checkout binding field: ${key}`);
+      throw new CheckoutBindingPolicyError("unsupported checkout binding field");
     }
   }
   const issuanceIdempotencyKey = readCheckoutBindingString(

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -772,8 +772,11 @@ export class LicenseStore {
         case "reconcile":
         case "cancel_at_period_end":
         case "payment_attention": {
-          if (input.command === "cancel_at_period_end") {
-            validateCancellationPeriodEnd(input.currentPeriodEnd, appliedAt);
+          const nonPaidPeriodEnd = input.command === "cancel_at_period_end"
+            ? input.currentPeriodEnd
+            : input.diagnosticCurrentPeriodEnd;
+          if (nonPaidPeriodEnd !== undefined) {
+            validateNonPaidPeriodEnd(nonPaidPeriodEnd, appliedAt);
           }
           const stale = isStaleNonMutatingEvent(
             input.eventCreatedAt,
@@ -1089,7 +1092,7 @@ function validatePaidPeriodEnd(
   return milliseconds;
 }
 
-function validateCancellationPeriodEnd(value: string, now: Date): void {
+function validateNonPaidPeriodEnd(value: string, now: Date): void {
   const milliseconds = Date.parse(value);
   if (!Number.isFinite(milliseconds) || milliseconds <= now.getTime()) {
     throw new SubscriptionLifecyclePolicyError("cancellation period end is invalid");

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -584,19 +584,10 @@ export class LicenseStore {
         return lifecycleResult("replayed", true, replayedRecord);
       }
 
-      const sameSecondTerminalRenewal =
-        record.status === "revoked" &&
-        input.command === "renew_paid" &&
-        this.getTerminalRevocationEventCreatedAt(input.issuanceIdempotencyKey) ===
-          input.eventCreatedAt;
-      if (record.status === "revoked" && !sameSecondTerminalRenewal) {
+      if (record.status === "revoked") {
         throw new SubscriptionLifecycleTerminalError("subscription entitlement is terminal");
       }
-      if (
-        record.status !== "active" &&
-        record.status !== "expired" &&
-        !sameSecondTerminalRenewal
-      ) {
+      if (record.status !== "active" && record.status !== "expired") {
         throw new SubscriptionLifecyclePolicyError("subscription entitlement state is invalid");
       }
 
@@ -612,8 +603,7 @@ export class LicenseStore {
           this.db
             .prepare(
               `update licenses
-               set expires_at = ?,
-                   status = case when status = 'revoked' then 'revoked' else 'active' end
+               set expires_at = ?, status = 'active'
                where license_key_hash = ?`
             )
             .run(new Date(effectivePeriodEnd).toISOString(), record.licenseKeyHash);
@@ -649,16 +639,27 @@ export class LicenseStore {
               : "updated";
           break;
         }
-        case "revoke":
+        case "revoke": {
+          const storedExpiry = record.expiresAt ? Date.parse(record.expiresAt) : Number.NaN;
+          if (!Number.isFinite(storedExpiry)) {
+            throw new SubscriptionLifecyclePolicyError("subscription entitlement expiry is invalid");
+          }
+          // Revocation is terminal at the provider event second. Clamping can
+          // only remove time, and makes a same-second pre-revoke renewal
+          // converge with revoke-first without rewriting append-only history.
+          const terminalExpiry = new Date(
+            Math.min(storedExpiry, input.eventCreatedAt * 1_000)
+          ).toISOString();
           this.db
             .prepare(
               `update licenses
-               set status = 'revoked', revocation_reason = ?
+               set expires_at = ?, status = 'revoked', revocation_reason = ?
                where license_key_hash = ?`
             )
-            .run(input.reason ?? null, record.licenseKeyHash);
+            .run(terminalExpiry, input.reason ?? null, record.licenseKeyHash);
           result = "terminally_revoked";
           break;
+        }
         default:
           throw new SubscriptionLifecycleUnsupportedCommandError(
             "subscription lifecycle command is not implemented"
@@ -756,23 +757,6 @@ export class LicenseStore {
     return this.db
       .prepare("select * from license_subscription_lifecycle_events where event_id = ?")
       .get(eventId) as SubscriptionLifecycleEventRow | undefined;
-  }
-
-  private getTerminalRevocationEventCreatedAt(
-    issuanceIdempotencyKey: string
-  ): number | undefined {
-    const row = this.db
-      .prepare(
-        `select event_created_at
-         from license_subscription_lifecycle_events
-         where issuance_idempotency_key = ?
-           and command = 'revoke'
-           and result = 'terminally_revoked'
-         order by event_created_at desc, event_id desc
-         limit 1`
-      )
-      .get(issuanceIdempotencyKey) as { event_created_at: number } | undefined;
-    return row?.event_created_at;
   }
 
   getLicenseByHash(licenseKeyHash: string): LicenseRecord | undefined {

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -40,6 +40,7 @@ const CHECKOUT_BINDING_BACKFILL_FIELDS = new Set([
 ]);
 
 export type SchemaMigrationStep =
+  | "version-zero-classified"
   | "transaction-started"
   | "core-schema-created"
   | "lifecycle-schema-created"
@@ -356,6 +357,7 @@ export class LicenseStore {
       throw new Error(`unsupported license database schema version ${version}`);
     }
 
+    options.migrationHook?.("version-zero-classified");
     this.db.exec("begin immediate");
     try {
       // Another process may have completed the migration while this connection

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -640,16 +640,10 @@ export class LicenseStore {
           break;
         }
         case "revoke": {
-          const storedExpiry = record.expiresAt ? Date.parse(record.expiresAt) : Number.NaN;
-          if (!Number.isFinite(storedExpiry)) {
-            throw new SubscriptionLifecyclePolicyError("subscription entitlement expiry is invalid");
-          }
-          // Revocation is terminal at the provider event second. Clamping can
-          // only remove time, and makes a same-second pre-revoke renewal
-          // converge with revoke-first without rewriting append-only history.
-          const terminalExpiry = new Date(
-            Math.min(storedExpiry, input.eventCreatedAt * 1_000)
-          ).toISOString();
+          // Terminal expiry is authoritative provider-event metadata, not
+          // usable paid time. Deriving it solely from the revoke second makes
+          // every prior active/expired/renewed state converge identically.
+          const terminalExpiry = new Date(input.eventCreatedAt * 1_000).toISOString();
           this.db
             .prepare(
               `update licenses

--- a/services/license-api/src/store.ts
+++ b/services/license-api/src/store.ts
@@ -3,6 +3,175 @@ import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
+const SCHEMA_VERSION = 2;
+
+export type SchemaMigrationStep =
+  | "transaction-started"
+  | "core-schema-created"
+  | "lifecycle-schema-created"
+  | "schema-verified"
+  | "version-set";
+
+export interface LicenseStoreOptions {
+  migrationHook?: (step: SchemaMigrationStep) => void;
+}
+
+interface TableColumn {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+}
+
+interface ForeignKeyRow {
+  table: string;
+  from: string;
+  to: string;
+}
+
+const CORE_SCHEMA = `
+  create table licenses (
+    license_key_hash text primary key,
+    plan text not null,
+    repo_visibility_scope text not null,
+    private_repo_allowed integer not null default 1,
+    update_entitlement integer not null default 0,
+    seats integer not null default 1,
+    expires_at text,
+    status text not null default 'active',
+    revocation_reason text,
+    created_at text not null default (datetime('now'))
+  );
+
+  create table activations (
+    license_key_hash text not null,
+    machine_id text not null,
+    repo text,
+    activated_at text not null default (datetime('now')),
+    last_seen_at text not null default (datetime('now')),
+    primary key (license_key_hash, machine_id)
+  );
+
+  create table license_issuance_events (
+    idempotency_key text primary key,
+    license_key_hash text not null,
+    request_hash text not null,
+    source text,
+    external_ref text,
+    created_at text not null default (datetime('now')),
+    foreign key (license_key_hash) references licenses(license_key_hash)
+  );
+`;
+
+const LIFECYCLE_SCHEMA = `
+  create table checkout_subscription_bindings (
+    issuance_idempotency_key text primary key,
+    license_key_hash text not null unique,
+    provider text not null,
+    provider_account_id text not null,
+    provider_mode text not null,
+    external_subscription_id text not null,
+    external_checkout_id text not null,
+    last_non_mutating_event_created_at integer,
+    created_at text not null default (datetime('now')),
+    unique (provider, provider_account_id, provider_mode, external_subscription_id),
+    foreign key (issuance_idempotency_key) references license_issuance_events(idempotency_key),
+    foreign key (license_key_hash) references licenses(license_key_hash)
+  );
+
+  create table license_subscription_lifecycle_events (
+    event_id text primary key,
+    issuance_idempotency_key text not null,
+    license_key_hash text not null,
+    external_subscription_id text not null,
+    request_hash text not null,
+    event_created_at integer not null,
+    provider text not null,
+    provider_account_id text not null,
+    provider_mode text not null,
+    provider_event_type text not null,
+    command text not null,
+    payment_reference_fingerprint text,
+    normalized_transition text not null,
+    result text not null,
+    created_at text not null default (datetime('now')),
+    foreign key (issuance_idempotency_key) references checkout_subscription_bindings(issuance_idempotency_key),
+    foreign key (license_key_hash) references licenses(license_key_hash)
+  );
+
+  create index license_subscription_lifecycle_events_issuance_time_idx
+    on license_subscription_lifecycle_events (issuance_idempotency_key, event_created_at);
+`;
+
+const EXPECTED_COLUMNS: Record<string, readonly TableColumn[]> = {
+  licenses: [
+    column("license_key_hash", "TEXT", 0, null, 1),
+    column("plan", "TEXT", 1),
+    column("repo_visibility_scope", "TEXT", 1),
+    column("private_repo_allowed", "INTEGER", 1, "1"),
+    column("update_entitlement", "INTEGER", 1, "0"),
+    column("seats", "INTEGER", 1, "1"),
+    column("expires_at", "TEXT", 0),
+    column("status", "TEXT", 1, "'active'"),
+    column("revocation_reason", "TEXT", 0),
+    column("created_at", "TEXT", 1, "datetime('now')")
+  ],
+  activations: [
+    column("license_key_hash", "TEXT", 1, null, 1),
+    column("machine_id", "TEXT", 1, null, 2),
+    column("repo", "TEXT", 0),
+    column("activated_at", "TEXT", 1, "datetime('now')"),
+    column("last_seen_at", "TEXT", 1, "datetime('now')")
+  ],
+  license_issuance_events: [
+    column("idempotency_key", "TEXT", 0, null, 1),
+    column("license_key_hash", "TEXT", 1),
+    column("request_hash", "TEXT", 1),
+    column("source", "TEXT", 0),
+    column("external_ref", "TEXT", 0),
+    column("created_at", "TEXT", 1, "datetime('now')")
+  ],
+  checkout_subscription_bindings: [
+    column("issuance_idempotency_key", "TEXT", 0, null, 1),
+    column("license_key_hash", "TEXT", 1),
+    column("provider", "TEXT", 1),
+    column("provider_account_id", "TEXT", 1),
+    column("provider_mode", "TEXT", 1),
+    column("external_subscription_id", "TEXT", 1),
+    column("external_checkout_id", "TEXT", 1),
+    column("last_non_mutating_event_created_at", "INTEGER", 0),
+    column("created_at", "TEXT", 1, "datetime('now')")
+  ],
+  license_subscription_lifecycle_events: [
+    column("event_id", "TEXT", 0, null, 1),
+    column("issuance_idempotency_key", "TEXT", 1),
+    column("license_key_hash", "TEXT", 1),
+    column("external_subscription_id", "TEXT", 1),
+    column("request_hash", "TEXT", 1),
+    column("event_created_at", "INTEGER", 1),
+    column("provider", "TEXT", 1),
+    column("provider_account_id", "TEXT", 1),
+    column("provider_mode", "TEXT", 1),
+    column("provider_event_type", "TEXT", 1),
+    column("command", "TEXT", 1),
+    column("payment_reference_fingerprint", "TEXT", 0),
+    column("normalized_transition", "TEXT", 1),
+    column("result", "TEXT", 1),
+    column("created_at", "TEXT", 1, "datetime('now')")
+  ]
+};
+
+function column(
+  name: string,
+  type: string,
+  notnull: number,
+  dflt_value: string | null = null,
+  pk = 0
+): TableColumn {
+  return { name, type, notnull, dflt_value, pk };
+}
+
 export type LicenseStatus = "active" | "revoked" | "expired";
 export type RepoVisibilityScope = "public" | "private" | "all";
 
@@ -95,47 +264,157 @@ export interface IssueIdempotentLicenseInput extends IssueLicenseInput {
 export class LicenseStore {
   private readonly db: DatabaseSync;
 
-  constructor(dbPath: string) {
+  constructor(dbPath: string, options: LicenseStoreOptions = {}) {
     if (dbPath !== ":memory:") mkdirSync(dirname(dbPath), { recursive: true });
     this.db = new DatabaseSync(dbPath);
-    this.db.exec("pragma foreign_keys = on");
-    this.ensureSchema();
+    try {
+      this.db.exec("pragma foreign_keys = on");
+      this.ensureSchema(options);
+    } catch (error) {
+      this.db.close();
+      throw error;
+    }
   }
 
-  private ensureSchema(): void {
-    this.db.exec(`
-      create table if not exists licenses (
-        license_key_hash text primary key,
-        plan text not null,
-        repo_visibility_scope text not null,
-        private_repo_allowed integer not null default 1,
-        update_entitlement integer not null default 0,
-        seats integer not null default 1,
-        expires_at text,
-        status text not null default 'active',
-        revocation_reason text,
-        created_at text not null default (datetime('now'))
-      );
+  private ensureSchema(options: LicenseStoreOptions): void {
+    const version = this.readUserVersion();
+    if (version === SCHEMA_VERSION) {
+      this.verifySchemaV2();
+      return;
+    }
+    if (version !== 0) {
+      throw new Error(`unsupported license database schema version ${version}`);
+    }
 
-      create table if not exists activations (
-        license_key_hash text not null,
-        machine_id text not null,
-        repo text,
-        activated_at text not null default (datetime('now')),
-        last_seen_at text not null default (datetime('now')),
-        primary key (license_key_hash, machine_id)
-      );
+    const tableNames = this.schemaObjectNames("table");
+    const isEmpty = tableNames.length === 0;
+    const isLegacy = this.isExactLegacySchema();
+    if (!isEmpty && !isLegacy) {
+      throw new Error("unknown non-empty schema at user_version 0");
+    }
 
-      create table if not exists license_issuance_events (
-        idempotency_key text primary key,
-        license_key_hash text not null,
-        request_hash text not null,
-        source text,
-        external_ref text,
-        created_at text not null default (datetime('now')),
-        foreign key (license_key_hash) references licenses(license_key_hash)
-      );
-    `);
+    this.db.exec("begin immediate");
+    try {
+      options.migrationHook?.("transaction-started");
+      if (isEmpty) this.db.exec(CORE_SCHEMA);
+      options.migrationHook?.("core-schema-created");
+      this.db.exec(LIFECYCLE_SCHEMA);
+      options.migrationHook?.("lifecycle-schema-created");
+      this.verifySchemaV2();
+      options.migrationHook?.("schema-verified");
+      this.db.exec(`pragma user_version = ${SCHEMA_VERSION}`);
+      options.migrationHook?.("version-set");
+      this.db.exec("commit");
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
+  private readUserVersion(): number {
+    const row = this.db.prepare("pragma user_version").get() as { user_version: number };
+    return Number(row.user_version);
+  }
+
+  private schemaObjectNames(type: "table" | "index" | "trigger" | "view"): string[] {
+    return (
+      this.db
+        .prepare("select name from sqlite_schema where type = ? and name not like 'sqlite_%' order by name")
+        .all(type) as unknown as Array<{ name: string }>
+    ).map(({ name }) => name);
+  }
+
+  private isExactLegacySchema(): boolean {
+    const legacyTables = ["activations", "license_issuance_events", "licenses"];
+    if (!sameStrings(this.schemaObjectNames("table"), legacyTables)) return false;
+    if (this.schemaObjectNames("index").length > 0) return false;
+    if (this.schemaObjectNames("trigger").length > 0) return false;
+    if (this.schemaObjectNames("view").length > 0) return false;
+    if (!legacyTables.every((table) => this.hasExpectedColumns(table))) return false;
+
+    const issuanceForeignKeys = this.foreignKeys("license_issuance_events");
+    if (
+      issuanceForeignKeys.length !== 1 ||
+      issuanceForeignKeys[0]?.table !== "licenses" ||
+      issuanceForeignKeys[0]?.from !== "license_key_hash" ||
+      issuanceForeignKeys[0]?.to !== "license_key_hash"
+    ) {
+      return false;
+    }
+    return this.foreignKeys("licenses").length === 0 && this.foreignKeys("activations").length === 0;
+  }
+
+  private hasExpectedColumns(table: string): boolean {
+    const actual = this.db.prepare(`pragma table_info(${table})`).all() as unknown as TableColumn[];
+    return JSON.stringify(actual.map(normalizeColumn)) === JSON.stringify(EXPECTED_COLUMNS[table]);
+  }
+
+  private foreignKeys(table: string): ForeignKeyRow[] {
+    return this.db.prepare(`pragma foreign_key_list(${table})`).all() as unknown as ForeignKeyRow[];
+  }
+
+  private uniqueColumnSets(table: string): string[] {
+    const indexes = this.db.prepare(`pragma index_list(${table})`).all() as unknown as Array<{
+      name: string;
+      unique: number;
+    }>;
+    return indexes
+      .filter((index) => index.unique === 1)
+      .map((index) => {
+        const columns = this.db.prepare(`pragma index_info(${index.name})`).all() as unknown as Array<{ name: string }>;
+        return columns.map(({ name }) => name).join(",");
+      })
+      .sort();
+  }
+
+  private verifySchemaV2(): void {
+    const expectedTables = [
+      "activations",
+      "checkout_subscription_bindings",
+      "license_issuance_events",
+      "license_subscription_lifecycle_events",
+      "licenses"
+    ];
+    if (!sameStrings(this.schemaObjectNames("table"), expectedTables)) {
+      throw new Error("license database schema v2 has unexpected tables");
+    }
+    if (!expectedTables.every((table) => this.hasExpectedColumns(table))) {
+      throw new Error("license database schema v2 has unexpected columns");
+    }
+    const indexes = this.schemaObjectNames("index");
+    if (!sameStrings(indexes, ["license_subscription_lifecycle_events_issuance_time_idx"])) {
+      throw new Error("license database schema v2 has unexpected indexes");
+    }
+
+    const indexColumns = (
+      this.db
+        .prepare("pragma index_info(license_subscription_lifecycle_events_issuance_time_idx)")
+        .all() as unknown as Array<{ name: string }>
+    ).map(({ name }) => name);
+    if (!sameStrings(indexColumns, ["issuance_idempotency_key", "event_created_at"])) {
+      throw new Error("license database schema v2 has an invalid lifecycle index");
+    }
+
+    const bindingForeignKeys = foreignKeySignatures(this.foreignKeys("checkout_subscription_bindings"));
+    const lifecycleForeignKeys = foreignKeySignatures(this.foreignKeys("license_subscription_lifecycle_events"));
+    if (
+      !sameStrings(bindingForeignKeys, [
+        "license_key_hash:licenses.license_key_hash",
+        "issuance_idempotency_key:license_issuance_events.idempotency_key"
+      ].sort()) ||
+      !sameStrings(lifecycleForeignKeys, [
+        "license_key_hash:licenses.license_key_hash",
+        "issuance_idempotency_key:checkout_subscription_bindings.issuance_idempotency_key"
+      ].sort()) ||
+      !sameStrings(this.uniqueColumnSets("checkout_subscription_bindings"), [
+        "issuance_idempotency_key",
+        "license_key_hash",
+        "provider,provider_account_id,provider_mode,external_subscription_id"
+      ].sort()) ||
+      !sameStrings(this.uniqueColumnSets("license_subscription_lifecycle_events"), ["event_id"])
+    ) {
+      throw new Error("license database schema v2 has unexpected constraints");
+    }
   }
 
   close(): void {
@@ -325,4 +604,22 @@ function mapActivation(row: ActivationRow): ActivationRecord {
     activatedAt: row.activated_at,
     lastSeenAt: row.last_seen_at
   };
+}
+
+function normalizeColumn(value: TableColumn): TableColumn {
+  return {
+    name: value.name,
+    type: value.type.toUpperCase(),
+    notnull: Number(value.notnull),
+    dflt_value: value.dflt_value?.replaceAll(/\s+/g, " ") ?? null,
+    pk: Number(value.pk)
+  };
+}
+
+function sameStrings(actual: readonly string[], expected: readonly string[]): boolean {
+  return actual.length === expected.length && actual.every((value, index) => value === expected[index]);
+}
+
+function foreignKeySignatures(rows: readonly ForeignKeyRow[]): string[] {
+  return rows.map((row) => `${row.from}:${row.table}.${row.to}`).sort();
 }

--- a/services/license-api/src/subscription-lifecycle.ts
+++ b/services/license-api/src/subscription-lifecycle.ts
@@ -236,11 +236,14 @@ export function parseSubscriptionLifecycleRequest(
       throw new LifecycleRequestError("currentPeriodEnd is forbidden for revoke");
     }
   } else if (command === "renew_paid" || command === "cancel_at_period_end") {
-    parsedPeriodEnd = readFuturePeriodEnd(body.currentPeriodEnd, now, true);
+    parsedPeriodEnd = readStrictPeriodEnd(body.currentPeriodEnd, true);
   } else if (body.currentPeriodEnd !== undefined) {
-    parsedPeriodEnd = readFuturePeriodEnd(body.currentPeriodEnd, now, false);
+    parsedPeriodEnd = readStrictPeriodEnd(body.currentPeriodEnd, false);
   }
 
+  if (command === "renew_paid" && cancelAtPeriodEnd) {
+    throw new LifecycleRequestError("cancelAtPeriodEnd must be false for renew_paid");
+  }
   if (command === "reconcile" && cancelAtPeriodEnd) {
     throw new LifecycleRequestError("cancelAtPeriodEnd must be false for reconcile");
   }
@@ -503,7 +506,7 @@ function readEventCreatedAt(value: unknown, now: Date): number {
   return timestamp;
 }
 
-function readFuturePeriodEnd(value: unknown, now: Date, required: boolean): string {
+function readStrictPeriodEnd(value: unknown, required: boolean): string {
   if (typeof value !== "string") {
     throw new LifecycleRequestError(
       required ? "currentPeriodEnd is required" : "currentPeriodEnd must be a timestamp"
@@ -515,9 +518,6 @@ function readFuturePeriodEnd(value: unknown, now: Date, required: boolean): stri
   const milliseconds = Date.parse(value);
   if (!Number.isFinite(milliseconds) || new Date(milliseconds).toISOString() !== value) {
     throw new LifecycleRequestError("currentPeriodEnd must be a valid timestamp");
-  }
-  if (milliseconds <= now.getTime()) {
-    throw new LifecycleRequestError("currentPeriodEnd must be in the future");
   }
   return value;
 }

--- a/services/license-api/src/subscription-lifecycle.ts
+++ b/services/license-api/src/subscription-lifecycle.ts
@@ -7,7 +7,6 @@ const MAX_EVENT_ID_LENGTH = 200;
 const MAX_PROVIDER_ACCOUNT_ID_LENGTH = 160;
 const MAX_SUBSCRIPTION_ID_LENGTH = 160;
 const MAX_PAYMENT_REFERENCE_LENGTH = 200;
-const MAX_REASON_LENGTH = 200;
 const MAX_FUTURE_SKEW_SECONDS = 5 * 60;
 
 const REQUEST_FIELDS = new Set([
@@ -107,7 +106,10 @@ export interface RevokeSubscriptionLifecycleRequest
     | "customer.subscription.deleted"
     | "customer.subscription.updated";
   readonly subscriptionStatus: "canceled" | "unpaid" | "incomplete_expired";
-  readonly reason?: string;
+  readonly reason:
+    | "subscription_canceled"
+    | "subscription_unpaid"
+    | "subscription_incomplete_expired";
 }
 
 export type SubscriptionLifecycleRequestWithoutHash =
@@ -244,12 +246,18 @@ export function parseSubscriptionLifecycleRequest(
     throw new LifecycleRequestError("cancelAtPeriodEnd must be true for cancel_at_period_end");
   }
 
-  let reason: string | undefined;
-  if (body.reason !== undefined) {
-    if (command !== "revoke") {
-      throw new LifecycleRequestError("reason is only allowed for revoke");
+  let reason: RevokeSubscriptionLifecycleRequest["reason"] | undefined;
+  if (command !== "revoke" && body.reason !== undefined) {
+    throw new LifecycleRequestError("reason is only allowed for revoke");
+  }
+  if (command === "revoke") {
+    reason = revokeReasonForStatus(subscriptionStatus);
+    if (body.reason !== undefined) {
+      const suppliedReason = readRequiredString(body, "reason", 40);
+      if (suppliedReason !== reason) {
+        throw new LifecycleRequestError("reason must match the server-derived code");
+      }
     }
-    reason = readRequiredString(body, "reason", MAX_REASON_LENGTH);
   }
 
   const common: CommonSubscriptionLifecycleRequest = {
@@ -319,7 +327,7 @@ export function parseSubscriptionLifecycleRequest(
         command,
         providerEventType: providerEventType as RevokeSubscriptionLifecycleRequest["providerEventType"],
         subscriptionStatus: subscriptionStatus as RevokeSubscriptionLifecycleRequest["subscriptionStatus"],
-        ...(reason !== undefined ? { reason } : {})
+        reason: reason!
       };
       break;
   }
@@ -328,6 +336,21 @@ export function parseSubscriptionLifecycleRequest(
     ...requestWithoutHash,
     requestHash: canonicalSubscriptionLifecycleRequestHash(requestWithoutHash)
   };
+}
+
+function revokeReasonForStatus(
+  status: string
+): RevokeSubscriptionLifecycleRequest["reason"] {
+  switch (status) {
+    case "canceled":
+      return "subscription_canceled";
+    case "unpaid":
+      return "subscription_unpaid";
+    case "incomplete_expired":
+      return "subscription_incomplete_expired";
+    default:
+      throw new LifecycleRequestError("subscriptionStatus is invalid for revoke");
+  }
 }
 
 export function canonicalSubscriptionLifecycleRequestHash(

--- a/services/license-api/src/subscription-lifecycle.ts
+++ b/services/license-api/src/subscription-lifecycle.ts
@@ -110,6 +110,8 @@ export interface RevokeSubscriptionLifecycleRequest
     | "subscription_canceled"
     | "subscription_unpaid"
     | "subscription_incomplete_expired";
+  /** Preserves schema-v1 replay hashing when the wire payload omitted reason. */
+  readonly reasonProvided: boolean;
 }
 
 export type SubscriptionLifecycleRequestWithoutHash =
@@ -327,7 +329,8 @@ export function parseSubscriptionLifecycleRequest(
         command,
         providerEventType: providerEventType as RevokeSubscriptionLifecycleRequest["providerEventType"],
         subscriptionStatus: subscriptionStatus as RevokeSubscriptionLifecycleRequest["subscriptionStatus"],
-        reason: reason!
+        reason: reason!,
+        reasonProvided: body.reason !== undefined
       };
       break;
   }
@@ -415,7 +418,7 @@ export function canonicalSubscriptionLifecycleRequestHash(
         request.providerEventType,
         request.subscriptionStatus,
         request.cancelAtPeriodEnd,
-        request.reason ?? null
+        request.reasonProvided === false ? null : request.reason ?? null
       ];
       break;
   }

--- a/services/license-api/src/subscription-lifecycle.ts
+++ b/services/license-api/src/subscription-lifecycle.ts
@@ -1,0 +1,368 @@
+import { createHash } from "node:crypto";
+
+export const MAX_LIFECYCLE_BODY_BYTES = 16 * 1024;
+
+const MAX_ISSUANCE_KEY_LENGTH = 200;
+const MAX_EVENT_ID_LENGTH = 200;
+const MAX_PROVIDER_ACCOUNT_ID_LENGTH = 160;
+const MAX_SUBSCRIPTION_ID_LENGTH = 160;
+const MAX_PAYMENT_REFERENCE_LENGTH = 200;
+const MAX_REASON_LENGTH = 200;
+const MAX_FUTURE_SKEW_SECONDS = 5 * 60;
+
+const REQUEST_FIELDS = new Set([
+  "schemaVersion",
+  "issuanceIdempotencyKey",
+  "eventId",
+  "eventCreatedAt",
+  "provider",
+  "providerAccountId",
+  "providerMode",
+  "externalSubscriptionId",
+  "providerEventType",
+  "command",
+  "paymentReference",
+  "amountPaidMinor",
+  "currency",
+  "paidOutOfBand",
+  "billingReason",
+  "subscriptionStatus",
+  "currentPeriodEnd",
+  "cancelAtPeriodEnd",
+  "reason"
+]);
+
+const PAYMENT_FIELDS = [
+  "paymentReference",
+  "amountPaidMinor",
+  "currency",
+  "paidOutOfBand",
+  "billingReason"
+] as const;
+
+export type SubscriptionLifecycleCommand =
+  | "renew_paid"
+  | "reconcile"
+  | "cancel_at_period_end"
+  | "payment_attention"
+  | "revoke";
+
+export type SubscriptionProviderMode = "test" | "live";
+
+export interface ParsedSubscriptionLifecycleRequest {
+  readonly schemaVersion: 1;
+  readonly issuanceIdempotencyKey: string;
+  readonly eventId: string;
+  readonly eventCreatedAt: number;
+  readonly provider: "stripe";
+  readonly providerAccountId: string;
+  readonly providerMode: SubscriptionProviderMode;
+  readonly externalSubscriptionId: string;
+  readonly providerEventType: string;
+  readonly command: SubscriptionLifecycleCommand;
+  readonly subscriptionStatus: string;
+  readonly cancelAtPeriodEnd: boolean;
+  readonly amountPaidMinor?: number;
+  readonly currency?: "usd";
+  readonly paidOutOfBand?: false;
+  readonly billingReason?: "subscription_cycle";
+  readonly currentPeriodEnd?: string;
+  readonly reason?: string;
+  readonly paymentReferenceFingerprint?: string;
+  readonly requestHash: string;
+}
+
+export class LifecycleRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LifecycleRequestError";
+  }
+}
+
+export function parseSubscriptionLifecycleRequest(
+  raw: string,
+  now: Date = new Date()
+): ParsedSubscriptionLifecycleRequest {
+  if (Buffer.byteLength(raw, "utf8") > MAX_LIFECYCLE_BODY_BYTES) {
+    throw new LifecycleRequestError("request body is too large");
+  }
+  if (!Number.isFinite(now.getTime())) {
+    throw new LifecycleRequestError("service clock is invalid");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = raw.length > 0 ? (JSON.parse(raw) as unknown) : {};
+  } catch {
+    throw new LifecycleRequestError("request body must be valid JSON");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new LifecycleRequestError("request body must be a JSON object");
+  }
+
+  const body = parsed as Record<string, unknown>;
+  if (Object.keys(body).some((key) => !REQUEST_FIELDS.has(key))) {
+    throw new LifecycleRequestError("request contains an unknown field");
+  }
+
+  if (body.schemaVersion !== 1) {
+    throw new LifecycleRequestError("schemaVersion must be 1");
+  }
+  const issuanceIdempotencyKey = readRequiredString(
+    body,
+    "issuanceIdempotencyKey",
+    MAX_ISSUANCE_KEY_LENGTH
+  );
+  const eventId = readRequiredString(body, "eventId", MAX_EVENT_ID_LENGTH);
+  const eventCreatedAt = readEventCreatedAt(body.eventCreatedAt, now);
+  const provider = readRequiredString(body, "provider", 16);
+  if (provider !== "stripe") throw new LifecycleRequestError("provider must be stripe");
+  const providerAccountId = readRequiredString(
+    body,
+    "providerAccountId",
+    MAX_PROVIDER_ACCOUNT_ID_LENGTH
+  );
+  const providerModeValue = readRequiredString(body, "providerMode", 16);
+  if (providerModeValue !== "test" && providerModeValue !== "live") {
+    throw new LifecycleRequestError("providerMode must be test or live");
+  }
+  const providerMode: SubscriptionProviderMode = providerModeValue;
+  const externalSubscriptionId = readRequiredString(
+    body,
+    "externalSubscriptionId",
+    MAX_SUBSCRIPTION_ID_LENGTH
+  );
+  const providerEventType = readRequiredString(body, "providerEventType", 80);
+  const commandValue = readRequiredString(body, "command", 40);
+  if (!isLifecycleCommand(commandValue)) {
+    throw new LifecycleRequestError("command is unsupported");
+  }
+  const command = commandValue;
+  const subscriptionStatus = readRequiredString(body, "subscriptionStatus", 40);
+  if (typeof body.cancelAtPeriodEnd !== "boolean") {
+    throw new LifecycleRequestError("cancelAtPeriodEnd must be a boolean");
+  }
+  const cancelAtPeriodEnd = body.cancelAtPeriodEnd;
+
+  validateCommandMatrix(command, providerEventType, subscriptionStatus);
+
+  let amountPaidMinor: number | undefined;
+  let currency: "usd" | undefined;
+  let paidOutOfBand: false | undefined;
+  let billingReason: "subscription_cycle" | undefined;
+  let paymentFingerprint: string | undefined;
+
+  if (command === "renew_paid") {
+    const paymentReference = readRequiredString(
+      body,
+      "paymentReference",
+      MAX_PAYMENT_REFERENCE_LENGTH
+    );
+    if (!Number.isSafeInteger(body.amountPaidMinor) || (body.amountPaidMinor as number) <= 0) {
+      throw new LifecycleRequestError("amountPaidMinor must be a positive integer");
+    }
+    amountPaidMinor = body.amountPaidMinor as number;
+    if (body.currency !== "usd") throw new LifecycleRequestError("currency must be usd");
+    currency = "usd";
+    if (body.paidOutOfBand !== false) {
+      throw new LifecycleRequestError("paidOutOfBand must be false");
+    }
+    paidOutOfBand = false;
+    if (body.billingReason !== "subscription_cycle") {
+      throw new LifecycleRequestError("billingReason must be subscription_cycle");
+    }
+    billingReason = "subscription_cycle";
+    paymentFingerprint = paymentReferenceFingerprint(paymentReference);
+  } else if (PAYMENT_FIELDS.some((field) => body[field] !== undefined)) {
+    throw new LifecycleRequestError("payment fields are forbidden for this command");
+  }
+
+  let currentPeriodEnd: string | undefined;
+  if (command === "revoke") {
+    if (body.currentPeriodEnd !== undefined) {
+      throw new LifecycleRequestError("currentPeriodEnd is forbidden for revoke");
+    }
+  } else if (command === "renew_paid" || command === "cancel_at_period_end") {
+    currentPeriodEnd = readFuturePeriodEnd(body.currentPeriodEnd, now, true);
+  } else if (body.currentPeriodEnd !== undefined) {
+    currentPeriodEnd = readFuturePeriodEnd(body.currentPeriodEnd, now, false);
+  }
+
+  if (command === "reconcile" && cancelAtPeriodEnd) {
+    throw new LifecycleRequestError("cancelAtPeriodEnd must be false for reconcile");
+  }
+  if (command === "cancel_at_period_end" && !cancelAtPeriodEnd) {
+    throw new LifecycleRequestError("cancelAtPeriodEnd must be true for cancel_at_period_end");
+  }
+
+  let reason: string | undefined;
+  if (body.reason !== undefined) {
+    if (command !== "revoke") {
+      throw new LifecycleRequestError("reason is only allowed for revoke");
+    }
+    reason = readRequiredString(body, "reason", MAX_REASON_LENGTH);
+  }
+
+  const requestWithoutHash: Omit<ParsedSubscriptionLifecycleRequest, "requestHash"> = {
+    schemaVersion: 1,
+    issuanceIdempotencyKey,
+    eventId,
+    eventCreatedAt,
+    provider: "stripe",
+    providerAccountId,
+    providerMode,
+    externalSubscriptionId,
+    providerEventType,
+    command,
+    subscriptionStatus,
+    cancelAtPeriodEnd,
+    ...(amountPaidMinor !== undefined ? { amountPaidMinor } : {}),
+    ...(currency !== undefined ? { currency } : {}),
+    ...(paidOutOfBand !== undefined ? { paidOutOfBand } : {}),
+    ...(billingReason !== undefined ? { billingReason } : {}),
+    ...(currentPeriodEnd !== undefined ? { currentPeriodEnd } : {}),
+    ...(reason !== undefined ? { reason } : {}),
+    ...(paymentFingerprint !== undefined
+      ? { paymentReferenceFingerprint: paymentFingerprint }
+      : {})
+  };
+
+  return {
+    ...requestWithoutHash,
+    requestHash: canonicalSubscriptionLifecycleRequestHash(requestWithoutHash)
+  };
+}
+
+export function canonicalSubscriptionLifecycleRequestHash(
+  request: Omit<ParsedSubscriptionLifecycleRequest, "requestHash"> | ParsedSubscriptionLifecycleRequest
+): string {
+  const canonicalFields = [
+    request.schemaVersion,
+    request.issuanceIdempotencyKey,
+    request.eventId,
+    request.eventCreatedAt,
+    request.provider,
+    request.providerAccountId,
+    request.providerMode,
+    request.externalSubscriptionId,
+    request.providerEventType,
+    request.command,
+    request.subscriptionStatus,
+    request.cancelAtPeriodEnd,
+    request.paymentReferenceFingerprint ?? null,
+    request.amountPaidMinor ?? null,
+    request.currency ?? null,
+    request.paidOutOfBand ?? null,
+    request.billingReason ?? null,
+    request.currentPeriodEnd ?? null,
+    request.reason ?? null
+  ];
+  return createHash("sha256")
+    .update("neondiff:subscription-lifecycle-request:v1\n")
+    .update(JSON.stringify(canonicalFields))
+    .digest("hex");
+}
+
+export function paymentReferenceFingerprint(paymentReference: string): string {
+  return createHash("sha256")
+    .update("neondiff:subscription-lifecycle-payment-reference:v1\n")
+    .update(paymentReference)
+    .digest("hex");
+}
+
+function validateCommandMatrix(
+  command: SubscriptionLifecycleCommand,
+  providerEventType: string,
+  subscriptionStatus: string
+): void {
+  const matrix: Readonly<
+    Record<
+      SubscriptionLifecycleCommand,
+      { readonly events: readonly string[]; readonly statuses: readonly string[] }
+    >
+  > = {
+    renew_paid: {
+      events: ["invoice.paid", "invoice.payment_succeeded"],
+      statuses: ["active"]
+    },
+    reconcile: {
+      events: ["customer.subscription.updated"],
+      statuses: ["active", "trialing"]
+    },
+    cancel_at_period_end: {
+      events: ["customer.subscription.updated"],
+      statuses: ["active", "trialing"]
+    },
+    payment_attention: {
+      events: ["invoice.payment_failed", "customer.subscription.updated"],
+      statuses: ["active", "past_due", "incomplete", "paused"]
+    },
+    revoke: {
+      events: ["customer.subscription.deleted", "customer.subscription.updated"],
+      statuses: ["canceled", "unpaid", "incomplete_expired"]
+    }
+  };
+  const rule = matrix[command];
+  if (!rule.events.includes(providerEventType)) {
+    throw new LifecycleRequestError(`providerEventType is invalid for ${command}`);
+  }
+  if (!rule.statuses.includes(subscriptionStatus)) {
+    throw new LifecycleRequestError(`subscriptionStatus is invalid for ${command}`);
+  }
+}
+
+function readRequiredString(
+  body: Record<string, unknown>,
+  field: string,
+  maxLength: number
+): string {
+  const value = body[field];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new LifecycleRequestError(`${field} is required`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > maxLength) {
+    throw new LifecycleRequestError(`${field} is too long`);
+  }
+  return trimmed;
+}
+
+function readEventCreatedAt(value: unknown, now: Date): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new LifecycleRequestError("eventCreatedAt must be an integer epoch");
+  }
+  const timestamp = value as number;
+  if (timestamp > Math.floor(now.getTime() / 1000) + MAX_FUTURE_SKEW_SECONDS) {
+    throw new LifecycleRequestError("eventCreatedAt is too far in the future");
+  }
+  return timestamp;
+}
+
+function readFuturePeriodEnd(value: unknown, now: Date, required: boolean): string {
+  if (typeof value !== "string") {
+    throw new LifecycleRequestError(
+      required ? "currentPeriodEnd is required" : "currentPeriodEnd must be a timestamp"
+    );
+  }
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) {
+    throw new LifecycleRequestError("currentPeriodEnd must be a strict UTC timestamp");
+  }
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds) || new Date(milliseconds).toISOString() !== value) {
+    throw new LifecycleRequestError("currentPeriodEnd must be a valid timestamp");
+  }
+  if (milliseconds <= now.getTime()) {
+    throw new LifecycleRequestError("currentPeriodEnd must be in the future");
+  }
+  return value;
+}
+
+function isLifecycleCommand(value: string): value is SubscriptionLifecycleCommand {
+  return (
+    value === "renew_paid" ||
+    value === "reconcile" ||
+    value === "cancel_at_period_end" ||
+    value === "payment_attention" ||
+    value === "revoke"
+  );
+}

--- a/services/license-api/src/subscription-lifecycle.ts
+++ b/services/license-api/src/subscription-lifecycle.ts
@@ -49,7 +49,7 @@ export type SubscriptionLifecycleCommand =
 
 export type SubscriptionProviderMode = "test" | "live";
 
-export interface ParsedSubscriptionLifecycleRequest {
+interface CommonSubscriptionLifecycleRequest {
   readonly schemaVersion: 1;
   readonly issuanceIdempotencyKey: string;
   readonly eventId: string;
@@ -58,19 +58,68 @@ export interface ParsedSubscriptionLifecycleRequest {
   readonly providerAccountId: string;
   readonly providerMode: SubscriptionProviderMode;
   readonly externalSubscriptionId: string;
-  readonly providerEventType: string;
-  readonly command: SubscriptionLifecycleCommand;
-  readonly subscriptionStatus: string;
   readonly cancelAtPeriodEnd: boolean;
-  readonly amountPaidMinor?: number;
-  readonly currency?: "usd";
-  readonly paidOutOfBand?: false;
-  readonly billingReason?: "subscription_cycle";
-  readonly currentPeriodEnd?: string;
-  readonly reason?: string;
-  readonly paymentReferenceFingerprint?: string;
-  readonly requestHash: string;
 }
+
+export interface RenewPaidSubscriptionLifecycleRequest
+  extends CommonSubscriptionLifecycleRequest {
+  readonly command: "renew_paid";
+  readonly providerEventType: "invoice.paid" | "invoice.payment_succeeded";
+  readonly subscriptionStatus: "active";
+  readonly paymentReferenceFingerprint: string;
+  readonly amountPaidMinor: number;
+  readonly currency: "usd";
+  readonly paidOutOfBand: false;
+  readonly billingReason: "subscription_cycle";
+  readonly currentPeriodEnd: string;
+}
+
+export interface ReconcileSubscriptionLifecycleRequest
+  extends CommonSubscriptionLifecycleRequest {
+  readonly command: "reconcile";
+  readonly providerEventType: "customer.subscription.updated";
+  readonly subscriptionStatus: "active" | "trialing";
+  readonly cancelAtPeriodEnd: false;
+  readonly diagnosticCurrentPeriodEnd?: string;
+}
+
+export interface CancelSubscriptionLifecycleRequest
+  extends CommonSubscriptionLifecycleRequest {
+  readonly command: "cancel_at_period_end";
+  readonly providerEventType: "customer.subscription.updated";
+  readonly subscriptionStatus: "active" | "trialing";
+  readonly cancelAtPeriodEnd: true;
+  readonly currentPeriodEnd: string;
+}
+
+export interface PaymentAttentionSubscriptionLifecycleRequest
+  extends CommonSubscriptionLifecycleRequest {
+  readonly command: "payment_attention";
+  readonly providerEventType: "invoice.payment_failed" | "customer.subscription.updated";
+  readonly subscriptionStatus: "active" | "past_due" | "incomplete" | "paused";
+  readonly diagnosticCurrentPeriodEnd?: string;
+}
+
+export interface RevokeSubscriptionLifecycleRequest
+  extends CommonSubscriptionLifecycleRequest {
+  readonly command: "revoke";
+  readonly providerEventType:
+    | "customer.subscription.deleted"
+    | "customer.subscription.updated";
+  readonly subscriptionStatus: "canceled" | "unpaid" | "incomplete_expired";
+  readonly reason?: string;
+}
+
+export type SubscriptionLifecycleRequestWithoutHash =
+  | RenewPaidSubscriptionLifecycleRequest
+  | ReconcileSubscriptionLifecycleRequest
+  | CancelSubscriptionLifecycleRequest
+  | PaymentAttentionSubscriptionLifecycleRequest
+  | RevokeSubscriptionLifecycleRequest;
+
+export type ParsedSubscriptionLifecycleRequest = SubscriptionLifecycleRequestWithoutHash & {
+  readonly requestHash: string;
+};
 
 export class LifecycleRequestError extends Error {
   constructor(message: string) {
@@ -177,15 +226,15 @@ export function parseSubscriptionLifecycleRequest(
     throw new LifecycleRequestError("payment fields are forbidden for this command");
   }
 
-  let currentPeriodEnd: string | undefined;
+  let parsedPeriodEnd: string | undefined;
   if (command === "revoke") {
     if (body.currentPeriodEnd !== undefined) {
       throw new LifecycleRequestError("currentPeriodEnd is forbidden for revoke");
     }
   } else if (command === "renew_paid" || command === "cancel_at_period_end") {
-    currentPeriodEnd = readFuturePeriodEnd(body.currentPeriodEnd, now, true);
+    parsedPeriodEnd = readFuturePeriodEnd(body.currentPeriodEnd, now, true);
   } else if (body.currentPeriodEnd !== undefined) {
-    currentPeriodEnd = readFuturePeriodEnd(body.currentPeriodEnd, now, false);
+    parsedPeriodEnd = readFuturePeriodEnd(body.currentPeriodEnd, now, false);
   }
 
   if (command === "reconcile" && cancelAtPeriodEnd) {
@@ -203,7 +252,7 @@ export function parseSubscriptionLifecycleRequest(
     reason = readRequiredString(body, "reason", MAX_REASON_LENGTH);
   }
 
-  const requestWithoutHash: Omit<ParsedSubscriptionLifecycleRequest, "requestHash"> = {
+  const common: CommonSubscriptionLifecycleRequest = {
     schemaVersion: 1,
     issuanceIdempotencyKey,
     eventId,
@@ -212,20 +261,68 @@ export function parseSubscriptionLifecycleRequest(
     providerAccountId,
     providerMode,
     externalSubscriptionId,
-    providerEventType,
-    command,
-    subscriptionStatus,
-    cancelAtPeriodEnd,
-    ...(amountPaidMinor !== undefined ? { amountPaidMinor } : {}),
-    ...(currency !== undefined ? { currency } : {}),
-    ...(paidOutOfBand !== undefined ? { paidOutOfBand } : {}),
-    ...(billingReason !== undefined ? { billingReason } : {}),
-    ...(currentPeriodEnd !== undefined ? { currentPeriodEnd } : {}),
-    ...(reason !== undefined ? { reason } : {}),
-    ...(paymentFingerprint !== undefined
-      ? { paymentReferenceFingerprint: paymentFingerprint }
-      : {})
+    cancelAtPeriodEnd
   };
+
+  let requestWithoutHash: SubscriptionLifecycleRequestWithoutHash;
+  switch (command) {
+    case "renew_paid":
+      requestWithoutHash = {
+        ...common,
+        command,
+        providerEventType: providerEventType as RenewPaidSubscriptionLifecycleRequest["providerEventType"],
+        subscriptionStatus: "active",
+        paymentReferenceFingerprint: paymentFingerprint!,
+        amountPaidMinor: amountPaidMinor!,
+        currency: currency!,
+        paidOutOfBand: paidOutOfBand!,
+        billingReason: billingReason!,
+        currentPeriodEnd: parsedPeriodEnd!
+      };
+      break;
+    case "reconcile":
+      requestWithoutHash = {
+        ...common,
+        command,
+        providerEventType: "customer.subscription.updated",
+        subscriptionStatus: subscriptionStatus as ReconcileSubscriptionLifecycleRequest["subscriptionStatus"],
+        cancelAtPeriodEnd: false,
+        ...(parsedPeriodEnd !== undefined
+          ? { diagnosticCurrentPeriodEnd: parsedPeriodEnd }
+          : {})
+      };
+      break;
+    case "cancel_at_period_end":
+      requestWithoutHash = {
+        ...common,
+        command,
+        providerEventType: "customer.subscription.updated",
+        subscriptionStatus: subscriptionStatus as CancelSubscriptionLifecycleRequest["subscriptionStatus"],
+        cancelAtPeriodEnd: true,
+        currentPeriodEnd: parsedPeriodEnd!
+      };
+      break;
+    case "payment_attention":
+      requestWithoutHash = {
+        ...common,
+        command,
+        providerEventType: providerEventType as PaymentAttentionSubscriptionLifecycleRequest["providerEventType"],
+        subscriptionStatus: subscriptionStatus as PaymentAttentionSubscriptionLifecycleRequest["subscriptionStatus"],
+        ...(parsedPeriodEnd !== undefined
+          ? { diagnosticCurrentPeriodEnd: parsedPeriodEnd }
+          : {})
+      };
+      break;
+    case "revoke":
+      requestWithoutHash = {
+        ...common,
+        command,
+        providerEventType: providerEventType as RevokeSubscriptionLifecycleRequest["providerEventType"],
+        subscriptionStatus: subscriptionStatus as RevokeSubscriptionLifecycleRequest["subscriptionStatus"],
+        ...(reason !== undefined ? { reason } : {})
+      };
+      break;
+  }
 
   return {
     ...requestWithoutHash,
@@ -234,9 +331,9 @@ export function parseSubscriptionLifecycleRequest(
 }
 
 export function canonicalSubscriptionLifecycleRequestHash(
-  request: Omit<ParsedSubscriptionLifecycleRequest, "requestHash"> | ParsedSubscriptionLifecycleRequest
+  request: SubscriptionLifecycleRequestWithoutHash | ParsedSubscriptionLifecycleRequest
 ): string {
-  const canonicalFields = [
+  const commonFields = [
     request.schemaVersion,
     request.issuanceIdempotencyKey,
     request.eventId,
@@ -245,21 +342,63 @@ export function canonicalSubscriptionLifecycleRequestHash(
     request.providerAccountId,
     request.providerMode,
     request.externalSubscriptionId,
-    request.providerEventType,
-    request.command,
-    request.subscriptionStatus,
-    request.cancelAtPeriodEnd,
-    request.paymentReferenceFingerprint ?? null,
-    request.amountPaidMinor ?? null,
-    request.currency ?? null,
-    request.paidOutOfBand ?? null,
-    request.billingReason ?? null,
-    request.currentPeriodEnd ?? null,
-    request.reason ?? null
   ];
+  let commandFields: readonly unknown[];
+  switch (request.command) {
+    case "renew_paid":
+      commandFields = [
+        request.command,
+        request.providerEventType,
+        request.subscriptionStatus,
+        request.cancelAtPeriodEnd,
+        request.paymentReferenceFingerprint,
+        request.amountPaidMinor,
+        request.currency,
+        request.paidOutOfBand,
+        request.billingReason,
+        request.currentPeriodEnd
+      ];
+      break;
+    case "reconcile":
+      commandFields = [
+        request.command,
+        request.providerEventType,
+        request.subscriptionStatus,
+        request.cancelAtPeriodEnd,
+        request.diagnosticCurrentPeriodEnd ?? null
+      ];
+      break;
+    case "cancel_at_period_end":
+      commandFields = [
+        request.command,
+        request.providerEventType,
+        request.subscriptionStatus,
+        request.cancelAtPeriodEnd,
+        request.currentPeriodEnd
+      ];
+      break;
+    case "payment_attention":
+      commandFields = [
+        request.command,
+        request.providerEventType,
+        request.subscriptionStatus,
+        request.cancelAtPeriodEnd,
+        request.diagnosticCurrentPeriodEnd ?? null
+      ];
+      break;
+    case "revoke":
+      commandFields = [
+        request.command,
+        request.providerEventType,
+        request.subscriptionStatus,
+        request.cancelAtPeriodEnd,
+        request.reason ?? null
+      ];
+      break;
+  }
   return createHash("sha256")
     .update("neondiff:subscription-lifecycle-request:v1\n")
-    .update(JSON.stringify(canonicalFields))
+    .update(JSON.stringify([...commonFields, ...commandFields]))
     .digest("hex");
 }
 

--- a/services/license-api/src/verify-legacy-restore.ts
+++ b/services/license-api/src/verify-legacy-restore.ts
@@ -1,0 +1,146 @@
+import { statSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+
+interface SchemaObjectSignature {
+  type: string;
+  name: string;
+  tableName: string;
+  sql: string;
+}
+
+const LEGACY_SCHEMA = `
+  create table licenses (
+    license_key_hash text primary key,
+    plan text not null,
+    repo_visibility_scope text not null,
+    private_repo_allowed integer not null default 1,
+    update_entitlement integer not null default 0,
+    seats integer not null default 1,
+    expires_at text,
+    status text not null default 'active',
+    revocation_reason text,
+    created_at text not null default (datetime('now'))
+  );
+  create table activations (
+    license_key_hash text not null,
+    machine_id text not null,
+    repo text,
+    activated_at text not null default (datetime('now')),
+    last_seen_at text not null default (datetime('now')),
+    primary key (license_key_hash, machine_id)
+  );
+  create table license_issuance_events (
+    idempotency_key text primary key,
+    license_key_hash text not null,
+    request_hash text not null,
+    source text,
+    external_ref text,
+    created_at text not null default (datetime('now')),
+    foreign key (license_key_hash) references licenses(license_key_hash)
+  );
+`;
+
+function readSchemaSignature(db: DatabaseSync): SchemaObjectSignature[] {
+  const rows = db.prepare(
+    `select type, name, tbl_name, sql
+     from sqlite_schema
+     where name not like 'sqlite_%'
+     order by type, name`
+  ).all() as unknown as Array<{
+    type: string;
+    name: string;
+    tbl_name: string;
+    sql: string;
+  }>;
+  return rows.map((row) => ({
+    type: row.type,
+    name: row.name,
+    tableName: row.tbl_name,
+    sql: normalizeSchemaSql(row.sql)
+  }));
+}
+
+function normalizeSchemaSql(sql: string): string {
+  let result = "";
+  let pendingSpace = false;
+  let quote: "'" | '"' | "`" | null = null;
+  for (let index = 0; index < sql.length; index += 1) {
+    const character = sql[index]!;
+    if (quote) {
+      result += character;
+      if (character === quote) {
+        if (sql[index + 1] === quote) {
+          result += quote;
+          index += 1;
+        } else {
+          quote = null;
+        }
+      }
+      continue;
+    }
+    if (character === "'" || character === '"' || character === "`") {
+      if (pendingSpace && result && !result.endsWith("(") && !result.endsWith(",")) result += " ";
+      pendingSpace = false;
+      quote = character;
+      result += character;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      pendingSpace = true;
+      continue;
+    }
+    if (character === "(" || character === ")" || character === "," || character === ";") {
+      result = result.trimEnd() + character;
+      pendingSpace = false;
+      continue;
+    }
+    if (pendingSpace && result && !result.endsWith("(") && !result.endsWith(",")) result += " ";
+    pendingSpace = false;
+    result += character.toLowerCase();
+  }
+  return result.trim().replace(/;$/, "");
+}
+
+function expectedLegacySignature(): SchemaObjectSignature[] {
+  const db = new DatabaseSync(":memory:");
+  try {
+    db.exec(LEGACY_SCHEMA);
+    return readSchemaSignature(db);
+  } finally {
+    db.close();
+  }
+}
+
+function verifyLegacyRestore(path: string): void {
+  if (!statSync(path).isFile()) throw new Error("restore target must be a regular file");
+  const db = new DatabaseSync(path, { readOnly: true });
+  try {
+    const quickCheck = db.prepare("pragma quick_check").all() as unknown as Array<Record<string, unknown>>;
+    if (quickCheck.length !== 1 || Object.values(quickCheck[0] ?? {})[0] !== "ok") {
+      throw new Error("restore quick-check failed");
+    }
+    const versionRow = db.prepare("pragma user_version").get() as { user_version: number };
+    if (Number(versionRow.user_version) !== 0) {
+      throw new Error("restore is not schema version 0");
+    }
+    if (JSON.stringify(readSchemaSignature(db)) !== JSON.stringify(expectedLegacySignature())) {
+      throw new Error("restore does not match the exact legacy schema signature");
+    }
+  } finally {
+    db.close();
+  }
+}
+
+const target = process.argv[2];
+if (!target || process.argv.length !== 3) {
+  console.error("usage: verify-legacy-restore <fresh-restored-database-path>");
+  process.exit(2);
+}
+
+try {
+  verifyLegacyRestore(target);
+  console.log("legacy restore verification ok");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : "legacy restore verification failed");
+  process.exit(1);
+}

--- a/services/license-api/test/admin.test.ts
+++ b/services/license-api/test/admin.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { after, beforeEach, describe, it } from "node:test";
 import { LicenseStore } from "../src/store.ts";
 import { runAdmin } from "../src/admin.ts";
+import { issueCheckoutLicense, type LicenseIssuanceRequest } from "../src/issuance.ts";
+import { parseSubscriptionLifecycleRequest } from "../src/subscription-lifecycle.ts";
 
 describe("admin issuance CLI", () => {
   let store: LicenseStore;
@@ -91,6 +93,46 @@ describe("admin issuance CLI", () => {
   it("revoke and show fail cleanly on an unknown key", () => {
     assert.equal(runAdmin(["revoke", "--key", "nd_live_unknownxxxxxxxxxxxxxxxxxxx"], store, out), 2);
     assert.equal(runAdmin(["show", "--key", "nd_live_unknownxxxxxxxxxxxxxxxxxxx"], store, out), 2);
+  });
+
+  it("renders only the server-derived lifecycle revoke reason code", () => {
+    store.close();
+    const now = new Date("2026-07-13T00:00:00.000Z");
+    store = new LicenseStore(":memory:", { now: () => now });
+    const issuance: LicenseIssuanceRequest = {
+      idempotencyKey: "checkout-session:admin-safe-reason",
+      checkoutLookupKey: "neondiff_monthly",
+      provider: "stripe",
+      providerAccountId: "acct_admin_safe_reason",
+      providerMode: "live",
+      externalSubscriptionId: "sub_admin_safe_reason",
+      externalCheckoutId: "cs_admin_safe_reason"
+    };
+    const issued = issueCheckoutLicense(store, issuance, "test-only-admin-safe-reason-secret");
+    assert.equal(issued.httpStatus, 200);
+    const rawKey = (issued.body as { licenseKey: string }).licenseKey;
+    const request = parseSubscriptionLifecycleRequest(JSON.stringify({
+      schemaVersion: 1,
+      issuanceIdempotencyKey: issuance.idempotencyKey,
+      eventId: "evt_admin_safe_reason",
+      eventCreatedAt: Math.floor(now.getTime() / 1_000),
+      provider: issuance.provider,
+      providerAccountId: issuance.providerAccountId,
+      providerMode: issuance.providerMode,
+      externalSubscriptionId: issuance.externalSubscriptionId,
+      providerEventType: "customer.subscription.deleted",
+      command: "revoke",
+      subscriptionStatus: "canceled",
+      cancelAtPeriodEnd: false
+    }), now);
+    store.applyCheckoutSubscriptionLifecycle(request);
+
+    lines = [];
+    assert.equal(runAdmin(["show", "--key", rawKey], store, out), 0);
+    const output = lines.join("\n");
+    assert.ok(output.includes("revocationReason=subscription_canceled"));
+    assert.ok(!output.includes("@"));
+    assert.doesNotMatch(output, /\u001b|forged-admin-line|cus_/);
   });
 
   it("bind-checkout-subscription dry-run writes nothing and emits only result plus fingerprint", () => {

--- a/services/license-api/test/admin.test.ts
+++ b/services/license-api/test/admin.test.ts
@@ -24,6 +24,34 @@ describe("admin issuance CLI", () => {
     return key;
   }
 
+  function issueLegacyCheckout(source = "checkout"): void {
+    store.issueIdempotentLicense("nd_live_legacyadminbackfillraw", {
+      idempotencyKey: "checkout-session:legacy-admin",
+      requestHash: "legacy-admin-request-hash",
+      source,
+      externalRef: "cs_legacy_admin",
+      plan: "monthly_support",
+      repoVisibilityScope: "private",
+      privateRepoAllowed: true,
+      updateEntitlement: true,
+      seats: 1,
+      expiresAt: "2026-08-13T00:00:00.000Z"
+    });
+  }
+
+  function bindArgs(extra: string[] = []): string[] {
+    return [
+      "bind-checkout-subscription",
+      "--issuance-idempotency-key", "checkout-session:legacy-admin",
+      "--provider", "stripe",
+      "--provider-account-id", "acct_admin_live",
+      "--provider-mode", "live",
+      "--external-subscription-id", "sub_legacy_admin",
+      "--external-checkout-id", "cs_legacy_admin",
+      ...extra
+    ];
+  }
+
   it("issue prints the raw key exactly once and stores only the hash", () => {
     const key = issue();
     // The key appears exactly once across all printed lines.
@@ -63,5 +91,99 @@ describe("admin issuance CLI", () => {
   it("revoke and show fail cleanly on an unknown key", () => {
     assert.equal(runAdmin(["revoke", "--key", "nd_live_unknownxxxxxxxxxxxxxxxxxxx"], store, out), 2);
     assert.equal(runAdmin(["show", "--key", "nd_live_unknownxxxxxxxxxxxxxxxxxxx"], store, out), 2);
+  });
+
+  it("bind-checkout-subscription dry-run writes nothing and emits only result plus fingerprint", () => {
+    issueLegacyCheckout();
+    lines = [];
+
+    assert.equal(runAdmin(bindArgs(["--dry-run"]), store, out), 0);
+    assert.equal(lines.length, 1);
+    const output = JSON.parse(lines[0]) as Record<string, unknown>;
+    assert.deepEqual(Object.keys(output).sort(), ["issuanceFingerprint", "result"]);
+    assert.equal(output.result, "would_bind");
+    assert.match(String(output.issuanceFingerprint), /^iss_[a-f0-9]{32}$/);
+
+    lines = [];
+    assert.equal(runAdmin(bindArgs(), store, out), 0);
+    assert.equal((JSON.parse(lines[0]) as Record<string, unknown>).result, "bound");
+  });
+
+  it("bind-checkout-subscription is redacted and identical replay is idempotent", () => {
+    issueLegacyCheckout();
+    const rawKey = "nd_live_legacyadminbackfillraw";
+    const licenseHash = store.getLicenseByKey(rawKey)!.licenseKeyHash;
+
+    assert.equal(runAdmin(bindArgs(), store, out), 0);
+    const first = JSON.parse(lines[0]) as Record<string, unknown>;
+    lines = [];
+    assert.equal(runAdmin(bindArgs(), store, out), 0);
+    const replay = JSON.parse(lines[0]) as Record<string, unknown>;
+
+    assert.equal(replay.result, "already_bound");
+    assert.equal(replay.issuanceFingerprint, first.issuanceFingerprint);
+    const output = JSON.stringify([first, replay]);
+    for (const secret of [
+      rawKey,
+      licenseHash,
+      "checkout-session:legacy-admin",
+      "acct_admin_live",
+      "sub_legacy_admin",
+      "cs_legacy_admin"
+    ]) {
+      assert.ok(!output.includes(secret));
+    }
+  });
+
+  it("bind-checkout-subscription classifies tuple conflicts, wrong source, and not found", () => {
+    issueLegacyCheckout();
+    assert.equal(runAdmin(bindArgs(), store, out), 0);
+
+    lines = [];
+    const changed = bindArgs();
+    changed[changed.indexOf("--external-subscription-id") + 1] = "sub_changed";
+    assert.equal(runAdmin(changed, store, out), 1);
+    assert.equal((JSON.parse(lines[0]) as Record<string, unknown>).result, "conflict");
+
+    store.close();
+    store = new LicenseStore(":memory:");
+    lines = [];
+    issueLegacyCheckout("admin");
+    assert.equal(runAdmin(bindArgs(), store, out), 1);
+    assert.equal((JSON.parse(lines[0]) as Record<string, unknown>).result, "wrong_source");
+
+    store.close();
+    store = new LicenseStore(":memory:");
+    lines = [];
+    assert.equal(runAdmin(bindArgs(), store, out), 1);
+    assert.equal((JSON.parse(lines[0]) as Record<string, unknown>).result, "not_found");
+  });
+
+  it("bind-checkout-subscription rejects missing values, positional args, unknown flags, and escalation", () => {
+    issueLegacyCheckout();
+    for (const extra of [
+      ["--raw-key", "nd_live_forbidden"],
+      ["--plan", "organization_support"],
+      ["--expires", "2099-01-01T00:00:00.000Z"],
+      ["--expiry", "2099-01-01T00:00:00.000Z"],
+      ["--seats", "99"],
+      ["--scope", "all"],
+      ["--ownership", "caller"],
+      ["--private-repo-allowed", "true"],
+      ["--update-entitlement"],
+      ["--unknown", "value"],
+      ["positional"],
+      ["--dry-run", "true"]
+    ]) {
+      lines = [];
+      assert.equal(runAdmin(bindArgs(extra), store, out), 2);
+      assert.deepEqual(JSON.parse(lines[0]), { result: "invalid" });
+    }
+
+    lines = [];
+    const missingValue = bindArgs();
+    missingValue.splice(missingValue.indexOf("--provider-account-id") + 1, 1);
+    assert.equal(runAdmin(missingValue, store, out), 2);
+    assert.deepEqual(JSON.parse(lines[0]), { result: "invalid" });
   });
 });

--- a/services/license-api/test/checkout-binding-backfill.test.ts
+++ b/services/license-api/test/checkout-binding-backfill.test.ts
@@ -92,9 +92,8 @@ function startBindingWorker(
   input: Record<string, unknown>
 ): {
   child: ChildProcess;
-  ready: Promise<void>;
-  outcome: Promise<WorkerOutcome>;
-  exited: Promise<void>;
+  ready: Promise<boolean>;
+  completion: Promise<WorkerOutcome>;
 } {
   const child = fork(new URL("./fixtures/checkout-binding-worker.ts", import.meta.url), [], {
     execArgv: ["--import", "tsx"],
@@ -110,67 +109,81 @@ function startBindingWorker(
   child.stderr?.on("data", (chunk: string) => {
     stderr += chunk;
   });
-  let readyResolve!: () => void;
-  let readyReject!: (error: Error) => void;
-  const ready = new Promise<void>((resolve, reject) => {
+  let readyResolve!: (ready: boolean) => void;
+  const ready = new Promise<boolean>((resolve) => {
     readyResolve = resolve;
-    readyReject = reject;
   });
-  let outcomeResolve!: (outcome: WorkerOutcome) => void;
-  let outcomeReject!: (error: Error) => void;
-  const outcome = new Promise<WorkerOutcome>((resolve, reject) => {
-    outcomeResolve = resolve;
-    outcomeReject = reject;
+  let completionResolve!: (outcome: WorkerOutcome) => void;
+  let completionReject!: (error: Error) => void;
+  const completion = new Promise<WorkerOutcome>((resolve, reject) => {
+    completionResolve = resolve;
+    completionReject = reject;
   });
-  let exitResolve!: () => void;
-  let exitReject!: (error: Error) => void;
-  const exited = new Promise<void>((resolve, reject) => {
-    exitResolve = resolve;
-    exitReject = reject;
-  });
+  let readySettled = false;
   let readyReceived = false;
-  let outcomeReceived = false;
+  let outcome: WorkerOutcome | undefined;
+  let failure: Error | undefined;
+
+  const settleReady = (value: boolean): void => {
+    if (readySettled) return;
+    readySettled = true;
+    readyResolve(value);
+  };
+  const failAndKill = (error: Error): void => {
+    failure ??= error;
+    settleReady(false);
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+  };
   const timeout = setTimeout(() => {
-    child.kill("SIGKILL");
-    const error = new Error(`checkout binding worker timed out${stderr ? `: ${stderr}` : ""}`);
-    readyReject(error);
-    outcomeReject(error);
-    exitReject(error);
+    failAndKill(
+      new Error(`checkout binding worker timed out${stderr ? `: ${stderr}` : ""}`)
+    );
   }, 5_000);
   child.on("message", (message: unknown) => {
-    const value = message as WorkerOutcome & { type: string };
+    const value = message as WorkerOutcome & { type: string; storeOpened?: boolean };
     if (value.type === "ready") {
+      if (readyReceived || value.storeOpened !== true) {
+        failAndKill(new Error("checkout binding worker READY before store opened"));
+        return;
+      }
       readyReceived = true;
-      readyResolve();
+      settleReady(true);
     } else if (value.type === "result" || value.type === "error") {
-      outcomeReceived = true;
-      outcomeResolve(value);
+      if (!readyReceived || outcome) {
+        failAndKill(new Error("checkout binding worker sent an invalid outcome"));
+        return;
+      }
+      outcome = value;
+    } else {
+      failAndKill(new Error("checkout binding worker sent an invalid protocol message"));
     }
   });
   child.on("error", (error) => {
-    clearTimeout(timeout);
-    readyReject(error);
-    outcomeReject(error);
-    exitReject(error);
+    failAndKill(error);
   });
   child.on("exit", (code, signal) => {
     clearTimeout(timeout);
-    if (code !== 0 || signal !== null || stderr.length > 0 || !readyReceived || !outcomeReceived) {
+    settleReady(false);
+    if (
+      failure ||
+      code !== 0 ||
+      signal !== null ||
+      stderr.length > 0 ||
+      !readyReceived ||
+      !outcome
+    ) {
       const details = [
         `checkout binding worker exited ${code ?? signal}`,
         !readyReceived ? "without READY" : "",
-        !outcomeReceived ? "without outcome" : "",
+        !outcome ? "without outcome" : "",
         stderr ? `stderr: ${stderr}` : ""
       ].filter(Boolean).join("; ");
-      const error = new Error(details);
-      readyReject(error);
-      outcomeReject(error);
-      exitReject(error);
+      completionReject(failure ?? new Error(details));
       return;
     }
-    exitResolve();
+    completionResolve(outcome);
   });
-  return { child, ready, outcome, exited };
+  return { child, ready, completion };
 }
 
 async function concurrentBindings(
@@ -180,18 +193,31 @@ async function concurrentBindings(
 ): Promise<WorkerOutcome[]> {
   const first = startBindingWorker(path, firstInput);
   const second = startBindingWorker(path, secondInput);
+  const workers = [first, second];
+  const completions = Promise.allSettled(workers.map((worker) => worker.completion));
   try {
-    await Promise.all([first.ready, second.ready]);
+    const ready = await Promise.all(workers.map((worker) => worker.ready));
+    if (!ready.every(Boolean)) {
+      const settled = await completions;
+      const failure = settled.find(
+        (result): result is PromiseRejectedResult => result.status === "rejected"
+      );
+      throw failure?.reason ?? new Error("checkout binding worker exited before READY");
+    }
     first.child.send("GO");
     second.child.send("GO");
-    const outcomes = await Promise.all([first.outcome, second.outcome]);
-    await Promise.all([first.exited, second.exited]);
-    return outcomes;
+    const settled = await completions;
+    const failure = settled.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected"
+    );
+    if (failure) throw failure.reason;
+    return settled.map((result) => (result as PromiseFulfilledResult<WorkerOutcome>).value);
   } finally {
-    for (const child of [first.child, second.child]) {
-      if (child.connected) child.disconnect();
+    for (const { child } of workers) {
       if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      if (child.connected) child.disconnect();
     }
+    await completions;
   }
 }
 

--- a/services/license-api/test/checkout-binding-backfill.test.ts
+++ b/services/license-api/test/checkout-binding-backfill.test.ts
@@ -238,10 +238,14 @@ describe("checkout subscription binding backfill store", () => {
   });
 
   it("rejects legacy entitlements that the subscription lifecycle cannot project", () => {
-    for (const [label, plan, expiresAt] of [
-      ["missing expiry", "monthly_support", undefined],
-      ["invalid expiry", "monthly_support", "not-a-timestamp"],
-      ["unsupported plan", "legacy_lifetime", "2026-08-13T00:00:00.000Z"]
+    for (const [label, overrides] of [
+      ["missing expiry", { expiresAt: undefined }],
+      ["invalid expiry", { expiresAt: "not-a-timestamp" }],
+      ["unsupported plan", { plan: "legacy_lifetime" }],
+      ["multiple seats", { seats: 2 }],
+      ["public scope", { repoVisibilityScope: "public" }],
+      ["private repositories disabled", { privateRepoAllowed: false }],
+      ["updates disabled", { updateEntitlement: false }]
     ] as const) {
       const path = databasePath();
       const store = new LicenseStore(path);
@@ -251,12 +255,13 @@ describe("checkout subscription binding backfill store", () => {
           requestHash: `legacy-request-hash:${label}`,
           source: "checkout",
           externalRef: "legacy-checkout-reference",
-          plan,
+          plan: "monthly_support",
           repoVisibilityScope: "private",
           privateRepoAllowed: true,
           updateEntitlement: true,
           seats: 1,
-          ...(expiresAt !== undefined ? { expiresAt } : {})
+          expiresAt: "2026-08-13T00:00:00.000Z",
+          ...overrides
         });
 
         assert.throws(

--- a/services/license-api/test/checkout-binding-backfill.test.ts
+++ b/services/license-api/test/checkout-binding-backfill.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { afterEach, describe, it } from "node:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { LicenseStore } from "../src/store.ts";
+
+const tempDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function databasePath(): string {
+  const directory = mkdtempSync(join(tmpdir(), "neondiff-checkout-backfill-"));
+  tempDirectories.push(directory);
+  return join(directory, "license.sqlite");
+}
+
+function binding(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    issuanceIdempotencyKey: "checkout-session:legacy-backfill",
+    provider: "stripe",
+    providerAccountId: "acct_product_live",
+    providerMode: "live",
+    externalSubscriptionId: "sub_legacy_backfill",
+    externalCheckoutId: "cs_legacy_backfill",
+    ...overrides
+  };
+}
+
+function issueLegacyCheckout(store: LicenseStore, source = "checkout"): void {
+  store.issueIdempotentLicense("nd_live_legacybackfillrawmaterial", {
+    idempotencyKey: "checkout-session:legacy-backfill",
+    requestHash: "legacy-request-hash",
+    source,
+    externalRef: "legacy-checkout-reference",
+    plan: "monthly_support",
+    repoVisibilityScope: "private",
+    privateRepoAllowed: true,
+    updateEntitlement: true,
+    seats: 1,
+    expiresAt: "2026-08-13T00:00:00.000Z"
+  });
+}
+
+function bind(store: LicenseStore, input = binding(), dryRun = false): Record<string, unknown> {
+  return (
+    store as unknown as {
+      bindCheckoutSubscription(
+        input: Record<string, unknown>,
+        options?: { dryRun?: boolean }
+      ): Record<string, unknown>;
+    }
+  ).bindCheckoutSubscription(input, { dryRun });
+}
+
+function bindingCount(path: string): number {
+  const db = new DatabaseSync(path);
+  try {
+    return Number(
+      (db.prepare("select count(*) as count from checkout_subscription_bindings").get() as {
+        count: number;
+      }).count
+    );
+  } finally {
+    db.close();
+  }
+}
+
+function errorName(error: unknown): string {
+  return error instanceof Error ? error.constructor.name : "";
+}
+
+describe("checkout subscription binding backfill store", () => {
+  it("dry-runs an existing checkout issuance with zero writes", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path);
+    try {
+      issueLegacyCheckout(store);
+      const result = bind(store, binding(), true);
+
+      assert.equal(result.result, "would_bind");
+      assert.match(String(result.issuanceFingerprint), /^iss_[a-f0-9]{32}$/);
+      assert.equal(bindingCount(path), 0);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("binds once and makes identical replay idempotent across store connections", () => {
+    const path = databasePath();
+    const first = new LicenseStore(path);
+    const second = new LicenseStore(path);
+    try {
+      issueLegacyCheckout(first);
+      const created = bind(first);
+      const replayed = bind(second);
+
+      assert.equal(created.result, "bound");
+      assert.equal(replayed.result, "already_bound");
+      assert.equal(replayed.issuanceFingerprint, created.issuanceFingerprint);
+      assert.equal(bindingCount(path), 1);
+    } finally {
+      second.close();
+      first.close();
+    }
+  });
+
+  it("conflicts when any immutable tuple field differs", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path);
+    try {
+      issueLegacyCheckout(store);
+      bind(store);
+      for (const changed of [
+        { providerAccountId: "acct_other" },
+        { providerMode: "test" },
+        { externalSubscriptionId: "sub_other" },
+        { externalCheckoutId: "cs_other" }
+      ]) {
+        assert.throws(
+          () => bind(store, binding(changed)),
+          (error: unknown) => errorName(error) === "CheckoutBindingConflictError"
+        );
+      }
+      assert.equal(bindingCount(path), 1);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("classifies missing issuance, wrong source, and missing license separately", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path);
+    try {
+      assert.throws(
+        () => bind(store),
+        (error: unknown) => errorName(error) === "CheckoutBindingNotFoundError"
+      );
+      issueLegacyCheckout(store, "admin");
+      assert.throws(
+        () => bind(store),
+        (error: unknown) => errorName(error) === "CheckoutBindingWrongSourceError"
+      );
+      store.close();
+
+      const db = new DatabaseSync(path);
+      db.exec("pragma foreign_keys = off");
+      db.prepare("update license_issuance_events set source = 'checkout'").run();
+      db.prepare("delete from licenses").run();
+      db.close();
+
+      const orphaned = new LicenseStore(path);
+      try {
+        assert.throws(
+          () => bind(orphaned),
+          (error: unknown) => errorName(error) === "CheckoutBindingNotFoundError"
+        );
+      } finally {
+        orphaned.close();
+      }
+    } finally {
+      try {
+        store.close();
+      } catch {}
+    }
+  });
+
+  it("validates direct-store input and rejects escalation fields", () => {
+    const store = new LicenseStore(":memory:");
+    try {
+      issueLegacyCheckout(store);
+      for (const input of [
+        binding({ rawKey: "nd_live_forbidden" }),
+        binding({ plan: "organization_support" }),
+        binding({ expiresAt: "2099-01-01T00:00:00.000Z" }),
+        binding({ seats: 99 }),
+        binding({ scope: "all" }),
+        binding({ ownership: "caller" }),
+        binding({ repoVisibilityScope: "all" }),
+        binding({ privateRepoAllowed: true }),
+        binding({ updateEntitlement: true }),
+        binding({ provider: "other" }),
+        binding({ providerMode: "staging" })
+      ]) {
+        assert.throws(
+          () => bind(store, input),
+          (error: unknown) => errorName(error) === "CheckoutBindingPolicyError"
+        );
+      }
+    } finally {
+      store.close();
+    }
+  });
+
+  it("bounds write-lock contention and persists no binding", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path, { busyTimeoutMs: 25 });
+    const blocker = new DatabaseSync(path);
+    try {
+      issueLegacyCheckout(store);
+      blocker.exec("begin immediate");
+      const startedAt = Date.now();
+      assert.throws(
+        () => bind(store),
+        (error: unknown) => errorName(error) === "CheckoutBindingTransientError"
+      );
+      assert.ok(Date.now() - startedAt < 1_000);
+      blocker.exec("rollback");
+      assert.equal(bindingCount(path), 0);
+    } finally {
+      try {
+        blocker.exec("rollback");
+      } catch {}
+      blocker.close();
+      store.close();
+    }
+  });
+});

--- a/services/license-api/test/checkout-binding-backfill.test.ts
+++ b/services/license-api/test/checkout-binding-backfill.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { fork, type ChildProcess } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import { afterEach, describe, it } from "node:test";
 import { tmpdir } from "node:os";
@@ -32,10 +33,15 @@ function binding(overrides: Record<string, unknown> = {}): Record<string, unknow
   };
 }
 
-function issueLegacyCheckout(store: LicenseStore, source = "checkout"): void {
-  store.issueIdempotentLicense("nd_live_legacybackfillrawmaterial", {
-    idempotencyKey: "checkout-session:legacy-backfill",
-    requestHash: "legacy-request-hash",
+function issueLegacyCheckout(
+  store: LicenseStore,
+  source = "checkout",
+  idempotencyKey = "checkout-session:legacy-backfill",
+  rawKey = "nd_live_legacybackfillrawmaterial"
+): void {
+  store.issueIdempotentLicense(rawKey, {
+    idempotencyKey,
+    requestHash: `legacy-request-hash:${idempotencyKey}`,
     source,
     externalRef: "legacy-checkout-reference",
     plan: "monthly_support",
@@ -73,6 +79,120 @@ function bindingCount(path: string): number {
 
 function errorName(error: unknown): string {
   return error instanceof Error ? error.constructor.name : "";
+}
+
+interface WorkerOutcome {
+  type: "result" | "error";
+  result?: string;
+  errorName?: string;
+}
+
+function startBindingWorker(
+  path: string,
+  input: Record<string, unknown>
+): {
+  child: ChildProcess;
+  ready: Promise<void>;
+  outcome: Promise<WorkerOutcome>;
+  exited: Promise<void>;
+} {
+  const child = fork(new URL("./fixtures/checkout-binding-worker.ts", import.meta.url), [], {
+    execArgv: ["--import", "tsx"],
+    env: {
+      ...process.env,
+      CHECKOUT_BINDING_DB_PATH: path,
+      CHECKOUT_BINDING_INPUT: JSON.stringify(input)
+    },
+    stdio: ["ignore", "pipe", "pipe", "ipc"]
+  });
+  let stderr = "";
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  let readyResolve!: () => void;
+  let readyReject!: (error: Error) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    readyResolve = resolve;
+    readyReject = reject;
+  });
+  let outcomeResolve!: (outcome: WorkerOutcome) => void;
+  let outcomeReject!: (error: Error) => void;
+  const outcome = new Promise<WorkerOutcome>((resolve, reject) => {
+    outcomeResolve = resolve;
+    outcomeReject = reject;
+  });
+  let exitResolve!: () => void;
+  let exitReject!: (error: Error) => void;
+  const exited = new Promise<void>((resolve, reject) => {
+    exitResolve = resolve;
+    exitReject = reject;
+  });
+  let readyReceived = false;
+  let outcomeReceived = false;
+  const timeout = setTimeout(() => {
+    child.kill("SIGKILL");
+    const error = new Error(`checkout binding worker timed out${stderr ? `: ${stderr}` : ""}`);
+    readyReject(error);
+    outcomeReject(error);
+    exitReject(error);
+  }, 5_000);
+  child.on("message", (message: unknown) => {
+    const value = message as WorkerOutcome & { type: string };
+    if (value.type === "ready") {
+      readyReceived = true;
+      readyResolve();
+    } else if (value.type === "result" || value.type === "error") {
+      outcomeReceived = true;
+      outcomeResolve(value);
+    }
+  });
+  child.on("error", (error) => {
+    clearTimeout(timeout);
+    readyReject(error);
+    outcomeReject(error);
+    exitReject(error);
+  });
+  child.on("exit", (code, signal) => {
+    clearTimeout(timeout);
+    if (code !== 0 || signal !== null || stderr.length > 0 || !readyReceived || !outcomeReceived) {
+      const details = [
+        `checkout binding worker exited ${code ?? signal}`,
+        !readyReceived ? "without READY" : "",
+        !outcomeReceived ? "without outcome" : "",
+        stderr ? `stderr: ${stderr}` : ""
+      ].filter(Boolean).join("; ");
+      const error = new Error(details);
+      readyReject(error);
+      outcomeReject(error);
+      exitReject(error);
+      return;
+    }
+    exitResolve();
+  });
+  return { child, ready, outcome, exited };
+}
+
+async function concurrentBindings(
+  path: string,
+  firstInput: Record<string, unknown>,
+  secondInput: Record<string, unknown>
+): Promise<WorkerOutcome[]> {
+  const first = startBindingWorker(path, firstInput);
+  const second = startBindingWorker(path, secondInput);
+  try {
+    await Promise.all([first.ready, second.ready]);
+    first.child.send("GO");
+    second.child.send("GO");
+    const outcomes = await Promise.all([first.outcome, second.outcome]);
+    await Promise.all([first.exited, second.exited]);
+    return outcomes;
+  } finally {
+    for (const child of [first.child, second.child]) {
+      if (child.connected) child.disconnect();
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    }
+  }
 }
 
 describe("checkout subscription binding backfill store", () => {
@@ -130,6 +250,164 @@ describe("checkout subscription binding backfill store", () => {
       assert.equal(bindingCount(path), 1);
     } finally {
       store.close();
+    }
+  });
+
+  it("conflicts without overwrite when a second real issuance claims the same unique tuple", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path);
+    try {
+      issueLegacyCheckout(store);
+      issueLegacyCheckout(
+        store,
+        "checkout",
+        "checkout-session:second-legacy-backfill",
+        "nd_live_secondlegacybackfillraw"
+      );
+      bind(store);
+      const second = binding({
+        issuanceIdempotencyKey: "checkout-session:second-legacy-backfill"
+      });
+
+      assert.throws(
+        () => bind(store, second),
+        (error: unknown) => errorName(error) === "CheckoutBindingConflictError"
+      );
+      const db = new DatabaseSync(path);
+      try {
+        const rows = db
+          .prepare(
+            `select issuance_idempotency_key, external_subscription_id
+             from checkout_subscription_bindings`
+          )
+          .all() as unknown as Array<Record<string, unknown>>;
+        assert.deepEqual(rows.map((row) => ({ ...row })), [{
+          issuance_idempotency_key: "checkout-session:legacy-backfill",
+          external_subscription_id: "sub_legacy_backfill"
+        }]);
+      } finally {
+        db.close();
+      }
+    } finally {
+      store.close();
+    }
+  });
+
+  it("conflicts without overwrite when issuance and binding point to different real licenses", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path);
+    try {
+      issueLegacyCheckout(store);
+      issueLegacyCheckout(
+        store,
+        "checkout",
+        "checkout-session:other-real-license",
+        "nd_live_otherreallicensebackfillraw"
+      );
+      bind(store);
+      const db = new DatabaseSync(path);
+      try {
+        db.exec("pragma foreign_keys = off");
+        db.prepare(
+          `update license_issuance_events
+           set license_key_hash = (
+             select license_key_hash from license_issuance_events where idempotency_key = ?
+           )
+           where idempotency_key = ?`
+        ).run("checkout-session:other-real-license", "checkout-session:legacy-backfill");
+      } finally {
+        db.close();
+      }
+
+      assert.throws(
+        () => bind(store),
+        (error: unknown) => errorName(error) === "CheckoutBindingConflictError"
+      );
+      const verification = new DatabaseSync(path);
+      try {
+        const row = verification
+          .prepare(
+            `select issuance_idempotency_key, license_key_hash
+             from checkout_subscription_bindings`
+          )
+          .get() as Record<string, unknown>;
+        assert.equal(row.issuance_idempotency_key, "checkout-session:legacy-backfill");
+        assert.notEqual(
+          row.license_key_hash,
+          store.getLicenseByKey("nd_live_otherreallicensebackfillraw")!.licenseKeyHash
+        );
+      } finally {
+        verification.close();
+      }
+    } finally {
+      store.close();
+    }
+  });
+
+  it("serializes genuinely concurrent identical attempts to bound and already_bound", async () => {
+    const path = databasePath();
+    const store = new LicenseStore(path);
+    issueLegacyCheckout(store);
+    store.close();
+
+    const outcomes = await concurrentBindings(path, binding(), binding());
+    assert.deepEqual(
+      outcomes.map((outcome) => outcome.result ?? outcome.errorName).sort(),
+      ["already_bound", "bound"]
+    );
+    assert.equal(bindingCount(path), 1);
+  });
+
+  it("serializes genuinely concurrent competing tuples to bound and typed conflict", async () => {
+    const path = databasePath();
+    const store = new LicenseStore(path);
+    issueLegacyCheckout(store);
+    const licenseKeyHash = store.getLicenseByKey("nd_live_legacybackfillrawmaterial")!
+      .licenseKeyHash;
+    store.close();
+
+    const firstInput = binding();
+    const secondInput = binding({ externalSubscriptionId: "sub_competing_backfill" });
+    const outcomes = await concurrentBindings(
+      path,
+      firstInput,
+      secondInput
+    );
+    assert.deepEqual(
+      outcomes.map((outcome) => outcome.result ?? outcome.errorName).sort(),
+      ["CheckoutBindingConflictError", "bound"]
+    );
+    const db = new DatabaseSync(path);
+    try {
+      const rows = db.prepare(
+        `select issuance_idempotency_key, license_key_hash, provider, provider_account_id,
+                provider_mode, external_subscription_id, external_checkout_id
+         from checkout_subscription_bindings`
+      ).all() as unknown as Array<Record<string, unknown>>;
+      assert.equal(rows.length, 1);
+      const persisted = { ...rows[0] };
+      const candidates = [firstInput, secondInput].map((candidate) => ({
+        issuance_idempotency_key: candidate.issuanceIdempotencyKey,
+        license_key_hash: licenseKeyHash,
+        provider: candidate.provider,
+        provider_account_id: candidate.providerAccountId,
+        provider_mode: candidate.providerMode,
+        external_subscription_id: candidate.externalSubscriptionId,
+        external_checkout_id: candidate.externalCheckoutId
+      }));
+      assert.ok(
+        candidates.some((candidate) => {
+          try {
+            assert.deepEqual(persisted, candidate);
+            return true;
+          } catch {
+            return false;
+          }
+        }),
+        "persisted binding must equal one complete competing tuple"
+      );
+    } finally {
+      db.close();
     }
   });
 
@@ -192,6 +470,40 @@ describe("checkout subscription binding backfill store", () => {
           (error: unknown) => errorName(error) === "CheckoutBindingPolicyError"
         );
       }
+    } finally {
+      store.close();
+    }
+  });
+
+  it("does not echo caller-controlled unknown field or option names", () => {
+    const store = new LicenseStore(":memory:");
+    try {
+      issueLegacyCheckout(store);
+      const fieldSentinel = "private_customer_field_sentinel";
+      const optionSentinel = "private_customer_option_sentinel";
+      assert.throws(
+        () => bind(store, binding({ [fieldSentinel]: "value" })),
+        (error: unknown) =>
+          errorName(error) === "CheckoutBindingPolicyError" &&
+          error instanceof Error &&
+          error.message === "unsupported checkout binding field" &&
+          !error.message.includes(fieldSentinel)
+      );
+      assert.throws(
+        () => (
+          store as unknown as {
+            bindCheckoutSubscription(
+              input: Record<string, unknown>,
+              options: Record<string, unknown>
+            ): unknown;
+          }
+        ).bindCheckoutSubscription(binding(), { [optionSentinel]: true }),
+        (error: unknown) =>
+          errorName(error) === "CheckoutBindingPolicyError" &&
+          error instanceof Error &&
+          error.message === "unsupported checkout binding option" &&
+          !error.message.includes(optionSentinel)
+      );
     } finally {
       store.close();
     }

--- a/services/license-api/test/checkout-binding-backfill.test.ts
+++ b/services/license-api/test/checkout-binding-backfill.test.ts
@@ -237,6 +237,40 @@ describe("checkout subscription binding backfill store", () => {
     }
   });
 
+  it("rejects legacy entitlements that the subscription lifecycle cannot project", () => {
+    for (const [label, plan, expiresAt] of [
+      ["missing expiry", "monthly_support", undefined],
+      ["invalid expiry", "monthly_support", "not-a-timestamp"],
+      ["unsupported plan", "legacy_lifetime", "2026-08-13T00:00:00.000Z"]
+    ] as const) {
+      const path = databasePath();
+      const store = new LicenseStore(path);
+      try {
+        store.issueIdempotentLicense(`nd_live_${label.replaceAll(" ", "")}`, {
+          idempotencyKey: "checkout-session:legacy-backfill",
+          requestHash: `legacy-request-hash:${label}`,
+          source: "checkout",
+          externalRef: "legacy-checkout-reference",
+          plan,
+          repoVisibilityScope: "private",
+          privateRepoAllowed: true,
+          updateEntitlement: true,
+          seats: 1,
+          ...(expiresAt !== undefined ? { expiresAt } : {})
+        });
+
+        assert.throws(
+          () => bind(store),
+          (error: unknown) => errorName(error) === "CheckoutBindingConflictError",
+          label
+        );
+        assert.equal(bindingCount(path), 0, label);
+      } finally {
+        store.close();
+      }
+    }
+  });
+
   it("binds once and makes identical replay idempotent across store connections", () => {
     const path = databasePath();
     const first = new LicenseStore(path);

--- a/services/license-api/test/fixtures/checkout-binding-worker.ts
+++ b/services/license-api/test/fixtures/checkout-binding-worker.ts
@@ -1,0 +1,30 @@
+import { LicenseStore } from "../../src/store.ts";
+
+const dbPath = process.env.CHECKOUT_BINDING_DB_PATH;
+const inputJson = process.env.CHECKOUT_BINDING_INPUT;
+if (!dbPath || !inputJson || !process.send) {
+  throw new Error("checkout binding worker configuration is missing");
+}
+
+process.send({ type: "ready" });
+
+process.once("message", (message: unknown) => {
+  if (message !== "GO") {
+    process.send?.({ type: "protocol_error" });
+    process.disconnect();
+    return;
+  }
+  const store = new LicenseStore(dbPath, { busyTimeoutMs: 1_000 });
+  try {
+    const result = store.bindCheckoutSubscription(JSON.parse(inputJson));
+    process.send?.({ type: "result", result: result.result });
+  } catch (error) {
+    process.send?.({
+      type: "error",
+      errorName: error instanceof Error ? error.constructor.name : "UnknownError"
+    });
+  } finally {
+    store.close();
+    process.disconnect();
+  }
+});

--- a/services/license-api/test/fixtures/checkout-binding-worker.ts
+++ b/services/license-api/test/fixtures/checkout-binding-worker.ts
@@ -5,18 +5,27 @@ const inputJson = process.env.CHECKOUT_BINDING_INPUT;
 if (!dbPath || !inputJson || !process.send) {
   throw new Error("checkout binding worker configuration is missing");
 }
+const input = JSON.parse(inputJson);
+const store = new LicenseStore(dbPath, { busyTimeoutMs: 1_000 });
+let storeClosed = false;
 
-process.send({ type: "ready" });
+function closeStore(): void {
+  if (storeClosed) return;
+  storeClosed = true;
+  store.close();
+}
+
+process.send({ type: "ready", storeOpened: true });
 
 process.once("message", (message: unknown) => {
   if (message !== "GO") {
     process.send?.({ type: "protocol_error" });
+    closeStore();
     process.disconnect();
     return;
   }
-  const store = new LicenseStore(dbPath, { busyTimeoutMs: 1_000 });
   try {
-    const result = store.bindCheckoutSubscription(JSON.parse(inputJson));
+    const result = store.bindCheckoutSubscription(input);
     process.send?.({ type: "result", result: result.result });
   } catch (error) {
     process.send?.({
@@ -24,7 +33,9 @@ process.once("message", (message: unknown) => {
       errorName: error instanceof Error ? error.constructor.name : "UnknownError"
     });
   } finally {
-    store.close();
+    closeStore();
     process.disconnect();
   }
 });
+
+process.once("disconnect", closeStore);

--- a/services/license-api/test/http.test.ts
+++ b/services/license-api/test/http.test.ts
@@ -297,7 +297,8 @@ describe("license issuance transport", () => {
         auth
       );
       assert.equal(response.status, 400);
-      assert.equal(response.json.detail, `unknown field: ${field}`);
+      assert.equal(response.json.detail, "request contains an unknown field");
+      assert.ok(!JSON.stringify(response.json).includes(field));
     }
   });
 

--- a/services/license-api/test/http.test.ts
+++ b/services/license-api/test/http.test.ts
@@ -325,6 +325,7 @@ describe("lifecycle issuance transport", () => {
     const started = await startLicenseServer({
       store: isolatedStore,
       issuanceSecret: "lifecycle-issuance-secret",
+      trustFlyProxyHeaders: true,
       lifecycleRateLimiter: new RateLimiter({ maxPerWindow: 1, windowMs: 60_000 }),
       lifecycleOidcVerifier: {
         verify: async () => {
@@ -364,6 +365,7 @@ describe("lifecycle issuance transport", () => {
     const started = await startLicenseServer({
       store: isolatedStore,
       issuanceSecret: "lifecycle-issuance-secret",
+      trustFlyProxyHeaders: true,
       lifecycleRateLimiter: new RateLimiter({ maxPerWindow: 1, windowMs: 60_000 }),
       lifecycleOidcVerifier: {
         verify: async () => {
@@ -412,6 +414,44 @@ describe("lifecycle issuance transport", () => {
       );
       assert.equal(response.status, 413);
       assert.equal(response.json.status, "invalid");
+    } finally {
+      started.server.close();
+      isolatedStore.close();
+    }
+  });
+
+  it("ignores forged Fly client addresses for direct OIDC lifecycle requests", async () => {
+    const isolatedStore = new LicenseStore(":memory:");
+    let verifierCalls = 0;
+    const started = await startLicenseServer({
+      store: isolatedStore,
+      issuanceSecret: "lifecycle-issuance-secret",
+      lifecycleRateLimiter: new RateLimiter({ maxPerWindow: 1, windowMs: 60_000 }),
+      lifecycleOidcVerifier: {
+        verify: async () => {
+          verifierCalls += 1;
+          throw new Error("invalid fixture token");
+        }
+      }
+    });
+    const body = {
+      releaseVersion: "v1.0.4",
+      candidateHead: "a".repeat(40),
+      packShasum: "b".repeat(40),
+      packIntegrity: `sha512-${"Y".repeat(86)}==`
+    };
+    try {
+      const first = await post(started.url, "/v1/admin/licenses/issue-lifecycle", body, {
+        Authorization: "Bearer first.invalid.token",
+        "Fly-Client-IP": "203.0.113.21"
+      });
+      const forgedRotation = await post(started.url, "/v1/admin/licenses/issue-lifecycle", body, {
+        Authorization: "Bearer second.invalid.token",
+        "Fly-Client-IP": "203.0.113.22"
+      });
+      assert.equal(first.status, 401);
+      assert.equal(forgedRotation.status, 429);
+      assert.equal(verifierCalls, 1);
     } finally {
       started.server.close();
       isolatedStore.close();

--- a/services/license-api/test/http.test.ts
+++ b/services/license-api/test/http.test.ts
@@ -7,6 +7,19 @@ import { RateLimiter } from "../src/service.ts";
 
 const fakeKey = (tag: string): string => ["nd", "live", `${tag}${"x".repeat(24 - tag.length)}`].join("_");
 
+function checkoutBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    idempotencyKey: "checkout-session:http-default",
+    checkoutLookupKey: "neondiff_monthly",
+    provider: "stripe",
+    providerAccountId: "acct_http_live",
+    providerMode: "live",
+    externalSubscriptionId: "sub_http_default",
+    externalCheckoutId: "cs_http_default",
+    ...overrides
+  };
+}
+
 async function post(
   url: string,
   path: string,
@@ -140,15 +153,13 @@ describe("license issuance transport", () => {
     const issued = await post(
       url,
       "/v1/admin/licenses/issue",
-      {
+      checkoutBody({
         idempotencyKey: "checkout-session-123",
         checkoutLookupKey: "neondiff_org_yearly",
-        customerEmail: "buyer@example.com",
-        externalCustomerId: "cus_123",
+        externalSubscriptionId: "sub_123",
         externalCheckoutId: "cs_123",
-        seats: 3,
-        expiresAt: "2027-07-08T00:00:00.000Z"
-      },
+        seats: 1
+      }),
       auth
     );
     assert.equal(issued.status, 200);
@@ -158,14 +169,16 @@ describe("license issuance transport", () => {
     assert.equal(issued.json.entitlement.plan, "org_yearly_support");
     assert.equal(issued.json.entitlement.repoVisibilityScope, "private");
     assert.equal(issued.json.entitlement.updateEntitlement, true);
-    assert.equal(issued.json.entitlement.seats, 3);
+    assert.equal(issued.json.entitlement.seats, 1);
+    assert.equal(issued.json.entitlement.expiresAt, "2026-08-07T00:00:00.000Z");
 
     const record = store.getLicenseByKey(issued.json.licenseKey);
     assert.ok(record);
     assert.equal(record.plan, "org_yearly_support");
     assert.equal(record.repoVisibilityScope, "private");
     assert.equal(record.updateEntitlement, true);
-    assert.equal(record.seats, 3);
+    assert.equal(record.seats, 1);
+    assert.equal(record.expiresAt, "2026-08-07T00:00:00.000Z");
 
     const activated = await post(url, "/v1/license/activate", {
       licenseKey: issued.json.licenseKey,
@@ -177,11 +190,12 @@ describe("license issuance transport", () => {
   });
 
   it("replays the same idempotency key without minting a duplicate license", async () => {
-    const body = {
+    const body = checkoutBody({
       idempotencyKey: "checkout-session-repeat",
       checkoutLookupKey: "neondiff_yearly",
+      externalSubscriptionId: "sub_repeat",
       externalCheckoutId: "cs_repeat"
-    };
+    });
     const first = await post(url, "/v1/admin/licenses/issue", body, auth);
     const second = await post(url, "/v1/admin/licenses/issue", body, auth);
     assert.equal(first.status, 200);
@@ -198,14 +212,23 @@ describe("license issuance transport", () => {
     const first = await post(
       url,
       "/v1/admin/licenses/issue",
-      { idempotencyKey: "checkout-session-conflict", checkoutLookupKey: "neondiff_monthly" },
+      checkoutBody({
+        idempotencyKey: "checkout-session-conflict",
+        externalSubscriptionId: "sub_conflict",
+        externalCheckoutId: "cs_conflict"
+      }),
       auth
     );
     assert.equal(first.status, 200);
     const conflict = await post(
       url,
       "/v1/admin/licenses/issue",
-      { idempotencyKey: "checkout-session-conflict", checkoutLookupKey: "neondiff_org_yearly" },
+      checkoutBody({
+        idempotencyKey: "checkout-session-conflict",
+        checkoutLookupKey: "neondiff_org_yearly",
+        externalSubscriptionId: "sub_conflict",
+        externalCheckoutId: "cs_conflict"
+      }),
       auth
     );
     assert.equal(conflict.status, 409);
@@ -216,11 +239,80 @@ describe("license issuance transport", () => {
     const res = await post(
       url,
       "/v1/admin/licenses/issue",
-      { idempotencyKey: "checkout-session-bad-plan", checkoutLookupKey: "neondiff_lifetime" },
+      checkoutBody({
+        idempotencyKey: "checkout-session-bad-plan",
+        checkoutLookupKey: "neondiff_lifetime",
+        externalSubscriptionId: "sub_bad_plan",
+        externalCheckoutId: "cs_bad_plan"
+      }),
       auth
     );
     assert.equal(res.status, 400);
     assert.equal(res.json.status, "invalid");
+  });
+
+  it("requires the complete checkout correlation tuple", async () => {
+    for (const field of [
+      "provider",
+      "providerAccountId",
+      "providerMode",
+      "externalSubscriptionId",
+      "externalCheckoutId"
+    ]) {
+      const body = checkoutBody({
+        idempotencyKey: `checkout-session:missing-${field}`,
+        externalSubscriptionId: `sub_missing_${field}`,
+        externalCheckoutId: `cs_missing_${field}`
+      });
+      delete body[field];
+      const response = await post(url, "/v1/admin/licenses/issue", body, auth);
+      assert.equal(response.status, 400);
+      assert.match(response.json.detail, new RegExp(`${field} is required`));
+    }
+  });
+
+  it("rejects caller entitlement authority and unknown fields", async () => {
+    for (const field of [
+      "expiresAt",
+      "plan",
+      "repoVisibilityScope",
+      "privateRepoAllowed",
+      "updateEntitlement",
+      "customerEmail",
+      "externalCustomerId",
+      "ownerId",
+      "unexpected"
+    ]) {
+      const response = await post(
+        url,
+        "/v1/admin/licenses/issue",
+        checkoutBody({
+          idempotencyKey: `checkout-session:authority-${field}`,
+          externalSubscriptionId: `sub_authority_${field}`,
+          externalCheckoutId: `cs_authority_${field}`,
+          [field]: "caller-value"
+        }),
+        auth
+      );
+      assert.equal(response.status, 400);
+      assert.equal(response.json.detail, `unknown field: ${field}`);
+    }
+  });
+
+  it("rejects deprecated multi-seat checkout requests", async () => {
+    const response = await post(
+      url,
+      "/v1/admin/licenses/issue",
+      checkoutBody({
+        idempotencyKey: "checkout-session:multi-seat",
+        externalSubscriptionId: "sub_multi_seat",
+        externalCheckoutId: "cs_multi_seat",
+        seats: 3
+      }),
+      auth
+    );
+    assert.equal(response.status, 400);
+    assert.match(response.json.detail, /seats is deprecated and must be exactly 1/);
   });
 });
 

--- a/services/license-api/test/http.test.ts
+++ b/services/license-api/test/http.test.ts
@@ -124,7 +124,9 @@ describe("license issuance transport", () => {
   const auth = { Authorization: `Bearer ${issuanceSecret}` };
 
   before(async () => {
-    store = new LicenseStore(":memory:");
+    store = new LicenseStore(":memory:", {
+      now: () => new Date("2026-07-08T00:00:00.000Z")
+    });
     const started = await startLicenseServer({
       store,
       issuanceSecret,

--- a/services/license-api/test/issuance-policy.test.ts
+++ b/services/license-api/test/issuance-policy.test.ts
@@ -144,7 +144,7 @@ describe("checkout issuance request authority", () => {
     ]) {
       assert.throws(
         () => parseIssuanceRequest(JSON.stringify({ ...request(), [field]: "caller-value" })),
-        new RegExp(`unknown field: ${field}`)
+        /request contains an unknown field/
       );
     }
   });

--- a/services/license-api/test/issuance-policy.test.ts
+++ b/services/license-api/test/issuance-policy.test.ts
@@ -11,7 +11,7 @@ import {
   parseIssuanceRequest,
   type LicenseIssuanceRequest
 } from "../src/issuance.ts";
-import { LicenseStore } from "../src/store.ts";
+import { CheckoutIssuancePolicyError, LicenseStore } from "../src/store.ts";
 
 const NOW = new Date("2026-07-13T00:00:00.000Z");
 const ISSUANCE_SECRET = "test-only-checkout-issuance-secret";
@@ -254,6 +254,50 @@ describe("atomic bound checkout issuance", () => {
     });
   }
 
+  for (const [name, inputOverride, expected] of [
+    ["empty issuance reference", { idempotencyKey: "   " }, /idempotencyKey is required/],
+    [
+      "oversized issuance reference",
+      { idempotencyKey: "a".repeat(201) },
+      /idempotencyKey is too long/
+    ],
+    [
+      "invalid issuance reference characters",
+      { idempotencyKey: "checkout/session" },
+      /idempotencyKey contains unsupported characters/
+    ],
+    ["empty lookup key", { checkoutLookupKey: "" }, /checkoutLookupKey is required/],
+    [
+      "oversized lookup key",
+      { checkoutLookupKey: "x".repeat(81) },
+      /checkoutLookupKey is too long/
+    ],
+    [
+      "unknown lookup key",
+      { checkoutLookupKey: "neondiff_lifetime" },
+      /checkoutLookupKey must be one of/
+    ]
+  ] as const) {
+    it(`rejects direct-store ${name} with a policy error before persistence`, () => {
+      const store = new LicenseStore(":memory:", { now: () => NOW });
+      const req = request({ idempotencyKey: `checkout-session:direct-${name.replaceAll(" ", "-")}` });
+      try {
+        assert.throws(
+          () =>
+            store.issueBoundCheckoutLicense(
+              derivedKey(req.idempotencyKey),
+              directBoundInput(req, inputOverride) as any
+            ),
+          (error: unknown) =>
+            error instanceof CheckoutIssuancePolicyError && expected.test(error.message)
+        );
+        assert.equal(store.listLicenses().length, 0);
+      } finally {
+        store.close();
+      }
+    });
+  }
+
   it("derives plan, one seat, and initial expiry from policy and the injected clock", () => {
     const cases = [
       ["neondiff_monthly", "monthly_support", "2026-07-20T00:00:00.000Z"],
@@ -308,6 +352,41 @@ describe("atomic bound checkout issuance", () => {
       );
       assert.equal(conflict.httpStatus, 409);
       assert.equal(conflict.body.status, "conflict");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("conflicts instead of presenting an admin-revoked checkout key as active", () => {
+    const store = new LicenseStore(":memory:", { now: () => NOW });
+    try {
+      const first = issueCheckoutLicense(store, request(), ISSUANCE_SECRET);
+      assert.equal(first.httpStatus, 200);
+      assert.equal(store.revokeLicense(first.body.licenseKey as string, "owner revoked"), true);
+
+      const replay = issueCheckoutLicense(store, request(), ISSUANCE_SECRET);
+      assert.equal(replay.httpStatus, 409);
+      assert.equal(replay.body.status, "conflict");
+      assert.ok(!JSON.stringify(replay.body).includes('"status":"active"'));
+      assert.equal(store.listLicenses().length, 1);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("conflicts instead of presenting an effectively expired checkout key as active", () => {
+    let currentTime = NOW;
+    const store = new LicenseStore(":memory:", { now: () => currentTime });
+    try {
+      const first = issueCheckoutLicense(store, request(), ISSUANCE_SECRET);
+      assert.equal(first.httpStatus, 200);
+      currentTime = new Date("2026-07-21T00:00:00.000Z");
+
+      const replay = issueCheckoutLicense(store, request(), ISSUANCE_SECRET);
+      assert.equal(replay.httpStatus, 409);
+      assert.equal(replay.body.status, "conflict");
+      assert.ok(!JSON.stringify(replay.body).includes('"status":"active"'));
+      assert.equal(store.listLicenses().length, 1);
     } finally {
       store.close();
     }

--- a/services/license-api/test/issuance-policy.test.ts
+++ b/services/license-api/test/issuance-policy.test.ts
@@ -36,6 +36,24 @@ function derivedKey(idempotencyKey: string): string {
   return ["nd", "live", digest.subarray(0, 24).toString("base64url")].join("_");
 }
 
+function directBoundInput(
+  req: LicenseIssuanceRequest,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    idempotencyKey: req.idempotencyKey,
+    checkoutLookupKey: req.checkoutLookupKey,
+    binding: {
+      provider: req.provider,
+      providerAccountId: req.providerAccountId,
+      providerMode: req.providerMode,
+      externalSubscriptionId: req.externalSubscriptionId,
+      externalCheckoutId: req.externalCheckoutId
+    },
+    ...overrides
+  };
+}
+
 describe("server-owned checkout policy", () => {
   it("defines the authoritative plan, trial, renewal cap, currency, and seat policy", () => {
     assert.deepEqual(checkoutPolicyFor("neondiff_monthly"), {
@@ -130,6 +148,36 @@ describe("checkout issuance request authority", () => {
 });
 
 describe("atomic bound checkout issuance", () => {
+  for (const [field, value] of [
+    ["plan", "caller_plan"],
+    ["repoVisibilityScope", "public"],
+    ["privateRepoAllowed", false],
+    ["updateEntitlement", false],
+    ["seats", 50],
+    ["expiresAt", "2099-01-01T00:00:00.000Z"],
+    ["requestHash", "caller-request-hash"],
+    ["externalRef", "caller-external-reference"],
+    ["source", "admin"]
+  ] as const) {
+    it(`rejects direct-store caller authority over ${field}`, () => {
+      const store = new LicenseStore(":memory:", { now: () => NOW });
+      const req = request({ idempotencyKey: `checkout-session:direct-${field}` });
+      try {
+        assert.throws(
+          () =>
+            store.issueBoundCheckoutLicense(
+              derivedKey(req.idempotencyKey),
+              directBoundInput(req, { [field]: value }) as any
+            ),
+          new RegExp(`unsupported bound checkout field: ${field}`)
+        );
+        assert.equal(store.listLicenses().length, 0);
+      } finally {
+        store.close();
+      }
+    });
+  }
+
   it("derives plan, one seat, and initial expiry from policy and the injected clock", () => {
     const cases = [
       ["neondiff_monthly", "monthly_support", "2026-07-20T00:00:00.000Z"],
@@ -138,7 +186,7 @@ describe("atomic bound checkout issuance", () => {
     ] as const;
 
     for (const [checkoutLookupKey, plan, expiresAt] of cases) {
-      const store = new LicenseStore(":memory:");
+      const store = new LicenseStore(":memory:", { now: () => NOW });
       try {
         const result = issueCheckoutLicense(
           store,
@@ -168,7 +216,7 @@ describe("atomic bound checkout issuance", () => {
   });
 
   it("replays only an exact bound request without minting a second license", () => {
-    const store = new LicenseStore(":memory:");
+    const store = new LicenseStore(":memory:", { now: () => NOW });
     try {
       const first = issueCheckoutLicense(store, request(), ISSUANCE_SECRET, NOW);
       const second = issueCheckoutLicense(store, request(), ISSUANCE_SECRET, NOW);
@@ -192,7 +240,7 @@ describe("atomic bound checkout issuance", () => {
   });
 
   it("quarantines an unbound legacy checkout replay", () => {
-    const store = new LicenseStore(":memory:");
+    const store = new LicenseStore(":memory:", { now: () => NOW });
     try {
       const idempotencyKey = "checkout-session:legacy-unbound";
       store.issueIdempotentLicense(derivedKey(idempotencyKey), {
@@ -266,40 +314,8 @@ describe("atomic bound checkout issuance", () => {
     }
   });
 
-  it("rejects direct attempts to bypass the one-seat checkout policy", () => {
-    const store = new LicenseStore(":memory:");
-    const req = request({ idempotencyKey: "checkout-session:store-policy-bypass" });
-    try {
-      assert.throws(
-        () =>
-          store.issueBoundCheckoutLicense(derivedKey(req.idempotencyKey), {
-            idempotencyKey: req.idempotencyKey,
-            requestHash: "direct-policy-bypass",
-            source: "checkout",
-            externalRef: req.externalCheckoutId,
-            plan: "org_yearly_support",
-            repoVisibilityScope: "private",
-            privateRepoAllowed: true,
-            updateEntitlement: true,
-            seats: 3,
-            binding: {
-              provider: req.provider,
-              providerAccountId: req.providerAccountId,
-              providerMode: req.providerMode,
-              externalSubscriptionId: req.externalSubscriptionId,
-              externalCheckoutId: req.externalCheckoutId
-            }
-          }),
-        /bound checkout issuance requires exactly one seat/
-      );
-      assert.equal(store.listLicenses().length, 0);
-    } finally {
-      store.close();
-    }
-  });
-
   it("rolls back license and issuance rows when immutable binding insertion conflicts", () => {
-    const store = new LicenseStore(":memory:");
+    const store = new LicenseStore(":memory:", { now: () => NOW });
     try {
       const first = issueCheckoutLicense(
         store,
@@ -335,6 +351,83 @@ describe("atomic bound checkout issuance", () => {
       assert.equal(store.listLicenses().length, 2);
     } finally {
       store.close();
+    }
+  });
+});
+
+describe("bound checkout issuance lock contention", () => {
+  it("returns a bounded transient result and then converges on exact replay after lock release", () => {
+    const directory = mkdtempSync(join(tmpdir(), "neondiff-checkout-lock-replay-"));
+    const databasePath = join(directory, "licenses.sqlite");
+    const store = new LicenseStore(databasePath, { busyTimeoutMs: 25, now: () => NOW });
+    const blocker = new DatabaseSync(databasePath);
+    const req = request({ idempotencyKey: "checkout-session:locked-exact-replay" });
+    try {
+      blocker.exec("begin immediate");
+      const startedAt = Date.now();
+      const unavailable = issueCheckoutLicense(store, req, ISSUANCE_SECRET, NOW);
+      const elapsedMs = Date.now() - startedAt;
+      assert.equal(unavailable.httpStatus, 503);
+      assert.deepEqual(unavailable.body, {
+        status: "unavailable",
+        detail: "license issuance temporarily unavailable"
+      });
+      assert.ok(elapsedMs >= 10 && elapsedMs < 1_000, `bounded wait was ${elapsedMs}ms`);
+      assert.equal(store.listLicenses().length, 0);
+
+      blocker.exec("rollback");
+      const issued = issueCheckoutLicense(store, req, ISSUANCE_SECRET, NOW);
+      const replayed = issueCheckoutLicense(store, req, ISSUANCE_SECRET, NOW);
+      assert.equal(issued.httpStatus, 200);
+      assert.equal(replayed.httpStatus, 200);
+      assert.equal(replayed.body.replayed, true);
+      assert.equal(replayed.body.licenseKey, issued.body.licenseKey);
+      assert.equal(store.listLicenses().length, 1);
+    } finally {
+      try {
+        blocker.exec("rollback");
+      } catch {}
+      blocker.close();
+      store.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("returns a bounded transient result and then a deterministic conflict after lock release", () => {
+    const directory = mkdtempSync(join(tmpdir(), "neondiff-checkout-lock-conflict-"));
+    const databasePath = join(directory, "licenses.sqlite");
+    const store = new LicenseStore(databasePath, { busyTimeoutMs: 25, now: () => NOW });
+    const blocker = new DatabaseSync(databasePath);
+    const req = request({ idempotencyKey: "checkout-session:locked-conflict" });
+    try {
+      const issued = issueCheckoutLicense(store, req, ISSUANCE_SECRET, NOW);
+      assert.equal(issued.httpStatus, 200);
+
+      blocker.exec("begin immediate");
+      const changed = request({
+        idempotencyKey: req.idempotencyKey,
+        externalCheckoutId: "cs_changed_after_lock"
+      });
+      const startedAt = Date.now();
+      const unavailable = issueCheckoutLicense(store, changed, ISSUANCE_SECRET, NOW);
+      const elapsedMs = Date.now() - startedAt;
+      assert.equal(unavailable.httpStatus, 503);
+      assert.ok(elapsedMs >= 10 && elapsedMs < 1_000, `bounded wait was ${elapsedMs}ms`);
+
+      blocker.exec("rollback");
+      const conflict = issueCheckoutLicense(store, changed, ISSUANCE_SECRET, NOW);
+      const replayed = issueCheckoutLicense(store, req, ISSUANCE_SECRET, NOW);
+      assert.equal(conflict.httpStatus, 409);
+      assert.equal(replayed.httpStatus, 200);
+      assert.equal(replayed.body.replayed, true);
+      assert.equal(store.listLicenses().length, 1);
+    } finally {
+      try {
+        blocker.exec("rollback");
+      } catch {}
+      blocker.close();
+      store.close();
+      rmSync(directory, { recursive: true, force: true });
     }
   });
 });

--- a/services/license-api/test/issuance-policy.test.ts
+++ b/services/license-api/test/issuance-policy.test.ts
@@ -87,6 +87,30 @@ describe("server-owned checkout policy", () => {
       updateEntitlement: true
     });
   });
+
+  it("cannot be mutated by an importer to change future issuance authority", () => {
+    const policy = checkoutPolicyFor("neondiff_monthly") as { plan: string };
+    const originalPlan = policy.plan;
+    try {
+      try {
+        policy.plan = "caller_controlled_plan";
+      } catch (error) {
+        assert.ok(error instanceof TypeError);
+      }
+
+      const store = new LicenseStore(":memory:", { now: () => NOW });
+      try {
+        const result = issueCheckoutLicense(store, request(), ISSUANCE_SECRET);
+        assert.equal(result.httpStatus, 200);
+        assert.equal(result.body.entitlement.plan, "monthly_support");
+        assert.equal(checkoutPolicyFor("neondiff_monthly").plan, "monthly_support");
+      } finally {
+        store.close();
+      }
+    } finally {
+      if (policy.plan !== originalPlan) policy.plan = originalPlan;
+    }
+  });
 });
 
 describe("checkout issuance request authority", () => {
@@ -178,6 +202,58 @@ describe("atomic bound checkout issuance", () => {
     });
   }
 
+  it("uses only the injected store clock when a direct caller passes a far-future date", () => {
+    const store = new LicenseStore(":memory:", { now: () => NOW });
+    const req = request({ idempotencyKey: "checkout-session:clock-bypass" });
+    try {
+      const issueWithBypass = store.issueBoundCheckoutLicense.bind(store) as (
+        rawKey: string,
+        input: Record<string, unknown>,
+        issuedAt: Date
+      ) => ReturnType<LicenseStore["issueBoundCheckoutLicense"]>;
+      const issued = issueWithBypass(
+        derivedKey(req.idempotencyKey),
+        directBoundInput(req),
+        new Date("2099-01-01T00:00:00.000Z")
+      );
+
+      assert.equal(issued.record.expiresAt, "2026-07-20T00:00:00.000Z");
+    } finally {
+      store.close();
+    }
+  });
+
+  for (const [name, bindingOverride, expected] of [
+    ["provider bypass", { provider: "paypal" }, /provider must be stripe/],
+    ["mode bypass", { providerMode: "production" }, /providerMode must be test or live/],
+    ["empty provider account", { providerAccountId: "   " }, /providerAccountId is required/],
+    ["empty subscription id", { externalSubscriptionId: "" }, /externalSubscriptionId is required/],
+    ["empty checkout id", { externalCheckoutId: "\t" }, /externalCheckoutId is required/],
+    ["oversized provider account", { providerAccountId: "a".repeat(161) }, /providerAccountId is too long/],
+    ["oversized subscription id", { externalSubscriptionId: "s".repeat(161) }, /externalSubscriptionId is too long/],
+    ["oversized checkout id", { externalCheckoutId: "c".repeat(161) }, /externalCheckoutId is too long/]
+  ] as const) {
+    it(`rejects direct-store ${name}`, () => {
+      const store = new LicenseStore(":memory:", { now: () => NOW });
+      const req = request({ idempotencyKey: `checkout-session:binding-${name.replaceAll(" ", "-")}` });
+      const input = directBoundInput(req);
+      input.binding = { ...(input.binding as Record<string, unknown>), ...bindingOverride };
+      try {
+        assert.throws(
+          () =>
+            store.issueBoundCheckoutLicense(
+              derivedKey(req.idempotencyKey),
+              input as any
+            ),
+          expected
+        );
+        assert.equal(store.listLicenses().length, 0);
+      } finally {
+        store.close();
+      }
+    });
+  }
+
   it("derives plan, one seat, and initial expiry from policy and the injected clock", () => {
     const cases = [
       ["neondiff_monthly", "monthly_support", "2026-07-20T00:00:00.000Z"],
@@ -196,8 +272,7 @@ describe("atomic bound checkout issuance", () => {
             externalSubscriptionId: `sub_${checkoutLookupKey}`,
             externalCheckoutId: `cs_${checkoutLookupKey}`
           }),
-          ISSUANCE_SECRET,
-          NOW
+          ISSUANCE_SECRET
         );
         assert.equal(result.httpStatus, 200);
         const body = result.body as { licenseKey: string; entitlement: Record<string, unknown> };
@@ -218,8 +293,8 @@ describe("atomic bound checkout issuance", () => {
   it("replays only an exact bound request without minting a second license", () => {
     const store = new LicenseStore(":memory:", { now: () => NOW });
     try {
-      const first = issueCheckoutLicense(store, request(), ISSUANCE_SECRET, NOW);
-      const second = issueCheckoutLicense(store, request(), ISSUANCE_SECRET, NOW);
+      const first = issueCheckoutLicense(store, request(), ISSUANCE_SECRET);
+      const second = issueCheckoutLicense(store, request(), ISSUANCE_SECRET);
       assert.equal(first.httpStatus, 200);
       assert.equal(second.httpStatus, 200);
       assert.equal(second.body.replayed, true);
@@ -229,8 +304,7 @@ describe("atomic bound checkout issuance", () => {
       const conflict = issueCheckoutLicense(
         store,
         request({ externalCheckoutId: "cs_changed" }),
-        ISSUANCE_SECRET,
-        NOW
+        ISSUANCE_SECRET
       );
       assert.equal(conflict.httpStatus, 409);
       assert.equal(conflict.body.status, "conflict");
@@ -257,8 +331,7 @@ describe("atomic bound checkout issuance", () => {
       const result = issueCheckoutLicense(
         store,
         request({ idempotencyKey, externalCheckoutId: "cs_legacy" }),
-        ISSUANCE_SECRET,
-        NOW
+        ISSUANCE_SECRET
       );
       assert.equal(result.httpStatus, 409);
       assert.equal(result.body.status, "conflict");
@@ -305,7 +378,7 @@ describe("atomic bound checkout issuance", () => {
         );
       database.close();
       store = new LicenseStore(databasePath);
-      const result = issueCheckoutLicense(store, req, ISSUANCE_SECRET, NOW);
+      const result = issueCheckoutLicense(store, req, ISSUANCE_SECRET);
       assert.equal(result.httpStatus, 409);
       assert.equal(result.body.status, "conflict");
     } finally {
@@ -320,8 +393,7 @@ describe("atomic bound checkout issuance", () => {
       const first = issueCheckoutLicense(
         store,
         request({ idempotencyKey: "checkout-session:tuple-owner" }),
-        ISSUANCE_SECRET,
-        NOW
+        ISSUANCE_SECRET
       );
       assert.equal(first.httpStatus, 200);
 
@@ -331,8 +403,7 @@ describe("atomic bound checkout issuance", () => {
           idempotencyKey: "checkout-session:tuple-conflict",
           externalCheckoutId: "cs_tuple_conflict"
         }),
-        ISSUANCE_SECRET,
-        NOW
+        ISSUANCE_SECRET
       );
       assert.equal(conflicted.httpStatus, 409);
       assert.equal(store.listLicenses().length, 1);
@@ -344,8 +415,7 @@ describe("atomic bound checkout issuance", () => {
           externalSubscriptionId: "sub_unique_after_rollback",
           externalCheckoutId: "cs_tuple_conflict"
         }),
-        ISSUANCE_SECRET,
-        NOW
+        ISSUANCE_SECRET
       );
       assert.equal(recovered.httpStatus, 200);
       assert.equal(store.listLicenses().length, 2);
@@ -365,7 +435,7 @@ describe("bound checkout issuance lock contention", () => {
     try {
       blocker.exec("begin immediate");
       const startedAt = Date.now();
-      const unavailable = issueCheckoutLicense(store, req, ISSUANCE_SECRET, NOW);
+      const unavailable = issueCheckoutLicense(store, req, ISSUANCE_SECRET);
       const elapsedMs = Date.now() - startedAt;
       assert.equal(unavailable.httpStatus, 503);
       assert.deepEqual(unavailable.body, {
@@ -376,8 +446,8 @@ describe("bound checkout issuance lock contention", () => {
       assert.equal(store.listLicenses().length, 0);
 
       blocker.exec("rollback");
-      const issued = issueCheckoutLicense(store, req, ISSUANCE_SECRET, NOW);
-      const replayed = issueCheckoutLicense(store, req, ISSUANCE_SECRET, NOW);
+      const issued = issueCheckoutLicense(store, req, ISSUANCE_SECRET);
+      const replayed = issueCheckoutLicense(store, req, ISSUANCE_SECRET);
       assert.equal(issued.httpStatus, 200);
       assert.equal(replayed.httpStatus, 200);
       assert.equal(replayed.body.replayed, true);
@@ -400,7 +470,7 @@ describe("bound checkout issuance lock contention", () => {
     const blocker = new DatabaseSync(databasePath);
     const req = request({ idempotencyKey: "checkout-session:locked-conflict" });
     try {
-      const issued = issueCheckoutLicense(store, req, ISSUANCE_SECRET, NOW);
+      const issued = issueCheckoutLicense(store, req, ISSUANCE_SECRET);
       assert.equal(issued.httpStatus, 200);
 
       blocker.exec("begin immediate");
@@ -409,14 +479,14 @@ describe("bound checkout issuance lock contention", () => {
         externalCheckoutId: "cs_changed_after_lock"
       });
       const startedAt = Date.now();
-      const unavailable = issueCheckoutLicense(store, changed, ISSUANCE_SECRET, NOW);
+      const unavailable = issueCheckoutLicense(store, changed, ISSUANCE_SECRET);
       const elapsedMs = Date.now() - startedAt;
       assert.equal(unavailable.httpStatus, 503);
       assert.ok(elapsedMs >= 10 && elapsedMs < 1_000, `bounded wait was ${elapsedMs}ms`);
 
       blocker.exec("rollback");
-      const conflict = issueCheckoutLicense(store, changed, ISSUANCE_SECRET, NOW);
-      const replayed = issueCheckoutLicense(store, req, ISSUANCE_SECRET, NOW);
+      const conflict = issueCheckoutLicense(store, changed, ISSUANCE_SECRET);
+      const replayed = issueCheckoutLicense(store, req, ISSUANCE_SECRET);
       assert.equal(conflict.httpStatus, 409);
       assert.equal(replayed.httpStatus, 200);
       assert.equal(replayed.body.replayed, true);

--- a/services/license-api/test/issuance-policy.test.ts
+++ b/services/license-api/test/issuance-policy.test.ts
@@ -1,0 +1,340 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { describe, it } from "node:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { checkoutPolicyFor } from "../src/checkout-policy.ts";
+import {
+  issueCheckoutLicense,
+  parseIssuanceRequest,
+  type LicenseIssuanceRequest
+} from "../src/issuance.ts";
+import { LicenseStore } from "../src/store.ts";
+
+const NOW = new Date("2026-07-13T00:00:00.000Z");
+const ISSUANCE_SECRET = "test-only-checkout-issuance-secret";
+
+function request(overrides: Partial<LicenseIssuanceRequest> = {}): LicenseIssuanceRequest {
+  return {
+    idempotencyKey: "checkout-session:policy-test",
+    checkoutLookupKey: "neondiff_monthly",
+    provider: "stripe",
+    providerAccountId: "acct_live_product",
+    providerMode: "live",
+    externalSubscriptionId: "sub_policy_test",
+    externalCheckoutId: "cs_policy_test",
+    ...overrides
+  };
+}
+
+function derivedKey(idempotencyKey: string): string {
+  const digest = createHmac("sha256", ISSUANCE_SECRET)
+    .update(`checkout-license:${idempotencyKey}`)
+    .digest();
+  return ["nd", "live", digest.subarray(0, 24).toString("base64url")].join("_");
+}
+
+describe("server-owned checkout policy", () => {
+  it("defines the authoritative plan, trial, renewal cap, currency, and seat policy", () => {
+    assert.deepEqual(checkoutPolicyFor("neondiff_monthly"), {
+      plan: "monthly_support",
+      trialDays: 7,
+      maximumPeriodDays: 62,
+      currency: "usd",
+      seats: 1,
+      repoVisibilityScope: "private",
+      privateRepoAllowed: true,
+      updateEntitlement: true
+    });
+    assert.deepEqual(checkoutPolicyFor("neondiff_yearly"), {
+      plan: "yearly_support",
+      trialDays: 7,
+      maximumPeriodDays: 400,
+      currency: "usd",
+      seats: 1,
+      repoVisibilityScope: "private",
+      privateRepoAllowed: true,
+      updateEntitlement: true
+    });
+    assert.deepEqual(checkoutPolicyFor("neondiff_org_yearly"), {
+      plan: "org_yearly_support",
+      trialDays: 30,
+      maximumPeriodDays: 400,
+      currency: "usd",
+      seats: 1,
+      repoVisibilityScope: "private",
+      privateRepoAllowed: true,
+      updateEntitlement: true
+    });
+  });
+});
+
+describe("checkout issuance request authority", () => {
+  it("requires the issuance reference and complete immutable provider correlation", () => {
+    for (const field of [
+      "idempotencyKey",
+      "checkoutLookupKey",
+      "provider",
+      "providerAccountId",
+      "providerMode",
+      "externalSubscriptionId",
+      "externalCheckoutId"
+    ] as const) {
+      const body = { ...request() } as Record<string, unknown>;
+      delete body[field];
+      assert.throws(() => parseIssuanceRequest(JSON.stringify(body)), new RegExp(`${field} is required`));
+    }
+  });
+
+  it("rejects caller-controlled expiry, plan, scope, ownership, and unknown fields", () => {
+    for (const field of [
+      "expiresAt",
+      "plan",
+      "repoVisibilityScope",
+      "privateRepoAllowed",
+      "updateEntitlement",
+      "customerEmail",
+      "externalCustomerId",
+      "ownerId",
+      "unexpected"
+    ]) {
+      assert.throws(
+        () => parseIssuanceRequest(JSON.stringify({ ...request(), [field]: "caller-value" })),
+        new RegExp(`unknown field: ${field}`)
+      );
+    }
+  });
+
+  it("accepts deprecated seats only when it is exactly one", () => {
+    assert.equal(parseIssuanceRequest(JSON.stringify({ ...request(), seats: 1 })).seats, 1);
+    for (const seats of [0, 2, 1.5, "1", null]) {
+      assert.throws(
+        () => parseIssuanceRequest(JSON.stringify({ ...request(), seats })),
+        /seats is deprecated and must be exactly 1/
+      );
+    }
+  });
+
+  it("accepts only the initial Stripe provider and separated test/live modes", () => {
+    assert.throws(
+      () => parseIssuanceRequest(JSON.stringify(request({ provider: "caller-provider" }))),
+      /provider must be stripe/
+    );
+    assert.throws(
+      () => parseIssuanceRequest(JSON.stringify(request({ providerMode: "production" }))),
+      /providerMode must be test or live/
+    );
+  });
+});
+
+describe("atomic bound checkout issuance", () => {
+  it("derives plan, one seat, and initial expiry from policy and the injected clock", () => {
+    const cases = [
+      ["neondiff_monthly", "monthly_support", "2026-07-20T00:00:00.000Z"],
+      ["neondiff_yearly", "yearly_support", "2026-07-20T00:00:00.000Z"],
+      ["neondiff_org_yearly", "org_yearly_support", "2026-08-12T00:00:00.000Z"]
+    ] as const;
+
+    for (const [checkoutLookupKey, plan, expiresAt] of cases) {
+      const store = new LicenseStore(":memory:");
+      try {
+        const result = issueCheckoutLicense(
+          store,
+          request({
+            idempotencyKey: `checkout-session:${checkoutLookupKey}`,
+            checkoutLookupKey,
+            externalSubscriptionId: `sub_${checkoutLookupKey}`,
+            externalCheckoutId: `cs_${checkoutLookupKey}`
+          }),
+          ISSUANCE_SECRET,
+          NOW
+        );
+        assert.equal(result.httpStatus, 200);
+        const body = result.body as { licenseKey: string; entitlement: Record<string, unknown> };
+        assert.equal(body.entitlement.plan, plan);
+        assert.equal(body.entitlement.seats, 1);
+        assert.equal(body.entitlement.expiresAt, expiresAt);
+        const record = store.getLicenseByKey(body.licenseKey);
+        assert.ok(record);
+        assert.equal(record.plan, plan);
+        assert.equal(record.seats, 1);
+        assert.equal(record.expiresAt, expiresAt);
+      } finally {
+        store.close();
+      }
+    }
+  });
+
+  it("replays only an exact bound request without minting a second license", () => {
+    const store = new LicenseStore(":memory:");
+    try {
+      const first = issueCheckoutLicense(store, request(), ISSUANCE_SECRET, NOW);
+      const second = issueCheckoutLicense(store, request(), ISSUANCE_SECRET, NOW);
+      assert.equal(first.httpStatus, 200);
+      assert.equal(second.httpStatus, 200);
+      assert.equal(second.body.replayed, true);
+      assert.equal(second.body.licenseKey, first.body.licenseKey);
+      assert.equal(store.listLicenses().length, 1);
+
+      const conflict = issueCheckoutLicense(
+        store,
+        request({ externalCheckoutId: "cs_changed" }),
+        ISSUANCE_SECRET,
+        NOW
+      );
+      assert.equal(conflict.httpStatus, 409);
+      assert.equal(conflict.body.status, "conflict");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("quarantines an unbound legacy checkout replay", () => {
+    const store = new LicenseStore(":memory:");
+    try {
+      const idempotencyKey = "checkout-session:legacy-unbound";
+      store.issueIdempotentLicense(derivedKey(idempotencyKey), {
+        idempotencyKey,
+        requestHash: "legacy-request-hash",
+        source: "checkout",
+        externalRef: "cs_legacy",
+        plan: "monthly_support",
+        repoVisibilityScope: "private",
+        privateRepoAllowed: true,
+        updateEntitlement: true,
+        seats: 1
+      });
+      const result = issueCheckoutLicense(
+        store,
+        request({ idempotencyKey, externalCheckoutId: "cs_legacy" }),
+        ISSUANCE_SECRET,
+        NOW
+      );
+      assert.equal(result.httpStatus, 409);
+      assert.equal(result.body.status, "conflict");
+      assert.ok(!JSON.stringify(result.body).includes(derivedKey(idempotencyKey)));
+    } finally {
+      store.close();
+    }
+  });
+
+  it("quarantines a bound multi-seat checkout replay", () => {
+    const directory = mkdtempSync(join(tmpdir(), "neondiff-multi-seat-replay-"));
+    const databasePath = join(directory, "licenses.sqlite");
+    const req = request({ idempotencyKey: "checkout-session:legacy-multi-seat" });
+    let store = new LicenseStore(databasePath);
+    try {
+      const issued = store.issueIdempotentLicense(derivedKey(req.idempotencyKey), {
+        idempotencyKey: req.idempotencyKey,
+        requestHash: "legacy-multi-seat-hash",
+        source: "checkout",
+        externalRef: req.externalCheckoutId,
+        plan: "org_yearly_support",
+        repoVisibilityScope: "private",
+        privateRepoAllowed: true,
+        updateEntitlement: true,
+        seats: 3
+      });
+      store.close();
+      const database = new DatabaseSync(databasePath);
+      database
+        .prepare(
+          `insert into checkout_subscription_bindings (
+            issuance_idempotency_key, license_key_hash, provider, provider_account_id,
+            provider_mode, external_subscription_id, external_checkout_id
+          ) values (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          req.idempotencyKey,
+          issued.record.licenseKeyHash,
+          req.provider,
+          req.providerAccountId,
+          req.providerMode,
+          req.externalSubscriptionId,
+          req.externalCheckoutId
+        );
+      database.close();
+      store = new LicenseStore(databasePath);
+      const result = issueCheckoutLicense(store, req, ISSUANCE_SECRET, NOW);
+      assert.equal(result.httpStatus, 409);
+      assert.equal(result.body.status, "conflict");
+    } finally {
+      store.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects direct attempts to bypass the one-seat checkout policy", () => {
+    const store = new LicenseStore(":memory:");
+    const req = request({ idempotencyKey: "checkout-session:store-policy-bypass" });
+    try {
+      assert.throws(
+        () =>
+          store.issueBoundCheckoutLicense(derivedKey(req.idempotencyKey), {
+            idempotencyKey: req.idempotencyKey,
+            requestHash: "direct-policy-bypass",
+            source: "checkout",
+            externalRef: req.externalCheckoutId,
+            plan: "org_yearly_support",
+            repoVisibilityScope: "private",
+            privateRepoAllowed: true,
+            updateEntitlement: true,
+            seats: 3,
+            binding: {
+              provider: req.provider,
+              providerAccountId: req.providerAccountId,
+              providerMode: req.providerMode,
+              externalSubscriptionId: req.externalSubscriptionId,
+              externalCheckoutId: req.externalCheckoutId
+            }
+          }),
+        /bound checkout issuance requires exactly one seat/
+      );
+      assert.equal(store.listLicenses().length, 0);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("rolls back license and issuance rows when immutable binding insertion conflicts", () => {
+    const store = new LicenseStore(":memory:");
+    try {
+      const first = issueCheckoutLicense(
+        store,
+        request({ idempotencyKey: "checkout-session:tuple-owner" }),
+        ISSUANCE_SECRET,
+        NOW
+      );
+      assert.equal(first.httpStatus, 200);
+
+      const conflicted = issueCheckoutLicense(
+        store,
+        request({
+          idempotencyKey: "checkout-session:tuple-conflict",
+          externalCheckoutId: "cs_tuple_conflict"
+        }),
+        ISSUANCE_SECRET,
+        NOW
+      );
+      assert.equal(conflicted.httpStatus, 409);
+      assert.equal(store.listLicenses().length, 1);
+
+      const recovered = issueCheckoutLicense(
+        store,
+        request({
+          idempotencyKey: "checkout-session:tuple-conflict",
+          externalSubscriptionId: "sub_unique_after_rollback",
+          externalCheckoutId: "cs_tuple_conflict"
+        }),
+        ISSUANCE_SECRET,
+        NOW
+      );
+      assert.equal(recovered.httpStatus, 200);
+      assert.equal(store.listLicenses().length, 2);
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/services/license-api/test/store-migration.test.ts
+++ b/services/license-api/test/store-migration.test.ts
@@ -1,0 +1,324 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, it } from "node:test";
+import { LicenseStore, type SchemaMigrationStep } from "../src/store.ts";
+
+const LEGACY_SCHEMA = `
+  create table licenses (
+    license_key_hash text primary key,
+    plan text not null,
+    repo_visibility_scope text not null,
+    private_repo_allowed integer not null default 1,
+    update_entitlement integer not null default 0,
+    seats integer not null default 1,
+    expires_at text,
+    status text not null default 'active',
+    revocation_reason text,
+    created_at text not null default (datetime('now'))
+  );
+
+  create table activations (
+    license_key_hash text not null,
+    machine_id text not null,
+    repo text,
+    activated_at text not null default (datetime('now')),
+    last_seen_at text not null default (datetime('now')),
+    primary key (license_key_hash, machine_id)
+  );
+
+  create table license_issuance_events (
+    idempotency_key text primary key,
+    license_key_hash text not null,
+    request_hash text not null,
+    source text,
+    external_ref text,
+    created_at text not null default (datetime('now')),
+    foreign key (license_key_hash) references licenses(license_key_hash)
+  );
+`;
+
+const tempDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function databasePath(): string {
+  const directory = mkdtempSync(join(tmpdir(), "neondiff-license-migration-"));
+  tempDirectories.push(directory);
+  return join(directory, "license.sqlite");
+}
+
+function open(path: string): DatabaseSync {
+  return new DatabaseSync(path);
+}
+
+function userVersion(db: DatabaseSync): number {
+  return Number((db.prepare("pragma user_version").get() as { user_version: number }).user_version);
+}
+
+function objectNames(db: DatabaseSync, type: "table" | "index" | "trigger"): string[] {
+  return (
+    db
+      .prepare("select name from sqlite_schema where type = ? and name not like 'sqlite_%' order by name")
+      .all(type) as unknown as Array<{ name: string }>
+  ).map(({ name }) => name);
+}
+
+function createLegacyDatabase(path: string): void {
+  const db = open(path);
+  db.exec("pragma foreign_keys = on");
+  db.exec(LEGACY_SCHEMA);
+  db.prepare(
+    `insert into licenses (
+      license_key_hash, plan, repo_visibility_scope, private_repo_allowed,
+      update_entitlement, seats, expires_at, status, created_at
+    ) values (?, 'yearly_support', 'private', 1, 1, 1, ?, 'active', ?)`
+  ).run("legacy-license-hash", "2027-07-13T00:00:00.000Z", "2026-07-13T00:00:00.000Z");
+  db.prepare(
+    `insert into activations (
+      license_key_hash, machine_id, repo, activated_at, last_seen_at
+    ) values (?, ?, ?, ?, ?)`
+  ).run(
+    "legacy-license-hash",
+    "legacy-machine",
+    "electricsheephq/example",
+    "2026-07-13T00:01:00.000Z",
+    "2026-07-13T00:02:00.000Z"
+  );
+  db.prepare(
+    `insert into license_issuance_events (
+      idempotency_key, license_key_hash, request_hash, source, external_ref, created_at
+    ) values (?, ?, ?, 'checkout', ?, ?)`
+  ).run(
+    "checkout-session:legacy",
+    "legacy-license-hash",
+    "legacy-request-hash",
+    "legacy-checkout-ref",
+    "2026-07-13T00:00:00.000Z"
+  );
+  db.close();
+}
+
+function assertLegacyRowsPreserved(db: DatabaseSync): void {
+  assert.deepEqual({ ...db.prepare("select * from licenses").get() }, {
+    license_key_hash: "legacy-license-hash",
+    plan: "yearly_support",
+    repo_visibility_scope: "private",
+    private_repo_allowed: 1,
+    update_entitlement: 1,
+    seats: 1,
+    expires_at: "2027-07-13T00:00:00.000Z",
+    status: "active",
+    revocation_reason: null,
+    created_at: "2026-07-13T00:00:00.000Z"
+  });
+  assert.deepEqual({ ...db.prepare("select * from activations").get() }, {
+    license_key_hash: "legacy-license-hash",
+    machine_id: "legacy-machine",
+    repo: "electricsheephq/example",
+    activated_at: "2026-07-13T00:01:00.000Z",
+    last_seen_at: "2026-07-13T00:02:00.000Z"
+  });
+  assert.deepEqual({ ...db.prepare("select * from license_issuance_events").get() }, {
+    idempotency_key: "checkout-session:legacy",
+    license_key_hash: "legacy-license-hash",
+    request_hash: "legacy-request-hash",
+    source: "checkout",
+    external_ref: "legacy-checkout-ref",
+    created_at: "2026-07-13T00:00:00.000Z"
+  });
+}
+
+describe("license store schema v2 migration", () => {
+  it("bootstraps an empty version-zero database directly to the complete v2 schema", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path);
+    store.close();
+
+    const db = open(path);
+    assert.equal(userVersion(db), 2);
+    assert.deepEqual(objectNames(db, "table"), [
+      "activations",
+      "checkout_subscription_bindings",
+      "license_issuance_events",
+      "license_subscription_lifecycle_events",
+      "licenses"
+    ]);
+    assert.ok(
+      objectNames(db, "index").includes("license_subscription_lifecycle_events_issuance_time_idx")
+    );
+    assert.deepEqual(
+      (
+        db.prepare("pragma table_info(checkout_subscription_bindings)").all() as unknown as Array<{ name: string }>
+      ).map(({ name }) => name),
+      [
+        "issuance_idempotency_key",
+        "license_key_hash",
+        "provider",
+        "provider_account_id",
+        "provider_mode",
+        "external_subscription_id",
+        "external_checkout_id",
+        "last_non_mutating_event_created_at",
+        "created_at"
+      ]
+    );
+    assert.deepEqual(
+      (
+        db.prepare("pragma table_info(license_subscription_lifecycle_events)").all() as unknown as Array<{
+          name: string;
+        }>
+      ).map(({ name }) => name),
+      [
+        "event_id",
+        "issuance_idempotency_key",
+        "license_key_hash",
+        "external_subscription_id",
+        "request_hash",
+        "event_created_at",
+        "provider",
+        "provider_account_id",
+        "provider_mode",
+        "provider_event_type",
+        "command",
+        "payment_reference_fingerprint",
+        "normalized_transition",
+        "result",
+        "created_at"
+      ]
+    );
+    db.close();
+  });
+
+  it("migrates only the exact legacy three-table schema and preserves every legacy row", () => {
+    const path = databasePath();
+    createLegacyDatabase(path);
+
+    const store = new LicenseStore(path);
+    store.close();
+
+    const db = open(path);
+    assert.equal(userVersion(db), 2);
+    assertLegacyRowsPreserved(db);
+    assert.ok(objectNames(db, "table").includes("checkout_subscription_bindings"));
+    assert.ok(objectNames(db, "table").includes("license_subscription_lifecycle_events"));
+    db.close();
+  });
+
+  it("reopens schema v2 without changing its schema or data", () => {
+    const path = databasePath();
+    createLegacyDatabase(path);
+    new LicenseStore(path).close();
+
+    const before = open(path);
+    const schemaBefore = before
+      .prepare("select type, name, sql from sqlite_schema where name not like 'sqlite_%' order by type, name")
+      .all();
+    before.close();
+
+    new LicenseStore(path).close();
+
+    const after = open(path);
+    assert.equal(userVersion(after), 2);
+    assert.deepEqual(
+      after.prepare("select type, name, sql from sqlite_schema where name not like 'sqlite_%' order by type, name").all(),
+      schemaBefore
+    );
+    assertLegacyRowsPreserved(after);
+    after.close();
+  });
+
+  it("rejects an unknown non-empty version-zero schema before any mutation", () => {
+    const path = databasePath();
+    const db = open(path);
+    db.exec("create table unexpected (value text not null); insert into unexpected values ('preserve-me')");
+    db.close();
+
+    assert.throws(() => new LicenseStore(path), /unknown non-empty schema at user_version 0/);
+
+    const inspected = open(path);
+    assert.equal(userVersion(inspected), 0);
+    assert.deepEqual(objectNames(inspected, "table"), ["unexpected"]);
+    assert.deepEqual({ ...inspected.prepare("select * from unexpected").get() }, { value: "preserve-me" });
+    inspected.close();
+  });
+
+  it("rejects a database labeled v2 when lifecycle constraints are missing", () => {
+    const path = databasePath();
+    const db = open(path);
+    db.exec(LEGACY_SCHEMA);
+    db.exec(`
+      create table checkout_subscription_bindings (
+        issuance_idempotency_key text primary key,
+        license_key_hash text not null,
+        provider text not null,
+        provider_account_id text not null,
+        provider_mode text not null,
+        external_subscription_id text not null,
+        external_checkout_id text not null,
+        last_non_mutating_event_created_at integer,
+        created_at text not null default (datetime('now'))
+      );
+      create table license_subscription_lifecycle_events (
+        event_id text primary key,
+        issuance_idempotency_key text not null,
+        license_key_hash text not null,
+        external_subscription_id text not null,
+        request_hash text not null,
+        event_created_at integer not null,
+        provider text not null,
+        provider_account_id text not null,
+        provider_mode text not null,
+        provider_event_type text not null,
+        command text not null,
+        payment_reference_fingerprint text,
+        normalized_transition text not null,
+        result text not null,
+        created_at text not null default (datetime('now'))
+      );
+      create index license_subscription_lifecycle_events_issuance_time_idx
+        on license_subscription_lifecycle_events (issuance_idempotency_key, event_created_at);
+      pragma user_version = 2;
+    `);
+    db.close();
+
+    assert.throws(() => new LicenseStore(path), /schema v2 has unexpected constraints/);
+  });
+
+  it("rolls back all additive DDL and user_version when a migration hook fails", () => {
+    const path = databasePath();
+    createLegacyDatabase(path);
+    const reached: SchemaMigrationStep[] = [];
+
+    assert.throws(
+      () =>
+        new LicenseStore(path, {
+          migrationHook(step) {
+            reached.push(step);
+            if (step === "lifecycle-schema-created") throw new Error("deterministic migration failure");
+          }
+        }),
+      /deterministic migration failure/
+    );
+    assert.ok(reached.includes("lifecycle-schema-created"));
+
+    const rolledBack = open(path);
+    assert.equal(userVersion(rolledBack), 0);
+    assert.deepEqual(objectNames(rolledBack, "table"), ["activations", "license_issuance_events", "licenses"]);
+    assert.deepEqual(objectNames(rolledBack, "index"), []);
+    assertLegacyRowsPreserved(rolledBack);
+    rolledBack.close();
+
+    new LicenseStore(path).close();
+    const recovered = open(path);
+    assert.equal(userVersion(recovered), 2);
+    assertLegacyRowsPreserved(recovered);
+    recovered.close();
+  });
+});

--- a/services/license-api/test/store-migration.test.ts
+++ b/services/license-api/test/store-migration.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -154,15 +154,20 @@ interface MigrationOpener {
   completion: Promise<{ status: "opened" | "error"; detail?: string }>;
 }
 
-function startMigrationOpener(path: string, releasePath: string): MigrationOpener {
+function startMigrationOpener(path: string, acknowledgmentPath: string): MigrationOpener {
   const source = `
-    import { existsSync } from "node:fs";
+    import { writeFileSync } from "node:fs";
     const { LicenseStore } = await import(process.env.LICENSE_STORE_MODULE_URL);
     process.stdout.write("READY\\n");
-    const wait = new Int32Array(new SharedArrayBuffer(4));
-    while (!existsSync(process.env.MIGRATION_RELEASE_PATH)) Atomics.wait(wait, 0, 0, 5);
     try {
-      new LicenseStore(process.env.MIGRATION_DB_PATH, { busyTimeoutMs: 1000 }).close();
+      new LicenseStore(process.env.MIGRATION_DB_PATH, {
+        busyTimeoutMs: 1000,
+        migrationHook(step) {
+          if (step === "version-zero-classified") {
+            writeFileSync(process.env.MIGRATION_ACKNOWLEDGMENT_PATH, String(process.pid), { flag: "wx" });
+          }
+        }
+      }).close();
       process.stdout.write("OPENED\\n");
     } catch (error) {
       process.stdout.write(
@@ -179,7 +184,7 @@ function startMigrationOpener(path: string, releasePath: string): MigrationOpene
         ...process.env,
         LICENSE_STORE_MODULE_URL: new URL("../src/store.ts", import.meta.url).href,
         MIGRATION_DB_PATH: path,
-        MIGRATION_RELEASE_PATH: releasePath
+        MIGRATION_ACKNOWLEDGMENT_PATH: acknowledgmentPath
       }
     }
   );
@@ -231,6 +236,15 @@ function startMigrationOpener(path: string, releasePath: string): MigrationOpene
   return { child, ready, completion };
 }
 
+async function waitForAcknowledgments(paths: readonly string[]): Promise<void> {
+  const deadline = Date.now() + 500;
+  while (!paths.every(existsSync) && Date.now() < deadline) await delay(5);
+  assert.ok(
+    paths.every(existsSync),
+    "both migration openers must classify version zero before the writer lock is released"
+  );
+}
+
 describe("license store schema v2 migration", () => {
   for (const [label, setup] of [
     ["empty bootstrap", (_path: string) => {}],
@@ -239,17 +253,19 @@ describe("license store schema v2 migration", () => {
     it(`lets concurrent ${label} openers converge after inspecting the same v0 state`, async () => {
       const path = databasePath();
       setup(path);
-      const releasePath = join(tempDirectories.at(-1)!, "release-openers");
+      const acknowledgmentPaths = [
+        join(tempDirectories.at(-1)!, "opener-one-classified"),
+        join(tempDirectories.at(-1)!, "opener-two-classified")
+      ];
       const blocker = open(path);
       blocker.exec("begin immediate");
       const openers = [
-        startMigrationOpener(path, releasePath),
-        startMigrationOpener(path, releasePath)
+        startMigrationOpener(path, acknowledgmentPaths[0]),
+        startMigrationOpener(path, acknowledgmentPaths[1])
       ];
       try {
         await Promise.all(openers.map(({ ready }) => ready));
-        writeFileSync(releasePath, "go");
-        await delay(100);
+        await waitForAcknowledgments(acknowledgmentPaths);
         blocker.exec("rollback");
 
         assert.deepEqual(

--- a/services/license-api/test/store-migration.test.ts
+++ b/services/license-api/test/store-migration.test.ts
@@ -62,12 +62,23 @@ function userVersion(db: DatabaseSync): number {
   return Number((db.prepare("pragma user_version").get() as { user_version: number }).user_version);
 }
 
-function objectNames(db: DatabaseSync, type: "table" | "index" | "trigger"): string[] {
+function objectNames(db: DatabaseSync, type: "table" | "index" | "trigger" | "view"): string[] {
   return (
     db
       .prepare("select name from sqlite_schema where type = ? and name not like 'sqlite_%' order by name")
       .all(type) as unknown as Array<{ name: string }>
   ).map(({ name }) => name);
+}
+
+function schemaRows(db: DatabaseSync): unknown[] {
+  return db
+    .prepare(
+      `select type, name, tbl_name, sql
+       from sqlite_schema
+       where name not like 'sqlite_%'
+       order by type, name`
+    )
+    .all();
 }
 
 function createLegacyDatabase(path: string): void {
@@ -249,6 +260,32 @@ describe("license store schema v2 migration", () => {
     inspected.close();
   });
 
+  for (const [label, schema] of [
+    ["an extra CHECK constraint", LEGACY_SCHEMA.replace("seats integer not null default 1", "seats integer not null default 1 check (seats > 0)")],
+    [
+      "an ON DELETE CASCADE action",
+      LEGACY_SCHEMA.replace(
+        "references licenses(license_key_hash)",
+        "references licenses(license_key_hash) on delete cascade"
+      )
+    ]
+  ] as const) {
+    it(`rejects a legacy lookalike with ${label} before mutation`, () => {
+      const path = databasePath();
+      const db = open(path);
+      db.exec(schema);
+      const before = schemaRows(db);
+      db.close();
+
+      assert.throws(() => new LicenseStore(path), /unknown non-empty schema at user_version 0/);
+
+      const inspected = open(path);
+      assert.equal(userVersion(inspected), 0);
+      assert.deepEqual(schemaRows(inspected), before);
+      inspected.close();
+    });
+  }
+
   it("rejects a database labeled v2 when lifecycle constraints are missing", () => {
     const path = databasePath();
     const db = open(path);
@@ -291,34 +328,109 @@ describe("license store schema v2 migration", () => {
     assert.throws(() => new LicenseStore(path), /schema v2 has unexpected constraints/);
   });
 
-  it("rolls back all additive DDL and user_version when a migration hook fails", () => {
-    const path = databasePath();
-    createLegacyDatabase(path);
-    const reached: SchemaMigrationStep[] = [];
+  for (const [label, mutation, type, name] of [
+    [
+      "mutation trigger",
+      `create trigger unexpected_license_mutation
+       after update on licenses
+       begin
+         update licenses set status = 'revoked'
+         where license_key_hash = new.license_key_hash;
+       end`,
+      "trigger",
+      "unexpected_license_mutation"
+    ],
+    [
+      "projection view",
+      "create view unexpected_license_projection as select license_key_hash from licenses",
+      "view",
+      "unexpected_license_projection"
+    ]
+  ] as const) {
+    it(`rejects an otherwise valid v2 schema with an unexpected ${label}`, () => {
+      const path = databasePath();
+      new LicenseStore(path).close();
+      const db = open(path);
+      db.exec(mutation);
+      db.close();
 
-    assert.throws(
-      () =>
-        new LicenseStore(path, {
-          migrationHook(step) {
-            reached.push(step);
-            if (step === "lifecycle-schema-created") throw new Error("deterministic migration failure");
-          }
-        }),
-      /deterministic migration failure/
-    );
-    assert.ok(reached.includes("lifecycle-schema-created"));
+      assert.throws(() => new LicenseStore(path), /schema v2 has unexpected objects/);
 
-    const rolledBack = open(path);
-    assert.equal(userVersion(rolledBack), 0);
-    assert.deepEqual(objectNames(rolledBack, "table"), ["activations", "license_issuance_events", "licenses"]);
-    assert.deepEqual(objectNames(rolledBack, "index"), []);
-    assertLegacyRowsPreserved(rolledBack);
-    rolledBack.close();
+      const inspected = open(path);
+      assert.equal(userVersion(inspected), 2);
+      assert.deepEqual(objectNames(inspected, type), [name]);
+      inspected.close();
+    });
+  }
 
-    new LicenseStore(path).close();
-    const recovered = open(path);
-    assert.equal(userVersion(recovered), 2);
-    assertLegacyRowsPreserved(recovered);
-    recovered.close();
-  });
+  const rollbackCases: Array<{
+    label: string;
+    setup(path: string): void;
+    steps: SchemaMigrationStep[];
+    assertUnchanged(db: DatabaseSync): void;
+    assertRecovered(db: DatabaseSync): void;
+  }> = [
+    {
+      label: "empty bootstrap",
+      setup() {},
+      steps: ["core-schema-created", "lifecycle-schema-created", "schema-verified", "version-set"],
+      assertUnchanged(db) {
+        assert.equal(userVersion(db), 0);
+        assert.deepEqual(schemaRows(db), []);
+      },
+      assertRecovered(db) {
+        assert.equal(userVersion(db), 2);
+        assert.deepEqual(objectNames(db, "table"), [
+          "activations",
+          "checkout_subscription_bindings",
+          "license_issuance_events",
+          "license_subscription_lifecycle_events",
+          "licenses"
+        ]);
+      }
+    },
+    {
+      label: "legacy migration",
+      setup: createLegacyDatabase,
+      steps: ["lifecycle-schema-created", "schema-verified", "version-set"],
+      assertUnchanged(db) {
+        assert.equal(userVersion(db), 0);
+        assert.deepEqual(objectNames(db, "table"), ["activations", "license_issuance_events", "licenses"]);
+        assert.deepEqual(objectNames(db, "index"), []);
+        assertLegacyRowsPreserved(db);
+      },
+      assertRecovered(db) {
+        assert.equal(userVersion(db), 2);
+        assertLegacyRowsPreserved(db);
+      }
+    }
+  ];
+
+  for (const migration of rollbackCases) {
+    for (const failingStep of migration.steps) {
+      it(`rolls back ${migration.label} when ${failingStep} fails and later reopens cleanly`, () => {
+        const path = databasePath();
+        migration.setup(path);
+
+        assert.throws(
+          () =>
+            new LicenseStore(path, {
+              migrationHook(step) {
+                if (step === failingStep) throw new Error(`deterministic failure at ${step}`);
+              }
+            }),
+          new RegExp(`deterministic failure at ${failingStep}`)
+        );
+
+        const rolledBack = open(path);
+        migration.assertUnchanged(rolledBack);
+        rolledBack.close();
+
+        new LicenseStore(path).close();
+        const recovered = open(path);
+        migration.assertRecovered(recovered);
+        recovered.close();
+      });
+    }
+  }
 });

--- a/services/license-api/test/store-migration.test.ts
+++ b/services/license-api/test/store-migration.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, it } from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 import { LicenseStore, type SchemaMigrationStep } from "../src/store.ts";
 
 const LEGACY_SCHEMA = `
@@ -146,7 +148,131 @@ function assertLegacyRowsPreserved(db: DatabaseSync): void {
   });
 }
 
+interface MigrationOpener {
+  child: ChildProcessWithoutNullStreams;
+  ready: Promise<void>;
+  completion: Promise<{ status: "opened" | "error"; detail?: string }>;
+}
+
+function startMigrationOpener(path: string, releasePath: string): MigrationOpener {
+  const source = `
+    import { existsSync } from "node:fs";
+    const { LicenseStore } = await import(process.env.LICENSE_STORE_MODULE_URL);
+    process.stdout.write("READY\\n");
+    const wait = new Int32Array(new SharedArrayBuffer(4));
+    while (!existsSync(process.env.MIGRATION_RELEASE_PATH)) Atomics.wait(wait, 0, 0, 5);
+    try {
+      new LicenseStore(process.env.MIGRATION_DB_PATH, { busyTimeoutMs: 1000 }).close();
+      process.stdout.write("OPENED\\n");
+    } catch (error) {
+      process.stdout.write(
+        "ERROR " + (error instanceof Error ? error.constructor.name + ":" + error.message : "unknown") + "\\n"
+      );
+    }
+  `;
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "--eval", source],
+    {
+      cwd: new URL("..", import.meta.url),
+      env: {
+        ...process.env,
+        LICENSE_STORE_MODULE_URL: new URL("../src/store.ts", import.meta.url).href,
+        MIGRATION_DB_PATH: path,
+        MIGRATION_RELEASE_PATH: releasePath
+      }
+    }
+  );
+  const timeout = setTimeout(() => {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+  }, 5_000);
+  let output = "";
+  let stderr = "";
+  let readyResolve!: () => void;
+  let readyReject!: (error: Error) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    readyResolve = resolve;
+    readyReject = reject;
+  });
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    output += chunk;
+    if (output.includes("READY\n")) readyResolve();
+  });
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  const completion = new Promise<{ status: "opened" | "error"; detail?: string }>(
+    (resolve, reject) => {
+      child.once("error", (error) => {
+        clearTimeout(timeout);
+        readyReject(error);
+        reject(error);
+      });
+      child.once("exit", (code, signal) => {
+        clearTimeout(timeout);
+        if (!output.includes("READY\n")) {
+          readyReject(new Error(`migration opener exited before ready: ${stderr}`));
+        }
+        if (code !== 0 || signal !== null || stderr.length > 0) {
+          reject(new Error(`migration opener exited ${code ?? signal}: ${stderr}`));
+          return;
+        }
+        const errorLine = output.split("\n").find((line) => line.startsWith("ERROR "));
+        resolve(
+          errorLine
+            ? { status: "error", detail: errorLine.slice("ERROR ".length) }
+            : { status: "opened" }
+        );
+      });
+    }
+  );
+  return { child, ready, completion };
+}
+
 describe("license store schema v2 migration", () => {
+  for (const [label, setup] of [
+    ["empty bootstrap", (_path: string) => {}],
+    ["legacy migration", createLegacyDatabase]
+  ] as const) {
+    it(`lets concurrent ${label} openers converge after inspecting the same v0 state`, async () => {
+      const path = databasePath();
+      setup(path);
+      const releasePath = join(tempDirectories.at(-1)!, "release-openers");
+      const blocker = open(path);
+      blocker.exec("begin immediate");
+      const openers = [
+        startMigrationOpener(path, releasePath),
+        startMigrationOpener(path, releasePath)
+      ];
+      try {
+        await Promise.all(openers.map(({ ready }) => ready));
+        writeFileSync(releasePath, "go");
+        await delay(100);
+        blocker.exec("rollback");
+
+        assert.deepEqual(
+          await Promise.all(openers.map(({ completion }) => completion)),
+          [{ status: "opened" }, { status: "opened" }]
+        );
+        const inspected = open(path);
+        assert.equal(userVersion(inspected), 2);
+        if (label === "legacy migration") assertLegacyRowsPreserved(inspected);
+        inspected.close();
+      } finally {
+        try {
+          blocker.exec("rollback");
+        } catch {}
+        blocker.close();
+        for (const { child } of openers) {
+          if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+        }
+        await Promise.allSettled(openers.map(({ completion }) => completion));
+      }
+    });
+  }
+
   it("bootstraps an empty version-zero database directly to the complete v2 schema", () => {
     const path = databasePath();
     const store = new LicenseStore(path);

--- a/services/license-api/test/subscription-lifecycle-authority-types.ts
+++ b/services/license-api/test/subscription-lifecycle-authority-types.ts
@@ -1,0 +1,24 @@
+import type { ParsedSubscriptionLifecycleRequest } from "../src/subscription-lifecycle.js";
+
+declare const request: ParsedSubscriptionLifecycleRequest;
+
+if (request.command === "renew_paid" || request.command === "cancel_at_period_end") {
+  const authoritativePeriod: string = request.currentPeriodEnd;
+  void authoritativePeriod;
+  // @ts-expect-error Diagnostic periods are not present on authoritative commands.
+  request.diagnosticCurrentPeriodEnd;
+}
+
+if (request.command === "reconcile" || request.command === "payment_attention") {
+  const diagnosticPeriod: string | undefined = request.diagnosticCurrentPeriodEnd;
+  void diagnosticPeriod;
+  // @ts-expect-error Diagnostic commands cannot expose an authoritative period.
+  request.currentPeriodEnd;
+}
+
+if (request.command === "revoke") {
+  // @ts-expect-error Revocation cannot carry an authoritative period.
+  request.currentPeriodEnd;
+  // @ts-expect-error Revocation cannot carry a diagnostic period.
+  request.diagnosticCurrentPeriodEnd;
+}

--- a/services/license-api/test/subscription-lifecycle-http.test.ts
+++ b/services/license-api/test/subscription-lifecycle-http.test.ts
@@ -66,7 +66,7 @@ function lifecycleBody(
       providerEventType: "customer.subscription.deleted",
       subscriptionStatus: "canceled",
       cancelAtPeriodEnd: false,
-      reason: "provider subscription terminated"
+      reason: "subscription_canceled"
     }
   } as const;
   return {
@@ -105,7 +105,13 @@ async function post(
 }
 
 async function withLifecycleServer(
-  run: (context: { store: LicenseStore; server: Server; url: string; issuance: LicenseIssuanceRequest }) => Promise<void>,
+  run: (context: {
+    store: LicenseStore;
+    server: Server;
+    url: string;
+    issuance: LicenseIssuanceRequest;
+    rawKey: string;
+  }) => Promise<void>,
   options: {
     store?: LicenseStore;
     subscriptionLifecycleRateLimiter?: RateLimiter;
@@ -118,6 +124,7 @@ async function withLifecycleServer(
   const issuance = issuanceRequest();
   const issued = issueCheckoutLicense(store, issuance, ISSUANCE_SECRET);
   assert.equal(issued.httpStatus, 200);
+  const rawKey = String(issued.body.licenseKey);
   const started = await startLicenseServer({
     store,
     issuanceSecret: ISSUANCE_SECRET,
@@ -129,7 +136,7 @@ async function withLifecycleServer(
     trustFlyProxyHeaders: options.trustFlyProxyHeaders
   });
   try {
-    await run({ store, server: started.server, url: started.url, issuance });
+    await run({ store, server: started.server, url: started.url, issuance, rawKey });
   } finally {
     started.server.close();
     store.close();
@@ -342,6 +349,47 @@ describe("guarded subscription lifecycle HTTP endpoint", () => {
       assert.deepEqual(policy.json, { status: "invalid" });
       assert.ok(!policy.text.includes(policyReference));
       assert.ok(!policy.text.includes("evt_policy_private"));
+    });
+  });
+
+  it("rejects caller-supplied revoke text and returns only the derived safe reason to license clients", async () => {
+    await withLifecycleServer(async ({ url, issuance, rawKey }) => {
+      for (const reason of [
+        "buyer@example.com",
+        "cus_private_customer_reference",
+        "canceled\r\nforged-admin-line",
+        "canceled\u001b[2J"
+      ]) {
+        const rejected = await post(
+          url,
+          "/v1/admin/licenses/lifecycle",
+          lifecycleBody("revoke", issuance, { eventId: `evt_reject_${reason.length}`, reason }),
+          AUTH
+        );
+        assert.equal(rejected.status, 400);
+        assert.deepEqual(rejected.json, { status: "invalid" });
+        assert.ok(!rejected.text.includes(reason));
+      }
+
+      const applied = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("revoke", issuance, {
+          eventId: "evt_safe_revoke_reason",
+          reason: "subscription_canceled"
+        }),
+        AUTH
+      );
+      assert.equal(applied.status, 200);
+
+      const revoked = await post(url, "/v1/license/activate", {
+        licenseKey: rawKey,
+        machineId: "machine-safe-reason"
+      });
+      assert.equal(revoked.status, 403);
+      assert.equal(revoked.json.status, "revoked");
+      assert.equal(revoked.json.revocationReason, "subscription_canceled");
+      assert.doesNotMatch(revoked.text, /@|cus_|\r|\n|\u001b|forged-admin-line/);
     });
   });
 

--- a/services/license-api/test/subscription-lifecycle-http.test.ts
+++ b/services/license-api/test/subscription-lifecycle-http.test.ts
@@ -1,0 +1,437 @@
+import assert from "node:assert/strict";
+import type { Server } from "node:http";
+import { describe, it } from "node:test";
+import { issueCheckoutLicense, type LicenseIssuanceRequest } from "../src/issuance.ts";
+import { startLicenseServer } from "../src/http.ts";
+import { RateLimiter } from "../src/service.ts";
+import {
+  LicenseStore,
+  SubscriptionLifecycleTransientError
+} from "../src/store.ts";
+
+const NOW = new Date("2026-07-13T00:00:00.000Z");
+const NOW_SECONDS = Math.floor(NOW.getTime() / 1_000);
+const ISSUANCE_SECRET = "test-only-lifecycle-http-secret";
+const AUTH = { Authorization: `Bearer ${ISSUANCE_SECRET}` };
+
+function issuanceRequest(
+  overrides: Partial<LicenseIssuanceRequest> = {}
+): LicenseIssuanceRequest {
+  return {
+    idempotencyKey: "checkout-session:lifecycle-http",
+    checkoutLookupKey: "neondiff_monthly",
+    provider: "stripe",
+    providerAccountId: "acct_lifecycle_http",
+    providerMode: "live",
+    externalSubscriptionId: "sub_lifecycle_http",
+    externalCheckoutId: "cs_lifecycle_http",
+    ...overrides
+  };
+}
+
+function lifecycleBody(
+  command: "renew_paid" | "reconcile" | "cancel_at_period_end" | "payment_attention" | "revoke" = "renew_paid",
+  issuance: LicenseIssuanceRequest = issuanceRequest(),
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const variants = {
+    renew_paid: {
+      providerEventType: "invoice.paid",
+      subscriptionStatus: "active",
+      paymentReference: "in_lifecycle_http_secret_reference",
+      amountPaidMinor: 100,
+      currency: "usd",
+      paidOutOfBand: false,
+      billingReason: "subscription_cycle",
+      currentPeriodEnd: "2026-08-13T00:00:00.000Z",
+      cancelAtPeriodEnd: false
+    },
+    reconcile: {
+      providerEventType: "customer.subscription.updated",
+      subscriptionStatus: "active",
+      cancelAtPeriodEnd: false
+    },
+    cancel_at_period_end: {
+      providerEventType: "customer.subscription.updated",
+      subscriptionStatus: "active",
+      currentPeriodEnd: "2026-07-20T00:00:00.000Z",
+      cancelAtPeriodEnd: true
+    },
+    payment_attention: {
+      providerEventType: "invoice.payment_failed",
+      subscriptionStatus: "past_due",
+      cancelAtPeriodEnd: false
+    },
+    revoke: {
+      providerEventType: "customer.subscription.deleted",
+      subscriptionStatus: "canceled",
+      cancelAtPeriodEnd: false,
+      reason: "provider subscription terminated"
+    }
+  } as const;
+  return {
+    schemaVersion: 1,
+    issuanceIdempotencyKey: issuance.idempotencyKey,
+    eventId: `evt_${command}_lifecycle_http`,
+    eventCreatedAt: NOW_SECONDS,
+    provider: issuance.provider,
+    providerAccountId: issuance.providerAccountId,
+    providerMode: issuance.providerMode,
+    externalSubscriptionId: issuance.externalSubscriptionId,
+    command,
+    ...variants[command],
+    ...overrides
+  };
+}
+
+async function post(
+  url: string,
+  path: string,
+  body: unknown,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; headers: Headers; text: string; json: Record<string, any> }> {
+  const response = await fetch(`${url}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: typeof body === "string" ? body : JSON.stringify(body)
+  });
+  const text = await response.text();
+  return {
+    status: response.status,
+    headers: response.headers,
+    text,
+    json: text ? JSON.parse(text) as Record<string, any> : {}
+  };
+}
+
+async function withLifecycleServer(
+  run: (context: { store: LicenseStore; server: Server; url: string; issuance: LicenseIssuanceRequest }) => Promise<void>,
+  options: {
+    store?: LicenseStore;
+    subscriptionLifecycleRateLimiter?: RateLimiter;
+    lifecycleRateLimiter?: RateLimiter;
+    lifecycleOidcVerifier?: { verify(token: string): Promise<any> };
+  } = {}
+): Promise<void> {
+  const store = options.store ?? new LicenseStore(":memory:", { now: () => NOW });
+  const issuance = issuanceRequest();
+  const issued = issueCheckoutLicense(store, issuance, ISSUANCE_SECRET);
+  assert.equal(issued.httpStatus, 200);
+  const started = await startLicenseServer({
+    store,
+    issuanceSecret: ISSUANCE_SECRET,
+    now: () => NOW,
+    rateLimiter: new RateLimiter({ maxPerWindow: 100, windowMs: 60_000 }),
+    subscriptionLifecycleRateLimiter: options.subscriptionLifecycleRateLimiter,
+    lifecycleRateLimiter: options.lifecycleRateLimiter,
+    lifecycleOidcVerifier: options.lifecycleOidcVerifier
+  });
+  try {
+    await run({ store, server: started.server, url: started.url, issuance });
+  } finally {
+    started.server.close();
+    store.close();
+  }
+}
+
+function assertRedactedLifecycleResponse(response: {
+  text: string;
+  json: Record<string, any>;
+}, forbidden: readonly string[] = []): void {
+  for (const value of [ISSUANCE_SECRET, ...forbidden]) {
+    assert.ok(!response.text.includes(value), `response leaked forbidden value: ${value}`);
+  }
+  assert.deepEqual(Object.keys(response.json).sort(), ["entitlement", "replayed", "status"]);
+  assert.deepEqual(Object.keys(response.json.entitlement).sort(), ["expiresAt", "plan", "seats", "status"]);
+}
+
+describe("guarded subscription lifecycle HTTP endpoint", () => {
+  it("authenticates before parsing or correlation lookup with one generic 401", async () => {
+    await withLifecycleServer(async ({ store, url }) => {
+      let applyCalls = 0;
+      const original = store.applyCheckoutSubscriptionLifecycle.bind(store);
+      store.applyCheckoutSubscriptionLifecycle = ((...args: Parameters<typeof original>) => {
+        applyCalls += 1;
+        return original(...args);
+      }) as typeof store.applyCheckoutSubscriptionLifecycle;
+      const secretReference = "checkout-session:does-not-exist-private";
+      const malformed = "{not-json-with-private-reference";
+      const missing = await post(url, "/v1/admin/licenses/lifecycle", malformed);
+      const invalid = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("renew_paid", issuanceRequest({ idempotencyKey: secretReference })),
+        { Authorization: "Bearer wrong-secret-private" }
+      );
+      assert.equal(missing.status, 401);
+      assert.equal(invalid.status, 401);
+      assert.deepEqual(missing.json, { status: "unauthorized" });
+      assert.deepEqual(invalid.json, missing.json);
+      assert.equal(applyCalls, 0);
+      assert.ok(!missing.text.includes("not-json"));
+      assert.ok(!invalid.text.includes(secretReference));
+      assert.ok(!invalid.text.includes("wrong-secret-private"));
+    });
+  });
+
+  it("accepts an exact 16 KiB body and rejects a larger authenticated body without echo", async () => {
+    await withLifecycleServer(async ({ url }) => {
+      const base = lifecycleBody("reconcile", issuanceRequest(), { padding: "" });
+      const fixedBytes = Buffer.byteLength(JSON.stringify(base));
+      const exactBody = JSON.stringify({ ...base, padding: "x".repeat(16 * 1024 - fixedBytes) });
+      assert.equal(Buffer.byteLength(exactBody), 16 * 1024);
+      const exact = await post(url, "/v1/admin/licenses/lifecycle", exactBody, AUTH);
+      assert.equal(exact.status, 400);
+      assert.deepEqual(exact.json, { status: "invalid" });
+
+      const marker = "oversized-private-marker";
+      const oversized = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        `${exactBody}${marker}`,
+        AUTH
+      );
+      assert.equal(oversized.status, 413);
+      assert.deepEqual(oversized.json, { status: "invalid" });
+      assert.ok(!oversized.text.includes(marker));
+    });
+  });
+
+  it("maps applied, replay, stale, attention, cancellation, and revoke results to redacted 200 responses", async () => {
+    for (const [command, expectedStatus] of [
+      ["renew_paid", "updated"],
+      ["reconcile", "updated"],
+      ["cancel_at_period_end", "updated"],
+      ["payment_attention", "payment_attention"],
+      ["revoke", "terminally_revoked"]
+    ] as const) {
+      await withLifecycleServer(async ({ url, issuance }) => {
+        const body = lifecycleBody(command, issuance);
+        const response = await post(url, "/v1/admin/licenses/lifecycle", body, AUTH);
+        assert.equal(response.status, 200, command);
+        assert.equal(response.json.status, expectedStatus);
+        assert.equal(response.json.replayed, false);
+        assertRedactedLifecycleResponse(response, [
+          body.issuanceIdempotencyKey as string,
+          body.eventId as string,
+          body.externalSubscriptionId as string,
+          "in_lifecycle_http_secret_reference",
+          "provider subscription terminated"
+        ]);
+      });
+    }
+
+    await withLifecycleServer(async ({ url, issuance }) => {
+      const body = lifecycleBody("renew_paid", issuance);
+      assert.equal((await post(url, "/v1/admin/licenses/lifecycle", body, AUTH)).status, 200);
+      const replay = await post(url, "/v1/admin/licenses/lifecycle", body, AUTH);
+      assert.equal(replay.status, 200);
+      assert.equal(replay.json.status, "replayed");
+      assert.equal(replay.json.replayed, true);
+      assertRedactedLifecycleResponse(replay, [body.eventId as string]);
+    });
+
+    await withLifecycleServer(async ({ url, issuance }) => {
+      const newer = lifecycleBody("reconcile", issuance, {
+        eventId: "evt_newer_http",
+        eventCreatedAt: NOW_SECONDS
+      });
+      const stale = lifecycleBody("reconcile", issuance, {
+        eventId: "evt_stale_http",
+        eventCreatedAt: NOW_SECONDS - 1
+      });
+      assert.equal((await post(url, "/v1/admin/licenses/lifecycle", newer, AUTH)).status, 200);
+      const response = await post(url, "/v1/admin/licenses/lifecycle", stale, AUTH);
+      assert.equal(response.status, 200);
+      assert.equal(response.json.status, "ignored_stale");
+      assert.equal(response.json.replayed, false);
+      assertRedactedLifecycleResponse(response, [stale.eventId as string]);
+    });
+  });
+
+  it("maps conflict and terminal outcomes to distinct redacted 409 states", async () => {
+    await withLifecycleServer(async ({ url, issuance }) => {
+      const first = lifecycleBody("reconcile", issuance, { eventId: "evt_conflict_http" });
+      assert.equal((await post(url, "/v1/admin/licenses/lifecycle", first, AUTH)).status, 200);
+      const conflict = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        { ...first, subscriptionStatus: "trialing" },
+        AUTH
+      );
+      assert.equal(conflict.status, 409);
+      assert.deepEqual(conflict.json, { status: "conflict" });
+      assert.ok(!conflict.text.includes("evt_conflict_http"));
+    });
+
+    await withLifecycleServer(async ({ url, issuance }) => {
+      assert.equal(
+        (await post(url, "/v1/admin/licenses/lifecycle", lifecycleBody("revoke", issuance), AUTH)).status,
+        200
+      );
+      const terminal = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("renew_paid", issuance, { eventId: "evt_after_terminal_http" }),
+        AUTH
+      );
+      assert.equal(terminal.status, 409);
+      assert.deepEqual(terminal.json, { status: "terminally_revoked" });
+      assert.ok(!terminal.text.includes("evt_after_terminal_http"));
+    });
+  });
+
+  it("maps unknown, unbound, and provider-correlation mismatches to the same redacted 404", async () => {
+    await withLifecycleServer(async ({ store, url, issuance }) => {
+      store.issueIdempotentLicense("nd_live_unboundHttpFixture000000", {
+        idempotencyKey: "checkout-session:unbound-http",
+        requestHash: "unbound",
+        source: "checkout",
+        externalRef: "cs_unbound_http",
+        plan: "monthly_support",
+        repoVisibilityScope: "private",
+        privateRepoAllowed: true,
+        updateEntitlement: true,
+        seats: 1,
+        expiresAt: "2026-07-20T00:00:00.000Z"
+      });
+      const cases = [
+        lifecycleBody("renew_paid", issuanceRequest({ idempotencyKey: "checkout-session:unknown-http" })),
+        lifecycleBody("renew_paid", issuanceRequest({ idempotencyKey: "checkout-session:unbound-http" })),
+        lifecycleBody("renew_paid", issuance, { providerAccountId: "acct_wrong_private" }),
+        lifecycleBody("renew_paid", issuance, { providerMode: "test" }),
+        lifecycleBody("renew_paid", issuance, { externalSubscriptionId: "sub_wrong_private" })
+      ];
+      for (const body of cases) {
+        const response = await post(url, "/v1/admin/licenses/lifecycle", body, AUTH);
+        assert.equal(response.status, 404);
+        assert.deepEqual(response.json, { status: "not_found" });
+        for (const value of Object.values(body)) {
+          if (typeof value === "string" && value.length > 8) assert.ok(!response.text.includes(value));
+        }
+      }
+    });
+  });
+
+  it("maps parser and store policy failures to the same redacted 400", async () => {
+    await withLifecycleServer(async ({ url, issuance }) => {
+      const malformed = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        "{invalid-private-json",
+        AUTH
+      );
+      assert.equal(malformed.status, 400);
+      assert.deepEqual(malformed.json, { status: "invalid" });
+      assert.ok(!malformed.text.includes("invalid-private-json"));
+
+      const policyReference = "policy-private-payment-reference";
+      const policy = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("renew_paid", issuance, {
+          eventId: "evt_policy_private",
+          paymentReference: policyReference,
+          currentPeriodEnd: "2027-12-31T00:00:00.000Z"
+        }),
+        AUTH
+      );
+      assert.equal(policy.status, 400);
+      assert.deepEqual(policy.json, { status: "invalid" });
+      assert.ok(!policy.text.includes(policyReference));
+      assert.ok(!policy.text.includes("evt_policy_private"));
+    });
+  });
+
+  it("maps bounded storage busy failures to 503 and redacts unexpected exceptions", async () => {
+    await withLifecycleServer(async ({ store, url, issuance }) => {
+      const secretError = "sqlite busy at private-ref-123";
+      store.applyCheckoutSubscriptionLifecycle = (() => {
+        throw new SubscriptionLifecycleTransientError(secretError);
+      }) as typeof store.applyCheckoutSubscriptionLifecycle;
+      const unavailable = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("renew_paid", issuance),
+        AUTH
+      );
+      assert.equal(unavailable.status, 503);
+      assert.deepEqual(unavailable.json, { status: "unavailable" });
+      assert.ok(!unavailable.text.includes(secretError));
+    });
+
+    await withLifecycleServer(async ({ store, url, issuance }) => {
+      const secretError = "internal exception private-ref-456";
+      store.applyCheckoutSubscriptionLifecycle = (() => {
+        throw new Error(secretError);
+      }) as typeof store.applyCheckoutSubscriptionLifecycle;
+      const failure = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("renew_paid", issuance),
+        AUTH
+      );
+      assert.equal(failure.status, 500);
+      assert.deepEqual(failure.json, { status: "server" });
+      assert.ok(!failure.text.includes(secretError));
+    });
+  });
+
+  it("uses a bounded redacted 429 with a dedicated limiter budget", async () => {
+    const subscriptionLimiter = new RateLimiter({ maxPerWindow: 1, windowMs: 60_000 });
+    const oidcLimiter = new RateLimiter({ maxPerWindow: 1, windowMs: 60_000 });
+    let oidcVerifierCalls = 0;
+    await withLifecycleServer(async ({ url, issuance }) => {
+      const oidcBody = {
+        releaseVersion: "v1.0.4",
+        candidateHead: "a".repeat(40),
+        packShasum: "b".repeat(40),
+        packIntegrity: `sha512-${"Y".repeat(86)}==`
+      };
+      await post(url, "/v1/admin/licenses/issue-lifecycle", oidcBody, {
+        Authorization: "Bearer invalid-oidc-one",
+        "Fly-Client-IP": "203.0.113.25"
+      });
+      const oidcLimited = await post(url, "/v1/admin/licenses/issue-lifecycle", oidcBody, {
+        Authorization: "Bearer invalid-oidc-two",
+        "Fly-Client-IP": "203.0.113.25"
+      });
+      assert.equal(oidcLimited.status, 429);
+
+      const first = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("reconcile", issuance),
+        { ...AUTH, "Fly-Client-IP": "203.0.113.25" }
+      );
+      assert.equal(first.status, 200);
+      const privateRef = "checkout-session:rate-limit-private";
+      const limited = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("reconcile", issuance, {
+          issuanceIdempotencyKey: privateRef,
+          eventId: "evt_rate_limit_private"
+        }),
+        { ...AUTH, "Fly-Client-IP": "203.0.113.25" }
+      );
+      assert.equal(limited.status, 429);
+      assert.deepEqual(limited.json, { status: "rate_limited" });
+      assert.match(limited.headers.get("retry-after") ?? "", /^\d+$/);
+      assert.ok(Number(limited.headers.get("retry-after")) >= 1);
+      assert.ok(Number(limited.headers.get("retry-after")) <= 60);
+      assert.ok(!limited.text.includes(privateRef));
+      assert.ok(!limited.text.includes(ISSUANCE_SECRET));
+      assert.equal(oidcVerifierCalls, 1);
+    }, {
+      subscriptionLifecycleRateLimiter: subscriptionLimiter,
+      lifecycleRateLimiter: oidcLimiter,
+      lifecycleOidcVerifier: {
+        verify: async () => {
+          oidcVerifierCalls += 1;
+          throw new Error("invalid oidc fixture");
+        }
+      }
+    });
+  });
+});

--- a/services/license-api/test/subscription-lifecycle-http.test.ts
+++ b/services/license-api/test/subscription-lifecycle-http.test.ts
@@ -114,13 +114,15 @@ async function withLifecycleServer(
   }) => Promise<void>,
   options: {
     store?: LicenseStore;
+    now?: () => Date;
     subscriptionLifecycleRateLimiter?: RateLimiter;
     lifecycleRateLimiter?: RateLimiter;
     lifecycleOidcVerifier?: { verify(token: string): Promise<any> };
     trustFlyProxyHeaders?: boolean;
   } = {}
 ): Promise<void> {
-  const store = options.store ?? new LicenseStore(":memory:", { now: () => NOW });
+  const now = options.now ?? (() => NOW);
+  const store = options.store ?? new LicenseStore(":memory:", { now });
   const issuance = issuanceRequest();
   const issued = issueCheckoutLicense(store, issuance, ISSUANCE_SECRET);
   assert.equal(issued.httpStatus, 200);
@@ -128,7 +130,7 @@ async function withLifecycleServer(
   const started = await startLicenseServer({
     store,
     issuanceSecret: ISSUANCE_SECRET,
-    now: () => NOW,
+    now,
     rateLimiter: new RateLimiter({ maxPerWindow: 100, windowMs: 60_000 }),
     subscriptionLifecycleRateLimiter: options.subscriptionLifecycleRateLimiter,
     lifecycleRateLimiter: options.lifecycleRateLimiter,
@@ -287,6 +289,88 @@ describe("guarded subscription lifecycle HTTP endpoint", () => {
       assert.equal(terminal.status, 409);
       assert.deepEqual(terminal.json, { status: "terminally_revoked" });
       assert.ok(!terminal.text.includes("evt_after_terminal_http"));
+    });
+  });
+
+  it("replays exact renewals and cancellations after their period ends", async () => {
+    for (const command of ["renew_paid", "cancel_at_period_end"] as const) {
+      let now = NOW;
+      await withLifecycleServer(async ({ url, issuance }) => {
+        const body = lifecycleBody(command, issuance, {
+          eventId: `evt_delayed_${command}_http`
+        });
+        assert.equal((await post(url, "/v1/admin/licenses/lifecycle", body, AUTH)).status, 200);
+
+        now = new Date("2026-08-21T00:00:00.000Z");
+        const replay = await post(url, "/v1/admin/licenses/lifecycle", body, AUTH);
+        assert.equal(replay.status, 200, command);
+        assert.equal(replay.json.status, "replayed", command);
+        assert.equal(replay.json.replayed, true, command);
+      }, { now: () => now });
+    }
+  });
+
+  it("preserves conflict detection for changed lifecycle content after expiry", async () => {
+    let now = NOW;
+    await withLifecycleServer(async ({ url, issuance }) => {
+      const original = lifecycleBody("renew_paid", issuance, {
+        eventId: "evt_changed_after_expiry_http"
+      });
+      assert.equal((await post(url, "/v1/admin/licenses/lifecycle", original, AUTH)).status, 200);
+
+      now = new Date("2026-08-21T00:00:00.000Z");
+      const conflict = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        { ...original, currentPeriodEnd: "2026-08-14T00:00:00.000Z" },
+        AUTH
+      );
+      assert.equal(conflict.status, 409);
+      assert.deepEqual(conflict.json, { status: "conflict" });
+    }, { now: () => now });
+  });
+
+  it("rejects brand-new elapsed renewals and cancellations without consuming the event ID", async () => {
+    for (const command of ["renew_paid", "cancel_at_period_end"] as const) {
+      let now = new Date("2026-08-21T00:00:00.000Z");
+      await withLifecycleServer(async ({ url, issuance }) => {
+        const body = lifecycleBody(command, issuance, {
+          eventId: `evt_new_elapsed_${command}_http`
+        });
+        const rejected = await post(url, "/v1/admin/licenses/lifecycle", body, AUTH);
+        assert.equal(rejected.status, 400, command);
+        assert.deepEqual(rejected.json, { status: "invalid" }, command);
+
+        now = NOW;
+        const retry = await post(url, "/v1/admin/licenses/lifecycle", body, AUTH);
+        assert.equal(retry.status, 200, command);
+        assert.equal(retry.json.status, "updated", command);
+        assert.equal(retry.json.replayed, false, command);
+      }, { now: () => now });
+    }
+  });
+
+  it("rejects canceling renewals without consuming the event ID", async () => {
+    await withLifecycleServer(async ({ url, issuance }) => {
+      const eventId = "evt_canceling_renewal_http";
+      const rejected = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("renew_paid", issuance, { eventId, cancelAtPeriodEnd: true }),
+        AUTH
+      );
+      assert.equal(rejected.status, 400);
+      assert.deepEqual(rejected.json, { status: "invalid" });
+
+      const retry = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("renew_paid", issuance, { eventId, cancelAtPeriodEnd: false }),
+        AUTH
+      );
+      assert.equal(retry.status, 200);
+      assert.equal(retry.json.status, "updated");
+      assert.equal(retry.json.replayed, false);
     });
   });
 

--- a/services/license-api/test/subscription-lifecycle-http.test.ts
+++ b/services/license-api/test/subscription-lifecycle-http.test.ts
@@ -111,6 +111,7 @@ async function withLifecycleServer(
     subscriptionLifecycleRateLimiter?: RateLimiter;
     lifecycleRateLimiter?: RateLimiter;
     lifecycleOidcVerifier?: { verify(token: string): Promise<any> };
+    trustFlyProxyHeaders?: boolean;
   } = {}
 ): Promise<void> {
   const store = options.store ?? new LicenseStore(":memory:", { now: () => NOW });
@@ -124,7 +125,8 @@ async function withLifecycleServer(
     rateLimiter: new RateLimiter({ maxPerWindow: 100, windowMs: 60_000 }),
     subscriptionLifecycleRateLimiter: options.subscriptionLifecycleRateLimiter,
     lifecycleRateLimiter: options.lifecycleRateLimiter,
-    lifecycleOidcVerifier: options.lifecycleOidcVerifier
+    lifecycleOidcVerifier: options.lifecycleOidcVerifier,
+    trustFlyProxyHeaders: options.trustFlyProxyHeaders
   });
   try {
     await run({ store, server: started.server, url: started.url, issuance });
@@ -432,6 +434,80 @@ describe("guarded subscription lifecycle HTTP endpoint", () => {
           throw new Error("invalid oidc fixture");
         }
       }
+    });
+  });
+
+  it("ignores forged Fly client addresses unless the Fly proxy trust boundary is enabled", async () => {
+    await withLifecycleServer(async ({ url, issuance }) => {
+      const first = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("reconcile", issuance, { eventId: "evt_untrusted_proxy_one" }),
+        { ...AUTH, "Fly-Client-IP": "203.0.113.31" }
+      );
+      const forgedRotation = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("reconcile", issuance, { eventId: "evt_untrusted_proxy_two" }),
+        { ...AUTH, "Fly-Client-IP": "203.0.113.32" }
+      );
+      assert.equal(first.status, 200);
+      assert.equal(forgedRotation.status, 429);
+    }, {
+      subscriptionLifecycleRateLimiter: new RateLimiter({
+        maxPerWindow: 1,
+        windowMs: 60_000
+      })
+    });
+  });
+
+  it("uses valid Fly client addresses only in explicitly trusted proxy mode", async () => {
+    await withLifecycleServer(async ({ url, issuance }) => {
+      const first = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("reconcile", issuance, { eventId: "evt_trusted_proxy_one" }),
+        { ...AUTH, "Fly-Client-IP": "203.0.113.41" }
+      );
+      const independent = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("reconcile", issuance, { eventId: "evt_trusted_proxy_two" }),
+        { ...AUTH, "Fly-Client-IP": "203.0.113.42" }
+      );
+      assert.equal(first.status, 200);
+      assert.equal(independent.status, 200);
+    }, {
+      trustFlyProxyHeaders: true,
+      subscriptionLifecycleRateLimiter: new RateLimiter({
+        maxPerWindow: 1,
+        windowMs: 60_000
+      })
+    });
+  });
+
+  it("fails malformed and multi-value Fly client headers safe to the socket budget", async () => {
+    await withLifecycleServer(async ({ url, issuance }) => {
+      const malformed = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("reconcile", issuance, { eventId: "evt_malformed_proxy" }),
+        { ...AUTH, "Fly-Client-IP": "not-an-ip" }
+      );
+      const multiValue = await post(
+        url,
+        "/v1/admin/licenses/lifecycle",
+        lifecycleBody("reconcile", issuance, { eventId: "evt_multi_proxy" }),
+        { ...AUTH, "Fly-Client-IP": "203.0.113.51, 203.0.113.52" }
+      );
+      assert.equal(malformed.status, 200);
+      assert.equal(multiValue.status, 429);
+    }, {
+      trustFlyProxyHeaders: true,
+      subscriptionLifecycleRateLimiter: new RateLimiter({
+        maxPerWindow: 1,
+        windowMs: 60_000
+      })
     });
   });
 });

--- a/services/license-api/test/subscription-lifecycle-parser.test.ts
+++ b/services/license-api/test/subscription-lifecycle-parser.test.ts
@@ -1,0 +1,279 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  LifecycleRequestError,
+  MAX_LIFECYCLE_BODY_BYTES,
+  canonicalSubscriptionLifecycleRequestHash,
+  parseSubscriptionLifecycleRequest,
+  paymentReferenceFingerprint
+} from "../src/subscription-lifecycle.js";
+
+const NOW = new Date("2026-07-13T12:00:00.000Z");
+
+function validRenewal(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    issuanceIdempotencyKey: "checkout-session:cs_live_parser",
+    eventId: "evt_live_paid_1",
+    eventCreatedAt: Math.floor(NOW.getTime() / 1000),
+    provider: "stripe",
+    providerAccountId: "acct_live_product",
+    providerMode: "live",
+    externalSubscriptionId: "sub_live_parser",
+    providerEventType: "invoice.paid",
+    command: "renew_paid",
+    paymentReference: "in_live_secret_reference",
+    amountPaidMinor: 100,
+    currency: "usd",
+    paidOutOfBand: false,
+    billingReason: "subscription_cycle",
+    subscriptionStatus: "active",
+    currentPeriodEnd: "2026-08-13T12:00:00.000Z",
+    cancelAtPeriodEnd: false,
+    ...overrides
+  };
+}
+
+function parse(body: Record<string, unknown>) {
+  return parseSubscriptionLifecycleRequest(JSON.stringify(body), NOW);
+}
+
+function invalid(body: Record<string, unknown>, pattern?: RegExp): void {
+  assert.throws(
+    () => parse(body),
+    (error: unknown) => {
+      assert.ok(error instanceof LifecycleRequestError);
+      if (pattern) assert.match(error.message, pattern);
+      assert.doesNotMatch(error.message, /in_live_secret_reference|sk_live|Bearer/i);
+      return true;
+    }
+  );
+}
+
+test("parses a paid renewal without retaining its raw payment reference", () => {
+  const parsed = parse(validRenewal());
+
+  assert.equal(parsed.command, "renew_paid");
+  assert.equal(parsed.currentPeriodEnd, "2026-08-13T12:00:00.000Z");
+  assert.equal(parsed.paymentReferenceFingerprint, paymentReferenceFingerprint("in_live_secret_reference"));
+  assert.equal("paymentReference" in parsed, false);
+  assert.match(parsed.paymentReferenceFingerprint!, /^[a-f0-9]{64}$/);
+  assert.match(parsed.requestHash, /^[a-f0-9]{64}$/);
+});
+
+test("rejects a body over the byte limit before JSON parsing", () => {
+  const raw = "{" + "x".repeat(MAX_LIFECYCLE_BODY_BYTES) + "}";
+  assert.throws(
+    () => parseSubscriptionLifecycleRequest(raw, NOW),
+    (error: unknown) =>
+      error instanceof LifecycleRequestError && error.message === "request body is too large"
+  );
+});
+
+test("rejects malformed, non-object, unknown-field, and incomplete requests generically", () => {
+  assert.throws(() => parseSubscriptionLifecycleRequest("{secret", NOW), /valid JSON/);
+  assert.throws(() => parseSubscriptionLifecycleRequest("[]", NOW), /JSON object/);
+  invalid(validRenewal({ sk_live_do_not_echo: "secret" }), /unknown field/);
+  const missing = validRenewal();
+  delete missing.eventId;
+  invalid(missing, /eventId is required/);
+});
+
+test("enforces bounded shared strings and the immutable Stripe provider tuple", () => {
+  for (const [name, overrides, pattern] of [
+    ["issuance", { issuanceIdempotencyKey: "x".repeat(201) }, /issuanceIdempotencyKey is too long/],
+    ["event", { eventId: "x".repeat(201) }, /eventId is too long/],
+    ["account", { providerAccountId: "x".repeat(161) }, /providerAccountId is too long/],
+    ["subscription", { externalSubscriptionId: "x".repeat(161) }, /externalSubscriptionId is too long/],
+    ["payment", { paymentReference: "x".repeat(201) }, /paymentReference is too long/],
+    ["provider", { provider: "adyen" }, /provider must be stripe/],
+    ["mode", { providerMode: "production" }, /providerMode must be test or live/],
+    ["empty account", { providerAccountId: "  " }, /providerAccountId is required/]
+  ] as const) {
+    invalid(validRenewal(overrides), pattern);
+    assert.ok(name);
+  }
+});
+
+test("requires an integer epoch event time and permits at most five minutes of future skew", () => {
+  for (const value of ["1783944000", 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+    invalid(validRenewal({ eventCreatedAt: value }), /eventCreatedAt must be an integer epoch/);
+  }
+  parse(validRenewal({ eventCreatedAt: Math.floor(NOW.getTime() / 1000) + 300 }));
+  invalid(
+    validRenewal({ eventCreatedAt: Math.floor(NOW.getTime() / 1000) + 301 }),
+    /eventCreatedAt is too far in the future/
+  );
+});
+
+test("accepts every supported command, provider-event, and status tuple", () => {
+  const cases: Record<string, unknown>[] = [
+    validRenewal(),
+    validRenewal({ providerEventType: "invoice.payment_succeeded" }),
+    {
+      ...validRenewal({
+        providerEventType: "customer.subscription.updated",
+        command: "reconcile",
+        subscriptionStatus: "trialing"
+      }),
+      cancelAtPeriodEnd: false
+    },
+    validRenewal({
+      providerEventType: "customer.subscription.updated",
+      command: "cancel_at_period_end",
+      subscriptionStatus: "active",
+      cancelAtPeriodEnd: true
+    }),
+    validRenewal({
+      providerEventType: "invoice.payment_failed",
+      command: "payment_attention",
+      subscriptionStatus: "past_due"
+    }),
+    validRenewal({
+      providerEventType: "customer.subscription.updated",
+      command: "payment_attention",
+      subscriptionStatus: "paused"
+    }),
+    validRenewal({
+      providerEventType: "customer.subscription.deleted",
+      command: "revoke",
+      subscriptionStatus: "canceled",
+      reason: "subscription deleted"
+    }),
+    validRenewal({
+      providerEventType: "customer.subscription.updated",
+      command: "revoke",
+      subscriptionStatus: "incomplete_expired"
+    })
+  ];
+
+  for (const body of cases) {
+    if (body.command !== "renew_paid") {
+      delete body.paymentReference;
+      delete body.amountPaidMinor;
+      delete body.currency;
+      delete body.paidOutOfBand;
+      delete body.billingReason;
+    }
+    if (body.command === "reconcile" || body.command === "payment_attention") {
+      delete body.currentPeriodEnd;
+    }
+    if (body.command === "revoke") delete body.currentPeriodEnd;
+    parse(body);
+  }
+});
+
+test("rejects unsupported command, event, and status cross-pairings", () => {
+  const cases: Array<[Record<string, unknown>, RegExp]> = [
+    [validRenewal({ command: "extend" }), /command is unsupported/],
+    [validRenewal({ providerEventType: "customer.subscription.updated" }), /providerEventType is invalid for renew_paid/],
+    [validRenewal({ subscriptionStatus: "trialing" }), /subscriptionStatus is invalid for renew_paid/],
+    [validRenewal({ command: "reconcile", providerEventType: "invoice.paid" }), /providerEventType is invalid for reconcile/],
+    [validRenewal({ command: "reconcile", providerEventType: "customer.subscription.updated", subscriptionStatus: "past_due" }), /subscriptionStatus is invalid for reconcile/],
+    [validRenewal({ command: "cancel_at_period_end", providerEventType: "customer.subscription.updated", subscriptionStatus: "past_due" }), /subscriptionStatus is invalid for cancel_at_period_end/],
+    [validRenewal({ command: "payment_attention", providerEventType: "invoice.paid", subscriptionStatus: "past_due" }), /providerEventType is invalid for payment_attention/],
+    [validRenewal({ command: "payment_attention", providerEventType: "invoice.payment_failed", subscriptionStatus: "trialing" }), /subscriptionStatus is invalid for payment_attention/],
+    [validRenewal({ command: "revoke", providerEventType: "invoice.payment_failed", subscriptionStatus: "canceled" }), /providerEventType is invalid for revoke/],
+    [validRenewal({ command: "revoke", providerEventType: "customer.subscription.deleted", subscriptionStatus: "active" }), /subscriptionStatus is invalid for revoke/]
+  ];
+  for (const [body, pattern] of cases) invalid(body, pattern);
+});
+
+test("requires paid active subscription-cycle evidence for renew_paid", () => {
+  for (const [overrides, pattern] of [
+    [{ paymentReference: "" }, /paymentReference is required/],
+    [{ amountPaidMinor: 0 }, /amountPaidMinor must be a positive integer/],
+    [{ amountPaidMinor: -1 }, /amountPaidMinor must be a positive integer/],
+    [{ amountPaidMinor: 1.5 }, /amountPaidMinor must be a positive integer/],
+    [{ currency: "USD" }, /currency must be usd/],
+    [{ currency: "eur" }, /currency must be usd/],
+    [{ paidOutOfBand: true }, /paidOutOfBand must be false/],
+    [{ billingReason: "manual" }, /billingReason must be subscription_cycle/],
+    [{ billingReason: "subscription_create" }, /billingReason must be subscription_cycle/],
+    [{ subscriptionStatus: "trialing" }, /subscriptionStatus is invalid for renew_paid/]
+  ] as const) {
+    invalid(validRenewal(overrides), pattern);
+  }
+});
+
+test("enforces command-specific payment, period-end, cancellation, and reason fields", () => {
+  const reconcile = validRenewal({
+    providerEventType: "customer.subscription.updated",
+    command: "reconcile",
+    subscriptionStatus: "active",
+    cancelAtPeriodEnd: false
+  });
+  delete reconcile.paymentReference;
+  delete reconcile.amountPaidMinor;
+  delete reconcile.currency;
+  delete reconcile.paidOutOfBand;
+  delete reconcile.billingReason;
+  parse(reconcile);
+  invalid({ ...reconcile, paymentReference: "in_live_secret_reference" }, /payment fields are forbidden/);
+  invalid({ ...reconcile, cancelAtPeriodEnd: true }, /cancelAtPeriodEnd must be false/);
+
+  const cancel = { ...reconcile, command: "cancel_at_period_end", cancelAtPeriodEnd: true };
+  parse(cancel);
+  invalid({ ...cancel, currentPeriodEnd: undefined }, /currentPeriodEnd is required/);
+  invalid({ ...cancel, cancelAtPeriodEnd: false }, /cancelAtPeriodEnd must be true/);
+
+  const attention = {
+    ...reconcile,
+    providerEventType: "invoice.payment_failed",
+    command: "payment_attention",
+    subscriptionStatus: "incomplete"
+  };
+  parse(attention);
+  invalid({ ...attention, amountPaidMinor: 100 }, /payment fields are forbidden/);
+
+  const revoke = {
+    ...reconcile,
+    providerEventType: "customer.subscription.deleted",
+    command: "revoke",
+    subscriptionStatus: "unpaid"
+  };
+  delete revoke.currentPeriodEnd;
+  parse(revoke);
+  invalid({ ...revoke, currentPeriodEnd: "2026-08-13T12:00:00.000Z" }, /currentPeriodEnd is forbidden/);
+  invalid({ ...revoke, currency: "usd" }, /payment fields are forbidden/);
+  invalid({ ...revoke, reason: "x".repeat(201) }, /reason is too long/);
+  invalid({ ...reconcile, reason: "not revoked" }, /reason is only allowed for revoke/);
+});
+
+test("validates optional or required period ends as strict future instants", () => {
+  for (const value of [
+    "not-a-date",
+    "2026-07-13T12:00:00.000Z",
+    "2026-07-13T11:59:59.999Z",
+    "2026-08-13",
+    1786622400000
+  ]) {
+    invalid(validRenewal({ currentPeriodEnd: value }), /currentPeriodEnd/);
+  }
+});
+
+test("uses fixed-order canonical hashing independent of object insertion order", () => {
+  const body = validRenewal();
+  const reversed = Object.fromEntries(Object.entries(body).reverse());
+  const first = parse(body);
+  const second = parse(reversed);
+
+  assert.equal(first.requestHash, second.requestHash);
+  assert.equal(canonicalSubscriptionLifecycleRequestHash(first), first.requestHash);
+  assert.notEqual(
+    parse(validRenewal({ eventId: "evt_live_paid_2" })).requestHash,
+    first.requestHash
+  );
+  assert.notEqual(
+    parse(validRenewal({ paymentReference: "in_live_other_reference" })).requestHash,
+    first.requestHash
+  );
+});
+
+test("payment fingerprints are deterministic, domain-separated, and never expose the reference", () => {
+  const first = paymentReferenceFingerprint("in_live_secret_reference");
+  const second = paymentReferenceFingerprint("in_live_secret_reference");
+  assert.equal(first, second);
+  assert.notEqual(first, paymentReferenceFingerprint("in_live_other_reference"));
+  assert.doesNotMatch(first, /in_live_secret_reference/);
+});

--- a/services/license-api/test/subscription-lifecycle-parser.test.ts
+++ b/services/license-api/test/subscription-lifecycle-parser.test.ts
@@ -378,14 +378,45 @@ test("enforces command-specific payment, period-end, cancellation, and reason fi
     ...reconcile,
     providerEventType: "customer.subscription.deleted",
     command: "revoke",
-    subscriptionStatus: "unpaid"
+    subscriptionStatus: "unpaid",
+    reason: "subscription_unpaid"
   };
   delete revoke.currentPeriodEnd;
   parse(revoke);
   invalid({ ...revoke, currentPeriodEnd: "2026-08-13T12:00:00.000Z" }, /currentPeriodEnd is forbidden/);
   invalid({ ...revoke, currency: "usd" }, /payment fields are forbidden/);
-  invalid({ ...revoke, reason: "x".repeat(201) }, /reason is too long/);
+  invalid({ ...revoke, reason: "x".repeat(201) }, /reason/);
   invalid({ ...reconcile, reason: "not revoked" }, /reason is only allowed for revoke/);
+});
+
+test("derives a non-secret revoke reason code and rejects arbitrary caller text", () => {
+  for (const [subscriptionStatus, expectedReason] of [
+    ["canceled", "subscription_canceled"],
+    ["unpaid", "subscription_unpaid"],
+    ["incomplete_expired", "subscription_incomplete_expired"]
+  ] as const) {
+    const withoutReason = parse(lifecycleBody("revoke", undefined, subscriptionStatus));
+    assert.equal(withoutReason.command, "revoke");
+    assert.equal(withoutReason.reason, expectedReason);
+
+    const exactReason = parse({
+      ...lifecycleBody("revoke", undefined, subscriptionStatus),
+      reason: expectedReason
+    });
+    assert.equal(exactReason.reason, expectedReason);
+
+    for (const unsafeReason of [
+      "buyer@example.com",
+      "cus_customer_reference",
+      "subscription canceled\r\nforged-admin-line",
+      "subscription canceled\u001b[2J"
+    ]) {
+      invalid(
+        { ...lifecycleBody("revoke", undefined, subscriptionStatus), reason: unsafeReason },
+        /reason must match the server-derived code/
+      );
+    }
+  }
 });
 
 test("validates optional or required period ends as strict future instants", () => {

--- a/services/license-api/test/subscription-lifecycle-parser.test.ts
+++ b/services/license-api/test/subscription-lifecycle-parser.test.ts
@@ -344,6 +344,13 @@ test("requires paid active subscription-cycle evidence for renew_paid", () => {
   }
 });
 
+test("requires renew_paid to represent a non-canceling subscription", () => {
+  invalid(
+    validRenewal({ cancelAtPeriodEnd: true }),
+    /cancelAtPeriodEnd must be false for renew_paid/
+  );
+});
+
 test("enforces command-specific payment, period-end, cancellation, and reason fields", () => {
   const reconcile = validRenewal({
     providerEventType: "customer.subscription.updated",
@@ -439,15 +446,18 @@ test("preserves schema-v1 omitted-reason replay hashing while deriving a safe st
   assert.notEqual(provided.requestHash, omitted.requestHash);
 });
 
-test("validates optional or required period ends as strict future instants", () => {
+test("validates period ends as strict UTC instants without applying clock freshness", () => {
   for (const value of [
     "not-a-date",
-    "2026-07-13T12:00:00.000Z",
-    "2026-07-13T11:59:59.999Z",
     "2026-08-13",
     1786622400000
   ]) {
     invalid(validRenewal({ currentPeriodEnd: value }), /currentPeriodEnd/);
+  }
+  for (const value of ["2026-07-13T12:00:00.000Z", "2026-07-13T11:59:59.999Z"]) {
+    const parsed = parse(validRenewal({ currentPeriodEnd: value }));
+    assert.equal(parsed.command, "renew_paid");
+    assert.equal(parsed.currentPeriodEnd, value);
   }
 });
 

--- a/services/license-api/test/subscription-lifecycle-parser.test.ts
+++ b/services/license-api/test/subscription-lifecycle-parser.test.ts
@@ -419,6 +419,26 @@ test("derives a non-secret revoke reason code and rejects arbitrary caller text"
   }
 });
 
+test("preserves schema-v1 omitted-reason replay hashing while deriving a safe stored reason", () => {
+  const omitted = parse(lifecycleBody("revoke", undefined, "canceled"));
+  assert.equal(omitted.command, "revoke");
+  assert.equal(omitted.reason, "subscription_canceled");
+  assert.equal(omitted.reasonProvided, false);
+  assert.equal(
+    omitted.requestHash,
+    "f263fb7a07ff32aafed816b368c7adf5bbe1b300ea59f58c54d08b9dd25c42b6"
+  );
+  assert.equal(canonicalSubscriptionLifecycleRequestHash(omitted), omitted.requestHash);
+
+  const provided = parse({
+    ...lifecycleBody("revoke", undefined, "canceled"),
+    reason: "subscription_canceled"
+  });
+  assert.equal(provided.command, "revoke");
+  assert.equal(provided.reasonProvided, true);
+  assert.notEqual(provided.requestHash, omitted.requestHash);
+});
+
 test("validates optional or required period ends as strict future instants", () => {
   for (const value of [
     "not-a-date",

--- a/services/license-api/test/subscription-lifecycle-parser.test.ts
+++ b/services/license-api/test/subscription-lifecycle-parser.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   LifecycleRequestError,
   MAX_LIFECYCLE_BODY_BYTES,
@@ -9,6 +11,59 @@ import {
 } from "../src/subscription-lifecycle.js";
 
 const NOW = new Date("2026-07-13T12:00:00.000Z");
+const SERVICE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+const COMMAND_MATRIX = {
+  renew_paid: {
+    events: ["invoice.paid", "invoice.payment_succeeded"],
+    statuses: ["active"]
+  },
+  reconcile: {
+    events: ["customer.subscription.updated"],
+    statuses: ["active", "trialing"]
+  },
+  cancel_at_period_end: {
+    events: ["customer.subscription.updated"],
+    statuses: ["active", "trialing"]
+  },
+  payment_attention: {
+    events: ["invoice.payment_failed", "customer.subscription.updated"],
+    statuses: ["active", "past_due", "incomplete", "paused"]
+  },
+  revoke: {
+    events: ["customer.subscription.deleted", "customer.subscription.updated"],
+    statuses: ["canceled", "unpaid", "incomplete_expired"]
+  }
+} as const;
+
+type MatrixCommand = keyof typeof COMMAND_MATRIX;
+
+const ALL_EVENTS = [
+  "invoice.paid",
+  "invoice.payment_succeeded",
+  "customer.subscription.updated",
+  "invoice.payment_failed",
+  "customer.subscription.deleted"
+] as const;
+
+const ALL_STATUSES = [
+  "active",
+  "trialing",
+  "past_due",
+  "incomplete",
+  "paused",
+  "canceled",
+  "unpaid",
+  "incomplete_expired"
+] as const;
+
+const PAYMENT_FIELDS = [
+  "paymentReference",
+  "amountPaidMinor",
+  "currency",
+  "paidOutOfBand",
+  "billingReason"
+] as const;
 
 function validRenewal(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -38,6 +93,27 @@ function parse(body: Record<string, unknown>) {
   return parseSubscriptionLifecycleRequest(JSON.stringify(body), NOW);
 }
 
+function lifecycleBody(
+  command: MatrixCommand,
+  event: string = COMMAND_MATRIX[command].events[0],
+  status: string = COMMAND_MATRIX[command].statuses[0]
+): Record<string, unknown> {
+  const body = validRenewal({
+    command,
+    providerEventType: event,
+    subscriptionStatus: status
+  });
+  if (command !== "renew_paid") {
+    for (const field of PAYMENT_FIELDS) delete body[field];
+  }
+  if (command === "reconcile" || command === "payment_attention") {
+    delete body.currentPeriodEnd;
+  }
+  if (command === "cancel_at_period_end") body.cancelAtPeriodEnd = true;
+  if (command === "revoke") delete body.currentPeriodEnd;
+  return body;
+}
+
 function invalid(body: Record<string, unknown>, pattern?: RegExp): void {
   assert.throws(
     () => parse(body),
@@ -59,6 +135,48 @@ test("parses a paid renewal without retaining its raw payment reference", () => 
   assert.equal("paymentReference" in parsed, false);
   assert.match(parsed.paymentReferenceFingerprint!, /^[a-f0-9]{64}$/);
   assert.match(parsed.requestHash, /^[a-f0-9]{64}$/);
+});
+
+test("separates diagnostic period ends from authoritative renewal and cancellation periods", () => {
+  for (const command of ["reconcile", "payment_attention"] as const) {
+    const parsed = parse({
+      ...lifecycleBody(command),
+      currentPeriodEnd: "2026-08-13T12:00:00.000Z"
+    });
+    assert.equal(parsed.command, command);
+    assert.equal(parsed.diagnosticCurrentPeriodEnd, "2026-08-13T12:00:00.000Z");
+    assert.equal("currentPeriodEnd" in parsed, false);
+  }
+
+  for (const command of ["renew_paid", "cancel_at_period_end"] as const) {
+    const parsed = parse(lifecycleBody(command));
+    assert.equal(parsed.command, command);
+    assert.equal(parsed.currentPeriodEnd, "2026-08-13T12:00:00.000Z");
+    assert.equal("diagnosticCurrentPeriodEnd" in parsed, false);
+  }
+});
+
+test("compile-time command narrowing prevents diagnostic period authority smuggling", () => {
+  assert.doesNotThrow(() =>
+    execFileSync(
+      process.execPath,
+      [
+        "node_modules/typescript/bin/tsc",
+        "--noEmit",
+        "--strict",
+        "--target",
+        "ES2023",
+        "--module",
+        "NodeNext",
+        "--moduleResolution",
+        "NodeNext",
+        "--types",
+        "node",
+        "test/subscription-lifecycle-authority-types.ts"
+      ],
+      { cwd: SERVICE_ROOT, stdio: "pipe" }
+    )
+  );
 });
 
 test("rejects a body over the byte limit before JSON parsing", () => {
@@ -106,77 +224,107 @@ test("requires an integer epoch event time and permits at most five minutes of f
   );
 });
 
-test("accepts every supported command, provider-event, and status tuple", () => {
-  const cases: Record<string, unknown>[] = [
-    validRenewal(),
-    validRenewal({ providerEventType: "invoice.payment_succeeded" }),
-    {
-      ...validRenewal({
-        providerEventType: "customer.subscription.updated",
-        command: "reconcile",
-        subscriptionStatus: "trialing"
-      }),
-      cancelAtPeriodEnd: false
-    },
-    validRenewal({
-      providerEventType: "customer.subscription.updated",
-      command: "cancel_at_period_end",
-      subscriptionStatus: "active",
-      cancelAtPeriodEnd: true
-    }),
-    validRenewal({
-      providerEventType: "invoice.payment_failed",
-      command: "payment_attention",
-      subscriptionStatus: "past_due"
-    }),
-    validRenewal({
-      providerEventType: "customer.subscription.updated",
-      command: "payment_attention",
-      subscriptionStatus: "paused"
-    }),
-    validRenewal({
-      providerEventType: "customer.subscription.deleted",
-      command: "revoke",
-      subscriptionStatus: "canceled",
-      reason: "subscription deleted"
-    }),
-    validRenewal({
-      providerEventType: "customer.subscription.updated",
-      command: "revoke",
-      subscriptionStatus: "incomplete_expired"
-    })
-  ];
-
-  for (const body of cases) {
-    if (body.command !== "renew_paid") {
-      delete body.paymentReference;
-      delete body.amountPaidMinor;
-      delete body.currency;
-      delete body.paidOutOfBand;
-      delete body.billingReason;
+test("accepts every valid command, provider-event, status, and optional-period combination", () => {
+  let accepted = 0;
+  for (const command of Object.keys(COMMAND_MATRIX) as MatrixCommand[]) {
+    const rule = COMMAND_MATRIX[command];
+    for (const event of rule.events) {
+      for (const status of rule.statuses) {
+        parse(lifecycleBody(command, event, status));
+        accepted += 1;
+        if (command === "reconcile" || command === "payment_attention") {
+          const parsed = parse({
+            ...lifecycleBody(command, event, status),
+            currentPeriodEnd: "2026-08-13T12:00:00.000Z"
+          });
+          assert.equal(parsed.diagnosticCurrentPeriodEnd, "2026-08-13T12:00:00.000Z");
+          accepted += 1;
+        }
+      }
     }
-    if (body.command === "reconcile" || body.command === "payment_attention") {
-      delete body.currentPeriodEnd;
-    }
-    if (body.command === "revoke") delete body.currentPeriodEnd;
-    parse(body);
   }
+  assert.equal(accepted, 30);
 });
 
-test("rejects unsupported command, event, and status cross-pairings", () => {
-  const cases: Array<[Record<string, unknown>, RegExp]> = [
-    [validRenewal({ command: "extend" }), /command is unsupported/],
-    [validRenewal({ providerEventType: "customer.subscription.updated" }), /providerEventType is invalid for renew_paid/],
-    [validRenewal({ subscriptionStatus: "trialing" }), /subscriptionStatus is invalid for renew_paid/],
-    [validRenewal({ command: "reconcile", providerEventType: "invoice.paid" }), /providerEventType is invalid for reconcile/],
-    [validRenewal({ command: "reconcile", providerEventType: "customer.subscription.updated", subscriptionStatus: "past_due" }), /subscriptionStatus is invalid for reconcile/],
-    [validRenewal({ command: "cancel_at_period_end", providerEventType: "customer.subscription.updated", subscriptionStatus: "past_due" }), /subscriptionStatus is invalid for cancel_at_period_end/],
-    [validRenewal({ command: "payment_attention", providerEventType: "invoice.paid", subscriptionStatus: "past_due" }), /providerEventType is invalid for payment_attention/],
-    [validRenewal({ command: "payment_attention", providerEventType: "invoice.payment_failed", subscriptionStatus: "trialing" }), /subscriptionStatus is invalid for payment_attention/],
-    [validRenewal({ command: "revoke", providerEventType: "invoice.payment_failed", subscriptionStatus: "canceled" }), /providerEventType is invalid for revoke/],
-    [validRenewal({ command: "revoke", providerEventType: "customer.subscription.deleted", subscriptionStatus: "active" }), /subscriptionStatus is invalid for revoke/]
-  ];
-  for (const [body, pattern] of cases) invalid(body, pattern);
+test("rejects every cross-command event and status tuple plus unsupported values", () => {
+  let rejected = 0;
+  for (const command of Object.keys(COMMAND_MATRIX) as MatrixCommand[]) {
+    const rule = COMMAND_MATRIX[command];
+    for (const event of ALL_EVENTS) {
+      for (const status of ALL_STATUSES) {
+        const isValid =
+          (rule.events as readonly string[]).includes(event) &&
+          (rule.statuses as readonly string[]).includes(status);
+        if (isValid) continue;
+        invalid(lifecycleBody(command, event, status));
+        rejected += 1;
+      }
+    }
+    invalid(lifecycleBody(command, "unsupported.event", rule.statuses[0]));
+    invalid(lifecycleBody(command, rule.events[0], "unsupported_status"));
+    rejected += 2;
+  }
+  assert.equal(rejected, 190);
+  invalid(validRenewal({ command: "extend" }), /command is unsupported/);
+});
+
+test("exhaustively enforces shared and command-specific required fields", () => {
+  const sharedRequired = [
+    "schemaVersion",
+    "issuanceIdempotencyKey",
+    "eventId",
+    "eventCreatedAt",
+    "provider",
+    "providerAccountId",
+    "providerMode",
+    "externalSubscriptionId",
+    "providerEventType",
+    "command",
+    "subscriptionStatus",
+    "cancelAtPeriodEnd"
+  ] as const;
+  for (const command of Object.keys(COMMAND_MATRIX) as MatrixCommand[]) {
+    for (const field of sharedRequired) {
+      const body = lifecycleBody(command);
+      delete body[field];
+      invalid(body);
+    }
+  }
+  for (const field of [...PAYMENT_FIELDS, "currentPeriodEnd"] as const) {
+    const body = lifecycleBody("renew_paid");
+    delete body[field];
+    invalid(body);
+  }
+  const cancel = lifecycleBody("cancel_at_period_end");
+  delete cancel.currentPeriodEnd;
+  invalid(cancel, /currentPeriodEnd is required/);
+});
+
+test("exhaustively rejects fields forbidden by each command", () => {
+  for (const command of [
+    "reconcile",
+    "cancel_at_period_end",
+    "payment_attention",
+    "revoke"
+  ] as const) {
+    for (const field of PAYMENT_FIELDS) {
+      invalid({ ...lifecycleBody(command), [field]: validRenewal()[field] }, /payment fields/);
+    }
+  }
+  for (const command of [
+    "renew_paid",
+    "reconcile",
+    "cancel_at_period_end",
+    "payment_attention"
+  ] as const) {
+    invalid({ ...lifecycleBody(command), reason: "not a revocation" }, /reason is only allowed/);
+  }
+  invalid(
+    { ...lifecycleBody("revoke"), currentPeriodEnd: "2026-08-13T12:00:00.000Z" },
+    /currentPeriodEnd is forbidden/
+  );
+  invalid({ ...lifecycleBody("reconcile"), cancelAtPeriodEnd: true }, /must be false/);
+  invalid({ ...lifecycleBody("cancel_at_period_end"), cancelAtPeriodEnd: false }, /must be true/);
 });
 
 test("requires paid active subscription-cycle evidence for renew_paid", () => {

--- a/services/license-api/test/subscription-lifecycle-store.test.ts
+++ b/services/license-api/test/subscription-lifecycle-store.test.ts
@@ -17,10 +17,15 @@ const ISSUANCE_SECRET = "test-only-lifecycle-issuance-secret";
 const DAY_MS = 24 * 60 * 60 * 1_000;
 
 type LifecycleResult = {
-  status: "updated" | "replayed";
+  status:
+    | "updated"
+    | "replayed"
+    | "ignored_stale"
+    | "payment_attention"
+    | "terminally_revoked";
   replayed: boolean;
   entitlement: {
-    status: "active";
+    status: "active" | "expired" | "revoked";
     plan: string;
     seats: number;
     expiresAt: string;
@@ -100,6 +105,54 @@ function renewal(
       subscriptionStatus: "active",
       currentPeriodEnd: "2026-08-13T00:00:00.000Z",
       cancelAtPeriodEnd: false,
+      ...overrides
+    }),
+    now
+  );
+}
+
+function lifecycleRequest(
+  command: "reconcile" | "cancel_at_period_end" | "payment_attention" | "revoke",
+  issuance: LicenseIssuanceRequest = issuanceRequest(),
+  overrides: Record<string, unknown> = {},
+  now: Date = NOW
+): ParsedSubscriptionLifecycleRequest {
+  const variants = {
+    reconcile: {
+      providerEventType: "customer.subscription.updated",
+      subscriptionStatus: "active",
+      cancelAtPeriodEnd: false
+    },
+    cancel_at_period_end: {
+      providerEventType: "customer.subscription.updated",
+      subscriptionStatus: "active",
+      currentPeriodEnd: "2026-08-20T00:00:00.000Z",
+      cancelAtPeriodEnd: true
+    },
+    payment_attention: {
+      providerEventType: "invoice.payment_failed",
+      subscriptionStatus: "past_due",
+      cancelAtPeriodEnd: false
+    },
+    revoke: {
+      providerEventType: "customer.subscription.deleted",
+      subscriptionStatus: "canceled",
+      cancelAtPeriodEnd: false,
+      reason: "provider subscription terminated"
+    }
+  } as const;
+  return parseSubscriptionLifecycleRequest(
+    JSON.stringify({
+      schemaVersion: 1,
+      issuanceIdempotencyKey: issuance.idempotencyKey,
+      eventId: `evt_${command}_lifecycle_store`,
+      eventCreatedAt: NOW_SECONDS,
+      provider: issuance.provider,
+      providerAccountId: issuance.providerAccountId,
+      providerMode: issuance.providerMode,
+      externalSubscriptionId: issuance.externalSubscriptionId,
+      command,
+      ...variants[command],
       ...overrides
     }),
     now
@@ -540,6 +593,361 @@ describe("checkout subscription lifecycle renewal", () => {
         blocker.exec("rollback");
       } catch {}
       blocker.close();
+      store.close();
+    }
+  });
+});
+
+describe("checkout subscription lifecycle ordering and terminal dominance", () => {
+  it("records reconcile without extending or reactivating the entitlement", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path, { now: () => NOW });
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:reconcile-record-only",
+        externalSubscriptionId: "sub_reconcile_record_only",
+        externalCheckoutId: "cs_reconcile_record_only"
+      });
+      const db = new DatabaseSync(path);
+      db.prepare("update licenses set status = 'expired' where license_key_hash = ?")
+        .run(issued.licenseKeyHash);
+      db.close();
+
+      const result = applyLifecycle(store, lifecycleRequest("reconcile", issued.request, {
+        currentPeriodEnd: "2026-08-20T00:00:00.000Z"
+      }));
+
+      assert.deepEqual(result, {
+        status: "updated",
+        replayed: false,
+        entitlement: {
+          status: "expired",
+          plan: "monthly_support",
+          seats: 1,
+          expiresAt: issued.expiresAt
+        }
+      });
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.status, "expired");
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.expiresAt, issued.expiresAt);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("audits older non-mutating events as ignored_stale without moving the watermark", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path, { now: () => NOW });
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:stale-audit",
+        externalSubscriptionId: "sub_stale_audit",
+        externalCheckoutId: "cs_stale_audit"
+      });
+      const newest = lifecycleRequest("cancel_at_period_end", issued.request, {
+        eventId: "evt_stale_newest",
+        eventCreatedAt: NOW_SECONDS
+      });
+      const stale = lifecycleRequest("payment_attention", issued.request, {
+        eventId: "evt_stale_older",
+        eventCreatedAt: NOW_SECONDS - 60
+      });
+
+      assert.equal(applyLifecycle(store, newest).status, "updated");
+      assert.equal(applyLifecycle(store, stale).status, "ignored_stale");
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.expiresAt, issued.expiresAt);
+
+      const binding = inspectDatabase<{ last_non_mutating_event_created_at: number }>(
+        path,
+        `select last_non_mutating_event_created_at
+         from checkout_subscription_bindings
+         where issuance_idempotency_key = ?`,
+        issued.request.idempotencyKey
+      )[0];
+      assert.equal(binding?.last_non_mutating_event_created_at, NOW_SECONDS);
+      assert.deepEqual(
+        inspectDatabase<{ event_id: string; result: string; normalized_transition: string }>(
+          path,
+          `select event_id, result, normalized_transition
+           from license_subscription_lifecycle_events
+           order by event_id`
+        ).map((row) => ({ ...row })),
+        [
+          {
+            event_id: "evt_stale_newest",
+            result: "updated",
+            normalized_transition: "cancel_at_period_end"
+          },
+          {
+            event_id: "evt_stale_older",
+            result: "ignored_stale",
+            normalized_transition: "payment_attention"
+          }
+        ]
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("preserves expiry exactly for cancellation and grants no time or early revoke for attention", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path, { now: () => NOW });
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:cancel-attention",
+        externalSubscriptionId: "sub_cancel_attention",
+        externalCheckoutId: "cs_cancel_attention"
+      });
+      const before = store.getLicenseByKey(issued.rawKey);
+
+      const cancellation = applyLifecycle(store, lifecycleRequest("cancel_at_period_end", issued.request, {
+        eventId: "evt_cancel_preserve_exact",
+        currentPeriodEnd: "2026-08-20T00:00:00.000Z"
+      }));
+      const attention = applyLifecycle(store, lifecycleRequest("payment_attention", issued.request, {
+        eventId: "evt_attention_no_time",
+        eventCreatedAt: NOW_SECONDS + 1,
+        currentPeriodEnd: "2026-08-21T00:00:00.000Z"
+      }));
+
+      assert.equal(cancellation.status, "updated");
+      assert.equal(attention.status, "payment_attention");
+      assert.deepEqual(store.getLicenseByKey(issued.rawKey), before);
+      assert.equal(attention.entitlement.status, "active");
+      assert.equal(attention.entitlement.expiresAt, issued.expiresAt);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("revokes without a period end, persists a bounded reason, and exact-replays terminal state", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path, { now: () => NOW });
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:terminal-revoke",
+        externalSubscriptionId: "sub_terminal_revoke",
+        externalCheckoutId: "cs_terminal_revoke"
+      });
+      const request = lifecycleRequest("revoke", issued.request, {
+        reason: "bounded provider termination reason"
+      });
+
+      assert.deepEqual(applyLifecycle(store, request), {
+        status: "terminally_revoked",
+        replayed: false,
+        entitlement: {
+          status: "revoked",
+          plan: "monthly_support",
+          seats: 1,
+          expiresAt: issued.expiresAt
+        }
+      });
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.revocationReason,
+        "bounded provider termination reason");
+      assert.deepEqual(applyLifecycle(store, request), {
+        status: "replayed",
+        replayed: true,
+        entitlement: {
+          status: "revoked",
+          plan: "monthly_support",
+          seats: 1,
+          expiresAt: issued.expiresAt
+        }
+      });
+      const ledger = inspectDatabase<{ normalized_transition: string; result: string }>(
+        path,
+        "select normalized_transition, result from license_subscription_lifecycle_events"
+      ).map((row) => ({ ...row }));
+      assert.deepEqual(ledger, [{
+        normalized_transition: "revoke",
+        result: "terminally_revoked"
+      }]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("cannot resurrect a terminal entitlement with later renew, reconcile, cancel, or attention", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path, { now: () => NOW });
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:no-resurrection",
+        externalSubscriptionId: "sub_no_resurrection",
+        externalCheckoutId: "cs_no_resurrection"
+      });
+      applyLifecycle(store, lifecycleRequest("revoke", issued.request));
+      const later = NOW_SECONDS + 30;
+      const requests = [
+        renewal(issued.request, { eventId: "evt_terminal_late_renew", eventCreatedAt: later }),
+        lifecycleRequest("reconcile", issued.request, {
+          eventId: "evt_terminal_late_reconcile", eventCreatedAt: later
+        }),
+        lifecycleRequest("cancel_at_period_end", issued.request, {
+          eventId: "evt_terminal_late_cancel", eventCreatedAt: later
+        }),
+        lifecycleRequest("payment_attention", issued.request, {
+          eventId: "evt_terminal_late_attention", eventCreatedAt: later
+        })
+      ];
+      for (const request of requests) {
+        assert.throws(
+          () => applyLifecycle(store, request),
+          (error: unknown) => errorName(error) === "SubscriptionLifecycleTerminalError"
+        );
+      }
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.status, "revoked");
+      assert.equal(
+        inspectDatabase<{ count: number }>(
+          path,
+          "select count(*) as count from license_subscription_lifecycle_events"
+        )[0]?.count,
+        1
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("converges for same-second renewal and update arrival orders with explicit equal-time precedence", () => {
+    const projections: Array<Record<string, unknown>> = [];
+    for (const updateCommand of ["reconcile", "cancel_at_period_end", "payment_attention"] as const) {
+      for (const order of ["renew-first", "update-first"] as const) {
+        const path = databasePath();
+        const firstStore = new LicenseStore(path, { now: () => NOW });
+        const secondStore = new LicenseStore(path, { now: () => NOW });
+        try {
+          const suffix = `${updateCommand}-${order}`;
+          const issued = issueBound(firstStore, {
+            idempotencyKey: `checkout-session:same-second-${suffix}`,
+            externalSubscriptionId: `sub_same_second_${suffix}`,
+            externalCheckoutId: `cs_same_second_${suffix}`
+          });
+          const paid = renewal(issued.request, {
+            eventId: `evt_paid_${suffix}`,
+            eventCreatedAt: NOW_SECONDS,
+            currentPeriodEnd: "2026-08-20T00:00:00.000Z"
+          });
+          const update = lifecycleRequest(updateCommand, issued.request, {
+            eventId: `evt_update_${suffix}`,
+            eventCreatedAt: NOW_SECONDS
+          });
+          const requests = order === "renew-first" ? [paid, update] : [update, paid];
+          const statuses = [
+            applyLifecycle(firstStore, requests[0]!).status,
+            applyLifecycle(secondStore, requests[1]!).status
+          ].sort();
+          const license = secondStore.getLicenseByKey(issued.rawKey)!;
+
+          projections.push({
+            updateCommand,
+            statuses,
+            license: {
+              status: license.status,
+              plan: license.plan,
+              seats: license.seats,
+              expiresAt: license.expiresAt
+            },
+            ledger: inspectDatabase<{ command: string; result: string }>(
+              path,
+              `select command, result
+               from license_subscription_lifecycle_events
+               order by command`
+            )
+          });
+        } finally {
+          secondStore.close();
+          firstStore.close();
+        }
+      }
+    }
+
+    for (let index = 0; index < projections.length; index += 2) {
+      const first = projections[index]!;
+      const second = projections[index + 1]!;
+      assert.deepEqual(first.statuses, second.statuses);
+      assert.deepEqual(first.license, second.license);
+      assert.deepEqual(first.ledger, second.ledger);
+      assert.equal((first.license as { expiresAt: string }).expiresAt,
+        "2026-08-20T00:00:00.000Z");
+    }
+  });
+
+  it("lets revoke dominate both arrival orders and preserves the key hash and activations", () => {
+    for (const order of ["renew-first", "revoke-first"] as const) {
+      const path = databasePath();
+      const store = new LicenseStore(path, { now: () => NOW });
+      try {
+        const issued = issueBound(store, {
+          idempotencyKey: `checkout-session:terminal-order-${order}`,
+          externalSubscriptionId: `sub_terminal_order_${order}`,
+          externalCheckoutId: `cs_terminal_order_${order}`
+        });
+        assert.equal(activate(store, {
+          licenseKey: issued.rawKey,
+          machineId: "machine-terminal-order",
+          repo: "owner/repo"
+        }, NOW).httpStatus, 200);
+        const activations = store.listActivations(issued.licenseKeyHash);
+        const paid = renewal(issued.request, { eventId: `evt_terminal_paid_${order}` });
+        const revoked = lifecycleRequest("revoke", issued.request, {
+          eventId: `evt_terminal_revoke_${order}`
+        });
+
+        if (order === "renew-first") {
+          applyLifecycle(store, paid);
+          applyLifecycle(store, revoked);
+        } else {
+          applyLifecycle(store, revoked);
+          assert.throws(
+            () => applyLifecycle(store, paid),
+            (error: unknown) => errorName(error) === "SubscriptionLifecycleTerminalError"
+          );
+        }
+
+        assert.equal(store.getLicenseByKey(issued.rawKey)?.status, "revoked");
+        assert.equal(store.getLicenseByKey(issued.rawKey)?.licenseKeyHash, issued.licenseKeyHash);
+        assert.deepEqual(store.listActivations(issued.licenseKeyHash), activations);
+      } finally {
+        store.close();
+      }
+    }
+  });
+
+  it("rolls back terminal mutation when its ledger insert fails", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path, { now: () => NOW });
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:terminal-rollback",
+        externalSubscriptionId: "sub_terminal_rollback",
+        externalCheckoutId: "cs_terminal_rollback"
+      });
+      const db = new DatabaseSync(path);
+      db.exec(`
+        create trigger reject_terminal_lifecycle_insert
+        before insert on license_subscription_lifecycle_events
+        begin
+          select raise(abort, 'deterministic terminal ledger fault');
+        end
+      `);
+      db.close();
+
+      assert.throws(
+        () => applyLifecycle(store, lifecycleRequest("revoke", issued.request)),
+        /deterministic terminal ledger fault/
+      );
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.status, "active");
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.revocationReason, undefined);
+      assert.equal(
+        inspectDatabase<{ count: number }>(
+          path,
+          "select count(*) as count from license_subscription_lifecycle_events"
+        )[0]?.count,
+        0
+      );
+    } finally {
       store.close();
     }
   });

--- a/services/license-api/test/subscription-lifecycle-store.test.ts
+++ b/services/license-api/test/subscription-lifecycle-store.test.ts
@@ -740,7 +740,7 @@ describe("checkout subscription lifecycle ordering and terminal dominance", () =
           status: "revoked",
           plan: "monthly_support",
           seats: 1,
-          expiresAt: issued.expiresAt
+          expiresAt: NOW.toISOString()
         }
       });
       assert.equal(store.getLicenseByKey(issued.rawKey)?.revocationReason,
@@ -752,7 +752,7 @@ describe("checkout subscription lifecycle ordering and terminal dominance", () =
           status: "revoked",
           plan: "monthly_support",
           seats: 1,
-          expiresAt: issued.expiresAt
+          expiresAt: NOW.toISOString()
         }
       });
       const ledger = inspectDatabase<{ normalized_transition: string; result: string }>(
@@ -836,7 +836,7 @@ describe("checkout subscription lifecycle ordering and terminal dominance", () =
           status: "revoked",
           plan: "monthly_support",
           seats: 1,
-          expiresAt: "2026-08-20T00:00:00.000Z"
+          expiresAt: "2026-07-13T00:00:01.000Z"
         }
       });
       const changed = renewal(issued.request, {
@@ -924,17 +924,18 @@ describe("checkout subscription lifecycle ordering and terminal dominance", () =
     }
   });
 
-  it("makes same-second paid renewal and revoke fully commutative with terminal dominance", () => {
-    const projections: Array<Record<string, unknown>> = [];
+  it("normalizes same-second renewal and revoke to one terminal entitlement without rewriting history", () => {
+    const entitlements: Array<Record<string, unknown>> = [];
+    const histories: Array<Array<Record<string, unknown>>> = [];
     for (const order of ["renew-first", "revoke-first"] as const) {
       const path = databasePath();
       const firstStore = new LicenseStore(path, { now: () => NOW });
       const secondStore = new LicenseStore(path, { now: () => NOW });
       try {
         const issued = issueBound(firstStore, {
-          idempotencyKey: `checkout-session:terminal-order-${order}`,
-          externalSubscriptionId: `sub_terminal_order_${order}`,
-          externalCheckoutId: `cs_terminal_order_${order}`
+          idempotencyKey: "checkout-session:terminal-order",
+          externalSubscriptionId: "sub_terminal_order",
+          externalCheckoutId: "cs_terminal_order"
         });
         assert.equal(activate(firstStore, {
           licenseKey: issued.rawKey,
@@ -951,24 +952,32 @@ describe("checkout subscription lifecycle ordering and terminal dominance", () =
           eventId: `evt_terminal_revoke_${order}`,
           eventCreatedAt: NOW_SECONDS
         });
-        const events = order === "renew-first" ? [paid, revoked] : [revoked, paid];
-        const statuses = [
-          applyLifecycle(firstStore, events[0]!).status,
-          applyLifecycle(secondStore, events[1]!).status
-        ].sort();
+        if (order === "renew-first") {
+          assert.equal(applyLifecycle(firstStore, paid).status, "updated");
+          assert.equal(applyLifecycle(secondStore, revoked).status, "terminally_revoked");
+        } else {
+          assert.equal(applyLifecycle(firstStore, revoked).status, "terminally_revoked");
+          const beforeRejectedRenewal = firstStore.getLicenseByKey(issued.rawKey);
+          assert.throws(
+            () => applyLifecycle(secondStore, paid),
+            (error: unknown) => errorName(error) === "SubscriptionLifecycleTerminalError"
+          );
+          assert.deepEqual(secondStore.getLicenseByKey(issued.rawKey), beforeRejectedRenewal);
+        }
         const license = secondStore.getLicenseByKey(issued.rawKey)!;
         assert.equal(license.licenseKeyHash, issued.licenseKeyHash);
         assert.deepEqual(secondStore.listActivations(issued.licenseKeyHash), activations);
-        projections.push({
-          statuses,
-          entitlement: {
-            status: license.status,
-            plan: license.plan,
-            seats: license.seats,
-            expiresAt: license.expiresAt,
-            revocationReason: license.revocationReason
-          },
-          ledger: inspectDatabase<{
+        entitlements.push({
+          status: license.status,
+          plan: license.plan,
+          seats: license.seats,
+          expiresAt: license.expiresAt,
+          revocationReason: license.revocationReason,
+          licenseKeyHash: license.licenseKeyHash,
+          activations: secondStore.listActivations(issued.licenseKeyHash)
+        });
+        histories.push(
+          inspectDatabase<{
             command: string;
             normalized_transition: string;
             result: string;
@@ -978,36 +987,43 @@ describe("checkout subscription lifecycle ordering and terminal dominance", () =
              from license_subscription_lifecycle_events
              order by command`
           ).map((row) => ({ ...row }))
-        });
+        );
       } finally {
         secondStore.close();
         firstStore.close();
       }
     }
 
-    assert.deepEqual(projections[0], projections[1]);
-    assert.deepEqual(projections[0], {
-      statuses: ["terminally_revoked", "updated"],
-      entitlement: {
-        status: "revoked",
-        plan: "monthly_support",
-        seats: 1,
-        expiresAt: "2026-08-20T00:00:00.000Z",
-        revocationReason: "provider subscription terminated"
-      },
-      ledger: [
-        {
-          command: "renew_paid",
-          normalized_transition: "renew_paid",
-          result: "updated"
-        },
-        {
-          command: "revoke",
-          normalized_transition: "revoke",
-          result: "terminally_revoked"
-        }
-      ]
+    assert.deepEqual(entitlements[0], entitlements[1]);
+    assert.deepEqual(entitlements[0], {
+      status: "revoked",
+      plan: "monthly_support",
+      seats: 1,
+      expiresAt: NOW.toISOString(),
+      revocationReason: "provider subscription terminated",
+      licenseKeyHash: (entitlements[0] as { licenseKeyHash: string }).licenseKeyHash,
+      activations: (entitlements[0] as { activations: unknown[] }).activations
     });
+    assert.deepEqual(histories[0], [
+      {
+        command: "renew_paid",
+        normalized_transition: "renew_paid",
+        result: "updated"
+      },
+      {
+        command: "revoke",
+        normalized_transition: "revoke",
+        result: "terminally_revoked"
+      }
+    ]);
+    assert.deepEqual(histories[1], [
+      {
+        command: "revoke",
+        normalized_transition: "revoke",
+        result: "terminally_revoked"
+      }
+    ]);
+    assert.notDeepEqual(histories[0], histories[1]);
   });
 
   it("rolls back every non-mutating watermark when its ledger insert fails", () => {

--- a/services/license-api/test/subscription-lifecycle-store.test.ts
+++ b/services/license-api/test/subscription-lifecycle-store.test.ts
@@ -810,6 +810,56 @@ describe("checkout subscription lifecycle ordering and terminal dominance", () =
     }
   });
 
+  it("replays an earlier successful renewal after revoke and still conflicts on changed reuse", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path, { now: () => NOW });
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:terminal-renewal-replay",
+        externalSubscriptionId: "sub_terminal_renewal_replay",
+        externalCheckoutId: "cs_terminal_renewal_replay"
+      });
+      const paid = renewal(issued.request, {
+        eventId: "evt_terminal_renewal_replay",
+        currentPeriodEnd: "2026-08-20T00:00:00.000Z"
+      });
+      applyLifecycle(store, paid);
+      applyLifecycle(store, lifecycleRequest("revoke", issued.request, {
+        eventId: "evt_terminal_after_renewal",
+        eventCreatedAt: NOW_SECONDS + 1
+      }));
+
+      assert.deepEqual(applyLifecycle(store, paid), {
+        status: "replayed",
+        replayed: true,
+        entitlement: {
+          status: "revoked",
+          plan: "monthly_support",
+          seats: 1,
+          expiresAt: "2026-08-20T00:00:00.000Z"
+        }
+      });
+      const changed = renewal(issued.request, {
+        eventId: paid.eventId,
+        currentPeriodEnd: "2026-08-21T00:00:00.000Z"
+      });
+      assert.throws(
+        () => applyLifecycle(store, changed),
+        (error: unknown) => errorName(error) === "SubscriptionLifecycleConflictError"
+      );
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.status, "revoked");
+      assert.equal(
+        inspectDatabase<{ count: number }>(
+          path,
+          "select count(*) as count from license_subscription_lifecycle_events"
+        )[0]?.count,
+        2
+      );
+    } finally {
+      store.close();
+    }
+  });
+
   it("converges for same-second renewal and update arrival orders with explicit equal-time precedence", () => {
     const projections: Array<Record<string, unknown>> = [];
     for (const updateCommand of ["reconcile", "cancel_at_period_end", "payment_attention"] as const) {
@@ -874,41 +924,135 @@ describe("checkout subscription lifecycle ordering and terminal dominance", () =
     }
   });
 
-  it("lets revoke dominate both arrival orders and preserves the key hash and activations", () => {
+  it("makes same-second paid renewal and revoke fully commutative with terminal dominance", () => {
+    const projections: Array<Record<string, unknown>> = [];
     for (const order of ["renew-first", "revoke-first"] as const) {
       const path = databasePath();
-      const store = new LicenseStore(path, { now: () => NOW });
+      const firstStore = new LicenseStore(path, { now: () => NOW });
+      const secondStore = new LicenseStore(path, { now: () => NOW });
       try {
-        const issued = issueBound(store, {
+        const issued = issueBound(firstStore, {
           idempotencyKey: `checkout-session:terminal-order-${order}`,
           externalSubscriptionId: `sub_terminal_order_${order}`,
           externalCheckoutId: `cs_terminal_order_${order}`
         });
-        assert.equal(activate(store, {
+        assert.equal(activate(firstStore, {
           licenseKey: issued.rawKey,
           machineId: "machine-terminal-order",
           repo: "owner/repo"
         }, NOW).httpStatus, 200);
-        const activations = store.listActivations(issued.licenseKeyHash);
-        const paid = renewal(issued.request, { eventId: `evt_terminal_paid_${order}` });
-        const revoked = lifecycleRequest("revoke", issued.request, {
-          eventId: `evt_terminal_revoke_${order}`
+        const activations = firstStore.listActivations(issued.licenseKeyHash);
+        const paid = renewal(issued.request, {
+          eventId: `evt_terminal_paid_${order}`,
+          eventCreatedAt: NOW_SECONDS,
+          currentPeriodEnd: "2026-08-20T00:00:00.000Z"
         });
+        const revoked = lifecycleRequest("revoke", issued.request, {
+          eventId: `evt_terminal_revoke_${order}`,
+          eventCreatedAt: NOW_SECONDS
+        });
+        const events = order === "renew-first" ? [paid, revoked] : [revoked, paid];
+        const statuses = [
+          applyLifecycle(firstStore, events[0]!).status,
+          applyLifecycle(secondStore, events[1]!).status
+        ].sort();
+        const license = secondStore.getLicenseByKey(issued.rawKey)!;
+        assert.equal(license.licenseKeyHash, issued.licenseKeyHash);
+        assert.deepEqual(secondStore.listActivations(issued.licenseKeyHash), activations);
+        projections.push({
+          statuses,
+          entitlement: {
+            status: license.status,
+            plan: license.plan,
+            seats: license.seats,
+            expiresAt: license.expiresAt,
+            revocationReason: license.revocationReason
+          },
+          ledger: inspectDatabase<{
+            command: string;
+            normalized_transition: string;
+            result: string;
+          }>(
+            path,
+            `select command, normalized_transition, result
+             from license_subscription_lifecycle_events
+             order by command`
+          ).map((row) => ({ ...row }))
+        });
+      } finally {
+        secondStore.close();
+        firstStore.close();
+      }
+    }
 
-        if (order === "renew-first") {
-          applyLifecycle(store, paid);
-          applyLifecycle(store, revoked);
-        } else {
-          applyLifecycle(store, revoked);
-          assert.throws(
-            () => applyLifecycle(store, paid),
-            (error: unknown) => errorName(error) === "SubscriptionLifecycleTerminalError"
-          );
+    assert.deepEqual(projections[0], projections[1]);
+    assert.deepEqual(projections[0], {
+      statuses: ["terminally_revoked", "updated"],
+      entitlement: {
+        status: "revoked",
+        plan: "monthly_support",
+        seats: 1,
+        expiresAt: "2026-08-20T00:00:00.000Z",
+        revocationReason: "provider subscription terminated"
+      },
+      ledger: [
+        {
+          command: "renew_paid",
+          normalized_transition: "renew_paid",
+          result: "updated"
+        },
+        {
+          command: "revoke",
+          normalized_transition: "revoke",
+          result: "terminally_revoked"
         }
+      ]
+    });
+  });
 
-        assert.equal(store.getLicenseByKey(issued.rawKey)?.status, "revoked");
-        assert.equal(store.getLicenseByKey(issued.rawKey)?.licenseKeyHash, issued.licenseKeyHash);
-        assert.deepEqual(store.listActivations(issued.licenseKeyHash), activations);
+  it("rolls back every non-mutating watermark when its ledger insert fails", () => {
+    for (const command of ["reconcile", "cancel_at_period_end", "payment_attention"] as const) {
+      const path = databasePath();
+      const store = new LicenseStore(path, { now: () => NOW });
+      try {
+        const issued = issueBound(store, {
+          idempotencyKey: `checkout-session:${command}-rollback`,
+          externalSubscriptionId: `sub_${command}_rollback`,
+          externalCheckoutId: `cs_${command}_rollback`
+        });
+        const before = store.getLicenseByKey(issued.rawKey);
+        const db = new DatabaseSync(path);
+        db.exec(`
+          create trigger reject_${command}_lifecycle_insert
+          before insert on license_subscription_lifecycle_events
+          begin
+            select raise(abort, 'deterministic ${command} ledger fault');
+          end
+        `);
+        db.close();
+
+        assert.throws(
+          () => applyLifecycle(store, lifecycleRequest(command, issued.request)),
+          new RegExp(`deterministic ${command} ledger fault`)
+        );
+        assert.deepEqual(store.getLicenseByKey(issued.rawKey), before);
+        assert.equal(
+          inspectDatabase<{ last_non_mutating_event_created_at: number | null }>(
+            path,
+            `select last_non_mutating_event_created_at
+             from checkout_subscription_bindings
+             where issuance_idempotency_key = ?`,
+            issued.request.idempotencyKey
+          )[0]?.last_non_mutating_event_created_at,
+          null
+        );
+        assert.equal(
+          inspectDatabase<{ count: number }>(
+            path,
+            "select count(*) as count from license_subscription_lifecycle_events"
+          )[0]?.count,
+          0
+        );
       } finally {
         store.close();
       }

--- a/services/license-api/test/subscription-lifecycle-store.test.ts
+++ b/services/license-api/test/subscription-lifecycle-store.test.ts
@@ -248,7 +248,11 @@ describe("checkout subscription lifecycle replay", () => {
     for (const [label, mutation] of [
       ["missing expiry", "update licenses set expires_at = null where license_key_hash = ?"],
       ["invalid expiry", "update licenses set expires_at = 'not-a-timestamp' where license_key_hash = ?"],
-      ["unsupported plan", "update licenses set plan = 'legacy_lifetime' where license_key_hash = ?"]
+      ["unsupported plan", "update licenses set plan = 'legacy_lifetime' where license_key_hash = ?"],
+      ["multiple seats", "update licenses set seats = 2 where license_key_hash = ?"],
+      ["public scope", "update licenses set repo_visibility_scope = 'public' where license_key_hash = ?"],
+      ["private repositories disabled", "update licenses set private_repo_allowed = 0 where license_key_hash = ?"],
+      ["updates disabled", "update licenses set update_entitlement = 0 where license_key_hash = ?"]
     ] as const) {
       const path = databasePath();
       const store = new LicenseStore(path, { now: () => NOW });
@@ -376,6 +380,84 @@ describe("checkout subscription lifecycle replay", () => {
     } finally {
       secondStore.close();
       firstStore.close();
+    }
+  });
+
+  it("reaches exact renewal and cancellation replays after their period ends", () => {
+    const delayedNow = new Date("2026-08-21T00:00:00.000Z");
+    for (const command of ["renew_paid", "cancel_at_period_end"] as const) {
+      const path = databasePath();
+      let storeNow = NOW;
+      const store = new LicenseStore(path, { now: () => storeNow });
+      try {
+        const issued = issueBound(store, {
+          idempotencyKey: `checkout-session:delayed-replay-${command}`,
+          externalSubscriptionId: `sub_delayed_replay_${command}`,
+          externalCheckoutId: `cs_delayed_replay_${command}`
+        });
+        const overrides = { eventId: `evt_delayed_replay_${command}` };
+        const original = command === "renew_paid"
+          ? renewal(issued.request, overrides)
+          : lifecycleRequest(command, issued.request, overrides);
+        applyLifecycle(store, original);
+
+        storeNow = delayedNow;
+        const delayed = command === "renew_paid"
+          ? renewal(issued.request, overrides, delayedNow)
+          : lifecycleRequest(command, issued.request, overrides, delayedNow);
+        assert.equal(delayed.requestHash, original.requestHash, command);
+        const replay = applyLifecycle(store, delayed);
+
+        assert.equal(replay.status, "replayed", command);
+        assert.equal(replay.replayed, true, command);
+        assert.equal(
+          inspectDatabase<{ count: number }>(
+            path,
+            "select count(*) as count from license_subscription_lifecycle_events"
+          )[0]?.count,
+          1,
+          command
+        );
+      } finally {
+        store.close();
+      }
+    }
+  });
+
+  it("rejects new renewal and cancellation events after their period ends", () => {
+    const delayedNow = new Date("2026-08-21T00:00:00.000Z");
+    for (const command of ["renew_paid", "cancel_at_period_end"] as const) {
+      const path = databasePath();
+      let storeNow = NOW;
+      const store = new LicenseStore(path, { now: () => storeNow });
+      try {
+        const issued = issueBound(store, {
+          idempotencyKey: `checkout-session:delayed-new-${command}`,
+          externalSubscriptionId: `sub_delayed_new_${command}`,
+          externalCheckoutId: `cs_delayed_new_${command}`
+        });
+        storeNow = delayedNow;
+        const overrides = { eventId: `evt_delayed_new_${command}` };
+        const request = command === "renew_paid"
+          ? renewal(issued.request, overrides, delayedNow)
+          : lifecycleRequest(command, issued.request, overrides, delayedNow);
+
+        assert.throws(
+          () => applyLifecycle(store, request),
+          (error: unknown) => errorName(error) === "SubscriptionLifecyclePolicyError",
+          command
+        );
+        assert.equal(
+          inspectDatabase<{ count: number }>(
+            path,
+            "select count(*) as count from license_subscription_lifecycle_events"
+          )[0]?.count,
+          0,
+          command
+        );
+      } finally {
+        store.close();
+      }
     }
   });
 

--- a/services/license-api/test/subscription-lifecycle-store.test.ts
+++ b/services/license-api/test/subscription-lifecycle-store.test.ts
@@ -461,6 +461,48 @@ describe("checkout subscription lifecycle replay", () => {
     }
   });
 
+  it("replays elapsed diagnostic periods but rejects brand-new elapsed diagnostics", () => {
+    const delayedNow = new Date("2026-08-21T00:00:00.000Z");
+    for (const command of ["reconcile", "payment_attention"] as const) {
+      const path = databasePath();
+      let storeNow = NOW;
+      const store = new LicenseStore(path, { now: () => storeNow });
+      try {
+        const issued = issueBound(store, {
+          idempotencyKey: `checkout-session:delayed-diagnostic-${command}`,
+          externalSubscriptionId: `sub_delayed_diagnostic_${command}`,
+          externalCheckoutId: `cs_delayed_diagnostic_${command}`
+        });
+        const period = "2026-08-20T00:00:00.000Z";
+        const original = lifecycleRequest(command, issued.request, {
+          eventId: `evt_delayed_diagnostic_${command}`,
+          currentPeriodEnd: period
+        });
+        applyLifecycle(store, original);
+
+        storeNow = delayedNow;
+        const delayedReplay = lifecycleRequest(command, issued.request, {
+          eventId: original.eventId,
+          currentPeriodEnd: period
+        }, delayedNow);
+        assert.equal(delayedReplay.requestHash, original.requestHash, command);
+        assert.equal(applyLifecycle(store, delayedReplay).status, "replayed", command);
+
+        const newElapsed = lifecycleRequest(command, issued.request, {
+          eventId: `evt_new_elapsed_diagnostic_${command}`,
+          currentPeriodEnd: period
+        }, delayedNow);
+        assert.throws(
+          () => applyLifecycle(store, newElapsed),
+          (error: unknown) => errorName(error) === "SubscriptionLifecyclePolicyError",
+          command
+        );
+      } finally {
+        store.close();
+      }
+    }
+  });
+
   it("projects an exact replay as expired after the paid period elapses", () => {
     const path = databasePath();
     let storeNow = NOW;

--- a/services/license-api/test/subscription-lifecycle-store.test.ts
+++ b/services/license-api/test/subscription-lifecycle-store.test.ts
@@ -429,9 +429,40 @@ describe("checkout subscription lifecycle renewal", () => {
       assert.ok(!JSON.stringify(result).includes(paymentReference));
       const ledger = inspectDatabase<Record<string, unknown>>(
         path,
-        "select * from license_subscription_lifecycle_events"
+        `select
+          event_id,
+          issuance_idempotency_key,
+          license_key_hash,
+          external_subscription_id,
+          request_hash,
+          event_created_at,
+          provider,
+          provider_account_id,
+          provider_mode,
+          provider_event_type,
+          command,
+          payment_reference_fingerprint,
+          normalized_transition,
+          result
+        from license_subscription_lifecycle_events`
       );
       assert.equal(ledger.length, 1);
+      assert.deepEqual({ ...ledger[0] }, {
+        event_id: request.eventId,
+        issuance_idempotency_key: issued.request.idempotencyKey,
+        license_key_hash: issued.licenseKeyHash,
+        external_subscription_id: issued.request.externalSubscriptionId,
+        request_hash: request.requestHash,
+        event_created_at: request.eventCreatedAt,
+        provider: issued.request.provider,
+        provider_account_id: issued.request.providerAccountId,
+        provider_mode: issued.request.providerMode,
+        provider_event_type: request.providerEventType,
+        command: request.command,
+        payment_reference_fingerprint: request.paymentReferenceFingerprint,
+        normalized_transition: "renew_paid",
+        result: "updated"
+      });
       assert.equal(ledger[0]?.payment_reference_fingerprint, request.paymentReferenceFingerprint);
       assert.ok(!JSON.stringify(ledger).includes(paymentReference));
       const bytes = readFileSync(path);

--- a/services/license-api/test/subscription-lifecycle-store.test.ts
+++ b/services/license-api/test/subscription-lifecycle-store.test.ts
@@ -1,0 +1,522 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { afterEach, describe, it } from "node:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { issueCheckoutLicense, type LicenseIssuanceRequest } from "../src/issuance.ts";
+import { activate } from "../src/service.ts";
+import type { ParsedSubscriptionLifecycleRequest } from "../src/subscription-lifecycle.ts";
+import { parseSubscriptionLifecycleRequest } from "../src/subscription-lifecycle.ts";
+import { LicenseStore, hashLicenseKey } from "../src/store.ts";
+
+const NOW = new Date("2026-07-13T00:00:00.000Z");
+const NOW_SECONDS = Math.floor(NOW.getTime() / 1_000);
+const ISSUANCE_SECRET = "test-only-lifecycle-issuance-secret";
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+type LifecycleResult = {
+  status: "updated" | "replayed";
+  replayed: boolean;
+  entitlement: {
+    status: "active";
+    plan: string;
+    seats: number;
+    expiresAt: string;
+  };
+};
+
+const tempDirectories = new Set<string>();
+
+afterEach(() => {
+  for (const directory of tempDirectories) rmSync(directory, { recursive: true, force: true });
+  tempDirectories.clear();
+});
+
+function databasePath(): string {
+  const directory = mkdtempSync(join(tmpdir(), "neondiff-lifecycle-store-"));
+  tempDirectories.add(directory);
+  return join(directory, "licenses.sqlite");
+}
+
+function issuanceRequest(
+  overrides: Partial<LicenseIssuanceRequest> = {}
+): LicenseIssuanceRequest {
+  return {
+    idempotencyKey: "checkout-session:lifecycle-store",
+    checkoutLookupKey: "neondiff_monthly",
+    provider: "stripe",
+    providerAccountId: "acct_product_live",
+    providerMode: "live",
+    externalSubscriptionId: "sub_lifecycle_store",
+    externalCheckoutId: "cs_lifecycle_store",
+    ...overrides
+  };
+}
+
+function issueBound(
+  store: LicenseStore,
+  overrides: Partial<LicenseIssuanceRequest> = {}
+): { request: LicenseIssuanceRequest; rawKey: string; licenseKeyHash: string; expiresAt: string } {
+  const request = issuanceRequest(overrides);
+  const result = issueCheckoutLicense(store, request, ISSUANCE_SECRET);
+  assert.equal(result.httpStatus, 200);
+  const body = result.body as {
+    licenseKey: string;
+    licenseKeyHash: string;
+    entitlement: { expiresAt: string };
+  };
+  return {
+    request,
+    rawKey: body.licenseKey,
+    licenseKeyHash: body.licenseKeyHash,
+    expiresAt: body.entitlement.expiresAt
+  };
+}
+
+function renewal(
+  issuance: LicenseIssuanceRequest = issuanceRequest(),
+  overrides: Record<string, unknown> = {},
+  now: Date = NOW
+): ParsedSubscriptionLifecycleRequest {
+  return parseSubscriptionLifecycleRequest(
+    JSON.stringify({
+      schemaVersion: 1,
+      issuanceIdempotencyKey: issuance.idempotencyKey,
+      eventId: "evt_paid_lifecycle_store",
+      eventCreatedAt: NOW_SECONDS,
+      provider: issuance.provider,
+      providerAccountId: issuance.providerAccountId,
+      providerMode: issuance.providerMode,
+      externalSubscriptionId: issuance.externalSubscriptionId,
+      providerEventType: "invoice.paid",
+      command: "renew_paid",
+      paymentReference: "invoice-reference-lifecycle-store",
+      amountPaidMinor: 100,
+      currency: "usd",
+      paidOutOfBand: false,
+      billingReason: "subscription_cycle",
+      subscriptionStatus: "active",
+      currentPeriodEnd: "2026-08-13T00:00:00.000Z",
+      cancelAtPeriodEnd: false,
+      ...overrides
+    }),
+    now
+  );
+}
+
+function applyLifecycle(
+  store: LicenseStore,
+  request: ParsedSubscriptionLifecycleRequest
+): LifecycleResult {
+  return (
+    store as unknown as {
+      applyCheckoutSubscriptionLifecycle(
+        input: ParsedSubscriptionLifecycleRequest
+      ): LifecycleResult;
+    }
+  ).applyCheckoutSubscriptionLifecycle(request);
+}
+
+function errorName(error: unknown): string {
+  return error instanceof Error ? error.constructor.name : "";
+}
+
+function inspectDatabase<T>(path: string, query: string, ...params: unknown[]): T[] {
+  const db = new DatabaseSync(path);
+  try {
+    return db.prepare(query).all(...params) as T[];
+  } finally {
+    db.close();
+  }
+}
+
+describe("checkout subscription lifecycle binding", () => {
+  it("rejects unknown, non-checkout, and unbound checkout issuance references", () => {
+    const store = new LicenseStore(":memory:", { now: () => NOW });
+    try {
+      assert.throws(
+        () => applyLifecycle(store, renewal()),
+        (error: unknown) => errorName(error) === "SubscriptionLifecycleNotFoundError"
+      );
+
+      for (const [idempotencyKey, source] of [
+        ["admin-issuance:lifecycle", "admin"],
+        ["legacy-checkout:lifecycle", "checkout"]
+      ] as const) {
+        const rawKey = derivedKey(idempotencyKey);
+        store.issueIdempotentLicense(rawKey, {
+          idempotencyKey,
+          requestHash: `request-hash-${source}`,
+          source,
+          externalRef: `external-ref-${source}`,
+          plan: "monthly_support",
+          repoVisibilityScope: "private",
+          privateRepoAllowed: true,
+          updateEntitlement: true,
+          seats: 1,
+          expiresAt: "2026-07-20T00:00:00.000Z"
+        });
+        assert.throws(
+          () => applyLifecycle(store, renewal(issuanceRequest({ idempotencyKey }))),
+          (error: unknown) => errorName(error) === "SubscriptionLifecycleNotFoundError"
+        );
+      }
+    } finally {
+      store.close();
+    }
+  });
+
+  it("requires the exact bound provider, account, mode, and subscription tuple", () => {
+    const store = new LicenseStore(":memory:", { now: () => NOW });
+    try {
+      const issued = issueBound(store);
+      for (const override of [
+        { provider: "other-provider" },
+        { providerAccountId: "acct_other" },
+        { providerMode: "test" },
+        { externalSubscriptionId: "sub_other" }
+      ]) {
+        const request = { ...renewal(issued.request), ...override } as ParsedSubscriptionLifecycleRequest;
+        assert.throws(
+          () => applyLifecycle(store, request),
+          (error: unknown) => errorName(error) === "SubscriptionLifecycleNotFoundError"
+        );
+      }
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.expiresAt, issued.expiresAt);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("checkout subscription lifecycle replay", () => {
+  it("replays the exact event and hash once across two database connections", () => {
+    const path = databasePath();
+    const firstStore = new LicenseStore(path, { now: () => NOW });
+    const secondStore = new LicenseStore(path, { now: () => NOW });
+    try {
+      const issued = issueBound(firstStore);
+      const request = renewal(issued.request);
+      const first = applyLifecycle(firstStore, request);
+      const replay = applyLifecycle(secondStore, request);
+
+      assert.deepEqual(first, {
+        status: "updated",
+        replayed: false,
+        entitlement: {
+          status: "active",
+          plan: "monthly_support",
+          seats: 1,
+          expiresAt: "2026-08-13T00:00:00.000Z"
+        }
+      });
+      assert.deepEqual(replay, {
+        ...first,
+        status: "replayed",
+        replayed: true
+      });
+      assert.equal(
+        inspectDatabase<{ count: number }>(
+          path,
+          "select count(*) as count from license_subscription_lifecycle_events"
+        )[0]?.count,
+        1
+      );
+    } finally {
+      secondStore.close();
+      firstStore.close();
+    }
+  });
+
+  it("conflicts when an event ID is reused with different canonical content", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path, { now: () => NOW });
+    try {
+      const issued = issueBound(store);
+      const original = renewal(issued.request);
+      applyLifecycle(store, original);
+      const changed = renewal(issued.request, {
+        eventId: original.eventId,
+        currentPeriodEnd: "2026-08-14T00:00:00.000Z"
+      });
+      const forgedHash = { ...changed, requestHash: original.requestHash };
+
+      assert.throws(
+        () => applyLifecycle(store, forgedHash),
+        (error: unknown) => errorName(error) === "SubscriptionLifecycleConflictError"
+      );
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.expiresAt, original.currentPeriodEnd);
+      assert.equal(
+        inspectDatabase<{ count: number }>(
+          path,
+          "select count(*) as count from license_subscription_lifecycle_events"
+        )[0]?.count,
+        1
+      );
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("checkout subscription lifecycle renewal", () => {
+  it("extends monotonically to max(existing, incoming) across two connections", () => {
+    for (const order of [
+      ["2026-08-20T00:00:00.000Z", "2026-08-10T00:00:00.000Z"],
+      ["2026-08-10T00:00:00.000Z", "2026-08-20T00:00:00.000Z"]
+    ] as const) {
+      const path = databasePath();
+      const firstStore = new LicenseStore(path, { now: () => NOW });
+      const secondStore = new LicenseStore(path, { now: () => NOW });
+      try {
+        const issued = issueBound(firstStore, {
+          idempotencyKey: `checkout-session:monotonic-${order[0].slice(8, 10)}`,
+          externalSubscriptionId: `sub_monotonic_${order[0].slice(8, 10)}`,
+          externalCheckoutId: `cs_monotonic_${order[0].slice(8, 10)}`
+        });
+        applyLifecycle(firstStore, renewal(issued.request, {
+          eventId: `evt_monotonic_${order[0]}`,
+          currentPeriodEnd: order[0]
+        }));
+        applyLifecycle(secondStore, renewal(issued.request, {
+          eventId: `evt_monotonic_${order[1]}`,
+          currentPeriodEnd: order[1]
+        }));
+        assert.equal(secondStore.getLicenseByKey(issued.rawKey)?.expiresAt, "2026-08-20T00:00:00.000Z");
+      } finally {
+        secondStore.close();
+        firstStore.close();
+      }
+    }
+  });
+
+  it("enforces a future period and the 62/400-day plan caps from the store clock", () => {
+    for (const [checkoutLookupKey, maximumDays] of [
+      ["neondiff_monthly", 62],
+      ["neondiff_yearly", 400],
+      ["neondiff_org_yearly", 400]
+    ] as const) {
+      const store = new LicenseStore(":memory:", { now: () => NOW });
+      try {
+        const issued = issueBound(store, {
+          idempotencyKey: `checkout-session:cap-${checkoutLookupKey}`,
+          checkoutLookupKey,
+          externalSubscriptionId: `sub_cap_${checkoutLookupKey}`,
+          externalCheckoutId: `cs_cap_${checkoutLookupKey}`
+        });
+        const validEnd = new Date(NOW.getTime() + maximumDays * DAY_MS).toISOString();
+        const valid = renewal(issued.request, {
+          eventId: `evt_cap_valid_${checkoutLookupKey}`,
+          currentPeriodEnd: validEnd
+        });
+        assert.equal(applyLifecycle(store, valid).entitlement.expiresAt, validEnd);
+
+        const tooFar = {
+          ...renewal(issued.request, {
+            eventId: `evt_cap_invalid_${checkoutLookupKey}`,
+            currentPeriodEnd: validEnd
+          }),
+          currentPeriodEnd: new Date(NOW.getTime() + (maximumDays * DAY_MS) + 1).toISOString()
+        } as ParsedSubscriptionLifecycleRequest;
+        assert.throws(
+          () => applyLifecycle(store, tooFar),
+          (error: unknown) => errorName(error) === "SubscriptionLifecyclePolicyError"
+        );
+        assert.equal(store.getLicenseByKey(issued.rawKey)?.expiresAt, validEnd);
+      } finally {
+        store.close();
+      }
+    }
+
+    const store = new LicenseStore(":memory:", { now: () => NOW });
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:past-period",
+        externalSubscriptionId: "sub_past_period",
+        externalCheckoutId: "cs_past_period"
+      });
+      const past = {
+        ...renewal(issued.request),
+        eventId: "evt_past_period",
+        currentPeriodEnd: NOW.toISOString()
+      } as ParsedSubscriptionLifecycleRequest;
+      assert.throws(
+        () => applyLifecycle(store, past),
+        (error: unknown) => errorName(error) === "SubscriptionLifecyclePolicyError"
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("reactivates only expired nonterminal licenses with a valid future paid end", () => {
+    for (const storedStatus of ["active", "expired"] as const) {
+      const path = databasePath();
+      const store = new LicenseStore(path, { now: () => NOW });
+      try {
+        const issued = issueBound(store, {
+          idempotencyKey: `checkout-session:reactivate-${storedStatus}`,
+          externalSubscriptionId: `sub_reactivate_${storedStatus}`,
+          externalCheckoutId: `cs_reactivate_${storedStatus}`
+        });
+        const db = new DatabaseSync(path);
+        db.prepare("update licenses set status = ?, expires_at = ? where license_key_hash = ?")
+          .run(storedStatus, "2026-07-12T00:00:00.000Z", issued.licenseKeyHash);
+        db.close();
+
+        const result = applyLifecycle(store, renewal(issued.request, {
+          eventId: `evt_reactivate_${storedStatus}`
+        }));
+        assert.equal(result.entitlement.status, "active");
+        assert.equal(store.getLicenseByKey(issued.rawKey)?.status, "active");
+        assert.equal(store.getLicenseByKey(issued.rawKey)?.expiresAt, "2026-08-13T00:00:00.000Z");
+      } finally {
+        store.close();
+      }
+    }
+
+    const path = databasePath();
+    const store = new LicenseStore(path, { now: () => NOW });
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:terminal-renewal",
+        externalSubscriptionId: "sub_terminal_renewal",
+        externalCheckoutId: "cs_terminal_renewal"
+      });
+      store.revokeLicense(issued.rawKey, "terminal owner action");
+      assert.throws(
+        () => applyLifecycle(store, renewal(issued.request)),
+        (error: unknown) => errorName(error) === "SubscriptionLifecycleTerminalError"
+      );
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.status, "revoked");
+      assert.equal(
+        inspectDatabase<{ count: number }>(
+          path,
+          "select count(*) as count from license_subscription_lifecycle_events"
+        )[0]?.count,
+        0
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("preserves the license hash and activation rows and redacts raw identifiers", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path, { now: () => NOW });
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:preserve-activation",
+        externalSubscriptionId: "sub_preserve_activation",
+        externalCheckoutId: "cs_preserve_activation"
+      });
+      const activated = activate(
+        store,
+        { licenseKey: issued.rawKey, machineId: "machine-preserved", repo: "owner/repo" },
+        NOW
+      );
+      assert.equal(activated.httpStatus, 200);
+      const before = store.listActivations(issued.licenseKeyHash);
+      const paymentReference = "invoice-reference-never-persist-verbatim";
+      const request = renewal(issued.request, { paymentReference });
+      const result = applyLifecycle(store, request);
+
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.licenseKeyHash, hashLicenseKey(issued.rawKey));
+      assert.deepEqual(store.listActivations(issued.licenseKeyHash), before);
+      assert.ok(!JSON.stringify(result).includes(issued.rawKey));
+      assert.ok(!JSON.stringify(result).includes(paymentReference));
+      const ledger = inspectDatabase<Record<string, unknown>>(
+        path,
+        "select * from license_subscription_lifecycle_events"
+      );
+      assert.equal(ledger.length, 1);
+      assert.equal(ledger[0]?.payment_reference_fingerprint, request.paymentReferenceFingerprint);
+      assert.ok(!JSON.stringify(ledger).includes(paymentReference));
+      const bytes = readFileSync(path);
+      assert.equal(bytes.includes(Buffer.from(issued.rawKey)), false);
+      assert.equal(bytes.includes(Buffer.from(paymentReference)), false);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("rolls back entitlement mutation when the lifecycle ledger insert is constrained", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path, { now: () => NOW });
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:rollback",
+        externalSubscriptionId: "sub_rollback",
+        externalCheckoutId: "cs_rollback"
+      });
+      const db = new DatabaseSync(path);
+      db.exec(`
+        create trigger reject_lifecycle_insert
+        before insert on license_subscription_lifecycle_events
+        begin
+          select raise(abort, 'deterministic lifecycle ledger fault');
+        end
+      `);
+      db.close();
+
+      assert.throws(
+        () => applyLifecycle(store, renewal(issued.request)),
+        /deterministic lifecycle ledger fault/
+      );
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.expiresAt, issued.expiresAt);
+      assert.equal(
+        inspectDatabase<{ count: number }>(
+          path,
+          "select count(*) as count from license_subscription_lifecycle_events"
+        )[0]?.count,
+        0
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("bounds BEGIN IMMEDIATE contention and leaves renewal state unchanged", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path, { now: () => NOW, busyTimeoutMs: 25 });
+    const blocker = new DatabaseSync(path);
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:contention",
+        externalSubscriptionId: "sub_contention",
+        externalCheckoutId: "cs_contention"
+      });
+      blocker.exec("begin immediate");
+      const startedAt = Date.now();
+      assert.throws(
+        () => applyLifecycle(store, renewal(issued.request)),
+        (error: unknown) => errorName(error) === "SubscriptionLifecycleTransientError"
+      );
+      assert.ok(Date.now() - startedAt < 1_000, "contention wait must remain bounded");
+      blocker.exec("rollback");
+      assert.equal(store.getLicenseByKey(issued.rawKey)?.expiresAt, issued.expiresAt);
+      assert.equal(
+        inspectDatabase<{ count: number }>(
+          path,
+          "select count(*) as count from license_subscription_lifecycle_events"
+        )[0]?.count,
+        0
+      );
+    } finally {
+      try {
+        blocker.exec("rollback");
+      } catch {}
+      blocker.close();
+      store.close();
+    }
+  });
+});
+
+function derivedKey(idempotencyKey: string): string {
+  const digest = createHmac("sha256", ISSUANCE_SECRET)
+    .update(`checkout-license:${idempotencyKey}`)
+    .digest();
+  return ["nd", "live", digest.subarray(0, 24).toString("base64url")].join("_");
+}

--- a/services/license-api/test/subscription-lifecycle-store.test.ts
+++ b/services/license-api/test/subscription-lifecycle-store.test.ts
@@ -137,8 +137,7 @@ function lifecycleRequest(
     revoke: {
       providerEventType: "customer.subscription.deleted",
       subscriptionStatus: "canceled",
-      cancelAtPeriodEnd: false,
-      reason: "provider subscription terminated"
+      cancelAtPeriodEnd: false
     }
   } as const;
   return parseSubscriptionLifecycleRequest(
@@ -245,6 +244,103 @@ describe("checkout subscription lifecycle binding", () => {
 });
 
 describe("checkout subscription lifecycle replay", () => {
+  it("rejects incompatible stored entitlements before the first lifecycle write", () => {
+    for (const [label, mutation] of [
+      ["missing expiry", "update licenses set expires_at = null where license_key_hash = ?"],
+      ["invalid expiry", "update licenses set expires_at = 'not-a-timestamp' where license_key_hash = ?"],
+      ["unsupported plan", "update licenses set plan = 'legacy_lifetime' where license_key_hash = ?"]
+    ] as const) {
+      const path = databasePath();
+      const store = new LicenseStore(path, { now: () => NOW });
+      try {
+        const issued = issueBound(store, {
+          idempotencyKey: `checkout-session:invalid-first-${label.replaceAll(" ", "-")}`,
+          externalSubscriptionId: `sub_invalid_first_${label.replaceAll(" ", "_")}`,
+          externalCheckoutId: `cs_invalid_first_${label.replaceAll(" ", "_")}`
+        });
+        const db = new DatabaseSync(path);
+        db.prepare(mutation).run(issued.licenseKeyHash);
+        db.close();
+
+        assert.throws(
+          () => applyLifecycle(store, lifecycleRequest("reconcile", issued.request)),
+          (error: unknown) => errorName(error) === "SubscriptionLifecyclePolicyError",
+          label
+        );
+        assert.equal(
+          inspectDatabase<{ count: number }>(
+            path,
+            "select count(*) as count from license_subscription_lifecycle_events"
+          )[0]?.count,
+          0,
+          label
+        );
+        assert.equal(
+          inspectDatabase<{ last_non_mutating_event_created_at: number | null }>(
+            path,
+            `select last_non_mutating_event_created_at
+             from checkout_subscription_bindings
+             where issuance_idempotency_key = ?`,
+            issued.request.idempotencyKey
+          )[0]?.last_non_mutating_event_created_at,
+          null,
+          label
+        );
+      } finally {
+        store.close();
+      }
+    }
+  });
+
+  it("returns the policy error without writing when an exact replay finds an incompatible entitlement", () => {
+    const path = databasePath();
+    const store = new LicenseStore(path, { now: () => NOW });
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:invalid-replay",
+        externalSubscriptionId: "sub_invalid_replay",
+        externalCheckoutId: "cs_invalid_replay"
+      });
+      const request = lifecycleRequest("reconcile", issued.request);
+      applyLifecycle(store, request);
+      const before = inspectDatabase<{
+        event_count: number;
+        watermark: number | null;
+      }>(
+        path,
+        `select
+           (select count(*) from license_subscription_lifecycle_events) as event_count,
+           last_non_mutating_event_created_at as watermark
+         from checkout_subscription_bindings
+         where issuance_idempotency_key = ?`,
+        issued.request.idempotencyKey
+      )[0]!;
+      const db = new DatabaseSync(path);
+      db.prepare("update licenses set expires_at = null where license_key_hash = ?")
+        .run(issued.licenseKeyHash);
+      db.close();
+
+      assert.throws(
+        () => applyLifecycle(store, request),
+        (error: unknown) => errorName(error) === "SubscriptionLifecyclePolicyError"
+      );
+      assert.deepEqual(
+        inspectDatabase<{ event_count: number; watermark: number | null }>(
+          path,
+          `select
+             (select count(*) from license_subscription_lifecycle_events) as event_count,
+             last_non_mutating_event_created_at as watermark
+           from checkout_subscription_bindings
+           where issuance_idempotency_key = ?`,
+          issued.request.idempotencyKey
+        )[0],
+        before
+      );
+    } finally {
+      store.close();
+    }
+  });
+
   it("replays the exact event and hash once across two database connections", () => {
     const path = databasePath();
     const firstStore = new LicenseStore(path, { now: () => NOW });
@@ -283,6 +379,34 @@ describe("checkout subscription lifecycle replay", () => {
     }
   });
 
+  it("projects an exact replay as expired after the paid period elapses", () => {
+    const path = databasePath();
+    let storeNow = NOW;
+    const store = new LicenseStore(path, { now: () => storeNow });
+    try {
+      const issued = issueBound(store, {
+        idempotencyKey: "checkout-session:expired-replay-projection",
+        externalSubscriptionId: "sub_expired_replay_projection",
+        externalCheckoutId: "cs_expired_replay_projection"
+      });
+      const request = lifecycleRequest("reconcile", issued.request);
+      assert.equal(applyLifecycle(store, request).entitlement.status, "active");
+
+      storeNow = new Date("2026-07-21T00:00:00.000Z");
+      const replay = applyLifecycle(store, request);
+
+      assert.equal(replay.status, "replayed");
+      assert.equal(replay.entitlement.status, "expired");
+      assert.equal(
+        activate(store, { licenseKey: issued.rawKey, machineId: "expired-replay-machine" }, storeNow)
+          .body.status,
+        "expired"
+      );
+    } finally {
+      store.close();
+    }
+  });
+
   it("conflicts when an event ID is reused with different canonical content", () => {
     const path = databasePath();
     const store = new LicenseStore(path, { now: () => NOW });
@@ -310,6 +434,85 @@ describe("checkout subscription lifecycle replay", () => {
       );
     } finally {
       store.close();
+    }
+  });
+
+  it("conflicts on reused event IDs before rejecting each changed correlation field", () => {
+    for (const [label, override] of [
+      ["provider", { provider: "other-provider" }],
+      ["provider account", { providerAccountId: "acct_other" }],
+      ["provider mode", { providerMode: "test" }],
+      ["subscription", { externalSubscriptionId: "sub_other" }]
+    ] as const) {
+      const path = databasePath();
+      const store = new LicenseStore(path, { now: () => NOW });
+      try {
+        const issued = issueBound(store, {
+          idempotencyKey: `checkout-session:reused-correlation-${label.replaceAll(" ", "-")}`,
+          externalSubscriptionId: `sub_reused_correlation_${label.replaceAll(" ", "_")}`,
+          externalCheckoutId: `cs_reused_correlation_${label.replaceAll(" ", "_")}`
+        });
+        const original = renewal(issued.request, {
+          eventId: `evt_reused_correlation_${label.replaceAll(" ", "_")}`
+        });
+        applyLifecycle(store, original);
+
+        assert.throws(
+          () => applyLifecycle(store, { ...original, ...override } as ParsedSubscriptionLifecycleRequest),
+          (error: unknown) => errorName(error) === "SubscriptionLifecycleConflictError",
+          label
+        );
+        assert.equal(
+          inspectDatabase<{ count: number }>(
+            path,
+            "select count(*) as count from license_subscription_lifecycle_events"
+          )[0]?.count,
+          1,
+          label
+        );
+      } finally {
+        store.close();
+      }
+    }
+  });
+
+  it("exact-replays before consulting each subsequently changed binding field", () => {
+    for (const [label, mutation] of [
+      ["provider", "update checkout_subscription_bindings set provider = 'other-provider' where issuance_idempotency_key = ?"],
+      ["provider account", "update checkout_subscription_bindings set provider_account_id = 'acct_other' where issuance_idempotency_key = ?"],
+      ["provider mode", "update checkout_subscription_bindings set provider_mode = 'test' where issuance_idempotency_key = ?"],
+      ["subscription", "update checkout_subscription_bindings set external_subscription_id = 'sub_other' where issuance_idempotency_key = ?"]
+    ] as const) {
+      const path = databasePath();
+      const store = new LicenseStore(path, { now: () => NOW });
+      try {
+        const issued = issueBound(store, {
+          idempotencyKey: `checkout-session:replay-binding-${label.replaceAll(" ", "-")}`,
+          externalSubscriptionId: `sub_replay_binding_${label.replaceAll(" ", "_")}`,
+          externalCheckoutId: `cs_replay_binding_${label.replaceAll(" ", "_")}`
+        });
+        const request = renewal(issued.request, {
+          eventId: `evt_replay_binding_${label.replaceAll(" ", "_")}`
+        });
+        applyLifecycle(store, request);
+        const db = new DatabaseSync(path);
+        db.prepare(mutation).run(issued.request.idempotencyKey);
+        db.close();
+
+        const replay = applyLifecycle(store, request);
+        assert.equal(replay.status, "replayed", label);
+        assert.equal(replay.replayed, true, label);
+        assert.equal(
+          inspectDatabase<{ count: number }>(
+            path,
+            "select count(*) as count from license_subscription_lifecycle_events"
+          )[0]?.count,
+          1,
+          label
+        );
+      } finally {
+        store.close();
+      }
     }
   });
 });
@@ -720,7 +923,7 @@ describe("checkout subscription lifecycle ordering and terminal dominance", () =
     }
   });
 
-  it("revokes without a period end, persists a bounded reason, and exact-replays terminal state", () => {
+  it("revokes without a period end, persists the safe reason code, and exact-replays terminal state", () => {
     const path = databasePath();
     const store = new LicenseStore(path, { now: () => NOW });
     try {
@@ -729,9 +932,7 @@ describe("checkout subscription lifecycle ordering and terminal dominance", () =
         externalSubscriptionId: "sub_terminal_revoke",
         externalCheckoutId: "cs_terminal_revoke"
       });
-      const request = lifecycleRequest("revoke", issued.request, {
-        reason: "bounded provider termination reason"
-      });
+      const request = lifecycleRequest("revoke", issued.request);
 
       assert.deepEqual(applyLifecycle(store, request), {
         status: "terminally_revoked",
@@ -744,7 +945,7 @@ describe("checkout subscription lifecycle ordering and terminal dominance", () =
         }
       });
       assert.equal(store.getLicenseByKey(issued.rawKey)?.revocationReason,
-        "bounded provider termination reason");
+        "subscription_canceled");
       assert.deepEqual(applyLifecycle(store, request), {
         status: "replayed",
         replayed: true,
@@ -1000,7 +1201,7 @@ describe("checkout subscription lifecycle ordering and terminal dominance", () =
       plan: "monthly_support",
       seats: 1,
       expiresAt: NOW.toISOString(),
-      revocationReason: "provider subscription terminated",
+      revocationReason: "subscription_canceled",
       licenseKeyHash: (entitlements[0] as { licenseKeyHash: string }).licenseKeyHash,
       activations: (entitlements[0] as { activations: unknown[] }).activations
     });

--- a/services/license-api/test/subscription-lifecycle-store.test.ts
+++ b/services/license-api/test/subscription-lifecycle-store.test.ts
@@ -1026,6 +1026,90 @@ describe("checkout subscription lifecycle ordering and terminal dominance", () =
     assert.notDeepEqual(histories[0], histories[1]);
   });
 
+  it("normalizes same-second renewal and revoke from an already expired entitlement", () => {
+    const projections: Array<Record<string, unknown>> = [];
+    const histories: Array<Array<Record<string, unknown>>> = [];
+    for (const order of ["renew-first", "revoke-first"] as const) {
+      const path = databasePath();
+      const firstStore = new LicenseStore(path, { now: () => NOW });
+      const secondStore = new LicenseStore(path, { now: () => NOW });
+      try {
+        const issued = issueBound(firstStore, {
+          idempotencyKey: "checkout-session:expired-terminal-order",
+          externalSubscriptionId: "sub_expired_terminal_order",
+          externalCheckoutId: "cs_expired_terminal_order"
+        });
+        assert.equal(activate(firstStore, {
+          licenseKey: issued.rawKey,
+          machineId: "machine-expired-terminal-order",
+          repo: "owner/repo"
+        }, NOW).httpStatus, 200);
+        const db = new DatabaseSync(path);
+        db.prepare(
+          "update licenses set status = 'expired', expires_at = ? where license_key_hash = ?"
+        ).run("2026-07-12T00:00:00.000Z", issued.licenseKeyHash);
+        db.close();
+        const activations = firstStore.listActivations(issued.licenseKeyHash);
+        const paid = renewal(issued.request, {
+          eventId: `evt_expired_terminal_paid_${order}`,
+          eventCreatedAt: NOW_SECONDS,
+          currentPeriodEnd: "2026-08-20T00:00:00.000Z"
+        });
+        const revoked = lifecycleRequest("revoke", issued.request, {
+          eventId: `evt_expired_terminal_revoke_${order}`,
+          eventCreatedAt: NOW_SECONDS
+        });
+
+        if (order === "renew-first") {
+          assert.equal(applyLifecycle(firstStore, paid).status, "updated");
+          assert.equal(applyLifecycle(secondStore, revoked).status, "terminally_revoked");
+        } else {
+          assert.equal(applyLifecycle(firstStore, revoked).status, "terminally_revoked");
+          const terminal = firstStore.getLicenseByKey(issued.rawKey);
+          assert.throws(
+            () => applyLifecycle(secondStore, paid),
+            (error: unknown) => errorName(error) === "SubscriptionLifecycleTerminalError"
+          );
+          assert.deepEqual(secondStore.getLicenseByKey(issued.rawKey), terminal);
+        }
+
+        const license = secondStore.getLicenseByKey(issued.rawKey)!;
+        projections.push({
+          status: license.status,
+          plan: license.plan,
+          seats: license.seats,
+          expiresAt: license.expiresAt,
+          revocationReason: license.revocationReason,
+          licenseKeyHash: license.licenseKeyHash,
+          activations: secondStore.listActivations(issued.licenseKeyHash)
+        });
+        assert.deepEqual(secondStore.listActivations(issued.licenseKeyHash), activations);
+        histories.push(
+          inspectDatabase<{ command: string; result: string }>(
+            path,
+            `select command, result
+             from license_subscription_lifecycle_events
+             order by command`
+          ).map((row) => ({ ...row }))
+        );
+      } finally {
+        secondStore.close();
+        firstStore.close();
+      }
+    }
+
+    assert.deepEqual(projections[0], projections[1]);
+    assert.equal(projections[0]?.status, "revoked");
+    assert.equal(projections[0]?.expiresAt, NOW.toISOString());
+    assert.deepEqual(histories[0], [
+      { command: "renew_paid", result: "updated" },
+      { command: "revoke", result: "terminally_revoked" }
+    ]);
+    assert.deepEqual(histories[1], [
+      { command: "revoke", result: "terminally_revoked" }
+    ]);
+  });
+
   it("rolls back every non-mutating watermark when its ledger insert fails", () => {
     for (const command of ["reconcile", "cancel_at_period_end", "payment_attention"] as const) {
       const path = databasePath();

--- a/src/checkout-issuance-smoke.ts
+++ b/src/checkout-issuance-smoke.ts
@@ -116,11 +116,13 @@ export function buildCheckoutIssuanceSmokeRequestPreview(input: {
   idempotencyKey?: string;
 } & CheckoutProviderTupleInput): CheckoutIssuanceSmokeRequestPreview {
   const checkoutLookupKey = normalizeCheckoutLookupKey(input.checkoutLookupKey);
-  const idempotencyKey = input.idempotencyKey ?? defaultIdempotencyKey(input.releaseVersion, checkoutLookupKey);
+  const providerTuple = normalizeCheckoutProviderTuple(input);
+  const idempotencyKey = input.idempotencyKey
+    ?? defaultIdempotencyKey(input.releaseVersion, checkoutLookupKey, providerTuple);
   return {
     idempotencyKey,
     checkoutLookupKey,
-    ...normalizeCheckoutProviderTuple(input)
+    ...providerTuple
   };
 }
 
@@ -141,6 +143,21 @@ export function normalizeCheckoutProviderTuple(
     ),
     externalCheckoutId: readProviderTupleField(input.externalCheckoutId, "externalCheckoutId")
   };
+}
+
+export function checkoutProviderTupleFingerprint(tuple: CheckoutProviderTuple): string {
+  const digest = createHash("sha256")
+    .update("neondiff-checkout-provider-tuple-v1\0")
+    .update(JSON.stringify([
+      tuple.provider,
+      tuple.providerAccountId,
+      tuple.providerMode,
+      tuple.externalSubscriptionId,
+      tuple.externalCheckoutId
+    ]))
+    .digest("hex")
+    .slice(0, 20);
+  return digest.match(/.{4}/g)!.join("_");
 }
 
 export function validateCheckoutIssuanceUrl(url: string): { ok: true } | { ok: false; detail: string } {
@@ -318,8 +335,18 @@ function normalizeCheckoutLookupKey(input: string): CheckoutLookupKey {
   throw new Error("checkoutLookupKey must be one of: neondiff_monthly, neondiff_yearly, neondiff_org_yearly");
 }
 
-function defaultIdempotencyKey(releaseVersion: string, checkoutLookupKey: CheckoutLookupKey): string {
-  return `neondiff-smoke-${releaseVersion}-${checkoutLookupKey}`;
+function defaultIdempotencyKey(
+  releaseVersion: string,
+  checkoutLookupKey: CheckoutLookupKey,
+  providerTuple: CheckoutProviderTuple
+): string {
+  return [
+    "neondiff-smoke",
+    releaseVersion,
+    checkoutLookupKey,
+    providerTuple.providerMode,
+    checkoutProviderTupleFingerprint(providerTuple)
+  ].join("-");
 }
 
 function summarizeCheckoutIssuanceRequest(

--- a/src/checkout-issuance-smoke.ts
+++ b/src/checkout-issuance-smoke.ts
@@ -62,6 +62,14 @@ export interface CheckoutIssuanceSmokeRequestSummary {
   providerMode: CheckoutProviderMode;
 }
 
+export type CheckoutIssuanceSmokeRequestResult =
+  | { ok: true; requestPreview: CheckoutIssuanceSmokeRequestPreview }
+  | {
+      ok: false;
+      errorCode: "invalid_provider_tuple" | "invalid_checkout_lookup_key";
+      detail: string;
+    };
+
 export interface AuthenticatedCheckoutIssuanceProof {
   evidenceKind: "license_api_checkout_issuance_authenticated";
   releaseVersion: string;
@@ -126,6 +134,24 @@ export function buildCheckoutIssuanceSmokeRequestPreview(input: {
   };
 }
 
+export function buildCheckoutIssuanceSmokeRequestResult(input: {
+  releaseVersion: string;
+  checkoutLookupKey: string;
+  idempotencyKey?: string;
+} & CheckoutProviderTupleInput): CheckoutIssuanceSmokeRequestResult {
+  try {
+    return { ok: true, requestPreview: buildCheckoutIssuanceSmokeRequestPreview(input) };
+  } catch (error) {
+    return {
+      ok: false,
+      errorCode: error instanceof InvalidProviderTupleError
+        ? "invalid_provider_tuple"
+        : "invalid_checkout_lookup_key",
+      detail: error instanceof Error ? error.message : "invalid checkout issuance input"
+    };
+  }
+}
+
 export function normalizeCheckoutProviderTuple(
   input: CheckoutProviderTupleInput
 ): CheckoutProviderTuple {
@@ -174,17 +200,9 @@ export function validateCheckoutIssuanceUrl(url: string): { ok: true } | { ok: f
 }
 
 export async function runCheckoutIssuanceSmoke(input: CheckoutIssuanceSmokeInput): Promise<CheckoutIssuanceSmokeResult> {
-  let requestPreview: CheckoutIssuanceSmokeRequestPreview;
-  try {
-    requestPreview = buildCheckoutIssuanceSmokeRequestPreview(input);
-  } catch (error) {
-    return failure(
-      error instanceof InvalidProviderTupleError
-        ? "invalid_provider_tuple"
-        : "invalid_checkout_lookup_key",
-      error instanceof Error ? error.message : "invalid checkout issuance input"
-    );
-  }
+  const requestResult = buildCheckoutIssuanceSmokeRequestResult(input);
+  if (!requestResult.ok) return failure(requestResult.errorCode, requestResult.detail);
+  const { requestPreview } = requestResult;
 
   const urlCheck = validateCheckoutIssuanceUrl(input.url);
   if (!urlCheck.ok) return failure("invalid_url", urlCheck.detail, { requestPreview });

--- a/src/checkout-issuance-smoke.ts
+++ b/src/checkout-issuance-smoke.ts
@@ -14,9 +14,25 @@ const DEFAULT_CAPTURE_CONTEXT = {
 } as const;
 
 export type CheckoutLookupKey = "neondiff_monthly" | "neondiff_yearly" | "neondiff_org_yearly";
+export type CheckoutProviderMode = "test" | "live";
 export type CheckoutIssuanceFetch = typeof fetch;
 
-export interface CheckoutIssuanceSmokeInput {
+export interface CheckoutProviderTupleInput {
+  providerAccountId: string;
+  providerMode: string;
+  externalSubscriptionId: string;
+  externalCheckoutId: string;
+}
+
+export interface CheckoutProviderTuple {
+  provider: "stripe";
+  providerAccountId: string;
+  providerMode: CheckoutProviderMode;
+  externalSubscriptionId: string;
+  externalCheckoutId: string;
+}
+
+export interface CheckoutIssuanceSmokeInput extends CheckoutProviderTupleInput {
   url: string;
   releaseVersion: string;
   checkoutLookupKey: string;
@@ -33,7 +49,17 @@ export interface CheckoutIssuanceSmokeInput {
 export interface CheckoutIssuanceSmokeRequestPreview {
   idempotencyKey: string;
   checkoutLookupKey: CheckoutLookupKey;
+  provider: "stripe";
+  providerAccountId: string;
+  providerMode: CheckoutProviderMode;
+  externalSubscriptionId: string;
   externalCheckoutId: string;
+}
+
+export interface CheckoutIssuanceSmokeRequestSummary {
+  checkoutLookupKey: CheckoutLookupKey;
+  provider: "stripe";
+  providerMode: CheckoutProviderMode;
 }
 
 export interface AuthenticatedCheckoutIssuanceProof {
@@ -59,7 +85,7 @@ export type CheckoutIssuanceSmokeResult =
       command: "checkout-issuance-smoke";
       proof: AuthenticatedCheckoutIssuanceProof;
       proofPath?: string;
-      requestPreview: CheckoutIssuanceSmokeRequestPreview;
+      requestPreview: CheckoutIssuanceSmokeRequestSummary;
       proofBoundary: string;
     }
   | {
@@ -69,6 +95,7 @@ export type CheckoutIssuanceSmokeResult =
         | "confirm_live_issuance_required"
         | "invalid_url"
         | "invalid_checkout_lookup_key"
+        | "invalid_provider_tuple"
         | "invalid_output_path"
         | "missing_secret_env"
         | "fetch_failed"
@@ -79,7 +106,7 @@ export type CheckoutIssuanceSmokeResult =
       detail: string;
       secretEnvName?: string;
       statusCode?: number;
-      requestPreview?: CheckoutIssuanceSmokeRequestPreview;
+      requestPreview?: CheckoutIssuanceSmokeRequestSummary;
       proofBoundary: string;
     };
 
@@ -87,13 +114,32 @@ export function buildCheckoutIssuanceSmokeRequestPreview(input: {
   releaseVersion: string;
   checkoutLookupKey: string;
   idempotencyKey?: string;
-}): CheckoutIssuanceSmokeRequestPreview {
+} & CheckoutProviderTupleInput): CheckoutIssuanceSmokeRequestPreview {
   const checkoutLookupKey = normalizeCheckoutLookupKey(input.checkoutLookupKey);
   const idempotencyKey = input.idempotencyKey ?? defaultIdempotencyKey(input.releaseVersion, checkoutLookupKey);
   return {
     idempotencyKey,
     checkoutLookupKey,
-    externalCheckoutId: idempotencyKey
+    ...normalizeCheckoutProviderTuple(input)
+  };
+}
+
+export function normalizeCheckoutProviderTuple(
+  input: CheckoutProviderTupleInput
+): CheckoutProviderTuple {
+  const providerMode = input.providerMode?.trim();
+  if (providerMode !== "test" && providerMode !== "live") {
+    throw new InvalidProviderTupleError("providerMode must be test or live");
+  }
+  return {
+    provider: "stripe",
+    providerAccountId: readProviderTupleField(input.providerAccountId, "providerAccountId"),
+    providerMode,
+    externalSubscriptionId: readProviderTupleField(
+      input.externalSubscriptionId,
+      "externalSubscriptionId"
+    ),
+    externalCheckoutId: readProviderTupleField(input.externalCheckoutId, "externalCheckoutId")
   };
 }
 
@@ -115,7 +161,12 @@ export async function runCheckoutIssuanceSmoke(input: CheckoutIssuanceSmokeInput
   try {
     requestPreview = buildCheckoutIssuanceSmokeRequestPreview(input);
   } catch (error) {
-    return failure("invalid_checkout_lookup_key", error instanceof Error ? error.message : "invalid checkout lookup key");
+    return failure(
+      error instanceof InvalidProviderTupleError
+        ? "invalid_provider_tuple"
+        : "invalid_checkout_lookup_key",
+      error instanceof Error ? error.message : "invalid checkout issuance input"
+    );
   }
 
   const urlCheck = validateCheckoutIssuanceUrl(input.url);
@@ -216,7 +267,7 @@ export async function runCheckoutIssuanceSmoke(input: CheckoutIssuanceSmokeInput
     command: "checkout-issuance-smoke",
     proof: proof.proof,
     ...(input.outputPath ? { proofPath: input.outputPath } : {}),
-    requestPreview,
+    requestPreview: summarizeCheckoutIssuanceRequest(requestPreview),
     proofBoundary: "Redacted authenticated checkout issuance proof only; raw license keys and bearer secrets are never written."
   };
 }
@@ -269,6 +320,29 @@ function normalizeCheckoutLookupKey(input: string): CheckoutLookupKey {
 
 function defaultIdempotencyKey(releaseVersion: string, checkoutLookupKey: CheckoutLookupKey): string {
   return `neondiff-smoke-${releaseVersion}-${checkoutLookupKey}`;
+}
+
+function summarizeCheckoutIssuanceRequest(
+  preview: CheckoutIssuanceSmokeRequestPreview
+): CheckoutIssuanceSmokeRequestSummary {
+  return {
+    checkoutLookupKey: preview.checkoutLookupKey,
+    provider: preview.provider,
+    providerMode: preview.providerMode
+  };
+}
+
+class InvalidProviderTupleError extends Error {}
+
+function readProviderTupleField(value: string, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new InvalidProviderTupleError(`${field} is required`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > 160) {
+    throw new InvalidProviderTupleError(`${field} is too long`);
+  }
+  return trimmed;
 }
 
 function resolveConfinedProofOutputPath(
@@ -394,8 +468,12 @@ function failure(
 function redactFailureExtra(
   extra: Partial<Extract<CheckoutIssuanceSmokeResult, { ok: false }>>
 ): Partial<Extract<CheckoutIssuanceSmokeResult, { ok: false }>> {
+  const requestPreview = extra.requestPreview as CheckoutIssuanceSmokeRequestPreview | undefined;
   return {
     ...extra,
+    ...(requestPreview
+      ? { requestPreview: summarizeCheckoutIssuanceRequest(requestPreview) }
+      : {}),
     ...(typeof extra.secretEnvName === "string"
       ? { secretEnvName: isSafeEnvName(extra.secretEnvName) ? extra.secretEnvName : "[redacted-secret]" }
       : {})

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,7 +62,7 @@ import {
   writeOutcomeLedgerPacket
 } from "./outcome-ledger.js";
 import {
-  buildCheckoutIssuanceSmokeRequestPreview,
+  buildCheckoutIssuanceSmokeRequestResult,
   runCheckoutIssuanceSmoke,
   validateCheckoutIssuanceUrl
 } from "./checkout-issuance-smoke.js";
@@ -222,21 +222,33 @@ async function main(): Promise<void> {
     }
     const dryRun = args["dry-run"] === undefined ? true : parseBooleanArg(args["dry-run"], "--dry-run");
     if (dryRun) {
+      const requestResult = buildCheckoutIssuanceSmokeRequestResult({
+        releaseVersion,
+        checkoutLookupKey,
+        providerAccountId,
+        providerMode,
+        externalSubscriptionId,
+        externalCheckoutId,
+        ...(idempotencyKey ? { idempotencyKey } : {})
+      });
+      if (!requestResult.ok) {
+        console.log(stringifyRedactedJson({
+          ok: false,
+          command: "checkout-issuance-smoke",
+          errorCode: requestResult.errorCode,
+          detail: requestResult.detail,
+          proofBoundary: "No authenticated checkout issuance proof was produced."
+        }));
+        process.exitCode = 1;
+        return;
+      }
       console.log(stringifyRedactedJson({
         ok: true,
         command: "checkout-issuance-smoke",
         mode: "dry_run",
         url,
         releaseVersion,
-        requestPreview: buildCheckoutIssuanceSmokeRequestPreview({
-          releaseVersion,
-          checkoutLookupKey,
-          providerAccountId,
-          providerMode,
-          externalSubscriptionId,
-          externalCheckoutId,
-          ...(idempotencyKey ? { idempotencyKey } : {})
-        }),
+        requestPreview: requestResult.requestPreview,
         proofBoundary: "Dry-run request preview only; no owner-held secret was read and no network request was sent."
       }));
       return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -204,6 +204,10 @@ async function main(): Promise<void> {
     const releaseVersion = parseSingleArg(args["release-version"] ?? "v1.0.0", "--release-version");
     const checkoutLookupKey = parseSingleArg(args["checkout-lookup-key"] ?? "neondiff_monthly", "--checkout-lookup-key");
     const idempotencyKey = args["idempotency-key"] ? parseSingleArg(args["idempotency-key"], "--idempotency-key") : undefined;
+    const providerAccountId = parseSingleArg(args["provider-account-id"] ?? "", "--provider-account-id");
+    const providerMode = parseSingleArg(args["provider-mode"] ?? "", "--provider-mode");
+    const externalSubscriptionId = parseSingleArg(args["external-subscription-id"] ?? "", "--external-subscription-id");
+    const externalCheckoutId = parseSingleArg(args["external-checkout-id"] ?? "", "--external-checkout-id");
     const urlCheck = validateCheckoutIssuanceUrl(url);
     if (!urlCheck.ok) {
       console.log(stringifyRedactedJson({
@@ -227,6 +231,10 @@ async function main(): Promise<void> {
         requestPreview: buildCheckoutIssuanceSmokeRequestPreview({
           releaseVersion,
           checkoutLookupKey,
+          providerAccountId,
+          providerMode,
+          externalSubscriptionId,
+          externalCheckoutId,
           ...(idempotencyKey ? { idempotencyKey } : {})
         }),
         proofBoundary: "Dry-run request preview only; no owner-held secret was read and no network request was sent."
@@ -238,6 +246,10 @@ async function main(): Promise<void> {
       url,
       releaseVersion,
       checkoutLookupKey,
+      providerAccountId,
+      providerMode,
+      externalSubscriptionId,
+      externalCheckoutId,
       confirmLiveIssuance: args["confirm-live-issuance"] === undefined
         ? false
         : parseBooleanArg(args["confirm-live-issuance"], "--confirm-live-issuance"),
@@ -3290,6 +3302,10 @@ const COMMAND_USAGE: Record<string, CommandUsage> = {
       { name: "--url", description: "Full /v1/admin/licenses/issue URL (default https://neondiff-license.fly.dev/v1/admin/licenses/issue)." },
       { name: "--release-version", description: "Release version recorded in the proof (default v1.0.0)." },
       { name: "--checkout-lookup-key", description: "Checkout lookup key to smoke: neondiff_monthly, neondiff_yearly, or neondiff_org_yearly." },
+      { name: "--provider-account-id", description: "Required Stripe account ID for the same test or live environment as the correlated objects." },
+      { name: "--provider-mode", description: "Required Stripe environment: test or live. Cross-environment correlation is rejected." },
+      { name: "--external-subscription-id", description: "Required Stripe subscription ID from the selected provider mode; no ID is synthesized." },
+      { name: "--external-checkout-id", description: "Required Stripe Checkout Session ID from the selected provider mode; no ID is synthesized." },
       { name: "--idempotency-key", description: "Optional stable smoke idempotency key; defaults to release/version/lookup-key." },
       { name: "--dry-run", description: "true by default; false sends the live POST." },
       { name: "--confirm-live-issuance", description: "Must be true with --dry-run false before reading --secret-env and sending the POST." },

--- a/src/license-lifecycle-smoke.ts
+++ b/src/license-lifecycle-smoke.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { hostname, platform } from "node:os";
 import { resolve } from "node:path";
 import {
+  checkoutProviderTupleFingerprint,
   normalizeCheckoutProviderTuple,
   type CheckoutProviderTupleInput
 } from "./checkout-issuance-smoke.js";
@@ -170,7 +171,13 @@ export async function runLicenseLifecycleSmoke(input: LicenseLifecycleSmokeInput
             packIntegrity: input.packIntegrity
           }
         : {
-            idempotencyKey: `neondiff-lifecycle-${input.releaseVersion}-${issuanceIdentity.slice(0, 24)}`,
+            idempotencyKey: [
+              "neondiff-lifecycle",
+              input.releaseVersion,
+              issuanceIdentity.slice(0, 16),
+              checkoutIssuanceCorrelation!.providerMode,
+              checkoutProviderTupleFingerprint(checkoutIssuanceCorrelation!)
+            ].join("-"),
             checkoutLookupKey: "neondiff_monthly",
             ...checkoutIssuanceCorrelation
           },

--- a/src/license-lifecycle-smoke.ts
+++ b/src/license-lifecycle-smoke.ts
@@ -3,6 +3,10 @@ import { createHash, randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { hostname, platform } from "node:os";
 import { resolve } from "node:path";
+import {
+  normalizeCheckoutProviderTuple,
+  type CheckoutProviderTupleInput
+} from "./checkout-issuance-smoke.js";
 
 const API_TIMEOUT_MS = 15_000;
 const CLI_TIMEOUT_MS = 20_000;
@@ -81,16 +85,12 @@ export type LicenseLifecycleSmokeResult =
       proofBoundary: string;
     };
 
-export interface LicenseLifecycleSmokeInput {
+interface LicenseLifecycleSmokeBaseInput {
   releaseVersion: string;
   candidateHead: string;
   packShasum: string;
   packIntegrity: string;
   apiBaseUrl: string;
-  issuanceAuthorization: {
-    kind: "shared-secret" | "github-oidc";
-    bearer: string;
-  };
   candidateCliPath: string;
   configPath: string;
   confirmLiveLifecycle: boolean;
@@ -101,6 +101,17 @@ export interface LicenseLifecycleSmokeInput {
   dashboardEvidenceRoot?: string;
   runDashboardProbe?: (phase: "preactivation" | "active") => Promise<DashboardProbeResult>;
 }
+
+export type LicenseLifecycleSmokeInput = LicenseLifecycleSmokeBaseInput & (
+  | {
+      issuanceAuthorization: { kind: "github-oidc"; bearer: string };
+      checkoutIssuanceCorrelation?: never;
+    }
+  | {
+      issuanceAuthorization: { kind: "shared-secret"; bearer: string };
+      checkoutIssuanceCorrelation: CheckoutProviderTupleInput;
+    }
+);
 
 export async function runLicenseLifecycleSmoke(input: LicenseLifecycleSmokeInput): Promise<LicenseLifecycleSmokeResult> {
   const boundary = "Disposable lifecycle only. The issuance bearer and raw license key stay in process memory or bounded candidate stdin and are never returned.";
@@ -145,6 +156,9 @@ export async function runLicenseLifecycleSmoke(input: LicenseLifecycleSmokeInput
       preactivationDashboard = { setupBlockedBeforeActivation: true, providerBlockedBeforeActivation: true };
     }
     const githubOidcIssuance = input.issuanceAuthorization.kind === "github-oidc";
+    const checkoutIssuanceCorrelation = githubOidcIssuance
+      ? undefined
+      : normalizeCheckoutProviderTuple(input.checkoutIssuanceCorrelation!);
     const issuance = await postJson(
       fetchImpl,
       `${input.apiBaseUrl}${githubOidcIssuance ? "/v1/admin/licenses/issue-lifecycle" : "/v1/admin/licenses/issue"}`,
@@ -158,7 +172,7 @@ export async function runLicenseLifecycleSmoke(input: LicenseLifecycleSmokeInput
         : {
             idempotencyKey: `neondiff-lifecycle-${input.releaseVersion}-${issuanceIdentity.slice(0, 24)}`,
             checkoutLookupKey: "neondiff_monthly",
-            externalCheckoutId: `lifecycle-${issuanceIdentity.slice(0, 32)}`
+            ...checkoutIssuanceCorrelation
           },
       input.issuanceAuthorization.bearer
     );
@@ -379,6 +393,8 @@ function isValidInput(input: LicenseLifecycleSmokeInput): boolean {
       && (input.issuanceAuthorization.kind === "shared-secret" || input.issuanceAuthorization.kind === "github-oidc")
       && input.issuanceAuthorization.bearer.length >= 8
       && input.issuanceAuthorization.bearer.length <= 16 * 1024
+      && (input.issuanceAuthorization.kind === "github-oidc"
+        || Boolean(normalizeCheckoutProviderTuple(input.checkoutIssuanceCorrelation!)))
       && Boolean(input.candidateCliPath && input.configPath);
   } catch {
     return false;

--- a/tests/checkout-issuance-smoke.test.ts
+++ b/tests/checkout-issuance-smoke.test.ts
@@ -200,7 +200,6 @@ describe("checkout issuance smoke", () => {
         releaseVersion: "v1.0.5",
         checkoutLookupKey: "neondiff_monthly",
         ...TEST_PROVIDER_TUPLE,
-        idempotencyKey: "neondiff-smoke-v1.0.5-listener-fixture",
         confirmLiveIssuance: true,
         secretEnvName: "LICENSE_ISSUANCE_SECRET",
         env: { LICENSE_ISSUANCE_SECRET: secretValue },
@@ -213,11 +212,7 @@ describe("checkout issuance smoke", () => {
         providerMode: "live"
       });
 
-      expect(crossed).toMatchObject({
-        ok: false,
-        errorCode: "unexpected_status",
-        statusCode: 409
-      });
+      expect(crossed.ok).toBe(true);
       const serialized = JSON.stringify(crossed);
       for (const sensitive of [
         secretValue,
@@ -525,11 +520,28 @@ describe("checkout issuance smoke", () => {
     });
 
     expect(preview).toEqual({
-      idempotencyKey: "neondiff-smoke-v1.0.0-neondiff_org_yearly",
+      idempotencyKey: expect.stringMatching(
+        /^neondiff-smoke-v1\.0\.0-neondiff_org_yearly-test-[a-f0-9]{4}(?:_[a-f0-9]{4}){4}$/
+      ),
       checkoutLookupKey: "neondiff_org_yearly",
       provider: "stripe",
       ...TEST_PROVIDER_TUPLE
     });
+    const livePreview = buildCheckoutIssuanceSmokeRequestPreview({
+      releaseVersion: "v1.0.0",
+      checkoutLookupKey: "neondiff_org_yearly",
+      ...TEST_PROVIDER_TUPLE,
+      providerMode: "live"
+    });
+    expect(livePreview.idempotencyKey).not.toBe(preview.idempotencyKey);
+    for (const rawIdentifier of [
+      TEST_PROVIDER_TUPLE.providerAccountId,
+      TEST_PROVIDER_TUPLE.externalSubscriptionId,
+      TEST_PROVIDER_TUPLE.externalCheckoutId
+    ]) {
+      expect(preview.idempotencyKey).not.toContain(rawIdentifier);
+      expect(livePreview.idempotencyKey).not.toContain(rawIdentifier);
+    }
   });
 
   it("exposes a dry-run CLI preview that does not require the owner-held secret", async () => {
@@ -559,7 +571,7 @@ describe("checkout issuance smoke", () => {
     expect(output.command).toBe("checkout-issuance-smoke");
     expect(output.mode).toBe("dry_run");
     expect(output.requestPreview).toEqual({
-      idempotencyKey: "neondiff-smoke-v1.0.0-neondiff_org_yearly",
+      idempotencyKey: "neondiff-smoke-v1.0.0-[redacted-secret]",
       checkoutLookupKey: "neondiff_org_yearly",
       provider: "stripe",
       ...TEST_PROVIDER_TUPLE

--- a/tests/checkout-issuance-smoke.test.ts
+++ b/tests/checkout-issuance-smoke.test.ts
@@ -579,6 +579,92 @@ describe("checkout issuance smoke", () => {
     expect(JSON.stringify(output)).not.toContain("LICENSE_ISSUANCE_SECRET");
   });
 
+  it("returns structured redacted JSON when CLI dry-run provider tuple fields are missing", async () => {
+    const failure = await runCliFailure([
+      "checkout-issuance-smoke",
+      "--url",
+      "https://license.example/v1/admin/licenses/issue",
+      "--release-version",
+      "v1.0.5",
+      "--checkout-lookup-key",
+      "neondiff_monthly",
+      "--dry-run",
+      "true"
+    ]);
+
+    expect(failure.output).toMatchObject({
+      ok: false,
+      command: "checkout-issuance-smoke",
+      errorCode: "invalid_provider_tuple",
+      detail: "providerMode must be test or live",
+      proofBoundary: "No authenticated checkout issuance proof was produced."
+    });
+    expect(failure.stderr).toBe("");
+  });
+
+  it("keeps invalid checkout lookup keys distinct from provider tuple failures in CLI dry-run", async () => {
+    const failure = await runCliFailure([
+      "checkout-issuance-smoke",
+      "--url",
+      "https://license.example/v1/admin/licenses/issue",
+      "--release-version",
+      "v1.0.5",
+      "--checkout-lookup-key",
+      "unsupported_plan",
+      "--provider-account-id",
+      TEST_PROVIDER_TUPLE.providerAccountId,
+      "--provider-mode",
+      TEST_PROVIDER_TUPLE.providerMode,
+      "--external-subscription-id",
+      TEST_PROVIDER_TUPLE.externalSubscriptionId,
+      "--external-checkout-id",
+      TEST_PROVIDER_TUPLE.externalCheckoutId,
+      "--dry-run",
+      "true"
+    ]);
+
+    expect(failure.output).toMatchObject({
+      ok: false,
+      command: "checkout-issuance-smoke",
+      errorCode: "invalid_checkout_lookup_key"
+    });
+    expect(failure.stderr).toBe("");
+  });
+
+  it("rejects and redacts a 161-character provider identifier in CLI dry-run", async () => {
+    const oversizedProviderAccountId = `acct_${"x".repeat(156)}`;
+    expect(oversizedProviderAccountId).toHaveLength(161);
+
+    const failure = await runCliFailure([
+      "checkout-issuance-smoke",
+      "--url",
+      "https://license.example/v1/admin/licenses/issue",
+      "--release-version",
+      "v1.0.5",
+      "--checkout-lookup-key",
+      "neondiff_monthly",
+      "--provider-account-id",
+      oversizedProviderAccountId,
+      "--provider-mode",
+      TEST_PROVIDER_TUPLE.providerMode,
+      "--external-subscription-id",
+      TEST_PROVIDER_TUPLE.externalSubscriptionId,
+      "--external-checkout-id",
+      TEST_PROVIDER_TUPLE.externalCheckoutId,
+      "--dry-run",
+      "true"
+    ]);
+
+    expect(failure.output).toMatchObject({
+      ok: false,
+      command: "checkout-issuance-smoke",
+      errorCode: "invalid_provider_tuple",
+      detail: "providerAccountId is too long"
+    });
+    expect(failure.stdout).not.toContain(oversizedProviderAccountId);
+    expect(failure.stderr).toBe("");
+  });
+
   it("rejects plaintext URLs in CLI dry-run before presenting a request preview", async () => {
     await expect(runCli([
       "checkout-issuance-smoke",
@@ -643,4 +729,23 @@ async function runCli(args: string[]): Promise<Record<string, unknown>> {
     maxBuffer: 1024 * 1024
   });
   return JSON.parse(stdout) as Record<string, unknown>;
+}
+
+async function runCliFailure(args: string[]): Promise<{
+  output: Record<string, unknown>;
+  stdout: string;
+  stderr: string;
+}> {
+  try {
+    await runCli(args);
+  } catch (error) {
+    const failure = error as { stdout?: unknown; stderr?: unknown };
+    if (typeof failure.stdout !== "string") throw error;
+    return {
+      output: JSON.parse(failure.stdout) as Record<string, unknown>,
+      stdout: failure.stdout,
+      stderr: typeof failure.stderr === "string" ? failure.stderr : ""
+    };
+  }
+  throw new Error("expected CLI command to fail");
 }

--- a/tests/checkout-issuance-smoke.test.ts
+++ b/tests/checkout-issuance-smoke.test.ts
@@ -191,7 +191,7 @@ describe("checkout issuance smoke", () => {
     });
   });
 
-  it("passes the real API listener and rejects a test/live replay conflict without leaking correlation", async () => {
+  it("passes separate test/live tuples through the real API listener without leaking correlation", async () => {
     const secretValue = "listener-fixture-issuance-secret";
     const api = createInProcessLicenseApi(secretValue);
     try {

--- a/tests/checkout-issuance-smoke.test.ts
+++ b/tests/checkout-issuance-smoke.test.ts
@@ -11,10 +11,17 @@ import {
   runCheckoutIssuanceSmoke,
   type CheckoutIssuanceFetch
 } from "../src/checkout-issuance-smoke.js";
+import { createInProcessLicenseApi } from "./helpers/in-process-license-api.js";
 
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
 const tsxCliPath = require.resolve("tsx/cli");
+const TEST_PROVIDER_TUPLE = {
+  providerAccountId: "acct_test_smoke_fixture",
+  providerMode: "test",
+  externalSubscriptionId: "sub_test_smoke_fixture",
+  externalCheckoutId: "cs_test_smoke_fixture"
+} as const;
 
 describe("checkout issuance smoke", () => {
   const tempRoots: string[] = [];
@@ -40,6 +47,7 @@ describe("checkout issuance smoke", () => {
       url: "https://license.example/v1/admin/licenses/issue",
       releaseVersion: "v1.0.0",
       checkoutLookupKey: "neondiff_monthly",
+      ...TEST_PROVIDER_TUPLE,
       confirmLiveIssuance: false,
       secretEnvName: "LICENSE_ISSUANCE_SECRET",
       env: { LICENSE_ISSUANCE_SECRET: "owner-held-proof-key" },
@@ -64,6 +72,7 @@ describe("checkout issuance smoke", () => {
       url: "https://license.example/v1/admin/licenses/issue",
       releaseVersion: "v1.0.0",
       checkoutLookupKey: "neondiff_monthly",
+      ...TEST_PROVIDER_TUPLE,
       confirmLiveIssuance: true,
       secretEnvName: "LICENSE_ISSUANCE_SECRET",
       env: {},
@@ -88,6 +97,7 @@ describe("checkout issuance smoke", () => {
       url: "http://license.example/v1/admin/licenses/issue",
       releaseVersion: "v1.0.0",
       checkoutLookupKey: "neondiff_monthly",
+      ...TEST_PROVIDER_TUPLE,
       confirmLiveIssuance: true,
       secretEnvName: "LICENSE_ISSUANCE_SECRET",
       env: { LICENSE_ISSUANCE_SECRET: "owner-held-proof-key" },
@@ -122,6 +132,7 @@ describe("checkout issuance smoke", () => {
       url: "https://license.example/v1/admin/licenses/issue",
       releaseVersion: "v1.0.0",
       checkoutLookupKey: "neondiff_yearly",
+      ...TEST_PROVIDER_TUPLE,
       confirmLiveIssuance: true,
       secretEnvName: "LICENSE_ISSUANCE_SECRET",
       env: { LICENSE_ISSUANCE_SECRET: secretValue },
@@ -145,7 +156,8 @@ describe("checkout issuance smoke", () => {
     expect(JSON.parse(String(observedRequest?.init?.body))).toEqual({
       idempotencyKey: "neondiff-smoke-v1.0.0-neondiff_yearly",
       checkoutLookupKey: "neondiff_yearly",
-      externalCheckoutId: "neondiff-smoke-v1.0.0-neondiff_yearly"
+      provider: "stripe",
+      ...TEST_PROVIDER_TUPLE
     });
 
     const proofText = readFileSync(join(root, outputPath), "utf8");
@@ -153,6 +165,9 @@ describe("checkout issuance smoke", () => {
     expect(proofText).not.toContain(licenseKey);
     expect(proofText).not.toContain("licenseKey");
     expect(proofText).not.toContain("Authorization");
+    expect(proofText).not.toContain(TEST_PROVIDER_TUPLE.providerAccountId);
+    expect(proofText).not.toContain(TEST_PROVIDER_TUPLE.externalSubscriptionId);
+    expect(proofText).not.toContain(TEST_PROVIDER_TUPLE.externalCheckoutId);
     expect(JSON.parse(proofText)).toEqual({
       evidenceKind: "license_api_checkout_issuance_authenticated",
       releaseVersion: "v1.0.0",
@@ -176,6 +191,70 @@ describe("checkout issuance smoke", () => {
     });
   });
 
+  it("passes the real API listener and rejects a test/live replay conflict without leaking correlation", async () => {
+    const secretValue = "listener-fixture-issuance-secret";
+    const api = createInProcessLicenseApi(secretValue);
+    try {
+      const baseInput = {
+        url: "https://license.example/v1/admin/licenses/issue",
+        releaseVersion: "v1.0.5",
+        checkoutLookupKey: "neondiff_monthly",
+        ...TEST_PROVIDER_TUPLE,
+        idempotencyKey: "neondiff-smoke-v1.0.5-listener-fixture",
+        confirmLiveIssuance: true,
+        secretEnvName: "LICENSE_ISSUANCE_SECRET",
+        env: { LICENSE_ISSUANCE_SECRET: secretValue },
+        fetchImpl: api.fetchImpl
+      } as const;
+
+      expect((await runCheckoutIssuanceSmoke(baseInput)).ok).toBe(true);
+      const crossed = await runCheckoutIssuanceSmoke({
+        ...baseInput,
+        providerMode: "live"
+      });
+
+      expect(crossed).toMatchObject({
+        ok: false,
+        errorCode: "unexpected_status",
+        statusCode: 409
+      });
+      const serialized = JSON.stringify(crossed);
+      for (const sensitive of [
+        secretValue,
+        TEST_PROVIDER_TUPLE.providerAccountId,
+        TEST_PROVIDER_TUPLE.externalSubscriptionId,
+        TEST_PROVIDER_TUPLE.externalCheckoutId
+      ]) {
+        expect(serialized).not.toContain(sensitive);
+      }
+    } finally {
+      api.close();
+    }
+  });
+
+  it("rejects a missing provider tuple before reading the bearer or calling the listener", async () => {
+    let called = false;
+    const result = await runCheckoutIssuanceSmoke({
+      url: "https://license.example/v1/admin/licenses/issue",
+      releaseVersion: "v1.0.5",
+      checkoutLookupKey: "neondiff_monthly",
+      ...TEST_PROVIDER_TUPLE,
+      externalSubscriptionId: "",
+      confirmLiveIssuance: true,
+      secretEnvName: "LICENSE_ISSUANCE_SECRET",
+      env: { LICENSE_ISSUANCE_SECRET: "must-not-be-read" },
+      fetchImpl: async () => {
+        called = true;
+        throw new Error("listener must not be called");
+      }
+    });
+
+    expect(result).toMatchObject({ ok: false, errorCode: "invalid_provider_tuple" });
+    expect(called).toBe(false);
+    expect(JSON.stringify(result)).not.toContain("must-not-be-read");
+    expect(JSON.stringify(result)).not.toContain(TEST_PROVIDER_TUPLE.providerAccountId);
+  });
+
   it("rejects symlinked proof output targets inside docs/evidence", async () => {
     const root = tempRoot();
     mkdirSync(join(root, "docs/evidence"), { recursive: true });
@@ -194,6 +273,7 @@ describe("checkout issuance smoke", () => {
       url: "https://license.example/v1/admin/licenses/issue",
       releaseVersion: "v1.0.0",
       checkoutLookupKey: "neondiff_monthly",
+      ...TEST_PROVIDER_TUPLE,
       confirmLiveIssuance: true,
       secretEnvName: "LICENSE_ISSUANCE_SECRET",
       env: { LICENSE_ISSUANCE_SECRET: secretValue },
@@ -225,6 +305,7 @@ describe("checkout issuance smoke", () => {
       url: "https://license.example/v1/admin/licenses/issue",
       releaseVersion: "v1.0.0",
       checkoutLookupKey: "neondiff_monthly",
+      ...TEST_PROVIDER_TUPLE,
       confirmLiveIssuance: true,
       secretEnvName: "LICENSE_ISSUANCE_SECRET",
       env: { LICENSE_ISSUANCE_SECRET: secretValue },
@@ -252,6 +333,7 @@ describe("checkout issuance smoke", () => {
       url: "https://license.example/v1/admin/licenses/issue",
       releaseVersion: "v1.0.0",
       checkoutLookupKey: "neondiff_monthly",
+      ...TEST_PROVIDER_TUPLE,
       confirmLiveIssuance: true,
       secretEnvName: "LICENSE_ISSUANCE_SECRET",
       env: { LICENSE_ISSUANCE_SECRET: secretValue },
@@ -280,6 +362,7 @@ describe("checkout issuance smoke", () => {
       url: "https://license.example/v1/admin/licenses/issue",
       releaseVersion: "v1.0.0",
       checkoutLookupKey: "neondiff_monthly",
+      ...TEST_PROVIDER_TUPLE,
       confirmLiveIssuance: true,
       secretEnvName: "LICENSE_ISSUANCE_SECRET",
       env: { LICENSE_ISSUANCE_SECRET: secretValue },
@@ -312,6 +395,7 @@ describe("checkout issuance smoke", () => {
       url: "https://license.example/v1/admin/licenses/issue",
       releaseVersion: "v1.0.0",
       checkoutLookupKey: "neondiff_monthly",
+      ...TEST_PROVIDER_TUPLE,
       confirmLiveIssuance: true,
       secretEnvName: "LICENSE_ISSUANCE_SECRET",
       env: { LICENSE_ISSUANCE_SECRET: secretValue },
@@ -342,6 +426,7 @@ describe("checkout issuance smoke", () => {
       url: "https://license.example/v1/admin/licenses/issue",
       releaseVersion: "v1.0.0",
       checkoutLookupKey: "neondiff_monthly",
+      ...TEST_PROVIDER_TUPLE,
       confirmLiveIssuance: true,
       secretEnvName: "LICENSE_ISSUANCE_SECRET",
       env: { LICENSE_ISSUANCE_SECRET: secretValue },
@@ -368,6 +453,7 @@ describe("checkout issuance smoke", () => {
       url: "https://license.example/v1/admin/licenses/issue",
       releaseVersion: "v1.0.0",
       checkoutLookupKey: "neondiff_monthly",
+      ...TEST_PROVIDER_TUPLE,
       confirmLiveIssuance: true,
       secretEnvName: "LICENSE_ISSUANCE_SECRET",
       env: { LICENSE_ISSUANCE_SECRET: secretValue },
@@ -395,6 +481,7 @@ describe("checkout issuance smoke", () => {
       url: "https://license.example/v1/admin/licenses/issue",
       releaseVersion: "v1.0.0",
       checkoutLookupKey: "neondiff_monthly",
+      ...TEST_PROVIDER_TUPLE,
       confirmLiveIssuance: true,
       secretEnvName: "LICENSE_ISSUANCE_SECRET",
       env: { LICENSE_ISSUANCE_SECRET: secretValue },
@@ -417,6 +504,7 @@ describe("checkout issuance smoke", () => {
       url: "https://license.example/v1/admin/licenses/issue",
       releaseVersion: "v1.0.0",
       checkoutLookupKey: "neondiff_monthly",
+      ...TEST_PROVIDER_TUPLE,
       confirmLiveIssuance: true,
       secretEnvName: mistakenSecretEnvName,
       env: {},
@@ -432,13 +520,15 @@ describe("checkout issuance smoke", () => {
   it("supports dry-run request preview without a secret or network call", () => {
     const preview = buildCheckoutIssuanceSmokeRequestPreview({
       releaseVersion: "v1.0.0",
-      checkoutLookupKey: "neondiff_org_yearly"
+      checkoutLookupKey: "neondiff_org_yearly",
+      ...TEST_PROVIDER_TUPLE
     });
 
     expect(preview).toEqual({
       idempotencyKey: "neondiff-smoke-v1.0.0-neondiff_org_yearly",
       checkoutLookupKey: "neondiff_org_yearly",
-      externalCheckoutId: "neondiff-smoke-v1.0.0-neondiff_org_yearly"
+      provider: "stripe",
+      ...TEST_PROVIDER_TUPLE
     });
   });
 
@@ -451,6 +541,14 @@ describe("checkout issuance smoke", () => {
       "v1.0.0",
       "--checkout-lookup-key",
       "neondiff_org_yearly",
+      "--provider-account-id",
+      TEST_PROVIDER_TUPLE.providerAccountId,
+      "--provider-mode",
+      TEST_PROVIDER_TUPLE.providerMode,
+      "--external-subscription-id",
+      TEST_PROVIDER_TUPLE.externalSubscriptionId,
+      "--external-checkout-id",
+      TEST_PROVIDER_TUPLE.externalCheckoutId,
       "--secret-env",
       "LICENSE_ISSUANCE_SECRET",
       "--dry-run",
@@ -463,7 +561,8 @@ describe("checkout issuance smoke", () => {
     expect(output.requestPreview).toEqual({
       idempotencyKey: "neondiff-smoke-v1.0.0-neondiff_org_yearly",
       checkoutLookupKey: "neondiff_org_yearly",
-      externalCheckoutId: "neondiff-smoke-v1.0.0-neondiff_org_yearly"
+      provider: "stripe",
+      ...TEST_PROVIDER_TUPLE
     });
     expect(JSON.stringify(output)).not.toContain("LICENSE_ISSUANCE_SECRET");
   });
@@ -493,6 +592,14 @@ describe("checkout issuance smoke", () => {
       "v1.0.0",
       "--checkout-lookup-key",
       "neondiff_monthly",
+      "--provider-account-id",
+      TEST_PROVIDER_TUPLE.providerAccountId,
+      "--provider-mode",
+      TEST_PROVIDER_TUPLE.providerMode,
+      "--external-subscription-id",
+      TEST_PROVIDER_TUPLE.externalSubscriptionId,
+      "--external-checkout-id",
+      TEST_PROVIDER_TUPLE.externalCheckoutId,
       "--secret-env",
       "NEONDIFF_TEST_ISSUANCE_KEY",
       "--dry-run",

--- a/tests/helpers/in-process-license-api.ts
+++ b/tests/helpers/in-process-license-api.ts
@@ -1,0 +1,66 @@
+import { createLicenseRequestListener } from "../../services/license-api/src/http.js";
+import { RateLimiter } from "../../services/license-api/src/service.js";
+import { LicenseStore } from "../../services/license-api/src/store.js";
+
+export interface InProcessLicenseApi {
+  fetchImpl: typeof fetch;
+  store: LicenseStore;
+  close(): void;
+}
+
+export function createInProcessLicenseApi(issuanceSecret: string): InProcessLicenseApi {
+  const now = () => new Date("2026-07-13T00:00:00.000Z");
+  const store = new LicenseStore(":memory:", { now });
+  const listener = createLicenseRequestListener({
+    store,
+    issuanceSecret,
+    now,
+    rateLimiter: new RateLimiter({ maxPerWindow: 1_000, windowMs: 60_000 })
+  });
+
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const path = new URL(String(input)).pathname;
+    const body = String(init?.body ?? "");
+    return await new Promise<Response>((resolve, reject) => {
+      const req: any = {
+        method: init?.method ?? "POST",
+        url: path,
+        headers: Object.fromEntries(new Headers(init?.headers).entries()),
+        socket: { remoteAddress: "127.0.0.1" },
+        on(event: string, callback: (value?: unknown) => void) {
+          if (event === "data" && body) callback(Buffer.from(body));
+          if (event === "end") callback();
+          if (event === "error") void callback;
+          return req;
+        },
+        destroy(error?: Error) {
+          if (error) reject(error);
+        }
+      };
+      let statusCode = 200;
+      let responseHeaders: Record<string, string> = {};
+      const responseChunks: string[] = [];
+      const res: any = {
+        writeHead(code: number, headers: Record<string, string>) {
+          statusCode = code;
+          responseHeaders = headers;
+          return res;
+        },
+        end(payload?: string) {
+          if (payload) responseChunks.push(payload);
+          resolve(new Response(responseChunks.join(""), {
+            status: statusCode,
+            headers: responseHeaders
+          }));
+        }
+      };
+      void listener(req, res).catch(reject);
+    });
+  }) as typeof fetch;
+
+  return {
+    fetchImpl,
+    store,
+    close: () => store.close()
+  };
+}

--- a/tests/helpers/in-process-license-api.ts
+++ b/tests/helpers/in-process-license-api.ts
@@ -22,6 +22,7 @@ export function createInProcessLicenseApi(issuanceSecret: string): InProcessLice
     const path = new URL(String(input)).pathname;
     const body = String(init?.body ?? "");
     return await new Promise<Response>((resolve, reject) => {
+      let requestErrorCallback: ((error: Error) => void) | undefined;
       const req: any = {
         method: init?.method ?? "POST",
         url: path,
@@ -30,11 +31,22 @@ export function createInProcessLicenseApi(issuanceSecret: string): InProcessLice
         on(event: string, callback: (value?: unknown) => void) {
           if (event === "data" && body) callback(Buffer.from(body));
           if (event === "end") callback();
-          if (event === "error") void callback;
+          if (event === "error") {
+            requestErrorCallback = callback as (error: Error) => void;
+          }
           return req;
         },
         destroy(error?: Error) {
-          if (error) reject(error);
+          if (!error) return;
+          if (requestErrorCallback) {
+            try {
+              requestErrorCallback(error);
+            } catch (callbackError) {
+              reject(callbackError);
+            }
+          } else {
+            reject(error);
+          }
         }
       };
       let statusCode = 200;

--- a/tests/license-lifecycle-smoke.test.ts
+++ b/tests/license-lifecycle-smoke.test.ts
@@ -211,7 +211,9 @@ describe("license lifecycle smoke", () => {
 
     expect(result).toMatchObject({ ok: false, errorCode: "issuance_failed" });
     expect(observedBody).toEqual({
-      idempotencyKey: expect.stringMatching(/^neondiff-lifecycle-v1\.0\.5-[a-f0-9]{24}$/),
+      idempotencyKey: expect.stringMatching(
+        /^neondiff-lifecycle-v1\.0\.5-[a-f0-9]{16}-test-[a-f0-9]{4}(?:_[a-f0-9]{4}){4}$/
+      ),
       checkoutLookupKey: "neondiff_monthly",
       provider: "stripe",
       ...sharedSecretCorrelation
@@ -264,8 +266,12 @@ describe("license lifecycle smoke", () => {
         ...baseInput,
         checkoutIssuanceCorrelation: { ...sharedSecretCorrelation, providerMode: "live" }
       });
-      expect(crossed).toMatchObject({ ok: false, errorCode: "issuance_failed" });
-      expect(candidateCalls).toBe(callsAfterFirst);
+      expect(crossed).toMatchObject({
+        ok: false,
+        errorCode: "candidate_failed",
+        cleanup: { localState: "confirmed_removed", remoteState: "confirmed_deactivated" }
+      });
+      expect(candidateCalls).toBeGreaterThan(callsAfterFirst);
       const serialized = JSON.stringify(crossed);
       for (const sensitive of [
         secretValue,

--- a/tests/license-lifecycle-smoke.test.ts
+++ b/tests/license-lifecycle-smoke.test.ts
@@ -5,9 +5,16 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { runLicenseLifecycleSmoke } from "../src/license-lifecycle-smoke.js";
+import { createInProcessLicenseApi } from "./helpers/in-process-license-api.js";
 
 describe("license lifecycle smoke", () => {
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const sharedSecretCorrelation = {
+    providerAccountId: "acct_test_lifecycle_fixture",
+    providerMode: "test" as const,
+    externalSubscriptionId: "sub_test_lifecycle_fixture",
+    externalCheckoutId: "cs_test_lifecycle_fixture"
+  };
 
   it("keeps the trusted wrapper on GitHub OIDC without secret arguments or shared-secret stdin", () => {
     const script = readFileSync(resolve(repoRoot, "scripts", "run-license-lifecycle-smoke.mjs"), "utf8");
@@ -163,6 +170,7 @@ describe("license lifecycle smoke", () => {
       packIntegrity: `sha512-${"Y".repeat(86)}==`,
       apiBaseUrl: "https://neondiff-license.fly.dev",
       issuanceAuthorization: { kind: "shared-secret", bearer: "not-read" },
+      checkoutIssuanceCorrelation: sharedSecretCorrelation,
       candidateCliPath: "/isolated/prefix/bin/neondiff",
       configPath: "/isolated/config.local.json",
       confirmLiveLifecycle: false,
@@ -177,6 +185,140 @@ describe("license lifecycle smoke", () => {
     });
     expect(result).toMatchObject({ ok: false, errorCode: "confirm_live_lifecycle_required" });
     expect(called).toBe(false);
+  });
+
+  it("sends the immutable Stripe tuple for shared-secret checkout issuance", async () => {
+    let observedBody: Record<string, unknown> | undefined;
+    const result = await runLicenseLifecycleSmoke({
+      releaseVersion: "v1.0.5",
+      candidateHead: "a".repeat(40),
+      packShasum: "b".repeat(40),
+      packIntegrity: `sha512-${"Y".repeat(86)}==`,
+      apiBaseUrl: "https://neondiff-license.fly.dev",
+      issuanceAuthorization: { kind: "shared-secret", bearer: "fixture-secret" },
+      checkoutIssuanceCorrelation: sharedSecretCorrelation,
+      candidateCliPath: "/isolated/prefix/bin/neondiff",
+      configPath: "/isolated/config.local.json",
+      confirmLiveLifecycle: true,
+      fetchImpl: async (_url, init) => {
+        observedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return new Response(JSON.stringify({ status: "server" }), { status: 500 });
+      },
+      runCandidateCommand: async () => {
+        throw new Error("candidate must not run after failed issuance");
+      }
+    });
+
+    expect(result).toMatchObject({ ok: false, errorCode: "issuance_failed" });
+    expect(observedBody).toEqual({
+      idempotencyKey: expect.stringMatching(/^neondiff-lifecycle-v1\.0\.5-[a-f0-9]{24}$/),
+      checkoutLookupKey: "neondiff_monthly",
+      provider: "stripe",
+      ...sharedSecretCorrelation
+    });
+  });
+
+  it("drives shared-secret issuance through the real listener and keeps test/live correlation out of errors", async () => {
+    const secretValue = "listener-fixture-lifecycle-secret";
+    const api = createInProcessLicenseApi(secretValue);
+    let localRemoved = false;
+    let candidateCalls = 0;
+    const baseInput = {
+      releaseVersion: "v1.0.5",
+      candidateHead: "a".repeat(40),
+      packShasum: "b".repeat(40),
+      packIntegrity: `sha512-${"Y".repeat(86)}==`,
+      apiBaseUrl: "https://neondiff-license.fly.dev",
+      issuanceAuthorization: { kind: "shared-secret" as const, bearer: secretValue },
+      checkoutIssuanceCorrelation: sharedSecretCorrelation,
+      candidateCliPath: "/isolated/prefix/bin/neondiff",
+      configPath: "/isolated/config.local.json",
+      confirmLiveLifecycle: true,
+      now: () => new Date("2026-07-13T00:00:00.000Z"),
+      fetchImpl: api.fetchImpl,
+      runCandidateCommand: async ({ args }: { args: string[] }) => {
+        candidateCalls += 1;
+        if (args[1] === "activate") {
+          return { exitCode: 1, stdout: JSON.stringify({ ok: false, status: "server" }), stderr: "" };
+        }
+        if (args[1] === "deactivate" && args.includes("false")) {
+          localRemoved = true;
+          return { exitCode: 0, stdout: JSON.stringify({ ok: true, status: "deactivated" }), stderr: "" };
+        }
+        if (args[1] === "status" && localRemoved) {
+          return { exitCode: 1, stdout: JSON.stringify({ ok: false, status: "missing" }), stderr: "" };
+        }
+        throw new Error("unexpected candidate command");
+      }
+    };
+
+    try {
+      const first = await runLicenseLifecycleSmoke(baseInput);
+      expect(first).toMatchObject({
+        ok: false,
+        errorCode: "candidate_failed",
+        cleanup: { localState: "confirmed_removed", remoteState: "confirmed_deactivated" }
+      });
+      const callsAfterFirst = candidateCalls;
+      const crossed = await runLicenseLifecycleSmoke({
+        ...baseInput,
+        checkoutIssuanceCorrelation: { ...sharedSecretCorrelation, providerMode: "live" }
+      });
+      expect(crossed).toMatchObject({ ok: false, errorCode: "issuance_failed" });
+      expect(candidateCalls).toBe(callsAfterFirst);
+      const serialized = JSON.stringify(crossed);
+      for (const sensitive of [
+        secretValue,
+        sharedSecretCorrelation.providerAccountId,
+        sharedSecretCorrelation.externalSubscriptionId,
+        sharedSecretCorrelation.externalCheckoutId
+      ]) {
+        expect(serialized).not.toContain(sensitive);
+      }
+    } finally {
+      api.close();
+    }
+  });
+
+  it("rejects an incomplete shared-secret correlation before reading the bearer or calling the API", async () => {
+    const secretValue = "must-not-cross-the-lifecycle-boundary";
+    let apiCalled = false;
+    let candidateCalled = false;
+    const result = await runLicenseLifecycleSmoke({
+      releaseVersion: "v1.0.5",
+      candidateHead: "a".repeat(40),
+      packShasum: "b".repeat(40),
+      packIntegrity: `sha512-${"Y".repeat(86)}==`,
+      apiBaseUrl: "https://neondiff-license.fly.dev",
+      issuanceAuthorization: { kind: "shared-secret", bearer: secretValue },
+      checkoutIssuanceCorrelation: {
+        ...sharedSecretCorrelation,
+        externalCheckoutId: ""
+      },
+      candidateCliPath: "/isolated/prefix/bin/neondiff",
+      configPath: "/isolated/config.local.json",
+      confirmLiveLifecycle: true,
+      fetchImpl: async () => {
+        apiCalled = true;
+        throw new Error("API must not be called for an incomplete tuple");
+      },
+      runCandidateCommand: async () => {
+        candidateCalled = true;
+        throw new Error("candidate must not run for an incomplete tuple");
+      }
+    });
+
+    expect(result).toMatchObject({ ok: false, errorCode: "invalid_input" });
+    expect(apiCalled).toBe(false);
+    expect(candidateCalled).toBe(false);
+    const serialized = JSON.stringify(result);
+    for (const sensitive of [
+      secretValue,
+      sharedSecretCorrelation.providerAccountId,
+      sharedSecretCorrelation.externalSubscriptionId
+    ]) {
+      expect(serialized).not.toContain(sensitive);
+    }
   });
 
   it("rejects a preactivation dashboard probe that does not prove setup blocking", async () => {
@@ -217,6 +359,7 @@ describe("license lifecycle smoke", () => {
       packIntegrity: `sha512-${"Y".repeat(86)}==`,
       apiBaseUrl: "https://neondiff-license.fly.dev",
       issuanceAuthorization: { kind: "shared-secret", bearer: "fixture-secret" },
+      checkoutIssuanceCorrelation: sharedSecretCorrelation,
       candidateCliPath: "/isolated/prefix/bin/neondiff",
       configPath: "/isolated/config.local.json",
       confirmLiveLifecycle: true,
@@ -239,6 +382,7 @@ describe("license lifecycle smoke", () => {
       packIntegrity: `sha512-${"Y".repeat(86)}==`,
       apiBaseUrl: "https://neondiff-license.fly.dev",
       issuanceAuthorization: { kind: "shared-secret", bearer: "fixture-secret" },
+      checkoutIssuanceCorrelation: sharedSecretCorrelation,
       candidateCliPath: "/isolated/prefix/bin/neondiff",
       configPath: "/isolated/config.local.json",
       confirmLiveLifecycle: true,
@@ -289,6 +433,7 @@ describe("license lifecycle smoke", () => {
         packIntegrity: `sha512-${"Y".repeat(86)}==`,
         apiBaseUrl: "https://neondiff-license.fly.dev",
         issuanceAuthorization: { kind: "shared-secret", bearer: "fixture-secret" },
+        checkoutIssuanceCorrelation: sharedSecretCorrelation,
         candidateCliPath: "/isolated/prefix/bin/neondiff",
         configPath: "/isolated/config.local.json",
         confirmLiveLifecycle: true,
@@ -319,6 +464,7 @@ describe("license lifecycle smoke", () => {
       packIntegrity: `sha512-${"Y".repeat(86)}==`,
       apiBaseUrl: "https://neondiff-license.fly.dev",
       issuanceAuthorization: { kind: "shared-secret", bearer: "fixture-secret" },
+      checkoutIssuanceCorrelation: sharedSecretCorrelation,
       candidateCliPath: "/isolated/prefix/bin/neondiff",
       configPath: "/isolated/config.local.json",
       confirmLiveLifecycle: true,
@@ -371,6 +517,7 @@ describe("license lifecycle smoke", () => {
       packIntegrity: `sha512-${"Y".repeat(86)}==`,
       apiBaseUrl: "https://neondiff-license.fly.dev",
       issuanceAuthorization: { kind: "shared-secret", bearer: "fixture-secret" },
+      checkoutIssuanceCorrelation: sharedSecretCorrelation,
       candidateCliPath: "/isolated/prefix/bin/neondiff",
       configPath: "/isolated/config.local.json",
       confirmLiveLifecycle: true,

--- a/tests/license-service-contract.test.ts
+++ b/tests/license-service-contract.test.ts
@@ -357,6 +357,15 @@ describe("client ↔ service contract (real src/license.ts against real service)
     });
     expect(activeAfterCancellation.status).toBe("active");
 
+    service.setNow(new Date("2026-07-21T00:00:00.000Z"));
+    const activeAfterOriginalTrial = await getLicenseStatus({
+      config,
+      repo: "owner/private",
+      refresh: true,
+      fetchImpl: service.fetchFor("machine-a")
+    });
+    expect(activeAfterOriginalTrial.status).toBe("active");
+
     service.setNow(new Date("2026-08-13T00:00:01.000Z"));
     const expired = await getLicenseStatus({
       config,

--- a/tests/license-service-contract.test.ts
+++ b/tests/license-service-contract.test.ts
@@ -152,7 +152,7 @@ function lifecycleRequest(
       providerEventType: "customer.subscription.deleted",
       subscriptionStatus: "canceled",
       cancelAtPeriodEnd: false,
-      reason: "provider subscription terminated"
+      reason: "subscription_canceled"
     }
   } as const;
   return {

--- a/tests/license-service-contract.test.ts
+++ b/tests/license-service-contract.test.ts
@@ -195,9 +195,24 @@ async function applyLifecycle(
 
 function expectLifecycleResponseRedacted(
   response: { text: string },
-  rawKey: string
+  rawKey: string,
+  request: Record<string, unknown>
 ): void {
-  for (const forbidden of [rawKey, "acct_contract", "sub_contract_", "cs_contract_"]) {
+  const requestIdentifiers = [
+    request.issuanceIdempotencyKey,
+    request.eventId,
+    request.provider,
+    request.providerAccountId,
+    request.providerMode,
+    request.externalSubscriptionId,
+    request.paymentReference
+  ].filter((value): value is string => typeof value === "string");
+  for (const forbidden of [
+    rawKey,
+    LIFECYCLE_ISSUANCE_SECRET,
+    "cs_contract_",
+    ...requestIdentifiers
+  ]) {
     expect(response.text).not.toContain(forbidden);
   }
 }
@@ -332,14 +347,12 @@ describe("client ↔ service contract (real src/license.ts against real service)
     expect(activated.status).toBe("active");
     expect(JSON.stringify(activated)).not.toContain(key);
 
-    const renewed = await applyLifecycle(
-      service,
-      lifecycleRequest("renew-cancel", "renew_paid", LIFECYCLE_START)
-    );
+    const renewalRequest = lifecycleRequest("renew-cancel", "renew_paid", LIFECYCLE_START);
+    const renewed = await applyLifecycle(service, renewalRequest);
     lifecycleEvidence.push(renewed.text);
     expect(renewed.status).toBe(200);
     expect(renewed.json.status).toBe("updated");
-    expectLifecycleResponseRedacted(renewed, key);
+    expectLifecycleResponseRedacted(renewed, key, renewalRequest);
 
     const activeAfterRenewal = await getLicenseStatus({
       config,
@@ -351,14 +364,16 @@ describe("client ↔ service contract (real src/license.ts against real service)
 
     const cancellationTime = new Date("2026-07-14T00:00:00.000Z");
     service.setNow(cancellationTime);
-    const cancelled = await applyLifecycle(
-      service,
-      lifecycleRequest("renew-cancel", "cancel_at_period_end", cancellationTime)
+    const cancellationRequest = lifecycleRequest(
+      "renew-cancel",
+      "cancel_at_period_end",
+      cancellationTime
     );
+    const cancelled = await applyLifecycle(service, cancellationRequest);
     lifecycleEvidence.push(cancelled.text);
     expect(cancelled.status).toBe(200);
     expect(cancelled.json.status).toBe("updated");
-    expectLifecycleResponseRedacted(cancelled, key);
+    expectLifecycleResponseRedacted(cancelled, key, cancellationRequest);
 
     const activeAfterCancellation = await getLicenseStatus({
       config,
@@ -404,13 +419,11 @@ describe("client ↔ service contract (real src/license.ts against real service)
     });
     expect(activated.status).toBe("active");
 
-    const revokedResponse = await applyLifecycle(
-      service,
-      lifecycleRequest("revoke", "revoke", LIFECYCLE_START)
-    );
+    const revocationRequest = lifecycleRequest("revoke", "revoke", LIFECYCLE_START);
+    const revokedResponse = await applyLifecycle(service, revocationRequest);
     expect(revokedResponse.status).toBe(200);
     expect(revokedResponse.json.status).toBe("terminally_revoked");
-    expectLifecycleResponseRedacted(revokedResponse, key);
+    expectLifecycleResponseRedacted(revokedResponse, key, revocationRequest);
 
     const revoked = await getLicenseStatus({
       config,
@@ -420,20 +433,18 @@ describe("client ↔ service contract (real src/license.ts against real service)
     expect(revoked.status).toBe("revoked");
     expect(JSON.stringify(revoked)).not.toContain(key);
 
-    const laterRenewal = await applyLifecycle(
-      service,
-      lifecycleRequest(
-        "revoke",
-        "renew_paid",
-        new Date(LIFECYCLE_START.getTime() + 60_000),
-        {
-          eventId: "evt_contract_revoke_later_renew_paid"
-        }
-      )
+    const laterRenewalRequest = lifecycleRequest(
+      "revoke",
+      "renew_paid",
+      new Date(LIFECYCLE_START.getTime() + 60_000),
+      {
+        eventId: "evt_contract_revoke_later_renew_paid"
+      }
     );
+    const laterRenewal = await applyLifecycle(service, laterRenewalRequest);
     expect(laterRenewal.status, laterRenewal.text).toBe(409);
     expect(laterRenewal.json).toEqual({ status: "terminally_revoked" });
-    expectLifecycleResponseRedacted(laterRenewal, key);
+    expectLifecycleResponseRedacted(laterRenewal, key, laterRenewalRequest);
 
     const stillRevoked = await getLicenseStatus({
       config,

--- a/tests/license-service-contract.test.ts
+++ b/tests/license-service-contract.test.ts
@@ -10,6 +10,10 @@ import {
 } from "../src/license.js";
 import { LicenseStore } from "../services/license-api/src/store.js";
 import { createLicenseRequestListener } from "../services/license-api/src/http.js";
+import {
+  issueCheckoutLicense,
+  type LicenseIssuanceRequest
+} from "../services/license-api/src/issuance.js";
 import { RateLimiter } from "../services/license-api/src/service.js";
 
 /**
@@ -28,12 +32,22 @@ import { RateLimiter } from "../services/license-api/src/service.js";
 
 interface MockService {
   fetchFor(machineId: string): typeof fetch;
+  issueBoundKey(tag: string): string;
+  setNow(now: Date): void;
 }
 
-function buildInProcessService(): { service: MockService; store: LicenseStore; issueKey: () => string; close: () => void } {
-  const store = new LicenseStore(":memory:");
+const LIFECYCLE_ISSUANCE_SECRET = "test-only-contract-lifecycle-secret";
+const LIFECYCLE_START = new Date("2026-07-13T00:00:00.000Z");
+
+function buildInProcessService(root: string): { service: MockService; store: LicenseStore; issueKey: () => string; close: () => void } {
+  let serviceNow = LIFECYCLE_START;
+  const store = new LicenseStore(join(root, "license-service.sqlite"), {
+    now: () => serviceNow
+  });
   const listener = createLicenseRequestListener({
     store,
+    issuanceSecret: LIFECYCLE_ISSUANCE_SECRET,
+    now: () => serviceNow,
     // Generous limiter so the contract sequence is never throttled.
     rateLimiter: new RateLimiter({ maxPerWindow: 1000, windowMs: 60_000 })
   });
@@ -44,13 +58,19 @@ function buildInProcessService(): { service: MockService; store: LicenseStore; i
       const path = new URL(url).pathname;
       const originalBody = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
       // Play the requested machine regardless of the client's localMachineId().
-      const body = JSON.stringify({ ...originalBody, machineId });
+      const body = JSON.stringify(
+        path.startsWith("/v1/license/")
+          ? { ...originalBody, machineId }
+          : originalBody
+      );
 
       return await new Promise<Response>((resolve) => {
         const chunks: Buffer[] = [];
         const req: any = {
           method: init?.method ?? "POST",
           url: path,
+          headers: Object.fromEntries(new Headers(init?.headers).entries()),
+          socket: { remoteAddress: "127.0.0.1" },
           on(event: string, cb: (arg?: unknown) => void) {
             if (event === "data") cb(Buffer.from(body));
             if (event === "end") cb();
@@ -78,10 +98,98 @@ function buildInProcessService(): { service: MockService; store: LicenseStore; i
   };
 
   return {
-    service: { fetchFor },
+    service: {
+      fetchFor,
+      issueBoundKey(tag: string): string {
+        const request: LicenseIssuanceRequest = {
+          idempotencyKey: `checkout-session:contract-${tag}`,
+          checkoutLookupKey: "neondiff_monthly",
+          provider: "stripe",
+          providerAccountId: "acct_contract",
+          providerMode: "live",
+          externalSubscriptionId: `sub_contract_${tag}`,
+          externalCheckoutId: `cs_contract_${tag}`
+        };
+        const result = issueCheckoutLicense(store, request, LIFECYCLE_ISSUANCE_SECRET);
+        if (result.httpStatus !== 200) throw new Error("bound checkout issuance failed");
+        return (result.body as { licenseKey: string }).licenseKey;
+      },
+      setNow(now: Date): void {
+        serviceNow = now;
+      }
+    },
     store,
     issueKey: () => store.issueLicense({ plan: "yearly", repoVisibilityScope: "private", seats: 1 }).rawKey,
     close: () => store.close()
+  };
+}
+
+function lifecycleRequest(
+  tag: string,
+  command: "renew_paid" | "cancel_at_period_end" | "revoke",
+  eventCreatedAt: Date,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const variants = {
+    renew_paid: {
+      providerEventType: "invoice.paid",
+      subscriptionStatus: "active",
+      paymentReference: `in_contract_${tag}`,
+      amountPaidMinor: 100,
+      currency: "usd",
+      paidOutOfBand: false,
+      billingReason: "subscription_cycle",
+      currentPeriodEnd: "2026-08-13T00:00:00.000Z",
+      cancelAtPeriodEnd: false
+    },
+    cancel_at_period_end: {
+      providerEventType: "customer.subscription.updated",
+      subscriptionStatus: "active",
+      currentPeriodEnd: "2026-08-13T00:00:00.000Z",
+      cancelAtPeriodEnd: true
+    },
+    revoke: {
+      providerEventType: "customer.subscription.deleted",
+      subscriptionStatus: "canceled",
+      cancelAtPeriodEnd: false,
+      reason: "provider subscription terminated"
+    }
+  } as const;
+  return {
+    schemaVersion: 1,
+    issuanceIdempotencyKey: `checkout-session:contract-${tag}`,
+    eventId: `evt_contract_${tag}_${command}`,
+    eventCreatedAt: Math.floor(eventCreatedAt.getTime() / 1_000),
+    provider: "stripe",
+    providerAccountId: "acct_contract",
+    providerMode: "live",
+    externalSubscriptionId: `sub_contract_${tag}`,
+    command,
+    ...variants[command],
+    ...overrides
+  };
+}
+
+async function applyLifecycle(
+  service: MockService,
+  body: Record<string, unknown>
+): Promise<{ status: number; text: string; json: Record<string, unknown> }> {
+  const response = await service.fetchFor("lifecycle-admin")(
+    "http://127.0.0.1:8080/v1/admin/licenses/lifecycle",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${LIFECYCLE_ISSUANCE_SECRET}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(body)
+    }
+  );
+  const text = await response.text();
+  return {
+    status: response.status,
+    text,
+    json: JSON.parse(text) as Record<string, unknown>
   };
 }
 
@@ -114,7 +222,7 @@ describe("client ↔ service contract (real src/license.ts against real service)
   it("activate → validate → deactivate → reactivate-different-machine parses to correct LicenseStatus", async () => {
     const root = mkdtempSync(join(tmpdir(), "nd-contract-"));
     roots.push(root);
-    const { service, issueKey, close } = buildInProcessService();
+    const { service, issueKey, close } = buildInProcessService(root);
     closers.push(close);
     const config = makeConfig(root, "http://127.0.0.1:8080");
     const key = issueKey();
@@ -177,7 +285,7 @@ describe("client ↔ service contract (real src/license.ts against real service)
   it("client maps revoked and expired denials through the real service", async () => {
     const root = mkdtempSync(join(tmpdir(), "nd-contract-"));
     roots.push(root);
-    const { service, store, issueKey, close } = buildInProcessService();
+    const { service, store, issueKey, close } = buildInProcessService(root);
     closers.push(close);
     const config = makeConfig(root, "http://127.0.0.1:8080");
 
@@ -195,5 +303,101 @@ describe("client ↔ service contract (real src/license.ts against real service)
       fetchImpl: service.fetchFor("machine-z")
     });
     expect(unknown.status).toBe("invalid");
+  });
+
+  it("keeps the v1.0.4 client active through paid renewal and cancellation, then expires at paid end", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nd-contract-lifecycle-"));
+    roots.push(root);
+    const { service, close } = buildInProcessService(root);
+    closers.push(close);
+    const config = makeConfig(root, "http://127.0.0.1:8080");
+    const key = service.issueBoundKey("renew-cancel");
+    const lifecycleEvidence: string[] = [];
+
+    const activated = await activateLicense({
+      config,
+      licenseKey: key,
+      repo: "owner/private",
+      fetchImpl: service.fetchFor("machine-a")
+    });
+    expect(activated.status).toBe("active");
+    expect(JSON.stringify(activated)).not.toContain(key);
+
+    const renewed = await applyLifecycle(
+      service,
+      lifecycleRequest("renew-cancel", "renew_paid", LIFECYCLE_START)
+    );
+    lifecycleEvidence.push(renewed.text);
+    expect(renewed.status).toBe(200);
+    expect(renewed.json.status).toBe("updated");
+
+    const activeAfterRenewal = await getLicenseStatus({
+      config,
+      repo: "owner/private",
+      refresh: true,
+      fetchImpl: service.fetchFor("machine-a")
+    });
+    expect(activeAfterRenewal.status).toBe("active");
+
+    const cancellationTime = new Date("2026-07-14T00:00:00.000Z");
+    service.setNow(cancellationTime);
+    const cancelled = await applyLifecycle(
+      service,
+      lifecycleRequest("renew-cancel", "cancel_at_period_end", cancellationTime)
+    );
+    lifecycleEvidence.push(cancelled.text);
+    expect(cancelled.status).toBe(200);
+    expect(cancelled.json.status).toBe("updated");
+
+    const activeAfterCancellation = await getLicenseStatus({
+      config,
+      repo: "owner/private",
+      refresh: true,
+      fetchImpl: service.fetchFor("machine-a")
+    });
+    expect(activeAfterCancellation.status).toBe("active");
+
+    service.setNow(new Date("2026-08-13T00:00:01.000Z"));
+    const expired = await getLicenseStatus({
+      config,
+      repo: "owner/private",
+      refresh: true,
+      fetchImpl: service.fetchFor("machine-a")
+    });
+    expect(expired.status).toBe("expired");
+    expect(JSON.stringify(expired)).not.toContain(key);
+    expect(lifecycleEvidence.join("\n")).not.toContain(key);
+  });
+
+  it("maps a terminal lifecycle revocation to revoked without leaking the bound key", async () => {
+    const root = mkdtempSync(join(tmpdir(), "nd-contract-lifecycle-"));
+    roots.push(root);
+    const { service, close } = buildInProcessService(root);
+    closers.push(close);
+    const config = makeConfig(root, "http://127.0.0.1:8080");
+    const key = service.issueBoundKey("revoke");
+
+    const activated = await activateLicense({
+      config,
+      licenseKey: key,
+      fetchImpl: service.fetchFor("machine-r")
+    });
+    expect(activated.status).toBe("active");
+
+    const revokedResponse = await applyLifecycle(
+      service,
+      lifecycleRequest("revoke", "revoke", LIFECYCLE_START)
+    );
+    expect(revokedResponse.status).toBe(200);
+    expect(revokedResponse.json.status).toBe("terminally_revoked");
+    expect(revokedResponse.text).not.toContain(key);
+
+    const revoked = await getLicenseStatus({
+      config,
+      refresh: true,
+      fetchImpl: service.fetchFor("machine-r")
+    });
+    expect(revoked.status).toBe("revoked");
+    expect(JSON.stringify(revoked)).not.toContain(key);
   });
 });

--- a/tests/license-service-contract.test.ts
+++ b/tests/license-service-contract.test.ts
@@ -378,7 +378,7 @@ describe("client ↔ service contract (real src/license.ts against real service)
     expect(lifecycleEvidence.join("\n")).not.toContain(key);
   });
 
-  it("maps a terminal lifecycle revocation to revoked without leaking the bound key", async () => {
+  it("keeps a terminally revoked entitlement revoked when a later paid renewal arrives", async () => {
     const root = mkdtempSync(join(tmpdir(), "nd-contract-lifecycle-"));
     roots.push(root);
     const { service, close } = buildInProcessService(root);
@@ -408,5 +408,28 @@ describe("client ↔ service contract (real src/license.ts against real service)
     });
     expect(revoked.status).toBe("revoked");
     expect(JSON.stringify(revoked)).not.toContain(key);
+
+    const laterRenewal = await applyLifecycle(
+      service,
+      lifecycleRequest(
+        "revoke",
+        "renew_paid",
+        new Date(LIFECYCLE_START.getTime() + 60_000),
+        {
+          eventId: "evt_contract_revoke_later_renew_paid"
+        }
+      )
+    );
+    expect(laterRenewal.status, laterRenewal.text).toBe(409);
+    expect(laterRenewal.json).toEqual({ status: "terminally_revoked" });
+    expect(laterRenewal.text).not.toContain(key);
+
+    const stillRevoked = await getLicenseStatus({
+      config,
+      refresh: true,
+      fetchImpl: service.fetchFor("machine-r")
+    });
+    expect(stillRevoked.status).toBe("revoked");
+    expect(JSON.stringify(stillRevoked)).not.toContain(key);
   });
 });

--- a/tests/license-service-contract.test.ts
+++ b/tests/license-service-contract.test.ts
@@ -193,6 +193,15 @@ async function applyLifecycle(
   };
 }
 
+function expectLifecycleResponseRedacted(
+  response: { text: string },
+  rawKey: string
+): void {
+  for (const forbidden of [rawKey, "acct_contract", "sub_contract_", "cs_contract_"]) {
+    expect(response.text).not.toContain(forbidden);
+  }
+}
+
 describe("client ↔ service contract (real src/license.ts against real service)", () => {
   const roots: string[] = [];
   const closers: Array<() => void> = [];
@@ -330,6 +339,7 @@ describe("client ↔ service contract (real src/license.ts against real service)
     lifecycleEvidence.push(renewed.text);
     expect(renewed.status).toBe(200);
     expect(renewed.json.status).toBe("updated");
+    expectLifecycleResponseRedacted(renewed, key);
 
     const activeAfterRenewal = await getLicenseStatus({
       config,
@@ -348,6 +358,7 @@ describe("client ↔ service contract (real src/license.ts against real service)
     lifecycleEvidence.push(cancelled.text);
     expect(cancelled.status).toBe(200);
     expect(cancelled.json.status).toBe("updated");
+    expectLifecycleResponseRedacted(cancelled, key);
 
     const activeAfterCancellation = await getLicenseStatus({
       config,
@@ -399,7 +410,7 @@ describe("client ↔ service contract (real src/license.ts against real service)
     );
     expect(revokedResponse.status).toBe(200);
     expect(revokedResponse.json.status).toBe("terminally_revoked");
-    expect(revokedResponse.text).not.toContain(key);
+    expectLifecycleResponseRedacted(revokedResponse, key);
 
     const revoked = await getLicenseStatus({
       config,
@@ -422,7 +433,7 @@ describe("client ↔ service contract (real src/license.ts against real service)
     );
     expect(laterRenewal.status, laterRenewal.text).toBe(409);
     expect(laterRenewal.json).toEqual({ status: "terminally_revoked" });
-    expect(laterRenewal.text).not.toContain(key);
+    expectLifecycleResponseRedacted(laterRenewal, key);
 
     const stillRevoked = await getLicenseStatus({
       config,

--- a/tests/license-service-dr.test.ts
+++ b/tests/license-service-dr.test.ts
@@ -21,7 +21,8 @@ const dbPath = "/data/license.sqlite";
 const litestreamVersion = "0.5.14";
 const litestreamLinuxX64Sha = "32083dd2af13840b273c538360b828368d7b82bbaa2c641106052dc7814ed956";
 const litestreamLinuxArm64Sha = "b49b3d01fb0a8b4d426ee613c080fba44acae0551587dc43525dcd93eee64b4f";
-const legacyRestoreVerifier = join(licenseApiDir, "dist/verify-legacy-restore.js");
+const licenseApiTypescriptCompiler = join(licenseApiDir, "node_modules/typescript/bin/tsc");
+const licenseApiTypescriptConfig = join(licenseApiDir, "tsconfig.json");
 
 const legacySchema = `
   create table licenses (
@@ -228,7 +229,16 @@ describe("license service disaster recovery wiring", () => {
     const root = mkdtempSync(join(tmpdir(), "nd-license-restore-verifier-"));
     try {
       const alternateCwd = join(root, "alternate-cwd");
+      const compiledRoot = join(root, "compiled-license-api");
       mkdirSync(alternateCwd);
+      execFileSync(process.execPath, [
+        licenseApiTypescriptCompiler,
+        "-p",
+        licenseApiTypescriptConfig,
+        "--outDir",
+        compiledRoot
+      ], { cwd: alternateCwd, stdio: "pipe" });
+      const legacyRestoreVerifier = join(compiledRoot, "verify-legacy-restore.js");
       const legacyPath = join(root, "legacy.sqlite");
       const legacyDb = new DatabaseSync(legacyPath);
       legacyDb.exec(legacySchema);

--- a/tests/license-service-dr.test.ts
+++ b/tests/license-service-dr.test.ts
@@ -1,8 +1,9 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   activateLicense,
@@ -14,13 +15,13 @@ import { createLicenseRequestListener } from "../services/license-api/src/http.j
 import { RateLimiter } from "../services/license-api/src/service.js";
 import { LicenseStore } from "../services/license-api/src/store.js";
 
-const repoRoot = process.cwd();
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const licenseApiDir = join(repoRoot, "services/license-api");
 const dbPath = "/data/license.sqlite";
 const litestreamVersion = "0.5.14";
 const litestreamLinuxX64Sha = "32083dd2af13840b273c538360b828368d7b82bbaa2c641106052dc7814ed956";
 const litestreamLinuxArm64Sha = "b49b3d01fb0a8b4d426ee613c080fba44acae0551587dc43525dcd93eee64b4f";
-const legacyRestoreVerifier = join(licenseApiDir, "src/verify-legacy-restore.ts");
+const legacyRestoreVerifier = join(licenseApiDir, "dist/verify-legacy-restore.js");
 
 const legacySchema = `
   create table licenses (
@@ -226,6 +227,8 @@ describe("license service disaster recovery wiring", () => {
   it("executes the shipped Node verifier against a real legacy restore and rejects non-legacy schema", () => {
     const root = mkdtempSync(join(tmpdir(), "nd-license-restore-verifier-"));
     try {
+      const alternateCwd = join(root, "alternate-cwd");
+      mkdirSync(alternateCwd);
       const legacyPath = join(root, "legacy.sqlite");
       const legacyDb = new DatabaseSync(legacyPath);
       legacyDb.exec(legacySchema);
@@ -233,8 +236,8 @@ describe("license service disaster recovery wiring", () => {
 
       const verified = execFileSync(
         process.execPath,
-        ["--import", "tsx", legacyRestoreVerifier, legacyPath],
-        { cwd: repoRoot, encoding: "utf8" }
+        [legacyRestoreVerifier, legacyPath],
+        { cwd: alternateCwd, encoding: "utf8" }
       );
       expect(verified.trim()).toBe("legacy restore verification ok");
 
@@ -243,8 +246,8 @@ describe("license service disaster recovery wiring", () => {
       v2Store.close();
       expect(() => execFileSync(
         process.execPath,
-        ["--import", "tsx", legacyRestoreVerifier, v2Path],
-        { cwd: repoRoot, encoding: "utf8", stdio: "pipe" }
+        [legacyRestoreVerifier, v2Path],
+        { cwd: alternateCwd, encoding: "utf8", stdio: "pipe" }
       )).toThrow();
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/tests/license-service-dr.test.ts
+++ b/tests/license-service-dr.test.ts
@@ -33,8 +33,8 @@ function licenseConfig(root: string, apiBaseUrl: string): LicenseConfig {
     keychainService: "neondiff-dr-test",
     keychainAccount: "neondiff-dr-test",
     requestTimeoutMs: 5_000,
-    offlineGraceMs: 10_000,
-    publicReposFree: true,
+    offlineGraceMs: 0,
+    publicReposFree: false,
     privateReposRequireEntitlement: true,
     updateEntitlementRequiresLicense: false
   };
@@ -128,6 +128,7 @@ describe("license service disaster recovery wiring", () => {
     const deployRunbook = readServiceFile("docs/deploy.md");
     const adminRunbook = readServiceFile("docs/admin-runbook.md");
     const drRunbook = readServiceFile("docs/disaster-recovery.md");
+    const lifecycleRunbook = readServiceFile("docs/subscription-lifecycle.md");
 
     expect(deployRunbook).toContain("disaster-recovery.md");
     expect(adminRunbook).toContain("disaster-recovery.md");
@@ -137,12 +138,37 @@ describe("license service disaster recovery wiring", () => {
     expect(drRunbook).toContain("flyctl secrets set");
     expect(drRunbook).toContain("timed staging restore drill");
     expect(drRunbook).toContain("This source-only PR does not prove live replication");
+    expect(drRunbook).toContain("offlineGraceMs=0");
+    expect(drRunbook).toContain("diagnostic only");
+    expect(drRunbook).toContain("pre-v2");
+    expect(drRunbook).toContain("fresh path or volume");
+    expect(drRunbook).toContain("Image rollback does not reverse the SQLite schema migration");
+    expect(drRunbook).toContain("Migration failure prevents the service from starting");
+    expect(drRunbook).toContain("Never copy an open SQLite database");
+    expect(adminRunbook).toContain("bind-checkout-subscription");
+    expect(adminRunbook).toContain("--dry-run");
+    expect(adminRunbook).toContain("No raw-key recovery or replacement-key minting");
+    expect(deployRunbook).toContain("Checkout remains held");
+    expect(deployRunbook).toContain("#559");
+    expect(lifecycleRunbook).toContain("POST /v1/admin/licenses/lifecycle");
+    expect(lifecycleRunbook).toContain("renew_paid");
+    expect(lifecycleRunbook).toContain("reconcile");
+    expect(lifecycleRunbook).toContain("cancel_at_period_end");
+    expect(lifecycleRunbook).toContain("payment_attention");
+    expect(lifecycleRunbook).toContain("revoke");
+    expect(lifecycleRunbook).toContain("Checkout remains held");
+    expect(lifecycleRunbook).toContain("#559");
+    expect(adminRunbook).not.toContain("copy of the volume");
+    expect(adminRunbook).not.toContain("revoke and re-issue");
+    expect(deployRunbook).not.toContain("flip license.enabled");
+    expect(deployRunbook).not.toContain("There is no in-app migration system");
+    expect(drRunbook).not.toContain("inside the configured offline grace window");
     expect(drRunbook).not.toContain("/Volumes/LEXAR/Codex");
     expect(drRunbook).not.toMatch(/AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|secret-access-key:\s+\S|account-key:\s+\S/i);
   });
 });
 
-describe("license service outage grace", () => {
+describe("license service mandatory-online outage behavior", () => {
   const roots: string[] = [];
   const stores: LicenseStore[] = [];
 
@@ -151,7 +177,7 @@ describe("license service outage grace", () => {
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   });
 
-  it("uses a real local license API activation, then fails closed after offline grace expires", async () => {
+  it("creates a diagnostic cache from real activation but never authorizes review during an outage", async () => {
     const root = mkdtempSync(join(tmpdir(), "nd-license-dr-"));
     roots.push(root);
     const store = new LicenseStore(join(root, "license.sqlite"));
@@ -170,55 +196,30 @@ describe("license service outage grace", () => {
     expect(activated).toMatchObject({ ok: true, status: "active", source: "api" });
     expect(existsSync(join(root, "entitlement.json"))).toBe(true);
 
-    const withinGraceStatus = await getLicenseStatus({
+    const outageStatus = await getLicenseStatus({
       config,
       repo: "owner/private",
       refresh: true,
-      now: new Date(base.getTime() + 5_000),
+      now: new Date(base.getTime() + 1),
       fetchImpl: outageFetch
     });
-    expect(withinGraceStatus).toMatchObject({
-      ok: true,
-      status: "active",
-      source: "cache",
-      stale: true,
-      classification: "network"
-    });
-
-    const withinGraceGate = await evaluateLicenseReviewGate({
-      config,
-      repo: "owner/private",
-      visibility: "private",
-      refresh: true,
-      now: new Date(base.getTime() + 5_000),
-      fetchImpl: outageFetch
-    });
-    expect(withinGraceGate).toMatchObject({ ok: true, status: "active" });
-
-    const afterGraceStatus = await getLicenseStatus({
-      config,
-      repo: "owner/private",
-      refresh: true,
-      now: new Date(base.getTime() + 11_000),
-      fetchImpl: outageFetch
-    });
-    expect(afterGraceStatus).toMatchObject({
+    expect(outageStatus).toMatchObject({
       ok: false,
       status: "network",
       source: "none",
       classification: "network"
     });
 
-    const afterGraceGate = await evaluateLicenseReviewGate({
+    const outageGate = await evaluateLicenseReviewGate({
       config,
       repo: "owner/private",
       visibility: "private",
       refresh: true,
-      now: new Date(base.getTime() + 11_000),
+      now: new Date(base.getTime() + 1),
       fetchImpl: outageFetch
     });
-    expect(afterGraceGate).toMatchObject({ ok: false, status: "network" });
-    expect(afterGraceGate.reason).toContain("license API network failure");
-    expect(afterGraceGate.reason).toContain("requires active entitlement");
+    expect(outageGate).toMatchObject({ ok: false, status: "network" });
+    expect(outageGate.reason).toContain("license API network failure");
+    expect(outageGate.reason).toContain("requires active entitlement");
   });
 });

--- a/tests/license-service-dr.test.ts
+++ b/tests/license-service-dr.test.ts
@@ -1,6 +1,8 @@
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   activateLicense,
@@ -18,6 +20,39 @@ const dbPath = "/data/license.sqlite";
 const litestreamVersion = "0.5.14";
 const litestreamLinuxX64Sha = "32083dd2af13840b273c538360b828368d7b82bbaa2c641106052dc7814ed956";
 const litestreamLinuxArm64Sha = "b49b3d01fb0a8b4d426ee613c080fba44acae0551587dc43525dcd93eee64b4f";
+const legacyRestoreVerifier = join(licenseApiDir, "src/verify-legacy-restore.ts");
+
+const legacySchema = `
+  create table licenses (
+    license_key_hash text primary key,
+    plan text not null,
+    repo_visibility_scope text not null,
+    private_repo_allowed integer not null default 1,
+    update_entitlement integer not null default 0,
+    seats integer not null default 1,
+    expires_at text,
+    status text not null default 'active',
+    revocation_reason text,
+    created_at text not null default (datetime('now'))
+  );
+  create table activations (
+    license_key_hash text not null,
+    machine_id text not null,
+    repo text,
+    activated_at text not null default (datetime('now')),
+    last_seen_at text not null default (datetime('now')),
+    primary key (license_key_hash, machine_id)
+  );
+  create table license_issuance_events (
+    idempotency_key text primary key,
+    license_key_hash text not null,
+    request_hash text not null,
+    source text,
+    external_ref text,
+    created_at text not null default (datetime('now')),
+    foreign key (license_key_hash) references licenses(license_key_hash)
+  );
+`;
 
 function readServiceFile(relativePath: string): string {
   return readFileSync(join(licenseApiDir, relativePath), "utf8");
@@ -151,8 +186,8 @@ describe("license service disaster recovery wiring", () => {
     expect(drRunbook).toContain(
       'litestream restore -timestamp "$PRE_V2_RECOVERY_TIMESTAMP" -config "$LITESTREAM_CONFIG" -o "$FRESH_RESTORE_PATH" "$LICENSE_DB_PATH"'
     );
-    expect(drRunbook).toContain('pragma quick_check');
-    expect(drRunbook).toContain('pragma user_version');
+    expect(drRunbook).toContain('node /app/dist/verify-legacy-restore.js "$FRESH_RESTORE_PATH"');
+    expect(drRunbook).not.toContain('sqlite3 "$FRESH_RESTORE_PATH"');
     expect(drRunbook).toContain("exact legacy schema signature");
     expect(drRunbook).toContain("non-writing replica destination");
     expect(deployRunbook).toContain("point-in-time restore command");
@@ -186,6 +221,34 @@ describe("license service disaster recovery wiring", () => {
     expect(serviceReadme).not.toContain("Cross-cutting: 429");
     expect(drRunbook).not.toContain("/Volumes/LEXAR/Codex");
     expect(drRunbook).not.toMatch(/AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|secret-access-key:\s+\S|account-key:\s+\S/i);
+  });
+
+  it("executes the shipped Node verifier against a real legacy restore and rejects non-legacy schema", () => {
+    const root = mkdtempSync(join(tmpdir(), "nd-license-restore-verifier-"));
+    try {
+      const legacyPath = join(root, "legacy.sqlite");
+      const legacyDb = new DatabaseSync(legacyPath);
+      legacyDb.exec(legacySchema);
+      legacyDb.close();
+
+      const verified = execFileSync(
+        process.execPath,
+        ["--import", "tsx", legacyRestoreVerifier, legacyPath],
+        { cwd: repoRoot, encoding: "utf8" }
+      );
+      expect(verified.trim()).toBe("legacy restore verification ok");
+
+      const v2Path = join(root, "v2.sqlite");
+      const v2Store = new LicenseStore(v2Path);
+      v2Store.close();
+      expect(() => execFileSync(
+        process.execPath,
+        ["--import", "tsx", legacyRestoreVerifier, v2Path],
+        { cwd: repoRoot, encoding: "utf8", stdio: "pipe" }
+      )).toThrow();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/license-service-dr.test.ts
+++ b/tests/license-service-dr.test.ts
@@ -129,6 +129,7 @@ describe("license service disaster recovery wiring", () => {
     const adminRunbook = readServiceFile("docs/admin-runbook.md");
     const drRunbook = readServiceFile("docs/disaster-recovery.md");
     const lifecycleRunbook = readServiceFile("docs/subscription-lifecycle.md");
+    const serviceReadme = readServiceFile("README.md");
 
     expect(deployRunbook).toContain("disaster-recovery.md");
     expect(adminRunbook).toContain("disaster-recovery.md");
@@ -163,6 +164,14 @@ describe("license service disaster recovery wiring", () => {
     expect(deployRunbook).not.toContain("flip license.enabled");
     expect(deployRunbook).not.toContain("There is no in-app migration system");
     expect(drRunbook).not.toContain("inside the configured offline grace window");
+    expect(drRunbook).not.toContain("-force");
+    expect(serviceReadme).toContain(
+      "Activation, validation, and deactivation use per-license-key rate limiting."
+    );
+    expect(serviceReadme).toContain(
+      "Subscription lifecycle and release-lifecycle issuance use separate client-address rate-limit budgets."
+    );
+    expect(serviceReadme).not.toContain("Cross-cutting: 429");
     expect(drRunbook).not.toContain("/Volumes/LEXAR/Codex");
     expect(drRunbook).not.toMatch(/AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|secret-access-key:\s+\S|account-key:\s+\S/i);
   });

--- a/tests/license-service-dr.test.ts
+++ b/tests/license-service-dr.test.ts
@@ -146,6 +146,18 @@ describe("license service disaster recovery wiring", () => {
     expect(drRunbook).toContain("Image rollback does not reverse the SQLite schema migration");
     expect(drRunbook).toContain("Migration failure prevents the service from starting");
     expect(drRunbook).toContain("Never copy an open SQLite database");
+    expect(drRunbook).toContain('PRE_V2_RECOVERY_TIMESTAMP="<recorded-rfc3339-timestamp>"');
+    expect(drRunbook).toContain('FRESH_RESTORE_PATH="<fresh-nonexistent-license-db-path>"');
+    expect(drRunbook).toContain(
+      'litestream restore -timestamp "$PRE_V2_RECOVERY_TIMESTAMP" -config "$LITESTREAM_CONFIG" -o "$FRESH_RESTORE_PATH" "$LICENSE_DB_PATH"'
+    );
+    expect(drRunbook).toContain('pragma quick_check');
+    expect(drRunbook).toContain('pragma user_version');
+    expect(drRunbook).toContain("exact legacy schema signature");
+    expect(drRunbook).toContain("non-writing replica destination");
+    expect(deployRunbook).toContain("point-in-time restore command");
+    expect(lifecycleRunbook).toContain("point-in-time restore command");
+    expect(drRunbook).not.toMatch(/rollback[\s\S]{0,500}restore -if-replica-exists/i);
     expect(adminRunbook).toContain("bind-checkout-subscription");
     expect(adminRunbook).toContain("--dry-run");
     expect(adminRunbook).toContain("No raw-key recovery or replacement-key minting");


### PR DESCRIPTION
## Summary

- migrate the license service to crash-safe SQLite schema v2 with immutable checkout/subscription bindings and an append-only lifecycle ledger
- make checkout issuance policy server-owned and reject caller control over plan, expiry, scope, ownership, update access, and seats
- add strict paid-renewal, reconciliation, cancellation, payment-attention, and terminal-revocation parsing and atomic application
- add a separately authenticated and rate-limited lifecycle HTTP endpoint plus an owner-only, dry-run-first legacy binding backfill command
- prove the unchanged v1.0.4 client through bound issuance, activation, paid renewal beyond the original trial, cancellation, paid-period expiry, revocation, seat enforcement, and raw-key non-leakage
- replace stale offline-cache and recovery guidance with mandatory-online fail-closed behavior and a fresh-target Litestream/schema-v2 rollout contract

## Why

NeonDiff's mandatory activation release could issue and validate licenses, but production renewal, cancellation, revocation, legacy checkout correlation, and schema rollback authority were not yet synchronized. That left supported customers vulnerable to expiry drift or ambiguous recovery behavior and blocked the next immutable release.

This PR makes the license API the sole lifecycle authority while preserving the shipped client protocol. Checkout remains held until the separate live rollout and release gates complete.

## Safety boundaries

- no Stripe, checkout, Fly deployment, production SQLite, npm, manifest, package version, GitHub Release, or live customer state was changed
- lifecycle and checkout correlations are strict, bounded, redacted, and test/live separated
- raw license keys and payment references are not stored in lifecycle evidence
- migration failure blocks service startup; image rollback does not reverse schema v2
- recovery requires a verified pre-v2 Litestream point restored to a fresh path or volume; in-place overwrite is forbidden
- offline cache is diagnostic only with `offlineGraceMs=0`; API outage fails closed
- issue #559 owns version/manifest, deployment, installed-client, live activation/no-bypass, Stripe, and release proof

## Validation

- license service: 164/164 tests passed; TypeScript build passed
- focused root activation/lifecycle/DR matrix: 54/54 tests passed
- full root suite: 2,073/2,073 tests across 118 files passed
- root TypeScript build passed
- public-claims scan passed
- secret scan passed across 669 tracked files
- actionlint and `git diff --check` passed
- independent task reviews closed all P0-P3 findings before publication

Advances #562. Release and production rollout remain gated by #559.
