### PR TITLE
fix(review): suppress consumed owner-command replays

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -629,6 +629,28 @@ async function enqueuePullIfEligible(input: {
   }
 
   await retireSupersededQueueJobsForPull(input);
+  const unresolvedAuthorization = /^[0-9a-f]{40}$/i.test(input.pull.head.sha)
+    ? input.state.getReviewEventAuthorizationConsumption(
+        input.repo,
+        input.pull.number,
+        input.pull.head.sha
+      )
+    : undefined;
+  if (unresolvedAuthorization?.incidentError && !unresolvedAuthorization.postedAt) {
+    recordReadinessTransition({
+      state: input.state,
+      repo: input.repo,
+      pull: input.pull,
+      readinessState: "failed",
+      reason: unresolvedAuthorization.incidentError,
+      commandAction: "request-changes",
+      ...(unresolvedAuthorization.incidentCommentId
+        ? { commandCommentId: unresolvedAuthorization.incidentCommentId }
+        : {}),
+      now: input.now
+    });
+    return "skipped_processed";
+  }
   if (processed || input.state.hasProcessed(input.repo, input.pull.number, input.pull.head.sha)) {
     backfillReadinessFromProcessedHead(input.state, input.repo, input.pull, input.now);
     await repairProcessedHeadStatusCommentIfNeeded({ ...input, processed });
@@ -1205,8 +1227,11 @@ function latestPendingRequestChanges(input: {
     input.pull.number,
     input.pull.head.sha
   );
-  const processed = input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha);
-  if (consumed && processed?.status === "posted") {
+  if (
+    consumed?.postedEvent &&
+    consumed.reviewUrl &&
+    consumed.postedAt
+  ) {
     for (const request of pending) {
       input.state.recordProcessedCommand({
         repo: input.repo,
@@ -2220,8 +2245,7 @@ function updateQueueJobAfterReviewStatus(input: {
       });
       return;
     }
-    case "posted_head_unverified":
-    case "skipped_consumed_authorization": {
+    case "posted_head_unverified": {
       const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
       input.state.updateReviewQueueJobState({
         jobId: input.job.jobId,
@@ -2232,6 +2256,14 @@ function updateQueueJobAfterReviewStatus(input: {
       });
       return;
     }
+    case "skipped_consumed_authorization":
+      input.state.updateReviewQueueJobState({
+        jobId: input.job.jobId,
+        state: "failed",
+        lastError: input.status,
+        now: input.now
+      });
+      return;
     case "skipped_provider_cooldown":
       markQueueJobProviderDeferredFromProcessed({ ...input, now: input.now });
       return;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1196,9 +1196,31 @@ function latestPendingRequestChanges(input: {
   repo: string;
   pull: PullRequestSummary;
 }): ReviewEventAuthorizationReviewRequest | undefined {
-  return input.requests.filter((request) =>
+  const pending = input.requests.filter((request) =>
     !input.state.hasProcessedCommand(input.repo, input.pull.number, input.pull.head.sha, request.commentId)
-  ).at(-1);
+  );
+  if (pending.length === 0) return undefined;
+  const consumed = input.state.getReviewEventAuthorizationConsumption(
+    input.repo,
+    input.pull.number,
+    input.pull.head.sha
+  );
+  const processed = input.state.getProcessedReview(input.repo, input.pull.number, input.pull.head.sha);
+  if (consumed && processed?.status === "posted") {
+    for (const request of pending) {
+      input.state.recordProcessedCommand({
+        repo: input.repo,
+        pullNumber: input.pull.number,
+        headSha: input.pull.head.sha,
+        commentId: request.commentId,
+        action: "request-changes",
+        status: "ignored",
+        author: request.author
+      });
+    }
+    return undefined;
+  }
+  return pending.at(-1);
 }
 
 export function admitPublicCommands(input: {

--- a/src/state.ts
+++ b/src/state.ts
@@ -356,6 +356,24 @@ export interface ReviewEventAuthorizationConsumptionRecord {
   commentId: number;
   author: string;
   consumedAt: string;
+  postedEvent?: ReviewEvent;
+  reviewUrl?: string;
+  postedAt?: string;
+  incidentError?: string;
+  incidentCommentId?: number;
+  incidentAt?: string;
+}
+
+export interface RecordAuthorizedReviewPostedInput {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  commentId: number;
+  author: string;
+  event: ReviewEvent;
+  reviewUrl: string;
+  preserveExistingBlocking?: boolean;
+  now?: Date;
 }
 
 export interface RepoMemoryNoteRecord {
@@ -793,6 +811,12 @@ export class ReviewStateStore {
         comment_id integer not null,
         author text not null,
         consumed_at text not null,
+        posted_event text,
+        review_url text,
+        posted_at text,
+        incident_error text,
+        incident_comment_id integer,
+        incident_at text,
         primary key (repo, pull_number, head_sha)
       );
 
@@ -812,6 +836,7 @@ export class ReviewStateStore {
         primary key (repo, pull_number, head_sha, command_comment_id)
       );
     `);
+    this.ensureReviewEventAuthorizationOutcomeColumns();
   }
 
   hasProcessed(repo: string, pullNumber: number, headSha: string): boolean {
@@ -1556,7 +1581,8 @@ export class ReviewStateStore {
     validateReviewEventAuthorizationCoordinates(repo, pullNumber, headSha);
     const row = this.db
       .prepare(
-        `select repo, pull_number, head_sha, comment_id, author, consumed_at
+        `select repo, pull_number, head_sha, comment_id, author, consumed_at,
+                posted_event, review_url, posted_at, incident_error, incident_comment_id, incident_at
          from review_event_authorization_consumptions
          where repo = ? and pull_number = ? and head_sha = ?`
       )
@@ -1567,6 +1593,12 @@ export class ReviewStateStore {
         comment_id: number;
         author: string;
         consumed_at: string;
+        posted_event: ReviewEvent | null;
+        review_url: string | null;
+        posted_at: string | null;
+        incident_error: string | null;
+        incident_comment_id: number | null;
+        incident_at: string | null;
       } | undefined;
     return row
       ? {
@@ -1575,9 +1607,183 @@ export class ReviewStateStore {
           headSha: row.head_sha,
           commentId: row.comment_id,
           author: row.author,
-          consumedAt: row.consumed_at
+          consumedAt: row.consumed_at,
+          ...(row.posted_event ? { postedEvent: row.posted_event } : {}),
+          ...(row.review_url ? { reviewUrl: row.review_url } : {}),
+          ...(row.posted_at ? { postedAt: row.posted_at } : {}),
+          ...(row.incident_error ? { incidentError: row.incident_error } : {}),
+          ...(row.incident_comment_id ? { incidentCommentId: row.incident_comment_id } : {}),
+          ...(row.incident_at ? { incidentAt: row.incident_at } : {})
         }
       : undefined;
+  }
+
+  /**
+   * Atomically links a consumed owner authorization to the durable GitHub review it created and
+   * records the processed-head outcome. A generic prior advisory row is intentionally insufficient:
+   * replay suppression may trust only this comment-linked receipt.
+   */
+  recordAuthorizedReviewPosted(input: RecordAuthorizedReviewPostedInput): void {
+    validateReviewEventAuthorizationConsumption(input);
+    if (!/^https:\/\/github\.com\//.test(input.reviewUrl)) {
+      throw new Error("reviewUrl must be a GitHub URL");
+    }
+    const postedAt = (input.now ?? new Date()).toISOString();
+    this.db.exec("begin immediate");
+    try {
+      const existingProcessed = this.getProcessedReview(input.repo, input.pullNumber, input.headSha);
+      const preserveExistingBlocking = Boolean(
+        input.preserveExistingBlocking &&
+        existingProcessed?.status === "posted" &&
+        existingProcessed.event === "REQUEST_CHANGES" &&
+        !existingProcessed.error
+      );
+      const receipt = this.db
+        .prepare(
+          `update review_event_authorization_consumptions
+           set posted_event = ?, review_url = ?, posted_at = ?,
+               incident_error = null, incident_comment_id = null, incident_at = null
+           where repo = ? and pull_number = ? and head_sha = ? and comment_id = ? and author = ?`
+        )
+        .run(
+          input.event,
+          input.reviewUrl,
+          postedAt,
+          input.repo,
+          input.pullNumber,
+          input.headSha.toLowerCase(),
+          input.commentId,
+          input.author
+        );
+      if (Number(receipt.changes) !== 1) {
+        throw new Error("refusing to record an authorized review without its exact consumption row");
+      }
+      if (!preserveExistingBlocking) {
+        this.db
+          .prepare(
+            `insert or replace into processed_reviews
+              (repo, pull_number, head_sha, status, event, review_url, error, created_at)
+             values (?, ?, ?, 'posted', ?, ?, null, datetime('now'))`
+          )
+          .run(input.repo, input.pullNumber, input.headSha, input.event, input.reviewUrl);
+      }
+      const readinessEvent = preserveExistingBlocking ? "REQUEST_CHANGES" : input.event;
+      const readinessUrl = preserveExistingBlocking ? existingProcessed?.reviewUrl : input.reviewUrl;
+      const readinessState: ReviewReadinessState = readinessEvent === "REQUEST_CHANGES" ? "needs_fix" : "ready_for_human";
+      const readinessReason = readinessEvent === "REQUEST_CHANGES" ? "request_changes_review_posted" : "comment_review_posted";
+      const existingReadiness = this.getReviewReadiness(input.repo, input.pullNumber, input.headSha);
+      this.db
+        .prepare(
+          `insert into review_readiness
+            (repo, pull_number, head_sha, state, reason, event, review_url,
+             command_action, command_comment_id, created_at, updated_at)
+           values (?, ?, ?, ?, ?, ?, ?, 'request-changes', ?, ?, ?)
+           on conflict(repo, pull_number, head_sha) do update set
+             state = excluded.state,
+             reason = excluded.reason,
+             event = excluded.event,
+             review_url = excluded.review_url,
+             command_action = excluded.command_action,
+             command_comment_id = excluded.command_comment_id,
+             updated_at = excluded.updated_at`
+        )
+        .run(
+          input.repo,
+          input.pullNumber,
+          input.headSha,
+          readinessState,
+          readinessReason,
+          readinessEvent,
+          readinessUrl ?? null,
+          input.commentId,
+          existingReadiness?.createdAt ?? postedAt,
+          postedAt
+        );
+      this.db
+        .prepare("delete from review_head_claims where repo = ? and pull_number = ? and head_sha = ?")
+        .run(input.repo, input.pullNumber, input.headSha);
+      this.db.exec("commit");
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
+  recordReviewEventAuthorizationIncident(input: {
+    repo: string;
+    pullNumber: number;
+    headSha: string;
+    triggerCommentId: number;
+    error: string;
+    now?: Date;
+  }): boolean {
+    validateReviewEventAuthorizationCoordinates(input.repo, input.pullNumber, input.headSha);
+    if (!Number.isInteger(input.triggerCommentId) || input.triggerCommentId < 1) {
+      throw new Error("triggerCommentId must be a positive integer");
+    }
+    const error = redactSecrets(input.error).trim().slice(0, 500);
+    if (!error) throw new Error("error must be a non-empty string");
+    const incidentAt = (input.now ?? new Date()).toISOString();
+    this.db.exec("begin immediate");
+    try {
+      const result = this.db
+        .prepare(
+          `update review_event_authorization_consumptions
+           set incident_error = ?, incident_comment_id = ?, incident_at = ?
+           where repo = ? and pull_number = ? and head_sha = ? and posted_at is null`
+        )
+        .run(
+          error,
+          input.triggerCommentId,
+          incidentAt,
+          input.repo,
+          input.pullNumber,
+          input.headSha.toLowerCase()
+        );
+      if (Number(result.changes) !== 1) {
+        const existing = this.db
+          .prepare(
+            `select posted_at from review_event_authorization_consumptions
+             where repo = ? and pull_number = ? and head_sha = ?`
+          )
+          .get(input.repo, input.pullNumber, input.headSha.toLowerCase()) as { posted_at: string | null } | undefined;
+        if (existing?.posted_at) {
+          this.db.exec("commit");
+          return false;
+        }
+        throw new Error("refusing to record an authorization incident without a consumption row");
+      }
+      const existingReadiness = this.getReviewReadiness(input.repo, input.pullNumber, input.headSha);
+      this.db
+        .prepare(
+          `insert into review_readiness
+            (repo, pull_number, head_sha, state, reason, event, review_url,
+             command_action, command_comment_id, created_at, updated_at)
+           values (?, ?, ?, 'failed', ?, null, null, 'request-changes', ?, ?, ?)
+           on conflict(repo, pull_number, head_sha) do update set
+             state = excluded.state,
+             reason = excluded.reason,
+             event = excluded.event,
+             review_url = excluded.review_url,
+             command_action = excluded.command_action,
+             command_comment_id = excluded.command_comment_id,
+             updated_at = excluded.updated_at`
+        )
+        .run(
+          input.repo,
+          input.pullNumber,
+          input.headSha,
+          error,
+          input.triggerCommentId,
+          existingReadiness?.createdAt ?? incidentAt,
+          incidentAt
+        );
+      this.db.exec("commit");
+      return true;
+    } catch (caught) {
+      this.db.exec("rollback");
+      throw caught;
+    }
   }
 
   tryAcquireIssueEnrichmentRunLease(
@@ -2729,6 +2935,43 @@ export class ReviewStateStore {
     return Boolean(row);
   }
 
+  getProcessedCommand(
+    repo: string,
+    pullNumber: number,
+    headSha: string,
+    commentId: number
+  ): ProcessedCommandRecord | undefined {
+    const row = this.db
+      .prepare(
+        `select repo, pull_number, head_sha, comment_id, action, status, author, url
+         from processed_commands
+         where repo = ? and pull_number = ? and head_sha = ? and comment_id = ?
+         limit 1`
+      )
+      .get(repo, pullNumber, headSha, commentId) as {
+        repo: string;
+        pull_number: number;
+        head_sha: string;
+        comment_id: number;
+        action: ProcessedCommandAction;
+        status: ProcessedCommandStatus;
+        author: string | null;
+        url: string | null;
+      } | undefined;
+    return row
+      ? {
+          repo: row.repo,
+          pullNumber: row.pull_number,
+          headSha: row.head_sha,
+          commentId: row.comment_id,
+          action: row.action,
+          status: row.status,
+          ...(row.author ? { author: row.author } : {}),
+          ...(row.url ? { url: row.url } : {})
+        }
+      : undefined;
+  }
+
   recordProcessedCommand(record: ProcessedCommandRecord): void {
     this.db
       .prepare(
@@ -2996,6 +3239,31 @@ export class ReviewStateStore {
     if (!names.has("coarse_line")) this.db.exec("alter table repo_memory_notes add column coarse_line integer");
     if (!names.has("coarse_title")) this.db.exec("alter table repo_memory_notes add column coarse_title text");
     if (!names.has("confirmed_by_human")) this.db.exec("alter table repo_memory_notes add column confirmed_by_human integer");
+  }
+
+  private ensureReviewEventAuthorizationOutcomeColumns(): void {
+    const columns = this.db
+      .prepare("pragma table_info(review_event_authorization_consumptions)")
+      .all() as unknown as Array<{ name: string }>;
+    const names = new Set(columns.map((column) => column.name));
+    if (!names.has("posted_event")) {
+      this.db.exec("alter table review_event_authorization_consumptions add column posted_event text");
+    }
+    if (!names.has("review_url")) {
+      this.db.exec("alter table review_event_authorization_consumptions add column review_url text");
+    }
+    if (!names.has("posted_at")) {
+      this.db.exec("alter table review_event_authorization_consumptions add column posted_at text");
+    }
+    if (!names.has("incident_error")) {
+      this.db.exec("alter table review_event_authorization_consumptions add column incident_error text");
+    }
+    if (!names.has("incident_comment_id")) {
+      this.db.exec("alter table review_event_authorization_consumptions add column incident_comment_id integer");
+    }
+    if (!names.has("incident_at")) {
+      this.db.exec("alter table review_event_authorization_consumptions add column incident_at text");
+    }
   }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -92,6 +92,7 @@ import {
   type ProcessedStatus,
   type ReviewQueueJobState,
   type ReviewHeadClaim,
+  type ReviewEventAuthorizationConsumptionRecord,
   type ReviewFindingRecord,
   type ReviewReadinessRecord,
   type ReviewReadinessState,
@@ -113,6 +114,34 @@ const LICENSE_GATE_UNKNOWN_REPO_VISIBILITY_CACHE_TTL_MS = 2 * 60_000;
 const LICENSE_GATE_REPO_VISIBILITY_CACHE_MAX_ENTRIES = 256;
 const LICENSE_GATE_RETRY_DELAY_MS = 15 * 60_000;
 const licenseGateRepoVisibilityCache = new Map<string, { visibility: "public" | "private" | "unknown"; expiresAtMs: number }>();
+
+function hasDurableAuthorizedReviewReceipt(
+  consumption: ReviewEventAuthorizationConsumptionRecord | undefined
+): consumption is ReviewEventAuthorizationConsumptionRecord & {
+  postedEvent: ReviewEvent;
+  reviewUrl: string;
+  postedAt: string;
+} {
+  if (!consumption) return false;
+  return Boolean(consumption.postedEvent) &&
+    Boolean(consumption.reviewUrl) &&
+    Boolean(consumption.postedAt);
+}
+
+function recordConsumedAuthorizationIncident(input: {
+  state: ReviewStateStore;
+  repo: string;
+  pull: PullRequestSummary;
+  triggerCommentId: number;
+}): boolean {
+  return input.state.recordReviewEventAuthorizationIncident({
+    repo: input.repo,
+    pullNumber: input.pull.number,
+    headSha: input.pull.head.sha,
+    triggerCommentId: input.triggerCommentId,
+    error: EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR
+  });
+}
 
 export function buildReviewProviderMetadata(config: BotConfig): ReviewProviderMetadata {
   const providerId = config.zcode.providerId ?? config.providers?.defaultProviderId ?? "zcode-glm";
@@ -1458,21 +1487,26 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   }
 
   const commandReviewRequested = commandDecision.shouldReview;
-  // The scheduler pre-records request-changes before the worker re-resolves it, so only a
-  // non-command decision needs this early exact-comment lookup to bypass a processed advisory head.
-  let exactOwnerReviewRequested = Boolean(
-    processed &&
-    input.commandCommentId &&
-    !commandReviewRequested &&
-    (await lookupQueuedReviewEventAuthorization({
-      mode: "trusted_command_only",
+  // The scheduler pre-records request-changes before the worker re-resolves it. Re-read the exact
+  // queued comment even when no processed row exists so a consumed crash-recovery command cannot
+  // fall through as an ordinary advisory review.
+  const queuedAuthorization = input.commandCommentId && !commandReviewRequested
+    ? await lookupQueuedReviewEventAuthorization({
+      mode: reviewEventPolicyMode,
       github,
       repo,
       pull,
       commandCommentId: input.commandCommentId,
       commandConfig: config.commands
-    })).status === "eligible"
-  );
+    })
+    : undefined;
+  let exactOwnerReviewRequested = queuedAuthorization?.status === "eligible";
+  const queuedProcessedCommand = input.commandCommentId
+    ? state.getProcessedCommand(repo, pull.number, pull.head.sha, input.commandCommentId)
+    : undefined;
+  const queuedOwnerRequestChanges = commandDecision.action === "request-changes" ||
+    queuedProcessedCommand?.action === "request-changes" ||
+    exactOwnerReviewRequested;
   let manualReviewRequested = commandReviewRequested || exactOwnerReviewRequested;
   if (manualReviewRequested) {
     const livePull = await github.getPull(repo, pull.number);
@@ -1485,16 +1519,25 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   }
   if (input.commandCommentId) {
     const consumption = state.getReviewEventAuthorizationConsumption(repo, pull.number, pull.head.sha);
-    const queuedRequestChanges = commandDecision.action === "request-changes" ||
-      exactOwnerReviewRequested ||
+    const queuedRequestChanges = queuedOwnerRequestChanges ||
       consumption?.commentId === input.commandCommentId;
     if (consumption && queuedRequestChanges) {
-      if (processed?.status === "posted") {
+      if (hasDurableAuthorizedReviewReceipt(consumption)) {
         await reconcileProcessedHeadAfterDirectReviewSafely({ config, github, state, repo, pull, dryRun: input.dryRun });
         return "skipped_processed";
       }
       const evidenceDir = buildEvidenceDir(config, repo, pull, commandDecision, input.commandCommentId);
       mkdirSync(evidenceDir, { recursive: true });
+      const incidentRecorded = recordConsumedAuthorizationIncident({
+        state,
+        repo,
+        pull,
+        triggerCommentId: input.commandCommentId
+      });
+      if (!incidentRecorded) {
+        await reconcileProcessedHeadAfterDirectReviewSafely({ config, github, state, repo, pull, dryRun: input.dryRun });
+        return "skipped_processed";
+      }
       writeRedactedJson(join(evidenceDir, "consumed-authorization-incident.json"), {
         reason: EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR,
         repo,
@@ -1502,13 +1545,6 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
         headSha: pull.head.sha,
         commentId: input.commandCommentId,
         consumedAt: consumption.consumedAt
-      });
-      state.recordProcessed({
-        repo,
-        pullNumber: pull.number,
-        headSha: pull.head.sha,
-        status: "skipped",
-        error: EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR
       });
       return "skipped_consumed_authorization";
     }
@@ -1908,6 +1944,50 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       commandCommentId: input.commandCommentId,
       commandConfig: config.commands
     });
+    if (reviewEventPolicyMode === "trusted_command_only" && queuedOwnerRequestChanges) {
+      const concurrentConsumption = state.getReviewEventAuthorizationConsumption(repo, pull.number, pull.head.sha);
+      if (concurrentConsumption) {
+        const triggerCommentId = input.commandCommentId ??
+          (commandDecision.action === "request-changes" ? commandDecision.commandId : concurrentConsumption.commentId);
+        if (hasDurableAuthorizedReviewReceipt(concurrentConsumption)) {
+          await reconcileProcessedHeadAfterDirectReviewSafely({
+            config,
+            github,
+            state,
+            repo,
+            pull,
+            dryRun: input.dryRun
+          });
+          return "skipped_processed";
+        }
+        const incidentRecorded = recordConsumedAuthorizationIncident({
+          state,
+          repo,
+          pull,
+          triggerCommentId
+        });
+        if (!incidentRecorded) {
+          await reconcileProcessedHeadAfterDirectReviewSafely({
+            config,
+            github,
+            state,
+            repo,
+            pull,
+            dryRun: input.dryRun
+          });
+          return "skipped_processed";
+        }
+        writeRedactedJson(join(evidenceDir, "consumed-authorization-incident.json"), {
+          reason: EXACT_AUTHORIZATION_ALREADY_CONSUMED_ERROR,
+          repo,
+          pullNumber: pull.number,
+          headSha: pull.head.sha,
+          commentId: triggerCommentId,
+          consumedAt: concurrentConsumption.consumedAt
+        });
+        return "skipped_consumed_authorization";
+      }
+    }
     exactOwnerReviewRequested = exactOwnerReviewRequested || authorization.status === "eligible";
     manualReviewRequested = commandReviewRequested || exactOwnerReviewRequested;
     if (reviewEventPolicyMode === "trusted_command_only") {
@@ -2009,7 +2089,24 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       body: reviewBodyAfterWalkthroughPost(plan),
       comments
     });
-    if (!preservedPriorBlockingRow) {
+    if (reviewEventResolution.consumed) {
+      if (
+        reviewEventResolution.authorization.status !== "eligible" ||
+        !review.html_url
+      ) {
+        throw new Error("consumed owner authorization did not produce a durable review receipt");
+      }
+      state.recordAuthorizedReviewPosted({
+        repo,
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        commentId: reviewEventResolution.authorization.commentId,
+        author: reviewEventResolution.authorization.author,
+        event: plan.event,
+        reviewUrl: review.html_url,
+        preserveExistingBlocking: preservedPriorBlockingRow
+      });
+    } else if (!preservedPriorBlockingRow) {
       state.recordProcessed({
         repo,
         pullNumber: pull.number,
@@ -2057,6 +2154,9 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     if ((headChangedDuringPost || postReviewHeadLookupFailed) && !preservedPriorVerifiedBlockingRow) {
       const durablePosted = state.getProcessedReview(repo, pull.number, pull.head.sha);
       if (durablePosted?.status === "posted") {
+        const uncertaintyReason = headChangedDuringPost
+          ? REVIEW_POSTED_HEAD_CHANGED_ERROR
+          : POST_REVIEW_HEAD_UNVERIFIED_ERROR;
         state.recordProcessed({
           repo,
           pullNumber: pull.number,
@@ -2064,7 +2164,19 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
           status: "posted",
           ...(durablePosted.event ? { event: durablePosted.event } : {}),
           ...(durablePosted.reviewUrl ? { reviewUrl: durablePosted.reviewUrl } : {}),
-          error: headChangedDuringPost ? REVIEW_POSTED_HEAD_CHANGED_ERROR : POST_REVIEW_HEAD_UNVERIFIED_ERROR
+          error: uncertaintyReason
+        });
+        state.recordReviewReadiness({
+          repo,
+          pullNumber: pull.number,
+          headSha: pull.head.sha,
+          state: headChangedDuringPost ? "stale" : "failed",
+          reason: uncertaintyReason,
+          ...(durablePosted.event ? { event: durablePosted.event } : {}),
+          ...(durablePosted.reviewUrl ? { reviewUrl: durablePosted.reviewUrl } : {}),
+          ...(input.commandCommentId
+            ? { commandAction: "request-changes" as const, commandCommentId: input.commandCommentId }
+            : {})
         });
       }
     }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1485,7 +1485,10 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
   }
   if (input.commandCommentId) {
     const consumption = state.getReviewEventAuthorizationConsumption(repo, pull.number, pull.head.sha);
-    if (consumption?.commentId === input.commandCommentId) {
+    const queuedRequestChanges = commandDecision.action === "request-changes" ||
+      exactOwnerReviewRequested ||
+      consumption?.commentId === input.commandCommentId;
+    if (consumption && queuedRequestChanges) {
       if (processed?.status === "posted") {
         await reconcileProcessedHeadAfterDirectReviewSafely({ config, github, state, repo, pull, dryRun: input.dryRun });
         return "skipped_processed";

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -541,7 +541,7 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
-  it("turns a consumed manual replay into a terminal tombstone and never enqueues automatic same-head work", async () => {
+  it("turns a consumed manual replay into a terminal incident and never enqueues automatic same-head work", async () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-scheduler-consumed-replay-"));
     roots.push(root);
     const config = schedulerConfig(root, ["org/repo-a"]);
@@ -588,9 +588,11 @@ describe("provider-aware review scheduler", () => {
     expect(replay.failed).toBe(1);
     expect(automatic.reviewed).toBe(0);
     expect(reviewCalls).toBe(1);
-    expect(state.getProcessedReview("org/repo-a", 1, HEAD_A)).toMatchObject({
-      status: "skipped",
-      error: "exact_authorization_already_consumed"
+    expect(state.getProcessedReview("org/repo-a", 1, HEAD_A)).toBeUndefined();
+    expect(state.getReviewEventAuthorizationConsumption("org/repo-a", 1, HEAD_A)).toMatchObject({
+      commentId: 930,
+      incidentError: "exact_authorization_already_consumed",
+      incidentCommentId: 930
     });
     expect(state.listReviewQueueJobs()).toHaveLength(1);
     expect(state.listReviewQueueJobs({ state: "failed" })).toHaveLength(1);
@@ -4492,13 +4494,25 @@ describe("provider-aware review scheduler", () => {
       });
       const event = consumed ? "REQUEST_CHANGES" as const : "COMMENT" as const;
       selectedEvents.push(event);
-      reviewState.recordProcessed({
-        repo,
-        pullNumber: reviewPull.number,
-        headSha: reviewPull.head.sha,
-        status: "posted",
-        event
-      });
+      if (consumed) {
+        reviewState.recordAuthorizedReviewPosted({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          commentId: commandCommentId!,
+          author: "maintainer",
+          event: "REQUEST_CHANGES",
+          reviewUrl: `https://github.com/${repo}/pull/${reviewPull.number}#pullrequestreview-1`
+        });
+      } else {
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "posted",
+          event
+        });
+      }
       return "reviewed_command";
     };
 
@@ -4527,12 +4541,87 @@ describe("provider-aware review scheduler", () => {
     expect(selectedEvents).toEqual(["REQUEST_CHANGES"]);
     expect(state.listReviewQueueJobs().map((job) => job.commentId)).toEqual([940]);
     expect(state.hasProcessedCommand("org/repo-a", 1, HEAD_A, 941)).toBe(true);
+    expect(state.getReviewEventAuthorizationConsumption("org/repo-a", 1, HEAD_A)).toMatchObject({
+      commentId: 940,
+      postedEvent: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-1"
+    });
     expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
       state: "needs_fix",
       event: "REQUEST_CHANGES",
       commandAction: "request-changes",
       commandCommentId: 940
     });
+    state.close();
+  });
+
+  it("does not treat an older advisory row as the receipt for a consumed blocking authorization", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-request-changes-unlinked-consumption-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@neondiff"],
+      trustedAuthors: ["maintainer"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    state.recordProcessed({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-1"
+    });
+    expect(state.tryConsumeReviewEventAuthorization({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      commentId: 942,
+      author: "maintainer"
+    })).toBe(true);
+    const comments = new Map([["org/repo-a#1", [
+      comment(943, "maintainer", `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`)
+    ]]]);
+    let reviewCalls = 0;
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), comments),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull }) => {
+        reviewCalls += 1;
+        reviewState.recordReviewEventAuthorizationIncident({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          triggerCommentId: 943,
+          error: "exact_authorization_already_consumed"
+        });
+        return "skipped_consumed_authorization";
+      }
+    });
+
+    expect(result.commandReviewRequested).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(reviewCalls).toBe(1);
+    expect(state.getProcessedReview("org/repo-a", 1, HEAD_A)).toMatchObject({
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/org/repo-a/pull/1#pullrequestreview-1"
+    });
+    expect(state.getReviewEventAuthorizationConsumption("org/repo-a", 1, HEAD_A)).toMatchObject({
+      commentId: 942,
+      incidentError: "exact_authorization_already_consumed",
+      incidentCommentId: 943
+    });
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "failed",
+      reason: "exact_authorization_already_consumed"
+    });
+    expect(state.hasProcessedCommand("org/repo-a", 1, HEAD_A, 943)).toBe(true);
     state.close();
   });
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -4460,7 +4460,7 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
-  it("queues a second new same-head command while the one-shot ledger keeps it advisory", async () => {
+  it("does not queue a second new same-head request-changes command after the one-shot ledger survives restart", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-request-changes-second-command-"));
     roots.push(root);
     const config = schedulerConfig(root, ["org/repo-a"]);
@@ -4470,7 +4470,7 @@ describe("provider-aware review scheduler", () => {
       trustedAuthors: ["maintainer"],
       acknowledge: false
     };
-    const state = new ReviewStateStore(config.statePath);
+    let state = new ReviewStateStore(config.statePath);
     const commentsForPull = [
       comment(940, "maintainer", `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`)
     ];
@@ -4509,6 +4509,8 @@ describe("provider-aware review scheduler", () => {
       options: { dryRun: false, useZCode: false },
       reviewPullImpl
     });
+    state.close();
+    state = new ReviewStateStore(config.statePath);
     commentsForPull.push(
       comment(941, "maintainer", `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`)
     );
@@ -4521,14 +4523,15 @@ describe("provider-aware review scheduler", () => {
     });
 
     expect(first.commandReviewRequested).toBe(1);
-    expect(second.commandReviewRequested).toBe(1);
-    expect(selectedEvents).toEqual(["REQUEST_CHANGES", "COMMENT"]);
-    expect(state.listReviewQueueJobs().map((job) => job.commentId)).toEqual([940, 941]);
+    expect(second.commandReviewRequested).toBe(0);
+    expect(selectedEvents).toEqual(["REQUEST_CHANGES"]);
+    expect(state.listReviewQueueJobs().map((job) => job.commentId)).toEqual([940]);
+    expect(state.hasProcessedCommand("org/repo-a", 1, HEAD_A, 941)).toBe(true);
     expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
-      state: "ready_for_human",
-      event: "COMMENT",
+      state: "needs_fix",
+      event: "REQUEST_CHANGES",
       commandAction: "request-changes",
-      commandCommentId: 941
+      commandCommentId: 940
     });
     state.close();
   });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1677,6 +1677,12 @@ describe("review state store", () => {
     });
 
     expect(store.hasProcessedCommand("electricsheephq/WorldOS", 1161, "head-a", 123)).toBe(true);
+    expect(store.getProcessedCommand("electricsheephq/WorldOS", 1161, "head-a", 123)).toMatchObject({
+      action: "review",
+      status: "triggered",
+      headSha: "head-a"
+    });
+    expect(store.getProcessedCommand("electricsheephq/WorldOS", 1161, "head-b", 123)).toBeUndefined();
     expect(store.hasProcessedCommand("electricsheephq/WorldOS", 1161, "head-b", 123)).toBe(true);
     expect(store.hasProcessedCommand("electricsheephq/WorldOS", 1161, "head-a", 124)).toBe(false);
     store.close();
@@ -1704,8 +1710,115 @@ describe("review state store", () => {
       author: "100yenadmin",
       consumedAt: "2026-07-13T00:00:00.000Z"
     });
+    store.recordAuthorizedReviewPosted({
+      ...authorization,
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-1",
+      now: new Date("2026-07-13T00:01:00.000Z")
+    });
+    expect(store.getReviewEventAuthorizationConsumption("owner/repo", 7, "A".repeat(40))).toEqual({
+      repo: "owner/repo",
+      pullNumber: 7,
+      headSha: "a".repeat(40),
+      commentId: 41,
+      author: "100yenadmin",
+      consumedAt: "2026-07-13T00:00:00.000Z",
+      postedEvent: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-1",
+      postedAt: "2026-07-13T00:01:00.000Z"
+    });
+    expect(store.getProcessedReview("owner/repo", 7, "A".repeat(40))).toMatchObject({
+      status: "posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-1"
+    });
+    expect(store.recordReviewEventAuthorizationIncident({
+      repo: "owner/repo",
+      pullNumber: 7,
+      headSha: "A".repeat(40),
+      triggerCommentId: 44,
+      error: "late_incident_must_lose"
+    })).toBe(false);
+    expect(store.getReviewEventAuthorizationConsumption("owner/repo", 7, "A".repeat(40))).not.toHaveProperty("incidentError");
+    expect(store.getReviewReadiness("owner/repo", 7, "A".repeat(40))).toMatchObject({
+      state: "needs_fix",
+      event: "REQUEST_CHANGES",
+      reason: "request_changes_review_posted"
+    });
     expect(store.tryConsumeReviewEventAuthorization({ ...authorization, commentId: 42 })).toBe(false);
     expect(store.tryConsumeReviewEventAuthorization({ ...authorization, commentId: 42, headSha: "b".repeat(40) })).toBe(true);
+    expect(store.recordReviewEventAuthorizationIncident({
+      repo: "owner/repo",
+      pullNumber: 7,
+      headSha: "b".repeat(40),
+      triggerCommentId: 43,
+      error: "exact_authorization_already_consumed",
+      now: new Date("2026-07-13T00:02:00.000Z")
+    })).toBe(true);
+    expect(store.getReviewEventAuthorizationConsumption("owner/repo", 7, "b".repeat(40))).toMatchObject({
+      commentId: 42,
+      incidentError: "exact_authorization_already_consumed",
+      incidentCommentId: 43,
+      incidentAt: "2026-07-13T00:02:00.000Z"
+    });
+    expect(store.getProcessedReview("owner/repo", 7, "b".repeat(40))).toBeUndefined();
+    expect(store.getReviewReadiness("owner/repo", 7, "b".repeat(40))).toMatchObject({
+      state: "failed",
+      reason: "exact_authorization_already_consumed"
+    });
+    store.recordAuthorizedReviewPosted({
+      ...authorization,
+      headSha: "b".repeat(40),
+      commentId: 42,
+      event: "COMMENT",
+      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-2",
+      now: new Date("2026-07-13T00:03:00.000Z")
+    });
+    expect(store.getReviewEventAuthorizationConsumption("owner/repo", 7, "b".repeat(40))).toMatchObject({
+      postedEvent: "COMMENT",
+      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-2"
+    });
+    expect(store.getReviewEventAuthorizationConsumption("owner/repo", 7, "b".repeat(40))).not.toHaveProperty("incidentError");
+    expect(store.getReviewReadiness("owner/repo", 7, "b".repeat(40))).toMatchObject({
+      state: "ready_for_human",
+      event: "COMMENT",
+      reason: "comment_review_posted"
+    });
+    const legacyBlockingHead = "d".repeat(40);
+    store.recordProcessed({
+      repo: "owner/repo",
+      pullNumber: 7,
+      headSha: legacyBlockingHead,
+      status: "posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-blocking"
+    });
+    expect(store.tryConsumeReviewEventAuthorization({
+      ...authorization,
+      headSha: legacyBlockingHead,
+      commentId: 45
+    })).toBe(true);
+    store.recordAuthorizedReviewPosted({
+      ...authorization,
+      headSha: legacyBlockingHead,
+      commentId: 45,
+      event: "COMMENT",
+      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-advisory",
+      preserveExistingBlocking: true
+    });
+    expect(store.getProcessedReview("owner/repo", 7, legacyBlockingHead)).toMatchObject({
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-blocking"
+    });
+    expect(store.getReviewEventAuthorizationConsumption("owner/repo", 7, legacyBlockingHead)).toMatchObject({
+      postedEvent: "COMMENT",
+      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-advisory"
+    });
+    expect(store.getReviewReadiness("owner/repo", 7, legacyBlockingHead)).toMatchObject({
+      state: "needs_fix",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-blocking"
+    });
     expect(() => store.tryConsumeReviewEventAuthorization({ ...authorization, repo: "invalid" })).toThrow("repo must be an owner/repo name");
     expect(() => store.tryConsumeReviewEventAuthorization({ ...authorization, pullNumber: 0 })).toThrow("pullNumber must be a positive integer");
     expect(() => store.tryConsumeReviewEventAuthorization({ ...authorization, headSha: "short" })).toThrow("headSha must be a 40-character hexadecimal SHA");
@@ -1756,11 +1869,31 @@ describe("review state store", () => {
         primary key (repo, pull_number, head_sha)
       );
       insert into processed_reviews (repo, pull_number, head_sha, status) values ('owner/repo', 7, '${"c".repeat(40)}', 'posted');
+      create table review_event_authorization_consumptions (
+        repo text not null,
+        pull_number integer not null,
+        head_sha text not null,
+        comment_id integer not null,
+        author text not null,
+        consumed_at text not null,
+        primary key (repo, pull_number, head_sha)
+      );
+      insert into review_event_authorization_consumptions
+        (repo, pull_number, head_sha, comment_id, author, consumed_at)
+      values ('owner/repo', 7, '${"c".repeat(40)}', 41, '100yenadmin', '2026-07-13T00:00:00.000Z');
     `);
     legacyDb.close();
 
     const store = new ReviewStateStore(dbPath);
     expect(store.hasProcessed("owner/repo", 7, "c".repeat(40))).toBe(true);
+    expect(store.getReviewEventAuthorizationConsumption("owner/repo", 7, "c".repeat(40))).toEqual({
+      repo: "owner/repo",
+      pullNumber: 7,
+      headSha: "c".repeat(40),
+      commentId: 41,
+      author: "100yenadmin",
+      consumedAt: "2026-07-13T00:00:00.000Z"
+    });
     expect(store.tryConsumeReviewEventAuthorization({
       repo: "owner/repo",
       pullNumber: 7,
@@ -1773,7 +1906,7 @@ describe("review state store", () => {
     const migratedDb = new DatabaseSync(dbPath);
     try {
       expect(migratedDb.prepare("select count(*) as count from processed_reviews").get()).toEqual({ count: 1 });
-      expect(migratedDb.prepare("select count(*) as count from review_event_authorization_consumptions").get()).toEqual({ count: 1 });
+      expect(migratedDb.prepare("select count(*) as count from review_event_authorization_consumptions").get()).toEqual({ count: 2 });
     } finally {
       migratedDb.close();
     }

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -1130,7 +1130,7 @@ describe("worker context budget preflight", () => {
     scenario.state.close();
   });
 
-  it("keeps the first blocking review durable when a second exact command posts an advisory in a separate evidence directory", async () => {
+  it("keeps the first blocking review durable and posts nothing for a second exact command", async () => {
     const headSha = "f".repeat(40);
     const first = await runOwnerPolicyReview({
       roots,
@@ -1151,35 +1151,24 @@ describe("worker context budget preflight", () => {
       commandCommentId: 60
     });
 
-    expect(second.result).toBe("reviewed_command");
-    expect(createdReviews.map((review) => review.event)).toEqual(["REQUEST_CHANGES", "COMMENT"]);
+    expect(second.result).toBe("skipped_processed");
+    expect(createdReviews.map((review) => review.event)).toEqual(["REQUEST_CHANGES"]);
     expect(second.state.getProcessedReview("electricsheephq/WorldOS", 519, headSha)).toEqual(blocking);
     expect(second.state.getReviewReadiness("electricsheephq/WorldOS", 519, headSha)).toMatchObject({
       state: "needs_fix",
       event: "REQUEST_CHANGES",
       reviewUrl: blocking?.reviewUrl
     });
-    expect(first.evidenceDir).not.toBe(second.evidenceDir);
     expect(first.evidenceDir).toContain("command-59");
-    expect(second.evidenceDir).toContain("command-60");
     expect(existsSync(join(first.evidenceDir, "review-event-decision.json"))).toBe(true);
-    expect(existsSync(join(second.evidenceDir, "review-event-decision.json"))).toBe(true);
     expect(existsSync(join(first.evidenceDir, "command.json"))).toBe(false);
-    expect(existsSync(join(second.evidenceDir, "command.json"))).toBe(false);
     expect(JSON.parse(readFileSync(join(first.evidenceDir, "posted-review.json"), "utf8"))).toEqual({
       event: "REQUEST_CHANGES",
       reviewId: 1,
       reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/519#pullrequestreview-1"
     });
-    expect(JSON.parse(readFileSync(join(second.evidenceDir, "posted-review.json"), "utf8"))).toEqual({
-      event: "COMMENT",
-      reviewId: 2,
-      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/519#pullrequestreview-2"
-    });
     expect(readFileSync(join(first.evidenceDir, "posted-review.json"), "utf8")).not.toContain("request-changes --repo");
-    expect(readFileSync(join(second.evidenceDir, "posted-review.json"), "utf8")).not.toContain("request-changes --repo");
     expect(JSON.stringify(readDecision(first.evidenceDir))).not.toContain("request-changes");
-    expect(JSON.stringify(readDecision(second.evidenceDir))).not.toContain("request-changes");
     second.state.close();
   });
 
@@ -1216,7 +1205,7 @@ describe("worker context budget preflight", () => {
     replay.state.close();
   });
 
-  it("does not contaminate a verified blocking row when a later advisory head reread fails", async () => {
+  it("does not post or contaminate a verified blocking row when a later exact command is replayed", async () => {
     const headSha = "2".repeat(40);
     const first = await runOwnerPolicyReview({
       roots,
@@ -1239,8 +1228,8 @@ describe("worker context budget preflight", () => {
       postReviewHeadLookupError: new Error("advisory reread unavailable")
     });
 
-    expect(advisory.result).toBe("posted_head_unverified");
-    expect(createdReviews.map((review) => review.event)).toEqual(["REQUEST_CHANGES", "COMMENT"]);
+    expect(advisory.result).toBe("skipped_processed");
+    expect(createdReviews.map((review) => review.event)).toEqual(["REQUEST_CHANGES"]);
     expect(advisory.state.getProcessedReview("electricsheephq/WorldOS", 521, headSha)).toEqual(blocking);
     advisory.state.close();
   });

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -726,9 +726,14 @@ describe("worker context budget preflight", () => {
     expect(scenario.result).toBe("skipped_consumed_authorization");
     expect(createdReviews).toEqual([]);
     expect(zcodePrompts).toEqual([]);
-    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 503, headSha)).toMatchObject({
-      status: "skipped",
-      error: "exact_authorization_already_consumed"
+    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 503, headSha)).toBeUndefined();
+    expect(scenario.state.getReviewEventAuthorizationConsumption("electricsheephq/WorldOS", 503, headSha)).toMatchObject({
+      incidentError: "exact_authorization_already_consumed",
+      incidentCommentId: 42
+    });
+    expect(scenario.state.getReviewReadiness("electricsheephq/WorldOS", 503, headSha)).toMatchObject({
+      state: "failed",
+      reason: "exact_authorization_already_consumed"
     });
     expect(JSON.parse(readFileSync(join(scenario.evidenceDir, "consumed-authorization-incident.json"), "utf8"))).toMatchObject({
       reason: "exact_authorization_already_consumed",
@@ -736,6 +741,153 @@ describe("worker context budget preflight", () => {
       pullNumber: 503,
       headSha,
       commentId: 42
+    });
+    scenario.state.close();
+  });
+
+  it("does not mistake an older advisory post for a consumed blocking authorization receipt", async () => {
+    const headSha = "2".repeat(40);
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 522,
+      headSha,
+      commandComment: requestChangesComment(72, 522, headSha),
+      commandCommentId: 72,
+      configureState: (state) => {
+        state.recordProcessed({
+          repo: "electricsheephq/WorldOS",
+          pullNumber: 522,
+          headSha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/522#pullrequestreview-1"
+        });
+        expect(state.tryConsumeReviewEventAuthorization({
+          repo: "electricsheephq/WorldOS",
+          pullNumber: 522,
+          headSha,
+          commentId: 71,
+          author: "100yenadmin"
+        })).toBe(true);
+      }
+    });
+
+    expect(scenario.result).toBe("skipped_consumed_authorization");
+    expect(createdReviews).toEqual([]);
+    expect(zcodePrompts).toEqual([]);
+    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 522, headSha)).toMatchObject({
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/522#pullrequestreview-1"
+    });
+    expect(scenario.state.getReviewEventAuthorizationConsumption("electricsheephq/WorldOS", 522, headSha)).toMatchObject({
+      commentId: 71,
+      incidentError: "exact_authorization_already_consumed",
+      incidentCommentId: 72
+    });
+    expect(scenario.state.getReviewReadiness("electricsheephq/WorldOS", 522, headSha)).toMatchObject({
+      state: "failed",
+      reason: "exact_authorization_already_consumed"
+    });
+    scenario.state.close();
+  });
+
+  it("rechecks the owner authorization receipt after a concurrent provider run reaches the post claim", async () => {
+    const headSha = "3".repeat(40);
+    let state!: ReviewStateStore;
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 523,
+      headSha,
+      commandComment: requestChangesComment(74, 523, headSha),
+      commandCommentId: 74,
+      lateCommentLookupError: new Error("late GitHub comment lookup failed"),
+      configureState: (configuredState) => {
+        state = configuredState;
+        const claim = state.tryClaimReviewHead.bind(state);
+        vi.spyOn(state, "tryClaimReviewHead").mockImplementation((input) => {
+          if (!state.getReviewEventAuthorizationConsumption("electricsheephq/WorldOS", 523, headSha)) {
+            expect(state.tryConsumeReviewEventAuthorization({
+              repo: "electricsheephq/WorldOS",
+              pullNumber: 523,
+              headSha,
+              commentId: 73,
+              author: "100yenadmin"
+            })).toBe(true);
+            state.recordAuthorizedReviewPosted({
+              repo: "electricsheephq/WorldOS",
+              pullNumber: 523,
+              headSha,
+              commentId: 73,
+              author: "100yenadmin",
+              event: "REQUEST_CHANGES",
+              reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/523#pullrequestreview-concurrent"
+            });
+          }
+          return claim(input);
+        });
+      }
+    });
+
+    expect(scenario.result).toBe("skipped_processed");
+    expect(scenario.exactCommentLookups).toEqual([74, 74]);
+    expect(zcodePrompts).toHaveLength(1);
+    expect(createdReviews).toEqual([]);
+    expect(scenario.state.getProcessedReview("electricsheephq/WorldOS", 523, headSha)).toMatchObject({
+      status: "posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/523#pullrequestreview-concurrent"
+    });
+    scenario.state.close();
+  });
+
+  it("lets a concurrent receipt win atomically after a worker reads an unreceipted consumption", async () => {
+    const headSha = "4".repeat(40);
+    let state!: ReviewStateStore;
+    const scenario = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 524,
+      headSha,
+      commandComment: requestChangesComment(77, 524, headSha),
+      commandCommentId: 77,
+      configureState: (configuredState) => {
+        state = configuredState;
+        expect(state.tryConsumeReviewEventAuthorization({
+          repo: "electricsheephq/WorldOS",
+          pullNumber: 524,
+          headSha,
+          commentId: 76,
+          author: "100yenadmin"
+        })).toBe(true);
+        const recordIncident = state.recordReviewEventAuthorizationIncident.bind(state);
+        vi.spyOn(state, "recordReviewEventAuthorizationIncident").mockImplementation((input) => {
+          if (!state.getReviewEventAuthorizationConsumption("electricsheephq/WorldOS", 524, headSha)?.postedAt) {
+            state.recordAuthorizedReviewPosted({
+              repo: "electricsheephq/WorldOS",
+              pullNumber: 524,
+              headSha,
+              commentId: 76,
+              author: "100yenadmin",
+              event: "REQUEST_CHANGES",
+              reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/524#pullrequestreview-concurrent"
+            });
+          }
+          return recordIncident(input);
+        });
+      }
+    });
+
+    expect(scenario.result).toBe("skipped_processed");
+    expect(createdReviews).toEqual([]);
+    expect(zcodePrompts).toEqual([]);
+    expect(scenario.state.getReviewEventAuthorizationConsumption("electricsheephq/WorldOS", 524, headSha)).toMatchObject({
+      postedEvent: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/524#pullrequestreview-concurrent"
+    });
+    expect(scenario.state.getReviewEventAuthorizationConsumption("electricsheephq/WorldOS", 524, headSha)).not.toHaveProperty("incidentError");
+    expect(scenario.state.getReviewReadiness("electricsheephq/WorldOS", 524, headSha)).toMatchObject({
+      state: "needs_fix",
+      reason: "request_changes_review_posted"
     });
     scenario.state.close();
   });
@@ -919,7 +1071,10 @@ describe("worker context budget preflight", () => {
       liveHeadSha: "4".repeat(40),
       reviewId: 1
     });
-    expect(scenario.state.getReviewReadiness("electricsheephq/WorldOS", 510, headSha)).toBeUndefined();
+    expect(scenario.state.getReviewReadiness("electricsheephq/WorldOS", 510, headSha)).toMatchObject({
+      state: "stale",
+      reason: "review_posted_head_changed"
+    });
     scenario.state.close();
   });
 
@@ -969,6 +1124,8 @@ describe("worker context budget preflight", () => {
       candidateSeverity: "P2"
     });
 
+    expect(scenario.error).toBeUndefined();
+    expect(scenario.result).toBe("reviewed_command");
     expect(createdReviews[0]?.event).toBe("COMMENT");
     expect(readDecision(scenario.evidenceDir)).toMatchObject({
       candidateEvent: "COMMENT",
@@ -984,7 +1141,25 @@ describe("worker context budget preflight", () => {
       commentId: 51,
       author: "100yenadmin"
     })).toBe(false);
-    scenario.state.close();
+    expect(scenario.state.getReviewEventAuthorizationConsumption("electricsheephq/WorldOS", 511, headSha)).toMatchObject({
+      commentId: 51,
+      postedEvent: "COMMENT",
+      reviewUrl: "https://github.com/electricsheephq/WorldOS/pull/511#pullrequestreview-1"
+    });
+
+    const replay = await runOwnerPolicyReview({
+      roots,
+      existing: scenario,
+      pullNumber: 511,
+      headSha,
+      commandComment: requestChangesComment(75, 511, headSha),
+      commandCommentId: 75,
+      candidateSeverity: "P2"
+    });
+    expect(replay.error).toBeUndefined();
+    expect(replay.result).toBe("skipped_processed");
+    expect(createdReviews.map((review) => review.event)).toEqual(["COMMENT"]);
+    replay.state.close();
   });
 
   it("lets an exact queued owner command supersede a posted advisory COMMENT on the same head", async () => {
@@ -1126,7 +1301,10 @@ describe("worker context budget preflight", () => {
       error: expect.stringContaining("[redacted-secret]")
     });
     expect(JSON.stringify(incident)).not.toContain(lookupSecret);
-    expect(scenario.state.getReviewReadiness("electricsheephq/WorldOS", 517, headSha)).toBeUndefined();
+    expect(scenario.state.getReviewReadiness("electricsheephq/WorldOS", 517, headSha)).toMatchObject({
+      state: "failed",
+      reason: "post_review_head_unverified"
+    });
     scenario.state.close();
   });
 
@@ -1245,6 +1423,7 @@ async function runOwnerPolicyReview(input: {
   commandCommentId?: number;
   dryRun?: boolean;
   commentLookupError?: Error;
+  lateCommentLookupError?: Error;
   moveHeadAfterCommentLookup?: string;
   moveHeadDuringPost?: string;
   moveHeadAfterConsume?: string;
@@ -1319,6 +1498,9 @@ async function runOwnerPolicyReview(input: {
     getIssueComment: async (_repo: string, commentId: number) => {
       exactCommentLookups.push(commentId);
       if (input.commentLookupError) throw input.commentLookupError;
+      if (input.lateCommentLookupError && exactCommentLookups.length > 1) {
+        throw input.lateCommentLookupError;
+      }
       if (input.moveHeadAfterCommentLookup) {
         livePull = pullSummary(input.pullNumber, input.moveHeadAfterCommentLookup);
       }


### PR DESCRIPTION
Closes the live replay blocker in #557.

The production fixture proved one-shot blocking authority, then exposed that a second new same-head request-changes comment still ran the provider and posted a duplicate advisory review. This PR makes the consumed owner-command path receipt-backed and crash-safe without weakening the fail-closed event gate:

- ties replay suppression to the exact consumed comment plus a durable posted-review receipt, rather than any older advisory row;
- records receipt, processed outcome, readiness, and head-claim release atomically;
- records unresolved post-consumption incidents with a serialized conditional transition, so receipt and incident writers cannot overwrite each other;
- preserves a verified prior blocking outcome when a later authorized COMMENT is the deterministic result;
- rechecks durable authorization identity after provider work and head-claim acquisition, including when a late GitHub comment lookup is unavailable;
- suppresses queued, direct, recovered, concurrent, restart, and lookup-degraded replay paths before any second post.

Local exact-head proof at 7278546f5dd21448079a0ee59fb59bddc7251a55:
- focused scheduler, state, and worker tests: 190/190 passed;
- build and postbuild passed;
- public-claims and secret scans passed;
- diff check passed;
- three independent adversarial reviews found no remaining finding at 95 percent confidence after the final transactional CAS amendment.

The production daemon is deliberately stopped and the live checkout remains pinned to 11e0ef6436bdd01f048f38ddca69757486ac28be. No runtime promotion will occur until current-head remote CI is green. After merge, the live acceptance matrix will use a fresh fixture head and require exactly one advisory COMMENT, exactly one owner-authorized REQUEST_CHANGES review, and no third review after duplicate command plus restart. The fixture PR must never merge.