### PR TITLE
fix(review): terminally no-op non-upgrade owner commands

### DIFF
--- a/src/operator-cli.ts
+++ b/src/operator-cli.ts
@@ -1865,6 +1865,7 @@ function describeActionableProviderDeferredJobs(
   actionableCount: number
 ): string {
   if (!budget) return `${actionableCount} retryable provider-deferred durable queue job(s)`;
+  const waitingHeadActive = budget.providerDeferred.waitingHeadActive ?? 0;
   const waitingCapacity =
     budget.providerDeferred.waitingProviderCapacity +
     budget.providerDeferred.waitingOrgCapacity +
@@ -1876,6 +1877,7 @@ function describeActionableProviderDeferredJobs(
     `; provider_deferred total=${budget.providerDeferred.total}` +
     ` retryable=${budget.providerDeferred.retryable}` +
     ` waiting_cooldown=${budget.providerDeferred.waitingCooldown}` +
+    (waitingHeadActive > 0 ? ` waiting_head_active=${waitingHeadActive}` : "") +
     ` waiting_capacity=${waitingCapacity}`
   );
 }

--- a/src/release-status.ts
+++ b/src/release-status.ts
@@ -2766,6 +2766,7 @@ function describeProviderDeferredQueueStatus(
       describeReviewQueueCounts(database)
     );
   }
+  const waitingHeadActive = budget.providerDeferred.waitingHeadActive ?? 0;
   const waitingCapacity =
     budget.providerDeferred.waitingProviderCapacity +
     budget.providerDeferred.waitingOrgCapacity +
@@ -2777,6 +2778,7 @@ function describeProviderDeferredQueueStatus(
     `; provider_deferred total=${budget.providerDeferred.total}` +
     ` retryable=${budget.providerDeferred.retryable}` +
     ` waiting_cooldown=${budget.providerDeferred.waitingCooldown}` +
+    (waitingHeadActive > 0 ? ` waiting_head_active=${waitingHeadActive}` : "") +
     ` waiting_capacity=${waitingCapacity}` +
     describeReviewQueueCounts(database)
   );

--- a/src/review-budget.ts
+++ b/src/review-budget.ts
@@ -7,6 +7,7 @@ export type ReviewQueueDelayReason =
   | "provider_capacity"
   | "org_capacity"
   | "repo_capacity"
+  | "head_active"
   | "manual_reserve"
   | "proof_cooldown"
   | "lease_limit";
@@ -90,6 +91,7 @@ export interface ReviewBudgetStatus {
     waitingProviderCapacity: number;
     waitingOrgCapacity: number;
     waitingRepoCapacity: number;
+    waitingHeadActive: number;
     waitingManualReserve: number;
     waitingLeaseLimit: number;
   };
@@ -205,13 +207,18 @@ export function buildReviewBudgetStatus(input: {
   const eligible = queued
     .filter((job) => job.state === "queued" || isRetryEligibleByNextEligibleAt(job, now))
     .sort(compareQueueJobsForBudget);
-  const hasManualAfter = buildManualEligibilitySuffix(eligible);
   const wouldLease: ReviewBudgetCandidate[] = [];
   const simulatedProviderActive = new Map(activeProvider);
   const simulatedOrgActive = new Map(activeOrg);
   const simulatedRepoActive = new Map(activeRepo);
+  const activeHeads = new Set(active.map(reviewQueueHeadKey));
 
   for (const [index, job] of eligible.entries()) {
+    const headKey = reviewQueueHeadKey(job);
+    if (activeHeads.has(headKey)) {
+      delayed.push(delay(job, "head_active"));
+      continue;
+    }
     const provider = providerKey(job);
     const providerCount = simulatedProviderActive.get(provider) ?? 0;
     const orgCount = simulatedOrgActive.get(job.org) ?? 0;
@@ -223,7 +230,7 @@ export function buildReviewBudgetStatus(input: {
       orgCount,
       repoCount,
       repoActiveLimit,
-      hasManualAfter: hasManualAfter[index] ?? false
+      hasManualAfter: hasRunnableManualAfter(eligible, index, activeHeads, headKey)
     });
     if (capacityReason) {
       delayed.push(delay(job, capacityReason));
@@ -237,6 +244,7 @@ export function buildReviewBudgetStatus(input: {
     simulatedProviderActive.set(provider, providerCount + 1);
     simulatedOrgActive.set(job.org, orgCount + 1);
     simulatedRepoActive.set(job.repo, repoCount + 1);
+    activeHeads.add(headKey);
   }
 
   const delayedByReason: Partial<Record<ReviewQueueDelayReason, number>> = {};
@@ -296,6 +304,7 @@ export function buildReviewBudgetStatus(input: {
       waitingProviderCapacity: providerDeferredByReason.get("provider_capacity") ?? 0,
       waitingOrgCapacity: providerDeferredByReason.get("org_capacity") ?? 0,
       waitingRepoCapacity: providerDeferredByReason.get("repo_capacity") ?? 0,
+      waitingHeadActive: providerDeferredByReason.get("head_active") ?? 0,
       waitingManualReserve: providerDeferredByReason.get("manual_reserve") ?? 0,
       waitingLeaseLimit: providerDeferredByReason.get("lease_limit") ?? 0
     },
@@ -358,6 +367,10 @@ function providerKey(job: ReviewQueueJobRecord): string {
   return job.providerId ?? "default";
 }
 
+function reviewQueueHeadKey(job: Pick<ReviewQueueJobRecord, "repo" | "pullNumber" | "headSha">): string {
+  return `${job.repo.toLowerCase()}#${job.pullNumber}@${job.headSha.toLowerCase()}`;
+}
+
 function isProviderDeferredEligible(job: ReviewQueueJobRecord, now: Date): boolean {
   if (job.state !== "provider_deferred") return true;
   return isRetryEligibleByNextEligibleAt(job, now);
@@ -401,14 +414,19 @@ function capacityDelayReason(
   return undefined;
 }
 
-function buildManualEligibilitySuffix(jobs: ReviewQueueJobRecord[]): boolean[] {
-  const result = new Array<boolean>(jobs.length).fill(false);
-  let seenManual = false;
-  for (let index = jobs.length - 1; index >= 0; index -= 1) {
-    result[index] = seenManual;
-    if (jobs[index]?.lane === "manual") seenManual = true;
+function hasRunnableManualAfter(
+  jobs: ReviewQueueJobRecord[],
+  index: number,
+  activeHeads: Set<string>,
+  candidateHeadKey: string
+): boolean {
+  for (let cursor = index + 1; cursor < jobs.length; cursor += 1) {
+    const job = jobs[cursor];
+    if (!job || job.lane !== "manual") continue;
+    const headKey = reviewQueueHeadKey(job);
+    if (headKey !== candidateHeadKey && !activeHeads.has(headKey)) return true;
   }
-  return result;
+  return false;
 }
 
 function candidate(job: ReviewQueueJobRecord): ReviewBudgetCandidate {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -636,7 +636,11 @@ async function enqueuePullIfEligible(input: {
         input.pull.head.sha
       )
     : undefined;
-  if (unresolvedAuthorization?.incidentError && !unresolvedAuthorization.postedAt) {
+  if (
+    unresolvedAuthorization?.incidentError &&
+    !unresolvedAuthorization.postedAt &&
+    !unresolvedAuthorization.terminalAt
+  ) {
     recordReadinessTransition({
       state: input.state,
       repo: input.repo,
@@ -1228,9 +1232,8 @@ function latestPendingRequestChanges(input: {
     input.pull.head.sha
   );
   if (
-    consumed?.postedEvent &&
-    consumed.reviewUrl &&
-    consumed.postedAt
+    (consumed?.postedEvent && consumed.reviewUrl && consumed.postedAt) ||
+    (consumed?.terminalOutcome === "no_op" && consumed.terminalReason && consumed.terminalAt)
   ) {
     for (const request of pending) {
       input.state.recordProcessedCommand({
@@ -1771,6 +1774,22 @@ function syncReadinessForReviewResult(input: {
   status: ReviewPullResult;
   now: Date;
 }): void {
+  if (input.status === "skipped_processed") {
+    const authorization = input.state.getReviewEventAuthorizationConsumption(
+      input.job.repo,
+      input.pull.number,
+      input.pull.head.sha
+    );
+    if (
+      authorization?.terminalOutcome === "no_op" &&
+      authorization.terminalReason &&
+      authorization.terminalAt
+    ) {
+      // recordAuthorizedReviewNoop already restored the prior advisory readiness atomically.
+      // Preserve that exact terminal outcome instead of relabeling it as a generic processed skip.
+      return;
+    }
+  }
   const processed = input.state.getProcessedReview(input.job.repo, input.pull.number, input.pull.head.sha);
   const readinessState = readinessStateForReviewResult(input.status, processed);
   if (!readinessState) return;

--- a/src/state.ts
+++ b/src/state.ts
@@ -145,6 +145,20 @@ export interface ReviewHeadClaim {
   ownerPid: number;
 }
 
+export interface ReviewHeadClaimInput {
+  repo: string;
+  pullNumber: number;
+  headSha: string;
+  claimTtlMs: number;
+  now?: Date;
+  ownerPid?: number;
+  allowProcessedOwnerSupersession?: boolean;
+}
+
+export type ReviewHeadClaimAttempt =
+  | { status: "acquired"; claim: ReviewHeadClaim }
+  | { status: "blocked"; reason: "active_claim" | "processed" };
+
 export interface IssueEnrichmentRunLease {
   leaseId: string;
   expiresAt: string;
@@ -359,6 +373,9 @@ export interface ReviewEventAuthorizationConsumptionRecord {
   postedEvent?: ReviewEvent;
   reviewUrl?: string;
   postedAt?: string;
+  terminalOutcome?: "no_op";
+  terminalReason?: string;
+  terminalAt?: string;
   incidentError?: string;
   incidentCommentId?: number;
   incidentAt?: string;
@@ -374,6 +391,10 @@ export interface RecordAuthorizedReviewPostedInput {
   reviewUrl: string;
   preserveExistingBlocking?: boolean;
   now?: Date;
+}
+
+export interface RecordAuthorizedReviewNoopInput extends ReviewEventAuthorizationConsumptionInput {
+  reason: "candidate_comment_already_posted";
 }
 
 export interface RepoMemoryNoteRecord {
@@ -814,6 +835,9 @@ export class ReviewStateStore {
         posted_event text,
         review_url text,
         posted_at text,
+        terminal_outcome text,
+        terminal_reason text,
+        terminal_at text,
         incident_error text,
         incident_comment_id integer,
         incident_at text,
@@ -871,26 +895,33 @@ export class ReviewStateStore {
   }
 
   recordProcessed(record: ProcessedReviewRecord): void {
-    this.db
-      .prepare(
-        `insert or replace into processed_reviews
-          (repo, pull_number, head_sha, status, event, review_url, error, created_at)
-         values (?, ?, ?, ?, ?, ?, ?, datetime('now'))`
-      )
-      .run(
-        record.repo,
-        record.pullNumber,
-        record.headSha,
-        record.status,
-        record.event ?? null,
-        record.reviewUrl ?? null,
-        record.error ?? null
-      );
-    // A recorded outcome for this head supersedes any in-flight per-head claim (#295): retire it so
-    // no stale claim row lingers to its TTL after the review is durable.
-    this.db
-      .prepare("delete from review_head_claims where repo = ? and pull_number = ? and head_sha = ?")
-      .run(record.repo, record.pullNumber, record.headSha);
+    this.db.exec("begin immediate");
+    try {
+      this.db
+        .prepare(
+          `insert or replace into processed_reviews
+            (repo, pull_number, head_sha, status, event, review_url, error, created_at)
+           values (?, ?, ?, ?, ?, ?, ?, datetime('now'))`
+        )
+        .run(
+          record.repo,
+          record.pullNumber,
+          record.headSha,
+          record.status,
+          record.event ?? null,
+          record.reviewUrl ?? null,
+          record.error ?? null
+        );
+      // Completion and claim retirement are one transaction. A later ordinary claimant must see
+      // either the live claim or the durable processed row, never a gap between the two.
+      this.db
+        .prepare("delete from review_head_claims where repo = ? and pull_number = ? and head_sha = ?")
+        .run(record.repo, record.pullNumber, record.headSha);
+      this.db.exec("commit");
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
   }
 
   recordFindingOutcomeLabel(record: FindingOutcomeLabelRecord): void {
@@ -1454,14 +1485,12 @@ export class ReviewStateStore {
    * success), reviewPull releases it in a finally (release-on-failure), and a TTL backstop sweeps
    * claims whose holder died mid-review — mirroring the review_run_leases TTL idiom.
    */
-  tryClaimReviewHead(input: {
-    repo: string;
-    pullNumber: number;
-    headSha: string;
-    claimTtlMs: number;
-    now?: Date;
-    ownerPid?: number;
-  }): ReviewHeadClaim | undefined {
+  tryClaimReviewHead(input: ReviewHeadClaimInput): ReviewHeadClaim | undefined {
+    const result = this.tryClaimReviewHeadWithOutcome(input);
+    return result.status === "acquired" ? result.claim : undefined;
+  }
+
+  tryClaimReviewHeadWithOutcome(input: ReviewHeadClaimInput): ReviewHeadClaimAttempt {
     if (!Number.isInteger(input.claimTtlMs)) throw new Error("claimTtlMs must be an integer");
     if (input.claimTtlMs < 1) throw new Error("claimTtlMs must be at least 1");
     const ownerPid = input.ownerPid ?? process.pid;
@@ -1482,7 +1511,16 @@ export class ReviewStateStore {
         .get(input.repo, input.pullNumber, input.headSha) as { claim_id: string } | undefined;
       if (existing) {
         this.db.exec("commit");
-        return undefined;
+        return { status: "blocked", reason: "active_claim" };
+      }
+      if (!input.allowProcessedOwnerSupersession) {
+        const processed = this.db
+          .prepare("select 1 from processed_reviews where repo = ? and pull_number = ? and head_sha = ? limit 1")
+          .get(input.repo, input.pullNumber, input.headSha);
+        if (processed) {
+          this.db.exec("commit");
+          return { status: "blocked", reason: "processed" };
+        }
       }
       this.db
         .prepare(
@@ -1490,7 +1528,7 @@ export class ReviewStateStore {
         )
         .run(input.repo, input.pullNumber, input.headSha, claimId, ownerPid, claimedAt, expiresAt);
       this.db.exec("commit");
-      return { claimId, expiresAt, ownerPid };
+      return { status: "acquired", claim: { claimId, expiresAt, ownerPid } };
     } catch (error) {
       this.db.exec("rollback");
       throw error;
@@ -1582,7 +1620,8 @@ export class ReviewStateStore {
     const row = this.db
       .prepare(
         `select repo, pull_number, head_sha, comment_id, author, consumed_at,
-                posted_event, review_url, posted_at, incident_error, incident_comment_id, incident_at
+                posted_event, review_url, posted_at, terminal_outcome, terminal_reason, terminal_at,
+                incident_error, incident_comment_id, incident_at
          from review_event_authorization_consumptions
          where repo = ? and pull_number = ? and head_sha = ?`
       )
@@ -1596,6 +1635,9 @@ export class ReviewStateStore {
         posted_event: ReviewEvent | null;
         review_url: string | null;
         posted_at: string | null;
+        terminal_outcome: "no_op" | null;
+        terminal_reason: string | null;
+        terminal_at: string | null;
         incident_error: string | null;
         incident_comment_id: number | null;
         incident_at: string | null;
@@ -1611,6 +1653,9 @@ export class ReviewStateStore {
           ...(row.posted_event ? { postedEvent: row.posted_event } : {}),
           ...(row.review_url ? { reviewUrl: row.review_url } : {}),
           ...(row.posted_at ? { postedAt: row.posted_at } : {}),
+          ...(row.terminal_outcome ? { terminalOutcome: row.terminal_outcome } : {}),
+          ...(row.terminal_reason ? { terminalReason: row.terminal_reason } : {}),
+          ...(row.terminal_at ? { terminalAt: row.terminal_at } : {}),
           ...(row.incident_error ? { incidentError: row.incident_error } : {}),
           ...(row.incident_comment_id ? { incidentCommentId: row.incident_comment_id } : {}),
           ...(row.incident_at ? { incidentAt: row.incident_at } : {})
@@ -1642,6 +1687,7 @@ export class ReviewStateStore {
         .prepare(
           `update review_event_authorization_consumptions
            set posted_event = ?, review_url = ?, posted_at = ?,
+               terminal_outcome = null, terminal_reason = null, terminal_at = null,
                incident_error = null, incident_comment_id = null, incident_at = null
            where repo = ? and pull_number = ? and head_sha = ? and comment_id = ? and author = ?`
         )
@@ -1709,6 +1755,162 @@ export class ReviewStateStore {
     }
   }
 
+  /**
+   * Terminally resolves an owner authorization when a prior advisory COMMENT already represents
+   * the exact head and the rerun still selects COMMENT. No second GitHub review is created; the
+   * original processed/readiness truth is preserved and restart/replay can trust this outcome.
+   */
+  recordAuthorizedReviewNoop(input: RecordAuthorizedReviewNoopInput): boolean {
+    validateReviewEventAuthorizationConsumption(input);
+    const terminalAt = (input.now ?? new Date()).toISOString();
+    this.db.exec("begin immediate");
+    try {
+      const consumption = this.db
+        .prepare(
+          `select comment_id, author, posted_at, terminal_at,
+                  incident_error, incident_comment_id, incident_at
+           from review_event_authorization_consumptions
+           where repo = ? and pull_number = ? and head_sha = ?`
+        )
+        .get(input.repo, input.pullNumber, input.headSha.toLowerCase()) as {
+          comment_id: number;
+          author: string;
+          posted_at: string | null;
+          terminal_at: string | null;
+          incident_error: string | null;
+          incident_comment_id: number | null;
+          incident_at: string | null;
+        } | undefined;
+      if (!consumption) {
+        throw new Error("refusing to record an authorized review no-op without its exact consumption row");
+      }
+      if (consumption.posted_at || consumption.terminal_at) {
+        this.db.exec("commit");
+        return false;
+      }
+      if (consumption.comment_id !== input.commentId || consumption.author !== input.author) {
+        throw new Error("refusing to record an authorized review no-op for a different authorization");
+      }
+      const processed = this.getProcessedReview(input.repo, input.pullNumber, input.headSha);
+      const readiness = this.getReviewReadiness(input.repo, input.pullNumber, input.headSha);
+      const matchingAdvisoryReadiness = Boolean(
+        readiness?.state === "ready_for_human" &&
+        readiness.event === "COMMENT" &&
+        readiness.reviewUrl === processed?.reviewUrl
+      );
+      const matchingSchedulerReadiness = Boolean(
+        (readiness?.state === "queued" || readiness?.state === "reviewing") &&
+        readiness.event === "COMMENT" &&
+        readiness.reviewUrl === processed?.reviewUrl &&
+        readiness.commandAction === "request-changes" &&
+        readiness.commandCommentId === input.commentId
+      );
+      const recoverableIncidentReadiness = Boolean(
+        consumption.incident_at &&
+        consumption.incident_error &&
+        consumption.incident_comment_id &&
+        readiness?.state === "failed" &&
+        readiness.reason === consumption.incident_error &&
+        readiness.commandAction === "request-changes" &&
+        readiness.commandCommentId === consumption.incident_comment_id
+      );
+      if (
+        processed?.status !== "posted" ||
+        processed.event !== "COMMENT" ||
+        !processed.reviewUrl ||
+        (!matchingAdvisoryReadiness && !matchingSchedulerReadiness && !recoverableIncidentReadiness)
+      ) {
+        throw new Error("authorized review no-op requires an existing posted COMMENT and matching readiness");
+      }
+      const result = this.db
+        .prepare(
+          `update review_event_authorization_consumptions
+           set terminal_outcome = 'no_op', terminal_reason = ?, terminal_at = ?,
+               incident_error = null, incident_comment_id = null, incident_at = null
+           where repo = ? and pull_number = ? and head_sha = ? and comment_id = ? and author = ?
+             and posted_at is null and terminal_at is null`
+        )
+        .run(
+          input.reason,
+          terminalAt,
+          input.repo,
+          input.pullNumber,
+          input.headSha.toLowerCase(),
+          input.commentId,
+          input.author
+        );
+      if (Number(result.changes) !== 1) {
+        const existing = this.db
+          .prepare(
+            `select posted_at, terminal_at from review_event_authorization_consumptions
+             where repo = ? and pull_number = ? and head_sha = ?`
+          )
+          .get(input.repo, input.pullNumber, input.headSha.toLowerCase()) as
+            { posted_at: string | null; terminal_at: string | null } | undefined;
+        if (existing?.posted_at || existing?.terminal_at) {
+          this.db.exec("commit");
+          return false;
+        }
+        throw new Error("refusing to record an authorized review no-op without its exact consumption row");
+      }
+      if (recoverableIncidentReadiness) {
+        const restoredReadiness = this.db
+          .prepare(
+            `update review_readiness
+             set state = 'ready_for_human', reason = 'comment_review_posted', event = 'COMMENT',
+                 review_url = ?, command_action = 'request-changes', command_comment_id = ?, updated_at = ?
+             where repo = ? and pull_number = ? and head_sha = ?
+               and state = 'failed' and reason = ?
+               and command_action = 'request-changes' and command_comment_id = ?`
+          )
+          .run(
+            processed.reviewUrl,
+            input.commentId,
+            terminalAt,
+            input.repo,
+            input.pullNumber,
+            input.headSha,
+            consumption.incident_error,
+            consumption.incident_comment_id
+          );
+        if (Number(restoredReadiness.changes) !== 1) {
+          throw new Error("authorized review no-op lost ownership of its incident readiness");
+        }
+      } else if (matchingSchedulerReadiness) {
+        const restoredReadiness = this.db
+          .prepare(
+            `update review_readiness
+             set state = 'ready_for_human', reason = 'comment_review_posted', event = 'COMMENT',
+                 review_url = ?, command_action = 'request-changes', command_comment_id = ?, updated_at = ?
+             where repo = ? and pull_number = ? and head_sha = ?
+               and state in ('queued', 'reviewing') and event = 'COMMENT' and review_url = ?
+               and command_action = 'request-changes' and command_comment_id = ?`
+          )
+          .run(
+            processed.reviewUrl,
+            input.commentId,
+            terminalAt,
+            input.repo,
+            input.pullNumber,
+            input.headSha,
+            processed.reviewUrl,
+            input.commentId
+          );
+        if (Number(restoredReadiness.changes) !== 1) {
+          throw new Error("authorized review no-op lost ownership of its scheduler readiness");
+        }
+      }
+      this.db
+        .prepare("delete from review_head_claims where repo = ? and pull_number = ? and head_sha = ?")
+        .run(input.repo, input.pullNumber, input.headSha);
+      this.db.exec("commit");
+      return true;
+    } catch (error) {
+      this.db.exec("rollback");
+      throw error;
+    }
+  }
+
   recordReviewEventAuthorizationIncident(input: {
     repo: string;
     pullNumber: number;
@@ -1730,7 +1932,7 @@ export class ReviewStateStore {
         .prepare(
           `update review_event_authorization_consumptions
            set incident_error = ?, incident_comment_id = ?, incident_at = ?
-           where repo = ? and pull_number = ? and head_sha = ? and posted_at is null`
+           where repo = ? and pull_number = ? and head_sha = ? and posted_at is null and terminal_at is null`
         )
         .run(
           error,
@@ -1743,11 +1945,12 @@ export class ReviewStateStore {
       if (Number(result.changes) !== 1) {
         const existing = this.db
           .prepare(
-            `select posted_at from review_event_authorization_consumptions
+            `select posted_at, terminal_at from review_event_authorization_consumptions
              where repo = ? and pull_number = ? and head_sha = ?`
           )
-          .get(input.repo, input.pullNumber, input.headSha.toLowerCase()) as { posted_at: string | null } | undefined;
-        if (existing?.posted_at) {
+          .get(input.repo, input.pullNumber, input.headSha.toLowerCase()) as
+            { posted_at: string | null; terminal_at: string | null } | undefined;
+        if (existing?.posted_at || existing?.terminal_at) {
           this.db.exec("commit");
           return false;
         }
@@ -2235,7 +2438,7 @@ export class ReviewStateStore {
     maxRepoActiveByRepo?: Record<string, number>;
     manualCommandReserve?: number;
     excludeJobIds?: Iterable<string>;
-    reservedActiveJobs?: Iterable<Pick<ReviewQueueJobRecord, "jobId" | "providerId" | "org" | "repo">>;
+    reservedActiveJobs?: Iterable<Pick<ReviewQueueJobRecord, "jobId" | "providerId" | "org" | "repo" | "pullNumber" | "headSha">>;
     limit?: number;
     leaseTtlMs?: number;
     aging?: { enabled: boolean; maxWaitMinutes: number };
@@ -2298,12 +2501,14 @@ export class ReviewStateStore {
       const providerActive = countBy(active, (job) => job.providerId ?? "default");
       const orgActive = countBy(active, (job) => job.org);
       const repoActive = countBy(active, (job) => job.repo);
-      const hasManualAfter = buildManualEligibilitySuffix(eligible);
+      const activeHeads = new Set(active.map(reviewQueueHeadKey));
 
       for (const [index, job] of eligible.entries()) {
         if (leased.length >= limit) break;
         if (active.length + leased.length >= maxGlobalActive) break;
         const provider = job.providerId ?? "default";
+        const headKey = reviewQueueHeadKey(job);
+        if (activeHeads.has(headKey)) continue;
         const providerCount = (providerActive.get(provider) ?? 0);
         if (providerCount >= input.maxProviderActive) continue;
         if ((orgActive.get(job.org) ?? 0) >= input.maxOrgActive) continue;
@@ -2311,7 +2516,7 @@ export class ReviewStateStore {
         if ((repoActive.get(job.repo) ?? 0) >= repoActiveLimit) continue;
         if (
           job.lane === "background" &&
-          hasManualAfter[index] &&
+          hasUncoveredManualAfter(eligible, index, activeHeads, headKey) &&
           manualCommandReserve > 0 &&
           providerCount >= effectiveProviderActive - manualCommandReserve
         ) {
@@ -2337,6 +2542,7 @@ export class ReviewStateStore {
         providerActive.set(provider, providerCount + 1);
         orgActive.set(job.org, (orgActive.get(job.org) ?? 0) + 1);
         repoActive.set(job.repo, (repoActive.get(job.repo) ?? 0) + 1);
+        activeHeads.add(headKey);
         leased.push(this.getReviewQueueJob(job.jobId)!);
       }
       this.db.exec("commit");
@@ -3255,6 +3461,15 @@ export class ReviewStateStore {
     if (!names.has("posted_at")) {
       this.db.exec("alter table review_event_authorization_consumptions add column posted_at text");
     }
+    if (!names.has("terminal_outcome")) {
+      this.db.exec("alter table review_event_authorization_consumptions add column terminal_outcome text");
+    }
+    if (!names.has("terminal_reason")) {
+      this.db.exec("alter table review_event_authorization_consumptions add column terminal_reason text");
+    }
+    if (!names.has("terminal_at")) {
+      this.db.exec("alter table review_event_authorization_consumptions add column terminal_at text");
+    }
     if (!names.has("incident_error")) {
       this.db.exec("alter table review_event_authorization_consumptions add column incident_error text");
     }
@@ -3544,6 +3759,10 @@ function repoOrg(repo: string): string {
   return repo.split("/")[0] ?? "";
 }
 
+function reviewQueueHeadKey(job: Pick<ReviewQueueJobRecord, "repo" | "pullNumber" | "headSha">): string {
+  return `${job.repo.toLowerCase()}#${job.pullNumber}@${job.headSha.toLowerCase()}`;
+}
+
 function isQueueJobEligible(job: ReviewQueueJobRecord, nowIso: string): boolean {
   if (job.state === "queued") return true;
   if (job.state !== "provider_deferred" && job.state !== "blocked_on_proof") return false;
@@ -3591,14 +3810,19 @@ function buildLeaseComparator(
   };
 }
 
-function buildManualEligibilitySuffix(jobs: ReviewQueueJobRecord[]): boolean[] {
-  const hasManualAfter = new Array<boolean>(jobs.length).fill(false);
-  let seenManual = false;
-  for (let index = jobs.length - 1; index >= 0; index -= 1) {
-    hasManualAfter[index] = seenManual;
-    if (jobs[index]?.lane === "manual") seenManual = true;
+function hasUncoveredManualAfter(
+  jobs: ReviewQueueJobRecord[],
+  currentIndex: number,
+  activeHeads: ReadonlySet<string>,
+  candidateHeadKey: string
+): boolean {
+  for (let index = currentIndex + 1; index < jobs.length; index += 1) {
+    const job = jobs[index];
+    if (!job || job.lane !== "manual") continue;
+    const manualHeadKey = reviewQueueHeadKey(job);
+    if (manualHeadKey !== candidateHeadKey && !activeHeads.has(manualHeadKey)) return true;
   }
-  return hasManualAfter;
+  return false;
 }
 
 function countBy<T>(items: T[], key: (item: T) => string): Map<string, number> {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -115,17 +115,17 @@ const LICENSE_GATE_REPO_VISIBILITY_CACHE_MAX_ENTRIES = 256;
 const LICENSE_GATE_RETRY_DELAY_MS = 15 * 60_000;
 const licenseGateRepoVisibilityCache = new Map<string, { visibility: "public" | "private" | "unknown"; expiresAtMs: number }>();
 
-function hasDurableAuthorizedReviewReceipt(
+function hasDurableAuthorizedReviewOutcome(
   consumption: ReviewEventAuthorizationConsumptionRecord | undefined
-): consumption is ReviewEventAuthorizationConsumptionRecord & {
-  postedEvent: ReviewEvent;
-  reviewUrl: string;
-  postedAt: string;
-} {
+): boolean {
   if (!consumption) return false;
-  return Boolean(consumption.postedEvent) &&
+  const receipt = Boolean(consumption.postedEvent) &&
     Boolean(consumption.reviewUrl) &&
     Boolean(consumption.postedAt);
+  const terminalNoop = consumption.terminalOutcome === "no_op" &&
+    Boolean(consumption.terminalReason) &&
+    Boolean(consumption.terminalAt);
+  return receipt || terminalNoop;
 }
 
 function recordConsumedAuthorizationIncident(input: {
@@ -1522,7 +1522,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     const queuedRequestChanges = queuedOwnerRequestChanges ||
       consumption?.commentId === input.commandCommentId;
     if (consumption && queuedRequestChanges) {
-      if (hasDurableAuthorizedReviewReceipt(consumption)) {
+      if (hasDurableAuthorizedReviewOutcome(consumption)) {
         await reconcileProcessedHeadAfterDirectReviewSafely({ config, github, state, repo, pull, dryRun: input.dryRun });
         return "skipped_processed";
       }
@@ -1918,16 +1918,33 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
     // Atomic per-head claim (#295): acquired here — after every eligibility/stale check and after the
     // dry-run branch, immediately before posting — so exactly one of a racing manual-review-pr and
     // daemon posts a review on this head. The loser records a structured skip and no-ops.
-    headClaim = state.tryClaimReviewHead({
+    const headClaimAttempt = state.tryClaimReviewHeadWithOutcome({
       repo,
       pullNumber: pull.number,
       headSha: pull.head.sha,
-      claimTtlMs: config.reviewConcurrency.leaseTtlMs
+      claimTtlMs: config.reviewConcurrency.leaseTtlMs,
+      // retry_failed_head is admitted only after the earlier processed-status validation; it must
+      // be able to replace that failed/deferred row after a successful provider retry.
+      allowProcessedOwnerSupersession: commandReviewRequested ||
+        (exactOwnerReviewRequested && queuedOwnerRequestChanges) ||
+        input.processedHeadPolicy === "retry_failed_head"
     });
-    if (!headClaim) {
-      recordConcurrentClaimSkip({ state, repo, pull, evidenceDir });
+    if (headClaimAttempt.status === "blocked") {
+      if (headClaimAttempt.reason === "active_claim") {
+        recordConcurrentClaimSkip({ state, repo, pull, evidenceDir });
+      } else {
+        await reconcileProcessedHeadAfterDirectReviewSafely({
+          config,
+          github,
+          state,
+          repo,
+          pull,
+          dryRun: input.dryRun
+        });
+      }
       return "skipped_processed";
     }
+    headClaim = headClaimAttempt.claim;
 
     const liveBeforePost = await github.getPull(repo, pull.number);
     const staleBeforePost = detectStalePullHead({ expected: pull, live: liveBeforePost, phase: "before_post" });
@@ -1949,7 +1966,7 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       if (concurrentConsumption) {
         const triggerCommentId = input.commandCommentId ??
           (commandDecision.action === "request-changes" ? commandDecision.commandId : concurrentConsumption.commentId);
-        if (hasDurableAuthorizedReviewReceipt(concurrentConsumption)) {
+        if (hasDurableAuthorizedReviewOutcome(concurrentConsumption)) {
           await reconcileProcessedHeadAfterDirectReviewSafely({
             config,
             github,
@@ -2020,6 +2037,43 @@ export async function reviewPull(input: ReviewPullInput): Promise<ReviewPullResu
       reviewEventDecisionEvidence
     );
     plan.event = reviewEventResolution.decision.selectedEvent;
+    const priorPostedBeforePublicPost = state.getProcessedReview(repo, pull.number, pull.head.sha);
+    if (
+      reviewEventResolution.consumed &&
+      plan.event === "COMMENT" &&
+      priorPostedBeforePublicPost?.status === "posted" &&
+      priorPostedBeforePublicPost.event === "COMMENT"
+    ) {
+      if (reviewEventResolution.authorization.status !== "eligible") {
+        throw new Error("consumed owner authorization was not eligible for terminal no-op resolution");
+      }
+      const recorded = state.recordAuthorizedReviewNoop({
+        repo,
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        commentId: reviewEventResolution.authorization.commentId,
+        author: reviewEventResolution.authorization.author,
+        reason: "candidate_comment_already_posted"
+      });
+      writeRedactedJson(join(evidenceDir, "authorized-review-noop.json"), {
+        reason: "candidate_comment_already_posted",
+        repo,
+        pullNumber: pull.number,
+        headSha: pull.head.sha,
+        commentId: reviewEventResolution.authorization.commentId,
+        priorReviewUrl: priorPostedBeforePublicPost.reviewUrl,
+        recorded
+      });
+      await reconcileProcessedHeadAfterDirectReviewSafely({
+        config,
+        github,
+        state,
+        repo,
+        pull,
+        dryRun: input.dryRun
+      });
+      return "skipped_processed";
+    }
     if (config.walkthrough.enabled) {
       plan.walkthrough = buildWalkthroughComment({
         repo,
@@ -3074,8 +3128,9 @@ export function recordConcurrentClaimSkip(input: {
   evidenceDir: string;
 }): void {
   // The other claimant owns this head (#295). Do NOT recordProcessed here: that would `insert or
-  // replace` the winner's row AND retire the winner's live claim. Record a skipped readiness note
-  // (separate table) plus an evidence file, matching the existing skip-evidence idiom, and log it.
+  // replace` the winner's row AND retire the winner's live claim. Do not write readiness either:
+  // the loser cannot distinguish an active winner from a winner that has just made terminal
+  // REQUEST_CHANGES/needs_fix truth durable. The winning claimant exclusively owns readiness.
   const evidence = {
     reason: "concurrent_review_claim_held",
     repo: input.repo,
@@ -3088,13 +3143,6 @@ export function recordConcurrentClaimSkip(input: {
   // network-data-to-evidence-file pattern itself is the evidence-packet design, triaged as a
   // class under #249).
   writeRedactedJson(join(input.evidenceDir, "concurrent-claim-skip.json"), evidence);
-  input.state.recordReviewReadiness({
-    repo: input.repo,
-    pullNumber: input.pull.number,
-    headSha: input.pull.head.sha,
-    state: "skipped",
-    reason: "concurrent_review_claim_held"
-  });
   console.warn(
     `[head-claim] concurrent claim held repo=${input.repo} pr=${input.pull.number} sha=${input.pull.head.sha}: skipping duplicate same-head review`
   );

--- a/tests/review-budget.test.ts
+++ b/tests/review-budget.test.ts
@@ -137,6 +137,7 @@ describe("review run budget", () => {
       waitingProviderCapacity: 0,
       waitingOrgCapacity: 0,
       waitingRepoCapacity: 0,
+      waitingHeadActive: 0,
       waitingManualReserve: 0,
       waitingLeaseLimit: 0
     });
@@ -197,6 +198,99 @@ describe("review run budget", () => {
       expect.objectContaining({ jobId: "background-b", reason: "manual_reserve" })
     ]);
     expect(status.manualReserve.backgroundSlotsAvailableBeforeReserve).toBe(1);
+  });
+
+  it("does not reserve a slot for a later manual job on a head already selected in the batch", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-budget-same-head-manual-reserve-"));
+    roots.push(root);
+    const config = {
+      ...minimalConfig(root),
+      reviewConcurrency: {
+        maxActiveRuns: 2,
+        leaseTtlMs: 60_000
+      },
+      reviewScheduler: {
+        enabled: true,
+        maxProviderActive: 2,
+        maxOrgActive: 2,
+        maxRepoActive: 2,
+        maxQueuedPerRepo: 10,
+        manualCommandReserve: 1,
+        backgroundPriority: 50
+      }
+    };
+    const now = new Date("2026-07-13T00:00:00.000Z");
+    const status = buildReviewBudgetStatus({
+      config,
+      now,
+      jobs: [
+        queueJob("background-same-head", {
+          repo: "owner/repo-a",
+          pullNumber: 1,
+          headSha: "same-head",
+          state: "queued",
+          priority: 1
+        }),
+        queueJob("background-other-head", {
+          repo: "owner/repo-b",
+          pullNumber: 2,
+          headSha: "other-head",
+          state: "queued",
+          priority: 2
+        }),
+        queueJob("manual-same-head", {
+          repo: "owner/repo-a",
+          pullNumber: 1,
+          headSha: "same-head",
+          state: "queued",
+          lane: "manual",
+          source: "manual_command",
+          priority: 10
+        })
+      ]
+    });
+
+    expect(status.wouldLease.map((entry) => entry.jobId)).toEqual([
+      "background-same-head",
+      "background-other-head"
+    ]);
+    expect(status.delayed).toEqual([
+      expect.objectContaining({ jobId: "manual-same-head", reason: "head_active" })
+    ]);
+  });
+
+  it("reports retryable provider-deferred work blocked by its already-active exact head", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-budget-provider-deferred-active-head-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const now = new Date("2026-07-13T00:00:00.000Z");
+    const coordinates = {
+      repo: "owner/repo-a",
+      pullNumber: 1,
+      headSha: "same-head"
+    };
+    const status = buildReviewBudgetStatus({
+      config,
+      now,
+      jobs: [
+        queueJob("active-same-head", { ...coordinates, state: "running" }),
+        queueJob("retry-same-head", {
+          ...coordinates,
+          state: "provider_deferred",
+          nextEligibleAt: "2026-07-12T23:59:00.000Z"
+        })
+      ]
+    });
+
+    expect(status.providerDeferred).toMatchObject({
+      total: 1,
+      retryable: 1,
+      readyToRetry: 0,
+      waitingHeadActive: 1
+    });
+    expect(status.delayed).toEqual([
+      expect.objectContaining({ jobId: "retry-same-head", reason: "head_active" })
+    ]);
   });
 
   it("separates retryable provider-deferred jobs from actionable ready-to-retry jobs", () => {

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -215,6 +215,193 @@ describe("provider-aware review scheduler", () => {
     state.close();
   });
 
+  it("runs only one durable job per exact PR head while other heads fill the bounded batch", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-exact-head-exclusion-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    config.reviewConcurrency.maxActiveRuns = 3;
+    config.reviewScheduler!.maxProviderActive = 3;
+    config.reviewScheduler!.maxOrgActive = 3;
+    config.reviewScheduler!.maxRepoActive = 3;
+    const state = new ReviewStateStore(config.statePath);
+
+    const backgroundSameHead = state.enqueueReviewQueueJob({
+      repo: "org-a/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      baseSha: "base-a",
+      source: "automatic",
+      lane: "background"
+    }).job;
+    state.enqueueReviewQueueJob({
+      repo: "org-b/repo-b",
+      pullNumber: 2,
+      headSha: HEAD_B,
+      baseSha: "base-b",
+      source: "automatic",
+      lane: "background"
+    });
+    state.enqueueReviewQueueJob({
+      repo: "org-c/repo-c",
+      pullNumber: 3,
+      headSha: HEAD_C,
+      baseSha: "base-c",
+      source: "automatic",
+      lane: "background"
+    });
+    const manualSameHead = state.enqueueReviewQueueJob({
+      repo: "org-a/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      baseSha: "base-a",
+      source: "manual_command",
+      lane: "manual",
+      commentId: 557,
+      priority: 10
+    }).job;
+
+    const started: string[] = [];
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => { release = resolve; });
+    const cycle = runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org-a/repo-a", [pull("org-a/repo-a", 1, HEAD_A, "base-a")]],
+        ["org-b/repo-b", [pull("org-b/repo-b", 2, HEAD_B, "base-b")]],
+        ["org-c/repo-c", [pull("org-c/repo-c", 3, HEAD_C, "base-c")]]
+      ])),
+      state,
+      options: { dryRun: true, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull, commandCommentId }) => {
+        started.push(`${repo}#${reviewPull.number}@${reviewPull.head.sha}:${commandCommentId ?? "automatic"}`);
+        await barrier;
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "dry_run",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-02T00:00:00.000Z")
+    });
+
+    let exclusionError: unknown;
+    try {
+      await vi.waitFor(() => expect(started).toHaveLength(3), { timeout: 250 });
+      expect(started).toEqual(expect.arrayContaining([
+        `org-a/repo-a#1@${HEAD_A}:557`,
+        `org-b/repo-b#2@${HEAD_B}:automatic`,
+        `org-c/repo-c#3@${HEAD_C}:automatic`
+      ]));
+      expect(started.filter((entry) => entry.startsWith(`org-a/repo-a#1@${HEAD_A}:`))).toHaveLength(1);
+    } catch (error) {
+      exclusionError = error;
+    } finally {
+      release();
+    }
+    const result = await cycle;
+    if (exclusionError) throw exclusionError;
+
+    expect(result.queue.leased).toBe(3);
+    expect(state.getReviewQueueJob(manualSameHead.jobId)).toMatchObject({
+      state: "queued",
+      lastError: "dry_run_completed_not_posted"
+    });
+    expect(state.getReviewQueueJob(backgroundSameHead.jobId)).toMatchObject({ state: "queued" });
+    expect(state.getReviewQueueJob(backgroundSameHead.jobId)?.lastError).toBeUndefined();
+    state.close();
+  });
+
+  it("backfills a manual reserve when its queued command shares a selected background head", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-exact-head-manual-reserve-"));
+    roots.push(root);
+    const config = schedulerConfig(root, []);
+    config.reviewConcurrency.maxActiveRuns = 2;
+    config.reviewScheduler!.maxProviderActive = 2;
+    config.reviewScheduler!.maxOrgActive = 2;
+    config.reviewScheduler!.maxRepoActive = 2;
+    config.reviewScheduler!.manualCommandReserve = 1;
+    const state = new ReviewStateStore(config.statePath);
+
+    const first = state.enqueueReviewQueueJob({
+      repo: "org-a/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      baseSha: "base-a",
+      source: "automatic",
+      lane: "background",
+      priority: 1
+    }).job;
+    const second = state.enqueueReviewQueueJob({
+      repo: "org-b/repo-b",
+      pullNumber: 2,
+      headSha: HEAD_B,
+      baseSha: "base-b",
+      source: "automatic",
+      lane: "background",
+      priority: 2
+    }).job;
+    const duplicateManual = state.enqueueReviewQueueJob({
+      repo: "org-a/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      baseSha: "base-a",
+      source: "manual_command",
+      lane: "manual",
+      commentId: 558,
+      priority: 10
+    }).job;
+
+    const started: string[] = [];
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => { release = resolve; });
+    const cycle = runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([
+        ["org-a/repo-a", [pull("org-a/repo-a", 1, HEAD_A, "base-a")]],
+        ["org-b/repo-b", [pull("org-b/repo-b", 2, HEAD_B, "base-b")]]
+      ])),
+      state,
+      options: { dryRun: true, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull, commandCommentId }) => {
+        started.push(`${repo}#${reviewPull.number}:${commandCommentId ?? "automatic"}`);
+        await barrier;
+        reviewState.recordProcessed({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          status: "dry_run",
+          event: "COMMENT"
+        });
+        return "reviewed";
+      },
+      now: new Date("2026-07-13T00:00:00.000Z")
+    });
+
+    let assertionError: unknown;
+    try {
+      await vi.waitFor(() => expect(started).toHaveLength(2), { timeout: 250 });
+      expect(started).toEqual(expect.arrayContaining([
+        "org-a/repo-a#1:automatic",
+        "org-b/repo-b#2:automatic"
+      ]));
+    } catch (error) {
+      assertionError = error;
+    } finally {
+      release();
+    }
+    const result = await cycle;
+    if (assertionError) throw assertionError;
+
+    expect(result.queue.leased).toBe(2);
+    expect(state.getReviewQueueJob(first.jobId)).toMatchObject({ state: "queued" });
+    expect(state.getReviewQueueJob(second.jobId)).toMatchObject({ state: "queued" });
+    expect(state.getReviewQueueJob(duplicateManual.jobId)).toMatchObject({ state: "queued" });
+    state.close();
+  });
+
   it("counts durable active leases against the global effective slot cap", async () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-global-active-cap-"));
     roots.push(root);
@@ -4402,6 +4589,93 @@ describe("provider-aware review scheduler", () => {
       event: "REQUEST_CHANGES",
       commandAction: "request-changes",
       commandCommentId: 901
+    });
+    state.close();
+  });
+
+  it("terminally no-ops a non-upgrade owner command through the scheduler lifecycle", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-scheduler-request-changes-noop-"));
+    roots.push(root);
+    const config = schedulerConfig(root, ["org/repo-a"]);
+    config.commands = {
+      enabled: true,
+      botMentions: ["@neondiff"],
+      trustedAuthors: ["maintainer"],
+      acknowledge: false
+    };
+    const state = new ReviewStateStore(config.statePath);
+    const priorReviewUrl = "https://github.com/org/repo-a/pull/1#pullrequestreview-prior";
+    state.recordProcessed({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: priorReviewUrl
+    });
+    state.recordReviewReadiness({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: HEAD_A,
+      state: "ready_for_human",
+      reason: "comment_review_posted",
+      event: "COMMENT",
+      reviewUrl: priorReviewUrl
+    });
+    const comments = new Map([["org/repo-a#1", [
+      comment(903, "maintainer", `@neondiff request-changes --repo org/repo-a --pr 1 --head ${HEAD_A}`)
+    ]]]);
+
+    const result = await runScheduledCycleWithDeps({
+      config,
+      github: githubFromMap(new Map([["org/repo-a", [pull("org/repo-a", 1, HEAD_A)]]]), comments),
+      state,
+      options: { dryRun: false, useZCode: false },
+      reviewPullImpl: async ({ state: reviewState, repo, pull: reviewPull, commandCommentId }) => {
+        expect(reviewState.getReviewReadiness(repo, reviewPull.number, reviewPull.head.sha)).toMatchObject({
+          state: "reviewing",
+          event: "COMMENT",
+          reviewUrl: priorReviewUrl,
+          commandAction: "request-changes",
+          commandCommentId: 903
+        });
+        expect(reviewState.tryConsumeReviewEventAuthorization({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          commentId: commandCommentId!,
+          author: "maintainer"
+        })).toBe(true);
+        expect(reviewState.recordAuthorizedReviewNoop({
+          repo,
+          pullNumber: reviewPull.number,
+          headSha: reviewPull.head.sha,
+          commentId: commandCommentId!,
+          author: "maintainer",
+          reason: "candidate_comment_already_posted"
+        })).toBe(true);
+        return "skipped_processed";
+      }
+    });
+
+    expect(result.skippedProcessed).toBe(1);
+    expect(state.getProcessedReview("org/repo-a", 1, HEAD_A)).toMatchObject({
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: priorReviewUrl
+    });
+    expect(state.getReviewReadiness("org/repo-a", 1, HEAD_A)).toMatchObject({
+      state: "ready_for_human",
+      reason: "comment_review_posted",
+      event: "COMMENT",
+      reviewUrl: priorReviewUrl,
+      commandAction: "request-changes",
+      commandCommentId: 903
+    });
+    expect(state.getReviewEventAuthorizationConsumption("org/repo-a", 1, HEAD_A)).toMatchObject({
+      commentId: 903,
+      terminalOutcome: "no_op",
+      terminalReason: "candidate_comment_already_posted"
     });
     state.close();
   });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1071,6 +1071,54 @@ describe("review state store", () => {
     store.close();
   });
 
+  it("does not reserve capacity for a later manual job on a head selected by background work", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-head-aware-manual-reserve-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const now = new Date("2026-07-01T00:00:00.000Z");
+
+    const backgroundX = store.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "head-x",
+      providerId: "zai",
+      priority: 1,
+      now
+    }).job;
+    const backgroundY = store.enqueueReviewQueueJob({
+      repo: "org/repo-b",
+      pullNumber: 2,
+      headSha: "head-y",
+      providerId: "zai",
+      priority: 2,
+      now
+    }).job;
+    const manualX = store.enqueueReviewQueueJob({
+      repo: "org/repo-a",
+      pullNumber: 1,
+      headSha: "head-x",
+      source: "manual_command",
+      commentId: 10,
+      providerId: "zai",
+      priority: 3,
+      now
+    }).job;
+
+    const leased = store.leaseNextReviewQueueJobs({
+      maxGlobalActive: 2,
+      maxProviderActive: 2,
+      maxOrgActive: 2,
+      maxRepoActive: 1,
+      manualCommandReserve: 1,
+      limit: 2,
+      now: new Date("2026-07-01T00:00:10.000Z")
+    });
+
+    expect(leased.map((job) => job.jobId)).toEqual([backgroundX.jobId, backgroundY.jobId]);
+    expect(store.getReviewQueueJob(manualX.jobId)).toMatchObject({ state: "queued" });
+    store.close();
+  });
+
   it("honors repo-specific active caps while leasing queued work", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-review-queue-repo-specific-lease-"));
     roots.push(root);
@@ -1851,6 +1899,248 @@ describe("review state store", () => {
     }
   });
 
+  it("records a terminal owner-authorization no-op without replacing the prior advisory review", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-event-authorization-noop-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const headSha = "7".repeat(40);
+    const priorReviewUrl = "https://github.com/owner/repo/pull/7#pullrequestreview-prior";
+    const authorization = {
+      repo: "owner/repo",
+      pullNumber: 7,
+      headSha,
+      commentId: 81,
+      author: "100yenadmin"
+    };
+
+    store.recordProcessed({
+      repo: authorization.repo,
+      pullNumber: authorization.pullNumber,
+      headSha,
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: priorReviewUrl
+    });
+    store.recordReviewReadiness({
+      repo: authorization.repo,
+      pullNumber: authorization.pullNumber,
+      headSha,
+      state: "ready_for_human",
+      reason: "comment_review_posted",
+      event: "COMMENT",
+      reviewUrl: priorReviewUrl,
+      now: new Date("2026-07-13T01:00:00.000Z")
+    });
+    const priorProcessed = store.getProcessedReview(authorization.repo, authorization.pullNumber, headSha);
+    const priorReadiness = store.getReviewReadiness(authorization.repo, authorization.pullNumber, headSha);
+    expect(store.tryConsumeReviewEventAuthorization({
+      ...authorization,
+      now: new Date("2026-07-13T01:01:00.000Z")
+    })).toBe(true);
+
+    expect(store.recordAuthorizedReviewNoop({
+      ...authorization,
+      reason: "candidate_comment_already_posted",
+      now: new Date("2026-07-13T01:02:00.000Z")
+    })).toBe(true);
+
+    expect(store.getReviewEventAuthorizationConsumption(authorization.repo, authorization.pullNumber, headSha)).toEqual({
+      repo: authorization.repo,
+      pullNumber: authorization.pullNumber,
+      headSha,
+      commentId: authorization.commentId,
+      author: authorization.author,
+      consumedAt: "2026-07-13T01:01:00.000Z",
+      terminalOutcome: "no_op",
+      terminalReason: "candidate_comment_already_posted",
+      terminalAt: "2026-07-13T01:02:00.000Z"
+    });
+    expect(store.getProcessedReview(authorization.repo, authorization.pullNumber, headSha)).toEqual(priorProcessed);
+    expect(store.getReviewReadiness(authorization.repo, authorization.pullNumber, headSha)).toEqual(priorReadiness);
+    expect(store.recordReviewEventAuthorizationIncident({
+      repo: authorization.repo,
+      pullNumber: authorization.pullNumber,
+      headSha,
+      triggerCommentId: 82,
+      error: "late_incident_must_lose"
+    })).toBe(false);
+    store.recordAuthorizedReviewPosted({
+      ...authorization,
+      event: "COMMENT",
+      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-late"
+    });
+    expect(store.getReviewEventAuthorizationConsumption(authorization.repo, authorization.pullNumber, headSha)).toMatchObject({
+      postedEvent: "COMMENT",
+      reviewUrl: "https://github.com/owner/repo/pull/7#pullrequestreview-late",
+      postedAt: expect.any(String)
+    });
+    expect(store.getReviewEventAuthorizationConsumption(authorization.repo, authorization.pullNumber, headSha)).not.toHaveProperty("terminalOutcome");
+    expect(store.recordAuthorizedReviewNoop({
+      ...authorization,
+      commentId: 82,
+      reason: "candidate_comment_already_posted"
+    })).toBe(false);
+    store.close();
+  });
+
+  it("orders authorization outcomes as receipt over no-op over incident", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-review-event-authorization-races-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const repo = "owner/repo";
+    const pullNumber = 8;
+    const priorReviewUrl = "https://github.com/owner/repo/pull/8#pullrequestreview-prior";
+    const preparePriorComment = (headSha: string, commentId: number) => {
+      store.recordProcessed({ repo, pullNumber, headSha, status: "posted", event: "COMMENT", reviewUrl: priorReviewUrl });
+      store.recordReviewReadiness({
+        repo,
+        pullNumber,
+        headSha,
+        state: "ready_for_human",
+        reason: "comment_review_posted",
+        event: "COMMENT",
+        reviewUrl: priorReviewUrl,
+        now: new Date("2026-07-13T03:00:00.000Z")
+      });
+      expect(store.tryConsumeReviewEventAuthorization({
+        repo,
+        pullNumber,
+        headSha,
+        commentId,
+        author: "100yenadmin",
+        now: new Date("2026-07-13T03:01:00.000Z")
+      })).toBe(true);
+    };
+
+    const incidentFirstHead = "8".repeat(40);
+    preparePriorComment(incidentFirstHead, 91);
+    expect(store.recordReviewEventAuthorizationIncident({
+      repo,
+      pullNumber,
+      headSha: incidentFirstHead,
+      triggerCommentId: 92,
+      error: "exact_authorization_already_consumed",
+      now: new Date("2026-07-13T03:02:00.000Z")
+    })).toBe(true);
+    expect(store.recordAuthorizedReviewNoop({
+      repo,
+      pullNumber,
+      headSha: incidentFirstHead,
+      commentId: 91,
+      author: "100yenadmin",
+      reason: "candidate_comment_already_posted",
+      now: new Date("2026-07-13T03:03:00.000Z")
+    })).toBe(true);
+    expect(store.getReviewEventAuthorizationConsumption(repo, pullNumber, incidentFirstHead)).toMatchObject({
+      terminalOutcome: "no_op",
+      terminalReason: "candidate_comment_already_posted",
+      terminalAt: "2026-07-13T03:03:00.000Z"
+    });
+    expect(store.getReviewEventAuthorizationConsumption(repo, pullNumber, incidentFirstHead)).not.toHaveProperty("incidentError");
+    expect(store.getReviewReadiness(repo, pullNumber, incidentFirstHead)).toMatchObject({
+      state: "ready_for_human",
+      reason: "comment_review_posted",
+      event: "COMMENT",
+      reviewUrl: priorReviewUrl,
+      commandAction: "request-changes",
+      commandCommentId: 91
+    });
+    expect(store.recordReviewEventAuthorizationIncident({
+      repo,
+      pullNumber,
+      headSha: incidentFirstHead,
+      triggerCommentId: 93,
+      error: "late_incident_must_lose"
+    })).toBe(false);
+
+    const receiptFirstHead = "9".repeat(40);
+    preparePriorComment(receiptFirstHead, 94);
+    store.recordAuthorizedReviewPosted({
+      repo,
+      pullNumber,
+      headSha: receiptFirstHead,
+      commentId: 94,
+      author: "100yenadmin",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/owner/repo/pull/8#pullrequestreview-blocking",
+      now: new Date("2026-07-13T03:04:00.000Z")
+    });
+    expect(store.recordAuthorizedReviewNoop({
+      repo,
+      pullNumber,
+      headSha: receiptFirstHead,
+      commentId: 94,
+      author: "100yenadmin",
+      reason: "candidate_comment_already_posted"
+    })).toBe(false);
+    expect(store.getReviewEventAuthorizationConsumption(repo, pullNumber, receiptFirstHead)).toMatchObject({
+      postedEvent: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/owner/repo/pull/8#pullrequestreview-blocking"
+    });
+    expect(store.getReviewEventAuthorizationConsumption(repo, pullNumber, receiptFirstHead)).not.toHaveProperty("terminalOutcome");
+
+    const supersededIncidentHead = "b".repeat(40);
+    preparePriorComment(supersededIncidentHead, 96);
+    expect(store.recordReviewEventAuthorizationIncident({
+      repo,
+      pullNumber,
+      headSha: supersededIncidentHead,
+      triggerCommentId: 97,
+      error: "exact_authorization_already_consumed",
+      now: new Date("2026-07-13T03:05:00.000Z")
+    })).toBe(true);
+    store.recordReviewReadiness({
+      repo,
+      pullNumber,
+      headSha: supersededIncidentHead,
+      state: "failed",
+      reason: "post_review_head_unverified",
+      event: "COMMENT",
+      reviewUrl: priorReviewUrl,
+      commandAction: "request-changes",
+      commandCommentId: 98,
+      now: new Date("2026-07-13T03:06:00.000Z")
+    });
+    expect(() => store.recordAuthorizedReviewNoop({
+      repo,
+      pullNumber,
+      headSha: supersededIncidentHead,
+      commentId: 96,
+      author: "100yenadmin",
+      reason: "candidate_comment_already_posted",
+      now: new Date("2026-07-13T03:07:00.000Z")
+    })).toThrow(/existing posted COMMENT.*readiness/i);
+    expect(store.getReviewEventAuthorizationConsumption(repo, pullNumber, supersededIncidentHead)).toMatchObject({
+      incidentError: "exact_authorization_already_consumed",
+      incidentCommentId: 97
+    });
+    expect(store.getReviewEventAuthorizationConsumption(repo, pullNumber, supersededIncidentHead)).not.toHaveProperty("terminalOutcome");
+    expect(store.getReviewReadiness(repo, pullNumber, supersededIncidentHead)).toMatchObject({
+      state: "failed",
+      reason: "post_review_head_unverified",
+      commandCommentId: 98
+    });
+
+    const missingReadinessHead = "a".repeat(40);
+    store.recordProcessed({ repo, pullNumber, headSha: missingReadinessHead, status: "posted", event: "COMMENT", reviewUrl: priorReviewUrl });
+    expect(store.tryConsumeReviewEventAuthorization({
+      repo,
+      pullNumber,
+      headSha: missingReadinessHead,
+      commentId: 95,
+      author: "100yenadmin"
+    })).toBe(true);
+    expect(() => store.recordAuthorizedReviewNoop({
+      repo,
+      pullNumber,
+      headSha: missingReadinessHead,
+      commentId: 95,
+      author: "100yenadmin",
+      reason: "candidate_comment_already_posted"
+    })).toThrow(/existing posted COMMENT.*readiness/i);
+    store.close();
+  });
+
   it("adds authorization state to a legacy database without losing prior rows", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-review-event-authorization-legacy-"));
     roots.push(root);
@@ -2026,7 +2316,87 @@ describe("review state store", () => {
     store.close();
   });
 
-  it("retires the per-head claim when the review is recorded so it is not re-claimed (#295)", () => {
+  it("refuses an ordinary claim after a processed head retires its prior claim", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-head-claim-processed-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const head = { repo: "r/x", pullNumber: 31, headSha: "sha-processed" };
+
+    const first = store.tryClaimReviewHead({
+      ...head,
+      claimTtlMs: 900_000,
+      now: new Date("2026-07-06T00:00:00.000Z")
+    });
+    expect(first).toBeDefined();
+    store.recordProcessed({
+      ...head,
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/r/x/pull/31#pullrequestreview-prior"
+    });
+
+    expect(store.tryClaimReviewHead({
+      ...head,
+      claimTtlMs: 900_000,
+      now: new Date("2026-07-06T00:00:01.000Z")
+    })).toBeUndefined();
+    store.close();
+  });
+
+  it("distinguishes an active claim from a durable processed-head rejection", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-head-claim-outcomes-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const activeHead = { repo: "r/x", pullNumber: 33, headSha: "sha-active" };
+    const processedHead = { repo: "r/x", pullNumber: 34, headSha: "sha-processed-outcome" };
+
+    expect(store.tryClaimReviewHeadWithOutcome({
+      ...activeHead,
+      claimTtlMs: 900_000,
+      now: new Date("2026-07-06T00:00:00.000Z")
+    })).toMatchObject({ status: "acquired", claim: { ownerPid: process.pid } });
+    expect(store.tryClaimReviewHeadWithOutcome({
+      ...activeHead,
+      claimTtlMs: 900_000,
+      now: new Date("2026-07-06T00:00:01.000Z")
+    })).toEqual({ status: "blocked", reason: "active_claim" });
+
+    store.recordProcessed({
+      ...processedHead,
+      status: "posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl: "https://github.com/r/x/pull/34#pullrequestreview-blocking"
+    });
+    expect(store.tryClaimReviewHeadWithOutcome({
+      ...processedHead,
+      claimTtlMs: 900_000,
+      now: new Date("2026-07-06T00:00:02.000Z")
+    })).toEqual({ status: "blocked", reason: "processed" });
+    store.close();
+  });
+
+  it("allows only an explicit validated-owner supersession to claim a processed head", () => {
+    const root = mkdtempSync(join(tmpdir(), "evaos-head-claim-owner-supersession-"));
+    roots.push(root);
+    const store = new ReviewStateStore(join(root, "state.sqlite"));
+    const head = { repo: "r/x", pullNumber: 32, headSha: "sha-owner-supersession" };
+    store.recordProcessed({
+      ...head,
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: "https://github.com/r/x/pull/32#pullrequestreview-prior"
+    });
+
+    expect(store.tryClaimReviewHead({
+      ...head,
+      claimTtlMs: 900_000,
+      allowProcessedOwnerSupersession: true,
+      now: new Date("2026-07-06T00:00:01.000Z")
+    })).toBeDefined();
+    store.close();
+  });
+
+  it("retires the per-head claim and refuses ordinary re-claim after the review is recorded (#295)", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-head-claim-retire-"));
     roots.push(root);
     const store = new ReviewStateStore(join(root, "state.sqlite"));
@@ -2036,9 +2406,10 @@ describe("review state store", () => {
     expect(claim).toBeDefined();
     store.recordProcessed({ repo: head.repo, pullNumber: head.pullNumber, headSha: head.headSha, status: "posted" });
 
-    // A completed review supersedes the claim: the claim row is retired (no stale row lingers to TTL).
+    // A completed review supersedes the claim: the claim row is retired and the processed row keeps
+    // ordinary workers from acquiring the exact head again.
     const afterRecord = store.tryClaimReviewHead({ ...head, claimTtlMs: 900_000, now: new Date("2026-07-06T00:00:02.000Z") });
-    expect(afterRecord).toBeDefined();
+    expect(afterRecord).toBeUndefined();
     store.close();
   });
 

--- a/tests/worker-context-budget.test.ts
+++ b/tests/worker-context-budget.test.ts
@@ -619,6 +619,49 @@ describe("worker context budget preflight", () => {
     state.close();
   });
 
+  it("lets a validated failed-head retry acquire the post claim and replace the failure", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-failed-head-live-retry-"));
+    roots.push(root);
+    const config = minimalConfig(root);
+    const state = new ReviewStateStore(config.statePath);
+    const pull = pullSummary(406, "f".repeat(40));
+    const file = pullFile("src/retry.ts", 200);
+    zcodeFindingsByPath.set(file.filename, [finding(file.filename, "Recovered retry finding")]);
+    state.recordProcessed({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "failed",
+      error: "transient provider failure"
+    });
+
+    const result = await reviewPull({
+      config,
+      github: githubForPull(pull, [file]),
+      state,
+      repo: "electricsheephq/WorldOS",
+      pull,
+      dryRun: false,
+      useZCode: true,
+      processedHeadPolicy: "retry_failed_head"
+    });
+
+    expect(result).toBe("reviewed");
+    expect(createdReviews).toHaveLength(1);
+    expect(createdReviews[0]).toMatchObject({
+      repo: "electricsheephq/WorldOS",
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      event: "COMMENT"
+    });
+    expect(state.getProcessedReview("electricsheephq/WorldOS", pull.number, pull.head.sha)).toMatchObject({
+      status: "posted",
+      event: "COMMENT",
+      reviewUrl: `https://github.com/electricsheephq/WorldOS/pull/${pull.number}#pullrequestreview-1`
+    });
+    state.close();
+  });
+
   it("downgrades an unauthorized P1 candidate to COMMENT without dropping inline findings", async () => {
     const scenario = await runOwnerPolicyReview({ roots, pullNumber: 501, enableWalkthrough: true });
 
@@ -804,8 +847,8 @@ describe("worker context budget preflight", () => {
       lateCommentLookupError: new Error("late GitHub comment lookup failed"),
       configureState: (configuredState) => {
         state = configuredState;
-        const claim = state.tryClaimReviewHead.bind(state);
-        vi.spyOn(state, "tryClaimReviewHead").mockImplementation((input) => {
+        const claim = state.tryClaimReviewHeadWithOutcome.bind(state);
+        vi.spyOn(state, "tryClaimReviewHeadWithOutcome").mockImplementation((input) => {
           if (!state.getReviewEventAuthorizationConsumption("electricsheephq/WorldOS", 523, headSha)) {
             expect(state.tryConsumeReviewEventAuthorization({
               repo: "electricsheephq/WorldOS",
@@ -1160,6 +1203,97 @@ describe("worker context budget preflight", () => {
     expect(replay.result).toBe("skipped_processed");
     expect(createdReviews.map((review) => review.event)).toEqual(["COMMENT"]);
     replay.state.close();
+  });
+
+  it("terminally consumes an owner command without reposting an already-posted COMMENT", async () => {
+    const headSha = "7".repeat(40);
+    const priorReviewUrl = "https://github.com/electricsheephq/WorldOS/pull/525#pullrequestreview-prior";
+    let priorProcessed: ReturnType<ReviewStateStore["getProcessedReview"]>;
+    let priorReadiness: ReturnType<ReviewStateStore["getReviewReadiness"]>;
+    const first = await runOwnerPolicyReview({
+      roots,
+      pullNumber: 525,
+      headSha,
+      commandComment: requestChangesComment(83, 525, headSha),
+      commandCommentId: 83,
+      candidateSeverity: "P2",
+      configureState: (state) => {
+        state.recordProcessed({
+          repo: "electricsheephq/WorldOS",
+          pullNumber: 525,
+          headSha,
+          status: "posted",
+          event: "COMMENT",
+          reviewUrl: priorReviewUrl
+        });
+        state.recordReviewReadiness({
+          repo: "electricsheephq/WorldOS",
+          pullNumber: 525,
+          headSha,
+          state: "ready_for_human",
+          reason: "comment_review_posted",
+          event: "COMMENT",
+          reviewUrl: priorReviewUrl,
+          now: new Date("2026-07-13T02:00:00.000Z")
+        });
+        priorProcessed = state.getProcessedReview("electricsheephq/WorldOS", 525, headSha);
+        priorReadiness = state.getReviewReadiness("electricsheephq/WorldOS", 525, headSha);
+      }
+    });
+
+    expect(first.error).toBeUndefined();
+    expect(first.result).toBe("skipped_processed");
+    expect(createdReviews).toEqual([]);
+    expect(zcodePrompts).toHaveLength(1);
+    expect(first.state.getProcessedReview("electricsheephq/WorldOS", 525, headSha)).toEqual(priorProcessed);
+    expect(first.state.getReviewReadiness("electricsheephq/WorldOS", 525, headSha)).toEqual(priorReadiness);
+    expect(first.state.getReviewEventAuthorizationConsumption("electricsheephq/WorldOS", 525, headSha)).toMatchObject({
+      commentId: 83,
+      author: "100yenadmin",
+      terminalOutcome: "no_op",
+      terminalReason: "candidate_comment_already_posted",
+      terminalAt: expect.any(String)
+    });
+    expect(first.state.getReviewEventAuthorizationConsumption("electricsheephq/WorldOS", 525, headSha)).not.toHaveProperty("postedAt");
+    expect(first.state.getReviewEventAuthorizationConsumption("electricsheephq/WorldOS", 525, headSha)).not.toHaveProperty("incidentError");
+    expect(existsSync(join(first.evidenceDir, "posted-review.json"))).toBe(false);
+
+    first.state.close();
+    const reopenedState = new ReviewStateStore(first.config.statePath);
+    const reopened = { root: first.root, config: first.config, state: reopenedState };
+    const replay = await runOwnerPolicyReview({
+      roots,
+      existing: reopened,
+      pullNumber: 525,
+      headSha,
+      commandComment: requestChangesComment(83, 525, headSha),
+      commandCommentId: 83,
+      candidateSeverity: "P2"
+    });
+    expect(replay.error).toBeUndefined();
+    expect(replay.result).toBe("skipped_processed");
+
+    const laterCommand = await runOwnerPolicyReview({
+      roots,
+      existing: reopened,
+      pullNumber: 525,
+      headSha,
+      commandComment: requestChangesComment(84, 525, headSha),
+      commandCommentId: 84,
+      candidateSeverity: "P2"
+    });
+    expect(laterCommand.error).toBeUndefined();
+    expect(laterCommand.result).toBe("skipped_processed");
+    expect(createdReviews).toEqual([]);
+    expect(zcodePrompts).toHaveLength(1);
+    expect(laterCommand.state.getProcessedReview("electricsheephq/WorldOS", 525, headSha)).toEqual(priorProcessed);
+    expect(laterCommand.state.getReviewReadiness("electricsheephq/WorldOS", 525, headSha)).toEqual(priorReadiness);
+    expect(laterCommand.state.getReviewEventAuthorizationConsumption("electricsheephq/WorldOS", 525, headSha)).toMatchObject({
+      commentId: 83,
+      terminalOutcome: "no_op",
+      terminalReason: "candidate_comment_already_posted"
+    });
+    laterCommand.state.close();
   });
 
   it("lets an exact queued owner command supersede a posted advisory COMMENT on the same head", async () => {

--- a/tests/worker-failure.test.ts
+++ b/tests/worker-failure.test.ts
@@ -3153,7 +3153,7 @@ describe("worker review failures", () => {
     state.close();
   });
 
-  it("records a concurrent-claim skip as a no-op that does not clobber the winner's processed row (#295)", () => {
+  it("records a concurrent-claim skip without clobbering the winner's processed row or readiness (#295)", () => {
     const root = mkdtempSync(join(tmpdir(), "evaos-worker-claim-skip-"));
     roots.push(root);
     const state = new ReviewStateStore(join(root, "state.sqlite"));
@@ -3161,17 +3161,41 @@ describe("worker review failures", () => {
     const pull = pullSummary(289, "winner-head");
 
     // The winner has posted a real review + holds no lingering claim.
-    state.recordProcessed({ repo, pullNumber: pull.number, headSha: pull.head.sha, status: "posted", event: "COMMENT", reviewUrl: "https://github.test/r/1" });
+    const reviewUrl = "https://github.com/electricsheephq/WorldOS/pull/289#pullrequestreview-1";
+    state.recordProcessed({
+      repo,
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      status: "posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl
+    });
+    state.recordReviewReadiness({
+      repo,
+      pullNumber: pull.number,
+      headSha: pull.head.sha,
+      state: "needs_fix",
+      reason: "request_changes_review_posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl
+    });
     const evidenceDir = join(root, "evidence");
 
     recordConcurrentClaimSkip({ state, repo, pull, evidenceDir });
 
     // Loser must NOT overwrite the winner's processed row...
-    expect(state.getProcessedReview(repo, pull.number, pull.head.sha)).toMatchObject({ status: "posted", event: "COMMENT" });
-    // ...and records a skipped readiness note + evidence file instead.
+    expect(state.getProcessedReview(repo, pull.number, pull.head.sha)).toMatchObject({
+      status: "posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl
+    });
+    // The loser cannot know whether the winner is still active or already terminal, so it leaves
+    // readiness entirely to the winning claimant and records evidence only.
     expect(state.getReviewReadiness(repo, pull.number, pull.head.sha)).toMatchObject({
-      state: "skipped",
-      reason: "concurrent_review_claim_held"
+      state: "needs_fix",
+      reason: "request_changes_review_posted",
+      event: "REQUEST_CHANGES",
+      reviewUrl
     });
     expect(JSON.parse(readFileSync(join(evidenceDir, "concurrent-claim-skip.json"), "utf8"))).toMatchObject({
       reason: "concurrent_review_claim_held"


### PR DESCRIPTION
## Summary

Contains the duplicate exact-head review path exposed by the live #583 replay and preserves owner blocking authority without treating a non-upgrade rerun as a second advisory review.

The live evidence has two distinct causes and this PR keeps them separate:

- the first exact-head `COMMENT` was the automatic advisory review;
- the second exact-head `COMMENT` was a trusted owner `request-changes` supersession whose fresh provider result contained only P2/P3 findings;
- replaying the same trusted command must not run the provider or create a third review after restart.

## Changes

- records a durable terminal no-op when an exact trusted owner authorization is consumed but the selected event remains `COMMENT` and a matching posted advisory already exists;
- treats the durable receipt or terminal no-op as one-shot authorization truth across restart/replay;
- preserves the prior processed review and readiness instead of posting another advisory;
- distinguishes active-claim contention from an already-processed head so a losing worker cannot downgrade durable `REQUEST_CHANGES / needs_fix` truth;
- permits only validated owner/manual or `retry_failed_head` paths to supersede a processed row;
- serializes exact-head queue leasing while still filling capacity with other heads;
- makes manual-slot reservation head-aware and reports provider-deferred `head_active` backpressure;
- keeps receipt > no-op > incident precedence transactional and uses exact readiness ownership/CAS for recovery.

## Proof

- 315/315 focused state, scheduler, budget, worker, command, and review-policy tests;
- 159/159 operator CLI and release-status tests;
- `npm run build` including postbuild;
- `npm run check:public-claims`;
- `npm run check:secrets` (677 tracked files);
- `git diff --check`;
- independent correctness, concurrency, security/test, and delta-only adversarial reviews; the two P1s and one P2 found during review were fixed and the final delta was clean at the 95% confidence gate.

## Runtime and proof boundary

- No runtime/config/launchd mutation is included in this PR. The production daemon remains stopped pending merge and exact-head replay proof.
- After merge, the staged duplicate command on #583 must produce no provider work and no third review before a new-head blocking-authority acceptance is run.
- This does not close the generic GitHub POST-accepted-before-local-receipt crash ambiguity. #295 remains open for that broader reconciliation boundary.
- The #585 three-lane rollout remains withheld until #557 live acceptance passes with zero active leases.

Refs #557
Refs #295
