### PR TITLE
feat(review): require trusted-owner authorization for REQUEST_CHANGES

### DIFF
--- a/config.active-profiles.example.json
+++ b/config.active-profiles.example.json
@@ -42,6 +42,9 @@
   },
   "reviewGate": {
     "maxInlineComments": 25,
+    "reviewEventPolicy": {
+      "mode": "trusted_command_only"
+    },
     "selfConsistency": {
       "enabled": false,
       "severities": [

--- a/config.example.json
+++ b/config.example.json
@@ -10,9 +10,12 @@
     "maxActiveRuns": 5,
     "leaseTtlMs": 900000
   },
-  "_reviewGateComment": "Deterministic post-model gate: ranking, comment cap, and REQUEST_CHANGES eligibility. maxInlineComments matches the built-in default; the rest are default-off/quieter-only knobs. See docs/neondiff-config.md.",
+  "_reviewGateComment": "Deterministic post-model gate plus public review-event selection. trusted_command_only is the safe default; automatic is explicit legacy compatibility only. See docs/neondiff-config.md.",
   "reviewGate": {
     "maxInlineComments": 25,
+    "reviewEventPolicy": {
+      "mode": "trusted_command_only"
+    },
     "_requestChangesConfidenceFloorsComment": "Optional per-severity confidence floor for REQUEST_CHANGES eligibility (only P0/P1 keys allowed). Quieter-only: a below-floor finding still posts as a comment. Uncomment to enable.",
     "_retryDegradedConfidencePenaltyComment": "Optional 0..1 confidence penalty applied to findings recovered via the strict-JSON retry path. Quieter-only; unset means no penalty.",
     "selfConsistency": {

--- a/docs/maintainer-commands.md
+++ b/docs/maintainer-commands.md
@@ -145,9 +145,11 @@ still cannot select `REQUEST_CHANGES` again.
 
 Command-triggered reviews and finishing-touch drafts write evidence under the
 normal PR/head evidence path with a `command-<comment-id>` subfolder. The
-evidence includes the command source JSON for reviews or the finishing-touch
-draft JSON/Markdown for draft-only commands. Polling reviews keep the existing
-evidence path shape.
+evidence includes command source JSON for ordinary reviews or the
+finishing-touch draft JSON/Markdown for draft-only commands. Exact
+`request-changes` jobs write bounded authorization-decision metadata and do not
+persist the raw comment body. Polling reviews keep the existing evidence path
+shape.
 
 The live daemon result includes command counters such as `skippedCommandStop`,
 `skippedCommandExplain`, `skippedFinishingTouchDraft`,

--- a/docs/maintainer-commands.md
+++ b/docs/maintainer-commands.md
@@ -27,6 +27,7 @@ Each command must appear as its own trimmed line in a PR comment:
 
 - `@neondiff review`
 - `@neondiff re-review`
+- `@neondiff request-changes --repo owner/name --pr 123 --head <40-character-current-head-sha>`
 - `@neondiff explain`
 - `@neondiff stop`
 - `@neondiff generate tests`
@@ -47,6 +48,28 @@ actual GitHub App slug chosen during installation.
 `review` and `re-review` route into the same ZCode review pipeline used by
 polling. They still use the current PR head SHA, current RIGHT-side diff-line
 validation, secret redaction, ZCode read-only policy, and Git clean checks.
+They do not authorize a `REQUEST_CHANGES` GitHub event.
+
+`request-changes` must be the exact one-line command shown above, using the
+configured bot mention, exact repository, positive PR number, and exact
+40-character current-head SHA. Only an explicit login in
+`commands.trustedAuthors` can authorize it; wildcard `"*"` trust never does.
+It queues one manual review attempt, and the queued job carries the exact GitHub
+comment id. A newer `stop` wins over an older request. Later ordinary `review`
+or `re-review` comments do not inherit or erase the exact authorization.
+
+The authorization is one-shot for the exact `{repo, PR, head SHA}`. A second
+new command on the same head may queue another analysis attempt, but the
+one-shot ledger downgrades its selected event to advisory `COMMENT`; a new head
+needs a new exact command. The first eligible authorization is consumed before
+the GitHub review POST, even if the candidate has already become `COMMENT`, and
+is never restored after timeout, 5xx, or another post failure.
+
+Missing, malformed, untrusted, wildcard-only, wrong-repo, wrong-PR, stale-head,
+duplicate, consumed, comment-read-failed, and local-state-failed authorization
+all remain advisory: findings still post, but the selected event is `COMMENT`.
+The review POST carries the expected SHA as `commit_id`; NeonDiff also performs
+its own live-head checks because `commit_id` alone is not current-head proof.
 
 `explain` records the command and can post a marker-backed status comment when
 `commands.acknowledge` is enabled. It does not start a review.
@@ -55,7 +78,8 @@ validation, secret redaction, ZCode read-only policy, and Git clean checks.
 the command is the latest unprocessed command.
 
 Command precedence is intentionally conservative: a latest `stop` command wins,
-`review` / `re-review` requests are not superseded by later draft-only
+an exact `request-changes` authorization is not erased by ordinary `review` or
+`re-review`, `review` / `re-review` requests are not superseded by later draft-only
 finishing-touch commands, and finishing-touch commands are processed only when no
 review command is pending for that PR/head.
 
@@ -111,6 +135,11 @@ Reprocessing the same command comment does nothing, including after a new push.
 A new head SHA needs a new trusted command comment. This keeps old `stop`
 comments from suppressing future pushes and keeps old `review` commands from
 silently re-triggering on new code.
+
+For `request-changes`, scheduler dedupe is also durable after its queue job
+becomes terminal. This queue dedupe is separate from the one-shot event ledger:
+a genuinely new exact command may queue, while a previously consumed exact head
+still cannot select `REQUEST_CHANGES` again.
 
 ## Evidence
 

--- a/docs/neondiff-config.md
+++ b/docs/neondiff-config.md
@@ -212,6 +212,7 @@ comments, and decides `REQUEST_CHANGES` vs `COMMENT` (`src/review-gate.ts`, `src
 | Key | Type | Default | What it does |
 | --- | --- | --- | --- |
 | `maxInlineComments` | `integer` | `25` | Hard cap on inline comments posted per review. Findings are sorted severity-first, then by `confidence` descending (ties broken by path, line, title), so when the cap trims the list it always keeps the highest-confidence findings within each severity tier. |
+| `reviewEventPolicy.mode` | `"trusted_command_only" \| "automatic"` | `"trusted_command_only"` | Selects the public GitHub review event. The safe default requires a trusted exact-repo/PR/current-head command before a candidate `REQUEST_CHANGES` can be posted. `automatic` is explicit legacy compatibility only. |
 | `requestChangesConfidenceFloors` | `{ P0?: number, P1?: number }` | unset (no floors) | Optional per-severity confidence floor, each `0..1`, for counting a P0/P1 finding toward `REQUEST_CHANGES` eligibility. |
 | `retryDegradedConfidencePenalty` | `number` (`0..1`) | unset (no penalty) | Optional confidence subtracted (floored at 0) from findings recovered via the strict-JSON retry path (#304) before the gate runs. |
 | `selfConsistency` | `SelfConsistencyConfig` | unset (disabled) | Opt-in second-draw re-check for high-severity findings (#303). See below. |
@@ -223,6 +224,37 @@ comments, and decides `REQUEST_CHANGES` vs `COMMENT` (`src/review-gate.ts`, `src
 - **`requestChangesConfidenceFloors` is quieter-only and unknown keys are rejected.** The object accepts only the literal keys `P0` and `P1` — any other key (including lowercase `p0`, or a typo) throws a config validation error rather than being silently ignored. A configured floor can only *demote* a finding out of `REQUEST_CHANGES` eligibility; a below-floor P0/P1 still posts as an inline comment, it just no longer forces the stricter review event. Leaving both floors unset is byte-identical to the pre-#287 gate.
 - **`retryDegradedConfidencePenalty` is quieter-only and default-off.** It only ever lowers a degraded finding's confidence (floored at 0), which can only remove it from ranking/cap contention or push it below a `requestChangesConfidenceFloors` floor — never raise confidence or add a finding. Unset means retry-recovered findings are scored identically to clean first-pass findings.
 - **`categoryPrecisionFloors` is quieter-only and unknown categories are rejected.** Keys must be valid regression-taxonomy categories — anything else throws a config validation error. A floor can only demote a finding out of `REQUEST_CHANGES` eligibility (the finding still posts); a floor of `0` never demotes. Nothing reads the calibration aggregate at review time — the config file remains the single inspectable source of gate behavior.
+- **Upgrades fail safe.** Omitting `reviewGate.reviewEventPolicy` or its parent config resolves to `trusted_command_only`. Existing installations retain automatic review-event behavior only by explicitly setting `reviewGate.reviewEventPolicy.mode` to `automatic`; that mode is legacy compatibility, not the recommended operating posture.
+
+#### `reviewEventPolicy`
+
+With `mode: "trusted_command_only"`, a deterministic candidate `REQUEST_CHANGES` becomes a public
+`REQUEST_CHANGES` review only after this exact one-line PR comment from an explicit login in
+`commands.trustedAuthors`:
+
+```text
+@neondiff request-changes --repo owner/name --pr 123 --head <40-character-current-head-sha>
+```
+
+The configured bot mention must match, and the repository, positive PR number, and 40-character
+head SHA must match the live review target exactly. The command queues one manual review attempt and
+is one-shot for that exact `{repo, pull request, head SHA}`. A second command for an already consumed
+head may queue analysis, but it cannot grant another `REQUEST_CHANGES`; a new head requires a new
+exact command. Ordinary `review` and `re-review` commands queue advisory analysis only and never
+grant, inherit, or erase `REQUEST_CHANGES` authority. A wildcard `"*"` trusted-author entry never
+authorizes this event.
+
+Authorization is consumed after the final pre-post current-head check and before the GitHub review
+POST, including when the candidate event has already become `COMMENT`. Consumption is not rolled
+back after a timeout, 5xx response, or other post failure. Missing, malformed, untrusted,
+wildcard-only, wrong-repo, wrong-PR, stale-head, duplicate, already-consumed, comment-read-failed,
+or local-state-failed authorization all select advisory `COMMENT`; findings are retained.
+
+Every review POST includes the expected head as GitHub `commit_id`. That binds the review to the
+named commit, but it is not by itself proof that the head stayed current: NeonDiff also reads the PR
+immediately before posting and again after posting. A head change during the POST is recorded as
+`head_changed_during_post` and is not claimed as current-head proof. Settings-preview evidence shows
+the configured mode only; it does not claim that a current authorization exists.
 
 #### `selfConsistency`
 

--- a/docs/schema/neondiff-config.schema.json
+++ b/docs/schema/neondiff-config.schema.json
@@ -76,6 +76,25 @@
         }
       }
     },
+    "reviewGate": {
+      "description": "Public review-event selection policy. Omission uses the safe trusted-command-only runtime default.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reviewEventPolicy": {
+          "description": "Selects whether REQUEST_CHANGES requires a one-shot exact-head trusted command. automatic is explicit legacy compatibility only.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["trusted_command_only", "automatic"],
+              "default": "trusted_command_only"
+            }
+          }
+        }
+      }
+    },
     "paths": {
       "description": "Review path filters. Exclusions win over inclusions.",
       "type": "object",

--- a/docs/superpowers/plans/2026-07-13-trusted-owner-review-event-policy.md
+++ b/docs/superpowers/plans/2026-07-13-trusted-owner-review-event-policy.md
@@ -173,6 +173,7 @@ git commit -m "feat(review): persist one-shot owner authorization"
 - Modify: `src/github.ts`
 - Modify: `tests/worker-context-budget.test.ts`
 - Modify: `tests/stale-head.test.ts`
+- Modify: `tests/github-app-read.test.ts`
 
 **Interfaces:**
 - Consumes: Task 1 policy decision and Task 2 authorization collector/atomic consume.
@@ -192,7 +193,7 @@ Add real worker-path cases for no authorization, exact trusted authorization, co
 
 - [ ] **Step 2: Verify RED**
 
-Run: `npm test -- tests/worker-context-budget.test.ts tests/stale-head.test.ts`
+Run: `npm test -- tests/worker-context-budget.test.ts tests/stale-head.test.ts tests/github-app-read.test.ts`
 
 Expected: FAIL because the worker still posts the deterministic candidate directly.
 
@@ -216,14 +217,14 @@ Consume an eligible command after the final live-head check even when the candid
 
 - [ ] **Step 4: Verify GREEN**
 
-Run: `npm test -- tests/review-event-policy.test.ts tests/commands.test.ts tests/state.test.ts tests/worker-context-budget.test.ts tests/stale-head.test.ts && npm run build`
+Run: `npm test -- tests/review-event-policy.test.ts tests/commands.test.ts tests/state.test.ts tests/worker-context-budget.test.ts tests/stale-head.test.ts tests/github-app-read.test.ts && npm run build`
 
 Expected: PASS; live and dry-run evidence distinguish candidate and selected events.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/worker.ts src/github.ts tests/worker-context-budget.test.ts tests/stale-head.test.ts
+git add src/worker.ts src/github.ts tests/worker-context-budget.test.ts tests/stale-head.test.ts tests/github-app-read.test.ts
 git commit -m "feat(review): enforce exact-head owner authorization"
 ```
 

--- a/docs/superpowers/plans/2026-07-13-trusted-owner-review-event-policy.md
+++ b/docs/superpowers/plans/2026-07-13-trusted-owner-review-event-policy.md
@@ -171,9 +171,11 @@ git commit -m "feat(review): persist one-shot owner authorization"
 **Files:**
 - Modify: `src/worker.ts`
 - Modify: `src/github.ts`
+- Modify: `src/review-event-policy.ts`
 - Modify: `tests/worker-context-budget.test.ts`
 - Modify: `tests/stale-head.test.ts`
 - Modify: `tests/github-app-read.test.ts`
+- Modify: `tests/review-event-policy.test.ts`
 
 **Interfaces:**
 - Consumes: Task 1 policy decision and Task 2 authorization collector/atomic consume.
@@ -224,7 +226,7 @@ Expected: PASS; live and dry-run evidence distinguish candidate and selected eve
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/worker.ts src/github.ts tests/worker-context-budget.test.ts tests/stale-head.test.ts tests/github-app-read.test.ts
+git add src/worker.ts src/github.ts src/review-event-policy.ts tests/worker-context-budget.test.ts tests/stale-head.test.ts tests/github-app-read.test.ts tests/review-event-policy.test.ts
 git commit -m "feat(review): enforce exact-head owner authorization"
 ```
 

--- a/docs/superpowers/plans/2026-07-13-trusted-owner-review-event-policy.md
+++ b/docs/superpowers/plans/2026-07-13-trusted-owner-review-event-policy.md
@@ -17,6 +17,7 @@
 - A valid authorization command queues one review attempt. Existing `review` / `re-review` commands continue to queue analysis but never authorize `REQUEST_CHANGES`.
 - Authorization is one-shot for `{repo, pull_number, head_sha}`. A second command for the same head is denied; a new head requires a new exact command. Dry-run never consumes authority.
 - The final comment reread and atomic consume occur after the existing `before_post` live-head check. The authority is consumed before GitHub review POST even when the candidate event is `COMMENT`, and it is never restored after timeout, 5xx, or another post failure. A GitHub comment-read failure fails closed to `COMMENT` without failing the advisory review.
+- Every review POST supplies the expected head as GitHub's `commit_id`. GitHub documents that this binds the review to the named commit but does not promise stale-head rejection, so the worker also rereads the PR immediately after POST and records `head_changed_during_post` when the live head moved; that review is never claimed as current-head proof.
 - Evidence stores candidate event, selected event, mode, decision reason, exact head, bounded redacted author, and comment id only. It never stores comment bodies, tokens, keys, or credentials.
 - NeonDiff still never submits `APPROVE`, merges, pushes, repairs branches, changes settings, or expands permissions.
 - Local validation remains focused; GitHub Actions owns the broad suite.
@@ -169,6 +170,7 @@ git commit -m "feat(review): persist one-shot owner authorization"
 
 **Files:**
 - Modify: `src/worker.ts`
+- Modify: `src/github.ts`
 - Modify: `tests/worker-context-budget.test.ts`
 - Modify: `tests/stale-head.test.ts`
 
@@ -186,7 +188,7 @@ expect(authorizedPostedReview.event).toBe("REQUEST_CHANGES");
 expect(store.getProcessedReview(REPO, PR, HEAD)?.event).toBe("REQUEST_CHANGES");
 ```
 
-Add real worker-path cases for no authorization, exact trusted authorization, consumed authorization, review/re-review only, comment lookup failure, dry-run non-consumption, and a head change between authorization lookup and post.
+Add real worker-path cases for no authorization, exact trusted authorization, consumed authorization, review/re-review only, comment lookup failure, dry-run non-consumption, a head change between authorization lookup and post, expected `commit_id` propagation, and a head change during POST.
 
 - [ ] **Step 2: Verify RED**
 
@@ -210,7 +212,7 @@ const finalDecision = decideReviewEventPolicy({
 plan.event = finalDecision.selectedEvent;
 ```
 
-Consume an eligible command after the final live-head check even when the candidate is already `COMMENT`, then decide the selected event. Never roll consumption back after a post failure. Rebuild the walkthrough from the final selected event before posting it. Write the redacted decision packet and final review plan before `createReview`. Never throw away findings when the selected event is `COMMENT`.
+Consume an eligible command after the final live-head check even when the candidate is already `COMMENT`, then decide the selected event. Never roll consumption back after a post failure. Require `headSha` in `GitHubApi.createReview` and send it as `commit_id`. Rebuild the walkthrough from the final selected event before posting it. Write the redacted decision packet and final review plan before `createReview`. Immediately reread the pull after posting; if the head moved, write a bounded `head_changed_during_post` incident and withhold current-head success evidence. Never throw away findings when the selected event is `COMMENT`.
 
 - [ ] **Step 4: Verify GREEN**
 
@@ -221,7 +223,7 @@ Expected: PASS; live and dry-run evidence distinguish candidate and selected eve
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/worker.ts tests/worker-context-budget.test.ts tests/stale-head.test.ts
+git add src/worker.ts src/github.ts tests/worker-context-budget.test.ts tests/stale-head.test.ts
 git commit -m "feat(review): enforce exact-head owner authorization"
 ```
 

--- a/docs/superpowers/plans/2026-07-13-trusted-owner-review-event-policy.md
+++ b/docs/superpowers/plans/2026-07-13-trusted-owner-review-event-policy.md
@@ -233,6 +233,7 @@ git commit -m "feat(review): enforce exact-head owner authorization"
 ### Task 4: Scheduler, public schema, settings preview, and operator documentation
 
 **Files:**
+- Modify: `src/scheduler.ts`
 - Modify: `tests/scheduler.test.ts`
 - Modify: `src/repo-policy.ts`
 - Modify: `tests/worker-settings-preview.test.ts`
@@ -282,7 +283,7 @@ Expected: PASS with no policy overclaim or secret-bearing evidence.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add tests/scheduler.test.ts src/repo-policy.ts tests/worker-settings-preview.test.ts docs/schema/neondiff-config.schema.json tests/neondiff-config-schema.test.ts config.example.json config.active-profiles.example.json docs/neondiff-config.md docs/maintainer-commands.md
+git add src/scheduler.ts tests/scheduler.test.ts src/repo-policy.ts tests/worker-settings-preview.test.ts docs/schema/neondiff-config.schema.json tests/neondiff-config-schema.test.ts config.example.json config.active-profiles.example.json docs/neondiff-config.md docs/maintainer-commands.md
 git commit -m "docs(review): publish owner-gated event contract"
 ```
 

--- a/docs/superpowers/plans/2026-07-13-trusted-owner-review-event-policy.md
+++ b/docs/superpowers/plans/2026-07-13-trusted-owner-review-event-policy.md
@@ -1,0 +1,332 @@
+# Trusted-Owner Review Event Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `REQUEST_CHANGES` an exact-head, trusted-owner, one-shot action while preserving autonomous advisory findings and current-head safety.
+
+**Architecture:** Keep the deterministic review gate's event as the candidate signal. A separate review-event policy selects the public GitHub event immediately before posting, using a freshly read owner command and an atomic SQLite consumption record; every missing, malformed, untrusted, stale, duplicate, consumed, or lookup-failed authorization selects `COMMENT`. The exact command names the repository, pull request, and current head, and it queues one review attempt; ordinary `review` / `re-review` commands never authorize `REQUEST_CHANGES`.
+
+**Tech Stack:** TypeScript, Vitest, Node SQLite, GitHub REST review/comments APIs, JSON Schema.
+
+## Global Constraints
+
+- Supported policy modes are `automatic` and `trusted_command_only` under `reviewGate.reviewEventPolicy.mode`; omitted configuration resolves to the safe `trusted_command_only` default, while `automatic` is an explicit legacy opt-in prohibited in the internal production config.
+- `trusted_command_only` never removes inline P0/P1 findings; it changes only the GitHub review event from candidate `REQUEST_CHANGES` to selected `COMMENT` unless a valid authorization is atomically consumed.
+- The authorization command is exactly `<configured bot mention> request-changes --repo <owner/name> --pr <positive integer> --head <40 lowercase-or-uppercase hexadecimal characters>` on one normalized line.
+- Authorization is accepted only from an explicit login in `commands.trustedAuthors`; wildcard `*` can never authorize `REQUEST_CHANGES`. The named repository, pull request, and normalized head must match the live review target exactly.
+- A valid authorization command queues one review attempt. Existing `review` / `re-review` commands continue to queue analysis but never authorize `REQUEST_CHANGES`.
+- Authorization is one-shot for `{repo, pull_number, head_sha}`. A second command for the same head is denied; a new head requires a new exact command. Dry-run never consumes authority.
+- The final comment reread and atomic consume occur after the existing `before_post` live-head check. The authority is consumed before GitHub review POST even when the candidate event is `COMMENT`, and it is never restored after timeout, 5xx, or another post failure. A GitHub comment-read failure fails closed to `COMMENT` without failing the advisory review.
+- Evidence stores candidate event, selected event, mode, decision reason, exact head, bounded redacted author, and comment id only. It never stores comment bodies, tokens, keys, or credentials.
+- NeonDiff still never submits `APPROVE`, merges, pushes, repairs branches, changes settings, or expands permissions.
+- Local validation remains focused; GitHub Actions owns the broad suite.
+
+---
+
+### Task 1: Pure policy and configuration contract
+
+**Files:**
+- Create: `src/review-event-policy.ts`
+- Create: `tests/review-event-policy.test.ts`
+- Modify: `src/config.ts`
+- Modify: `tests/confidence-config.test.ts`
+
+**Interfaces:**
+- Produces: `ReviewEventPolicyConfig`, `ReviewEventAuthorizationAttempt`, `ReviewEventDecision`, `selectReviewEventAuthorizationAttempt`, and `decideReviewEventPolicy`.
+- Consumes later: Task 3 uses the pure decision object without reimplementing policy rules.
+
+- [ ] **Step 1: Write failing policy tests**
+
+```ts
+expect(decideReviewEventPolicy({
+  mode: "trusted_command_only",
+  candidateEvent: "REQUEST_CHANGES",
+  headSha: HEAD,
+  authorization: { status: "missing" }
+})).toMatchObject({ selectedEvent: "COMMENT", reason: "authorization_missing" });
+
+expect(decideReviewEventPolicy({
+  mode: "trusted_command_only",
+  candidateEvent: "REQUEST_CHANGES",
+  headSha: HEAD,
+  authorization: { status: "eligible", headSha: HEAD, author: "100yenadmin", commentId: 41 }
+})).toMatchObject({ selectedEvent: "REQUEST_CHANGES", reason: "authorization_eligible" });
+```
+
+Cover candidate `COMMENT`, `automatic`, missing, malformed, untrusted, stale head, lookup failure, and eligible exact head. Assert output never includes a command body.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `npm test -- tests/review-event-policy.test.ts tests/confidence-config.test.ts`
+
+Expected: FAIL because the policy types/module and configuration field do not exist.
+
+- [ ] **Step 3: Implement the pure contract and fail-closed validation**
+
+```ts
+export type ReviewEventPolicyMode = "automatic" | "trusted_command_only";
+
+export interface ReviewEventPolicyConfig {
+  mode: ReviewEventPolicyMode;
+}
+
+export interface ReviewEventDecision {
+  candidateEvent: ReviewEvent;
+  selectedEvent: ReviewEvent;
+  mode: ReviewEventPolicyMode;
+  reason: ReviewEventDecisionReason;
+  headSha: string;
+  author?: string;
+  commentId?: number;
+}
+```
+
+Add `reviewEventPolicy: { mode: "trusted_command_only" }` under `DEFAULT_CONFIG.reviewGate`, merge old configs additively, reject unknown keys/modes, and keep the pure selector free of GitHub and SQLite dependencies. Permit `automatic` only as an explicit compatibility mode.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `npm test -- tests/review-event-policy.test.ts tests/confidence-config.test.ts && npm run build`
+
+Expected: PASS with pristine output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/review-event-policy.ts src/config.ts tests/review-event-policy.test.ts tests/confidence-config.test.ts
+git commit -m "feat(review): add owner-gated event policy"
+```
+
+---
+
+### Task 2: Authorization command parsing and atomic one-shot state
+
+**Files:**
+- Modify: `src/commands.ts`
+- Modify: `tests/commands.test.ts`
+- Modify: `src/state.ts`
+- Modify: `tests/state.test.ts`
+
+**Interfaces:**
+- Produces: an exact `request-changes` command parse carrying bounded repo/PR/head metadata and `ReviewStateStore.tryConsumeReviewEventAuthorization(input): boolean`.
+- Preserves: existing review/re-review scheduling semantics; the new command queues exactly one manual review attempt.
+
+- [ ] **Step 1: Write failing parser and state tests**
+
+```ts
+const attempts = collectReviewEventAuthorizationAttempts([
+  comment(41, "100yenadmin", `@neondiff request-changes --repo org/repo --pr 7 --head ${HEAD}`)
+], commandConfig, { repo: "org/repo", pullNumber: 7, headSha: HEAD });
+expect(attempts.selected).toMatchObject({ status: "eligible", headSha: HEAD, commentId: 41 });
+
+expect(store.tryConsumeReviewEventAuthorization({
+  repo: "org/repo", pullNumber: 7, headSha: HEAD, commentId: 41, author: "100yenadmin"
+})).toBe(true);
+expect(store.tryConsumeReviewEventAuthorization({
+  repo: "org/repo", pullNumber: 7, headSha: HEAD, commentId: 41, author: "100yenadmin"
+})).toBe(false);
+```
+
+Cover uppercase SHA normalization, malformed/short SHA, repo/PR/head mismatch, untrusted author, wildcard-only trust, duplicate comment, a second command on the same head, and a new command on a new head. Assert ordinary `review` / `re-review` commands produce no authorization attempt and `request-changes` produces one queued review request.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `npm test -- tests/commands.test.ts tests/state.test.ts`
+
+Expected: FAIL because authorization parsing and the consumption table do not exist.
+
+- [ ] **Step 3: Implement parsing and the additive SQLite table**
+
+```sql
+create table if not exists review_event_authorization_consumptions (
+  repo text not null,
+  pull_number integer not null,
+  head_sha text not null,
+  comment_id integer not null,
+  author text not null,
+  consumed_at text not null,
+  primary key (repo, pull_number, head_sha)
+);
+```
+
+Parse only the exact flag-based command and reject extra or reordered tokens. Return bounded metadata, never the comment body. Implement consume as `insert ... on conflict do nothing` and return `changes === 1`; validate repo, PR, comment id, explicit author, and the 40-character SHA before the write.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `npm test -- tests/commands.test.ts tests/state.test.ts && npm run build`
+
+Expected: PASS; a legacy database opens and gains the table without losing prior rows.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands.ts src/state.ts tests/commands.test.ts tests/state.test.ts
+git commit -m "feat(review): persist one-shot owner authorization"
+```
+
+---
+
+### Task 3: Apply the policy at the final live-post boundary
+
+**Files:**
+- Modify: `src/worker.ts`
+- Modify: `tests/worker-context-budget.test.ts`
+- Modify: `tests/stale-head.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 policy decision and Task 2 authorization collector/atomic consume.
+- Produces: `review-event-decision.json`; `ReviewPlan.event` and `processed_reviews.event` contain the selected public event.
+
+- [ ] **Step 1: Write failing worker tests**
+
+```ts
+expect(postedReview.event).toBe("COMMENT");
+expect(postedReview.comments).toContainEqual(expect.objectContaining({ severity: "P1" }));
+
+expect(authorizedPostedReview.event).toBe("REQUEST_CHANGES");
+expect(store.getProcessedReview(REPO, PR, HEAD)?.event).toBe("REQUEST_CHANGES");
+```
+
+Add real worker-path cases for no authorization, exact trusted authorization, consumed authorization, review/re-review only, comment lookup failure, dry-run non-consumption, and a head change between authorization lookup and post.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `npm test -- tests/worker-context-budget.test.ts tests/stale-head.test.ts`
+
+Expected: FAIL because the worker still posts the deterministic candidate directly.
+
+- [ ] **Step 3: Integrate without weakening current-head checks**
+
+```ts
+const candidateEvent = selfConsistency.event;
+// dry-run: select without consuming and label the decision as dry-run evidence
+// live: after liveBeforePost passes, re-read comments, select the exact-head attempt,
+// atomically consume it, and downgrade to COMMENT if lookup/consume fails.
+const finalDecision = decideReviewEventPolicy({
+  mode: config.reviewGate.reviewEventPolicy.mode,
+  candidateEvent,
+  headSha: pull.head.sha,
+  authorization
+});
+plan.event = finalDecision.selectedEvent;
+```
+
+Consume an eligible command after the final live-head check even when the candidate is already `COMMENT`, then decide the selected event. Never roll consumption back after a post failure. Rebuild the walkthrough from the final selected event before posting it. Write the redacted decision packet and final review plan before `createReview`. Never throw away findings when the selected event is `COMMENT`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `npm test -- tests/review-event-policy.test.ts tests/commands.test.ts tests/state.test.ts tests/worker-context-budget.test.ts tests/stale-head.test.ts && npm run build`
+
+Expected: PASS; live and dry-run evidence distinguish candidate and selected events.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/worker.ts tests/worker-context-budget.test.ts tests/stale-head.test.ts
+git commit -m "feat(review): enforce exact-head owner authorization"
+```
+
+---
+
+### Task 4: Scheduler, public schema, settings preview, and operator documentation
+
+**Files:**
+- Modify: `tests/scheduler.test.ts`
+- Modify: `src/repo-policy.ts`
+- Modify: `tests/worker-settings-preview.test.ts`
+- Modify: `docs/schema/neondiff-config.schema.json`
+- Modify: `tests/neondiff-config-schema.test.ts`
+- Modify: `config.example.json`
+- Modify: `config.active-profiles.example.json`
+- Modify: `docs/neondiff-config.md`
+- Modify: `docs/maintainer-commands.md`
+
+**Interfaces:**
+- Scheduler treats `request-changes` as a manual analysis request and carries its comment id into the queued job; ordinary review/re-review commands remain advisory-only authority-wise.
+- Settings preview exposes the configured policy mode without claiming authorization.
+
+- [ ] **Step 1: Write failing scheduler/schema/preview tests**
+
+```ts
+expect(result.commandReviewRequested).toBe(1); // exact command queues one attempt
+expect(state.listReviewQueueJobs({ state: "queued" })).toHaveLength(1);
+expect(settings.reviewGate.reviewEventPolicy).toEqual({ mode: "trusted_command_only" });
+```
+
+Pin readiness to `needs_fix` only when the persisted selected event is `REQUEST_CHANGES`; stale/untrusted/malformed authorization with a P1 candidate must persist `COMMENT` and `ready_for_human`.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `npm test -- tests/scheduler.test.ts tests/worker-settings-preview.test.ts tests/neondiff-config-schema.test.ts`
+
+Expected: FAIL because the schema/preview and authorization scheduling contract are absent.
+
+- [ ] **Step 3: Implement schema/examples/docs**
+
+Document the exact one-command operator flow:
+
+```text
+@neondiff request-changes --repo owner/name --pr 123 --head <40-character-current-head-sha>
+```
+
+Document that the command queues one attempt, authority is one-shot per exact head, a second command on that head is denied, a new head needs a new exact command, review/re-review never authorize, wildcard trust never authorizes, and every failure mode remains advisory. Set examples and upgrade behavior to the safe `trusted_command_only` default; document `automatic` only as explicit legacy compatibility.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `npm test -- tests/scheduler.test.ts tests/worker-settings-preview.test.ts tests/neondiff-config-schema.test.ts tests/commands.test.ts && npm run build && npm run check:public-claims && npm run check:secrets`
+
+Expected: PASS with no policy overclaim or secret-bearing evidence.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/scheduler.test.ts src/repo-policy.ts tests/worker-settings-preview.test.ts docs/schema/neondiff-config.schema.json tests/neondiff-config-schema.test.ts config.example.json config.active-profiles.example.json docs/neondiff-config.md docs/maintainer-commands.md
+git commit -m "docs(review): publish owner-gated event contract"
+```
+
+---
+
+### Task 5: Exact-head review, merge, and internal daemon promotion proof
+
+**Files:**
+- Modify only if evidence paths are repository-owned: `docs/evidence/<release>/...`
+- External live config after merge: `/Volumes/LEXAR/Codex/evaos-code-review-bot/config/active-installed-live.json`
+
+**Interfaces:**
+- Consumes the merged implementation artifact.
+- Produces issue #557 proof for source, configuration, runtime, and exact-head command behavior.
+
+- [ ] **Step 1: Run focused pre-PR validation**
+
+```bash
+npm test -- tests/review-event-policy.test.ts tests/commands.test.ts tests/state.test.ts tests/worker-context-budget.test.ts tests/stale-head.test.ts tests/scheduler.test.ts tests/worker-settings-preview.test.ts tests/neondiff-config-schema.test.ts
+npm run build
+npm run check:public-claims
+npm run check:secrets
+git diff --check origin/main...HEAD
+```
+
+- [ ] **Step 2: Obtain exact-head GitHub proof**
+
+Require green CI, CodeQL, Linux daemon smoke, applicable Swift gates, independent spec/security review, CodeRabbit, evaOS review, and zero unresolved review threads before merge.
+
+- [ ] **Step 3: Merge without publishing a release**
+
+Verify the merge commit on `main` and post-merge CI. Do not mutate npm, tags, GitHub Releases, checkout, Stripe, Fly, or production license state.
+
+- [ ] **Step 4: Promote the internal daemon under the owner-gated config**
+
+From the merged artifact, back up the existing config privately, add:
+
+```json
+"reviewGate": { "reviewEventPolicy": { "mode": "trusted_command_only" } }
+```
+
+Validate config, restart only the owned LaunchAgent, and verify launchd PID/heartbeat/current source identity.
+
+- [ ] **Step 5: Run live no-bypass proof on an owner-controlled fixture PR**
+
+Prove: autonomous P1 posts `COMMENT`; untrusted, wildcard-only, malformed, stale, and consumed authorization do not produce `REQUEST_CHANGES`; ordinary `review`/`re-review` does not authorize; one exact trusted `request-changes` command permits exactly one `REQUEST_CHANGES` on the named head. Record only redacted comment ids, authors, head SHA, event decisions, review URLs, and runtime identity.
+
+- [ ] **Step 6: Update #557 and the release tracker**
+
+Report what is proven and keep #559 blocked until this live runtime proof and its post-merge source evidence are complete.

--- a/docs/superpowers/plans/2026-07-13-trusted-owner-review-event-policy.md
+++ b/docs/superpowers/plans/2026-07-13-trusted-owner-review-event-policy.md
@@ -235,6 +235,8 @@ git commit -m "feat(review): enforce exact-head owner authorization"
 ### Task 4: Scheduler, public schema, settings preview, and operator documentation
 
 **Files:**
+- Modify: `src/commands.ts`
+- Modify: `src/state.ts`
 - Modify: `src/scheduler.ts`
 - Modify: `tests/scheduler.test.ts`
 - Modify: `src/repo-policy.ts`
@@ -285,7 +287,7 @@ Expected: PASS with no policy overclaim or secret-bearing evidence.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/scheduler.ts tests/scheduler.test.ts src/repo-policy.ts tests/worker-settings-preview.test.ts docs/schema/neondiff-config.schema.json tests/neondiff-config-schema.test.ts config.example.json config.active-profiles.example.json docs/neondiff-config.md docs/maintainer-commands.md
+git add src/commands.ts src/state.ts src/scheduler.ts tests/scheduler.test.ts src/repo-policy.ts tests/worker-settings-preview.test.ts docs/schema/neondiff-config.schema.json tests/neondiff-config-schema.test.ts config.example.json config.active-profiles.example.json docs/neondiff-config.md docs/maintainer-commands.md
 git commit -m "docs(review): publish owner-gated event contract"
 ```
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -307,17 +307,18 @@ function parseRequestChangesCommand(
 ): ParsedRequestChangesCommand | undefined {
   if (!body) return undefined;
   const normalizedMentions = new Set(mentions.map((mention) => mention.toLowerCase()));
-  const candidateLines = body
-    .split(/\r?\n/)
-    .map((line) => line.trim().replace(/\s+/g, " "))
-    .filter((line) => {
-      const [mention, action] = line.toLowerCase().split(" ", 2);
-      return normalizedMentions.has(mention) && action === "request-changes";
-    });
-  if (candidateLines.length === 0) return undefined;
-  if (candidateLines.length !== 1) return { status: "malformed" };
+  const trimmed = body.trim();
+  const normalized = trimmed.replace(/\s+/g, " ");
+  const mentionsRequestChanges = [...normalizedMentions].some((mention) =>
+    normalized.toLowerCase().includes(`${mention} request-changes`)
+  );
+  if (!mentionsRequestChanges) return undefined;
+  if (!trimmed || /[\r\n]/.test(trimmed)) return { status: "malformed" };
 
-  const tokens = candidateLines[0].split(" ");
+  const tokens = normalized.split(" ");
+  if (!normalizedMentions.has(tokens[0].toLowerCase()) || tokens[1]?.toLowerCase() !== "request-changes") {
+    return { status: "malformed" };
+  }
   if (tokens.length !== 8 || tokens[2] !== "--repo" || tokens[4] !== "--pr" || tokens[6] !== "--head") {
     return { status: "malformed" };
   }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,9 @@
 import type { CommandConfig } from "./config.js";
 import {
+  selectReviewEventAuthorizationAttempt,
+  type ReviewEventAuthorizationAttempt
+} from "./review-event-policy.js";
+import {
   FINISHING_TOUCH_ACTIONS,
   parseFinishingTouchCommand,
   type FinishingTouchAction
@@ -37,6 +41,29 @@ export interface CollectedReviewCommands {
    * is enabled. NOT yet authorized — the caller must apply the stateful bot + cooldown gate. */
   publicEligible: ReviewCommand[];
   unauthorized: UnauthorizedReviewCommand[];
+}
+
+export interface ReviewEventAuthorizationTarget {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+}
+
+/** Bounded request metadata only: the source command body must never leave the parser. */
+export interface ReviewEventAuthorizationReviewRequest {
+  action: "request-changes";
+  commentId: number;
+  author: string;
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+}
+
+export interface CollectedReviewEventAuthorizationAttempts {
+  attempts: ReviewEventAuthorizationAttempt[];
+  selected: ReviewEventAuthorizationAttempt;
+  /** Valid exact-target commands for the scheduler to enqueue as manual review requests. */
+  reviewRequests: ReviewEventAuthorizationReviewRequest[];
 }
 
 export type CommandDecision =
@@ -92,6 +119,73 @@ export function collectTrustedReviewCommands(
     commands: commands.sort((left, right) => left.commentId - right.commentId),
     publicEligible: publicEligible.sort((left, right) => left.commentId - right.commentId),
     unauthorized
+  };
+}
+
+/**
+ * Parses only whole-line request-changes commands. It deliberately returns bounded metadata rather
+ * than the raw GitHub comment body; legacy review/re-review command handling remains separate.
+ */
+export function collectReviewEventAuthorizationAttempts(
+  comments: IssueCommentCommandSource[],
+  config: CommandConfig,
+  target: ReviewEventAuthorizationTarget
+): CollectedReviewEventAuthorizationAttempts {
+  if (!config.enabled) return { attempts: [], selected: { status: "missing" }, reviewRequests: [] };
+
+  const attempts: ReviewEventAuthorizationAttempt[] = [];
+  const reviewRequests: ReviewEventAuthorizationReviewRequest[] = [];
+  const seenCommentIds = new Set<number>();
+  for (const comment of comments) {
+    if (!Number.isSafeInteger(comment.id) || comment.id < 1 || seenCommentIds.has(comment.id)) continue;
+    seenCommentIds.add(comment.id);
+
+    const parsed = parseRequestChangesCommand(comment.body, config.botMentions);
+    if (!parsed) continue;
+    const author = boundedAuthor(comment.user?.login);
+    const metadata = {
+      ...(author === undefined ? {} : { author }),
+      commentId: comment.id
+    };
+
+    if (parsed.status === "malformed") {
+      attempts.push({ status: "malformed", ...metadata });
+      continue;
+    }
+    if (!author || !isExplicitTrustedAuthor(author, config)) {
+      attempts.push({ status: "untrusted", ...metadata });
+      continue;
+    }
+    if (
+      parsed.repo !== target.repo ||
+      parsed.pullNumber !== target.pullNumber ||
+      parsed.headSha !== normalizeHeadSha(target.headSha)
+    ) {
+      attempts.push({ status: "stale_head", headSha: parsed.headSha, ...metadata });
+      continue;
+    }
+
+    const attempt: ReviewEventAuthorizationAttempt = {
+      status: "eligible",
+      headSha: parsed.headSha,
+      author,
+      commentId: comment.id
+    };
+    attempts.push(attempt);
+    reviewRequests.push({
+      action: "request-changes",
+      commentId: comment.id,
+      author,
+      repo: parsed.repo,
+      pullNumber: parsed.pullNumber,
+      headSha: parsed.headSha
+    });
+  }
+
+  return {
+    attempts,
+    selected: selectReviewEventAuthorizationAttempt(attempts, target.headSha),
+    reviewRequests
   };
 }
 
@@ -203,6 +297,55 @@ function parseCommandAction(body: string | null | undefined, mentions: string[])
   return parseFinishingTouchCommand({ body, botMentions: mentions })?.action;
 }
 
+type ParsedRequestChangesCommand =
+  | { status: "malformed" }
+  | { status: "parsed"; repo: string; pullNumber: number; headSha: string };
+
+function parseRequestChangesCommand(
+  body: string | null | undefined,
+  mentions: string[]
+): ParsedRequestChangesCommand | undefined {
+  if (!body) return undefined;
+  const normalizedMentions = new Set(mentions.map((mention) => mention.toLowerCase()));
+  const candidateLines = body
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/\s+/g, " "))
+    .filter((line) => {
+      const [mention, action] = line.toLowerCase().split(" ", 2);
+      return normalizedMentions.has(mention) && action === "request-changes";
+    });
+  if (candidateLines.length === 0) return undefined;
+  if (candidateLines.length !== 1) return { status: "malformed" };
+
+  const tokens = candidateLines[0].split(" ");
+  if (tokens.length !== 8 || tokens[2] !== "--repo" || tokens[4] !== "--pr" || tokens[6] !== "--head") {
+    return { status: "malformed" };
+  }
+  const repo = tokens[3];
+  const pullNumber = Number(tokens[5]);
+  const headSha = normalizeHeadSha(tokens[7]);
+  if (!isRepoName(repo) || !/^[1-9]\d*$/.test(tokens[5]) || !Number.isSafeInteger(pullNumber) || !headSha) {
+    return { status: "malformed" };
+  }
+  return { status: "parsed", repo, pullNumber, headSha };
+}
+
+function normalizeHeadSha(headSha: string): string | undefined {
+  return /^[0-9a-f]{40}$/i.test(headSha) ? headSha.toLowerCase() : undefined;
+}
+
+function isRepoName(repo: string): boolean {
+  return /^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/.test(repo);
+}
+
+function boundedAuthor(author: string | undefined): string | undefined {
+  return author && /^[A-Za-z0-9-]{1,39}$/.test(author) ? author : undefined;
+}
+
 function isTrustedAuthor(author: string, config: CommandConfig): boolean {
   return config.trustedAuthors.includes(author) || config.trustedAuthors.includes("*");
+}
+
+function isExplicitTrustedAuthor(author: string, config: CommandConfig): boolean {
+  return author !== "*" && config.trustedAuthors.includes(author);
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -9,7 +9,7 @@ import {
   type FinishingTouchAction
 } from "./finishing-touches.js";
 
-export type ReviewCommandAction = "review" | "re-review" | "explain" | "stop" | FinishingTouchAction;
+export type ReviewCommandAction = "review" | "re-review" | "request-changes" | "explain" | "stop" | FinishingTouchAction;
 
 export interface IssueCommentCommandSource {
   id: number;
@@ -254,7 +254,7 @@ export function isBotCommandComment(user: { login: string; type?: string } | nul
 }
 
 export function isReviewCommandAction(action: ReviewCommandAction): boolean {
-  return action === "review" || action === "re-review";
+  return action === "review" || action === "re-review" || action === "request-changes";
 }
 
 export function isFinishingTouchCommandAction(action: ReviewCommandAction): action is FinishingTouchAction {

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ import { REGRESSION_CATEGORIES, type CategoryPrecisionFloors, type RequestChange
 import type { ReviewMode, ReviewModeDefinition, ReviewModesConfig } from "./review-mode-types.js";
 import { validateRelativePacketPath, type RepoWikiContextConfig } from "./repo-wiki-context.js";
 import { DEFAULT_REVIEW_LENS_CONFIG, validateReviewLensConfig, type ReviewLensConfig } from "./review-lenses.js";
+import type { ReviewEventPolicyConfig } from "./review-event-policy.js";
 import { containsSecretLikeText } from "./secrets.js";
 import type { SkillPackContextConfig } from "./skill-packs.js";
 
@@ -222,6 +223,8 @@ export interface ReviewSchedulerConfig {
 export interface ReviewGateConfig {
   /** Max inline comments posted per review; the highest-ranked findings survive the cap. */
   maxInlineComments: number;
+  /** The public GitHub event selection policy; defaults to trusted owner authorization only. */
+  reviewEventPolicy: ReviewEventPolicyConfig;
   /** Optional per-severity confidence floors for REQUEST_CHANGES eligibility (default off). */
   requestChangesConfidenceFloors?: RequestChangesConfidenceFloors;
   /** Optional confidence subtracted (0..1, floor 0) from findings recovered via the strict-JSON
@@ -350,7 +353,10 @@ const DEFAULT_CONFIG: BotConfig = {
     publicDisplay: buildPublicConfidencePolicy()
   },
   reviewGate: {
-    maxInlineComments: 25
+    maxInlineComments: 25,
+    reviewEventPolicy: {
+      mode: "trusted_command_only"
+    }
   },
   repoMemory: {
     enabled: false,
@@ -810,6 +816,7 @@ function validatePublicCommandsConfig(value: unknown, label: string): void {
 function validateReviewGateConfig(value: unknown, label: string): void {
   if (!isRecord(value)) throw new Error(`${label} must be an object`);
   validatePositiveInteger(value.maxInlineComments, `${label}.maxInlineComments`);
+  validateReviewEventPolicyConfig(value.reviewEventPolicy, `${label}.reviewEventPolicy`);
   if (value.requestChangesConfidenceFloors !== undefined) {
     if (!isRecord(value.requestChangesConfidenceFloors)) {
       throw new Error(`${label}.requestChangesConfidenceFloors must be an object`);
@@ -839,6 +846,16 @@ function validateReviewGateConfig(value: unknown, label: string): void {
     }
   }
   if (value.selfConsistency !== undefined) validateSelfConsistencyConfig(value.selfConsistency, `${label}.selfConsistency`);
+}
+
+function validateReviewEventPolicyConfig(value: unknown, label: string): void {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  for (const key of Object.keys(value)) {
+    if (key !== "mode") throw new Error(`${label} has unknown key "${key}"; expected only mode`);
+  }
+  if (value.mode !== "automatic" && value.mode !== "trusted_command_only") {
+    throw new Error(`${label}.mode must be one of automatic or trusted_command_only`);
+  }
 }
 
 function validateSelfConsistencyConfig(value: unknown, label: string): void {

--- a/src/github.ts
+++ b/src/github.ts
@@ -249,6 +249,15 @@ export class GitHubApi {
     }
   }
 
+  async getIssueComment(repo: string, commentId: number): Promise<IssueCommentCommandSource> {
+    if (!Number.isSafeInteger(commentId) || commentId < 1) {
+      throw new Error("commentId must be a positive safe integer");
+    }
+    return this.request<IssueCommentCommandSource>(`/repos/${repo}/issues/comments/${commentId}`, {
+      token: await this.getReadToken(repo)
+    });
+  }
+
   async getIssueOrPull(
     repo: string,
     issueNumber: number,
@@ -307,10 +316,14 @@ export class GitHubApi {
   async createReview(input: {
     repo: string;
     pullNumber: number;
+    headSha: string;
     event: ReviewEvent;
     body: string;
     comments: ReviewComment[];
   }): Promise<{ html_url?: string; id: number }> {
+    if (!/^[0-9a-f]{40}$/i.test(input.headSha)) {
+      throw new Error("headSha must be a 40-character hexadecimal commit SHA");
+    }
     if (!this.canPostAsApp()) {
       throw new Error("GitHub App credentials are required before posting reviews.");
     }
@@ -319,6 +332,7 @@ export class GitHubApi {
       method: "POST",
       token,
       body: {
+        commit_id: input.headSha.toLowerCase(),
         event: input.event,
         body: input.body,
         comments: input.comments.map((comment) => ({

--- a/src/repo-policy.ts
+++ b/src/repo-policy.ts
@@ -75,6 +75,11 @@ export interface UnsupportedReviewSettingEvidence {
 
 export interface ReviewSettingsPreview {
   profile: "chill" | "assertive";
+  reviewGate: {
+    reviewEventPolicy: {
+      mode: "automatic" | "trusted_command_only";
+    };
+  };
   sampleProfile?: ReviewSettingsProfileMetadata;
   sections: ReviewSettingsPreviewSection[];
   pathInstructions: ReviewSettingsPathInstruction[];
@@ -313,6 +318,11 @@ export function buildReviewSettingsPreview(config: BotConfig, profile: ResolvedR
   const unsupportedSettings = buildUnsupportedReviewSettingsMatrix();
   return {
     profile: profile.reviewProfile ?? "assertive",
+    reviewGate: {
+      reviewEventPolicy: {
+        mode: config.reviewGate?.reviewEventPolicy?.mode ?? "trusted_command_only"
+      }
+    },
     sampleProfile: sampleProfileForReviewProfile(profile.reviewProfile ?? "assertive"),
     sections: [
       { key: "reviewSummary", label: "Review summary", enabled: true, mode: "inline_review" },

--- a/src/review-event-policy.ts
+++ b/src/review-event-policy.ts
@@ -12,7 +12,7 @@ type AuthorizationMetadata = {
 };
 
 export type ReviewEventAuthorizationAttempt =
-  | ({ status: "missing" | "malformed" | "untrusted" | "lookup_failed" | "consumed" } & AuthorizationMetadata)
+  | ({ status: "missing" | "malformed" | "untrusted" | "lookup_failed" | "consumed" | "state_error" } & AuthorizationMetadata)
   | ({ status: "stale_head"; headSha: string } & AuthorizationMetadata)
   | ({ status: "eligible"; headSha: string; author: string; commentId: number });
 
@@ -25,6 +25,7 @@ export type ReviewEventDecisionReason =
   | "authorization_stale_head"
   | "authorization_lookup_failed"
   | "authorization_consumed"
+  | "authorization_state_error"
   | "authorization_eligible";
 
 export interface ReviewEventDecision {
@@ -110,6 +111,8 @@ function authorizationReason(status: Exclude<ReviewEventAuthorizationAttempt["st
       return "authorization_lookup_failed";
     case "consumed":
       return "authorization_consumed";
+    case "state_error":
+      return "authorization_state_error";
   }
 }
 

--- a/src/review-event-policy.ts
+++ b/src/review-event-policy.ts
@@ -1,0 +1,126 @@
+import type { ReviewEvent } from "./types.js";
+
+export type ReviewEventPolicyMode = "automatic" | "trusted_command_only";
+
+export interface ReviewEventPolicyConfig {
+  mode: ReviewEventPolicyMode;
+}
+
+type AuthorizationMetadata = {
+  author?: string;
+  commentId?: number;
+};
+
+export type ReviewEventAuthorizationAttempt =
+  | ({ status: "missing" | "malformed" | "untrusted" | "lookup_failed" | "consumed" } & AuthorizationMetadata)
+  | ({ status: "stale_head"; headSha: string } & AuthorizationMetadata)
+  | ({ status: "eligible"; headSha: string; author: string; commentId: number });
+
+export type ReviewEventDecisionReason =
+  | "automatic"
+  | "candidate_comment"
+  | "authorization_missing"
+  | "authorization_malformed"
+  | "authorization_untrusted"
+  | "authorization_stale_head"
+  | "authorization_lookup_failed"
+  | "authorization_consumed"
+  | "authorization_eligible";
+
+export interface ReviewEventDecision {
+  candidateEvent: ReviewEvent;
+  selectedEvent: ReviewEvent;
+  mode: ReviewEventPolicyMode;
+  reason: ReviewEventDecisionReason;
+  headSha: string;
+  author?: string;
+  commentId?: number;
+}
+
+export interface DecideReviewEventPolicyInput {
+  mode: ReviewEventPolicyMode;
+  candidateEvent: ReviewEvent;
+  headSha: string;
+  authorization: ReviewEventAuthorizationAttempt;
+}
+
+/**
+ * Select the most recent eligible authorization for the supplied exact head. Invalid attempts do
+ * not prevent an independently valid owner authorization from being considered.
+ */
+export function selectReviewEventAuthorizationAttempt(
+  attempts: readonly ReviewEventAuthorizationAttempt[],
+  headSha: string
+): ReviewEventAuthorizationAttempt {
+  const normalizedHeadSha = normalizeHeadSha(headSha);
+  const mostRecentEligible = [...attempts].reverse().find((attempt) =>
+    attempt.status === "eligible" && normalizedHeadSha !== undefined && normalizeHeadSha(attempt.headSha) === normalizedHeadSha
+  );
+  if (mostRecentEligible) return mostRecentEligible;
+
+  return [...attempts].reverse().find((attempt) => attempt.status !== "missing") ?? { status: "missing" };
+}
+
+export function decideReviewEventPolicy(input: DecideReviewEventPolicyInput): ReviewEventDecision {
+  const headSha = normalizeHeadSha(input.headSha) ?? input.headSha;
+  const base = {
+    candidateEvent: input.candidateEvent,
+    mode: input.mode,
+    headSha
+  };
+
+  if (input.mode === "automatic") {
+    return { ...base, selectedEvent: input.candidateEvent, reason: "automatic" };
+  }
+
+  if (input.candidateEvent === "COMMENT") {
+    return { ...base, selectedEvent: "COMMENT", reason: "candidate_comment" };
+  }
+
+  const authorization = input.authorization;
+  const metadata = selectedMetadata(authorization);
+  if (authorization.status === "eligible") {
+    const authorizationHeadSha = normalizeHeadSha(authorization.headSha);
+    const currentHeadSha = normalizeHeadSha(input.headSha);
+    if (authorizationHeadSha !== undefined && currentHeadSha !== undefined && authorizationHeadSha === currentHeadSha) {
+      return { ...base, selectedEvent: "REQUEST_CHANGES", reason: "authorization_eligible", ...metadata };
+    }
+    return { ...base, selectedEvent: "COMMENT", reason: "authorization_stale_head", ...metadata };
+  }
+
+  return {
+    ...base,
+    selectedEvent: "COMMENT",
+    reason: authorizationReason(authorization.status),
+    ...metadata
+  };
+}
+
+function authorizationReason(status: Exclude<ReviewEventAuthorizationAttempt["status"], "eligible">): ReviewEventDecisionReason {
+  switch (status) {
+    case "missing":
+      return "authorization_missing";
+    case "malformed":
+      return "authorization_malformed";
+    case "untrusted":
+      return "authorization_untrusted";
+    case "stale_head":
+      return "authorization_stale_head";
+    case "lookup_failed":
+      return "authorization_lookup_failed";
+    case "consumed":
+      return "authorization_consumed";
+  }
+}
+
+function normalizeHeadSha(headSha: string): string | undefined {
+  return /^[0-9a-f]{40}$/i.test(headSha) ? headSha.toLowerCase() : undefined;
+}
+
+function selectedMetadata(authorization: ReviewEventAuthorizationAttempt): AuthorizationMetadata {
+  const author = typeof authorization.author === "string" ? authorization.author.slice(0, 100) : undefined;
+  const commentId = Number.isSafeInteger(authorization.commentId) && (authorization.commentId as number) > 0
+    ? authorization.commentId
+    : undefined;
+  return { ...(author === undefined ? {} : { author }), ...(commentId === undefined ? {} : { commentId }) };
+}

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -2,12 +2,14 @@ import { join } from "node:path";
 import { isPreActivationExistingPull } from "./activation-policy.js";
 import { loadConfig, type BotConfig, type RepoReviewSchedulerConfig } from "./config.js";
 import {
+  collectReviewEventAuthorizationAttempts,
   collectTrustedReviewCommands,
   decideCommandAction,
   isBotCommandComment,
   isFinishingTouchCommandAction,
   isReviewCommandAction,
   type CommandDecision,
+  type ReviewEventAuthorizationReviewRequest,
   type ReviewCommand
 } from "./commands.js";
 import { isFinishingTouchActionEnabled } from "./finishing-touches.js";
@@ -534,6 +536,17 @@ async function enqueuePullIfEligible(input: {
       await retireSupersededQueueJobsForPull(input);
     }
     const queued = enqueueReviewJob(input, commandDecision);
+    if (commandDecision.action === "request-changes") {
+      input.state.recordProcessedCommand({
+        repo: input.repo,
+        pullNumber: input.pull.number,
+        headSha: input.pull.head.sha,
+        commentId: commandDecision.commandId,
+        action: "request-changes",
+        status: "triggered",
+        author: commandDecision.command.author
+      });
+    }
     recordReadinessForEnqueue({
       state: input.state,
       repo: input.repo,
@@ -1078,6 +1091,11 @@ async function resolveSchedulerCommandDecision(input: {
     return { action: "none", shouldReview: false };
   }
   const collected = collectTrustedReviewCommands(comments, input.config.commands);
+  const authorizationRequests = collectReviewEventAuthorizationAttempts(comments, input.config.commands, {
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha
+  }).reviewRequests;
   const repoProfile = resolveRepoProfile(input.config, input.repo);
   // Public review/re-review policy (#345): the stateful bot + per-head cooldown gate runs HERE, where
   // the store and head SHA are in scope (mirrors the #295 per-head-claim placement). Admitted public
@@ -1092,6 +1110,39 @@ async function resolveSchedulerCommandDecision(input: {
     comments
   });
   const authorizedCommands = [...collected.commands, ...admittedPublic].sort((left, right) => left.commentId - right.commentId);
+  const requestChanges = latestPendingRequestChanges({
+    requests: authorizationRequests,
+    state: input.state,
+    repo: input.repo,
+    pull: input.pull
+  });
+  const newerStop = requestChanges
+    ? collected.commands.filter((command) => command.action === "stop" && command.commentId > requestChanges.commentId).at(-1)
+    : undefined;
+  if (requestChanges && !newerStop) {
+    return {
+      action: "request-changes",
+      shouldReview: true,
+      commandId: requestChanges.commentId,
+      command: {
+        action: "request-changes",
+        commentId: requestChanges.commentId,
+        author: requestChanges.author,
+        body: ""
+      }
+    };
+  }
+  if (requestChanges && newerStop) {
+    input.state.recordProcessedCommand({
+      repo: input.repo,
+      pullNumber: input.pull.number,
+      headSha: input.pull.head.sha,
+      commentId: requestChanges.commentId,
+      action: "request-changes",
+      status: "ignored",
+      author: requestChanges.author
+    });
+  }
   return decideCommandAction({
     commands: authorizedCommands.filter((command) =>
       !isFinishingTouchCommandAction(command.action) ||
@@ -1103,6 +1154,17 @@ async function resolveSchedulerCommandDecision(input: {
     hasProcessedCommand: (repo, pullNumber, headSha, commentId) =>
       input.state.hasProcessedCommand(repo, pullNumber, headSha, commentId)
   });
+}
+
+function latestPendingRequestChanges(input: {
+  requests: ReviewEventAuthorizationReviewRequest[];
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+}): ReviewEventAuthorizationReviewRequest | undefined {
+  return input.requests.filter((request) =>
+    !input.state.hasProcessedCommand(input.repo, input.pull.number, input.pull.head.sha, request.commentId)
+  ).at(-1);
 }
 
 export function admitPublicCommands(input: {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1651,6 +1651,11 @@ function reviewResultStatusCommentState(
     case "reviewed":
     case "reviewed_command":
       return "completed";
+    case "posted_stale_head":
+      return "stale_head";
+    case "posted_head_unverified":
+    case "skipped_consumed_authorization":
+      return "failed";
     case "skipped_processed":
       return reviewStatusCommentStateForProcessedStatus(processed);
     case "skipped_provider_cooldown":
@@ -1806,6 +1811,11 @@ function readinessStateForReviewResult(
     case "reviewed":
     case "reviewed_command":
       return processed?.event === "REQUEST_CHANGES" ? "needs_fix" : "ready_for_human";
+    case "posted_stale_head":
+      return "stale";
+    case "posted_head_unverified":
+    case "skipped_consumed_authorization":
+      return "failed";
     case "skipped_processed":
       return readinessStateForProcessedStatus(processed?.status, processed?.event, processed?.error);
     case "skipped_provider_cooldown":
@@ -1839,6 +1849,12 @@ function readinessReasonForReviewResult(
     case "reviewed":
     case "reviewed_command":
       return processed?.event === "REQUEST_CHANGES" ? "request_changes_review_posted" : "comment_review_posted";
+    case "posted_stale_head":
+      return "head_changed_during_review_post";
+    case "posted_head_unverified":
+      return "post_review_head_unverified";
+    case "skipped_consumed_authorization":
+      return "exact_authorization_already_consumed";
     case "skipped_processed":
       return processed ? readinessReasonForProcessedHead(processed) : "processed_head_already_unknown";
     case "skipped_provider_cooldown":
@@ -2027,6 +2043,11 @@ function updateReviewerSessionJobAfterReviewStatus(input: {
     case "reviewed_command":
       updateReviewerSessionJobFromQueueStatus(input, "completed", input.dryRun ? "dry_run" : "posted");
       return;
+    case "posted_stale_head":
+    case "posted_head_unverified":
+    case "skipped_consumed_authorization":
+      updateReviewerSessionJobFromQueueStatus(input, "failed", "failed");
+      return;
     case "skipped_processed": {
       const processed = input.state.getProcessedReview(input.job.repo, input.job.pullNumber, input.job.headSha);
       if (parseProviderCooldownError(processed?.error)) {
@@ -2088,6 +2109,27 @@ function updateQueueJobAfterReviewStatus(input: {
         state: input.dryRun ? "queued" : "posted",
         ...(processed?.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
         lastError: input.dryRun ? "dry_run_completed_not_posted" : input.status
+      });
+      return;
+    }
+    case "posted_stale_head": {
+      const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
+      input.state.updateReviewQueueJobState({
+        jobId: input.job.jobId,
+        state: "stale_retired",
+        ...(processed?.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
+        lastError: "review_posted_head_changed"
+      });
+      return;
+    }
+    case "posted_head_unverified":
+    case "skipped_consumed_authorization": {
+      const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
+      input.state.updateReviewQueueJobState({
+        jobId: input.job.jobId,
+        state: "failed",
+        ...(processed?.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
+        lastError: input.status
       });
       return;
     }
@@ -2392,6 +2434,15 @@ function applyReviewStatus(result: ScheduledRunResult, status: ReviewPullResult 
       result.reviewed += 1;
       result.queue.completed += 1;
       if (status === "reviewed_command") result.commandReviewRequested += 1;
+      break;
+    case "posted_stale_head":
+      result.skippedStaleHead += 1;
+      result.queue.staleRetired += 1;
+      break;
+    case "posted_head_unverified":
+    case "skipped_consumed_authorization":
+      result.failed += 1;
+      result.queue.failedQueueJobs += 1;
       break;
     case "skipped_draft":
       result.skippedDraft += 1;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -38,6 +38,9 @@ import {
 } from "./review-budget.js";
 import {
   ACTIVATION_BASELINE_EXISTING_HEAD_ERROR,
+  EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR,
+  POST_REVIEW_HEAD_UNVERIFIED_ERROR,
+  REVIEW_POSTED_HEAD_CHANGED_ERROR,
   isActivationBaselineProcessedReview,
   parseProviderCooldownError,
   ReviewStateStore,
@@ -1850,11 +1853,11 @@ function readinessReasonForReviewResult(
     case "reviewed_command":
       return processed?.event === "REQUEST_CHANGES" ? "request_changes_review_posted" : "comment_review_posted";
     case "posted_stale_head":
-      return "head_changed_during_review_post";
+      return REVIEW_POSTED_HEAD_CHANGED_ERROR;
     case "posted_head_unverified":
-      return "post_review_head_unverified";
+      return POST_REVIEW_HEAD_UNVERIFIED_ERROR;
     case "skipped_consumed_authorization":
-      return "exact_authorization_already_consumed";
+      return EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR;
     case "skipped_processed":
       return processed ? readinessReasonForProcessedHead(processed) : "processed_head_already_unknown";
     case "skipped_provider_cooldown":
@@ -1890,6 +1893,8 @@ function readinessStateForProcessedStatus(
   error?: string
 ): ReviewReadinessState {
   if (parseProviderCooldownError(error)) return "provider_deferred";
+  if (error === POST_REVIEW_HEAD_UNVERIFIED_ERROR || error === EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR) return "failed";
+  if (error === REVIEW_POSTED_HEAD_CHANGED_ERROR) return "stale";
   switch (status) {
     case "posted":
     case "dry_run":
@@ -1910,6 +1915,13 @@ function readinessReasonForProcessedHead(processed: { status: ProcessedStatus; e
   if (providerCooldown) return `processed_head_provider_deferred: ${providerCooldown.reason ?? "provider_cooldown"}`;
   if (processed.status === "skipped" && processed.error === ACTIVATION_BASELINE_EXISTING_HEAD_ERROR) {
     return ACTIVATION_BASELINE_EXISTING_HEAD_ERROR;
+  }
+  if (
+    processed.error === POST_REVIEW_HEAD_UNVERIFIED_ERROR ||
+    processed.error === REVIEW_POSTED_HEAD_CHANGED_ERROR ||
+    processed.error === EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR
+  ) {
+    return processed.error;
   }
   return `processed_head_already_${processed.status}`;
 }
@@ -2151,7 +2163,7 @@ function updateQueueJobAfterReviewStatus(input: {
       }
       input.state.updateReviewQueueJobState({
         jobId: input.job.jobId,
-        state: reviewQueueJobStateForProcessedStatus(processed?.status, input.dryRun),
+        state: reviewQueueJobStateForProcessedStatus(processed?.status, input.dryRun, processed?.error),
         ...(processed?.reviewUrl ? { reviewUrl: processed.reviewUrl } : {}),
         lastError: `processed_head_already_${processed?.status ?? "unknown"}`
       });
@@ -2253,6 +2265,10 @@ function reviewStatusCommentStateForProcessedStatus(
   processed?: { status: ProcessedStatus; error?: string }
 ): ReviewStatusCommentState {
   if (parseProviderCooldownError(processed?.error)) return "provider_deferred";
+  if (processed?.error === POST_REVIEW_HEAD_UNVERIFIED_ERROR || processed?.error === EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR) {
+    return "failed";
+  }
+  if (processed?.error === REVIEW_POSTED_HEAD_CHANGED_ERROR) return "stale_head";
   const status = processed?.status;
   switch (status) {
     case "posted":
@@ -2269,7 +2285,13 @@ function reviewStatusCommentStateForProcessedStatus(
   }
 }
 
-function reviewQueueJobStateForProcessedStatus(status: ProcessedStatus | undefined, dryRun: boolean): ReviewQueueJobState {
+function reviewQueueJobStateForProcessedStatus(
+  status: ProcessedStatus | undefined,
+  dryRun: boolean,
+  error?: string
+): ReviewQueueJobState {
+  if (error === POST_REVIEW_HEAD_UNVERIFIED_ERROR || error === EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR) return "failed";
+  if (error === REVIEW_POSTED_HEAD_CHANGED_ERROR) return "stale_retired";
   switch (status) {
     case "posted":
       return "posted";

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1815,8 +1815,9 @@ function readinessStateForReviewResult(
     case "reviewed_command":
       return processed?.event === "REQUEST_CHANGES" ? "needs_fix" : "ready_for_human";
     case "posted_stale_head":
-      return "stale";
+      return isPriorVerifiedBlockingReview(processed) ? "needs_fix" : "stale";
     case "posted_head_unverified":
+      return isPriorVerifiedBlockingReview(processed) ? "needs_fix" : "failed";
     case "skipped_consumed_authorization":
       return "failed";
     case "skipped_processed":
@@ -1853,9 +1854,9 @@ function readinessReasonForReviewResult(
     case "reviewed_command":
       return processed?.event === "REQUEST_CHANGES" ? "request_changes_review_posted" : "comment_review_posted";
     case "posted_stale_head":
-      return REVIEW_POSTED_HEAD_CHANGED_ERROR;
+      return isPriorVerifiedBlockingReview(processed) ? "request_changes_review_posted" : REVIEW_POSTED_HEAD_CHANGED_ERROR;
     case "posted_head_unverified":
-      return POST_REVIEW_HEAD_UNVERIFIED_ERROR;
+      return isPriorVerifiedBlockingReview(processed) ? "request_changes_review_posted" : POST_REVIEW_HEAD_UNVERIFIED_ERROR;
     case "skipped_consumed_authorization":
       return EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR;
     case "skipped_processed":
@@ -1885,6 +1886,12 @@ function readinessReasonForReviewResult(
     default:
       return assertNever(status);
   }
+}
+
+function isPriorVerifiedBlockingReview(
+  processed?: { status: ProcessedStatus; event?: ReviewEvent; error?: string }
+): boolean {
+  return processed?.status === "posted" && processed.event === "REQUEST_CHANGES" && !processed.error;
 }
 
 function readinessStateForProcessedStatus(

--- a/src/state.ts
+++ b/src/state.ts
@@ -346,6 +346,15 @@ export interface ReviewEventAuthorizationConsumptionInput {
   now?: Date;
 }
 
+export interface ReviewEventAuthorizationConsumptionRecord {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  commentId: number;
+  author: string;
+  consumedAt: string;
+}
+
 export interface RepoMemoryNoteRecord {
   noteId: string;
   repo: string;
@@ -1533,6 +1542,39 @@ export class ReviewStateStore {
         (input.now ?? new Date()).toISOString()
       );
     return Number(result.changes) === 1;
+  }
+
+  /** Reads the one-shot authorization ledger without mutating or renewing it. */
+  getReviewEventAuthorizationConsumption(
+    repo: string,
+    pullNumber: number,
+    headSha: string
+  ): ReviewEventAuthorizationConsumptionRecord | undefined {
+    validateReviewEventAuthorizationCoordinates(repo, pullNumber, headSha);
+    const row = this.db
+      .prepare(
+        `select repo, pull_number, head_sha, comment_id, author, consumed_at
+         from review_event_authorization_consumptions
+         where repo = ? and pull_number = ? and head_sha = ?`
+      )
+      .get(repo, pullNumber, headSha.toLowerCase()) as {
+        repo: string;
+        pull_number: number;
+        head_sha: string;
+        comment_id: number;
+        author: string;
+        consumed_at: string;
+      } | undefined;
+    return row
+      ? {
+          repo: row.repo,
+          pullNumber: row.pull_number,
+          headSha: row.head_sha,
+          commentId: row.comment_id,
+          author: row.author,
+          consumedAt: row.consumed_at
+        }
+      : undefined;
   }
 
   tryAcquireIssueEnrichmentRunLease(
@@ -3059,17 +3101,21 @@ function validatePullAndCommand(pullNumber: number, commandCommentId: number): v
 }
 
 function validateReviewEventAuthorizationConsumption(input: ReviewEventAuthorizationConsumptionInput): void {
-  validateRepoName(input.repo, "repo");
-  if (!/^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/.test(input.repo)) {
-    throw new Error("repo must be an owner/repo name");
-  }
-  if (!Number.isInteger(input.pullNumber) || input.pullNumber < 1) throw new Error("pullNumber must be a positive integer");
+  validateReviewEventAuthorizationCoordinates(input.repo, input.pullNumber, input.headSha);
   if (!Number.isInteger(input.commentId) || input.commentId < 1) throw new Error("commentId must be a positive integer");
-  if (!/^[0-9a-f]{40}$/i.test(input.headSha)) {
-    throw new Error("headSha must be a 40-character hexadecimal SHA");
-  }
   if (!/^[A-Za-z0-9-]{1,39}$/.test(input.author)) {
     throw new Error("author must be a non-empty string");
+  }
+}
+
+function validateReviewEventAuthorizationCoordinates(repo: string, pullNumber: number, headSha: string): void {
+  validateRepoName(repo, "repo");
+  if (!/^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/.test(repo)) {
+    throw new Error("repo must be an owner/repo name");
+  }
+  if (!Number.isInteger(pullNumber) || pullNumber < 1) throw new Error("pullNumber must be a positive integer");
+  if (!/^[0-9a-f]{40}$/i.test(headSha)) {
+    throw new Error("headSha must be a 40-character hexadecimal SHA");
   }
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -116,6 +116,9 @@ export interface RepoActivationRecord {
 }
 
 export const ACTIVATION_BASELINE_EXISTING_HEAD_ERROR = "activation_baseline_existing_head";
+export const EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR = "exact_authorization_already_consumed";
+export const POST_REVIEW_HEAD_UNVERIFIED_ERROR = "post_review_head_unverified";
+export const REVIEW_POSTED_HEAD_CHANGED_ERROR = "review_posted_head_changed";
 
 export function isActivationBaselineProcessedReview(
   processed: Pick<StoredProcessedReviewRecord, "status" | "error"> | undefined

--- a/src/state.ts
+++ b/src/state.ts
@@ -7,7 +7,7 @@ import type { FinishingTouchAction } from "./finishing-touches.js";
 import type { ReviewEvent } from "./types.js";
 
 export type ProcessedStatus = "dry_run" | "posted" | "skipped" | "failed";
-export type ProcessedCommandAction = "review" | "re-review" | "explain" | "stop" | FinishingTouchAction;
+export type ProcessedCommandAction = "review" | "re-review" | "request-changes" | "explain" | "stop" | FinishingTouchAction;
 export type ProcessedCommandStatus = "triggered" | "explained" | "stopped" | "ignored";
 export type FinishingTouchDraftStatus = "drafted" | "rejected";
 export type ReviewerSessionState = "warming" | "active" | "draining" | "expired" | "failed";

--- a/src/state.ts
+++ b/src/state.ts
@@ -337,6 +337,15 @@ export interface ProcessedCommandRecord {
   url?: string;
 }
 
+export interface ReviewEventAuthorizationConsumptionInput {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  commentId: number;
+  author: string;
+  now?: Date;
+}
+
 export interface RepoMemoryNoteRecord {
   noteId: string;
   repo: string;
@@ -763,6 +772,16 @@ export class ReviewStateStore {
         url text,
         created_at text not null default (datetime('now')),
         primary key (repo, pull_number, head_sha, comment_id)
+      );
+
+      create table if not exists review_event_authorization_consumptions (
+        repo text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        comment_id integer not null,
+        author text not null,
+        consumed_at text not null,
+        primary key (repo, pull_number, head_sha)
       );
 
       create table if not exists finishing_touch_drafts (
@@ -1493,6 +1512,27 @@ export class ReviewStateStore {
       this.db.exec("rollback");
       throw error;
     }
+  }
+
+  /** Atomically consumes one explicit trusted-owner authorization for an exact review head. */
+  tryConsumeReviewEventAuthorization(input: ReviewEventAuthorizationConsumptionInput): boolean {
+    validateReviewEventAuthorizationConsumption(input);
+    const result = this.db
+      .prepare(
+        `insert into review_event_authorization_consumptions
+          (repo, pull_number, head_sha, comment_id, author, consumed_at)
+         values (?, ?, ?, ?, ?, ?)
+         on conflict(repo, pull_number, head_sha) do nothing`
+      )
+      .run(
+        input.repo,
+        input.pullNumber,
+        input.headSha.toLowerCase(),
+        input.commentId,
+        input.author,
+        (input.now ?? new Date()).toISOString()
+      );
+    return Number(result.changes) === 1;
   }
 
   tryAcquireIssueEnrichmentRunLease(
@@ -3015,6 +3055,21 @@ function validatePullAndCommand(pullNumber: number, commandCommentId: number): v
   if (!Number.isInteger(pullNumber) || pullNumber < 1) throw new Error("pullNumber must be a positive integer");
   if (!Number.isInteger(commandCommentId) || commandCommentId < 1) {
     throw new Error("commandCommentId must be a positive integer");
+  }
+}
+
+function validateReviewEventAuthorizationConsumption(input: ReviewEventAuthorizationConsumptionInput): void {
+  validateRepoName(input.repo, "repo");
+  if (!/^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/.test(input.repo)) {
+    throw new Error("repo must be an owner/repo name");
+  }
+  if (!Number.isInteger(input.pullNumber) || input.pullNumber < 1) throw new Error("pullNumber must be a positive integer");
+  if (!Number.isInteger(input.commentId) || input.commentId < 1) throw new Error("commentId must be a positive integer");
+  if (!/^[0-9a-f]{40}$/i.test(input.headSha)) {
+    throw new Error("headSha must be a 40-character hexadecimal SHA");
+  }
+  if (!/^[A-Za-z0-9-]{1,39}$/.test(input.author)) {
+    throw new Error("author must be a non-empty string");
   }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1810,6 +1810,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       commandCommentId: input.commandCommentId,
       commandConfig: config.commands
     });
+    exactOwnerReviewRequested = exactOwnerReviewRequested || authorization.status === "eligible";
+    manualReviewRequested = commandReviewRequested || exactOwnerReviewRequested;
     if (reviewEventPolicyMode === "trusted_command_only") {
       const liveBeforeConsume = await github.getPull(repo, pull.number);
       const staleBeforeConsume = detectStalePullHead({ expected: pull, live: liveBeforeConsume, phase: "before_post" });
@@ -1827,8 +1829,6 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       pull,
       dryRun: false
     });
-    exactOwnerReviewRequested = exactOwnerReviewRequested || reviewEventResolution.authorization.status === "eligible";
-    manualReviewRequested = commandReviewRequested || exactOwnerReviewRequested;
     const reviewEventDecisionEvidence = buildReviewEventDecisionEvidence(reviewEventResolution, false);
     if (
       reviewEventResolution.consumed &&

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1458,9 +1458,12 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   }
 
   const commandReviewRequested = commandDecision.shouldReview;
+  // The scheduler pre-records request-changes before the worker re-resolves it, so only a
+  // non-command decision needs this early exact-comment lookup to bypass a processed advisory head.
   let exactOwnerReviewRequested = Boolean(
     processed &&
     input.commandCommentId &&
+    !commandReviewRequested &&
     (await lookupQueuedReviewEventAuthorization({
       mode: "trusted_command_only",
       github,
@@ -1795,7 +1798,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       dryRun: input.dryRun,
       commandDecision
     });
-    const walkthrough = config.walkthrough.enabled
+    const walkthrough = config.walkthrough.enabled && input.dryRun
       ? buildWalkthroughComment({
           repo,
           pull,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -83,6 +83,9 @@ import { buildSkillPackContextPacket, type SkillPackContextPacket } from "./skil
 import { writeSecureFileSync } from "./temp-files.js";
 import {
   ACTIVATION_BASELINE_EXISTING_HEAD_ERROR,
+  EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR,
+  POST_REVIEW_HEAD_UNVERIFIED_ERROR,
+  REVIEW_POSTED_HEAD_CHANGED_ERROR,
   isActivationBaselineProcessedReview,
   parseProviderCooldownError,
   ReviewStateStore,
@@ -399,25 +402,68 @@ export async function runOnce(options: RunOnceOptions): Promise<RunOnceResult> {
           result.failed += 1;
           continue;
         }
-        if (status === "reviewed" || status === "reviewed_command") result.reviewed += 1;
-        if (status === "skipped_draft") result.skippedDraft += 1;
-        if (status === "skipped_canary") result.skippedCanary += 1;
-        if (status === "skipped_policy" || status === "skipped_license_gate") result.skippedPolicy += 1;
-        if (status === "skipped_license_gate") result.skippedLicenseGate += 1;
-        if (status === "skipped_command_stop") result.skippedCommandStop += 1;
-        if (status === "skipped_command_explain") result.skippedCommandExplain += 1;
-        if (status === "skipped_finishing_touch_draft") result.skippedFinishingTouchDraft += 1;
-        if (status === "reviewed_command") result.commandReviewRequested += 1;
-        if (status === "skipped_processed") result.skippedProcessed += 1;
-        if (status === "skipped_capacity") result.skippedCapacity += 1;
-        if (status === "skipped_context_budget") result.skippedContextBudget += 1;
-        if (status === "skipped_provider_cooldown") result.skippedProviderCooldown += 1;
-        if (status === "skipped_stale_head") result.skippedStaleHead += 1;
+        applyReviewPullResultToRunOnceResult(result, status);
       }
     }
     return result;
   } finally {
     state.close();
+  }
+}
+
+export function applyReviewPullResultToRunOnceResult(result: RunOnceResult, status: ReviewPullResult): void {
+  switch (status) {
+    case "reviewed":
+      result.reviewed += 1;
+      return;
+    case "reviewed_command":
+      result.reviewed += 1;
+      result.commandReviewRequested += 1;
+      return;
+    case "posted_head_unverified":
+    case "skipped_consumed_authorization":
+      result.failed += 1;
+      return;
+    case "posted_stale_head":
+    case "skipped_stale_head":
+      result.skippedStaleHead += 1;
+      return;
+    case "skipped_draft":
+      result.skippedDraft += 1;
+      return;
+    case "skipped_canary":
+      result.skippedCanary += 1;
+      return;
+    case "skipped_policy":
+      result.skippedPolicy += 1;
+      return;
+    case "skipped_license_gate":
+      result.skippedPolicy += 1;
+      result.skippedLicenseGate += 1;
+      return;
+    case "skipped_command_stop":
+      result.skippedCommandStop += 1;
+      return;
+    case "skipped_command_explain":
+      result.skippedCommandExplain += 1;
+      return;
+    case "skipped_finishing_touch_draft":
+      result.skippedFinishingTouchDraft += 1;
+      return;
+    case "skipped_processed":
+      result.skippedProcessed += 1;
+      return;
+    case "skipped_capacity":
+      result.skippedCapacity += 1;
+      return;
+    case "skipped_context_budget":
+      result.skippedContextBudget += 1;
+      return;
+    case "skipped_provider_cooldown":
+      result.skippedProviderCooldown += 1;
+      return;
+    default:
+      assertNever(status);
   }
 }
 
@@ -1444,12 +1490,19 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision, input.commandCommentId);
       mkdirSync(evidenceDir, { recursive: true });
       writeRedactedJson(join(evidenceDir, "consumed-authorization-incident.json"), {
-        reason: "exact_authorization_already_consumed",
+        reason: EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR,
         repo,
         pullNumber: pull.number,
         headSha: pull.head.sha,
         commentId: input.commandCommentId,
         consumedAt: consumption.consumedAt
+      });
+      state.recordProcessed({
+        repo,
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        status: "skipped",
+        error: EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR
       });
       return "skipped_consumed_authorization";
     }
@@ -1945,6 +1998,11 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       body: reviewBodyAfterWalkthroughPost(plan),
       comments
     });
+    writeRedactedJson(join(evidenceDir, "posted-review.json"), {
+      event: plan.event,
+      reviewId: review.id,
+      reviewUrl: review.html_url
+    });
     const priorPosted = state.getProcessedReview(repo, pull.number, pull.head.sha);
     if (!(priorPosted?.status === "posted" && priorPosted.event === "REQUEST_CHANGES" && plan.event === "COMMENT")) {
       state.recordProcessed({
@@ -1985,6 +2043,20 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         reviewId: review.id,
         error: redactSecrets(error instanceof Error ? error.message : String(error)).slice(0, 300)
       });
+    }
+    if (headChangedDuringPost || postReviewHeadLookupFailed) {
+      const durablePosted = state.getProcessedReview(repo, pull.number, pull.head.sha);
+      if (durablePosted?.status === "posted") {
+        state.recordProcessed({
+          repo,
+          pullNumber: pull.number,
+          headSha: pull.head.sha,
+          status: "posted",
+          ...(durablePosted.event ? { event: durablePosted.event } : {}),
+          ...(durablePosted.reviewUrl ? { reviewUrl: durablePosted.reviewUrl } : {}),
+          error: headChangedDuringPost ? REVIEW_POSTED_HEAD_CHANGED_ERROR : POST_REVIEW_HEAD_UNVERIFIED_ERROR
+        });
+      }
     }
     releaseReviewCapacity();
     if (headChangedDuringPost) return "posted_stale_head";

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1393,7 +1393,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   }
 
   const commandReviewRequested = commandDecision.shouldReview;
-  const exactOwnerReviewRequested = Boolean(
+  let exactOwnerReviewRequested = Boolean(
     processed &&
     input.commandCommentId &&
     (await lookupQueuedReviewEventAuthorization({
@@ -1405,7 +1405,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       commandConfig: config.commands
     })).status === "eligible"
   );
-  if (commandReviewRequested || exactOwnerReviewRequested) {
+  let manualReviewRequested = commandReviewRequested || exactOwnerReviewRequested;
+  if (manualReviewRequested) {
     const livePull = await github.getPull(repo, pull.number);
     const stale = detectStalePullHead({ expected: pull, live: livePull, phase: "before_review" });
     if (stale) {
@@ -1416,8 +1417,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   }
   if (
     input.processedHeadPolicy !== "retry_failed_head" &&
-    !commandReviewRequested &&
-    !exactOwnerReviewRequested &&
+    !manualReviewRequested &&
     (processed || state.hasProcessed(repo, pull.number, pull.head.sha))
   ) {
     // This is a provider-free visibility repair for a GitHub review that is
@@ -1691,6 +1691,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
           dryRun: true
         })
       : undefined;
+    exactOwnerReviewRequested = exactOwnerReviewRequested || dryRunReviewEventResolution?.authorization.status === "eligible";
+    manualReviewRequested = commandReviewRequested || exactOwnerReviewRequested;
     const selectedEvent = dryRunReviewEventResolution?.decision.selectedEvent ?? candidateEvent;
     writeRedactedJson(join(evidenceDir, "deterministic-gate.json"), { ...gate, dropped });
     const summary = buildSummary({
@@ -1776,7 +1778,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       // Dry-run posts nothing public, so it does NOT acquire a per-head claim (#295): claiming would
       // add contention/TTL churn for a run that cannot violate the at-most-one-posted-review invariant.
       state.recordProcessed({ repo, pullNumber: pull.number, headSha: pull.head.sha, status: "dry_run", event: plan.event });
-      return commandReviewRequested ? "reviewed_command" : "reviewed";
+      return manualReviewRequested ? "reviewed_command" : "reviewed";
     }
 
     // Atomic per-head claim (#295): acquired here — after every eligibility/stale check and after the
@@ -1825,6 +1827,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       pull,
       dryRun: false
     });
+    exactOwnerReviewRequested = exactOwnerReviewRequested || reviewEventResolution.authorization.status === "eligible";
+    manualReviewRequested = commandReviewRequested || exactOwnerReviewRequested;
     const reviewEventDecisionEvidence = buildReviewEventDecisionEvidence(reviewEventResolution, false);
     if (
       reviewEventResolution.consumed &&
@@ -1951,7 +1955,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         dryRun: input.dryRun
       });
     }
-    return commandReviewRequested ? "reviewed_command" : "reviewed";
+    return manualReviewRequested ? "reviewed_command" : "reviewed";
   } finally {
     releaseReviewCapacity();
   }
@@ -2757,6 +2761,7 @@ function recordStaleHeadSkip(input: {
 }): void {
   mkdirSync(input.evidenceDir, { recursive: true });
   writeRedactedJson(join(input.evidenceDir, "stale-head.json"), input.stale);
+  if (input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha)?.status === "posted") return;
   input.state.recordProcessed({
     repo: input.repo,
     pullNumber: input.pull.number,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1990,6 +1990,11 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     if (await recordStaleHeadBeforePostIfMoved({ state, github, repo, pull, evidenceDir })) {
       return "skipped_stale_head";
     }
+    const priorPosted = state.getProcessedReview(repo, pull.number, pull.head.sha);
+    const preservedPriorBlockingRow = Boolean(
+      priorPosted?.status === "posted" && priorPosted.event === "REQUEST_CHANGES" && plan.event === "COMMENT"
+    );
+    const preservedPriorVerifiedBlockingRow = preservedPriorBlockingRow && !priorPosted?.error;
     const review = await reviewGithub.createReview({
       repo,
       pullNumber: pull.number,
@@ -1998,13 +2003,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       body: reviewBodyAfterWalkthroughPost(plan),
       comments
     });
-    writeRedactedJson(join(evidenceDir, "posted-review.json"), {
-      event: plan.event,
-      reviewId: review.id,
-      reviewUrl: review.html_url
-    });
-    const priorPosted = state.getProcessedReview(repo, pull.number, pull.head.sha);
-    if (!(priorPosted?.status === "posted" && priorPosted.event === "REQUEST_CHANGES" && plan.event === "COMMENT")) {
+    if (!preservedPriorBlockingRow) {
       state.recordProcessed({
         repo,
         pullNumber: pull.number,
@@ -2014,6 +2013,11 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         reviewUrl: review.html_url
       });
     }
+    writeRedactedJsonBestEffort(join(evidenceDir, "posted-review.json"), {
+      event: plan.event,
+      reviewId: review.id,
+      reviewUrl: review.html_url
+    });
     // Public-safe findings ledger (#357): record the coordinates we just posted publicly so the
     // daemon calibration-observe pass can re-derive outcome labels later. BEST-EFFORT / FAIL-OPEN —
     // the review is already durable; observation bookkeeping must never block or fail the review.
@@ -2024,7 +2028,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       const liveAfterPost = await github.getPull(repo, pull.number);
       headChangedDuringPost = liveAfterPost.head.sha !== pull.head.sha;
       if (headChangedDuringPost) {
-        writeRedactedJson(join(evidenceDir, "head-changed-during-post.json"), {
+        writeRedactedJsonBestEffort(join(evidenceDir, "head-changed-during-post.json"), {
           reason: "head_changed_during_post",
           repo,
           pullNumber: pull.number,
@@ -2035,7 +2039,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       }
     } catch (error) {
       postReviewHeadLookupFailed = true;
-      writeRedactedJson(join(evidenceDir, "post-review-head-lookup-failed.json"), {
+      writeRedactedJsonBestEffort(join(evidenceDir, "post-review-head-lookup-failed.json"), {
         reason: "post_review_head_lookup_failed",
         repo,
         pullNumber: pull.number,
@@ -2044,7 +2048,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         error: redactSecrets(error instanceof Error ? error.message : String(error)).slice(0, 300)
       });
     }
-    if (headChangedDuringPost || postReviewHeadLookupFailed) {
+    if ((headChangedDuringPost || postReviewHeadLookupFailed) && !preservedPriorVerifiedBlockingRow) {
       const durablePosted = state.getProcessedReview(repo, pull.number, pull.head.sha);
       if (durablePosted?.status === "posted") {
         state.recordProcessed({
@@ -3899,6 +3903,14 @@ function sanitizeDroppedFindings(dropped: ReviewPlan["dropped"], publicConfidenc
 
 function writeRedactedJson(path: string, value: unknown): void {
   writeSecureFileSync(path, `${redactSecrets(JSON.stringify(value, null, 2))}\n`);
+}
+
+function writeRedactedJsonBestEffort(path: string, value: unknown): void {
+  try {
+    writeRedactedJson(path, value);
+  } catch {
+    // A successful remote review POST is already durable. Optional local evidence must never make it retryable.
+  }
 }
 
 function writeRedactedText(path: string, value: string): void {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -248,6 +248,9 @@ export interface ProviderErrorClassification {
 export type ReviewPullResult =
   | "reviewed"
   | "reviewed_command"
+  | "posted_stale_head"
+  | "posted_head_unverified"
+  | "skipped_consumed_authorization"
   | "skipped_draft"
   | "skipped_canary"
   | "skipped_policy"
@@ -281,6 +284,9 @@ export function isSuccessfulRetryStatus(status: RetryFailedHeadResult["status"])
     case "skipped_context_budget":
     case "skipped_provider_cooldown":
     case "skipped_stale_head":
+    case "posted_stale_head":
+    case "posted_head_unverified":
+    case "skipped_consumed_authorization":
       return false;
     default:
       return assertNever(status);
@@ -857,10 +863,13 @@ function retryStatusCommentState(
     case "skipped_context_budget":
       return "skipped";
     case "skipped_stale_head":
+    case "posted_stale_head":
       return "stale_head";
     case "skipped_closed":
       return "closed_or_merged_before_review";
     case "failed":
+    case "posted_head_unverified":
+    case "skipped_consumed_authorization":
       return "failed";
     case "skipped_capacity":
       return "provider_deferred";
@@ -1061,7 +1070,17 @@ function retryQueuePatchForStatus(input: {
         lastError: input.processedError ?? "license_entitlement_required",
         sessionJobState: "assigned"
       };
+    case "posted_stale_head":
+      return {
+        state: "stale_retired",
+        ...(input.processedReviewUrl ? { reviewUrl: input.processedReviewUrl } : {}),
+        lastError: "retry_did_not_review=posted_stale_head",
+        sessionJobState: "skipped",
+        sessionProcessedStatus: "skipped"
+      };
     case "failed":
+    case "posted_head_unverified":
+    case "skipped_consumed_authorization":
     case "skipped_draft":
     case "skipped_canary":
     case "skipped_policy":
@@ -1410,9 +1429,29 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     const livePull = await github.getPull(repo, pull.number);
     const stale = detectStalePullHead({ expected: pull, live: livePull, phase: "before_review" });
     if (stale) {
-      const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision);
+      const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision, input.commandCommentId);
       recordStaleHeadSkip({ state, repo, pull, stale, evidenceDir });
       return "skipped_stale_head";
+    }
+  }
+  if (input.commandCommentId) {
+    const consumption = state.getReviewEventAuthorizationConsumption(repo, pull.number, pull.head.sha);
+    if (consumption?.commentId === input.commandCommentId) {
+      if (processed?.status === "posted") {
+        await reconcileProcessedHeadAfterDirectReviewSafely({ config, github, state, repo, pull, dryRun: input.dryRun });
+        return "skipped_processed";
+      }
+      const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision, input.commandCommentId);
+      mkdirSync(evidenceDir, { recursive: true });
+      writeRedactedJson(join(evidenceDir, "consumed-authorization-incident.json"), {
+        reason: "exact_authorization_already_consumed",
+        repo,
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        commentId: input.commandCommentId,
+        consumedAt: consumption.consumedAt
+      });
+      return "skipped_consumed_authorization";
     }
   }
   if (
@@ -1451,7 +1490,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     if (current?.status !== "failed" && !isProviderCooldownProcessedReview(current ?? { status: "" })) {
       return "skipped_processed";
     }
-    const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision);
+    const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision, input.commandCommentId);
     const liveBeforeReview = await github.getPull(repo, pull.number);
     const staleBeforeReview = detectStalePullHead({ expected: pull, live: liveBeforeReview, phase: "before_review" });
     if (staleBeforeReview) {
@@ -1494,7 +1533,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   try {
     if (!acquireReviewCapacity()) return "skipped_capacity";
 
-    const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision);
+    const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision, input.commandCommentId);
     if (commandReviewRequested) {
       await recordAndAcknowledgeCommandDecision({ config, github, state, repo, pull, commandDecision });
     }
@@ -1906,14 +1945,17 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       body: reviewBodyAfterWalkthroughPost(plan),
       comments
     });
-    state.recordProcessed({
-      repo,
-      pullNumber: pull.number,
-      headSha: pull.head.sha,
-      status: "posted",
-      event: plan.event,
-      reviewUrl: review.html_url
-    });
+    const priorPosted = state.getProcessedReview(repo, pull.number, pull.head.sha);
+    if (!(priorPosted?.status === "posted" && priorPosted.event === "REQUEST_CHANGES" && plan.event === "COMMENT")) {
+      state.recordProcessed({
+        repo,
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        status: "posted",
+        event: plan.event,
+        reviewUrl: review.html_url
+      });
+    }
     // Public-safe findings ledger (#357): record the coordinates we just posted publicly so the
     // daemon calibration-observe pass can re-derive outcome labels later. BEST-EFFORT / FAIL-OPEN —
     // the review is already durable; observation bookkeeping must never block or fail the review.
@@ -1945,6 +1987,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       });
     }
     releaseReviewCapacity();
+    if (headChangedDuringPost) return "posted_stale_head";
+    if (postReviewHeadLookupFailed) return "posted_head_unverified";
     if (!headChangedDuringPost && !postReviewHeadLookupFailed && input.processedHeadPolicy !== "retry_failed_head") {
       await reconcileProcessedHeadAfterDirectReviewSafely({
         config,
@@ -2387,10 +2431,12 @@ function buildEvidenceDir(
   config: BotConfig,
   repo: string,
   pull: PullRequestSummary,
-  commandDecision: CommandDecision
+  commandDecision: CommandDecision,
+  commandCommentId?: number
 ): string {
   const evidenceBaseDir = join(config.evidenceDir, localDateFolder(), repo.replace("/", "__"), `pr-${pull.number}`, pull.head.sha);
-  return commandDecision.action !== "none" ? join(evidenceBaseDir, `command-${commandDecision.commandId}`) : evidenceBaseDir;
+  const scopedCommentId = commandDecision.action !== "none" ? commandDecision.commandId : commandCommentId;
+  return scopedCommentId ? join(evidenceBaseDir, `command-${scopedCommentId}`) : evidenceBaseDir;
 }
 
 function recordLicenseAdmissionBlock(input: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1244,6 +1244,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   }
 
   const processed = getProcessedReviewIfAvailable(state, repo, pull.number, pull.head.sha);
+  const reviewEventPolicyMode = config.reviewGate?.reviewEventPolicy?.mode ?? "trusted_command_only";
   if (
     input.processedHeadPolicy !== "retry_failed_head" &&
     !input.allowActivationBaselineCommandLookup &&
@@ -1392,7 +1393,19 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   }
 
   const commandReviewRequested = commandDecision.shouldReview;
-  if (commandReviewRequested) {
+  const exactOwnerReviewRequested = Boolean(
+    processed &&
+    input.commandCommentId &&
+    (await lookupQueuedReviewEventAuthorization({
+      mode: "trusted_command_only",
+      github,
+      repo,
+      pull,
+      commandCommentId: input.commandCommentId,
+      commandConfig: config.commands
+    })).status === "eligible"
+  );
+  if (commandReviewRequested || exactOwnerReviewRequested) {
     const livePull = await github.getPull(repo, pull.number);
     const stale = detectStalePullHead({ expected: pull, live: livePull, phase: "before_review" });
     if (stale) {
@@ -1404,6 +1417,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   if (
     input.processedHeadPolicy !== "retry_failed_head" &&
     !commandReviewRequested &&
+    !exactOwnerReviewRequested &&
     (processed || state.hasProcessed(repo, pull.number, pull.head.sha))
   ) {
     // This is a provider-free visibility repair for a GitHub review that is
@@ -1664,7 +1678,6 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     // and relies on sanitizePublicConfidenceText/redactSecrets idempotency tests.
     const dropped = sanitizeDroppedFindings(gate.dropped, config.confidenceCalibration?.publicDisplay);
     const candidateEvent = selfConsistency.event;
-    const reviewEventPolicyMode = config.reviewGate?.reviewEventPolicy?.mode ?? "trusted_command_only";
     const dryRunReviewEventResolution = input.dryRun
       ? await resolveReviewEventDecision({
           mode: reviewEventPolicyMode,
@@ -1812,9 +1825,17 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       pull,
       dryRun: false
     });
+    const reviewEventDecisionEvidence = buildReviewEventDecisionEvidence(reviewEventResolution, false);
+    if (
+      reviewEventResolution.consumed &&
+      await recordStaleHeadBeforePostIfMoved({ state, github, repo, pull, evidenceDir })
+    ) {
+      writeRedactedJson(join(evidenceDir, "review-event-decision.json"), reviewEventDecisionEvidence);
+      return "skipped_stale_head";
+    }
     writeRedactedJson(
       join(evidenceDir, "review-event-decision.json"),
-      buildReviewEventDecisionEvidence(reviewEventResolution, false)
+      reviewEventDecisionEvidence
     );
     plan.event = reviewEventResolution.decision.selectedEvent;
     if (config.walkthrough.enabled) {
@@ -1837,6 +1858,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     if (plan.enrichment) writeRedactedText(join(evidenceDir, "enrichment.md"), plan.enrichment.body);
 
     const reviewGithub = new GitHubApi(config.github);
+    const walkthroughPostAttempted = Boolean(plan.walkthrough?.postIssueComment && reviewGithub.canPostAsApp());
     plan.walkthroughComment = await postWalkthroughComment({
       github: reviewGithub,
       repo,
@@ -1844,6 +1866,15 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       evidenceDir,
       walkthrough: plan.walkthrough
     });
+    if (
+      walkthroughPostAttempted &&
+      await recordStaleHeadBeforePostIfMoved({ state, github, repo, pull, evidenceDir })
+    ) {
+      return "skipped_stale_head";
+    }
+    const enrichmentPostAttempted = Boolean(
+      config.enrichment?.enabled === true && plan.enrichment?.postIssueComment && reviewGithub.canPostAsApp()
+    );
     plan.enrichmentComment = await postEnrichmentComment({
       enabled: config.enrichment?.enabled === true,
       dryRun: input.dryRun,
@@ -1853,7 +1884,16 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       enrichment: plan.enrichment,
       evidenceDir
     });
+    if (
+      enrichmentPostAttempted &&
+      await recordStaleHeadBeforePostIfMoved({ state, github, repo, pull, evidenceDir })
+    ) {
+      return "skipped_stale_head";
+    }
     writeRedactedJson(join(evidenceDir, "review-plan.json"), plan);
+    if (await recordStaleHeadBeforePostIfMoved({ state, github, repo, pull, evidenceDir })) {
+      return "skipped_stale_head";
+    }
     const review = await reviewGithub.createReview({
       repo,
       pullNumber: pull.number,
@@ -1874,20 +1914,34 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     // daemon calibration-observe pass can re-derive outcome labels later. BEST-EFFORT / FAIL-OPEN —
     // the review is already durable; observation bookkeeping must never block or fail the review.
     recordPostedReviewFindings({ state, repo, pull, comments });
-    const liveAfterPost = await github.getPull(repo, pull.number);
-    const headChangedDuringPost = liveAfterPost.head.sha !== pull.head.sha;
-    if (headChangedDuringPost) {
-      writeRedactedJson(join(evidenceDir, "head-changed-during-post.json"), {
-        reason: "head_changed_during_post",
+    let headChangedDuringPost = false;
+    let postReviewHeadLookupFailed = false;
+    try {
+      const liveAfterPost = await github.getPull(repo, pull.number);
+      headChangedDuringPost = liveAfterPost.head.sha !== pull.head.sha;
+      if (headChangedDuringPost) {
+        writeRedactedJson(join(evidenceDir, "head-changed-during-post.json"), {
+          reason: "head_changed_during_post",
+          repo,
+          pullNumber: pull.number,
+          expectedHeadSha: pull.head.sha,
+          liveHeadSha: liveAfterPost.head.sha,
+          reviewId: review.id
+        });
+      }
+    } catch (error) {
+      postReviewHeadLookupFailed = true;
+      writeRedactedJson(join(evidenceDir, "post-review-head-lookup-failed.json"), {
+        reason: "post_review_head_lookup_failed",
         repo,
         pullNumber: pull.number,
         expectedHeadSha: pull.head.sha,
-        liveHeadSha: liveAfterPost.head.sha,
-        reviewId: review.id
+        reviewId: review.id,
+        error: redactSecrets(error instanceof Error ? error.message : String(error)).slice(0, 300)
       });
     }
     releaseReviewCapacity();
-    if (!headChangedDuringPost && input.processedHeadPolicy !== "retry_failed_head") {
+    if (!headChangedDuringPost && !postReviewHeadLookupFailed && input.processedHeadPolicy !== "retry_failed_head") {
       await reconcileProcessedHeadAfterDirectReviewSafely({
         config,
         github,
@@ -2710,6 +2764,20 @@ function recordStaleHeadSkip(input: {
     status: "skipped",
     error: `${input.stale.reason}: live=${input.stale.liveHeadSha}`
   });
+}
+
+async function recordStaleHeadBeforePostIfMoved(input: {
+  state: ReviewStateStore;
+  github: GitHubApi;
+  repo: string;
+  pull: PullRequestSummary;
+  evidenceDir: string;
+}): Promise<boolean> {
+  const live = await input.github.getPull(input.repo, input.pull.number);
+  const stale = detectStalePullHead({ expected: input.pull, live, phase: "before_post" });
+  if (!stale) return false;
+  recordStaleHeadSkip({ ...input, stale });
+  return true;
 }
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4,6 +4,7 @@ import { isPreActivationExistingPull } from "./activation-policy.js";
 import {
   buildCommandStatusBody,
   buildCommandStatusMarker,
+  collectReviewEventAuthorizationAttempts,
   collectTrustedReviewCommands,
   decideCommandAction,
   isFinishingTouchCommandAction,
@@ -47,6 +48,12 @@ import {
   resolveRepoProfile
 } from "./repo-policy.js";
 import { applyDeterministicReviewGate, type RepoMemoryFalsePositiveEntry } from "./review-gate.js";
+import {
+  decideReviewEventPolicy,
+  type ReviewEventAuthorizationAttempt,
+  type ReviewEventDecision,
+  type ReviewEventPolicyMode
+} from "./review-event-policy.js";
 import { selectReviewMode } from "./review-mode-router.js";
 import type { ReviewModeAnalysisPlan } from "./review-mode-types.js";
 import {
@@ -1656,7 +1663,22 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     // Gate output is already public-safe; this second pass keeps evidence redacted
     // and relies on sanitizePublicConfidenceText/redactSecrets idempotency tests.
     const dropped = sanitizeDroppedFindings(gate.dropped, config.confidenceCalibration?.publicDisplay);
-    const event = selfConsistency.event;
+    const candidateEvent = selfConsistency.event;
+    const reviewEventPolicyMode = config.reviewGate?.reviewEventPolicy?.mode ?? "trusted_command_only";
+    const dryRunReviewEventResolution = input.dryRun
+      ? await resolveReviewEventDecision({
+          mode: reviewEventPolicyMode,
+          candidateEvent,
+          github,
+          state,
+          repo,
+          pull,
+          commandCommentId: input.commandCommentId,
+          commandConfig: config.commands,
+          dryRun: true
+        })
+      : undefined;
+    const selectedEvent = dryRunReviewEventResolution?.decision.selectedEvent ?? candidateEvent;
     writeRedactedJson(join(evidenceDir, "deterministic-gate.json"), { ...gate, dropped });
     const summary = buildSummary({
       repo,
@@ -1673,7 +1695,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
           files: reviewFiles,
           comments,
           dropped,
-          event,
+          event: selectedEvent,
           validation,
           proof,
           settingsPreview,
@@ -1697,7 +1719,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         })
       : undefined;
     const plan: ReviewPlan = {
-      event,
+      event: selectedEvent,
       comments,
       dropped,
       summary,
@@ -1708,9 +1730,13 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       ...(enrichment ? { enrichment } : {})
     };
 
-    if (walkthrough) writeRedactedText(join(evidenceDir, "walkthrough.md"), walkthrough.body);
-    if (enrichment) writeRedactedText(join(evidenceDir, "enrichment.md"), enrichment.body);
+    if (input.dryRun && walkthrough) writeRedactedText(join(evidenceDir, "walkthrough.md"), walkthrough.body);
+    if (input.dryRun && enrichment) writeRedactedText(join(evidenceDir, "enrichment.md"), enrichment.body);
     if (input.dryRun) {
+      writeRedactedJson(
+        join(evidenceDir, "review-event-decision.json"),
+        buildReviewEventDecisionEvidence(dryRunReviewEventResolution!, true)
+      );
       writeDryRunOutcomeLedgerEvidence({
         evidenceDir,
         repo,
@@ -1731,12 +1757,12 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
             }
       });
     }
-    writeRedactedJson(join(evidenceDir, "review-plan.json"), plan);
+    if (input.dryRun) writeRedactedJson(join(evidenceDir, "review-plan.json"), plan);
 
     if (input.dryRun) {
       // Dry-run posts nothing public, so it does NOT acquire a per-head claim (#295): claiming would
       // add contention/TTL churn for a run that cannot violate the at-most-one-posted-review invariant.
-      state.recordProcessed({ repo, pullNumber: pull.number, headSha: pull.head.sha, status: "dry_run", event });
+      state.recordProcessed({ repo, pullNumber: pull.number, headSha: pull.head.sha, status: "dry_run", event: plan.event });
       return commandReviewRequested ? "reviewed_command" : "reviewed";
     }
 
@@ -1761,6 +1787,55 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       return "skipped_stale_head";
     }
 
+    const authorization = await lookupQueuedReviewEventAuthorization({
+      mode: reviewEventPolicyMode,
+      github,
+      repo,
+      pull,
+      commandCommentId: input.commandCommentId,
+      commandConfig: config.commands
+    });
+    if (reviewEventPolicyMode === "trusted_command_only") {
+      const liveBeforeConsume = await github.getPull(repo, pull.number);
+      const staleBeforeConsume = detectStalePullHead({ expected: pull, live: liveBeforeConsume, phase: "before_post" });
+      if (staleBeforeConsume) {
+        recordStaleHeadSkip({ state, repo, pull, stale: staleBeforeConsume, evidenceDir });
+        return "skipped_stale_head";
+      }
+    }
+    const reviewEventResolution = decideAndConsumeReviewEvent({
+      mode: reviewEventPolicyMode,
+      candidateEvent,
+      authorization,
+      state,
+      repo,
+      pull,
+      dryRun: false
+    });
+    writeRedactedJson(
+      join(evidenceDir, "review-event-decision.json"),
+      buildReviewEventDecisionEvidence(reviewEventResolution, false)
+    );
+    plan.event = reviewEventResolution.decision.selectedEvent;
+    if (config.walkthrough.enabled) {
+      plan.walkthrough = buildWalkthroughComment({
+        repo,
+        pull,
+        files: reviewFiles,
+        comments,
+        dropped,
+        event: plan.event,
+        validation,
+        proof,
+        settingsPreview,
+        provider: buildReviewProviderMetadata(config),
+        postIssueComment: config.walkthrough.postIssueComment,
+        publicConfidencePolicy: config.confidenceCalibration?.publicDisplay
+      });
+    }
+    if (plan.walkthrough) writeRedactedText(join(evidenceDir, "walkthrough.md"), plan.walkthrough.body);
+    if (plan.enrichment) writeRedactedText(join(evidenceDir, "enrichment.md"), plan.enrichment.body);
+
     const reviewGithub = new GitHubApi(config.github);
     plan.walkthroughComment = await postWalkthroughComment({
       github: reviewGithub,
@@ -1782,7 +1857,8 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     const review = await reviewGithub.createReview({
       repo,
       pullNumber: pull.number,
-      event,
+      headSha: pull.head.sha,
+      event: plan.event,
       body: reviewBodyAfterWalkthroughPost(plan),
       comments
     });
@@ -1791,15 +1867,27 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       pullNumber: pull.number,
       headSha: pull.head.sha,
       status: "posted",
-      event,
+      event: plan.event,
       reviewUrl: review.html_url
     });
     // Public-safe findings ledger (#357): record the coordinates we just posted publicly so the
     // daemon calibration-observe pass can re-derive outcome labels later. BEST-EFFORT / FAIL-OPEN —
     // the review is already durable; observation bookkeeping must never block or fail the review.
     recordPostedReviewFindings({ state, repo, pull, comments });
+    const liveAfterPost = await github.getPull(repo, pull.number);
+    const headChangedDuringPost = liveAfterPost.head.sha !== pull.head.sha;
+    if (headChangedDuringPost) {
+      writeRedactedJson(join(evidenceDir, "head-changed-during-post.json"), {
+        reason: "head_changed_during_post",
+        repo,
+        pullNumber: pull.number,
+        expectedHeadSha: pull.head.sha,
+        liveHeadSha: liveAfterPost.head.sha,
+        reviewId: review.id
+      });
+    }
     releaseReviewCapacity();
-    if (input.processedHeadPolicy !== "retry_failed_head") {
+    if (!headChangedDuringPost && input.processedHeadPolicy !== "retry_failed_head") {
       await reconcileProcessedHeadAfterDirectReviewSafely({
         config,
         github,
@@ -3391,6 +3479,128 @@ function retryFailureError(previousError: string | undefined, error: unknown): s
 
 function assertNever(value: never): never {
   throw new Error(`Unhandled retry status: ${String(value)}`);
+}
+
+interface ReviewEventResolution {
+  decision: ReviewEventDecision;
+  authorization: ReviewEventAuthorizationAttempt;
+  consumed: boolean;
+}
+
+async function resolveReviewEventDecision(input: {
+  mode: ReviewEventPolicyMode;
+  candidateEvent: ReviewEvent;
+  github: GitHubApi;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  commandCommentId?: number;
+  commandConfig: BotConfig["commands"];
+  dryRun: boolean;
+}): Promise<ReviewEventResolution> {
+  const authorization = await lookupQueuedReviewEventAuthorization({
+    mode: input.mode,
+    github: input.github,
+    repo: input.repo,
+    pull: input.pull,
+    commandCommentId: input.commandCommentId,
+    commandConfig: input.commandConfig
+  });
+  return decideAndConsumeReviewEvent({ ...input, authorization });
+}
+
+async function lookupQueuedReviewEventAuthorization(input: {
+  mode: ReviewEventPolicyMode;
+  github: GitHubApi;
+  repo: string;
+  pull: PullRequestSummary;
+  commandCommentId?: number;
+  commandConfig: BotConfig["commands"];
+}): Promise<ReviewEventAuthorizationAttempt> {
+  if (input.mode === "automatic") return { status: "missing" };
+  if (!input.commandCommentId) return { status: "missing" };
+
+  try {
+    const comment = await input.github.getIssueComment(input.repo, input.commandCommentId);
+    if (comment.id !== input.commandCommentId) {
+      return { status: "lookup_failed", commentId: input.commandCommentId };
+    }
+    const selected = collectReviewEventAuthorizationAttempts([comment], input.commandConfig, {
+      repo: input.repo,
+      pullNumber: input.pull.number,
+      headSha: input.pull.head.sha
+    }).selected;
+    return selected.status === "missing"
+      ? { status: "missing", commentId: input.commandCommentId }
+      : selected;
+  } catch {
+    return { status: "lookup_failed", commentId: input.commandCommentId };
+  }
+}
+
+function decideAndConsumeReviewEvent(input: {
+  mode: ReviewEventPolicyMode;
+  candidateEvent: ReviewEvent;
+  authorization: ReviewEventAuthorizationAttempt;
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  dryRun: boolean;
+}): ReviewEventResolution {
+  let authorization = input.authorization;
+  let consumed = false;
+  if (input.mode === "trusted_command_only" && !input.dryRun && authorization.status === "eligible") {
+    try {
+      consumed = input.state.tryConsumeReviewEventAuthorization({
+        repo: input.repo,
+        pullNumber: input.pull.number,
+        headSha: input.pull.head.sha,
+        commentId: authorization.commentId,
+        author: authorization.author
+      });
+      if (!consumed) {
+        authorization = {
+          status: "consumed",
+          author: authorization.author,
+          commentId: authorization.commentId
+        };
+      }
+    } catch {
+      authorization = {
+        status: "state_error",
+        author: authorization.author,
+        commentId: authorization.commentId
+      };
+    }
+  }
+
+  return {
+    decision: decideReviewEventPolicy({
+      mode: input.mode,
+      candidateEvent: input.candidateEvent,
+      headSha: input.pull.head.sha,
+      authorization
+    }),
+    authorization,
+    consumed
+  };
+}
+
+function buildReviewEventDecisionEvidence(resolution: ReviewEventResolution, dryRun: boolean): Record<string, unknown> {
+  const { decision, authorization } = resolution;
+  const author = decision.author ?? authorization.author;
+  const commentId = decision.commentId ?? authorization.commentId;
+  return {
+    candidateEvent: decision.candidateEvent,
+    selectedEvent: decision.selectedEvent,
+    mode: decision.mode,
+    reason: decision.reason,
+    headSha: decision.headSha,
+    ...(author ? { author } : {}),
+    ...(commentId ? { commentId } : {}),
+    consumed: resolution.consumed,
+    dryRun
+  };
 }
 
 async function resolvePullCommandDecision(input: {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   classifyCommandAuthorization,
+  collectReviewEventAuthorizationAttempts,
   collectTrustedReviewCommands,
   decideCommandAction,
   isBotCommandComment,
@@ -214,6 +215,67 @@ describe("public command authorization classification (#345)", () => {
     const reviewOnly = { ...trusted, publicCommands: { enabled: true, actions: ["review"] as Array<"review" | "re-review">, cooldownMinutes: 10 } };
     expect(classifyCommandAuthorization({ action: "review", author: "randopublic" }, reviewOnly)).toBe("public-eligible");
     expect(classifyCommandAuthorization({ action: "re-review", author: "randopublic" }, reviewOnly)).toBe("unauthorized");
+  });
+});
+
+describe("trusted request-changes authorization commands (#557)", () => {
+  const HEAD = "a".repeat(40);
+  const config = { enabled: true, botMentions: ["@neondiff"], trustedAuthors: ["100yenadmin"], acknowledge: false };
+  const target = { repo: "owner/repo", pullNumber: 7, headSha: HEAD };
+
+  it("collects an exact trusted command as bounded exact-head metadata and queues one review", () => {
+    const commandBody = `@neondiff request-changes --repo owner/repo --pr 7 --head ${HEAD.toUpperCase()}`;
+    const comments = [comment(41, "100yenadmin", commandBody)];
+    const attempts = collectReviewEventAuthorizationAttempts(comments, config, target);
+
+    expect(attempts.selected).toEqual({
+      status: "eligible",
+      author: "100yenadmin",
+      commentId: 41,
+      headSha: HEAD
+    });
+    expect(attempts).not.toHaveProperty("body");
+    expect(JSON.stringify(attempts)).not.toContain(commandBody);
+    expect(attempts.reviewRequests).toEqual([
+      { action: "request-changes", commentId: 41, author: "100yenadmin", repo: "owner/repo", pullNumber: 7, headSha: HEAD }
+    ]);
+  });
+
+  it("fails closed for malformed commands, mismatched targets, untrusted authors, and wildcard-only trust", () => {
+    const cases = [
+      { comment: comment(41, "100yenadmin", `@neondiff request-changes --repo owner/repo --pr 7 --head ${"a".repeat(39)}`), config, expected: "malformed" },
+      { comment: comment(42, "100yenadmin", `@neondiff request-changes --repo other/repo --pr 7 --head ${HEAD}`), config, expected: "stale_head" },
+      { comment: comment(43, "100yenadmin", `@neondiff request-changes --repo owner/repo --pr 8 --head ${HEAD}`), config, expected: "stale_head" },
+      { comment: comment(44, "100yenadmin", `@neondiff request-changes --repo owner/repo --pr 7 --head ${"b".repeat(40)}`), config, expected: "stale_head" },
+      { comment: comment(45, "outside", `@neondiff request-changes --repo owner/repo --pr 7 --head ${HEAD}`), config, expected: "untrusted" },
+      { comment: comment(46, "outside", `@neondiff request-changes --repo owner/repo --pr 7 --head ${HEAD}`), config: { ...config, trustedAuthors: ["*"] }, expected: "untrusted" },
+      { comment: comment(47, "100yenadmin", `@neondiff request-changes --pr 7 --repo owner/repo --head ${HEAD}`), config, expected: "malformed" },
+      { comment: comment(48, "100yenadmin", `@neondiff request-changes --repo owner/repo --pr 7 --head ${HEAD} extra`), config, expected: "malformed" }
+    ] as const;
+
+    for (const entry of cases) {
+      expect(collectReviewEventAuthorizationAttempts([entry.comment], entry.config, target).selected).toMatchObject({
+        status: entry.expected,
+        commentId: entry.comment.id
+      });
+    }
+  });
+
+  it("does not treat ordinary review or re-review commands as authorization attempts", () => {
+    const attempts = collectReviewEventAuthorizationAttempts([
+      comment(41, "100yenadmin", "@neondiff review"),
+      comment(42, "100yenadmin", "@neondiff re-review")
+    ], config, target);
+
+    expect(attempts).toEqual({ attempts: [], selected: { status: "missing" }, reviewRequests: [] });
+  });
+
+  it("deduplicates a repeated comment ID before returning review requests", () => {
+    const repeated = comment(41, "100yenadmin", `@neondiff request-changes --repo owner/repo --pr 7 --head ${HEAD}`);
+    const attempts = collectReviewEventAuthorizationAttempts([repeated, repeated], config, target);
+
+    expect(attempts.attempts).toHaveLength(1);
+    expect(attempts.reviewRequests).toHaveLength(1);
   });
 });
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -261,6 +261,25 @@ describe("trusted request-changes authorization commands (#557)", () => {
     }
   });
 
+  it("requires the entire trimmed body to be exactly one request-changes command", () => {
+    const command = `@neondiff request-changes --repo owner/repo --pr 7 --head ${HEAD}`;
+    const bodies = [
+      `Please review this carefully. ${command}`,
+      `${command} Thank you.`,
+      `\`\`\`text\n${command}\n\`\`\``,
+      `${command}\nThis must not be an embedded multi-line command.`
+    ];
+
+    for (const [index, body] of bodies.entries()) {
+      const attempts = collectReviewEventAuthorizationAttempts([comment(60 + index, "100yenadmin", body)], config, target);
+      expect(attempts).toEqual({
+        attempts: [{ status: "malformed", author: "100yenadmin", commentId: 60 + index }],
+        selected: { status: "malformed", author: "100yenadmin", commentId: 60 + index },
+        reviewRequests: []
+      });
+    }
+  });
+
   it("does not treat ordinary review or re-review commands as authorization attempts", () => {
     const attempts = collectReviewEventAuthorizationAttempts([
       comment(41, "100yenadmin", "@neondiff review"),

--- a/tests/confidence-config.test.ts
+++ b/tests/confidence-config.test.ts
@@ -122,11 +122,26 @@ describe("confidence calibration config", () => {
 });
 
 describe("review gate config", () => {
-  it("defaults review gate to the built-in inline comment cap without confidence floors", () => {
+  it("defaults review gate to the built-in inline comment cap and trusted-command-only event policy", () => {
     const config = loadConfigFromObject({});
 
-    expect(config.reviewGate).toMatchObject({ maxInlineComments: 25 });
+    expect(config.reviewGate).toMatchObject({
+      maxInlineComments: 25,
+      reviewEventPolicy: { mode: "trusted_command_only" }
+    });
     expect(config.reviewGate?.requestChangesConfidenceFloors).toBeUndefined();
+  });
+
+  it("accepts explicit automatic compatibility mode and rejects malformed review event policies", () => {
+    expect(loadConfigFromObject({ reviewGate: { reviewEventPolicy: { mode: "automatic" } } }).reviewGate?.reviewEventPolicy).toEqual({
+      mode: "automatic"
+    });
+    expect(() => loadConfigFromObject({ reviewGate: { reviewEventPolicy: { mode: "always_request_changes" } } })).toThrow(
+      /reviewGate\.reviewEventPolicy\.mode must be one of automatic or trusted_command_only/
+    );
+    expect(() => loadConfigFromObject({ reviewGate: { reviewEventPolicy: { mode: "automatic", extra: true } } })).toThrow(
+      /reviewGate\.reviewEventPolicy has unknown key "extra"; expected only mode/
+    );
   });
 
   it("accepts an explicit inline comment cap and per-severity confidence floors", () => {

--- a/tests/github-app-read.test.ts
+++ b/tests/github-app-read.test.ts
@@ -46,6 +46,98 @@ describe("GitHub App read authentication", () => {
     expect(readCall?.authorization).not.toBe("Bearer fallback-token");
   });
 
+  it("binds a created review to the validated expected commit", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-create-review-head-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    const headSha = "a".repeat(40);
+    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
+    globalThis.fetch = vi.fn(async (url, init) => {
+      calls.push({
+        url: String(url),
+        method: init?.method ?? "GET",
+        body: init?.body ? JSON.parse(String(init.body)) : undefined
+      });
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/app/installations/123/access_tokens")) {
+        return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      }
+      if (String(url).endsWith("/repos/owner/repo/pulls/42/reviews")) {
+        return jsonResponse({ id: 77, html_url: "https://github.test/review/77" });
+      }
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+    await github.createReview({
+      repo: "owner/repo",
+      pullNumber: 42,
+      headSha,
+      event: "COMMENT",
+      body: "Review summary",
+      comments: []
+    });
+
+    expect(calls.find((call) => call.url.endsWith("/repos/owner/repo/pulls/42/reviews"))).toMatchObject({
+      method: "POST",
+      body: {
+        commit_id: headSha,
+        event: "COMMENT",
+        body: "Review summary",
+        comments: []
+      }
+    });
+  });
+
+  it("reads only the exact queued issue comment id", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-exact-comment-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url) => {
+      calls.push(String(url));
+      if (String(url).endsWith("/repos/owner/repo/installation")) return jsonResponse({ id: 123 });
+      if (String(url).endsWith("/app/installations/123/access_tokens")) {
+        return jsonResponse({ token: "installation-token", expires_at: "2999-01-01T00:00:00Z" });
+      }
+      if (String(url).endsWith("/repos/owner/repo/issues/comments/41")) {
+        return jsonResponse({ id: 41, body: "bounded command", user: { login: "owner", type: "User" } });
+      }
+      return jsonResponse({ message: "unexpected" }, 404);
+    }) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+    await expect(github.getIssueComment("owner/repo", 41)).resolves.toMatchObject({ id: 41 });
+
+    expect(calls.filter((url) => url.includes("/issues/"))).toEqual([
+      expect.stringMatching(/\/repos\/owner\/repo\/issues\/comments\/41$/)
+    ]);
+  });
+
+  it("rejects an invalid review head before posting", async () => {
+    const root = mkdtempSync(join(tmpdir(), "github-app-create-review-invalid-head-"));
+    roots.push(root);
+    const privateKeyPath = join(root, "app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(privateKeyPath, privateKey.export({ type: "pkcs1", format: "pem" }));
+    globalThis.fetch = vi.fn(async () => jsonResponse({ message: "must not be called" }, 500)) as typeof fetch;
+
+    const github = new GitHubApi({ appId: "4184532", privateKeyPath });
+    await expect(github.createReview({
+      repo: "owner/repo",
+      pullNumber: 42,
+      headSha: "not-a-head",
+      event: "COMMENT",
+      body: "Review summary",
+      comments: []
+    })).rejects.toThrow(/headSha must be a 40-character hexadecimal commit SHA/);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it("preserves GitHub Enterprise API base paths for read calls", async () => {
     const calls: string[] = [];
     globalThis.fetch = vi.fn(async (url) => {

--- a/tests/neondiff-config-schema.test.ts
+++ b/tests/neondiff-config-schema.test.ts
@@ -123,6 +123,13 @@ describe("NeonDiff config schema draft", () => {
     }
 
     expect(get("properties.review.properties.profile.default", schema)).toBe("conservative");
+    expect(get("properties.reviewGate.properties.reviewEventPolicy.properties.mode.default", schema)).toBe(
+      "trusted_command_only"
+    );
+    expect(get("properties.reviewGate.properties.reviewEventPolicy.properties.mode.enum", schema)).toEqual([
+      "trusted_command_only",
+      "automatic"
+    ]);
     expect(get("properties.safetyGates.properties.mutation.properties.enabled.default", schema)).toBe(false);
     expect(get("properties.finishingTouches.properties.enabled.default", schema)).toBe(false);
     expect(get("properties.issueEnrichment.properties.enabled.default", schema)).toBe(false);
@@ -152,6 +159,31 @@ describe("NeonDiff config schema draft", () => {
     expect(get("$defs.repoSlug.pattern", schema)).toBe(
       "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?/[A-Za-z0-9](?:[A-Za-z0-9._-]{0,98}[A-Za-z0-9])?$"
     );
+  });
+
+  it("accepts the safe review-event default and only the explicit legacy compatibility mode", () => {
+    const validate = compileSchema();
+    const baseConfig = readJson(join(fixtureRoot, "valid-minimal.json"));
+
+    expectValidFixture(validate, "omitted review event policy", baseConfig);
+    for (const mode of ["trusted_command_only", "automatic"]) {
+      expectValidFixture(validate, `review event policy ${mode}`, {
+        ...baseConfig,
+        reviewGate: { reviewEventPolicy: { mode } }
+      });
+    }
+
+    const invalidErrors = validateConfig(validate, {
+      ...baseConfig,
+      reviewGate: { reviewEventPolicy: { mode: "always_request_changes" } }
+    });
+    expect(errorPaths(invalidErrors)).toContain("/reviewGate/reviewEventPolicy/mode");
+  });
+
+  it("publishes the safe runtime review-event mode in committed JSON examples", () => {
+    for (const path of ["config.example.json", "config.active-profiles.example.json"]) {
+      expect(get("reviewGate.reviewEventPolicy.mode", readJson(path)), path).toBe("trusted_command_only");
+    }
   });
 
   it("validates JSON fixtures against the published JSON Schema", () => {

--- a/tests/repo-policy.test.ts
+++ b/tests/repo-policy.test.ts
@@ -412,6 +412,11 @@ describe("repo profile registry", () => {
 
     expect(buildReviewSettingsPreview(config, profile)).toEqual({
       profile: "assertive",
+      reviewGate: {
+        reviewEventPolicy: {
+          mode: "trusted_command_only"
+        }
+      },
       sampleProfile: {
         id: "assertive",
         label: "Assertive",

--- a/tests/review-event-policy.test.ts
+++ b/tests/review-event-policy.test.ts
@@ -40,7 +40,8 @@ describe("review event policy", () => {
     ["malformed", { status: "malformed", commentId: 41 }],
     ["untrusted", { status: "untrusted", author: "outside-contributor", commentId: 41 }],
     ["stale head", { status: "stale_head", headSha: "b".repeat(40), author: "100yenadmin", commentId: 41 }],
-    ["lookup failure", { status: "lookup_failed" }]
+    ["lookup failure", { status: "lookup_failed" }],
+    ["consumed", { status: "consumed", author: "100yenadmin", commentId: 41 }]
   ] as const)("fails closed for %s authorization", (_label, authorization) => {
     expect(decideReviewEventPolicy({
       mode: "trusted_command_only",

--- a/tests/review-event-policy.test.ts
+++ b/tests/review-event-policy.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideReviewEventPolicy,
+  selectReviewEventAuthorizationAttempt,
+  type ReviewEventAuthorizationAttempt
+} from "../src/review-event-policy.js";
+
+const HEAD = "a".repeat(40);
+
+describe("review event policy", () => {
+  it("keeps the candidate event in explicit automatic compatibility mode", () => {
+    expect(decideReviewEventPolicy({
+      mode: "automatic",
+      candidateEvent: "REQUEST_CHANGES",
+      headSha: HEAD,
+      authorization: { status: "missing" }
+    })).toEqual({
+      candidateEvent: "REQUEST_CHANGES",
+      selectedEvent: "REQUEST_CHANGES",
+      mode: "automatic",
+      reason: "automatic",
+      headSha: HEAD
+    });
+  });
+
+  it("keeps a comment candidate advisory even with an eligible authorization", () => {
+    expect(decideReviewEventPolicy({
+      mode: "trusted_command_only",
+      candidateEvent: "COMMENT",
+      headSha: HEAD,
+      authorization: eligibleAuthorization()
+    })).toMatchObject({
+      selectedEvent: "COMMENT",
+      reason: "candidate_comment"
+    });
+  });
+
+  it.each([
+    ["missing", { status: "missing" }],
+    ["malformed", { status: "malformed", commentId: 41 }],
+    ["untrusted", { status: "untrusted", author: "outside-contributor", commentId: 41 }],
+    ["stale head", { status: "stale_head", headSha: "b".repeat(40), author: "100yenadmin", commentId: 41 }],
+    ["lookup failure", { status: "lookup_failed" }]
+  ] as const)("fails closed for %s authorization", (_label, authorization) => {
+    expect(decideReviewEventPolicy({
+      mode: "trusted_command_only",
+      candidateEvent: "REQUEST_CHANGES",
+      headSha: HEAD,
+      authorization
+    })).toMatchObject({
+      selectedEvent: "COMMENT",
+      reason: `authorization_${authorization.status}`
+    });
+  });
+
+  it("permits REQUEST_CHANGES only for an eligible exact normalized head", () => {
+    const decision = decideReviewEventPolicy({
+      mode: "trusted_command_only",
+      candidateEvent: "REQUEST_CHANGES",
+      headSha: HEAD,
+      authorization: {
+        ...eligibleAuthorization({ headSha: HEAD.toUpperCase() }),
+        commandBody: "@neondiff request-changes --repo owner/repo --pr 7 --head secret"
+      } as ReviewEventAuthorizationAttempt
+    });
+
+    expect(decision).toMatchObject({
+      selectedEvent: "REQUEST_CHANGES",
+      reason: "authorization_eligible",
+      headSha: HEAD,
+      author: "100yenadmin",
+      commentId: 41
+    });
+    expect(decision).not.toHaveProperty("commandBody");
+  });
+
+  it("downgrades an incorrectly labelled eligible authorization for another head", () => {
+    expect(decideReviewEventPolicy({
+      mode: "trusted_command_only",
+      candidateEvent: "REQUEST_CHANGES",
+      headSha: HEAD,
+      authorization: eligibleAuthorization({ headSha: "b".repeat(40) })
+    })).toMatchObject({
+      selectedEvent: "COMMENT",
+      reason: "authorization_stale_head"
+    });
+  });
+
+  it("fails closed when an eligible authorization has an invalid head", () => {
+    expect(decideReviewEventPolicy({
+      mode: "trusted_command_only",
+      candidateEvent: "REQUEST_CHANGES",
+      headSha: "not-a-sha",
+      authorization: eligibleAuthorization({ headSha: "also-not-a-sha" })
+    })).toMatchObject({
+      selectedEvent: "COMMENT",
+      reason: "authorization_stale_head"
+    });
+  });
+
+  it("selects an eligible authorization for the exact head without retaining command text", () => {
+    const attempts: ReviewEventAuthorizationAttempt[] = [
+      { status: "malformed", author: "100yenadmin", commentId: 40 },
+      { status: "eligible", headSha: "b".repeat(40), author: "100yenadmin", commentId: 41 },
+      eligibleAuthorization({ commentId: 42 })
+    ];
+
+    expect(selectReviewEventAuthorizationAttempt(attempts, HEAD)).toEqual(eligibleAuthorization({ commentId: 42 }));
+  });
+});
+
+function eligibleAuthorization(overrides: Partial<Extract<ReviewEventAuthorizationAttempt, { status: "eligible" }>> = {}) {
+  return {
+    status: "eligible" as const,
+    headSha: HEAD,
+    author: "100yenadmin",
+    commentId: 41,
+    ...overrides
+  };
+}

--- a/tests/review-event-policy.test.ts
+++ b/tests/review-event-policy.test.ts
@@ -41,7 +41,8 @@ describe("review event policy", () => {
     ["untrusted", { status: "untrusted", author: "outside-contributor", commentId: 41 }],
     ["stale head", { status: "stale_head", headSha: "b".repeat(40), author: "100yenadmin", commentId: 41 }],
     ["lookup failure", { status: "lookup_failed" }],
-    ["consumed", { status: "consumed", author: "100yenadmin", commentId: 41 }]
+    ["consumed", { status: "consumed", author: "100yenadmin", commentId: 41 }],
+    ["state error", { status: "state_error", author: "100yenadmin", commentId: 41 }]
   ] as const)("fails closed for %s authorization", (_label, authorization) => {
     expect(decideReviewEventPolicy({
       mode: "trusted_command_only",

--- a/tests/run-once-cli.test.ts
+++ b/tests/run-once-cli.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parsePositiveInteger } from "../src/cli-args.js";
 import { buildRunOnceCliReport, runOnceCliCommand, runOnceCliExitCode, serializeRunOnceCliReport } from "../src/run-once-cli.js";
-import { assertExpectedReviewPrHead, type RunOnceResult } from "../src/worker.js";
+import { applyReviewPullResultToRunOnceResult, assertExpectedReviewPrHead, type ReviewPullResult, type RunOnceResult } from "../src/worker.js";
 import type { ProductionLicenseAdmission } from "../src/license-admission.js";
 
 describe("run-once CLI reporting", () => {
@@ -134,6 +134,17 @@ describe("run-once CLI reporting", () => {
       }
     });
     expect(runOnceCliExitCode(result)).toBe(1);
+  });
+
+  it.each([
+    ["posted_stale_head", 0, true],
+    ["posted_head_unverified", 1, false],
+    ["skipped_consumed_authorization", 1, false]
+  ] as const)("reports legacy run-once status %s exhaustively", (status, exitCode, ok) => {
+    const result = runOnceResult();
+    applyReviewPullResultToRunOnceResult(result, status as ReviewPullResult);
+    expect(buildRunOnceCliReport({ result, dryRun: false, useZCode: true })).toMatchObject({ ok, result });
+    expect(runOnceCliExitCode(result)).toBe(exitCode);
   });
 
   it("keeps broad-scan license gate skips ok so intentional proof blocks do not fail the sweep", () => {

--- a/tests/run-once-result.test.ts
+++ b/tests/run-once-result.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { applyReviewPullResultToRunOnceResult, type RunOnceResult } from "../src/worker.js";
+
+function emptyResult(): RunOnceResult {
+  return {
+    reposScanned: 1,
+    pullsSeen: 1,
+    reviewed: 0,
+    failed: 0,
+    skippedDraft: 0,
+    skippedCanary: 0,
+    skippedPolicy: 0,
+    skippedLicenseGate: 0,
+    skippedCommandStop: 0,
+    skippedCommandExplain: 0,
+    skippedFinishingTouchDraft: 0,
+    commandReviewRequested: 0,
+    skippedProcessed: 0,
+    skippedCapacity: 0,
+    skippedContextBudget: 0,
+    skippedProviderCooldown: 0,
+    skippedStaleHead: 0,
+    baselinedExisting: 0,
+    policySkips: []
+  };
+}
+
+describe("runOnce review result aggregation", () => {
+  it.each([
+    ["posted_stale_head", { skippedStaleHead: 1, failed: 0 }],
+    ["posted_head_unverified", { skippedStaleHead: 0, failed: 1 }],
+    ["skipped_consumed_authorization", { skippedStaleHead: 0, failed: 1 }]
+  ] as const)("maps %s without counting a completed review", (status, expected) => {
+    const result = emptyResult();
+    applyReviewPullResultToRunOnceResult(result, status);
+    expect(result).toMatchObject({ reviewed: 0, ...expected });
+  });
+});

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -3942,6 +3942,319 @@ describe("provider-aware review scheduler", () => {
     });
     state.close();
   });
+
+  it("queues an exact trusted request-changes command over an already-posted advisory", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-request-changes-advisory-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@neondiff"],
+      trustedAuthors: ["maintainer"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    state.recordProcessed({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      status: "posted",
+      event: "COMMENT"
+    });
+    const comments = new Map([["org/repo-a#1", [
+      comment(901, "maintainer", `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`)
+    ]]]);
+    const seenCommentIds: Array<number | undefined> = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), comments),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull, commandCommentId }) => {
+        seenCommentIds.push(commandCommentId);
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event: "REQUEST_CHANGES"
+        });
+        return "reviewed_command";
+      }
+    });
+
+    expect(result.commandReviewRequested).toBe(1);
+    expect(seenCommentIds).toEqual([901]);
+    expect(state.listReviewQueueJobs({ state: "posted" })).toEqual([
+      expect.objectContaining({ source: "manual_command", lane: "manual", commentId: 901 })
+    ]);
+    expect(state.hasProcessedCommand("org/repo-a", 1, HEAD_A, 901)).toBe(true);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "needs_fix",
+      reason: "request_changes_review_posted",
+      event: "REQUEST_CHANGES",
+      commandAction: "request-changes",
+      commandCommentId: 901
+    });
+    state.close();
+  });
+
+  it("does not re-enqueue the same request-changes comment after its job becomes terminal", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-request-changes-dedupe-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@neondiff"],
+      trustedAuthors: ["maintainer"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const comments = new Map([["org/repo-a#1", [
+      comment(902, "maintainer", `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`)
+    ]]]);
+    const github = githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), comments);
+    let reviewCalls = 0;
+    const reviewPullImpl: (input: ReviewPullInput) => Promise<ReviewPullResult> = async ({ state: reviewState, repo, pull: reviewPull }) => {
+      reviewCalls += 1;
+      reviewState.recordProcessed({
+        repo,
+        pullNumber: reviewPull.number,
+        headSha: reviewPull.head.sha,
+        status: "posted",
+        event: "COMMENT"
+      });
+      return "reviewed_command";
+    };
+
+    const first = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl
+    });
+    const second = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl
+    });
+
+    expect(first.commandReviewRequested).toBe(1);
+    expect(second.commandReviewRequested).toBe(0);
+    expect(reviewCalls).toBe(1);
+    expect(state.listReviewQueueJobs()).toHaveLength(1);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "ready_for_human",
+      event: "COMMENT",
+      commandAction: "request-changes",
+      commandCommentId: 902
+    });
+    state.close();
+  });
+
+  it("queues a second new same-head command while the one-shot ledger keeps it advisory", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-request-changes-second-command-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@neondiff"],
+      trustedAuthors: ["maintainer"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const commentsForPull = [
+      comment(940, "maintainer", `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`)
+    ];
+    const comments = new Map([["org/repo-a#1", commentsForPull]]);
+    const github = githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), comments);
+    const selectedEvents: string[] = [];
+    const reviewPullImpl: (input: ReviewPullInput) => Promise<ReviewPullResult> = async ({
+      state: reviewState,
+      repo,
+      pull: reviewPull,
+      commandCommentId
+    }) => {
+      const consumed = reviewState.tryConsumeReviewEventAuthorization({
+        repo,
+        pullNumber: reviewPull.number,
+        headSha: reviewPull.head.sha,
+        commentId: commandCommentId!,
+        author: "maintainer"
+      });
+      const event = consumed ? "REQUEST_CHANGES" as const : "COMMENT" as const;
+      selectedEvents.push(event);
+      reviewState.recordProcessed({
+        repo,
+        pullNumber: reviewPull.number,
+        headSha: reviewPull.head.sha,
+        status: "posted",
+        event
+      });
+      return "reviewed_command";
+    };
+
+    const first = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl
+    });
+    commentsForPull.push(
+      comment(941, "maintainer", `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`)
+    );
+    const second = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl
+    });
+
+    expect(first.commandReviewRequested).toBe(1);
+    expect(second.commandReviewRequested).toBe(1);
+    expect(selectedEvents).toEqual(["REQUEST_CHANGES", "COMMENT"]);
+    expect(state.listReviewQueueJobs().map((job) => job.commentId)).toEqual([940, 941]);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "ready_for_human",
+      event: "COMMENT",
+      commandAction: "request-changes",
+      commandCommentId: 941
+    });
+    state.close();
+  });
+
+  for (const newerAction of ["review", "re-review"] as const) {
+    it(`does not let a newer ${newerAction} command erase exact request-changes authority`, async () => {
+      const root = mkdtempSync(join(tmpdir(), `neondiff-scheduler-request-changes-${newerAction}-`));
+      roots.push(root);
+      const config = schedulerConfig(root, ["org/repo-a"]);
+      config.commands = {
+        enabled: true,
+        botMentions: ["@neondiff"],
+        trustedAuthors: ["maintainer"],
+        acknowledge: false
+      };
+      const state = new ReviewStateStore(config.statePath);
+      const comments = new Map([["org/repo-a#1", [
+        comment(910, "maintainer", `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`),
+        comment(911, "maintainer", `@neondiff ${newerAction}`)
+      ]]]);
+      const seenCommentIds: Array<number | undefined> = [];
+
+      const result = await runScheduledCycleWithDeps({
+        config,
+        github: githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), comments),
+        state,
+        options: { dryRun: false, useZCode: false },
+        reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull, commandCommentId }) => {
+          seenCommentIds.push(commandCommentId);
+          reviewState.recordProcessed({
+            repo,
+            pullNumber: reviewPull.number,
+            headSha: reviewPull.head.sha,
+            status: "posted",
+            event: "REQUEST_CHANGES"
+          });
+          return "reviewed_command";
+        }
+      });
+
+      expect(result.commandReviewRequested).toBe(1);
+      expect(seenCommentIds).toEqual([910]);
+      expect(state.hasProcessedCommand("org/repo-a", 1, HEAD_A, 910)).toBe(true);
+      expect(state.hasProcessedCommand("org/repo-a", 1, HEAD_A, 911)).toBe(false);
+      state.close();
+    });
+  }
+
+  it("keeps a newer stop ahead of an older request-changes authorization across scans", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-request-changes-stop-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@neondiff"],
+      trustedAuthors: ["maintainer"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const comments = new Map([["org/repo-a#1", [
+      comment(920, "maintainer", `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`),
+      comment(921, "maintainer", "@neondiff stop")
+    ]]]);
+    const github = githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), comments);
+
+    const first = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: reviewPull
+    });
+    const second = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: reviewPull
+    });
+
+    expect(first.skippedCommandStop).toBe(1);
+    expect(first.commandReviewRequested).toBe(0);
+    expect(second.commandReviewRequested).toBe(0);
+    expect(state.listReviewQueueJobs().some((job) => job.commentId === 920)).toBe(false);
+    state.close();
+  });
+
+  it("does not queue untrusted, wildcard-only, malformed, or stale request-changes attempts", async () => {
+    const cases = [
+      { name: "untrusted", trustedAuthors: ["maintainer"], author: "outside", body: `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}` },
+      { name: "wildcard-only", trustedAuthors: ["*"], author: "outside", body: `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}` },
+      { name: "malformed", trustedAuthors: ["maintainer"], author: "maintainer", body: `@neondiff request-changes --pr 1 --repo org/repo-a --head ${HEAD_A}` },
+      { name: "stale", trustedAuthors: ["maintainer"], author: "maintainer", body: `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_B}` }
+    ];
+
+    for (const testCase of cases) {
+      const root = mkdtempSync(join(tmpdir(), `neondiff-scheduler-request-changes-denied-${testCase.name}-`));
+      roots.push(root);
+      const config = schedulerConfig(root, ["org/repo-a"]);
+      config.commands = {
+        enabled: true,
+        botMentions: ["@neondiff"],
+        trustedAuthors: testCase.trustedAuthors,
+        acknowledge: false
+      };
+      const state = new ReviewStateStore(config.statePath);
+      const comments = new Map([["org/repo-a#1", [comment(930, testCase.author, testCase.body)]]]);
+
+      const result = await runScheduledCycleWithDeps({
+        config,
+        github: githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), comments),
+        state,
+        options: { dryRun: false, useZCode: false },
+        reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+          reviewState.recordProcessed({
+            repo,
+            pullNumber: reviewPull.number,
+            headSha: reviewPull.head.sha,
+            status: "posted",
+            event: "COMMENT"
+          });
+          return "reviewed";
+        }
+      });
+
+      expect(result.commandReviewRequested, testCase.name).toBe(0);
+      expect(state.listReviewQueueJobs().filter((job) => job.source === "manual_command"), testCase.name).toEqual([]);
+      state.close();
+    }
+  });
 });
 
 function schedulerConfig(root: string, repos: string[]): BotConfig {

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -339,6 +339,104 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it.each([
+    ["posted_head_unverified", "post_review_head_unverified", "failed"],
+    ["posted_stale_head", "review_posted_head_changed", "stale"]
+  ] as const)("keeps %s terminal across later scheduler cycles", async (workerStatus, marker, readinessState) => {
+    const root = mkdtempSync(join(tmpdir(), `evaos-scheduler-${workerStatus}-durable-`));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const statusCalls: StatusCommentCall[] = [];
+    const github = githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), new Map(), statusCalls);
+    let reviewCalls = 0;
+    const reviewPullImpl: (input: ReviewPullInput) => Promise<ReviewPullResult> = async ({ state: reviewState }) => {
+      reviewCalls += 1;
+      reviewState.recordProcessed({
+        repo: "org/repo-a",
+        pullNumber: 1,
+        headSha: HEAD_A,
+        status: "posted",
+        event: "REQUEST_CHANGES",
+        reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-unverified",
+        error: marker
+      });
+      return workerStatus;
+    };
+
+    await runScheduledCycleWithDeps({ config, github, state, options: { dryRun: false }, reviewPullImpl });
+    const readinessAfterIncident = state.getReviewReadiness("org/repo-a", 1, HEAD_A);
+    await runScheduledCycleWithDeps({ config, github, state, options: { dryRun: false }, reviewPullImpl });
+
+    expect(reviewCalls).toBe(1);
+    expect(state.getProcessedReview("org/repo-a", 1, HEAD_A)).toMatchObject({
+      status: "posted",
+      error: marker
+    });
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toEqual(readinessAfterIncident);
+    expect(readinessAfterIncident).toMatchObject({ state: readinessState, reason: marker });
+    expect(statusCalls.map(statusFromBody)).not.toContain("completed");
+    state.close();
+  });
+
+  it("turns a consumed manual replay into a terminal tombstone and never enqueues automatic same-head work", async () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-consumed-replay-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@neondiff"],
+      trustedAuthors: ["maintainer"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    expect(state.tryConsumeReviewEventAuthorization({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      commentId: 930,
+      author: "maintainer"
+    })).toBe(true);
+    const comments = new Map([["org/repo-a#1", [
+      comment(930, "maintainer", `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`)
+    ]]]);
+    const github = githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), comments);
+    let reviewCalls = 0;
+    const trackedReviewPull: (input: ReviewPullInput) => Promise<ReviewPullResult> = async (input) => {
+      reviewCalls += 1;
+      return reviewPull(input);
+    };
+
+    const replay = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: trackedReviewPull
+    });
+    comments.set("org/repo-a#1", []);
+    const automatic = await runScheduledCycleWithDeps({
+      config,
+      github,
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: trackedReviewPull
+    });
+
+    expect(replay.failed).toBe(1);
+    expect(automatic.reviewed).toBe(0);
+    expect(reviewCalls).toBe(1);
+    expect(state.getProcessedReview("org/repo-a", 1, HEAD_A)).toMatchObject({
+      status: "skipped",
+      error: "exact_authorization_already_consumed"
+    });
+    expect(state.listReviewQueueJobs()).toHaveLength(1);
+    expect(state.listReviewQueueJobs({ state: "failed" })).toHaveLength(1);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({ state: "failed" });
+    state.close();
+  });
+
   it("maps context-budget skips into skipped readiness and failed durable queue state", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-context-budget-skip-"));
     roots.push(root);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -297,6 +297,48 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it.each([
+    ["posted_stale_head", "stale_retired", "stale", "stale_head"],
+    ["posted_head_unverified", "failed", "failed", "failed"],
+    ["skipped_consumed_authorization", "failed", "failed", "failed"]
+  ] as const)("does not advertise %s as a completed review", async (workerStatus, queueState, readinessState, publicState) => {
+    const root = mkdtempSync(join(tmpdir(), `evaos-scheduler-${workerStatus}-`));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.reviewStatusComment!.enabled = true;
+    const state = new ReviewStateStore(config.statePath);
+    const statusCalls: StatusCommentCall[] = [];
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), new Map(), statusCalls),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        if (workerStatus !== "skipped_consumed_authorization") {
+          reviewState.recordProcessed({
+            repo,
+            pullNumber: reviewPull.number,
+            headSha: reviewPull.head.sha,
+            status: "posted",
+            event: "REQUEST_CHANGES",
+            reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-incident"
+          });
+        }
+        return workerStatus;
+      },
+      now: new Date("2026-07-13T00:00:00.000Z")
+    });
+
+    expect(result.reviewed).toBe(0);
+    expect(result.queue.completed).toBe(0);
+    expect(state.listReviewQueueJobs({ state: queueState })).toHaveLength(1);
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({ state: readinessState });
+    expect(statusCalls.map(statusFromBody)).toEqual(["queued", "in_progress", publicState]);
+    expect(statusCalls.map(statusFromBody)).not.toContain("completed");
+    state.close();
+  });
+
   it("maps context-budget skips into skipped readiness and failed durable queue state", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-context-budget-skip-"));
     roots.push(root);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -322,7 +322,8 @@ describe("provider-aware review scheduler", () => {
             headSha: reviewPull.head.sha,
             status: "posted",
             event: "REQUEST_CHANGES",
-            reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-incident"
+            reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-incident",
+            error: workerStatus === "posted_stale_head" ? "review_posted_head_changed" : "post_review_head_unverified"
           });
         }
         return workerStatus;
@@ -436,6 +437,56 @@ describe("provider-aware review scheduler", () => {
     expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({ state: "failed" });
     state.close();
   });
+
+  it.each(["posted_head_unverified", "posted_stale_head"] as const)(
+    "keeps prior verified REQUEST_CHANGES readiness after a later advisory returns %s",
+    async (workerStatus) => {
+      const root = mkdtempSync(join(tmpdir(), `evaos-scheduler-prior-blocking-${workerStatus}-`));
+      roots.push(root);
+      const config = schedulerConfig(root, ["org/repo-a"]);
+      const state = new ReviewStateStore(config.statePath);
+      const reviewUrl = "https://github.com/org/repo-a/pull/1#pullrequestreview-blocking";
+      state.recordProcessed({
+        repo: "org/repo-a",
+        pullNumber: 1,
+        headSha: HEAD_A,
+        status: "posted",
+        event: "REQUEST_CHANGES",
+        reviewUrl
+      });
+      let reviewCalls = 0;
+      const reviewPullImpl: (input: ReviewPullInput) => Promise<ReviewPullResult> = async () => {
+        reviewCalls += 1;
+        return workerStatus;
+      };
+      const comments = new Map([["org/repo-a#1", [
+        comment(931, "maintainer", `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`)
+      ]]]);
+      config.commands = {
+        enabled: true,
+        botMentions: ["@neondiff"],
+        trustedAuthors: ["maintainer"],
+        acknowledge: false
+      };
+      const github = githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), comments);
+
+      await runScheduledCycleWithDeps({ config, github, state, options: { dryRun: false }, reviewPullImpl });
+      const immediate = state.getReviewReadiness("org/repo-a", 1, HEAD_A);
+      comments.set("org/repo-a#1", []);
+      await runScheduledCycleWithDeps({ config, github, state, options: { dryRun: false }, reviewPullImpl });
+
+      expect(reviewCalls).toBe(1);
+      expect(state.getProcessedReview("org/repo-a", 1, HEAD_A)).toMatchObject({
+        status: "posted",
+        event: "REQUEST_CHANGES",
+        reviewUrl
+      });
+      expect(state.getProcessedReview("org/repo-a", 1, HEAD_A)?.error).toBeUndefined();
+      expect(immediate).toMatchObject({ state: "needs_fix", event: "REQUEST_CHANGES", reviewUrl });
+      expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toEqual(immediate);
+      state.close();
+    }
+  );
 
   it("maps context-budget skips into skipped readiness and failed durable queue state", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-context-budget-skip-"));

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1658,6 +1658,30 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("uses the SQLite one-shot key across independent state-store connections", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-event-authorization-connections-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const first = new ReviewStateStore(dbPath);
+    const second = new ReviewStateStore(dbPath);
+    const authorization = {
+      repo: "owner/repo",
+      pullNumber: 7,
+      headSha: "e".repeat(40),
+      commentId: 41,
+      author: "100yenadmin"
+    };
+
+    try {
+      expect(first.tryConsumeReviewEventAuthorization(authorization)).toBe(true);
+      expect(second.tryConsumeReviewEventAuthorization({ ...authorization, commentId: 42 })).toBe(false);
+      expect(second.tryConsumeReviewEventAuthorization({ ...authorization, commentId: 43, headSha: "f".repeat(40) })).toBe(true);
+    } finally {
+      first.close();
+      second.close();
+    }
+  });
+
   it("adds authorization state to a legacy database without losing prior rows", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-review-event-authorization-legacy-"));
     roots.push(root);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1635,6 +1635,70 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("atomically consumes a trusted owner authorization once per exact review head", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-event-authorization-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const authorization = {
+      repo: "owner/repo",
+      pullNumber: 7,
+      headSha: "A".repeat(40),
+      commentId: 41,
+      author: "100yenadmin"
+    };
+
+    expect(store.tryConsumeReviewEventAuthorization(authorization)).toBe(true);
+    expect(store.tryConsumeReviewEventAuthorization({ ...authorization, commentId: 42 })).toBe(false);
+    expect(store.tryConsumeReviewEventAuthorization({ ...authorization, commentId: 42, headSha: "b".repeat(40) })).toBe(true);
+    expect(() => store.tryConsumeReviewEventAuthorization({ ...authorization, repo: "invalid" })).toThrow("repo must be an owner/repo name");
+    expect(() => store.tryConsumeReviewEventAuthorization({ ...authorization, pullNumber: 0 })).toThrow("pullNumber must be a positive integer");
+    expect(() => store.tryConsumeReviewEventAuthorization({ ...authorization, headSha: "short" })).toThrow("headSha must be a 40-character hexadecimal SHA");
+    expect(() => store.tryConsumeReviewEventAuthorization({ ...authorization, commentId: 0 })).toThrow("commentId must be a positive integer");
+    expect(() => store.tryConsumeReviewEventAuthorization({ ...authorization, author: "" })).toThrow("author must be a non-empty string");
+    store.close();
+  });
+
+  it("adds authorization state to a legacy database without losing prior rows", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-event-authorization-legacy-"));
+    roots.push(root);
+    const dbPath = join(root, "state.sqlite");
+    const legacyDb = new DatabaseSync(dbPath);
+    legacyDb.exec(`
+      create table processed_reviews (
+        repo text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        status text not null,
+        event text,
+        review_url text,
+        error text,
+        created_at text not null default (datetime('now')),
+        primary key (repo, pull_number, head_sha)
+      );
+      insert into processed_reviews (repo, pull_number, head_sha, status) values ('owner/repo', 7, '${"c".repeat(40)}', 'posted');
+    `);
+    legacyDb.close();
+
+    const store = new ReviewStateStore(dbPath);
+    expect(store.hasProcessed("owner/repo", 7, "c".repeat(40))).toBe(true);
+    expect(store.tryConsumeReviewEventAuthorization({
+      repo: "owner/repo",
+      pullNumber: 7,
+      headSha: "d".repeat(40),
+      commentId: 42,
+      author: "100yenadmin"
+    })).toBe(true);
+    store.close();
+
+    const migratedDb = new DatabaseSync(dbPath);
+    try {
+      expect(migratedDb.prepare("select count(*) as count from processed_reviews").get()).toEqual({ count: 1 });
+      expect(migratedDb.prepare("select count(*) as count from review_event_authorization_consumptions").get()).toEqual({ count: 1 });
+    } finally {
+      migratedDb.close();
+    }
+  });
+
   it("records finishing-touch draft outputs per command and head", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-finishing-touch-state-"));
     roots.push(root);

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1647,7 +1647,16 @@ describe("review state store", () => {
       author: "100yenadmin"
     };
 
-    expect(store.tryConsumeReviewEventAuthorization(authorization)).toBe(true);
+    expect(store.getReviewEventAuthorizationConsumption("owner/repo", 7, "A".repeat(40))).toBeUndefined();
+    expect(store.tryConsumeReviewEventAuthorization({ ...authorization, now: new Date("2026-07-13T00:00:00.000Z") })).toBe(true);
+    expect(store.getReviewEventAuthorizationConsumption("owner/repo", 7, "A".repeat(40))).toEqual({
+      repo: "owner/repo",
+      pullNumber: 7,
+      headSha: "a".repeat(40),
+      commentId: 41,
+      author: "100yenadmin",
+      consumedAt: "2026-07-13T00:00:00.000Z"
+    });
     expect(store.tryConsumeReviewEventAuthorization({ ...authorization, commentId: 42 })).toBe(false);
     expect(store.tryConsumeReviewEventAuthorization({ ...authorization, commentId: 42, headSha: "b".repeat(40) })).toBe(true);
     expect(() => store.tryConsumeReviewEventAuthorization({ ...authorization, repo: "invalid" })).toThrow("repo must be an owner/repo name");

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -14,10 +14,15 @@ const zcodeFailuresByPath = vi.hoisted(() => new Map<string, string>());
 const createdReviews = vi.hoisted((): Array<{
   repo: string;
   pullNumber: number;
+  headSha: string;
   event: string;
   body: string;
   comments: Array<{ path: string; line: number; title: string }>;
 }> => []);
+const reviewPostControl = vi.hoisted((): {
+  error?: Error;
+  afterCreate?: () => void;
+} => ({}));
 
 vi.mock("../src/git.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/git.js")>();
@@ -66,11 +71,14 @@ vi.mock("../src/github.js", async (importOriginal) => {
       async createReview(input: {
         repo: string;
         pullNumber: number;
+        headSha: string;
         event: string;
         body: string;
         comments: Array<{ path: string; line: number; title: string }>;
       }): Promise<{ html_url: string; id: number }> {
+        if (reviewPostControl.error) throw reviewPostControl.error;
         createdReviews.push(input);
+        reviewPostControl.afterCreate?.();
         return {
           html_url: `https://github.com/${input.repo}/pull/${input.pullNumber}#pullrequestreview-${createdReviews.length}`,
           id: createdReviews.length
@@ -99,6 +107,8 @@ describe("worker context budget preflight", () => {
     zcodeFindingsByPath.clear();
     zcodeFailuresByPath.clear();
     createdReviews.length = 0;
+    delete reviewPostControl.error;
+    delete reviewPostControl.afterCreate;
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   });
 
@@ -573,7 +583,402 @@ describe("worker context budget preflight", () => {
     expect(existsSync(join(evidenceDir, "review-error.json"))).toBe(false);
     state.close();
   });
+
+  it("downgrades an unauthorized P1 candidate to COMMENT without dropping inline findings", async () => {
+    const scenario = await runOwnerPolicyReview({ roots, pullNumber: 501, enableWalkthrough: true });
+
+    expect(scenario.result).toBe("reviewed");
+    expect(createdReviews).toHaveLength(1);
+    expect(createdReviews[0]).toMatchObject({
+      headSha: scenario.pull.head.sha,
+      event: "COMMENT",
+      comments: [expect.objectContaining({ severity: "P1" })]
+    });
+    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 501, scenario.pull.head.sha)).toMatchObject({
+      status: "posted",
+      event: "COMMENT"
+    });
+    expect(readDecision(scenario.evidenceDir)).toEqual({
+      candidateEvent: "REQUEST_CHANGES",
+      selectedEvent: "COMMENT",
+      mode: "trusted_command_only",
+      reason: "authorization_missing",
+      headSha: scenario.pull.head.sha,
+      consumed: false,
+      dryRun: false
+    });
+    expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "review-plan.json"), "utf8")).walkthrough.body).toContain(
+      "Review event: `COMMENT`."
+    );
+    scenario.state.close();
+  });
+
+  it("posts and persists REQUEST_CHANGES only for the exact queued trusted owner command", async () => {
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 502,
+      commandComment: requestChangesComment(41, 502, "b".repeat(40)),
+      commandCommentId: 41
+    });
+
+    expect(scenario.result).toBe("reviewed");
+    expect(createdReviews[0]).toMatchObject({ headSha: scenario.pull.head.sha, event: "REQUEST_CHANGES" });
+    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 502, scenario.pull.head.sha)).toMatchObject({
+      status: "posted",
+      event: "REQUEST_CHANGES"
+    });
+    expect(readDecision(scenario.evidenceDir)).toMatchObject({
+      candidateEvent: "REQUEST_CHANGES",
+      selectedEvent: "REQUEST_CHANGES",
+      reason: "authorization_eligible",
+      author: "100yenadmin",
+      commentId: 41,
+      consumed: true,
+      dryRun: false
+    });
+    expect(JSON.stringify(readDecision(scenario.evidenceDir))).not.toContain("request-changes");
+    expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "review-plan.json"), "utf8")).event).toBe("REQUEST_CHANGES");
+    scenario.state.close();
+  });
+
+  it("fails closed when the exact authorization was already consumed", async () => {
+    const headSha = "c".repeat(40);
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 503,
+      headSha,
+      commandComment: requestChangesComment(42, 503, headSha),
+      commandCommentId: 42,
+      configureState: (state) => {
+        expect(state.tryConsumeReviewEventAuthorization({
+          repo: "electricsheephq/WorldOS",
+          pullNumber: 503,
+          headSha,
+          commentId: 42,
+          author: "100yenadmin"
+        })).toBe(true);
+      }
+    });
+
+    expect(createdReviews[0]?.event).toBe("COMMENT");
+    expect(readDecision(scenario.evidenceDir)).toMatchObject({
+      selectedEvent: "COMMENT",
+      reason: "authorization_consumed",
+      commentId: 42,
+      consumed: false
+    });
+    scenario.state.close();
+  });
+
+  it("re-fetches only the queued ordinary command id and ignores another valid authorization", async () => {
+    const headSha = "d".repeat(40);
+    const ordinaryComment = {
+      id: 43,
+      body: "@evaos-code-review-bot re-review",
+      user: { login: "100yenadmin", type: "User" }
+    };
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 504,
+      headSha,
+      commandComment: ordinaryComment,
+      otherListedComments: [requestChangesComment(44, 504, headSha)],
+      commandCommentId: 43
+    });
+
+    expect(scenario.exactCommentLookups).toEqual([43]);
+    expect(createdReviews[0]?.event).toBe("COMMENT");
+    expect(readDecision(scenario.evidenceDir)).toMatchObject({
+      selectedEvent: "COMMENT",
+      reason: "authorization_missing",
+      commentId: 43,
+      consumed: false
+    });
+    scenario.state.close();
+  });
+
+  it("fails closed to COMMENT when the exact comment lookup fails", async () => {
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 505,
+      commandCommentId: 45,
+      commentLookupError: new Error("GitHub comment read failed")
+    });
+
+    expect(createdReviews[0]?.event).toBe("COMMENT");
+    expect(readDecision(scenario.evidenceDir)).toMatchObject({
+      selectedEvent: "COMMENT",
+      reason: "authorization_lookup_failed",
+      commentId: 45,
+      consumed: false
+    });
+    scenario.state.close();
+  });
+
+  it("fails closed to COMMENT when atomic authorization consumption throws", async () => {
+    const headSha = "e".repeat(40);
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 506,
+      headSha,
+      commandComment: requestChangesComment(46, 506, headSha),
+      commandCommentId: 46,
+      configureState: (state) => {
+        vi.spyOn(state, "tryConsumeReviewEventAuthorization").mockImplementation(() => {
+          throw new Error("database is busy");
+        });
+      }
+    });
+
+    expect(createdReviews[0]?.event).toBe("COMMENT");
+    expect(readDecision(scenario.evidenceDir)).toMatchObject({
+      selectedEvent: "COMMENT",
+      reason: "authorization_state_error",
+      commentId: 46,
+      consumed: false
+    });
+    scenario.state.close();
+  });
+
+  it("records an explicit dry-run decision without consuming or posting", async () => {
+    const headSha = "f".repeat(40);
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 507,
+      headSha,
+      commandComment: requestChangesComment(47, 507, headSha),
+      commandCommentId: 47,
+      dryRun: true
+    });
+
+    expect(createdReviews).toEqual([]);
+    expect(readDecision(scenario.evidenceDir)).toMatchObject({
+      candidateEvent: "REQUEST_CHANGES",
+      selectedEvent: "REQUEST_CHANGES",
+      reason: "authorization_eligible",
+      commentId: 47,
+      consumed: false,
+      dryRun: true
+    });
+    expect(scenario.state.tryConsumeReviewEventAuthorization({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 507,
+      headSha,
+      commentId: 47,
+      author: "100yenadmin"
+    })).toBe(true);
+    scenario.state.close();
+  });
+
+  it("does not consume when the head moves after exact authorization lookup and before post", async () => {
+    const headSha = "1".repeat(40);
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 508,
+      headSha,
+      commandComment: requestChangesComment(48, 508, headSha),
+      commandCommentId: 48,
+      moveHeadAfterCommentLookup: "2".repeat(40)
+    });
+
+    expect(scenario.result).toBe("skipped_stale_head");
+    expect(createdReviews).toEqual([]);
+    expect(scenario.state.tryConsumeReviewEventAuthorization({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 508,
+      headSha,
+      commentId: 48,
+      author: "100yenadmin"
+    })).toBe(true);
+    scenario.state.close();
+  });
+
+  it("never restores consumed authority after a review POST failure", async () => {
+    const headSha = "2".repeat(40);
+    reviewPostControl.error = new Error("GitHub review POST failed");
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 509,
+      headSha,
+      commandComment: requestChangesComment(49, 509, headSha),
+      commandCommentId: 49
+    });
+
+    expect(scenario.error).toEqual(expect.objectContaining({ message: "GitHub review POST failed" }));
+    expect(scenario.state.tryConsumeReviewEventAuthorization({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 509,
+      headSha,
+      commentId: 49,
+      author: "100yenadmin"
+    })).toBe(false);
+    scenario.state.close();
+  });
+
+  it("records a bounded incident and withholds current-head readiness when the head moves during POST", async () => {
+    const headSha = "3".repeat(40);
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 510,
+      headSha,
+      commandComment: requestChangesComment(50, 510, headSha),
+      commandCommentId: 50,
+      moveHeadDuringPost: "4".repeat(40)
+    });
+
+    expect(scenario.result).toBe("reviewed");
+    expect(createdReviews[0]).toMatchObject({ headSha, event: "REQUEST_CHANGES" });
+    expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "head-changed-during-post.json"), "utf8"))).toEqual({
+      reason: "head_changed_during_post",
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 510,
+      expectedHeadSha: headSha,
+      liveHeadSha: "4".repeat(40),
+      reviewId: 1
+    });
+    expect(scenario.state.getReviewReadiness("electricsheephq/WorldOS", 510, headSha)).toBeUndefined();
+    scenario.state.close();
+  });
+
+  it("consumes an exact eligible command even when the deterministic candidate is already COMMENT", async () => {
+    const headSha = "5".repeat(40);
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 511,
+      headSha,
+      commandComment: requestChangesComment(51, 511, headSha),
+      commandCommentId: 51,
+      candidateSeverity: "P2"
+    });
+
+    expect(createdReviews[0]?.event).toBe("COMMENT");
+    expect(readDecision(scenario.evidenceDir)).toMatchObject({
+      candidateEvent: "COMMENT",
+      selectedEvent: "COMMENT",
+      reason: "candidate_comment",
+      commentId: 51,
+      consumed: true
+    });
+    expect(scenario.state.tryConsumeReviewEventAuthorization({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 511,
+      headSha,
+      commentId: 51,
+      author: "100yenadmin"
+    })).toBe(false);
+    scenario.state.close();
+  });
 });
+
+async function runOwnerPolicyReview(input: {
+  roots: string[];
+  pullNumber: number;
+  headSha?: string;
+  commandComment?: { id: number; body: string; user: { login: string; type: string } };
+  otherListedComments?: Array<{ id: number; body: string; user: { login: string; type: string } }>;
+  commandCommentId?: number;
+  dryRun?: boolean;
+  commentLookupError?: Error;
+  moveHeadAfterCommentLookup?: string;
+  moveHeadDuringPost?: string;
+  enableWalkthrough?: boolean;
+  candidateSeverity?: "P1" | "P2";
+  configureState?: (state: ReviewStateStore) => void;
+}) {
+  const root = mkdtempSync(join(tmpdir(), "neondiff-owner-policy-"));
+  input.roots.push(root);
+  const config = minimalConfig(root);
+  config.commands = {
+    enabled: true,
+    botMentions: ["@evaos-code-review-bot"],
+    trustedAuthors: ["100yenadmin"],
+    acknowledge: false
+  };
+  config.reviewGate = {
+    maxInlineComments: 25,
+    reviewEventPolicy: { mode: "trusted_command_only" }
+  };
+  config.walkthrough.enabled = input.enableWalkthrough ?? false;
+  const state = new ReviewStateStore(config.statePath);
+  input.configureState?.(state);
+  const headSha = input.headSha ?? "b".repeat(40);
+  const pull = pullSummary(input.pullNumber, headSha);
+  let livePull = pull;
+  const file = pullFile(`src/policy-${input.pullNumber}.ts`, 200);
+  zcodeFindingsByPath.set(file.filename, [
+    input.candidateSeverity === "P2"
+      ? finding(file.filename, `P2 policy finding ${input.pullNumber}`)
+      : p1Finding(file.filename, `P1 policy finding ${input.pullNumber}`)
+  ]);
+  const exactCommentLookups: number[] = [];
+  if (input.moveHeadDuringPost) {
+    reviewPostControl.afterCreate = () => {
+      livePull = pullSummary(input.pullNumber, input.moveHeadDuringPost!);
+    };
+  }
+  const github = {
+    getPull: async () => livePull,
+    listPullFiles: async () => [file],
+    listIssueComments: async () => [
+      ...(input.commandComment ? [input.commandComment] : []),
+      ...(input.otherListedComments ?? [])
+    ],
+    getIssueComment: async (_repo: string, commentId: number) => {
+      exactCommentLookups.push(commentId);
+      if (input.commentLookupError) throw input.commentLookupError;
+      if (input.moveHeadAfterCommentLookup) {
+        livePull = pullSummary(input.pullNumber, input.moveHeadAfterCommentLookup);
+      }
+      return input.commandComment ?? {
+        id: commentId,
+        body: "ordinary non-authorization comment",
+        user: { login: "100yenadmin", type: "User" }
+      };
+    },
+    canPostAsApp: () => false
+  } as unknown as GitHubApi;
+
+  let result: Awaited<ReturnType<typeof reviewPull>> | undefined;
+  let error: unknown;
+  try {
+    result = await reviewPull({
+      config,
+      github,
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: input.dryRun ?? false,
+      useZCode: true,
+      ...(input.commandCommentId ? { commandCommentId: input.commandCommentId } : {})
+    });
+  } catch (caught) {
+    error = caught;
+  }
+
+  const commandSubdir = input.commandComment?.body.endsWith("re-review") ? `command-${input.commandComment.id}` : undefined;
+  const evidenceDir = join(
+    root,
+    "evidence",
+    localDateFolder(),
+    "electricsheephq__WorldOS",
+    `pr-${input.pullNumber}`,
+    headSha,
+    ...(commandSubdir ? [commandSubdir] : [])
+  );
+  return { root, config, state, pull, result, error, evidenceDir, exactCommentLookups };
+}
+
+function requestChangesComment(id: number, pullNumber: number, headSha: string) {
+  return {
+    id,
+    body: `@evaos-code-review-bot request-changes --repo electricsheephq/WorldOS --pr ${pullNumber} --head ${headSha}`,
+    user: { login: "100yenadmin", type: "User" }
+  };
+}
+
+function readDecision(evidenceDir: string) {
+  return JSON.parse(readFileSync(join(evidenceDir, "review-event-decision.json"), "utf8"));
+}
 
 function minimalConfig(root: string): BotConfig {
   return {
@@ -705,6 +1110,14 @@ function finding(path: string, title: string): Finding {
     confidence: 0.9,
     category: "runtime_correctness",
     why_this_matters: `${title} matters`
+  };
+}
+
+function p1Finding(path: string, title: string): Finding {
+  return {
+    ...finding(path, title),
+    severity: "P1",
+    confidence: 0.99
   };
 }
 

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -25,6 +25,7 @@ const reviewPostControl = vi.hoisted((): {
   afterAuxiliaryPost?: () => void;
 } => ({}));
 const evidenceWriteControl = vi.hoisted((): { failPostedReview?: boolean } => ({}));
+const walkthroughBuildEvents = vi.hoisted((): string[] => []);
 
 vi.mock("../src/git.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/git.js")>();
@@ -108,6 +109,17 @@ vi.mock("../src/temp-files.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../src/walkthrough.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/walkthrough.js")>();
+  return {
+    ...actual,
+    buildWalkthroughComment: vi.fn((input: Parameters<typeof actual.buildWalkthroughComment>[0]) => {
+      walkthroughBuildEvents.push(input.event);
+      return actual.buildWalkthroughComment(input);
+    })
+  };
+});
+
 const { localDateFolder, prepareFailedHeadRetry, reviewPull: reviewPullImpl } = await import("../src/worker.js");
 const reviewPull = (input: Parameters<typeof reviewPullImpl>[0]) => reviewPullImpl({
   ...input,
@@ -127,6 +139,7 @@ describe("worker context budget preflight", () => {
     zcodeFindingsByPath.clear();
     zcodeFailuresByPath.clear();
     createdReviews.length = 0;
+    walkthroughBuildEvents.length = 0;
     delete reviewPostControl.error;
     delete reviewPostControl.afterCreate;
     delete reviewPostControl.afterAuxiliaryPost;
@@ -632,6 +645,34 @@ describe("worker context budget preflight", () => {
     expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "review-plan.json"), "utf8")).walkthrough.body).toContain(
       "Review event: `COMMENT`."
     );
+    expect(walkthroughBuildEvents).toEqual(["COMMENT"]);
+    scenario.state.close();
+  });
+
+  it("does not preflight exact authorization for an ordinary command on a processed head", async () => {
+    const headSha = "a".repeat(40);
+    const commandComment = {
+      id: 40,
+      body: "@evaos-code-review-bot re-review",
+      user: { login: "100yenadmin", type: "User" }
+    };
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 500,
+      headSha,
+      commandComment,
+      commandCommentId: commandComment.id,
+      configureState: (state) => state.recordProcessed({
+        repo: "electricsheephq/WorldOS",
+        pullNumber: 500,
+        headSha,
+        status: "posted",
+        event: "COMMENT"
+      })
+    });
+
+    expect(scenario.result).toBe("reviewed_command");
+    expect(scenario.exactCommentLookups).toEqual([commandComment.id]);
     scenario.state.close();
   });
 

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -22,6 +22,7 @@ const createdReviews = vi.hoisted((): Array<{
 const reviewPostControl = vi.hoisted((): {
   error?: Error;
   afterCreate?: () => void;
+  afterAuxiliaryPost?: () => void;
 } => ({}));
 
 vi.mock("../src/git.js", async (importOriginal) => {
@@ -68,6 +69,11 @@ vi.mock("../src/github.js", async (importOriginal) => {
         return true;
       }
 
+      async upsertIssueComment(): Promise<{ action: "created"; html_url: string; id: number }> {
+        reviewPostControl.afterAuxiliaryPost?.();
+        return { action: "created", html_url: "https://github.test/comment/1", id: 1 };
+      }
+
       async createReview(input: {
         repo: string;
         pullNumber: number;
@@ -109,6 +115,7 @@ describe("worker context budget preflight", () => {
     createdReviews.length = 0;
     delete reviewPostControl.error;
     delete reviewPostControl.afterCreate;
+    delete reviewPostControl.afterAuxiliaryPost;
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   });
 
@@ -868,6 +875,142 @@ describe("worker context budget preflight", () => {
     })).toBe(false);
     scenario.state.close();
   });
+
+  it("lets an exact queued owner command supersede a posted advisory COMMENT on the same head", async () => {
+    const headSha = "6".repeat(40);
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 512,
+      headSha,
+      commandComment: requestChangesComment(52, 512, headSha),
+      commandCommentId: 52,
+      configureState: (state) => state.recordProcessed({
+        repo: "electricsheephq/WorldOS",
+        pullNumber: 512,
+        headSha,
+        status: "posted",
+        event: "COMMENT"
+      })
+    });
+
+    expect(scenario.result).toBe("reviewed");
+    expect(scenario.exactCommentLookups).toEqual([52, 52]);
+    expect(createdReviews).toHaveLength(1);
+    expect(createdReviews[0]?.event).toBe("REQUEST_CHANGES");
+    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 512, headSha)).toMatchObject({
+      status: "posted",
+      event: "REQUEST_CHANGES"
+    });
+    scenario.state.close();
+  });
+
+  it.each([
+    ["untrusted", { id: 53, body: `@evaos-code-review-bot request-changes --repo electricsheephq/WorldOS --pr 513 --head ${"7".repeat(40)}`, user: { login: "outside-contributor", type: "User" } }],
+    ["malformed", { id: 54, body: "@evaos-code-review-bot request-changes --repo electricsheephq/WorldOS --pr 514 --head short", user: { login: "100yenadmin", type: "User" } }]
+  ])("does not give a same-head processed bypass to an %s command", async (_label, commandComment) => {
+    const pullNumber = commandComment.id === 53 ? 513 : 514;
+    const headSha = commandComment.id === 53 ? "7".repeat(40) : "8".repeat(40);
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber,
+      headSha,
+      commandComment,
+      commandCommentId: commandComment.id,
+      configureState: (state) => state.recordProcessed({
+        repo: "electricsheephq/WorldOS",
+        pullNumber,
+        headSha,
+        status: "posted",
+        event: "COMMENT"
+      })
+    });
+
+    expect(scenario.result).toBe("skipped_processed");
+    expect(scenario.exactCommentLookups).toEqual([commandComment.id]);
+    expect(createdReviews).toEqual([]);
+    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", pullNumber, headSha)?.event).toBe("COMMENT");
+    scenario.state.close();
+  });
+
+  it("keeps consumed authority consumed when the head moves before any auxiliary or review POST", async () => {
+    const headSha = "9".repeat(40);
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 515,
+      headSha,
+      commandComment: requestChangesComment(55, 515, headSha),
+      commandCommentId: 55,
+      moveHeadAfterConsume: "a".repeat(40)
+    });
+
+    expect(scenario.result).toBe("skipped_stale_head");
+    expect(createdReviews).toEqual([]);
+    expect(scenario.state.tryConsumeReviewEventAuthorization({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 515,
+      headSha,
+      commentId: 55,
+      author: "100yenadmin"
+    })).toBe(false);
+    scenario.state.close();
+  });
+
+  it("stops before review when the head moves during an auxiliary walkthrough POST", async () => {
+    const headSha = "a".repeat(40);
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 516,
+      headSha,
+      commandComment: requestChangesComment(56, 516, headSha),
+      commandCommentId: 56,
+      enableWalkthroughPost: true,
+      moveHeadAfterAuxiliaryPost: "b".repeat(40)
+    });
+
+    expect(scenario.result).toBe("skipped_stale_head");
+    expect(createdReviews).toEqual([]);
+    expect(scenario.state.tryConsumeReviewEventAuthorization({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 516,
+      headSha,
+      commentId: 56,
+      author: "100yenadmin"
+    })).toBe(false);
+    scenario.state.close();
+  });
+
+  it("keeps a successful review posted when the immediate post-review head lookup fails", async () => {
+    const headSha = "c".repeat(40);
+    const lookupSecret = "ghp_post_lookup_secret";
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 517,
+      headSha,
+      commandComment: requestChangesComment(57, 517, headSha),
+      commandCommentId: 57,
+      postReviewHeadLookupError: new Error(`post lookup failed ${lookupSecret}`)
+    });
+
+    expect(scenario.error).toBeUndefined();
+    expect(scenario.result).toBe("reviewed");
+    expect(createdReviews).toHaveLength(1);
+    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 517, headSha)).toMatchObject({
+      status: "posted",
+      event: "REQUEST_CHANGES"
+    });
+    const incident = JSON.parse(readFileSync(join(scenario.evidenceDir, "post-review-head-lookup-failed.json"), "utf8"));
+    expect(incident).toMatchObject({
+      reason: "post_review_head_lookup_failed",
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 517,
+      expectedHeadSha: headSha,
+      reviewId: 1,
+      error: expect.stringContaining("[redacted-secret]")
+    });
+    expect(JSON.stringify(incident)).not.toContain(lookupSecret);
+    expect(scenario.state.getReviewReadiness("electricsheephq/WorldOS", 517, headSha)).toBeUndefined();
+    scenario.state.close();
+  });
 });
 
 async function runOwnerPolicyReview(input: {
@@ -881,7 +1024,11 @@ async function runOwnerPolicyReview(input: {
   commentLookupError?: Error;
   moveHeadAfterCommentLookup?: string;
   moveHeadDuringPost?: string;
+  moveHeadAfterConsume?: string;
+  moveHeadAfterAuxiliaryPost?: string;
+  postReviewHeadLookupError?: Error;
   enableWalkthrough?: boolean;
+  enableWalkthroughPost?: boolean;
   candidateSeverity?: "P1" | "P2";
   configureState?: (state: ReviewStateStore) => void;
 }) {
@@ -898,12 +1045,21 @@ async function runOwnerPolicyReview(input: {
     maxInlineComments: 25,
     reviewEventPolicy: { mode: "trusted_command_only" }
   };
-  config.walkthrough.enabled = input.enableWalkthrough ?? false;
+  config.walkthrough.enabled = input.enableWalkthrough === true || input.enableWalkthroughPost === true;
+  config.walkthrough.postIssueComment = input.enableWalkthroughPost ?? false;
   const state = new ReviewStateStore(config.statePath);
-  input.configureState?.(state);
   const headSha = input.headSha ?? "b".repeat(40);
   const pull = pullSummary(input.pullNumber, headSha);
   let livePull = pull;
+  input.configureState?.(state);
+  if (input.moveHeadAfterConsume) {
+    const consume = state.tryConsumeReviewEventAuthorization.bind(state);
+    vi.spyOn(state, "tryConsumeReviewEventAuthorization").mockImplementation((authorization) => {
+      const consumed = consume(authorization);
+      livePull = pullSummary(input.pullNumber, input.moveHeadAfterConsume!);
+      return consumed;
+    });
+  }
   const file = pullFile(`src/policy-${input.pullNumber}.ts`, 200);
   zcodeFindingsByPath.set(file.filename, [
     input.candidateSeverity === "P2"
@@ -911,13 +1067,27 @@ async function runOwnerPolicyReview(input: {
       : p1Finding(file.filename, `P1 policy finding ${input.pullNumber}`)
   ]);
   const exactCommentLookups: number[] = [];
-  if (input.moveHeadDuringPost) {
+  if (input.moveHeadDuringPost || input.postReviewHeadLookupError) {
     reviewPostControl.afterCreate = () => {
-      livePull = pullSummary(input.pullNumber, input.moveHeadDuringPost!);
+      if (input.moveHeadDuringPost) livePull = pullSummary(input.pullNumber, input.moveHeadDuringPost);
+      if (input.postReviewHeadLookupError) postReviewHeadLookupError = input.postReviewHeadLookupError;
     };
   }
+  if (input.moveHeadAfterAuxiliaryPost) {
+    reviewPostControl.afterAuxiliaryPost = () => {
+      livePull = pullSummary(input.pullNumber, input.moveHeadAfterAuxiliaryPost!);
+    };
+  }
+  let postReviewHeadLookupError: Error | undefined;
   const github = {
-    getPull: async () => livePull,
+    getPull: async () => {
+      if (postReviewHeadLookupError) {
+        const error = postReviewHeadLookupError;
+        postReviewHeadLookupError = undefined;
+        throw error;
+      }
+      return livePull;
+    },
     listPullFiles: async () => [file],
     listIssueComments: async () => [
       ...(input.commandComment ? [input.commandComment] : []),

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -667,13 +667,15 @@ describe("worker context budget preflight", () => {
       }
     });
 
-    expect(scenario.result).toBe("reviewed_command");
-    expect(createdReviews[0]?.event).toBe("COMMENT");
-    expect(readDecision(scenario.evidenceDir)).toMatchObject({
-      selectedEvent: "COMMENT",
-      reason: "authorization_consumed",
-      commentId: 42,
-      consumed: false
+    expect(scenario.result).toBe("skipped_consumed_authorization");
+    expect(createdReviews).toEqual([]);
+    expect(zcodePrompts).toEqual([]);
+    expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "consumed-authorization-incident.json"), "utf8"))).toMatchObject({
+      reason: "exact_authorization_already_consumed",
+      repo: "electricsheephq/WorldOS",
+      pullNumber: 503,
+      headSha,
+      commentId: 42
     });
     scenario.state.close();
   });
@@ -836,7 +838,7 @@ describe("worker context budget preflight", () => {
       moveHeadDuringPost: "4".repeat(40)
     });
 
-    expect(scenario.result).toBe("reviewed_command");
+    expect(scenario.result).toBe("posted_stale_head");
     expect(createdReviews[0]).toMatchObject({ headSha, event: "REQUEST_CHANGES" });
     expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "head-changed-during-post.json"), "utf8"))).toEqual({
       reason: "head_changed_during_post",
@@ -1030,7 +1032,7 @@ describe("worker context budget preflight", () => {
     });
 
     expect(scenario.error).toBeUndefined();
-    expect(scenario.result).toBe("reviewed_command");
+    expect(scenario.result).toBe("posted_head_unverified");
     expect(createdReviews).toHaveLength(1);
     expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 517, headSha)).toMatchObject({
       status: "posted",
@@ -1049,10 +1051,52 @@ describe("worker context budget preflight", () => {
     expect(scenario.state.getReviewReadiness("electricsheephq/WorldOS", 517, headSha)).toBeUndefined();
     scenario.state.close();
   });
+
+  it("keeps the first blocking review durable when a second exact command posts an advisory in a separate evidence directory", async () => {
+    const headSha = "f".repeat(40);
+    const first = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 519,
+      headSha,
+      commandComment: requestChangesComment(59, 519, headSha),
+      commandCommentId: 59
+    });
+    const blocking = first.state.getProcessedReview("electricsheephq/WorldOS", 519, headSha);
+    expect(blocking).toMatchObject({ status: "posted", event: "REQUEST_CHANGES" });
+
+    const second = await runOwnerPolicyReview({
+      roots,
+      existing: first,
+      pullNumber: 519,
+      headSha,
+      commandComment: requestChangesComment(60, 519, headSha),
+      commandCommentId: 60
+    });
+
+    expect(second.result).toBe("reviewed_command");
+    expect(createdReviews.map((review) => review.event)).toEqual(["REQUEST_CHANGES", "COMMENT"]);
+    expect(second.state.getProcessedReview("electricsheephq/WorldOS", 519, headSha)).toEqual(blocking);
+    expect(second.state.getReviewReadiness("electricsheephq/WorldOS", 519, headSha)).toMatchObject({
+      state: "needs_fix",
+      event: "REQUEST_CHANGES",
+      reviewUrl: blocking?.reviewUrl
+    });
+    expect(first.evidenceDir).not.toBe(second.evidenceDir);
+    expect(first.evidenceDir).toContain("command-59");
+    expect(second.evidenceDir).toContain("command-60");
+    expect(existsSync(join(first.evidenceDir, "review-event-decision.json"))).toBe(true);
+    expect(existsSync(join(second.evidenceDir, "review-event-decision.json"))).toBe(true);
+    expect(existsSync(join(first.evidenceDir, "command.json"))).toBe(false);
+    expect(existsSync(join(second.evidenceDir, "command.json"))).toBe(false);
+    expect(JSON.stringify(readDecision(first.evidenceDir))).not.toContain("request-changes");
+    expect(JSON.stringify(readDecision(second.evidenceDir))).not.toContain("request-changes");
+    second.state.close();
+  });
 });
 
 async function runOwnerPolicyReview(input: {
   roots: string[];
+  existing?: { root: string; config: BotConfig; state: ReviewStateStore };
   pullNumber: number;
   headSha?: string;
   commandComment?: { id: number; body: string; user: { login: string; type: string } };
@@ -1070,9 +1114,9 @@ async function runOwnerPolicyReview(input: {
   candidateSeverity?: "P1" | "P2";
   configureState?: (state: ReviewStateStore) => void;
 }) {
-  const root = mkdtempSync(join(tmpdir(), "neondiff-owner-policy-"));
-  input.roots.push(root);
-  const config = minimalConfig(root);
+  const root = input.existing?.root ?? mkdtempSync(join(tmpdir(), "neondiff-owner-policy-"));
+  if (!input.existing) input.roots.push(root);
+  const config = input.existing?.config ?? minimalConfig(root);
   config.commands = {
     enabled: true,
     botMentions: ["@evaos-code-review-bot"],
@@ -1085,7 +1129,7 @@ async function runOwnerPolicyReview(input: {
   };
   config.walkthrough.enabled = input.enableWalkthrough === true || input.enableWalkthroughPost === true;
   config.walkthrough.postIssueComment = input.enableWalkthroughPost ?? false;
-  const state = new ReviewStateStore(config.statePath);
+  const state = input.existing?.state ?? new ReviewStateStore(config.statePath);
   const headSha = input.headSha ?? "b".repeat(40);
   const pull = pullSummary(input.pullNumber, headSha);
   let livePull = pull;
@@ -1163,7 +1207,7 @@ async function runOwnerPolicyReview(input: {
     error = caught;
   }
 
-  const commandSubdir = input.commandComment?.body.endsWith("re-review") ? `command-${input.commandComment.id}` : undefined;
+  const commandSubdir = input.commandCommentId ? `command-${input.commandCommentId}` : undefined;
   const evidenceDir = join(
     root,
     "evidence",

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -670,6 +670,10 @@ describe("worker context budget preflight", () => {
     expect(scenario.result).toBe("skipped_consumed_authorization");
     expect(createdReviews).toEqual([]);
     expect(zcodePrompts).toEqual([]);
+    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 503, headSha)).toMatchObject({
+      status: "skipped",
+      error: "exact_authorization_already_consumed"
+    });
     expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "consumed-authorization-incident.json"), "utf8"))).toMatchObject({
       reason: "exact_authorization_already_consumed",
       repo: "electricsheephq/WorldOS",
@@ -840,6 +844,17 @@ describe("worker context budget preflight", () => {
 
     expect(scenario.result).toBe("posted_stale_head");
     expect(createdReviews[0]).toMatchObject({ headSha, event: "REQUEST_CHANGES" });
+    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 510, headSha)).toMatchObject({
+      status: "posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/510#pullrequestreview-1",
+      error: "review_posted_head_changed"
+    });
+    expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "posted-review.json"), "utf8"))).toEqual({
+      event: "REQUEST_CHANGES",
+      reviewId: 1,
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/510#pullrequestreview-1"
+    });
     expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "head-changed-during-post.json"), "utf8"))).toEqual({
       reason: "head_changed_during_post",
       repo: "electricsheephq/WorldOS",
@@ -1036,7 +1051,14 @@ describe("worker context budget preflight", () => {
     expect(createdReviews).toHaveLength(1);
     expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 517, headSha)).toMatchObject({
       status: "posted",
-      event: "REQUEST_CHANGES"
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/517#pullrequestreview-1",
+      error: "post_review_head_unverified"
+    });
+    expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "posted-review.json"), "utf8"))).toEqual({
+      event: "REQUEST_CHANGES",
+      reviewId: 1,
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/517#pullrequestreview-1"
     });
     const incident = JSON.parse(readFileSync(join(scenario.evidenceDir, "post-review-head-lookup-failed.json"), "utf8"));
     expect(incident).toMatchObject({
@@ -1088,6 +1110,18 @@ describe("worker context budget preflight", () => {
     expect(existsSync(join(second.evidenceDir, "review-event-decision.json"))).toBe(true);
     expect(existsSync(join(first.evidenceDir, "command.json"))).toBe(false);
     expect(existsSync(join(second.evidenceDir, "command.json"))).toBe(false);
+    expect(JSON.parse(readFileSync(join(first.evidenceDir, "posted-review.json"), "utf8"))).toEqual({
+      event: "REQUEST_CHANGES",
+      reviewId: 1,
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/519#pullrequestreview-1"
+    });
+    expect(JSON.parse(readFileSync(join(second.evidenceDir, "posted-review.json"), "utf8"))).toEqual({
+      event: "COMMENT",
+      reviewId: 2,
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/519#pullrequestreview-2"
+    });
+    expect(readFileSync(join(first.evidenceDir, "posted-review.json"), "utf8")).not.toContain("request-changes --repo");
+    expect(readFileSync(join(second.evidenceDir, "posted-review.json"), "utf8")).not.toContain("request-changes --repo");
     expect(JSON.stringify(readDecision(first.evidenceDir))).not.toContain("request-changes");
     expect(JSON.stringify(readDecision(second.evidenceDir))).not.toContain("request-changes");
     second.state.close();

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -667,6 +667,7 @@ describe("worker context budget preflight", () => {
       }
     });
 
+    expect(scenario.result).toBe("reviewed_command");
     expect(createdReviews[0]?.event).toBe("COMMENT");
     expect(readDecision(scenario.evidenceDir)).toMatchObject({
       selectedEvent: "COMMENT",
@@ -737,6 +738,7 @@ describe("worker context budget preflight", () => {
       }
     });
 
+    expect(scenario.result).toBe("reviewed_command");
     expect(createdReviews[0]?.event).toBe("COMMENT");
     expect(readDecision(scenario.evidenceDir)).toMatchObject({
       selectedEvent: "COMMENT",

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -24,6 +24,7 @@ const reviewPostControl = vi.hoisted((): {
   afterCreate?: () => void;
   afterAuxiliaryPost?: () => void;
 } => ({}));
+const evidenceWriteControl = vi.hoisted((): { failPostedReview?: boolean } => ({}));
 
 vi.mock("../src/git.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/git.js")>();
@@ -94,6 +95,19 @@ vi.mock("../src/github.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../src/temp-files.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/temp-files.js")>();
+  return {
+    ...actual,
+    writeSecureFileSync: (path: string, contents: string) => {
+      if (evidenceWriteControl.failPostedReview && path.endsWith("posted-review.json")) {
+        throw new Error("injected posted-review evidence failure");
+      }
+      return actual.writeSecureFileSync(path, contents);
+    }
+  };
+});
+
 const { localDateFolder, prepareFailedHeadRetry, reviewPull: reviewPullImpl } = await import("../src/worker.js");
 const reviewPull = (input: Parameters<typeof reviewPullImpl>[0]) => reviewPullImpl({
   ...input,
@@ -116,6 +130,7 @@ describe("worker context budget preflight", () => {
     delete reviewPostControl.error;
     delete reviewPostControl.afterCreate;
     delete reviewPostControl.afterAuxiliaryPost;
+    delete evidenceWriteControl.failPostedReview;
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   });
 
@@ -1125,6 +1140,68 @@ describe("worker context budget preflight", () => {
     expect(JSON.stringify(readDecision(first.evidenceDir))).not.toContain("request-changes");
     expect(JSON.stringify(readDecision(second.evidenceDir))).not.toContain("request-changes");
     second.state.close();
+  });
+
+  it("keeps a successful remote review durable when posted-review evidence cannot be written", async () => {
+    const headSha = "1".repeat(40);
+    evidenceWriteControl.failPostedReview = true;
+    const first = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 520,
+      headSha,
+      commandComment: requestChangesComment(61, 520, headSha),
+      commandCommentId: 61
+    });
+
+    expect(first.error).toBeUndefined();
+    expect(first.result).toBe("reviewed_command");
+    expect(first.state.getProcessedReview("electricsheephq/WorldOS", 520, headSha)).toMatchObject({
+      status: "posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/520#pullrequestreview-1"
+    });
+    expect(existsSync(join(first.evidenceDir, "posted-review.json"))).toBe(false);
+
+    const replay = await runOwnerPolicyReview({
+      roots,
+      existing: first,
+      pullNumber: 520,
+      headSha,
+      commandComment: requestChangesComment(61, 520, headSha),
+      commandCommentId: 61
+    });
+    expect(replay.result).toBe("skipped_processed");
+    expect(createdReviews).toHaveLength(1);
+    replay.state.close();
+  });
+
+  it("does not contaminate a verified blocking row when a later advisory head reread fails", async () => {
+    const headSha = "2".repeat(40);
+    const first = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 521,
+      headSha,
+      commandComment: requestChangesComment(62, 521, headSha),
+      commandCommentId: 62
+    });
+    const blocking = first.state.getProcessedReview("electricsheephq/WorldOS", 521, headSha);
+    expect(blocking).toMatchObject({ status: "posted", event: "REQUEST_CHANGES" });
+    expect(blocking?.error).toBeUndefined();
+
+    const advisory = await runOwnerPolicyReview({
+      roots,
+      existing: first,
+      pullNumber: 521,
+      headSha,
+      commandComment: requestChangesComment(63, 521, headSha),
+      commandCommentId: 63,
+      postReviewHeadLookupError: new Error("advisory reread unavailable")
+    });
+
+    expect(advisory.result).toBe("posted_head_unverified");
+    expect(createdReviews.map((review) => review.event)).toEqual(["REQUEST_CHANGES", "COMMENT"]);
+    expect(advisory.state.getProcessedReview("electricsheephq/WorldOS", 521, headSha)).toEqual(blocking);
+    advisory.state.close();
   });
 });
 

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -628,7 +628,7 @@ describe("worker context budget preflight", () => {
       commandCommentId: 41
     });
 
-    expect(scenario.result).toBe("reviewed");
+    expect(scenario.result).toBe("reviewed_command");
     expect(createdReviews[0]).toMatchObject({ headSha: scenario.pull.head.sha, event: "REQUEST_CHANGES" });
     expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 502, scenario.pull.head.sha)).toMatchObject({
       status: "posted",
@@ -758,6 +758,7 @@ describe("worker context budget preflight", () => {
       dryRun: true
     });
 
+    expect(scenario.result).toBe("reviewed_command");
     expect(createdReviews).toEqual([]);
     expect(readDecision(scenario.evidenceDir)).toMatchObject({
       candidateEvent: "REQUEST_CHANGES",
@@ -833,7 +834,7 @@ describe("worker context budget preflight", () => {
       moveHeadDuringPost: "4".repeat(40)
     });
 
-    expect(scenario.result).toBe("reviewed");
+    expect(scenario.result).toBe("reviewed_command");
     expect(createdReviews[0]).toMatchObject({ headSha, event: "REQUEST_CHANGES" });
     expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "head-changed-during-post.json"), "utf8"))).toEqual({
       reason: "head_changed_during_post",
@@ -844,6 +845,41 @@ describe("worker context budget preflight", () => {
       reviewId: 1
     });
     expect(scenario.state.getReviewReadiness("electricsheephq/WorldOS", 510, headSha)).toBeUndefined();
+    scenario.state.close();
+  });
+
+  it("preserves a prior posted review row when an exact owner supersession becomes stale", async () => {
+    const headSha = "d".repeat(40);
+    const reviewUrl = "https://github.com/electricsheephq/WorldOS/pull/518#pullrequestreview-518";
+    let postedBeforeSupersession: ReturnType<ReviewStateStore["getProcessedReview"]>;
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 518,
+      headSha,
+      commandComment: requestChangesComment(58, 518, headSha),
+      commandCommentId: 58,
+      moveHeadAfterCommentLookup: "e".repeat(40),
+      configureState: (state) => {
+        state.recordProcessed({
+          repo: "electricsheephq/WorldOS",
+          pullNumber: 518,
+          headSha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl
+        });
+        postedBeforeSupersession = state.getProcessedReview("electricsheephq/WorldOS", 518, headSha);
+      }
+    });
+
+    expect(scenario.result).toBe("skipped_stale_head");
+    expect(createdReviews).toEqual([]);
+    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 518, headSha)).toEqual(postedBeforeSupersession);
+    expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "stale-head.json"), "utf8"))).toMatchObject({
+      reason: "stale_head_before_review",
+      expectedHeadSha: headSha,
+      liveHeadSha: "e".repeat(40)
+    });
     scenario.state.close();
   });
 
@@ -893,7 +929,7 @@ describe("worker context budget preflight", () => {
       })
     });
 
-    expect(scenario.result).toBe("reviewed");
+    expect(scenario.result).toBe("reviewed_command");
     expect(scenario.exactCommentLookups).toEqual([52, 52]);
     expect(createdReviews).toHaveLength(1);
     expect(createdReviews[0]?.event).toBe("REQUEST_CHANGES");
@@ -992,7 +1028,7 @@ describe("worker context budget preflight", () => {
     });
 
     expect(scenario.error).toBeUndefined();
-    expect(scenario.result).toBe("reviewed");
+    expect(scenario.result).toBe("reviewed_command");
     expect(createdReviews).toHaveLength(1);
     expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 517, headSha)).toMatchObject({
       status: "posted",

--- a/tests/worker-settings-preview.test.ts
+++ b/tests/worker-settings-preview.test.ts
@@ -88,6 +88,10 @@ describe("worker review settings preview evidence", () => {
       enabled: true,
       mode: "inline_review"
     });
+    expect(preview.reviewGate).toEqual({
+      reviewEventPolicy: { mode: "trusted_command_only" }
+    });
+    expect(preview).not.toHaveProperty("reviewEventAuthorization");
     expect(walkthrough).toContain("### Review Settings Preview");
     expect(walkthrough).toContain("Provider: GLM/Z.ai through ZCode (`zcode-glm`, zcode, model `GLM-5.2`).");
     expect(walkthrough).toContain("- Enabled sections: Review summary (inline_review); Walkthrough (inline_review)");


### PR DESCRIPTION
## Summary

Implements the source side of #557 so NeonDiff analysis remains autonomous and advisory, while the public GitHub `REQUEST_CHANGES` event requires one exact, trusted-owner, current-head command.

- defaults `reviewGate.reviewEventPolicy.mode` to fail-closed `trusted_command_only`; `automatic` is explicit legacy compatibility only;
- accepts only the exact whole-body command `@neondiff request-changes --repo <owner/name> --pr <positive integer> --head <40-char SHA>` from an explicitly trusted login (wildcard `*` never authorizes);
- queues the exact comment as one manual attempt, preserves command ordering/dedupe, and consumes authority atomically once per repo/PR/head;
- re-fetches the exact queued comment, revalidates live head, fails every lookup/state/stale/consumed path to `COMMENT`, and retains inline findings;
- binds review POSTs to `commit_id`, closes auxiliary-post race windows, records post-race/read incidents, and preserves prior posted-review truth;
- publishes the safe config schema, settings preview, examples, and maintainer contract without claiming live promotion.

## Local proof on exact head

- `npm test -- tests/review-event-policy.test.ts tests/confidence-config.test.ts tests/commands.test.ts tests/state.test.ts tests/worker-context-budget.test.ts tests/stale-head.test.ts tests/github-app-read.test.ts tests/scheduler.test.ts tests/worker-settings-preview.test.ts tests/neondiff-config-schema.test.ts tests/worker-failure.test.ts tests/review-budget.test.ts` — 12 files, 348 tests passed
- `npm run build` — passed, including postbuild secret-rule check
- `actionlint` — passed
- `npm run check:public-claims` — passed
- `npm run check:secrets` — passed, 674 tracked files
- `git diff --check origin/main...HEAD` — passed

## Review focus

Please scrutinize exact-comment isolation, same-head supersession, consume-before-post behavior, stale-head windows, processed-command replay suppression, SQLite contention/error downgrade, `commit_id` payload binding, post-read incident handling, and raw-body/secret exclusion.

## Proof boundary

This PR is source and local-test proof only. It does **not** prove the internal daemon has been upgraded, that a live exact-owner fixture produced one `REQUEST_CHANGES`, or that a public release is ready. Keep #557 open until post-merge CI and upgraded-daemon no-bypass proof are attached. No npm, tag, GitHub Release, Stripe, license API, checkout, or runtime surface is changed by this PR.
