### PR TITLE
fix(cli): recover stopped launchd service from installed plist

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -292,7 +292,10 @@ path exists. Pass `--plist` for any other first-time or recovery path. A
 concurrent loader that wins the race after the check is treated idempotently:
 NeonDiff confirms the service is now loaded and continues with `kickstart`.
 Dry-run output includes `launchdLoaded`, the selected operation, and the exact
-planned commands without bootstrapping or restarting the service.
+planned commands without bootstrapping or restarting the service. To derive
+that plan, dry-run start issues a read-only
+`launchctl print gui/<uid>/<launchd-label>` probe; an ambiguous response fails
+closed instead of guessing whether the service is loaded.
 Use only operator-owned plist paths. The CLI validates the plist `Label` against
 `--launchd-label` and warns when the plist lives outside the NeonDiff package
 root. Live mutation with an external plist also requires

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -284,18 +284,24 @@ neondiff daemon stop --launchd-label com.example.neondiff --dry-run true
 
 `daemon start` and `daemon stop` default to dry-run planning. Live launchd
 mutation requires both `--dry-run false` and `--confirm true`.
-`daemon start` without `--plist` restarts an already loaded LaunchAgent with
-`kickstart`; first-time LaunchAgent installation must pass the plist path so the
-dry-run plan includes `bootstrap`. If a live `bootstrap` fails because the
-LaunchAgent is already loaded, rerun `daemon start` without `--plist` to perform
-the kickstart-only restart path.
+`daemon start` first checks whether the label is registered in the current
+`gui/<uid>` launchd domain. A loaded service gets `kickstart -k`. An unloaded
+service gets `bootstrap` followed by `kickstart`; without `--plist`, NeonDiff
+uses `~/Library/LaunchAgents/<launchd-label>.plist` when that exact standard
+path exists. Pass `--plist` for any other first-time or recovery path. A
+concurrent loader that wins the race after the check is treated idempotently:
+NeonDiff confirms the service is now loaded and continues with `kickstart`.
+Dry-run output includes `launchdLoaded`, the selected operation, and the exact
+planned commands without bootstrapping or restarting the service.
 Use only operator-owned plist paths. The CLI validates the plist `Label` against
 `--launchd-label` and warns when the plist lives outside the NeonDiff package
 root. Live mutation with an external plist also requires
 `--allow-external-plist true`; keep the default off unless the release issue
 names the exact operator-owned plist path. The external-plist check is a lexical
 path warning, not a realpath/symlink containment proof, so do not rely on it as
-a filesystem security boundary.
+a filesystem security boundary. The automatically selected exact standard
+LaunchAgent path does not require that override; explicitly supplied paths
+outside the package root still do.
 
 Live `review-pr` posting is intentionally harder than dry-run inspection. Use
 `--dry-run true` for normal local checks. A live scoped PR review requires

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -63,6 +63,9 @@ launchd domain. `daemon start` detects that state, plans `bootstrap` followed by
 loaded it plans only `kickstart -k`. Dry-run start performs only the read-only
 `launchctl print gui/<uid>/<label>` probe needed to distinguish those states;
 an ambiguous probe failure is reported fail-closed and no mutation is planned.
+Confirmed start accepts a concurrent bootstrap race only when bootstrap reports
+an explicit already-loaded signature and a follow-up print proves the service
+is loaded; unrelated bootstrap errors remain failures.
 If the plist is elsewhere, add its exact
 operator-owned path with `--plist`; an external path still requires
 `--allow-external-plist true` for confirmed mutation.

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -49,3 +49,39 @@ Only switch to `--dry-run false` after:
 - ZCode worktrees stay clean after runs,
 - GLM/Z.ai rate limits are not firing,
 - `npm run doctor` reports `readMode: "app_installation"` and successful read checks for every pilot repo.
+
+## Supported Stop And Start Recovery
+
+Use the JSON-first CLI instead of choosing `bootstrap` or `kickstart` from
+plist existence alone:
+
+```bash
+neondiff daemon stop \
+  --launchd-label com.electricsheephq.evaos-code-review-bot \
+  --dry-run true
+neondiff daemon stop \
+  --launchd-label com.electricsheephq.evaos-code-review-bot \
+  --dry-run false \
+  --confirm true
+neondiff daemon start \
+  --config /absolute/path/to/config.local.json \
+  --launchd-label com.electricsheephq.evaos-code-review-bot \
+  --dry-run true
+neondiff daemon start \
+  --config /absolute/path/to/config.local.json \
+  --launchd-label com.electricsheephq.evaos-code-review-bot \
+  --dry-run false \
+  --confirm true
+```
+
+After `bootout`, the plist normally remains at
+`~/Library/LaunchAgents/<label>.plist` while the service is absent from the
+launchd domain. `daemon start` detects that state, plans `bootstrap` followed by
+`kickstart -k`, and reports `launchdLoaded: false`. When the service is already
+loaded it plans only `kickstart -k`. If the plist is elsewhere, add its exact
+operator-owned path with `--plist`; an external path still requires
+`--allow-external-plist true` for confirmed mutation.
+
+After a confirmed start, verify a new PID and a current heartbeat with `daemon
+status` or `runtime-inventory`. A plist on disk, `RunAtLoad`, or `KeepAlive`
+alone is not proof that the service is registered or healthy.

--- a/docs/launchd.md
+++ b/docs/launchd.md
@@ -53,32 +53,17 @@ Only switch to `--dry-run false` after:
 ## Supported Stop And Start Recovery
 
 Use the JSON-first CLI instead of choosing `bootstrap` or `kickstart` from
-plist existence alone:
-
-```bash
-neondiff daemon stop \
-  --launchd-label com.electricsheephq.evaos-code-review-bot \
-  --dry-run true
-neondiff daemon stop \
-  --launchd-label com.electricsheephq.evaos-code-review-bot \
-  --dry-run false \
-  --confirm true
-neondiff daemon start \
-  --config /absolute/path/to/config.local.json \
-  --launchd-label com.electricsheephq.evaos-code-review-bot \
-  --dry-run true
-neondiff daemon start \
-  --config /absolute/path/to/config.local.json \
-  --launchd-label com.electricsheephq.evaos-code-review-bot \
-  --dry-run false \
-  --confirm true
-```
+plist existence alone. The executable stop/start sequence and confirmation
+requirements live in [the operator CLI guide](operator-cli.md#common-operator-flows).
 
 After `bootout`, the plist normally remains at
 `~/Library/LaunchAgents/<label>.plist` while the service is absent from the
 launchd domain. `daemon start` detects that state, plans `bootstrap` followed by
 `kickstart -k`, and reports `launchdLoaded: false`. When the service is already
-loaded it plans only `kickstart -k`. If the plist is elsewhere, add its exact
+loaded it plans only `kickstart -k`. Dry-run start performs only the read-only
+`launchctl print gui/<uid>/<label>` probe needed to distinguish those states;
+an ambiguous probe failure is reported fail-closed and no mutation is planned.
+If the plist is elsewhere, add its exact
 operator-owned path with `--plist`; an external path still requires
 `--allow-external-plist true` for confirmed mutation.
 

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -291,6 +291,27 @@ Classify whether the bot is idle, healthy-active, or blocked:
 npx tsx src/cli.ts runtime-inventory --json --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot
 ```
 
+Recover the standard macOS LaunchAgent only after runtime inventory shows no
+active work. Inspect both plans first; these dry runs do not mutate launchd:
+
+```bash
+npx tsx src/cli.ts daemon stop --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run true
+npx tsx src/cli.ts daemon start --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run true
+```
+
+After approving the exact label, config, detected launchd state, plist path,
+and planned commands, run the confirmed stop/start sequence:
+
+```bash
+npx tsx src/cli.ts daemon stop --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run false --confirm true
+npx tsx src/cli.ts daemon start --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run false --confirm true
+```
+
+Confirmed start remains activation-gated. If the operator-owned plist is not
+the standard `~/Library/LaunchAgents/<label>.plist`, pass its exact path with
+`--plist`; confirmed external paths additionally require
+`--allow-external-plist true`.
+
 `runtime-inventory` treats issue-enrichment runtime as a separate lane from PR
 review health. Failed issue-enrichment records remain blocking because an
 operator must inspect them before promotion. Deferred issue-enrichment records

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -252,14 +252,19 @@ evaos-review-bot status --config config.local.json
   requires both `--dry-run false` and `--confirm true`.
   When `start` uses `--plist <path>`, `stop` can either pass the same `--plist`
   to boot out by domain/plist or omit `--plist` to boot out by service label.
-  `start` without `--plist` restarts an already loaded LaunchAgent; first-time
-  installation must pass `--plist`. Use only operator-owned plist paths. Live
+  `start` checks `launchctl print gui/<uid>/<label>` separately from plist
+  existence. It kickstarts a loaded service; when unloaded, it bootstraps the
+  supplied plist or the exact standard
+  `~/Library/LaunchAgents/<label>.plist`, then kickstarts it. A bootstrap race
+  is accepted only after a second launchd check proves the service became
+  loaded. Dry-run reports the detected state and plan but performs no launchd
+  mutation. Use only operator-owned plist paths. Live
   mutation with a `--plist` outside the NeonDiff package root requires
   `--allow-external-plist true`; dry-run still reports the warning and planned
   commands without mutating launchd. The external-plist warning is a lexical
   path check, not a realpath/symlink containment proof.
-  If a live `bootstrap` fails because the LaunchAgent is already loaded, rerun
-  `daemon start` without `--plist` to use the kickstart-only restart path.
+  The automatically selected exact standard LaunchAgent path does not require
+  the external-plist override; other external paths still do.
 - `daemon --config <config.json> --dry-run true --once true`: runs one
   daemon cycle and exits. This is intended for deterministic local smoke tests
   and operator diagnostics; omit `--once true` for the normal long-running

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -292,18 +292,19 @@ npx tsx src/cli.ts runtime-inventory --json --config config.local.json --launchd
 ```
 
 Recover the standard macOS LaunchAgent only after runtime inventory shows no
-active work. Inspect both plans first; these dry runs do not mutate launchd:
+active work. Inspect and approve the stop plan before mutating launchd:
 
 ```bash
 npx tsx src/cli.ts daemon stop --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run true
-npx tsx src/cli.ts daemon start --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run true
+npx tsx src/cli.ts daemon stop --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run false --confirm true
 ```
 
-After approving the exact label, config, detected launchd state, plist path,
-and planned commands, run the confirmed stop/start sequence:
+Once stop succeeds, dry-run start against the now-unloaded service so the plan
+shows the actual detected state and plist/bootstrap commands. Approve that exact
+label, config, state, plist path, and plan before confirmed start:
 
 ```bash
-npx tsx src/cli.ts daemon stop --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run false --confirm true
+npx tsx src/cli.ts daemon start --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run true
 npx tsx src/cli.ts daemon start --config config.local.json --launchd-label com.electricsheephq.evaos-code-review-bot --dry-run false --confirm true
 ```
 

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -257,8 +257,11 @@ evaos-review-bot status --config config.local.json
   supplied plist or the exact standard
   `~/Library/LaunchAgents/<label>.plist`, then kickstarts it. A bootstrap race
   is accepted only after a second launchd check proves the service became
-  loaded. Dry-run reports the detected state and plan but performs no launchd
-  mutation. Use only operator-owned plist paths. Live
+  loaded. Dry-run start issues only the read-only
+  `launchctl print gui/<uid>/<label>` probe needed to report the detected state
+  and exact plan; it performs no launchd mutation. An ambiguous probe response
+  fails closed with structured JSON instead of guessing whether the service is
+  loaded. Use only operator-owned plist paths. Live
   mutation with a `--plist` outside the NeonDiff package root requires
   `--allow-external-plist true`; dry-run still reports the warning and planned
   commands without mutating launchd. The external-plist warning is a lexical

--- a/docs/operator-cli.md
+++ b/docs/operator-cli.md
@@ -256,8 +256,9 @@ evaos-review-bot status --config config.local.json
   existence. It kickstarts a loaded service; when unloaded, it bootstraps the
   supplied plist or the exact standard
   `~/Library/LaunchAgents/<label>.plist`, then kickstarts it. A bootstrap race
-  is accepted only after a second launchd check proves the service became
-  loaded. Dry-run start issues only the read-only
+  is accepted only when bootstrap reports an explicit already-loaded signature
+  and a second launchd check proves the service became loaded. Other bootstrap
+  errors remain failures even if a service appears. Dry-run start issues only the read-only
   `launchctl print gui/<uid>/<label>` probe needed to report the detected state
   and exact plan; it performs no launchd mutation. An ambiguous probe response
   fails closed with structured JSON instead of guessing whether the service is

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,10 @@ import { collectCoverageAudit, CoverageStateReader } from "./coverage-audit.js";
 import { collectProviderThrottleReport } from "./provider-throttle-report.js";
 import { runDaemonCycle, shouldExitDaemonAfterFailedCycle } from "./daemon.js";
 import {
+  runLaunchdControlCommand,
+  type LaunchctlResult
+} from "./launchd-control.js";
+import {
   closeSync,
   existsSync,
   mkdirSync,
@@ -19,6 +23,7 @@ import {
   writeFileSync
 } from "node:fs";
 import { basename, dirname, extname, join, parse as parsePath, resolve, sep } from "node:path";
+import { homedir } from "node:os";
 import {
   assertEvalOutputDirSafe,
   buildEvalPromotionDecisionMarkdown,
@@ -2514,11 +2519,12 @@ type DaemonControlResult = {
   dryRun?: boolean;
   launchdLabel?: string;
   launchdTarget?: string;
+  launchdLoaded?: boolean;
   operation?: "bootstrap_then_kickstart" | "kickstart_existing" | "bootout_plist" | "bootout_service" | "status";
   plistPath?: string;
   warning?: string;
   plannedCommands?: string[][];
-  results?: Array<{ command: string[]; exitCode: number; stdout?: string; stderr?: string; error?: string; signal?: string }>;
+  results?: LaunchctlResult[];
   status?: ReleaseStatus;
   error?: string;
 };
@@ -2590,84 +2596,26 @@ function runDaemonControlCommand(
   const confirm = args.confirm === "true";
   const allowExternalPlist = args["allow-external-plist"] === "true";
   const launchdLabel = parseLaunchdLabelArg(args["launchd-label"], "--launchd-label");
-  const plistPath = args.plist ? resolve(parseSingleArg(args.plist, "--plist")) : undefined;
-  if (plistPath) assertPlistLabelMatches(plistPath, launchdLabel);
+  const requestedPlistPath = args.plist ? resolve(parseSingleArg(args.plist, "--plist")) : undefined;
   const launchdTarget = launchdServiceTarget(launchdLabel);
-  const commands = buildDaemonLaunchctlCommands({
+  const standardPlistPath = defaultLaunchdPlistPath(launchdLabel);
+  return runLaunchdControlCommand({
     action,
-    launchdLabel,
-    ...(plistPath ? { plistPath } : {})
-  });
-  const operation = daemonControlOperation(action, plistPath);
-  const warning = plistPath ? daemonPlistWarning(plistPath) : undefined;
-  if (dryRun) {
-    return {
-      ok: true,
-      command: `daemon ${action}`,
-      dryRun,
-      launchdLabel,
-      launchdTarget,
-      operation,
-      ...(plistPath ? { plistPath } : {}),
-      ...(warning ? { warning } : {}),
-      plannedCommands: commands
-    };
-  }
-  const launchdSessionError = launchdUserSessionError();
-  if (launchdSessionError) {
-    return {
-      ok: false,
-      command: `daemon ${action}`,
-      dryRun,
-      launchdLabel,
-      launchdTarget,
-      operation,
-      ...(plistPath ? { plistPath } : {}),
-      ...(warning ? { warning } : {}),
-      plannedCommands: commands,
-      error: launchdSessionError
-    };
-  }
-  if (warning && !allowExternalPlist) {
-    return {
-      ok: false,
-      command: `daemon ${action}`,
-      dryRun,
-      launchdLabel,
-      launchdTarget,
-      operation,
-      ...(plistPath ? { plistPath } : {}),
-      warning,
-      plannedCommands: commands,
-      error: `daemon ${action} requires --allow-external-plist true when --dry-run false uses a --plist outside the NeonDiff package root`
-    };
-  }
-  if (!confirm) {
-    return {
-      ok: false,
-      command: `daemon ${action}`,
-      dryRun,
-      launchdLabel,
-      launchdTarget,
-      operation,
-      ...(plistPath ? { plistPath } : {}),
-      ...(warning ? { warning } : {}),
-      plannedCommands: commands,
-      error: `daemon ${action} requires --confirm true when --dry-run false is used`
-    };
-  }
-  const results = runLaunchctlPlan(commands);
-  return {
-    ok: results.every((result) => result.exitCode === 0),
-    command: `daemon ${action}`,
     dryRun,
+    confirm,
+    allowExternalPlist,
     launchdLabel,
     launchdTarget,
-    operation,
-    ...(plistPath ? { plistPath } : {}),
-    ...(warning ? { warning } : {}),
-    results
-  };
+    launchdDomain: launchdDomainTarget(),
+    standardPlistPath,
+    ...(requestedPlistPath ? { requestedPlistPath } : {})
+  }, {
+    executeLaunchctl: runLaunchctl,
+    plistExists: existsSync,
+    assertPlistLabelMatches,
+    plistWarning: daemonPlistWarning,
+    launchdSessionError: launchdUserSessionError
+  });
 }
 
 function currentDaemonPlatform(): string {
@@ -2692,30 +2640,8 @@ function unsupportedNonDarwinDaemonControl(
   };
 }
 
-function buildDaemonLaunchctlCommands(input: {
-  action: "start" | "stop";
-  launchdLabel: string;
-  plistPath?: string;
-}): string[][] {
-  const domain = launchdDomainTarget();
-  const service = launchdServiceTarget(input.launchdLabel);
-  if (input.action === "start") {
-    return [
-      ...(input.plistPath ? [["launchctl", "bootstrap", domain, input.plistPath]] : []),
-      ["launchctl", "kickstart", "-k", service]
-    ];
-  }
-  return input.plistPath
-    ? [["launchctl", "bootout", domain, input.plistPath]]
-    : [["launchctl", "bootout", service]];
-}
-
-function daemonControlOperation(
-  action: "start" | "stop",
-  plistPath?: string
-): "bootstrap_then_kickstart" | "kickstart_existing" | "bootout_plist" | "bootout_service" {
-  if (action === "start") return plistPath ? "bootstrap_then_kickstart" : "kickstart_existing";
-  return plistPath ? "bootout_plist" : "bootout_service";
+function defaultLaunchdPlistPath(launchdLabel: string): string {
+  return join(process.env.HOME || homedir(), "Library", "LaunchAgents", `${launchdLabel}.plist`);
 }
 
 function daemonPlistWarning(plistPath: string): string | undefined {
@@ -2726,34 +2652,10 @@ function daemonPlistWarning(plistPath: string): string | undefined {
   return "--plist is outside the NeonDiff package root; use only operator-owned plist paths";
 }
 
-function runLaunchctlPlan(commands: string[][]): Array<{
-  command: string[];
-  exitCode: number;
-  stdout?: string;
-  stderr?: string;
-  error?: string;
-  signal?: string;
-}> {
-  const results = [];
-  for (const command of commands) {
-    const result = runLaunchctl(command);
-    results.push(result);
-    if (result.exitCode !== 0) break;
-  }
-  return results;
-}
-
-function runLaunchctl(command: string[]): {
-  command: string[];
-  exitCode: number;
-  stdout?: string;
-  stderr?: string;
-  error?: string;
-  signal?: string;
-} {
+function runLaunchctl(command: string[]): LaunchctlResult {
   const [binary, ...args] = command;
   if (binary !== "launchctl") throw new Error(`unsupported daemon control command: ${command.join(" ")}`);
-  const result = spawnSync(binary, args, {
+  const result = spawnSync("/bin/launchctl", args, {
     encoding: "utf8",
     timeout: LAUNCHCTL_TIMEOUT_MS
   });
@@ -2785,7 +2687,7 @@ function assertPlistLabelMatches(plistPath: string, launchdLabel: string): void 
 }
 
 function readPlistLabel(plistPath: string): string {
-  const result = spawnSync("plutil", ["-extract", "Label", "raw", plistPath], {
+  const result = spawnSync("/usr/bin/plutil", ["-extract", "Label", "raw", plistPath], {
     encoding: "utf8",
     timeout: PLUTIL_TIMEOUT_MS
   });

--- a/src/launchd-control.ts
+++ b/src/launchd-control.ts
@@ -100,6 +100,8 @@ export function runLaunchdControlCommand(
     ...(plistPath ? { plistPath } : {})
   });
   const operation = daemonControlOperation(action, plistPath);
+  // Auto-selected standard plists are trusted by this command contract. Only
+  // an operator-supplied --plist participates in the external-path warning.
   const warning = plistPath && requestedPlistPath ? dependencies.plistWarning(plistPath) : undefined;
   const resultBase = {
     command,
@@ -144,7 +146,7 @@ export function inspectLaunchdServiceLoaded(
   const result = executeLaunchctl(["launchctl", "print", launchdTarget]);
   if (result.exitCode === 0) return true;
   const detail = `${result.stderr ?? ""}\n${result.stdout ?? ""}`.toLowerCase();
-  if (result.exitCode === 113 || detail.includes("could not find service") || detail.includes("service not found")) {
+  if (detail.includes("could not find service") || detail.includes("service not found")) {
     return false;
   }
   throw new Error(
@@ -166,6 +168,7 @@ export function runLaunchctlPlan(
       command[1] === "bootstrap" &&
       options?.acceptAlreadyLoadedBootstrap &&
       options.launchdTarget &&
+      isAlreadyLoadedBootstrapFailure(result) &&
       inspectLaunchdServiceLoaded(options.launchdTarget, executeLaunchctl)
     ) {
       results.push({
@@ -180,6 +183,11 @@ export function runLaunchctlPlan(
     if (result.exitCode !== 0) break;
   }
   return results;
+}
+
+function isAlreadyLoadedBootstrapFailure(result: LaunchctlResult): boolean {
+  const detail = `${result.stderr ?? ""}\n${result.stdout ?? ""}`.toLowerCase();
+  return detail.includes("service already bootstrapped") || detail.includes("service already loaded");
 }
 
 function buildDaemonLaunchctlCommands(input: {

--- a/src/launchd-control.ts
+++ b/src/launchd-control.ts
@@ -1,0 +1,208 @@
+export type LaunchctlResult = {
+  command: string[];
+  exitCode: number;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+  signal?: string;
+  observedExitCode?: number;
+  acceptedAs?: "already_loaded";
+};
+
+export type LaunchctlExecutor = (command: string[]) => LaunchctlResult;
+
+export type LaunchdControlResult = {
+  ok: boolean;
+  command: "daemon start" | "daemon stop";
+  dryRun: boolean;
+  launchdLabel: string;
+  launchdTarget: string;
+  launchdLoaded?: boolean;
+  operation?: "bootstrap_then_kickstart" | "kickstart_existing" | "bootout_plist" | "bootout_service";
+  plistPath?: string;
+  warning?: string;
+  plannedCommands?: string[][];
+  results?: LaunchctlResult[];
+  error?: string;
+};
+
+export type LaunchdControlDependencies = {
+  executeLaunchctl: LaunchctlExecutor;
+  plistExists: (path: string) => boolean;
+  assertPlistLabelMatches: (path: string, launchdLabel: string) => void;
+  plistWarning: (path: string) => string | undefined;
+  launchdSessionError: () => string | undefined;
+};
+
+export function runLaunchdControlCommand(
+  input: {
+    action: "start" | "stop";
+    dryRun: boolean;
+    confirm: boolean;
+    allowExternalPlist: boolean;
+    launchdLabel: string;
+    launchdTarget: string;
+    launchdDomain: string;
+    standardPlistPath: string;
+    requestedPlistPath?: string;
+  },
+  dependencies: LaunchdControlDependencies
+): LaunchdControlResult {
+  const {
+    action,
+    dryRun,
+    confirm,
+    allowExternalPlist,
+    launchdLabel,
+    launchdTarget,
+    launchdDomain,
+    standardPlistPath,
+    requestedPlistPath
+  } = input;
+  const command: "daemon start" | "daemon stop" = `daemon ${action}`;
+  if (!dryRun && !confirm) {
+    return {
+      ok: false,
+      command,
+      dryRun,
+      launchdLabel,
+      launchdTarget,
+      error: `daemon ${action} requires --confirm true when --dry-run false is used`
+    };
+  }
+  if (requestedPlistPath) dependencies.assertPlistLabelMatches(requestedPlistPath, launchdLabel);
+  const launchdLoaded = action === "start"
+    ? inspectLaunchdServiceLoaded(launchdTarget, dependencies.executeLaunchctl)
+    : undefined;
+  const plistPath = action === "start" && launchdLoaded === false
+    ? requestedPlistPath ?? (dependencies.plistExists(standardPlistPath) ? standardPlistPath : undefined)
+    : action === "stop"
+      ? requestedPlistPath
+      : undefined;
+  if (action === "start" && launchdLoaded === false && !plistPath && (dryRun || confirm)) {
+    return {
+      ok: false,
+      command: "daemon start",
+      dryRun,
+      launchdLabel,
+      launchdTarget,
+      launchdLoaded,
+      error: `launchd service is not loaded and no plist was found; pass --plist or install ${standardPlistPath}`
+    };
+  }
+  if (action === "start" && plistPath && plistPath !== requestedPlistPath) {
+    dependencies.assertPlistLabelMatches(plistPath, launchdLabel);
+  }
+  const commands = buildDaemonLaunchctlCommands({
+    action,
+    launchdDomain,
+    launchdTarget,
+    ...(plistPath ? { plistPath } : {})
+  });
+  const operation = daemonControlOperation(action, plistPath);
+  const warning = plistPath && requestedPlistPath ? dependencies.plistWarning(plistPath) : undefined;
+  const resultBase = {
+    command,
+    dryRun,
+    launchdLabel,
+    launchdTarget,
+    ...(launchdLoaded !== undefined ? { launchdLoaded } : {}),
+    operation,
+    ...(plistPath ? { plistPath } : {}),
+    ...(warning ? { warning } : {})
+  };
+  if (dryRun) {
+    return { ok: true, ...resultBase, plannedCommands: commands };
+  }
+  const launchdSessionError = dependencies.launchdSessionError();
+  if (launchdSessionError) {
+    return { ok: false, ...resultBase, plannedCommands: commands, error: launchdSessionError };
+  }
+  if (warning && !allowExternalPlist) {
+    return {
+      ok: false,
+      ...resultBase,
+      plannedCommands: commands,
+      error: `daemon ${action} requires --allow-external-plist true when --dry-run false uses a --plist outside the NeonDiff package root`
+    };
+  }
+  const results = runLaunchctlPlan(commands, dependencies.executeLaunchctl, {
+    acceptAlreadyLoadedBootstrap: action === "start",
+    launchdTarget
+  });
+  return {
+    ok: results.every((result) => result.exitCode === 0),
+    ...resultBase,
+    results
+  };
+}
+
+export function inspectLaunchdServiceLoaded(
+  launchdTarget: string,
+  executeLaunchctl: LaunchctlExecutor
+): boolean {
+  const result = executeLaunchctl(["launchctl", "print", launchdTarget]);
+  if (result.exitCode === 0) return true;
+  const detail = `${result.stderr ?? ""}\n${result.stdout ?? ""}`.toLowerCase();
+  if (result.exitCode === 113 || detail.includes("could not find service") || detail.includes("service not found")) {
+    return false;
+  }
+  throw new Error(
+    `failed to inspect launchd service ${launchdTarget}` +
+    (result.error ? `: ${result.error}` : detail.trim() ? `: ${detail.trim()}` : ` (exit ${result.exitCode})`)
+  );
+}
+
+export function runLaunchctlPlan(
+  commands: string[][],
+  executeLaunchctl: LaunchctlExecutor,
+  options?: { acceptAlreadyLoadedBootstrap?: boolean; launchdTarget?: string }
+): LaunchctlResult[] {
+  const results: LaunchctlResult[] = [];
+  for (const command of commands) {
+    const result = executeLaunchctl(command);
+    if (
+      result.exitCode !== 0 &&
+      command[1] === "bootstrap" &&
+      options?.acceptAlreadyLoadedBootstrap &&
+      options.launchdTarget &&
+      inspectLaunchdServiceLoaded(options.launchdTarget, executeLaunchctl)
+    ) {
+      results.push({
+        ...result,
+        exitCode: 0,
+        observedExitCode: result.exitCode,
+        acceptedAs: "already_loaded"
+      });
+      continue;
+    }
+    results.push(result);
+    if (result.exitCode !== 0) break;
+  }
+  return results;
+}
+
+function buildDaemonLaunchctlCommands(input: {
+  action: "start" | "stop";
+  launchdDomain: string;
+  launchdTarget: string;
+  plistPath?: string;
+}): string[][] {
+  if (input.action === "start") {
+    return [
+      ...(input.plistPath ? [["launchctl", "bootstrap", input.launchdDomain, input.plistPath]] : []),
+      ["launchctl", "kickstart", "-k", input.launchdTarget]
+    ];
+  }
+  return input.plistPath
+    ? [["launchctl", "bootout", input.launchdDomain, input.plistPath]]
+    : [["launchctl", "bootout", input.launchdTarget]];
+}
+
+function daemonControlOperation(
+  action: "start" | "stop",
+  plistPath?: string
+): "bootstrap_then_kickstart" | "kickstart_existing" | "bootout_plist" | "bootout_service" {
+  if (action === "start") return plistPath ? "bootstrap_then_kickstart" : "kickstart_existing";
+  return plistPath ? "bootout_plist" : "bootout_service";
+}

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -14,6 +14,11 @@ import type { ProviderApiKeyVerificationInput } from "../src/local-dashboard.js"
 import { runProvidersVerifyCommand } from "../src/providers-verify-command.js";
 import { ReviewStateStore } from "../src/state.js";
 import { createTestLicenseAdmission } from "./helpers/license-admission.js";
+import {
+  runLaunchdControlCommand,
+  type LaunchctlResult,
+  type LaunchdControlDependencies
+} from "../src/launchd-control.js";
 
 const execFileAsync = promisify(execFile);
 const require = createRequire(import.meta.url);
@@ -3336,21 +3341,12 @@ exit 1
     expect(stdout).not.toContain("temporarily overloaded");
   });
 
-  it("prints launchd daemon control plans in dry-run mode by default", async () => {
-    const { stdout: startStdout } = await runCli([
-      "daemon",
-      "start",
-      "--launchd-label",
-      "com.example.neondiff"
-    ], { env: darwinDaemonEnv });
-    const { stdout: stopStdout } = await runCli([
-      "daemon",
-      "stop",
-      "--launchd-label",
-      "com.example.neondiff"
-    ], { env: darwinDaemonEnv });
+  it("builds launchd daemon control plans in dry-run mode by default", () => {
+    const launchctl = createLaunchctlHarness({ loaded: true });
+    const start = runTestLaunchdControl({ action: "start" }, launchctl.dependencies);
+    const stop = runTestLaunchdControl({ action: "stop" }, launchctl.dependencies);
 
-    expect(JSON.parse(startStdout)).toMatchObject({
+    expect(start).toMatchObject({
       ok: true,
       command: "daemon start",
       dryRun: true,
@@ -3358,7 +3354,7 @@ exit 1
       operation: "kickstart_existing",
       plannedCommands: [["launchctl", "kickstart", "-k", expect.stringMatching(/gui\/\d+\/com\.example\.neondiff/)]]
     });
-    expect(JSON.parse(stopStdout)).toMatchObject({
+    expect(stop).toMatchObject({
       ok: true,
       command: "daemon stop",
       dryRun: true,
@@ -3366,6 +3362,150 @@ exit 1
       operation: "bootout_service",
       plannedCommands: [["launchctl", "bootout", expect.stringMatching(/gui\/\d+\/com\.example\.neondiff/)]]
     });
+  });
+
+  it("does not execute a PATH-controlled launchctl during daemon start dry-run", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-launchd-path-poison-"));
+    roots.push(root);
+    const binDir = join(root, "bin");
+    const markerPath = join(root, "poisoned-launchctl-ran");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(binDir, "launchctl"), `#!/bin/sh
+: > "$NEONDIFF_TEST_POISON_MARKER"
+exit 113
+`, { mode: 0o755 });
+
+    await runCli([
+      "daemon",
+      "start",
+      "--launchd-label",
+      "com.example.neondiff.path-poison"
+    ], {
+      env: {
+        ...darwinDaemonEnv,
+        HOME: root,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        NEONDIFF_TEST_POISON_MARKER: markerPath
+      }
+    }).catch(() => undefined);
+
+    expect(existsSync(markerPath)).toBe(false);
+  });
+
+  it("does not execute a PATH-controlled plutil during plist validation", async () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-plutil-path-poison-"));
+    roots.push(root);
+    const launchdLabel = "com.example.neondiff.plutil-path-poison";
+    const launchAgentsDir = join(root, "Library", "LaunchAgents");
+    const plistPath = join(launchAgentsDir, `${launchdLabel}.plist`);
+    const binDir = join(root, "bin");
+    const markerPath = join(root, "poisoned-plutil-ran");
+    mkdirSync(launchAgentsDir, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    writeLaunchdPlist(plistPath, launchdLabel);
+    writeFileSync(join(binDir, "plutil"), `#!/bin/sh
+: > "$NEONDIFF_TEST_POISON_MARKER"
+printf '%s\\n' "$NEONDIFF_TEST_PLUTIL_LABEL"
+exit 0
+`, { mode: 0o755 });
+
+    const { stdout } = await runCli([
+      "daemon",
+      "stop",
+      "--launchd-label",
+      launchdLabel,
+      "--plist",
+      plistPath
+    ], {
+      env: {
+        ...darwinDaemonEnv,
+        HOME: root,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        NEONDIFF_TEST_POISON_MARKER: markerPath,
+        NEONDIFF_TEST_PLUTIL_LABEL: launchdLabel
+      }
+    });
+
+    expect(JSON.parse(stdout)).toMatchObject({
+      ok: true,
+      command: "daemon stop",
+      dryRun: true,
+      operation: "bootout_plist",
+      plistPath,
+      plannedCommands: [["launchctl", "bootout", expect.stringMatching(/^gui\/\d+$/), plistPath]]
+    });
+    expect(existsSync(markerPath)).toBe(false);
+  });
+
+  it("plans bootstrap from the standard plist when the launchd service is not loaded", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-launchd-stopped-"));
+    roots.push(root);
+    const launchAgentsDir = join(root, "Library", "LaunchAgents");
+    const plistPath = join(launchAgentsDir, "com.example.neondiff.plist");
+    mkdirSync(launchAgentsDir, { recursive: true });
+    writeLaunchdPlist(plistPath, "com.example.neondiff");
+    const launchctl = createLaunchctlHarness({ loaded: false });
+    const output = runTestLaunchdControl({ standardPlistPath: plistPath }, launchctl.dependencies);
+
+    expect(output).toMatchObject({
+      ok: true,
+      command: "daemon start",
+      dryRun: true,
+      operation: "bootstrap_then_kickstart",
+      plistPath,
+      plannedCommands: [
+        ["launchctl", "bootstrap", expect.stringMatching(/^gui\/\d+$/), plistPath],
+        ["launchctl", "kickstart", "-k", expect.stringMatching(/gui\/\d+\/com\.example\.neondiff/)]
+      ]
+    });
+    expect(launchctl.commands).toEqual([["launchctl", "print", expect.stringMatching(/^gui\/\d+\/com\.example\.neondiff$/)]]);
+  });
+
+  it("fails start planning when the service is unloaded and no plist exists", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-launchd-missing-plist-"));
+    roots.push(root);
+    const standardPlistPath = join(root, "Library", "LaunchAgents", "com.example.neondiff.plist");
+    const launchctl = createLaunchctlHarness({ loaded: false });
+
+    const output = runTestLaunchdControl({ standardPlistPath }, launchctl.dependencies);
+
+    expect(output).toMatchObject({
+      ok: false,
+      command: "daemon start",
+      dryRun: true,
+      launchdLoaded: false,
+      error: `launchd service is not loaded and no plist was found; pass --plist or install ${standardPlistPath}`
+    });
+    expect(output.plannedCommands).toBeUndefined();
+    expect(output.operation).toBeUndefined();
+    expect(launchctl.commands).toEqual([["launchctl", "print", expect.stringMatching(/^gui\/\d+\/com\.example\.neondiff$/)]]);
+  });
+
+  it("plans kickstart only when the launchd service is already loaded", () => {
+    const launchctl = createLaunchctlHarness({ loaded: true });
+    const output = runTestLaunchdControl({ action: "start" }, launchctl.dependencies);
+
+    expect(output).toMatchObject({
+      ok: true,
+      command: "daemon start",
+      dryRun: true,
+      operation: "kickstart_existing",
+      plannedCommands: [
+        ["launchctl", "kickstart", "-k", expect.stringMatching(/gui\/\d+\/com\.example\.neondiff/)]
+      ]
+    });
+    expect(launchctl.commands).toEqual([["launchctl", "print", expect.stringMatching(/^gui\/\d+\/com\.example\.neondiff$/)]]);
+  });
+
+  it("fails closed when launchctl print cannot classify the service state", () => {
+    const launchctl = createLaunchctlHarness({
+      loaded: false,
+      printFailure: { exitCode: 64, stderr: "Operation not permitted" }
+    });
+
+    expect(() => runTestLaunchdControl({ action: "start" }, launchctl.dependencies))
+      .toThrow("failed to inspect launchd service");
+    expect(launchctl.commands).toEqual([["launchctl", "print", expect.stringMatching(/^gui\/\d+\/com\.example\.neondiff$/)]]);
   });
 
   it("requires config for daemon status", async () => {
@@ -3433,17 +3573,10 @@ exit 1
     roots.push(root);
     const plistPath = join(root, "com.example.neondiff.plist");
     writeLaunchdPlist(plistPath, "com.example.neondiff");
+    const launchctl = createLaunchctlHarness({ loaded: false });
+    const output = runTestLaunchdControl({ requestedPlistPath: plistPath }, launchctl.dependencies);
 
-    const { stdout } = await runCli([
-      "daemon",
-      "start",
-      "--launchd-label",
-      "com.example.neondiff",
-      "--plist",
-      plistPath
-    ], { env: darwinDaemonEnv });
-
-    expect(JSON.parse(stdout)).toMatchObject({
+    expect(output).toMatchObject({
       ok: true,
       command: "daemon start",
       dryRun: true,
@@ -3496,6 +3629,130 @@ exit 1
     ], { env: darwinDaemonEnv })).rejects.toMatchObject({
       stdout: expect.stringContaining("requires --confirm true")
     });
+  });
+
+  it("rejects unconfirmed live start before launchctl or plist inspection", () => {
+    const calls: string[] = [];
+    const output = runTestLaunchdControl({
+      dryRun: false,
+      confirm: false,
+      requestedPlistPath: "/operator/owned/com.example.neondiff.plist"
+    }, {
+      executeLaunchctl(command) {
+        calls.push(`launchctl:${command[1]}`);
+        return { command, exitCode: 0 };
+      },
+      plistExists(path) {
+        calls.push(`plist-exists:${path}`);
+        return true;
+      },
+      assertPlistLabelMatches(path) {
+        calls.push(`plist-label:${path}`);
+      },
+      plistWarning(path) {
+        calls.push(`plist-warning:${path}`);
+        return undefined;
+      },
+      launchdSessionError() {
+        calls.push("launchd-session");
+        return undefined;
+      }
+    });
+
+    expect(output).toMatchObject({
+      ok: false,
+      command: "daemon start",
+      dryRun: false,
+      error: "daemon start requires --confirm true when --dry-run false is used"
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("continues with kickstart when bootstrap races with another loader", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-launchd-bootstrap-race-"));
+    roots.push(root);
+    const plistPath = join(root, "com.example.neondiff.plist");
+    writeLaunchdPlist(plistPath, "com.example.neondiff");
+    const launchctl = createLaunchctlHarness({ loaded: false, bootstrapRace: true });
+    const output = runTestLaunchdControl({
+      requestedPlistPath: plistPath,
+      dryRun: false,
+      confirm: true,
+      allowExternalPlist: true
+    }, launchctl.dependencies);
+
+    expect(output).toMatchObject({
+      ok: true,
+      command: "daemon start",
+      dryRun: false,
+      launchdLoaded: false,
+      operation: "bootstrap_then_kickstart",
+      results: [
+        {
+          command: ["launchctl", "bootstrap", expect.stringMatching(/^gui\/\d+$/), plistPath],
+          exitCode: 0,
+          observedExitCode: 5,
+          acceptedAs: "already_loaded"
+        },
+        {
+          command: ["launchctl", "kickstart", "-k", expect.stringMatching(/gui\/\d+\/com\.example\.neondiff/)],
+          exitCode: 0
+        }
+      ]
+    });
+    expect(launchctl.commands).toEqual([
+      ["launchctl", "print", expect.stringMatching(/^gui\/\d+\/com\.example\.neondiff$/)],
+      ["launchctl", "bootstrap", expect.stringMatching(/^gui\/\d+$/), plistPath],
+      ["launchctl", "print", expect.stringMatching(/^gui\/\d+\/com\.example\.neondiff$/)],
+      ["launchctl", "kickstart", "-k", expect.stringMatching(/^gui\/\d+\/com\.example\.neondiff$/)]
+    ]);
+  });
+
+  it("bootstraps the exact standard LaunchAgent path without an external-plist override", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-launchd-standard-live-"));
+    roots.push(root);
+    const launchAgentsDir = join(root, "Library", "LaunchAgents");
+    const plistPath = join(launchAgentsDir, "com.example.neondiff.plist");
+    mkdirSync(launchAgentsDir, { recursive: true });
+    writeLaunchdPlist(plistPath, "com.example.neondiff");
+    const plistBeforeStart = readFileSync(plistPath, "utf8");
+    const launchctl = createLaunchctlHarness({ loaded: false });
+    const output = runTestLaunchdControl({
+      standardPlistPath: plistPath,
+      dryRun: false,
+      confirm: true
+    }, launchctl.dependencies);
+
+    expect(output).toMatchObject({
+      ok: true,
+      operation: "bootstrap_then_kickstart",
+      plistPath,
+      results: [
+        { command: ["launchctl", "bootstrap", expect.stringMatching(/^gui\/\d+$/), plistPath], exitCode: 0 },
+        { command: ["launchctl", "kickstart", "-k", expect.any(String)], exitCode: 0 }
+      ]
+    });
+    expect(output.warning).toBeUndefined();
+    expect(readFileSync(plistPath, "utf8")).toBe(plistBeforeStart);
+  });
+
+  it("requires an external-plist opt-in before confirmed launchctl mutation", () => {
+    const root = mkdtempSync(join(tmpdir(), "neondiff-launchd-external-opt-in-"));
+    roots.push(root);
+    const plistPath = join(root, "com.example.neondiff.plist");
+    writeLaunchdPlist(plistPath, "com.example.neondiff");
+    const launchctl = createLaunchctlHarness({ loaded: false });
+    const output = runTestLaunchdControl({
+      requestedPlistPath: plistPath,
+      dryRun: false,
+      confirm: true
+    }, launchctl.dependencies);
+
+    expect(output).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("requires --allow-external-plist true")
+    });
+    expect(launchctl.commands).toEqual([["launchctl", "print", expect.stringMatching(/^gui\/\d+\/com\.example\.neondiff$/)]]);
   });
 
   it("requires activation before confirmed live daemon mutation with an external plist", async () => {
@@ -3721,4 +3978,64 @@ function writeLaunchdPlist(path: string, label: string): void {
 </dict>
 </plist>
 `);
+}
+
+function runTestLaunchdControl(
+  overrides: Partial<Parameters<typeof runLaunchdControlCommand>[0]>,
+  dependencies: LaunchdControlDependencies
+) {
+  const launchdLabel = overrides.launchdLabel ?? "com.example.neondiff";
+  const launchdDomain = overrides.launchdDomain ?? `gui/${process.getuid?.() ?? 501}`;
+  return runLaunchdControlCommand({
+    action: "start",
+    dryRun: true,
+    confirm: false,
+    allowExternalPlist: false,
+    launchdLabel,
+    launchdDomain,
+    launchdTarget: `${launchdDomain}/${launchdLabel}`,
+    standardPlistPath: join(tmpdir(), "neondiff-missing-launchagents", `${launchdLabel}.plist`),
+    ...overrides
+  }, dependencies);
+}
+
+function createLaunchctlHarness(options: {
+  loaded: boolean;
+  bootstrapRace?: boolean;
+  printFailure?: Omit<LaunchctlResult, "command">;
+}): { commands: string[][]; dependencies: LaunchdControlDependencies } {
+  const commands: string[][] = [];
+  let loaded = options.loaded;
+  const executeLaunchctl = (command: string[]): LaunchctlResult => {
+    commands.push(command);
+    if (command[1] === "print") {
+      if (options.printFailure) return { command, ...options.printFailure };
+      return loaded
+        ? { command, exitCode: 0, stdout: "service loaded" }
+        : { command, exitCode: 113, stderr: "Could not find service" };
+    }
+    if (command[1] === "bootstrap" && options.bootstrapRace) {
+      loaded = true;
+      return { command, exitCode: 5, stderr: "Bootstrap failed: 5: Input/output error" };
+    }
+    return { command, exitCode: 0 };
+  };
+  return {
+    commands,
+    dependencies: {
+      executeLaunchctl,
+      plistExists: existsSync,
+      assertPlistLabelMatches(path, launchdLabel) {
+        const xml = readFileSync(path, "utf8");
+        const match = xml.match(/<key>\s*Label\s*<\/key>\s*<string>([^<]+)<\/string>/);
+        if (match?.[1] !== launchdLabel) throw new Error("plist label mismatch");
+      },
+      plistWarning(path) {
+        return path === repoRoot || path.startsWith(`${repoRoot}/`)
+          ? undefined
+          : "--plist is outside the NeonDiff package root; use only operator-owned plist paths";
+      },
+      launchdSessionError: () => undefined
+    }
+  };
 }

--- a/tests/public-cli.test.ts
+++ b/tests/public-cli.test.ts
@@ -16,6 +16,7 @@ import { ReviewStateStore } from "../src/state.js";
 import { createTestLicenseAdmission } from "./helpers/license-admission.js";
 import {
   runLaunchdControlCommand,
+  runLaunchctlPlan,
   type LaunchctlResult,
   type LaunchdControlDependencies
 } from "../src/launchd-control.js";
@@ -3437,6 +3438,41 @@ exit 0
     expect(existsSync(markerPath)).toBe(false);
   });
 
+  it.runIf(process.platform === "darwin")(
+    "exercises the golden unloaded start plan through the real CLI boundary",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "neondiff-launchd-cli-plan-"));
+      roots.push(root);
+      const launchdLabel = `com.example.neondiff.cli-plan.${process.pid}.${Date.now()}`;
+      const launchAgentsDir = join(root, "Library", "LaunchAgents");
+      const plistPath = join(launchAgentsDir, `${launchdLabel}.plist`);
+      mkdirSync(launchAgentsDir, { recursive: true });
+      writeLaunchdPlist(plistPath, launchdLabel);
+
+      const { stdout } = await runCli([
+        "daemon",
+        "start",
+        "--launchd-label",
+        launchdLabel,
+        "--dry-run",
+        "true"
+      ], { env: { ...darwinDaemonEnv, HOME: root } });
+
+      expect(JSON.parse(stdout)).toMatchObject({
+        ok: true,
+        command: "daemon start",
+        dryRun: true,
+        launchdLoaded: false,
+        operation: "bootstrap_then_kickstart",
+        plistPath,
+        plannedCommands: [
+          ["launchctl", "bootstrap", expect.stringMatching(/^gui\/\d+$/), plistPath],
+          ["launchctl", "kickstart", "-k", expect.stringContaining(launchdLabel)]
+        ]
+      });
+    }
+  );
+
   it("plans bootstrap from the standard plist when the launchd service is not loaded", () => {
     const root = mkdtempSync(join(tmpdir(), "neondiff-launchd-stopped-"));
     roots.push(root);
@@ -3506,6 +3542,16 @@ exit 0
     expect(() => runTestLaunchdControl({ action: "start" }, launchctl.dependencies))
       .toThrow("failed to inspect launchd service");
     expect(launchctl.commands).toEqual([["launchctl", "print", expect.stringMatching(/^gui\/\d+\/com\.example\.neondiff$/)]]);
+  });
+
+  it("does not treat exit 113 without a not-found diagnostic as unloaded", () => {
+    const launchctl = createLaunchctlHarness({
+      loaded: false,
+      printFailure: { exitCode: 113, stderr: "Operation not permitted" }
+    });
+
+    expect(() => runTestLaunchdControl({ action: "start" }, launchctl.dependencies))
+      .toThrow("failed to inspect launchd service");
   });
 
   it("requires config for daemon status", async () => {
@@ -3691,7 +3737,7 @@ exit 0
         {
           command: ["launchctl", "bootstrap", expect.stringMatching(/^gui\/\d+$/), plistPath],
           exitCode: 0,
-          observedExitCode: 5,
+          observedExitCode: 125,
           acceptedAs: "already_loaded"
         },
         {
@@ -3705,6 +3751,37 @@ exit 0
       ["launchctl", "bootstrap", expect.stringMatching(/^gui\/\d+$/), plistPath],
       ["launchctl", "print", expect.stringMatching(/^gui\/\d+\/com\.example\.neondiff$/)],
       ["launchctl", "kickstart", "-k", expect.stringMatching(/^gui\/\d+\/com\.example\.neondiff$/)]
+    ]);
+  });
+
+  it("does not mask an unrelated bootstrap failure when a service appears", () => {
+    let serviceLoaded = false;
+    const commands = [
+      ["launchctl", "bootstrap", "gui/501", "/operator/owned/com.example.neondiff.plist"],
+      ["launchctl", "kickstart", "-k", "gui/501/com.example.neondiff"]
+    ];
+    const results = runLaunchctlPlan(commands, (command) => {
+      if (command[1] === "bootstrap") {
+        serviceLoaded = true;
+        return { command, exitCode: 5, stderr: "Bootstrap failed: 5: Input/output error" };
+      }
+      if (command[1] === "print") {
+        return serviceLoaded
+          ? { command, exitCode: 0, stdout: "service loaded" }
+          : { command, exitCode: 113, stderr: "Could not find service" };
+      }
+      return { command, exitCode: 0 };
+    }, {
+      acceptAlreadyLoadedBootstrap: true,
+      launchdTarget: "gui/501/com.example.neondiff"
+    });
+
+    expect(results).toEqual([
+      {
+        command: ["launchctl", "bootstrap", "gui/501", "/operator/owned/com.example.neondiff.plist"],
+        exitCode: 5,
+        stderr: "Bootstrap failed: 5: Input/output error"
+      }
     ]);
   });
 
@@ -4016,7 +4093,7 @@ function createLaunchctlHarness(options: {
     }
     if (command[1] === "bootstrap" && options.bootstrapRace) {
       loaded = true;
-      return { command, exitCode: 5, stderr: "Bootstrap failed: 5: Input/output error" };
+      return { command, exitCode: 125, stderr: "Bootstrap failed: 125: Service already bootstrapped" };
     }
     return { command, exitCode: 0 };
   };


### PR DESCRIPTION
## Summary

- distinguish launchd registration from plist existence with `launchctl print`
- kickstart an already loaded service; bootstrap then kickstart an unloaded service from the exact standard or explicitly supplied plist
- fail closed on unknown inspection errors and accept bootstrap races only after re-confirming registration
- preserve dry-run, confirmation, activation, external-plist, and no-plist-rewrite boundaries
- pin production execution to `/bin/launchctl` and `/usr/bin/plutil`; tests inject only the OS boundary
- document the supported stop/start recovery flow

Tracks #582.

## Local proof at `b01561e1a45e787eaec04964bc02bca0bf30e193`

- poisoned-PATH `launchctl` regression: observed red, then green
- poisoned-PATH `plutil` regression: observed red, then green
- focused launcher slice: 17 passed, 72 skipped
- build and explicit postbuild: passed
- public claims scan: passed
- secret scan: passed (678 tracked files)
- `git diff --check`: passed
- independent final security review: clean at the 95% gate

## Proof boundary

This PR contains unit/integration-level command orchestration proof only. Do not close #582 or claim launcher recovery complete until the merged exact head passes a real Mac `stop -> start -> new PID -> current heartbeat` acceptance using the installed LaunchAgent without rewriting its plist or configuration.
